### PR TITLE
[DS][55/n] Avoid looking back across all history on first tick

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -289,8 +289,9 @@ class AssetGraphView:
         from dagster._core.definitions.data_version import CachingStaleStatusResolver
         from dagster._core.instance import DagsterInstance
 
+        instance = instance or DagsterInstance.ephemeral()
         stale_resolver = CachingStaleStatusResolver(
-            instance=instance or DagsterInstance.ephemeral(),
+            instance=instance,
             asset_graph=defs.get_asset_graph(),
         )
         check.invariant(stale_resolver.instance_queryer, "Ensure instance queryer is constructed")
@@ -298,7 +299,7 @@ class AssetGraphView:
             stale_resolver=stale_resolver,
             temporal_context=TemporalContext(
                 effective_dt=effective_dt or pendulum.now(),
-                last_event_id=last_event_id,
+                last_event_id=last_event_id or instance.event_log_storage.get_maximum_record_id(),
             ),
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -107,8 +107,7 @@ class AssetDaemonContext:
         self._asset_graph_view = AssetGraphView(
             temporal_context=TemporalContext(
                 effective_dt=self.instance_queryer.evaluation_time,
-                # TODO: we should eventually pass in an explicit last_event_id
-                last_event_id=None,
+                last_event_id=instance.event_log_storage.get_maximum_record_id(),
             ),
             stale_resolver=stale_resolver,
         )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/rule_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/rule_condition.py
@@ -30,7 +30,7 @@ class RuleCondition(AssetCondition):
     def evaluate(self, context: SchedulingContext) -> SchedulingResult:
         context.logger.debug(f"Evaluating rule: {self.rule.to_snapshot()}")
         # Allow for access to legacy context in legacy rule evaluation
-        evaluation_result = self.rule.evaluate_for_asset(context._replace(allow_legacy_access=True))
+        evaluation_result = self.rule.evaluate_for_asset(context)
         context.logger.debug(
             f"Rule returned {evaluation_result.true_subset.size} partitions "
             f"({evaluation_result.end_timestamp - evaluation_result.start_timestamp:.2f} seconds)"

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -602,16 +602,12 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
                 AssetKeyPartitionKey(child_asset_key)
             )
         ]
-
         child_asset = self.asset_graph.get(child_asset_key)
         if not child_asset.parent_keys:
-            # return set(), latest_storage_id
             return set(), max(filter(None, [latest_storage_id, *max_storage_ids]), default=None)
 
         child_time_partitions_def = get_time_partitions_def(child_asset.partitions_def)
-
         child_asset_partitions_with_updated_parents = set()
-
         for parent_asset_key in self.asset_graph.get(child_asset_key).parent_keys:
             # ignore non-existent parents
             if not self.asset_graph.has(parent_asset_key):


### PR DESCRIPTION
## Summary & Motivation

This needs to be updated, but the basic idea is that in the DS paradigm, if you have no previous cursor, you should not attempt to run a query that looks back across all history

## How I Tested These Changes
