### PR TITLE
Fix neighbor propagation

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -346,7 +346,7 @@ class AutomationResult(NamedTuple):
 
     @property
     def true_subset(self) -> AssetSubset:
-        return self.serializable_evaluation.true_subset
+        return self.true_slice.convert_to_valid_asset_subset()
 
     @staticmethod
     def _create(
@@ -437,7 +437,7 @@ class AutomationResult(NamedTuple):
 
     def get_new_cursor(self) -> AutomationConditionCursor:
         return AutomationConditionCursor(
-            previous_requested_subset=self.true_subset,
+            previous_requested_subset=self.serializable_evaluation.true_subset,
             effective_timestamp=self.temporal_context.effective_dt.timestamp(),
             last_event_id=self.temporal_context.last_event_id,
             node_cursors_by_unique_id=self.get_child_node_cursors(),

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -346,7 +346,7 @@ class AutomationResult(NamedTuple):
 
     @property
     def true_subset(self) -> AssetSubset:
-        return self.true_slice.convert_to_valid_asset_subset()
+        return self.serializable_evaluation.true_subset
 
     @staticmethod
     def _create(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -151,10 +151,14 @@ class AutomationConditionEvaluator:
                     # the subset of all required neighbors
                     if neighbor_key in self.current_results_by_key:
                         neighbor_result = self.current_results_by_key[neighbor_key]
+                        neighbor_true_subset = result.serializable_evaluation.true_subset._replace(
+                            asset_key=neighbor_key
+                        )
+                        neighbor_evaluation = result.serializable_evaluation._replace(
+                            true_subset=neighbor_true_subset
+                        )
                         self.current_results_by_key[neighbor_key] = neighbor_result._replace(
-                            serializable_evaluation=result.serializable_evaluation.true_subset._replace(
-                                asset_key=neighbor_key
-                            ),
+                            serializable_evaluation=neighbor_evaluation
                         )
                     self.to_request |= {
                         ap._replace(asset_key=neighbor_key)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/asset_daemon_scenario.py
@@ -154,6 +154,9 @@ class AssetDaemonScenarioState(ScenarioState):
             respect_materialization_data_versions=False,
             logger=self.logger,
         ).evaluate()
+        check.is_list(new_run_requests, of_type=RunRequest)
+        check.inst(new_cursor, AssetDaemonCursor)
+        check.is_list(new_evaluations, of_type=AssetConditionEvaluation)
 
         # make sure these run requests are available on the instance
         for request in new_run_requests:


### PR DESCRIPTION
## Summary & Motivation

Discovered during manual testing -- in the weird case where you have non-subsettable multi assets with different policies, we need to do some hacking to make sure that the evaluation objects work out correctly. This was messed up in the refactor where we moved to NamedTuples, and it wasn't noticed as the `_replace()` method loses any type information.

## How I Tested These Changes
