### PR TITLE
[ui] Show a run timeline on backfill details pages

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
@@ -1,29 +1,29 @@
-import {gql, useApolloClient, useQuery} from '@apollo/client';
+import {gql, useQuery} from '@apollo/client';
 import {
+  Alert,
   Box,
-  ButtonLink,
   Colors,
   Heading,
   NonIdealState,
   Page,
   PageHeader,
   Spinner,
-  Table,
-  Tag,
+  Tab,
+  Tabs,
 } from '@dagster-io/ui-components';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import {useEffect, useReducer} from 'react';
-import {Link, useHistory, useParams} from 'react-router-dom';
+import {Link, useParams} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {BACKFILL_ACTIONS_BACKFILL_FRAGMENT, BackfillActionsMenu} from './BackfillActionsMenu';
+import {BackfillPartitionsTab} from './BackfillPartitionsTab';
+import {BackfillRunsTab} from './BackfillRunsTab';
 import {BackfillStatusTagForPage} from './BackfillStatusTagForPage';
 import {TargetPartitionsDisplay} from './TargetPartitionsDisplay';
 import {
-  BackfillPartitionsForAssetKeyQuery,
-  BackfillPartitionsForAssetKeyQueryVariables,
   BackfillStatusesByAssetQuery,
   BackfillStatusesByAssetQueryVariables,
 } from './types/BackfillPage.types';
@@ -32,25 +32,24 @@ import {PythonErrorInfo} from '../../app/PythonErrorInfo';
 import {QueryRefreshCountdown, useQueryRefreshAtInterval} from '../../app/QueryRefresh';
 import {useTrackPageView} from '../../app/analytics';
 import {Timestamp} from '../../app/time/Timestamp';
-import {tokenForAssetKey} from '../../asset-graph/Utils';
-import {asAssetKeyInput} from '../../assets/asInput';
-import {assetDetailsPathForKey} from '../../assets/assetDetailsPathForKey';
-import {AssetViewParams} from '../../assets/types';
-import {AssetKey, BulkActionStatus, RunStatus} from '../../graphql/types';
+import {BulkActionStatus} from '../../graphql/types';
 import {useDocumentTitle} from '../../hooks/useDocumentTitle';
+import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
 import {useBlockTraceOnQueryResult} from '../../performance/TraceContext';
-import {RunFilterToken, runsPathWithFilters} from '../../runs/RunsFilterInput';
 import {testId} from '../../testing/testId';
 
 dayjs.extend(duration);
 dayjs.extend(relativeTime);
 
 export const BackfillPage = () => {
-  const client = useApolloClient();
-  const history = useHistory();
   const {backfillId} = useParams<{backfillId: string}>();
   useTrackPageView();
   useDocumentTitle(`Backfill | ${backfillId}`);
+
+  const [selectedTab, setSelectedTab] = useQueryPersistedState({
+    queryKey: 'tab',
+    defaults: {tab: 'partitions'},
+  });
 
   const queryResult = useQuery<BackfillStatusesByAssetQuery, BackfillStatusesByAssetQueryVariables>(
     BACKFILL_DETAILS_QUERY,
@@ -58,7 +57,7 @@ export const BackfillPage = () => {
   );
   useBlockTraceOnQueryResult(queryResult, 'BackfillStatusesByAssetQuery');
 
-  const {data} = queryResult;
+  const {data, error} = queryResult;
 
   const backfill =
     data?.partitionBackfillOrError.__typename === 'PartitionBackfill'
@@ -88,81 +87,6 @@ export const BackfillPage = () => {
     }
 
     const backfill = data.partitionBackfillOrError;
-
-    function getRunsUrl(status: 'inProgress' | 'complete' | 'failed' | 'targeted') {
-      const filters: RunFilterToken[] = [
-        {
-          token: 'tag',
-          value: `dagster/backfill=${backfillId}`,
-        },
-      ];
-      switch (status) {
-        case 'inProgress':
-          filters.push(
-            {
-              token: 'status',
-              value: RunStatus.STARTED,
-            },
-            {
-              token: 'status',
-              value: RunStatus.QUEUED,
-            },
-            {
-              token: 'status',
-              value: RunStatus.STARTING,
-            },
-            {
-              token: 'status',
-              value: RunStatus.CANCELING,
-            },
-            {
-              token: 'status',
-              value: RunStatus.NOT_STARTED,
-            },
-          );
-          break;
-        case 'complete':
-          filters.push({
-            token: 'status',
-            value: RunStatus.SUCCESS,
-          });
-          break;
-        case 'failed':
-          filters.push({
-            token: 'status',
-            value: RunStatus.FAILURE,
-          });
-          filters.push({
-            token: 'status',
-            value: RunStatus.CANCELED,
-          });
-          break;
-      }
-      return runsPathWithFilters(filters);
-    }
-
-    const onShowAssetDetails = async (assetKey: AssetKey, isPartitioned: boolean) => {
-      let params: AssetViewParams = {};
-
-      if (isPartitioned) {
-        const resp = await client.query<
-          BackfillPartitionsForAssetKeyQuery,
-          BackfillPartitionsForAssetKeyQueryVariables
-        >({
-          query: BACKFILL_PARTITIONS_FOR_ASSET_KEY_QUERY,
-          variables: {backfillId, assetKey: asAssetKeyInput(assetKey)},
-        });
-        const data =
-          resp.data.partitionBackfillOrError.__typename === 'PartitionBackfill'
-            ? resp.data.partitionBackfillOrError.partitionsTargetedForAssetKey
-            : null;
-
-        if (data && data.ranges?.length) {
-          params = {default_range: data.ranges.map((r) => `[${r.start}...${r.end}]`).join(',')};
-        }
-      }
-      return history.push(assetDetailsPathForKey(assetKey, params));
-    };
 
     return (
       <>
@@ -205,98 +129,18 @@ export const BackfillPage = () => {
           />
           <Detail label="Status" detail={<BackfillStatusTagForPage backfill={backfill} />} />
         </Box>
-        <Table>
-          <thead>
-            <tr>
-              <th style={{width: '50%'}}>Asset name</th>
-              <th>
-                <Link to={getRunsUrl('targeted')}>Partitions targeted</Link>
-              </th>
-              <th>
-                <Link to={getRunsUrl('inProgress')}>In progress</Link>
-              </th>
-              <th>
-                <Link to={getRunsUrl('complete')}>Completed</Link>
-              </th>
-              <th>
-                <Link to={getRunsUrl('failed')}>Failed</Link>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {backfill.assetBackfillData?.assetBackfillStatuses.map((asset) => {
-              let targeted;
-              let inProgress;
-              let completed;
-              let failed;
-              if (asset.__typename === 'AssetPartitionsStatusCounts') {
-                targeted = asset.numPartitionsTargeted;
-                inProgress = asset.numPartitionsInProgress;
-                completed = asset.numPartitionsMaterialized;
-                failed = asset.numPartitionsFailed;
-              } else {
-                targeted = 1;
-                failed = asset.failed ? 1 : 0;
-                inProgress = asset.inProgress ? 1 : 0;
-                completed = asset.materialized ? 1 : 0;
-              }
-              return (
-                <tr
-                  key={tokenForAssetKey(asset.assetKey)}
-                  data-testid={testId(`backfill-asset-row-${tokenForAssetKey(asset.assetKey)}`)}
-                >
-                  <td>
-                    <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
-                      <div>
-                        <ButtonLink
-                          onClick={() =>
-                            onShowAssetDetails(
-                              asset.assetKey,
-                              asset.__typename === 'AssetPartitionsStatusCounts',
-                            )
-                          }
-                        >
-                          {asset.assetKey.path.join('/')}
-                        </ButtonLink>
-                      </div>
-                      <div>
-                        <StatusBar
-                          targeted={targeted}
-                          inProgress={inProgress}
-                          completed={completed}
-                          failed={failed}
-                        />
-                      </div>
-                    </Box>
-                  </td>
-                  {asset.__typename === 'AssetPartitionsStatusCounts' ? (
-                    <>
-                      <td>{targeted}</td>
-                      <td>{inProgress}</td>
-                      <td>{completed}</td>
-                      <td>{failed}</td>
-                    </>
-                  ) : (
-                    <>
-                      <td>-</td>
-                      <td>
-                        {inProgress ? (
-                          <Tag icon="spinner" intent="primary">
-                            In progress
-                          </Tag>
-                        ) : (
-                          '-'
-                        )}
-                      </td>
-                      <td>{completed ? <Tag intent="success">Completed</Tag> : '-'}</td>
-                      <td>{failed ? <Tag intent="danger">Failed</Tag> : '-'}</td>
-                    </>
-                  )}
-                </tr>
-              );
-            })}
-          </tbody>
-        </Table>
+        <Box padding={{left: 24}} border="bottom">
+          <Tabs size="large" selectedTabId={selectedTab}>
+            <Tab id="partitions" title="Partitions" onClick={() => setSelectedTab('partitions')} />
+            <Tab id="runs" title="Runs" onClick={() => setSelectedTab('runs')} />
+          </Tabs>
+        </Box>
+
+        {error?.graphQLErrors && (
+          <Alert intent="error" title={error.graphQLErrors.map((err) => err.message)} />
+        )}
+        {selectedTab === 'partitions' && <BackfillPartitionsTab backfill={backfill} />}
+        {selectedTab === 'runs' && <BackfillRunsTab backfill={backfill} />}
       </>
     );
   }
@@ -338,39 +182,6 @@ const Detail = ({label, detail}: {label: JSX.Element | string; detail: JSX.Eleme
   </Box>
 );
 
-function StatusBar({
-  targeted,
-  inProgress,
-  completed,
-  failed,
-}: {
-  targeted: number;
-  inProgress: number;
-  completed: number;
-  failed: number;
-}) {
-  return (
-    <div
-      style={{
-        borderRadius: '8px',
-        backgroundColor: Colors.backgroundLight(),
-        display: 'grid',
-        gridTemplateColumns: `${(100 * completed) / targeted}% ${(100 * failed) / targeted}% ${
-          (100 * inProgress) / targeted
-        }%`,
-        gridTemplateRows: '100%',
-        height: '12px',
-        width: '200px',
-        overflow: 'hidden',
-      }}
-    >
-      <div style={{background: Colors.accentGreen()}} />
-      <div style={{background: Colors.accentRed()}} />
-      <div style={{background: Colors.accentBlue()}} />
-    </div>
-  );
-}
-
 const Label = styled.div`
   color: ${Colors.textLight()};
   font-size: 12px;
@@ -395,7 +206,7 @@ const Duration = ({start, end}: {start: number; end?: number | null}) => {
 export const BACKFILL_DETAILS_QUERY = gql`
   query BackfillStatusesByAsset($backfillId: String!) {
     partitionBackfillOrError(backfillId: $backfillId) {
-      ...PartitionBackfillFragment
+      ...BackfillDetailsBackfillFragment
       ...PythonErrorFragment
       ... on BackfillNotFoundError {
         message
@@ -403,7 +214,7 @@ export const BACKFILL_DETAILS_QUERY = gql`
     }
   }
 
-  fragment PartitionBackfillFragment on PartitionBackfill {
+  fragment BackfillDetailsBackfillFragment on PartitionBackfill {
     id
     status
     timestamp
@@ -443,6 +254,7 @@ export const BACKFILL_DETAILS_QUERY = gql`
       }
     }
   }
+
   ${PYTHON_ERROR_FRAGMENT}
   ${BACKFILL_ACTIONS_BACKFILL_FRAGMENT}
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
@@ -5,7 +5,6 @@ import {
   Colors,
   Heading,
   NonIdealState,
-  Page,
   PageHeader,
   Spinner,
   Tab,
@@ -146,7 +145,7 @@ export const BackfillPage = () => {
   }
 
   return (
-    <Page>
+    <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
       <PageHeader
         title={
           <Heading>
@@ -171,7 +170,7 @@ export const BackfillPage = () => {
         }
       />
       {content()}
-    </Page>
+    </Box>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPartitionsTab.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPartitionsTab.tsx
@@ -1,0 +1,253 @@
+import {gql, useApolloClient} from '@apollo/client';
+import {Box, ButtonLink, Colors, NonIdealState, Table, Tag} from '@dagster-io/ui-components';
+import React from 'react';
+import {Link, useHistory} from 'react-router-dom';
+
+import {BackfillDetailsBackfillFragment} from './types/BackfillPage.types';
+import {tokenForAssetKey} from '../../asset-graph/Utils';
+import {asAssetKeyInput} from '../../assets/asInput';
+import {assetDetailsPathForKey} from '../../assets/assetDetailsPathForKey';
+import {AssetViewParams} from '../../assets/types';
+import {AssetKey, RunStatus} from '../../graphql/types';
+import {RunFilterToken, runsPathWithFilters} from '../../runs/RunsFilterInput';
+import {testId} from '../../testing/testId';
+import {
+  BackfillPartitionsForAssetKeyQuery,
+  BackfillPartitionsForAssetKeyQueryVariables,
+} from '../backfill/types/BackfillPage.types';
+
+export const BackfillPartitionsTab = ({backfill}: {backfill: BackfillDetailsBackfillFragment}) => {
+  const client = useApolloClient();
+  const history = useHistory();
+
+  function getRunsUrl(status: 'inProgress' | 'complete' | 'failed' | 'targeted') {
+    const filters: RunFilterToken[] = [
+      {
+        token: 'tag',
+        value: `dagster/backfill=${backfill.id}`,
+      },
+    ];
+    switch (status) {
+      case 'inProgress':
+        filters.push(
+          {
+            token: 'status',
+            value: RunStatus.STARTED,
+          },
+          {
+            token: 'status',
+            value: RunStatus.QUEUED,
+          },
+          {
+            token: 'status',
+            value: RunStatus.STARTING,
+          },
+          {
+            token: 'status',
+            value: RunStatus.CANCELING,
+          },
+          {
+            token: 'status',
+            value: RunStatus.NOT_STARTED,
+          },
+        );
+        break;
+      case 'complete':
+        filters.push({
+          token: 'status',
+          value: RunStatus.SUCCESS,
+        });
+        break;
+      case 'failed':
+        filters.push({
+          token: 'status',
+          value: RunStatus.FAILURE,
+        });
+        filters.push({
+          token: 'status',
+          value: RunStatus.CANCELED,
+        });
+        break;
+    }
+    return runsPathWithFilters(filters);
+  }
+
+  const onShowAssetDetails = async (assetKey: AssetKey, isPartitioned: boolean) => {
+    let params: AssetViewParams = {};
+
+    if (isPartitioned) {
+      const resp = await client.query<
+        BackfillPartitionsForAssetKeyQuery,
+        BackfillPartitionsForAssetKeyQueryVariables
+      >({
+        query: BACKFILL_PARTITIONS_FOR_ASSET_KEY_QUERY,
+        variables: {backfillId: backfill.id, assetKey: asAssetKeyInput(assetKey)},
+      });
+      const data =
+        resp.data.partitionBackfillOrError.__typename === 'PartitionBackfill'
+          ? resp.data.partitionBackfillOrError.partitionsTargetedForAssetKey
+          : null;
+
+      if (data && data.ranges?.length) {
+        params = {default_range: data.ranges.map((r) => `[${r.start}...${r.end}]`).join(',')};
+      }
+    }
+    return history.push(assetDetailsPathForKey(assetKey, params));
+  };
+
+  if (!backfill.assetBackfillData?.assetBackfillStatuses.length) {
+    return (
+      <Box margin={48}>
+        <NonIdealState
+          title="Partition statuses unavailable"
+          description="Dagster was unable to load per-partition statuses. This may occur if the backfilled assets or jobs no longer exist in your loaded code locations."
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th style={{width: '50%'}}>Asset name</th>
+          <th>
+            <Link to={getRunsUrl('targeted')}>Partitions targeted</Link>
+          </th>
+          <th>
+            <Link to={getRunsUrl('inProgress')}>In progress</Link>
+          </th>
+          <th>
+            <Link to={getRunsUrl('complete')}>Completed</Link>
+          </th>
+          <th>
+            <Link to={getRunsUrl('failed')}>Failed</Link>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {backfill.assetBackfillData?.assetBackfillStatuses.map((asset) => {
+          let targeted;
+          let inProgress;
+          let completed;
+          let failed;
+          if (asset.__typename === 'AssetPartitionsStatusCounts') {
+            targeted = asset.numPartitionsTargeted;
+            inProgress = asset.numPartitionsInProgress;
+            completed = asset.numPartitionsMaterialized;
+            failed = asset.numPartitionsFailed;
+          } else {
+            targeted = 1;
+            failed = asset.failed ? 1 : 0;
+            inProgress = asset.inProgress ? 1 : 0;
+            completed = asset.materialized ? 1 : 0;
+          }
+          return (
+            <tr
+              key={tokenForAssetKey(asset.assetKey)}
+              data-testid={testId(`backfill-asset-row-${tokenForAssetKey(asset.assetKey)}`)}
+            >
+              <td>
+                <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
+                  <div>
+                    <ButtonLink
+                      onClick={() =>
+                        onShowAssetDetails(
+                          asset.assetKey,
+                          asset.__typename === 'AssetPartitionsStatusCounts',
+                        )
+                      }
+                    >
+                      {asset.assetKey.path.join('/')}
+                    </ButtonLink>
+                  </div>
+                  <div>
+                    <StatusBar
+                      targeted={targeted}
+                      inProgress={inProgress}
+                      completed={completed}
+                      failed={failed}
+                    />
+                  </div>
+                </Box>
+              </td>
+              {asset.__typename === 'AssetPartitionsStatusCounts' ? (
+                <>
+                  <td>{targeted}</td>
+                  <td>{inProgress}</td>
+                  <td>{completed}</td>
+                  <td>{failed}</td>
+                </>
+              ) : (
+                <>
+                  <td>-</td>
+                  <td>
+                    {inProgress ? (
+                      <Tag icon="spinner" intent="primary">
+                        In progress
+                      </Tag>
+                    ) : (
+                      '-'
+                    )}
+                  </td>
+                  <td>{completed ? <Tag intent="success">Completed</Tag> : '-'}</td>
+                  <td>{failed ? <Tag intent="danger">Failed</Tag> : '-'}</td>
+                </>
+              )}
+            </tr>
+          );
+        })}
+      </tbody>
+    </Table>
+  );
+};
+
+export const BACKFILL_PARTITIONS_FOR_ASSET_KEY_QUERY = gql`
+  query BackfillPartitionsForAssetKey($backfillId: String!, $assetKey: AssetKeyInput!) {
+    partitionBackfillOrError(backfillId: $backfillId) {
+      ... on PartitionBackfill {
+        id
+        partitionsTargetedForAssetKey(assetKey: $assetKey) {
+          partitionKeys
+          ranges {
+            start
+            end
+          }
+        }
+      }
+    }
+  }
+`;
+
+function StatusBar({
+  targeted,
+  inProgress,
+  completed,
+  failed,
+}: {
+  targeted: number;
+  inProgress: number;
+  completed: number;
+  failed: number;
+}) {
+  return (
+    <div
+      style={{
+        borderRadius: '8px',
+        backgroundColor: Colors.backgroundLight(),
+        display: 'grid',
+        gridTemplateColumns: `${(100 * completed) / targeted}% ${(100 * failed) / targeted}% ${
+          (100 * inProgress) / targeted
+        }%`,
+        gridTemplateRows: '100%',
+        height: '12px',
+        width: '200px',
+        overflow: 'hidden',
+      }}
+    >
+      <div style={{background: Colors.accentGreen()}} />
+      <div style={{background: Colors.accentRed()}} />
+      <div style={{background: Colors.accentBlue()}} />
+    </div>
+  );
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
@@ -133,18 +133,20 @@ const ExecutionRunTable = ({
   }
 
   return (
-    <StickyTableContainer $top={56}>
-      <RunTable
-        runs={pipelineRunsOrError.results}
-        actionBarComponents={actionBarComponents}
-        actionBarSticky
-      />
-      {pipelineRunsOrError.results.length > 0 ? (
-        <div style={{marginTop: '16px'}}>
-          <CursorHistoryControls {...paginationProps} />
-        </div>
-      ) : null}
-    </StickyTableContainer>
+    <Box style={{flex: 1, overflowY: 'auto'}}>
+      <StickyTableContainer $top={56}>
+        <RunTable
+          runs={pipelineRunsOrError.results}
+          actionBarComponents={actionBarComponents}
+          actionBarSticky
+        />
+        {pipelineRunsOrError.results.length > 0 ? (
+          <Box margin={{vertical: 16}}>
+            <CursorHistoryControls {...paginationProps} />
+          </Box>
+        ) : null}
+      </StickyTableContainer>
+    </Box>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
@@ -1,0 +1,202 @@
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Colors,
+  CursorHistoryControls,
+  ErrorBoundary,
+  NonIdealState,
+  Spinner,
+} from '@dagster-io/ui-components';
+import React, {useDeferredValue, useMemo} from 'react';
+
+import {ExecutionTimeline} from './ExecutionTimeline';
+import {BackfillDetailsBackfillFragment} from './types/BackfillPage.types';
+import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../../app/QueryRefresh';
+import {RunsFilter} from '../../graphql/types';
+import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
+import {useTimelineRange} from '../../overview/OverviewTimelineRoot';
+import {RunTable} from '../../runs/RunTable';
+import {DagsterTag} from '../../runs/RunTag';
+import {usePaginatedRunsTableRuns} from '../../runs/RunsRoot';
+import {HourWindow} from '../../runs/useHourWindow';
+import {useRunsForTimeline} from '../../runs/useRunsForTimeline';
+import {StickyTableContainer} from '../../ui/StickyTableContainer';
+
+const BACKFILL_RUNS_HOUR_WINDOW_KEY = 'dagster.backfill-run-timeline-hour-window';
+
+export const BackfillRunsTab = ({backfill}: {backfill: BackfillDetailsBackfillFragment}) => {
+  const [view, setView] = useQueryPersistedState<'timeline' | 'list'>({
+    defaults: {view: 'timeline'},
+    queryKey: 'view',
+  });
+
+  const {rangeMs, hourWindow, setHourWindow, onPageEarlier, onPageLater, onPageNow} =
+    useTimelineRange({
+      maxNowMs: backfill.endTimestamp ? backfill.endTimestamp * 1000 : undefined,
+      hourWindowStorageKey: BACKFILL_RUNS_HOUR_WINDOW_KEY,
+      lookaheadHours: 0.1, // no ticks, so miminal "future" needed
+    });
+
+  const filter: RunsFilter = useMemo(
+    () => ({tags: [{key: DagsterTag.Backfill, value: backfill.id}]}),
+    [backfill],
+  );
+
+  const annotations = useMemo(
+    () =>
+      backfill.endTimestamp
+        ? [
+            {ms: backfill.timestamp * 1000, label: 'Start'},
+            {ms: backfill.endTimestamp * 1000, label: 'End'},
+          ]
+        : [{ms: backfill.timestamp * 1000, label: 'Start'}],
+    [backfill.timestamp, backfill.endTimestamp],
+  );
+
+  const actionBarComponents = (
+    <Box flex={{direction: 'row', gap: 16}} style={{position: 'sticky', top: 0}}>
+      <ButtonGroup
+        activeItems={new Set([view])}
+        onClick={(id: 'timeline' | 'list') => {
+          setView(id);
+        }}
+        buttons={[
+          {id: 'timeline', icon: 'gantt_waterfall', label: 'Timeline'},
+          {id: 'list', icon: 'list', label: 'List'},
+        ]}
+      />
+      <div style={{flex: 1}} />
+      {view === 'timeline' && (
+        <ButtonGroup<HourWindow>
+          activeItems={new Set([hourWindow])}
+          buttons={[
+            {id: '1', label: '1hr'},
+            {id: '6', label: '6hr'},
+            {id: '12', label: '12hr'},
+            {id: '24', label: '24hr'},
+          ]}
+          onClick={(hrWindow: HourWindow) => setHourWindow(hrWindow)}
+        />
+      )}
+      {view === 'timeline' && (
+        <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+          <Button onClick={onPageEarlier}>&larr;</Button>
+          <Button onClick={onPageNow}>{backfill.endTimestamp ? 'Jump to End' : 'Now'}</Button>
+          <Button onClick={onPageLater}>&rarr;</Button>
+        </Box>
+      )}
+    </Box>
+  );
+
+  return (
+    <Box flex={{direction: 'column'}} style={{minHeight: 0}}>
+      {view === 'timeline' ? (
+        <ExecutionRunTimeline
+          filter={filter}
+          rangeMs={rangeMs}
+          annotations={annotations}
+          actionBarComponents={actionBarComponents}
+        />
+      ) : (
+        <ExecutionRunTable filter={filter} actionBarComponents={actionBarComponents} />
+      )}
+    </Box>
+  );
+};
+
+const ExecutionRunTable = ({
+  filter,
+  actionBarComponents,
+}: {
+  filter: RunsFilter;
+  actionBarComponents: React.ReactNode;
+}) => {
+  const {queryResult, paginationProps} = usePaginatedRunsTableRuns(filter);
+  const pipelineRunsOrError = queryResult.data?.pipelineRunsOrError;
+
+  useQueryRefreshAtInterval(queryResult, 15000);
+
+  if (!pipelineRunsOrError) {
+    return (
+      <Box padding={{vertical: 48}}>
+        <Spinner purpose="page" />
+      </Box>
+    );
+  }
+  if (pipelineRunsOrError.__typename !== 'Runs') {
+    return (
+      <Box padding={{vertical: 64}}>
+        <NonIdealState icon="error" title="Query Error" description={pipelineRunsOrError.message} />
+      </Box>
+    );
+  }
+
+  return (
+    <StickyTableContainer $top={56}>
+      <RunTable
+        runs={pipelineRunsOrError.results}
+        actionBarComponents={actionBarComponents}
+        actionBarSticky
+      />
+      {pipelineRunsOrError.results.length > 0 ? (
+        <div style={{marginTop: '16px'}}>
+          <CursorHistoryControls {...paginationProps} />
+        </div>
+      ) : null}
+    </StickyTableContainer>
+  );
+};
+
+const ExecutionRunTimeline = ({
+  rangeMs,
+  annotations,
+  filter,
+  actionBarComponents,
+}: {
+  rangeMs: [number, number];
+  annotations: {label: string; ms: number}[];
+  filter: RunsFilter;
+  actionBarComponents: React.ReactNode;
+}) => {
+  const runsForTimelineRet = useRunsForTimeline({
+    refreshInterval: 2 * FIFTEEN_SECONDS,
+    showTicks: false,
+    rangeMs,
+    filter,
+  });
+
+  // Use deferred value to allow paginating quickly with the UI feeling more responsive.
+  const {jobs, initialLoading} = useDeferredValue(runsForTimelineRet);
+
+  // Unwrap the timeline to show runs on separate rows, and sort them explicitly by
+  // newest => oldest so that they match what you see in the "List" tab.
+  const job = jobs[0];
+  const {runs, now} = React.useMemo(() => {
+    const now = Date.now();
+    return job
+      ? {runs: [...job.runs].sort((a, b) => b.startTime - a.startTime), now}
+      : {runs: [], now};
+  }, [job]);
+
+  return (
+    <>
+      <Box
+        padding={{horizontal: 24, vertical: 12}}
+        style={{position: 'sticky', top: 0, zIndex: 2, background: Colors.backgroundDefault()}}
+        border="bottom"
+      >
+        {actionBarComponents}
+      </Box>
+      <ErrorBoundary region="timeline">
+        <ExecutionTimeline
+          loading={initialLoading}
+          rangeMs={rangeMs}
+          annotations={annotations}
+          runs={runs}
+          now={now}
+        />
+      </ErrorBoundary>
+    </>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
@@ -158,7 +158,7 @@ const ExecutionRunTimeline = ({
 }: {
   rangeMs: [number, number];
   annotations: {label: string; ms: number}[];
-  filter: RunsFilter;
+  filter: RunsFilter; // note: must be memoized
   actionBarComponents: React.ReactNode;
 }) => {
   const runsForTimelineRet = useRunsForTimeline({

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/ExecutionTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/ExecutionTimeline.tsx
@@ -1,0 +1,155 @@
+import {Box, useViewport} from '@dagster-io/ui-components';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import React from 'react';
+import {Link} from 'react-router-dom';
+
+import {RunStatusDot} from '../../runs/RunStatusDots';
+import {
+  CONSTANTS,
+  RunChunk,
+  RunChunks,
+  RunsEmptyOrLoading,
+  TimeDividers,
+  TimelineRowContainer,
+  TimelineRun,
+} from '../../runs/RunTimeline';
+import {TimeElapsed} from '../../runs/TimeElapsed';
+import {RunBatch, batchRunsForTimeline} from '../../runs/batchRunsForTimeline';
+import {mergeStatusToBackground} from '../../runs/mergeStatusToBackground';
+import {Container, Inner} from '../../ui/VirtualizedTable';
+
+const {DATE_TIME_HEIGHT, ONE_HOUR_MSEC, EMPTY_STATE_HEIGHT, LEFT_SIDE_SPACE_ALLOTTED} = CONSTANTS;
+
+type Props = {
+  loading?: boolean;
+  runs: TimelineRun[];
+  rangeMs: [number, number];
+  annotations: {label: string; ms: number}[];
+  now: number;
+};
+
+export const ExecutionTimeline = (props: Props) => {
+  const {loading = false, runs, rangeMs, annotations, now} = props;
+  const parentRef = React.useRef<HTMLDivElement | null>(null);
+  const {
+    viewport: {width, height},
+    containerProps: {ref: measureRef},
+  } = useViewport();
+
+  const rowVirtualizer = useVirtualizer({
+    count: runs.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: (_: number) => 32,
+    overscan: 40,
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const items = rowVirtualizer.getVirtualItems();
+
+  if (!width) {
+    return <div style={{height: DATE_TIME_HEIGHT + EMPTY_STATE_HEIGHT}} ref={measureRef} />;
+  }
+
+  return (
+    <>
+      <Box
+        padding={{left: 24}}
+        border="bottom"
+        flex={{direction: 'column', justifyContent: 'center'}}
+        style={{
+          fontSize: '16px',
+          flex: `0 0 ${DATE_TIME_HEIGHT}px`,
+        }}
+      />
+      <div style={{position: 'relative'}}>
+        <TimeDividers
+          now={now}
+          interval={rangeMs[1] - rangeMs[0] > ONE_HOUR_MSEC * 4 ? ONE_HOUR_MSEC : ONE_HOUR_MSEC / 6}
+          rangeMs={rangeMs}
+          annotations={annotations}
+          height={runs.length > 0 ? height : 0}
+        />
+      </div>
+      {runs.length ? (
+        <div ref={measureRef} style={{overflow: 'hidden', position: 'relative'}}>
+          <Container ref={parentRef}>
+            <Inner $totalHeight={totalHeight}>
+              {items.map(({index, key, size, start}) => (
+                <ExecutionTimelineRow
+                  key={key}
+                  run={runs[index]!}
+                  top={start}
+                  height={size}
+                  range={rangeMs}
+                  width={width}
+                />
+              ))}
+            </Inner>
+          </Container>
+        </div>
+      ) : (
+        <div ref={measureRef}>
+          <RunsEmptyOrLoading loading={loading} includesTicks={false} />
+        </div>
+      )}
+    </>
+  );
+};
+
+export const ExecutionTimelineRow = ({
+  run,
+  top,
+  height,
+  range,
+  width: containerWidth,
+}: {
+  run: TimelineRun;
+  top: number;
+  height: number;
+  range: [number, number];
+  width: number;
+}) => {
+  const [start, end] = range;
+  const width = containerWidth - LEFT_SIDE_SPACE_ALLOTTED;
+
+  const chunk = React.useMemo(() => {
+    const batches: RunBatch<TimelineRun>[] = batchRunsForTimeline({
+      runs: [run],
+      start,
+      end,
+      width,
+      minChunkWidth: 4,
+      minMultipleWidth: 4,
+    });
+
+    return batches[0];
+  }, [run, start, end, width]);
+
+  return (
+    <TimelineRowContainer $height={height} $start={top}>
+      <Box
+        style={{width: LEFT_SIDE_SPACE_ALLOTTED}}
+        padding={{horizontal: 24}}
+        flex={{justifyContent: 'space-between', alignItems: 'center'}}
+      >
+        <Box flex={{alignItems: 'center', gap: 4}}>
+          <RunStatusDot status={run.status} size={12} />
+          <Link to={`/runs/${run.id}`}>{run.id.slice(0, 8)}</Link>
+        </Box>
+        <TimeElapsed startUnix={run.startTime / 1000} endUnix={run.endTime / 1000} />
+      </Box>
+      <RunChunks>
+        {chunk && (
+          <RunChunk
+            $background={mergeStatusToBackground(chunk.runs)}
+            $multiple={false}
+            style={{
+              left: `${chunk.left}px`,
+              width: `${chunk.width}px`,
+            }}
+          />
+        )}
+      </RunChunks>
+    </TimelineRowContainer>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPage.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPage.types.ts
@@ -80,7 +80,7 @@ export type BackfillStatusesByAssetQuery = {
       };
 };
 
-export type PartitionBackfillFragment = {
+export type BackfillDetailsBackfillFragment = {
   __typename: 'PartitionBackfill';
   id: string;
   status: Types.BulkActionStatus;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPartitionsTab.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPartitionsTab.types.ts
@@ -1,0 +1,24 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../../graphql/types';
+
+export type BackfillPartitionsForAssetKeyQueryVariables = Types.Exact<{
+  backfillId: Types.Scalars['String']['input'];
+  assetKey: Types.AssetKeyInput;
+}>;
+
+export type BackfillPartitionsForAssetKeyQuery = {
+  __typename: 'Query';
+  partitionBackfillOrError:
+    | {__typename: 'BackfillNotFoundError'}
+    | {
+        __typename: 'PartitionBackfill';
+        id: string;
+        partitionsTargetedForAssetKey: {
+          __typename: 'AssetBackfillTargetPartitions';
+          partitionKeys: Array<string> | null;
+          ranges: Array<{__typename: 'PartitionKeyRange'; start: string; end: string}> | null;
+        } | null;
+      }
+    | {__typename: 'PythonError'};
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/HourlyDataCache.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/HourlyDataCache.tsx
@@ -20,13 +20,13 @@ export class HourlyDataCache<T> {
    * @param id A unique ID for the hourly data cache in this deployment
    * @param [keyPrefix=''] A unique key identifying the timeline view [incorporating filters, etc.]
    */
-  constructor(id?: string | false, keyPrefix = '') {
+  constructor(id?: string | false, keyPrefix = '', keyMaxCount = 1) {
     this.indexedDBKey = keyPrefix ? `${keyPrefix}-hourlyData` : 'hourlyData';
 
     if (id) {
       this.indexedDBCache = cache<string, typeof this.cache>({
         dbName: `HourlyDataCache:${id}`,
-        maxCount: 3, // >1 because we have both the overview timeline and backfill timelines
+        maxCount: keyMaxCount,
       });
       this.loadCacheFromIndexedDB();
       this.clearOldEntries();

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/HourlyDataCache.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/HourlyDataCache.tsx
@@ -9,16 +9,24 @@ type Subscription<T> = (data: T[]) => void;
 export const defaultOptions = {
   expiry: new Date('3000-01-01'), // never expire,
 };
+
 export class HourlyDataCache<T> {
   private cache: Map<number, Array<TimeWindow<T>>> = new Map();
   private subscriptions: Array<{hour: number; callback: Subscription<T>}> = [];
-  private indexedDBCache?: ReturnType<typeof cache<'hourlyData', typeof this.cache>>;
+  private indexedDBCache?: ReturnType<typeof cache<string, typeof this.cache>>;
+  private indexedDBKey: string;
 
-  constructor(id?: string | false) {
+  /**
+   * @param id A unique ID for the hourly data cache in this deployment
+   * @param [keyPrefix=''] A unique key identifying the timeline view [incorporating filters, etc.]
+   */
+  constructor(id?: string | false, keyPrefix = '') {
+    this.indexedDBKey = keyPrefix ? `${keyPrefix}-hourlyData` : 'hourlyData';
+
     if (id) {
-      this.indexedDBCache = cache<'hourlyData', typeof this.cache>({
+      this.indexedDBCache = cache<string, typeof this.cache>({
         dbName: `HourlyDataCache:${id}`,
-        maxCount: 1, // We only store 1 entry
+        maxCount: 3, // >1 because we have both the overview timeline and backfill timelines
       });
       this.loadCacheFromIndexedDB();
       this.clearOldEntries();
@@ -38,11 +46,11 @@ export class HourlyDataCache<T> {
       if (!this.indexedDBCache) {
         return;
       }
-      if (!(await this.indexedDBCache.has('hourlyData'))) {
+      if (!(await this.indexedDBCache.has(this.indexedDBKey))) {
         res();
         return;
       }
-      const cachedData = await this.indexedDBCache.get('hourlyData');
+      const cachedData = await this.indexedDBCache.get(this.indexedDBKey);
       if (cachedData) {
         this.cache = new Map(cachedData.value);
       }
@@ -55,7 +63,7 @@ export class HourlyDataCache<T> {
     if (!this.indexedDBCache) {
       return;
     }
-    await this.indexedDBCache.set('hourlyData', this.cache, defaultOptions);
+    await this.indexedDBCache.set(this.indexedDBKey, this.cache, defaultOptions);
   }
 
   public async clearOldEntries() {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
@@ -2,6 +2,7 @@ import {gql} from '@apollo/client';
 import {
   Box,
   Checkbox,
+  Colors,
   Icon,
   NonIdealState,
   ProductTour,
@@ -25,6 +26,7 @@ interface RunTableProps {
   runs: RunTableRunFragment[];
   filter?: RunsFilter;
   onAddTag?: (token: RunFilterToken) => void;
+  actionBarSticky?: boolean;
   actionBarComponents?: React.ReactNode;
   highlightedIds?: string[];
   additionalColumnHeaders?: React.ReactNode[];
@@ -41,6 +43,7 @@ export const RunTable = (props: RunTableProps) => {
     filter,
     onAddTag,
     highlightedIds,
+    actionBarSticky,
     actionBarComponents,
     belowActionBarComponents,
     hideCreatedBy,
@@ -150,6 +153,7 @@ export const RunTable = (props: RunTableProps) => {
   return (
     <>
       <ActionBar
+        sticky={actionBarSticky}
         top={
           <Box
             flex={{
@@ -224,9 +228,25 @@ export const RUN_TABLE_RUN_FRAGMENT = gql`
   ${RUN_TAGS_FRAGMENT}
 `;
 
-function ActionBar({top, bottom}: {top: React.ReactNode; bottom?: React.ReactNode}) {
+function ActionBar({
+  top,
+  bottom,
+  sticky,
+}: {
+  top: React.ReactNode;
+  bottom?: React.ReactNode;
+  sticky?: boolean;
+}) {
   return (
-    <Box flex={{direction: 'column'}} padding={{vertical: 12}}>
+    <Box
+      flex={{direction: 'column'}}
+      padding={{vertical: 12}}
+      style={
+        sticky
+          ? {position: 'sticky', top: 0, background: Colors.backgroundDefault(), zIndex: 2}
+          : {}
+      }
+    >
       <Box flex={{alignItems: 'center', gap: 12}} padding={{left: 24, right: 12}}>
         {top}
       </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsRoot.tsx
@@ -35,6 +35,7 @@ import {
   useQueryRefreshAtInterval,
 } from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
+import {RunsFilter} from '../graphql/types';
 import {usePortalSlot} from '../hooks/usePortalSlot';
 import {usePageLoadTrace} from '../performance';
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
@@ -43,13 +44,7 @@ import {StickyTableContainer} from '../ui/StickyTableContainer';
 
 const PAGE_SIZE = 25;
 
-export const RunsRoot = () => {
-  useTrackPageView();
-  const trace = usePageLoadTrace('RunsRoot');
-
-  const [filterTokens, setFilterTokens] = useQueryPersistedRunFilters();
-  const filter = runsFilterForSearchTokens(filterTokens);
-
+export function usePaginatedRunsTableRuns(filter: RunsFilter) {
   const {queryResult, paginationProps} = useCursorPaginatedQuery<
     RunsRootQuery,
     RunsRootQueryVariables
@@ -72,6 +67,17 @@ export const RunsRoot = () => {
     query: RUNS_ROOT_QUERY,
     pageSize: PAGE_SIZE,
   });
+  return {queryResult, paginationProps};
+}
+
+export const RunsRoot = () => {
+  useTrackPageView();
+  const trace = usePageLoadTrace('RunsRoot');
+
+  const [filterTokens, setFilterTokens] = useQueryPersistedRunFilters();
+  const filter = runsFilterForSearchTokens(filterTokens);
+  const {queryResult, paginationProps} = usePaginatedRunsTableRuns(filter);
+
   useBlockTraceOnQueryResult(queryResult, 'RunsRootQuery');
 
   const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__stories__/RunTimeline.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__stories__/RunTimeline.stories.tsx
@@ -35,7 +35,7 @@ export const OneRow = () => {
     ];
   }, [sixHoursAgo, now]);
 
-  return <RunTimeline jobs={jobs} range={[sixHoursAgo, now]} />;
+  return <RunTimeline jobs={jobs} rangeMs={[sixHoursAgo, now]} />;
 };
 
 export const RowWithOverlappingRuns = () => {
@@ -58,7 +58,7 @@ export const RowWithOverlappingRuns = () => {
     ];
   }, [sixHoursAgo, now]);
 
-  return <RunTimeline jobs={jobs} range={[sixHoursAgo, now]} />;
+  return <RunTimeline jobs={jobs} rangeMs={[sixHoursAgo, now]} />;
 };
 
 export const OverlapWithRunning = () => {
@@ -99,7 +99,7 @@ export const OverlapWithRunning = () => {
     ];
   }, [twoHoursAgo, now]);
 
-  return <RunTimeline jobs={jobs} range={[twoHoursAgo, now + 60 * 6000]} />;
+  return <RunTimeline jobs={jobs} rangeMs={[twoHoursAgo, now + 60 * 6000]} />;
 };
 
 export const ManyRows = () => {
@@ -123,7 +123,7 @@ export const ManyRows = () => {
     }, []);
   }, [sixHoursAgo, now]);
 
-  return <RunTimeline jobs={jobs} range={[sixHoursAgo, now]} />;
+  return <RunTimeline jobs={jobs} rangeMs={[sixHoursAgo, now]} />;
 };
 
 export const VeryLongRunning = () => {
@@ -170,7 +170,7 @@ export const VeryLongRunning = () => {
     ];
   }, [twoDaysAgo, sixHoursAgo]);
 
-  return <RunTimeline jobs={jobs} range={[fourHoursAgo, future]} />;
+  return <RunTimeline jobs={jobs} rangeMs={[fourHoursAgo, future]} />;
 };
 
 export const MultipleStatusesBatched = () => {
@@ -223,7 +223,7 @@ export const MultipleStatusesBatched = () => {
     ];
   }, [twoHoursAgo, now]);
 
-  return <RunTimeline jobs={jobs} range={[twoHoursAgo, now]} />;
+  return <RunTimeline jobs={jobs} rangeMs={[twoHoursAgo, now]} />;
 };
 
 export const BatchThresholdTesting = () => {
@@ -288,5 +288,5 @@ export const BatchThresholdTesting = () => {
     ];
   }, [threeHoursAgo, now]);
 
-  return <RunTimeline jobs={jobs} range={[threeHoursAgo, now + 60 * 60 * 1000]} />;
+  return <RunTimeline jobs={jobs} rangeMs={[threeHoursAgo, now + 60 * 60 * 1000]} />;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useHourWindow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useHourWindow.tsx
@@ -8,6 +8,7 @@ export type HourWindow = '1' | '6' | '12' | '24';
 
 export const useHourWindow = (
   defaultValue: HourWindow,
+  storageKey = HOUR_WINDOW_KEY,
 ): [HourWindow, (value: HourWindow) => void] => {
   const validate = useCallback(
     (value: string) => {
@@ -24,7 +25,7 @@ export const useHourWindow = (
     [defaultValue],
   );
 
-  const [hourWindow, setHourWindow] = useStateWithStorage(HOUR_WINDOW_KEY, validate);
+  const [hourWindow, setHourWindow] = useStateWithStorage(storageKey, validate);
   const setHourWindowWithDefault = useCallback(
     (value: HourWindow) => {
       setHourWindow(value || defaultValue);

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -58,14 +58,18 @@ export const useRunsForTimeline = ({
   const client = useApolloClient();
 
   const {localCacheIdPrefix} = useContext(AppContext);
-  const completedRunsCache = useMemo(
-    () =>
-      new HourlyDataCache<RunTimelineFragment>(
-        localCacheIdPrefix ? `${localCacheIdPrefix}-useRunsForTimeline` : false,
+  const completedRunsCache = useMemo(() => {
+    if (filter) {
+      return new HourlyDataCache<RunTimelineFragment>(
+        localCacheIdPrefix ? `${localCacheIdPrefix}-useRunsForTimeline-filtered` : false,
         JSON.stringify(filter),
-      ),
-    [filter, localCacheIdPrefix],
-  );
+        3,
+      );
+    }
+    return new HourlyDataCache<RunTimelineFragment>(
+      localCacheIdPrefix ? `${localCacheIdPrefix}-useRunsForTimeline` : false,
+    );
+  }, [filter, localCacheIdPrefix]);
   const [runsNotCapturedByUpdateBuckets, setRunsNotCapturedByUpdateBuckets] = useState<
     RunTimelineFragment[]
   >([]);

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -34,11 +34,13 @@ export const useRunsForTimeline = ({
   filter,
   batchLimit = BATCH_LIMIT,
   refreshInterval = 2 * FIFTEEN_SECONDS,
+  showTicks = true,
 }: {
   rangeMs: readonly [number, number];
   filter?: RunsFilter;
   refreshInterval?: number;
   batchLimit?: number;
+  showTicks?: boolean;
 }) => {
   const runsFilter = useMemo(() => {
     return filter ?? {};
@@ -60,9 +62,9 @@ export const useRunsForTimeline = ({
     () =>
       new HourlyDataCache<RunTimelineFragment>(
         localCacheIdPrefix ? `${localCacheIdPrefix}-useRunsForTimeline` : false,
+        JSON.stringify(filter),
       ),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [runsFilter],
+    [filter, localCacheIdPrefix],
   );
   const [runsNotCapturedByUpdateBuckets, setRunsNotCapturedByUpdateBuckets] = useState<
     RunTimelineFragment[]
@@ -242,7 +244,7 @@ export const useRunsForTimeline = ({
         error: e,
       }));
     }
-  }, [client, runsFilter]);
+  }, [client, runsFilter, batchLimit]);
 
   const [futureTicksQueryData, setFutureTicksQueryData] = useState<
     Pick<QueryResult<FutureTicksQuery>, 'data' | 'error' | 'called' | 'loading'>
@@ -251,11 +253,13 @@ export const useRunsForTimeline = ({
   const fetchFutureTicks = useCallback(async () => {
     const queryData = await client.query<FutureTicksQuery, FutureTicksQueryVariables>({
       query: FUTURE_TICKS_QUERY,
-      variables: {tickCursor: startSec, ticksUntil: _end / 1000.0},
+      variables: showTicks
+        ? {tickCursor: startSec, ticksUntil: _end / 1000.0}
+        : {tickCursor: startSec, ticksUntil: startSec},
       fetchPolicy: 'no-cache',
     });
     setFutureTicksQueryData({...queryData, called: true});
-  }, [startSec, _end, client]);
+  }, [startSec, _end, client, showTicks]);
 
   useBlockTraceOnQueryResult(ongoingRunsQueryData, 'OngoingRunTimelineQuery');
   useBlockTraceOnQueryResult(completedRunsQueryData, 'CompletedRunTimelineQuery');
@@ -443,7 +447,7 @@ export const useRunsForTimeline = ({
 
   const initialLoading =
     (loadingOngoingRunsData && !ongoingRunsData) ||
-    (loadingCompletedRunsData && !completedRunsQueryData) ||
+    (loadingCompletedRunsData && !completedRunsData) ||
     (loadingFutureTicksData && !futureTicksData) ||
     !workspaceOrError;
 


### PR DESCRIPTION
## Summary & Motivation

This PR adds a second "Runs" tab to the existing backfill detail page, which presets both list and timeline views of the runs launched by the backfill.

This feature is not behind a feature flag, since it's fairly low risk and available as an additional tab (not the default tab of this view).

<img width="1721" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/f71aea64-255d-43f4-a887-afa8e0050fe6">


## How I Tested These Changes

