### PR TITLE
[DS][51/n] Add perf test

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_perf.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_perf.py
@@ -1,0 +1,41 @@
+import time
+
+import pytest
+from dagster import (
+    DailyPartitionsDefinition,
+    Definitions,
+    HourlyPartitionsDefinition,
+    SchedulingCondition,
+)
+from dagster_test.toys.auto_materializing.large_graph import AssetLayerConfig, build_assets
+
+from dagster_tests.conftest import IS_BUILDKITE
+from dagster_tests.definitions_tests.auto_materialize_tests.test_user_space_ds_api import (
+    execute_ds_ticks,
+)
+
+
+@pytest.mark.skipif(IS_BUILDKITE, reason="Temporary")
+def test_eager_perf() -> None:
+    hourly_partitions_def = HourlyPartitionsDefinition("2020-01-01-00:00")
+    daily_partitions_def = DailyPartitionsDefinition("2020-01-01")
+    assets = build_assets(
+        id="perf_test",
+        layer_configs=[
+            AssetLayerConfig(100, 0, hourly_partitions_def),
+            AssetLayerConfig(200, 2, hourly_partitions_def),
+            AssetLayerConfig(200, 4, hourly_partitions_def),
+            AssetLayerConfig(200, 4, daily_partitions_def),
+            AssetLayerConfig(200, 2, daily_partitions_def),
+            AssetLayerConfig(100, 2, daily_partitions_def),
+        ],
+        auto_materialize_policy=SchedulingCondition.eager().as_auto_materialize_policy(),
+    )
+
+    start = time.time()
+    for _ in execute_ds_ticks(defs=Definitions(assets=assets), n=2):
+        end = time.time()
+        duration = end - start
+        # all iterations should take less than 10 seconds on this graph
+        assert duration < 10.0
+        start = time.time()

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_user_space_ds_api.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_user_space_ds_api.py
@@ -1,9 +1,10 @@
 import logging
-from typing import AbstractSet, NamedTuple, Sequence
+import time
+from typing import AbstractSet, Iterator, NamedTuple, Sequence
 
 import mock
 import pytest
-from dagster import SchedulingCondition, asset
+from dagster import SchedulingCondition, asset, deserialize_value, serialize_value
 from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.data_time import CachingDataTimeResolver
@@ -29,29 +30,38 @@ class SchedulingTickResult(NamedTuple):
     asset_partition_keys: AbstractSet[AssetKeyPartitionKey]
 
 
-def execute_ds_tick(defs: Definitions) -> SchedulingTickResult:
+def execute_ds_ticks(defs: Definitions, n: int) -> Iterator[SchedulingTickResult]:
     asset_graph = defs.get_asset_graph()
-    asset_graph_view = AssetGraphView.for_test(defs)
-    data_time_resolver = CachingDataTimeResolver(
-        asset_graph_view.get_inner_queryer_for_back_compat()
-    )
 
-    evaluator = SchedulingConditionEvaluator(
-        asset_graph=asset_graph,
-        asset_keys=asset_graph.all_asset_keys,
-        asset_graph_view=asset_graph_view,
-        logger=logging.getLogger(__name__),
-        data_time_resolver=data_time_resolver,
-        cursor=AssetDaemonCursor.empty(),
-        respect_materialization_data_versions=True,
-        auto_materialize_run_tags={},
-    )
-    result = evaluator.evaluate()
+    cursor = AssetDaemonCursor.empty()
+    for i in range(n):
+        asset_graph_view = AssetGraphView.for_test(defs)
+        data_time_resolver = CachingDataTimeResolver(
+            asset_graph_view.get_inner_queryer_for_back_compat()
+        )
+        evaluator = SchedulingConditionEvaluator(
+            asset_graph=asset_graph,
+            asset_keys=asset_graph.all_asset_keys,
+            asset_graph_view=asset_graph_view,
+            logger=logging.getLogger(__name__),
+            data_time_resolver=data_time_resolver,
+            cursor=cursor,
+            respect_materialization_data_versions=False,
+            auto_materialize_run_tags={},
+        )
+        result = evaluator.evaluate()
+        cursor = cursor.with_updates(
+            evaluation_id=i,
+            evaluation_timestamp=time.time(),
+            newly_observe_requested_asset_keys=[],
+            evaluation_state=result[0],
+        )
+        cursor = deserialize_value(serialize_value(cursor), AssetDaemonCursor)
+        yield SchedulingTickResult(evaluation_states=result[0], asset_partition_keys=result[1])
 
-    return SchedulingTickResult(
-        evaluation_states=result[0],
-        asset_partition_keys=result[1],
-    )
+
+def execute_ds_tick(defs: Definitions) -> SchedulingTickResult:
+    return next(execute_ds_ticks(defs, n=1))
 
 
 def test_basic_asset_scheduling_test() -> None:


### PR DESCRIPTION
## Summary & Motivation

Adds a perf test that lets us track how efficiently we can compute conditions against large asset graphs.

For now, because the perf test will fail without some of the upstack changes, disabling this on BK

## How I Tested These Changes
