### PR TITLE
Use compute_required_resource_keys_for_underlying_op in @asset construction

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -27,7 +27,6 @@ from dagster._core.definitions.decorators.assets_definition_factory import (
 )
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping, RawMetadataMapping
-from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._core.types.dagster_type import DagsterType
 from dagster._utils.warnings import disable_dagster_warnings
@@ -50,6 +49,7 @@ from .assets_definition_factory import (
     AssetsDefinitionBuilderArgs,
     build_asset_ins,
     build_asset_outs,
+    compute_required_resource_keys,
 )
 
 
@@ -343,17 +343,18 @@ def create_assets_def_from_fn_and_decorator_args(
     )
 
     with disable_dagster_warnings():
-        arg_resource_keys = {arg.name for arg in get_resource_args(fn)}
-
-        bare_required_resource_keys = set(args.required_resource_keys)
-
         resource_defs_dict = args.resource_defs
-        resource_defs_keys = set(resource_defs_dict.keys())
-        decorator_resource_keys = bare_required_resource_keys | resource_defs_keys
 
         # TODO: rename op_resource_defs and asset_resource_defs and document
         # the strange logic -- schrockn 2024-06-03
         op_resource_defs = wrap_resources_for_execution(resource_defs_dict)
+
+        op_required_resource_keys = compute_required_resource_keys(
+            required_resource_keys=args.required_resource_keys,
+            resource_defs=op_resource_defs,
+            fn=fn,
+            decorator_name="@asset",
+        )
 
         io_manager_key = args.io_manager_key
         if args.io_manager_def:
@@ -373,15 +374,7 @@ def create_assets_def_from_fn_and_decorator_args(
 
         asset_resource_defs = wrap_resources_for_execution(resource_defs_dict)
 
-        check.param_invariant(
-            len(bare_required_resource_keys) == 0 or len(arg_resource_keys) == 0,
-            "Cannot specify resource requirements in both @asset decorator and as arguments"
-            " to the decorated function",
-        )
-
         io_manager_key = cast(str, io_manager_key) if io_manager_key else DEFAULT_IO_MANAGER_KEY
-
-        op_required_resource_keys = decorator_resource_keys - arg_resource_keys
 
         # check backfill policy is BackfillPolicyType.SINGLE_RUN for non-partitioned asset
         if args.partitions_def is None:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/assets_definition_factory.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/assets_definition_factory.py
@@ -189,12 +189,12 @@ def make_keys_by_output_name(
 
 
 def compute_required_resource_keys(
-    required_resource_keys: Set[str],
+    required_resource_keys: AbstractSet[str],
     resource_defs: Mapping[str, ResourceDefinition],
     fn: Callable[..., Any],
     decorator_name: str,
-) -> Set[str]:
-    bare_required_resource_keys = required_resource_keys.copy()
+) -> AbstractSet[str]:
+    bare_required_resource_keys = set(required_resource_keys)
     resource_defs_keys = set(resource_defs.keys())
     required_resource_keys = bare_required_resource_keys | resource_defs_keys
     arg_resource_keys = {arg.name for arg in get_resource_args(fn)}
@@ -224,7 +224,7 @@ class AssetsDefinitionBuilderArgs(NamedTuple):
     config_schema: Optional[UserConfigSchema]
     retry_policy: Optional[RetryPolicy]
     compute_kind: Optional[str]
-    required_resource_keys: Set[str]
+    required_resource_keys: AbstractSet[str]
     assets_def_resource_defs: Mapping[str, ResourceDefinition]
     op_def_resource_defs: Mapping[str, ResourceDefinition]
     backfill_policy: Optional[BackfillPolicy]


### PR DESCRIPTION
## Summary & Motivation

Here is another example of the resource key manipulation that is duplicated in this code path. Using it in `@asset`. Eventual goal is remove it entirely but this is a good incremental step. This code path is quite risky and subtlely complicated so taking a conservative approach here.

## How I Tested These Changes

BK
