### PR TITLE
[DS][57/n] Use slimmed cursor object in storage

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -2,13 +2,7 @@ import dataclasses
 import json
 from dataclasses import dataclass
 from functools import cached_property
-from typing import (
-    TYPE_CHECKING,
-    Mapping,
-    NamedTuple,
-    Optional,
-    Sequence,
-)
+from typing import TYPE_CHECKING, Mapping, NamedTuple, Optional, Sequence
 
 from dagster._core.definitions.events import AssetKey
 from dagster._serdes.serdes import (
@@ -27,9 +21,9 @@ from .base_asset_graph import BaseAssetGraph
 
 if TYPE_CHECKING:
     from .declarative_scheduling.serialized_objects import (
-        AssetConditionEvaluation,
         AssetConditionEvaluationState,
         AssetConditionSnapshot,
+        SchedulingConditionCursor,
     )
 
 
@@ -74,62 +68,69 @@ class AssetDaemonCursor:
 
     Attributes:
         evaluation_id (int): The ID of the evaluation that produced this cursor.
-        previous_evaluation_state (Sequence[AssetConditionEvaluationInfo]): The evaluation info
-            recorded for each asset on the previous tick.
+        previous_evaluation_state (Sequence[AssetConditionEvaluationState]): (DEPRECATED) The
+            evaluation info recorded for each asset on the previous tick.
+        previous_cursors (Sequence[SchedulingConditionCursor]): The cursor objects for each asset
+            recorded on the previous tick.
     """
 
     evaluation_id: int
-    previous_evaluation_state: Sequence["AssetConditionEvaluationState"]
-
     last_observe_request_timestamp_by_asset_key: Mapping[AssetKey, float]
+
+    previous_evaluation_state: Optional[Sequence["AssetConditionEvaluationState"]]
+    previous_condition_cursors: Optional[Sequence["SchedulingConditionCursor"]] = None
 
     @staticmethod
     def empty(evaluation_id: int = 0) -> "AssetDaemonCursor":
         return AssetDaemonCursor(
             evaluation_id=evaluation_id,
-            previous_evaluation_state=[],
+            previous_evaluation_state=None,
+            previous_condition_cursors=[],
             last_observe_request_timestamp_by_asset_key={},
         )
 
     @cached_property
-    def previous_evaluation_state_by_key(
-        self,
-    ) -> Mapping[AssetKey, "AssetConditionEvaluationState"]:
-        """Efficient lookup of previous evaluation info by asset key."""
-        return {
-            evaluation_state.asset_key: evaluation_state
-            for evaluation_state in self.previous_evaluation_state
-        }
+    def previous_condition_cursors_by_key(self) -> Mapping[AssetKey, "SchedulingConditionCursor"]:
+        """Efficient lookup of previous cursor by asset key."""
+        from dagster._core.definitions.declarative_scheduling.serialized_objects import (
+            SchedulingConditionCursor,
+        )
 
-    def get_previous_evaluation_state(
+        if self.previous_condition_cursors is None:
+            # automatically convert AssetConditionEvaluationState objects to SchedulingConditionCursor
+            return {
+                evaluation_state.asset_key: SchedulingConditionCursor.backcompat_from_evaluation_state(
+                    evaluation_state
+                )
+                for evaluation_state in self.previous_evaluation_state or []
+            }
+        else:
+            return {cursor.asset_key: cursor for cursor in self.previous_condition_cursors}
+
+    def get_previous_condition_cursor(
         self, asset_key: AssetKey
-    ) -> Optional["AssetConditionEvaluationState"]:
-        """Returns the AssetConditionCursor associated with the given asset key. If no stored
+    ) -> Optional["SchedulingConditionCursor"]:
+        """Returns the SchedulingConditionCursor associated with the given asset key. If no stored
         cursor exists, returns an empty cursor.
         """
-        return self.previous_evaluation_state_by_key.get(asset_key)
-
-    def get_previous_evaluation(self, asset_key: AssetKey) -> Optional["AssetConditionEvaluation"]:
-        """Returns the previous AssetConditionEvaluation for a given asset key, if it exists."""
-        previous_evaluation_state = self.get_previous_evaluation_state(asset_key)
-        return previous_evaluation_state.previous_evaluation if previous_evaluation_state else None
+        return self.previous_condition_cursors_by_key.get(asset_key)
 
     def with_updates(
         self,
         evaluation_id: int,
         evaluation_timestamp: float,
         newly_observe_requested_asset_keys: Sequence[AssetKey],
-        evaluation_state: Sequence["AssetConditionEvaluationState"],
+        condition_cursors: Sequence["SchedulingConditionCursor"],
     ) -> "AssetDaemonCursor":
         # do not "forget" about values for non-evaluated assets
-        new_evaluation_state_by_key = dict(self.previous_evaluation_state_by_key)
-        for new_state in evaluation_state:
-            new_evaluation_state_by_key[new_state.asset_key] = new_state
+        new_condition_cursors = dict(self.previous_condition_cursors_by_key)
+        for cursor in condition_cursors:
+            new_condition_cursors[cursor.asset_key] = cursor
 
         return dataclasses.replace(
             self,
             evaluation_id=evaluation_id,
-            previous_evaluation_state=list(new_evaluation_state_by_key.values()),
+            previous_condition_cursors=list(new_condition_cursors.values()),
             last_observe_request_timestamp_by_asset_key={
                 **self.last_observe_request_timestamp_by_asset_key,
                 **{
@@ -165,6 +166,7 @@ def backcompat_deserialize_asset_daemon_cursor_str(
     return AssetDaemonCursor(
         evaluation_id=data.get("evaluation_id") or default_evaluation_id,
         previous_evaluation_state=[],
+        previous_condition_cursors=[],
         last_observe_request_timestamp_by_asset_key={},
     )
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/asset_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/legacy/asset_condition.py
@@ -5,7 +5,7 @@ class AssetCondition(SchedulingCondition):
     """Deprecated: Use SchedulingCondition instead."""
 
     @property
-    def store_subsets(self) -> bool:
+    def requires_cursor(self) -> bool:
         return True
 
     @staticmethod

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/parent_newer_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/parent_newer_condition.py
@@ -13,7 +13,7 @@ from dagster._serdes.serdes import whitelist_for_serdes
 @whitelist_for_serdes
 class ParentNewerCondition(SchedulingCondition):
     @property
-    def store_subsets(self) -> bool:
+    def requires_cursor(self) -> bool:
         return True
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
@@ -108,7 +108,7 @@ class NewlyUpdatedCondition(SliceSchedulingCondition):
 
     def compute_slice(self, context: SchedulingContext) -> AssetSlice:
         # if it's the first time evaluating, just return the empty slice
-        if context.node_cursor is None:
+        if context.cursor is None:
             return context.asset_graph_view.create_empty_slice(context.asset_key)
         else:
             return context.asset_graph_view.compute_updated_since_cursor_slice(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operators/since_operator.py
@@ -12,7 +12,7 @@ class SinceCondition(SchedulingCondition):
     reset_condition: SchedulingCondition
 
     @property
-    def store_subsets(self) -> bool:
+    def requires_cursor(self) -> bool:
         return True
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
@@ -1,6 +1,6 @@
 import datetime
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Sequence, Tuple, Union
 
 import pendulum
 
@@ -12,10 +12,10 @@ from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.declarative_scheduling.serialized_objects import (
     AssetConditionSnapshot,
     AssetSubsetWithMetadata,
+    SchedulingConditionNodeCursor,
 )
 from dagster._core.definitions.metadata import MetadataMapping
 from dagster._model import DagsterModel
-from dagster._serdes.serdes import PackableValue
 from dagster._utils.security import non_secure_md5_hash_str
 
 if TYPE_CHECKING:
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
 @experimental
 class SchedulingCondition(ABC, DagsterModel):
     @property
-    def store_subsets(self) -> bool:
+    def requires_cursor(self) -> bool:
         return False
 
     @property
@@ -335,6 +335,7 @@ class SchedulingResult(DagsterModel):
 
     extra_state: Any
     child_results: Sequence["SchedulingResult"]
+    node_cursor: Optional[SchedulingConditionNodeCursor]
 
     @property
     def true_subset(self) -> AssetSubset:
@@ -345,8 +346,10 @@ class SchedulingResult(DagsterModel):
         context: "SchedulingContext",
         true_slice: AssetSlice,
         child_results: Sequence["SchedulingResult"],
+        extra_state: Optional[Union[AssetSubset, Sequence[AssetSubset]]] = None,
     ) -> "SchedulingResult":
         """Returns a new AssetConditionEvaluation from the given child results."""
+        candidate_subset = context.candidate_slice.convert_to_valid_asset_subset()
         return SchedulingResult(
             condition=context.condition,
             condition_unique_id=context.condition_unique_id,
@@ -357,6 +360,14 @@ class SchedulingResult(DagsterModel):
             subsets_with_metadata=[],
             child_results=child_results,
             extra_state=None,
+            node_cursor=SchedulingConditionNodeCursor(
+                true_subset=true_slice.convert_to_valid_asset_subset(),
+                candidate_subset=candidate_subset,
+                subsets_with_metadata=[],
+                extra_state=extra_state,
+            )
+            if context.condition.requires_cursor
+            else None,
         )
 
     @staticmethod
@@ -365,7 +376,7 @@ class SchedulingResult(DagsterModel):
         true_slice: AssetSlice,
         subsets_with_metadata: Sequence[AssetSubsetWithMetadata] = [],
         slices_with_metadata: Sequence[Tuple[AssetSlice, MetadataMapping]] = [],
-        extra_state: PackableValue = None,
+        extra_state: Optional[Union[AssetSubset, Sequence[AssetSubset]]] = None,
     ) -> "SchedulingResult":
         """Returns a new AssetConditionEvaluation from the given parameters."""
         check.param_invariant(
@@ -380,14 +391,23 @@ class SchedulingResult(DagsterModel):
                 )
                 for asset_slice, metadata in slices_with_metadata
             ]
+        candidate_subset = context.candidate_slice.convert_to_valid_asset_subset()
         return SchedulingResult(
             condition=context.condition,
             condition_unique_id=context.condition_unique_id,
             start_timestamp=context.create_time.timestamp(),
             end_timestamp=pendulum.now("UTC").timestamp(),
             true_slice=true_slice,
-            candidate_subset=context.candidate_slice.convert_to_valid_asset_subset(),
+            candidate_subset=candidate_subset,
             subsets_with_metadata=subsets_with_metadata,
             child_results=[],
             extra_state=extra_state,
+            node_cursor=SchedulingConditionNodeCursor(
+                true_subset=true_slice.convert_to_valid_asset_subset(),
+                candidate_subset=candidate_subset,
+                subsets_with_metadata=subsets_with_metadata,
+                extra_state=extra_state,
+            )
+            if context.condition.requires_cursor
+            else None,
         )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_context.py
@@ -105,7 +105,7 @@ class SchedulingContext(NamedTuple):
         asset_graph_view: AssetGraphView,
         logger: logging.Logger,
         current_tick_evaluation_info_by_key: Mapping[AssetKey, SchedulingEvaluationInfo],
-        previous_evaluation_info: Optional[SchedulingEvaluationInfo],
+        condition_cursor: Optional[SchedulingConditionCursor],
         legacy_context: "LegacyRuleEvaluationContext",
     ) -> "SchedulingContext":
         asset_graph = asset_graph_view.asset_graph
@@ -122,7 +122,7 @@ class SchedulingContext(NamedTuple):
             parent_context=None,
             create_time=pendulum.now("UTC"),
             logger=logger,
-            cursor=previous_evaluation_info.cursor if previous_evaluation_info else None,
+            cursor=condition_cursor,
             current_tick_evaluation_info_by_key=current_tick_evaluation_info_by_key,
             inner_legacy_context=legacy_context,
             non_agv_instance_interface=NonAGVInstanceInterface(
@@ -238,21 +238,13 @@ class SchedulingContext(NamedTuple):
 
     @property
     def previous_evaluation_max_storage_id(self) -> Optional[int]:
-        """Returns the maximum storage ID for the previous time this node was evaluated. If this
-        node has never been evaluated, returns None.
-        """
-        return (
-            self.cursor.temporal_context.last_event_id if self.cursor and self.node_cursor else None
-        )
+        """Returns the maximum storage ID for the previous time this asset was evaluated."""
+        return self.cursor.temporal_context.last_event_id if self.cursor else None
 
     @property
     def previous_evaluation_effective_dt(self) -> Optional[datetime.datetime]:
-        """Returns the datetime for the previous time this node was evaluated. If this node has
-        never been evaluated, returns None.
-        """
-        return (
-            self.cursor.temporal_context.effective_dt if self.cursor and self.node_cursor else None
-        )
+        """Returns the datetime for the previous time this asset was evaluated."""
+        return self.cursor.temporal_context.effective_dt if self.cursor else None
 
     @property
     def new_max_storage_id(self) -> Optional[int]:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
@@ -127,5 +127,5 @@ class SchedulingEvaluationInfo(DagsterModel):
             temporal_context=temporal_context,
             evaluation_nodes=nodes,
             requested_slice=requested_slice,
-            cursor=SchedulingConditionCursor.from_evaluation_state(state),
+            cursor=SchedulingConditionCursor.backcompat_from_evaluation_state(state),
         )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_asset_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_asset_condition.py
@@ -41,7 +41,7 @@ def test_missing_unpartitioned() -> None:
     assert result.true_subset.size == 0
 
     # if we evaluate from scratch, it's also False
-    _, result = state.without_previous_evaluation_state().evaluate("A")
+    _, result = state.without_cursor().evaluate("A")
     assert result.true_subset.size == 0
 
 
@@ -70,7 +70,7 @@ def test_missing_time_partitioned() -> None:
     assert result.true_subset.size == 4
 
     # if we evaluate from scratch, they're still False
-    _, result = state.without_previous_evaluation_state().evaluate("A")
+    _, result = state.without_cursor().evaluate("A")
     assert result.true_subset.size == 4
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
@@ -46,7 +46,7 @@ def test_missing_unpartitioned() -> None:
     assert result.true_subset.size == 0
 
     # if we evaluate from scratch, it's also False
-    _, result = state.without_previous_evaluation_state().evaluate("A")
+    _, result = state.without_cursor().evaluate("A")
     assert result.true_subset.size == 0
 
 
@@ -86,7 +86,7 @@ def test_missing_time_partitioned() -> None:
     assert result.true_subset.size == 3
 
     # if we evaluate from scratch, get the same answer
-    _, result = state.without_previous_evaluation_state().evaluate("A")
+    _, result = state.without_cursor().evaluate("A")
     assert result.true_subset.size == 3
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_parent_newer_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_parent_newer_condition.py
@@ -35,7 +35,7 @@ def test_parent_newer_unpartitioned() -> None:
     assert result.true_subset.size == 1
 
     # recalculate from scratch, B is still newer
-    state = state.without_previous_evaluation_state()
+    state = state.without_cursor()
     state, result = state.evaluate("C")
     assert result.true_subset.size == 1
 
@@ -85,6 +85,6 @@ def test_parent_newer_partitioned() -> None:
     assert result.true_subset.size == 2
 
     # recalculate from scratch, both still have newer parents
-    state = state.without_previous_evaluation_state()
+    state = state.without_cursor()
     state, result = state.evaluate("C")
     assert result.true_subset.size == 2

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_user_space_ds_api.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_user_space_ds_api.py
@@ -20,6 +20,7 @@ from dagster._core.test_utils import MockedRunLauncher, in_process_test_workspac
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._daemon.asset_daemon import AssetDaemon
+from dagster._serdes.serdes import deserialize_value, serialize_value
 from dagster._utils import file_relative_path
 
 from .user_space_ds_defs import amp_sensor, downstream, upstream
@@ -55,8 +56,11 @@ def execute_ds_ticks(defs: Definitions, n: int) -> Iterator[SchedulingTickResult
             evaluation_id=i,
             evaluation_timestamp=time.time(),
             newly_observe_requested_asset_keys=[],
-            evaluation_state=result[0],
+            condition_cursors=result[2],
         )
+
+        serialized_cursor = serialize_value(cursor)
+        cursor = deserialize_value(serialized_cursor, AssetDaemonCursor)
 
         yield SchedulingTickResult(evaluation_states=result[0], asset_partition_keys=result[1])
 


### PR DESCRIPTION
## Summary & Motivation

This is the continuation of the previous PR's work, where now we actually store the slimmed-down cursor in our serialized objects.

One decision I made here was to (at least temporarily) not delete any information in the old format from the cursor, which makes it a bit easier to roll back this change in the event of an emergency. We can always go back and wipe out the old value later.

On case in perf_test.py, this PR results in the cursor becoming almost 30x smaller.

## How I Tested These Changes
