### PR TITLE
Make `AssetsDefinition.node_def` optional

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -23,6 +23,12 @@ if TYPE_CHECKING:
 # for externally materialized assets.
 SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE = "dagster/asset_execution_type"
 
+
+# SYSTEM_METADATA_KEY_IO_MANAGER_KEY lives on the metadata of an asset without a node def and
+# determines the io_manager_key that can be used to load it. This is necessary because IO manager
+# keys are otherwise encoded inside OutputDefinitions within NodeDefinitions.
+SYSTEM_METADATA_KEY_IO_MANAGER_KEY = "dagster/io_manager_key"
+
 # SYSTEM_METADATA_KEY_AUTO_OBSERVE_INTERVAL_MINUTES lives on the metadata of
 # external assets resulting from a source asset conversion. It contains the
 # `auto_observe_interval_minutes` value from the source asset and is consulted

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -49,7 +49,11 @@ from dagster._core.definitions.resource_requirement import (
 )
 from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
-from dagster._core.definitions.utils import normalize_group_name, validate_asset_owner
+from dagster._core.definitions.utils import (
+    DEFAULT_IO_MANAGER_KEY,
+    normalize_group_name,
+    validate_asset_owner,
+)
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
     DagsterInvalidInvocationError,
@@ -60,7 +64,7 @@ from dagster._utils.merger import merge_dicts
 from dagster._utils.security import non_secure_md5_hash_str
 from dagster._utils.warnings import ExperimentalWarning, disable_dagster_warnings
 
-from .asset_spec import AssetSpec
+from .asset_spec import SYSTEM_METADATA_KEY_IO_MANAGER_KEY, AssetSpec
 from .dependency import NodeHandle
 from .events import AssetKey, CoercibleToAssetKey, CoercibleToAssetKeyPrefix
 from .node_definition import NodeDefinition
@@ -102,7 +106,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         "owners_by_key",
     }
 
-    _node_def: NodeDefinition
+    _node_def: Optional[NodeDefinition]
     _keys_by_input_name: Mapping[str, AssetKey]
     _keys_by_output_name: Mapping[str, AssetKey]
     _partitions_def: Optional[PartitionsDefinition]
@@ -122,9 +126,9 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
     def __init__(
         self,
         *,
-        keys_by_input_name: Mapping[str, AssetKey],
-        keys_by_output_name: Mapping[str, AssetKey],
-        node_def: NodeDefinition,
+        keys_by_input_name: Mapping[str, AssetKey] = {},
+        keys_by_output_name: Mapping[str, AssetKey] = {},
+        node_def: Optional[NodeDefinition] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
         partition_mappings: Optional[Mapping[AssetKey, PartitionMapping]] = None,
         asset_deps: Optional[Mapping[AssetKey, AbstractSet[AssetKey]]] = None,
@@ -161,6 +165,22 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
 
         if isinstance(node_def, GraphDefinition):
             _validate_graph_def(node_def)
+
+        if node_def is None:
+            check.invariant(
+                len(keys_by_input_name) == 0,
+                "node_def is None, so keys_by_input_name must be empty",
+            )
+            check.invariant(
+                len(keys_by_output_name) == 0,
+                "node_def is None, so keys_by_output_name must be empty",
+            )
+            check.invariant(
+                backfill_policy is None, "node_def is None, so backfill_policy must be None"
+            )
+            check.invariant(
+                not can_subset, "node_def is None, so backfill_policy must not be provided"
+            )
 
         self._node_def = node_def
         self._keys_by_input_name = check.mapping_param(
@@ -240,6 +260,8 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
                     all_asset_keys=all_asset_keys,
                 )
 
+            check.invariant(node_def, "Must provide node_def if not providing specs")
+
             resolved_specs = _asset_specs_from_attr_key_params(
                 all_asset_keys=all_asset_keys,
                 keys_by_input_name=keys_by_input_name,
@@ -265,13 +287,27 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
 
             group_name = normalize_group_name(spec.group_name)
 
-            output_def, _ = node_def.resolve_output_to_origin(output_names_by_key[spec.key], None)
-            metadata = {**output_def.metadata, **(spec.metadata or {})}
+            if node_def is not None:
+                output_def, _ = node_def.resolve_output_to_origin(
+                    output_names_by_key[spec.key], None
+                )
+                node_def_description = node_def.description
+                output_def_metadata = output_def.metadata
+                output_def_description = output_def.description
+                output_def_code_version = output_def.code_version
+                skippable = not output_def.is_required
+            else:
+                node_def_description = None
+                output_def_metadata = {}
+                output_def_description = None
+                output_def_code_version = None
+                skippable = False
+
+            metadata = {**output_def_metadata, **(spec.metadata or {})}
             # We construct description from three sources of truth here. This
             # highly unfortunate. See commentary in @multi_asset's call to dagster_internal_init.
-            description = spec.description or output_def.description or node_def.description
-            code_version = spec.code_version or output_def.code_version
-            skippable = not output_def.is_required
+            description = spec.description or output_def_description or node_def_description
+            code_version = spec.code_version or output_def_code_version
 
             check.invariant(
                 not (
@@ -296,7 +332,9 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         self._specs_by_key = {spec.key: spec for spec in normalized_specs}
 
         self._partition_mappings = get_partition_mappings_from_deps(
-            {}, [dep for spec in normalized_specs for dep in spec.deps], node_def.name
+            {},
+            [dep for spec in normalized_specs for dep in spec.deps],
+            node_def.name if node_def else "external assets",
         )
         self._selected_asset_keys, self._selected_asset_check_keys = _resolve_selections(
             all_asset_keys=self._specs_by_key.keys(),
@@ -362,8 +400,8 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         from .graph_definition import GraphDefinition
 
         # defer to GraphDefinition.__call__ for graph backed assets, or if invoked in composition
-        if isinstance(self.node_def, GraphDefinition) or is_in_composition():
-            return self._node_def(*args, **kwargs)
+        if isinstance(self._node_def, GraphDefinition) or is_in_composition():
+            return check.not_none(self._node_def)(*args, **kwargs)
 
         # invoke against self to allow assets def information to be used
         return direct_invocation_result(self, *args, **kwargs)
@@ -781,7 +819,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         """NodeDefinition: Returns the OpDefinition or GraphDefinition that is used to materialize
         the assets in this AssetsDefinition.
         """
-        return self._node_def
+        return check.not_none(self._node_def, "This AssetsDefinition has no node_def")
 
     @public
     @property
@@ -1024,6 +1062,9 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
 
     @property
     def execution_type(self) -> AssetExecutionType:
+        if self._node_def is None:
+            return AssetExecutionType.UNEXECUTABLE
+
         value = self._get_external_asset_metadata_value(SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE)
         if value is None:
             return AssetExecutionType.MATERIALIZATION
@@ -1078,10 +1119,13 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             f"Asset check key {key.to_user_string()} not found in AssetsDefinition"
         )
 
-    def get_op_def_for_asset_key(self, key: AssetKey) -> OpDefinition:
+    def get_op_def_for_asset_key(self, key: AssetKey) -> Optional[OpDefinition]:
         """If this is an op-backed asset, returns the op def. If it's a graph-backed asset,
         returns the op def within the graph that produces the given asset key.
         """
+        if self._node_def is None:
+            return None
+
         output_name = self.get_output_name_for_asset_key(key)
         return self.node_def.resolve_output_to_origin_op_def(output_name)
 
@@ -1387,10 +1431,19 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
             )
 
     def get_io_manager_key_for_asset_key(self, key: AssetKey) -> str:
-        output_name = self.get_output_name_for_asset_key(key)
-        return self.node_def.resolve_output_to_origin(
-            output_name, NodeHandle(self.node_def.name, parent=None)
-        )[0].io_manager_key
+        if self._node_def is None:
+            return self._specs_by_key[key].metadata.get(
+                SYSTEM_METADATA_KEY_IO_MANAGER_KEY, DEFAULT_IO_MANAGER_KEY
+            )
+        else:
+            check.invariant(
+                SYSTEM_METADATA_KEY_IO_MANAGER_KEY not in self._specs_by_key[key].metadata
+            )
+
+            output_name = self.get_output_name_for_asset_key(key)
+            return self.node_def.resolve_output_to_origin(
+                output_name, NodeHandle(self.node_def.name, parent=None)
+            )[0].io_manager_key
 
     def get_resource_requirements(self) -> Iterator[ResourceRequirement]:
         if self.is_executable:

--- a/python_modules/dagster/dagster/_core/definitions/external_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset.py
@@ -4,19 +4,17 @@ from dagster import _check as check
 from dagster._core.definitions.asset_spec import (
     SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE,
     SYSTEM_METADATA_KEY_AUTO_OBSERVE_INTERVAL_MINUTES,
+    SYSTEM_METADATA_KEY_IO_MANAGER_KEY,
     AssetExecutionType,
     AssetSpec,
 )
 from dagster._core.definitions.assets import AssetsDefinition
-from dagster._core.definitions.decorators.asset_decorator import asset, multi_asset
-from dagster._core.definitions.events import Output
+from dagster._core.definitions.op_definition import OpDefinition
+from dagster._core.definitions.output import Out
 from dagster._core.definitions.source_asset import (
-    SYSTEM_METADATA_KEY_SOURCE_ASSET_OBSERVATION,
     SourceAsset,
     wrap_source_asset_observe_fn_in_op_compute_fn,
 )
-from dagster._core.errors import DagsterInvariantViolationError
-from dagster._core.execution.context.compute import AssetExecutionContext
 from dagster._utils.warnings import disable_dagster_warnings
 
 
@@ -87,7 +85,7 @@ def external_assets_from_specs(specs: Sequence[AssetSpec]) -> List[AssetsDefinit
     eroding trust.
 
     Args:
-            specs (Sequence[AssetSpec]): The specs for the assets.
+        specs (Sequence[AssetSpec]): The specs for the assets.
     """
     assets_defs = []
     for spec in specs:
@@ -102,53 +100,39 @@ def external_assets_from_specs(specs: Sequence[AssetSpec]) -> List[AssetsDefinit
         )
 
         with disable_dagster_warnings():
-
-            @multi_asset(
-                name=spec.key.to_python_identifier(),
-                specs=[
-                    AssetSpec.dagster_internal_init(
-                        key=spec.key,
-                        description=spec.description,
-                        group_name=spec.group_name,
-                        freshness_policy=spec.freshness_policy,
-                        metadata={
-                            **(spec.metadata or {}),
-                            **{
-                                SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: (
-                                    AssetExecutionType.UNEXECUTABLE.value
-                                )
-                            },
-                        },
-                        deps=spec.deps,
-                        tags=spec.tags,
-                        owners=spec.owners,
-                        skippable=False,
-                        code_version=None,
-                        auto_materialize_policy=None,
-                    )
-                ],
-            )
-            def _external_assets_def(context: AssetExecutionContext) -> None:
-                raise DagsterInvariantViolationError(
-                    "You have attempted to execute an unexecutable asset"
-                    f" {context.asset_key.to_user_string}."
-                )
-
-            assets_defs.append(_external_assets_def)
+            assets_defs.append(AssetsDefinition(specs=[spec]))
 
     return assets_defs
 
 
 def create_external_asset_from_source_asset(source_asset: SourceAsset) -> AssetsDefinition:
+    if source_asset.observe_fn is not None:
+        keys_by_output_name = {"result": source_asset.key}
+        node_def = OpDefinition(
+            name=source_asset.key.to_python_identifier(),
+            compute_fn=wrap_source_asset_observe_fn_in_op_compute_fn(source_asset),
+            # We need to access the raw attribute because the property will return a computed value that
+            # includes requirements for the io manager. Those requirements will be inferred again when
+            # we create an AssetsDefinition.
+            required_resource_keys=source_asset._required_resource_keys,  # noqa: SLF001,
+            outs={"result": Out(io_manager_key=source_asset.io_manager_key)},
+        )
+        extra_metadata_entries = {
+            SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: AssetExecutionType.OBSERVATION.value
+        }
+    else:
+        keys_by_output_name = {}
+        node_def = None
+        extra_metadata_entries = (
+            {SYSTEM_METADATA_KEY_IO_MANAGER_KEY: source_asset.io_manager_key}
+            if source_asset.io_manager_key is not None
+            else {}
+        )
+
     observe_interval = source_asset.auto_observe_interval_minutes
-    execution_type = (
-        AssetExecutionType.UNEXECUTABLE.value
-        if source_asset.observe_fn is None
-        else AssetExecutionType.OBSERVATION.value
-    )
     metadata = {
         **source_asset.raw_metadata,
-        SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: execution_type,
+        **extra_metadata_entries,
         **(
             {SYSTEM_METADATA_KEY_AUTO_OBSERVE_INTERVAL_MINUTES: observe_interval}
             if observe_interval
@@ -157,38 +141,26 @@ def create_external_asset_from_source_asset(source_asset: SourceAsset) -> Assets
     }
 
     with disable_dagster_warnings():
-
-        @asset(
+        spec = AssetSpec(
             key=source_asset.key,
             metadata=metadata,
             group_name=source_asset.group_name,
             description=source_asset.description,
+            tags=source_asset.tags,
+            freshness_policy=source_asset.freshness_policy,
+            deps=[],
+            owners=[],
+        )
+
+        return AssetsDefinition(
+            specs=[spec],
+            keys_by_output_name=keys_by_output_name,
+            node_def=node_def,
             partitions_def=source_asset.partitions_def,
-            io_manager_key=source_asset.io_manager_key,
             # We don't pass the `io_manager_def` because it will already be present in
             # `resource_defs` (it is added during `SourceAsset` initialization).
             resource_defs=source_asset.resource_defs,
-            # We need to access the raw attribute because the property will return a computed value that
-            # includes requirements for the io manager. Those requirements will be inferred again when
-            # we create an AssetsDefinition.
-            required_resource_keys=source_asset._required_resource_keys,  # noqa: SLF001
-            freshness_policy=source_asset.freshness_policy,
-            tags=source_asset.tags,
         )
-        def _shim_assets_def(context: AssetExecutionContext):
-            if not source_asset.observe_fn:
-                raise NotImplementedError(f"Asset {source_asset.key} is not executable")
-
-            op_function = wrap_source_asset_observe_fn_in_op_compute_fn(source_asset)
-            return_value = op_function.decorated_fn(context)
-            check.invariant(
-                isinstance(return_value, Output)
-                and SYSTEM_METADATA_KEY_SOURCE_ASSET_OBSERVATION in return_value.metadata,
-                "The wrapped decorated_fn should return an Output with a special metadata key.",
-            )
-            return return_value
-
-    return _shim_assets_def
 
 
 # Create unexecutable assets defs for each asset key in the provided assets def. This is used to
@@ -199,4 +171,7 @@ def create_unexecutable_external_assets_from_assets_def(
     if not assets_def.is_executable:
         return [assets_def]
     else:
-        return [create_external_asset_from_source_asset(sa) for sa in assets_def.to_source_assets()]
+        with disable_dagster_warnings():
+            return [
+                create_external_asset_from_source_asset(sa) for sa in assets_def.to_source_assets()
+            ]

--- a/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_value_loader.py
@@ -113,7 +113,11 @@ class AssetValueLoader:
             )
             io_manager_key = assets_def.get_io_manager_key_for_asset_key(asset_key)
             io_manager_def = resource_defs[io_manager_key]
-            name = assets_def.get_output_name_for_asset_key(asset_key)
+            name = (
+                assets_def.get_output_name_for_asset_key(asset_key)
+                if assets_def.is_executable
+                else None
+            )
             output_definition_metadata = assets_def.specs_by_key[asset_key].metadata
             op_def = assets_def.get_op_def_for_asset_key(asset_key)
             asset_partitions_def = assets_def.partitions_def

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -10,9 +10,11 @@ from dagster import (
     AssetKey,
     AssetOut,
     AssetsDefinition,
+    BackfillPolicy,
     DagsterEventType,
     DailyPartitionsDefinition,
     Definitions,
+    ExperimentalWarning,
     FreshnessPolicy,
     GraphOut,
     IdentityPartitionMapping,
@@ -2174,3 +2176,36 @@ def test_asset_spec_skippable():
         node_def=op1, keys_by_output_name={"result": AssetKey("asset1")}, keys_by_input_name={}
     )
     assert next(iter(assets_def.specs)).skippable
+
+
+def test_construct_assets_definition_no_args() -> None:
+    with pytest.raises(CheckError, match="Must provide node_def if not providing specs"):
+        AssetsDefinition()
+
+
+def test_construct_assets_definition_without_node_def() -> None:
+    spec = AssetSpec("asset1", tags={"foo": "bar"}, group_name="hello")
+    with pytest.warns(ExperimentalWarning):
+        assets_def = AssetsDefinition(specs=[spec])
+    assert not assets_def.is_executable
+    assert list(assets_def.specs) == [spec]
+
+
+def test_construct_assets_definition_without_node_def_attr_by_keys() -> None:
+    with pytest.raises(CheckError):
+        AssetsDefinition(group_names_by_key={AssetKey("foo"): "foo_group"})
+
+
+def test_construct_assets_definition_without_node_def_with_bad_param_combo() -> None:
+    spec = AssetSpec("asset1", tags={"foo": "bar"}, group_name="hello")
+    with pytest.raises(CheckError):
+        AssetsDefinition(specs=[spec], backfill_policy=BackfillPolicy.single_run())
+
+    with pytest.raises(CheckError):
+        AssetsDefinition(specs=[spec], keys_by_input_name={"input": AssetKey("asset0")})
+
+    with pytest.raises(CheckError):
+        AssetsDefinition(specs=[spec], keys_by_output_name={"result": AssetKey("asset1")})
+
+    with pytest.raises(CheckError):
+        AssetsDefinition(specs=[spec], can_subset=True)

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -20,11 +20,7 @@ from dagster import (
 from dagster._check import ParameterCheckError
 from dagster._core.definitions import AssetIn, SourceAsset, asset, multi_asset
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.asset_spec import (
-    SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE,
-    AssetExecutionType,
-    AssetSpec,
-)
+from dagster._core.definitions.asset_spec import AssetExecutionType, AssetSpec
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.external_asset import external_assets_from_specs
@@ -316,9 +312,6 @@ def test_input_name_matches_output_name():
             execution_type=AssetExecutionType.UNEXECUTABLE,
             job_names=[],
             group_name=DEFAULT_GROUP_NAME,
-            metadata={
-                SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: AssetExecutionType.UNEXECUTABLE.value
-            },
         ),
         ExternalAssetNode(
             asset_key=AssetKey("something"),
@@ -781,9 +774,6 @@ def test_source_asset_with_op():
             depended_by=[ExternalAssetDependedBy(AssetKey("bar"))],
             job_names=[],
             group_name=DEFAULT_GROUP_NAME,
-            metadata={
-                SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: AssetExecutionType.UNEXECUTABLE.value
-            },
         ),
     ]
 
@@ -805,9 +795,6 @@ def test_unused_source_asset():
             job_names=[],
             group_name=DEFAULT_GROUP_NAME,
             is_source=True,
-            metadata={
-                SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: AssetExecutionType.UNEXECUTABLE.value
-            },
         ),
         ExternalAssetNode(
             asset_key=AssetKey("foo"),
@@ -818,9 +805,6 @@ def test_unused_source_asset():
             job_names=[],
             group_name=DEFAULT_GROUP_NAME,
             is_source=True,
-            metadata={
-                SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: AssetExecutionType.UNEXECUTABLE.value
-            },
         ),
     ]
 
@@ -850,9 +834,6 @@ def test_used_source_asset():
             job_names=[],
             group_name=DEFAULT_GROUP_NAME,
             is_source=True,
-            metadata={
-                SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: AssetExecutionType.UNEXECUTABLE.value
-            },
             tags={"biz": "baz"},
         ),
         ExternalAssetNode(
@@ -1283,9 +1264,6 @@ def test_external_assets_def_to_external_asset_graph():
             dependencies=[],
             depended_by=[ExternalAssetDependedBy(downstream_asset_key=AssetKey("asset2"))],
             execution_type=AssetExecutionType.UNEXECUTABLE,
-            metadata={
-                SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: AssetExecutionType.UNEXECUTABLE.value
-            },
             group_name=DEFAULT_GROUP_NAME,
         ),
         ExternalAssetNode(
@@ -1293,9 +1271,6 @@ def test_external_assets_def_to_external_asset_graph():
             dependencies=[ExternalAssetDependency(upstream_asset_key=AssetKey(["asset1"]))],
             depended_by=[],
             execution_type=AssetExecutionType.UNEXECUTABLE,
-            metadata={
-                SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: AssetExecutionType.UNEXECUTABLE.value
-            },
             group_name=DEFAULT_GROUP_NAME,
         ),
     ]

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -897,7 +897,6 @@ def test_get_all_asset_specs():
         "asset5",
         group_name="default",
         tags={"biz": "boz"},
-        metadata={"dagster/asset_execution_type": "UNEXECUTABLE"},
     )
     assert asset_specs_by_key[AssetKey("asset6")] == AssetSpec(
         "asset6",

--- a/python_modules/dagster/dagster_tests/storage_tests/test_asset_value_loader.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_asset_value_loader.py
@@ -76,7 +76,6 @@ def test_source_asset():
             assert context.asset_key == AssetKey("asset1")
             assert context.upstream_output.asset_key == AssetKey("asset1")
             assert context.upstream_output.definition_metadata["a"] == "b"
-            assert context.upstream_output.name == "result"
             assert context.dagster_type.typing_type == int
             return 5
 


### PR DESCRIPTION
## Summary & Motivation

Makes the `_node_def` property on `AssetsDefinition` optional. This means that:
- `AssetsDefinition`s constructed using `external_assets_from_specs` no longer include a dummy function.
- `AssetsDefinition`s created from `SourceAsset`s no longer include a dummy function.
- `{SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: "UNEXECUTABLE"}` goes away
- `external_assets_from_specs(spec)` now functions identically to `[AssetsDefinition(specs=[spec])]`

A question that came up while implementing this was: what to do about IO managers? `SourceAsset` has an `io_manager_key` attribute. IO manager keys are currently stored inside `OutputDefinition`s. Previously, when converting `SourceAsset`s to `AssetsDefinition`s, we were stashing the `io_manager_key` inside the output defs on the dummy node. This PR adds a "dagster/io_manager_key" asset definition metadata key for these cases. An alternative would be to give `AssetSpec` an `io_manager_key` attribute.

## How I Tested These Changes

TODO: need to add a few direct AssetsDefinition construction tests before this is mergeable
