### PR TITLE
Asset health perf - increase batch size + parallel fetches

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThread.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThread.tsx
@@ -80,7 +80,7 @@ export class LiveDataThread<T> {
   }
 
   private async _batchedQueryKeys() {
-    if (this.activeFetches >= BATCH_PARALLEL_FETCHES) {
+    if (this.activeFetches >= this._parallelFetches) {
       return;
     }
     const keys = this.manager.determineKeysToFetch(this.getObservedKeys(), this._batchSize);

--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThread.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThread.tsx
@@ -84,6 +84,7 @@ export class LiveDataThread<T> {
       return;
     }
     const keys = this.manager.determineKeysToFetch(this.getObservedKeys(), this._batchSize);
+    console.log({keys}, this._batchSize, this._parallelFetches, this);
     if (!keys.length) {
       return;
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThreadManager.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThreadManager.tsx
@@ -15,7 +15,6 @@ export class LiveDataThreadManager<T> {
   private pollRate: number = 30000;
   private listeners: Record<string, undefined | Listener<T>[]>;
   private isPaused: boolean;
-  private batchSize: number;
 
   private onSubscriptionsChanged(_allKeys: string[]) {}
   private onUpdatedOrUpdating() {}
@@ -24,14 +23,13 @@ export class LiveDataThreadManager<T> {
     return {};
   }
 
-  constructor(queryKeys: (keys: string[]) => Promise<Record<string, T>>, batchSize?: number) {
+  constructor(queryKeys: (keys: string[]) => Promise<Record<string, T>>) {
     this.queryKeys = queryKeys;
     this.lastFetchedOrRequested = {};
     this.cache = {};
     this.threads = {};
     this.listeners = {};
     this.isPaused = false;
-    this.batchSize = batchSize || BATCH_SIZE;
   }
 
   public setPollRate(pollRate: number) {
@@ -57,7 +55,7 @@ export class LiveDataThreadManager<T> {
   public subscribe(key: string, listener: Listener<T>, threadID: LiveDataThreadID = 'default') {
     let _thread = this.threads[threadID];
     if (!_thread) {
-      _thread = new LiveDataThread(this, this.queryKeys);
+      _thread = new LiveDataThread(threadID, this, this.queryKeys);
       if (!this.isPaused) {
         _thread.startFetchLoop();
       }
@@ -103,10 +101,10 @@ export class LiveDataThreadManager<T> {
   }
 
   // Function used by threads.
-  public determineKeysToFetch(keys: string[]) {
+  public determineKeysToFetch(keys: string[], batchSize: number) {
     const keysToFetch: string[] = [];
     const keysWithoutData: string[] = [];
-    while (keys.length && keysWithoutData.length < this.batchSize) {
+    while (keys.length && keysWithoutData.length < batchSize) {
       const key = keys.shift()!;
       const isRequested = !!this.lastFetchedOrRequested[key]?.requested;
       if (isRequested) {

--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThreadManager.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThreadManager.tsx
@@ -1,5 +1,4 @@
 import {LiveDataThread, LiveDataThreadID} from './LiveDataThread';
-import {BATCH_SIZE} from './util';
 import {isDocumentVisible} from '../hooks/useDocumentVisibility';
 
 type Listener<T> = (stringKey: string, data?: T | undefined) => void;
@@ -122,7 +121,7 @@ export class LiveDataThreadManager<T> {
     }
 
     // Prioritize fetching keys for which there is no data in the cache
-    return keysWithoutData.concat(keysToFetch).slice(0, BATCH_SIZE);
+    return keysWithoutData.concat(keysToFetch).slice(0, batchSize);
   }
 
   public areKeysRefreshing(keys: string[]) {

--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/util.ts
@@ -11,3 +11,10 @@ export const BATCHING_INTERVAL = 250;
 
 export const SUBSCRIPTION_IDLE_POLL_RATE = 30 * 1000;
 export const SUBSCRIPTION_MAX_POLL_RATE = 2 * 1000;
+
+export const threadIDToLimits = {
+  ['AssetHealth' as string]: {
+    batchSize: 250,
+    parallelThreads: 4,
+  },
+};


### PR DESCRIPTION
## Summary & Motivation

As titled

## How I Tested These Changes
Loaded asset health and saw 4 parallel fetches with 250 keys each
<img width="654" alt="Screenshot 2024-06-04 at 4 45 18 AM" src="https://github.com/dagster-io/dagster/assets/2286579/624e367b-3720-4f2a-acd4-9cd697c52d0c">

