### PR TITLE
[ui] use number formatter for row count metadata

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -150,7 +150,7 @@ export const AssetNodeOverview = ({
             />
           </Box>
         ) : undefined}
-        {rowCountMeta ? (
+        {rowCountMeta?.intValue ? (
           <Box flex={{direction: 'column', gap: 6}}>
             <Subtitle2>Row count</Subtitle2>
             <Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -61,6 +61,7 @@ import {ScheduleOrSensorTag} from '../nav/ScheduleOrSensorTag';
 import {useRepositoryLocationForAddress} from '../nav/useRepositoryLocationForAddress';
 import {Description} from '../pipelines/Description';
 import {PipelineTag} from '../pipelines/PipelineReference';
+import {numberFormatter} from '../ui/formatters';
 import {buildTagString} from '../ui/tagAsString';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
@@ -153,7 +154,7 @@ export const AssetNodeOverview = ({
           <Box flex={{direction: 'column', gap: 6}}>
             <Subtitle2>Row count</Subtitle2>
             <Box>
-              <Tag icon="table_rows">{rowCountMeta.intValue}</Tag>
+              <Tag icon="table_rows">{numberFormatter.format(rowCountMeta.intValue)}</Tag>
             </Box>
           </Box>
         ) : undefined}


### PR DESCRIPTION
## Summary

Small tweak which uses the number formatter to add commas to the row count number.

<img width="428" alt="Screenshot 2024-05-24 at 9 28 15 AM" src="https://github.com/dagster-io/dagster/assets/10215173/c3340a96-849f-417f-bca3-8cb6622bab49">



## Test Plan

local test

