### PR TITLE
Rename AssetKeyPartitionKey -> AssetPartitionKey

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, AbstractSet, Mapping, NamedTuple, NewType, Opt
 
 from dagster import _check as check
 from dagster._core.definitions.asset_subset import AssetSubset, ValidAssetSubset
-from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetKey, AssetPartitionKey
 from dagster._core.definitions.multi_dimensional_partitions import (
     MultiPartitionKey,
     MultiPartitionsDefinition,
@@ -130,7 +130,7 @@ class AssetSlice:
             for akpk in self._compatible_subset.asset_partitions
         }
 
-    def expensively_compute_asset_partitions(self) -> AbstractSet[AssetKeyPartitionKey]:
+    def expensively_compute_asset_partitions(self) -> AbstractSet[AssetPartitionKey]:
         # this method requires computing all partition keys of the definition, which
         # may be expensive
         return self._compatible_subset.asset_partitions
@@ -364,7 +364,7 @@ class AssetGraphView:
         return _slice_from_valid_subset(self, subset)
 
     def get_asset_slice_from_asset_partitions(
-        self, asset_partitions: AbstractSet[AssetKeyPartitionKey]
+        self, asset_partitions: AbstractSet[AssetPartitionKey]
     ) -> "AssetSlice":
         asset_keys = {akpk.asset_key for akpk in asset_partitions}
         check.invariant(len(asset_keys) == 1, "Must have exactly one asset key")

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -25,7 +25,7 @@ from dagster._core.definitions.auto_materialize_policy import AutoMaterializePol
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.data_version import CachingStaleStatusResolver
 from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
-from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetKey, AssetPartitionKey
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.time_window_partitions import get_time_partitions_def
 from dagster._core.instance import DynamicPartitionsStore
@@ -154,7 +154,7 @@ class AssetDaemonContext:
 
     def get_asset_condition_evaluations(
         self,
-    ) -> Tuple[Sequence[AutomationResult], AbstractSet[AssetKeyPartitionKey]]:
+    ) -> Tuple[Sequence[AutomationResult], AbstractSet[AssetPartitionKey]]:
         """Returns a mapping from asset key to the AutoMaterializeAssetEvaluation for that key, a
         sequence of new per-asset cursors, and the set of all asset partitions that should be
         materialized or discarded this tick.
@@ -230,7 +230,7 @@ class AssetDaemonContext:
 
 
 def build_run_requests(
-    asset_partitions: Iterable[AssetKeyPartitionKey],
+    asset_partitions: Iterable[AssetPartitionKey],
     asset_graph: BaseAssetGraph,
     run_tags: Optional[Mapping[str, str]],
 ) -> Sequence[RunRequest]:
@@ -277,7 +277,7 @@ def build_run_requests(
 
 
 def build_run_requests_with_backfill_policies(
-    asset_partitions: Iterable[AssetKeyPartitionKey],
+    asset_partitions: Iterable[AssetPartitionKey],
     asset_graph: BaseAssetGraph,
     run_tags: Optional[Mapping[str, str]],
     dynamic_partitions_store: DynamicPartitionsStore,

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -27,7 +27,7 @@ from dagster._serdes.serdes import (
 
 from .asset_subset import AssetSubset
 from .base_asset_graph import BaseAssetGraph
-from .events import AssetKey, AssetKeyPartitionKey
+from .events import AssetKey, AssetPartitionKey
 
 
 class PartitionsSubsetMappingNamedTupleSerializer(NamedTupleSerializer):
@@ -105,19 +105,19 @@ class AssetGraphSubset(NamedTuple):
         else:
             return self.partitions_subsets_by_asset_key[asset_key]
 
-    def iterate_asset_partitions(self) -> Iterable[AssetKeyPartitionKey]:
+    def iterate_asset_partitions(self) -> Iterable[AssetPartitionKey]:
         for (
             asset_key,
             partitions_subset,
         ) in self.partitions_subsets_by_asset_key.items():
             for partition_key in partitions_subset.get_partition_keys():
-                yield AssetKeyPartitionKey(asset_key, partition_key)
+                yield AssetPartitionKey(asset_key, partition_key)
 
         for asset_key in self.non_partitioned_asset_keys:
-            yield AssetKeyPartitionKey(asset_key, None)
+            yield AssetPartitionKey(asset_key, None)
 
-    def __contains__(self, asset: Union[AssetKey, AssetKeyPartitionKey]) -> bool:
-        """If asset is an AssetKeyPartitionKey, check if the given AssetKeyPartitionKey is in the
+    def __contains__(self, asset: Union[AssetKey, AssetPartitionKey]) -> bool:
+        """If asset is an AssetPartitionKey, check if the given AssetPartitionKey is in the
         subset. If asset is an AssetKey, check if any of partitions of the given AssetKey are in
         the subset.
         """
@@ -236,7 +236,7 @@ class AssetGraphSubset(NamedTuple):
     @classmethod
     def from_asset_partition_set(
         cls,
-        asset_partitions_set: AbstractSet[AssetKeyPartitionKey],
+        asset_partitions_set: AbstractSet[AssetPartitionKey],
         asset_graph: BaseAssetGraph,
     ) -> "AssetGraphSubset":
         partitions_by_asset_key = defaultdict(set)

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -25,7 +25,7 @@ from dagster._core.definitions.data_version import (
     DataVersion,
     get_input_event_pointer_tag,
 )
-from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetKey, AssetPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessMinutes
 from dagster._core.definitions.time_window_partitions import (
     BaseTimeWindowPartitionsSubset,
@@ -200,7 +200,7 @@ class CachingDataTimeResolver:
             if before_cursor is not None:
                 parent_record = (
                     self._instance_queryer.get_latest_materialization_or_observation_record(
-                        AssetKeyPartitionKey(parent_key), before_cursor=before_cursor
+                        AssetPartitionKey(parent_key), before_cursor=before_cursor
                     )
                 )
                 if parent_record is not None:
@@ -497,7 +497,7 @@ class CachingDataTimeResolver:
         self, asset_key: AssetKey, current_time: datetime.datetime
     ) -> Optional[datetime.datetime]:
         latest_record = self.instance_queryer.get_latest_materialization_or_observation_record(
-            AssetKeyPartitionKey(asset_key)
+            AssetPartitionKey(asset_key)
         )
         if latest_record is None:
             return None
@@ -513,7 +513,7 @@ class CachingDataTimeResolver:
         self, asset_key: AssetKey, current_time: datetime.datetime
     ) -> Optional[datetime.datetime]:
         latest_record = self.instance_queryer.get_latest_materialization_or_observation_record(
-            AssetKeyPartitionKey(asset_key)
+            AssetPartitionKey(asset_key)
         )
         if latest_record is None:
             return None

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -9,7 +9,7 @@ from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
-from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetKey, AssetPartitionKey
 
 from ..asset_daemon_cursor import AssetDaemonCursor
 from ..base_asset_graph import BaseAssetGraph
@@ -61,7 +61,7 @@ class AutomationConditionEvaluator:
     asset_graph_view: AssetGraphView
     current_results_by_key: Dict[AssetKey, AutomationResult]
     expected_data_time_mapping: Dict[AssetKey, Optional[datetime.datetime]]
-    to_request: Set[AssetKeyPartitionKey]
+    to_request: Set[AssetPartitionKey]
     num_checked_assets: int
     num_asset_keys: int
     logger: logging.Logger
@@ -98,7 +98,7 @@ class AutomationConditionEvaluator:
         self.instance_queryer.prefetch_asset_records(self.asset_records_to_prefetch)
         self.logger.info("Done prefetching asset records.")
 
-    def evaluate(self) -> Tuple[Sequence[AutomationResult], AbstractSet[AssetKeyPartitionKey]]:
+    def evaluate(self) -> Tuple[Sequence[AutomationResult], AbstractSet[AssetPartitionKey]]:
         self.prefetch()
         for asset_key in self.asset_graph.toposorted_asset_keys:
             # an asset may have already been visited if it was part of a non-subsettable multi-asset

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
@@ -22,7 +22,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     AutomationConditionNodeCursor,
     HistoricalAllPartitionsSubsetSentinel,
 )
-from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetPartitionKey
 from dagster._core.definitions.partition import PartitionsDefinition
 
 from .legacy.legacy_context import LegacyRuleEvaluationContext
@@ -59,10 +59,10 @@ class NonAGVInstanceInterface:
     def get_parent_asset_partitions_updated_after_child(
         self,
         *,
-        asset_partition: AssetKeyPartitionKey,
-        parent_asset_partitions: AbstractSet[AssetKeyPartitionKey],
+        asset_partition: AssetPartitionKey,
+        parent_asset_partitions: AbstractSet[AssetPartitionKey],
         ignored_parent_keys: AbstractSet[AssetKey],
-    ) -> AbstractSet[AssetKeyPartitionKey]:
+    ) -> AbstractSet[AssetPartitionKey]:
         return self._queryer.get_parent_asset_partitions_updated_after_child(
             asset_partition=asset_partition,
             parent_asset_partitions=parent_asset_partitions,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
@@ -24,7 +24,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     HistoricalAllPartitionsSubsetSentinel,
 )
-from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetKey, AssetPartitionKey
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.partition import PartitionsDefinition
 
@@ -374,8 +374,8 @@ class LegacyRuleEvaluationContext:
         return materializable_in_same_run(self.asset_graph, child_key, parent_key)
 
     def get_parents_that_will_not_be_materialized_on_current_tick(
-        self, *, asset_partition: AssetKeyPartitionKey
-    ) -> AbstractSet[AssetKeyPartitionKey]:
+        self, *, asset_partition: AssetPartitionKey
+    ) -> AbstractSet[AssetPartitionKey]:
         """Returns the set of parent asset partitions that will not be updated in the same run of
         this asset partition if a run is launched for this asset partition on this tick.
         """
@@ -391,7 +391,7 @@ class LegacyRuleEvaluationContext:
             or not self.materializable_in_same_run(asset_partition.asset_key, parent.asset_key)
         }
 
-    def will_update_asset_partition(self, asset_partition: AssetKeyPartitionKey) -> bool:
+    def will_update_asset_partition(self, asset_partition: AssetPartitionKey) -> bool:
         parent_result = self.current_results_by_key.get(asset_partition.asset_key)
         if not parent_result:
             return False
@@ -400,7 +400,7 @@ class LegacyRuleEvaluationContext:
     def add_evaluation_data_from_previous_tick(
         self,
         asset_partitions_by_frozen_metadata: Mapping[
-            FrozenSet[Tuple[str, MetadataValue]], AbstractSet[AssetKeyPartitionKey]
+            FrozenSet[Tuple[str, MetadataValue]], AbstractSet[AssetPartitionKey]
         ],
         ignore_subset: AssetSubset,
     ) -> Tuple[ValidAssetSubset, Sequence[AssetSubsetWithMetadata]]:

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
     from dagster._core.execution.context.output import OutputContext
 
 
-class AssetKeyPartitionKey(NamedTuple):
+class AssetPartitionKey(NamedTuple):
     """An AssetKey with an (optional) partition key. Refers either to a non-partitioned asset or a
     partition of a partitioned asset.
     """

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -12,7 +12,7 @@ import datetime
 from typing import TYPE_CHECKING, AbstractSet, Optional, Sequence, Tuple
 
 from dagster._core.definitions.asset_subset import AssetSubset, ValidAssetSubset
-from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._seven.compat.pendulum import PendulumInterval
 from dagster._utils.schedules import cron_string_iterator
@@ -134,7 +134,7 @@ def get_expected_data_time_for_asset_key(
             # if the parent will be materialized on this tick, and it's not in the same repo, then
             # we must wait for this asset to be materialized
             if isinstance(asset_graph, RemoteAssetGraph) and context.will_update_asset_partition(
-                AssetKeyPartitionKey(parent_key)
+                AssetPartitionKey(parent_key)
             ):
                 parent_repo = asset_graph.get_repository_handle(parent_key)
                 if parent_repo != asset_graph.get_repository_handle(asset_key):
@@ -156,7 +156,7 @@ def get_expected_data_time_for_asset_key(
 def freshness_evaluation_results_for_asset_key(
     context: "LegacyRuleEvaluationContext",
 ) -> Tuple[ValidAssetSubset, Sequence["AssetSubsetWithMetadata"]]:
-    """Returns a set of AssetKeyPartitionKeys to materialize in order to abide by the given
+    """Returns a set of AssetPartitionKeys to materialize in order to abide by the given
     FreshnessPolicies.
 
     Attempts to minimize the total number of asset executions.

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -31,7 +31,7 @@ from dagster._core.definitions.asset_daemon_context import (
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_selection import KeysAssetSelection
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
-from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetKey, AssetPartitionKey
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import IdentityPartitionMapping
@@ -189,7 +189,7 @@ class AssetBackfillData(NamedTuple):
 
     def get_target_root_asset_partitions(
         self, instance_queryer: CachingInstanceQueryer
-    ) -> Iterable[AssetKeyPartitionKey]:
+    ) -> Iterable[AssetPartitionKey]:
         def _get_self_and_downstream_targeted_subset(
             initial_subset: AssetGraphSubset,
         ) -> AssetGraphSubset:
@@ -623,7 +623,7 @@ def _get_requested_asset_partitions_from_run_requests(
     run_requests: Sequence[RunRequest],
     asset_graph: RemoteAssetGraph,
     instance_queryer: CachingInstanceQueryer,
-) -> AbstractSet[AssetKeyPartitionKey]:
+) -> AbstractSet[AssetPartitionKey]:
     requested_partitions = set()
     for run_request in run_requests:
         # Run request targets a range of partitions
@@ -648,13 +648,13 @@ def _get_requested_asset_partitions_from_run_requests(
                 PartitionKeyRange(range_start, range_end), instance_queryer
             )
             requested_partitions = requested_partitions | {
-                AssetKeyPartitionKey(asset_key, partition_key)
+                AssetPartitionKey(asset_key, partition_key)
                 for asset_key in selected_assets
                 for partition_key in partitions_in_range
             }
         else:
             requested_partitions = requested_partitions | {
-                AssetKeyPartitionKey(asset_key, run_request.partition_key)
+                AssetPartitionKey(asset_key, run_request.partition_key)
                 for asset_key in cast(Sequence[AssetKey], run_request.asset_selection)
             }
 
@@ -1128,7 +1128,7 @@ def get_asset_backfill_iteration_materialized_partitions(
             ]
             recently_materialized_asset_partitions |= AssetGraphSubset.from_asset_partition_set(
                 {
-                    AssetKeyPartitionKey(asset_key, record.partition_key)
+                    AssetPartitionKey(asset_key, record.partition_key)
                     for record in records_in_backfill
                 },
                 asset_graph,
@@ -1200,7 +1200,7 @@ def execute_asset_backfill_iteration_inner(
     This is a generator so that we can return control to the daemon and let it heartbeat during
     expensive operations.
     """
-    initial_candidates: Set[AssetKeyPartitionKey] = set()
+    initial_candidates: Set[AssetPartitionKey] = set()
     request_roots = not asset_backfill_data.requested_runs_for_target_roots
     if request_roots:
         logger.info("Not all root assets have been requested, finding root assets.")
@@ -1348,9 +1348,9 @@ def execute_asset_backfill_iteration_inner(
 
 
 def can_run_with_parent(
-    parent: AssetKeyPartitionKey,
-    candidate: AssetKeyPartitionKey,
-    candidates_unit: Iterable[AssetKeyPartitionKey],
+    parent: AssetPartitionKey,
+    candidate: AssetPartitionKey,
+    candidates_unit: Iterable[AssetPartitionKey],
     asset_graph: RemoteAssetGraph,
     target_subset: AssetGraphSubset,
     asset_partitions_to_request_map: Mapping[AssetKey, AbstractSet[Optional[str]]],
@@ -1440,8 +1440,8 @@ def can_run_with_parent(
 
 def should_backfill_atomic_asset_partitions_unit(
     asset_graph: RemoteAssetGraph,
-    candidates_unit: Iterable[AssetKeyPartitionKey],
-    asset_partitions_to_request: AbstractSet[AssetKeyPartitionKey],
+    candidates_unit: Iterable[AssetPartitionKey],
+    asset_partitions_to_request: AbstractSet[AssetPartitionKey],
     target_subset: AssetGraphSubset,
     requested_subset: AssetGraphSubset,
     materialized_subset: AssetGraphSubset,
@@ -1500,7 +1500,7 @@ def should_backfill_atomic_asset_partitions_unit(
 
 def _get_failed_asset_partitions(
     instance_queryer: CachingInstanceQueryer, backfill_id: str, asset_graph: RemoteAssetGraph
-) -> Sequence[AssetKeyPartitionKey]:
+) -> Sequence[AssetPartitionKey]:
     """Returns asset partitions that materializations were requested for as part of the backfill, but
     will not be materialized.
 
@@ -1514,7 +1514,7 @@ def _get_failed_asset_partitions(
         )
     )
 
-    result: List[AssetKeyPartitionKey] = []
+    result: List[AssetPartitionKey] = []
 
     for run in runs:
         if (
@@ -1552,7 +1552,7 @@ def _get_failed_asset_partitions(
                 run_id=run.run_id
             )
             result.extend(
-                AssetKeyPartitionKey(asset_key, partition_key)
+                AssetPartitionKey(asset_key, partition_key)
                 for asset_key in planned_asset_keys - completed_asset_keys
             )
 

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -12,7 +12,7 @@ from dagster._core.definitions.auto_materialize_rule_evaluation import (
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AssetConditionEvaluationWithRunIds,
 )
-from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetKey, AssetPartitionKey
 from dagster._core.definitions.partition import PartitionsDefinition
 
 # re-export
@@ -442,7 +442,7 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
         asset_partitions = set()
         for run_request in self.tick_data.run_requests or []:
             for asset_key in run_request.asset_selection or []:
-                asset_partitions.add(AssetKeyPartitionKey(asset_key, run_request.partition_key))
+                asset_partitions.add(AssetPartitionKey(asset_key, run_request.partition_key))
         return len(asset_partitions)
 
     @property

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -30,7 +30,7 @@ from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.decorators.asset_check_decorator import asset_check
-from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetPartitionKey
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import UpstreamPartitionsResult
@@ -113,8 +113,8 @@ def test_get_children_partitions_unpartitioned_parent_partitioned_child(
         asset_graph = asset_graph_from_assets([parent, child])
 
         expected_asset_partitions = {
-            AssetKeyPartitionKey(child.key, "a"),
-            AssetKeyPartitionKey(child.key, "b"),
+            AssetPartitionKey(child.key, "a"),
+            AssetPartitionKey(child.key, "b"),
         }
         assert (
             asset_graph.get_children_partitions(instance, current_time, parent.key)
@@ -145,8 +145,8 @@ def test_get_parent_partitions_unpartitioned_child_partitioned_parent(
 
         asset_graph = asset_graph_from_assets([parent, child])
         expected_asset_partitions = {
-            AssetKeyPartitionKey(parent.key, "a"),
-            AssetKeyPartitionKey(parent.key, "b"),
+            AssetPartitionKey(parent.key, "a"),
+            AssetPartitionKey(parent.key, "b"),
         }
         assert (
             asset_graph.get_parents_partitions(instance, current_time, child.key).parent_partitions
@@ -176,10 +176,10 @@ def test_get_children_partitions_fan_out(asset_graph_from_assets: Callable[..., 
         current_time = pendulum.now("UTC")
 
         expected_asset_partitions = {
-            AssetKeyPartitionKey(child.key, f"2022-01-03-{str(hour).zfill(2)}:00")
+            AssetPartitionKey(child.key, f"2022-01-03-{str(hour).zfill(2)}:00")
             for hour in range(24)
         }
-        parent_asset_partition = AssetKeyPartitionKey(parent.key, "2022-01-03")
+        parent_asset_partition = AssetPartitionKey(parent.key, "2022-01-03")
 
         assert (
             asset_graph.get_children_partitions(instance, current_time, parent.key, "2022-01-03")
@@ -213,10 +213,10 @@ def test_get_parent_partitions_fan_in(
         current_time = pendulum.now("UTC")
 
         expected_asset_partitions = {
-            AssetKeyPartitionKey(parent.key, f"2022-01-03-{str(hour).zfill(2)}:00")
+            AssetPartitionKey(parent.key, f"2022-01-03-{str(hour).zfill(2)}:00")
             for hour in range(24)
         }
-        child_asset_partition = AssetKeyPartitionKey(child.key, "2022-01-03")
+        child_asset_partition = AssetPartitionKey(child.key, "2022-01-03")
 
         assert (
             asset_graph.get_parents_partitions(
@@ -252,7 +252,7 @@ def test_get_parent_partitions_non_default_partition_mapping(
         with instance_for_test() as instance:
             current_time = pendulum.now("UTC")
 
-            expected_asset_partitions = {AssetKeyPartitionKey(parent.key, "2022-01-02")}
+            expected_asset_partitions = {AssetPartitionKey(parent.key, "2022-01-02")}
             mapped_partitions_result = asset_graph.get_parents_partitions(
                 instance, current_time, child.key
             )
@@ -333,14 +333,14 @@ def test_custom_unsupported_partition_mapping():
         assert internal_asset_graph.get_parents_partitions(
             instance, current_time, child.key, "2"
         ).parent_partitions == {
-            AssetKeyPartitionKey(parent.key, "1"),
-            AssetKeyPartitionKey(parent.key, "2"),
+            AssetPartitionKey(parent.key, "1"),
+            AssetPartitionKey(parent.key, "2"),
         }
 
         # external falls back to default PartitionMapping
         assert external_asset_graph.get_parents_partitions(
             instance, current_time, child.key, "2"
-        ).parent_partitions == {AssetKeyPartitionKey(parent.key, "2")}
+        ).parent_partitions == {AssetPartitionKey(parent.key, "2")}
 
 
 def test_required_multi_asset_sets_non_subsettable_multi_asset(
@@ -602,14 +602,14 @@ def test_asset_graph_subset_contains(
     )
 
     assert unpartitioned1.key in asset_graph_subset
-    assert AssetKeyPartitionKey(unpartitioned1.key) in asset_graph_subset
+    assert AssetPartitionKey(unpartitioned1.key) in asset_graph_subset
     assert partitioned1.key in asset_graph_subset
-    assert AssetKeyPartitionKey(partitioned1.key, "2022-01-01") in asset_graph_subset
-    assert AssetKeyPartitionKey(partitioned1.key, "2022-01-02") not in asset_graph_subset
+    assert AssetPartitionKey(partitioned1.key, "2022-01-01") in asset_graph_subset
+    assert AssetPartitionKey(partitioned1.key, "2022-01-02") not in asset_graph_subset
     assert unpartitioned2.key not in asset_graph_subset
-    assert AssetKeyPartitionKey(unpartitioned2.key) not in asset_graph_subset
+    assert AssetPartitionKey(unpartitioned2.key) not in asset_graph_subset
     assert partitioned2.key not in asset_graph_subset
-    assert AssetKeyPartitionKey(partitioned2.key, "2022-01-01") not in asset_graph_subset
+    assert AssetPartitionKey(partitioned2.key, "2022-01-01") not in asset_graph_subset
 
 
 def test_asset_graph_difference(asset_graph_from_assets: Callable[..., BaseAssetGraph]):

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_subset.py
@@ -13,7 +13,7 @@ from dagster import (
     StaticPartitionsDefinition,
 )
 from dagster._core.definitions.asset_subset import AssetSubset, ValidAssetSubset
-from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetPartitionKey
 from dagster._core.definitions.partition import AllPartitionsSubset, DefaultPartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
     PartitionKeysTimeWindowPartitionsSubset,
@@ -45,7 +45,7 @@ def test_empty_subset_subset(partitions_def: Optional[PartitionsDefinition]) -> 
 
     partition_keys = {None} if partitions_def is None else partitions_def.get_partition_keys()
     for pk in partition_keys:
-        assert AssetKeyPartitionKey(key, pk) not in empty_subset
+        assert AssetPartitionKey(key, pk) not in empty_subset
 
     assert empty_subset.asset_partitions == set()
 
@@ -59,9 +59,9 @@ def test_all_subset(partitions_def: Optional[PartitionsDefinition]) -> None:
     partition_keys = {None} if partitions_def is None else partitions_def.get_partition_keys()
     assert all_subset.size == len(partition_keys)
     for pk in partition_keys:
-        assert AssetKeyPartitionKey(key, pk) in all_subset
+        assert AssetPartitionKey(key, pk) in all_subset
 
-    assert all_subset.asset_partitions == {AssetKeyPartitionKey(key, pk) for pk in partition_keys}
+    assert all_subset.asset_partitions == {AssetPartitionKey(key, pk) for pk in partition_keys}
 
 
 @pytest.mark.parametrize("partitions_def", partitions_defs)

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -41,7 +41,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
-from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetPartitionKey
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.selector import (
     PartitionRangeSelector,
@@ -228,7 +228,7 @@ def test_from_asset_partitions_target_subset(
     )
     assert backfill_data.target_subset == AssetGraphSubset.from_asset_partition_set(
         {
-            AssetKeyPartitionKey(AssetKey(asset_key_str), partition_key)
+            AssetPartitionKey(AssetKey(asset_key_str), partition_key)
             for asset_key_str, partition_key in expected_target_asset_partitions
         },
         asset_graph=asset_graph,
@@ -319,7 +319,7 @@ def test_scenario_to_completion(scenario: AssetBackfillScenario, failures: str, 
                 dynamic_partitions_store=instance,
             )
             if failures == "no_failures":
-                fail_asset_partitions: Set[AssetKeyPartitionKey] = set()
+                fail_asset_partitions: Set[AssetPartitionKey] = set()
             elif failures == "root_failures":
                 fail_asset_partitions = set(
                     (
@@ -409,7 +409,7 @@ def test_do_not_rerequest_while_existing_run_in_progress():
     )
 
     assert (
-        AssetKeyPartitionKey(downstream.key, partition_key="2023-01-01")
+        AssetPartitionKey(downstream.key, partition_key="2023-01-01")
         in asset_backfill_data.requested_subset
     )
 
@@ -464,7 +464,7 @@ def make_random_subset(
     evaluation_time: datetime.datetime,
 ) -> AssetGraphSubset:
     # all partitions downstream of half of the partitions in each partitioned root asset
-    root_asset_partitions: Set[AssetKeyPartitionKey] = set()
+    root_asset_partitions: Set[AssetPartitionKey] = set()
     for i, root_asset_key in enumerate(sorted(asset_graph.root_materializable_asset_keys)):
         partitions_def = asset_graph.get(root_asset_key).partitions_def
 
@@ -477,12 +477,12 @@ def make_random_subset(
             start_index = len(partition_keys) // 2
             chosen_partition_keys = partition_keys[start_index:]
             root_asset_partitions.update(
-                AssetKeyPartitionKey(root_asset_key, partition_key)
+                AssetPartitionKey(root_asset_key, partition_key)
                 for partition_key in chosen_partition_keys
             )
         else:
             if i % 2 == 0:
-                root_asset_partitions.add(AssetKeyPartitionKey(root_asset_key, None))
+                root_asset_partitions.add(AssetPartitionKey(root_asset_key, None))
 
     target_asset_partitions, _ = asset_graph.bfs_filter_asset_partitions(
         instance, lambda _a, _b: (True, ""), root_asset_partitions, evaluation_time=evaluation_time
@@ -497,15 +497,14 @@ def make_subset_from_partition_keys(
     instance: DagsterInstance,
     evaluation_time: datetime.datetime,
 ) -> AssetGraphSubset:
-    root_asset_partitions: Set[AssetKeyPartitionKey] = set()
+    root_asset_partitions: Set[AssetPartitionKey] = set()
     for i, root_asset_key in enumerate(sorted(asset_graph.root_materializable_asset_keys)):
         if asset_graph.get(root_asset_key).is_partitioned:
             root_asset_partitions.update(
-                AssetKeyPartitionKey(root_asset_key, partition_key)
-                for partition_key in partition_keys
+                AssetPartitionKey(root_asset_key, partition_key) for partition_key in partition_keys
             )
         else:
-            root_asset_partitions.add(AssetKeyPartitionKey(root_asset_key, None))
+            root_asset_partitions.add(AssetPartitionKey(root_asset_key, None))
 
     target_asset_partitions, _ = asset_graph.bfs_filter_asset_partitions(
         instance, lambda _a, _b: (True, ""), root_asset_partitions, evaluation_time=evaluation_time
@@ -568,15 +567,15 @@ def run_backfill_to_completion(
     asset_graph: RemoteAssetGraph,
     assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
     backfill_data: AssetBackfillData,
-    fail_asset_partitions: Iterable[AssetKeyPartitionKey],
+    fail_asset_partitions: Iterable[AssetPartitionKey],
     instance: DagsterInstance,
-) -> Tuple[AssetBackfillData, AbstractSet[AssetKeyPartitionKey], AbstractSet[AssetKeyPartitionKey]]:
+) -> Tuple[AssetBackfillData, AbstractSet[AssetPartitionKey], AbstractSet[AssetPartitionKey]]:
     iteration_count = 0
     instance = instance or DagsterInstance.ephemeral()
     backfill_id = "backfillid_x"
 
     # assert each asset partition only targeted once
-    requested_asset_partitions: Set[AssetKeyPartitionKey] = set()
+    requested_asset_partitions: Set[AssetPartitionKey] = set()
 
     fail_and_downstream_asset_partitions, _ = asset_graph.bfs_filter_asset_partitions(
         instance,
@@ -651,7 +650,7 @@ def run_backfill_to_completion(
                 failed_asset_keys=[
                     asset_key
                     for asset_key in asset_keys
-                    if AssetKeyPartitionKey(asset_key, run_request.partition_key)
+                    if AssetPartitionKey(asset_key, run_request.partition_key)
                     in fail_asset_partitions
                 ],
                 tags=run_request.tags,
@@ -663,7 +662,7 @@ def run_backfill_to_completion(
 
 def _requested_asset_partitions_in_run_request(
     run_request: RunRequest, asset_graph: BaseAssetGraph
-) -> Set[AssetKeyPartitionKey]:
+) -> Set[AssetPartitionKey]:
     asset_keys = run_request.asset_selection
     assert asset_keys is not None
     requested_asset_partitions = set()
@@ -693,7 +692,7 @@ def _requested_asset_partitions_in_run_request(
     else:
         # backfill was a partition by partition backfill
         for asset_key in asset_keys:
-            asset_partition = AssetKeyPartitionKey(asset_key, run_request.partition_key)
+            asset_partition = AssetPartitionKey(asset_key, run_request.partition_key)
             assert (
                 asset_partition not in requested_asset_partitions
             ), f"{asset_partition} requested twice. Requested: {requested_asset_partitions}."
@@ -892,7 +891,7 @@ def test_asset_backfill_status_counts():
         assets_by_repo_name=assets_by_repo_name,
         backfill_data=backfill_data,
         fail_asset_partitions=[
-            AssetKeyPartitionKey(
+            AssetPartitionKey(
                 asset_key=upstream_daily_partitioned_asset.key, partition_key="2023-01-09"
             )
         ],
@@ -1173,11 +1172,11 @@ def test_asset_backfill_cancels_without_fetching_downstreams_of_failed_partition
         )
 
     assert (
-        AssetKeyPartitionKey(upstream_hourly_partitioned_asset.key, "2023-01-09-00:00")
+        AssetPartitionKey(upstream_hourly_partitioned_asset.key, "2023-01-09-00:00")
         in asset_backfill_data.failed_and_downstream_subset
     )
     assert (
-        AssetKeyPartitionKey(downstream_daily_partitioned_asset.key, "2023-01-09")
+        AssetPartitionKey(downstream_daily_partitioned_asset.key, "2023-01-09")
         in asset_backfill_data.failed_and_downstream_subset
     )
 
@@ -1195,11 +1194,11 @@ def test_asset_backfill_cancels_without_fetching_downstreams_of_failed_partition
 
     assert isinstance(canceling_backfill_data, AssetBackfillData)
     assert (
-        AssetKeyPartitionKey(upstream_hourly_partitioned_asset.key, "2023-01-09-00:00")
+        AssetPartitionKey(upstream_hourly_partitioned_asset.key, "2023-01-09-00:00")
         in canceling_backfill_data.failed_and_downstream_subset
     )
     assert (
-        AssetKeyPartitionKey(downstream_daily_partitioned_asset.key, "2023-01-09")
+        AssetPartitionKey(downstream_daily_partitioned_asset.key, "2023-01-09")
         in canceling_backfill_data.failed_and_downstream_subset
     )
 
@@ -1243,7 +1242,7 @@ def test_asset_backfill_target_asset_and_same_partitioning_grandchild():
         backfill_start_time=pendulum.datetime(2023, 10, 5, 0, 0, 0),
     )
     assert set(asset_backfill_data.target_subset.iterate_asset_partitions()) == {
-        AssetKeyPartitionKey(asset_key, partition_key)
+        AssetPartitionKey(asset_key, partition_key)
         for asset_key in [foo.key, foo_grandchild.key]
         for partition_key in all_partitions
     }
@@ -1293,9 +1292,9 @@ def test_asset_backfill_target_asset_and_differently_partitioned_grandchild():
     )
 
     expected_targeted_partitions = {
-        AssetKeyPartitionKey(foo_grandchild.key, "2023-10-01"),
+        AssetPartitionKey(foo_grandchild.key, "2023-10-01"),
         *{
-            AssetKeyPartitionKey(asset_key, partition_key)
+            AssetPartitionKey(asset_key, partition_key)
             for asset_key in [foo.key]
             for partition_key in [f"2023-10-0{x}" for x in range(1, 8)]
         },
@@ -1415,15 +1414,15 @@ def test_connected_assets_disconnected_partitions():
 
     target_root_partitions = asset_backfill_data.get_target_root_asset_partitions(instance_queryer)
     assert set(target_root_partitions) == {
-        AssetKeyPartitionKey(asset_key=AssetKey(["foo"]), partition_key="2023-10-05"),
-        AssetKeyPartitionKey(asset_key=AssetKey(["foo"]), partition_key="2023-10-03"),
-        AssetKeyPartitionKey(asset_key=AssetKey(["foo"]), partition_key="2023-10-04"),
-        AssetKeyPartitionKey(asset_key=AssetKey(["foo"]), partition_key="2023-10-02"),
-        AssetKeyPartitionKey(asset_key=AssetKey(["foo"]), partition_key="2023-10-01"),
-        AssetKeyPartitionKey(asset_key=AssetKey(["foo_grandchild"]), partition_key="2023-10-11"),
-        AssetKeyPartitionKey(asset_key=AssetKey(["foo_grandchild"]), partition_key="2023-10-13"),
-        AssetKeyPartitionKey(asset_key=AssetKey(["foo_grandchild"]), partition_key="2023-10-12"),
-        AssetKeyPartitionKey(asset_key=AssetKey(["foo_grandchild"]), partition_key="2023-10-10"),
+        AssetPartitionKey(asset_key=AssetKey(["foo"]), partition_key="2023-10-05"),
+        AssetPartitionKey(asset_key=AssetKey(["foo"]), partition_key="2023-10-03"),
+        AssetPartitionKey(asset_key=AssetKey(["foo"]), partition_key="2023-10-04"),
+        AssetPartitionKey(asset_key=AssetKey(["foo"]), partition_key="2023-10-02"),
+        AssetPartitionKey(asset_key=AssetKey(["foo"]), partition_key="2023-10-01"),
+        AssetPartitionKey(asset_key=AssetKey(["foo_grandchild"]), partition_key="2023-10-11"),
+        AssetPartitionKey(asset_key=AssetKey(["foo_grandchild"]), partition_key="2023-10-13"),
+        AssetPartitionKey(asset_key=AssetKey(["foo_grandchild"]), partition_key="2023-10-12"),
+        AssetPartitionKey(asset_key=AssetKey(["foo_grandchild"]), partition_key="2023-10-10"),
     }
 
 
@@ -1621,9 +1620,9 @@ def test_multi_asset_internal_deps_asset_backfill():
     backfill_data = _single_backfill_iteration(
         "fake_id", asset_backfill_data, asset_graph, instance, repo_with_unpartitioned_root
     )
-    assert AssetKeyPartitionKey(AssetKey("a"), "1") in backfill_data.requested_subset
-    assert AssetKeyPartitionKey(AssetKey("b"), "1") in backfill_data.requested_subset
-    assert AssetKeyPartitionKey(AssetKey("c"), "1") in backfill_data.requested_subset
+    assert AssetPartitionKey(AssetKey("a"), "1") in backfill_data.requested_subset
+    assert AssetPartitionKey(AssetKey("b"), "1") in backfill_data.requested_subset
+    assert AssetPartitionKey(AssetKey("c"), "1") in backfill_data.requested_subset
 
 
 def test_multi_asset_internal_and_external_deps_asset_backfill() -> None:
@@ -1660,9 +1659,9 @@ def test_multi_asset_internal_and_external_deps_asset_backfill() -> None:
     backfill_data = _single_backfill_iteration(
         "fake_id", asset_backfill_data, asset_graph, instance, repo_with_unpartitioned_root
     )
-    assert AssetKeyPartitionKey(AssetKey("a"), "1") in backfill_data.requested_subset
-    assert AssetKeyPartitionKey(AssetKey("b"), "1") in backfill_data.requested_subset
-    assert AssetKeyPartitionKey(AssetKey("c"), "1") in backfill_data.requested_subset
+    assert AssetPartitionKey(AssetKey("a"), "1") in backfill_data.requested_subset
+    assert AssetPartitionKey(AssetKey("b"), "1") in backfill_data.requested_subset
+    assert AssetPartitionKey(AssetKey("c"), "1") in backfill_data.requested_subset
 
 
 def test_run_request_partition_order():

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -21,7 +21,7 @@ from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.data_version import DataVersion
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
-from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetPartitionKey
 from dagster._core.definitions.materialize import materialize_to_memory
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition
@@ -139,7 +139,7 @@ def test_calculate_data_time_unpartitioned(ignore_asset_tags, runs_to_expected_d
             for asset_keys, expected_data_times in expected_index_mapping.items():
                 for ak in asset_keys:
                     latest_asset_record = data_time_queryer.instance_queryer.get_latest_materialization_or_observation_record(
-                        AssetKeyPartitionKey(AssetKey(ak))
+                        AssetPartitionKey(AssetKey(ak))
                     )
                     if ignore_asset_tags:
                         # simulate an environment where materialization tags were not populated

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -36,7 +36,7 @@ from dagster import (
 from dagster._core.definitions import StaticPartitionsDefinition
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.backfill_policy import BackfillPolicy
-from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetPartitionKey
 from dagster._core.definitions.partition import DynamicPartitionsDefinition, PartitionedConfig
 from dagster._core.definitions.selector import (
     PartitionRangeSelector,
@@ -1834,7 +1834,7 @@ def test_asset_backfill_with_multi_run_backfill_policy(
             updated_backfill.asset_backfill_data
         ).requested_subset.iterate_asset_partitions()
     ) == [
-        AssetKeyPartitionKey(asset_with_multi_run_backfill_policy.key, partition)
+        AssetPartitionKey(asset_with_multi_run_backfill_policy.key, partition)
         for partition in partitions
     ]
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
@@ -26,7 +26,7 @@ from dagster._core.definitions.declarative_automation.operators.boolean_operator
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AutomationConditionCursor,
 )
-from dagster._core.definitions.events import AssetKeyPartitionKey, CoercibleToAssetKey
+from dagster._core.definitions.events import AssetPartitionKey, CoercibleToAssetKey
 from dagster._seven.compat.pendulum import pendulum_freeze_time
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
@@ -51,7 +51,7 @@ class FalseAssetCondition(AutomationCondition):
 class AutomationConditionScenarioState(ScenarioState):
     automation_condition: Optional[AutomationCondition] = None
     condition_cursor: Optional[AutomationConditionCursor] = None
-    requested_asset_partitions: Optional[Sequence[AssetKeyPartitionKey]] = None
+    requested_asset_partitions: Optional[Sequence[AssetPartitionKey]] = None
     ensure_empty_result: bool = True
 
     def _get_current_results_by_key(
@@ -143,6 +143,6 @@ class AutomationConditionScenarioState(ScenarioState):
         return dataclasses.replace(self, condition_cursor=None)
 
     def with_requested_asset_partitions(
-        self, requested_asset_partitions: Sequence[AssetKeyPartitionKey]
+        self, requested_asset_partitions: Sequence[AssetPartitionKey]
     ) -> "AutomationConditionScenarioState":
         return dataclasses.replace(self, requested_asset_partitions=requested_asset_partitions)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
@@ -9,7 +9,7 @@ from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
-from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetPartitionKey
 
 from dagster_tests.definitions_tests.auto_materialize_tests.scenario_state import ScenarioSpec
 
@@ -66,7 +66,7 @@ def test_dep_missing_unpartitioned(is_any: bool) -> None:
     assert result.true_subset.size == 0
 
     # one parent true, still one false
-    true_set.add(AssetKeyPartitionKey(AssetKey("A")))
+    true_set.add(AssetPartitionKey(AssetKey("A")))
     state, result = state.evaluate("C")
     if is_any:
         assert result.true_subset.size == 1
@@ -74,7 +74,7 @@ def test_dep_missing_unpartitioned(is_any: bool) -> None:
         assert result.true_subset.size == 0
 
     # both parents true
-    true_set.add(AssetKeyPartitionKey(AssetKey("B")))
+    true_set.add(AssetPartitionKey(AssetKey("B")))
     state, result = state.evaluate("C")
     assert result.true_subset.size == 1
 
@@ -95,7 +95,7 @@ def test_dep_missing_partitioned(is_any: bool) -> None:
     state, result = state.evaluate("C")
     assert result.true_subset.size == 0
 
-    true_set.add(AssetKeyPartitionKey(AssetKey("A"), "1"))
+    true_set.add(AssetPartitionKey(AssetKey("A"), "1"))
     state, result = state.evaluate("C")
     if is_any:
         # one parent is true for partition 1
@@ -104,7 +104,7 @@ def test_dep_missing_partitioned(is_any: bool) -> None:
         # neither 1 nor 2 have all parents true
         assert result.true_subset.size == 0
 
-    true_set.add(AssetKeyPartitionKey(AssetKey("A"), "2"))
+    true_set.add(AssetPartitionKey(AssetKey("A"), "2"))
     state, result = state.evaluate("C")
     if is_any:
         # both partitions 1 and 2 have at least one true parent
@@ -113,7 +113,7 @@ def test_dep_missing_partitioned(is_any: bool) -> None:
         # neither 1 nor 2 have all parents true
         assert result.true_subset.size == 0
 
-    true_set.add(AssetKeyPartitionKey(AssetKey("B"), "1"))
+    true_set.add(AssetPartitionKey(AssetKey("B"), "1"))
     state, result = state.evaluate("C")
     if is_any:
         assert result.true_subset.size == 2
@@ -121,7 +121,7 @@ def test_dep_missing_partitioned(is_any: bool) -> None:
         # now partition 1 has all parents true
         assert result.true_subset.size == 1
 
-    true_set.add(AssetKeyPartitionKey(AssetKey("B"), "2"))
+    true_set.add(AssetPartitionKey(AssetKey("B"), "2"))
     state, result = state.evaluate("C")
     if is_any:
         assert result.true_subset.size == 2

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_failed_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_failed_condition.py
@@ -1,6 +1,6 @@
 from dagster import AutomationCondition
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetPartitionKey
 
 from ..base_scenario import run_request
 from ..scenario_specs import one_asset, two_partitions_def
@@ -40,7 +40,7 @@ def test_in_progress_static_partitioned() -> None:
     state = state.with_failed_run_for_asset("A", partition_key="1")
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
-    assert result.true_subset.asset_partitions == {AssetKeyPartitionKey(AssetKey("A"), "1")}
+    assert result.true_subset.asset_partitions == {AssetPartitionKey(AssetKey("A"), "1")}
 
     # now that partition succeeds
     state = state.with_runs(run_request("A", partition_key="1"))

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_in_progress_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_in_progress_condition.py
@@ -1,6 +1,6 @@
 from dagster import AutomationCondition
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetPartitionKey
 
 from ..scenario_specs import one_asset, two_partitions_def
 from .asset_condition_scenario import AutomationConditionScenarioState
@@ -40,7 +40,7 @@ def test_in_progress_static_partitioned() -> None:
     state = state.with_in_progress_run_for_asset("A", partition_key="1")
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
-    assert result.true_subset.asset_partitions == {AssetKeyPartitionKey(AssetKey("A"), "1")}
+    assert result.true_subset.asset_partitions == {AssetPartitionKey(AssetKey("A"), "1")}
 
     # run completes
     state = state.with_in_progress_runs_completed()

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_latest_time_window_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_latest_time_window_condition.py
@@ -2,7 +2,7 @@ import datetime
 
 from dagster import AutomationCondition
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetPartitionKey
 
 from ..scenario_specs import (
     daily_partitions_def,
@@ -68,16 +68,12 @@ def test_in_latest_time_window_time_partitioned() -> None:
     state = state.with_current_time("2020-02-02T01:00:00")
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
-    assert result.true_subset.asset_partitions == {
-        AssetKeyPartitionKey(AssetKey("A"), "2020-02-01")
-    }
+    assert result.true_subset.asset_partitions == {AssetPartitionKey(AssetKey("A"), "2020-02-01")}
 
     state = state.with_current_time_advanced(days=5)
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
-    assert result.true_subset.asset_partitions == {
-        AssetKeyPartitionKey(AssetKey("A"), "2020-02-06")
-    }
+    assert result.true_subset.asset_partitions == {AssetPartitionKey(AssetKey("A"), "2020-02-06")}
 
 
 def test_in_latest_time_window_time_partitioned_lookback() -> None:
@@ -97,16 +93,16 @@ def test_in_latest_time_window_time_partitioned_lookback() -> None:
     state, result = state.evaluate("A")
     assert result.true_subset.size == 3
     assert result.true_subset.asset_partitions == {
-        AssetKeyPartitionKey(AssetKey("A"), "2020-02-06"),
-        AssetKeyPartitionKey(AssetKey("A"), "2020-02-05"),
-        AssetKeyPartitionKey(AssetKey("A"), "2020-02-04"),
+        AssetPartitionKey(AssetKey("A"), "2020-02-06"),
+        AssetPartitionKey(AssetKey("A"), "2020-02-05"),
+        AssetPartitionKey(AssetKey("A"), "2020-02-04"),
     }
 
     state = state.with_current_time_advanced(days=5)
     state, result = state.evaluate("A")
     assert result.true_subset.size == 3
     assert result.true_subset.asset_partitions == {
-        AssetKeyPartitionKey(AssetKey("A"), "2020-02-11"),
-        AssetKeyPartitionKey(AssetKey("A"), "2020-02-10"),
-        AssetKeyPartitionKey(AssetKey("A"), "2020-02-09"),
+        AssetPartitionKey(AssetKey("A"), "2020-02-11"),
+        AssetPartitionKey(AssetKey("A"), "2020-02-10"),
+        AssetPartitionKey(AssetKey("A"), "2020-02-09"),
     }

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_newly_requested_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_newly_requested_condition.py
@@ -1,6 +1,6 @@
 from dagster._core.definitions.declarative_automation import NewlyRequestedCondition
 from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
-from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetKey, AssetPartitionKey
 
 from ..scenario_specs import one_asset
 from .asset_condition_scenario import AutomationConditionScenarioState
@@ -31,11 +31,11 @@ def test_requested_previous_tick() -> None:
     assert get_result(result).true_subset.size == 0
 
     # now we ensure that the asset does get requested this tick
-    true_set.add(AssetKeyPartitionKey(AssetKey("A")))
+    true_set.add(AssetPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
     # requested this tick, not the previous tick
     assert get_result(result).true_subset.size == 0
-    true_set.remove(AssetKeyPartitionKey(AssetKey("A")))
+    true_set.remove(AssetPartitionKey(AssetKey("A")))
 
     # requested on the previous tick
     state, result = state.evaluate("A")

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_newly_true_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_newly_true_condition.py
@@ -1,6 +1,6 @@
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.declarative_automation import NewlyTrueCondition
-from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetPartitionKey
 
 from ..scenario_specs import one_asset
 from .asset_condition_scenario import AutomationConditionScenarioState
@@ -18,7 +18,7 @@ def test_newly_true_condition() -> None:
     assert result.true_subset.size == 0
 
     # becomes true
-    true_set.add(AssetKeyPartitionKey(AssetKey("A")))
+    true_set.add(AssetPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
 
@@ -35,7 +35,7 @@ def test_newly_true_condition() -> None:
     assert result.true_subset.size == 0
 
     # now condition becomes false, result still false
-    true_set.remove(AssetKeyPartitionKey(AssetKey("A")))
+    true_set.remove(AssetPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
     assert result.true_subset.size == 0
 
@@ -44,7 +44,7 @@ def test_newly_true_condition() -> None:
     assert result.true_subset.size == 0
 
     # becomes true again
-    true_set.add(AssetKeyPartitionKey(AssetKey("A")))
+    true_set.add(AssetPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_since_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_since_condition.py
@@ -1,6 +1,6 @@
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.declarative_automation import SinceCondition
-from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetPartitionKey
 
 from ..scenario_specs import one_asset
 from .asset_condition_scenario import AutomationConditionScenarioState
@@ -21,38 +21,38 @@ def test_since_condition_unpartitioned() -> None:
     assert result.true_subset.size == 0
 
     # primary becomes true, but reference has never been true
-    true_set_primary.add(AssetKeyPartitionKey(AssetKey("A")))
+    true_set_primary.add(AssetPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
-    true_set_primary.remove(AssetKeyPartitionKey(AssetKey("A")))
+    true_set_primary.remove(AssetPartitionKey(AssetKey("A")))
 
     # reference becomes true, and it's after primary
-    true_set_reference.add(AssetKeyPartitionKey(AssetKey("A")))
+    true_set_reference.add(AssetPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
     assert result.true_subset.size == 0
-    true_set_reference.remove(AssetKeyPartitionKey(AssetKey("A")))
+    true_set_reference.remove(AssetPartitionKey(AssetKey("A")))
 
     # primary becomes true again, and it's since reference has become true
-    true_set_primary.add(AssetKeyPartitionKey(AssetKey("A")))
+    true_set_primary.add(AssetPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
-    true_set_primary.remove(AssetKeyPartitionKey(AssetKey("A")))
+    true_set_primary.remove(AssetPartitionKey(AssetKey("A")))
 
     # remains true on the neprimaryt evaluation
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
 
     # primary becomes true again, still doesn't change anything
-    true_set_primary.add(AssetKeyPartitionKey(AssetKey("A")))
+    true_set_primary.add(AssetPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
     assert result.true_subset.size == 1
-    true_set_primary.remove(AssetKeyPartitionKey(AssetKey("A")))
+    true_set_primary.remove(AssetPartitionKey(AssetKey("A")))
 
     # now reference becomes true again
-    true_set_reference.add(AssetKeyPartitionKey(AssetKey("A")))
+    true_set_reference.add(AssetPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
     assert result.true_subset.size == 0
-    true_set_reference.remove(AssetKeyPartitionKey(AssetKey("A")))
+    true_set_reference.remove(AssetPartitionKey(AssetKey("A")))
 
     # remains false on the neprimaryt evaluation
     state, result = state.evaluate("A")

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_will_be_requested_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_will_be_requested_condition.py
@@ -1,5 +1,5 @@
 from dagster import AssetKey, AutomationCondition
-from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetPartitionKey
 
 from ..scenario_specs import two_assets_in_sequence, two_partitions_def
 from .asset_condition_scenario import AutomationConditionScenarioState
@@ -14,7 +14,7 @@ def test_will_be_requested_unpartitioned() -> None:
     assert result.true_subset.size == 0
 
     # parent is requested
-    state = state.with_requested_asset_partitions([AssetKeyPartitionKey(AssetKey("A"))])
+    state = state.with_requested_asset_partitions([AssetPartitionKey(AssetKey("A"))])
     state, result = state.evaluate("B")
     assert result.true_subset.size == 1
 
@@ -30,14 +30,14 @@ def test_will_be_requested_static_partitioned() -> None:
     assert result.true_subset.size == 0
 
     # one requested parent
-    state = state.with_requested_asset_partitions([AssetKeyPartitionKey(AssetKey("A"), "1")])
+    state = state.with_requested_asset_partitions([AssetPartitionKey(AssetKey("A"), "1")])
     state, result = state.evaluate("B")
     assert result.true_subset.size == 1
-    assert result.true_subset.asset_partitions == {AssetKeyPartitionKey(AssetKey("B"), "1")}
+    assert result.true_subset.asset_partitions == {AssetPartitionKey(AssetKey("B"), "1")}
 
     # two requested parents
     state = state.with_requested_asset_partitions(
-        [AssetKeyPartitionKey(AssetKey("A"), "1"), AssetKeyPartitionKey(AssetKey("A"), "2")]
+        [AssetPartitionKey(AssetKey("A"), "1"), AssetPartitionKey(AssetKey("A"), "2")]
     )
     state, result = state.evaluate("B")
     assert result.true_subset.size == 2
@@ -54,13 +54,13 @@ def test_will_be_requested_different_partitions() -> None:
     assert result.true_subset.size == 0
 
     # one requested parent, but can't execute in same run
-    state = state.with_requested_asset_partitions([AssetKeyPartitionKey(AssetKey("A"), "1")])
+    state = state.with_requested_asset_partitions([AssetPartitionKey(AssetKey("A"), "1")])
     state, result = state.evaluate("B")
     assert result.true_subset.size == 0
 
     # two requested parents, but can't execute in same run
     state = state.with_requested_asset_partitions(
-        [AssetKeyPartitionKey(AssetKey("A"), "1"), AssetKeyPartitionKey(AssetKey("A"), "2")]
+        [AssetPartitionKey(AssetKey("A"), "1"), AssetPartitionKey(AssetKey("A"), "2")]
     )
     state, result = state.evaluate("B")
     assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_user_space_ds_api.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_user_space_ds_api.py
@@ -13,7 +13,7 @@ from dagster._core.definitions.declarative_automation.automation_condition_evalu
     AutomationConditionEvaluator,
 )
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.events import AssetPartitionKey
 from dagster._core.test_utils import MockedRunLauncher, in_process_test_workspace, instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceProcessContext
@@ -26,7 +26,7 @@ from .user_space_ds_defs import amp_sensor, downstream, upstream
 
 class AutomationTickResult(NamedTuple):
     results: Sequence[AutomationResult]
-    asset_partition_keys: AbstractSet[AssetKeyPartitionKey]
+    asset_partition_keys: AbstractSet[AssetPartitionKey]
 
 
 def execute_ds_ticks(defs: Definitions, n: int) -> Iterator[AutomationTickResult]:
@@ -87,8 +87,8 @@ def test_basic_asset_scheduling_test() -> None:
     result = execute_ds_tick(defs)
     assert result
     assert result.asset_partition_keys == {
-        AssetKeyPartitionKey(upstream.key),
-        AssetKeyPartitionKey(downstream.key),
+        AssetPartitionKey(upstream.key),
+        AssetPartitionKey(downstream.key),
     }
     # both are true because both missing
     assert result.results[0].true_subset.bool_value

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario.py
@@ -21,7 +21,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     AssetConditionEvaluation,
     AssetSubsetWithMetadata,
 )
-from dagster._core.definitions.events import AssetKeyPartitionKey, CoercibleToAssetKey
+from dagster._core.definitions.events import AssetPartitionKey, CoercibleToAssetKey
 from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
 )
@@ -88,7 +88,7 @@ class AssetRuleEvaluationSpec(NamedTuple):
             asset_key,
             asset_graph.get(asset_key).partitions_def,
             {
-                AssetKeyPartitionKey(asset_key, partition_key)
+                AssetPartitionKey(asset_key, partition_key)
                 for partition_key in self.partitions or [None]
             },
         )
@@ -307,7 +307,7 @@ class AssetDaemonScenarioState(ScenarioState):
         )[-1]
 
         expected_requested_asset_partitions = {
-            AssetKeyPartitionKey(asset_key=ak, partition_key=rr.partition_key)
+            AssetPartitionKey(asset_key=ak, partition_key=rr.partition_key)
             for rr in expected_run_requests
             for ak in (rr.asset_selection or set())
         }

--- a/python_modules/dagster/dagster_tests/execution_tests/versioning_tests/test_data_versions.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/versioning_tests/test_data_versions.py
@@ -31,7 +31,7 @@ from dagster._core.definitions.data_version import (
     extract_data_version_from_entry,
 )
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
-from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey, Output
+from dagster._core.definitions.events import AssetKey, AssetPartitionKey, Output
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.definitions.partition_mapping import AllPartitionMapping
@@ -630,8 +630,8 @@ def test_stale_status_many_to_one_partitions() -> None:
     def asset3(asset2):
         return 1
 
-    a1_foo_key = AssetKeyPartitionKey(asset1.key, "alpha")
-    a1_bar_key = AssetKeyPartitionKey(asset1.key, "beta")
+    a1_foo_key = AssetPartitionKey(asset1.key, "alpha")
+    a1_bar_key = AssetPartitionKey(asset1.key, "beta")
 
     all_assets = [asset1, asset2, asset3]
     with instance_for_test() as instance:


### PR DESCRIPTION
## Summary & Motivation

Companion PR: https://github.com/dagster-io/internal/pull/9992

- Rename `AssetKeyPartitionKey` -> `AssetPartitionKey`

## How I Tested These Changes

Existing test suite.