### PR TITLE
[DS][56/n] Use slimmed cursor object for internal computation

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/asset_condition.py
@@ -4,6 +4,10 @@ from ..scheduling_condition import SchedulingCondition
 class AssetCondition(SchedulingCondition):
     """Deprecated: Use SchedulingCondition instead."""
 
+    @property
+    def store_subsets(self) -> bool:
+        return True
+
     @staticmethod
     def parent_newer() -> "SchedulingCondition":
         """Returns an AssetCondition that is true for an asset partition when at least one parent

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/parent_newer_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/parent_newer_condition.py
@@ -13,6 +13,10 @@ from dagster._serdes.serdes import whitelist_for_serdes
 @whitelist_for_serdes
 class ParentNewerCondition(SchedulingCondition):
     @property
+    def store_subsets(self) -> bool:
+        return True
+
+    @property
     def description(self) -> str:
         return "At least one parent has been updated more recently than the candidate."
 
@@ -92,9 +96,9 @@ class ParentNewerCondition(SchedulingCondition):
         slice_to_evaluate = self.compute_slice_to_evaluate(context)
         new_parent_newer_slice = self.compute_parent_newer_slice(context, slice_to_evaluate)
 
-        if context.previous_evaluation_node and context.previous_evaluation_node.true_slice:
+        if context.node_cursor and context.previous_true_slice:
             # combine new results calculated this tick with results from the previous tick
-            true_slice = context.previous_evaluation_node.true_slice.compute_difference(
+            true_slice = context.previous_true_slice.compute_difference(
                 slice_to_evaluate
             ).compute_union(new_parent_newer_slice)
         else:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
@@ -108,7 +108,7 @@ class NewlyUpdatedCondition(SliceSchedulingCondition):
 
     def compute_slice(self, context: SchedulingContext) -> AssetSlice:
         # if it's the first time evaluating, just return the empty slice
-        if context.previous_evaluation_node is None:
+        if context.node_cursor is None:
             return context.asset_graph_view.create_empty_slice(context.asset_key)
         else:
             return context.asset_graph_view.compute_updated_since_cursor_slice(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/since_operator.py
@@ -12,6 +12,10 @@ class SinceCondition(SchedulingCondition):
     reset_condition: SchedulingCondition
 
     @property
+    def store_subsets(self) -> bool:
+        return True
+
+    @property
     def description(self) -> str:
         return (
             "Trigger condition has become true since the last time the reset condition became true."

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
@@ -47,6 +47,10 @@ if TYPE_CHECKING:
 @experimental
 class SchedulingCondition(ABC, DagsterModel):
     @property
+    def store_subsets(self) -> bool:
+        return False
+
+    @property
     def children(self) -> Sequence["SchedulingCondition"]:
         return []
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition_evaluator.py
@@ -35,6 +35,7 @@ from .legacy.legacy_context import (
 )
 from .serialized_objects import (
     AssetConditionEvaluationState,
+    SchedulingConditionCursor,
 )
 
 if TYPE_CHECKING:
@@ -230,7 +231,9 @@ class SchedulingConditionEvaluator:
 
         legacy_context = LegacyRuleEvaluationContext.create(
             asset_key=asset_key,
-            previous_evaluation_state=previous_evaluation_state,
+            cursor=SchedulingConditionCursor.from_evaluation_state(previous_evaluation_state)
+            if previous_evaluation_state
+            else None,
             condition=asset_condition,
             instance_queryer=self.instance_queryer,
             data_time_resolver=self.data_time_resolver,
@@ -259,4 +262,4 @@ class SchedulingConditionEvaluator:
         expected_data_time = get_expected_data_time_for_asset_key(
             legacy_context, will_materialize=result.true_subset.size > 0
         )
-        return AssetConditionEvaluationState.create(context, result), expected_data_time
+        return (AssetConditionEvaluationState.create(context, result), expected_data_time)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
@@ -12,6 +12,7 @@ from dagster._core.definitions.declarative_scheduling.serialized_objects import 
     AssetConditionEvaluation,
     AssetConditionEvaluationState,
     AssetSubsetWithMetadata,
+    SchedulingConditionCursor,
 )
 from dagster._core.definitions.metadata import MetadataMapping
 from dagster._model import DagsterModel
@@ -102,6 +103,7 @@ class SchedulingEvaluationInfo(DagsterModel):
     temporal_context: TemporalContext
     evaluation_nodes: Sequence[SchedulingEvaluationResultNode]
     requested_slice: Optional[AssetSlice]
+    cursor: Optional[SchedulingConditionCursor]
 
     def get_evaluation_node(self, unique_id: str) -> Optional[SchedulingEvaluationResultNode]:
         for node in self.evaluation_nodes:
@@ -125,4 +127,5 @@ class SchedulingEvaluationInfo(DagsterModel):
             temporal_context=temporal_context,
             evaluation_nodes=nodes,
             requested_slice=requested_slice,
+            cursor=SchedulingConditionCursor.from_evaluation_state(state),
         )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
@@ -75,6 +75,7 @@ class SchedulingConditionScenarioState(ScenarioState):
                         asset_key, asset_graph_view.asset_graph.get(asset_key).partitions_def, aps
                     )
                 ),
+                cursor=None,
             )
             for asset_key, aps in ap_by_key.items()
         }

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_user_space_ds_api.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_user_space_ds_api.py
@@ -4,7 +4,7 @@ from typing import AbstractSet, Iterator, NamedTuple, Sequence
 
 import mock
 import pytest
-from dagster import SchedulingCondition, asset, deserialize_value, serialize_value
+from dagster import SchedulingCondition, asset
 from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.data_time import CachingDataTimeResolver
@@ -50,13 +50,14 @@ def execute_ds_ticks(defs: Definitions, n: int) -> Iterator[SchedulingTickResult
             auto_materialize_run_tags={},
         )
         result = evaluator.evaluate()
+
         cursor = cursor.with_updates(
             evaluation_id=i,
             evaluation_timestamp=time.time(),
             newly_observe_requested_asset_keys=[],
             evaluation_state=result[0],
         )
-        cursor = deserialize_value(serialize_value(cursor), AssetDaemonCursor)
+
         yield SchedulingTickResult(evaluation_states=result[0], asset_partition_keys=result[1])
 
 


### PR DESCRIPTION
## Summary & Motivation

This is the first step in migrating us to using a slimmed-down cursor object within our internals. Currently, we store the entire AssetConditionEvaluationState object inside of our cursor. This object contains high-fidelity information about each node of computation in our graph. This _is_ necessary to store for use in the UI, as we want to record all relevant information about each node, but it is way more information than required for incremental calculations.

This PR splits off a simplified SchedulingConditionCursor class, which contains just a flattened mapping of condition node id to SchedulingConditionNodeCursor, which contains some relevant properties. We then refactor the internals to pull information off of this class. Because of this flattened structure, we have the freedom to store no information at all for nodes in the condition evaluation that do not require a cursor to function (which is the majority of them).

To keep things a bit simpler, this PR does not actually change any storage implementations (that'll happen in the next PR in the stack), and instead does a conversion from big complex object to simple cursor after deserializing the complex object from storage.

## How I Tested These Changes
