### PR TITLE
pass through retry_policy for dbt assets

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -23,6 +23,7 @@ from dagster import (
     DagsterInvalidDefinitionError,
     Nothing,
     PartitionsDefinition,
+    RetryPolicy,
     TimeWindowPartitionsDefinition,
     multi_asset,
 )
@@ -78,6 +79,7 @@ def dbt_assets(
     op_tags: Optional[Mapping[str, Any]] = None,
     required_resource_keys: Optional[Set[str]] = None,
     project: Optional[DbtProject] = None,
+    retry_policy: Optional[RetryPolicy] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a definition for how to compute a set of dbt resources, described by a manifest.json.
     When invoking dbt commands using :py:class:`~dagster_dbt.DbtCliResource`'s
@@ -403,6 +405,7 @@ def dbt_assets(
         op_tags=resolved_op_tags,
         check_specs=check_specs,
         backfill_policy=backfill_policy,
+        retry_policy=retry_policy,
     )
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -114,6 +114,7 @@ def dbt_assets(
         project (Optional[DbtProject]): A DbtProject instance which provides a pointer to the dbt
             project location and manifest. Not required, but needed to attach code references from
             model code to Dagster assets.
+        retry_policy (Optional[RetryPolicy]): The retry policy for the op that computes the asset.
 
     Examples:
         Running ``dbt build`` for a dbt project:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -325,15 +325,9 @@ def test_retry_policy(
     test_jaffle_shop_manifest: Dict[str, Any],
     retry_policy: Optional[RetryPolicy],
 ) -> None:
-    class CustomDagsterDbtTranslator(DagsterDbtTranslator):
-        def get_freshness_policy(self, _: Mapping[str, Any]) -> Optional[FreshnessPolicy]:
-            # Disable freshness policies when using static partitions
-            return None
-
     @dbt_assets(
         manifest=test_jaffle_shop_manifest,
         retry_policy=retry_policy,
-        dagster_dbt_translator=CustomDagsterDbtTranslator(),
     )
     def my_dbt_assets(): ...
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -12,10 +12,13 @@ from dagster import (
     Definitions,
     DependencyDefinition,
     FreshnessPolicy,
+    Jitter,
     LastPartitionMapping,
     NodeInvocation,
+    OpDefinition,
     PartitionMapping,
     PartitionsDefinition,
+    RetryPolicy,
     StaticPartitionsDefinition,
     TimeWindowPartitionMapping,
     asset,
@@ -303,6 +306,39 @@ def test_backfill_policy(
     def my_dbt_assets(): ...
 
     assert my_dbt_assets.backfill_policy == expected_backfill_policy
+
+
+@pytest.mark.parametrize(
+    "retry_policy",
+    [
+        None,
+        RetryPolicy(max_retries=1),
+        RetryPolicy(max_retries=2, delay=1, jitter=Jitter.FULL),
+    ],
+    ids=[
+        "no retry policy",
+        "retry policy",
+        "retry policy with jitter",
+    ],
+)
+def test_retry_policy(
+    test_jaffle_shop_manifest: Dict[str, Any],
+    retry_policy: Optional[RetryPolicy],
+) -> None:
+    class CustomDagsterDbtTranslator(DagsterDbtTranslator):
+        def get_freshness_policy(self, _: Mapping[str, Any]) -> Optional[FreshnessPolicy]:
+            # Disable freshness policies when using static partitions
+            return None
+
+    @dbt_assets(
+        manifest=test_jaffle_shop_manifest,
+        retry_policy=retry_policy,
+        dagster_dbt_translator=CustomDagsterDbtTranslator(),
+    )
+    def my_dbt_assets(): ...
+
+    assert isinstance(my_dbt_assets.node_def, OpDefinition)
+    assert my_dbt_assets.node_def.retry_policy == retry_policy
 
 
 def test_op_tags(test_jaffle_shop_manifest: Dict[str, Any]):


### PR DESCRIPTION
## Summary & Motivation
There's no way to pass a retry policy to a dbt asset.  I assumed this was mostly an oversight, and not an explicit decision.

Might need to sanity check that retries make sense in the dbt world.

In a lot of cases, users will probably want to run `dbt retry` (instead of op-level retry) to not lose the per-model granularity of failures, but there is a case to be made to still configure a coarse-grained op-level retry with the standard retry options (e.g. delay, jitter, etc)

## How I Tested These Changes
BK