### PR TITLE
RFC: enable setting compute kind via asset tags

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1658,6 +1658,16 @@ def asset_3():
     yield Output(7)
 
 
+@asset(compute_kind="mycomputekind")
+def compute_kind_on_op_tags_asset():
+    pass
+
+
+@asset(tags={"dagster/compute_kind": "myothercomputekind"})
+def compute_kind_on_asset_tags_asset():
+    pass
+
+
 failure_assets_job = define_asset_job("failure_assets_job", [asset_1, asset_2, asset_3])
 
 
@@ -2067,6 +2077,8 @@ def define_assets():
         asset_1,
         asset_2,
         asset_3,
+        compute_kind_on_op_tags_asset,
+        compute_kind_on_asset_tags_asset,
         foo,
         bar,
         foo_bar,

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -1727,6 +1727,8 @@ def external_asset_nodes_from_defs(
     for key in sorted(asset_graph.all_asset_keys):
         asset_node = asset_graph.get(key)
 
+        compute_kind_from_asset_tags = asset_node.tags.get("dagster/compute_kind")
+
         # Materializable assets (which are always part of at least one job, due to asset base jobs)
         # have various fields related to their op/output/jobs etc defined. External assets have null
         # values for all these fields.
@@ -1748,7 +1750,7 @@ def external_asset_nodes_from_defs(
             op_names = sorted([str(handle) for handle in node_handles])
             op_name = graph_name or next(iter(op_names), None) or node_def.name
             job_names = sorted([jd.name for jd in job_defs_by_asset_key[key]])
-            compute_kind = node_def.tags.get("kind")
+            compute_kind = compute_kind_from_asset_tags or node_def.tags.get("kind")
             node_definition_name = node_def.name
 
             # Confusingly, the `name` field sometimes mismatches the `name` field on the
@@ -1765,7 +1767,7 @@ def external_asset_nodes_from_defs(
             op_names = []
             op_name = None
             job_names = []
-            compute_kind = None
+            compute_kind = compute_kind_from_asset_tags
             node_definition_name = None
             output_name = None
             required_top_level_resources = []


### PR DESCRIPTION
## Summary & Motivation

This enables setting compute kinds on external assets. It also allows different compute kinds within a multi asset, which was requested here: https://github.com/dagster-io/dagster/issues/14595.

An alternative would be to introduce a `compute_kind` property on `AssetSpec`.

## How I Tested These Changes
