### PR TITLE
[DS][53/n] Avoid slow get_partition_keys calls

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -89,10 +89,10 @@ class AssetSubset(DagsterModel):
 
     @property
     def is_empty(self) -> bool:
-        # avoid calculating the full size of the subset if it's an AllPartitionsSubset
-        if isinstance(self.value, AllPartitionsSubset):
-            return False
-        return self.size == 0
+        if self.is_partitioned:
+            return self.subset_value.is_empty
+        else:
+            return not self.bool_value
 
     def is_compatible_with_partitions_def(
         self, partitions_def: Optional[PartitionsDefinition]

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -942,6 +942,10 @@ def cron_schedule_from_schedule_type_and_offsets(
 class PartitionsSubset(ABC, Generic[T_str]):
     """Represents a subset of the partitions within a PartitionsDefinition."""
 
+    @property
+    def is_empty(self) -> bool:
+        return len(list(self.get_partition_keys())) == 0
+
     @abstractmethod
     def get_partition_keys_not_in_subset(
         self,
@@ -978,7 +982,7 @@ class PartitionsSubset(ABC, Generic[T_str]):
         )
 
     def __or__(self, other: "PartitionsSubset") -> "PartitionsSubset":
-        if self is other:
+        if self is other or other.is_empty:
             return self
         # Anything | AllPartitionsSubset = AllPartitionsSubset
         if isinstance(other, AllPartitionsSubset):
@@ -988,6 +992,8 @@ class PartitionsSubset(ABC, Generic[T_str]):
     def __sub__(self, other: "PartitionsSubset") -> "PartitionsSubset":
         if self is other:
             return self.empty_subset()
+        if other.is_empty:
+            return self
         # Anything - AllPartitionsSubset = Empty
         if isinstance(other, AllPartitionsSubset):
             return self.empty_subset()
@@ -998,6 +1004,8 @@ class PartitionsSubset(ABC, Generic[T_str]):
     def __and__(self, other: "PartitionsSubset") -> "PartitionsSubset":
         if self is other:
             return self
+        if other.is_empty:
+            return other
         # Anything & AllPartitionsSubset = Anything
         if isinstance(other, AllPartitionsSubset):
             return self
@@ -1232,6 +1240,10 @@ class AllPartitionsSubset(
             current_time=current_time,
         )
 
+    @property
+    def is_empty(self) -> bool:
+        return False
+
     def get_partition_keys(self, current_time: Optional[datetime] = None) -> Sequence[str]:
         check.param_invariant(current_time is None, "current_time")
         return self.partitions_def.get_partition_keys(
@@ -1276,8 +1288,15 @@ class AllPartitionsSubset(
         return other
 
     def __sub__(self, other: "PartitionsSubset") -> "PartitionsSubset":
+        from .time_window_partitions import (
+            BaseTimeWindowPartitionsSubset,
+            TimeWindowPartitionsSubset,
+        )
+
         if self == other:
             return self.partitions_def.empty_subset()
+        elif isinstance(other, BaseTimeWindowPartitionsSubset):
+            return TimeWindowPartitionsSubset.from_all_partitions_subset(self) - other
         return self.partitions_def.empty_subset().with_partition_keys(
             set(self.get_partition_keys()).difference(set(other.get_partition_keys()))
         )


### PR DESCRIPTION
## Summary & Motivation

It's a shame that we can't quite merge the PR that removes the PartitionKeysTimePartitionSubset yet, and instead we have to settle for this workaround sort of stuff.

## How I Tested These Changes
