### PR TITLE
[ui] fix external code links rendering as relative

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLink.tsx
@@ -93,7 +93,11 @@ export const CodeLink = ({codeLinkData}: {codeLinkData: CodeReferencesMetadataEn
               {sources.map((source) => (
                 <Tooltip
                   key={getCodeReferenceKey(source)}
-                  content={getCodeReferenceLink(codeLinkProtocol, source)}
+                  content={
+                    <Box style={{maxWidth: 500, wordBreak: 'break-all'}}>
+                      {getCodeReferenceLink(codeLinkProtocol, source)}
+                    </Box>
+                  }
                   position="bottom"
                   display="block"
                 >
@@ -111,7 +115,14 @@ export const CodeLink = ({codeLinkData}: {codeLinkData: CodeReferencesMetadataEn
           <Button rightIcon={<Icon name="expand_more" />}>Open source code</Button>
         </Popover>
       ) : (
-        <Tooltip content={getCodeReferenceLink(codeLinkProtocol, firstSource)} position="bottom">
+        <Tooltip
+          content={
+            <Box style={{maxWidth: 500, wordBreak: 'break-all'}}>
+              {getCodeReferenceLink(codeLinkProtocol, firstSource)}
+            </Box>
+          }
+          position="bottom"
+        >
           <ExternalAnchorButton
             icon={<Icon name={getCodeReferenceIcon(firstSource)} />}
             href={getCodeReferenceLink(codeLinkProtocol, firstSource)}

--- a/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLink.tsx
@@ -1,4 +1,11 @@
-import {Box, Menu, MiddleTruncate, Popover, Tooltip} from '@dagster-io/ui-components';
+import {
+  Box,
+  Menu,
+  MenuExternalLink,
+  MiddleTruncate,
+  Popover,
+  Tooltip,
+} from '@dagster-io/ui-components';
 import {Button, ExternalAnchorButton} from '@dagster-io/ui-components/src/components/Button';
 import {Icon, IconName} from '@dagster-io/ui-components/src/components/Icon';
 import * as React from 'react';
@@ -6,7 +13,6 @@ import * as React from 'react';
 import {CodeLinkProtocolContext, ProtocolData} from './CodeLinkProtocol';
 import {assertUnreachable} from '../app/Util';
 import {CodeReferencesMetadataEntry, SourceLocation} from '../graphql/types';
-import {MenuLink} from '../ui/MenuLink';
 
 const getCodeReferenceIcon = (codeReference: SourceLocation): IconName => {
   switch (codeReference.__typename) {
@@ -91,9 +97,9 @@ export const CodeLink = ({codeLinkData}: {codeLinkData: CodeReferencesMetadataEn
                   position="bottom"
                   display="block"
                 >
-                  <MenuLink
+                  <MenuExternalLink
                     text={getCodeReferenceEntryLabel(source)}
-                    to={getCodeReferenceLink(codeLinkProtocol, source)}
+                    href={getCodeReferenceLink(codeLinkProtocol, source)}
                     icon={<Icon name={getCodeReferenceIcon(source)} />}
                     style={{maxWidth: 300}}
                   />


### PR DESCRIPTION
## Summary
Fixes these menu links, which didn't link properly to external URLs (instead prefixing with `dagster.cloud...`) - this was changed from a `MenuItem` w/ `onClick` right before merge and the new behavior wasn't validated 😅 

Also bounds the tooltips, which looks nicer.


<img width="591" alt="Screenshot 2024-05-31 at 10 37 59 AM" src="https://github.com/dagster-io/dagster/assets/10215173/8a5522fe-d1d4-459d-a1fb-a1e6dc14420b">
