### PR TITLE
[blueprints] add yaml utils for loading list of pydantic models

### DIFF
--- a/python_modules/dagster/dagster/_utils/pydantic_yaml.py
+++ b/python_modules/dagster/dagster/_utils/pydantic_yaml.py
@@ -17,9 +17,23 @@ T = TypeVar("T", bound=BaseModel)
 def _parse_and_populate_model_with_annotated_errors(
     cls: Type[T],
     obj_parse_root: ValueAndSourcePositionTree,
-    file_root: Optional[ValueAndSourcePositionTree] = None,
-    obj_key_path_prefix: KeyPath = [],
+    file_root: Optional[ValueAndSourcePositionTree],
+    obj_key_path_prefix: KeyPath,
 ) -> T:
+    """Helper function to parse the Pydantic model from the parsed YAML object and populate source
+    position information on the model and its sub-objects.
+
+    Raises more helpful errors than Pydantic's default error messages, including the source position
+    in the YAML file where the error occurred.
+
+    Args:
+        cls (Type[T]): The Pydantic model class to use for validation.
+        obj_parse_root (ValueAndSourcePositionTree): The parsed YAML object to use for validation.
+        file_root (Optional[ValueAndSourcePositionTree]): The root of the parsed YAML file, used for
+            error reporting.
+        obj_key_path_prefix (KeyPath): The path of keys that lead to the current object, used for
+            both error reporting and populating source position information.
+    """
     try:
         model = parse_obj_as(cls, obj_parse_root.value)
     except ValidationError as e:

--- a/python_modules/dagster/dagster/_utils/pydantic_yaml.py
+++ b/python_modules/dagster/dagster/_utils/pydantic_yaml.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Type, TypeVar
 
 from pydantic import BaseModel, ValidationError, parse_obj_as
 
+from dagster._core.errors import DagsterInvariantViolationError
 from dagster._model.pydantic_compat_layer import USING_PYDANTIC_1
 
 from .source_position import (
@@ -113,7 +114,7 @@ def parse_yaml_file_to_pydantic_list(cls: Type[T], src: str, filename: str = "<s
     parsed = parse_yaml_with_source_positions(src, filename)
 
     if not isinstance(parsed.value, list):
-        raise ValueError(
+        raise DagsterInvariantViolationError(
             f"Error parsing YAML file {filename}: Expected a list of objects at document root, but got {type(parsed.value)}"
         )
 

--- a/python_modules/dagster/dagster/_utils/pydantic_yaml.py
+++ b/python_modules/dagster/dagster/_utils/pydantic_yaml.py
@@ -1,13 +1,51 @@
-from typing import Type, TypeVar
+from typing import List, Optional, Type, TypeVar
 
 from pydantic import BaseModel, ValidationError, parse_obj_as
 
 from dagster._model.pydantic_compat_layer import USING_PYDANTIC_1
 
-from .source_position import KeyPath, populate_source_position_and_key_paths
+from .source_position import (
+    KeyPath,
+    ValueAndSourcePositionTree,
+    populate_source_position_and_key_paths,
+)
 from .yaml_utils import parse_yaml_with_source_positions
 
 T = TypeVar("T", bound=BaseModel)
+
+
+def _parse_and_populate_model_with_annotated_errors(
+    cls: Type[T],
+    obj_parse_root: ValueAndSourcePositionTree,
+    file_root: Optional[ValueAndSourcePositionTree] = None,
+    obj_key_path_prefix: KeyPath = [],
+) -> T:
+    try:
+        model = parse_obj_as(cls, obj_parse_root.value)
+    except ValidationError as e:
+        if USING_PYDANTIC_1:
+            raise e
+        else:
+            line_errors = []
+            for error in e.errors():
+                key_path: KeyPath = list(obj_key_path_prefix) + list(error["loc"])
+                key_path_str = ".".join(str(part) for part in key_path)
+                source_position = (file_root or obj_parse_root).source_position_tree.lookup(
+                    key_path
+                )
+                line_errors.append({**error, "loc": [key_path_str + " at " + str(source_position)]})
+
+            raise ValidationError.from_exception_data(  # type: ignore
+                title=e.title,  # type: ignore
+                line_errors=line_errors,
+                input_type="json",
+                hide_input=False,
+            ) from None
+
+    populate_source_position_and_key_paths(
+        model, obj_parse_root.source_position_tree, obj_key_path_prefix
+    )
+    return model
 
 
 def parse_yaml_file_to_pydantic(cls: Type[T], src: str, filename: str = "<string>") -> T:
@@ -32,25 +70,49 @@ def parse_yaml_file_to_pydantic(cls: Type[T], src: str, filename: str = "<string
             that the model corresponds to.
     """
     parsed = parse_yaml_with_source_positions(src, filename)
-    try:
-        model = parse_obj_as(cls, parsed.value)
-    except ValidationError as e:
-        if USING_PYDANTIC_1:
-            raise e
-        else:
-            line_errors = []
-            for error in e.errors():
-                key_path: KeyPath = error["loc"]
-                key_path_str = ".".join(str(part) for part in key_path)
-                source_position = parsed.source_position_tree.lookup(key_path)
-                line_errors.append({**error, "loc": [key_path_str + " at " + str(source_position)]})
+    return _parse_and_populate_model_with_annotated_errors(
+        cls=cls, obj_parse_root=parsed, file_root=parsed, obj_key_path_prefix=[]
+    )
 
-            raise ValidationError.from_exception_data(  # type: ignore
-                title=e.title,  # type: ignore
-                line_errors=line_errors,
-                input_type="json",
-                hide_input=False,
-            ) from None
 
-    populate_source_position_and_key_paths(model, parsed.source_position_tree)
-    return model
+def parse_yaml_file_to_pydantic_list(cls: Type[T], src: str, filename: str = "<string>") -> List[T]:
+    """Parse the YAML source and create a list of Pydantic model instances from it.
+
+    Attaches source position information to the `_source_position_and_key_path` attribute of the
+    Pydantic model instance and sub-objects.
+
+    Args:
+        cls (type[T]): The Pydantic model class to use for validation.
+        src (str): The YAML source string to be parsed.
+        filename (str): The filename associated with the YAML source, used for error reporting.
+            Defaults to "<string>" if not provided.
+
+    Returns:
+        T: A list of instances of the Pydantic model class, with the `_source_position_and_key_path`
+            attribute populated on each list element and all the objects inside them.
+
+    Raises:
+        ValidationError: If the YAML data does not conform to the Pydantic model schema. If using
+            Pydantic2+, errors will include context information about the position in the document
+            that the model corresponds to.
+    """
+    parsed = parse_yaml_with_source_positions(src, filename)
+
+    if not isinstance(parsed.value, list):
+        raise ValueError(
+            f"Error parsing YAML file {filename}: Expected a list of objects at document root, but got {type(parsed.value)}"
+        )
+
+    results = []
+    for i, entry in enumerate(parsed.value):
+        results.append(
+            _parse_and_populate_model_with_annotated_errors(
+                cls=cls,
+                obj_parse_root=ValueAndSourcePositionTree(
+                    value=entry, source_position_tree=parsed.source_position_tree.children[i]
+                ),
+                file_root=parsed,
+                obj_key_path_prefix=[i],
+            )
+        )
+    return results

--- a/python_modules/dagster/dagster_tests/utils_tests/test_pydantic_yaml.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_pydantic_yaml.py
@@ -1,7 +1,10 @@
 import traceback
 
 import pytest
-from dagster._utils.pydantic_yaml import parse_yaml_file_to_pydantic
+from dagster._utils.pydantic_yaml import (
+    parse_yaml_file_to_pydantic,
+    parse_yaml_file_to_pydantic_list,
+)
 from dagster._utils.source_position import HasSourcePositionAndKeyPath
 from pydantic import BaseModel, ValidationError
 
@@ -35,3 +38,44 @@ def test_parse_yaml_file_to_pydantic() -> None:
     rv = parse_yaml_file_to_pydantic(MyModel, "child:\n  name: foo")
     assert rv.child.name == "foo"
     assert str(rv.child._source_position_and_key_path.source_position) == "<string>:2"  # noqa: SLF001 # type: ignore
+
+
+def test_parse_yaml_file_to_pydantic_list_error() -> None:
+    class BrokenModel2(BaseModel):
+        bar: str
+
+    class BrokenModel(BaseModel):
+        foo: list[BrokenModel2]
+
+    with pytest.raises(ValidationError) as excinfo:
+        parse_yaml_file_to_pydantic_list(BrokenModel, "- foo:\n  - bar: 'asdf'\n- foo:\n  - bar: 1")
+
+    e = excinfo.value
+    e_str = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+
+    # Ensure that the error message contains the correct path
+    assert "1.foo.0.bar at <string>:4" in e_str
+
+
+def test_parse_yaml_file_to_pydantic_list() -> None:
+    class MyModel2(BaseModel, HasSourcePositionAndKeyPath):
+        name: str
+
+    class MyModel(BaseModel):
+        child: MyModel2
+
+    rv = parse_yaml_file_to_pydantic_list(
+        MyModel, "- child:\n    name: foo\n- child:\n    name: bar"
+    )
+    assert rv[0].child.name == "foo"
+    assert str(rv[0].child._source_position_and_key_path.source_position) == "<string>:2"  # noqa: SLF001 # type: ignore
+    assert (
+        ".".join(str(item) for item in rv[0].child._source_position_and_key_path.key_path)  # noqa: SLF001 # type: ignore
+        == "0.child"
+    )
+    assert rv[1].child.name == "bar"
+    assert str(rv[1].child._source_position_and_key_path.source_position) == "<string>:4"  # noqa: SLF001 # type: ignore
+    assert (
+        ".".join(str(item) for item in rv[1].child._source_position_and_key_path.key_path)  # noqa: SLF001 # type: ignore
+        == "1.child"
+    )


### PR DESCRIPTION
## Summary

Introduces some YAML utils which handle breaking apart a YAML list at the top level and parsing its elements into Pydantic models.

## Test Plan

Unit tests.