### PR TITLE
Fix error link to not assume networkError type to be ServerError + handle other error type

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/src/App.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/App.tsx
@@ -1,6 +1,6 @@
 import {App} from '@dagster-io/ui-core/app/App';
 import {createAppCache} from '@dagster-io/ui-core/app/AppCache';
-import {errorLink, setupErrorToasts} from '@dagster-io/ui-core/app/AppError';
+import {createErrorLink, setupErrorToasts} from '@dagster-io/ui-core/app/AppError';
 import {AppProvider} from '@dagster-io/ui-core/app/AppProvider';
 import {AppTopNav} from '@dagster-io/ui-core/app/AppTopNav/AppTopNav';
 import {ContentRoot} from '@dagster-io/ui-core/app/ContentRoot';
@@ -19,7 +19,7 @@ import {telemetryLink} from './telemetryLink';
 
 const {pathPrefix, telemetryEnabled, liveDataPollRate, instanceId} = extractInitializationData();
 
-const apolloLinks = [logLink, errorLink, timeStartLink];
+const apolloLinks = [logLink, createErrorLink(true), timeStartLink];
 
 if (telemetryEnabled) {
   apolloLinks.unshift(telemetryLink(pathPrefix));

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppError.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppError.tsx
@@ -1,4 +1,3 @@
-import {ServerError} from '@apollo/client';
 import {onError} from '@apollo/client/link/error';
 import {Observable} from '@apollo/client/utilities';
 import {Colors, FontFamily, Toaster} from '@dagster-io/ui-components';
@@ -48,28 +47,43 @@ const showNetworkError = async (statusCode: number) => {
   }
 };
 
-export const errorLink = onError((response) => {
-  if (response.graphQLErrors) {
-    const {graphQLErrors, operation} = response;
-    const {operationName} = operation;
-    graphQLErrors.forEach((error) => showGraphQLError(error as DagsterGraphQLError, operationName));
-  }
-  if (response.networkError) {
+export const createErrorLink = (toastOnErrors?: boolean) =>
+  onError((response) => {
+    if (response.graphQLErrors) {
+      const {graphQLErrors, operation} = response;
+      const {operationName} = operation;
+      graphQLErrors.forEach((error) => {
+        if (toastOnErrors) {
+          showGraphQLError(error, operationName);
+        }
+        console.error('[Graphql error]', operationName, error);
+      });
+    }
     // if we have a network error but there is still graphql data
     // the payload should contain a meaningful error for the product to handle
-    const serverError = response.networkError as ServerError;
-    if (serverError.result && typeof serverError.result === 'object') {
+    const serverError = response.networkError;
+
+    if (
+      'response' in response &&
+      response.response &&
+      'data' in response.response &&
+      response.response.data
+    ) {
+      return Observable.from([{data: response.response.data}]);
+    }
+    if (serverError && 'result' in serverError && typeof serverError.result === 'object') {
       // we can return an observable here (normally used to perform retries)
       // to flow the error payload to the product
       return Observable.from([serverError.result]);
     }
-    if (response.networkError && 'statusCode' in response.networkError) {
-      showNetworkError(response.networkError.statusCode);
+    if (response.networkError) {
+      if (toastOnErrors && 'statusCode' in response.networkError) {
+        showNetworkError(response.networkError.statusCode);
+      }
+      console.error('[Network error]', response.networkError);
     }
-    console.error('[Network error]', response.networkError);
-  }
-  return;
-});
+    return;
+  });
 
 interface AppStackTraceLinkProps {
   error: DagsterGraphQLError;

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppError.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppError.tsx
@@ -61,16 +61,18 @@ export const createErrorLink = (toastOnErrors?: boolean) =>
     }
     // if we have a network error but there is still graphql data
     // the payload should contain a meaningful error for the product to handle
-    const serverError = response.networkError;
-
     if (
       'response' in response &&
       response.response &&
       'data' in response.response &&
       response.response.data
     ) {
+      // This is a bit hacky but if you try forwarding response.response directly it seems
+      // the errors property prevents it from making it to the react code so instead we grab just the data property.
       return Observable.from([{data: response.response.data}]);
     }
+
+    const serverError = response.networkError;
     if (serverError && 'result' in serverError && typeof serverError.result === 'object') {
       // we can return an observable here (normally used to perform retries)
       // to flow the error payload to the product


### PR DESCRIPTION
## Summary & Motivation

- Fix an issue where `response.networkError` object doesn't have a `result` key 
- Change errorLink to createErrorLink to reuse this logic for cloud instead of maintaining two implementations and allow passing in an arg for whether to toast or not
- Push useful data for a different type of error through to the UI

## How I Tested These Changes

Tested with cloud and OSS.
