### PR TITLE
Update scheduling-your-pipeline.mdx

### DIFF
--- a/docs/content/tutorial/scheduling-your-pipeline.mdx
+++ b/docs/content/tutorial/scheduling-your-pipeline.mdx
@@ -96,6 +96,7 @@ hackernews_schedule = ScheduleDefinition(
 
 defs = Definitions(
     assets=all_assets,
+    jobs=[hackernews_job],
     schedules=[hackernews_schedule],
 )
 ```


### PR DESCRIPTION

## Summary & Motivation

In the tutorial, the jobs parameter was inadvertently omitted from the code snippet. This pull request adds the line
 jobs=[hackernews_job],


## How I Tested These Changes
