### PR TITLE
Prefix IndexedDB cache keys with `localCacheIdPrefix`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -1,7 +1,7 @@
 import {gql, useApolloClient} from '@apollo/client';
 import {Box, ButtonGroup} from '@dagster-io/ui-components';
 import * as React from 'react';
-import {useCallback, useEffect, useLayoutEffect, useMemo, useState} from 'react';
+import {useCallback, useContext, useEffect, useLayoutEffect, useMemo, useState} from 'react';
 import {useRouteMatch} from 'react-router-dom';
 import {useSetRecoilState} from 'recoil';
 
@@ -18,6 +18,7 @@ import {
 } from './types/AssetsCatalogTable.types';
 import {useAssetCatalogFiltering} from './useAssetCatalogFiltering';
 import {AssetViewType, useAssetView} from './useAssetView';
+import {AppContext} from '../app/AppContext';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useRefreshAtInterval} from '../app/QueryRefresh';
@@ -40,11 +41,13 @@ export function useAllAssets(groupSelector?: AssetGroupSelector) {
     assets: Asset[] | undefined;
   }>({error: undefined, assets: undefined});
 
+  const {localCacheIdPrefix} = useContext(AppContext);
+
   const assetsQuery = useIndexedDBCachedQuery<
     AssetCatalogTableQuery,
     AssetCatalogTableQueryVariables
   >({
-    key: 'allAssets',
+    key: `${localCacheIdPrefix}/allAssets`,
     query: ASSET_CATALOG_TABLE_QUERY,
     version: 1,
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -12,6 +12,7 @@ import {
   SearchSecondaryQueryVariables,
 } from './types/useGlobalSearch.types';
 import {useIndexedDBCachedQuery} from './useIndexedDBCachedQuery';
+import {AppContext} from '../app/AppContext';
 import {CloudOSSContext} from '../app/CloudOSSContext';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Utils';
@@ -311,13 +312,15 @@ export const useGlobalSearch = ({includeAssetFilters}: {includeAssetFilters: boo
   const {useAugmentSearchResults} = useContext(CloudOSSContext);
   const augmentSearchResults = useAugmentSearchResults();
 
+  const {localCacheIdPrefix} = useContext(AppContext);
+
   const {
     data: primaryData,
     fetch: fetchPrimaryData,
     loading: primaryDataLoading,
   } = useIndexedDBCachedQuery<SearchPrimaryQuery, SearchPrimaryQueryVariables>({
     query: SEARCH_PRIMARY_QUERY,
-    key: 'SearchPrimary',
+    key: `${localCacheIdPrefix}/SearchPrimary`,
     version: SEARCH_PRIMARY_DATA_VERSION,
   });
 
@@ -327,7 +330,7 @@ export const useGlobalSearch = ({includeAssetFilters}: {includeAssetFilters: boo
     loading: secondaryDataLoading,
   } = useIndexedDBCachedQuery<SearchSecondaryQuery, SearchSecondaryQueryVariables>({
     query: SEARCH_SECONDARY_QUERY,
-    key: 'SearchSecondary',
+    key: `${localCacheIdPrefix}/SearchSecondary`,
     version: SEARCH_SECONDARY_DATA_VERSION,
   });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
@@ -1,7 +1,7 @@
 import {ApolloQueryResult, gql} from '@apollo/client';
 import sortBy from 'lodash/sortBy';
 import * as React from 'react';
-import {useMemo} from 'react';
+import {useContext, useMemo} from 'react';
 
 import {REPOSITORY_INFO_FRAGMENT} from './RepositoryInformation';
 import {buildRepoAddress} from './buildRepoAddress';
@@ -192,13 +192,14 @@ export const ROOT_WORKSPACE_QUERY = gql`
  * in the workspace, and loading/error state for the relevant query.
  */
 const useWorkspaceState = (): WorkspaceState => {
+  const {localCacheIdPrefix} = useContext(AppContext);
   const {
     data,
     loading,
     fetch: refetch,
   } = useIndexedDBCachedQuery<RootWorkspaceQuery, RootWorkspaceQueryVariables>({
     query: ROOT_WORKSPACE_QUERY,
-    key: 'RootWorkspace',
+    key: `${localCacheIdPrefix}/RootWorkspace`,
     version: 1,
   });
   useMemo(() => refetch(), [refetch]);


### PR DESCRIPTION
## Summary & Motivation

Our existing indexeddb cache keys are not taking deployment into account causing the cache to be overwritten / temporarily shared between deployments. We should instead isolate the caches from each other by using `localCacheIdPrefix`

In OSS `localCacheIdPrefix` is equal to an instance ID that gets cleared if they create a new home folder.
In Cloud its equal to the combination of org + deployment ID

