### PR TITLE
[blueprints][rfc] BlueprintDefinitionSet blueprint for grouping + applying customization to objects

### DIFF
--- a/python_modules/dagster/dagster/_core/blueprints/definiton_set_blueprint.py
+++ b/python_modules/dagster/dagster/_core/blueprints/definiton_set_blueprint.py
@@ -1,0 +1,91 @@
+from typing import Any, Generic, List, Mapping, Optional, Sequence
+
+from typing_extensions import TypeVar
+
+from dagster import _check as check
+from dagster._core.blueprints.blueprint import Blueprint, BlueprintDefinitions
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._model import DagsterModel
+from dagster._utils.merger import merge_dicts
+
+T = TypeVar("T", bound=Blueprint)
+
+
+class OverridableAssetSpecProperties(DagsterModel):
+    metadata: Mapping[str, Any] = {}
+    group_name: Optional[str] = None
+    code_version: Optional[str] = None
+    owners: Sequence[str] = []
+    tags: Mapping[str, str] = {}
+
+
+class BlueprintDefintionSet(Blueprint, OverridableAssetSpecProperties, Generic[T]):
+    """A blueprint that allows customization for a set of definitions,
+    provided by nested blueprints.
+    """
+
+    contents: List[T]
+
+    def build_defs(self) -> BlueprintDefinitions:
+        nested_defs = [nested_blueprint.build_defs() for nested_blueprint in self.contents]
+        defs = BlueprintDefinitions.merge(*nested_defs)
+
+        new_assets = []
+        for assets_def in defs.assets or []:
+            if not isinstance(assets_def, AssetsDefinition):
+                new_assets.append(assets_def)
+                continue
+
+            spec_keys_to_replace = {}
+            spec_keys_to_replace_by_key = {}
+
+            if self.group_name:
+                check.invariant(
+                    not any(value != "default" for value in assets_def.group_names_by_key.values()),
+                    "Definition set does not support overriding group names which are already set in the nested blueprints.",
+                )
+                spec_keys_to_replace["group_name"] = self.group_name
+
+            if self.code_version:
+                check.invariant(
+                    not any(assets_def.code_versions_by_key.values()),
+                    "Definition set does not support overriding code versions which are already set in the nested blueprints.",
+                )
+                spec_keys_to_replace["code_version"] = self.code_version
+
+            if self.owners:
+                check.invariant(
+                    not any(assets_def.owners_by_key.values()),
+                    "Definition set does not support overriding owners which are already set in the nested blueprints.",
+                )
+                spec_keys_to_replace["owners"] = self.owners
+
+            if self.tags:
+                spec_keys_to_replace_by_key["tags"] = {
+                    k: merge_dicts(assets_def.tags_by_key[k], self.tags) for k in assets_def.keys
+                }
+            if self.metadata:
+                spec_keys_to_replace_by_key["metadata"] = {
+                    k: merge_dicts(assets_def.metadata_by_key[k], self.metadata)
+                    for k in assets_def.keys
+                }
+
+            new_asset_def = AssetsDefinition.dagster_internal_init(
+                **{
+                    **assets_def.get_attributes_dict(),
+                    **{
+                        "specs": [
+                            spec._replace(
+                                **spec_keys_to_replace,
+                                **(
+                                    {k: v[spec.key] for k, v in spec_keys_to_replace_by_key.items()}
+                                ),
+                            )
+                            for spec in assets_def.specs
+                        ]
+                    },
+                }
+            )
+            new_assets.append(new_asset_def)
+
+        return defs._replace(assets=new_assets)

--- a/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/test_definition_set_blueprint.py
+++ b/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/test_definition_set_blueprint.py
@@ -41,6 +41,34 @@ def test_definition_set_blueprint_from_yaml() -> None:
         assert assets_def.code_versions_by_key[key] == "v1"
 
 
+def test_definition_set_blueprint_from_yaml_nested() -> None:
+    # we can define a very nested structure from the generic type
+    NestedBlueprintType = Union[SimpleAssetBlueprint, BlueprintDefintionSet[SimpleAssetBlueprint]]
+    FurtherNestedBlueprintType = Union[
+        NestedBlueprintType, BlueprintDefintionSet[NestedBlueprintType]
+    ]
+
+    defs = load_defs_from_yaml(
+        path=Path(__file__).parent / "yaml_files" / "definition_set_nested.yaml",
+        per_file_blueprint_type=FurtherNestedBlueprintType,
+    )
+    assert set(defs.get_asset_graph().all_asset_keys) == {
+        AssetKey("asset1"),
+        AssetKey("asset2"),
+    }
+
+    asset_1_key = AssetKey("asset1")
+    asset_1_def = defs.get_assets_def(asset_1_key)
+    assert asset_1_def.metadata_by_key[asset_1_key]["lorem"] == "ipsum"
+    assert asset_1_def.tags_by_key[asset_1_key] == {"outer": "tag"}
+
+    asset_2_key = AssetKey("asset2")
+    asset_2_def = defs.get_assets_def(asset_2_key)
+    assert asset_2_def.metadata_by_key[asset_2_key]["foo"] == "bar"
+    assert asset_2_def.metadata_by_key[asset_2_key]["lorem"] == "ipsum"
+    assert asset_2_def.tags_by_key[asset_2_key] == {"outer": "tag", "inner": "tag"}
+
+
 class AdvancedAssetBlueprint(Blueprint):
     key: str
     metadata: Optional[Dict[str, Any]] = None

--- a/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/test_definition_set_blueprint.py
+++ b/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/test_definition_set_blueprint.py
@@ -1,0 +1,138 @@
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+from dagster import AssetKey, asset
+from dagster._core.blueprints.blueprint import (
+    Blueprint,
+    BlueprintDefinitions,
+)
+from dagster._core.blueprints.definiton_set_blueprint import BlueprintDefintionSet
+from dagster._core.blueprints.load_from_yaml import load_defs_from_yaml
+
+
+class SimpleAssetBlueprint(Blueprint):
+    key: str
+
+    def build_defs(self) -> BlueprintDefinitions:
+        @asset(key=self.key)
+        def _asset(): ...
+
+        return BlueprintDefinitions(assets=[_asset])
+
+
+def test_definition_set_blueprint_from_yaml() -> None:
+    defs = load_defs_from_yaml(
+        path=Path(__file__).parent / "yaml_files" / "definition_set_basic.yaml",
+        per_file_blueprint_type=BlueprintDefintionSet[SimpleAssetBlueprint],
+    )
+    assert set(defs.get_asset_graph().all_asset_keys) == {
+        AssetKey("asset1"),
+        AssetKey("asset2"),
+        AssetKey("asset3"),
+    }
+
+    for key in [AssetKey("asset1"), AssetKey("asset2"), AssetKey("asset3")]:
+        assets_def = defs.get_assets_def(key)
+        assert assets_def.metadata_by_key[key]["foo"] == "bar"
+        assert assets_def.group_names_by_key[key] == "my_asset_group"
+        assert assets_def.tags_by_key[key] == {"tag1": "value1", "tag2": "value2"}
+        assert assets_def.owners_by_key[key] == ["rex@dagsterlabs.com"]
+        assert assets_def.code_versions_by_key[key] == "v1"
+
+
+class AdvancedAssetBlueprint(Blueprint):
+    key: str
+    metadata: Optional[Dict[str, Any]] = None
+    group_name: Optional[str] = None
+    code_version: Optional[str] = None
+    owners: Optional[List[str]] = None
+    tags: Optional[Dict[str, str]] = None
+
+    def build_defs(self) -> BlueprintDefinitions:
+        @asset(
+            key=self.key,
+            metadata=self.metadata,
+            group_name=self.group_name,
+            code_version=self.code_version,
+            owners=self.owners,
+            tags=self.tags,
+        )
+        def _asset(): ...
+
+        return BlueprintDefinitions(assets=[_asset])
+
+
+def test_definition_set_blueprint_override() -> None:
+    # tags and metadata are appended and not replaced
+
+    defs = (
+        BlueprintDefintionSet[AdvancedAssetBlueprint](
+            contents=[
+                AdvancedAssetBlueprint(
+                    key="asset1",
+                    metadata={"foo": "bar"},
+                    group_name="my_asset_group",
+                    code_version="v1",
+                    owners=["rex@dagsterlabs.com"],
+                    tags={"tag1": "value1", "tag2": "value2"},
+                ),
+                AdvancedAssetBlueprint(
+                    key="asset2",
+                ),
+            ],
+            metadata={"baz": "quux"},
+            tags={"tag3": "value3"},
+        )
+        .build_defs()
+        .to_definitions()
+    )
+
+    assert set(defs.get_asset_graph().all_asset_keys) == {AssetKey("asset1"), AssetKey("asset2")}
+
+    asset_1_key = AssetKey("asset1")
+    asset_1_def = defs.get_assets_def(asset_1_key)
+    assert asset_1_def.metadata_by_key[asset_1_key] == {"foo": "bar", "baz": "quux"}
+    assert asset_1_def.group_names_by_key[asset_1_key] == "my_asset_group"
+    assert asset_1_def.tags_by_key[asset_1_key] == {
+        "tag1": "value1",
+        "tag2": "value2",
+        "tag3": "value3",
+    }
+    assert asset_1_def.owners_by_key[asset_1_key] == ["rex@dagsterlabs.com"]
+
+    asset_2_key = AssetKey("asset2")
+    asset_2_def = defs.get_assets_def(asset_2_key)
+    assert asset_2_def.metadata_by_key[asset_2_key] == {"baz": "quux"}
+    assert asset_2_def.group_names_by_key[asset_2_key] == "default"
+    assert asset_2_def.tags_by_key[asset_2_key] == {"tag3": "value3"}
+    assert asset_2_def.owners_by_key[asset_2_key] == []
+
+
+def test_definition_set_blueprint_override_already_set() -> None:
+    with pytest.raises(Exception, match="overriding group names"):
+        BlueprintDefintionSet[AdvancedAssetBlueprint](
+            contents=[
+                AdvancedAssetBlueprint(
+                    key="asset1",
+                    group_name="my_asset_group",
+                ),
+            ],
+            group_name="my_other_asset_group",
+        ).build_defs().to_definitions()
+
+    with pytest.raises(Exception, match="overriding owners"):
+        BlueprintDefintionSet[AdvancedAssetBlueprint](
+            contents=[
+                AdvancedAssetBlueprint(key="asset1", owners=["rex@dagsterlabs.com"]),
+            ],
+            owners=["ben@dagsterlabs.com"],
+        ).build_defs().to_definitions()
+
+    with pytest.raises(Exception, match="overriding code version"):
+        BlueprintDefintionSet[AdvancedAssetBlueprint](
+            contents=[
+                AdvancedAssetBlueprint(key="asset1", code_version="v1"),
+            ],
+            code_version="v2",
+        ).build_defs().to_definitions()

--- a/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/yaml_files/definition_set_basic.yaml
+++ b/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/yaml_files/definition_set_basic.yaml
@@ -1,0 +1,12 @@
+contents:
+  - key: asset1
+  - key: asset2
+  - key: asset3
+metadata:
+  foo: bar
+group_name: my_asset_group
+code_version: "v1"
+owners: ["rex@dagsterlabs.com"]
+tags:
+  tag1: value1
+  tag2: value2

--- a/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/yaml_files/definition_set_nested.yaml
+++ b/python_modules/dagster/dagster_tests/core_tests/blueprint_tests/yaml_files/definition_set_nested.yaml
@@ -1,0 +1,13 @@
+contents:
+  - key: asset1
+  - contents:
+      - key: asset2
+    metadata:
+      foo: bar
+    tags:
+      inner: tag
+
+metadata:
+  lorem: ipsum
+tags:
+  outer: tag


### PR DESCRIPTION
## Summary

Patterns out a  `BlueprintDefintionSet` object (name very much pending) which can be used to customize properties of the outputs of nested blueprints. This is in some sense the Blueprint analogue to https://github.com/dagster-io/internal/discussions/9751.

It is a Generic type, so `load_defs_from_yaml` can be supplied with a spec-ed down version:

```python
defs = load_defs_from_yaml(
  path=...,
  per_file_blueprint_type=BlueprintDefinitionSet[Union[MyCoolBlueprint, MyOtherCoolBlueprint]]
)
```
```yaml
contents:
  - key: asset1
    description: wow, an asset
    type: my_cool_blueprint
  - key: asset2
    description: another asset
    type: my_cool_blueprint
  - key: asset3
    description: a third asset
    type: my_other_cool_blueprint
    metadata:
      baz: quux
metadata:
  foo: bar
group_name: my_asset_group
code_version: "v1"
owners: ["rex@dagsterlabs.com"]
tags:
  tag1: value1
  tag2: value2

```

For now, this class errors if you try to overwrite properties already set on nested objects, but will merge tags and metadata.

TODO: Only attaches to assets for now - also attach to other object types.

## Test Plan

Unit tests.
