### PR TITLE
RFC: Let's start vendoring dependencies

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_job.py
@@ -15,8 +15,6 @@ from typing import (
     Union,
 )
 
-from toposort import CircularDependencyError
-
 import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_checks import has_only_asset_checks
@@ -29,6 +27,7 @@ from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidSu
 from dagster._core.selector.subset_selector import AssetSelectionData
 from dagster._core.utils import toposort
 from dagster._utils.merger import merge_dicts
+from dagster._vendored.toposort.toposort import CircularDependencyError
 
 from .asset_layer import AssetLayer
 from .assets import AssetsDefinition

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -17,7 +17,6 @@ from typing import (
     cast,
 )
 
-from toposort import CircularDependencyError
 from typing_extensions import Self
 
 import dagster._check as check
@@ -34,6 +33,7 @@ from dagster._core.types.dagster_type import (
 )
 from dagster._core.utils import toposort_flatten
 from dagster._utils.warnings import normalize_renamed_param
+from dagster._vendored.toposort.toposort import CircularDependencyError
 
 from .dependency import (
     DependencyMapping,

--- a/python_modules/dagster/dagster/_core/utils.py
+++ b/python_modules/dagster/dagster/_core/utils.py
@@ -22,11 +22,11 @@ from typing import (
 )
 from weakref import WeakSet
 
-import toposort as toposort_
 from typing_extensions import Final
 
 import dagster._check as check
 from dagster._utils import library_version_from_core_version, parse_package_version
+from dagster._vendored.toposort import toposort as toposort_
 
 BACKFILL_TAG_LENGTH = 8
 

--- a/python_modules/dagster/dagster/_vendored/toposort/__init__.py
+++ b/python_modules/dagster/dagster/_vendored/toposort/__init__.py
@@ -1,0 +1,40 @@
+## Vendored toposort module
+
+"""Vendored from https://gitlab.com/ericvsmith/toposort/-/blob/master/src/toposort.py?ref_type=heads on 2024-05-30.
+
+pyproject.toml at time of vendoring:
+
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "toposort"
+requires-python = ">=3.6"
+authors = [
+    {name = "Eric V. Smith", email = "eric@trueblade.com"},
+]
+license = {text = "Apache License Version 2.0"}
+description = "Implements a topological sort algorithm."
+readme = {file = "README.md", content-type = "text/markdown"}
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+]
+dynamic = ["version"]
+
+[project.urls]
+source = "https://gitlab.com/ericvsmith/toposort"
+
+[tool.setuptools.dynamic]
+# See https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata
+version = {attr = "toposort.__version__"}
+"""

--- a/python_modules/dagster/dagster/_vendored/toposort/toposort.py
+++ b/python_modules/dagster/dagster/_vendored/toposort/toposort.py
@@ -1,0 +1,92 @@
+# Vendored from https://gitlab.com/ericvsmith/toposort/-/blob/master/src/toposort.py?ref_type=heads
+#######################################################################
+# Implements a topological sort algorithm.
+#
+# Copyright 2014-2021 True Blade Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Notes:
+#  Based on http://code.activestate.com/recipes/578272-topological-sort
+#   with these major changes:
+#    Added unittests.
+#    Deleted doctests (maybe not the best idea in the world, but it cleans
+#     up the docstring).
+#    Moved functools import to the top of the file.
+#    Changed assert to a ValueError.
+#    Changed iter[items|keys] to [items|keys], for python 3
+#     compatibility. I don't think it matters for python 2 these are
+#     now lists instead of iterables.
+#    Copy the input so as to leave it unmodified.
+#    Renamed function from toposort2 to toposort.
+#    Handle empty input.
+#    Switch tests to use set literals.
+#
+########################################################################
+
+__all__ = ["toposort", "toposort_flatten", "CircularDependencyError"]
+__version__ = "1.10"
+
+
+class CircularDependencyError(ValueError):
+    def __init__(self, data):
+        s = f"Circular dependencies exist among these items: {{{', '.join(f'{key}:{value}' for key, value in data.items())}}}"
+        super(CircularDependencyError, self).__init__(s)
+        self.data = data
+
+
+def toposort(data):
+    """\
+Dependencies are expressed as a dictionary whose keys are items
+    and whose values are a set of dependent items. Output is a list of
+    sets in topological order. The first set consists of items with no
+    dependences, each subsequent set consists of items that depend upon
+    items in the preceeding sets.
+    """
+    # Special case empty input.
+    if len(data) == 0:
+        return
+
+    # Copy the input so as to leave it unmodified.
+    # Discard self-dependencies and copy two levels deep.
+    data = {item: set(e for e in dep if e != item) for item, dep in data.items()}
+
+    # Find all items that don't depend on anything.
+    extra_items_in_deps = {value for values in data.values() for value in values} - set(data.keys())
+    # The line below does N unions of value sets, which is much slower than the
+    # set comprehension above which does 1 union of N value sets. The speedup
+    # gain is around 200x on a graph with 190k nodes.
+    # extra_items_in_deps = _reduce(set.union, data.values()) - set(data.keys())
+
+    # Add empty dependences where needed.
+    data.update({item: set() for item in extra_items_in_deps})
+    while True:
+        ordered = set(item for item, dep in data.items() if len(dep) == 0)
+        if not ordered:
+            break
+        yield ordered
+        data = {item: (dep - ordered) for item, dep in data.items() if item not in ordered}
+    if len(data) != 0:
+        raise CircularDependencyError(data)
+
+
+def toposort_flatten(data, sort=True):
+    """\
+Returns a single list of dependencies. For any set returned by
+    toposort(), those items are sorted and appended to the result (just to
+    make the results deterministic).
+    """
+    result = []
+    for d in toposort(data):
+        result.extend((sorted if sort else list)(d))
+    return result

--- a/python_modules/dagster/dagster/_vendored/toposort/toposort.py
+++ b/python_modules/dagster/dagster/_vendored/toposort/toposort.py
@@ -1,4 +1,4 @@
-# Vendored from https://gitlab.com/ericvsmith/toposort/-/blob/master/src/toposort.py?ref_type=heads
+# Vendored from https://gitlab.com/ericvsmith/toposort/-/blob/e67c242ceec5908564837ce6ac2cb661659b0cc8/src/toposort.py
 #######################################################################
 # Implements a topological sort algorithm.
 #

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -744,7 +744,7 @@ def test_job_with_reserved_name():
 
 
 def test_asset_cycle():
-    from toposort import CircularDependencyError
+    from dagster._vendored.toposort.toposort import CircularDependencyError
 
     @asset
     def a(s, c):

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -104,7 +104,6 @@ setup(
         "typing_extensions>=4.4.0,<5",
         "structlog",
         "sqlalchemy>=1.0,<3",
-        "toposort>=1.0",
         "watchdog>=0.8.3",
         'psutil>=1.0; platform_system=="Windows"',
         # https://github.com/mhammond/pywin32/issues/1439


### PR DESCRIPTION
## Summary & Motivation

I am proposing that we start to default to vendoring dependencies whenever it is feasible. This will reduce our testing surface area and we are less likely to be thrashed by the Python ecosystem.

This just manually does this for now, but we could write some tooling support for this if necessary (automatically copy stuff down, don't ruff or typecheck the files, etc).

## How I Tested These Changes

BK
