### PR TITLE
bump ruff -> 0.4.5 for native languages server

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.4.4
+  rev: v0.4.5
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ extend-exclude = [
 line-length = 100
 
 # Fail if Ruff is not running this version.
-required-version = "0.4.4"
+required-version = "0.4.5"
 
 [tool.ruff.lint]
 

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -165,7 +165,7 @@ setup(
             "types-toml",  # version will be resolved against toml
         ],
         "ruff": [
-            "ruff==0.4.4",
+            "ruff==0.4.5",
         ],
     },
     entry_points={


### PR DESCRIPTION
Unfortunately 0.4.4 did not solve my ruff crashing all the time woes.

But 0.4.5 supports a new native language server option
https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff

## How I Tested These Changes

make ruff