### PR TITLE
[dagster-embedded-elt] prepend partition to pipeline name only when asset is partitioned

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
@@ -168,10 +168,11 @@ class DagsterDltResource(ConfigurableResource):
                     if dlt_source_resource
                 ]
             )
+
         # https://github.com/dagster-io/dagster/issues/21022
-        if context.has_partition_key:
-            last_partition_key = context.partition_keys[-1]
-            dlt_pipeline.pipeline_name += f"_{last_partition_key}"
+        if isinstance(context, AssetExecutionContext):
+            if context.assets_def.partitions_def is not None:
+                dlt_pipeline.pipeline_name += f"_{context.partition_key}"
 
         load_info = dlt_pipeline.run(dlt_source, **kwargs)
 


### PR DESCRIPTION
## Summary & Motivation

We were running into a problem where `context.has_partition_key` was true even when the _dlt_ asset was not partitioned, thus `context.partition_keys` was undefined.

This is because `context.has_partition_key` is scoped to the _run_. I should note that this was relatively unclear to me, as I assumed that the property on the `AssetExecutionContext` would be scoped to the asset.

```
dagster._core.errors.DagsterInvariantViolationError: Cannot access partition_keys for a non-partitioned run

  File "/opt/dagster/app/dagster_open_platform/assets/dlt.py", line 67, in thinkific_assets
    yield from dlt.run(context=context)
  File "/usr/local/lib/python3.11/site-packages/dagster_embedded_elt/dlt/resource.py", line 173, in run
    last_partition_key = context.partition_keys[-1]
                         ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/dagster/_core/execution/context/compute.py", line 1677, in partition_keys
    return self.op_execution_context.partition_keys
```

## How I Tested These Changes

- Unit tests ran green
