### PR TITLE
Clarifying rename of AssetsDefinitionFactory-related classes and properties

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -597,7 +597,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         check_specs: Optional[Sequence[AssetCheckSpec]] = None,
         owners_by_output_name: Optional[Mapping[str, Sequence[str]]] = None,
     ) -> "AssetsDefinition":
-        from dagster._core.definitions.decorators.assets_definition_factory import (
+        from dagster._core.definitions.decorators.decorator_assets_definition_builder import (
             _assign_output_names_to_check_specs,
             _validate_check_specs_target_relevant_asset_keys,
         )

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -33,7 +33,7 @@ from dagster._utils.warnings import disable_dagster_warnings
 
 from ..input import In
 from .asset_decorator import make_asset_deps
-from .assets_definition_factory import (
+from .decorator_assets_definition_builder import (
     build_asset_ins,
     get_function_params_without_context_or_config_or_resources,
 )

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -175,7 +175,7 @@ class _ObservableSourceAsset:
             key_prefix=self.key_prefix,
             name=self.name,
             fn=observe_fn,
-            decorator="@observable_source_asset",
+            decorator_name="@observable_source_asset",
         )
 
         arg_resource_keys = {arg.name for arg in get_resource_args(observe_fn)}

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -35,7 +35,7 @@ from dagster import (
     _check as check,
     define_asset_job,
 )
-from dagster._core.definitions.decorators.assets_definition_factory import (
+from dagster._core.definitions.decorators.decorator_assets_definition_builder import (
     validate_and_assign_output_names_to_check_specs,
 )
 from dagster._core.definitions.metadata import TableMetadataSet


### PR DESCRIPTION
## Summary & Motivation

Various pieces of good feedback raised by @sryza done here to avoid merge conflicts.

* More use of `NamedIn` and `NamedOut` rather than raw tuples
* outs_by_output_name instead of asset_outs_by_output_name
outs_by_output_name instead of asset_outs_by_output_name
* ins_by_input_name instead asset_ins_by_input_name

## How I Tested These Changes

BK
