### PR TITLE
Remove overly defensive job index invariant

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/job_index.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/job_index.py
@@ -32,12 +32,6 @@ class JobIndex:
             parent_job_snapshot, "parent_job_snapshot", JobSnapshot
         )
 
-        if self.job_snapshot.lineage_snapshot:
-            check.invariant(
-                self.parent_job_snapshot is not None,
-                "Can not create JobIndex for job_snapshot with lineage without parent_job_snapshot",
-            )
-
         node_def_snaps: Sequence[Union[OpDefSnap, GraphDefSnap]] = [
             *job_snapshot.node_defs_snapshot.op_def_snaps,
             *job_snapshot.node_defs_snapshot.graph_def_snaps,


### PR DESCRIPTION
Summary:
We believe that this invariant is no longer always true and is causing more trouble than it is worth.

Test Plan:
Load a subsetted single-asset run of an asset job, no more spurious graphql error

## Summary & Motivation

## How I Tested These Changes
