### PR TITLE
RFC: SlingResourceBlueprint, SlingSyncAssetsBlueprint

### DIFF
--- a/python_modules/dagster/dagster/_utils/pydantic_yaml.py
+++ b/python_modules/dagster/dagster/_utils/pydantic_yaml.py
@@ -1,4 +1,4 @@
-from typing import Type, TypeVar
+from typing import Any, Callable, Optional, Type, TypeVar
 
 from pydantic import BaseModel, ValidationError, parse_obj_as
 
@@ -10,7 +10,12 @@ from .yaml_utils import parse_yaml_with_source_positions
 T = TypeVar("T", bound=BaseModel)
 
 
-def parse_yaml_file_to_pydantic(cls: Type[T], src: str, filename: str = "<string>") -> T:
+def parse_yaml_file_to_pydantic(
+    cls: Type[T],
+    src: str,
+    filename: str = "<string>",
+    leaf_resolver: Optional[Callable[[Any], Any]] = None,
+) -> T:
     """Parse the YAML source and create a Pydantic model instance from it.
 
     Attaches source position information to the `_source_position_and_key_path` attribute of the
@@ -31,7 +36,7 @@ def parse_yaml_file_to_pydantic(cls: Type[T], src: str, filename: str = "<string
             Pydantic2+, errors will include context information about the position in the document
             that the model corresponds to.
     """
-    parsed = parse_yaml_with_source_positions(src, filename)
+    parsed = parse_yaml_with_source_positions(src, filename, leaf_resolver=leaf_resolver)
     try:
         model = parse_obj_as(cls, parsed.value)
     except ValidationError as e:

--- a/python_modules/dagster/dagster/_utils/yaml_utils.py
+++ b/python_modules/dagster/dagster/_utils/yaml_utils.py
@@ -1,6 +1,6 @@
 import functools
 import glob
-from typing import Any, Dict, List, Mapping, Sequence, Type, cast
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Type, cast
 
 import yaml
 
@@ -166,6 +166,7 @@ def parse_yaml_with_source_positions(
     src: str,
     filename: str = "<string>",
     implicits_to_remove: Sequence[str] = [YAML_TIMESTAMP_TAG],
+    leaf_resolver: Optional[Callable[[Any], Any]] = None,
 ) -> ValueAndSourcePositionTree:
     """Parse YAML source with source position information.
     This function takes a YAML source string and an optional filename, and returns a
@@ -231,6 +232,8 @@ def parse_yaml_with_source_positions(
                     list_with_raw_values,
                     SourcePositionTree(position=source_position, children=child_trees),
                 )
+            if leaf_resolver:
+                value = leaf_resolver(value)
 
             return ValueAndSourcePositionTree(
                 value,

--- a/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/test_load_defs_from_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/test_load_defs_from_yaml.py
@@ -14,6 +14,7 @@ from dagster._core.definitions.metadata.source_code import (
     CodeReferencesMetadataSet,
     LocalFileCodeReference,
 )
+from dagster._core.test_utils import environ
 from dagster._model.pydantic_compat_layer import USING_PYDANTIC_1
 from pydantic import ValidationError
 
@@ -207,3 +208,43 @@ def test_source_file_name() -> None:
 
     metadata = defs.get_assets_def("asset1").metadata_by_key[AssetKey("asset1")]
     assert metadata["source_file_name"] == "single_blueprint.yaml"
+
+
+def test_basic_env_var_jinja_templating() -> None:
+    with environ({"ASSET_NAME": "my_asset"}):
+        defs = load_defs_from_yaml(
+            path=Path(__file__).parent / "yaml_files" / "single_blueprint_with_env_var.yaml",
+            per_file_blueprint_type=SimpleAssetBlueprint,
+        )
+        assert set(defs.get_asset_graph().all_asset_keys) == {AssetKey("my_asset")}
+
+
+def test_basic_env_var_jinja_templating_err() -> None:
+    if "ASSET_NAME" in os.environ:
+        del os.environ["ASSET_NAME"]
+
+    with pytest.raises(
+        DagsterBuildDefinitionsFromConfigError, match="Environment variable ASSET_NAME"
+    ):
+        load_defs_from_yaml(
+            path=Path(__file__).parent / "yaml_files" / "single_blueprint_with_env_var.yaml",
+            per_file_blueprint_type=SimpleAssetBlueprint,
+        )
+
+
+def test_basic_env_var_jinja_templating_no_env_var_default() -> None:
+    with environ({"ASSET_NAME": "foo"}):
+        defs = load_defs_from_yaml(
+            path=Path(__file__).parent
+            / "yaml_files"
+            / "single_blueprint_with_env_var_default.yaml",
+            per_file_blueprint_type=SimpleAssetBlueprint,
+        )
+        assert set(defs.get_asset_graph().all_asset_keys) == {AssetKey("foo")}
+
+    # Should use default value of "bar" if ASSET_NAME is not set
+    defs = load_defs_from_yaml(
+        path=Path(__file__).parent / "yaml_files" / "single_blueprint_with_env_var_default.yaml",
+        per_file_blueprint_type=SimpleAssetBlueprint,
+    )
+    assert set(defs.get_asset_graph().all_asset_keys) == {AssetKey("bar")}

--- a/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/yaml_files/single_blueprint_with_env_var.yaml
+++ b/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/yaml_files/single_blueprint_with_env_var.yaml
@@ -1,0 +1,1 @@
+key: "{{ env_var('ASSET_NAME') }}"

--- a/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/yaml_files/single_blueprint_with_env_var_default.yaml
+++ b/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/yaml_files/single_blueprint_with_env_var_default.yaml
@@ -1,0 +1,1 @@
+key: "{{ env_var('ASSET_NAME', 'bar') }}"

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/blueprints.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/blueprints.py
@@ -44,7 +44,7 @@ class SlingResourceBlueprint(Blueprint):
         )
 
 
-class SlingSyncAssetsBlueprint(Blueprint):
+class SlingSyncBlueprint(Blueprint):
     """Blueprint which creates a Dagster asset for one or more Sling replication configurations.
 
     Follows the schema of the Sling replication file, see the Sling documentation for more information.

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/blueprints.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/blueprints.py
@@ -1,0 +1,77 @@
+from typing import Any, Dict, Literal, Optional
+
+from dagster import AssetExecutionContext
+from dagster._core.blueprints.blueprint import Blueprint, BlueprintDefinitions
+from dagster._model.pydantic_compat_layer import USING_PYDANTIC_2
+from pydantic import ConfigDict, Field
+
+from dagster_embedded_elt.sling.asset_decorator import sling_assets
+from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingResource
+
+
+class SlingResourceBlueprint(Blueprint):
+    """Blueprint which creates a Dagster resource that holds a collection of Sling connections.
+
+    Templated after the Sling environment file, see the Sling documentation for more information.
+    https://docs.slingdata.io/sling-cli/environment.
+    """
+
+    type: Literal["dagster_embedded_elt/sling_resource"] = "dagster_embedded_elt/sling_resource"
+    dagster_resource_name: str = Field(
+        "sling",
+        description="The name of the Dagster resource that will be created to hold the connections.",
+    )
+    connections: Dict[str, Any] = Field(
+        ..., description="A dictionary of connection configurations."
+    )
+    variables: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="A dictionary of variables which can be used in the connection configs.",
+    )
+
+    def build_defs(self) -> BlueprintDefinitions:
+        for name, connection_details in self.connections.items():
+            if "type" not in connection_details:
+                raise ValueError(
+                    f"Connection details for connection '{name}' must include a 'type'."
+                )
+
+        connections = [
+            SlingConnectionResource(name=key, **value) for key, value in self.connections.items()
+        ]
+        return BlueprintDefinitions(
+            resources={self.dagster_resource_name: SlingResource(connections=connections)}
+        )
+
+
+class SlingSyncAssetsBlueprint(Blueprint):
+    """Blueprint which creates a Dagster asset for one or more Sling replication configurations.
+
+    Follows the schema of the Sling replication file, see the Sling documentation for more information.
+    https://docs.slingdata.io/sling-cli/run/configuration/replication
+    """
+
+    # Ensures that other fields can be passed in, even if they are not explicitly defined
+    if USING_PYDANTIC_2:
+        model_config = ConfigDict(extra="allow")  # type: ignore
+    else:
+
+        class Config:
+            extra = "allow"
+
+    type: Literal["dagster_embedded_elt/sling_assets"] = "dagster_embedded_elt/sling_assets"
+    dagster_op_name: str = Field(
+        ...,
+        description="The name of the underlying Dagster op to create.",
+    )
+
+    def build_defs(self) -> BlueprintDefinitions:
+        replication_config = {**dict(self)}
+        del replication_config["dagster_op_name"]
+        del replication_config["type"]
+
+        @sling_assets(replication_config=replication_config, name=self.dagster_op_name)
+        def my_sling_assets(context: AssetExecutionContext, sling: SlingResource):
+            yield from sling.replicate(context=context)
+
+        return BlueprintDefinitions(assets=[my_sling_assets])

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/blueprints/env.yaml
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/blueprints/env.yaml
@@ -1,0 +1,11 @@
+type: dagster_embedded_elt/sling_resource
+
+# below is exactly the same as a Sling Environment file
+# https://docs.slingdata.io/sling-cli/environment
+connections:
+  file_conn:
+    type: file
+
+  sqlite_conn:
+    type: sqlite
+    connection_string: 'sqlite://{{ env_var("PATH_TO_SQLITE_DB") }}'

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/blueprints/replication_config.yaml
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/blueprints/replication_config.yaml
@@ -1,0 +1,15 @@
+type: dagster_embedded_elt/sling_assets
+dagster_op_name: file_to_sqlite_sync
+
+# below is exactly the same as a Sling replication config file
+# https://docs.slingdata.io/sling-cli/run/configuration/replication
+source: file_conn
+target: sqlite_conn
+
+defaults:
+  mode: full-refresh
+  object: "{stream_table}"
+
+streams:
+  "file://{{ env_var('PATH_TO_CSV_FILE') }}":
+    object: "main.tbl"

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/blueprints/replication_config.yaml
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/blueprints/replication_config.yaml
@@ -1,5 +1,4 @@
 type: dagster_embedded_elt/sling_assets
-dagster_op_name: file_to_sqlite_sync
 
 # below is exactly the same as a Sling replication config file
 # https://docs.slingdata.io/sling-cli/run/configuration/replication

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/blueprints/test.csv
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/blueprints/test.csv
@@ -1,0 +1,4 @@
+SPECIES_CODE,SPECIES_NAME,UPDATED_AT
+abcdef,scrubjay,1
+defghi,bluejay,2
+jklnop,blackbird,2

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/blueprints/test_blueprints.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/blueprints/test_blueprints.py
@@ -1,0 +1,37 @@
+import os
+import sqlite3
+from pathlib import Path
+from typing import Union
+
+from dagster._core.blueprints.load_from_yaml import load_defs_from_yaml
+from dagster._core.definitions.materialize import materialize
+from dagster._core.test_utils import environ
+from dagster_embedded_elt.sling import (
+    SlingReplicationParam,
+)
+from dagster_embedded_elt.sling.blueprints import SlingResourceBlueprint, SlingSyncAssetsBlueprint
+
+
+def test_load_basic_resources_and_sync(
+    csv_to_sqlite_replication_config: SlingReplicationParam,
+    path_to_temp_sqlite_db: str,
+    sqlite_connection: sqlite3.Connection,
+):
+    with environ(
+        {
+            "PATH_TO_SQLITE_DB": path_to_temp_sqlite_db,
+            "PATH_TO_CSV_FILE": os.fspath(Path(__file__).parent / "test.csv"),
+        }
+    ):
+        defs = load_defs_from_yaml(
+            path=Path(__file__).parent,
+            per_file_blueprint_type=Union[SlingSyncAssetsBlueprint, SlingResourceBlueprint],
+        )
+
+        res = materialize(list(defs.assets), resources=defs.resources)  # type: ignore
+
+        assert res.success
+        assert len(res.get_asset_materialization_events()) == 1
+
+        counts = sqlite_connection.execute("SELECT count(1) FROM main.tbl").fetchone()[0]
+        assert counts == 3

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/blueprints/test_blueprints.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/blueprints/test_blueprints.py
@@ -9,7 +9,7 @@ from dagster._core.test_utils import environ
 from dagster_embedded_elt.sling import (
     SlingReplicationParam,
 )
-from dagster_embedded_elt.sling.blueprints import SlingResourceBlueprint, SlingSyncAssetsBlueprint
+from dagster_embedded_elt.sling.blueprints import SlingResourceBlueprint, SlingSyncBlueprint
 
 
 def test_load_basic_resources_and_sync(
@@ -25,7 +25,7 @@ def test_load_basic_resources_and_sync(
     ):
         defs = load_defs_from_yaml(
             path=Path(__file__).parent,
-            per_file_blueprint_type=Union[SlingSyncAssetsBlueprint, SlingResourceBlueprint],
+            per_file_blueprint_type=Union[SlingSyncBlueprint, SlingResourceBlueprint],
         )
 
         res = materialize(list(defs.assets), resources=defs.resources)  # type: ignore


### PR DESCRIPTION
## Summary

Exploration building some blueprints for `dagster_embedded_elt`'s Sling stuff.

Separate Blueprints for building a resource and for building syncs. These can almost entirely be derived from the two types of YAML files that Sling provides, with a few dagster-specific fields needed for naming (in the future, maybe could use filename) & for `type` disambiguation when loading the Blueprints.

- Replication config file (maps to assets in dagster-land): https://docs.slingdata.io/sling-cli/run/configuration/replication
- Environment file (maps to resource in dagster-land): https://docs.slingdata.io/sling-cli/environment

This feels pretty nice in that you can _almost_ get assets out-of-the-box without any Dagster specific configuration (with the caveats described above). Sling appears to ignore any extra keys, so you can still use the Blueprintified Sling config with the CLI directly.

## Test Plan

Brief unit test.