### PR TITLE
[blueprints] Track used env vars on Blueprint file

### DIFF
--- a/python_modules/dagster/dagster/_core/blueprints/blueprint.py
+++ b/python_modules/dagster/dagster/_core/blueprints/blueprint.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterable, Mapping, NamedTuple, Optional, Union
+from typing import Any, Dict, Iterable, Mapping, NamedTuple, Optional, Set, Union
+
+from pydantic import PrivateAttr
 
 from dagster import _check as check
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
@@ -133,6 +135,8 @@ class Blueprint(DagsterModel, ABC, HasSourcePositionAndKeyPath):
     - A build_defs implementation that generates Dagster Definitions from field values
     """
 
+    _used_env_vars: Set[str] = PrivateAttr(set())
+
     @abstractmethod
     def build_defs(self) -> BlueprintDefinitions:
         raise NotImplementedError()
@@ -156,3 +160,6 @@ class Blueprint(DagsterModel, ABC, HasSourcePositionAndKeyPath):
             raise DagsterBuildDefinitionsFromConfigError(
                 f"Error when building definitions from config with type {cls_name} at {source_pos}"
             ) from e
+
+    def with_used_env_vars(self, env_vars: Set[str]) -> "Blueprint":
+        return self.copy(update={"_used_env_vars": env_vars})

--- a/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/yaml_files/single_blueprint_with_many_env_var.yaml
+++ b/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/yaml_files/single_blueprint_with_many_env_var.yaml
@@ -1,0 +1,4 @@
+key: asset1
+foo: {{ env_var("FOO") }}
+bar: {{ env_var("BAR") }}
+baz: "{{ env_var("BAZ") }} {{ env_var("QUX") }}"


### PR DESCRIPTION
## Summary

Follow-on to the Jinja PR which demonstrates tracking env vars used in each Blueprint. I can imagine us serializing this information as part of the serialized Blueprint representation that goes in Definitions, and then displaying backlinks to `EnbvVar`s in Cloud.

## Test Plan

Unit test.