### PR TITLE
introduce ISubclassesMustSpecifyAllArgs utility

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -58,6 +58,7 @@ from dagster._core.storage.dagster_run import DagsterRun
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils import IHasInternalInit, normalize_to_repository
 from dagster._utils.merger import merge_dicts
+from dagster._utils.subclasses_must_specify_all_args import ISubclassesMustSpecifyAllArgs
 from dagster._utils.warnings import normalize_renamed_param
 
 from ..decorator_utils import (
@@ -115,7 +116,7 @@ DEFAULT_SENSOR_DAEMON_INTERVAL = 30
     breaking_version="2.0",
     additional_warn_text="Use `last_tick_completion_time` instead.",
 )
-class SensorEvaluationContext:
+class SensorEvaluationContext(ISubclassesMustSpecifyAllArgs):
     """The context object available as the argument to the evaluation function of a :py:class:`dagster.SensorDefinition`.
 
     Users should not instantiate this object directly. To construct a

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -53,6 +53,9 @@ import dagster._check as check
 import dagster._seven as seven
 
 from .internal_init import IHasInternalInit as IHasInternalInit
+from .subclasses_must_specify_all_args import (
+    ISubclassesMustSpecifyAllArgs as ISubclassesMustSpecifyAllArgs,
+)
 
 if sys.version_info > (3,):
     from pathlib import Path

--- a/python_modules/dagster/dagster/_utils/subclasses_must_specify_all_args.py
+++ b/python_modules/dagster/dagster/_utils/subclasses_must_specify_all_args.py
@@ -1,0 +1,2 @@
+class ISubclassesMustSpecifyAllArgs:
+    """Marker interface which indicates that all subclasses must call the __init__ method of this class with all arguments."""

--- a/python_modules/dagster/dagster_tests/general_tests/test_subclasses_must_specify_all_args_implementations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_subclasses_must_specify_all_args_implementations.py
@@ -1,0 +1,37 @@
+import ast
+import inspect
+from typing import Type, cast
+
+import dagster as dagster
+import pytest
+from dagster._utils import ISubclassesMustSpecifyAllArgs
+from dagster._utils.test import get_all_direct_subclasses_of_marker
+
+SPECIFY_ALL_ARGS_SUBCLASSES = get_all_direct_subclasses_of_marker(ISubclassesMustSpecifyAllArgs)
+
+
+@pytest.mark.parametrize("cls", SPECIFY_ALL_ARGS_SUBCLASSES)
+def test_dagster_internal_init_class_follow_rules(cls: Type):
+    implementers = get_all_direct_subclasses_of_marker(cls)
+    init_params = inspect.signature(cls.__init__).parameters
+    init_params_no_self = {k for k, v in init_params.items() if k != "self"}
+
+    for implementer in implementers:
+        implementer_init_fn = next(
+            fd
+            for fd in cast(ast.ClassDef, ast.parse(inspect.getsource(implementer)).body[0]).body
+            if isinstance(fd, ast.FunctionDef) and fd.name == "__init__"
+        )
+
+        last_init_expression = implementer_init_fn.body[-1]
+        assert isinstance(last_init_expression, ast.Expr)
+        assert isinstance(last_init_expression.value, ast.Call)
+
+        # ensure func name is right
+
+        kwargs = last_init_expression.value.keywords
+        kwarg_names = [kw.arg for kw in kwargs]
+
+        assert (
+            set(kwarg_names) == init_params_no_self
+        ), f"{implementer.__name__} must specify all args to super().__init__"


### PR DESCRIPTION
## Summary

Introduces an `ISubclassesMustSpecifyAllArgs` similar to #13970, which a class can implement to indicate that all subclasses should provide all kwargs to `super().__init__`.

This is not achievable with `IHasInternalInit` because of specific behavior around `__init__` vs calling an internal constructor (like `dagster_internal_init`).

Any class which implements this interface will be evaluated as part of our Python test suite, and the super call inspected to make sure it has a matching kwarg set.

Implements for `SensorEvaluationContext`, to prevent bugs like #17461 (fixed in #22261) from arising in the future.

## Test Plan

Inspect/ast test
