### PR TITLE
Remove expensive step-level tracking when computing whether or not a run is in the middle of materializing an asset for display purposes

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetRunLinking.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetRunLinking.tsx
@@ -26,7 +26,7 @@ export const AssetLatestRunSpinner = ({
   }
   if (liveData?.unstartedRunIds?.length) {
     return (
-      <Tooltip content="A run has started that will rematerialize this asset soon.">
+      <Tooltip content="A run that targets this asset is queued.">
         <Spinner purpose={purpose} stopped />
       </Tooltip>
     );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
@@ -210,11 +210,11 @@ export const AssetPartitionDetail = ({
     latestRunForPartition?.id !== latestEventRun?.id ? latestRunForPartition : null;
   const currentRunStatusMessage =
     currentRun?.status === RunStatus.STARTED
-      ? 'has started and is refreshing this partition.'
+      ? 'that targets this partition has started .'
       : currentRun?.status === RunStatus.STARTING
-      ? 'is starting and will refresh this partition.'
+      ? 'that targets this partition is starting.'
       : currentRun?.status === RunStatus.QUEUED
-      ? 'is queued and is refreshing this partition.'
+      ? 'that targets this partition is queued.'
       : undefined;
 
   const repositoryOrigin = latestEventRun?.repositoryOrigin;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/CurrentRunsBanner.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/CurrentRunsBanner.tsx
@@ -50,14 +50,12 @@ export const CurrentRunsBanner = ({
                   {inProgressRunIds.length && unstartedRunIds.length ? ' ' : ''}
                   {unstartedRunIds.length > 1 && (
                     <>
-                      Runs <RunIdLinks ids={unstartedRunIds} /> have started and will refresh this
-                      asset.
+                      Runs <RunIdLinks ids={unstartedRunIds} /> that target this asset are queued.
                     </>
                   )}
                   {unstartedRunIds.length === 1 && (
                     <>
-                      Run <RunIdLinks ids={unstartedRunIds} /> has started and will refresh this
-                      asset.
+                      Run <RunIdLinks ids={unstartedRunIds} /> that targets this asset are queued.
                     </>
                   )}
                 </div>


### PR DESCRIPTION
Summary:
This is a change that makes an explicit tradeoff for performance when displaying in progress runs in the asset graph and asset status UI - instead of doing granular step-level tracking of each run to determine whether it is literally in the middle of a step that intends to materialize that asset or not, which requires making expensive event log queries that can very plausibly time out for large runs, we consider the run to be 'in progress' for that asset if it is in an in-progress state and has not materialized the asset yet.

The product impact of this change would be that if a run has started but hasn't yet gotten around to the specific step that has materialized that asset yet, it would still be shown as an 'in progress run' for that asset.

I believe that if we feel step level tracking is important enough to make that distinction in the UI, we should add the requisite events and derived tables to make it efficient to do so.

Test Plan:
Render asset graph page for a multi-step job that materializes an asset
While it is queued, it shows up as 'has been enqueued and will refresh this asset'
Once it starts, even once the 2nd step that actually refreshes the asset has started, the UI ssays "run xxx is currently refreshing this asset".

## Summary & Motivation

## How I Tested These Changes
