### PR TITLE
[DS][50/n] Add include_selection and exclude_selection to DepSchedulingCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -3,9 +3,6 @@ from typing import TYPE_CHECKING, AbstractSet, Dict, FrozenSet, NamedTuple, Opti
 
 import dagster._check as check
 from dagster._annotations import deprecated, experimental, public
-from dagster._core.definitions.declarative_scheduling.scheduling_condition import (
-    SchedulingCondition,
-)
 from dagster._serdes.serdes import (
     NamedTupleSerializer,
     UnpackContext,
@@ -17,6 +14,9 @@ if TYPE_CHECKING:
     from dagster._core.definitions.auto_materialize_rule import (
         AutoMaterializeRule,
         AutoMaterializeRuleSnapshot,
+    )
+    from dagster._core.definitions.declarative_scheduling.scheduling_condition import (
+        SchedulingCondition,
     )
 
 
@@ -65,7 +65,7 @@ class AutoMaterializePolicy(
         [
             ("rules", FrozenSet["AutoMaterializeRule"]),
             ("max_materializations_per_minute", Optional[int]),
-            ("asset_condition", Optional[SchedulingCondition]),
+            ("asset_condition", Optional["SchedulingCondition"]),
         ],
     )
 ):
@@ -128,7 +128,7 @@ class AutoMaterializePolicy(
         cls,
         rules: AbstractSet["AutoMaterializeRule"],
         max_materializations_per_minute: Optional[int] = 1,
-        asset_condition: Optional[SchedulingCondition] = None,
+        asset_condition: Optional["SchedulingCondition"] = None,
     ):
         from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 
@@ -158,7 +158,9 @@ class AutoMaterializePolicy(
 
     @property
     def materialize_rules(self) -> AbstractSet["AutoMaterializeRule"]:
-        from dagster._core.definitions.auto_materialize_rule import AutoMaterializeDecisionType
+        from dagster._core.definitions.auto_materialize_rule_evaluation import (
+            AutoMaterializeDecisionType,
+        )
 
         return {
             rule
@@ -168,19 +170,21 @@ class AutoMaterializePolicy(
 
     @property
     def skip_rules(self) -> AbstractSet["AutoMaterializeRule"]:
-        from dagster._core.definitions.auto_materialize_rule import AutoMaterializeDecisionType
+        from dagster._core.definitions.auto_materialize_rule_evaluation import (
+            AutoMaterializeDecisionType,
+        )
 
         return {
             rule for rule in self.rules if rule.decision_type == AutoMaterializeDecisionType.SKIP
         }
 
     @staticmethod
-    def from_asset_condition(asset_condition: SchedulingCondition) -> "AutoMaterializePolicy":
+    def from_asset_condition(asset_condition: "SchedulingCondition") -> "AutoMaterializePolicy":
         return AutoMaterializePolicy.from_scheduling_condition(asset_condition)
 
     @staticmethod
     def from_scheduling_condition(
-        scheduling_condition: SchedulingCondition,
+        scheduling_condition: "SchedulingCondition",
     ) -> "AutoMaterializePolicy":
         """Constructs an AutoMaterializePolicy which will materialize an asset partition whenever
         the provided scheduling_condition evaluates to True.
@@ -293,14 +297,10 @@ class AutoMaterializePolicy(
     def rule_snapshots(self) -> Sequence["AutoMaterializeRuleSnapshot"]:
         return [rule.to_snapshot() for rule in self.rules]
 
-    def to_scheduling_condition(self) -> SchedulingCondition:
+    def to_scheduling_condition(self) -> "SchedulingCondition":
         """Converts a set of materialize / skip rules into a single binary expression."""
         from .auto_materialize_rule_impls import DiscardOnMaxMaterializationsExceededRule
-        from .declarative_scheduling.operators.boolean_operators import (
-            AndAssetCondition,
-            NotAssetCondition,
-            OrAssetCondition,
-        )
+        from .declarative_scheduling import AndAssetCondition, NotAssetCondition, OrAssetCondition
 
         if self.asset_condition is not None:
             return self.asset_condition

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule.py
@@ -1,17 +1,17 @@
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional
 
 import pytz
 
 import dagster._check as check
 from dagster._annotations import public
-from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    AutoMaterializeDecisionType,
-    AutoMaterializeRuleSnapshot,
-)
 from dagster._utils.schedules import is_valid_cron_string
 
 if TYPE_CHECKING:
+    from dagster._core.definitions.auto_materialize_rule_evaluation import (
+        AutoMaterializeDecisionType,
+        AutoMaterializeRuleSnapshot,
+    )
     from dagster._core.definitions.auto_materialize_rule_impls import (
         AutoMaterializeAssetPartitionsFilter,
         MaterializeOnCronRule,
@@ -49,12 +49,14 @@ class AutoMaterializeRule(ABC):
     are produced by the materialize rules. Other than that, there is no ordering between rules.
     """
 
-    @abstractproperty
-    def decision_type(self) -> AutoMaterializeDecisionType:
+    @property
+    @abstractmethod
+    def decision_type(self) -> "AutoMaterializeDecisionType":
         """The decision type of the rule (either `MATERIALIZE` or `SKIP`)."""
         ...
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def description(self) -> str:
         """A human-readable description of this rule. As a basic guideline, this string should
         complete the sentence: 'Indicates an asset should be (materialize/skipped) when ____'.
@@ -252,8 +254,12 @@ class AutoMaterializeRule(ABC):
 
         return SkipOnRunInProgressRule()
 
-    def to_snapshot(self) -> AutoMaterializeRuleSnapshot:
+    def to_snapshot(self) -> "AutoMaterializeRuleSnapshot":
         """Returns a serializable snapshot of this rule for historical evaluations."""
+        from dagster._core.definitions.auto_materialize_rule_evaluation import (
+            AutoMaterializeRuleSnapshot,
+        )
+
         return AutoMaterializeRuleSnapshot(
             class_name=self.__class__.__name__,
             description=self.description,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/dep_operators.py
@@ -1,4 +1,9 @@
+from abc import abstractmethod
+from typing import AbstractSet, Optional
+
 from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._serdes.serdes import whitelist_for_serdes
 
 from ..scheduling_condition import SchedulingCondition, SchedulingResult
@@ -37,20 +42,64 @@ class DepConditionWrapperCondition(SchedulingCondition):
 
 class DepCondition(SchedulingCondition):
     operand: SchedulingCondition
+    allow_selection: Optional[AssetSelection] = None
+    ignore_selection: Optional[AssetSelection] = None
+
+    @property
+    @abstractmethod
+    def base_description(self) -> str: ...
+
+    @property
+    def description(self) -> str:
+        description = f"{self.base_description} deps"
+        if self.allow_selection is not None:
+            description += f" within selection {self.allow_selection}"
+        if self.ignore_selection is not None:
+            description += f" except for {self.ignore_selection}"
+        return description
+
+    def allow(self, selection: AssetSelection) -> "DepCondition":
+        """Returns a copy of this condition that will only consider dependencies within the provided
+        AssetSelection.
+        """
+        allow_selection = (
+            selection if self.allow_selection is None else selection | self.allow_selection
+        )
+        return self.model_copy(update={"allow_selection": allow_selection})
+
+    def ignore(self, selection: AssetSelection) -> "DepCondition":
+        """Returns a copy of this condition that will ignore dependencies within the provided
+        AssetSelection.
+        """
+        ignore_selection = (
+            selection if self.ignore_selection is None else selection | self.ignore_selection
+        )
+        return self.model_copy(update={"ignore_selection": ignore_selection})
+
+    def _get_dep_keys(
+        self, asset_key: AssetKey, asset_graph: BaseAssetGraph
+    ) -> AbstractSet[AssetKey]:
+        dep_keys = asset_graph.get(asset_key).parent_keys
+        if self.allow_selection is not None:
+            dep_keys &= self.allow_selection.resolve(asset_graph)
+        if self.ignore_selection is not None:
+            dep_keys -= self.ignore_selection.resolve(asset_graph)
+        return dep_keys
 
 
 @whitelist_for_serdes
 class AnyDepsCondition(DepCondition):
     @property
-    def description(self) -> str:
-        return "Any deps"
+    def base_description(self) -> str:
+        return "Any"
 
     def evaluate(self, context: SchedulingContext) -> SchedulingResult:
         dep_results = []
         true_slice = context.asset_graph_view.create_empty_slice(context.asset_key)
 
-        dep_keys = context.asset_graph_view.asset_graph.get(context.asset_key).parent_keys
-        for i, dep_key in enumerate(sorted(dep_keys)):
+        for i, dep_key in enumerate(
+            sorted(self._get_dep_keys(context.asset_key, context.asset_graph))
+        ):
             dep_condition = DepConditionWrapperCondition(dep_key=dep_key, operand=self.operand)
             dep_result = dep_condition.evaluate(
                 context.for_child_condition(
@@ -71,15 +120,16 @@ class AnyDepsCondition(DepCondition):
 @whitelist_for_serdes
 class AllDepsCondition(DepCondition):
     @property
-    def description(self) -> str:
-        return "All deps"
+    def base_description(self) -> str:
+        return "All"
 
     def evaluate(self, context: SchedulingContext) -> SchedulingResult:
         dep_results = []
         true_slice = context.candidate_slice
 
-        dep_keys = context.asset_graph_view.asset_graph.get(context.asset_key).parent_keys
-        for i, dep_key in enumerate(sorted(dep_keys)):
+        for i, dep_key in enumerate(
+            sorted(self._get_dep_keys(context.asset_key, context.asset_graph))
+        ):
             dep_condition = DepConditionWrapperCondition(dep_key=dep_key, operand=self.operand)
             dep_result = dep_condition.evaluate(
                 context.for_child_condition(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
@@ -7,6 +7,7 @@ import pendulum
 import dagster._check as check
 from dagster._annotations import experimental
 from dagster._core.asset_graph_view.asset_graph_view import AssetSlice
+from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.declarative_scheduling.serialized_objects import (
     AssetConditionSnapshot,
@@ -152,15 +153,27 @@ class SchedulingCondition(ABC, DagsterModel):
     def any_deps_match(condition: "SchedulingCondition") -> "AnyDepsCondition":
         """Returns a SchedulingCondition that is true for an asset partition if at least one partition
         of any of its dependencies evaluate to True for the given condition.
+
+        Args:
+            condition (SchedulingCondition): The SchedulingCondition that will be evaluated against
+                this asset's dependencies.
         """
         from .operators import AnyDepsCondition
 
         return AnyDepsCondition(operand=condition)
 
     @staticmethod
-    def all_deps_match(condition: "SchedulingCondition") -> "AllDepsCondition":
+    def all_deps_match(
+        condition: "SchedulingCondition",
+        include_selection: Optional[AssetSelection] = None,
+        exclude_selection: Optional[AssetSelection] = None,
+    ) -> "AllDepsCondition":
         """Returns a SchedulingCondition that is true for an asset partition if at least one partition
         of all of its dependencies evaluate to True for the given condition.
+
+        Args:
+            condition (SchedulingCondition): The SchedulingCondition that will be evaluated against
+                this asset's dependencies.
         """
         from .operators import AllDepsCondition
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
@@ -93,7 +93,7 @@ class SchedulingConditionScenarioState(ScenarioState):
             else check.not_none(self.scheduling_condition)
         )
         asset_graph = self.scenario_spec.with_asset_properties(
-            asset,
+            keys=[asset],
             auto_materialize_policy=AutoMaterializePolicy.from_asset_condition(asset_condition),
         ).asset_graph
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
@@ -1,7 +1,11 @@
+from typing import Sequence
+
 import dagster._check as check
 import pytest
 from dagster import SchedulingCondition
 from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.declarative_scheduling.scheduling_condition import SchedulingResult
 from dagster._core.definitions.declarative_scheduling.scheduling_context import (
@@ -9,6 +13,9 @@ from dagster._core.definitions.declarative_scheduling.scheduling_context import 
 )
 from dagster._core.definitions.events import AssetKeyPartitionKey
 
+from dagster_tests.definitions_tests.auto_materialize_tests.scenario_state import ScenarioSpec
+
+from ..base_scenario import run_request
 from ..scenario_specs import one_asset_depends_on_two, two_partitions_def
 from .asset_condition_scenario import SchedulingConditionScenarioState
 
@@ -123,3 +130,101 @@ def test_dep_missing_partitioned(is_any: bool) -> None:
     else:
         # now partition 2 has all parents true
         assert result.true_subset.size == 2
+
+
+@pytest.mark.parametrize("is_any", [True, False])
+@pytest.mark.parametrize("is_include", [True, False])
+@pytest.mark.parametrize(
+    "expected_initial_result_size,materialized_asset_partitions,expected_final_result_size",
+    [
+        # after A is materialized, B is still missing, but is ignored
+        (2, ["A1"], 1),
+        (2, ["A1", "A2"], 0),
+        # materializations of B have no effect
+        (2, ["A1", "B2"], 1),
+        (2, ["B1", "B2"], 2),
+    ],
+)
+def test_dep_missing_partitioned_selections(
+    is_any: bool,
+    is_include: bool,
+    expected_initial_result_size: int,
+    materialized_asset_partitions: Sequence[str],
+    expected_final_result_size: int,
+) -> None:
+    # NOTE: because all selections resolve to a single parent asset, ANY and ALL return the same
+    # results
+    if is_any:
+        condition = SchedulingCondition.any_deps_match(SchedulingCondition.missing())
+    else:
+        condition = SchedulingCondition.all_deps_match(SchedulingCondition.missing())
+
+    if is_include:
+        condition = condition.allow(AssetSelection.keys("A"))
+    else:
+        condition = condition.ignore(AssetSelection.keys("B"))
+    state = SchedulingConditionScenarioState(
+        one_asset_depends_on_two, scheduling_condition=condition
+    ).with_asset_properties(partitions_def=two_partitions_def)
+    # all parents are missing
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == expected_initial_result_size
+    state = state.with_runs(*(run_request(s[0], s[1]) for s in materialized_asset_partitions))
+    state, result = state.evaluate("C")
+    assert result.true_subset.size == expected_final_result_size
+
+
+complex_scenario_spec = ScenarioSpec(
+    asset_specs=[
+        AssetSpec("A", group_name="foo"),
+        AssetSpec("B", group_name="foo"),
+        AssetSpec("C", group_name="foo"),
+        AssetSpec("D", group_name="bar"),
+        AssetSpec("E", group_name="bar"),
+        AssetSpec("downstream", deps=["A", "B", "C", "D", "E"]),
+    ]
+)
+
+
+def test_dep_missing_complex_include() -> None:
+    # true if any dependencies within the "bar" group are missing, or "A" is missing
+    condition = SchedulingCondition.any_deps_match(
+        SchedulingCondition.missing(),
+    ).allow(AssetSelection.keys("A") | AssetSelection.groups("bar"))
+    state = SchedulingConditionScenarioState(complex_scenario_spec, scheduling_condition=condition)
+
+    # all start off as missing
+    state, result = state.evaluate("downstream")
+    assert result.true_subset.size == 1
+
+    # A materialized, D and E still missing
+    state = state.with_runs(run_request(["A"]))
+    state, result = state.evaluate("downstream")
+    assert result.true_subset.size == 1
+
+    # D and E materialized, and all the other missing things are in the exclude selection
+    state = state.with_runs(run_request(["D", "E"]))
+    state, result = state.evaluate("downstream")
+    assert result.true_subset.size == 0
+
+
+def test_dep_missing_complex_exclude() -> None:
+    # true if any dependencies are missing, ignoring A and anything in the "bar" group
+    condition = SchedulingCondition.any_deps_match(
+        SchedulingCondition.missing(),
+    ).ignore(AssetSelection.keys("A") | AssetSelection.groups("bar"))
+    state = SchedulingConditionScenarioState(complex_scenario_spec, scheduling_condition=condition)
+
+    # all start off as missing
+    state, result = state.evaluate("downstream")
+    assert result.true_subset.size == 1
+
+    # B materialized, C still missing
+    state = state.with_runs(run_request(["B"]))
+    state, result = state.evaluate("downstream")
+    assert result.true_subset.size == 1
+
+    # C materialized, and all the other missing things are in the exclude selection
+    state = state.with_runs(run_request(["C"]))
+    state, result = state.evaluate("downstream")
+    assert result.true_subset.size == 0


### PR DESCRIPTION
## Summary & Motivation

As title -- previous iterations of this also added similar selection arguments to the ParentNewer condition. However, that didn't make a ton of sense because "ParentNewer" is purely a status like "code version updated" and calculating it in a different way is odd. Below this in the stack, we added a NewlyUpdated condition, which can compose with the AnyDepsCondition and take advantage of these arguments for users who want filter based on parent updates

## How I Tested These Changes
