### PR TITLE
Correctly cursor through asset keys when an asset key is passed in to EventLogStorage.get_asset_keys that is not in the list of asset keys

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -2536,6 +2536,11 @@ class TestEventLogStorage:
             assert len(asset_keys) == 1
             assert asset_keys[0].to_string() == '["b", "z"]'
 
+            # pagination still works even if the key is not in the list
+            asset_keys = storage.get_asset_keys(cursor='["b", "w"]', limit=1)
+            assert len(asset_keys) == 1
+            assert asset_keys[0].to_string() == '["b", "x"]'
+
             # prefix filter
             asset_keys = storage.get_asset_keys(prefix=["b"])
             assert len(asset_keys) == 3


### PR DESCRIPTION
Summary:
get_assets_or_error returns a mix of assets that are in the database and assets that have definitions but are not yet in the database (e.g. because they have never been materialized). If you pass in the key of an asset that is in the latter list, the current logic here will not accept it as a valid cursor index since it is not in the list. Instead, make the logic here return any keys that are > the passed in cursor (like the implementation in SqlEventLogStorage does)

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
