### PR TITLE
[DA] Fix error with freshness-based scheduling

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1910,10 +1910,17 @@ class BaseTimeWindowPartitionsSubset(PartitionsSubset):
     def __len__(self) -> int:
         return self.num_partitions
 
-    def __contains__(self, partition_key: str) -> bool:
-        time_window = cast(
-            TimeWindowPartitionsDefinition, self.partitions_def
-        ).time_window_for_partition_key(partition_key)
+    def __contains__(self, partition_key: Optional[str]) -> bool:
+        if partition_key is None:
+            return False
+
+        try:
+            time_window = cast(
+                TimeWindowPartitionsDefinition, self.partitions_def
+            ).time_window_for_partition_key(partition_key)
+        except ValueError:
+            # invalid partition key
+            return False
 
         time_window_start_timestamp = time_window.start.timestamp()
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -1028,16 +1028,21 @@ def test_current_time_window_partitions_serialization():
     assert deserialized.get_partition_keys() == ["2015-01-02", "2015-01-04"]
 
 
-def test_time_window_partitions_contains():
+@pytest.mark.parametrize(
+    "subset_class", [TimeWindowPartitionsSubset, PartitionKeysTimeWindowPartitionsSubset]
+)
+def test_time_window_partitions_contains(subset_class: BaseTimeWindowPartitionsSubset) -> None:
     partitions_def = DailyPartitionsDefinition(start_date="2015-01-01")
     keys = ["2015-01-06", "2015-01-07", "2015-01-08", "2015-01-10"]
-    subset = partitions_def.empty_subset().with_partition_keys(keys)
+    subset = subset_class.empty_subset(partitions_def).with_partition_keys(keys)
     for key in keys:
         assert key in subset
 
     assert "2015-01-05" not in subset
     assert "2015-01-09" not in subset
     assert "2015-01-11" not in subset
+    assert None not in subset
+    assert "<not a time string>" not in subset
 
 
 def test_dst_transition_15_minute_partitions() -> None:


### PR DESCRIPTION
## Summary & Motivation

Long story short, this issue was lying in wait for a long time, but we never hit it because all of our BaseTimeWindowPartitionSubsets were in the "partition key" format rather than the "time window" format. If you check if <random non-time-window key, in the detected case, None> in <partition key set>, that's totally fine, but if you check if that same "invalid" key is in <time window set>, then you get an error.

This PR makes the time window set copy the same behavior of the non-time window set.

## How I Tested These Changes
