### PR TITLE
Fix multi-asset sensor logging

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -215,6 +215,9 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
             If needed by the sensor, top-level resource definitions will be pulled from these
             definitions. You can provide either this or `repository_def`.
         last_sensor_start_time (Optional[float]): The last time the sensor was started.
+        log_key (Optional[List[str]]): The log key to use for this sensor tick.
+        sensor_name (Optional[str]): The name of the sensor, used for logging and error messages.
+        code_location_origin (Optional[CodeLocationOrigin]): The code location that the sensor is in.
 
     Example:
         .. code-block:: python
@@ -300,7 +303,7 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
             last_sensor_start_time=last_sensor_start_time,
             sensor_name=sensor_name,
             definitions=definitions,
-            last_completion_time=last_completion_time,
+            last_completion_time=None,
             code_location_origin=code_location_origin,
             log_key=log_key,
         )
@@ -1171,9 +1174,10 @@ class MultiAssetSensorDefinition(SensorDefinition):
                     instance=context.instance,
                     resource_defs=context.resource_defs,
                     sensor_name=context._sensor_name,  # noqa: SLF001
-                    last_completion_time=context.last_completion_time,
                     code_location_origin=context.code_location_origin,
                     log_key=context.log_key,
+                    # deprecated
+                    last_completion_time=None,
                 ) as multi_asset_sensor_context:
                     context_param_name = get_context_param_name(materialization_fn)
                     context_param = (

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -1170,7 +1170,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
                     monitored_assets=monitored_assets,
                     instance=context.instance,
                     resource_defs=context.resource_defs,
-                    sensor_name=context.sensor_name,
+                    sensor_name=context._sensor_name,  # noqa: SLF001
                     last_completion_time=context.last_completion_time,
                     code_location_origin=context.code_location_origin,
                     log_key=context.log_key,

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -1148,7 +1148,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
         )
 
         def _wrap_asset_fn(materialization_fn):
-            def _fn(context: SensorEvaluationContext):
+            def _fn(context):
                 def _check_cursor_not_set(sensor_result: SensorResult):
                     if sensor_result.cursor:
                         raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -3,7 +3,6 @@ import json
 from collections import OrderedDict, defaultdict
 from typing import (
     TYPE_CHECKING,
-    Any,
     Callable,
     Dict,
     Iterable,
@@ -1149,7 +1148,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
         )
 
         def _wrap_asset_fn(materialization_fn):
-            def _fn(context: SensorEvaluationContext) -> Iterator[Any]:
+            def _fn(context: SensorEvaluationContext):
                 def _check_cursor_not_set(sensor_result: SensorResult):
                     if sensor_result.cursor:
                         raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -115,7 +115,7 @@ DEFAULT_SENSOR_DAEMON_INTERVAL = 30
     breaking_version="2.0",
     additional_warn_text="Use `last_tick_completion_time` instead.",
 )
-class SensorEvaluationContext:
+class SensorEvaluationContext(IHasInternalInit):
     """The context object available as the argument to the evaluation function of a :py:class:`dagster.SensorDefinition`.
 
     Users should not instantiate this object directly. To construct a
@@ -154,6 +154,41 @@ class SensorEvaluationContext:
                 ...
 
     """
+
+    @staticmethod
+    def dagster_internal_init(
+        instance_ref: Optional[InstanceRef],
+        last_tick_completion_time: Optional[float],
+        last_run_key: Optional[str],
+        cursor: Optional[str],
+        log_key: Optional[Sequence[str]],
+        repository_name: Optional[str],
+        repository_def: Optional["RepositoryDefinition"],
+        instance: Optional[DagsterInstance],
+        sensor_name: Optional[str],
+        resources: Optional[Mapping[str, "ResourceDefinition"]],
+        definitions: Optional["Definitions"],
+        last_sensor_start_time: Optional[float],
+        code_location_origin: Optional["CodeLocationOrigin"],
+        # deprecated param
+        last_completion_time: Optional[float],
+    ):
+        return SensorEvaluationContext(
+            instance_ref=instance_ref,
+            last_tick_completion_time=last_tick_completion_time,
+            last_run_key=last_run_key,
+            cursor=cursor,
+            log_key=log_key,
+            repository_name=repository_name,
+            repository_def=repository_def,
+            instance=instance,
+            sensor_name=sensor_name,
+            resources=resources,
+            definitions=definitions,
+            last_sensor_start_time=last_sensor_start_time,
+            code_location_origin=code_location_origin,
+            last_completion_time=last_completion_time,
+        )
 
     def __init__(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -115,7 +115,7 @@ DEFAULT_SENSOR_DAEMON_INTERVAL = 30
     breaking_version="2.0",
     additional_warn_text="Use `last_tick_completion_time` instead.",
 )
-class SensorEvaluationContext(IHasInternalInit):
+class SensorEvaluationContext:
     """The context object available as the argument to the evaluation function of a :py:class:`dagster.SensorDefinition`.
 
     Users should not instantiate this object directly. To construct a
@@ -154,41 +154,6 @@ class SensorEvaluationContext(IHasInternalInit):
                 ...
 
     """
-
-    @staticmethod
-    def dagster_internal_init(
-        instance_ref: Optional[InstanceRef],
-        last_tick_completion_time: Optional[float],
-        last_run_key: Optional[str],
-        cursor: Optional[str],
-        log_key: Optional[Sequence[str]],
-        repository_name: Optional[str],
-        repository_def: Optional["RepositoryDefinition"],
-        instance: Optional[DagsterInstance],
-        sensor_name: Optional[str],
-        resources: Optional[Mapping[str, "ResourceDefinition"]],
-        definitions: Optional["Definitions"],
-        last_sensor_start_time: Optional[float],
-        code_location_origin: Optional["CodeLocationOrigin"],
-        # deprecated param
-        last_completion_time: Optional[float],
-    ):
-        return SensorEvaluationContext(
-            instance_ref=instance_ref,
-            last_tick_completion_time=last_tick_completion_time,
-            last_run_key=last_run_key,
-            cursor=cursor,
-            log_key=log_key,
-            repository_name=repository_name,
-            repository_def=repository_def,
-            instance=instance,
-            sensor_name=sensor_name,
-            resources=resources,
-            definitions=definitions,
-            last_sensor_start_time=last_sensor_start_time,
-            code_location_origin=code_location_origin,
-            last_completion_time=last_completion_time,
-        )
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary

Addresses #17461. Ensures the contextual info needed to set up sensor logging is properly passed through for multi-asset sensors.

Feels like we may want a `dagster_internal_init` pattern here for `SensorEvaluationContext`, but not sure we can do so for a subclass constructor, which has to call its superclass constructor.


## Test Plan

New, previously failing unit test.
