### PR TITLE
`AssetExecutionContext.has_partition_key_range`

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -369,6 +369,12 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
 
     @public
     @property
+    def has_partition_key_range(self) -> bool:
+        """Whether the current run is a partitioned run."""
+        return self._step_execution_context.has_partition_key_range
+
+    @public
+    @property
     def partition_key_range(self) -> PartitionKeyRange:
         """The range of partition keys for the current run.
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -602,6 +602,7 @@ def test_partition_range_single_run():
     @asset(partitions_def=partitions_def)
     def upstream_asset(context) -> None:
         key_range = PartitionKeyRange(start="2020-01-01", end="2020-01-03")
+        assert context.has_partition_key_range
         assert context.partition_key_range == key_range
         assert context.partition_time_window == TimeWindow(
             partitions_def.time_window_for_partition_key(key_range.start).start,

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_execution_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_execution_context.py
@@ -64,6 +64,7 @@ def test_deprecation_warnings():
         "get_output_metadata",
         "has_asset_checks_def",
         "has_partition_key",
+        "has_partition_key_range",
         "instance",
         "job_name",
         "output_for_asset_key",


### PR DESCRIPTION
## Summary & Motivation

`AssetExecutionContext` currently has `has_partition_key`, but not `has_partition_key_range`.  Adding the latter was a request from a user, which seems reasonable.

I know there have been concerns in the past about large numbers of properties on the context object, so open to alternatives here as well.

## How I Tested These Changes
