### PR TITLE
[ui] allow owner: prefix to pop up owner filters

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useAssetOwnerFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useAssetOwnerFilter.tsx
@@ -47,7 +47,7 @@ export const useAssetOwnerFilter = ({
       () =>
         allAssetOwners.map((value) => ({
           value,
-          match: [stringValueFromOwner(value)],
+          match: [`owner:${stringValueFromOwner(value)}`],
         })),
       [allAssetOwners],
     ),


### PR DESCRIPTION
## Summary

Expands the match string for owner filters from `email@domain.com` to `owner:email@domain.com`, so both typing the email or typing `owner:` and then a prefix of the email will pop it up in catalog & in filters dropdown.

## Test Plan

Tested locally.
