### PR TITLE
`ShellCommandBlueprint` and `BlueprintAssetsDefinition`

### DIFF
--- a/python_modules/dagster/dagster/_core/blueprints/blueprint.py
+++ b/python_modules/dagster/dagster/_core/blueprints/blueprint.py
@@ -32,18 +32,16 @@ class BlueprintDefinitions(NamedTuple):
     on the set of definitions. For example, it can include assets without their required resources.
     """
 
-    assets: Optional[Iterable[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]] = (
-        None
-    )
-    schedules: Optional[
-        Iterable[Union[ScheduleDefinition, UnresolvedPartitionedAssetScheduleDefinition]]
-    ] = None
-    sensors: Optional[Iterable[SensorDefinition]] = None
-    jobs: Optional[Iterable[Union[JobDefinition, UnresolvedAssetJobDefinition]]] = None
-    resources: Optional[Mapping[str, Any]] = None
+    assets: Iterable[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]] = []
+    schedules: Iterable[
+        Union[ScheduleDefinition, UnresolvedPartitionedAssetScheduleDefinition]
+    ] = []
+    sensors: Iterable[SensorDefinition] = []
+    jobs: Iterable[Union[JobDefinition, UnresolvedAssetJobDefinition]] = []
+    resources: Mapping[str, Any] = {}
     executor: Optional[Union[ExecutorDefinition, Executor]] = None
-    loggers: Optional[Mapping[str, LoggerDefinition]] = None
-    asset_checks: Optional[Iterable[AssetChecksDefinition]] = None
+    loggers: Mapping[str, LoggerDefinition] = {}
+    asset_checks: Iterable[AssetChecksDefinition] = []
 
     def to_definitions(self) -> Definitions:
         return Definitions(

--- a/python_modules/dagster/dagster/_core/blueprints/blueprint_assets_definition.py
+++ b/python_modules/dagster/dagster/_core/blueprints/blueprint_assets_definition.py
@@ -1,0 +1,51 @@
+from abc import abstractmethod
+from typing import AbstractSet, Any, Mapping, Optional, Sequence
+
+from dagster._core.blueprints.blueprint import Blueprint, BlueprintDefinitions
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.assets import unique_id_from_asset_and_check_keys
+from dagster._core.definitions.decorators.asset_decorator import multi_asset
+from dagster._core.execution.context.compute import AssetExecutionContext
+from dagster._model import DagsterModel
+
+
+class AssetSpecModel(DagsterModel):
+    key: str
+    deps: Sequence[str] = []
+    description: Optional[str] = None
+    metadata: Mapping[str, Any] = {}
+    group_name: Optional[str] = None
+    skippable: bool = False
+    code_version: Optional[str] = None
+    owners: Sequence[str] = []
+    tags: Mapping[str, str] = {}
+
+    def to_asset_spec(self) -> AssetSpec:
+        return AssetSpec(**self.__dict__)
+
+
+class BlueprintAssetsDefinition(Blueprint):
+    """A blueprint that produces an AssetsDefinition."""
+
+    assets: Sequence[AssetSpecModel]
+
+    def build_defs(self) -> BlueprintDefinitions:
+        specs = [spec_model.to_asset_spec() for spec_model in self.assets]
+
+        @multi_asset(
+            name=f"assets_{unique_id_from_asset_and_check_keys([spec.key for spec in specs], [])}",
+            specs=specs,
+            required_resource_keys=self.get_required_resource_keys(),
+        )
+        def _assets(context: AssetExecutionContext):
+            return self.materialize(context=context)
+
+        return BlueprintDefinitions(assets=[_assets])
+
+    @staticmethod
+    def get_required_resource_keys() -> AbstractSet[str]:
+        return set()
+
+    @abstractmethod
+    def materialize(self, context: AssetExecutionContext):
+        raise NotImplementedError()

--- a/python_modules/dagster/dagster/_core/blueprints/shell_command_blueprint.py
+++ b/python_modules/dagster/dagster/_core/blueprints/shell_command_blueprint.py
@@ -1,0 +1,38 @@
+from typing import AbstractSet, Literal, Mapping, Optional, Sequence, Union
+
+from pydantic import Field
+
+from dagster import AssetExecutionContext
+from dagster._core.blueprints.blueprint_assets_definition import BlueprintAssetsDefinition
+
+
+class ShellCommandBlueprint(BlueprintAssetsDefinition):
+    """A blueprint for one or more assets whose shared materialization function is a shell command.
+
+    Requires the code location to include a "pipes_subprocess_client" resource with type
+    dagster.PipesSubprocessClient.
+    """
+
+    type: Literal["dagster/shell_command"] = "dagster/shell_command"
+    command: Union[str, Sequence[str]] = Field(
+        ..., description="The command to run. Will be passed to `subprocess.Popen()`."
+    )
+    env: Optional[Mapping[str, str]] = Field(
+        default=None,
+        description="An optional dict of environment variables to pass to the subprocess.",
+    )
+    cwd: Optional[str] = Field(
+        default=None, description="Working directory in which to launch the subprocess command."
+    )
+    extras: Optional[Mapping[str, str]] = Field(
+        default=None, description="An optional dict of extra parameters to pass to the subprocess."
+    )
+
+    @staticmethod
+    def get_required_resource_keys() -> AbstractSet[str]:
+        return {"pipes_subprocess_client"}
+
+    def materialize(self, context: AssetExecutionContext):
+        return context.resources.pipes_subprocess_client.run(
+            context=context, command=self.command, env=self.env, cwd=self.cwd, extras=self.extras
+        ).get_results()

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -522,7 +522,7 @@ def multi_asset(
     deps: Optional[Iterable[CoercibleToAssetDep]] = None,
     description: Optional[str] = None,
     config_schema: Optional[UserConfigSchema] = None,
-    required_resource_keys: Optional[Set[str]] = None,
+    required_resource_keys: Optional[AbstractSet[str]] = None,
     compute_kind: Optional[str] = None,
     internal_asset_deps: Optional[Mapping[str, Set[AssetKey]]] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
@@ -647,7 +647,7 @@ def multi_asset(
         additional_message="Only dicts are supported for asset config_schema.",
     )
 
-    bare_required_resource_keys = required_resource_keys.copy()
+    bare_required_resource_keys = set(required_resource_keys)
     resource_defs_keys = set(resource_defs.keys())
     required_resource_keys = bare_required_resource_keys | resource_defs_keys
 

--- a/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/test_shell_command_blueprint.py
+++ b/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/test_shell_command_blueprint.py
@@ -1,0 +1,130 @@
+import re
+import shutil
+from typing import cast
+
+from dagster import AssetKey, AssetsDefinition, MarkdownMetadataValue, materialize
+from dagster._core.blueprints.blueprint import BlueprintDefinitions
+from dagster._core.blueprints.blueprint_assets_definition import AssetSpecModel
+from dagster._core.blueprints.shell_command_blueprint import ShellCommandBlueprint
+from dagster._core.definitions.data_version import (
+    DATA_VERSION_IS_USER_PROVIDED_TAG,
+    DATA_VERSION_TAG,
+)
+from dagster._core.pipes.subprocess import PipesSubprocessClient
+from dagster_tests.execution_tests.pipes_tests.test_subprocess import temp_script
+
+
+def test_single_asset_shell_command_blueprint() -> None:
+    single_asset_blueprint = ShellCommandBlueprint(
+        assets=[AssetSpecModel(key="asset1")], command=["echo", '"hello"']
+    )
+    defs = single_asset_blueprint.build_defs()
+    asset1 = cast(AssetsDefinition, next(iter(defs.assets)))
+    assert asset1.key == AssetKey("asset1")
+    assert materialize(
+        [asset1], resources={"pipes_subprocess_client": PipesSubprocessClient()}
+    ).success
+
+
+def test_single_asset_shell_command_blueprint_pipes(capsys) -> None:
+    def script_fn():
+        from dagster_pipes import open_dagster_pipes
+
+        with open_dagster_pipes() as context:
+            context.log.info("hello world")
+            context.report_asset_materialization(
+                metadata={"bar": {"raw_value": context.get_extra("bar"), "type": "md"}},
+                data_version="alpha",
+            )
+
+    extras = {"bar": "baz"}
+    with temp_script(script_fn) as script_path:
+        single_asset_blueprint = ShellCommandBlueprint(
+            assets=[AssetSpecModel(key="asset1")],
+            command=[cast(str, shutil.which("python")), script_path],
+            extras=extras,
+        )
+        defs = single_asset_blueprint.build_defs()
+        asset1 = cast(AssetsDefinition, next(iter(defs.assets)))
+
+        result = materialize(
+            [asset1],
+            resources={"pipes_subprocess_client": PipesSubprocessClient()},
+        )
+
+    mat = result.get_asset_materialization_events()[0].step_materialization_data.materialization
+    assert isinstance(mat.metadata["bar"], MarkdownMetadataValue)
+    assert mat.metadata["bar"].value == "baz"
+    assert mat.tags
+    assert mat.tags[DATA_VERSION_TAG] == "alpha"
+    assert mat.tags[DATA_VERSION_IS_USER_PROVIDED_TAG]
+
+    captured = capsys.readouterr()
+    assert re.search(r"dagster - INFO - [^\n]+ - hello world\n", captured.err, re.MULTILINE)
+
+
+def test_multi_asset_shell_command_blueprint() -> None:
+    multi_asset_blueprint = ShellCommandBlueprint(
+        assets=[AssetSpecModel(key="asset1"), AssetSpecModel(key="asset2")],
+        command=["echo", '"hello"'],
+    )
+    defs = multi_asset_blueprint.build_defs()
+    assets = cast(AssetsDefinition, next(iter(defs.assets)))
+    assert assets.keys == {AssetKey("asset1"), AssetKey("asset2")}
+    assert materialize(
+        [assets], resources={"pipes_subprocess_client": PipesSubprocessClient()}
+    ).success
+
+
+def test_multi_asset_shell_command_blueprint_pipes(capsys) -> None:
+    def script_fn():
+        from dagster_pipes import open_dagster_pipes
+
+        with open_dagster_pipes() as context:
+            context.log.info("hello world")
+            context.report_asset_materialization(asset_key="asset1", metadata={"mkey": "mval"})
+            context.report_asset_materialization(asset_key="asset2")
+
+    with temp_script(script_fn) as script_path:
+        multi_asset_blueprint = ShellCommandBlueprint(
+            assets=[AssetSpecModel(key="asset1"), AssetSpecModel(key="asset2")],
+            command=[cast(str, shutil.which("python")), script_path],
+        )
+
+        defs = multi_asset_blueprint.build_defs()
+        assets = cast(AssetsDefinition, next(iter(defs.assets)))
+
+        result = materialize(
+            [assets],
+            resources={"pipes_subprocess_client": PipesSubprocessClient()},
+        )
+
+    mat1 = result.get_asset_materialization_events()[0].step_materialization_data.materialization
+    mat2 = result.get_asset_materialization_events()[1].step_materialization_data.materialization
+
+    assert mat1.asset_key == AssetKey("asset1")
+    assert mat1.metadata["mkey"].value == "mval"
+    assert mat2.asset_key == AssetKey("asset2")
+
+    captured = capsys.readouterr()
+    assert re.search(r"dagster - INFO - [^\n]+ - hello world\n", captured.err, re.MULTILINE)
+
+
+def test_op_name_collisions() -> None:
+    single_asset_blueprint1 = ShellCommandBlueprint(
+        assets=[AssetSpecModel(key="asset1")], command=["echo", '"hello"']
+    )
+    single_asset_blueprint2 = ShellCommandBlueprint(
+        assets=[AssetSpecModel(key="asset2")], command=["echo", '"hello"']
+    )
+    resources = {"pipes_subprocess_client": PipesSubprocessClient()}
+    blueprint_defs = BlueprintDefinitions.merge(
+        single_asset_blueprint1.build_defs(),
+        single_asset_blueprint2.build_defs(),
+        BlueprintDefinitions(resources=resources),
+    )
+    blueprint_defs.to_definitions()
+
+    materialize(
+        [cast(AssetsDefinition, asset) for asset in blueprint_defs.assets], resources=resources
+    )


### PR DESCRIPTION
## Summary & Motivation

This PR explores a few related ideas:
- Out-of-the-box blueprints corresponding to standard pipes clients (databricks & subprocess).
- Single-assets and multi-asset blueprints as separate blueprints.
- Base blueprint types for helping define out-of-the-box blueprints

One question that came up when implementing multi-asset blueprints was what to name the equivalent of `AssetSpec` in blueprint-land. Which points to a general question of what to name classes that are part of defining blueprints but don't correspond to code location-level definitions of their own.

This PR goes with `AssetSpecModel`. An alternative would have been `AssetSpecBlueprint`. However, the `Blueprint` base class currently has a `build_defs` method, which wouldn't make sense for `AssetSpecBlueprint`. We could potentially make this work by renaming the `Blueprint` base class to `DefinitionsBlueprint`.

## How I Tested These Changes
