### PR TITLE
[TWP][2/n] Remove PartitionKeysTimeWindowPartitionSubset

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -30,7 +30,6 @@ from dagster._core.definitions.partition import (
     PartitionsSubset,
 )
 from dagster._core.definitions.time_window_partitions import (
-    BaseTimeWindowPartitionsSubset,
     PartitionRangeStatus,
     TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,
@@ -530,7 +529,7 @@ def build_partition_statuses(
         " in_progress_partitions_subset to be of the same type",
     )
 
-    if isinstance(materialized_partitions_subset, BaseTimeWindowPartitionsSubset):
+    if isinstance(materialized_partitions_subset, TimeWindowPartitionsSubset):
         ranges = fetch_flattened_time_window_ranges(
             {
                 PartitionRangeStatus.MATERIALIZED: materialized_partitions_subset,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
@@ -8,7 +8,7 @@ from dagster._core.definitions.declarative_scheduling.serialized_objects import 
     AssetConditionEvaluation,
 )
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
-from dagster._core.definitions.time_window_partitions import BaseTimeWindowPartitionsSubset
+from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsSubset
 from dagster._core.scheduler.instigation import AutoMaterializeAssetEvaluationRecord
 
 from dagster_graphql.implementation.events import iterate_metadata_entries
@@ -45,7 +45,7 @@ class GrapheneAssetSubsetValue(graphene.ObjectType):
         bool_value, partition_keys, partition_key_ranges = None, None, None
         if isinstance(value, bool):
             bool_value = value
-        elif isinstance(value, BaseTimeWindowPartitionsSubset):
+        elif isinstance(value, TimeWindowPartitionsSubset):
             partition_key_ranges = [
                 GraphenePartitionKeyRange(start, end)
                 for start, end in value.get_partition_key_ranges(value.partitions_def)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -7,7 +7,7 @@ from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPo
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import (
-    BaseTimeWindowPartitionsSubset,
+    TimeWindowPartitionsSubset,
 )
 from dagster._core.execution.asset_backfill import (
     AssetBackfillStatus,
@@ -137,7 +137,7 @@ class GrapheneAssetBackfillTargetPartitions(graphene.ObjectType):
     def __init__(self, partition_subset: PartitionsSubset):
         from dagster_graphql.schema.partition_sets import GraphenePartitionKeyRange
 
-        if isinstance(partition_subset, BaseTimeWindowPartitionsSubset):
+        if isinstance(partition_subset, TimeWindowPartitionsSubset):
             ranges = [
                 GraphenePartitionKeyRange(start, end)
                 for start, end in partition_subset.get_partition_key_ranges(

--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -22,9 +22,9 @@ from dagster._core.definitions.partition import (
     DefaultPartitionsSubset,
 )
 from dagster._core.definitions.time_window_partitions import (
-    BaseTimeWindowPartitionsSubset,
     TimeWindow,
     TimeWindowPartitionsDefinition,
+    TimeWindowPartitionsSubset,
     get_time_partitions_def,
 )
 from dagster._utils.cached_method import cached_method
@@ -192,7 +192,7 @@ class AssetSlice:
             self._time_window_partitions_def_in_context(), "Must be time windowed."
         )
 
-        if isinstance(self._compatible_subset.subset_value, BaseTimeWindowPartitionsSubset):
+        if isinstance(self._compatible_subset.subset_value, TimeWindowPartitionsSubset):
             return self._compatible_subset.subset_value.included_time_windows
         elif isinstance(self._compatible_subset.subset_value, AllPartitionsSubset):
             last_tw = tw_partitions_def.get_last_partition_window(
@@ -215,10 +215,8 @@ class AssetSlice:
                 tw_partition_keys.add(tm_partition_key)
 
             subset_from_tw = tw_partitions_def.subset_with_partition_keys(tw_partition_keys)
-            check.inst(
-                subset_from_tw, BaseTimeWindowPartitionsSubset, "Must be time window subset."
-            )
-            if isinstance(subset_from_tw, BaseTimeWindowPartitionsSubset):
+            check.inst(subset_from_tw, TimeWindowPartitionsSubset, "Must be time window subset.")
+            if isinstance(subset_from_tw, TimeWindowPartitionsSubset):
                 return subset_from_tw.included_time_windows
             else:
                 check.failed(

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -38,8 +38,8 @@ from .events import AssetKey, AssetKeyPartitionKey
 class PartitionsSubsetMappingNamedTupleSerializer(NamedTupleSerializer):
     """Serializes NamedTuples with fields that are mappings containing PartitionsSubsets.
 
-    This is necessary because PartitionKeysTimeWindowPartitionsSubsets are not serializable,
-    so we convert them to TimeWindowPartitionsSubsets.
+    This is necessary because not all PartitionsSubsets are natively serializable, and so they
+    must first be converted into a serializable form.
     """
 
     def before_pack(self, value: NamedTuple) -> NamedTuple:
@@ -48,8 +48,6 @@ class PartitionsSubsetMappingNamedTupleSerializer(NamedTupleSerializer):
             if isinstance(field_value, Mapping) and all(
                 isinstance(v, PartitionsSubset) for v in field_value.values()
             ):
-                # PartitionKeysTimeWindowPartitionsSubsets are not serializable, so
-                # we convert them to TimeWindowPartitionsSubsets
                 subsets_by_key = {k: v.to_serializable_subset() for k, v in field_value.items()}
 
                 # If the mapping is keyed by AssetKey wrap it in a SerializableNonScalarKeyMapping

--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -18,7 +18,7 @@ from dagster._core.definitions.partition import (
     PartitionsSubset,
 )
 from dagster._core.definitions.time_window_partitions import (
-    BaseTimeWindowPartitionsSubset,
+    TimeWindowPartitionsSubset,
 )
 from dagster._model import DagsterModel, InstanceOf
 from dagster._serdes.serdes import (
@@ -100,7 +100,7 @@ class AssetSubset(DagsterModel):
         if self.is_partitioned:
             # for some PartitionSubset types, we have access to the underlying partitions
             # definitions, so we can ensure those are identical
-            if isinstance(self.value, (BaseTimeWindowPartitionsSubset, AllPartitionsSubset)):
+            if isinstance(self.value, (TimeWindowPartitionsSubset, AllPartitionsSubset)):
                 return self.value.partitions_def == partitions_def
             else:
                 return partitions_def is not None
@@ -108,7 +108,7 @@ class AssetSubset(DagsterModel):
             return partitions_def is None
 
     def _is_compatible_with_subset(self, other: "AssetSubset") -> bool:
-        if isinstance(other.value, (BaseTimeWindowPartitionsSubset, AllPartitionsSubset)):
+        if isinstance(other.value, (TimeWindowPartitionsSubset, AllPartitionsSubset)):
             return self.is_compatible_with_partitions_def(other.value.partitions_def)
         else:
             return self.is_partitioned == other.is_partitioned

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -28,8 +28,8 @@ from dagster._core.definitions.data_version import (
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessMinutes
 from dagster._core.definitions.time_window_partitions import (
-    BaseTimeWindowPartitionsSubset,
     TimeWindowPartitionsDefinition,
+    TimeWindowPartitionsSubset,
 )
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import EventLogRecord
@@ -91,7 +91,7 @@ class CachingDataTimeResolver:
             )
         )
 
-        if not isinstance(partition_subset, BaseTimeWindowPartitionsSubset):
+        if not isinstance(partition_subset, TimeWindowPartitionsSubset):
             check.failed(f"Invalid partition subset {type(partition_subset)}")
 
         sorted_time_windows = sorted(partition_subset.included_time_windows)

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -6,7 +6,6 @@ from dagster._annotations import PublicAttr, experimental_param
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_mapping import PartitionMapping, UpstreamPartitionsResult
 from dagster._core.definitions.time_window_partitions import (
-    BaseTimeWindowPartitionsSubset,
     TimeWindow,
     TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,
@@ -129,8 +128,8 @@ class TimeWindowPartitionMapping(
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> UpstreamPartitionsResult:
-        if not isinstance(downstream_partitions_subset, BaseTimeWindowPartitionsSubset):
-            check.failed("downstream_partitions_subset must be a BaseTimeWindowPartitionsSubset")
+        if not isinstance(downstream_partitions_subset, TimeWindowPartitionsSubset):
+            check.failed("downstream_partitions_subset must be a TimeWindowPartitionsSubset")
 
         return self._map_partitions(
             downstream_partitions_subset.partitions_def,
@@ -207,8 +206,8 @@ class TimeWindowPartitionMapping(
             mapping_downstream_to_upstream (bool): True if from_partitions_def is the downstream
                 partitions def and to_partitions_def is the upstream partitions def.
         """
-        if not isinstance(from_partitions_subset, BaseTimeWindowPartitionsSubset):
-            check.failed("from_partitions_subset must be a BaseTimeWindowPartitionsSubset")
+        if not isinstance(from_partitions_subset, TimeWindowPartitionsSubset):
+            check.failed("from_partitions_subset must be a TimeWindowPartitionsSubset")
 
         if not isinstance(from_partitions_def, TimeWindowPartitionsDefinition):
             check.failed("from_partitions_def must be a TimeWindowPartitionsDefinition")
@@ -353,7 +352,7 @@ class TimeWindowPartitionMapping(
         self,
         from_partitions_def: TimeWindowPartitionsDefinition,
         to_partitions_def: TimeWindowPartitionsDefinition,
-        from_partitions_subset: BaseTimeWindowPartitionsSubset,
+        from_partitions_subset: TimeWindowPartitionsSubset,
         start_offset: int,
         end_offset: int,
         current_time: Optional[datetime],

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -2,12 +2,10 @@ import functools
 import hashlib
 import json
 import re
-from abc import abstractmethod, abstractproperty
 from datetime import date, datetime, timedelta
 from enum import Enum
 from functools import cached_property
 from typing import (
-    AbstractSet,
     Any,
     Callable,
     FrozenSet,
@@ -1004,7 +1002,7 @@ class TimeWindowPartitionsDefinition(
 
     @property
     def partitions_subset_class(self) -> Type["PartitionsSubset"]:
-        return PartitionKeysTimeWindowPartitionsSubset
+        return TimeWindowPartitionsSubset
 
     def empty_subset(self) -> "PartitionsSubset":
         return self.partitions_subset_class.empty_subset(self)
@@ -1655,24 +1653,108 @@ def weekly_partitioned_config(
     return inner
 
 
-class BaseTimeWindowPartitionsSubset(PartitionsSubset):
-    """A base class that represents PartitionSubsets for TimeWindowPartitionsDefinitions.
-    Contains shared logic for time window partitions subsets, such as building time windows
-    from partition keys.
+class TimeWindowPartitionsSubsetSerializer(NamedTupleSerializer):
+    # TimeWindowPartitionsSubsets have custom logic to delay calculating num_partitions until it
+    # is needed to improve performance. When serializing, we want to serialize the number of
+    # partitions, so we force calculation.
+    def before_pack(self, value: "TimeWindowPartitionsSubset") -> "TimeWindowPartitionsSubset":
+        # value.num_partitions will calculate the number of partitions if the field is None
+        # We want to check if the field is None and replace the value with the calculated value
+        # for serialization
+        if value._asdict()["num_partitions"] is None:
+            return TimeWindowPartitionsSubset(
+                partitions_def=value.partitions_def,
+                num_partitions=value.num_partitions,
+                included_time_windows=value.included_time_windows,
+            )
+        return value
+
+
+@whitelist_for_serdes(serializer=TimeWindowPartitionsSubsetSerializer)
+class TimeWindowPartitionsSubset(
+    PartitionsSubset,
+    NamedTuple(
+        "_TimeWindowPartitionsSubset",
+        [
+            ("partitions_def", TimeWindowPartitionsDefinition),
+            ("num_partitions", Optional[int]),
+            ("included_time_windows", Sequence[TimeWindow]),
+        ],
+    ),
+):
+    """A PartitionsSubset for a TimeWindowPartitionsDefinition, which internally represents the
+    included partitions using TimeWindows.
     """
 
     # Every time we change the serialization format, we should increment the version number.
     # This will ensure that we can gracefully degrade when deserializing old data.
     SERIALIZATION_VERSION = 1
 
-    @abstractproperty
-    def included_time_windows(self) -> Sequence[TimeWindow]: ...
+    def __new__(
+        cls,
+        partitions_def: TimeWindowPartitionsDefinition,
+        num_partitions: Optional[int],
+        included_time_windows: Sequence[TimeWindow],
+    ):
+        return super(TimeWindowPartitionsSubset, cls).__new__(
+            cls,
+            partitions_def=check.inst_param(
+                partitions_def, "partitions_def", TimeWindowPartitionsDefinition
+            ),
+            num_partitions=check.opt_int_param(num_partitions, "num_partitions"),
+            included_time_windows=check.sequence_param(
+                included_time_windows, "included_time_windows", of_type=TimeWindow
+            ),
+        )
 
-    @abstractproperty
-    def num_partitions(self) -> int: ...
+    @property
+    def included_time_windows(self) -> Sequence[TimeWindow]:
+        return self._asdict()["included_time_windows"]
 
-    @abstractproperty
-    def partitions_def(self) -> TimeWindowPartitionsDefinition: ...
+    @property
+    def partitions_def(self) -> TimeWindowPartitionsDefinition:
+        return self._asdict()["partitions_def"]
+
+    @property
+    def first_start(self) -> datetime:
+        """The start datetime of the earliest partition in the subset."""
+        if len(self.included_time_windows) == 0:
+            check.failed("Empty subset")
+        return self.included_time_windows[0].start
+
+    @property
+    def is_empty(self) -> bool:
+        return len(self.included_time_windows) == 0
+
+    def cheap_ends_before(self, dt: datetime, dt_cron_schedule: str) -> bool:
+        """Performs a cheap calculation that checks whether the latest window in this subset ends
+        before the given dt. If this returns True, then it means the latest window definitely ends
+        before the given dt. If this returns False, it means it may or may not end before the given
+        dt.
+
+        Args:
+            dt_cron_schedule (str): A cron schedule that dt is on one of the ticks of.
+        """
+        return self.included_time_windows[-1].end.timestamp() <= dt.timestamp()
+
+    @cached_property
+    def num_partitions(self) -> int:
+        num_partitions_ = self._asdict()["num_partitions"]
+        if num_partitions_ is None:
+            return sum(
+                len(self.partitions_def.get_partition_keys_in_time_window(time_window))
+                for time_window in self.included_time_windows
+            )
+        return num_partitions_
+
+    @classmethod
+    def _num_partitions_from_time_windows(
+        cls, partitions_def: TimeWindowPartitionsDefinition, time_windows: Sequence[TimeWindow]
+    ) -> int:
+        return sum(
+            len(partitions_def.get_partition_keys_in_time_window(time_window))
+            for time_window in time_windows
+        )
 
     def _get_partition_time_windows_not_in_subset(
         self,
@@ -1740,20 +1822,6 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
                 ).get_partition_keys_in_time_window(tw)
             )
         return partition_keys
-
-    @abstractproperty
-    def first_start(self) -> datetime: ...
-
-    @abstractproperty
-    def is_empty(self) -> bool: ...
-
-    @abstractmethod
-    def cheap_ends_before(self, dt: datetime, dt_cron_schedule: str) -> bool: ...
-
-    @abstractmethod
-    def with_partitions_def(
-        self, partitions_def: TimeWindowPartitionsDefinition
-    ) -> "BaseTimeWindowPartitionsSubset": ...
 
     def get_partition_key_ranges(
         self,
@@ -1825,6 +1893,228 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
                 num_added_partitions += 1
 
         return result_windows, num_added_partitions
+
+    @public
+    def get_partition_keys(self) -> Iterable[str]:
+        return [
+            pk
+            for time_window in self.included_time_windows
+            for pk in self.partitions_def.get_partition_keys_in_time_window(time_window)
+        ]
+
+    def with_partition_keys(self, partition_keys: Iterable[str]) -> "TimeWindowPartitionsSubset":
+        result_windows, added_partitions = self._add_partitions_to_time_windows(
+            self.included_time_windows, list(partition_keys)
+        )
+
+        return TimeWindowPartitionsSubset(
+            self.partitions_def,
+            num_partitions=self.num_partitions + added_partitions,
+            included_time_windows=result_windows,
+        )
+
+    @classmethod
+    def empty_subset(
+        cls, partitions_def: Optional[PartitionsDefinition] = None
+    ) -> "PartitionsSubset":
+        if not isinstance(partitions_def, TimeWindowPartitionsDefinition):
+            check.failed("Partitions definition must be a TimeWindowPartitionsDefinition")
+        partitions_def = cast(TimeWindowPartitionsDefinition, partitions_def)
+        return cls(partitions_def, 0, [])
+
+    def with_partitions_def(
+        self, partitions_def: TimeWindowPartitionsDefinition
+    ) -> "TimeWindowPartitionsSubset":
+        check.invariant(
+            partitions_def.cron_schedule == self.partitions_def.cron_schedule,
+            "num_partitions would become inaccurate if the partitions_defs had different cron"
+            " schedules",
+        )
+        return TimeWindowPartitionsSubset(
+            partitions_def=partitions_def,
+            num_partitions=self.num_partitions,
+            included_time_windows=self.included_time_windows,
+        )
+
+    def __repr__(self) -> str:
+        return f"TimeWindowPartitionsSubset({self.get_partition_key_ranges(self.partitions_def)})"
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, TimeWindowPartitionsSubset)
+            and self.partitions_def == other.partitions_def
+            and self.included_time_windows == other.included_time_windows
+        )
+
+    def __and__(self, other: "PartitionsSubset") -> "PartitionsSubset":
+        if self == other:
+            return self
+
+        empty_subset = self.empty_subset(self.partitions_def)
+        if other is empty_subset:
+            return other
+
+        if not isinstance(other, TimeWindowPartitionsSubset):
+            return super().__and__(other)
+
+        self_time_windows_iter = iter(
+            sorted(self.included_time_windows, key=lambda tw: tw.start.timestamp())
+        )
+        other_time_windows_iter = iter(
+            sorted(other.included_time_windows, key=lambda tw: tw.start.timestamp())
+        )
+
+        result_windows = []
+        self_window = next(self_time_windows_iter, None)
+        other_window = next(other_time_windows_iter, None)
+        while self_window and other_window:
+            # find the intersection between the current two windows
+            start = max(self_window.start, other_window.start)
+            end = min(self_window.end, other_window.end)
+
+            # these windows intersect
+            if start < end:
+                result_windows.append(TimeWindow(start=start, end=end))
+
+            # advance the iterator with the earliest end time to find the next potential intersection
+            if self_window.end < other_window.end:
+                self_window = next(self_time_windows_iter, None)
+            else:
+                other_window = next(other_time_windows_iter, None)
+
+        return TimeWindowPartitionsSubset(
+            partitions_def=self.partitions_def,
+            num_partitions=None,  # lazily calculated
+            included_time_windows=result_windows,
+        )
+
+    def __or__(self, other: "PartitionsSubset") -> "PartitionsSubset":
+        if self == other:
+            return self
+
+        empty_subset = self.empty_subset(self.partitions_def)
+        if other is empty_subset:
+            return self
+
+        if not isinstance(other, TimeWindowPartitionsSubset):
+            return super().__or__(other)
+
+        input_time_windows = sorted(
+            [*self.included_time_windows, *other.included_time_windows],
+            key=lambda tw: tw.start.timestamp(),
+        )
+        result_windows = [input_time_windows[0]] if len(input_time_windows) > 0 else []
+        for window in input_time_windows[1:]:
+            latest_window = result_windows[-1]
+            if window.start <= latest_window.end:
+                # merge this window with the latest window
+                result_windows[-1] = TimeWindow(
+                    latest_window.start, max(latest_window.end, window.end)
+                )
+            else:
+                result_windows.append(window)
+
+        return TimeWindowPartitionsSubset(
+            partitions_def=self.partitions_def,
+            num_partitions=None,  # lazily calculated
+            included_time_windows=result_windows,
+        )
+
+    def __sub__(self, other: "PartitionsSubset") -> "PartitionsSubset":
+        if self is other:
+            return self.empty_subset(self.partitions_def)
+
+        empty_subset = self.empty_subset(self.partitions_def)
+
+        if other is empty_subset:
+            return self
+
+        if not isinstance(other, TimeWindowPartitionsSubset):
+            return empty_subset.with_partition_keys(
+                set(self.get_partition_keys()).difference(set(other.get_partition_keys()))
+            )
+
+        time_windows = sorted(self.included_time_windows, key=lambda tw: tw.start.timestamp())
+        other_time_windows = sorted(
+            other.included_time_windows, key=lambda tw: tw.start.timestamp()
+        )
+
+        next_time_window_index_to_process = 0
+        next_other_window_index_to_process = 0
+
+        # Slide through both sets of windows, moving to the next window once its start has passed
+        # the end of the window is it being compared to
+        while (next_time_window_index_to_process < len(time_windows)) and (
+            next_other_window_index_to_process < len(other_time_windows)
+        ):
+            time_window = time_windows[next_time_window_index_to_process]
+            other_time_window = other_time_windows[next_other_window_index_to_process]
+
+            # Perform the subtraction and splice the 0, 1, or 2 result windows
+            # back into the time_windows list
+
+            subtracted_time_windows = time_window.subtract(other_time_window)
+
+            time_windows[
+                next_time_window_index_to_process : next_time_window_index_to_process + 1
+            ] = subtracted_time_windows
+
+            if len(subtracted_time_windows) == 0:
+                # other_time_window fully consumed time_window
+                # next_time_window_index_to_process can stay the same since everything has shifted over one
+                pass
+            else:
+                updated_time_window = time_windows[next_time_window_index_to_process]
+                if updated_time_window.end <= other_time_window.start:
+                    # Current subtractor is too early to intersect, can advance
+                    next_time_window_index_to_process += 1
+                elif other_time_window.end <= updated_time_window.start:
+                    # current subtractee is too early to intersect, can advance
+                    next_other_window_index_to_process += 1
+                else:
+                    check.failed(
+                        "After subtraction, the new window should no longer intersect with the other window"
+                    )
+
+        return TimeWindowPartitionsSubset(
+            partitions_def=self.partitions_def,
+            num_partitions=None,
+            included_time_windows=time_windows,
+        )
+
+    def __len__(self) -> int:
+        return self.num_partitions
+
+    def __contains__(self, partition_key: str) -> bool:
+        time_window = cast(
+            TimeWindowPartitionsDefinition, self.partitions_def
+        ).time_window_for_partition_key(partition_key)
+
+        time_window_start_timestamp = time_window.start.timestamp()
+
+        return any(
+            time_window_start_timestamp >= included_time_window.start.timestamp()
+            and time_window_start_timestamp < included_time_window.end.timestamp()
+            for included_time_window in self.included_time_windows
+        )
+
+    def to_serializable_subset(self) -> "TimeWindowPartitionsSubset":
+        from dagster._core.remote_representation.external_data import (
+            external_time_window_partitions_definition_from_def,
+        )
+
+        # in cases where we're dealing with (e.g.) HourlyPartitionsDefinition, we need to convert
+        # this partitions definition into a raw TimeWindowPartitionsDefinition to make it
+        # serializable. to do this, we just convert it to its external representation and back.
+        # note that we rarely serialize subsets on the user code side of a serialization boundary,
+        # and so this conversion is rarely necessary.
+        partitions_def = self.partitions_def
+        if type(self.partitions_def) != TimeWindowPartitionsSubset:
+            partitions_def = external_time_window_partitions_definition_from_def(
+                partitions_def
+            ).get_partitions_definition()
+            return self.with_partitions_def(partitions_def)
+        return self
 
     def serialize(self) -> str:
         return json.dumps(
@@ -1910,505 +2200,6 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
             and data.get("time_windows") is not None
             and data.get("num_partitions") is not None
         )
-
-    def __len__(self) -> int:
-        return self.num_partitions
-
-    def __contains__(self, partition_key: str) -> bool:
-        time_window = cast(
-            TimeWindowPartitionsDefinition, self.partitions_def
-        ).time_window_for_partition_key(partition_key)
-
-        time_window_start_timestamp = time_window.start.timestamp()
-
-        return any(
-            time_window_start_timestamp >= included_time_window.start.timestamp()
-            and time_window_start_timestamp < included_time_window.end.timestamp()
-            for included_time_window in self.included_time_windows
-        )
-
-    def __eq__(self, other):
-        return (
-            isinstance(other, BaseTimeWindowPartitionsSubset)
-            and self.partitions_def == other.partitions_def
-            and self.included_time_windows == other.included_time_windows
-        )
-
-    def __or__(self, other: "PartitionsSubset") -> "PartitionsSubset":
-        if self is other:
-            return self
-        return self.with_partition_keys(other.get_partition_keys())
-
-    def __sub__(self, other: "PartitionsSubset") -> "PartitionsSubset":
-        if self is other:
-            return self.empty_subset(self.partitions_def)
-
-        empty_subset = self.empty_subset(self.partitions_def)
-
-        if other is empty_subset:
-            return self
-
-        return empty_subset.with_partition_keys(
-            set(self.get_partition_keys()).difference(set(other.get_partition_keys()))
-        )
-
-    def __and__(self, other: "PartitionsSubset") -> "PartitionsSubset":
-        if self is other:
-            return self
-
-        empty_subset = self.empty_subset(self.partitions_def)
-        if other is empty_subset:
-            return empty_subset
-
-        return empty_subset.with_partition_keys(
-            set(self.get_partition_keys()) & set(other.get_partition_keys())
-        )
-
-
-class PartitionKeysTimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
-    """A PartitionsSubset for a TimeWindowPartitionsDefinition, which internally represents the
-    included partitions using strings.
-    """
-
-    def __init__(
-        self,
-        partitions_def: TimeWindowPartitionsDefinition,
-        included_partition_keys: AbstractSet[str],
-    ):
-        self._partitions_def = check.inst_param(
-            partitions_def, "partitions_def", TimeWindowPartitionsDefinition
-        )
-        self._included_partition_keys = check.set_param(
-            included_partition_keys, "included_partition_keys", of_type=str
-        )
-
-    @property
-    def partitions_def(self) -> TimeWindowPartitionsDefinition:
-        return self._partitions_def
-
-    def with_partition_keys(
-        self, partition_keys: Iterable[str]
-    ) -> "BaseTimeWindowPartitionsSubset":
-        new_partitions = {*(self._included_partition_keys or []), *partition_keys}
-        return PartitionKeysTimeWindowPartitionsSubset(
-            self._partitions_def,
-            included_partition_keys=new_partitions,
-        )
-
-    @cached_property
-    def included_time_windows(self) -> Sequence[TimeWindow]:
-        result_time_windows, _ = self._add_partitions_to_time_windows(
-            initial_windows=[],
-            partition_keys=list(check.not_none(self._included_partition_keys)),
-            validate=False,
-        )
-        return result_time_windows
-
-    @cached_property
-    def num_partitions(self) -> int:
-        return len(self._included_partition_keys)
-
-    @public
-    def get_partition_keys(self) -> Iterable[str]:
-        return list(self._included_partition_keys) if self._included_partition_keys else []
-
-    @property
-    def first_start(self) -> datetime:
-        """The start datetime of the earliest partition in the subset."""
-        if len(self._included_partition_keys) == 1:
-            # Avoid expensive conversion from partition keys to time windows if possible
-            return self._partitions_def.start_time_for_partition_key(
-                next(iter(self._included_partition_keys))
-            )
-        else:
-            if len(self.included_time_windows) == 0:
-                check.failed(
-                    f"Empty subset. self._included_partition_keys: {self._included_partition_keys}"
-                )
-            return self.included_time_windows[0].start
-
-    @property
-    def is_empty(self) -> bool:
-        return len(self._included_partition_keys) == 0
-
-    def cheap_ends_before(self, dt: datetime, dt_cron_schedule: str) -> bool:
-        """Performs a cheap calculation that checks whether the latest window in this subset ends
-        before the given dt. If this returns True, then it means the latest window definitely ends
-        before the given dt. If this returns False, it means it may or may not end before the given
-        dt.
-
-        Args:
-            dt_cron_schedule (str): A cron schedule that dt is on one of the ticks of.
-        """
-        if len(self._included_partition_keys) == 1:
-            # Getting just the partition start time is cheaper than invoking croniter to get the
-            # full window.
-            # If we know that the start time is earlier than dt and that the partitions are slim
-            # enough that the end time can't put them past dt, then we know that the end time is
-            # earlier than dt.
-            if (self._partitions_def.cron_schedule == dt_cron_schedule) or (
-                self._partitions_def.is_basic_hourly
-                and dt_cron_schedule in ["0 0 * * *", "0 * * * *"]
-            ):
-                return (
-                    self._partitions_def.start_time_for_partition_key(
-                        next(iter(self._included_partition_keys))
-                    )
-                    < dt
-                )
-
-        return False
-
-    def __contains__(self, partition_key: str) -> bool:
-        return partition_key in self._included_partition_keys
-
-    def __eq__(self, other):
-        return (
-            isinstance(other, PartitionKeysTimeWindowPartitionsSubset)
-            and self._partitions_def == other._partitions_def
-            and self._included_partition_keys == other._included_partition_keys
-        ) or super(PartitionKeysTimeWindowPartitionsSubset, self).__eq__(other)
-
-    @classmethod
-    def empty_subset(
-        cls, partitions_def: Optional[PartitionsDefinition] = None
-    ) -> "PartitionsSubset":
-        if not isinstance(partitions_def, TimeWindowPartitionsDefinition):
-            check.failed("Partitions definition must be a TimeWindowPartitionsDefinition")
-        partitions_def = cast(TimeWindowPartitionsDefinition, partitions_def)
-        return cls(partitions_def, set())
-
-    def with_partitions_def(
-        self, partitions_def: TimeWindowPartitionsDefinition
-    ) -> "BaseTimeWindowPartitionsSubset":
-        check.invariant(
-            partitions_def.cron_schedule == self._partitions_def.cron_schedule,
-            "num_partitions would become inaccurate if the partitions_defs had different cron"
-            " schedules",
-        )
-        return PartitionKeysTimeWindowPartitionsSubset(
-            partitions_def=partitions_def,
-            included_partition_keys=self._included_partition_keys,
-        )
-
-    def __repr__(self) -> str:
-        return f"PartitionKeysTimeWindowPartitionsSubset({self.get_partition_key_ranges(self.partitions_def)})"
-
-    def to_serializable_subset(self) -> "TimeWindowPartitionsSubset":
-        from dagster._core.remote_representation.external_data import (
-            external_time_window_partitions_definition_from_def,
-        )
-
-        # in cases where we're dealing with (e.g.) HourlyPartitionsDefinition, we need to convert
-        # this partitions definition into a raw TimeWindowPartitionsDefinition to make it
-        # serializable. to do this, we just convert it to its external representation and back.
-        partitions_def = self.partitions_def
-        if type(self.partitions_def) != TimeWindowPartitionsSubset:
-            partitions_def = external_time_window_partitions_definition_from_def(
-                partitions_def
-            ).get_partitions_definition()
-        return TimeWindowPartitionsSubset(
-            partitions_def, self.num_partitions, self.included_time_windows
-        )
-
-
-class TimeWindowPartitionsSubsetSerializer(NamedTupleSerializer):
-    # TimeWindowPartitionsSubsets have custom logic to delay calculating num_partitions until it
-    # is needed to improve performance. When serializing, we want to serialize the number of
-    # partitions, so we force calculation.
-    def before_pack(self, value: "TimeWindowPartitionsSubset") -> "TimeWindowPartitionsSubset":
-        # value.num_partitions will calculate the number of partitions if the field is None
-        # We want to check if the field is None and replace the value with the calculated value
-        # for serialization
-        if value._asdict()["num_partitions"] is None:
-            return TimeWindowPartitionsSubset(
-                partitions_def=value.partitions_def,
-                num_partitions=value.num_partitions,
-                included_time_windows=value.included_time_windows,
-            )
-        return value
-
-
-@whitelist_for_serdes(serializer=TimeWindowPartitionsSubsetSerializer)
-class TimeWindowPartitionsSubset(
-    BaseTimeWindowPartitionsSubset,
-    NamedTuple(
-        "_TimeWindowPartitionsSubset",
-        [
-            ("partitions_def", TimeWindowPartitionsDefinition),
-            ("num_partitions", Optional[int]),
-            ("included_time_windows", Sequence[TimeWindow]),
-        ],
-    ),
-):
-    """A PartitionsSubset for a TimeWindowPartitionsDefinition, which internally represents the
-    included partitions using TimeWindows.
-    """
-
-    def __new__(
-        cls,
-        partitions_def: TimeWindowPartitionsDefinition,
-        num_partitions: Optional[int],
-        included_time_windows: Sequence[TimeWindow],
-    ):
-        return super(TimeWindowPartitionsSubset, cls).__new__(
-            cls,
-            partitions_def=check.inst_param(
-                partitions_def, "partitions_def", TimeWindowPartitionsDefinition
-            ),
-            num_partitions=check.opt_int_param(num_partitions, "num_partitions"),
-            included_time_windows=check.sequence_param(
-                included_time_windows, "included_time_windows", of_type=TimeWindow
-            ),
-        )
-
-    @property
-    def included_time_windows(self) -> Sequence[TimeWindow]:
-        return self._asdict()["included_time_windows"]
-
-    @property
-    def partitions_def(self) -> TimeWindowPartitionsDefinition:
-        return self._asdict()["partitions_def"]
-
-    @property
-    def first_start(self) -> datetime:
-        """The start datetime of the earliest partition in the subset."""
-        if len(self.included_time_windows) == 0:
-            check.failed("Empty subset")
-        return self.included_time_windows[0].start
-
-    @property
-    def is_empty(self) -> bool:
-        return len(self.included_time_windows) == 0
-
-    def cheap_ends_before(self, dt: datetime, dt_cron_schedule: str) -> bool:
-        """Performs a cheap calculation that checks whether the latest window in this subset ends
-        before the given dt. If this returns True, then it means the latest window definitely ends
-        before the given dt. If this returns False, it means it may or may not end before the given
-        dt.
-
-        Args:
-            dt_cron_schedule (str): A cron schedule that dt is on one of the ticks of.
-        """
-        return self.included_time_windows[-1].end.timestamp() <= dt.timestamp()
-
-    @cached_property
-    def num_partitions(self) -> int:
-        num_partitions_ = self._asdict()["num_partitions"]
-        if num_partitions_ is None:
-            return sum(
-                len(self.partitions_def.get_partition_keys_in_time_window(time_window))
-                for time_window in self.included_time_windows
-            )
-        return num_partitions_
-
-    @classmethod
-    def _num_partitions_from_time_windows(
-        cls, partitions_def: TimeWindowPartitionsDefinition, time_windows: Sequence[TimeWindow]
-    ) -> int:
-        return sum(
-            len(partitions_def.get_partition_keys_in_time_window(time_window))
-            for time_window in time_windows
-        )
-
-    @public
-    def get_partition_keys(self) -> Iterable[str]:
-        return [
-            pk
-            for time_window in self.included_time_windows
-            for pk in self.partitions_def.get_partition_keys_in_time_window(time_window)
-        ]
-
-    def with_partition_keys(self, partition_keys: Iterable[str]) -> "TimeWindowPartitionsSubset":
-        result_windows, added_partitions = self._add_partitions_to_time_windows(
-            self.included_time_windows, list(partition_keys)
-        )
-
-        return TimeWindowPartitionsSubset(
-            self.partitions_def,
-            num_partitions=self.num_partitions + added_partitions,
-            included_time_windows=result_windows,
-        )
-
-    @classmethod
-    def empty_subset(
-        cls, partitions_def: Optional[PartitionsDefinition] = None
-    ) -> "PartitionsSubset":
-        if not isinstance(partitions_def, TimeWindowPartitionsDefinition):
-            check.failed("Partitions definition must be a TimeWindowPartitionsDefinition")
-        partitions_def = cast(TimeWindowPartitionsDefinition, partitions_def)
-        return cls(partitions_def, 0, [])
-
-    def with_partitions_def(
-        self, partitions_def: TimeWindowPartitionsDefinition
-    ) -> "TimeWindowPartitionsSubset":
-        check.invariant(
-            partitions_def.cron_schedule == self.partitions_def.cron_schedule,
-            "num_partitions would become inaccurate if the partitions_defs had different cron"
-            " schedules",
-        )
-        return TimeWindowPartitionsSubset(
-            partitions_def=partitions_def,
-            num_partitions=self.num_partitions,
-            included_time_windows=self.included_time_windows,
-        )
-
-    def __repr__(self) -> str:
-        return f"TimeWindowPartitionsSubset({self.get_partition_key_ranges(self.partitions_def)})"
-
-    def __and__(self, other: "PartitionsSubset") -> "PartitionsSubset":
-        if self == other:
-            return self
-
-        empty_subset = self.empty_subset(self.partitions_def)
-        if other is empty_subset:
-            return other
-
-        if not isinstance(other, TimeWindowPartitionsSubset):
-            return super().__and__(other)
-
-        self_time_windows_iter = iter(
-            sorted(self.included_time_windows, key=lambda tw: tw.start.timestamp())
-        )
-        other_time_windows_iter = iter(
-            sorted(other.included_time_windows, key=lambda tw: tw.start.timestamp())
-        )
-
-        result_windows = []
-        self_window = next(self_time_windows_iter, None)
-        other_window = next(other_time_windows_iter, None)
-        while self_window and other_window:
-            # find the intersection between the current two windows
-            start = max(self_window.start, other_window.start)
-            end = min(self_window.end, other_window.end)
-
-            # these windows intersect
-            if start < end:
-                result_windows.append(TimeWindow(start=start, end=end))
-
-            # advance the iterator with the earliest end time to find the next potential intersection
-            if self_window.end < other_window.end:
-                self_window = next(self_time_windows_iter, None)
-            else:
-                other_window = next(other_time_windows_iter, None)
-
-        return TimeWindowPartitionsSubset(
-            partitions_def=self.partitions_def,
-            num_partitions=None,  # lazily calculated
-            included_time_windows=result_windows,
-        )
-
-    def __or__(self, other: "PartitionsSubset") -> "PartitionsSubset":
-        if self == other:
-            return self
-
-        empty_subset = self.empty_subset(self.partitions_def)
-        if other is empty_subset:
-            return self
-
-        if not isinstance(other, TimeWindowPartitionsSubset):
-            return super().__or__(other)
-
-        input_time_windows = sorted(
-            [*self.included_time_windows, *other.included_time_windows],
-            key=lambda tw: tw.start.timestamp(),
-        )
-        result_windows = [input_time_windows[0]]
-        for window in input_time_windows[1:]:
-            latest_window = result_windows[-1]
-            if window.start <= latest_window.end:
-                # merge this window with the latest window
-                result_windows[-1] = TimeWindow(
-                    latest_window.start, max(latest_window.end, window.end)
-                )
-            else:
-                result_windows.append(window)
-
-        return TimeWindowPartitionsSubset(
-            partitions_def=self.partitions_def,
-            num_partitions=None,  # lazily calculated
-            included_time_windows=result_windows,
-        )
-
-    def __sub__(self, other: "PartitionsSubset") -> "PartitionsSubset":
-        if self is other:
-            return self.empty_subset(self.partitions_def)
-
-        empty_subset = self.empty_subset(self.partitions_def)
-
-        if other is empty_subset:
-            return self
-
-        if not isinstance(other, TimeWindowPartitionsSubset):
-            return empty_subset.with_partition_keys(
-                set(self.get_partition_keys()).difference(set(other.get_partition_keys()))
-            )
-
-        time_windows = sorted(self.included_time_windows, key=lambda tw: tw.start.timestamp())
-        other_time_windows = sorted(
-            other.included_time_windows, key=lambda tw: tw.start.timestamp()
-        )
-
-        next_time_window_index_to_process = 0
-        next_other_window_index_to_process = 0
-
-        # Slide through both sets of windows, moving to the next window once its start has passed
-        # the end of the window is it being compared to
-        while (next_time_window_index_to_process < len(time_windows)) and (
-            next_other_window_index_to_process < len(other_time_windows)
-        ):
-            time_window = time_windows[next_time_window_index_to_process]
-            other_time_window = other_time_windows[next_other_window_index_to_process]
-
-            # Perform the subtraction and splice the 0, 1, or 2 result windows
-            # back into the time_windows list
-
-            subtracted_time_windows = time_window.subtract(other_time_window)
-
-            time_windows[
-                next_time_window_index_to_process : next_time_window_index_to_process + 1
-            ] = subtracted_time_windows
-
-            if len(subtracted_time_windows) == 0:
-                # other_time_window fully consumed time_window
-                # next_time_window_index_to_process can stay the same since everything has shifted over one
-                pass
-            else:
-                updated_time_window = time_windows[next_time_window_index_to_process]
-                if updated_time_window.end <= other_time_window.start:
-                    # Current subtractor is too early to intersect, can advance
-                    next_time_window_index_to_process += 1
-                elif other_time_window.end <= updated_time_window.start:
-                    # current subtractee is too early to intersect, can advance
-                    next_other_window_index_to_process += 1
-                else:
-                    check.failed(
-                        "After subtraction, the new window should no longer intersect with the other window"
-                    )
-
-        return TimeWindowPartitionsSubset(
-            partitions_def=self.partitions_def,
-            num_partitions=None,
-            included_time_windows=time_windows,
-        )
-
-    def to_serializable_subset(self) -> "TimeWindowPartitionsSubset":
-        from dagster._core.remote_representation.external_data import (
-            external_time_window_partitions_definition_from_def,
-        )
-
-        # in cases where we're dealing with (e.g.) HourlyPartitionsDefinition, we need to convert
-        # this partitions definition into a raw TimeWindowPartitionsDefinition to make it
-        # serializable. to do this, we just convert it to its external representation and back.
-        # note that we rarely serialize subsets on the user code side of a serialization boundary,
-        # and so this conversion is rarely necessary.
-        partitions_def = self.partitions_def
-        if type(self.partitions_def) != TimeWindowPartitionsSubset:
-            partitions_def = external_time_window_partitions_definition_from_def(
-                partitions_def
-            ).get_partitions_definition()
-            return self.with_partitions_def(partitions_def)
-        return self
 
 
 class PartitionRangeStatus(Enum):
@@ -2520,7 +2311,7 @@ def _flatten(
 
 
 def fetch_flattened_time_window_ranges(
-    subsets: Mapping[PartitionRangeStatus, BaseTimeWindowPartitionsSubset],
+    subsets: Mapping[PartitionRangeStatus, TimeWindowPartitionsSubset],
 ) -> Sequence[PartitionTimeWindowStatus]:
     """Given potentially overlapping subsets, return a flattened list of timewindows where the highest priority status wins
     on overlaps.

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_time_window_partition_mapping.py
@@ -11,7 +11,7 @@ from dagster import (
     WeeklyPartitionsDefinition,
 )
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.time_window_partitions import BaseTimeWindowPartitionsSubset
+from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsSubset
 
 
 def subset_with_keys(partitions_def: TimeWindowPartitionsDefinition, keys: Sequence[str]):
@@ -788,7 +788,7 @@ def test_daily_upstream_of_yearly():
     ],
 )
 def test_downstream_partition_has_valid_upstream_partitions(
-    downstream_partitions_subset: BaseTimeWindowPartitionsSubset,
+    downstream_partitions_subset: TimeWindowPartitionsSubset,
     upstream_partitions_def: TimeWindowPartitionsDefinition,
     allow_nonexistent_upstream_partitions: bool,
     current_time: datetime,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_subset.py
@@ -15,11 +15,7 @@ from dagster import (
 from dagster._core.definitions.asset_subset import AssetSubset, ValidAssetSubset
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.partition import AllPartitionsSubset, DefaultPartitionsSubset
-from dagster._core.definitions.time_window_partitions import (
-    PartitionKeysTimeWindowPartitionsSubset,
-    TimeWindow,
-    TimeWindowPartitionsSubset,
-)
+from dagster._core.definitions.time_window_partitions import TimeWindow, TimeWindowPartitionsSubset
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._seven.compat.pendulum import create_pendulum_time
 
@@ -112,15 +108,8 @@ def test_operations(
                 ),
             ],
         ),
-        PartitionKeysTimeWindowPartitionsSubset(
-            partitions_def=DailyPartitionsDefinition("2020-01-01"),
-            included_partition_keys={
-                "2020-01-01",
-                "2020-01-04",
-                "2022-01-02",
-                "2022-01-03",
-                "2022-01-04",
-            },
+        DailyPartitionsDefinition("2020-01-01").subset_with_partition_keys(
+            ["2020-01-01", "2020-01-04", "2022-01-02", "2022-01-03", "2022-01-04"]
         ),
         DefaultPartitionsSubset(subset={"a", "b", "c", "d", "e"}),
         AllPartitionsSubset(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -10,7 +10,6 @@ from dagster import (
 )
 from dagster._core.definitions.partition import AllPartitionsSubset, DefaultPartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
-    PartitionKeysTimeWindowPartitionsSubset,
     TimeWindowPartitionsDefinition,
     TimeWindowPartitionsSubset,
 )
@@ -87,7 +86,7 @@ def test_get_subset_type():
 
 def test_empty_subsets():
     assert type(static_partitions.empty_subset()) is DefaultPartitionsSubset
-    assert type(time_window_partitions.empty_subset()) is PartitionKeysTimeWindowPartitionsSubset
+    assert type(time_window_partitions.empty_subset()) is TimeWindowPartitionsSubset
 
 
 @pytest.mark.parametrize(
@@ -180,18 +179,15 @@ def test_all_partitions_subset_time_window_partitions_def() -> None:
             time_window_partitions_def, Mock(), pendulum.now("UTC")
         )
 
-        subset = PartitionKeysTimeWindowPartitionsSubset(
-            time_window_partitions_def,
-            included_partition_keys={"2020-01-01", "2020-01-02", "2020-01-03"},
+        subset = time_window_partitions_def.subset_with_partition_keys(
+            {"2020-01-01", "2020-01-02", "2020-01-03"}
         )
         assert all_subset & subset == subset
         assert all_subset | subset == all_subset
-        assert all_subset - subset == PartitionKeysTimeWindowPartitionsSubset(
-            time_window_partitions_def, included_partition_keys={"2020-01-04", "2020-01-05"}
+        assert all_subset - subset == time_window_partitions_def.subset_with_partition_keys(
+            {"2020-01-04", "2020-01-05"}
         )
-        assert subset - all_subset == PartitionKeysTimeWindowPartitionsSubset(
-            time_window_partitions_def, included_partition_keys=set()
-        )
+        assert subset - all_subset == time_window_partitions_def.empty_subset()
 
         round_trip_subset = deserialize_value(serialize_value(all_subset.to_serializable_subset()))  # type: ignore
         assert isinstance(round_trip_subset, TimeWindowPartitionsSubset)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -20,9 +20,7 @@ from dagster import (
 )
 from dagster._check import CheckError
 from dagster._core.definitions.time_window_partitions import (
-    BaseTimeWindowPartitionsSubset,
     DatetimeFieldSerializer,
-    PartitionKeysTimeWindowPartitionsSubset,
     ScheduleType,
     TimeWindow,
     TimeWindowPartitionsSubset,
@@ -780,10 +778,6 @@ def test_start_not_aligned():
 
 
 @pytest.mark.parametrize(
-    "partitions_subset_class",
-    [PartitionKeysTimeWindowPartitionsSubset, TimeWindowPartitionsSubset],
-)
-@pytest.mark.parametrize(
     "case_str",
     [
         "+",
@@ -799,9 +793,7 @@ def test_start_not_aligned():
         "--+++---+++--",
     ],
 )
-def test_partition_subset_get_partition_keys_not_in_subset(
-    case_str: str, partitions_subset_class: BaseTimeWindowPartitionsSubset
-):
+def test_partition_subset_get_partition_keys_not_in_subset(case_str: str):
     partitions_def = DailyPartitionsDefinition(start_date="2015-01-01")
     full_set_keys = partitions_def.get_partition_keys(
         current_time=datetime(year=2015, month=1, day=30)
@@ -815,8 +807,8 @@ def test_partition_subset_get_partition_keys_not_in_subset(
             expected_keys_not_in_subset.append(full_set_keys[i])
 
     subset = cast(
-        BaseTimeWindowPartitionsSubset,
-        partitions_subset_class.empty_subset(partitions_def).with_partition_keys(subset_keys),
+        TimeWindowPartitionsSubset,
+        partitions_def.subset_with_partition_keys(subset_keys),
     )
     for partition_key in subset_keys:
         assert partition_key in subset
@@ -857,10 +849,6 @@ def test_time_partitions_subset_identical_serialization():
     assert serialized1 == serialized2
 
 
-@pytest.mark.parametrize(
-    "partitions_subset_class",
-    [PartitionKeysTimeWindowPartitionsSubset, TimeWindowPartitionsSubset],
-)
 @pytest.mark.parametrize(
     "initial, added",
     [
@@ -930,9 +918,7 @@ def test_time_partitions_subset_identical_serialization():
         ),
     ],
 )
-def test_partition_subset_with_partition_keys(
-    initial: str, added: str, partitions_subset_class: BaseTimeWindowPartitionsSubset
-):
+def test_partition_subset_with_partition_keys(initial: str, added: str):
     assert len(initial) == len(added)
     partitions_def = DailyPartitionsDefinition(start_date="2015-01-01")
     full_set_keys = partitions_def.get_partition_keys(
@@ -951,13 +937,9 @@ def test_partition_subset_with_partition_keys(
         if initial[i] != "+" and added[i] != "+":
             expected_keys_not_in_updated_subset.append(full_set_keys[i])
 
-    subset = partitions_subset_class.empty_subset(partitions_def).with_partition_keys(
-        initial_subset_keys
-    )
+    subset = partitions_def.subset_with_partition_keys(initial_subset_keys)
     assert all(partition_key in subset for partition_key in initial_subset_keys)
-    updated_subset = cast(
-        BaseTimeWindowPartitionsSubset, subset.with_partition_keys(added_subset_keys)
-    )
+    updated_subset = cast(TimeWindowPartitionsSubset, subset.with_partition_keys(added_subset_keys))
     assert all(partition_key in updated_subset for partition_key in added_subset_keys)
     assert (
         updated_subset.get_partition_keys_not_in_subset(
@@ -1535,18 +1517,24 @@ def test_cannot_pickle_time_window_partitions_def():
         pickle.loads(pickle.dumps(partitions_def))
 
 
-def test_time_window_partitions_subset_add_partition_to_front():
+def test_time_window_partitions_subset_add_partition_to_front() -> None:
     partitions_def = DailyPartitionsDefinition("2023-01-01")
-    partition_keys_subset = PartitionKeysTimeWindowPartitionsSubset(partitions_def, {"2023-01-01"})
-    time_windows_subset = TimeWindowPartitionsSubset(
+    a_subset = TimeWindowPartitionsSubset(
+        partitions_def,
+        num_partitions=None,
+        included_time_windows=[time_window("2023-01-01", "2023-01-02")],
+    )
+    b_subset = TimeWindowPartitionsSubset(
         partitions_def,
         num_partitions=1,
         included_time_windows=[time_window("2023-01-02", "2023-01-03")],
     )
 
-    combined = time_windows_subset | partition_keys_subset
-    assert combined == PartitionKeysTimeWindowPartitionsSubset(
-        partitions_def, {"2023-01-01", "2023-01-02"}
+    combined = a_subset | b_subset
+    assert combined == TimeWindowPartitionsSubset(
+        partitions_def,
+        num_partitions=2,
+        included_time_windows=[time_window("2023-01-01", "2023-01-03")],
     )
 
 


### PR DESCRIPTION
## Summary & Motivation

This class was created to make up for the fact that we had no efficient way of doing basic set operations efficiently on time-window-based subsets. We've since fixed these issues, and now the behavior of by, default, calling `my_time_partitions_def.subset_with_partition_keys(...)` returning a PartitionKeysTimeWindowPartitionsSubset is a performance liability, as it means that it will result in slow operations when used against TimeWindowPartitionsSubsets. Removing this class entirely greatly simplifies the mental model here.

Note that this means we can also remove the BaseTimeWindowPartitionsSubset class, I just wanted to keep this PR a bit smaller, so I'll do that in a follow up.


## How I Tested These Changes
