### PR TITLE
Collapse imports where possible

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_nightly_pipeline.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_nightly_pipeline.py
@@ -3,9 +3,7 @@ from typing import List
 from ..package_spec import PackageSpec
 from ..python_version import AvailablePythonVersion
 from ..steps.packages import build_steps_from_package_specs, gcp_creds_extra_cmds
-from ..utils import (
-    BuildkiteStep,
-)
+from ..utils import BuildkiteStep
 
 
 def build_dagster_oss_nightly_steps() -> List[BuildkiteStep]:

--- a/docs/content/concepts/io-management/io-managers.mdx
+++ b/docs/content/concepts/io-management/io-managers.mdx
@@ -675,11 +675,7 @@ The `UPathIOManager` already implements the `load_input` and `handle_output` met
 import pandas as pd
 from upath import UPath
 
-from dagster import (
-    InputContext,
-    OutputContext,
-    UPathIOManager,
-)
+from dagster import InputContext, OutputContext, UPathIOManager
 
 
 class PandasParquetIOManager(UPathIOManager):

--- a/docs/content/getting-started/quickstart.mdx
+++ b/docs/content/getting-started/quickstart.mdx
@@ -133,11 +133,7 @@ import json
 import pandas as pd
 import requests
 
-from dagster import (
-    MaterializeResult,
-    MetadataValue,
-    asset,
-)
+from dagster import MaterializeResult, MetadataValue, asset
 
 from .configurations import HNStoriesConfig
 

--- a/docs/content/integrations/airflow/migrating-to-dagster.mdx
+++ b/docs/content/integrations/airflow/migrating-to-dagster.mdx
@@ -98,9 +98,7 @@ In the `dagster_migration.py` file you created in [Step 1](#step-1-prepare-your-
 ```python file=/integrations/airflow/migrate_repo.py
 import os
 
-from dagster_airflow import (
-    make_dagster_definitions_from_airflow_dags_path,
-)
+from dagster_airflow import make_dagster_definitions_from_airflow_dags_path
 
 migrated_airflow_definitions = make_dagster_definitions_from_airflow_dags_path(
     os.path.abspath("./dags/"),

--- a/docs/content/integrations/airflow/reference.mdx
+++ b/docs/content/integrations/airflow/reference.mdx
@@ -16,9 +16,7 @@ To load all Airflow DAGS in a file path into a [Dagster repository](/concepts/re
 ```python file=/integrations/airflow/migrate_repo.py
 import os
 
-from dagster_airflow import (
-    make_dagster_definitions_from_airflow_dags_path,
-)
+from dagster_airflow import make_dagster_definitions_from_airflow_dags_path
 
 migrated_airflow_definitions = make_dagster_definitions_from_airflow_dags_path(
     os.path.abspath("./dags/"),

--- a/docs/content/integrations/bigquery/reference.mdx
+++ b/docs/content/integrations/bigquery/reference.mdx
@@ -430,16 +430,8 @@ The `BigQueryPySparkIOManager` requires that a `SparkSession` be active and conf
 from dagster_gcp_pyspark import BigQueryPySparkIOManager
 from dagster_pyspark import pyspark_resource
 from pyspark import SparkFiles
-from pyspark.sql import (
-    DataFrame,
-    SparkSession,
-)
-from pyspark.sql.types import (
-    DoubleType,
-    StringType,
-    StructField,
-    StructType,
-)
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import DoubleType, StringType, StructField, StructType
 
 from dagster import AssetExecutionContext, Definitions, asset
 
@@ -486,16 +478,8 @@ defs = Definitions(
 ```python file=/integrations/bigquery/reference/pyspark_with_spark_session.py
 from dagster_gcp_pyspark import BigQueryPySparkIOManager
 from pyspark import SparkFiles
-from pyspark.sql import (
-    DataFrame,
-    SparkSession,
-)
-from pyspark.sql.types import (
-    DoubleType,
-    StringType,
-    StructField,
-    StructType,
-)
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import DoubleType, StringType, StructField, StructType
 
 from dagster import Definitions, asset
 

--- a/docs/content/integrations/databricks.mdx
+++ b/docs/content/integrations/databricks.mdx
@@ -82,11 +82,7 @@ def my_databricks_job():
 ```python startafter=start_define_databricks_custom_op endbefore=end_define_databricks_custom_op file=/integrations/databricks/databricks.py dedent=4
 from databricks_cli.sdk import DbfsService
 
-from dagster import (
-    AssetExecutionContext,
-    job,
-    op,
-)
+from dagster import AssetExecutionContext, job, op
 
 @op(required_resource_keys={"databricks"})
 def my_databricks_op(context: AssetExecutionContext) -> None:
@@ -107,12 +103,7 @@ def my_databricks_job():
 ```python startafter=start_define_databricks_custom_asset endbefore=end_define_databricks_custom_asset file=/integrations/databricks/databricks.py dedent=4
 from databricks_cli.sdk import JobsService
 
-from dagster import (
-    AssetExecutionContext,
-    AssetSelection,
-    asset,
-    define_asset_job,
-)
+from dagster import AssetExecutionContext, AssetSelection, asset, define_asset_job
 
 @asset(required_resource_keys={"databricks"})
 def my_databricks_table(context: AssetExecutionContext) -> None:
@@ -140,11 +131,7 @@ Now that your Databricks API calls are modeled within Dagster, you can [schedule
 In the example below, we schedule the `materialize_databricks_table` and `my_databricks_job` jobs to run daily:
 
 ```python startafter=start_schedule_databricks endbefore=end_schedule_databricks file=/integrations/databricks/databricks.py dedent=4
-from dagster import (
-    AssetSelection,
-    Definitions,
-    ScheduleDefinition,
-)
+from dagster import AssetSelection, Definitions, ScheduleDefinition
 
 defs = Definitions(
     assets=[my_databricks_table],

--- a/docs/content/integrations/duckdb/reference.mdx
+++ b/docs/content/integrations/duckdb/reference.mdx
@@ -426,15 +426,8 @@ The `DuckDBPySparkIOManager` requires an active `SparkSession`. You can either c
 from dagster_duckdb_pyspark import DuckDBPySparkIOManager
 from dagster_pyspark import pyspark_resource
 from pyspark import SparkFiles
-from pyspark.sql import (
-    DataFrame,
-)
-from pyspark.sql.types import (
-    DoubleType,
-    StringType,
-    StructField,
-    StructType,
-)
+from pyspark.sql import DataFrame
+from pyspark.sql.types import DoubleType, StringType, StructField, StructType
 
 from dagster import AssetExecutionContext, Definitions, asset
 
@@ -477,16 +470,8 @@ defs = Definitions(
 ```python file=/integrations/duckdb/reference/pyspark_with_spark_session.py startafter=start endbefore=end
 from dagster_duckdb_pyspark import DuckDBPySparkIOManager
 from pyspark import SparkFiles
-from pyspark.sql import (
-    DataFrame,
-    SparkSession,
-)
-from pyspark.sql.types import (
-    DoubleType,
-    StringType,
-    StructField,
-    StructType,
-)
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import DoubleType, StringType, StructField, StructType
 
 from dagster import Definitions, asset
 

--- a/docs/content/integrations/embedded-elt/sling.mdx
+++ b/docs/content/integrations/embedded-elt/sling.mdx
@@ -96,10 +96,7 @@ replication_config = {
 Next, you'll create a <PyObject module="dagster_embedded_elt.sling" object="SlingResource" /> object that contains references to the connections specified in the replication configuration:
 
 ```python file=/integrations/embedded_elt/sling_connection_resources.py
-from dagster_embedded_elt.sling.resources import (
-    SlingConnectionResource,
-    SlingResource,
-)
+from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingResource
 
 from dagster import EnvVar
 
@@ -144,10 +141,7 @@ Next, define a Sling asset using the <PyObject module="dagster_embedded_elt.slin
 Each stream will render two assets, one for the source stream and one for the target destination. You can override how assets are named by passing in a custom <PyObject module="dagster_embedded_elt.sling" object="DagsterSlingTranslator" /> object.
 
 ```python file=/integrations/embedded_elt/sling_dagster_translator.py lines=1-16
-from dagster_embedded_elt.sling import (
-    SlingResource,
-    sling_assets,
-)
+from dagster_embedded_elt.sling import SlingResource, sling_assets
 
 from dagster import Definitions, file_relative_path
 
@@ -160,6 +154,9 @@ def my_assets(context, sling: SlingResource):
     yield from sling.replicate(context=context)
     for row in sling.stream_raw_logs():
         context.log.info(row)
+
+
+defs = Definitions(
 ```
 
 ---
@@ -169,10 +166,7 @@ def my_assets(context, sling: SlingResource):
 The last step is to include the Sling assets and resource in a <PyObject object="Definitions" /> object. This enables Dagster tools to load everything we've defined:
 
 ```python file=/integrations/embedded_elt/sling_dagster_translator.py lines=19-26
-defs = Definitions(
-    assets=[
-        my_assets,
-    ],
+],
     resources={
         "sling": sling_resource,
     },

--- a/docs/content/integrations/openai.mdx
+++ b/docs/content/integrations/openai.mdx
@@ -69,13 +69,7 @@ The OpenAI resource can be used in assets in order to interact with the OpenAI A
 ```python startafter=start_example endbefore=end_example file=/integrations/openai/assets.py
 from dagster_openai import OpenAIResource
 
-from dagster import (
-    AssetExecutionContext,
-    Definitions,
-    EnvVar,
-    asset,
-    define_asset_job,
-)
+from dagster import AssetExecutionContext, Definitions, EnvVar, asset, define_asset_job
 
 
 @asset(compute_kind="OpenAI")
@@ -109,13 +103,7 @@ The OpenAI resource can also be used in ops. **Note**: Currently, the OpenAI res
 ```python startafter=start_example endbefore=end_example file=/integrations/openai/ops.py
 from dagster_openai import OpenAIResource
 
-from dagster import (
-    Definitions,
-    EnvVar,
-    GraphDefinition,
-    OpExecutionContext,
-    op,
-)
+from dagster import Definitions, EnvVar, GraphDefinition, OpExecutionContext, op
 
 
 @op

--- a/docs/content/integrations/snowflake/reference.mdx
+++ b/docs/content/integrations/snowflake/reference.mdx
@@ -551,15 +551,8 @@ The `SnowflakePySparkIOManager` requires that a `SparkSession` be active and con
 from dagster_pyspark import pyspark_resource
 from dagster_snowflake_pyspark import SnowflakePySparkIOManager
 from pyspark import SparkFiles
-from pyspark.sql import (
-    DataFrame,
-)
-from pyspark.sql.types import (
-    DoubleType,
-    StringType,
-    StructField,
-    StructType,
-)
+from pyspark.sql import DataFrame
+from pyspark.sql.types import DoubleType, StringType, StructField, StructType
 
 from dagster import AssetExecutionContext, Definitions, EnvVar, asset
 
@@ -610,16 +603,8 @@ defs = Definitions(
 ```python file=/integrations/snowflake/pyspark_with_spark_session.py
 from dagster_snowflake_pyspark import SnowflakePySparkIOManager
 from pyspark import SparkFiles
-from pyspark.sql import (
-    DataFrame,
-    SparkSession,
-)
-from pyspark.sql.types import (
-    DoubleType,
-    StringType,
-    StructField,
-    StructType,
-)
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import DoubleType, StringType, StructField, StructType
 
 from dagster import Definitions, EnvVar, asset
 

--- a/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py
+++ b/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py
@@ -22,9 +22,7 @@ from sphinx.ext.autodoc import (
 from sphinx.util import logging
 from typing_extensions import Literal, TypeAlias
 
-from dagster_sphinx.configurable import (
-    ConfigurableDocumenter,
-)
+from dagster_sphinx.configurable import ConfigurableDocumenter
 from dagster_sphinx.docstring_flags import (
     FlagDirective,
     depart_flag,

--- a/examples/assets_dbt_python/assets_dbt_python/__init__.py
+++ b/examples/assets_dbt_python/assets_dbt_python/__init__.py
@@ -10,11 +10,7 @@ from dagster import (
 from dagster_duckdb_pandas import DuckDBPandasIOManager
 
 from .assets import forecasting, raw_data
-from .assets.dbt import (
-    DBT_PROJECT_DIR,
-    dbt_project_assets,
-    dbt_resource,
-)
+from .assets.dbt import DBT_PROJECT_DIR, dbt_project_assets, dbt_resource
 
 raw_data_assets = load_assets_from_package_module(
     raw_data,

--- a/examples/assets_dbt_python/assets_dbt_python/assets/dbt/__init__.py
+++ b/examples/assets_dbt_python/assets_dbt_python/assets/dbt/__init__.py
@@ -1,12 +1,7 @@
 from typing import Any, Mapping
 
 from dagster import AssetExecutionContext, AssetKey, file_relative_path
-from dagster_dbt import (
-    DagsterDbtTranslator,
-    DbtCliResource,
-    dbt_assets,
-    get_asset_key_for_model,
-)
+from dagster_dbt import DagsterDbtTranslator, DbtCliResource, dbt_assets, get_asset_key_for_model
 
 DBT_PROJECT_DIR = file_relative_path(__file__, "../../../dbt_project")
 

--- a/examples/assets_smoke_test/assets_smoke_test_tests/test_smoke_python_and_dbt_assets.py
+++ b/examples/assets_smoke_test/assets_smoke_test_tests/test_smoke_python_and_dbt_assets.py
@@ -6,10 +6,7 @@ from dagster_dbt import DbtCliResource
 from dagster_snowflake_pandas import SnowflakePandasIOManager
 
 from assets_smoke_test import python_and_dbt_assets
-from assets_smoke_test.python_and_dbt_assets import (
-    DBT_PROJECT_DIR,
-    raw_country_populations,
-)
+from assets_smoke_test.python_and_dbt_assets import DBT_PROJECT_DIR, raw_country_populations
 
 
 def smoke_all_test():

--- a/examples/docs_snippets/docs_snippets/concepts/io_management/filesystem_io_manager.py
+++ b/examples/docs_snippets/docs_snippets/concepts/io_management/filesystem_io_manager.py
@@ -2,11 +2,7 @@
 import pandas as pd
 from upath import UPath
 
-from dagster import (
-    InputContext,
-    OutputContext,
-    UPathIOManager,
-)
+from dagster import InputContext, OutputContext, UPathIOManager
 
 
 class PandasParquetIOManager(UPathIOManager):

--- a/examples/docs_snippets/docs_snippets/getting-started/quickstart/assets.py
+++ b/examples/docs_snippets/docs_snippets/getting-started/quickstart/assets.py
@@ -3,11 +3,7 @@ import json
 import pandas as pd
 import requests
 
-from dagster import (
-    MaterializeResult,
-    MetadataValue,
-    asset,
-)
+from dagster import MaterializeResult, MetadataValue, asset
 
 from .configurations import HNStoriesConfig
 

--- a/examples/docs_snippets/docs_snippets/integrations/airflow/migrate_repo.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airflow/migrate_repo.py
@@ -1,8 +1,6 @@
 import os
 
-from dagster_airflow import (
-    make_dagster_definitions_from_airflow_dags_path,
-)
+from dagster_airflow import make_dagster_definitions_from_airflow_dags_path
 
 migrated_airflow_definitions = make_dagster_definitions_from_airflow_dags_path(
     os.path.abspath("./dags/"),

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/pyspark_with_spark_resource.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/pyspark_with_spark_resource.py
@@ -1,16 +1,8 @@
 from dagster_gcp_pyspark import BigQueryPySparkIOManager
 from dagster_pyspark import pyspark_resource
 from pyspark import SparkFiles
-from pyspark.sql import (
-    DataFrame,
-    SparkSession,
-)
-from pyspark.sql.types import (
-    DoubleType,
-    StringType,
-    StructField,
-    StructType,
-)
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import DoubleType, StringType, StructField, StructType
 
 from dagster import AssetExecutionContext, Definitions, asset
 

--- a/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/pyspark_with_spark_session.py
+++ b/examples/docs_snippets/docs_snippets/integrations/bigquery/reference/pyspark_with_spark_session.py
@@ -1,15 +1,7 @@
 from dagster_gcp_pyspark import BigQueryPySparkIOManager
 from pyspark import SparkFiles
-from pyspark.sql import (
-    DataFrame,
-    SparkSession,
-)
-from pyspark.sql.types import (
-    DoubleType,
-    StringType,
-    StructField,
-    StructType,
-)
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import DoubleType, StringType, StructField, StructType
 
 from dagster import Definitions, asset
 

--- a/examples/docs_snippets/docs_snippets/integrations/databricks/databricks.py
+++ b/examples/docs_snippets/docs_snippets/integrations/databricks/databricks.py
@@ -21,12 +21,7 @@ def scope_define_databricks_custom_asset():
     # start_define_databricks_custom_asset
     from databricks_cli.sdk import JobsService
 
-    from dagster import (
-        AssetExecutionContext,
-        AssetSelection,
-        asset,
-        define_asset_job,
-    )
+    from dagster import AssetExecutionContext, AssetSelection, asset, define_asset_job
 
     @asset(required_resource_keys={"databricks"})
     def my_databricks_table(context: AssetExecutionContext) -> None:
@@ -49,11 +44,7 @@ def scope_define_databricks_custom_op():
     # start_define_databricks_custom_op
     from databricks_cli.sdk import DbfsService
 
-    from dagster import (
-        AssetExecutionContext,
-        job,
-        op,
-    )
+    from dagster import AssetExecutionContext, job, op
 
     @op(required_resource_keys={"databricks"})
     def my_databricks_op(context: AssetExecutionContext) -> None:
@@ -104,11 +95,7 @@ def scope_schedule_databricks():
     def my_databricks_job(): ...
 
     # start_schedule_databricks
-    from dagster import (
-        AssetSelection,
-        Definitions,
-        ScheduleDefinition,
-    )
+    from dagster import AssetSelection, Definitions, ScheduleDefinition
 
     defs = Definitions(
         assets=[my_databricks_table],

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/pyspark_with_spark_resource.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/pyspark_with_spark_resource.py
@@ -1,15 +1,8 @@
 from dagster_duckdb_pyspark import DuckDBPySparkIOManager
 from dagster_pyspark import pyspark_resource
 from pyspark import SparkFiles
-from pyspark.sql import (
-    DataFrame,
-)
-from pyspark.sql.types import (
-    DoubleType,
-    StringType,
-    StructField,
-    StructType,
-)
+from pyspark.sql import DataFrame
+from pyspark.sql.types import DoubleType, StringType, StructField, StructType
 
 from dagster import AssetExecutionContext, Definitions, asset
 

--- a/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/pyspark_with_spark_session.py
+++ b/examples/docs_snippets/docs_snippets/integrations/duckdb/reference/pyspark_with_spark_session.py
@@ -3,16 +3,8 @@
 # start
 from dagster_duckdb_pyspark import DuckDBPySparkIOManager
 from pyspark import SparkFiles
-from pyspark.sql import (
-    DataFrame,
-    SparkSession,
-)
-from pyspark.sql.types import (
-    DoubleType,
-    StringType,
-    StructField,
-    StructType,
-)
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import DoubleType, StringType, StructField, StructType
 
 from dagster import Definitions, asset
 

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/sling_connection_resources.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/sling_connection_resources.py
@@ -1,8 +1,5 @@
 # pyright: reportCallIssue=none
-from dagster_embedded_elt.sling.resources import (
-    SlingConnectionResource,
-    SlingResource,
-)
+from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingResource
 
 from dagster import EnvVar
 

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/sling_dagster_translator.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/sling_dagster_translator.py
@@ -1,7 +1,4 @@
-from dagster_embedded_elt.sling import (
-    SlingResource,
-    sling_assets,
-)
+from dagster_embedded_elt.sling import SlingResource, sling_assets
 
 from dagster import Definitions, file_relative_path
 

--- a/examples/docs_snippets/docs_snippets/integrations/openai/assets.py
+++ b/examples/docs_snippets/docs_snippets/integrations/openai/assets.py
@@ -1,13 +1,7 @@
 # start_example
 from dagster_openai import OpenAIResource
 
-from dagster import (
-    AssetExecutionContext,
-    Definitions,
-    EnvVar,
-    asset,
-    define_asset_job,
-)
+from dagster import AssetExecutionContext, Definitions, EnvVar, asset, define_asset_job
 
 
 @asset(compute_kind="OpenAI")

--- a/examples/docs_snippets/docs_snippets/integrations/openai/ops.py
+++ b/examples/docs_snippets/docs_snippets/integrations/openai/ops.py
@@ -1,13 +1,7 @@
 # start_example
 from dagster_openai import OpenAIResource
 
-from dagster import (
-    Definitions,
-    EnvVar,
-    GraphDefinition,
-    OpExecutionContext,
-    op,
-)
+from dagster import Definitions, EnvVar, GraphDefinition, OpExecutionContext, op
 
 
 @op

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/pyspark_with_spark_resource.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/pyspark_with_spark_resource.py
@@ -1,15 +1,8 @@
 from dagster_pyspark import pyspark_resource
 from dagster_snowflake_pyspark import SnowflakePySparkIOManager
 from pyspark import SparkFiles
-from pyspark.sql import (
-    DataFrame,
-)
-from pyspark.sql.types import (
-    DoubleType,
-    StringType,
-    StructField,
-    StructType,
-)
+from pyspark.sql import DataFrame
+from pyspark.sql.types import DoubleType, StringType, StructField, StructType
 
 from dagster import AssetExecutionContext, Definitions, EnvVar, asset
 

--- a/examples/docs_snippets/docs_snippets/integrations/snowflake/pyspark_with_spark_session.py
+++ b/examples/docs_snippets/docs_snippets/integrations/snowflake/pyspark_with_spark_session.py
@@ -1,15 +1,7 @@
 from dagster_snowflake_pyspark import SnowflakePySparkIOManager
 from pyspark import SparkFiles
-from pyspark.sql import (
-    DataFrame,
-    SparkSession,
-)
-from pyspark.sql.types import (
-    DoubleType,
-    StringType,
-    StructField,
-    StructType,
-)
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import DoubleType, StringType, StructField, StructType
 
 from dagster import Definitions, EnvVar, asset
 

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_observable_source_asset.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_observable_source_asset.py
@@ -1,6 +1,4 @@
-from dagster._core.definitions.data_version import (
-    extract_data_version_from_entry,
-)
+from dagster._core.definitions.data_version import extract_data_version_from_entry
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.instance_for_test import instance_for_test
 from dagster._core.test_utils import create_test_asset_job

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/backfills_tests/test_single_run_backfill_asset.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/partitions_schedules_sensors_tests/backfills_tests/test_single_run_backfill_asset.py
@@ -1,8 +1,4 @@
-from dagster import (
-    SourceAsset,
-    materialize,
-    mem_io_manager,
-)
+from dagster import SourceAsset, materialize, mem_io_manager
 from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
     ASSET_PARTITION_RANGE_START_TAG,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/resources_tests/test_pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/resources_tests/test_pythonic_resources.py
@@ -8,9 +8,7 @@ from dagster._core.errors import DagsterInvalidConfigError
 
 
 def test_new_resource_testing() -> None:
-    from docs_snippets.concepts.resources.pythonic_resources import (
-        new_resource_testing,
-    )
+    from docs_snippets.concepts.resources.pythonic_resources import new_resource_testing
 
     new_resource_testing()
 
@@ -62,9 +60,7 @@ def test_new_resources_configurable_defs() -> None:
 
 
 def test_new_resource_runtime() -> None:
-    from docs_snippets.concepts.resources.pythonic_resources import (
-        new_resource_runtime,
-    )
+    from docs_snippets.concepts.resources.pythonic_resources import new_resource_runtime
 
     defs = new_resource_runtime()
 

--- a/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_monitoring_daemon_examples.py
+++ b/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_monitoring_daemon_examples.py
@@ -1,8 +1,5 @@
 from dagster import MAX_RUNTIME_SECONDS_TAG
-from docs_snippets.deploying.monitoring_daemon.run_timeouts import (
-    asset_job,
-    my_job,
-)
+from docs_snippets.deploying.monitoring_daemon.run_timeouts import asset_job, my_job
 
 
 def test_run_timeouts():

--- a/examples/docs_snippets/docs_snippets_tests/tutorial_tests/connecting/test_resources.py
+++ b/examples/docs_snippets/docs_snippets_tests/tutorial_tests/connecting/test_resources.py
@@ -5,9 +5,7 @@ from docs_snippets.tutorial.connecting import (
     connecting_with_config,
     connecting_with_envvar,
 )
-from docs_snippets.tutorial.connecting.resources import (
-    DataGeneratorResource,
-)
+from docs_snippets.tutorial.connecting.resources import DataGeneratorResource
 
 
 def test_definitions_with_resources():

--- a/examples/experimental/external_assets/airflow_example.py
+++ b/examples/experimental/external_assets/airflow_example.py
@@ -1,7 +1,5 @@
 from airflow import DAG
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
-    KubernetesPodOperator,
-)
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from pendulum import datetime
 
 default_args = {

--- a/examples/experimental/external_assets/external_assets/__init__.py
+++ b/examples/experimental/external_assets/external_assets/__init__.py
@@ -1,9 +1,7 @@
 import os
 
 import kubernetes
-from dagster import (
-    Definitions,
-)
+from dagster import Definitions
 from dagster_k8s import PipesK8sClient
 
 from .external_assets import external_asset_defs

--- a/examples/experimental/external_assets/external_assets/external_assets/__init__.py
+++ b/examples/experimental/external_assets/external_assets/external_assets/__init__.py
@@ -3,9 +3,7 @@ import os
 import yaml
 from dagster import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.definitions.external_asset import (
-    external_assets_from_specs,
-)
+from dagster._core.definitions.external_asset import external_assets_from_specs
 
 
 def build_asset_specs_from_external_definitions():

--- a/examples/experimental/sling_decorator/sling_decorator/__init__.py
+++ b/examples/experimental/sling_decorator/sling_decorator/__init__.py
@@ -1,11 +1,6 @@
 from dagster import Definitions, file_relative_path
-from dagster_embedded_elt.sling import (
-    sling_assets,
-)
-from dagster_embedded_elt.sling.resources import (
-    SlingConnectionResource,
-    SlingResource,
-)
+from dagster_embedded_elt.sling import sling_assets
+from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingResource
 
 replication_config = file_relative_path(__file__, "../sling_replication.yaml")
 

--- a/examples/project_analytics/dagster_pypi/__init__.py
+++ b/examples/project_analytics/dagster_pypi/__init__.py
@@ -1,9 +1,4 @@
-from dagster import (
-    Definitions,
-    ScheduleDefinition,
-    define_asset_job,
-    load_assets_from_modules,
-)
+from dagster import Definitions, ScheduleDefinition, define_asset_job, load_assets_from_modules
 
 from . import assets, resources
 

--- a/examples/project_analytics/dagster_pypi/assets.py
+++ b/examples/project_analytics/dagster_pypi/assets.py
@@ -1,19 +1,8 @@
 import pandas as pd
-from dagster import (
-    AssetExecutionContext,
-    DailyPartitionsDefinition,
-    MetadataValue,
-    asset,
-)
+from dagster import AssetExecutionContext, DailyPartitionsDefinition, MetadataValue, asset
 from dagster_dbt import DbtCliResource, dbt_assets, get_asset_key_for_model
 
-from .resources import (
-    ENV,
-    HEX_PROJECT_ID,
-    GithubResource,
-    PyPiResource,
-    resource_def,
-)
+from .resources import ENV, HEX_PROJECT_ID, GithubResource, PyPiResource, resource_def
 
 dbt_parse_invocation = resource_def[ENV.upper()]["dbt"].cli(["parse"]).wait()
 dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")

--- a/examples/project_fully_featured/project_fully_featured/__init__.py
+++ b/examples/project_fully_featured/project_fully_featured/__init__.py
@@ -8,11 +8,7 @@ from .assets import (
     hacker_news_dbt_assets,
     recommender_assets,
 )
-from .jobs import (
-    activity_analytics_assets_sensor,
-    core_assets_schedule,
-    recommender_assets_sensor,
-)
+from .jobs import activity_analytics_assets_sensor, core_assets_schedule, recommender_assets_sensor
 from .resources import RESOURCES_LOCAL, RESOURCES_PROD, RESOURCES_STAGING
 from .sensors import make_slack_on_failure_sensor
 

--- a/examples/project_fully_featured/project_fully_featured/assets/__init__.py
+++ b/examples/project_fully_featured/project_fully_featured/assets/__init__.py
@@ -2,11 +2,7 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from dagster import AssetExecutionContext, AssetKey, load_assets_from_package_module
-from dagster_dbt import (
-    DagsterDbtTranslator,
-    DbtCliResource,
-    dbt_assets,
-)
+from dagster_dbt import DagsterDbtTranslator, DbtCliResource, dbt_assets
 
 from . import activity_analytics, core, recommender
 

--- a/examples/project_fully_featured/project_fully_featured/assets/core/items.py
+++ b/examples/project_fully_featured/project_fully_featured/assets/core/items.py
@@ -1,14 +1,7 @@
 from dagster import AssetExecutionContext, Output, asset
 from pandas import DataFrame
 from pyspark.sql import DataFrame as SparkDF
-from pyspark.sql.types import (
-    ArrayType,
-    DoubleType,
-    LongType,
-    StringType,
-    StructField,
-    StructType,
-)
+from pyspark.sql.types import ArrayType, DoubleType, LongType, StringType, StructField, StructType
 
 from project_fully_featured.partitions import hourly_partitions
 from project_fully_featured.resources.hn_resource import HNClient

--- a/examples/project_fully_featured/project_fully_featured/resources/__init__.py
+++ b/examples/project_fully_featured/project_fully_featured/resources/__init__.py
@@ -8,10 +8,7 @@ from dagster_pyspark import pyspark_resource
 
 from .duckdb_parquet_io_manager import DuckDBPartitionedParquetIOManager
 from .hn_resource import HNAPIClient, HNAPISubsampleClient
-from .parquet_io_manager import (
-    LocalPartitionedParquetIOManager,
-    S3PartitionedParquetIOManager,
-)
+from .parquet_io_manager import LocalPartitionedParquetIOManager, S3PartitionedParquetIOManager
 from .snowflake_io_manager import SnowflakeIOManager
 
 DBT_PROJECT_DIR = file_relative_path(__file__, "../../dbt_project")

--- a/examples/project_fully_featured/project_fully_featured/sensors/hn_tables_updated_sensor.py
+++ b/examples/project_fully_featured/project_fully_featured/sensors/hn_tables_updated_sensor.py
@@ -1,12 +1,6 @@
 import json
 
-from dagster import (
-    AssetKey,
-    AssetRecordsFilter,
-    RunRequest,
-    SensorDefinition,
-    sensor,
-)
+from dagster import AssetKey, AssetRecordsFilter, RunRequest, SensorDefinition, sensor
 
 
 def make_hn_tables_updated_sensor(job) -> SensorDefinition:

--- a/examples/project_fully_featured/project_fully_featured_tests/recommender_tests/assets_tests/test_user_story_matrix.py
+++ b/examples/project_fully_featured/project_fully_featured_tests/recommender_tests/assets_tests/test_user_story_matrix.py
@@ -1,9 +1,7 @@
 import pytest
 from pandas import DataFrame
 
-from project_fully_featured.assets.recommender.user_story_matrix import (
-    user_story_matrix,
-)
+from project_fully_featured.assets.recommender.user_story_matrix import user_story_matrix
 
 
 @pytest.mark.parametrize(

--- a/examples/project_fully_featured/project_fully_featured_tests/recommender_tests/assets_tests/test_user_top_recommended_stories.py
+++ b/examples/project_fully_featured/project_fully_featured_tests/recommender_tests/assets_tests/test_user_top_recommended_stories.py
@@ -3,9 +3,7 @@ from pandas import DataFrame, Series
 from scipy.sparse import coo_matrix
 from sklearn.decomposition import TruncatedSVD
 
-from project_fully_featured.assets.recommender.user_story_matrix import (
-    IndexedCooMatrix,
-)
+from project_fully_featured.assets.recommender.user_story_matrix import IndexedCooMatrix
 from project_fully_featured.assets.recommender.user_top_recommended_stories import (
     user_top_recommended_stories,
 )

--- a/examples/project_fully_featured/project_fully_featured_tests/test_core.py
+++ b/examples/project_fully_featured/project_fully_featured_tests/test_core.py
@@ -11,9 +11,7 @@ from dagster_pyspark import pyspark_resource
 
 from project_fully_featured.assets import core
 from project_fully_featured.resources.hn_resource import HNSnapshotClient
-from project_fully_featured.resources.parquet_io_manager import (
-    LocalPartitionedParquetIOManager,
-)
+from project_fully_featured.resources.parquet_io_manager import LocalPartitionedParquetIOManager
 
 
 def test_download():

--- a/examples/project_fully_featured/project_fully_featured_tests/test_resources/test_parquet_io_manager.py
+++ b/examples/project_fully_featured/project_fully_featured_tests/test_resources/test_parquet_io_manager.py
@@ -7,9 +7,7 @@ from dagster_pyspark import pyspark_resource
 from pyspark.sql import DataFrame as SparkDF
 
 from project_fully_featured.partitions import hourly_partitions
-from project_fully_featured.resources.parquet_io_manager import (
-    LocalPartitionedParquetIOManager,
-)
+from project_fully_featured.resources.parquet_io_manager import LocalPartitionedParquetIOManager
 
 
 def test_io_manager():

--- a/examples/project_fully_featured/project_fully_featured_tests/test_sensors/test_hn_tables_updated_sensor.py
+++ b/examples/project_fully_featured/project_fully_featured_tests/test_sensors/test_hn_tables_updated_sensor.py
@@ -5,9 +5,7 @@ from unittest import mock
 from dagster import EventLogRecord, EventRecordsResult, GraphDefinition, build_sensor_context
 from dagster._core.test_utils import instance_for_test
 
-from project_fully_featured.sensors.hn_tables_updated_sensor import (
-    make_hn_tables_updated_sensor,
-)
+from project_fully_featured.sensors.hn_tables_updated_sensor import make_hn_tables_updated_sensor
 
 
 def get_mock_fetch_materializations(asset_events: List[Tuple[str, int]]):

--- a/examples/project_fully_featured/project_fully_featured_tests/test_sensors/test_slack_on_failure_sensor.py
+++ b/examples/project_fully_featured/project_fully_featured_tests/test_sensors/test_slack_on_failure_sensor.py
@@ -1,8 +1,6 @@
 from dagster import repository
 
-from project_fully_featured.sensors.slack_on_failure_sensor import (
-    make_slack_on_failure_sensor,
-)
+from project_fully_featured.sensors.slack_on_failure_sensor import make_slack_on_failure_sensor
 
 
 def test_slack_on_failure_def():

--- a/examples/with_airflow/with_airflow/__init__.py
+++ b/examples/with_airflow/with_airflow/__init__.py
@@ -1,6 +1,4 @@
-from .assets_repository import (
-    sda_examples as sda_examples,
-)
+from .assets_repository import sda_examples as sda_examples
 from .repository import (
     airflow_examples_repo as airflow_examples_repo,
     task_flow_repo as task_flow_repo,

--- a/examples/with_openai/baseline.py
+++ b/examples/with_openai/baseline.py
@@ -4,13 +4,7 @@ import subprocess
 import tempfile
 
 import requests
-from dagster import (
-    AssetSelection,
-    Definitions,
-    EnvVar,
-    asset,
-    define_asset_job,
-)
+from dagster import AssetSelection, Definitions, EnvVar, asset, define_asset_job
 from dagster_openai import OpenAIResource
 from langchain.docstore.document import Document
 from langchain.embeddings.openai import OpenAIEmbeddings

--- a/examples/with_openai/with_openai/definitions.py
+++ b/examples/with_openai/with_openai/definitions.py
@@ -1,14 +1,7 @@
 import json
 import os
 
-from dagster import (
-    Definitions,
-    EnvVar,
-    RunRequest,
-    SensorResult,
-    load_assets_from_modules,
-    sensor,
-)
+from dagster import Definitions, EnvVar, RunRequest, SensorResult, load_assets_from_modules, sensor
 from dagster_aws.s3 import S3PickleIOManager, S3Resource
 from dagster_openai import OpenAIResource
 

--- a/examples/with_wandb/with_wandb/definitions.py
+++ b/examples/with_wandb/with_wandb/definitions.py
@@ -1,9 +1,4 @@
-from dagster import (
-    Definitions,
-    StringSource,
-    load_assets_from_package_module,
-    make_values_resource,
-)
+from dagster import Definitions, StringSource, load_assets_from_package_module, make_values_resource
 from dagster_wandb import wandb_artifacts_io_manager, wandb_resource
 
 from . import assets

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -33,11 +33,7 @@ from schema.charts.dagster.subschema.daemon import (
 )
 from schema.charts.dagster.subschema.postgresql import PostgreSQL, Service
 from schema.charts.dagster.subschema.python_logs import PythonLogs
-from schema.charts.dagster.subschema.retention import (
-    Retention,
-    TickRetention,
-    TickRetentionByType,
-)
+from schema.charts.dagster.subschema.retention import Retention, TickRetention, TickRetentionByType
 from schema.charts.dagster.subschema.run_launcher import (
     CeleryK8sRunLauncherConfig,
     K8sRunLauncherConfig,

--- a/helm/dagster/schema/schema_tests/test_instance_migrate.py
+++ b/helm/dagster/schema/schema_tests/test_instance_migrate.py
@@ -5,9 +5,7 @@ from dagster_k8s.models import k8s_model_from_dict, k8s_snake_case_dict
 from kubernetes import client as k8s_client
 from kubernetes.client import models
 from schema.charts.dagster.subschema.migrate import Migrate
-from schema.charts.dagster.subschema.webserver import (
-    Webserver,
-)
+from schema.charts.dagster.subschema.webserver import Webserver
 from schema.charts.dagster.values import DagsterHelmValues
 from schema.charts.utils import kubernetes
 from schema.utils.helm_template import HelmTemplate

--- a/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/utils.py
+++ b/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/utils.py
@@ -3,10 +3,7 @@ import sys
 from contextlib import contextmanager
 
 from dagster import job, op, repository
-from dagster._core.remote_representation import (
-    JobHandle,
-    ManagedGrpcPythonEnvCodeLocationOrigin,
-)
+from dagster._core.remote_representation import JobHandle, ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.load_target import PythonFileTarget
 

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_executor.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_executor.py
@@ -34,9 +34,7 @@ from dagster_test.test_project import (
     get_test_project_docker_image,
     get_test_project_environments_path,
 )
-from dagster_test.test_project.test_jobs.repo import (
-    define_memoization_job,
-)
+from dagster_test.test_project.test_jobs.repo import define_memoization_job
 
 
 @pytest.mark.integration

--- a/integration_tests/test_suites/k8s-test-suite/tests/test_pipes.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_pipes.py
@@ -5,17 +5,13 @@ import kubernetes
 import pytest
 from dagster import AssetExecutionContext, asset, materialize
 from dagster._core.instance import DagsterInstance
-from dagster._core.pipes.client import (
-    PipesContextInjector,
-)
+from dagster._core.pipes.client import PipesContextInjector
 from dagster._core.pipes.utils import PipesEnvContextInjector, open_pipes_session
 from dagster_k8s import execute_k8s_job
 from dagster_k8s.client import DagsterKubernetesClient
 from dagster_k8s.pipes import PipesK8sClient, PipesK8sPodLogsMessageReader
 from dagster_pipes import PipesContextData, PipesDefaultContextLoader
-from dagster_test.test_project import (
-    get_test_project_docker_image,
-)
+from dagster_test.test_project import get_test_project_docker_image
 
 POLL_INTERVAL = 0.5
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,6 +253,9 @@ builtins-ignorelist = ["id"]
 # (`foo`) into a single statement.
 combine-as-imports = true
 
+# In cases where imports are automatically removed, allows the imports to be automatically collapsed
+split-on-trailing-comma = false
+
 # Imports of the form `from foo import bar as baz` show one `import bar as baz`
 # per line. Useful for __init__.py files that just re-export symbols.
 force-wrap-aliases = true

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
@@ -1,8 +1,6 @@
 from typing import Iterable, Iterator, List, Mapping, Optional, Tuple, cast
 
-from dagster import (
-    _check as check,
-)
+from dagster import _check as check
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
@@ -31,9 +29,7 @@ from dagster_graphql.schema.asset_checks import (
 )
 from dagster_graphql.schema.inputs import GraphenePipelineSelector
 
-from ..schema.asset_checks import (
-    GrapheneAssetCheckExecution,
-)
+from ..schema.asset_checks import GrapheneAssetCheckExecution
 from .fetch_asset_checks import asset_checks_iter
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -13,9 +13,7 @@ from dagster._core.events import (
     DagsterEventType,
     EngineEventData,
 )
-from dagster._core.instance import (
-    DagsterInstance,
-)
+from dagster._core.instance import DagsterInstance
 from dagster._core.storage.captured_log_manager import CapturedLogManager
 from dagster._core.storage.compute_log_manager import ComputeIOType, ComputeLogFileData
 from dagster._core.storage.dagster_run import CANCELABLE_RUN_STATUSES
@@ -26,9 +24,7 @@ from starlette.concurrency import (
 )
 
 if TYPE_CHECKING:
-    from dagster_graphql.schema.roots.mutation import (
-        GrapheneTerminateRunPolicy,
-    )
+    from dagster_graphql.schema.roots.mutation import GrapheneTerminateRunPolicy
 
 from ..utils import assert_permission, assert_permission_for_location
 from .backfill import (
@@ -164,9 +160,7 @@ def terminate_pipeline_execution_for_runs(
     run_ids: Sequence[str],
     terminate_policy: "GrapheneTerminateRunPolicy",
 ) -> "GrapheneTerminateRunsResult":
-    from ...schema.roots.mutation import (
-        GrapheneTerminateRunsResult,
-    )
+    from ...schema.roots.mutation import GrapheneTerminateRunsResult
 
     check.sequence_param(run_ids, "run_id", of_type=str)
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/dynamic_partitions.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/dynamic_partitions.py
@@ -1,13 +1,9 @@
 from typing import TYPE_CHECKING, Sequence
 
-from dagster._core.definitions.selector import (
-    RepositorySelector,
-)
+from dagster._core.definitions.selector import RepositorySelector
 from dagster._core.workspace.permissions import Permissions
 
-from dagster_graphql.schema.errors import (
-    GrapheneDuplicateDynamicPartitionError,
-)
+from dagster_graphql.schema.errors import GrapheneDuplicateDynamicPartitionError
 
 from ..utils import UserFacingGraphQLError, assert_permission_for_location
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -7,11 +7,7 @@ from dagster._core.storage.dagster_run import DagsterRun, RunsFilter
 from dagster._core.workspace.permissions import Permissions
 
 from ..external import get_external_job_or_raise
-from ..utils import (
-    ExecutionMetadata,
-    ExecutionParams,
-    assert_permission_for_location,
-)
+from ..utils import ExecutionMetadata, ExecutionParams, assert_permission_for_location
 from .run_lifecycle import create_valid_pipeline_run
 
 if TYPE_CHECKING:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
@@ -15,9 +15,7 @@ from dagster._core.storage.asset_check_execution_record import (
 from dagster._core.storage.dagster_run import DagsterRunStatus, RunsFilter
 from dagster._core.workspace.context import WorkspaceRequestContext
 
-from ..schema.asset_checks import (
-    GrapheneAssetCheckExecution,
-)
+from ..schema.asset_checks import GrapheneAssetCheckExecution
 from .fetch_assets import repository_iter
 
 if TYPE_CHECKING:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -55,10 +55,7 @@ from dagster._core.storage.partition_status_cache import (
 )
 from dagster._core.workspace.context import WorkspaceRequestContext
 
-from dagster_graphql.implementation.loader import (
-    CrossRepoAssetDependedByLoader,
-    StaleStatusLoader,
-)
+from dagster_graphql.implementation.loader import CrossRepoAssetDependedByLoader, StaleStatusLoader
 
 if TYPE_CHECKING:
     from ..schema.asset_graph import GrapheneAssetNode, GrapheneAssetNodeDefinitionCollision

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_backfills.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_backfills.py
@@ -5,10 +5,7 @@ from dagster._core.execution.backfill import BulkActionStatus
 if TYPE_CHECKING:
     from dagster_graphql.schema.util import ResolveInfo
 
-    from ..schema.backfill import (
-        GraphenePartitionBackfill,
-        GraphenePartitionBackfills,
-    )
+    from ..schema.backfill import GraphenePartitionBackfill, GraphenePartitionBackfills
 
 
 def get_backfill(graphene_info: "ResolveInfo", backfill_id: str) -> "GraphenePartitionBackfill":

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -4,10 +4,7 @@ from typing import TYPE_CHECKING, Optional, Sequence, Union
 import dagster._check as check
 from dagster._core.definitions.selector import RepositorySelector
 from dagster._core.errors import DagsterUserCodeProcessError
-from dagster._core.remote_representation import (
-    ExternalPartitionSet,
-    RepositoryHandle,
-)
+from dagster._core.remote_representation import ExternalPartitionSet, RepositoryHandle
 from dagster._core.remote_representation.external_data import (
     ExternalPartitionExecutionErrorData,
     ExternalPartitionNamesData,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -14,11 +14,7 @@ from dagster._seven import get_current_datetime_in_utc, get_timestamp_from_utc_d
 from dagster_graphql.schema.util import ResolveInfo
 
 from .loader import RepositoryScopedBatchLoader
-from .utils import (
-    UserFacingGraphQLError,
-    assert_permission,
-    assert_permission_for_location,
-)
+from .utils import UserFacingGraphQLError, assert_permission, assert_permission_for_location
 
 if TYPE_CHECKING:
     from ..schema.instigation import GrapheneDryRunInstigationTick

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -14,11 +14,7 @@ from dagster._seven import get_current_datetime_in_utc, get_timestamp_from_utc_d
 from dagster_graphql.schema.util import ResolveInfo
 
 from .loader import RepositoryScopedBatchLoader
-from .utils import (
-    UserFacingGraphQLError,
-    assert_permission,
-    assert_permission_for_location,
-)
+from .utils import UserFacingGraphQLError, assert_permission, assert_permission_for_location
 
 if TYPE_CHECKING:
     from dagster_graphql.schema.instigation import GrapheneDryRunInstigationTick

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_ticks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_ticks.py
@@ -2,10 +2,7 @@ import warnings
 from typing import TYPE_CHECKING, Optional, Sequence
 
 import pendulum
-from dagster._core.scheduler.instigation import (
-    InstigatorType,
-    TickStatus,
-)
+from dagster._core.scheduler.instigation import InstigatorType, TickStatus
 
 if TYPE_CHECKING:
     from ..schema.util import ResolveInfo

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/run_config_schema.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/run_config_schema.py
@@ -12,9 +12,7 @@ from .external import get_external_job_or_raise
 from .utils import JobSubsetSelector, UserFacingGraphQLError
 
 if TYPE_CHECKING:
-    from ..schema.pipelines.config import (
-        GraphenePipelineConfigValidationValid,
-    )
+    from ..schema.pipelines.config import GraphenePipelineConfigValidationValid
     from ..schema.run_config import GrapheneRunConfigSchema
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -17,9 +17,7 @@ from dagster._core.definitions.data_version import (
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader, PartitionsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
-from dagster._core.definitions.sensor_definition import (
-    SensorType,
-)
+from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import AssetRecordsFilter
 from dagster._core.events import DagsterEventType
@@ -69,14 +67,8 @@ from ..implementation.fetch_assets import (
     get_freshness_info,
     get_partition_subsets,
 )
-from ..implementation.loader import (
-    CrossRepoAssetDependedByLoader,
-    StaleStatusLoader,
-)
-from ..schema.asset_checks import (
-    AssetChecksOrErrorUnion,
-    GrapheneAssetChecksOrError,
-)
+from ..implementation.loader import CrossRepoAssetDependedByLoader, StaleStatusLoader
+from ..schema.asset_checks import AssetChecksOrErrorUnion, GrapheneAssetChecksOrError
 from . import external
 from .asset_key import GrapheneAssetKey
 from .auto_materialize_policy import GrapheneAutoMaterializePolicy

--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -2,9 +2,7 @@ from typing import Optional, Sequence, Tuple
 
 import graphene
 from dagster import PartitionsDefinition
-from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    AutoMaterializeDecisionType,
-)
+from dagster._core.definitions.auto_materialize_rule_evaluation import AutoMaterializeDecisionType
 from dagster._core.definitions.declarative_automation.legacy.rule_condition import RuleCondition
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AssetConditionEvaluation,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -6,18 +6,13 @@ from dagster import AssetKey
 from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPolicyType
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.time_window_partitions import (
-    BaseTimeWindowPartitionsSubset,
-)
+from dagster._core.definitions.time_window_partitions import BaseTimeWindowPartitionsSubset
 from dagster._core.execution.asset_backfill import (
     AssetBackfillStatus,
     PartitionedAssetBackfillStatus,
     UnpartitionedAssetBackfillStatus,
 )
-from dagster._core.execution.backfill import (
-    BulkActionStatus,
-    PartitionBackfill,
-)
+from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.external import ExternalPartitionSet
 from dagster._core.storage.dagster_run import DagsterRun, RunPartitionData, RunRecord, RunsFilter
@@ -50,13 +45,9 @@ from .pipelines.config import GrapheneRunConfigValidationInvalid
 from .util import ResolveInfo, non_null_list
 
 if TYPE_CHECKING:
-    from dagster_graphql.schema.partition_sets import (
-        GraphenePartitionStatusCounts,
-    )
+    from dagster_graphql.schema.partition_sets import GraphenePartitionStatusCounts
 
-    from ..schema.partition_sets import (
-        GraphenePartitionSet,
-    )
+    from ..schema.partition_sets import GraphenePartitionSet
     from .pipelines.pipeline import GrapheneRun
 
 pipeline_execution_error_types = (

--- a/python_modules/dagster-graphql/dagster_graphql/schema/env_vars.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/env_vars.py
@@ -1,13 +1,9 @@
 from typing import List, Sequence
 
 import graphene
-from dagster._core.remote_representation.external_data import (
-    EnvVarConsumer,
-)
+from dagster._core.remote_representation.external_data import EnvVarConsumer
 
-from dagster_graphql.schema.errors import (
-    GraphenePythonError,
-)
+from dagster_graphql.schema.errors import GraphenePythonError
 from dagster_graphql.schema.util import non_null_list
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -8,9 +8,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
-from dagster._core.definitions.sensor_definition import (
-    SensorType,
-)
+from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.remote_representation import (
     CodeLocation,
     ExternalRepository,
@@ -23,21 +21,12 @@ from dagster._core.remote_representation.grpc_server_state_subscriber import (
     LocationStateChangeEventType,
     LocationStateSubscriber,
 )
-from dagster._core.workspace.context import (
-    BaseWorkspaceRequestContext,
-    WorkspaceProcessContext,
-)
-from dagster._core.workspace.workspace import (
-    CodeLocationEntry,
-    CodeLocationLoadStatus,
-)
+from dagster._core.workspace.context import BaseWorkspaceRequestContext, WorkspaceProcessContext
+from dagster._core.workspace.workspace import CodeLocationEntry, CodeLocationLoadStatus
 
 from dagster_graphql.implementation.asset_checks_loader import AssetChecksLoader
 from dagster_graphql.implementation.fetch_solids import get_solid, get_solids
-from dagster_graphql.implementation.loader import (
-    RepositoryScopedBatchLoader,
-    StaleStatusLoader,
-)
+from dagster_graphql.implementation.loader import RepositoryScopedBatchLoader, StaleStatusLoader
 
 from .asset_graph import GrapheneAssetGroup, GrapheneAssetNode
 from .errors import GraphenePythonError, GrapheneRepositoryNotFoundError

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instance.py
@@ -1,7 +1,5 @@
 import sys
-from typing import (
-    TYPE_CHECKING,
-)
+from typing import TYPE_CHECKING
 
 import dagster._check as check
 import graphene

--- a/python_modules/dagster-graphql/dagster_graphql/schema/metadata.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/metadata.py
@@ -1,11 +1,7 @@
 import graphene
 
 from .asset_key import GrapheneAssetKey
-from .table import (
-    GrapheneTable,
-    GrapheneTableColumnLineageEntry,
-    GrapheneTableSchema,
-)
+from .table import GrapheneTable, GrapheneTableColumnLineageEntry, GrapheneTableSchema
 from .util import non_null_list
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -16,10 +16,7 @@ from dagster._core.definitions.selector import (
 )
 from dagster._core.execution.backfill import BulkActionStatus
 from dagster._core.nux import get_has_seen_nux
-from dagster._core.scheduler.instigation import (
-    InstigatorStatus,
-    InstigatorType,
-)
+from dagster._core.scheduler.instigation import InstigatorStatus, InstigatorType
 from dagster._core.workspace.permissions import Permissions
 
 from dagster_graphql.implementation.asset_checks_loader import AssetChecksLoader
@@ -62,9 +59,7 @@ from ...implementation.fetch_assets import (
     get_assets,
 )
 from ...implementation.fetch_backfills import get_backfill, get_backfills
-from ...implementation.fetch_instigators import (
-    get_instigator_state_or_error,
-)
+from ...implementation.fetch_instigators import get_instigator_state_or_error
 from ...implementation.fetch_partition_sets import get_partition_set, get_partition_sets_or_error
 from ...implementation.fetch_pipelines import (
     get_job_or_error,
@@ -92,10 +87,7 @@ from ...implementation.fetch_schedules import (
 from ...implementation.fetch_sensors import get_sensor_or_error, get_sensors_or_error
 from ...implementation.fetch_solids import get_graph_or_error
 from ...implementation.fetch_ticks import get_instigation_ticks
-from ...implementation.loader import (
-    CrossRepoAssetDependedByLoader,
-    StaleStatusLoader,
-)
+from ...implementation.loader import CrossRepoAssetDependedByLoader, StaleStatusLoader
 from ...implementation.run_config_schema import resolve_run_config_schema_or_error
 from ...implementation.utils import (
     capture_error,
@@ -149,10 +141,7 @@ from ..logs.compute_logs import (
     GrapheneCapturedLogsMetadata,
     from_captured_log_data,
 )
-from ..partition_sets import (
-    GraphenePartitionSetOrError,
-    GraphenePartitionSetsOrError,
-)
+from ..partition_sets import GraphenePartitionSetOrError, GraphenePartitionSetsOrError
 from ..permissions import GraphenePermission
 from ..pipelines.config_result import GraphenePipelineConfigValidationResult
 from ..pipelines.pipeline import GrapheneEventConnectionOrError, GrapheneRunOrError

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -4,9 +4,7 @@ import dagster._check as check
 import graphene
 from dagster import DefaultSensorStatus
 from dagster._core.definitions.selector import SensorSelector
-from dagster._core.definitions.sensor_definition import (
-    SensorType,
-)
+from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.remote_representation import ExternalSensor, ExternalTargetData
 from dagster._core.remote_representation.external import ExternalRepository
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/graphql_context_test_suite.py
@@ -24,14 +24,9 @@ from dagster._core.workspace.load_target import (
     WorkspaceFileTarget,
 )
 from dagster._grpc.client import DagsterGrpcClient
-from dagster._grpc.server import (
-    GrpcServerProcess,
-    wait_for_grpc_server,
-)
+from dagster._grpc.server import GrpcServerProcess, wait_for_grpc_server
 from dagster._serdes.ipc import open_ipc_subprocess
-from dagster._utils import (
-    safe_tempfile_path,
-)
+from dagster._utils import safe_tempfile_path
 from dagster._utils.merger import merge_dicts
 from dagster._utils.test import FilesystemTestScheduler
 from dagster._utils.test.postgres_instance import TestPostgresInstance

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -92,9 +92,7 @@ from dagster._core.definitions.decorators.sensor_decorator import sensor
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import Failure
 from dagster._core.definitions.executor_definition import in_process_executor
-from dagster._core.definitions.external_asset import (
-    external_asset_from_spec,
-)
+from dagster._core.definitions.external_asset import external_asset_from_spec
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.metadata import MetadataValue

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_api_backcompat.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_api_backcompat.py
@@ -3,10 +3,7 @@ import time
 from dagster import job, op, repository
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.test_utils import instance_for_test
-from dagster_graphql.test.utils import (
-    define_out_of_process_context,
-    execute_dagster_graphql,
-)
+from dagster_graphql.test.utils import define_out_of_process_context, execute_dagster_graphql
 
 RUNS_QUERY = """
 query RunsQuery {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_checks.py
@@ -16,10 +16,7 @@ from dagster._core.test_utils import create_run_for_test, poll_for_finished_run
 from dagster._core.utils import make_new_run_id
 from dagster._core.workspace.context import WorkspaceRequestContext
 from dagster_graphql.client.query import ERROR_FRAGMENT
-from dagster_graphql.test.utils import (
-    execute_dagster_graphql,
-    infer_job_selector,
-)
+from dagster_graphql.test.utils import execute_dagster_graphql, infer_job_selector
 
 from dagster_graphql_tests.graphql.graphql_context_test_suite import (
     ExecutingGraphQLContextTestMatrix,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_auto_materialize_asset_evaluations.py
@@ -1,16 +1,12 @@
 import dagster._check as check
-from dagster._core.definitions.asset_daemon_cursor import (
-    AssetDaemonCursor,
-)
+from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
     deserialize_auto_materialize_asset_evaluation_to_asset_condition_evaluation_with_run_ids,
 )
 from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.workspace.context import WorkspaceRequestContext
-from dagster._daemon.asset_daemon import (
-    _PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY,
-)
+from dagster._daemon.asset_daemon import _PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY
 from dagster._serdes.serdes import serialize_value
 from dagster_graphql.test.utils import execute_dagster_graphql
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_context.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_context.py
@@ -7,10 +7,7 @@ import pytest
 from dagster import job, op, repository
 from dagster._core.remote_representation.code_location import GrpcServerCodeLocation
 from dagster._core.test_utils import instance_for_test
-from dagster_graphql.test.utils import (
-    define_out_of_process_workspace,
-    main_repo_location_name,
-)
+from dagster_graphql.test.utils import define_out_of_process_workspace, main_repo_location_name
 
 
 def get_repo():

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_data_versions.py
@@ -20,9 +20,7 @@ from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.test_utils import instance_for_test, wait_for_runs_to_finish
 from dagster._core.workspace.context import WorkspaceRequestContext
-from dagster_graphql.client.query import (
-    LAUNCH_PIPELINE_EXECUTION_MUTATION,
-)
+from dagster_graphql.client.query import LAUNCH_PIPELINE_EXECUTION_MUTATION
 from dagster_graphql.test.utils import (
     GqlAssetKey,
     GqlResult,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_nux.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_nux.py
@@ -1,7 +1,5 @@
 import mock
-from dagster_graphql.test.utils import (
-    execute_dagster_graphql,
-)
+from dagster_graphql.test.utils import execute_dagster_graphql
 
 SET_NUX_SEEN_MUTATION = """
     mutation SetNuxSeen {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -18,10 +18,7 @@ from dagster._core.execution.asset_backfill import (
     execute_asset_backfill_iteration,
     execute_asset_backfill_iteration_inner,
 )
-from dagster._core.execution.backfill import (
-    BulkActionStatus,
-    PartitionBackfill,
-)
+from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.remote_representation.origin import RemotePartitionSetOrigin
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import (

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
@@ -4,10 +4,7 @@ from time import sleep
 from dagster._core.events import RunFailureReason
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.storage.dagster_run import DagsterRunStatus
-from dagster._core.storage.tags import (
-    RESUME_RETRY_TAG,
-    RUN_FAILURE_REASON_TAG,
-)
+from dagster._core.storage.tags import RESUME_RETRY_TAG, RUN_FAILURE_REASON_TAG
 from dagster._core.test_utils import create_run_for_test, poll_for_finished_run
 from dagster._core.workspace.context import WorkspaceRequestContext
 from dagster._seven.temp_dir import get_system_temp_directory

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -3,10 +3,7 @@ import sys
 
 import pendulum
 import pytest
-from dagster._core.remote_representation import (
-    InProcessCodeLocationOrigin,
-    RemoteRepositoryOrigin,
-)
+from dagster._core.remote_representation import InProcessCodeLocationOrigin, RemoteRepositoryOrigin
 from dagster._core.scheduler.instigation import (
     InstigatorState,
     InstigatorStatus,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -4,13 +4,8 @@ import sys
 import pendulum
 import pytest
 from dagster._core.definitions.run_request import InstigatorType
-from dagster._core.definitions.sensor_definition import (
-    SensorType,
-)
-from dagster._core.remote_representation import (
-    InProcessCodeLocationOrigin,
-    RemoteRepositoryOrigin,
-)
+from dagster._core.definitions.sensor_definition import SensorType
+from dagster._core.remote_representation import InProcessCodeLocationOrigin, RemoteRepositoryOrigin
 from dagster._core.scheduler.instigation import (
     InstigatorState,
     InstigatorStatus,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_utilized_env_vars.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_utilized_env_vars.py
@@ -1,7 +1,4 @@
-from dagster_graphql.test.utils import (
-    execute_dagster_graphql,
-    infer_repository_selector,
-)
+from dagster_graphql.test.utils import execute_dagster_graphql, infer_repository_selector
 
 UTILIZED_ENV_VARS_QUERY = """
 query UtilizedEnvVarsQuery($selector: RepositorySelector!) {

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_workspace.py
@@ -6,9 +6,7 @@ from unittest import mock
 import pytest
 from dagster import file_relative_path
 from dagster._core.remote_representation import ManagedGrpcPythonEnvCodeLocationOrigin
-from dagster._core.remote_representation.feature_flags import (
-    CodeLocationFeatureFlags,
-)
+from dagster._core.remote_representation.feature_flags import CodeLocationFeatureFlags
 from dagster._core.test_utils import environ
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.load import location_origins_from_yaml_paths

--- a/python_modules/dagster-test/dagster_test/benchmarks/partition_stale_status.py
+++ b/python_modules/dagster-test/dagster_test/benchmarks/partition_stale_status.py
@@ -3,10 +3,7 @@ import argparse
 from random import randint
 from typing import Sequence, Union
 
-from dagster import (
-    StaticPartitionsDefinition,
-    asset,
-)
+from dagster import StaticPartitionsDefinition, asset
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import (
@@ -21,9 +18,7 @@ from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
     ASSET_PARTITION_RANGE_START_TAG,
 )
-from dagster._utils.test.data_versions import (
-    materialize_asset,
-)
+from dagster._utils.test.data_versions import materialize_asset
 
 from dagster_test.utils.benchmark import ProfilingSession
 

--- a/python_modules/dagster-test/dagster_test/toys/asset_reconciliation/eager_reconciliation.py
+++ b/python_modules/dagster-test/dagster_test/toys/asset_reconciliation/eager_reconciliation.py
@@ -1,9 +1,4 @@
-from dagster import (
-    AutoMaterializePolicy,
-    Definitions,
-    asset,
-    load_assets_from_current_module,
-)
+from dagster import AutoMaterializePolicy, Definitions, asset, load_assets_from_current_module
 
 
 @asset

--- a/python_modules/dagster-test/dagster_test/toys/external_execution/__init__.py
+++ b/python_modules/dagster-test/dagster_test/toys/external_execution/__init__.py
@@ -2,9 +2,7 @@ import os
 import sys
 
 from dagster import AssetExecutionContext, Config, Definitions, asset
-from dagster._core.pipes.subprocess import (
-    PipesSubprocessClient,
-)
+from dagster._core.pipes.subprocess import PipesSubprocessClient
 from pydantic import Field
 
 # Add package container to path

--- a/python_modules/dagster-test/dagster_test/toys/freshness_checks.py
+++ b/python_modules/dagster-test/dagster_test/toys/freshness_checks.py
@@ -16,9 +16,7 @@ from dagster import (
     define_asset_job,
     observable_source_asset,
 )
-from dagster._core.definitions.asset_selection import (
-    KeysAssetSelection,
-)
+from dagster._core.definitions.asset_selection import KeysAssetSelection
 
 
 @observable_source_asset(group_name="freshness_checks")

--- a/python_modules/dagster-test/dagster_test/toys/partitioned_assets/partitioned_run_request_sensors.py
+++ b/python_modules/dagster-test/dagster_test/toys/partitioned_assets/partitioned_run_request_sensors.py
@@ -3,9 +3,7 @@ import random
 from dagster import AssetSelection, RunRequest, SensorResult, define_asset_job, sensor
 
 from .dynamic_asset_partitions import ints_dynamic_asset, ints_dynamic_partitions_def
-from .hourly_and_daily_and_unpartitioned import (
-    upstream_daily_partitioned_asset,
-)
+from .hourly_and_daily_and_unpartitioned import upstream_daily_partitioned_asset
 
 
 @sensor(asset_selection=AssetSelection.assets(ints_dynamic_asset))

--- a/python_modules/dagster-test/dagster_test/toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/toys/repo.py
@@ -6,14 +6,7 @@ from dagster import ExperimentalWarning
 warnings.filterwarnings("ignore", category=ExperimentalWarning)
 
 import pendulum
-from dagster import (
-    AssetMaterialization,
-    Output,
-    graph,
-    load_assets_from_modules,
-    op,
-    repository,
-)
+from dagster import AssetMaterialization, Output, graph, load_assets_from_modules, op, repository
 
 from dagster_test.toys import big_honkin_asset_graph as big_honkin_asset_graph_module
 from dagster_test.toys.asset_sensors import get_asset_sensors_repo
@@ -25,10 +18,7 @@ from dagster_test.toys.cross_repo_assets import (
     upstream_repo_assets,
 )
 from dagster_test.toys.dynamic import dynamic_job
-from dagster_test.toys.error_monster import (
-    error_monster_failing_job,
-    error_monster_passing_job,
-)
+from dagster_test.toys.error_monster import error_monster_failing_job, error_monster_passing_job
 from dagster_test.toys.graph_backed_assets import graph_backed_asset
 from dagster_test.toys.hammer import hammer_default_executor_job
 from dagster_test.toys.input_managers import df_stats_job
@@ -68,12 +58,8 @@ from .auto_materializing.large_graph import (
     auto_materialize_large_static_graph as auto_materialize_large_static_graph,
     auto_materialize_large_time_graph as auto_materialize_large_time_graph,
 )
-from .auto_materializing.repo_1 import (
-    auto_materialize_repo_1 as auto_materialize_repo_1,
-)
-from .auto_materializing.repo_2 import (
-    auto_materialize_repo_2 as auto_materialize_repo_2,
-)
+from .auto_materializing.repo_1 import auto_materialize_repo_1 as auto_materialize_repo_1
+from .auto_materializing.repo_2 import auto_materialize_repo_2 as auto_materialize_repo_2
 from .freshness_checks import get_freshness_defs_pile
 from .schedules import get_toys_schedules
 from .sensors import get_toys_sensors

--- a/python_modules/dagster-test/dagster_test_tests/toys_tests/partitioned_assets_tests/test_dynamic_asset_partitions.py
+++ b/python_modules/dagster-test/dagster_test_tests/toys_tests/partitioned_assets_tests/test_dynamic_asset_partitions.py
@@ -1,8 +1,4 @@
-from dagster import (
-    DagsterInstance,
-    MultiPartitionKey,
-    materialize_to_memory,
-)
+from dagster import DagsterInstance, MultiPartitionKey, materialize_to_memory
 from dagster_test.toys.partitioned_assets.dynamic_asset_partitions import (
     customers_dynamic_partitions_asset1,
     customers_dynamic_partitions_asset2,

--- a/python_modules/dagster-test/dagster_test_tests/toys_tests/test_asset_sensors.py
+++ b/python_modules/dagster-test/dagster_test_tests/toys_tests/test_asset_sensors.py
@@ -1,8 +1,5 @@
 from dagster import build_multi_asset_sensor_context, instance_for_test, materialize
-from dagster_test.toys.asset_sensors import (
-    partitioned_assets,
-    partitioned_multi_asset_sensor,
-)
+from dagster_test.toys.asset_sensors import partitioned_assets, partitioned_multi_asset_sensor
 from dagster_test.toys.repo import assets_with_sensors_repository
 
 partitioned_asset = partitioned_assets[0]

--- a/python_modules/dagster-webserver/dagster_webserver/app.py
+++ b/python_modules/dagster-webserver/dagster_webserver/app.py
@@ -1,8 +1,6 @@
 from typing import Optional
 
-from dagster import (
-    _check as check,
-)
+from dagster import _check as check
 from dagster._core.execution.compute_logs import warn_if_compute_logs_disabled
 from dagster._core.telemetry import log_workspace_stats
 from dagster._core.workspace.context import IWorkspaceProcessContext

--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -18,9 +18,7 @@ from dagster._cli.workspace.cli_target import WORKSPACE_TARGET_WARNING, ClickArg
 from dagster._core.instance import InstanceRef
 from dagster._core.telemetry import START_DAGSTER_WEBSERVER, log_action
 from dagster._core.telemetry_upload import uploading_logging_thread
-from dagster._core.workspace.context import (
-    IWorkspaceProcessContext,
-)
+from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._serdes import deserialize_value
 from dagster._utils import DEFAULT_WORKSPACE_YAML_FILENAME, find_free_port, is_port_in_use
 from dagster._utils.log import configure_loggers

--- a/python_modules/dagster-webserver/dagster_webserver/debug.py
+++ b/python_modules/dagster-webserver/dagster_webserver/debug.py
@@ -2,9 +2,7 @@ from gzip import GzipFile
 from typing import Any, Optional
 
 import click
-from dagster import (
-    DagsterInstance,
-)
+from dagster import DagsterInstance
 from dagster._core.debug import DebugRunPayload
 from dagster._core.workspace.context import (
     BaseWorkspaceRequestContext,

--- a/python_modules/dagster-webserver/dagster_webserver/external_assets.py
+++ b/python_modules/dagster-webserver/dagster_webserver/external_assets.py
@@ -12,9 +12,7 @@ from dagster._core.definitions.events import AssetKey, AssetMaterialization
 from dagster._core.workspace.context import BaseWorkspaceRequestContext
 from dagster._seven import json
 from starlette.requests import Request
-from starlette.responses import (
-    JSONResponse,
-)
+from starlette.responses import JSONResponse
 
 
 def _asset_key_from_request(key: str, request: Request, json_body):

--- a/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_asset_events.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_asset_events.py
@@ -1,8 +1,6 @@
 import inspect
 
-from dagster import (
-    DagsterInstance,
-)
+from dagster import DagsterInstance
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.data_version import (

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -352,9 +352,7 @@ from dagster._core.definitions.repository_definition import (
     RepositoryData as RepositoryData,
     RepositoryDefinition as RepositoryDefinition,
 )
-from dagster._core.definitions.resource_annotation import (
-    ResourceParam as ResourceParam,
-)
+from dagster._core.definitions.resource_annotation import ResourceParam as ResourceParam
 from dagster._core.definitions.resource_definition import (
     ResourceDefinition as ResourceDefinition,
     make_values_resource as make_values_resource,
@@ -612,9 +610,7 @@ from dagster._serdes.serdes import (
     deserialize_value as deserialize_value,
     serialize_value as serialize_value,
 )
-from dagster._utils import (
-    file_relative_path as file_relative_path,
-)
+from dagster._utils import file_relative_path as file_relative_path
 from dagster._utils.alert import (
     make_email_on_run_failure_sensor as make_email_on_run_failure_sensor,
 )

--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -10,10 +10,7 @@ from dagster._core.decorator_utils import (
     get_decorator_target,
     is_resource_def,
 )
-from dagster._utils.warnings import (
-    deprecation_warning,
-    experimental_warning,
-)
+from dagster._utils.warnings import deprecation_warning, experimental_warning
 
 # For the time being, `Annotatable` is set to `Any` even though it should be set to `Decoratable` to
 # avoid choking the type checker. Choking happens because of a niche scenario where

--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -14,10 +14,7 @@ from dagster._core.execution.api import execute_job
 from dagster._core.instance import DagsterInstance
 from dagster._core.origin import JobPythonOrigin
 from dagster._core.telemetry import telemetry_wrapper
-from dagster._utils.hosted_user_process import (
-    recon_job_from_origin,
-    recon_repository_from_origin,
-)
+from dagster._utils.hosted_user_process import recon_job_from_origin, recon_repository_from_origin
 from dagster._utils.interrupts import capture_interrupts
 
 from .utils import get_instance_for_cli, get_possibly_temporary_instance_for_cli

--- a/python_modules/dagster/dagster/_config/evaluate_value_result.py
+++ b/python_modules/dagster/dagster/_config/evaluate_value_result.py
@@ -1,12 +1,5 @@
 # pylint disable is for bug: https://github.com/PyCQA/pylint/issues/3299
-from typing import (
-    Any,
-    Generator,
-    Generic,
-    Optional,
-    Sequence,
-    TypeVar,
-)
+from typing import Any, Generator, Generic, Optional, Sequence, TypeVar
 
 import dagster._check as check
 

--- a/python_modules/dagster/dagster/_config/pythonic_config/attach_other_object_to_context.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/attach_other_object_to_context.py
@@ -1,6 +1,4 @@
-from typing import (
-    Any,
-)
+from typing import Any
 
 
 class IAttachDifferentObjectToOpContext:

--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -1,15 +1,6 @@
 import re
 from enum import Enum
-from typing import (
-    Any,
-    Dict,
-    List,
-    Mapping,
-    Optional,
-    Set,
-    Type,
-    cast,
-)
+from typing import Any, Dict, List, Mapping, Optional, Set, Type, cast
 
 from pydantic import BaseModel, ConfigDict
 from typing_extensions import TypeVar
@@ -19,14 +10,8 @@ from dagster import (
     Field as DagsterField,
     Shape,
 )
-from dagster._config.field_utils import (
-    EnvVar,
-    IntEnvVar,
-    Permissive,
-)
-from dagster._core.definitions.definition_config_schema import (
-    DefinitionConfigSchema,
-)
+from dagster._config.field_utils import EnvVar, IntEnvVar, Permissive
+from dagster._core.definitions.definition_config_schema import DefinitionConfigSchema
 from dagster._core.errors import (
     DagsterInvalidConfigDefinitionError,
     DagsterInvalidDefinitionError,

--- a/python_modules/dagster/dagster/_config/pythonic_config/conversion_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/conversion_utils.py
@@ -1,32 +1,15 @@
 import inspect
 from enum import Enum
-from typing import (
-    Any,
-    Dict,
-    List,
-    Mapping,
-    Optional,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, Dict, List, Mapping, Optional, Type, TypeVar, Union
 
 from typing_extensions import Annotated, get_args, get_origin
 
-from dagster import (
-    Enum as DagsterEnum,
-)
-from dagster._config.config_type import (
-    Array,
-    ConfigType,
-    Noneable,
-)
+from dagster import Enum as DagsterEnum
+from dagster._config.config_type import Array, ConfigType, Noneable
 from dagster._config.post_process import resolve_defaults
 from dagster._config.source import BoolSource, IntSource, StringSource
 from dagster._config.validate import validate_config
-from dagster._core.definitions.definition_config_schema import (
-    DefinitionConfigSchema,
-)
+from dagster._core.definitions.definition_config_schema import DefinitionConfigSchema
 from dagster._core.errors import (
     DagsterInvalidConfigDefinitionError,
     DagsterInvalidConfigError,
@@ -48,11 +31,7 @@ except ImportError:
 
 import dagster._check as check
 from dagster import Field, Selector
-from dagster._config.field_utils import (
-    FIELD_NO_DEFAULT_PROVIDED,
-    Map,
-    convert_potential_field,
-)
+from dagster._config.field_utils import FIELD_NO_DEFAULT_PROVIDED, Map, convert_potential_field
 from dagster._model.pydantic_compat_layer import ModelFieldCompat, PydanticUndefined, model_fields
 from dagster._utils.typing_api import is_closed_python_optional_type
 

--- a/python_modules/dagster/dagster/_config/pythonic_config/io_manager.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/io_manager.py
@@ -1,26 +1,10 @@
 from abc import abstractmethod
-from typing import (
-    AbstractSet,
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    Mapping,
-    Optional,
-    Type,
-    Union,
-    cast,
-)
+from typing import AbstractSet, Any, Callable, Dict, Generic, Mapping, Optional, Type, Union, cast
 
 from typing_extensions import TypeVar
 
-from dagster._core.definitions.definition_config_schema import (
-    CoercableToConfigSchema,
-)
-from dagster._core.definitions.resource_definition import (
-    ResourceDefinition,
-    ResourceFunction,
-)
+from dagster._core.definitions.definition_config_schema import CoercableToConfigSchema
+from dagster._core.definitions.resource_definition import ResourceDefinition, ResourceFunction
 from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.storage.io_manager import IOManager, IOManagerDefinition
 from dagster._utils.cached_method import cached_method

--- a/python_modules/dagster/dagster/_config/pythonic_config/resource.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/resource.py
@@ -20,14 +20,10 @@ from typing import (
 
 from typing_extensions import TypeAlias, TypeGuard, get_args, get_origin
 
-from dagster import (
-    Field as DagsterField,
-)
+from dagster import Field as DagsterField
 from dagster._annotations import deprecated
 from dagster._config.field_utils import config_dictionary_from_values
-from dagster._config.pythonic_config.typing_utils import (
-    TypecheckAllowPartialResourceInitParams,
-)
+from dagster._config.pythonic_config.typing_utils import TypecheckAllowPartialResourceInitParams
 from dagster._config.validate import validate_config
 from dagster._core.definitions.definition_config_schema import (
     ConfiguredDefinitionConfigSchema,
@@ -35,9 +31,7 @@ from dagster._core.definitions.definition_config_schema import (
 )
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.execution.context.init import InitResourceContext, build_init_resource_context
-from dagster._model.pydantic_compat_layer import (
-    model_fields,
-)
+from dagster._model.pydantic_compat_layer import model_fields
 from dagster._utils.cached_method import cached_method
 from dagster._utils.typing_api import is_closed_python_optional_type
 
@@ -69,10 +63,7 @@ from dagster._core.definitions.resource_definition import (
 from dagster._core.storage.io_manager import IOManagerDefinition
 
 from .config import Config, MakeConfigCacheable, infer_schema_from_config_class
-from .conversion_utils import (
-    TResValue,
-    _curry_config_schema,
-)
+from .conversion_utils import TResValue, _curry_config_schema
 from .typing_utils import BaseResourceMeta, LateBoundTypesForResourceTypeChecking
 
 T_Self = TypeVar("T_Self", bound="ConfigurableResourceFactory")

--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -1,13 +1,5 @@
 from datetime import datetime, timedelta
-from typing import (
-    TYPE_CHECKING,
-    AbstractSet,
-    Mapping,
-    NamedTuple,
-    NewType,
-    Optional,
-    Sequence,
-)
+from typing import TYPE_CHECKING, AbstractSet, Mapping, NamedTuple, NewType, Optional, Sequence
 
 from dagster import _check as check
 from dagster._core.definitions.asset_subset import AssetSubset, ValidAssetSubset
@@ -17,10 +9,7 @@ from dagster._core.definitions.multi_dimensional_partitions import (
     MultiPartitionsDefinition,
     PartitionDimensionDefinition,
 )
-from dagster._core.definitions.partition import (
-    AllPartitionsSubset,
-    DefaultPartitionsSubset,
-)
+from dagster._core.definitions.partition import AllPartitionsSubset, DefaultPartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
     BaseTimeWindowPartitionsSubset,
     TimeWindow,

--- a/python_modules/dagster/dagster/_core/code_pointer.py
+++ b/python_modules/dagster/dagster/_core/code_pointer.py
@@ -184,9 +184,7 @@ class FileCodePointer(
 
 
 def _load_target_from_module(module: ModuleType, fn_name: str, error_suffix: str) -> object:
-    from dagster._core.definitions.load_assets_from_modules import (
-        assets_from_modules,
-    )
+    from dagster._core.definitions.load_assets_from_modules import assets_from_modules
     from dagster._core.workspace.autodiscovery import LOAD_ALL_ASSETS
 
     if fn_name == LOAD_ALL_ASSETS:

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/last_update.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/last_update.py
@@ -15,9 +15,7 @@ from dagster._core.definitions.metadata import (
     MetadataValue,
     TimestampMetadataValue,
 )
-from dagster._core.execution.context.compute import (
-    AssetCheckExecutionContext,
-)
+from dagster._core.execution.context.compute import AssetCheckExecutionContext
 from dagster._utils.schedules import (
     get_latest_completed_cron_tick,
     get_next_cron_tick,

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/sensor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/sensor.py
@@ -13,11 +13,7 @@ from ...asset_selection import AssetSelection
 from ...decorators import sensor
 from ...run_request import RunRequest, SkipReason
 from ...sensor_definition import DefaultSensorStatus, SensorDefinition, SensorEvaluationContext
-from ..utils import (
-    FRESH_UNTIL_METADATA_KEY,
-    ensure_no_duplicate_asset_checks,
-    seconds_in_words,
-)
+from ..utils import FRESH_UNTIL_METADATA_KEY, ensure_no_duplicate_asset_checks, seconds_in_words
 
 DEFAULT_FRESHNESS_SENSOR_NAME = "freshness_checks_sensor"
 MAXIMUM_RUNTIME_SECONDS = 35  # Due to GRPC communications, only allow this sensor to run for 40 seconds before pausing iteration and resuming in the next run. Leave a bit of time for run requests to be processed.

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/time_partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/time_partition.py
@@ -14,12 +14,8 @@ from dagster._core.definitions.metadata import (
     MetadataValue,
     TimestampMetadataValue,
 )
-from dagster._core.definitions.time_window_partitions import (
-    TimeWindowPartitionsDefinition,
-)
-from dagster._core.execution.context.compute import (
-    AssetCheckExecutionContext,
-)
+from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
+from dagster._core.execution.context.compute import AssetCheckExecutionContext
 from dagster._utils.schedules import (
     get_latest_completed_cron_tick,
     get_next_cron_tick,

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_result.py
@@ -6,10 +6,7 @@ from dagster._core.definitions.asset_check_evaluation import (
     AssetCheckEvaluation,
     AssetCheckEvaluationTargetMaterializationData,
 )
-from dagster._core.definitions.asset_check_spec import (
-    AssetCheckKey,
-    AssetCheckSeverity,
-)
+from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSeverity
 from dagster._core.definitions.events import (
     AssetKey,
     CoercibleToAssetKey,

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -3,10 +3,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping, NamedTuple, Optional, 
 
 import dagster._check as check
 from dagster._annotations import PublicAttr
-from dagster._core.definitions.asset_key import (
-    AssetKey,
-    CoercibleToAssetKey,
-)
+from dagster._core.definitions.asset_key import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.metadata import RawMetadataMapping
 from dagster._serdes.serdes import whitelist_for_serdes
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_checks.py
@@ -1,9 +1,4 @@
-from typing import (
-    Any,
-    Mapping,
-    Optional,
-    Sequence,
-)
+from typing import Any, Mapping, Optional, Sequence
 
 from dagster import _check as check
 from dagster._annotations import deprecated

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -27,9 +27,7 @@ from dagster._core.definitions.data_version import CachingStaleStatusResolver
 from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.run_request import RunRequest
-from dagster._core.definitions.time_window_partitions import (
-    get_time_partitions_def,
-)
+from dagster._core.definitions.time_window_partitions import get_time_partitions_def
 from dagster._core.instance import DynamicPartitionsStore
 
 from ... import PartitionKeyRange
@@ -38,9 +36,7 @@ from .asset_daemon_cursor import AssetDaemonCursor
 from .auto_materialize_rule import AutoMaterializeRule
 from .backfill_policy import BackfillPolicy, BackfillPolicyType
 from .base_asset_graph import BaseAssetGraph
-from .declarative_automation.serialized_objects import (
-    AssetConditionEvaluation,
-)
+from .declarative_automation.serialized_objects import AssetConditionEvaluation
 from .partition import PartitionsDefinition, ScheduleType
 
 if TYPE_CHECKING:

--- a/python_modules/dagster/dagster/_core/definitions/asset_dep.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_dep.py
@@ -11,10 +11,7 @@ from dagster._core.definitions.partition_mapping import (
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 
-from .events import (
-    AssetKey,
-    CoercibleToAssetKey,
-)
+from .events import AssetKey, CoercibleToAssetKey
 
 if TYPE_CHECKING:
     from dagster._core.definitions.assets import AssetsDefinition

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -24,9 +24,7 @@ from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.resolved_asset_deps import ResolvedAssetDependencies
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
-from dagster._core.selector.subset_selector import (
-    generate_asset_dep_graph,
-)
+from dagster._core.selector.subset_selector import generate_asset_dep_graph
 
 
 class AssetNode(BaseAssetNode):

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -8,9 +8,7 @@ from dagster._core.remote_representation import ExternalRepository
 from dagster._core.workspace.context import BaseWorkspaceRequestContext
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.events import (
-        AssetKey,
-    )
+    from dagster._core.definitions.events import AssetKey
 
 
 class ChangeReason(Enum):

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -16,13 +16,8 @@ from typing import (
 )
 
 from dagster import _check as check
-from dagster._core.definitions.partition import (
-    PartitionsDefinition,
-    PartitionsSubset,
-)
-from dagster._core.errors import (
-    DagsterDefinitionChangedDeserializationError,
-)
+from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
+from dagster._core.errors import DagsterDefinitionChangedDeserializationError
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._serdes.serdes import (
     NamedTupleSerializer,

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -18,9 +18,7 @@ from typing import (
 import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSpec
 
-from ..errors import (
-    DagsterInvariantViolationError,
-)
+from ..errors import DagsterInvariantViolationError
 from .dependency import NodeHandle, NodeInputHandle, NodeOutput, NodeOutputHandle
 from .events import AssetKey
 from .graph_definition import GraphDefinition

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -1,13 +1,5 @@
 from enum import Enum
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Iterable,
-    Mapping,
-    NamedTuple,
-    Optional,
-    Sequence,
-)
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, NamedTuple, Optional, Sequence
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, experimental_param
@@ -16,10 +8,7 @@ from dagster._serdes.serdes import whitelist_for_serdes
 from dagster._utils.internal_init import IHasInternalInit
 
 from .auto_materialize_policy import AutoMaterializePolicy
-from .events import (
-    AssetKey,
-    CoercibleToAssetKey,
-)
+from .events import AssetKey, CoercibleToAssetKey
 from .freshness_policy import FreshnessPolicy
 from .utils import validate_tags_strict
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -11,10 +11,7 @@ from dagster._core.definitions.partition import (
 )
 from dagster._core.definitions.time_window_partitions import BaseTimeWindowPartitionsSubset
 from dagster._model import InstanceOf
-from dagster._serdes.serdes import (
-    NamedTupleSerializer,
-    whitelist_for_serdes,
-)
+from dagster._serdes.serdes import NamedTupleSerializer, whitelist_for_serdes
 
 if TYPE_CHECKING:
     from dagster._core.instance import DynamicPartitionsStore

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
@@ -1,17 +1,7 @@
 from abc import ABC, abstractproperty
 from collections import defaultdict
 from enum import Enum
-from typing import (
-    AbstractSet,
-    Dict,
-    FrozenSet,
-    NamedTuple,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import AbstractSet, Dict, FrozenSet, NamedTuple, Optional, Sequence, Tuple, Union, cast
 
 import dagster._check as check
 from dagster._core.definitions.asset_subset import AssetSubset
@@ -144,9 +134,7 @@ def deserialize_auto_materialize_asset_evaluation_to_asset_condition_evaluation_
     """Provides a backcompat layer to allow deserializing old AutoMaterializeAssetEvaluation
     objects into the new AssetConditionEvaluationWithRunIds objects.
     """
-    from .declarative_automation.serialized_objects import (
-        AssetConditionEvaluationWithRunIds,
-    )
+    from .declarative_automation.serialized_objects import AssetConditionEvaluationWithRunIds
 
     class BackcompatDeserializer(BackcompatAutoMaterializeAssetEvaluationSerializer):
         @property
@@ -232,9 +220,7 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
         is_partitioned: bool,
         rule_snapshot: AutoMaterializeRuleSnapshot,
     ) -> "AssetConditionEvaluation":
-        from .declarative_automation.serialized_objects import (
-            HistoricalAllPartitionsSubsetSentinel,
-        )
+        from .declarative_automation.serialized_objects import HistoricalAllPartitionsSubsetSentinel
 
         condition_snapshot = self._asset_condition_snapshot_from_rule_snapshot(rule_snapshot)
 
@@ -279,9 +265,7 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
             NotAssetCondition,
             OrAssetCondition,
         )
-        from .declarative_automation.serialized_objects import (
-            HistoricalAllPartitionsSubsetSentinel,
-        )
+        from .declarative_automation.serialized_objects import HistoricalAllPartitionsSubsetSentinel
 
         partition_subsets_by_condition_by_rule_snapshot = defaultdict(list)
         for elt in partition_subsets_by_condition:
@@ -369,9 +353,7 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
         context: UnpackContext,
     ) -> "AssetConditionEvaluationWithRunIds":
         from .declarative_automation.operators.boolean_operators import AndAssetCondition
-        from .declarative_automation.serialized_objects import (
-            HistoricalAllPartitionsSubsetSentinel,
-        )
+        from .declarative_automation.serialized_objects import HistoricalAllPartitionsSubsetSentinel
 
         asset_key = cast(AssetKey, unpacked_dict.get("asset_key"))
         partition_subsets_by_condition = cast(

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -36,13 +36,8 @@ from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import AssetRecordsFilter
 from dagster._core.storage.dagster_run import IN_PROGRESS_RUN_STATUSES, RunsFilter
 from dagster._core.storage.tags import AUTO_MATERIALIZE_TAG
-from dagster._serdes.serdes import (
-    whitelist_for_serdes,
-)
-from dagster._utils.schedules import (
-    cron_string_iterator,
-    reverse_cron_string_iterator,
-)
+from dagster._serdes.serdes import whitelist_for_serdes
+from dagster._utils.schedules import cron_string_iterator, reverse_cron_string_iterator
 
 from .base_asset_graph import sort_key_for_asset_partition
 
@@ -51,9 +46,7 @@ if TYPE_CHECKING:
         AutomationResult,
     )
 
-    from .declarative_automation.automation_context import (
-        AutomationContext,
-    )
+    from .declarative_automation.automation_context import AutomationContext
 
 
 @deprecated(

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -34,24 +34,15 @@ from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.instance import DynamicPartitionsStore
-from dagster._core.selector.subset_selector import (
-    DependencyGraph,
-    fetch_sources,
-)
+from dagster._core.selector.subset_selector import DependencyGraph, fetch_sources
 from dagster._core.utils import toposort
 from dagster._utils.cached_method import cached_method
 
 from .events import AssetKeyPartitionKey
 from .partition import PartitionsSubset
 from .partition_key_range import PartitionKeyRange
-from .partition_mapping import (
-    UpstreamPartitionsResult,
-    infer_partition_mapping,
-)
-from .time_window_partitions import (
-    get_time_partition_key,
-    get_time_partitions_def,
-)
+from .partition_mapping import UpstreamPartitionsResult, infer_partition_mapping
+from .time_window_partitions import get_time_partition_key, get_time_partitions_def
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_graph_subset import AssetGraphSubset

--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -915,10 +915,7 @@ def do_composition(
             the user has not explicitly provided the output definitions.
             This should be removed in 0.11.0.
     """
-    from .decorators.op_decorator import (
-        NoContextDecoratedOpFunction,
-        resolve_checked_op_fn_inputs,
-    )
+    from .decorators.op_decorator import NoContextDecoratedOpFunction, resolve_checked_op_fn_inputs
 
     actual_output_defs: Sequence[OutputDefinition]
     if provided_output_defs is None:

--- a/python_modules/dagster/dagster/_core/definitions/data_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_version.py
@@ -709,9 +709,7 @@ class CachingStaleStatusResolver:
         self, *, key: "AssetKeyPartitionKey"
     ) -> Sequence["AssetKeyPartitionKey"]:
         from dagster import AllPartitionMapping
-        from dagster._core.definitions.events import (
-            AssetKeyPartitionKey,
-        )
+        from dagster._core.definitions.events import AssetKeyPartitionKey
         from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
 
         asset_deps = self.asset_graph.get(key.asset_key).parent_keys

--- a/python_modules/dagster/dagster/_core/definitions/decorators/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/__init__.py
@@ -2,26 +2,16 @@ from .asset_decorator import (
     asset as asset,
     multi_asset as multi_asset,
 )
-from .config_mapping_decorator import (
-    config_mapping as config_mapping,
-)
-from .graph_decorator import (
-    graph as graph,
-)
+from .config_mapping_decorator import config_mapping as config_mapping
+from .graph_decorator import graph as graph
 from .hook_decorator import (
     failure_hook as failure_hook,
     success_hook as success_hook,
 )
-from .job_decorator import (
-    job as job,
-)
+from .job_decorator import job as job
 from .op_decorator import op as op
-from .repository_decorator import (
-    repository as repository,
-)
-from .schedule_decorator import (
-    schedule as schedule,
-)
+from .repository_decorator import repository as repository
+from .schedule_decorator import schedule as schedule
 from .sensor_decorator import (
     asset_sensor as asset_sensor,
     sensor as sensor,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -28,9 +28,7 @@ from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.execution.build_resources import wrap_resources_for_execution
-from dagster._utils.warnings import (
-    disable_dagster_warnings,
-)
+from dagster._utils.warnings import disable_dagster_warnings
 
 from ..input import In
 from .asset_decorator import (

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -27,14 +27,10 @@ from dagster._core.definitions.auto_materialize_policy import AutoMaterializePol
 from dagster._core.definitions.config import ConfigMapping
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping, RawMetadataMapping
-from dagster._core.definitions.resource_annotation import (
-    get_resource_args,
-)
+from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._core.types.dagster_type import DagsterType
-from dagster._utils.warnings import (
-    disable_dagster_warnings,
-)
+from dagster._utils.warnings import disable_dagster_warnings
 
 from ..asset_check_spec import AssetCheckSpec
 from ..asset_in import AssetIn
@@ -50,12 +46,7 @@ from ..output import GraphOut, Out
 from ..partition import PartitionsDefinition
 from ..policy import RetryPolicy
 from ..resource_definition import ResourceDefinition
-from ..utils import (
-    DEFAULT_IO_MANAGER_KEY,
-    DEFAULT_OUTPUT,
-    NoValueSentinel,
-    validate_tags_strict,
-)
+from ..utils import DEFAULT_IO_MANAGER_KEY, DEFAULT_OUTPUT, NoValueSentinel, validate_tags_strict
 
 
 @overload
@@ -361,9 +352,7 @@ class _Asset:
         self.owners = owners
 
     def __call__(self, fn: Callable[..., Any]) -> AssetsDefinition:
-        from dagster._config.pythonic_config import (
-            validate_resource_annotated_function,
-        )
+        from dagster._config.pythonic_config import validate_resource_annotated_function
         from dagster._core.execution.build_resources import wrap_resources_for_execution
 
         validate_resource_annotated_function(fn)

--- a/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/op_decorator.py
@@ -26,9 +26,7 @@ from dagster._core.decorator_utils import (
     positional_arg_name_list,
 )
 from dagster._core.definitions.inference import infer_input_props
-from dagster._core.definitions.resource_annotation import (
-    get_resource_args,
-)
+from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.types.dagster_type import DagsterTypeKind
 from dagster._utils.warnings import config_argument_warning, normalize_renamed_param

--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -17,10 +17,7 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._core.decorator_utils import get_function_params
-from dagster._core.definitions.metadata import (
-    RawMetadataValue,
-    normalize_metadata,
-)
+from dagster._core.definitions.metadata import RawMetadataValue, normalize_metadata
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -1,20 +1,9 @@
 import copy
 from functools import update_wrapper
-from typing import (
-    Callable,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Set,
-    Union,
-    cast,
-)
+from typing import Callable, List, Mapping, Optional, Sequence, Set, Union, cast
 
 import dagster._check as check
-from dagster._core.definitions.resource_annotation import (
-    get_resource_args,
-)
+from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.sensor_definition import get_context_param_name
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -12,14 +12,9 @@ from dagster._core.definitions.decorators.asset_decorator import (
     multi_asset,
     resolve_asset_key_and_name_for_decorator,
 )
-from dagster._core.definitions.events import (
-    CoercibleToAssetKey,
-    CoercibleToAssetKeyPrefix,
-)
+from dagster._core.definitions.events import CoercibleToAssetKey, CoercibleToAssetKeyPrefix
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
-from dagster._core.definitions.metadata import (
-    RawMetadataMapping,
-)
+from dagster._core.definitions.metadata import RawMetadataMapping
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.resource_definition import ResourceDefinition

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -14,9 +14,7 @@ from typing import (
 
 import dagster._check as check
 from dagster._annotations import deprecated, experimental, public
-from dagster._config.pythonic_config import (
-    attach_resource_id_to_key_mapping,
-)
+from dagster._config.pythonic_config import attach_resource_id_to_key_mapping
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_spec import AssetSpec

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -27,9 +27,7 @@ import dagster._check as check
 from dagster._annotations import PublicAttr, public
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster._serdes.serdes import (
-    whitelist_for_serdes,
-)
+from dagster._serdes.serdes import whitelist_for_serdes
 from dagster._utils import hash_collection
 
 from .hook_definition import HookDefinition

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -14,16 +14,12 @@ from typing import TYPE_CHECKING, AbstractSet, Optional, Sequence, Tuple
 from dagster._core.definitions.asset_subset import AssetSubset, ValidAssetSubset
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
-from dagster._seven.compat.pendulum import (
-    PendulumInterval,
-)
+from dagster._seven.compat.pendulum import PendulumInterval
 from dagster._utils.schedules import cron_string_iterator
 
 if TYPE_CHECKING:
     from .auto_materialize_rule_evaluation import TextRuleEvaluationData
-    from .declarative_automation.legacy.legacy_context import (
-        LegacyRuleEvaluationContext,
-    )
+    from .declarative_automation.legacy.legacy_context import LegacyRuleEvaluationContext
     from .declarative_automation.serialized_objects import AssetSubsetWithMetadata
 
 

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -6,10 +6,7 @@ from dagster._annotations import deprecated
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._serdes import whitelist_for_serdes
 from dagster._seven.compat.pendulum import pendulum_create_timezone
-from dagster._utils.schedules import (
-    is_valid_cron_schedule,
-    reverse_cron_string_iterator,
-)
+from dagster._utils.schedules import is_valid_cron_schedule, reverse_cron_string_iterator
 
 from .events import AssetKey
 

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy_sensor_definition.py
@@ -17,10 +17,7 @@ from dagster._core.errors import (
     user_code_error_boundary,
 )
 from dagster._core.instance import DagsterInstance
-from dagster._serdes import (
-    serialize_value,
-    whitelist_for_serdes,
-)
+from dagster._serdes import serialize_value, whitelist_for_serdes
 from dagster._serdes.errors import DeserializationError
 from dagster._serdes.serdes import deserialize_value
 from dagster._seven import JSONDecodeError

--- a/python_modules/dagster/dagster/_core/definitions/inference.py
+++ b/python_modules/dagster/dagster/_core/definitions/inference.py
@@ -1,12 +1,5 @@
 from inspect import Parameter, Signature, isgeneratorfunction, signature
-from typing import (
-    Any,
-    Callable,
-    Mapping,
-    NamedTuple,
-    Optional,
-    Sequence,
-)
+from typing import Any, Callable, Mapping, NamedTuple, Optional, Sequence
 
 from dagster._core.decorator_utils import get_type_hints
 from dagster._seven import is_module_available

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -27,12 +27,7 @@ from dagster._config.validate import validate_config
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.backfill_policy import BackfillPolicy
-from dagster._core.definitions.dependency import (
-    Node,
-    NodeHandle,
-    NodeInputHandle,
-    NodeInvocation,
-)
+from dagster._core.definitions.dependency import Node, NodeHandle, NodeInputHandle, NodeInvocation
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.node_definition import NodeDefinition
 from dagster._core.definitions.op_definition import OpDefinition
@@ -51,10 +46,7 @@ from dagster._core.errors import (
     DagsterInvalidSubsetError,
     DagsterInvariantViolationError,
 )
-from dagster._core.selector.subset_selector import (
-    AssetSelectionData,
-    OpSelectionData,
-)
+from dagster._core.selector.subset_selector import AssetSelectionData, OpSelectionData
 from dagster._core.storage.io_manager import (
     IOManagerDefinition,
     dagster_maintained_io_manager,
@@ -68,11 +60,7 @@ from dagster._utils.merger import merge_dicts
 
 from .asset_layer import AssetLayer
 from .config import ConfigMapping
-from .dependency import (
-    DependencyMapping,
-    DependencyStructure,
-    OpNode,
-)
+from .dependency import DependencyMapping, DependencyStructure, OpNode
 from .executor_definition import ExecutorDefinition, multi_or_in_process_executor
 from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .hook_definition import HookDefinition
@@ -784,10 +772,7 @@ class JobDefinition(IHasInternalInit):
     def _get_job_def_for_asset_selection(
         self, selection_data: AssetSelectionData
     ) -> "JobDefinition":
-        from dagster._core.definitions.asset_job import (
-            build_asset_job,
-            get_asset_graph_for_job,
-        )
+        from dagster._core.definitions.asset_job import build_asset_job, get_asset_graph_for_job
 
         # If a non-null check selection is provided, use that. Otherwise the selection will resolve
         # to all checks matching a selected asset by default.
@@ -1198,9 +1183,7 @@ def _infer_asset_layer_from_source_asset_deps(job_graph_def: GraphDefinition) ->
     """For non-asset jobs that have some inputs that are fed from assets, constructs an
     AssetLayer that includes these assets as loadables.
     """
-    from dagster._core.definitions.asset_graph import (
-        AssetGraph,
-    )
+    from dagster._core.definitions.asset_graph import AssetGraph
 
     asset_keys_by_node_input_handle: Dict[NodeInputHandle, AssetKey] = {}
     all_input_assets: List[AssetsDefinition] = []

--- a/python_modules/dagster/dagster/_core/definitions/load_asset_checks_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_asset_checks_from_modules.py
@@ -7,10 +7,7 @@ import dagster._check as check
 from dagster._core.definitions.assets import AssetsDefinition
 
 from .asset_checks import AssetChecksDefinition, has_only_asset_checks
-from .asset_key import (
-    CoercibleToAssetKeyPrefix,
-    check_opt_coercible_to_asset_key_prefix_param,
-)
+from .asset_key import CoercibleToAssetKeyPrefix, check_opt_coercible_to_asset_key_prefix_param
 from .load_assets_from_modules import (
     find_modules_in_package,
     find_objects_in_module_of_types,

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -2,18 +2,7 @@ import inspect
 import pkgutil
 from importlib import import_module
 from types import ModuleType
-from typing import (
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import Dict, Iterable, Iterator, List, Optional, Sequence, Set, Tuple, Union, cast
 
 import dagster._check as check
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -1,17 +1,6 @@
 import os
 from datetime import datetime
-from typing import (
-    Any,
-    Dict,
-    Generic,
-    List,
-    Mapping,
-    NamedTuple,
-    Optional,
-    Sequence,
-    Union,
-    cast,
-)
+from typing import Any, Dict, Generic, List, Mapping, NamedTuple, Optional, Sequence, Union, cast
 
 from typing_extensions import TypeAlias, TypeVar
 
@@ -27,10 +16,7 @@ from dagster._serdes.serdes import (
     WhitelistMap,
     pack_value,
 )
-from dagster._utils.warnings import (
-    deprecation_warning,
-    normalize_renamed_param,
-)
+from dagster._utils.warnings import deprecation_warning, normalize_renamed_param
 
 from .metadata_set import (
     NamespacedMetadataSet as NamespacedMetadataSet,

--- a/python_modules/dagster/dagster/_core/definitions/metadata/metadata_value.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/metadata_value.py
@@ -1,16 +1,7 @@
 import os
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import (
-    Any,
-    Callable,
-    Generic,
-    Mapping,
-    NamedTuple,
-    Optional,
-    Sequence,
-    Union,
-)
+from typing import Any, Callable, Generic, Mapping, NamedTuple, Optional, Sequence, Union
 
 from typing_extensions import Self, TypeVar
 
@@ -20,9 +11,7 @@ from dagster._annotations import PublicAttr, experimental, public
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.errors import DagsterInvalidMetadata
 from dagster._serdes import whitelist_for_serdes
-from dagster._serdes.serdes import (
-    PackableValue,
-)
+from dagster._serdes.serdes import PackableValue
 
 from .table import (  # re-exported
     TableColumn as TableColumn,

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -1,15 +1,7 @@
 import inspect
 import os
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    List,
-    Optional,
-    Sequence,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._annotations import experimental

--- a/python_modules/dagster/dagster/_core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/table.py
@@ -3,9 +3,7 @@ from typing import Mapping, NamedTuple, Optional, Sequence, Union
 import dagster._check as check
 from dagster._annotations import PublicAttr, experimental, public
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._serdes.serdes import (
-    whitelist_for_serdes,
-)
+from dagster._serdes.serdes import whitelist_for_serdes
 
 # ########################
 # ##### TABLE RECORD

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -1,16 +1,5 @@
 import inspect
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Mapping,
-    NamedTuple,
-    Set,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Dict, Mapping, NamedTuple, Set, Tuple, TypeVar, Union, cast
 
 import dagster._check as check
 from dagster._core.decorator_utils import get_function_params

--- a/python_modules/dagster/dagster/_core/definitions/output.py
+++ b/python_modules/dagster/dagster/_core/definitions/output.py
@@ -1,12 +1,5 @@
 import inspect
-from typing import (
-    Any,
-    NamedTuple,
-    Optional,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, NamedTuple, Optional, Type, TypeVar, Union
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, deprecated_param

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -3,9 +3,7 @@ import hashlib
 import json
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from datetime import (
-    datetime,
-)
+from datetime import datetime
 from enum import Enum
 from typing import (
     AbstractSet,
@@ -37,9 +35,7 @@ from dagster._core.storage.tags import PARTITION_NAME_TAG, PARTITION_SET_TAG
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils import xor
 from dagster._utils.cached_method import cached_method
-from dagster._utils.warnings import (
-    normalize_renamed_param,
-)
+from dagster._utils.warnings import normalize_renamed_param
 
 from ..errors import (
     DagsterInvalidDefinitionError,

--- a/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
@@ -6,10 +6,7 @@ from dagster._core.errors import DagsterInvalidDefinitionError
 from .decorators.schedule_decorator import schedule
 from .job_definition import JobDefinition
 from .multi_dimensional_partitions import MultiPartitionsDefinition
-from .partition import (
-    PartitionsDefinition,
-    StaticPartitionsDefinition,
-)
+from .partition import PartitionsDefinition, StaticPartitionsDefinition
 from .run_request import RunRequest, SkipReason
 from .schedule_definition import (
     DefaultScheduleStatus,

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/caching_index.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/caching_index.py
@@ -1,14 +1,4 @@
-from typing import (
-    Callable,
-    Dict,
-    Generic,
-    Mapping,
-    Optional,
-    Sequence,
-    Type,
-    Union,
-    cast,
-)
+from typing import Callable, Dict, Generic, Mapping, Optional, Sequence, Type, Union, cast
 
 import dagster._check as check
 from dagster._core.errors import DagsterInvariantViolationError

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -24,10 +24,7 @@ from dagster._config.pythonic_config import (
 )
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.asset_job import (
-    get_base_asset_jobs,
-    is_base_asset_job_name,
-)
+from dagster._core.definitions.asset_job import get_base_asset_jobs, is_base_asset_job_name
 from dagster._core.definitions.auto_materialize_sensor_definition import (
     AutoMaterializeSensorDefinition,
 )

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -17,9 +17,7 @@ import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.asset_job import (
-    ASSET_BASE_JOB_PREFIX,
-)
+from dagster._core.definitions.asset_job import ASSET_BASE_JOB_PREFIX
 from dagster._core.definitions.cacheable_assets import AssetsDefinitionCacheableData
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import ExecutorDefinition
@@ -38,9 +36,7 @@ from dagster._utils import hash_collection
 from dagster._utils.cached_method import cached_method
 
 from .repository_data import CachingRepositoryData, RepositoryData
-from .valid_definitions import (
-    RepositoryListDefinition as RepositoryListDefinition,
-)
+from .valid_definitions import RepositoryListDefinition as RepositoryListDefinition
 
 if TYPE_CHECKING:
     from dagster._core.definitions import AssetsDefinition

--- a/python_modules/dagster/dagster/_core/definitions/result.py
+++ b/python_modules/dagster/dagster/_core/definitions/result.py
@@ -5,10 +5,7 @@ from dagster._annotations import PublicAttr, experimental
 from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.data_version import DataVersion
 
-from .events import (
-    AssetKey,
-    CoercibleToAssetKey,
-)
+from .events import AssetKey, CoercibleToAssetKey
 from .metadata import RawMetadataMapping
 
 

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -17,14 +17,7 @@ from typing import (
 from typing_extensions import TypeAlias
 
 from dagster._annotations import public
-from dagster._config import (
-    ALL_CONFIG_BUILTINS,
-    ConfigType,
-    Field,
-    Permissive,
-    Selector,
-    Shape,
-)
+from dagster._config import ALL_CONFIG_BUILTINS, ConfigType, Field, Permissive, Selector, Shape
 from dagster._core.definitions.asset_layer import AssetLayer
 from dagster._core.definitions.executor_definition import (
     ExecutorDefinition,

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -209,10 +209,7 @@ class RunRequest(
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> "RunRequest":
         from dagster._core.definitions.job_definition import JobDefinition
-        from dagster._core.definitions.partition import (
-            PartitionedConfig,
-            PartitionsDefinition,
-        )
+        from dagster._core.definitions.partition import PartitionedConfig, PartitionsDefinition
 
         if self.partition_key is None:
             check.failed(
@@ -290,9 +287,7 @@ def _check_valid_partition_key_after_dynamic_partitions_requests(
     dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
 ):
     from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
-    from dagster._core.definitions.partition import (
-        DynamicPartitionsDefinition,
-    )
+    from dagster._core.definitions.partition import DynamicPartitionsDefinition
 
     if isinstance(partitions_def, MultiPartitionsDefinition):
         multipartition_key = partitions_def.get_partition_key_from_str(partition_key)

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -25,31 +25,18 @@ import dagster._check as check
 from dagster._annotations import deprecated_param, public
 from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.definitions.resource_annotation import get_resource_args
-from dagster._core.definitions.scoped_resources_builder import (
-    Resources,
-    ScopedResourcesBuilder,
-)
+from dagster._core.definitions.scoped_resources_builder import Resources, ScopedResourcesBuilder
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
     DagsterInvariantViolationError,
     RunStatusSensorExecutionError,
     user_code_error_boundary,
 )
-from dagster._core.event_api import (
-    RunStatusChangeEventType,
-    RunStatusChangeRecordsFilter,
-)
-from dagster._core.events import (
-    PIPELINE_RUN_STATUS_TO_EVENT_TYPE,
-    DagsterEvent,
-    DagsterEventType,
-)
+from dagster._core.event_api import RunStatusChangeEventType, RunStatusChangeRecordsFilter
+from dagster._core.events import PIPELINE_RUN_STATUS_TO_EVENT_TYPE, DagsterEvent, DagsterEventType
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
-from dagster._serdes import (
-    serialize_value,
-    whitelist_for_serdes,
-)
+from dagster._serdes import serialize_value, whitelist_for_serdes
 from dagster._serdes.errors import DeserializationError
 from dagster._serdes.serdes import deserialize_value
 from dagster._seven import JSONDecodeError
@@ -199,9 +186,7 @@ class RunStatusSensorContext:
 
     @property
     def resources(self) -> Resources:
-        from dagster._core.definitions.scoped_resources_builder import (
-            IContainsGenerator,
-        )
+        from dagster._core.definitions.scoped_resources_builder import IContainsGenerator
         from dagster._core.execution.build_resources import build_resources
 
         if not self._resources:

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -241,9 +241,7 @@ class ScheduleEvaluationContext:
         """Mapping of resource key to resource definition to be made available
         during schedule execution.
         """
-        from dagster._core.definitions.scoped_resources_builder import (
-            IContainsGenerator,
-        )
+        from dagster._core.definitions.scoped_resources_builder import IContainsGenerator
         from dagster._core.execution.build_resources import build_resources
 
         if not self._resources:

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -30,21 +30,12 @@ import dagster._check as check
 from dagster._annotations import deprecated, deprecated_param, public
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.asset_selection import CoercibleToAssetSelection
-from dagster._core.definitions.events import (
-    AssetMaterialization,
-    AssetObservation,
-)
+from dagster._core.definitions.events import AssetMaterialization, AssetObservation
 from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.definitions.job_definition import JobDefinition
-from dagster._core.definitions.partition import (
-    CachingDynamicPartitionsLoader,
-)
-from dagster._core.definitions.resource_annotation import (
-    get_resource_args,
-)
-from dagster._core.definitions.resource_definition import (
-    Resources,
-)
+from dagster._core.definitions.partition import CachingDynamicPartitionsLoader
+from dagster._core.definitions.resource_annotation import get_resource_args
+from dagster._core.definitions.resource_definition import Resources
 from dagster._core.definitions.scoped_resources_builder import ScopedResourcesBuilder
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
@@ -60,9 +51,7 @@ from dagster._utils import IHasInternalInit, normalize_to_repository
 from dagster._utils.merger import merge_dicts
 from dagster._utils.warnings import normalize_renamed_param
 
-from ..decorator_utils import (
-    get_function_params,
-)
+from ..decorator_utils import get_function_params
 from .asset_selection import AssetSelection, KeysAssetSelection
 from .graph_definition import GraphDefinition
 from .run_request import (
@@ -272,9 +261,7 @@ class SensorEvaluationContext:
     @property
     def resources(self) -> Resources:
         """Resources: A mapping from resource key to instantiated resources for this sensor."""
-        from dagster._core.definitions.scoped_resources_builder import (
-            IContainsGenerator,
-        )
+        from dagster._core.definitions.scoped_resources_builder import IContainsGenerator
         from dagster._core.execution.build_resources import build_resources
 
         if not self._resources:

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -54,9 +54,7 @@ from dagster._core.errors import (
 from .utils import validate_tags_strict
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.decorators.op_decorator import (
-        DecoratedOpFunction,
-    )
+    from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
 from dagster._core.storage.io_manager import IOManagerDefinition
 from dagster._utils.merger import merge_dicts
 from dagster._utils.warnings import disable_dagster_warnings
@@ -78,9 +76,7 @@ def wrap_source_asset_observe_fn_in_op_compute_fn(
         DecoratedOpFunction,
         is_context_provided,
     )
-    from dagster._core.execution.context.compute import (
-        OpExecutionContext,
-    )
+    from dagster._core.execution.context.compute import OpExecutionContext
 
     check.not_none(source_asset.observe_fn, "Must be an observable source asset")
     assert source_asset.observe_fn  # for type checker
@@ -225,9 +221,7 @@ class SourceAsset(ResourceAddable):
         _required_resource_keys: Optional[AbstractSet[str]] = None,
         # Add additional fields to with_resources and with_group below
     ):
-        from dagster._core.execution.build_resources import (
-            wrap_resources_for_execution,
-        )
+        from dagster._core.execution.build_resources import wrap_resources_for_execution
 
         self.key = AssetKey.from_coercible(key)
         metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -30,9 +30,7 @@ import dagster._check as check
 from dagster._annotations import PublicAttr, public
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.instance import DynamicPartitionsStore
-from dagster._serdes import (
-    whitelist_for_serdes,
-)
+from dagster._serdes import whitelist_for_serdes
 from dagster._serdes.serdes import (
     FieldSerializer,
     NamedTupleSerializer,
@@ -57,10 +55,7 @@ from dagster._utils.schedules import (
     reverse_cron_string_iterator,
 )
 
-from ..errors import (
-    DagsterInvalidDefinitionError,
-    DagsterInvalidDeserializationVersionError,
-)
+from ..errors import DagsterInvalidDefinitionError, DagsterInvalidDeserializationVersionError
 from .partition import (
     DEFAULT_DATE_FORMAT,
     AllPartitionsSubset,

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -4,10 +4,7 @@ from typing import TYPE_CHECKING, AbstractSet, Any, Mapping, NamedTuple, Optiona
 import dagster._check as check
 from dagster._annotations import deprecated
 from dagster._core.definitions import AssetKey
-from dagster._core.definitions.asset_job import (
-    build_asset_job,
-    get_asset_graph_for_job,
-)
+from dagster._core.definitions.asset_job import build_asset_job, get_asset_graph_for_job
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.hook_definition import HookDefinition

--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -50,15 +50,8 @@ from dagster._core.execution.plan.outputs import StepOutputData
 from dagster._core.log_manager import DagsterLogManager
 from dagster._core.storage.captured_log_manager import CapturedLogContext
 from dagster._core.storage.dagster_run import DagsterRunStatus
-from dagster._serdes import (
-    NamedTupleSerializer,
-    whitelist_for_serdes,
-)
-from dagster._serdes.serdes import (
-    EnumSerializer,
-    UnpackContext,
-    is_whitelisted_for_serdes_object,
-)
+from dagster._serdes import NamedTupleSerializer, whitelist_for_serdes
+from dagster._serdes.serdes import EnumSerializer, UnpackContext, is_whitelisted_for_serdes_object
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 from dagster._utils.timing import format_duration
 

--- a/python_modules/dagster/dagster/_core/events/log.py
+++ b/python_modules/dagster/dagster/_core/events/log.py
@@ -7,11 +7,7 @@ from dagster._core.definitions.events import AssetMaterialization, AssetObservat
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.events import DagsterEvent, DagsterEventType
 from dagster._core.utils import coerce_valid_log_level
-from dagster._serdes.serdes import (
-    deserialize_value,
-    serialize_value,
-    whitelist_for_serdes,
-)
+from dagster._serdes.serdes import deserialize_value, serialize_value, whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo
 from dagster._utils.log import (
     StructuredLoggerHandler,

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -63,10 +63,7 @@ from dagster._core.storage.tags import (
     BACKFILL_ID_TAG,
     PARTITION_NAME_TAG,
 )
-from dagster._core.workspace.context import (
-    BaseWorkspaceRequestContext,
-    IWorkspaceProcessContext,
-)
+from dagster._core.workspace.context import BaseWorkspaceRequestContext, IWorkspaceProcessContext
 from dagster._core.workspace.workspace import IWorkspace
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils import utc_datetime_from_timestamp

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -1,9 +1,7 @@
 from abc import ABC, ABCMeta, abstractmethod
 from contextlib import contextmanager
 from contextvars import ContextVar
-from inspect import (
-    _empty as EmptyAnnotation,
-)
+from inspect import _empty as EmptyAnnotation
 from typing import (
     AbstractSet,
     Any,
@@ -19,11 +17,7 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster._annotations import (
-    deprecated,
-    experimental,
-    public,
-)
+from dagster._annotations import deprecated, experimental, public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSpec
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import (
@@ -59,9 +53,7 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.log_manager import DagsterLogManager
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._utils.forked_pdb import ForkedPdb
-from dagster._utils.warnings import (
-    deprecation_warning,
-)
+from dagster._utils.warnings import deprecation_warning
 
 from .system import StepExecutionContext
 

--- a/python_modules/dagster/dagster/_core/execution/context/data_version_cache.py
+++ b/python_modules/dagster/dagster/_core/execution/context/data_version_cache.py
@@ -9,12 +9,7 @@ in the user_context module.
 
 from dataclasses import dataclass
 from hashlib import sha256
-from typing import (
-    Dict,
-    List,
-    Optional,
-    Sequence,
-)
+from typing import Dict, List, Optional, Sequence
 
 import dagster._check as check
 from dagster._core.definitions.data_version import (
@@ -25,9 +20,7 @@ from dagster._core.definitions.data_version import (
 from dagster._core.definitions.events import AssetKey
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.data_version import (
-        DataVersion,
-    )
+    from dagster._core.definitions.data_version import DataVersion
     from dagster._core.event_api import EventLogRecord
     from dagster._core.events import DagsterEventType
     from dagster._core.storage.event_log.base import AssetRecord
@@ -99,9 +92,7 @@ class DataVersionCache:
         self.is_external_input_asset_version_info_loaded = True
 
     def _fetch_input_asset_version_info(self, asset_keys: Sequence[AssetKey]) -> None:
-        from dagster._core.definitions.data_version import (
-            extract_data_version_from_entry,
-        )
+        from dagster._core.definitions.data_version import extract_data_version_from_entry
 
         asset_records_by_key = self._fetch_asset_records(asset_keys)
         for key in asset_keys:
@@ -195,9 +186,7 @@ class DataVersionCache:
     def _get_partitions_data_version_from_keys(
         self, key: AssetKey, partition_keys: Sequence[str]
     ) -> "DataVersion":
-        from dagster._core.definitions.data_version import (
-            DataVersion,
-        )
+        from dagster._core.definitions.data_version import DataVersion
         from dagster._core.events import DagsterEventType
 
         # TODO: this needs to account for observations also

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -1,28 +1,13 @@
 from datetime import datetime
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Iterable,
-    Iterator,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, List, Mapping, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._annotations import deprecated, deprecated_param, public
 from dagster._core.definitions.events import AssetKey, AssetObservation, CoercibleToAssetKey
-from dagster._core.definitions.metadata import (
-    ArbitraryMetadataMapping,
-    MetadataValue,
-)
+from dagster._core.definitions.metadata import ArbitraryMetadataMapping, MetadataValue
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.time_window_partitions import (
-    TimeWindow,
-)
+from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.instance import DagsterInstance, DynamicPartitionsStore
 from dagster._utils.warnings import normalize_renamed_param

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -32,9 +32,7 @@ from dagster._core.definitions.multi_dimensional_partitions import MultiPartitio
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
-from dagster._core.definitions.partition_mapping import (
-    infer_partition_mapping,
-)
+from dagster._core.definitions.partition_mapping import infer_partition_mapping
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.reconstruct import ReconstructableJob
 from dagster._core.definitions.repository_definition.repository_definition import (
@@ -70,9 +68,7 @@ from .input import InputContext
 from .output import OutputContext, get_output_context
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.data_version import (
-        DataVersion,
-    )
+    from dagster._core.definitions.data_version import DataVersion
     from dagster._core.definitions.dependency import NodeHandle
     from dagster._core.definitions.resource_definition import Resources
     from dagster._core.execution.plan.plan import ExecutionPlan

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -10,14 +10,8 @@ from dagster._core.errors import DagsterBackfillFailedError
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation import (
-    CodeLocation,
-    ExternalJob,
-    ExternalPartitionSet,
-)
-from dagster._core.remote_representation.external_data import (
-    ExternalPartitionSetExecutionParamData,
-)
+from dagster._core.remote_representation import CodeLocation, ExternalJob, ExternalPartitionSet
+from dagster._core.remote_representation.external_data import ExternalPartitionSetExecutionParamData
 from dagster._core.remote_representation.origin import RemotePartitionSetOrigin
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import (
@@ -30,10 +24,7 @@ from dagster._core.storage.tags import (
 )
 from dagster._core.telemetry import BACKFILL_RUN_CREATED, hash_name, log_action
 from dagster._core.utils import make_new_run_id
-from dagster._core.workspace.context import (
-    BaseWorkspaceRequestContext,
-    IWorkspaceProcessContext,
-)
+from dagster._core.workspace.context import BaseWorkspaceRequestContext, IWorkspaceProcessContext
 from dagster._utils import check_for_debug_crash
 from dagster._utils.error import SerializableErrorInfo
 from dagster._utils.merger import merge_dicts

--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -1,16 +1,6 @@
 import asyncio
 import inspect
-from typing import (
-    Any,
-    AsyncIterator,
-    Iterator,
-    List,
-    Mapping,
-    Sequence,
-    Set,
-    TypeVar,
-    Union,
-)
+from typing import Any, AsyncIterator, Iterator, List, Mapping, Sequence, Set, TypeVar, Union
 
 from typing_extensions import TypeAlias
 
@@ -30,10 +20,7 @@ from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_layer import AssetLayer
 from dagster._core.definitions.op_definition import OpComputeFunction
 from dagster._core.definitions.result import AssetResult, MaterializeResult, ObserveResult
-from dagster._core.errors import (
-    DagsterExecutionStepExecutionError,
-    DagsterInvariantViolationError,
-)
+from dagster._core.errors import DagsterExecutionStepExecutionError, DagsterInvariantViolationError
 from dagster._core.events import DagsterEvent
 from dagster._core.execution.context.compute import (
     AssetCheckExecutionContext,

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -1,16 +1,6 @@
 import inspect
 import warnings
-from typing import (
-    AbstractSet,
-    Any,
-    Dict,
-    Iterator,
-    Mapping,
-    Optional,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import AbstractSet, Any, Dict, Iterator, Mapping, Optional, Tuple, Union, cast
 
 from typing_extensions import TypedDict
 
@@ -42,10 +32,7 @@ from dagster._core.definitions.data_version import (
 )
 from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
 from dagster._core.definitions.events import DynamicOutput
-from dagster._core.definitions.metadata import (
-    MetadataValue,
-    normalize_metadata,
-)
+from dagster._core.definitions.metadata import MetadataValue, normalize_metadata
 from dagster._core.definitions.multi_dimensional_partitions import (
     MultiPartitionKey,
     get_tags_from_multi_partition_key,
@@ -74,10 +61,7 @@ from dagster._core.storage.tags import BACKFILL_ID_TAG, MEMOIZED_RUN_TAG
 from dagster._core.types.dagster_type import DagsterType
 from dagster._utils import iterate_with_context
 from dagster._utils.timing import time_execution_scope
-from dagster._utils.warnings import (
-    disable_dagster_warnings,
-    experimental_warning,
-)
+from dagster._utils.warnings import disable_dagster_warnings, experimental_warning
 
 from .compute import OpOutputUnion
 from .compute_generator import create_op_compute_wrapper

--- a/python_modules/dagster/dagster/_core/execution/plan/instance_concurrency_context.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/instance_concurrency_context.py
@@ -1,12 +1,7 @@
 import time
 from collections import defaultdict
 from types import TracebackType
-from typing import (
-    List,
-    Optional,
-    Set,
-    Type,
-)
+from typing import List, Optional, Set, Type
 
 from typing_extensions import Self
 

--- a/python_modules/dagster/dagster/_core/execution/plan/outputs.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/outputs.py
@@ -1,10 +1,7 @@
 from typing import Mapping, NamedTuple, Optional
 
 import dagster._check as check
-from dagster._core.definitions import (
-    AssetMaterialization,
-    NodeHandle,
-)
+from dagster._core.definitions import AssetMaterialization, NodeHandle
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import (

--- a/python_modules/dagster/dagster/_core/execution/run_metrics_thread.py
+++ b/python_modules/dagster/dagster/_core/execution/run_metrics_thread.py
@@ -10,9 +10,7 @@ import dagster._check as check
 from dagster._core.execution.telemetry import RunTelemetryData
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun
-from dagster._utils.container import (
-    retrieve_containerized_utilization_metrics,
-)
+from dagster._utils.container import retrieve_containerized_utilization_metrics
 
 DEFAULT_RUN_METRICS_POLL_INTERVAL_SECONDS = 15.0
 DEFAULT_RUN_METRICS_SHUTDOWN_SECONDS = 30

--- a/python_modules/dagster/dagster/_core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/_core/executor/multiprocess.py
@@ -5,9 +5,7 @@ from contextlib import ExitStack
 from multiprocessing.context import BaseContext as MultiprocessingBaseContext
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Mapping, Optional, Sequence
 
-from dagster import (
-    _check as check,
-)
+from dagster import _check as check
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.reconstruct import ReconstructableJob
 from dagster._core.definitions.repository_definition import RepositoryLoadData

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -75,10 +75,7 @@ from dagster._seven import get_current_datetime_in_utc
 from dagster._utils import PrintFn, is_uuid, traced
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.merger import merge_dicts
-from dagster._utils.warnings import (
-    deprecation_warning,
-    experimental_warning,
-)
+from dagster._utils.warnings import deprecation_warning, experimental_warning
 
 from .config import (
     DAGSTER_CONFIG_YAML_FILENAME,
@@ -106,9 +103,7 @@ RUNLESS_JOB_NAME = ""
 if TYPE_CHECKING:
     from dagster._core.debug import DebugRunPayload
     from dagster._core.definitions.asset_check_spec import AssetCheckKey
-    from dagster._core.definitions.job_definition import (
-        JobDefinition,
-    )
+    from dagster._core.definitions.job_definition import JobDefinition
     from dagster._core.definitions.partition import PartitionsDefinition
     from dagster._core.definitions.repository_definition.repository_definition import (
         RepositoryLoadData,
@@ -1263,9 +1258,7 @@ class DagsterInstance(DynamicPartitionsStore):
         )
 
         if execution_plan_snapshot:
-            from ..op_concurrency_limits_counter import (
-                compute_run_op_concurrency_info_for_snapshot,
-            )
+            from ..op_concurrency_limits_counter import compute_run_op_concurrency_info_for_snapshot
 
             run_op_concurrency = compute_run_op_concurrency_info_for_snapshot(
                 execution_plan_snapshot
@@ -1369,10 +1362,7 @@ class DagsterInstance(DynamicPartitionsStore):
     ) -> None:
         from dagster._core.definitions.partition import DynamicPartitionsDefinition
         from dagster._core.definitions.partition_key_range import PartitionKeyRange
-        from dagster._core.events import (
-            AssetMaterializationPlannedData,
-            DagsterEvent,
-        )
+        from dagster._core.events import AssetMaterializationPlannedData, DagsterEvent
 
         partition_tag = dagster_run.tags.get(PARTITION_NAME_TAG)
         partition_range_start, partition_range_end = (
@@ -1435,10 +1425,7 @@ class DagsterInstance(DynamicPartitionsStore):
         execution_plan_snapshot: "ExecutionPlanSnapshot",
         asset_job_partitions_def: Optional["PartitionsDefinition"],
     ) -> None:
-        from dagster._core.events import (
-            DagsterEvent,
-            DagsterEventType,
-        )
+        from dagster._core.events import DagsterEvent, DagsterEventType
 
         job_name = dagster_run.job_name
 
@@ -1644,9 +1631,7 @@ class DagsterInstance(DynamicPartitionsStore):
         run_config: Optional[Mapping[str, Any]] = None,
         use_parent_run_tags: bool = False,
     ) -> DagsterRun:
-        from dagster._core.execution.plan.resume_retry import (
-            ReexecutionStrategy,
-        )
+        from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
         from dagster._core.execution.plan.state import KnownExecutionState
         from dagster._core.remote_representation import CodeLocation, ExternalJob
 
@@ -2086,10 +2071,7 @@ class DagsterInstance(DynamicPartitionsStore):
         """
         from dagster._core.event_api import EventLogCursor
         from dagster._core.events import DagsterEventType
-        from dagster._core.storage.event_log.base import (
-            EventRecordsFilter,
-            EventRecordsResult,
-        )
+        from dagster._core.storage.event_log.base import EventRecordsFilter, EventRecordsResult
 
         event_records_filter = (
             EventRecordsFilter(DagsterEventType.ASSET_MATERIALIZATION_PLANNED, records_filter)

--- a/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
+++ b/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
@@ -4,9 +4,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Optional, cast
 from typing_extensions import Self
 
 import dagster._seven as seven
-from dagster import (
-    _check as check,
-)
+from dagster import _check as check
 from dagster._config.config_schema import UserConfigSchema
 from dagster._core.errors import (
     DagsterInvariantViolationError,
@@ -15,10 +13,7 @@ from dagster._core.errors import (
 )
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.storage.tags import GRPC_INFO_TAG
-from dagster._serdes import (
-    ConfigurableClass,
-    deserialize_value,
-)
+from dagster._serdes import ConfigurableClass, deserialize_value
 from dagster._serdes.config_class import ConfigurableClassData
 from dagster._utils.merger import merge_dicts
 
@@ -100,9 +95,7 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
 
     def launch_run(self, context: LaunchRunContext) -> None:
         # defer for perf
-        from dagster._core.remote_representation.code_location import (
-            GrpcServerCodeLocation,
-        )
+        from dagster._core.remote_representation.code_location import GrpcServerCodeLocation
 
         run = context.dagster_run
 

--- a/python_modules/dagster/dagster/_core/log_manager.py
+++ b/python_modules/dagster/dagster/_core/log_manager.py
@@ -1,16 +1,7 @@
 import datetime
 import logging
 import threading
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Mapping,
-    Optional,
-    Sequence,
-    TypedDict,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, TypedDict, Union, cast
 
 from typing_extensions import Final
 

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -26,10 +26,7 @@ from dagster import (
 )
 from dagster._annotations import experimental
 from dagster._core.errors import DagsterInvariantViolationError, DagsterPipesExecutionError
-from dagster._core.pipes.client import (
-    PipesContextInjector,
-    PipesMessageReader,
-)
+from dagster._core.pipes.client import PipesContextInjector, PipesMessageReader
 from dagster._core.pipes.context import (
     PipesMessageHandler,
     PipesSession,

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -21,9 +21,7 @@ from dagster._config.snap import ConfigFieldSnap, ConfigSchemaSnapshot
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.metadata import (
-    MetadataValue,
-)
+from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.schedule_definition import DefaultScheduleStatus

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -53,9 +53,7 @@ from dagster._core.definitions.asset_spec import (
     SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE,
     AssetExecutionType,
 )
-from dagster._core.definitions.assets import (
-    AssetsDefinition,
-)
+from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.auto_materialize_sensor_definition import (
     AutoMaterializeSensorDefinition,
@@ -101,10 +99,7 @@ from dagster._core.snap.mode import ResourceDefSnap, build_resource_def_snap
 from dagster._core.storage.io_manager import IOManagerDefinition
 from dagster._core.utils import is_valid_email
 from dagster._serdes import whitelist_for_serdes
-from dagster._serdes.serdes import (
-    FieldSerializer,
-    is_whitelisted_for_serdes_object,
-)
+from dagster._serdes.serdes import FieldSerializer, is_whitelisted_for_serdes_object
 from dagster._utils.error import SerializableErrorInfo
 
 DEFAULT_MODE_NAME = "default"

--- a/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
@@ -2,16 +2,7 @@ import sys
 import threading
 import uuid
 from contextlib import AbstractContextManager
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    NamedTuple,
-    Optional,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union, cast
 
 import pendulum
 from typing_extensions import TypeGuard

--- a/python_modules/dagster/dagster/_core/remote_representation/handle.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/handle.py
@@ -3,10 +3,7 @@ from typing import TYPE_CHECKING, Mapping, NamedTuple
 import dagster._check as check
 from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.origin import RepositoryPythonOrigin
-from dagster._core.remote_representation.origin import (
-    CodeLocationOrigin,
-    RemoteRepositoryOrigin,
-)
+from dagster._core.remote_representation.origin import CodeLocationOrigin, RemoteRepositoryOrigin
 
 if TYPE_CHECKING:
     from dagster._core.remote_representation.code_location import CodeLocation

--- a/python_modules/dagster/dagster/_core/remote_representation/job_index.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/job_index.py
@@ -3,11 +3,7 @@ from typing import Any, Mapping, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._config import ConfigSchemaSnapshot
-from dagster._core.snap import (
-    DependencyStructureIndex,
-    JobSnapshot,
-    create_job_snapshot_id,
-)
+from dagster._core.snap import DependencyStructureIndex, JobSnapshot, create_job_snapshot_id
 from dagster._core.snap.dagster_types import DagsterTypeSnap
 from dagster._core.snap.mode import ModeDefSnap
 from dagster._core.snap.node import GraphDefSnap, OpDefSnap

--- a/python_modules/dagster/dagster/_core/remote_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/origin.py
@@ -25,10 +25,7 @@ from dagster._core.errors import DagsterInvariantViolationError, DagsterUserCode
 from dagster._core.instance.config import DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
 from dagster._core.origin import DEFAULT_DAGSTER_ENTRY_POINT
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._serdes import (
-    create_snapshot_id,
-    whitelist_for_serdes,
-)
+from dagster._serdes import create_snapshot_id, whitelist_for_serdes
 
 if TYPE_CHECKING:
     from dagster._core.instance import DagsterInstance
@@ -199,9 +196,7 @@ class InProcessCodeLocationOrigin(
         return {}
 
     def create_location(self, instance: "DagsterInstance") -> "InProcessCodeLocation":
-        from dagster._core.remote_representation.code_location import (
-            InProcessCodeLocation,
-        )
+        from dagster._core.remote_representation.code_location import InProcessCodeLocation
 
         return InProcessCodeLocation(self, instance=instance)
 
@@ -347,9 +342,7 @@ class GrpcServerCodeLocationOrigin(
         return {key: value for key, value in metadata.items() if value is not None}
 
     def reload_location(self, instance: "DagsterInstance") -> "GrpcServerCodeLocation":
-        from dagster._core.remote_representation.code_location import (
-            GrpcServerCodeLocation,
-        )
+        from dagster._core.remote_representation.code_location import GrpcServerCodeLocation
 
         try:
             self.create_client().reload_code(timeout=instance.code_server_reload_timeout)
@@ -366,9 +359,7 @@ class GrpcServerCodeLocationOrigin(
         return GrpcServerCodeLocation(self, instance=instance)
 
     def create_location(self, instance: "DagsterInstance") -> "GrpcServerCodeLocation":
-        from dagster._core.remote_representation.code_location import (
-            GrpcServerCodeLocation,
-        )
+        from dagster._core.remote_representation.code_location import GrpcServerCodeLocation
 
         return GrpcServerCodeLocation(self, instance=instance)
 

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -25,11 +25,7 @@ from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.remote_representation.origin import RemoteInstigatorOrigin
 from dagster._serdes import create_snapshot_id
 from dagster._serdes.errors import DeserializationError
-from dagster._serdes.serdes import (
-    EnumSerializer,
-    deserialize_value,
-    whitelist_for_serdes,
-)
+from dagster._serdes.serdes import EnumSerializer, deserialize_value, whitelist_for_serdes
 from dagster._utils import datetime_as_float, xor
 from dagster._utils.error import SerializableErrorInfo
 from dagster._utils.merger import merge_dicts

--- a/python_modules/dagster/dagster/_core/snap/job_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/job_snapshot.py
@@ -23,9 +23,7 @@ from dagster._config import (
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.job_definition import (
-    JobDefinition,
-)
+from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.metadata import (
     MetadataFieldSerializer,
     MetadataValue,
@@ -33,26 +31,14 @@ from dagster._core.definitions.metadata import (
     normalize_metadata,
 )
 from dagster._core.utils import toposort_flatten
-from dagster._serdes import (
-    create_snapshot_id,
-    deserialize_value,
-    whitelist_for_serdes,
-)
+from dagster._serdes import create_snapshot_id, deserialize_value, whitelist_for_serdes
 from dagster._serdes.serdes import NamedTupleSerializer
 
 from .config_types import build_config_schema_snapshot
 from .dagster_types import DagsterTypeNamespaceSnapshot, build_dagster_type_namespace_snapshot
-from .dep_snapshot import (
-    DependencyStructureSnapshot,
-    build_dep_structure_snapshot_from_graph_def,
-)
+from .dep_snapshot import DependencyStructureSnapshot, build_dep_structure_snapshot_from_graph_def
 from .mode import ModeDefSnap, build_mode_def_snap
-from .node import (
-    GraphDefSnap,
-    NodeDefsSnapshot,
-    OpDefSnap,
-    build_node_defs_snapshot,
-)
+from .node import GraphDefSnap, NodeDefsSnapshot, OpDefSnap, build_node_defs_snapshot
 
 
 def create_job_snapshot_id(snapshot: "JobSnapshot") -> str:

--- a/python_modules/dagster/dagster/_core/snap/node.py
+++ b/python_modules/dagster/dagster/_core/snap/node.py
@@ -18,10 +18,7 @@ from dagster._core.definitions.metadata import (
 )
 from dagster._serdes import whitelist_for_serdes
 
-from .dep_snapshot import (
-    DependencyStructureSnapshot,
-    build_dep_structure_snapshot_from_graph_def,
-)
+from .dep_snapshot import DependencyStructureSnapshot, build_dep_structure_snapshot_from_graph_def
 
 
 @whitelist_for_serdes(

--- a/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/branching/branching_io_manager.py
@@ -1,10 +1,7 @@
 from typing import Any, Optional
 
 from dagster import InputContext, OutputContext
-from dagster._config.pythonic_config import (
-    ConfigurableIOManager,
-    ResourceDependency,
-)
+from dagster._config.pythonic_config import ConfigurableIOManager, ResourceDependency
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
 from dagster._core.definitions.metadata import TextMetadataValue
 from dagster._core.event_api import AssetRecordsFilter

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -24,10 +24,7 @@ from dagster._core.loader import InstanceLoadableBy
 from dagster._core.origin import JobPythonOrigin
 from dagster._core.storage.tags import PARENT_RUN_ID_TAG, ROOT_RUN_ID_TAG
 from dagster._core.utils import make_new_run_id
-from dagster._serdes.serdes import (
-    NamedTupleSerializer,
-    whitelist_for_serdes,
-)
+from dagster._serdes.serdes import NamedTupleSerializer, whitelist_for_serdes
 
 from .tags import (
     BACKFILL_ID_TAG,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -68,10 +68,7 @@ from dagster._core.storage.sqlalchemy_compat import (
     db_select,
     db_subquery,
 )
-from dagster._serdes import (
-    deserialize_value,
-    serialize_value,
-)
+from dagster._serdes import deserialize_value, serialize_value
 from dagster._serdes.errors import DeserializationError
 from dagster._utils import (
     PrintFn,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -44,10 +44,7 @@ from dagster._core.storage.sql import (
 )
 from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.sqlite import create_db_conn_string
-from dagster._serdes import (
-    ConfigurableClass,
-    ConfigurableClassData,
-)
+from dagster._serdes import ConfigurableClass, ConfigurableClassData
 from dagster._serdes.errors import DeserializationError
 from dagster._serdes.serdes import deserialize_value
 from dagster._utils import mkdir_p

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -1,17 +1,6 @@
-from typing import (
-    TYPE_CHECKING,
-    Iterable,
-    Mapping,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Set, Tuple, Union
 
-from dagster import (
-    _check as check,
-)
+from dagster import _check as check
 from dagster._config.config_schema import UserConfigSchema
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.declarative_automation.serialized_objects import (
@@ -19,9 +8,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
 )
 from dagster._core.definitions.events import AssetKey
 from dagster._core.event_api import EventHandlerFn
-from dagster._core.storage.asset_check_execution_record import (
-    AssetCheckExecutionRecord,
-)
+from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecord
 from dagster._core.storage.event_log.base import AssetCheckSummaryRecord
 from dagster._serdes import ConfigurableClass, ConfigurableClassData
 from dagster._utils import PrintFn

--- a/python_modules/dagster/dagster/_core/storage/migration/bigint_migration.py
+++ b/python_modules/dagster/dagster/_core/storage/migration/bigint_migration.py
@@ -3,10 +3,7 @@ from typing import Any, Callable
 import sqlalchemy as db
 
 from dagster._core.instance import DagsterInstance
-from dagster._core.storage.event_log import (
-    SqlEventLogStorage,
-    SqliteEventLogStorage,
-)
+from dagster._core.storage.event_log import SqlEventLogStorage, SqliteEventLogStorage
 from dagster._core.storage.event_log.schema import (
     AssetKeyTable,
     DynamicPartitionsTable,
@@ -21,10 +18,7 @@ from dagster._core.storage.runs.schema import (
     SecondaryIndexMigrationTable as RunSecondaryIndexTable,
     SnapshotsTable,
 )
-from dagster._core.storage.schedules import (
-    SqliteScheduleStorage,
-    SqlScheduleStorage,
-)
+from dagster._core.storage.schedules import SqliteScheduleStorage, SqlScheduleStorage
 from dagster._core.storage.schedules.schema import (
     InstigatorsTable,
     JobTable,

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -62,10 +62,7 @@ from dagster._core.storage.tags import (
     RUN_FAILURE_REASON_TAG,
 )
 from dagster._daemon.types import DaemonHeartbeat
-from dagster._serdes import (
-    deserialize_value,
-    serialize_value,
-)
+from dagster._serdes import deserialize_value, serialize_value
 from dagster._seven import JSONDecodeError
 from dagster._utils import PrintFn, utc_datetime_from_timestamp
 from dagster._utils.merger import merge_dicts

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -52,9 +52,7 @@ from dagster._core.errors import DagsterUserCodeUnreachableError
 from dagster._core.events import DagsterEvent
 from dagster._core.instance import DagsterInstance
 from dagster._core.launcher import RunLauncher
-from dagster._core.remote_representation.origin import (
-    InProcessCodeLocationOrigin,
-)
+from dagster._core.remote_representation.origin import InProcessCodeLocationOrigin
 from dagster._core.run_coordinator import RunCoordinator, SubmitRunContext
 from dagster._core.secrets import SecretsLoader
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter

--- a/python_modules/dagster/dagster/_core/types/config_schema.py
+++ b/python_modules/dagster/dagster/_core/types/config_schema.py
@@ -10,15 +10,10 @@ from dagster._config import ConfigType
 from dagster._core.decorator_utils import get_function_params, validate_expected_params
 from dagster._core.errors import DagsterInvalidDefinitionError
 
-from ..definitions.resource_requirement import (
-    ResourceRequirement,
-    TypeLoaderResourceRequirement,
-)
+from ..definitions.resource_requirement import ResourceRequirement, TypeLoaderResourceRequirement
 
 if TYPE_CHECKING:
-    from dagster._core.execution.context.system import (
-        DagsterTypeLoaderContext,
-    )
+    from dagster._core.execution.context.system import DagsterTypeLoaderContext
 
 
 class DagsterTypeLoader(ABC):

--- a/python_modules/dagster/dagster/_core/types/dagster_type.py
+++ b/python_modules/dagster/dagster/_core/types/dagster_type.py
@@ -24,11 +24,7 @@ from dagster._config import (
     Noneable as ConfigNoneable,
 )
 from dagster._core.definitions.events import DynamicOutput, Output, TypeCheck
-from dagster._core.definitions.metadata import (
-    MetadataValue,
-    RawMetadataValue,
-    normalize_metadata,
-)
+from dagster._core.definitions.metadata import MetadataValue, RawMetadataValue, normalize_metadata
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._serdes import whitelist_for_serdes
 from dagster._seven import is_subclass

--- a/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
+++ b/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
@@ -2,11 +2,7 @@ import inspect
 from types import ModuleType
 from typing import Callable, NamedTuple, Optional, Sequence, Tuple, Type, Union
 
-from dagster import (
-    DagsterInvariantViolationError,
-    GraphDefinition,
-    RepositoryDefinition,
-)
+from dagster import DagsterInvariantViolationError, GraphDefinition, RepositoryDefinition
 from dagster._core.code_pointer import load_python_file, load_python_module
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.load_assets_from_modules import assets_from_modules

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -12,10 +12,7 @@ from typing_extensions import Self
 
 import dagster._check as check
 from dagster._core.definitions.selector import JobSubsetSelector
-from dagster._core.errors import (
-    DagsterCodeLocationLoadError,
-    DagsterCodeLocationNotFoundError,
-)
+from dagster._core.errors import DagsterCodeLocationLoadError, DagsterCodeLocationNotFoundError
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation import (
@@ -27,9 +24,7 @@ from dagster._core.remote_representation import (
     GrpcServerCodeLocation,
     RepositoryHandle,
 )
-from dagster._core.remote_representation.grpc_server_registry import (
-    GrpcServerRegistry,
-)
+from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
 from dagster._core.remote_representation.grpc_server_state_subscriber import (
     LocationStateChangeEvent,
     LocationStateChangeEventType,

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -27,23 +27,12 @@ from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
 )
-from dagster._core.definitions.run_request import (
-    InstigatorType,
-    RunRequest,
-)
-from dagster._core.definitions.sensor_definition import (
-    DefaultSensorStatus,
-    SensorType,
-)
-from dagster._core.errors import (
-    DagsterCodeLocationLoadError,
-    DagsterUserCodeUnreachableError,
-)
+from dagster._core.definitions.run_request import InstigatorType, RunRequest
+from dagster._core.definitions.sensor_definition import DefaultSensorStatus, SensorType
+from dagster._core.errors import DagsterCodeLocationLoadError, DagsterUserCodeUnreachableError
 from dagster._core.execution.submit_asset_runs import submit_asset_run
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation import (
-    ExternalSensor,
-)
+from dagster._core.remote_representation import ExternalSensor
 from dagster._core.remote_representation.external import ExternalRepository
 from dagster._core.remote_representation.origin import RemoteInstigatorOrigin
 from dagster._core.scheduler.instigation import (
@@ -68,10 +57,7 @@ from dagster._daemon.sensor import is_under_min_interval, mark_sensor_state_for_
 from dagster._daemon.utils import DaemonErrorCapture
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
-from dagster._utils import (
-    SingleInstigatorDebugCrashFlags,
-    check_for_debug_crash,
-)
+from dagster._utils import SingleInstigatorDebugCrashFlags, check_for_debug_crash
 
 _LEGACY_PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY = "ASSET_DAEMON_CURSOR"
 _PRE_SENSOR_AUTO_MATERIALIZE_CURSOR_KEY = "ASSET_DAEMON_CURSOR_NEW"

--- a/python_modules/dagster/dagster/_daemon/daemon.py
+++ b/python_modules/dagster/dagster/_daemon/daemon.py
@@ -31,10 +31,7 @@ from dagster._daemon.sensor import execute_sensor_iteration_loop
 from dagster._daemon.types import DaemonHeartbeat
 from dagster._daemon.utils import DaemonErrorCapture
 from dagster._scheduler.scheduler import execute_scheduler_iteration_loop
-from dagster._utils.error import (
-    SerializableErrorInfo,
-    serializable_error_info_from_exc_info,
-)
+from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
 if TYPE_CHECKING:
     from pendulum.datetime import DateTime

--- a/python_modules/dagster/dagster/_daemon/monitoring/concurrency.py
+++ b/python_modules/dagster/dagster/_daemon/monitoring/concurrency.py
@@ -3,10 +3,7 @@ from typing import Iterator, Optional
 
 import pendulum
 
-from dagster._core.storage.dagster_run import (
-    FINISHED_STATUSES,
-    RunsFilter,
-)
+from dagster._core.storage.dagster_run import FINISHED_STATUSES, RunsFilter
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._utils import DebugCrashFlags
 from dagster._utils.error import SerializableErrorInfo

--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -11,10 +11,7 @@ from dagster import (
     DagsterEventType,
     _check as check,
 )
-from dagster._core.errors import (
-    DagsterCodeLocationLoadError,
-    DagsterUserCodeUnreachableError,
-)
+from dagster._core.errors import DagsterCodeLocationLoadError, DagsterUserCodeUnreachableError
 from dagster._core.events import EngineEventData
 from dagster._core.instance import DagsterInstance
 from dagster._core.launcher import LaunchRunContext

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -31,9 +31,7 @@ from dagster._core.definitions.run_request import (
     RunRequest,
 )
 from dagster._core.definitions.selector import JobSubsetSelector
-from dagster._core.definitions.sensor_definition import (
-    DefaultSensorStatus,
-)
+from dagster._core.definitions.sensor_definition import DefaultSensorStatus
 from dagster._core.definitions.utils import normalize_tags
 from dagster._core.errors import DagsterError
 from dagster._core.instance import DagsterInstance

--- a/python_modules/dagster/dagster/_daemon/workspace.py
+++ b/python_modules/dagster/dagster/_daemon/workspace.py
@@ -2,9 +2,7 @@ from abc import abstractmethod
 from typing import Mapping, Sequence
 
 from dagster._core.errors import DagsterCodeLocationLoadError
-from dagster._core.remote_representation.code_location import (
-    CodeLocation,
-)
+from dagster._core.remote_representation.code_location import CodeLocation
 from dagster._core.workspace.workspace import (
     CodeLocationEntry,
     CodeLocationStatusEntry,

--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -7,14 +7,10 @@ from typing import TYPE_CHECKING, Dict, Optional
 import dagster._check as check
 from dagster._core.instance import InstanceRef
 from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
-from dagster._core.remote_representation.origin import (
-    ManagedGrpcPythonEnvCodeLocationOrigin,
-)
+from dagster._core.remote_representation.origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.client import DEFAULT_GRPC_TIMEOUT
-from dagster._grpc.types import (
-    SensorExecutionArgs,
-)
+from dagster._grpc.types import SensorExecutionArgs
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._utils.error import serializable_error_info_from_exc_info
 

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -63,11 +63,7 @@ from dagster._core.utils import FuturesAwareThreadPoolExecutor, RequestUtilizati
 from dagster._core.workspace.autodiscovery import LoadableTarget
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._serdes.ipc import IPCErrorMessage, open_ipc_subprocess
-from dagster._utils import (
-    find_free_port,
-    get_run_crash_explanation,
-    safe_tempfile_path_unmanaged,
-)
+from dagster._utils import find_free_port, get_run_crash_explanation, safe_tempfile_path_unmanaged
 from dagster._utils.container import (
     ContainerUtilizationMetrics,
     retrieve_containerized_utilization_metrics,

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -28,10 +28,7 @@ from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.schedule_definition import DefaultScheduleStatus
 from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.definitions.utils import normalize_tags
-from dagster._core.errors import (
-    DagsterCodeLocationLoadError,
-    DagsterUserCodeUnreachableError,
-)
+from dagster._core.errors import DagsterCodeLocationLoadError, DagsterUserCodeUnreachableError
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation import ExternalSchedule
 from dagster._core.remote_representation.code_location import CodeLocation

--- a/python_modules/dagster/dagster/_scheduler/stale.py
+++ b/python_modules/dagster/dagster/_scheduler/stale.py
@@ -1,16 +1,10 @@
 from typing import List, Sequence, Union
 
 import dagster._check as check
-from dagster._core.definitions.data_version import (
-    CachingStaleStatusResolver,
-    StaleStatus,
-)
+from dagster._core.definitions.data_version import CachingStaleStatusResolver, StaleStatus
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.run_request import RunRequest
-from dagster._core.remote_representation.external import (
-    ExternalSchedule,
-    ExternalSensor,
-)
+from dagster._core.remote_representation.external import ExternalSchedule, ExternalSensor
 from dagster._core.workspace.context import WorkspaceProcessContext
 
 

--- a/python_modules/dagster/dagster/_serdes/config_class.py
+++ b/python_modules/dagster/dagster/_serdes/config_class.py
@@ -19,10 +19,7 @@ import dagster._check as check
 from dagster._utils import convert_dagster_submodule_name
 from dagster._utils.yaml_utils import load_run_config_yaml
 
-from .serdes import (
-    NamedTupleSerializer,
-    whitelist_for_serdes,
-)
+from .serdes import NamedTupleSerializer, whitelist_for_serdes
 
 if TYPE_CHECKING:
     from dagster._config.config_schema import UserConfigSchema

--- a/python_modules/dagster/dagster/_serdes/ipc.py
+++ b/python_modules/dagster/dagster/_serdes/ipc.py
@@ -10,11 +10,7 @@ from typing import Any, Iterator, NamedTuple, Optional, Sequence, Tuple
 
 import dagster._check as check
 from dagster._core.errors import DagsterError
-from dagster._serdes.serdes import (
-    deserialize_value,
-    serialize_value,
-    whitelist_for_serdes,
-)
+from dagster._serdes.serdes import deserialize_value, serialize_value, whitelist_for_serdes
 from dagster._utils.error import (
     ExceptionInfo,
     SerializableErrorInfo,

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -27,10 +27,7 @@ from dagster._core.definitions.data_version import (
     extract_data_version_from_entry,
 )
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
-from dagster._core.definitions.partition import (
-    PartitionsDefinition,
-    PartitionsSubset,
-)
+from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
     TimeWindowPartitionsDefinition,
     get_time_partition_key,

--- a/python_modules/dagster/dagster/_utils/env.py
+++ b/python_modules/dagster/dagster/_utils/env.py
@@ -1,9 +1,6 @@
 import os
 from contextlib import contextmanager
-from typing import (
-    Iterator,
-    Mapping,
-)
+from typing import Iterator, Mapping
 
 
 @contextmanager

--- a/python_modules/dagster/dagster/_utils/hosted_user_process.py
+++ b/python_modules/dagster/dagster/_utils/hosted_user_process.py
@@ -12,9 +12,7 @@ import dagster._check as check
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
 from dagster._core.origin import JobPythonOrigin, RepositoryPythonOrigin
 from dagster._core.remote_representation import ExternalJob
-from dagster._core.remote_representation.external_data import (
-    external_job_data_from_def,
-)
+from dagster._core.remote_representation.external_data import external_job_data_from_def
 
 
 def recon_job_from_origin(origin: JobPythonOrigin) -> ReconstructableJob:

--- a/python_modules/dagster/dagster/_utils/schedules.py
+++ b/python_modules/dagster/dagster/_utils/schedules.py
@@ -13,9 +13,7 @@ from dateutil.tz import datetime_ambiguous, datetime_exists
 import dagster._check as check
 from dagster._core.definitions.partition import ScheduleType
 from dagster._seven.compat.datetime import timezone_from_string
-from dagster._seven.compat.pendulum import (
-    pendulum_create_timezone,
-)
+from dagster._seven.compat.pendulum import pendulum_create_timezone
 
 # Monthly schedules with 29-31 won't reliably run every month
 MAX_DAY_OF_MONTH_WITH_GUARANTEED_MONTHLY_INTERVAL = 28

--- a/python_modules/dagster/dagster/_utils/test/mysql_instance.py
+++ b/python_modules/dagster/dagster/_utils/test/mysql_instance.py
@@ -120,9 +120,7 @@ class TestMySQLInstance:
             TestMySQLInstance.dagster_mysql_installed(),
             "dagster_mysql must be installed to test with mysql",
         )
-        from dagster_mysql.schedule_storage.schedule_storage import (
-            MySQLScheduleStorage,
-        )
+        from dagster_mysql.schedule_storage.schedule_storage import MySQLScheduleStorage
 
         storage = MySQLScheduleStorage.create_clean_storage(conn_string)
         assert storage

--- a/python_modules/dagster/dagster/_utils/test/postgres_instance.py
+++ b/python_modules/dagster/dagster/_utils/test/postgres_instance.py
@@ -106,9 +106,7 @@ class TestPostgresInstance:
             TestPostgresInstance.dagster_postgres_installed(),
             "dagster_postgres must be installed to test with postgres",
         )
-        from dagster_postgres.event_log import (
-            PostgresEventLogStorage,
-        )
+        from dagster_postgres.event_log import PostgresEventLogStorage
 
         storage = PostgresEventLogStorage.create_clean_storage(
             conn_string, should_autocreate_tables=should_autocreate_tables
@@ -122,9 +120,7 @@ class TestPostgresInstance:
             TestPostgresInstance.dagster_postgres_installed(),
             "dagster_postgres must be installed to test with postgres",
         )
-        from dagster_postgres.schedule_storage.schedule_storage import (
-            PostgresScheduleStorage,
-        )
+        from dagster_postgres.schedule_storage.schedule_storage import PostgresScheduleStorage
 
         storage = PostgresScheduleStorage.create_clean_storage(
             conn_string, should_autocreate_tables=should_autocreate_tables

--- a/python_modules/dagster/dagster/_utils/warnings.py
+++ b/python_modules/dagster/dagster/_utils/warnings.py
@@ -4,10 +4,7 @@ from contextvars import ContextVar
 from typing import Callable, Iterator, Optional, TypeVar
 
 import dagster._check as check
-from dagster._core.decorator_utils import (
-    Decoratable,
-    apply_context_manager_decorator,
-)
+from dagster._core.decorator_utils import Decoratable, apply_context_manager_decorator
 
 T = TypeVar("T")
 

--- a/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
+++ b/python_modules/dagster/dagster_tests/api_tests/api_tests_repo.py
@@ -17,10 +17,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.decorators.sensor_decorator import sensor
-from dagster._core.definitions.partition import (
-    PartitionedConfig,
-    StaticPartitionsDefinition,
-)
+from dagster._core.definitions.partition import PartitionedConfig, StaticPartitionsDefinition
 from dagster._core.definitions.sensor_definition import RunRequest
 from dagster._core.errors import DagsterError
 

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -3,9 +3,7 @@ from contextlib import contextmanager
 
 import pytest
 from dagster import IntMetadataValue, TextMetadataValue, job, op, repository
-from dagster._api.snapshot_repository import (
-    sync_get_streaming_external_repositories_data_grpc,
-)
+from dagster._api.snapshot_repository import sync_get_streaming_external_repositories_data_grpc
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation import (

--- a/python_modules/dagster/dagster_tests/api_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/api_tests/utils.py
@@ -4,10 +4,7 @@ from typing import Iterator, Optional
 
 from dagster import file_relative_path
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation import (
-    JobHandle,
-    ManagedGrpcPythonEnvCodeLocationOrigin,
-)
+from dagster._core.remote_representation import JobHandle, ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.remote_representation.code_location import GrpcServerCodeLocation
 from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.test_utils import instance_for_test

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_static_partition_mapping.py
@@ -1,10 +1,7 @@
 import pytest
 from dagster import StaticPartitionMapping, StaticPartitionsDefinition
 from dagster._core.definitions.partition import DefaultPartitionsSubset
-from dagster._serdes.serdes import (
-    deserialize_value,
-    serialize_value,
-)
+from dagster._serdes.serdes import deserialize_value, serialize_value
 
 
 def test_single_valued_static_mapping():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -36,9 +36,7 @@ from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import UpstreamPartitionsResult
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.source_asset import SourceAsset
-from dagster._core.errors import (
-    DagsterDefinitionChangedDeserializationError,
-)
+from dagster._core.errors import DagsterDefinitionChangedDeserializationError
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.remote_representation.external_data import (
     external_asset_checks_from_defs,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
@@ -68,9 +68,7 @@ from dagster._core.test_utils import (
     raise_exception_on_warnings,
 )
 from dagster._utils import safe_tempfile_path
-from dagster._utils.warnings import (
-    disable_dagster_warnings,
-)
+from dagster._utils.warnings import disable_dagster_warnings
 
 
 @pytest.fixture(autouse=True)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -35,12 +35,7 @@ from dagster import (
 )
 from dagster._check import CheckError
 from dagster._config.pythonic_config import Config
-from dagster._core.definitions import (
-    AssetIn,
-    AssetsDefinition,
-    asset,
-    multi_asset,
-)
+from dagster._core.definitions import AssetIn, AssetsDefinition, asset, multi_asset
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.decorators.config_mapping_decorator import config_mapping
 from dagster._core.definitions.policy import RetryPolicy

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -25,10 +25,7 @@ from dagster._core.remote_representation import InProcessCodeLocationOrigin
 from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceRequestContext
-from dagster._core.workspace.workspace import (
-    CodeLocationEntry,
-    CodeLocationLoadStatus,
-)
+from dagster._core.workspace.workspace import CodeLocationEntry, CodeLocationLoadStatus
 
 
 @asset

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
@@ -7,10 +7,7 @@ from dagster import (
     IOManager,
     StaticPartitionsDefinition,
 )
-from dagster._core.definitions.data_version import (
-    DataVersion,
-    extract_data_version_from_entry,
-)
+from dagster._core.definitions.data_version import DataVersion, extract_data_version_from_entry
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import TextMetadataValue

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -3,11 +3,7 @@ from unittest.mock import Mock
 
 import pendulum
 import pytest
-from dagster import (
-    DailyPartitionsDefinition,
-    MultiPartitionsDefinition,
-    StaticPartitionsDefinition,
-)
+from dagster import DailyPartitionsDefinition, MultiPartitionsDefinition, StaticPartitionsDefinition
 from dagster._core.definitions.partition import AllPartitionsSubset, DefaultPartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
     PartitionKeysTimeWindowPartitionsSubset,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
@@ -2,10 +2,7 @@ from typing import Optional
 
 import pytest
 from dagster._config.pythonic_config import ConfigurableResource
-from dagster._core.definitions.data_version import (
-    DataVersion,
-    extract_data_version_from_entry,
-)
+from dagster._core.definitions.data_version import DataVersion, extract_data_version_from_entry
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
 from dagster._core.definitions.definitions_class import Definitions

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -29,10 +29,7 @@ from dagster._cli.run import (
 )
 from dagster._cli.workspace.cli_target import ClickArgMapping
 from dagster._core.definitions.decorators.sensor_decorator import sensor
-from dagster._core.definitions.partition import (
-    PartitionedConfig,
-    StaticPartitionsDefinition,
-)
+from dagster._core.definitions.partition import PartitionedConfig, StaticPartitionsDefinition
 from dagster._core.definitions.sensor_definition import RunRequest
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.memoizable_io_manager import versioned_filesystem_io_manager

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_active.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_active.py
@@ -1,10 +1,7 @@
 import math
 import tempfile
 from collections import defaultdict
-from typing import (
-    List,
-    Set,
-)
+from typing import List, Set
 
 import pytest
 from dagster import job, op

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -31,10 +31,7 @@ from dagster import (
 from dagster._check import CheckError
 from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.job_definition import JobDefinition
-from dagster._core.definitions.partition import (
-    PartitionedConfig,
-    StaticPartitionsDefinition,
-)
+from dagster._core.definitions.partition import PartitionedConfig, StaticPartitionsDefinition
 from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition, TimeWindow
 from dagster._core.errors import (
     DagsterConfigMappingFunctionError,

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -41,10 +41,7 @@ from dagster._core.snap import (
     create_job_snapshot_id,
     snapshot_from_execution_plan,
 )
-from dagster._core.storage.partition_status_cache import (
-    AssetPartitionStatus,
-    AssetStatusCacheValue,
-)
+from dagster._core.storage.partition_status_cache import AssetPartitionStatus, AssetStatusCacheValue
 from dagster._core.storage.sqlite_storage import (
     _event_logs_directory,
     _runs_directory,

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_configured.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_configured.py
@@ -1,13 +1,7 @@
 from typing import Any, Dict
 
 import pytest
-from dagster import (
-    Config,
-    RunConfig,
-    configured,
-    job,
-    op,
-)
+from dagster import Config, RunConfig, configured, job, op
 from dagster._check import CheckError
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_binding.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_binding.py
@@ -21,9 +21,7 @@ from dagster import (
 from dagster._core.definitions.repository_definition.repository_data_builder import (
     build_caching_repository_data_from_dict,
 )
-from dagster._core.errors import (
-    DagsterInvalidDefinitionError,
-)
+from dagster._core.errors import DagsterInvalidDefinitionError
 
 
 def test_bind_resource_to_job_at_defn_time_err() -> None:

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_direct_invocation.py
@@ -1,11 +1,5 @@
 import pytest
-from dagster import (
-    AssetExecutionContext,
-    ConfigurableResource,
-    OpExecutionContext,
-    asset,
-    op,
-)
+from dagster import AssetExecutionContext, ConfigurableResource, OpExecutionContext, asset, op
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.execution.context.invocation import build_asset_context, build_op_context
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_env_vars.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_env_vars.py
@@ -3,16 +3,8 @@ import os
 from typing import List, Mapping
 
 import pytest
-from dagster import (
-    Config,
-    ConfigurableResource,
-    Definitions,
-    EnvVar,
-    asset,
-)
-from dagster._core.errors import (
-    DagsterInvalidConfigError,
-)
+from dagster import Config, ConfigurableResource, Definitions, EnvVar, asset
+from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.test_utils import environ
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
@@ -30,9 +30,7 @@ from dagster import (
 )
 from dagster._check import CheckError
 from dagster._config.pythonic_config import ConfigurableResourceFactory
-from dagster._core.errors import (
-    DagsterInvalidDefinitionError,
-)
+from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._utils.cached_method import cached_method
 from pydantic import (
     Field as PyField,

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
@@ -15,10 +15,7 @@ from dagster import (
     resource,
 )
 from dagster._check import CheckError
-from dagster._config.pythonic_config import (
-    ConfigurableIOManager,
-    ConfigurableResourceFactory,
-)
+from dagster._config.pythonic_config import ConfigurableIOManager, ConfigurableResourceFactory
 from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.storage.io_manager import IOManager
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
@@ -1,15 +1,4 @@
-from dagster import (
-    Array,
-    Enum,
-    EnumValue,
-    Field,
-    Noneable,
-    ScalarUnion,
-    Selector,
-    Shape,
-    job,
-    op,
-)
+from dagster import Array, Enum, EnumValue, Field, Noneable, ScalarUnion, Selector, Shape, job, op
 from dagster._config import ConfigTypeKind, Map, resolve_to_config_type
 from dagster._config.snap import ConfigSchemaSnapshot, ConfigTypeSnap
 from dagster._core.definitions.job_definition import JobDefinition
@@ -19,11 +8,7 @@ from dagster._core.snap import (
     snap_from_config_type,
 )
 from dagster._core.types.dagster_type import DagsterType
-from dagster._serdes import (
-    deserialize_value,
-    serialize_pp,
-    serialize_value,
-)
+from dagster._serdes import deserialize_value, serialize_pp, serialize_value
 
 
 def snap_from_dagster_type(dagster_type: DagsterType) -> ConfigTypeSnap:

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_job_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_job_snap.py
@@ -16,10 +16,7 @@ from dagster._core.snap.dep_snapshot import (
     OutputHandleSnap,
     build_dep_structure_snapshot_from_graph_def,
 )
-from dagster._serdes import (
-    serialize_pp,
-    serialize_value,
-)
+from dagster._serdes import serialize_pp, serialize_value
 from dagster._serdes.serdes import deserialize_value
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_node_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_node_def_snap.py
@@ -1,9 +1,5 @@
 from dagster import In, Out, graph, op
-from dagster._core.snap import (
-    DependencyStructureIndex,
-    GraphDefSnap,
-    build_graph_def_snap,
-)
+from dagster._core.snap import DependencyStructureIndex, GraphDefSnap, build_graph_def_snap
 from dagster._core.snap.node import OpDefSnap, build_op_def_snap
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -26,10 +26,7 @@ from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.execution.context.init import InitResourceContext
-from dagster._core.remote_representation import (
-    ExternalJobData,
-    external_repository_data_from_def,
-)
+from dagster._core.remote_representation import ExternalJobData, external_repository_data_from_def
 from dagster._core.remote_representation.external_data import (
     ExternalResourceData,
     NestedResource,

--- a/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/system_config_tests/test_system_config.py
@@ -20,15 +20,8 @@ from dagster._config import ConfigTypeKind, process_config
 from dagster._config.config_type import ConfigType
 from dagster._core.definitions import create_run_config_schema
 from dagster._core.definitions.job_definition import JobDefinition
-from dagster._core.definitions.run_config import (
-    RunConfigSchemaCreationData,
-    define_node_shape,
-)
-from dagster._core.system_config.objects import (
-    OpConfig,
-    ResolvedRunConfig,
-    ResourceConfig,
-)
+from dagster._core.definitions.run_config import RunConfigSchemaCreationData, define_node_shape
+from dagster._core.system_config.objects import OpConfig, ResolvedRunConfig, ResourceConfig
 from dagster._loggers import default_loggers
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_external_execution_plan.py
@@ -30,10 +30,7 @@ from dagster._core.definitions.cacheable_assets import (
 from dagster._core.definitions.job_base import InMemoryJob
 from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._core.definitions.metadata.table import TableColumn, TableSchema
-from dagster._core.definitions.reconstruct import (
-    ReconstructableJob,
-    ReconstructableRepository,
-)
+from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
 from dagster._core.definitions.repository_definition.valid_definitions import (
     PendingRepositoryListDefinition,
 )

--- a/python_modules/dagster/dagster_tests/core_tests/test_job_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_job_execution.py
@@ -22,28 +22,15 @@ from dagster import (
     op,
     reconstructable,
 )
-from dagster._core.definitions.dependency import (
-    DependencyMapping,
-    DependencyStructure,
-    OpNode,
-)
-from dagster._core.definitions.graph_definition import (
-    create_adjacency_lists,
-)
+from dagster._core.definitions.dependency import DependencyMapping, DependencyStructure, OpNode
+from dagster._core.definitions.graph_definition import create_adjacency_lists
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.errors import DagsterExecutionStepNotFoundError, DagsterInvariantViolationError
 from dagster._core.execution.api import ReexecutionOptions, execute_job
 from dagster._core.instance import DagsterInstance
-from dagster._core.test_utils import (
-    instance_for_test,
-)
-from dagster._core.utility_ops import (
-    create_op_with_deps,
-    create_root_op,
-    create_stub_op,
-    input_set,
-)
+from dagster._core.test_utils import instance_for_test
+from dagster._core.utility_ops import create_op_with_deps, create_root_op, create_stub_op, input_set
 from dagster._core.workspace.load import location_origin_from_python_file
 
 # protected members

--- a/python_modules/dagster/dagster_tests/core_tests/test_mask_user_code_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_mask_user_code_errors.py
@@ -54,9 +54,7 @@ ERROR_ID_REGEX = r"Error occurred during user code execution, error ID ([a-z0-9\
 
 
 def test_masking_sensor_execution(instance, enable_masking_user_code_errors, capsys) -> None:
-    from dagster._api.snapshot_sensor import (
-        sync_get_external_sensor_execution_data_ephemeral_grpc,
-    )
+    from dagster._api.snapshot_sensor import sync_get_external_sensor_execution_data_ephemeral_grpc
 
     with get_bar_repo_handle(instance) as repository_handle:
         try:

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -45,10 +45,7 @@ from dagster._core.errors import (
     DagsterTypeCheckDidNotPass,
 )
 from dagster._core.execution.context.compute import AssetExecutionContext, OpExecutionContext
-from dagster._core.execution.context.invocation import (
-    DirectOpExecutionContext,
-    build_asset_context,
-)
+from dagster._core.execution.context.invocation import DirectOpExecutionContext, build_asset_context
 from dagster._model.pydantic_compat_layer import USING_PYDANTIC_1
 from dagster._utils.test import wrap_op_in_graph_and_execute
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_with_config.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_with_config.py
@@ -1,14 +1,5 @@
 import pytest
-from dagster import (
-    ConfigMapping,
-    DagsterInvalidConfigError,
-    Field,
-    In,
-    String,
-    graph,
-    job,
-    op,
-)
+from dagster import ConfigMapping, DagsterInvalidConfigError, Field, In, String, graph, job, op
 from dagster._core.storage.input_manager import input_manager
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_user_code_boundary.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_user_code_boundary.py
@@ -1,12 +1,4 @@
-from dagster import (
-    In,
-    String,
-    dagster_type_loader,
-    job,
-    op,
-    resource,
-    usable_as_dagster_type,
-)
+from dagster import In, String, dagster_type_loader, job, op, resource, usable_as_dagster_type
 
 
 class UserError(Exception):

--- a/python_modules/dagster/dagster_tests/core_tests/workspace_tests/test_request_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/workspace_tests/test_request_context.py
@@ -3,20 +3,14 @@ from typing import Mapping
 from unittest import mock
 
 import pytest
-from dagster._core.errors import (
-    DagsterCodeLocationLoadError,
-    DagsterCodeLocationNotFoundError,
-)
+from dagster._core.errors import DagsterCodeLocationLoadError, DagsterCodeLocationNotFoundError
 from dagster._core.remote_representation.feature_flags import (
     CodeLocationFeatureFlags,
     get_feature_flags_for_location,
 )
 from dagster._core.remote_representation.origin import RegisteredCodeLocationOrigin
 from dagster._core.workspace.context import WorkspaceRequestContext
-from dagster._core.workspace.workspace import (
-    CodeLocationEntry,
-    CodeLocationLoadStatus,
-)
+from dagster._core.workspace.workspace import CodeLocationEntry, CodeLocationLoadStatus
 from dagster._utils.error import SerializableErrorInfo
 
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_asset_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_asset_sensor_run.py
@@ -2,14 +2,8 @@ from dagster import materialize
 from dagster._core.scheduler.instigation import TickStatus
 from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_freeze_time, to_timezone
 
-from .test_run_status_sensors import (
-    instance_with_single_code_location_multiple_repos_with_sensors,
-)
-from .test_sensor_run import (
-    a_source_asset,
-    evaluate_sensors,
-    validate_tick,
-)
+from .test_run_status_sensors import instance_with_single_code_location_multiple_repos_with_sensors
+from .test_sensor_run import a_source_asset, evaluate_sensors, validate_tick
 
 
 def test_monitor_source_asset_sensor(executor):

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
@@ -44,9 +44,7 @@ from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.instance import DagsterInstance
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus, TickStatus
 from dagster._core.storage.dagster_run import DagsterRunStatus
-from dagster._core.test_utils import (
-    create_test_daemon_workspace_context,
-)
+from dagster._core.test_utils import create_test_daemon_workspace_context
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import ModuleTarget

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -13,9 +13,7 @@ from dagster import (
 )
 from dagster._core.definitions.instigation_logger import get_instigation_log_records
 from dagster._core.definitions.run_status_sensor_definition import RunStatusSensorCursor
-from dagster._core.definitions.sensor_definition import (
-    SensorType,
-)
+from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.events import DagsterEvent, DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._core.instance import DagsterInstance

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -71,9 +71,7 @@ from dagster._core.remote_representation import (
     RemoteRepositoryOrigin,
 )
 from dagster._core.remote_representation.external import ExternalRepository
-from dagster._core.remote_representation.origin import (
-    ManagedGrpcPythonEnvCodeLocationOrigin,
-)
+from dagster._core.remote_representation.origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.scheduler.instigation import (
     DynamicPartitionsRequestResult,
     InstigatorState,

--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -9,9 +9,7 @@ from dagster._core.remote_representation import (
     ExternalRepository,
     InProcessCodeLocationOrigin,
 )
-from dagster._core.remote_representation.origin import (
-    ManagedGrpcPythonEnvCodeLocationOrigin,
-)
+from dagster._core.remote_representation.origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.test_utils import (
     InProcessTestWorkspaceLoadTarget,
     create_test_daemon_workspace_context,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -33,9 +33,7 @@ from dagster import (
     op,
     repository,
 )
-from dagster._core.definitions import (
-    StaticPartitionsDefinition,
-)
+from dagster._core.definitions import StaticPartitionsDefinition
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.events import AssetKeyPartitionKey
@@ -45,9 +43,7 @@ from dagster._core.definitions.selector import (
     PartitionsByAssetSelector,
     PartitionsSelector,
 )
-from dagster._core.errors import (
-    DagsterUserCodeUnreachableError,
-)
+from dagster._core.errors import DagsterUserCodeUnreachableError
 from dagster._core.execution.asset_backfill import RUN_CHUNK_SIZE
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.remote_representation import (
@@ -62,12 +58,7 @@ from dagster._core.storage.tags import (
     BACKFILL_ID_TAG,
     PARTITION_NAME_TAG,
 )
-from dagster._core.test_utils import (
-    environ,
-    step_did_not_run,
-    step_failed,
-    step_succeeded,
-)
+from dagster._core.test_utils import environ, step_did_not_run, step_failed, step_succeeded
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._daemon import get_default_daemon_logger

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
@@ -5,9 +5,7 @@ import pendulum
 import pytest
 from dagster import DagsterInstance
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
-from dagster._core.remote_representation import (
-    ExternalRepository,
-)
+from dagster._core.remote_representation import ExternalRepository
 from dagster._core.test_utils import (
     cleanup_test_instance,
     create_test_daemon_workspace_context,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_locations/concurrency_limited_workspace.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_locations/concurrency_limited_workspace.py
@@ -1,11 +1,4 @@
-from dagster import (
-    AssetIn,
-    Definitions,
-    asset,
-    define_asset_job,
-    job,
-    op,
-)
+from dagster import AssetIn, Definitions, asset, define_asset_job, job, op
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.storage.tags import GLOBAL_CONCURRENCY_TAG
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -23,9 +23,7 @@ from dagster._daemon.run_coordinator.queued_run_coordinator_daemon import Queued
 from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_freeze_time, to_timezone
 from dagster._utils import file_relative_path
 
-from dagster_tests.api_tests.utils import (
-    get_foo_job_handle,
-)
+from dagster_tests.api_tests.utils import get_foo_job_handle
 
 BAD_RUN_ID_UUID = make_new_run_id()
 BAD_USER_CODE_RUN_ID_UUID = make_new_run_id()

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -14,9 +14,7 @@ from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.auto_materialize_sensor_definition import (
     AutoMaterializeSensorDefinition,
 )
-from dagster._core.definitions.sensor_definition import (
-    SensorType,
-)
+from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.remote_representation.external import ExternalRepository
 from dagster._core.remote_representation.external_data import external_repository_data_from_def
 from dagster._core.remote_representation.handle import RepositoryHandle

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
@@ -16,9 +16,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
     AutomationResult,
 )
-from dagster._core.definitions.declarative_automation.automation_context import (
-    AutomationContext,
-)
+from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._core.definitions.declarative_automation.legacy.legacy_context import (
     LegacyRuleEvaluationContext,
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
@@ -8,9 +8,7 @@ from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
-from dagster._core.definitions.declarative_automation.automation_context import (
-    AutomationContext,
-)
+from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._core.definitions.events import AssetKeyPartitionKey
 
 from dagster_tests.definitions_tests.auto_materialize_tests.scenario_state import ScenarioSpec

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
@@ -1,9 +1,7 @@
 import datetime
 
 from dagster import AutoMaterializePolicy, Definitions, asset
-from dagster._core.definitions.declarative_automation.legacy.asset_condition import (
-    AssetCondition,
-)
+from dagster._core.definitions.declarative_automation.legacy.asset_condition import AssetCondition
 from dagster._core.remote_representation.external_data import external_repository_data_from_def
 from dagster._serdes import serialize_value
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -49,9 +49,7 @@ from dagster._core.definitions.asset_daemon_context import (
     AssetDaemonContext,
     get_implicit_auto_materialize_policy,
 )
-from dagster._core.definitions.asset_daemon_cursor import (
-    AssetDaemonCursor,
-)
+from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
@@ -66,9 +64,7 @@ from dagster._core.definitions.data_version import DataVersionsByPartition
 from dagster._core.definitions.events import CoercibleToAssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.observe import observe
-from dagster._core.definitions.partition import (
-    PartitionsSubset,
-)
+from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.events import AssetMaterializationPlannedData, DagsterEvent, DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.asset_backfill import AssetBackfillData

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/active_run_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/active_run_scenarios.py
@@ -1,10 +1,7 @@
 import datetime
 from typing import Optional
 
-from dagster import (
-    DailyPartitionsDefinition,
-    PartitionKeyRange,
-)
+from dagster import DailyPartitionsDefinition, PartitionKeyRange
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.time_window_partitions import HourlyPartitionsDefinition

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/auto_materialize_policy_scenarios.py
@@ -1,10 +1,6 @@
 import datetime
 
-from dagster import (
-    Field,
-    PartitionKeyRange,
-    StringSource,
-)
+from dagster import Field, PartitionKeyRange, StringSource
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
@@ -34,9 +30,7 @@ from .asset_graphs import (
     one_parent_starts_later_and_nonexistent_upstream_partitions_not_allowed,
 )
 from .basic_scenarios import diamond
-from .freshness_policy_scenarios import (
-    daily_to_unpartitioned,
-)
+from .freshness_policy_scenarios import daily_to_unpartitioned
 from .partition_scenarios import (
     hourly_partitions_def,
     hourly_to_daily_partitions,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/blocking_check_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/blocking_check_scenarios.py
@@ -1,11 +1,7 @@
 from dagster import AssetCheckResult, AutoMaterializePolicy, asset, asset_check
 from dagster._core.definitions.asset_checks import build_asset_with_blocking_check
 
-from ..base_scenario import (
-    AssetReconciliationScenario,
-    run,
-    run_request,
-)
+from ..base_scenario import AssetReconciliationScenario, run, run_request
 
 
 @asset(auto_materialize_policy=AutoMaterializePolicy.eager())

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/freshness_policy_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/freshness_policy_scenarios.py
@@ -1,13 +1,8 @@
 import datetime
 
-from dagster import (
-    AssetSelection,
-    DailyPartitionsDefinition,
-)
+from dagster import AssetSelection, DailyPartitionsDefinition
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
-from dagster._core.definitions.auto_materialize_rule_evaluation import (
-    TextRuleEvaluationData,
-)
+from dagster._core.definitions.auto_materialize_rule_evaluation import TextRuleEvaluationData
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 
 from ..base_scenario import (

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/partition_scenarios.py
@@ -8,9 +8,7 @@ from dagster import (
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_rule_evaluation import AutoMaterializeRuleEvaluation
-from dagster._core.definitions.partition import (
-    DynamicPartitionsDefinition,
-)
+from dagster._core.definitions.partition import DynamicPartitionsDefinition
 from dagster._core.definitions.time_window_partitions import (
     HourlyPartitionsDefinition,
     TimeWindowPartitionsSubset,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/scenarios.py
@@ -2,9 +2,7 @@ from dagster import Definitions
 from dagster._core.definitions.executor_definition import in_process_executor
 
 from .active_run_scenarios import active_run_scenarios
-from .auto_materialize_policy_scenarios import (
-    auto_materialize_policy_scenarios,
-)
+from .auto_materialize_policy_scenarios import auto_materialize_policy_scenarios
 from .auto_observe_scenarios import auto_observe_scenarios
 from .basic_scenarios import basic_scenarios
 from .blocking_check_scenarios import blocking_check_scenarios

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/version_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenarios/version_scenarios.py
@@ -1,11 +1,6 @@
 from dagster._core.definitions.partition import StaticPartitionsDefinition
 
-from ..base_scenario import (
-    AssetReconciliationScenario,
-    asset_def,
-    run,
-    run_request,
-)
+from ..base_scenario import AssetReconciliationScenario, asset_def, run, run_request
 
 three_partitions_def = StaticPartitionsDefinition(["a", "b", "c"])
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon.py
@@ -5,12 +5,7 @@ from typing import Any, Generator, Mapping, Optional, Sequence, cast
 
 import pendulum
 import pytest
-from dagster import (
-    AssetSpec,
-    AutoMaterializeRule,
-    DagsterInstance,
-    instance_for_test,
-)
+from dagster import AssetSpec, AutoMaterializeRule, DagsterInstance, instance_for_test
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
@@ -46,18 +41,9 @@ from dagster._serdes.serdes import serialize_value
 
 from dagster_tests.definitions_tests.auto_materialize_tests.scenario_state import ScenarioSpec
 
-from .base_scenario import (
-    run_request,
-)
-from .scenario_specs import (
-    one_asset,
-    two_assets_in_sequence,
-    two_partitions_def,
-)
-from .updated_scenarios.asset_daemon_scenario import (
-    AssetDaemonScenario,
-    AssetRuleEvaluationSpec,
-)
+from .base_scenario import run_request
+from .scenario_specs import one_asset, two_assets_in_sequence, two_partitions_def
+from .updated_scenarios.asset_daemon_scenario import AssetDaemonScenario, AssetRuleEvaluationSpec
 from .updated_scenarios.basic_scenarios import basic_scenarios
 from .updated_scenarios.cron_scenarios import (
     basic_hourly_cron_rule,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_failure_recovery.py
@@ -7,13 +7,9 @@ from dagster._core.errors import DagsterUserCodeUnreachableError
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance.ref import InstanceRef
 from dagster._core.instance_for_test import instance_for_test
-from dagster._core.scheduler.instigation import (
-    TickStatus,
-)
+from dagster._core.scheduler.instigation import TickStatus
 from dagster._core.storage.tags import PARTITION_NAME_TAG
-from dagster._core.test_utils import (
-    cleanup_test_instance,
-)
+from dagster._core.test_utils import cleanup_test_instance
 from dagster._daemon.asset_daemon import (
     _PRE_SENSOR_AUTO_MATERIALIZE_ORIGIN_ID,
     _PRE_SENSOR_AUTO_MATERIALIZE_SELECTOR_ID,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_asset_daemon_fast.py
@@ -1,19 +1,8 @@
 import pytest
-from dagster import (
-    AssetMaterialization,
-    AssetSelection,
-    DagsterInstance,
-    job,
-    op,
-)
-from dagster._core.definitions.time_window_partitions import (
-    HourlyPartitionsDefinition,
-)
+from dagster import AssetMaterialization, AssetSelection, DagsterInstance, job, op
+from dagster._core.definitions.time_window_partitions import HourlyPartitionsDefinition
 
-from .base_scenario import (
-    AssetReconciliationScenario,
-    asset_def,
-)
+from .base_scenario import AssetReconciliationScenario, asset_def
 from .scenarios.scenarios import ASSET_RECONCILIATION_SCENARIOS
 
 #############################

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario.py
@@ -2,27 +2,11 @@ import dataclasses
 import itertools
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from typing import (
-    Any,
-    Callable,
-    NamedTuple,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    cast,
-)
+from typing import Any, Callable, NamedTuple, Optional, Sequence, Tuple, Type, cast
 
 import dagster._check as check
-from dagster import (
-    AssetKey,
-    DagsterInstance,
-    RunRequest,
-    RunsFilter,
-)
-from dagster._core.definitions.asset_daemon_context import (
-    AssetDaemonContext,
-)
+from dagster import AssetKey, DagsterInstance, RunRequest, RunsFilter
+from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
 from dagster._core.definitions.asset_daemon_cursor import (
     AssetDaemonCursor,
     backcompat_deserialize_asset_daemon_cursor_str,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/basic_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/basic_scenarios.py
@@ -14,10 +14,7 @@ from ..scenario_specs import (
     two_assets_in_sequence,
 )
 from ..scenario_state import ScenarioSpec
-from .asset_daemon_scenario import (
-    AssetDaemonScenario,
-    AssetRuleEvaluationSpec,
-)
+from .asset_daemon_scenario import AssetDaemonScenario, AssetRuleEvaluationSpec
 
 basic_scenarios = [
     AssetDaemonScenario(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/cron_scenarios.py
@@ -1,9 +1,7 @@
 import pytest
 from dagster import AutoMaterializePolicy, AutoMaterializeRule
 from dagster._check import ParameterCheckError
-from dagster._core.definitions.auto_materialize_rule_impls import (
-    WaitingOnAssetsRuleEvaluationData,
-)
+from dagster._core.definitions.auto_materialize_rule_impls import WaitingOnAssetsRuleEvaluationData
 
 from ..base_scenario import run_request
 from ..scenario_specs import (

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/user_space_ds_defs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/user_space_ds_defs.py
@@ -1,7 +1,5 @@
 from dagster import AutomationCondition, DefaultSensorStatus, Definitions, asset
-from dagster._core.definitions.auto_materialize_sensor_definition import (
-    AutomationSensorDefinition,
-)
+from dagster._core.definitions.auto_materialize_sensor_definition import AutomationSensorDefinition
 
 eager_policy = AutomationCondition.eager().as_auto_materialize_policy()
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_job.py
@@ -1,16 +1,7 @@
 import logging
 import warnings
 
-from dagster import (
-    ConfigMapping,
-    DagsterInstance,
-    Field,
-    JobDefinition,
-    job,
-    logger,
-    op,
-    resource,
-)
+from dagster import ConfigMapping, DagsterInstance, Field, JobDefinition, job, logger, op, resource
 from dagster._core.definitions.utils import normalize_tags
 from dagster._core.storage.tags import MAX_RETRIES_TAG, RETRY_ON_ASSET_OR_OP_FAILURE_TAG
 from dagster._core.utils import coerce_valid_log_level

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/conftest.py
@@ -4,9 +4,7 @@ from typing import Iterator, Optional, Sequence
 
 import pendulum
 import pytest
-from dagster import (
-    define_asset_job,
-)
+from dagster import define_asset_job
 from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_selection import AssetSelection

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_last_update_freshness.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_last_update_freshness.py
@@ -5,9 +5,7 @@ import json
 
 import pendulum
 import pytest
-from dagster import (
-    asset,
-)
+from dagster import asset
 from dagster._check import CheckError
 from dagster._core.definitions.asset_check_factories.freshness_checks.last_update import (
     build_last_update_freshness_checks,
@@ -19,10 +17,7 @@ from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_selection import AssetChecksForAssetKeysSelection
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.metadata import (
-    JsonMetadataValue,
-    TimestampMetadataValue,
-)
+from dagster._core.definitions.metadata import JsonMetadataValue, TimestampMetadataValue
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.instance import DagsterInstance

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_sensor.py
@@ -6,12 +6,7 @@ import time
 
 import pendulum
 import pytest
-from dagster import (
-    AssetCheckKey,
-    AssetKey,
-    DagsterInstance,
-    asset,
-)
+from dagster import AssetCheckKey, AssetKey, DagsterInstance, asset
 from dagster._check import CheckError
 from dagster._core.definitions.asset_check_evaluation import (
     AssetCheckEvaluation,
@@ -23,19 +18,14 @@ from dagster._core.definitions.asset_check_factories.freshness_checks.last_updat
 from dagster._core.definitions.asset_check_factories.freshness_checks.sensor import (
     build_sensor_for_freshness_checks,
 )
-from dagster._core.definitions.asset_check_factories.utils import (
-    FRESH_UNTIL_METADATA_KEY,
-)
+from dagster._core.definitions.asset_check_factories.utils import FRESH_UNTIL_METADATA_KEY
 from dagster._core.definitions.asset_out import AssetOut
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.metadata import FloatMetadataValue
 from dagster._core.definitions.run_request import RunRequest, SkipReason
 from dagster._core.definitions.sensor_definition import build_sensor_context
-from dagster._core.events import (
-    DagsterEvent,
-    DagsterEventType,
-)
+from dagster._core.events import DagsterEvent, DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._core.utils import make_new_run_id
 from dagster._seven.compat.pendulum import pendulum_freeze_time

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_time_partition_freshness.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_time_partition_freshness.py
@@ -6,9 +6,7 @@ from typing import Iterator
 
 import pendulum
 import pytest
-from dagster import (
-    asset,
-)
+from dagster import asset
 from dagster._check import CheckError
 from dagster._core.definitions.asset_check_factories.freshness_checks.time_partition import (
     build_time_partition_freshness_checks,
@@ -23,10 +21,7 @@ from dagster._core.definitions.asset_selection import AssetChecksForAssetKeysSel
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.metadata import (
-    JsonMetadataValue,
-    TimestampMetadataValue,
-)
+from dagster._core.definitions.metadata import JsonMetadataValue, TimestampMetadataValue
 from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.time_window_partitions import (

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_executor_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_executor_definition.py
@@ -24,9 +24,7 @@ from dagster._core.errors import (
 from dagster._core.events import DagsterEventType, RunFailureReason
 from dagster._core.execution.retries import RetryMode
 from dagster._core.executor.multiprocess import MultiprocessExecutor
-from dagster._core.storage.tags import (
-    RUN_FAILURE_REASON_TAG,
-)
+from dagster._core.storage.tags import RUN_FAILURE_REASON_TAG
 from dagster._core.test_utils import environ, instance_for_test
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_flatten_time_window_ranges.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_flatten_time_window_ranges.py
@@ -2,10 +2,7 @@ from datetime import datetime
 from typing import cast
 
 import pendulum
-from dagster import (
-    DailyPartitionsDefinition,
-    PartitionKeyRange,
-)
+from dagster import DailyPartitionsDefinition, PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import (
     PartitionRangeStatus,
     PartitionTimeWindowStatus,

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_schedule.py
@@ -2,12 +2,7 @@ import warnings
 from datetime import datetime
 
 import pytest
-from dagster import (
-    DagsterInvalidDefinitionError,
-    ScheduleDefinition,
-    build_schedule_context,
-    graph,
-)
+from dagster import DagsterInvalidDefinitionError, ScheduleDefinition, build_schedule_context, graph
 from dagster._core.definitions.run_config import RunConfig
 
 

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_multiprocessing.py
@@ -26,9 +26,7 @@ from dagster._core.execution.api import execute_job
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.captured_log_manager import CapturedLogManager
 from dagster._core.storage.mem_io_manager import mem_io_manager
-from dagster._core.test_utils import (
-    instance_for_test,
-)
+from dagster._core.test_utils import instance_for_test
 from dagster._utils import safe_tempfile_path, segfault
 
 from .retry_jobs import (

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
@@ -2,15 +2,7 @@ import threading
 import time
 
 import pytest
-from dagster import (
-    Failure,
-    RetryPolicy,
-    graph,
-    in_process_executor,
-    job,
-    op,
-    repository,
-)
+from dagster import Failure, RetryPolicy, graph, in_process_executor, job, op, repository
 from dagster._core.definitions.events import AssetKey, AssetMaterialization
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.reconstruct import reconstructable

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
@@ -20,10 +20,7 @@ from dagster import (
 from dagster._config import Permissive
 from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 from dagster._core.definitions.executor_definition import multiple_process_executor_requirements
-from dagster._core.definitions.reconstruct import (
-    ReconstructableJob,
-    ReconstructableRepository,
-)
+from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
 from dagster._core.definitions.repository_definition import AssetsDefinitionCacheableData
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import ReexecutionOptions, execute_job

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_api_iterators.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_api_iterators.py
@@ -13,9 +13,7 @@ from dagster import (
 from dagster._core.definitions.executor_definition import in_process_executor
 from dagster._core.definitions.job_base import InMemoryJob
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster._core.events import (
-    DagsterEvent,
-)
+from dagster._core.events import DagsterEvent
 from dagster._core.events.log import EventLogEntry, construct_event_logger
 from dagster._core.execution.api import (
     create_execution_plan,

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_in_process_client.py
@@ -14,14 +14,9 @@ from dagster import (
 from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.context.compute import AssetCheckExecutionContext
-from dagster_pipes import (
-    DagsterPipesError,
-    PipesContext,
-)
+from dagster_pipes import DagsterPipesError, PipesContext
 
-from .in_process_client import (
-    InProcessPipesClient,
-)
+from .in_process_client import InProcessPipesClient
 
 
 def execute_asset_through_def(assets_def, resources) -> ExecuteInProcessResult:

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -41,9 +41,7 @@ from dagster._core.execution.context.compute import AssetExecutionContext, OpExe
 from dagster._core.execution.context.invocation import build_asset_context
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance_for_test import instance_for_test
-from dagster._core.pipes.subprocess import (
-    PipesSubprocessClient,
-)
+from dagster._core.pipes.subprocess import PipesSubprocessClient
 from dagster._core.pipes.utils import (
     PipesEnvContextInjector,
     PipesTempFileContextInjector,
@@ -72,9 +70,7 @@ def temp_script(script_fn: Callable[[], Any]) -> Iterator[str]:
 def external_script() -> Iterator[str]:
     # This is called in an external process and so cannot access outer scope
     def script_fn():
-        from dagster_pipes import (
-            open_dagster_pipes,
-        )
+        from dagster_pipes import open_dagster_pipes
 
         with open_dagster_pipes() as context:
             context.log.info("hello world")
@@ -351,11 +347,7 @@ PATH_WITH_NONEXISTENT_DIR = "/tmp/does-not-exist/foo"
 
 def test_pipes_no_orchestration():
     def script_fn():
-        from dagster_pipes import (
-            PipesContext,
-            PipesEnvVarParamsLoader,
-            open_dagster_pipes,
-        )
+        from dagster_pipes import PipesContext, PipesEnvVarParamsLoader, open_dagster_pipes
 
         loader = PipesEnvVarParamsLoader()
         assert not loader.is_dagster_pipes_process()

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -14,10 +14,7 @@ from dagster._core.definitions.repository_definition.valid_definitions import (
 from dagster._core.remote_representation.origin import InProcessCodeLocationOrigin
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceRequestContext
-from dagster._core.workspace.workspace import (
-    CodeLocationEntry,
-    CodeLocationLoadStatus,
-)
+from dagster._core.workspace.workspace import CodeLocationEntry, CodeLocationLoadStatus
 
 
 @pytest.fixture

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_execution_plan_snapshot.py
@@ -1,16 +1,6 @@
 import os
 
-from dagster import (
-    DynamicOut,
-    DynamicOutput,
-    In,
-    List,
-    Out,
-    Output,
-    fs_io_manager,
-    job,
-    op,
-)
+from dagster import DynamicOut, DynamicOutput, In, List, Out, Output, fs_io_manager, job, op
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.reconstruct import reconstructable
 from dagster._core.execution.api import create_execution_plan, execute_run

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_metrics.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_metrics.py
@@ -9,23 +9,12 @@ from typing import Any
 import pytest
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation import RemoteRepositoryOrigin
-from dagster._core.remote_representation.origin import (
-    GrpcServerCodeLocationOrigin,
-)
-from dagster._core.test_utils import (
-    instance_for_test,
-)
+from dagster._core.remote_representation.origin import GrpcServerCodeLocationOrigin
+from dagster._core.test_utils import instance_for_test
 from dagster._grpc.client import DagsterGrpcClient
-from dagster._grpc.server import (
-    METRICS_RETRIEVAL_FUNCTIONS,
-    DagsterApiServer,
-    wait_for_grpc_server,
-)
+from dagster._grpc.server import METRICS_RETRIEVAL_FUNCTIONS, DagsterApiServer, wait_for_grpc_server
 from dagster._grpc.types import SensorExecutionArgs
-from dagster._utils import (
-    file_relative_path,
-    find_free_port,
-)
+from dagster._utils import file_relative_path, find_free_port
 
 
 def is_grpc_method(attr_name: str, obj: Any) -> bool:

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -24,19 +24,11 @@ from dagster._core.test_utils import (
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.client import DagsterGrpcClient
-from dagster._grpc.server import (
-    ExecuteExternalJobArgs,
-    open_server_process,
-    wait_for_grpc_server,
-)
+from dagster._grpc.server import ExecuteExternalJobArgs, open_server_process, wait_for_grpc_server
 from dagster._grpc.types import ListRepositoriesResponse, SensorExecutionArgs, StartRunResult
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
-from dagster._utils import (
-    file_relative_path,
-    find_free_port,
-    safe_tempfile_path_unmanaged,
-)
+from dagster._utils import file_relative_path, find_free_port, safe_tempfile_path_unmanaged
 from dagster._utils.error import SerializableErrorInfo
 from dagster.version import __version__ as dagster_version
 

--- a/python_modules/dagster/dagster_tests/general_tests/loadable_target_origin_context/loadable_target_origin_test_repo.py
+++ b/python_modules/dagster/dagster_tests/general_tests/loadable_target_origin_context/loadable_target_origin_test_repo.py
@@ -1,6 +1,4 @@
-from dagster import (
-    Definitions,
-)
+from dagster import Definitions
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 
 assert LoadableTargetOrigin.get() is not None, "LoadableTargetOrigin is not available from context"

--- a/python_modules/dagster/dagster_tests/general_tests/loadable_target_origin_context/test_loadable_target_origin_context.py
+++ b/python_modules/dagster/dagster_tests/general_tests/loadable_target_origin_context/test_loadable_target_origin_context.py
@@ -1,11 +1,7 @@
 import sys
 
 from dagster._api.list_repositories import sync_list_repositories_ephemeral_grpc
-from dagster._core.code_pointer import (
-    FileCodePointer,
-    ModuleCodePointer,
-    PackageCodePointer,
-)
+from dagster._core.code_pointer import FileCodePointer, ModuleCodePointer, PackageCodePointer
 from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
 )

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_op_isolation.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_op_isolation.py
@@ -13,12 +13,7 @@ from dagster._core.definitions.decorators import graph
 from dagster._core.definitions.input import In
 from dagster._core.definitions.output import Out
 from dagster._core.test_utils import nesting_graph
-from dagster._core.utility_ops import (
-    create_op_with_deps,
-    create_root_op,
-    create_stub_op,
-    input_set,
-)
+from dagster._core.utility_ops import create_op_with_deps, create_root_op, create_stub_op, input_set
 from dagster._utils.test import wrap_op_in_graph_and_execute
 
 

--- a/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_warnings.py
+++ b/python_modules/dagster/dagster_tests/general_tests/utils_tests/test_warnings.py
@@ -4,10 +4,7 @@ import warnings
 import pytest
 from dagster._annotations import experimental
 from dagster._check import CheckError
-from dagster._utils.warnings import (
-    normalize_renamed_param,
-    suppress_dagster_warnings,
-)
+from dagster._utils.warnings import normalize_renamed_param, suppress_dagster_warnings
 
 
 def is_new(old_flag=None, new_flag=None):

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_pythonic_resources.py
@@ -19,13 +19,8 @@ from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
 )
 from dagster._core.definitions.schedule_definition import RunRequest
-from dagster._core.scheduler.instigation import (
-    InstigatorTick,
-    TickStatus,
-)
-from dagster._core.test_utils import (
-    create_test_daemon_workspace_context,
-)
+from dagster._core.scheduler.instigation import InstigatorTick, TickStatus
+from dagster._core.test_utils import create_test_daemon_workspace_context
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._core.workspace.load_target import ModuleTarget

--- a/python_modules/dagster/dagster_tests/storage_tests/test_no_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_no_io_manager.py
@@ -1,12 +1,6 @@
 from typing import Any
 
-from dagster import (
-    IOManager,
-    asset,
-    job,
-    materialize,
-    op,
-)
+from dagster import IOManager, asset, job, materialize, op
 
 
 class TestIOManager(IOManager):

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -91,9 +91,7 @@ from dagster._core.remote_representation.origin import (
     RemoteJobOrigin,
     RemoteRepositoryOrigin,
 )
-from dagster._core.storage.asset_check_execution_record import (
-    AssetCheckExecutionRecordStatus,
-)
+from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecordStatus
 from dagster._core.storage.event_log import InMemoryEventLogStorage, SqlEventLogStorage
 from dagster._core.storage.event_log.base import EventLogStorage
 from dagster._core.storage.event_log.migration import (

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/partition_status_cache.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/partition_status_cache.py
@@ -33,9 +33,7 @@ from dagster._core.test_utils import create_run_for_test
 from dagster._core.utils import make_new_run_id
 from dagster._utils import Counter, traced_counter
 
-from .event_log_storage import (
-    create_and_delete_test_runs,
-)
+from .event_log_storage import create_and_delete_test_runs
 
 
 class TestPartitionStatusCache:

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -24,11 +24,7 @@ from dagster._core.remote_representation import (
 )
 from dagster._core.run_coordinator import DefaultRunCoordinator
 from dagster._core.snap import create_job_snapshot_id
-from dagster._core.storage.dagster_run import (
-    DagsterRun,
-    DagsterRunStatus,
-    RunsFilter,
-)
+from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.event_log import InMemoryEventLogStorage
 from dagster._core.storage.noop_compute_log_manager import NoOpComputeLogManager
 from dagster._core.storage.root import LocalArtifactStorage

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_cloud_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_cloud_resources.py
@@ -2,9 +2,7 @@ import re
 
 import pytest
 import responses
-from dagster import (
-    Failure,
-)
+from dagster import Failure
 from dagster_airbyte import AirbyteCloudResource, AirbyteOutput, AirbyteState
 
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/__init__.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/__init__.py
@@ -1,9 +1,7 @@
 from airflow.plugins_manager import AirflowPlugin
 from dagster._core.libraries import DagsterLibraryRegistry
 
-from .dagster_asset_factory import (
-    load_assets_from_airflow_dag as load_assets_from_airflow_dag,
-)
+from .dagster_asset_factory import load_assets_from_airflow_dag as load_assets_from_airflow_dag
 from .dagster_factory import (
     make_dagster_definitions_from_airflow_dag_bag as make_dagster_definitions_from_airflow_dag_bag,
     make_dagster_definitions_from_airflow_dags_path as make_dagster_definitions_from_airflow_dags_path,

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_asset_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_asset_factory.py
@@ -13,10 +13,7 @@ from dagster._core.definitions.graph_definition import create_adjacency_lists
 from dagster._utils.schedules import is_valid_cron_schedule
 
 from dagster_airflow.dagster_job_factory import make_dagster_job_from_airflow_dag
-from dagster_airflow.utils import (
-    DagsterAirflowError,
-    normalized_name,
-)
+from dagster_airflow.utils import DagsterAirflowError, normalized_name
 
 
 def _build_asset_dependencies(

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_factory.py
@@ -22,9 +22,7 @@ from dagster_airflow.resources import (
 )
 from dagster_airflow.resources.airflow_ephemeral_db import AirflowEphemeralDatabase
 from dagster_airflow.resources.airflow_persistent_db import AirflowPersistentDatabase
-from dagster_airflow.utils import (
-    is_airflow_2_loaded_in_environment,
-)
+from dagster_airflow.utils import is_airflow_2_loaded_in_environment
 
 
 def make_dagster_definitions_from_airflow_dag_bag(

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/dagster_job_factory.py
@@ -15,9 +15,7 @@ from dagster_airflow.airflow_dag_converter import get_graph_definition_args
 from dagster_airflow.resources import (
     make_ephemeral_airflow_db_resource as make_ephemeral_airflow_db_resource,
 )
-from dagster_airflow.utils import (
-    normalized_name,
-)
+from dagster_airflow.utils import normalized_name
 
 
 def make_dagster_job_from_airflow_dag(

--- a/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_db.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow/resources/airflow_db.py
@@ -11,9 +11,7 @@ from dagster import (
 )
 from dagster._core.instance import AIRFLOW_EXECUTION_DATE_STR
 
-from dagster_airflow.utils import (
-    is_airflow_2_loaded_in_environment,
-)
+from dagster_airflow.utils import is_airflow_2_loaded_in_environment
 
 if is_airflow_2_loaded_in_environment():
     from airflow.utils.state import DagRunState

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_dag_run_conf.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_dag_run_conf.py
@@ -2,10 +2,7 @@ import os
 import tempfile
 
 from airflow.models import DagBag, Variable
-from dagster_airflow import (
-    make_dagster_job_from_airflow_dag,
-    make_ephemeral_airflow_db_resource,
-)
+from dagster_airflow import make_dagster_job_from_airflow_dag, make_ephemeral_airflow_db_resource
 
 from dagster_airflow_tests.marks import requires_local_db
 

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_dag_bag_airflow_2.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_job_factory/test_load_dag_bag_airflow_2.py
@@ -12,9 +12,7 @@ from dagster_airflow import (
 
 from dagster_airflow_tests.marks import requires_local_db, requires_no_db
 
-from ..airflow_utils import (
-    test_make_from_dagbag_inputs_airflow_2,
-)
+from ..airflow_utils import test_make_from_dagbag_inputs_airflow_2
 
 
 @pytest.mark.skipif(airflow_version < "2.0.0", reason="requires airflow 2")

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_op_execution.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_op_execution.py
@@ -8,9 +8,7 @@ from unittest import mock
 from airflow import __version__ as airflow_version
 
 if airflow_version >= "2.0.0":
-    from airflow.providers.apache.spark.operators.spark_submit import (
-        SparkSubmitOperator,
-    )
+    from airflow.providers.apache.spark.operators.spark_submit import SparkSubmitOperator
 else:
     from airflow.contrib.operators.spark_submit_operator import (  # type: ignore (airflow 1 compat)
         SparkSubmitOperator,

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_persistent_db/conftest.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_persistent_db/conftest.py
@@ -15,9 +15,7 @@ from airflow.utils import db
 from dagster import DagsterInstance
 from dagster._core.test_utils import environ, instance_for_test
 from dagster._utils import file_relative_path
-from dagster_airflow.utils import (
-    is_airflow_2_loaded_in_environment,
-)
+from dagster_airflow.utils import is_airflow_2_loaded_in_environment
 from sqlalchemy.exc import OperationalError
 
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_pipes.py
@@ -17,14 +17,10 @@ from dagster._core.definitions.data_version import (
     DATA_VERSION_TAG,
 )
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.metadata import (
-    MarkdownMetadataValue,
-)
+from dagster._core.definitions.metadata import MarkdownMetadataValue
 from dagster._core.execution.context.compute import AssetExecutionContext
 from dagster._core.instance_for_test import instance_for_test
-from dagster._core.pipes.subprocess import (
-    PipesSubprocessClient,
-)
+from dagster._core.pipes.subprocess import PipesSubprocessClient
 from dagster._core.pipes.utils import PipesEnvContextInjector
 from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecordStatus
 from dagster_aws.pipes import (
@@ -62,11 +58,7 @@ def external_script() -> Iterator[str]:
         import time
 
         import boto3
-        from dagster_pipes import (
-            PipesS3ContextLoader,
-            PipesS3MessageWriter,
-            open_dagster_pipes,
-        )
+        from dagster_pipes import PipesS3ContextLoader, PipesS3MessageWriter, open_dagster_pipes
 
         client = boto3.client("s3", region_name="us-east-1", endpoint_url="http://localhost:5193")
         context_loader = PipesS3ContextLoader(client=client)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ssm_tests/test_resources.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ssm_tests/test_resources.py
@@ -1,10 +1,6 @@
 import os
 
-from dagster import (
-    asset,
-    build_init_resource_context,
-    materialize,
-)
+from dagster import asset, build_init_resource_context, materialize
 from dagster._core.test_utils import environ
 from dagster_aws.ssm import ParameterStoreResource, ParameterStoreTag, parameter_store_resource
 

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
@@ -33,10 +33,7 @@ from dagster._core.types.dagster_type import resolve_dagster_type
 from dagster._core.utils import make_new_run_id
 from dagster_azure.adls2 import create_adls2_client
 from dagster_azure.adls2.fake_adls2_resource import fake_adls2_resource
-from dagster_azure.adls2.io_manager import (
-    PickledObjectADLS2IOManager,
-    adls2_pickle_io_manager,
-)
+from dagster_azure.adls2.io_manager import PickledObjectADLS2IOManager, adls2_pickle_io_manager
 from dagster_azure.adls2.resources import adls2_resource
 from dagster_azure.blob import create_blob_client
 from upath import UPath

--- a/python_modules/libraries/dagster-dask/dagster_dask_tests/test_execute.py
+++ b/python_modules/libraries/dagster-dask/dagster_dask_tests/test_execute.py
@@ -5,13 +5,7 @@ from threading import Thread
 
 import dagster_pandas as dagster_pd
 import pytest
-from dagster import (
-    VersionStrategy,
-    file_relative_path,
-    job,
-    op,
-    reconstructable,
-)
+from dagster import VersionStrategy, file_relative_path, job, op, reconstructable
 from dagster._core.definitions.input import In
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.events import DagsterEventType

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -26,9 +26,7 @@ from typing_extensions import Final
 
 import dagster_databricks
 
-from .types import (
-    DatabricksRunState,
-)
+from .types import DatabricksRunState
 from .version import __version__
 
 # wait at most 24 hours by default for run execution

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -38,10 +38,7 @@ from databricks.sdk.core import DatabricksError
 from databricks.sdk.service import jobs
 
 from dagster_databricks import databricks_step_main
-from dagster_databricks.databricks import (
-    DEFAULT_RUN_MAX_WAIT_TIME_SEC,
-    DatabricksJobRunner,
-)
+from dagster_databricks.databricks import DEFAULT_RUN_MAX_WAIT_TIME_SEC, DatabricksJobRunner
 
 from .configs import (
     define_azure_credentials,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -25,11 +25,7 @@ from dagster._core.pipes.utils import (
     PipesLogReader,
     open_pipes_session,
 )
-from dagster_pipes import (
-    PipesContextData,
-    PipesExtras,
-    PipesParams,
-)
+from dagster_pipes import PipesContextData, PipesExtras, PipesParams
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import files, jobs
 from pydantic import Field

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
@@ -1,11 +1,6 @@
 from typing import Any, Dict, Optional
 
-from dagster import (
-    Config,
-    ConfigurableResource,
-    IAttachDifferentObjectToOpContext,
-    resource,
-)
+from dagster import Config, ConfigurableResource, IAttachDifferentObjectToOpContext, resource
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._model.pydantic_compat_layer import compat_model_validator
 from pydantic import Field

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_blueprints.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_blueprints.py
@@ -1,13 +1,7 @@
 from typing import cast
 from unittest.mock import MagicMock
 
-from dagster import (
-    AssetKey,
-    AssetsDefinition,
-    MaterializeResult,
-    PipesClient,
-    materialize,
-)
+from dagster import AssetKey, AssetsDefinition, MaterializeResult, PipesClient, materialize
 from dagster._core.blueprints.blueprint import BlueprintDefinitions
 from dagster._core.blueprints.blueprint_assets_definition import AssetSpecModel
 from dagster._core.pipes.client import PipesClientCompletedInvocation

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_ops.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_ops.py
@@ -4,10 +4,7 @@ import pytest
 from dagster import job
 from dagster._check import CheckError
 from dagster_databricks import DatabricksClientResource, databricks_client
-from dagster_databricks.ops import (
-    create_databricks_run_now_op,
-    create_databricks_submit_run_op,
-)
+from dagster_databricks.ops import create_databricks_run_now_op, create_databricks_submit_run_op
 from databricks.sdk.service import jobs
 from pytest_mock import MockerFixture
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
@@ -10,9 +10,7 @@ from dagster_databricks._test_utils import (
     temp_dbfs_script,
     upload_dagster_pipes_whl,
 )
-from dagster_databricks.pipes import (
-    PipesDatabricksClient,
-)
+from dagster_databricks.pipes import PipesDatabricksClient
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import jobs
 
@@ -22,11 +20,7 @@ IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 def script_fn():
     import sys
 
-    from dagster_pipes import (
-        PipesDbfsContextLoader,
-        PipesDbfsMessageWriter,
-        open_dagster_pipes,
-    )
+    from dagster_pipes import PipesDbfsContextLoader, PipesDbfsMessageWriter, open_dagster_pipes
 
     with open_dagster_pipes(
         context_loader=PipesDbfsContextLoader(),

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
@@ -9,9 +9,7 @@ from dagster._core.test_utils import instance_for_test
 from dagster._utils.merger import deep_merge_dicts
 from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
 from dagster_azure.adls2 import adls2_pickle_io_manager, adls2_resource
-from dagster_databricks import (
-    databricks_pyspark_step_launcher,
-)
+from dagster_databricks import databricks_pyspark_step_launcher
 from dagster_databricks.types import (
     DatabricksRunLifeCycleState,
     DatabricksRunResultState,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_decorator.py
@@ -1,16 +1,6 @@
 import os
 from pathlib import Path
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    FrozenSet,
-    Mapping,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-)
+from typing import Any, Callable, Dict, FrozenSet, Mapping, Optional, Sequence, Set, Tuple
 
 from dagster import (
     AssetCheckKey,
@@ -33,9 +23,7 @@ from dagster._core.definitions.metadata.source_code import (
     LocalFileCodeReference,
 )
 from dagster._core.definitions.tags import StorageKindTagSet
-from dagster._utils.warnings import (
-    experimental_warning,
-)
+from dagster._utils.warnings import experimental_warning
 
 from dagster_dbt.dbt_project import DbtProject
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -44,10 +44,7 @@ from dagster._core.definitions.metadata import RawMetadataMapping, RawMetadataVa
 from dagster._core.errors import DagsterInvalidSubsetError
 from dagster._utils.merger import deep_merge_dicts
 from dagster._utils.security import non_secure_md5_hash_str
-from dagster._utils.warnings import (
-    deprecation_warning,
-    normalize_renamed_param,
-)
+from dagster._utils.warnings import deprecation_warning, normalize_renamed_param
 
 from dagster_dbt.asset_utils import (
     default_asset_key_fn,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
@@ -16,9 +16,7 @@ from typing_extensions import Annotated
 from ..dbt_core_version import DBT_CORE_VERSION_UPPER_BOUND
 from ..dbt_project import DbtProject
 from ..include import STARTER_PROJECT_PATH
-from ..version import (
-    __version__ as dagster_dbt_version,
-)
+from ..version import __version__ as dagster_dbt_version
 
 app = typer.Typer(
     no_args_is_help=True,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -113,10 +113,7 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
 
     @staticmethod
     def parse_dbt_command(dbt_command: str) -> Namespace:
-        from dbt.cli.flags import (
-            Flags,
-            args_to_context,
-        )
+        from dbt.cli.flags import Flags, args_to_context
 
         args = shlex.split(dbt_command)[1:]
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -50,10 +50,7 @@ from dagster import (
     get_dagster_logger,
 )
 from dagster._annotations import experimental, public
-from dagster._core.definitions.metadata import (
-    TableMetadataSet,
-    TextMetadataValue,
-)
+from dagster._core.definitions.metadata import TableMetadataSet, TextMetadataValue
 from dagster._core.errors import DagsterExecutionInterruptedError, DagsterInvalidPropertyError
 from dagster._model.pydantic_compat_layer import compat_model_validator
 from dagster._utils import pushd
@@ -68,12 +65,7 @@ from dbt.node_types import NodeType
 from dbt.version import __version__ as dbt_version
 from packaging import version
 from pydantic import Field, validator
-from sqlglot import (
-    MappingSchema,
-    exp,
-    parse_one,
-    to_table,
-)
+from sqlglot import MappingSchema, exp, parse_one, to_table
 from sqlglot.expressions import normalize_table_name
 from sqlglot.lineage import lineage
 from sqlglot.optimizer import optimize
@@ -92,16 +84,10 @@ from ..dagster_dbt_translator import (
     validate_opt_translator,
     validate_translator,
 )
-from ..dbt_manifest import (
-    DbtManifestParam,
-    validate_manifest,
-)
+from ..dbt_manifest import DbtManifestParam, validate_manifest
 from ..dbt_project import DbtProject
 from ..errors import DagsterDbtCliRuntimeError
-from ..utils import (
-    ASSET_RESOURCE_TYPES,
-    get_dbt_resource_props_by_dbt_unique_id_from_manifest,
-)
+from ..utils import ASSET_RESOURCE_TYPES, get_dbt_resource_props_by_dbt_unique_id_from_manifest
 from .utils import imap
 
 IS_DBT_CORE_VERSION_LESS_THAN_1_8_0 = version.parse(dbt_version) < version.parse("1.8.0")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -1,15 +1,5 @@
 from argparse import Namespace
-from typing import (
-    AbstractSet,
-    Any,
-    Callable,
-    Dict,
-    Iterator,
-    Mapping,
-    Optional,
-    Sequence,
-    Union,
-)
+from typing import AbstractSet, Any, Callable, Dict, Iterator, Mapping, Optional, Sequence, Union
 
 import dateutil
 from dagster import (

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_check_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_check_selection.py
@@ -3,9 +3,7 @@ from typing import Any, Dict
 import pytest
 from dagster import AssetCheckKey, AssetKey, AssetsDefinition
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster_dbt import (
-    build_dbt_asset_selection,
-)
+from dagster_dbt import build_dbt_asset_selection
 from dagster_dbt.asset_decorator import dbt_assets
 
 pytest.importorskip("dbt.version", "1.6")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_checks.py
@@ -20,10 +20,7 @@ from dagster_dbt.asset_defs import load_assets_from_dbt_manifest
 from dagster_dbt.core.resources_v2 import DbtCliResource
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, DagsterDbtTranslatorSettings
 
-from ..dbt_projects import (
-    test_asset_checks_path,
-    test_dbt_alias_path,
-)
+from ..dbt_projects import test_asset_checks_path, test_dbt_alias_path
 
 pytest.importorskip("dbt.version", "1.6")
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
@@ -15,9 +15,7 @@ from dagster_dbt import DbtProject
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, DagsterDbtTranslatorSettings
 
-from ..dbt_projects import (
-    test_jaffle_shop_path,
-)
+from ..dbt_projects import test_jaffle_shop_path
 
 JAFFLE_SHOP_ROOT_PATH = os.path.normpath(test_jaffle_shop_path)
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_def_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_def_metadata.py
@@ -2,9 +2,7 @@ import os
 from typing import Any, Dict
 
 import pytest
-from dagster import (
-    AssetExecutionContext,
-)
+from dagster import AssetExecutionContext
 from dagster._core.definitions.metadata.metadata_set import TableMetadataSet
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.core.resources_v2 import DbtCliResource

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -6,23 +6,13 @@ from typing import Any, Dict, List, Optional, Union, cast
 
 import pydantic
 import pytest
-from dagster import (
-    In,
-    Nothing,
-    Out,
-    job,
-    materialize,
-    op,
-)
+from dagster import In, Nothing, Out, job, materialize, op
 from dagster._core.definitions.metadata.metadata_value import FloatMetadataValue, TextMetadataValue
 from dagster._core.errors import DagsterExecutionInterruptedError
 from dagster._core.execution.context.compute import AssetExecutionContext, OpExecutionContext
 from dagster_dbt import dbt_assets
 from dagster_dbt.asset_utils import build_dbt_asset_selection
-from dagster_dbt.core.resources_v2 import (
-    PARTIAL_PARSE_FILE_NAME,
-    DbtCliResource,
-)
+from dagster_dbt.core.resources_v2 import PARTIAL_PARSE_FILE_NAME, DbtCliResource
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator, DagsterDbtTranslatorSettings
 from dagster_dbt.dbt_project import DbtProject
 from dagster_dbt.errors import DagsterDbtCliRuntimeError

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/legacy/test_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/legacy/test_utils.py
@@ -6,10 +6,7 @@ from dagster_dbt.core.utils import _create_command_list
 from dagster_dbt.types import DbtOutput
 from dagster_dbt.utils import generate_materializations
 
-from .sample_results import (
-    DBT_18_RUN_RESULTS_SAMPLE,
-    DBT_CLI_V1_RUN_RESULTS_SAMPLE,
-)
+from .sample_results import DBT_18_RUN_RESULTS_SAMPLE, DBT_CLI_V1_RUN_RESULTS_SAMPLE
 
 
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-deltalake-pandas/dagster_deltalake_pandas/deltalake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-deltalake-pandas/dagster_deltalake_pandas/deltalake_pandas_type_handler.py
@@ -2,13 +2,8 @@ from typing import Any, Dict, Optional, Sequence, Tuple, Type
 
 import pandas as pd
 import pyarrow as pa
-from dagster._core.storage.db_io_manager import (
-    DbTypeHandler,
-)
-from dagster_deltalake.handler import (
-    DeltalakeBaseArrowTypeHandler,
-    DeltaLakePyArrowTypeHandler,
-)
+from dagster._core.storage.db_io_manager import DbTypeHandler
+from dagster_deltalake.handler import DeltalakeBaseArrowTypeHandler, DeltaLakePyArrowTypeHandler
 from dagster_deltalake.io_manager import DeltaLakeIOManager
 
 

--- a/python_modules/libraries/dagster-deltalake-polars/dagster_deltalake_polars/deltalake_polars_type_handler.py
+++ b/python_modules/libraries/dagster-deltalake-polars/dagster_deltalake_polars/deltalake_polars_type_handler.py
@@ -4,10 +4,7 @@ import polars as pl
 import pyarrow as pa
 import pyarrow.dataset as ds
 from dagster import InputContext
-from dagster._core.storage.db_io_manager import (
-    DbTypeHandler,
-    TableSlice,
-)
+from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
 from dagster_deltalake.handler import (
     DeltalakeBaseArrowTypeHandler,
     DeltaLakePyArrowTypeHandler,

--- a/python_modules/libraries/dagster-deltalake-polars/dagster_deltalake_polars_tests/test_type_handler_save_modes.py
+++ b/python_modules/libraries/dagster-deltalake-polars/dagster_deltalake_polars_tests/test_type_handler_save_modes.py
@@ -2,11 +2,7 @@ import os
 
 import polars as pl
 import pytest
-from dagster import (
-    Out,
-    graph,
-    op,
-)
+from dagster import Out, graph, op
 from dagster_deltalake import LocalConfig
 from dagster_deltalake.io_manager import WriteMode
 from dagster_deltalake_polars import DeltaLakePolarsIOManager

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake/handler.py
@@ -19,11 +19,7 @@ import pyarrow.compute as pc
 import pyarrow.dataset as ds
 from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
 from dagster._core.definitions.time_window_partitions import TimeWindow
-from dagster._core.storage.db_io_manager import (
-    DbTypeHandler,
-    TablePartitionDimension,
-    TableSlice,
-)
+from dagster._core.storage.db_io_manager import DbTypeHandler, TablePartitionDimension, TableSlice
 from deltalake import DeltaTable, WriterProperties, write_deltalake
 from deltalake.schema import (
     Field as DeltaField,

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_metadata_inputs.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_metadata_inputs.py
@@ -2,11 +2,7 @@ import os
 
 import pyarrow as pa
 import pytest
-from dagster import (
-    Out,
-    graph,
-    op,
-)
+from dagster import Out, graph, op
 from dagster_deltalake import DeltaLakePyarrowIOManager, LocalConfig, WriterEngine
 from deltalake import DeltaTable
 

--- a/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_type_handler_extra_params.py
+++ b/python_modules/libraries/dagster-deltalake/dagster_deltalake_tests/test_type_handler_extra_params.py
@@ -2,11 +2,7 @@ import os
 
 import pyarrow as pa
 import pytest
-from dagster import (
-    Out,
-    graph,
-    op,
-)
+from dagster import Out, graph, op
 from dagster_deltalake import DeltaLakePyarrowIOManager, LocalConfig, WriterEngine
 from deltalake import DeltaTable
 

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -14,20 +14,13 @@ from dagster._core.pipes.client import (
     PipesContextInjector,
     PipesMessageReader,
 )
-from dagster._core.pipes.context import (
-    PipesMessageHandler,
-)
+from dagster._core.pipes.context import PipesMessageHandler
 from dagster._core.pipes.utils import (
     PipesEnvContextInjector,
     extract_message_or_forward_to_stdout,
     open_pipes_session,
 )
-from dagster_pipes import (
-    DagsterPipesError,
-    PipesDefaultMessageWriter,
-    PipesExtras,
-    PipesParams,
-)
+from dagster_pipes import DagsterPipesError, PipesDefaultMessageWriter, PipesExtras, PipesParams
 
 
 @experimental

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_pipes.py
@@ -3,9 +3,7 @@ import tempfile
 
 import pytest
 from dagster import AssetExecutionContext, asset, materialize
-from dagster._core.pipes.utils import (
-    PipesFileContextInjector,
-)
+from dagster._core.pipes.utils import PipesFileContextInjector
 from dagster_docker.pipes import PipesDockerClient
 from dagster_test.test_project import (
     IS_BUILDKITE,

--- a/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pandas/dagster_duckdb_pandas/duckdb_pandas_type_handler.py
@@ -4,11 +4,7 @@ import pandas as pd
 from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
 from dagster._core.definitions.metadata import TableMetadataSet
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
-from dagster_duckdb.io_manager import (
-    DuckDbClient,
-    DuckDBIOManager,
-    build_duckdb_io_manager,
-)
+from dagster_duckdb.io_manager import DuckDbClient, DuckDBIOManager, build_duckdb_io_manager
 
 
 class DuckDBPandasTypeHandler(DbTypeHandler[pd.DataFrame]):

--- a/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-duckdb-pyspark/dagster_duckdb_pyspark/duckdb_pyspark_type_handler.py
@@ -5,11 +5,7 @@ import pyspark
 import pyspark.sql
 from dagster import InputContext, MetadataValue, OutputContext, TableColumn, TableSchema
 from dagster._core.storage.db_io_manager import DbTypeHandler, TableSlice
-from dagster_duckdb.io_manager import (
-    DuckDbClient,
-    DuckDBIOManager,
-    build_duckdb_io_manager,
-)
+from dagster_duckdb.io_manager import DuckDbClient, DuckDBIOManager, build_duckdb_io_manager
 from pyspark.sql import SparkSession
 from pyspark.sql.types import StructType
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/translator.py
@@ -1,10 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping, Optional
 
-from dagster import (
-    AssetKey,
-    AutoMaterializePolicy,
-)
+from dagster import AssetKey, AutoMaterializePolicy
 from dagster._annotations import public
 from dlt.extract.resource import DltResource
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
@@ -2,12 +2,7 @@ import re
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping, Optional
 
-from dagster import (
-    AssetKey,
-    AutoMaterializePolicy,
-    FreshnessPolicy,
-    MetadataValue,
-)
+from dagster import AssetKey, AutoMaterializePolicy, FreshnessPolicy, MetadataValue
 from dagster._annotations import public
 
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_asset_decorator.py
@@ -13,10 +13,7 @@ from dagster import (
     file_relative_path,
 )
 from dagster._core.definitions.materialize import materialize
-from dagster_embedded_elt.sling import (
-    SlingReplicationParam,
-    sling_assets,
-)
+from dagster_embedded_elt.sling import SlingReplicationParam, sling_assets
 from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
 from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingResource
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_assets.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_assets.py
@@ -4,11 +4,7 @@ import sqlite3
 import pytest
 from dagster import AssetSpec, Definitions
 from dagster._core.definitions.materialize import materialize
-from dagster_embedded_elt.sling import (
-    SlingMode,
-    SlingResource,
-    build_sling_asset,
-)
+from dagster_embedded_elt.sling import SlingMode, SlingResource, build_sling_asset
 
 ASSET_SPEC = AssetSpec(
     key=["main", "tbl"],

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/ops.py
@@ -1,14 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from dagster import (
-    AssetKey,
-    Config,
-    In,
-    Nothing,
-    Out,
-    Output,
-    op,
-)
+from dagster import AssetKey, Config, In, Nothing, Out, Output, op
 from pydantic import Field
 
 from dagster_fivetran.resources import DEFAULT_POLL_INTERVAL, FivetranResource

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/bigquery/io_manager.py
@@ -4,9 +4,7 @@ from typing import Generator, Optional, Sequence, Type, cast
 
 from dagster import IOManagerDefinition, OutputContext, io_manager
 from dagster._annotations import experimental
-from dagster._config.pythonic_config import (
-    ConfigurableIOManagerFactory,
-)
+from dagster._config.pythonic_config import ConfigurableIOManagerFactory
 from dagster._core.storage.db_io_manager import (
     DbClient,
     DbIOManager,

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_io_manager.py
@@ -29,9 +29,7 @@ from dagster._core.definitions.unresolved_asset_job_definition import define_ass
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.execution.plan.outputs import StepOutputHandle
-from dagster._core.storage.dagster_run import (
-    DagsterRun as DagsterRun,
-)
+from dagster._core.storage.dagster_run import DagsterRun as DagsterRun
 from dagster._core.system_config.objects import ResolvedRunConfig
 from dagster._core.types.dagster_type import resolve_dagster_type
 from dagster._core.utils import make_new_run_id

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/container_context.py
@@ -1,16 +1,6 @@
 import copy
 import logging
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Mapping,
-    NamedTuple,
-    Optional,
-    Sequence,
-    Set,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Dict, Mapping, NamedTuple, Optional, Sequence, Set, cast
 
 import dagster._check as check
 import kubernetes

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -3,9 +3,7 @@ import sys
 from typing import Any, Mapping, Optional, Sequence
 
 import kubernetes
-from dagster import (
-    _check as check,
-)
+from dagster import _check as check
 from dagster._cli.api import ExecuteRunArgs
 from dagster._core.events import EngineEventData
 from dagster._core.launcher import LaunchRunContext, ResumeRunContext, RunLauncher

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -20,9 +20,7 @@ from dagster._core.pipes.client import (
     PipesMessageReader,
     PipesParams,
 )
-from dagster._core.pipes.context import (
-    PipesMessageHandler,
-)
+from dagster._core.pipes.context import PipesMessageHandler
 from dagster._core.pipes.utils import (
     PipesEnvContextInjector,
     extract_message_or_forward_to_stdout,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_pipes.py
@@ -3,10 +3,7 @@ from pathlib import Path
 import pytest
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster_k8s.pipes import _DEV_NULL_MESSAGE_WRITER, _detect_current_namespace, build_pod_body
-from dagster_pipes import (
-    DAGSTER_PIPES_CONTEXT_ENV_VAR,
-    DAGSTER_PIPES_MESSAGES_ENV_VAR,
-)
+from dagster_pipes import DAGSTER_PIPES_CONTEXT_ENV_VAR, DAGSTER_PIPES_MESSAGES_ENV_VAR
 
 
 @pytest.fixture

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -7,14 +7,7 @@ from urllib.parse import urlparse
 
 import pytest
 import sqlalchemy as db
-from dagster import (
-    AssetKey,
-    AssetMaterialization,
-    AssetObservation,
-    Output,
-    job,
-    op,
-)
+from dagster import AssetKey, AssetMaterialization, AssetObservation, Output, job, op
 from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.instance import DagsterInstance

--- a/python_modules/libraries/dagster-openai/dagster_openai/resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai/resources.py
@@ -13,9 +13,7 @@ from dagster import (
     OpExecutionContext,
 )
 from dagster._annotations import experimental, public
-from dagster._core.errors import (
-    DagsterInvariantViolationError,
-)
+from dagster._core.errors import DagsterInvariantViolationError
 from openai import Client
 from pydantic import Field, PrivateAttr
 

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/delta.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/delta.py
@@ -2,17 +2,7 @@ import json
 from collections import defaultdict
 from enum import Enum
 from pprint import pformat
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Literal,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Sequence, Tuple, Union, overload
 
 import polars as pl
 from dagster import InputContext, MetadataValue, MultiPartitionKey, OutputContext

--- a/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
+++ b/python_modules/libraries/dagster-prometheus/dagster_prometheus/resources.py
@@ -1,8 +1,5 @@
 import prometheus_client
-from dagster import (
-    ConfigurableResource,
-    resource,
-)
+from dagster import ConfigurableResource, resource
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.init import InitResourceContext
 from prometheus_client.exposition import default_handler

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/snowflake_io_manager.py
@@ -3,9 +3,7 @@ from contextlib import contextmanager
 from typing import Optional, Sequence, Type, cast
 
 from dagster import IOManagerDefinition, OutputContext, io_manager
-from dagster._config.pythonic_config import (
-    ConfigurableIOManagerFactory,
-)
+from dagster._config.pythonic_config import ConfigurableIOManagerFactory
 from dagster._core.definitions.time_window_partitions import TimeWindow
 from dagster._core.storage.db_io_manager import (
     DbClient,

--- a/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
@@ -19,10 +19,7 @@ from dagster._core.execution.context.init import InitResourceContext
 from dagster._utils import mkdir_p
 from paramiko.client import SSHClient
 from paramiko.config import SSH_PORT
-from pydantic import (
-    Field,
-    PrivateAttr,
-)
+from pydantic import Field, PrivateAttr
 from sshtunnel import SSHTunnelForwarder
 
 

--- a/python_modules/libraries/dagster-wandb/dagster_wandb_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb_tests/test_io_manager.py
@@ -14,11 +14,7 @@ from dagster import (
     build_input_context,
     build_output_context,
 )
-from dagster_wandb import (
-    WandbArtifactsIOManagerError,
-    wandb_artifacts_io_manager,
-    wandb_resource,
-)
+from dagster_wandb import WandbArtifactsIOManagerError, wandb_artifacts_io_manager, wandb_resource
 from dagster_wandb.io_manager import UNIT_TEST_RUN_ID
 from wandb import Artifact
 

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_manager.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_manager.py
@@ -7,10 +7,7 @@ import threading
 
 import dagstermill
 import pytest
-from dagster import (
-    AssetMaterialization,
-    ResourceDefinition,
-)
+from dagster import AssetMaterialization, ResourceDefinition
 from dagster._core.definitions.dependency import NodeHandle
 from dagster._core.definitions.reconstruct import ReconstructableJob
 from dagster._core.errors import DagsterInvariantViolationError


### PR DESCRIPTION
## Summary & Motivation

This is a thing that has annoyed me for awhile. The heart of this PR is just in pyproject.toml, the rest is just from me running `make ruff`.

Basically just collapses down:

```python
from x import (
    a,
    b,
    c,
)
```
into:

```python
from x import a, b, c
```

automatically.

You can end up with those lines if you originally had a longer import list (which required multiple lines), but over time removed some imports. Generally, you trust the autoformatter to handle that and never scroll back up to realize that you now have an unnecessarily long import statement.

## How I Tested These Changes
