### PR TITLE
[blueprints] add LocalFileCodeReference to `load_defs_from_yaml`-loaded assets

### DIFF
--- a/python_modules/dagster/dagster/_core/blueprints/load_from_yaml.py
+++ b/python_modules/dagster/dagster/_core/blueprints/load_from_yaml.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Type, Union
 
@@ -5,9 +6,68 @@ from dagster import (
     Definitions,
     _check as check,
 )
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.metadata.source_code import (
+    CodeReferencesMetadataSet,
+    CodeReferencesMetadataValue,
+    LocalFileCodeReference,
+)
 from dagster._utils.pydantic_yaml import parse_yaml_file_to_pydantic
 
 from .blueprint import Blueprint, BlueprintDefinitions
+
+
+def _attach_code_references_to_definitions(
+    file_path: Path, blueprint: BlueprintDefinitions
+) -> BlueprintDefinitions:
+    """Attaches code reference metadata pointing to the specified file path to all assets in the
+    output blueprint definitions.
+    """
+    assets_defs = blueprint.assets or []
+    new_assets_defs = []
+
+    for assets_def in assets_defs:
+        if not isinstance(assets_def, AssetsDefinition):
+            new_assets_defs.append(assets_def)
+            continue
+
+        new_metadata_by_key = {}
+        for key in assets_def.metadata_by_key.keys():
+            existing_references_meta = CodeReferencesMetadataSet.extract(
+                assets_def.metadata_by_key[key]
+            )
+            existing_references = (
+                existing_references_meta.code_references.code_references
+                if existing_references_meta.code_references
+                else []
+            )
+
+            new_metadata_by_key[key] = {
+                **assets_def.metadata_by_key[key],
+                **CodeReferencesMetadataSet(
+                    code_references=CodeReferencesMetadataValue(
+                        code_references=[
+                            *existing_references,
+                            LocalFileCodeReference(file_path=os.fspath(file_path)),
+                        ],
+                    )
+                ),
+            }
+
+        new_assets_defs.append(
+            AssetsDefinition.dagster_internal_init(
+                **{
+                    **assets_def.get_attributes_dict(),
+                    **{
+                        "specs": [
+                            spec._replace(metadata=new_metadata_by_key[spec.key])
+                            for spec in assets_def.specs
+                        ]
+                    },
+                }
+            )
+        )
+    return blueprint._replace(assets=new_assets_defs)
 
 
 def load_defs_from_yaml(
@@ -32,11 +92,20 @@ def load_defs_from_yaml(
     else:
         file_paths = list(resolved_path.rglob("*.yaml")) + list(resolved_path.rglob("*.yml"))
 
-    blueprints = [
-        parse_yaml_file_to_pydantic(per_file_blueprint_type, file_path.read_text(), str(file_path))
+    blueprints = {
+        file_path: parse_yaml_file_to_pydantic(
+            per_file_blueprint_type, file_path.read_text(), str(file_path)
+        )
         for file_path in file_paths
+    }
+
+    def_sets = {
+        file_path: blueprint.build_defs_add_context_to_errors()
+        for file_path, blueprint in blueprints.items()
+    }
+    def_sets_with_code_references = [
+        _attach_code_references_to_definitions(file_path, def_set)
+        for file_path, def_set in def_sets.items()
     ]
 
-    def_sets = [blueprints.build_defs_add_context_to_errors() for blueprints in blueprints]
-
-    return BlueprintDefinitions.merge(*def_sets).to_definitions()
+    return BlueprintDefinitions.merge(*def_sets_with_code_references).to_definitions()

--- a/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/test_load_defs_from_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/test_load_defs_from_yaml.py
@@ -54,6 +54,7 @@ def test_single_file_single_blueprint() -> None:
     assert reference.file_path == os.fspath(
         Path(__file__).parent / "yaml_files" / "single_blueprint.yaml"
     )
+    assert reference.line_number == 1
 
 
 def test_dir_of_single_blueprints() -> None:
@@ -76,6 +77,7 @@ def test_dir_of_single_blueprints() -> None:
         assert reference.file_path == os.fspath(
             Path(__file__).parent / "yaml_files" / "dir_of_single_blueprints" / expected_filename
         )
+        assert reference.line_number == 1
 
 
 def test_abstract_blueprint() -> None:

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/blueprints/test2.csv
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/blueprints/test2.csv
@@ -1,0 +1,4 @@
+SPECIES_CODE,SPECIES_NAME,UPDATED_AT
+abcdef,scrubjay,1
+defghi,bluejay,2
+jklnop,blackbird,2


### PR DESCRIPTION
## Summary

Adds logic to automatically attach `LocalFileCodeReference`s to any assets returned from `build_defs_add_context_to_errors` in `load_defs_from_yaml`.

For now, this is pretty straightforward, since we have a correspondence between a single file and its blueprint. We pull the position in the file from the Blueprint's `_source_position_and_key_path`.

## Test Plan

Add some assertions around code references to existing unit tests.