### PR TITLE
Add back custom error handling logic

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppError.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppError.tsx
@@ -1,4 +1,6 @@
+import {ServerError} from '@apollo/client';
 import {onError} from '@apollo/client/link/error';
+import {Observable} from '@apollo/client/utilities';
 import {Colors, FontFamily, Toaster} from '@dagster-io/ui-components';
 import {GraphQLError} from 'graphql';
 import memoize from 'lodash/memoize';
@@ -53,6 +55,14 @@ export const errorLink = onError((response) => {
     graphQLErrors.forEach((error) => showGraphQLError(error as DagsterGraphQLError, operationName));
   }
   if (response.networkError) {
+    // if we have a network error but there is still graphql data
+    // the payload should contain a meaningful error for the product to handle
+    const serverError = response.networkError as ServerError;
+    if (serverError.result && typeof serverError.result === 'object') {
+      // we can return an observable here (normally used to perform retries)
+      // to flow the error payload to the product
+      return Observable.from([serverError.result]);
+    }
     if (response.networkError && 'statusCode' in response.networkError) {
       showNetworkError(response.networkError.statusCode);
     }


### PR DESCRIPTION
## Summary & Motivation

Fixes https://linear.app/dagster-labs/issue/FE-371/dagsterinvalidconfigerror-not-return-in-the-ui

https://github.com/dagster-io/dagster/pull/21361/files Removed this logic because of a typescript error making me think the logic was wrong (and because I suspect it's breaking our type contracts). Turns out we're relying on this behavior already in the product in some places though.

What's a little unclear to me is why [internal](https://github.com/dagster-io/internal/blob/0b5e0e71a2f4104c5c76bb246d6537a19132a00d/dagster-cloud/js_modules/app-cloud/src/app/authLink.tsx#L14) doesn't have this logic. I suspect it needs it too so I'll add it there too. Although, if the error is nested inside, it's a little unclear to me if we should be forwarding this to the UI as I suspect it might be breaking typescript contracts.

## How I Tested These Changes

Locally