### PR TITLE
Revert "Pin requests < 2.32.0"

### DIFF
--- a/integration_tests/test_suites/backcompat-test-suite/webserver_service/pins.txt
+++ b/integration_tests/test_suites/backcompat-test-suite/webserver_service/pins.txt
@@ -16,6 +16,3 @@ sqlalchemy<2.0.0
 
 # Added pendulum pin in later versions
 pendulum<3
-
-# 2.32.0 breaks our docker tests https://buildkite.com/dagster/dagster-dagster/builds/83562
-requests<2.32.0

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -138,7 +138,6 @@ setup(
             "morefs[asynclocal]",
             "fsspec<2024.5.0",  # morefs incompatibly
             "rapidfuzz",
-            "requests<2.32.0",  # 2.32.0 breaks our docker tests https://buildkite.com/dagster/dagster-dagster/builds/83562
         ],
         "mypy": ["mypy==1.8.0"],
         "pyright": [

--- a/python_modules/libraries/dagster-celery-docker/setup.py
+++ b/python_modules/libraries/dagster-celery-docker/setup.py
@@ -36,7 +36,6 @@ setup(
         f"dagster-celery{pin}",
         f"dagster-graphql{pin}",
         "docker",
-        "requests<2.32.0",  # 2.32.0 breaks our docker tests https://buildkite.com/dagster/dagster-dagster/builds/83562
     ],
     zip_safe=False,
 )

--- a/python_modules/libraries/dagster-docker/setup.py
+++ b/python_modules/libraries/dagster-docker/setup.py
@@ -34,11 +34,6 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_docker_tests*"]),
     python_requires=">=3.8,<3.13",
-    install_requires=[
-        f"dagster{pin}",
-        "docker",
-        "docker-image-py",
-        "requests<2.32.0",  # 2.32.0 breaks our docker tests https://buildkite.com/dagster/dagster-dagster/builds/83562
-    ],
+    install_requires=[f"dagster{pin}", "docker", "docker-image-py"],
     zip_safe=False,
 )


### PR DESCRIPTION
Reverts dagster-io/dagster#21977

Docker has released a new version and requests has yanked the offending versions so we should be able to remove this pin before our release goes out this week.