### PR TITLE
Check if an asset node has an autoMaterializePolicy before showing there is no automation

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -299,7 +299,10 @@ export const AssetNodeOverview = ({
       },
     ];
 
-    if (attributes.every((props) => isEmptyChildren(props.children))) {
+    if (
+      attributes.every((props) => isEmptyChildren(props.children)) &&
+      !assetNode.autoMaterializePolicy
+    ) {
       return (
         <SectionEmptyState
           title="No automations found for this asset"


### PR DESCRIPTION
## Summary & Motivation

In a recent PR I removed the outdated automation policy section but in doing so introduced a bug since I didn't realize we were iterating over the sections to determine if an asset has any automations. This PR fixes that check.
