### PR TITLE
[blueprints] Track used env vars on Blueprint file

### DIFF
--- a/examples/experimental/dagster-blueprints/dagster_blueprints/blueprint.py
+++ b/examples/experimental/dagster-blueprints/dagster_blueprints/blueprint.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterable, Mapping, NamedTuple, Optional, Union
+from typing import Any, Dict, Iterable, Mapping, NamedTuple, Optional, Set, Union
 
 from dagster import _check as check
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
@@ -19,6 +19,7 @@ from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.executor.base import Executor
 from dagster._model import DagsterModel
 from dagster._utils.source_position import HasSourcePositionAndKeyPath
+from pydantic import PrivateAttr
 
 
 class DagsterBuildDefinitionsFromConfigError(Exception):
@@ -131,6 +132,8 @@ class Blueprint(DagsterModel, ABC, HasSourcePositionAndKeyPath):
     - A build_defs implementation that generates Dagster Definitions from field values
     """
 
+    _used_env_vars: Set[str] = PrivateAttr(set())
+
     @abstractmethod
     def build_defs(self) -> BlueprintDefinitions:
         raise NotImplementedError()
@@ -154,3 +157,6 @@ class Blueprint(DagsterModel, ABC, HasSourcePositionAndKeyPath):
             raise DagsterBuildDefinitionsFromConfigError(
                 f"Error when building definitions from config with type {cls_name} at {source_pos}"
             ) from e
+
+    def with_used_env_vars(self, env_vars: Set[str]) -> "Blueprint":
+        return self.copy(update={"_used_env_vars": env_vars})

--- a/examples/experimental/dagster-blueprints/dagster_blueprints_tests/test_load_defs_from_yaml.py
+++ b/examples/experimental/dagster-blueprints/dagster_blueprints_tests/test_load_defs_from_yaml.py
@@ -472,3 +472,28 @@ def test_basic_env_var_jinja_escaping() -> None:
         defs.get_assets_def("asset1").descriptions_by_key[AssetKey("asset1")]
         == "{{ env_var('ASSET_NAME') }}"
     )
+
+
+class SimpleAssetBlueprintTrackEnvVars(Blueprint):
+    key: str
+    foo: str
+    bar: str
+    baz: str
+
+    def build_defs(self) -> BlueprintDefinitions:
+        @asset(key=self.key, metadata={"used_env_vars": sorted(list(self._used_env_vars))})
+        def _asset(): ...
+
+        return BlueprintDefinitions(assets=[_asset])
+
+
+def test_track_env_vars() -> None:
+    with environ({"FOO": "foo", "BAR": "bar", "BAZ": "baz", "QUX": "qux"}):
+        defs = load_defs_from_yaml(
+            path=Path(__file__).parent / "yaml_files" / "single_blueprint_with_many_env_var.yaml",
+            per_file_blueprint_type=SimpleAssetBlueprintTrackEnvVars,
+        )
+        assert set(defs.get_asset_graph().all_asset_keys) == {AssetKey("asset1")}
+
+        asset_metadata = defs.get_assets_def("asset1").metadata_by_key[AssetKey("asset1")]
+        assert asset_metadata["used_env_vars"] == ["BAR", "BAZ", "FOO", "QUX"]

--- a/examples/experimental/dagster-blueprints/dagster_blueprints_tests/yaml_files/single_blueprint_with_many_env_var.yaml
+++ b/examples/experimental/dagster-blueprints/dagster_blueprints_tests/yaml_files/single_blueprint_with_many_env_var.yaml
@@ -1,0 +1,4 @@
+key: asset1
+foo: "{{ env_var('FOO') }}"
+bar: "{{ env_var('BAR') }}"
+baz: "{{ env_var('BAZ') }} {{ env_var('QUX') }}"


### PR DESCRIPTION
## Sumamry


Follow-on to the Jinja PR which demonstrates tracking env vars used in each Blueprint. I can imagine us serializing this information as part of the serialized Blueprint representation that goes in Definitions,
 and then displaying backlinks to `EnvVar`s in Cloud.

## Test Plan

Unit test.
