### PR TITLE
Add freshness checks to example projects

### DIFF
--- a/examples/assets_modern_data_stack/assets_modern_data_stack/__init__.py
+++ b/examples/assets_modern_data_stack/assets_modern_data_stack/__init__.py
@@ -4,11 +4,18 @@ from dagster import (
     define_asset_job,
     load_assets_from_package_module,
 )
+from dagster._core.definitions.asset_check_factories.freshness_checks.sensor import (
+    build_sensor_for_freshness_checks,
+)
 from dagster_airbyte import AirbyteResource
 
 from . import assets
+from .assets.forecasting import freshness_checks
 from .db_io_manager import DbIOManager
 from .utils.constants import AIRBYTE_CONFIG, POSTGRES_CONFIG, dbt_resource
+
+# The freshness check sensor will run our freshness checks even if the underlying asset fails to run, for whatever reason.
+freshness_check_sensor = build_sensor_for_freshness_checks(freshness_checks=freshness_checks)
 
 defs = Definitions(
     assets=load_assets_from_package_module(assets),
@@ -17,10 +24,12 @@ defs = Definitions(
         "dbt": dbt_resource,
         "db_io_manager": DbIOManager(**POSTGRES_CONFIG),
     },
+    asset_checks=freshness_checks,
     schedules=[
         # update all assets once a day
         ScheduleDefinition(
             job=define_asset_job("all_assets", selection="*"), cron_schedule="@daily"
         ),
     ],
+    sensors=[freshness_check_sensor],
 )

--- a/examples/assets_modern_data_stack/assets_modern_data_stack/assets/forecasting.py
+++ b/examples/assets_modern_data_stack/assets_modern_data_stack/assets/forecasting.py
@@ -1,6 +1,11 @@
+import datetime
+
 import numpy as np
 import pandas as pd
 from dagster import AssetExecutionContext, asset
+from dagster._core.definitions.asset_check_factories.freshness_checks.last_update import (
+    build_last_update_freshness_checks,
+)
 from dagster_airbyte import build_airbyte_assets
 from dagster_dbt import DbtCliResource, dbt_assets
 from scipy import optimize
@@ -45,3 +50,11 @@ def predicted_orders(
     future_dates = pd.date_range(start=start_date, end=start_date + pd.DateOffset(days=30))
     predicted_data = model_func(x=future_dates.astype(np.int64), a=a, b=b)
     return pd.DataFrame({"order_date": future_dates, "num_orders": predicted_data})
+
+
+# Each of these assets should be getting run every day. If it hasn't been run in the last
+# 2 days, we consider it stale.
+freshness_checks = build_last_update_freshness_checks(
+    assets=[predicted_orders, order_forecast_model],
+    lower_bound_delta=datetime.timedelta(days=2),
+)


### PR DESCRIPTION
There are currently no asset checks in any of our example projects. This adds some basic freshness checks to two of our example projects.
