### PR TITLE
Fix RunTimeline bucket pagination

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
@@ -80,7 +80,7 @@ export const OverviewTimelineRoot = ({Header, TabButton}: Props) => {
     [hourWindow, now, offsetMsec],
   );
 
-  const runsForTimelineRet = useRunsForTimeline(range);
+  const runsForTimelineRet = useRunsForTimeline({rangeMs: range});
 
   // Use deferred value to allow paginating quickly with the UI feeling more responsive.
   const {jobs, initialLoading, refreshState} = useDeferredValue(runsForTimelineRet);

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/fetchPaginatedBucketData.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/fetchPaginatedBucketData.ts
@@ -7,10 +7,12 @@ export type QueryResultData<DataType> = {
 
 export async function fetchPaginatedBucketData<BucketType, DataType, CursorType, ErrorType>({
   buckets,
+  adjustBucket,
   fetchData,
   setQueryData,
 }: {
   buckets: BucketType[];
+  adjustBucket?: (bucket: BucketType) => BucketType;
   fetchData: (
     bucket: BucketType,
     cursor: CursorType | undefined,
@@ -30,11 +32,12 @@ export async function fetchPaginatedBucketData<BucketType, DataType, CursorType,
   }));
   try {
     const results = await Promise.all(
-      buckets.map((bucket) =>
-        fetchPaginatedData<DataType, CursorType, ErrorType>({
-          fetchData: (cursor) => fetchData(bucket, cursor),
-        }),
-      ),
+      buckets.map((bucket) => {
+        const adjustedBucket = adjustBucket ? adjustBucket(bucket) : bucket;
+        return fetchPaginatedData<DataType, CursorType, ErrorType>({
+          fetchData: (cursor) => fetchData(adjustedBucket, cursor),
+        });
+      }),
     );
     setQueryData({
       data: results.flat(),

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/fetchPaginatedBucketData.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/fetchPaginatedBucketData.ts
@@ -7,12 +7,10 @@ export type QueryResultData<DataType> = {
 
 export async function fetchPaginatedBucketData<BucketType, DataType, CursorType, ErrorType>({
   buckets,
-  adjustBucket,
   fetchData,
   setQueryData,
 }: {
   buckets: BucketType[];
-  adjustBucket?: (bucket: BucketType) => BucketType;
   fetchData: (
     bucket: BucketType,
     cursor: CursorType | undefined,
@@ -32,12 +30,11 @@ export async function fetchPaginatedBucketData<BucketType, DataType, CursorType,
   }));
   try {
     const results = await Promise.all(
-      buckets.map((bucket) => {
-        const adjustedBucket = adjustBucket ? adjustBucket(bucket) : bucket;
-        return fetchPaginatedData<DataType, CursorType, ErrorType>({
-          fetchData: (cursor) => fetchData(adjustedBucket, cursor),
-        });
-      }),
+      buckets.map((bucket) =>
+        fetchPaginatedData<DataType, CursorType, ErrorType>({
+          fetchData: (cursor) => fetchData(bucket, cursor),
+        }),
+      ),
     );
     setQueryData({
       data: results.flat(),

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -180,7 +180,7 @@ export const useRunsForTimeline = ({
         };
       },
     });
-  }, [buckets, client, completedRunsCache, runsFilter]);
+  }, [batchLimit, buckets, client, completedRunsCache, runsFilter]);
 
   const fetchOngoingRunsQueryData = useCallback(async () => {
     setOngoingRunsData(({data}) => ({

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -106,9 +106,7 @@ export const useRunsForTimeline = ({
 
   const fetchCompletedRunsQueryData = useCallback(async () => {
     return await fetchPaginatedBucketData({
-      buckets,
-      setQueryData: setCompletedRunsData,
-      adjustBucket: (bucket) => {
+      buckets: buckets.map((bucket) => {
         let updatedAfter = bucket[0];
         let updatedBefore = bucket[1];
         const missingRange = completedRunsCache.getMissingIntervals(updatedAfter);
@@ -119,7 +117,8 @@ export const useRunsForTimeline = ({
           updatedBefore = Math.min(missingRange[0][1], updatedBefore);
         }
         return [updatedAfter, updatedBefore] as [number, number];
-      },
+      }),
+      setQueryData: setCompletedRunsData,
       async fetchData(bucket, cursor: string | undefined) {
         await completedRunsCache.loadCacheFromIndexedDB();
         const updatedBefore = bucket[1];


### PR DESCRIPTION
## Summary & Motivation

Currently when we're paginating we call `getMissingIntervals` within the paginated fetch loop. This is a bug because after the first fetch we add data for the time range and then `getMissingIntervals` ends up returning a 1 millisecond time range for the subsequent paginated fetches of that bucket. Instead we should be calling getMissingIntervals when determining the bucket to fetch and then when paginating we keep using the same bucket.

## How I Tested These Changes

Loaded a timeline page, set the BATCH_LIMIT to 1 and made sure we paginated and fetched the rest of the runs for the bucket (current bug would result in just 1 run per bucket).

Wrote a jest test
