### PR TITLE
Add command and flag examples to dbt reference

### DIFF
--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -233,7 +233,8 @@ daily_dbt_assets_schedule = build_schedule_from_dbt_selection(
     job_name="daily_dbt_models",
     cron_schedule="@daily",
     dbt_select="tag:daily",
-    config=RunConfig(ops={"my_dbt_assets": MyDbtConfig(full_refresh=True)}),
+    # If your definition of `@dbt_assets` has Dagster Configuration, you can specify it here.
+    # config=RunConfig(ops={"my_dbt_assets": MyDbtConfig(full_refresh=True)}),
 )
 ```
 

--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -125,7 +125,7 @@ In production, `DAGSTER_DBT_PARSE_PROJECT_ON_LOAD` should be unset so that your 
 
 ## Using config with `@dbt_assets`
 
-Like for a standard \[software-defined asset], `@dbt_assets` can use a config system to enable [run configuration](/concepts/configuration/config-schema#run-configuration). This allows to provide parameters to jobs at the time they're executed.
+Like for a standard \[software-defined asset], `@dbt_assets` can use a config system to enable [run configuration](/concepts/configuration/config-schema). This allows to provide parameters to jobs at the time they're executed.
 
 In the context of dbt, this can be useful if you want to run commands or flags for specific use cases. For instance, you may want to run [dbt seed](https://docs.getdbt.com/reference/commands/seed) or add [the --full-refresh flag](https://docs.getdbt.com/reference/resource-configs/full_refresh) to your dbt commands in some cases. Using a config system, the `@dbt_assets` object can be easily modified to support this use case.
 
@@ -139,12 +139,8 @@ from dagster_dbt import (
     dbt_assets,
 )
 
-RELATIVE_PATH_TO_MY_DBT_PROJECT = "./gitlab-jaffle-shop-test"
-
 my_project = DbtProject(
-    project_dir=Path(__file__)
-    .joinpath("..", RELATIVE_PATH_TO_MY_DBT_PROJECT)
-    .resolve(),
+    project_dir=Path(__file__).joinpath("..", "./path/to/my-dbt-project").resolve(),
 )
 
 class MyDbtConfig(Config):

--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -125,24 +125,36 @@ In production, `DAGSTER_DBT_PARSE_PROJECT_ON_LOAD` should be unset so that your 
 
 ## Using config with your `@dbt_assets`
 
-Like for a standard [software-defined asset], your `@dbt_assets` can use a config system to enable [run configuration](/concepts/configuration/config-schema#run-configuration). This allows to provide parameters to jobs at the time they're executed.deployment
+Like for a standard \[software-defined asset], your `@dbt_assets` can use a config system to enable [run configuration](/concepts/configuration/config-schema#run-configuration). This allows to provide parameters to jobs at the time they're executed.
 
-In the context of dbt, this can be useful if you want to run commands or flags for specific use cases.
+In the context of dbt, this can be useful if you want to run commands or flags for specific use cases. For instance, you may want to run [dbt seed](https://docs.getdbt.com/reference/commands/seed) or add [the --full-refresh flag](https://docs.getdbt.com/reference/resource-configs/full_refresh) to your dbt commands in some cases. Using a config system, the `@dbt_assets` object can be easily modified to support this use case.
 
-```python dedent=4
-from dagster import asset, Config
-from dagster_dbt import dbt_assets
+```python startafter=start_config_dbt_assets endbefore=end_config_dbt_assets file=/integrations/dbt/dbt.py dedent=4
+from pathlib import Path
 
-...
+from dagster import AssetExecutionContext, Config
+from dagster_dbt import (
+    DbtCliResource,
+    DbtProject,
+    dbt_assets,
+)
+
+RELATIVE_PATH_TO_MY_DBT_PROJECT = "./gitlab-jaffle-shop-test"
+
+my_project = DbtProject(
+    project_dir=Path(__file__)
+    .joinpath("..", RELATIVE_PATH_TO_MY_DBT_PROJECT)
+    .resolve(),
+)
 
 class MyDbtConfig(Config):
     full_refresh: bool
     seed: bool
 
-
 @dbt_assets(manifest=my_project.manifest_path)
-def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource, config: MyDbtConfig):
-
+def my_dbt_assets(
+    context: AssetExecutionContext, dbt: DbtCliResource, config: MyDbtConfig
+):
     commands = ["build"]
 
     if config.full_refresh:
@@ -151,19 +163,42 @@ def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource, config: M
         dbt.cli(["seed"]).wait()
 
     yield from dbt.cli(commands, context=context).stream()
+```
 
+Now that the `@dbt_assets` object is updated, the run configuration can be passed to a job.
 
-my_dbt_assets_schedule = build_schedule_from_dbt_selection(
-    [my_dbt_assets],
-    job_name="all_dbt_assets",
-    cron_schedule="0 0 * * *",
-    dbt_select="fqn:*",
+```python startafter=start_config_dbt_job endbefore=end_config_dbt_job file=/integrations/dbt/dbt.py dedent=4
+from dagster import RunConfig, define_asset_job
+from dagster_dbt import build_dbt_asset_selection
+
+my_job = define_asset_job(
+    name="all_dbt_assets",
+    selection=build_dbt_asset_selection(
+        [my_dbt_assets],
+    ),
     config=RunConfig(
-        ops={"my_dbt_asset": MyDbtConfig(full_refresh=True, seed=True)}
-    )
+        ops={"my_dbt_assets": MyDbtConfig(full_refresh=True, seed=True)}
+    ),
 )
 ```
 
+In the example above, the job is configured to use both the `dbt seed` command and the `--full-refresh` flag with the dbt build command when materializing the assets.
+
+If this job should be run with this configuration only at specific moment, a schedule can be created instead. In the context of dbt, using the `build_schedule_from_dbt_selection` function allows to create both the schedule and job definitions at the same time.
+
+```python startafter=start_config_dbt_schedule endbefore=end_config_dbt_schedule file=/integrations/dbt/dbt.py dedent=4
+from dagster import RunConfig
+from dagster_dbt import build_schedule_from_dbt_selection
+
+my_schedule = build_schedule_from_dbt_selection(
+    [my_dbt_assets],
+    job_name="all_dbt_assets",
+    cron_schedule="0 0 * * *",
+    config=RunConfig(
+        ops={"my_dbt_assets": MyDbtConfig(full_refresh=True, seed=True)}
+    ),
+)
+```
 
 ---
 

--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -123,6 +123,50 @@ In production, `DAGSTER_DBT_PARSE_PROJECT_ON_LOAD` should be unset so that your 
 
 ---
 
+## Using config with your `@dbt_assets`
+
+Like for a standard [software-defined asset], your `@dbt_assets` can use a config system to enable [run configuration](/concepts/configuration/config-schema#run-configuration). This allows to provide parameters to jobs at the time they're executed.deployment
+
+In the context of dbt, this can be useful if you want to run commands or flags for specific use cases.
+
+```python dedent=4
+from dagster import asset, Config
+from dagster_dbt import dbt_assets
+
+...
+
+class MyDbtConfig(Config):
+    full_refresh: bool
+    seed: bool
+
+
+@dbt_assets(manifest=my_project.manifest_path)
+def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource, config: MyDbtConfig):
+
+    commands = ["build"]
+
+    if config.full_refresh:
+        commands.append("--full-refresh")
+    if config.seed:
+        dbt.cli(["seed"]).wait()
+
+    yield from dbt.cli(commands, context=context).stream()
+
+
+my_dbt_assets_schedule = build_schedule_from_dbt_selection(
+    [my_dbt_assets],
+    job_name="all_dbt_assets",
+    cron_schedule="0 0 * * *",
+    dbt_select="fqn:*",
+    config=RunConfig(
+        ops={"my_dbt_asset": MyDbtConfig(full_refresh=True, seed=True)}
+    )
+)
+```
+
+
+---
+
 ## Deploying a Dagster project with a dbt project
 
 <Note>

--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -123,9 +123,9 @@ In production, `DAGSTER_DBT_PARSE_PROJECT_ON_LOAD` should be unset so that your 
 
 ---
 
-## Using config with your `@dbt_assets`
+## Using config with `@dbt_assets`
 
-Like for a standard \[software-defined asset], your `@dbt_assets` can use a config system to enable [run configuration](/concepts/configuration/config-schema#run-configuration). This allows to provide parameters to jobs at the time they're executed.
+Like for a standard \[software-defined asset], `@dbt_assets` can use a config system to enable [run configuration](/concepts/configuration/config-schema#run-configuration). This allows to provide parameters to jobs at the time they're executed.
 
 In the context of dbt, this can be useful if you want to run commands or flags for specific use cases. For instance, you may want to run [dbt seed](https://docs.getdbt.com/reference/commands/seed) or add [the --full-refresh flag](https://docs.getdbt.com/reference/resource-configs/full_refresh) to your dbt commands in some cases. Using a config system, the `@dbt_assets` object can be easily modified to support this use case.
 

--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -123,81 +123,6 @@ In production, `DAGSTER_DBT_PARSE_PROJECT_ON_LOAD` should be unset so that your 
 
 ---
 
-## Using config with `@dbt_assets`
-
-Like for a standard \[software-defined asset], `@dbt_assets` can use a config system to enable [run configuration](/concepts/configuration/config-schema). This allows to provide parameters to jobs at the time they're executed.
-
-In the context of dbt, this can be useful if you want to run commands or flags for specific use cases. For instance, you may want to run [dbt seed](https://docs.getdbt.com/reference/commands/seed) or add [the --full-refresh flag](https://docs.getdbt.com/reference/resource-configs/full_refresh) to your dbt commands in some cases. Using a config system, the `@dbt_assets` object can be easily modified to support this use case.
-
-```python startafter=start_config_dbt_assets endbefore=end_config_dbt_assets file=/integrations/dbt/dbt.py dedent=4
-from pathlib import Path
-
-from dagster import AssetExecutionContext, Config
-from dagster_dbt import (
-    DbtCliResource,
-    DbtProject,
-    dbt_assets,
-)
-
-my_project = DbtProject(
-    project_dir=Path(__file__).joinpath("..", "./path/to/my-dbt-project").resolve(),
-)
-
-class MyDbtConfig(Config):
-    full_refresh: bool
-    seed: bool
-
-@dbt_assets(manifest=my_project.manifest_path)
-def my_dbt_assets(
-    context: AssetExecutionContext, dbt: DbtCliResource, config: MyDbtConfig
-):
-    commands = ["build"]
-
-    if config.full_refresh:
-        commands.append("--full-refresh")
-    if config.seed:
-        dbt.cli(["seed"]).wait()
-
-    yield from dbt.cli(commands, context=context).stream()
-```
-
-Now that the `@dbt_assets` object is updated, the run configuration can be passed to a job.
-
-```python startafter=start_config_dbt_job endbefore=end_config_dbt_job file=/integrations/dbt/dbt.py dedent=4
-from dagster import RunConfig, define_asset_job
-from dagster_dbt import build_dbt_asset_selection
-
-my_job = define_asset_job(
-    name="all_dbt_assets",
-    selection=build_dbt_asset_selection(
-        [my_dbt_assets],
-    ),
-    config=RunConfig(
-        ops={"my_dbt_assets": MyDbtConfig(full_refresh=True, seed=True)}
-    ),
-)
-```
-
-In the example above, the job is configured to use both the `dbt seed` command and the `--full-refresh` flag with the dbt build command when materializing the assets.
-
-If this job should be run with this configuration only at specific moment, a schedule can be created instead. In the context of dbt, using the `build_schedule_from_dbt_selection` function allows to create both the schedule and job definitions at the same time.
-
-```python startafter=start_config_dbt_schedule endbefore=end_config_dbt_schedule file=/integrations/dbt/dbt.py dedent=4
-from dagster import RunConfig
-from dagster_dbt import build_schedule_from_dbt_selection
-
-my_schedule = build_schedule_from_dbt_selection(
-    [my_dbt_assets],
-    job_name="all_dbt_assets",
-    cron_schedule="0 0 * * *",
-    config=RunConfig(
-        ops={"my_dbt_assets": MyDbtConfig(full_refresh=True, seed=True)}
-    ),
-)
-```
-
----
-
 ## Deploying a Dagster project with a dbt project
 
 <Note>
@@ -242,6 +167,53 @@ In your CI/CD workflows for your Dagster and dbt project:
 
 ---
 
+## Using config with `@dbt_assets`
+
+Like for a standard \[software-defined asset], `@dbt_assets` can use a config system to enable [run configuration](/concepts/configuration/config-schema). This allows to provide parameters to jobs at the time they're executed.
+
+In the context of dbt, this can be useful if you want to run commands or flags for specific use cases. For instance, you may want to add [the --full-refresh flag](https://docs.getdbt.com/reference/resource-configs/full_refresh) to your dbt commands in some cases. Using a config system, the `@dbt_assets` object can be easily modified to support this use case.
+
+```python startafter=start_config_dbt_assets endbefore=end_config_dbt_assets file=/integrations/dbt/dbt.py dedent=4
+from pathlib import Path
+
+from dagster import AssetExecutionContext, Config
+from dagster_dbt import DbtCliResource, dbt_assets
+
+class MyDbtConfig(Config):
+    full_refresh: bool
+
+@dbt_assets(manifest=Path("target", "manifest.json"))
+def my_dbt_assets(
+    context: AssetExecutionContext, dbt: DbtCliResource, config: MyDbtConfig
+):
+    dbt_build_args = ["build"]
+    if config.full_refresh:
+        dbt_build_args += ["--full-refresh"]
+
+    yield from dbt.cli(dbt_build_args, context=context).stream()
+```
+
+Now that the `@dbt_assets` object is updated, the run configuration can be passed to a job.
+
+```python startafter=start_config_dbt_job endbefore=end_config_dbt_job file=/integrations/dbt/dbt.py dedent=4
+from dagster import RunConfig, define_asset_job
+from dagster_dbt import build_dbt_asset_selection
+
+my_job = define_asset_job(
+    name="all_dbt_assets",
+    selection=build_dbt_asset_selection(
+        [my_dbt_assets],
+    ),
+    config=RunConfig(
+        ops={"my_dbt_assets": MyDbtConfig(full_refresh=True, seed=True)}
+    ),
+)
+```
+
+In the example above, the job is configured to use the `--full-refresh` flag with the dbt build command when materializing the assets.
+
+---
+
 ## Scheduling dbt jobs
 
 Once you have your dbt assets, you can define a job to materialize a selection of these assets on a schedule.
@@ -261,6 +233,7 @@ daily_dbt_assets_schedule = build_schedule_from_dbt_selection(
     job_name="daily_dbt_models",
     cron_schedule="@daily",
     dbt_select="tag:daily",
+    config=RunConfig(ops={"my_dbt_assets": MyDbtConfig(full_refresh=True)}),
 )
 ```
 

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -377,11 +377,9 @@ def scope_config_dbt_assets():
         dbt_assets,
     )
 
-    RELATIVE_PATH_TO_MY_DBT_PROJECT = "./my-dbt-project"
-
     my_project = DbtProject(
         project_dir=Path(__file__)
-        .joinpath("..", RELATIVE_PATH_TO_MY_DBT_PROJECT)
+        .joinpath("..", "./path/to/my-dbt-project")
         .resolve(),
     )
 

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -409,18 +409,3 @@ def scope_config_dbt_assets():
     )
 
     # end_config_dbt_job
-
-    # start_config_dbt_schedule
-    from dagster import RunConfig
-    from dagster_dbt import build_schedule_from_dbt_selection
-
-    my_schedule = build_schedule_from_dbt_selection(
-        [my_dbt_assets],
-        job_name="all_dbt_assets",
-        cron_schedule="0 0 * * *",
-        config=RunConfig(
-            ops={"my_dbt_assets": MyDbtConfig(full_refresh=True, seed=True)}
-        ),
-    )
-
-    # end_config_dbt_schedule

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -30,6 +30,11 @@ def scope_compile_dbt_manifest(manifest):
 
 
 def scope_schedule_assets_dbt_only(manifest):
+    from dagster import Config, RunConfig
+
+    class MyDbtConfig(Config):
+        full_refresh: bool
+
     # start_schedule_assets_dbt_only
     from dagster_dbt import build_schedule_from_dbt_selection, dbt_assets
 
@@ -41,6 +46,7 @@ def scope_schedule_assets_dbt_only(manifest):
         job_name="daily_dbt_models",
         cron_schedule="@daily",
         dbt_select="tag:daily",
+        config=RunConfig(ops={"my_dbt_assets": MyDbtConfig(full_refresh=True)}),
     )
     # end_schedule_assets_dbt_only
 
@@ -371,32 +377,20 @@ def scope_config_dbt_assets():
     from pathlib import Path
 
     from dagster import AssetExecutionContext, Config
-    from dagster_dbt import (
-        DbtCliResource,
-        DbtProject,
-        dbt_assets,
-    )
-
-    my_project = DbtProject(
-        project_dir=Path(__file__).joinpath("..", "./path/to/my-dbt-project").resolve(),
-    )
+    from dagster_dbt import DbtCliResource, dbt_assets
 
     class MyDbtConfig(Config):
         full_refresh: bool
-        seed: bool
 
-    @dbt_assets(manifest=my_project.manifest_path)
+    @dbt_assets(manifest=Path("target", "manifest.json"))
     def my_dbt_assets(
         context: AssetExecutionContext, dbt: DbtCliResource, config: MyDbtConfig
     ):
-        commands = ["build"]
-
+        dbt_build_args = ["build"]
         if config.full_refresh:
-            commands.append("--full-refresh")
-        if config.seed:
-            dbt.cli(["seed"]).wait()
+            dbt_build_args += ["--full-refresh"]
 
-        yield from dbt.cli(commands, context=context).stream()
+        yield from dbt.cli(dbt_build_args, context=context).stream()
 
     # end_config_dbt_assets
 

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -377,7 +377,7 @@ def scope_config_dbt_assets():
         dbt_assets,
     )
 
-    RELATIVE_PATH_TO_MY_DBT_PROJECT = "./gitlab-jaffle-shop-test"
+    RELATIVE_PATH_TO_MY_DBT_PROJECT = "./my-dbt-project"
 
     my_project = DbtProject(
         project_dir=Path(__file__)

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -46,7 +46,8 @@ def scope_schedule_assets_dbt_only(manifest):
         job_name="daily_dbt_models",
         cron_schedule="@daily",
         dbt_select="tag:daily",
-        config=RunConfig(ops={"my_dbt_assets": MyDbtConfig(full_refresh=True)}),
+        # If your definition of `@dbt_assets` has Dagster Configuration, you can specify it here.
+        # config=RunConfig(ops={"my_dbt_assets": MyDbtConfig(full_refresh=True)}),
     )
     # end_schedule_assets_dbt_only
 

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -378,9 +378,7 @@ def scope_config_dbt_assets():
     )
 
     my_project = DbtProject(
-        project_dir=Path(__file__)
-        .joinpath("..", "./path/to/my-dbt-project")
-        .resolve(),
+        project_dir=Path(__file__).joinpath("..", "./path/to/my-dbt-project").resolve(),
     )
 
     class MyDbtConfig(Config):


### PR DESCRIPTION
## Summary & Motivation

This PR fixes DS-253 by adding examples on how configuring @dbt_assets for different use cases. Running an additional dbt command and flag is covered.

## How I Tested These Changes

Doc preview
Code snippets tested locally
