### PR TITLE
Pass `tags`, `owners` from `external_assets_from_specs`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/external_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset.py
@@ -119,6 +119,7 @@ def external_assets_from_specs(specs: Sequence[AssetSpec]) -> List[AssetsDefinit
                     },
                     deps=spec.deps,
                     tags=spec.tags,
+                    owners=spec.owners,
                 )
             ],
         )

--- a/python_modules/dagster/dagster/_core/definitions/external_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset.py
@@ -104,7 +104,7 @@ def external_assets_from_specs(specs: Sequence[AssetSpec]) -> List[AssetsDefinit
         @multi_asset(
             name=spec.key.to_python_identifier(),
             specs=[
-                AssetSpec(
+                AssetSpec.dagster_internal_init(
                     key=spec.key,
                     description=spec.description,
                     group_name=spec.group_name,
@@ -120,6 +120,9 @@ def external_assets_from_specs(specs: Sequence[AssetSpec]) -> List[AssetsDefinit
                     deps=spec.deps,
                     tags=spec.tags,
                     owners=spec.owners,
+                    skippable=False,
+                    code_version=None,
+                    auto_materialize_policy=None,
                 )
             ],
         )

--- a/python_modules/dagster/dagster/_core/definitions/external_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset.py
@@ -118,6 +118,7 @@ def external_assets_from_specs(specs: Sequence[AssetSpec]) -> List[AssetsDefinit
                         },
                     },
                     deps=spec.deps,
+                    tags=spec.tags,
                 )
             ],
         )

--- a/python_modules/dagster/dagster/_core/definitions/external_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset.py
@@ -101,38 +101,40 @@ def external_assets_from_specs(specs: Sequence[AssetSpec]) -> List[AssetsDefinit
             "skippable must be False since it is ignored and False is the default",
         )
 
-        @multi_asset(
-            name=spec.key.to_python_identifier(),
-            specs=[
-                AssetSpec.dagster_internal_init(
-                    key=spec.key,
-                    description=spec.description,
-                    group_name=spec.group_name,
-                    freshness_policy=spec.freshness_policy,
-                    metadata={
-                        **(spec.metadata or {}),
-                        **{
-                            SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: (
-                                AssetExecutionType.UNEXECUTABLE.value
-                            )
-                        },
-                    },
-                    deps=spec.deps,
-                    tags=spec.tags,
-                    owners=spec.owners,
-                    skippable=False,
-                    code_version=None,
-                    auto_materialize_policy=None,
-                )
-            ],
-        )
-        def _external_assets_def(context: AssetExecutionContext) -> None:
-            raise DagsterInvariantViolationError(
-                "You have attempted to execute an unexecutable asset"
-                f" {context.asset_key.to_user_string}."
-            )
+        with disable_dagster_warnings():
 
-        assets_defs.append(_external_assets_def)
+            @multi_asset(
+                name=spec.key.to_python_identifier(),
+                specs=[
+                    AssetSpec.dagster_internal_init(
+                        key=spec.key,
+                        description=spec.description,
+                        group_name=spec.group_name,
+                        freshness_policy=spec.freshness_policy,
+                        metadata={
+                            **(spec.metadata or {}),
+                            **{
+                                SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: (
+                                    AssetExecutionType.UNEXECUTABLE.value
+                                )
+                            },
+                        },
+                        deps=spec.deps,
+                        tags=spec.tags,
+                        owners=spec.owners,
+                        skippable=False,
+                        code_version=None,
+                        auto_materialize_policy=None,
+                    )
+                ],
+            )
+            def _external_assets_def(context: AssetExecutionContext) -> None:
+                raise DagsterInvariantViolationError(
+                    "You have attempted to execute an unexecutable asset"
+                    f" {context.asset_key.to_user_string}."
+                )
+
+            assets_defs.append(_external_assets_def)
 
     return assets_defs
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_external_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_external_assets.py
@@ -54,6 +54,24 @@ def test_external_asset_basic_creation() -> None:
     assert not assets_def.is_executable
 
 
+def test_external_asset_tags() -> None:
+    assets_def = next(
+        iter(
+            external_assets_from_specs(
+                specs=[
+                    AssetSpec(
+                        key="external_asset_one",
+                        tags={"foo": "bar", "baz": "qux"},
+                    )
+                ]
+            )
+        )
+    )
+    assert isinstance(assets_def, AssetsDefinition)
+    expected_key = AssetKey(["external_asset_one"])
+    assert assets_def.tags_by_key[expected_key] == {"foo": "bar", "baz": "qux"}
+
+
 def test_external_asset_with_hyphens() -> None:
     key = AssetKey(["with-hyphen", "external_asset_one"])
     assets_def = next(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_external_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_external_assets.py
@@ -54,7 +54,7 @@ def test_external_asset_basic_creation() -> None:
     assert not assets_def.is_executable
 
 
-def test_external_asset_tags() -> None:
+def test_external_asset_tags_owners() -> None:
     assets_def = next(
         iter(
             external_assets_from_specs(
@@ -62,6 +62,7 @@ def test_external_asset_tags() -> None:
                     AssetSpec(
                         key="external_asset_one",
                         tags={"foo": "bar", "baz": "qux"},
+                        owners=["ben@dagsterlabs.com"],
                     )
                 ]
             )
@@ -70,6 +71,7 @@ def test_external_asset_tags() -> None:
     assert isinstance(assets_def, AssetsDefinition)
     expected_key = AssetKey(["external_asset_one"])
     assert assets_def.tags_by_key[expected_key] == {"foo": "bar", "baz": "qux"}
+    assert assets_def.owners_by_key[expected_key] == ["ben@dagsterlabs.com"]
 
 
 def test_external_asset_with_hyphens() -> None:


### PR DESCRIPTION
## Summary

Makes sure tags are passed along from specs when calling `external_assets_from_specs`

## Test Plan

New unit test
