### PR TITLE
[ui] fix Timeline stutters

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
@@ -15,7 +15,7 @@ import {WorkspaceContext} from '../workspace/WorkspaceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 const LOOKAHEAD_HOURS = 1;
 const ONE_HOUR = 60 * 60 * 1000;
-const POLL_INTERVAL = 5 * 1000;
+const POLL_INTERVAL = 30 * 1000;
 
 const hourWindowToOffset = (hourWindow: HourWindow) => {
   switch (hourWindow) {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -410,7 +410,8 @@ export const useRunsForTimeline = ({
     const earliest = jobs.reduce(
       (accum, job) => {
         const startTimes = job.runs.map((job) => job.startTime);
-        return {...accum, [job.key]: Math.min(...startTimes)};
+        accum[job.key] = Math.min(...startTimes);
+        return accum;
       },
       {} as {[jobKey: string]: number},
     );


### PR DESCRIPTION
* fix the poorly performing `reduce` operation that would lock up the browser on a high volume of jobs/runs
* reduce the poll interval to limit the times we recalculate the timeline

## How I Tested These Changes

profiled a deployment with many jobs & runs - memo updates reduced from 3+s to ~150ms

before
![Screenshot 2024-05-29 at 2 37 52 PM](https://github.com/dagster-io/dagster/assets/202219/d3a72a15-20dc-4fe9-85e7-4976eb3fde70)

after
![Screenshot 2024-05-29 at 2 39 30 PM](https://github.com/dagster-io/dagster/assets/202219/28e28f8c-b065-4d29-b4d4-53bcabcc0412)
