### PR TITLE
[ui][global search] Set up `useAugmentSearchResults` in `CloudOSSContext`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/CloudOSSContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/CloudOSSContext.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {SearchResult} from '../search/types';
+
 type FeatureContext = {
   canSeeMaterializeAction: boolean;
   canSeeWipeMaterializationAction: boolean;
@@ -12,6 +14,7 @@ export const CloudOSSContext = React.createContext<{
   isBranchDeployment: boolean;
   featureContext: FeatureContext;
   onViewChange: (view: {path: string}) => void;
+  useAugmentSearchResults: () => (results: SearchResult[]) => SearchResult[];
 }>({
   isBranchDeployment: false,
   featureContext: {
@@ -22,4 +25,5 @@ export const CloudOSSContext = React.createContext<{
     canSeeExecuteChecksAction: true,
   },
   onViewChange: () => {},
+  useAugmentSearchResults: () => (results) => results,
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadHooksContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadHooksContext.tsx
@@ -12,17 +12,6 @@ type LaunchpadHooksContextValue = {
   LaunchRootExecutionButton?: typeof LaunchRootExecutionButton;
   useLaunchWithTelemetry?: typeof useLaunchWithTelemetry;
   UserDisplay?: typeof UserDisplay;
-  useAllUserDetails?: () => {
-    users: {
-      id: string;
-      user: {
-        name: string | null;
-        email: string;
-        picture: string | null;
-      } | null;
-    }[];
-    loading: boolean;
-  };
   MaterializeButton?: typeof Button;
   PythonErrorInfoHeader?: React.ComponentType<{
     error: GenericError | PythonErrorFragment;
@@ -43,7 +32,6 @@ export function useLaunchPadHooks() {
     useLaunchWithTelemetry: overrideUseLaunchWithTelemetry,
     MaterializeButton: OverrideMaterializeButton,
     UserDisplay: OverrideUserDisplay,
-    useAllUserDetails,
     PythonErrorInfoHeader,
     StaticFilterSorter,
   } = React.useContext(LaunchpadHooksContext);
@@ -54,7 +42,6 @@ export function useLaunchPadHooks() {
     MaterializeButton: OverrideMaterializeButton ?? Button,
     PythonErrorInfoHeader,
     UserDisplay: OverrideUserDisplay ?? UserDisplay,
-    useAllUserDetails,
     StaticFilterSorter,
   };
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadHooksContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadHooksContext.tsx
@@ -12,6 +12,17 @@ type LaunchpadHooksContextValue = {
   LaunchRootExecutionButton?: typeof LaunchRootExecutionButton;
   useLaunchWithTelemetry?: typeof useLaunchWithTelemetry;
   UserDisplay?: typeof UserDisplay;
+  useAllUserDetails?: () => {
+    users: {
+      id: string;
+      user: {
+        name: string | null;
+        email: string;
+        picture: string | null;
+      } | null;
+    }[];
+    loading: boolean;
+  };
   MaterializeButton?: typeof Button;
   PythonErrorInfoHeader?: React.ComponentType<{
     error: GenericError | PythonErrorFragment;
@@ -32,6 +43,7 @@ export function useLaunchPadHooks() {
     useLaunchWithTelemetry: overrideUseLaunchWithTelemetry,
     MaterializeButton: OverrideMaterializeButton,
     UserDisplay: OverrideUserDisplay,
+    useAllUserDetails,
     PythonErrorInfoHeader,
     StaticFilterSorter,
   } = React.useContext(LaunchpadHooksContext);
@@ -42,6 +54,7 @@ export function useLaunchPadHooks() {
     MaterializeButton: OverrideMaterializeButton ?? Button,
     PythonErrorInfoHeader,
     UserDisplay: OverrideUserDisplay ?? UserDisplay,
+    useAllUserDetails,
     StaticFilterSorter,
   };
 }


### PR DESCRIPTION
## Summary

Adds a new entry to `CloudOSSContext` to let us inject a function which can be used to augment global search results. Used in cloud to display users' full names in the search pane.

This allows you to search by a user's name in addition to (or in place of) their email.

<img width="876" alt="Screenshot 2024-05-23 at 1 49 45 PM" src="https://github.com/dagster-io/dagster/assets/10215173/f204e597-e094-4824-8fb6-a1cf8937e11c">


## Test Plan

Shadow dagit.
