### PR TITLE
[ui] Remove asset overview feature flag

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -11,17 +11,12 @@ export const FeatureFlag = {
   flagDisableWebsockets: 'flagDisableWebsockets' as const,
   flagSidebarResources: 'flagSidebarResources' as const,
   flagDisableAutoLoadDefaults: 'flagDisableAutoLoadDefaults' as const,
-  flagUseNewOverviewPage: 'flagUseNewOverviewPage' as const,
   flagSettingsPage: 'flagSettingsPage' as const,
 };
 export type FeatureFlagType = keyof typeof FeatureFlag;
 
 export const getFeatureFlags: () => FeatureFlagType[] = memoize(
-  () =>
-    getJSONForKey(DAGSTER_FLAGS_KEY) || [
-      // Enable the new asset details page by default.
-      FeatureFlag.flagUseNewOverviewPage,
-    ],
+  () => getJSONForKey(DAGSTER_FLAGS_KEY) || [],
 );
 
 export const featureEnabled = memoize((flag: FeatureFlagType) => getFeatureFlags().includes(flag));

--- a/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/getVisibleFeatureFlagRows.tsx
@@ -21,10 +21,6 @@ export const getVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagDebugConsoleLogging,
   },
   {
-    key: 'Use new asset overview page',
-    flagType: FeatureFlag.flagUseNewOverviewPage,
-  },
-  {
     key: 'New navigation',
     label: (
       <>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
@@ -4,7 +4,6 @@ import {useMemo} from 'react';
 
 import {AssetViewParams} from './types';
 import {AssetViewDefinitionNodeFragment} from './types/AssetView.types';
-import {FeatureFlag, featureEnabled} from '../app/Flags';
 import {TabLink} from '../ui/TabLink';
 
 interface Props {
@@ -34,8 +33,6 @@ export const DEFAULT_ASSET_TAB_ORDER = [
   'partitions',
   'events',
   'checks',
-  'plots',
-  'definition',
   'lineage',
   'automation',
 ] as const;
@@ -57,14 +54,12 @@ export const buildAssetViewParams = (params: AssetViewParams) => `?${qs.stringif
 
 export const buildAssetTabMap = (input: AssetTabConfigInput) => {
   const {definition, params} = input;
-  const flagUseNewOverviewPage = featureEnabled(FeatureFlag.flagUseNewOverviewPage);
 
   return {
     overview: {
       id: 'overview',
       title: 'Overview',
       to: buildAssetViewParams({...params, view: 'overview'}),
-      hidden: !flagUseNewOverviewPage,
     } as AssetTabConfig,
     partitions: {
       id: 'partitions',
@@ -81,19 +76,6 @@ export const buildAssetTabMap = (input: AssetTabConfigInput) => {
       id: 'events',
       title: 'Events',
       to: buildAssetViewParams({...params, view: 'events', partition: undefined}),
-    } as AssetTabConfig,
-    plots: {
-      id: 'plots',
-      title: 'Plots',
-      to: buildAssetViewParams({...params, view: 'plots'}),
-      hidden: flagUseNewOverviewPage,
-    } as AssetTabConfig,
-    definition: {
-      id: 'definition',
-      title: 'Definition',
-      to: buildAssetViewParams({...params, view: 'definition'}),
-      disabled: !definition,
-      hidden: flagUseNewOverviewPage,
     } as AssetTabConfig,
     lineage: {
       id: 'lineage',

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -10,7 +10,7 @@ import {AssetEvents} from './AssetEvents';
 import {AssetFeatureContext} from './AssetFeatureContext';
 import {metadataForAssetNode} from './AssetMetadata';
 import {ASSET_NODE_DEFINITION_FRAGMENT, AssetNodeDefinition} from './AssetNodeDefinition';
-import {ASSET_NODE_INSTIGATORS_FRAGMENT, AssetNodeInstigatorTag} from './AssetNodeInstigatorTag';
+import {ASSET_NODE_INSTIGATORS_FRAGMENT} from './AssetNodeInstigatorTag';
 import {AssetNodeLineage} from './AssetNodeLineage';
 import {
   AssetNodeOverview,
@@ -22,12 +22,9 @@ import {AssetPartitions} from './AssetPartitions';
 import {AssetPlotsPage} from './AssetPlotsPage';
 import {AssetTabs} from './AssetTabs';
 import {AssetAutomaterializePolicyPage} from './AutoMaterializePolicyPage/AssetAutomaterializePolicyPage';
-import {useAutoMaterializeSensorFlag} from './AutoMaterializeSensorFlag';
-import {AutomaterializeDaemonStatusTag} from './AutomaterializeDaemonStatusTag';
 import {ChangedReasonsTag} from './ChangedReasons';
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
 import {LaunchAssetObservationButton} from './LaunchAssetObservationButton';
-import {OverdueTag} from './OverdueTag';
 import {UNDERLYING_OPS_ASSET_NODE_FRAGMENT} from './UnderlyingOpsOrGraph';
 import {AssetChecks} from './asset-checks/AssetChecks';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
@@ -39,7 +36,6 @@ import {
 } from './types/AssetView.types';
 import {healthRefreshHintFromLiveData} from './usePartitionHealthData';
 import {useReportEventsModal} from './useReportEventsModal';
-import {useFeatureFlags} from '../app/Flags';
 import {currentPageAtom} from '../app/analytics';
 import {Timestamp} from '../app/time/Timestamp';
 import {AssetLiveDataRefreshButton, useAssetLiveData} from '../asset-data/AssetLiveDataProvider';
@@ -56,11 +52,8 @@ import {CodeLink} from '../code-links/CodeLink';
 import {CodeReferencesMetadataEntry} from '../graphql/types';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {isCanonicalCodeSourceEntry} from '../metadata/TableSchema';
-import {RepositoryLink} from '../nav/RepositoryLink';
 import {PageLoadTrace} from '../performance';
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
-import {buildRepoAddress} from '../workspace/buildRepoAddress';
-import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 interface Props {
   assetKey: AssetKey;
@@ -71,7 +64,6 @@ interface Props {
 export const AssetView = ({assetKey, trace, headerBreadcrumbs}: Props) => {
   const [params, setParams] = useQueryPersistedState<AssetViewParams>({});
   const {useTabBuilder, renderFeatureView} = useContext(AssetFeatureContext);
-  const {flagUseNewOverviewPage} = useFeatureFlags();
 
   // Load the asset definition
   const {definition, definitionQueryResult, lastMaterialization} =
@@ -79,11 +71,7 @@ export const AssetView = ({assetKey, trace, headerBreadcrumbs}: Props) => {
 
   const tabList = useTabBuilder({definition, params});
 
-  const defaultTab = flagUseNewOverviewPage
-    ? 'overview'
-    : tabList.some((t) => t.id === 'partitions')
-    ? 'partitions'
-    : 'events';
+  const defaultTab = 'overview';
   const selectedTab = params.view || defaultTab;
 
   // Load the asset graph - a large graph for the Lineage tab, a small graph for the Definition tab
@@ -539,64 +527,10 @@ const AssetViewPageHeaderTags = ({
   liveData?: LiveDataForNodeWithStaleData;
   onShowUpstream: () => void;
 }) => {
-  const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
-  const {flagUseNewOverviewPage} = useFeatureFlags();
-  const repoAddress = definition
-    ? buildRepoAddress(definition.repository.name, definition.repository.location.name)
-    : null;
-
   // In the new UI, all other tags are shown in the right sidebar of the overview tab.
   // When the old code below is removed, some of these components may no longer be used.
-  if (flagUseNewOverviewPage) {
-    return (
-      <>
-        {definition ? (
-          <>
-            <StaleReasonsTag
-              liveData={liveData}
-              assetKey={definition.assetKey}
-              onClick={onShowUpstream}
-            />
-            <ChangedReasonsTag
-              changedReasons={definition.changedReasons}
-              assetKey={definition.assetKey}
-            />
-          </>
-        ) : null}
-        {definition?.isSource ? (
-          <Tag>Source Asset</Tag>
-        ) : !definition?.isExecutable ? (
-          <Tag>External Asset</Tag>
-        ) : undefined}
-      </>
-    );
-  }
-
   return (
     <>
-      {definition && repoAddress ? (
-        <Tag icon="asset">
-          Asset in <RepositoryLink repoAddress={repoAddress} />
-        </Tag>
-      ) : (
-        <Tag icon="asset_non_sda">Asset</Tag>
-      )}
-      {definition && repoAddress && (
-        <AssetNodeInstigatorTag assetNode={definition} repoAddress={repoAddress} />
-      )}
-      {definition && repoAddress && definition.groupName && (
-        <Tag icon="asset_group">
-          <Link to={workspacePathFromAddress(repoAddress, `/asset-groups/${definition.groupName}`)}>
-            {definition.groupName}
-          </Link>
-        </Tag>
-      )}
-      {automaterializeSensorsFlagState === 'has-global-amp' && definition?.autoMaterializePolicy ? (
-        <AutomaterializeDaemonStatusTag />
-      ) : null}
-      {definition && definition.freshnessPolicy && (
-        <OverdueTag policy={definition.freshnessPolicy} assetKey={definition.assetKey} />
-      )}
       {definition ? (
         <>
           <StaleReasonsTag
@@ -610,6 +544,11 @@ const AssetViewPageHeaderTags = ({
           />
         </>
       ) : null}
+      {definition?.isSource ? (
+        <Tag>Source Asset</Tag>
+      ) : !definition?.isExecutable ? (
+        <Tag>External Asset</Tag>
+      ) : undefined}
     </>
   );
 };


### PR DESCRIPTION
The asset overview feature flag gates the new asset details page and the catalog page in internal. This is already set to be "on" by default. 

Now that these pages are un-experimentalized, we can remove the feature flag and always rely on these pages.
https://linear.app/dagster-labs/issue/PLUS-1120/remove-asset-overviewcatalog-feature-flags