### PR TITLE
[docs] - Fix token name in Dagster+ Kubernetes docs

### DIFF
--- a/docs/content/dagster-plus/deployment/agents/kubernetes/configuring-running-kubernetes-agent.mdx
+++ b/docs/content/dagster-plus/deployment/agents/kubernetes/configuring-running-kubernetes-agent.mdx
@@ -55,7 +55,7 @@ In this step, you'll create a Kubernetes namespace for your Dagster+ resources. 
 2. Add the agent token you created in [Step 1](#step-1-generate-a-dagster-agent-token) as a secret in the Kubernetes cluster:
 
    ```shell
-   kubectl create secret generic dagster-plus-agent-token \
+   kubectl create secret generic dagster-cloud-agent-token \
        --from-literal=DAGSTER_CLOUD_AGENT_TOKEN=<your_agent_token> \
        --namespace dagster-plus
    ```


### PR DESCRIPTION
## Summary & Motivation

This PR corrects the name of a token in the Dagster+ Kubernetes guide to `dagster-cloud`.

## How I Tested These Changes
