### PR TITLE
Fix error in k8s configuration docs

### DIFF
--- a/docs/content/deployment/guides/kubernetes/customizing-your-deployment.mdx
+++ b/docs/content/deployment/guides/kubernetes/customizing-your-deployment.mdx
@@ -237,13 +237,15 @@ Consider the following example:
   }
   ```
 
-- **But a specific job** has the `pod_spec_config` key in the `dagster-k8s/config` tag set to:
+- **But a specific job** has the `dagster-k8s/config` tag set to:
 
   ```json
   {
-    "node_selector": { "region": "east" },
-    "dns_policy": "Default",
-    "image_pull_secrets": [{ "name": "another-secret" }]
+    "pod_spec_config": {
+      "node_selector": { "region": "east" },
+      "dns_policy": "Default",
+      "image_pull_secrets": [{ "name": "another-secret" }]
+    }
   }
   ```
 
@@ -271,12 +273,14 @@ To modify the previous example:
   }
   ```
 
-- **But a specific job** has the `pod_spec_config` key in the `dagster-k8s/config` tag set to:
+- **But a specific job** has the `dagster-k8s/config` tag set to:
 
   ```json
   {
-    "node_selector": { "region": "east" },
-    "image_pull_secrets": [{ "name": "another-secret" }],
+    "pod_spec_config": {
+      "node_selector": { "region": "east" },
+      "image_pull_secrets": [{ "name": "another-secret" }]
+    },
     "merge_behavior": "SHALLOW"
   }
   ```


### PR DESCRIPTION
Summary:
We were incorrectly saying that merge_behavior is a child of pod_spec_config, but it is a sibling. Update the docs to reflect reality.

## Summary & Motivation

## How I Tested These Changes
