### PR TITLE
Stop hiding server errors

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -10,6 +10,7 @@ from dagster._core.definitions.utils import normalize_tags
 from gql import Client, gql
 from gql.transport import Transport
 from gql.transport.requests import RequestsHTTPTransport
+from gql.transport.exceptions import TransportServerError
 
 from .client_queries import (
     CLIENT_GET_REPO_LOCATIONS_NAMES_AND_PIPELINES_QUERY,
@@ -103,6 +104,12 @@ class DagsterGraphQLClient:
     def _execute(self, query: str, variables: Optional[Dict[str, Any]] = None):
         try:
             return self._client.execute(gql(query), variable_values=variables)
+        except TransportServerError as exc:
+            raise DagsterGraphQLClientError(
+                f"Server error with code {exc.code}\nand message {exc.message}\n"
+                f"occured during execution of query \n{query}\n with variables"
+                f" \n{variables}\n"
+            ) from exc
         except Exception as exc:  # catch generic Exception from the gql client
             raise DagsterGraphQLClientError(
                 f"Exception occured during execution of query \n{query}\n with variables"

--- a/python_modules/dagster-graphql/dagster_graphql/client/client.py
+++ b/python_modules/dagster-graphql/dagster_graphql/client/client.py
@@ -9,8 +9,8 @@ from dagster._core.definitions.run_config import RunConfig, convert_config_input
 from dagster._core.definitions.utils import normalize_tags
 from gql import Client, gql
 from gql.transport import Transport
-from gql.transport.requests import RequestsHTTPTransport
 from gql.transport.exceptions import TransportServerError
+from gql.transport.requests import RequestsHTTPTransport
 
 from .client_queries import (
     CLIENT_GET_REPO_LOCATIONS_NAMES_AND_PIPELINES_QUERY,
@@ -106,7 +106,7 @@ class DagsterGraphQLClient:
             return self._client.execute(gql(query), variable_values=variables)
         except TransportServerError as exc:
             raise DagsterGraphQLClientError(
-                f"Server error with code {exc.code}\nand message {exc.message}\n"
+                f"Server error with code {exc.code}\nand message {exc}\n"
                 f"occured during execution of query \n{query}\n with variables"
                 f" \n{variables}\n"
             ) from exc


### PR DESCRIPTION
This will allow the user to get the relevant information on the real error that caused the exception (such as 403)

## Summary & Motivation
We encountered a GraphQL error and spent a few hours debugging it only to find out it was an 403 error. Sadly, this message was hidden by the general except clause. We believe this change may be helpful for other users.

## How I Tested These Changes
Queried to get an 403 error on our servers and see the updated error message.
