### PR TITLE
Deprecate custom PartitionsDefinition subclass

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -33,6 +33,12 @@ from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
+from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
+from dagster._core.definitions.partition import (
+    DynamicPartitionsDefinition,
+    PartitionsDefinition,
+    StaticPartitionsDefinition,
+)
 from dagster._core.definitions.partitioned_schedule import (
     UnresolvedPartitionedAssetScheduleDefinition,
 )
@@ -40,8 +46,10 @@ from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.schedule_definition import ScheduleDefinition
 from dagster._core.definitions.sensor_definition import SensorDefinition
 from dagster._core.definitions.source_asset import SourceAsset
+from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
+from dagster._utils.warnings import deprecation_warning
 
 from .repository_data import CachingRepositoryData
 from .valid_definitions import VALID_REPOSITORY_DATA_DICT_KEYS, RepositoryListDefinition
@@ -49,6 +57,16 @@ from .valid_definitions import VALID_REPOSITORY_DATA_DICT_KEYS, RepositoryListDe
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_check_spec import AssetCheckKey
     from dagster._core.definitions.events import AssetKey
+
+# We throw an error if the user attaches an instance of a custom `PartitionsDefinition` subclass to
+# a definition-- we can't support custom PartitionsDefinition subclasses due to us needing to load
+# them in the host process.
+VALID_PARTITIONS_DEFINITION_CLASSES = (
+    StaticPartitionsDefinition,
+    DynamicPartitionsDefinition,
+    TimeWindowPartitionsDefinition,
+    MultiPartitionsDefinition,
+)
 
 
 def _find_env_vars(config_entry: Any) -> Set[str]:
@@ -163,6 +181,7 @@ def build_caching_repository_data_from_list(
     asset_check_keys: Set["AssetCheckKey"] = set()
     source_assets: List[SourceAsset] = []
     asset_checks_defs: List[AssetChecksDefinition] = []
+    partitions_defs: Set[PartitionsDefinition] = set()
     for definition in repository_definitions:
         if isinstance(definition, JobDefinition):
             if (
@@ -176,6 +195,8 @@ def build_caching_repository_data_from_list(
                     f"Attempted to provide job called {definition.name} to repository, which "
                     "is a reserved name. Please rename the job."
                 )
+            if definition.partitions_def is not None:
+                partitions_defs.add(definition.partitions_def)
             jobs[definition.name] = definition
         elif isinstance(definition, SensorDefinition):
             if definition.name in schedule_and_sensor_names:
@@ -215,6 +236,8 @@ def build_caching_repository_data_from_list(
                     f"Duplicate definition found for unresolved job '{definition.name}'"
                 )
             # we can only resolve these once we have all assets
+            if definition.partitions_def is not None:
+                partitions_defs.add(definition.partitions_def)
             unresolved_jobs[definition.name] = definition
         elif isinstance(definition, AssetChecksDefinition):
             for key in definition.check_keys:
@@ -229,6 +252,8 @@ def build_caching_repository_data_from_list(
             for key in definition.check_keys:
                 if key in asset_check_keys:
                     raise DagsterInvalidDefinitionError(f"Duplicate asset check key: {key}")
+            if definition.partitions_def is not None:
+                partitions_defs.add(definition.partitions_def)
 
             asset_keys.update(definition.keys)
             asset_check_keys.update(definition.check_keys)
@@ -238,6 +263,9 @@ def build_caching_repository_data_from_list(
             asset_keys.add(definition.key)
         else:
             check.failed(f"Unexpected repository entry {definition}")
+
+    for partitions_def in partitions_defs:
+        _validate_partitions_definition(partitions_def)
 
     asset_graph = AssetGraph.from_assets([*assets_defs, *asset_checks_defs, *source_assets])
     source_assets_by_key = {source_asset.key: source_asset for source_asset in source_assets}
@@ -474,6 +502,18 @@ def _validate_auto_materialize_sensors(
                     )
                 else:
                     sensor_names_by_asset_key[asset_key] = sensor.name
+
+
+def _validate_partitions_definition(partitions_def: PartitionsDefinition) -> None:
+    if not isinstance(partitions_def, VALID_PARTITIONS_DEFINITION_CLASSES):
+        valid_names = ", ".join([cls.__name__ for cls in VALID_PARTITIONS_DEFINITION_CLASSES])
+        deprecation_warning(
+            "Support for custom PartitionsDefinition subclasses",
+            breaking_version="1.9.0",
+            additional_warn_text="All passed-in PartitionsDefinition"
+            f" objects must be an instance of one of ({valid_names})."
+            f" Found instance of {type(partitions_def).__name__}",
+        )
 
 
 def _get_error_msg_for_target_conflict(targeter, target_type, target_name, dupe_target_type):

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -1,4 +1,6 @@
 import re
+from datetime import datetime
+from typing import Any, Optional, Sequence
 
 import pytest
 from dagster import (
@@ -39,6 +41,7 @@ from dagster._core.definitions.executor_definition import executor
 from dagster._core.definitions.external_asset import create_external_asset_from_source_asset
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.logger_definition import logger
+from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.repository_definition import (
     PendingRepositoryDefinition,
     RepositoryDefinition,
@@ -901,3 +904,23 @@ def test_get_all_asset_specs():
         group_name="blag",
         metadata={"dagster/asset_execution_type": "OBSERVATION"},
     )
+
+
+def test_invalid_partitions_subclass():
+    class CustomPartitionsDefinition(PartitionsDefinition):
+        def get_partition_keys(
+            self,
+            current_time: Optional[datetime] = None,
+            dynamic_partitions_store: Any = None,
+        ) -> Sequence[str]:
+            return ["a", "b", "c"]
+
+    @asset(partitions_def=CustomPartitionsDefinition())
+    def asset1():
+        pass
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="custom PartitionsDefinition subclasses",
+    ):
+        Definitions(assets=[asset1])


### PR DESCRIPTION
## Summary & Motivation

Throw a deprecation warning a custom `PartitionsDefinition` class is passed into a `Definitions` object. We can promote to a hard error on a minor release. Would've prevented the problem discussed here: https://dagsterlabs.slack.com/archives/C06K1DMN81W/p1716420434864219

## How I Tested These Changes
