### PR TITLE
[DS][58/n] Reorganize result objects

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/operands/slice_conditions.py
@@ -77,13 +77,13 @@ class WillBeRequestedCondition(SliceSchedulingCondition):
         )
 
     def compute_slice(self, context: SchedulingContext) -> AssetSlice:
-        current_info = context.current_tick_evaluation_info_by_key.get(context.asset_key)
+        current_result = context.current_tick_results_by_key.get(context.asset_key)
         if (
-            current_info
-            and current_info.requested_slice
+            current_result
+            and current_result.true_slice
             and self._executable_with_root_context_key(context)
         ):
-            return current_info.requested_slice
+            return current_result.true_slice
         else:
             return context.asset_graph_view.create_empty_slice(context.asset_key)
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition.py
@@ -1,20 +1,24 @@
 import datetime
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Union
 
 import pendulum
 
-import dagster._check as check
 from dagster._annotations import experimental
-from dagster._core.asset_graph_view.asset_graph_view import AssetSlice
+from dagster._core.asset_graph_view.asset_graph_view import AssetSlice, TemporalContext
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.declarative_scheduling.serialized_objects import (
+    AssetConditionEvaluation,
     AssetConditionSnapshot,
     AssetSubsetWithMetadata,
+    SchedulingConditionCursor,
     SchedulingConditionNodeCursor,
+    get_serializable_candidate_subset,
 )
-from dagster._core.definitions.metadata import MetadataMapping
+from dagster._core.definitions.partition import AllPartitionsSubset
+from dagster._core.definitions.time_window_partitions import BaseTimeWindowPartitionsSubset
 from dagster._model import DagsterModel
 from dagster._utils.security import non_secure_md5_hash_str
 
@@ -326,20 +330,80 @@ class SchedulingCondition(ABC, DagsterModel):
 class SchedulingResult(DagsterModel):
     condition: SchedulingCondition
     condition_unique_id: str
+    value_hash: str
+
     start_timestamp: float
     end_timestamp: float
 
+    temporal_context: TemporalContext
+
     true_slice: AssetSlice
-    candidate_subset: AssetSubset
-    subsets_with_metadata: Sequence[AssetSubsetWithMetadata]
+    candidate_slice: AssetSlice
+
+    child_results: Sequence["SchedulingResult"]
+
+    node_cursor: Optional[SchedulingConditionNodeCursor]
+    serializable_evaluation: AssetConditionEvaluation
 
     extra_state: Any
-    child_results: Sequence["SchedulingResult"]
-    node_cursor: Optional[SchedulingConditionNodeCursor]
+    subsets_with_metadata: Sequence[AssetSubsetWithMetadata]
+
+    @property
+    def asset_key(self) -> AssetKey:
+        return self.true_slice.asset_key
 
     @property
     def true_subset(self) -> AssetSubset:
         return self.true_slice.convert_to_valid_asset_subset()
+
+    @staticmethod
+    def _create(
+        context: "SchedulingContext",
+        true_slice: AssetSlice,
+        subsets_with_metadata: Sequence[AssetSubsetWithMetadata],
+        extra_state: Optional[Union[AssetSubset, Sequence[AssetSubset]]],
+        child_results: Sequence["SchedulingResult"],
+    ) -> "SchedulingResult":
+        start_timestamp = context.create_time.timestamp()
+        end_timestamp = pendulum.now("UTC").timestamp()
+
+        return SchedulingResult(
+            condition=context.condition,
+            condition_unique_id=context.condition_unique_id,
+            value_hash=_compute_value_hash(
+                condition_unique_id=context.condition_unique_id,
+                condition_description=context.condition.description,
+                true_slice=true_slice,
+                candidate_slice=context.candidate_slice,
+                subsets_with_metadata=subsets_with_metadata,
+                child_results=child_results,
+            ),
+            start_timestamp=start_timestamp,
+            end_timestamp=end_timestamp,
+            temporal_context=context.new_temporal_context,
+            true_slice=true_slice,
+            candidate_slice=context.candidate_slice,
+            subsets_with_metadata=[],
+            child_results=child_results,
+            extra_state=None,
+            node_cursor=_create_node_cursor(
+                true_slice=true_slice,
+                candidate_slice=context.candidate_slice,
+                subsets_with_metadata=subsets_with_metadata,
+                extra_state=extra_state,
+            )
+            if context.condition.requires_cursor
+            else None,
+            serializable_evaluation=_create_serializable_evaluation(
+                context=context,
+                true_slice=true_slice,
+                candidate_slice=context.candidate_slice,
+                subsets_with_metadata=subsets_with_metadata,
+                start_timestamp=start_timestamp,
+                end_timestamp=end_timestamp,
+                child_results=child_results,
+            ),
+        )
 
     @staticmethod
     def create_from_children(
@@ -349,25 +413,12 @@ class SchedulingResult(DagsterModel):
         extra_state: Optional[Union[AssetSubset, Sequence[AssetSubset]]] = None,
     ) -> "SchedulingResult":
         """Returns a new AssetConditionEvaluation from the given child results."""
-        candidate_subset = context.candidate_slice.convert_to_valid_asset_subset()
-        return SchedulingResult(
-            condition=context.condition,
-            condition_unique_id=context.condition_unique_id,
-            start_timestamp=context.create_time.timestamp(),
-            end_timestamp=pendulum.now("UTC").timestamp(),
+        return SchedulingResult._create(
+            context=context,
             true_slice=true_slice,
-            candidate_subset=context.candidate_slice.convert_to_valid_asset_subset(),
             subsets_with_metadata=[],
+            extra_state=extra_state,
             child_results=child_results,
-            extra_state=None,
-            node_cursor=SchedulingConditionNodeCursor(
-                true_subset=true_slice.convert_to_valid_asset_subset(),
-                candidate_subset=candidate_subset,
-                subsets_with_metadata=[],
-                extra_state=extra_state,
-            )
-            if context.condition.requires_cursor
-            else None,
         )
 
     @staticmethod
@@ -375,39 +426,109 @@ class SchedulingResult(DagsterModel):
         context: "SchedulingContext",
         true_slice: AssetSlice,
         subsets_with_metadata: Sequence[AssetSubsetWithMetadata] = [],
-        slices_with_metadata: Sequence[Tuple[AssetSlice, MetadataMapping]] = [],
         extra_state: Optional[Union[AssetSubset, Sequence[AssetSubset]]] = None,
     ) -> "SchedulingResult":
         """Returns a new AssetConditionEvaluation from the given parameters."""
-        check.param_invariant(
-            not (bool(subsets_with_metadata) and bool(slices_with_metadata)),
-            "slices_with_metadata",
-            "Cannot provide both subsets_with_metadata and slices_with_metadata.",
-        )
-        if slices_with_metadata:
-            subsets_with_metadata = [
-                AssetSubsetWithMetadata(
-                    subset=asset_slice.convert_to_valid_asset_subset(), metadata=metadata
-                )
-                for asset_slice, metadata in slices_with_metadata
-            ]
-        candidate_subset = context.candidate_slice.convert_to_valid_asset_subset()
-        return SchedulingResult(
-            condition=context.condition,
-            condition_unique_id=context.condition_unique_id,
-            start_timestamp=context.create_time.timestamp(),
-            end_timestamp=pendulum.now("UTC").timestamp(),
+        return SchedulingResult._create(
+            context=context,
             true_slice=true_slice,
-            candidate_subset=candidate_subset,
             subsets_with_metadata=subsets_with_metadata,
-            child_results=[],
             extra_state=extra_state,
-            node_cursor=SchedulingConditionNodeCursor(
-                true_subset=true_slice.convert_to_valid_asset_subset(),
-                candidate_subset=candidate_subset,
-                subsets_with_metadata=subsets_with_metadata,
-                extra_state=extra_state,
-            )
-            if context.condition.requires_cursor
-            else None,
+            child_results=[],
         )
+
+    def get_child_node_cursors(self) -> Mapping[str, SchedulingConditionNodeCursor]:
+        node_cursors = {self.condition_unique_id: self.node_cursor} if self.node_cursor else {}
+        for child_result in self.child_results:
+            node_cursors.update(child_result.get_child_node_cursors())
+        return node_cursors
+
+    def get_new_cursor(self) -> SchedulingConditionCursor:
+        return SchedulingConditionCursor(
+            previous_requested_subset=self.true_subset,
+            effective_timestamp=self.temporal_context.effective_dt.timestamp(),
+            last_event_id=self.temporal_context.last_event_id,
+            node_cursors_by_unique_id=self.get_child_node_cursors(),
+            result_value_hash=self.value_hash,
+        )
+
+
+def _create_node_cursor(
+    true_slice: AssetSlice,
+    candidate_slice: AssetSlice,
+    subsets_with_metadata: Sequence[AssetSubsetWithMetadata],
+    extra_state: Optional[Union[AssetSubset, Sequence[AssetSubset]]],
+) -> SchedulingConditionNodeCursor:
+    return SchedulingConditionNodeCursor(
+        true_subset=true_slice.convert_to_valid_asset_subset(),
+        candidate_subset=get_serializable_candidate_subset(
+            candidate_slice.convert_to_valid_asset_subset()
+        ),
+        subsets_with_metadata=subsets_with_metadata,
+        extra_state=extra_state,
+    )
+
+
+def _create_serializable_evaluation(
+    context: "SchedulingContext",
+    true_slice: AssetSlice,
+    candidate_slice: AssetSlice,
+    subsets_with_metadata: Sequence[AssetSubsetWithMetadata],
+    start_timestamp: float,
+    end_timestamp: float,
+    child_results: Sequence[SchedulingResult],
+) -> AssetConditionEvaluation:
+    return AssetConditionEvaluation(
+        condition_snapshot=context.condition.get_snapshot(context.condition_unique_id),
+        true_subset=true_slice.convert_to_valid_asset_subset(),
+        candidate_subset=get_serializable_candidate_subset(
+            candidate_slice.convert_to_valid_asset_subset()
+        ),
+        subsets_with_metadata=subsets_with_metadata,
+        start_timestamp=start_timestamp,
+        end_timestamp=end_timestamp,
+        child_evaluations=[child_result.serializable_evaluation for child_result in child_results],
+    )
+
+
+def _compute_value_hash(
+    condition_unique_id: str,
+    condition_description: str,
+    true_slice: AssetSlice,
+    candidate_slice: AssetSlice,
+    subsets_with_metadata: Sequence[AssetSubsetWithMetadata],
+    child_results: Sequence[SchedulingResult],
+) -> str:
+    """Computes a unique hash representing the values contained within an evaluation result. This
+    string will be identical for results which have identical values, allowing us to detect changes
+    without serializing the entire value.
+    """
+    components: Sequence[str] = [
+        condition_unique_id,
+        condition_description,
+        _compute_subset_value_str(true_slice.convert_to_valid_asset_subset()),
+        _compute_subset_value_str(candidate_slice.convert_to_valid_asset_subset()),
+        *(_compute_subset_with_metadata_value_str(swm) for swm in subsets_with_metadata),
+        *(child_result.value_hash for child_result in child_results),
+    ]
+    return non_secure_md5_hash_str("".join(components).encode("utf-8"))
+
+
+def _compute_subset_value_str(subset: AssetSubset) -> str:
+    """Computes a unique string representing a given AssetSubsets. This string will be equal for
+    equivalent AssetSubsets.
+    """
+    if isinstance(subset.value, bool):
+        return str(subset.value)
+    elif isinstance(subset.value, AllPartitionsSubset):
+        return AllPartitionsSubset.__name__
+    elif isinstance(subset.value, BaseTimeWindowPartitionsSubset):
+        return str(list(sorted(subset.value.included_time_windows)))
+    else:
+        return str(list(sorted(subset.asset_partitions)))
+
+
+def _compute_subset_with_metadata_value_str(subset_with_metadata: AssetSubsetWithMetadata):
+    return _compute_subset_value_str(subset_with_metadata.subset) + str(
+        sorted(subset_with_metadata.frozen_metadata)
+    )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_condition_evaluator.py
@@ -3,45 +3,23 @@ import datetime
 import logging
 import time
 from collections import defaultdict
-from typing import (
-    TYPE_CHECKING,
-    AbstractSet,
-    Dict,
-    Mapping,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-)
+from typing import TYPE_CHECKING, AbstractSet, Dict, Mapping, Optional, Sequence, Set, Tuple
 
 import dagster._check as check
-from dagster._core.asset_graph_view.asset_graph_view import (
-    AssetGraphView,
-)
+from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
 from dagster._core.definitions.data_time import CachingDataTimeResolver
-from dagster._core.definitions.declarative_scheduling.scheduling_context import (
-    SchedulingContext,
-)
-from dagster._core.definitions.declarative_scheduling.scheduling_evaluation_info import (
-    SchedulingEvaluationInfo,
-)
+from dagster._core.definitions.declarative_scheduling.scheduling_condition import SchedulingResult
+from dagster._core.definitions.declarative_scheduling.scheduling_context import SchedulingContext
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 
 from ..asset_daemon_cursor import AssetDaemonCursor
 from ..base_asset_graph import BaseAssetGraph
 from ..freshness_based_auto_materialize import get_expected_data_time_for_asset_key
-from .legacy.legacy_context import (
-    LegacyRuleEvaluationContext,
-)
-from .serialized_objects import (
-    AssetConditionEvaluationState,
-    SchedulingConditionCursor,
-)
+from .legacy.legacy_context import LegacyRuleEvaluationContext
+from .serialized_objects import AssetConditionEvaluationState
 
 if TYPE_CHECKING:
-    from dagster._utils.caching_instance_queryer import (
-        CachingInstanceQueryer,
-    )
+    from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from dataclasses import dataclass
 
@@ -74,7 +52,7 @@ class SchedulingConditionEvaluator:
         self.auto_materialize_run_tags = auto_materialize_run_tags
 
         self.evaluation_state_by_key = {}
-        self.current_evaluation_info_by_key = {}
+        self.current_results_by_key = {}
         self.condition_cursors = []
         self.expected_data_time_mapping = defaultdict()
         self.to_request = set()
@@ -85,7 +63,7 @@ class SchedulingConditionEvaluator:
     asset_keys: AbstractSet[AssetKey]
     asset_graph_view: AssetGraphView
     evaluation_state_by_key: Dict[AssetKey, AssetConditionEvaluationState]
-    current_evaluation_info_by_key: Dict[AssetKey, SchedulingEvaluationInfo]
+    current_results_by_key: Dict[AssetKey, SchedulingResult]
     expected_data_time_mapping: Dict[AssetKey, Optional[datetime.datetime]]
     to_request: Set[AssetKeyPartitionKey]
     num_checked_assets: int
@@ -124,13 +102,7 @@ class SchedulingConditionEvaluator:
         self.instance_queryer.prefetch_asset_records(self.asset_records_to_prefetch)
         self.logger.info("Done prefetching asset records.")
 
-    def evaluate(
-        self,
-    ) -> Tuple[
-        Sequence[AssetConditionEvaluationState],
-        AbstractSet[AssetKeyPartitionKey],
-        Sequence[SchedulingConditionCursor],
-    ]:
+    def evaluate(self) -> Tuple[Sequence[SchedulingResult], AbstractSet[AssetKeyPartitionKey]]:
         self.prefetch()
         for asset_key in self.asset_graph.toposorted_asset_keys:
             # an asset may have already been visited if it was part of a non-subsettable multi-asset
@@ -145,21 +117,18 @@ class SchedulingConditionEvaluator:
             )
 
             try:
-                (evaluation_state, expected_data_time, cursor) = self.evaluate_asset(
-                    asset_key,
-                    self.evaluation_state_by_key,
-                    self.expected_data_time_mapping,
-                    self.current_evaluation_info_by_key,
+                (result, expected_data_time) = self.evaluate_asset(
+                    asset_key, self.expected_data_time_mapping, self.current_results_by_key
                 )
             except Exception as e:
                 raise Exception(
                     f"Error while evaluating conditions for asset {asset_key.to_user_string()}"
                 ) from e
 
-            num_requested = evaluation_state.true_subset.size
+            num_requested = result.true_subset.size
             log_fn = self.logger.info if num_requested > 0 else self.logger.debug
 
-            to_request_asset_partitions = evaluation_state.true_subset.asset_partitions
+            to_request_asset_partitions = result.true_subset.asset_partitions
             to_request_str = ",".join(
                 [(ap.partition_key or "No partition") for ap in to_request_asset_partitions]
             )
@@ -170,13 +139,7 @@ class SchedulingConditionEvaluator:
                 f" requested ({to_request_str}) ({format(time.time()-start_time, '.3f')} seconds)"
             )
 
-            self.evaluation_state_by_key[asset_key] = evaluation_state
-            self.current_evaluation_info_by_key[asset_key] = (
-                SchedulingEvaluationInfo.from_asset_condition_evaluation_state(
-                    self.asset_graph_view, evaluation_state
-                )
-            )
-            self.condition_cursors.append(cursor)
+            self.current_results_by_key[asset_key] = result
             self.expected_data_time_mapping[asset_key] = expected_data_time
 
             # if we need to materialize any partitions of a non-subsettable multi-asset, we need to
@@ -204,36 +167,18 @@ class SchedulingConditionEvaluator:
                         )
                     self.to_request |= {
                         ap._replace(asset_key=neighbor_key)
-                        for ap in evaluation_state.true_subset.asset_partitions
+                        for ap in result.true_subset.asset_partitions
                     }
 
-        return (
-            list(self.evaluation_state_by_key.values()),
-            self.to_request,
-            self.condition_cursors,
-        )
+        return list(self.current_results_by_key.values()), self.to_request
 
     def evaluate_asset(
         self,
         asset_key: AssetKey,
-        evaluation_state_by_key: Mapping[AssetKey, AssetConditionEvaluationState],
         expected_data_time_mapping: Mapping[AssetKey, Optional[datetime.datetime]],
-        current_evaluation_info_by_key: Mapping[AssetKey, SchedulingEvaluationInfo],
-    ) -> Tuple[
-        AssetConditionEvaluationState, Optional[datetime.datetime], SchedulingConditionCursor
-    ]:
-        """Evaluates the auto materialize policy of a given asset key.
-
-        Params:
-            - asset_key: The asset key to evaluate.
-            - will_materialize_mapping: A mapping of AssetKey to the set of AssetKeyPartitionKeys
-                that will be materialized this tick. As this function is called in topological order,
-                this mapping will contain the expected materializations of all upstream assets.
-            - expected_data_time_mapping: A mapping of AssetKey to the expected data time of the
-                asset after this tick. As this function is called in topological order, this mapping
-                will contain the expected data times of all upstream assets.
-
-        """
+        current_results_by_key: Mapping[AssetKey, SchedulingResult],
+    ) -> Tuple[SchedulingResult, Optional[datetime.datetime]]:
+        """Evaluates the auto materialize policy of a given asset key."""
         # convert the legacy AutoMaterializePolicy to an Evaluator
         asset_condition = check.not_none(
             self.asset_graph.get(asset_key).auto_materialize_policy
@@ -245,7 +190,7 @@ class SchedulingConditionEvaluator:
             condition=asset_condition,
             instance_queryer=self.instance_queryer,
             data_time_resolver=self.data_time_resolver,
-            evaluation_state_by_key=evaluation_state_by_key,
+            current_results_by_key=current_results_by_key,
             expected_data_time_mapping=expected_data_time_mapping,
             respect_materialization_data_versions=self.respect_materialization_data_versions,
             auto_materialize_run_tags=self.auto_materialize_run_tags,
@@ -256,21 +201,13 @@ class SchedulingConditionEvaluator:
             asset_key=asset_key,
             asset_graph_view=self.asset_graph_view,
             logger=self.logger,
-            current_tick_evaluation_info_by_key=current_evaluation_info_by_key,
+            current_tick_results_by_key=current_results_by_key,
             condition_cursor=self.cursor.get_previous_condition_cursor(asset_key),
             legacy_context=legacy_context,
         )
 
         result = asset_condition.evaluate(context)
-
         expected_data_time = get_expected_data_time_for_asset_key(
             legacy_context, will_materialize=result.true_subset.size > 0
         )
-        evaluation_state = AssetConditionEvaluationState.create(context, result)
-        return (
-            evaluation_state,
-            expected_data_time,
-            SchedulingConditionCursor.from_result(
-                context, result, evaluation_state.previous_evaluation.get_result_hash()
-            ),
-        )
+        return result, expected_data_time

--- a/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_scheduling/scheduling_evaluation_info.py
@@ -1,22 +1,10 @@
-import itertools
-from typing import Any, NamedTuple, Optional, Sequence
+from typing import NamedTuple, Optional
 
-from dagster._core.asset_graph_view.asset_graph_view import (
-    AssetGraphView,
-    AssetSlice,
-    TemporalContext,
-)
-from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.asset_subset import AssetSubset
+from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView, AssetSlice
 from dagster._core.definitions.declarative_scheduling.serialized_objects import (
-    AssetConditionEvaluation,
-    AssetConditionEvaluationState,
     AssetSubsetWithMetadata,
-    SchedulingConditionCursor,
 )
 from dagster._core.definitions.metadata import MetadataMapping
-from dagster._model import DagsterModel
-from dagster._utils import utc_datetime_from_timestamp
 
 
 class AssetSliceWithMetadata(NamedTuple):
@@ -36,96 +24,3 @@ class AssetSliceWithMetadata(NamedTuple):
         if asset_slice is None:
             return None
         return AssetSliceWithMetadata(asset_slice=asset_slice, metadata=metadata)
-
-
-class SchedulingEvaluationResultNode(DagsterModel):
-    """Represents the results of evaluating a single condition in the broader evaluation tree."""
-
-    asset_key: AssetKey
-    condition_unique_id: str
-
-    true_slice: Optional[AssetSlice]
-    candidate_slice: Optional[AssetSlice]
-    slices_with_metadata: Sequence[AssetSliceWithMetadata]
-
-    extra_state: Any
-
-    @staticmethod
-    def nodes_for_evaluation(
-        asset_graph_view: AssetGraphView,
-        state: AssetConditionEvaluationState,
-        condition_evaluation: AssetConditionEvaluation,
-    ) -> Sequence["SchedulingEvaluationResultNode"]:
-        unique_id = condition_evaluation.condition_snapshot.unique_id
-        asset_key = condition_evaluation.asset_key
-        # we store AllPartitionsSubset as a sentinel value to avoid serializing the entire set of
-        # partitions on each tick. this logic handles converting that back to an AllPartitionsSubset
-        # at read time.
-        candidate_slice = (
-            asset_graph_view.get_asset_slice_from_subset(condition_evaluation.candidate_subset)
-            if isinstance(condition_evaluation.candidate_subset, AssetSubset)
-            else asset_graph_view.get_asset_slice(asset_key=asset_key)
-        )
-
-        # only carry forward subsets that are compatible with the current partitions def
-        slices_with_metadata = list(
-            filter(
-                None,
-                [
-                    AssetSliceWithMetadata.from_asset_subset_with_metadata(
-                        asset_graph_view=asset_graph_view,
-                        asset_subset_with_metadata=subset_with_metadata,
-                    )
-                    for subset_with_metadata in condition_evaluation.subsets_with_metadata
-                ],
-            )
-        )
-        node = SchedulingEvaluationResultNode.model_construct(
-            asset_key=asset_key,
-            condition_unique_id=unique_id,
-            true_slice=asset_graph_view.get_asset_slice_from_subset(
-                condition_evaluation.true_subset
-            ),
-            candidate_slice=candidate_slice,
-            slices_with_metadata=slices_with_metadata,
-            extra_state=state.extra_state_by_unique_id.get(unique_id),
-        )
-        child_nodes = [
-            SchedulingEvaluationResultNode.nodes_for_evaluation(asset_graph_view, state, child)
-            for child in condition_evaluation.child_evaluations
-        ]
-        return list(itertools.chain([node], *child_nodes))
-
-
-class SchedulingEvaluationInfo(DagsterModel):
-    """Represents computed information for the entire evaluation tree."""
-
-    temporal_context: TemporalContext
-    evaluation_nodes: Sequence[SchedulingEvaluationResultNode]
-    requested_slice: Optional[AssetSlice]
-    cursor: Optional[SchedulingConditionCursor]
-
-    def get_evaluation_node(self, unique_id: str) -> Optional[SchedulingEvaluationResultNode]:
-        for node in self.evaluation_nodes:
-            if node.condition_unique_id == unique_id:
-                return node
-        return None
-
-    @staticmethod
-    def from_asset_condition_evaluation_state(
-        asset_graph_view: AssetGraphView, state: AssetConditionEvaluationState
-    ) -> "SchedulingEvaluationInfo":
-        temporal_context = TemporalContext(
-            effective_dt=utc_datetime_from_timestamp(state.previous_tick_evaluation_timestamp or 0),
-            last_event_id=state.max_storage_id,
-        )
-        nodes = SchedulingEvaluationResultNode.nodes_for_evaluation(
-            asset_graph_view, state, state.previous_evaluation
-        )
-        requested_slice = asset_graph_view.get_asset_slice_from_subset(state.true_subset)
-        return SchedulingEvaluationInfo(
-            temporal_context=temporal_context,
-            evaluation_nodes=nodes,
-            requested_slice=requested_slice,
-            cursor=SchedulingConditionCursor.backcompat_from_evaluation_state(state),
-        )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_asset_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_asset_condition.py
@@ -1,7 +1,4 @@
 from dagster import AutoMaterializePolicy, Definitions, SchedulingCondition, asset
-from dagster._core.definitions.declarative_scheduling.serialized_objects import (
-    AssetConditionEvaluation,
-)
 from dagster._core.remote_representation.external_data import external_repository_data_from_def
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
@@ -23,22 +20,17 @@ def test_missing_unpartitioned() -> None:
 
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
-
-    evaluation1 = deserialize_value(
-        serialize_value(AssetConditionEvaluation.from_result(result)), AssetConditionEvaluation
-    )
+    original_value_hash = result.value_hash
 
     # still true
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
-
-    evaluation2 = AssetConditionEvaluation.from_result(result)
-
-    assert evaluation2.equivalent_to_stored_evaluation(evaluation1)
+    assert result.value_hash == original_value_hash
 
     # after a run of A it's now False
     state, result = state.with_runs(run_request("A")).evaluate("A")
     assert result.true_subset.size == 0
+    assert result.value_hash != original_value_hash
 
     # if we evaluate from scratch, it's also False
     _, result = state.without_cursor().evaluate("A")

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
@@ -4,12 +4,8 @@ from dagster import AutoMaterializePolicy, Definitions, asset
 from dagster._core.definitions.declarative_scheduling.legacy.asset_condition import (
     AssetCondition,
 )
-from dagster._core.definitions.declarative_scheduling.serialized_objects import (
-    AssetConditionEvaluation,
-)
 from dagster._core.remote_representation.external_data import external_repository_data_from_def
 from dagster._serdes import serialize_value
-from dagster._serdes.serdes import deserialize_value
 
 from ..base_scenario import run_request
 from ..scenario_specs import (
@@ -28,22 +24,17 @@ def test_missing_unpartitioned() -> None:
 
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
-
-    evaluation1 = deserialize_value(
-        serialize_value(AssetConditionEvaluation.from_result(result)), AssetConditionEvaluation
-    )
+    original_value_hash = result.value_hash
 
     # still true
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
-
-    evaluation2 = AssetConditionEvaluation.from_result(result)
-
-    assert evaluation2.equivalent_to_stored_evaluation(evaluation1)
+    assert result.value_hash == original_value_hash
 
     # after a run of A it's now False
     state, result = state.with_runs(run_request("A")).evaluate("A")
     assert result.true_subset.size == 0
+    assert result.value_hash != original_value_hash
 
     # if we evaluate from scratch, it's also False
     _, result = state.without_cursor().evaluate("A")

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_result_value_hash.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_result_value_hash.py
@@ -1,0 +1,61 @@
+import pytest
+from dagster import (
+    AssetSpec,
+    DailyPartitionsDefinition,
+    # doing this rename to make the test cases fit on a single line for readability
+    SchedulingCondition as SC,
+)
+
+from dagster_tests.definitions_tests.auto_materialize_tests.base_scenario import run_request
+
+from ..scenario_specs import ScenarioSpec
+from .asset_condition_scenario import SchedulingConditionScenarioState
+
+one_parent = ScenarioSpec(asset_specs=[AssetSpec("A"), AssetSpec("downstream", deps=["A"])])
+two_parents = ScenarioSpec(
+    asset_specs=[AssetSpec("A"), AssetSpec("B"), AssetSpec("downstream", deps=["A", "B"])]
+)
+
+daily_partitions = DailyPartitionsDefinition(start_date="2020-01-01")
+one_parent_daily = one_parent.with_asset_properties(partitions_def=daily_partitions)
+two_parents_daily = two_parents.with_asset_properties(partitions_def=daily_partitions)
+
+
+@pytest.mark.parametrize(
+    ["expected_value_hash", "condition", "scenario_spec", "materialize_A"],
+    [
+        # cron condition returns a unique value hash if parents change, if schedule changes, if the
+        # partitions def changes, or if an asset is materialized
+        ("a92dbabace17f6e01d1401b24fa8ef91", SC.on_cron("0 * * * *"), one_parent, False),
+        ("e05365738d0ab47ba9f7b190caa29937", SC.on_cron("0 * * * *"), one_parent, True),
+        ("64bbf6ecddf773acb296d3e2e46dc0f8", SC.on_cron("0 0 * * *"), one_parent, False),
+        ("949c0ff067cc0bd50ca162d0fbbc345b", SC.on_cron("0 * * * *"), one_parent_daily, False),
+        ("f6655af0492e256b4abd3f1cde6bf7c9", SC.on_cron("0 * * * *"), two_parents, False),
+        ("71a75f6029a963e6336bc611f1c23dde", SC.on_cron("0 * * * *"), two_parents_daily, False),
+        # same as above
+        ("f2c737a2ae995a3ef9b7de145a41f249", SC.eager(), one_parent, False),
+        ("696704072f276a082ce065681d167b5f", SC.eager(), one_parent, True),
+        ("0cff09ea2ac9ee4472c2bb42a5be61f0", SC.eager(), one_parent_daily, False),
+        ("6089616e33622bf574cc2c273b9e2de1", SC.eager(), two_parents, False),
+        ("6306aac109c81f251b9cf731da5a0146", SC.eager(), two_parents_daily, False),
+        # missing condition is invariant to changes other than partitions def changes
+        ("707c5cea910e6dc1694cb6c388de9177", SC.missing(), one_parent, False),
+        ("707c5cea910e6dc1694cb6c388de9177", SC.missing(), one_parent, True),
+        ("707c5cea910e6dc1694cb6c388de9177", SC.missing(), two_parents, False),
+        ("18766936401c96c0b298b293bfdbde1e", SC.missing(), two_parents_daily, False),
+        ("18766936401c96c0b298b293bfdbde1e", SC.missing(), one_parent_daily, False),
+    ],
+)
+def test_value_hash(
+    condition: SC, scenario_spec: ScenarioSpec, expected_value_hash: str, materialize_A: bool
+) -> None:
+    state = SchedulingConditionScenarioState(
+        scenario_spec, scheduling_condition=condition
+    ).with_current_time("2024-01-01")
+
+    state, _ = state.evaluate("downstream")
+    if materialize_A:
+        state = state.with_runs(run_request("A"))
+
+    state, result = state.evaluate("downstream")
+    assert result.value_hash == expected_value_hash

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_user_space_ds_api.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_user_space_ds_api.py
@@ -8,11 +8,9 @@ from dagster import SchedulingCondition, asset
 from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.data_time import CachingDataTimeResolver
+from dagster._core.definitions.declarative_scheduling.scheduling_condition import SchedulingResult
 from dagster._core.definitions.declarative_scheduling.scheduling_condition_evaluator import (
     SchedulingConditionEvaluator,
-)
-from dagster._core.definitions.declarative_scheduling.serialized_objects import (
-    AssetConditionEvaluationState,
 )
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetKeyPartitionKey
@@ -27,7 +25,7 @@ from .user_space_ds_defs import amp_sensor, downstream, upstream
 
 
 class SchedulingTickResult(NamedTuple):
-    evaluation_states: Sequence[AssetConditionEvaluationState]
+    results: Sequence[SchedulingResult]
     asset_partition_keys: AbstractSet[AssetKeyPartitionKey]
 
 
@@ -50,19 +48,19 @@ def execute_ds_ticks(defs: Definitions, n: int) -> Iterator[SchedulingTickResult
             respect_materialization_data_versions=False,
             auto_materialize_run_tags={},
         )
-        result = evaluator.evaluate()
+        results, to_request = evaluator.evaluate()
 
         cursor = cursor.with_updates(
             evaluation_id=i,
             evaluation_timestamp=time.time(),
             newly_observe_requested_asset_keys=[],
-            condition_cursors=result[2],
+            condition_cursors=[result.get_new_cursor() for result in results],
         )
 
         serialized_cursor = serialize_value(cursor)
         cursor = deserialize_value(serialized_cursor, AssetDaemonCursor)
 
-        yield SchedulingTickResult(evaluation_states=result[0], asset_partition_keys=result[1])
+        yield SchedulingTickResult(results=results, asset_partition_keys=to_request)
 
 
 def execute_ds_tick(defs: Definitions) -> SchedulingTickResult:
@@ -93,8 +91,8 @@ def test_basic_asset_scheduling_test() -> None:
         AssetKeyPartitionKey(downstream.key),
     }
     # both are true because both missing
-    assert result.evaluation_states[0].true_subset.bool_value
-    assert result.evaluation_states[1].true_subset.bool_value
+    assert result.results[0].true_subset.bool_value
+    assert result.results[1].true_subset.bool_value
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary & Motivation

This is a pretty red diff, as we were doing a lot of weird contortion in the past converting to and from different object types depending on the use case. This simplifies the model greatly, where at a high level we just have 3 object types to think about:

- SchedulingResult: An in-memory, non-serializable object that represetns the result of an evaluation. This is what gets returned when you evaluate a condition, and "thinks" in terms of AssetSlice objects.
- SchedulingConditionCursor: A serializable object that is used to track incremental state about an evaluation, to make future evaluations more efficient. It contains a list of SchedulingConditionNodeCursors, for condition nodes which require more specific bits of information in order to be computed efficiently. These are lightweight, containing only the required information, and are eventually stored on the AssetDaemonCursor.
- AssetConditionEvaluation: A serializable object that represents the entire tree of computations that occurred on a given tick. This is used to power the UI, and contains information about all nodes in the evaluation. This is much larger than a SchedulingConditionCursor, and only gets written out to the database if a value in it meaningfully changes. It does not get stored in the cursor.

## How I Tested These Changes
