### PR TITLE
[ui] Show materialization status for External Assets

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
@@ -21,6 +21,7 @@ export type AssetNodeMenuNode = {
   assetKey: AssetKeyInput;
   definition: {
     isSource: boolean;
+    isObservable: boolean;
     isExecutable: boolean;
     hasMaterializePermission: boolean;
   };
@@ -63,7 +64,7 @@ export const useAssetNodeMenu = ({
 
   const {liveData} = useAssetBaseData(node.assetKey, 'context-menu');
 
-  const isSource = node.definition.isSource;
+  const isObservable = node.definition.isObservable;
   const lastMaterializationRunID = liveData?.lastMaterialization?.runId;
   const lastObservationID = liveData?.lastObservation?.runId;
 
@@ -82,7 +83,7 @@ export const useAssetNodeMenu = ({
             to={`/runs/${lastMaterializationRunID || lastObservationID}`}
             text={
               <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-                View latest {isSource ? 'observation' : 'materialization'}
+                View latest {isObservable ? 'observation' : 'materialization'}
                 {liveData ? null : <Spinner purpose="caption-text" />}
               </Box>
             }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeStatusContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeStatusContent.tsx
@@ -62,7 +62,7 @@ export function buildAssetNodeStatusContent({
   liveData,
   expanded,
 }: StatusContentArgs) {
-  return definition.isSource
+  return definition.isObservable
     ? _buildSourceAssetNodeStatusContent({
         assetKey,
         definition,
@@ -397,6 +397,15 @@ export function _buildAssetNodeStatusContent({
           )}
         </>
       ),
+    };
+  }
+
+  if (!lastMaterialization && definition.isSource) {
+    return {
+      case: StatusCase.SOURCE_NO_STATE as const,
+      background: Colors.backgroundLight(),
+      border: Colors.borderDefault(),
+      content: <span>–</span>,
     };
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -116,7 +116,7 @@ export const SidebarAssetInfo = ({graphNode}: {graphNode: GraphNode}) => {
         asset={asset}
         assetLastMaterializedAt={lastMaterialization?.timestamp}
         recentEvents={recentEvents}
-        isSourceAsset={definition.isSource}
+        isObservable={definition.isObservable}
         stepKey={stepKeyForAsset(definition)}
         liveData={liveData}
       />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetActionMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetActionMenu.tsx
@@ -93,7 +93,7 @@ export const AssetActionMenu = (props: Props) => {
 export const useExecuteAssetMenuItem = (
   path: string[],
   definition: {
-    isSource: boolean;
+    isObservable: boolean;
     isExecutable: boolean;
     hasMaterializePermission: boolean;
   } | null,
@@ -113,7 +113,7 @@ export const useExecuteAssetMenuItem = (
     return {executeItem: null, launchpadElement: null};
   }
 
-  if (definition?.isExecutable && definition.isSource && definition.hasMaterializePermission) {
+  if (definition?.isExecutable && definition.isObservable && definition.hasMaterializePermission) {
     return {
       launchpadElement: null,
       executeItem: (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -128,7 +128,9 @@ export const AssetNodeOverview = ({
     <Box flex={{direction: 'column', gap: 16}}>
       <Box style={{display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))'}}>
         <Box flex={{direction: 'column', gap: 6}}>
-          <Subtitle2>Latest {assetNode?.isSource ? 'observation' : 'materialization'}</Subtitle2>
+          <Subtitle2>
+            Latest {assetNode?.isObservable ? 'observation' : 'materialization'}
+          </Subtitle2>
           <Box flex={{gap: 8, alignItems: 'center'}}>
             {liveData ? (
               <SimpleStakeholderAssetStatus liveData={liveData} assetNode={assetNode} />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetSidebarActivitySummary.tsx
@@ -20,7 +20,7 @@ import {SidebarSection} from '../pipelines/SidebarComponents';
 interface Props {
   asset: SidebarAssetFragment;
   liveData?: LiveDataForNodeWithStaleData;
-  isSourceAsset: boolean;
+  isObservable: boolean;
   stepKey: string;
   recentEvents: RecentAssetEvents;
 
@@ -32,7 +32,7 @@ interface Props {
 export const AssetSidebarActivitySummary = ({
   asset,
   assetLastMaterializedAt,
-  isSourceAsset,
+  isObservable,
   liveData,
   stepKey,
   recentEvents,
@@ -41,7 +41,7 @@ export const AssetSidebarActivitySummary = ({
     recentEvents;
 
   const grouped = useGroupedEvents(xAxis, materializations, observations, loadedPartitionKeys);
-  const displayedEvent = isSourceAsset ? observations[0] : materializations[0];
+  const displayedEvent = isObservable ? observations[0] : materializations[0];
 
   useEffect(() => {
     refetch();
@@ -93,7 +93,7 @@ export const AssetSidebarActivitySummary = ({
 
       {loadedPartitionKeys.length > 1 ? null : (
         <>
-          <SidebarSection title={!isSourceAsset ? 'Latest materialization' : 'Latest observation'}>
+          <SidebarSection title={!isObservable ? 'Latest materialization' : 'Latest observation'}>
             {displayedEvent ? (
               <div style={{margin: -1, maxWidth: '100%', overflowX: 'auto'}}>
                 <LatestMaterializationMetadata
@@ -112,12 +112,12 @@ export const AssetSidebarActivitySummary = ({
                 margin={{horizontal: 24, vertical: 12}}
                 style={{color: Colors.textLight(), fontSize: '0.8rem'}}
               >
-                {!isSourceAsset ? `No materializations found` : `No observations found`}
+                {!isObservable ? `No materializations found` : `No observations found`}
               </Box>
             )}
           </SidebarSection>
           <SidebarSection
-            title={!isSourceAsset ? 'Materialization tags' : 'Observation tags'}
+            title={!isObservable ? 'Materialization tags' : 'Observation tags'}
             collapsedByDefault
           >
             {displayedEvent ? (
@@ -133,7 +133,7 @@ export const AssetSidebarActivitySummary = ({
                 margin={{horizontal: 24, vertical: 12}}
                 style={{color: Colors.textLight(), fontSize: '0.8rem'}}
               >
-                {!isSourceAsset ? `No materializations found` : `No observations found`}
+                {!isObservable ? `No materializations found` : `No observations found`}
               </Box>
             )}
           </SidebarSection>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -91,14 +91,14 @@ type Asset =
       hasMaterializePermission: boolean;
       partitionDefinition: {__typename: string} | null;
       isExecutable: boolean;
-      isSource: boolean;
+      isObservable: boolean;
     }
   | {
       assetKey: AssetKey;
       hasMaterializePermission: boolean;
       isPartitioned: boolean;
       isExecutable: boolean;
-      isSource: boolean;
+      isObservable: boolean;
     };
 
 export type AssetsInScope = {all: Asset[]; skipAllTerm?: boolean} | {selected: Asset[]};
@@ -125,7 +125,7 @@ function optionsForButton(scope: AssetsInScope): LaunchOption[] {
   // If you pass a set of selected assets, we always show just one option
   // to materialize that selection.
   if ('selected' in scope) {
-    const executable = scope.selected.filter((a) => !a.isSource && a.isExecutable);
+    const executable = scope.selected.filter((a) => !a.isObservable && a.isExecutable);
 
     return [
       {
@@ -138,7 +138,7 @@ function optionsForButton(scope: AssetsInScope): LaunchOption[] {
   }
 
   const options: LaunchOption[] = [];
-  const executable = scope.all.filter((a) => !a.isSource && a.isExecutable);
+  const executable = scope.all.filter((a) => !a.isObservable && a.isExecutable);
 
   options.push({
     assetKeys: executable.map((a) => a.assetKey),
@@ -152,15 +152,19 @@ function optionsForButton(scope: AssetsInScope): LaunchOption[] {
 }
 
 export function executionDisabledMessageForAssets(
-  assets: {isSource: boolean; isExecutable: boolean; hasMaterializePermission: boolean}[],
+  assets: {
+    isObservable: boolean;
+    isExecutable: boolean;
+    hasMaterializePermission: boolean;
+  }[],
 ) {
   if (!assets.length) {
     return null;
   }
   return assets.some((a) => !a.hasMaterializePermission)
     ? 'You do not have permission to materialize assets'
-    : assets.every((a) => a.isSource)
-    ? 'Source assets cannot be materialized'
+    : assets.every((a) => a.isObservable)
+    ? 'Observable assets cannot be materialized'
     : assets.every((a) => !a.isExecutable)
     ? 'External assets cannot be materialized'
     : null;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -445,10 +445,10 @@ async function stateForLaunchingAssets(
   forceLaunchpad: boolean,
   preferredJobName?: string,
 ): Promise<LaunchAssetsState> {
-  if (assets.some((x) => x.isSource)) {
+  if (assets.some((x) => x.isObservable)) {
     return {
       type: 'error',
-      error: 'One or more source assets are selected and cannot be materialized.',
+      error: 'One or more observable assets are selected and cannot be materialized.',
     };
   }
   if (assets.some((x) => !x.isExecutable)) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
@@ -131,7 +131,7 @@ export const RecentUpdatesTimeline = ({
     return (
       <Box flex={{direction: 'column', gap: 8}}>
         <Subtitle2>Recent updates</Subtitle2>
-        <Caption color={Colors.textLight()}>No materialization events found</Caption>
+        <Caption color={Colors.textLighter()}>No materialization events found</Caption>
       </Box>
     );
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/SimpleStakeholderAssetStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/SimpleStakeholderAssetStatus.tsx
@@ -62,7 +62,7 @@ export const SimpleStakeholderAssetStatus = ({
       />
     );
   }
-  if (liveData.lastObservation && assetNode.isSource) {
+  if (liveData.lastObservation && assetNode.isObservable) {
     return (
       <Tag intent="none">
         <Timestamp timestamp={{ms: Number(liveData.lastObservation.timestamp)}} />
@@ -72,7 +72,7 @@ export const SimpleStakeholderAssetStatus = ({
 
   return (
     <Caption color={Colors.textLighter()}>
-      {assetNode.isSource ? 'Never observed' : 'Never materialized'}
+      {assetNode.isObservable ? 'Never observed' : 'Never materialized'}
     </Caption>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
@@ -132,6 +132,7 @@ export const UNPARTITIONED_SOURCE_ASSET = buildAssetNode({
   ...UNPARTITIONED_ASSET,
   id: 'test.py.repo.["unpartitioned_source_asset"]',
   isSource: true,
+  isObservable: true,
   assetKey: buildAssetKey({path: ['unpartitioned_source_asset']}),
 });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -111,7 +111,7 @@ describe('LaunchAssetExecutionButton', () => {
       );
     });
 
-    it('should be disabled if the entire selection is source assets', async () => {
+    it('should be disabled if the entire selection is observable assets', async () => {
       renderButton({
         scope: {selected: [UNPARTITIONED_SOURCE_ASSET]},
       });
@@ -119,7 +119,7 @@ describe('LaunchAssetExecutionButton', () => {
       expect(button).toBeDisabled();
 
       userEvent.hover(button);
-      expect(await screen.findByText('Source assets cannot be materialized')).toBeDefined();
+      expect(await screen.findByText('Observable assets cannot be materialized')).toBeDefined();
     });
   });
 


### PR DESCRIPTION
## Summary & Motivation

This PR is a fix for FE-365 (https://linear.app/dagster-labs/issue/FE-365/report-event-is-creating-materialization-events-on-external-assets) and reflects this goal:

Assets with isObservable=true should show "Last Observation", and allow you to click "Observe". All other assets should show materialization state. 

To date, we've used `isSource` in a lot of these places when we meant `isObservable`.

Note: Work here is likely not done. We still use `isSource` in places where we mean `isExecutable`, and there are places in the UI (screenshot below) we refer to "Source asset". We may need to take a tour through the remaining callsites on a quiet(er) day.

## How I Tested These Changes

I created a source asset (below) with a materialization, and verified that I now see the materialization oriented stats. I also verified that for `observable_source_assets`, I still see "Last Observation", etc.

![image](https://github.com/dagster-io/dagster/assets/1037212/95b9d0b9-e806-4bc7-835a-de32dd1a26a8)
![image](https://github.com/dagster-io/dagster/assets/1037212/37e22506-7807-430e-99b6-ab1b7bb18535)
