### PR TITLE
Use dagster._utils.core.toposort in asset graph code

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_job.py
@@ -15,7 +15,7 @@ from typing import (
     Union,
 )
 
-from toposort import CircularDependencyError, toposort
+from toposort import CircularDependencyError
 
 import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
@@ -27,6 +27,7 @@ from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidSubsetError
 from dagster._core.selector.subset_selector import AssetSelectionData
+from dagster._core.utils import toposort
 from dagster._utils.merger import merge_dicts
 
 from .asset_layer import AssetLayer

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -23,8 +23,6 @@ from typing import (
     cast,
 )
 
-import toposort
-
 import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_subset import ValidAssetSubset
@@ -40,6 +38,7 @@ from dagster._core.selector.subset_selector import (
     DependencyGraph,
     fetch_sources,
 )
+from dagster._core.utils import toposort
 from dagster._utils.cached_method import cached_method
 
 from .events import AssetKeyPartitionKey
@@ -223,7 +222,7 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
         """
         return [
             item
-            for items_in_level in toposort.toposort(self.asset_dep_graph["upstream"])
+            for items_in_level in toposort(self.asset_dep_graph["upstream"])
             for item in sorted(items_in_level)
         ]
 
@@ -232,7 +231,7 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
         """Return topologically sorted asset keys grouped into sets containing keys of the same
         topological level.
         """
-        return [set(level) for level in toposort.toposort(self.asset_dep_graph["upstream"])]
+        return [set(level) for level in toposort(self.asset_dep_graph["upstream"])]
 
     @cached_property
     def unpartitioned_asset_keys(self) -> AbstractSet[AssetKey]:

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -17,7 +17,7 @@ from typing import (
     cast,
 )
 
-from toposort import CircularDependencyError, toposort_flatten
+from toposort import CircularDependencyError
 from typing_extensions import Self
 
 import dagster._check as check
@@ -32,6 +32,7 @@ from dagster._core.types.dagster_type import (
     DagsterTypeKind,
     construct_dagster_type_dictionary,
 )
+from dagster._core.utils import toposort_flatten
 from dagster._utils.warnings import normalize_renamed_param
 
 from .dependency import (


### PR DESCRIPTION
## Summary & Motivation

Sometimes we use vanilla toposort and sometimes we use our utils variant. Let's only use our internal version

## How I Tested These Changes

BK
