### PR TITLE
[blueprints] Introduce basic `YamlBlueprintsLoader` class

### DIFF
--- a/python_modules/dagster/dagster/_model/pydantic_compat_layer.py
+++ b/python_modules/dagster/dagster/_model/pydantic_compat_layer.py
@@ -1,3 +1,4 @@
+import json
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Type
 
 import pydantic
@@ -151,3 +152,17 @@ def build_validation_error(
             input_type=input_type,
             hide_input=hide_input,
         )
+
+
+def json_schema_from_type(model_type: Type[BaseModel]):
+    """Pydantic version stable way to get the JSON schema for a Pydantic model."""
+    # This nicely handles the case where the per_file_blueprint_type is actually
+    # a union type etc.
+    if USING_PYDANTIC_2:
+        from pydantic import TypeAdapter
+
+        return TypeAdapter(model_type).json_schema()
+    else:
+        from pydantic.tools import schema_json_of
+
+        return json.loads(schema_json_of(model_type))

--- a/python_modules/dagster/dagster/_model/pydantic_compat_layer.py
+++ b/python_modules/dagster/dagster/_model/pydantic_compat_layer.py
@@ -158,11 +158,12 @@ def json_schema_from_type(model_type: Type[BaseModel]):
     """Pydantic version stable way to get the JSON schema for a Pydantic model."""
     # This nicely handles the case where the per_file_blueprint_type is actually
     # a union type etc.
-    if USING_PYDANTIC_2:
-        from pydantic import TypeAdapter
-
-        return TypeAdapter(model_type).json_schema()
-    else:
+    if USING_PYDANTIC_1:
         from pydantic.tools import schema_json_of
 
         return json.loads(schema_json_of(model_type))
+
+    else:
+        from pydantic import TypeAdapter  # type: ignore
+
+        return TypeAdapter(model_type).json_schema()

--- a/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/__snapshots__/test_load_defs_from_yaml.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/__snapshots__/test_load_defs_from_yaml.ambr
@@ -1,0 +1,174 @@
+# serializer version: 1
+# name: test_loader_schema[1]
+  dict({
+    '$ref': '#/definitions/SimpleAssetBlueprint',
+    'definitions': dict({
+      'SimpleAssetBlueprint': dict({
+        'additionalProperties': False,
+        'description': '''
+          A blob of user-provided, structured metadata that specifies a set of Dagster definitions,
+          like assets, jobs, schedules, sensors, resources, or asset checks.
+
+          Base class for user-provided types. Users override and provide:
+          - The set of fields
+          - A build_defs implementation that generates Dagster Definitions from field values
+        ''',
+        'properties': dict({
+          'key': dict({
+            'title': 'Key',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'key',
+        ]),
+        'title': 'SimpleAssetBlueprint',
+        'type': 'object',
+      }),
+    }),
+    'title': 'ParsingModel[SimpleAssetBlueprint]',
+  })
+# ---
+# name: test_loader_schema[2]
+  dict({
+    'additionalProperties': False,
+    'properties': dict({
+      'key': dict({
+        'title': 'Key',
+        'type': 'string',
+      }),
+    }),
+    'required': list([
+      'key',
+    ]),
+    'title': 'SimpleAssetBlueprint',
+    'type': 'object',
+  })
+# ---
+# name: test_loader_schema_union[1]
+  dict({
+    'anyOf': list([
+      dict({
+        '$ref': '#/definitions/FooAssetBlueprint',
+      }),
+      dict({
+        '$ref': '#/definitions/BarAssetBlueprint',
+      }),
+    ]),
+    'definitions': dict({
+      'BarAssetBlueprint': dict({
+        'additionalProperties': False,
+        'description': '''
+          A blob of user-provided, structured metadata that specifies a set of Dagster definitions,
+          like assets, jobs, schedules, sensors, resources, or asset checks.
+
+          Base class for user-provided types. Users override and provide:
+          - The set of fields
+          - A build_defs implementation that generates Dagster Definitions from field values
+        ''',
+        'properties': dict({
+          'string': dict({
+            'title': 'String',
+            'type': 'string',
+          }),
+          'type': dict({
+            'default': 'bar',
+            'enum': list([
+              'bar',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'string',
+        ]),
+        'title': 'BarAssetBlueprint',
+        'type': 'object',
+      }),
+      'FooAssetBlueprint': dict({
+        'additionalProperties': False,
+        'description': '''
+          A blob of user-provided, structured metadata that specifies a set of Dagster definitions,
+          like assets, jobs, schedules, sensors, resources, or asset checks.
+
+          Base class for user-provided types. Users override and provide:
+          - The set of fields
+          - A build_defs implementation that generates Dagster Definitions from field values
+        ''',
+        'properties': dict({
+          'number': dict({
+            'title': 'Number',
+            'type': 'integer',
+          }),
+          'type': dict({
+            'default': 'foo',
+            'enum': list([
+              'foo',
+            ]),
+            'title': 'Type',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'number',
+        ]),
+        'title': 'FooAssetBlueprint',
+        'type': 'object',
+      }),
+    }),
+    'title': 'ParsingModel[Union[FooAssetBlueprint, BarAssetBlueprint]]',
+  })
+# ---
+# name: test_loader_schema_union[2]
+  dict({
+    '$defs': dict({
+      'BarAssetBlueprint': dict({
+        'additionalProperties': False,
+        'properties': dict({
+          'string': dict({
+            'title': 'String',
+            'type': 'string',
+          }),
+          'type': dict({
+            'const': 'bar',
+            'default': 'bar',
+            'title': 'Type',
+          }),
+        }),
+        'required': list([
+          'string',
+        ]),
+        'title': 'BarAssetBlueprint',
+        'type': 'object',
+      }),
+      'FooAssetBlueprint': dict({
+        'additionalProperties': False,
+        'properties': dict({
+          'number': dict({
+            'title': 'Number',
+            'type': 'integer',
+          }),
+          'type': dict({
+            'const': 'foo',
+            'default': 'foo',
+            'title': 'Type',
+          }),
+        }),
+        'required': list([
+          'number',
+        ]),
+        'title': 'FooAssetBlueprint',
+        'type': 'object',
+      }),
+    }),
+    'anyOf': list([
+      dict({
+        '$ref': '#/$defs/FooAssetBlueprint',
+      }),
+      dict({
+        '$ref': '#/$defs/BarAssetBlueprint',
+      }),
+    ]),
+  })
+# ---

--- a/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/test_load_defs_from_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/test_load_defs_from_yaml.py
@@ -15,7 +15,7 @@ from dagster._core.definitions.metadata.source_code import (
     LocalFileCodeReference,
 )
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster._model.pydantic_compat_layer import USING_PYDANTIC_1
+from dagster._model.pydantic_compat_layer import USING_PYDANTIC_1, USING_PYDANTIC_2
 from pydantic import ValidationError
 
 
@@ -239,24 +239,30 @@ def test_additional_resources() -> None:
     assert set(defs.get_asset_graph().all_asset_keys) == {AssetKey("asset1")}
 
 
-def test_loader_schema() -> None:
+@pytest.mark.parametrize("pydantic_version", [2 if USING_PYDANTIC_2 else 1])
+def test_loader_schema(snapshot, pydantic_version: int) -> None:
     class SimpleAssetBlueprint(Blueprint):
         key: str
 
     loader = YamlBlueprintsLoader(path=Path(__file__), per_file_blueprint_type=SimpleAssetBlueprint)
 
-    assert loader.model_json_schema() == {
-        "title": "SimpleAssetBlueprint",
-        "type": "object",
-        "properties": {
-            "key": {"title": "Key", "type": "string"},
-        },
-        "required": ["key"],
-        "additionalProperties": False,
-    }
+    model_schema = loader.model_json_schema()
+    snapshot.assert_match(model_schema)
+
+    # Pydantic 1 JSON schema has the blueprint as a definition rather than a top-level object
+    # Pydantic 2 JSON schema has the blueprint as a top-level object
+    if model_schema["title"] == "ParsingModel[SimpleAssetBlueprint]":
+        assert model_schema["#ref"] == "#/definitions/SimpleAssetBlueprint"
+        model_schema = model_schema["definitions"]["SimpleAssetBlueprint"]
+
+    assert model_schema["title"] == "SimpleAssetBlueprint"
+    assert model_schema["type"] == "object"
+    model_keys = model_schema["properties"].keys()
+    assert set(model_keys) == {"key"}
 
 
-def test_loader_schema_union() -> None:
+@pytest.mark.parametrize("pydantic_version", [2 if USING_PYDANTIC_2 else 1])
+def test_loader_schema_union(snapshot, pydantic_version: int) -> None:
     class FooAssetBlueprint(Blueprint):
         type: Literal["foo"] = "foo"
         number: int
@@ -269,40 +275,13 @@ def test_loader_schema_union() -> None:
         path=Path(__file__), per_file_blueprint_type=Union[FooAssetBlueprint, BarAssetBlueprint]
     )
 
-    assert loader.model_json_schema() == {
-        "$defs": {
-            "BarAssetBlueprint": {
-                "title": "BarAssetBlueprint",
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "const": "bar",
-                        "default": "bar",
-                        "enum": ["bar"],
-                        "title": "Type",
-                        "type": "string",
-                    },
-                    "string": {"title": "String", "type": "string"},
-                },
-                "required": ["string"],
-                "additionalProperties": False,
-            },
-            "FooAssetBlueprint": {
-                "title": "FooAssetBlueprint",
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "const": "foo",
-                        "default": "foo",
-                        "enum": ["foo"],
-                        "title": "Type",
-                        "type": "string",
-                    },
-                    "number": {"title": "Number", "type": "integer"},
-                },
-                "required": ["number"],
-                "additionalProperties": False,
-            },
-        },
-        "anyOf": [{"$ref": "#/$defs/FooAssetBlueprint"}, {"$ref": "#/$defs/BarAssetBlueprint"}],
-    }
+    model_schema = loader.model_json_schema()
+    snapshot.assert_match(model_schema)
+
+    # Pydantic 1 uses $ref, Pydantic 2 uses #ref
+    # Just make sure the top-level union object points to both blueprints
+    assert len(model_schema["anyOf"]) == 2
+    any_of_refs = [
+        item.get("#ref", item.get("$ref")).split("/")[-1] for item in model_schema["anyOf"]
+    ]
+    assert set(any_of_refs) == {"FooAssetBlueprint", "BarAssetBlueprint"}


### PR DESCRIPTION
## Summary

Introduces just the `YamlBlueprintsLoader` from #22017, CLI stuff will be more properly handled in a stacked PR.

## Test Plan

A few tests to make sure we can extract a proper schema from the basic model case and the union case.