### PR TITLE
Speed up counting TimeWindowPartitionsSubset partitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -2197,7 +2197,7 @@ class TimeWindowPartitionsSubset(
         num_partitions_ = self._asdict()["num_partitions"]
         if num_partitions_ is None:
             return sum(
-                len(self.partitions_def.get_partition_keys_in_time_window(time_window))
+                self.partitions_def.get_num_partitions_in_window(time_window)
                 for time_window in self.included_time_windows
             )
         return num_partitions_


### PR DESCRIPTION
Summary:
I thought I included this in https://github.com/dagster-io/dagster/pull/22014 but it appears I did not. This should dramatically speed up counting partitions in TimeWindowPartitionsSubset that cover large time windows.

Test Plan: BK and speedscope over representative large asset graph

## Summary & Motivation

## How I Tested These Changes
