### PR TITLE
Add AssetPartitionWipeRange class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -32,6 +32,7 @@ from dagster._core.definitions.data_version import (
     DATA_VERSION_TAG,
     DataVersion,
 )
+from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX, REPORTING_USER_TAG
 from dagster._serdes import whitelist_for_serdes
 from dagster._serdes.serdes import NamedTupleSerializer
@@ -56,6 +57,15 @@ class AssetKeyPartitionKey(NamedTuple):
 
     asset_key: AssetKey
     partition_key: Optional[str] = None
+
+
+# This is currently used only for the asset partition wipe codepath. In the future, we can rename
+# to AssetPartitionRange or similar for more general use.
+class AssetPartitionWipeRange(NamedTuple):
+    """An AssetKey with a partition range."""
+
+    asset_key: AssetKey
+    partition_range: Optional[PartitionKeyRange]
 
 
 DynamicAssetKey = Callable[["OutputContext"], Optional[AssetKey]]


### PR DESCRIPTION
## Summary & Motivation

Add an `AssetPartitionWipeRange` class to complement `AssetKeyPartitionKey`. This is used upstack in partition wiping PRs.

Like `AssetKeyPartitionKey`, this uses `None` for the `partition_range` if there is no range-- this is interpreted as "the whole asset".

This is called `AssetPartitionWipeRange` instead of just `AssetPartitionRange` to scope this abstraction explicitly to partition wiping for the time being. Later I expect to rename this to just `AssetPartitionRange` or similar as part of a broader rename of partition abstractions.

## How I Tested These Changes

Existing test suite.