### PR TITLE
[DS][54/n] Make slice conversion more efficient

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -69,11 +69,25 @@ class TemporalContext(NamedTuple):
 _AssetSliceCompatibleSubset = NewType("_AssetSliceCompatibleSubset", ValidAssetSubset)
 
 
-def _slice_from_subset(asset_graph_view: "AssetGraphView", subset: AssetSubset) -> "AssetSlice":
-    valid_subset = subset.as_valid(
-        asset_graph_view.asset_graph.get(subset.asset_key).partitions_def
-    )
-    return AssetSlice(asset_graph_view, _AssetSliceCompatibleSubset(valid_subset))
+def _slice_from_subset(
+    asset_graph_view: "AssetGraphView", subset: AssetSubset
+) -> Optional["AssetSlice"]:
+    partitions_def = asset_graph_view.asset_graph.get(subset.asset_key).partitions_def
+    if subset.is_compatible_with_partitions_def(partitions_def):
+        return _slice_from_valid_subset(
+            asset_graph_view,
+            subset
+            if isinstance(subset, ValidAssetSubset)
+            else ValidAssetSubset(asset_key=subset.asset_key, value=subset.value),
+        )
+    else:
+        return None
+
+
+def _slice_from_valid_subset(
+    asset_graph_view: "AssetGraphView", subset: ValidAssetSubset
+) -> "AssetSlice":
+    return AssetSlice(asset_graph_view, _AssetSliceCompatibleSubset(subset))
 
 
 class AssetSlice:
@@ -165,17 +179,17 @@ class AssetSlice:
         return {ak: self.compute_child_slice(ak) for ak in self.child_keys}
 
     def compute_difference(self, other: "AssetSlice") -> "AssetSlice":
-        return _slice_from_subset(
+        return _slice_from_valid_subset(
             self._asset_graph_view, self._compatible_subset - other.convert_to_valid_asset_subset()
         )
 
     def compute_union(self, other: "AssetSlice") -> "AssetSlice":
-        return _slice_from_subset(
+        return _slice_from_valid_subset(
             self._asset_graph_view, self._compatible_subset | other.convert_to_valid_asset_subset()
         )
 
     def compute_intersection(self, other: "AssetSlice") -> "AssetSlice":
-        return _slice_from_subset(
+        return _slice_from_valid_subset(
             self._asset_graph_view, self._compatible_subset & other.convert_to_valid_asset_subset()
         )
 
@@ -336,10 +350,11 @@ class AssetGraphView:
     def _get_partitions_def(self, asset_key: "AssetKey") -> Optional["PartitionsDefinition"]:
         return self.asset_graph.get(asset_key).partitions_def
 
-    def get_asset_slice(self, asset_key: "AssetKey") -> "AssetSlice":
+    @cached_method
+    def get_asset_slice(self, *, asset_key: "AssetKey") -> "AssetSlice":
         # not compute_asset_slice because dynamic partitions store
         # is just passed to AssetSubset.all, not invoked
-        return _slice_from_subset(
+        return _slice_from_valid_subset(
             self,
             AssetSubset.all(
                 asset_key=asset_key,
@@ -356,7 +371,7 @@ class AssetGraphView:
             return None
 
     def get_asset_slice_from_valid_subset(self, subset: ValidAssetSubset) -> "AssetSlice":
-        return _slice_from_subset(self, subset)
+        return _slice_from_valid_subset(self, subset)
 
     def get_asset_slice_from_asset_partitions(
         self, asset_partitions: AbstractSet[AssetKeyPartitionKey]
@@ -364,7 +379,7 @@ class AssetGraphView:
         asset_keys = {akpk.asset_key for akpk in asset_partitions}
         check.invariant(len(asset_keys) == 1, "Must have exactly one asset key")
         asset_key = asset_keys.pop()
-        return _slice_from_subset(
+        return _slice_from_valid_subset(
             self,
             ValidAssetSubset.from_asset_partitions_set(
                 asset_key=asset_key,
@@ -374,7 +389,7 @@ class AssetGraphView:
         )
 
     def create_empty_slice(self, asset_key: AssetKey) -> AssetSlice:
-        return _slice_from_subset(
+        return _slice_from_valid_subset(
             self,
             AssetSubset.empty(asset_key, self._get_partitions_def(asset_key)),
         )
@@ -382,7 +397,7 @@ class AssetGraphView:
     def compute_parent_asset_slice(
         self, parent_asset_key: AssetKey, asset_slice: AssetSlice
     ) -> AssetSlice:
-        return _slice_from_subset(
+        return _slice_from_valid_subset(
             self,
             self.asset_graph.get_parent_asset_subset(
                 dynamic_partitions_store=self._queryer,
@@ -395,7 +410,7 @@ class AssetGraphView:
     def compute_child_asset_slice(
         self, child_asset_key: "AssetKey", asset_slice: AssetSlice
     ) -> "AssetSlice":
-        return _slice_from_subset(
+        return _slice_from_valid_subset(
             self,
             self.asset_graph.get_child_asset_subset(
                 dynamic_partitions_store=self._queryer,
@@ -422,7 +437,7 @@ class AssetGraphView:
                     f"Partition key {partition_key} not in partitions def {partitions_def}"
                 )
 
-        return _slice_from_subset(
+        return _slice_from_valid_subset(
             self,
             asset_slice.convert_to_valid_asset_subset()
             & AssetSubset.from_partition_keys(
@@ -442,7 +457,7 @@ class AssetGraphView:
         time_partitions_def = get_time_partitions_def(partitions_def)
         if time_partitions_def is None:
             # if the asset has no time dimension, then return a full slice
-            return self.get_asset_slice(asset_key)
+            return self.get_asset_slice(asset_key=asset_key)
 
         latest_time_window = time_partitions_def.get_last_partition_window(self.effective_dt)
         if latest_time_window is None:
@@ -500,13 +515,15 @@ class AssetGraphView:
 
     @cached_method
     def compute_in_progress_asset_slice(self, *, asset_key: "AssetKey") -> "AssetSlice":
-        return _slice_from_subset(
+        return _slice_from_valid_subset(
             self, self._queryer.get_in_progress_asset_subset(asset_key=asset_key)
         )
 
     @cached_method
     def compute_failed_asset_slice(self, *, asset_key: "AssetKey") -> "AssetSlice":
-        return _slice_from_subset(self, self._queryer.get_failed_asset_subset(asset_key=asset_key))
+        return _slice_from_valid_subset(
+            self, self._queryer.get_failed_asset_subset(asset_key=asset_key)
+        )
 
     @cached_method
     def compute_updated_since_cursor_slice(
@@ -561,7 +578,7 @@ class AssetGraphView:
         partitions_def: TimeWindowPartitionsDefinition,
         time_window: TimeWindow,
     ) -> "AssetSlice":
-        return self.get_asset_slice(asset_key).compute_intersection_with_partition_keys(
+        return self.get_asset_slice(asset_key=asset_key).compute_intersection_with_partition_keys(
             set(partitions_def.get_partition_keys_in_time_window(time_window))
         )
 
@@ -572,7 +589,7 @@ class AssetGraphView:
         # in the underlying PartitionsSet. We could add a specialized PartitionsSubset
         # subclass that itself composed two PartitionsSubset to avoid materializing the entire
         # partitions range.
-        return self.get_asset_slice(asset_key).compute_intersection_with_partition_keys(
+        return self.get_asset_slice(asset_key=asset_key).compute_intersection_with_partition_keys(
             {
                 MultiPartitionKey(
                     {

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/newly_true_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/newly_true_operator.py
@@ -24,7 +24,7 @@ class NewlyTrueCondition(SchedulingCondition):
             self.operand,
             child_index=0,
             # must evaluate child condition over the entire slice to avoid missing state transitions
-            candidate_slice=context.asset_graph_view.get_asset_slice(context.asset_key),
+            candidate_slice=context.asset_graph_view.get_asset_slice(asset_key=context.asset_key),
         )
         child_result = self.operand.evaluate(child_context)
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/since_operator.py
@@ -23,7 +23,9 @@ class SinceCondition(SchedulingCondition):
 
     def evaluate(self, context: SchedulingContext) -> SchedulingResult:
         # must evaluate child condition over the entire slice to avoid missing state transitions
-        child_candidate_slice = context.asset_graph_view.get_asset_slice(context.asset_key)
+        child_candidate_slice = context.asset_graph_view.get_asset_slice(
+            asset_key=context.asset_key
+        )
 
         # compute result for trigger condition
         trigger_context = context.for_child_condition(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
@@ -106,7 +106,7 @@ class SchedulingContext(NamedTuple):
         scheduling_condition = auto_materialize_policy.to_scheduling_condition()
 
         return SchedulingContext(
-            candidate_slice=asset_graph_view.get_asset_slice(asset_key),
+            candidate_slice=asset_graph_view.get_asset_slice(asset_key=asset_key),
             condition=scheduling_condition,
             condition_unique_id=scheduling_condition.get_unique_id(
                 parent_unique_id=None, index=None

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
@@ -47,15 +47,16 @@ def test_slice_traversal_static_partitions() -> None:
 
     asset_graph_view_t0 = AssetGraphView.for_test(defs, instance)
     assert (
-        asset_graph_view_t0.get_asset_slice(up_numbers.key).compute_partition_keys() == number_keys
+        asset_graph_view_t0.get_asset_slice(asset_key=up_numbers.key).compute_partition_keys()
+        == number_keys
     )
     assert (
-        asset_graph_view_t0.get_asset_slice(down_letters.key).compute_partition_keys()
+        asset_graph_view_t0.get_asset_slice(asset_key=down_letters.key).compute_partition_keys()
         == letter_keys
     )
 
     # from full up to down
-    up_slice = asset_graph_view_t0.get_asset_slice(up_numbers.key)
+    up_slice = asset_graph_view_t0.get_asset_slice(asset_key=up_numbers.key)
     assert up_slice.compute_partition_keys() == {"1", "2", "3"}
     assert up_slice.compute_child_slice(down_letters.key).compute_partition_keys() == {
         "a",
@@ -64,7 +65,7 @@ def test_slice_traversal_static_partitions() -> None:
     }
 
     # from full up to down
-    down_slice = asset_graph_view_t0.get_asset_slice(down_letters.key)
+    down_slice = asset_graph_view_t0.get_asset_slice(asset_key=down_letters.key)
     assert down_slice.compute_partition_keys() == {"a", "b", "c"}
     assert down_slice.compute_parent_slice(up_numbers.key).compute_partition_keys() == {
         "1",
@@ -96,9 +97,9 @@ def test_only_partition_keys() -> None:
     asset_graph_view_t0 = AssetGraphView.for_test(defs, instance)
 
     assert asset_graph_view_t0.get_asset_slice(
-        up_numbers.key
+        asset_key=up_numbers.key
     ).compute_intersection_with_partition_keys({"1", "2"}).compute_partition_keys() == {"1", "2"}
 
     assert asset_graph_view_t0.get_asset_slice(
-        up_numbers.key
+        asset_key=up_numbers.key
     ).compute_intersection_with_partition_keys({"3"}).compute_partition_keys() == set(["3"])

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_latest_time_window.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_latest_time_window.py
@@ -48,9 +48,9 @@ def test_latest_time_slice_no_end() -> None:
         defs, instance, effective_dt=pendulum.datetime(2020, 2, 4)
     )
 
-    assert asset_graph_view_on_2_4.get_asset_slice(daily.key).compute_partition_keys() == set(
-        partition_key_list
-    )
+    assert asset_graph_view_on_2_4.get_asset_slice(
+        asset_key=daily.key
+    ).compute_partition_keys() == set(partition_key_list)
 
     assert asset_graph_view_on_2_4.compute_latest_time_window_slice(
         daily.key
@@ -70,9 +70,9 @@ def test_latest_time_slice_no_end() -> None:
         defs, instance, effective_dt=pendulum.datetime(2020, 2, 5)
     )
 
-    assert asset_graph_view_on_2_5.get_asset_slice(daily.key).compute_partition_keys() == set(
-        partition_key_list + ["2020-02-04"]
-    )
+    assert asset_graph_view_on_2_5.get_asset_slice(
+        asset_key=daily.key
+    ).compute_partition_keys() == set(partition_key_list + ["2020-02-04"])
 
     assert asset_graph_view_on_2_5.compute_latest_time_window_slice(
         daily.key
@@ -84,7 +84,10 @@ def test_latest_time_slice_no_end() -> None:
         defs, instance, effective_dt=pendulum.datetime(2020, 1, 1)
     )
 
-    assert asset_graph_view_on_1_1.get_asset_slice(daily.key).compute_partition_keys() == set()
+    assert (
+        asset_graph_view_on_1_1.get_asset_slice(asset_key=daily.key).compute_partition_keys()
+        == set()
+    )
 
     assert (
         asset_graph_view_on_1_1.compute_latest_time_window_slice(daily.key).compute_partition_keys()
@@ -100,10 +103,10 @@ def test_latest_time_slice_no_end() -> None:
         defs, instance, effective_dt=pendulum.datetime(2020, 2, 2, minute=1)
     )
     assert asset_graph_view_on_2_2_plus_1_min.get_asset_slice(
-        daily.key
+        asset_key=daily.key
     ).compute_partition_keys() == set(["2020-02-01"])
 
-    tw = _tw(asset_graph_view_on_2_2_plus_1_min.get_asset_slice(daily.key))
+    tw = _tw(asset_graph_view_on_2_2_plus_1_min.get_asset_slice(asset_key=daily.key))
 
     assert tw.start == datetime.min
     assert tw.end == pendulum.datetime(2020, 2, 2)
@@ -164,7 +167,7 @@ def test_latest_time_slice_unpartitioned() -> None:
     instance = DagsterInstance.ephemeral()
 
     asset_graph_view = AssetGraphView.for_test(defs, instance)
-    assert not asset_graph_view.get_asset_slice(unpartitioned.key).is_empty
+    assert not asset_graph_view.get_asset_slice(asset_key=unpartitioned.key).is_empty
     assert not asset_graph_view.compute_latest_time_window_slice(unpartitioned.key).is_empty
 
 
@@ -214,7 +217,7 @@ def test_multi_dimesional_with_time_partition_latest_time_window() -> None:
         defs, instance, effective_dt=pendulum.datetime(2020, 3, 3)
     )
 
-    md_slice = asset_graph_view_within_partition.get_asset_slice(multi_dimensional.key)
+    md_slice = asset_graph_view_within_partition.get_asset_slice(asset_key=multi_dimensional.key)
     assert md_slice.compute_partition_keys() == set(partition_keys)
     last_tw_slice = asset_graph_view_within_partition.compute_latest_time_window_slice(
         multi_dimensional.key
@@ -253,7 +256,7 @@ def test_multi_dimesional_without_time_partition_latest_time_window() -> None:
     defs = Definitions([multi_dimensional])
     instance = DagsterInstance.ephemeral()
     asset_graph_view = AssetGraphView.for_test(defs, instance)
-    md_slice = asset_graph_view.get_asset_slice(multi_dimensional.key)
+    md_slice = asset_graph_view.get_asset_slice(asset_key=multi_dimensional.key)
     assert md_slice.compute_partition_keys() == set(partition_keys)
     assert asset_graph_view.compute_latest_time_window_slice(
         multi_dimensional.key
@@ -283,7 +286,7 @@ def test_dynamic_partitioning_latest_time_window() -> None:
 
     asset_graph_view = AssetGraphView.for_test(defs, instance)
     assert (
-        asset_graph_view.get_asset_slice(dynamic_asset.key).compute_partition_keys()
+        asset_graph_view.get_asset_slice(asset_key=dynamic_asset.key).compute_partition_keys()
         == partition_keys
     )
     assert (
@@ -305,7 +308,7 @@ def test_dynamic_partitioning_latest_time_window() -> None:
             partition_keys.append(MultiPartitionKey({"daily": daily_pk, "dynamic": dynamic_pk}))
 
     assert asset_graph_view.get_asset_slice(
-        dynamic_multi_dimensional.key
+        asset_key=dynamic_multi_dimensional.key
     ).compute_partition_keys() == set(partition_keys)
     assert asset_graph_view.compute_latest_time_window_slice(
         dynamic_multi_dimensional.key


### PR DESCRIPTION
## Summary & Motivation

It is not free to do isinstance checks, so I make two separate entrypoints for converting from asset subset to asset slice. For the common case, where we know that a subset is guaranteed to be valid, we skip the instance check entirely.

Also uses a cached_method for get_asset_slice, as the AssetSlice itself caches some properties/methods, and so returning the same object instance from get_asset_slice means different call sites get to share the same cache.

## How I Tested These Changes
