### PR TITLE
simpler AssetsDefinition.with_attributes args and remove check props

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -6,7 +6,6 @@ from dagster._annotations import PublicAttr
 from dagster._core.definitions.asset_key import (
     AssetKey,
     CoercibleToAssetKey,
-    CoercibleToAssetKeyPrefix,
 )
 from dagster._core.definitions.metadata import RawMetadataMapping
 from dagster._serdes.serdes import whitelist_for_serdes
@@ -46,9 +45,6 @@ class AssetCheckKey(NamedTuple):
             asset_key=AssetKey.from_graphql_input(graphql_input["assetKey"]),
             name=graphql_input["name"],
         )
-
-    def with_asset_key_prefix(self, prefix: CoercibleToAssetKeyPrefix) -> "AssetCheckKey":
-        return self._replace(asset_key=self.asset_key.with_prefix(prefix))
 
     def to_user_string(self) -> str:
         return f"{self.asset_key.to_user_string()}:{self.name}"
@@ -138,6 +134,3 @@ class AssetCheckSpec(
     @property
     def key(self) -> AssetCheckKey:
         return AssetCheckKey(self.asset_key, self.name)
-
-    def with_asset_key_prefix(self, prefix: CoercibleToAssetKeyPrefix) -> "AssetCheckSpec":
-        return self._replace(asset_key=self.asset_key.with_prefix(prefix))

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -408,7 +408,10 @@ def prefix_assets(
     result_assets: List[AssetsDefinition] = []
     for assets_def in assets_defs:
         output_asset_key_replacements = {
-            asset_key: AssetKey([*key_prefix, *asset_key.path]) for asset_key in assets_def.keys
+            asset_key: AssetKey([*key_prefix, *asset_key.path])
+            for asset_key in (
+                assets_def.keys | {check_key.asset_key for check_key in assets_def.check_keys}
+            )
         }
         input_asset_key_replacements = {}
         for dep_asset_key in assets_def.keys_by_input_name.values():
@@ -420,21 +423,11 @@ def prefix_assets(
                 input_asset_key_replacements[dep_asset_key] = AssetKey(
                     [*source_key_prefix, *dep_asset_key.path]
                 )
-        check_specs_by_output_name = {
-            output_name: check_spec.with_asset_key_prefix(key_prefix)
-            for output_name, check_spec in assets_def.check_specs_by_output_name.items()
-        }
-
-        selected_asset_check_keys = {
-            key.with_asset_key_prefix(key_prefix) for key in assets_def.check_keys
-        }
 
         result_assets.append(
             assets_def.with_attributes(
                 output_asset_key_replacements=output_asset_key_replacements,
                 input_asset_key_replacements=input_asset_key_replacements,
-                check_specs_by_output_name=check_specs_by_output_name,
-                selected_asset_check_keys=selected_asset_check_keys,
             )
         )
 
@@ -478,7 +471,7 @@ def assets_with_attributes(
                 group_names_by_key=(
                     {asset_key: group_name for asset_key in asset.keys}
                     if group_name is not None
-                    else None
+                    else {}
                 ),
                 freshness_policy=freshness_policy,
                 auto_materialize_policy=auto_materialize_policy,


### PR DESCRIPTION
## Summary & Motivation

These check props can be handled internally, like the other asset key replacements.

Also, use empty collections instead of `None` to remove unnecessary degrees of freedom.

## How I Tested These Changes
