### PR TITLE
[ui] FilterDropdown: allow submitting before suggestions are loaded

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/FilterDropdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/FilterDropdown.tsx
@@ -182,6 +182,11 @@ export const FilterDropdown = ({filters, setIsOpen, setPortaledElements}: Filter
       } else if (event.key === 'Enter' || event.key === ' ') {
         if (focusedItemIndex === -1) {
           // They're typing in the search bar
+          if (event.key === 'Enter' && allResultsJsx.length === 1) {
+            // "Enter" submits the current search term
+            event.preventDefault();
+            allResultsJsx[0]?.props.onClick?.();
+          }
           return;
         }
         event.preventDefault();


### PR DESCRIPTION
## Summary & Motivation

The `FilterDropdown` component is used to filter runs by tags and other options. When you pull up an individual tag, it will try to fetch all the tag values and display them as a suggestion. For instance, we tag with the CPU allocation of each job, so adding a filter for that tag shows these suggestions:
<img width="267" alt="image" src="https://github.com/dagster-io/dagster/assets/3344958/365d78ad-d5a0-416b-a25e-080048d16923">

Our issue is that since we have a lot of runs it takes a very long time to load suggestions - **and you can't submit until the suggestions are loaded**. This means it takes a very long time to use any filter in the dagster UI. Here's what it looks like to add a tag filter in our dagster UI:

https://github.com/dagster-io/dagster/assets/3344958/779a2bd6-ebff-4d9c-b8fc-443ea892c400

To improve this situation, in this PR I make it possible to submit whatever you've currently typed by pressing "Enter", regardless of if the suggestions have loaded or not.

cc @salazarm who wrote most of this component.


## How I Tested These Changes

1. run a dagster backend + frontend
2. open Chrome Devtools > Network > Throttling. I created a [custom throttling profile](https://developer.chrome.com/docs/devtools/settings/throttling) that adds 5 seconds of latency to every network request, to simulate the endpoint taking a long time.
3. open http://localhost:3000/runs > Filter > Tag, type a tag name & tag value

### Before

I have to wait 5 seconds for the tag values to load in order to submit.

https://github.com/dagster-io/dagster/assets/3344958/bf15eed4-7693-47a6-8d5e-df9b563fb5f5


### After

I can submit the tag key & value by pressing Enter.

https://github.com/dagster-io/dagster/assets/3344958/69a788c3-ed40-490a-a9e6-2bc6363f66c3