### PR TITLE
Apply a limit in the step delegating executor query

### DIFF
--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
@@ -147,7 +147,12 @@ def test_execute():
 def test_execute_with_tailer_offset():
     TestStepHandler.reset()
     with instance_for_test() as instance:
-        with environ({"DAGSTER_EXECUTOR_POP_EVENTS_OFFSET": "100000"}):
+        with environ(
+            {
+                "DAGSTER_EXECUTOR_POP_EVENTS_OFFSET": "100000",
+                "DAGSTER_EXECUTOR_POP_EVENTS_LIMIT": "2",  # limit env var is ignored since it is lower than the offset - if it was not ignored, the run would never finish
+            }
+        ):
             result = execute_job(
                 reconstructable(foo_job),
                 instance=instance,


### PR DESCRIPTION
Summary:
Ensures that we don't ever issue an unbounded events query while procesing events for a run. Note that if the offset field is set, it's important that the limit be greater than that offset to avoid looping over the same offsetted events forever.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
