### PR TITLE
Use compute_required_resource_keys_for_underlying_op in @asset_check

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -35,6 +35,7 @@ from ..input import In
 from .asset_decorator import make_asset_deps
 from .decorator_assets_definition_builder import (
     build_asset_ins,
+    compute_required_resource_keys,
     get_function_params_without_context_or_config_or_resources,
 )
 from .op_decorator import _Op
@@ -213,18 +214,14 @@ def asset_check(
             metadata=metadata,
         )
 
-        arg_resource_keys = {arg.name for arg in get_resource_args(fn)}
+        resource_defs_for_execution = wrap_resources_for_execution(resource_defs)
 
-        check.param_invariant(
-            len(required_resource_keys or []) == 0 or len(arg_resource_keys) == 0,
-            "Cannot specify resource requirements in both @asset_check decorator and as arguments"
-            " to the decorated function",
+        op_required_resource_keys = compute_required_resource_keys(
+            required_resource_keys or set(),
+            resource_defs_for_execution,
+            fn=fn,
+            decorator_name="@asset_check",
         )
-
-        resource_defs_keys = set(resource_defs.keys() if resource_defs else [])
-        decorator_resource_keys = (required_resource_keys or set()) | resource_defs_keys
-
-        op_required_resource_keys = decorator_resource_keys - arg_resource_keys
 
         out = Out(dagster_type=None)
 
@@ -249,7 +246,7 @@ def asset_check(
                 for asset_key, input_tuple in input_tuples_by_asset_key.items()
             },
             node_def=op_def,
-            resource_defs=wrap_resources_for_execution(resource_defs),
+            resource_defs=resource_defs_for_execution,
             check_specs_by_output_name={op_def.output_defs[0].name: spec},
             can_subset=False,
         )


### PR DESCRIPTION
## Summary & Motivation

Using `compute_required_resource_keys` in `asset_check` codepath.

## How I Tested These Changes

BK