### PR TITLE
RFC: Use stainless for our REST APIs?

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/openapi.yml
+++ b/python_modules/dagster-webserver/dagster_webserver/openapi.yml
@@ -1,0 +1,68 @@
+openapi: 3.1.0
+info:
+  title: Dagster Webserver API 
+  description: |-
+    OpenAPI-compliant Dagster Webserver API endpoint
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.11
+servers:
+  - url: https://petstore3.swagger.io/api/v3
+# tags:
+#   - name: pet
+#     description: Everything about your Pets
+#   - name: store
+#     description: Access to Petstore orders
+#   - name: user
+#     description: Operations about user
+
+paths:
+  /v1/report_asset_materialization:
+    post:
+      summary: Report Asset Materialization
+      description: Report Asset Materialization
+      operationId: report_asset_materialization
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReportAssetMatParam'
+      responses:
+        '200':
+          description: OK
+          # content:
+          #   application/json:
+          #     schema:
+          #       $ref: '#/components/schemas/AssetMaterializationEvent'
+        '400':
+          description: Bad Request
+          # content:
+          #   application/json:
+          #     schema:
+          #       $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
+          # content:
+          #   application/json:
+          #     schema:
+          #       $ref: '#/components/schemas/Error'
+
+components:
+  schemas:
+    ReportAssetMatParam:
+      type: object
+      properties:
+        asset_key:
+          type: string
+        data_version:
+          type: string
+        partition:
+          type: string
+        description:
+          type: string
+      required:
+        - asset_key
+        - partition
+        - materialization   
+  

--- a/python_modules/dagster-webserver/dagster_webserver/openapi.yml
+++ b/python_modules/dagster-webserver/dagster_webserver/openapi.yml
@@ -63,6 +63,4 @@ components:
           type: string
       required:
         - asset_key
-        - partition
-        - materialization   
   


### PR DESCRIPTION
## Summary & Motivation

I noticed that we spent a bunch of time handrolling documentation about our REST API endpoints such as https://github.com/dagster-io/dagster/pull/22065.

I think we should consider using [stainless](https://www.stainlessapi.com/) for this.

With stainless you provide an openAPI spec and they produce idiomatic SDKs in a bunch of different target programming languages. I did Python and JS but it also supports Go, Kotlin, Java, and more to come presumably.

I uploaded this spec to stainless and had it autogenerate the github repos for the SDKs:

* Python: https://github.com/stainless-sdks/dagster-plus-rest-python
* Node: https://github.com/stainless-sdks/dagster-plus-rest-node


For this I handrolled an open api spec for demonstration purposes and did not test it, but for real we would want to code to some Python framework that produces this for us.


## How I Tested These Changes

Looked at produced repos
