### PR TITLE
[ui] promote uri, relation id fields in catalog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -14,6 +14,7 @@ import {
   Skeleton,
   Subtitle2,
   Tag,
+  Tooltip,
 } from '@dagster-io/ui-components';
 import dayjs from 'dayjs';
 import React, {useMemo, useState} from 'react';
@@ -40,7 +41,9 @@ import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinition.types';
 import {useLatestPartitionEvents} from './useLatestPartitionEvents';
 import {useRecentAssetEvents} from './useRecentAssetEvents';
 import {showCustomAlert} from '../app/CustomAlertProvider';
+import {showSharedToaster} from '../app/DomUtils';
 import {COMMON_COLLATOR} from '../app/Util';
+import {useCopyToClipboard} from '../app/browser';
 import {
   LiveDataForNode,
   displayNameForAssetKey,
@@ -286,12 +289,16 @@ export const AssetNodeOverview = ({
         )}
       </AttributeAndValue>
       <AttributeAndValue label="Relation identifier">
-        {relationIdentifierMetadata && relationIdentifierMetadata.text}
+        {relationIdentifierMetadata && (
+          <ClickToCopyValue value={relationIdentifierMetadata.text}>
+            {relationIdentifierMetadata.text}
+          </ClickToCopyValue>
+        )}
       </AttributeAndValue>
       <AttributeAndValue label="URI">
         {uriMetadata &&
           (uriMetadata.__typename === 'TextMetadataEntry' ? (
-            uriMetadata.text
+            <ClickToCopyValue value={uriMetadata.text}>{uriMetadata.text}</ClickToCopyValue>
           ) : (
             <a target="_blank" rel="noreferrer" href={uriMetadata.url}>
               {uriMetadata.url}
@@ -549,6 +556,26 @@ const AssetNodeOverviewContainer = ({
 
 const isEmptyChildren = (children: React.ReactNode) =>
   !children || (children instanceof Array && children.length === 0);
+
+const ClickToCopyValue = ({value, children}: {value: string; children: React.ReactNode}) => {
+  const copy = useCopyToClipboard();
+  const onCopy = async () => {
+    copy(value);
+    await showSharedToaster({
+      intent: 'success',
+      icon: 'copy_to_clipboard_done',
+      message: 'Copied!',
+    });
+  };
+
+  return (
+    <Tooltip content="Click to copy" placement="bottom" display="block">
+      <div onClick={onCopy} style={{cursor: 'pointer'}}>
+        {children}
+      </div>
+    </Tooltip>
+  );
+};
 
 const AttributeAndValue = ({
   label,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -279,31 +279,42 @@ export const AssetNodeOverview = ({
           <AssetComputeKindTag style={{position: 'relative'}} definition={assetNode} reduceColor />
         )}
       </AttributeAndValue>
-      <AttributeAndValue label="Storage kind">
-        {storageKindTag && (
-          <AssetStorageKindTag
-            style={{position: 'relative'}}
-            storageKind={storageKindTag.value}
-            reduceColor
-          />
+      <AttributeAndValue label="Storage">
+        {(relationIdentifierMetadata || uriMetadata || storageKindTag) && (
+          <Box flex={{direction: 'column', gap: 4}}>
+            {relationIdentifierMetadata && (
+              <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+                {relationIdentifierMetadata.text}
+                <CopyButton value={relationIdentifierMetadata.text} />
+              </Box>
+            )}
+            {uriMetadata && (
+              <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
+                {uriMetadata.__typename === 'TextMetadataEntry' ? (
+                  uriMetadata.text
+                ) : (
+                  <a target="_blank" rel="noreferrer" href={uriMetadata.url}>
+                    {uriMetadata.url}
+                  </a>
+                )}
+                <CopyButton
+                  value={
+                    uriMetadata.__typename === 'TextMetadataEntry'
+                      ? uriMetadata?.text
+                      : uriMetadata.url
+                  }
+                />
+              </Box>
+            )}
+            {storageKindTag && (
+              <AssetStorageKindTag
+                style={{position: 'relative'}}
+                storageKind={storageKindTag.value}
+                reduceColor
+              />
+            )}
+          </Box>
         )}
-      </AttributeAndValue>
-      <AttributeAndValue label="Relation identifier">
-        {relationIdentifierMetadata && (
-          <ClickToCopyValue value={relationIdentifierMetadata.text}>
-            {relationIdentifierMetadata.text}
-          </ClickToCopyValue>
-        )}
-      </AttributeAndValue>
-      <AttributeAndValue label="URI">
-        {uriMetadata &&
-          (uriMetadata.__typename === 'TextMetadataEntry' ? (
-            <ClickToCopyValue value={uriMetadata.text}>{uriMetadata.text}</ClickToCopyValue>
-          ) : (
-            <a target="_blank" rel="noreferrer" href={uriMetadata.url}>
-              {uriMetadata.url}
-            </a>
-          ))}
       </AttributeAndValue>
       <AttributeAndValue label="Tags">
         {filteredTags &&
@@ -557,7 +568,7 @@ const AssetNodeOverviewContainer = ({
 const isEmptyChildren = (children: React.ReactNode) =>
   !children || (children instanceof Array && children.length === 0);
 
-const ClickToCopyValue = ({value, children}: {value: string; children: React.ReactNode}) => {
+const CopyButton = ({value}: {value: string}) => {
   const copy = useCopyToClipboard();
   const onCopy = async () => {
     copy(value);
@@ -569,9 +580,9 @@ const ClickToCopyValue = ({value, children}: {value: string; children: React.Rea
   };
 
   return (
-    <Tooltip content="Click to copy" placement="bottom" display="block">
+    <Tooltip content="Copy" placement="bottom" display="block">
       <div onClick={onCopy} style={{cursor: 'pointer'}}>
-        {children}
+        <Icon name="content_copy" />
       </div>
     </Tooltip>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -59,7 +59,12 @@ import {
 import {IntMetadataEntry} from '../graphql/types';
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
 import {isCanonicalRowCountMetadataEntry} from '../metadata/MetadataEntry';
-import {TableSchema, TableSchemaAssetContext} from '../metadata/TableSchema';
+import {
+  TableSchema,
+  TableSchemaAssetContext,
+  isCanonicalRelationIdentifierEntry,
+  isCanonicalUriEntry,
+} from '../metadata/TableSchema';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {ScheduleOrSensorTag} from '../nav/ScheduleOrSensorTag';
 import {useRepositoryLocationForAddress} from '../nav/useRepositoryLocationForAddress';
@@ -222,6 +227,10 @@ export const AssetNodeOverview = ({
 
   const storageKindTag = assetNode.tags?.find(isCanonicalStorageKindTag);
   const filteredTags = assetNode.tags?.filter((tag) => tag.key !== 'dagster/storage_kind');
+  const relationIdentifierMetadata = assetNode.metadataEntries?.find(
+    isCanonicalRelationIdentifierEntry,
+  );
+  const uriMetadata = assetNode.metadataEntries?.find(isCanonicalUriEntry);
 
   const renderDefinitionSection = () => (
     <Box flex={{direction: 'column', gap: 12}}>
@@ -275,6 +284,19 @@ export const AssetNodeOverview = ({
             reduceColor
           />
         )}
+      </AttributeAndValue>
+      <AttributeAndValue label="Relation identifier">
+        {relationIdentifierMetadata && relationIdentifierMetadata.text}
+      </AttributeAndValue>
+      <AttributeAndValue label="URI">
+        {uriMetadata &&
+          (uriMetadata.__typename === 'TextMetadataEntry' ? (
+            uriMetadata.text
+          ) : (
+            <a target="_blank" rel="noreferrer" href={uriMetadata.url}>
+              {uriMetadata.url}
+            </a>
+          ))}
       </AttributeAndValue>
       <AttributeAndValue label="Tags">
         {filteredTags &&

--- a/js_modules/dagster-ui/packages/ui-core/src/metadata/TableSchema.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/metadata/TableSchema.tsx
@@ -22,6 +22,8 @@ import {
   CodeReferencesMetadataEntry,
   TableColumnLineageMetadataEntry,
   TableSchemaMetadataEntry,
+  TextMetadataEntry,
+  UrlMetadataEntry,
 } from '../graphql/types';
 import {Description} from '../pipelines/Description';
 
@@ -49,6 +51,14 @@ export const isCanonicalCodeSourceEntry = (
   m: MetadataEntryLabelOnly,
 ): m is CodeReferencesMetadataEntry =>
   m && m.__typename === 'CodeReferencesMetadataEntry' && m.label === 'dagster/code_references';
+
+export const isCanonicalRelationIdentifierEntry = (
+  m: MetadataEntryLabelOnly,
+): m is TextMetadataEntry => m && m.label === 'dagster/relation_identifier';
+
+export const isCanonicalUriEntry = (
+  m: MetadataEntryLabelOnly,
+): m is TextMetadataEntry | UrlMetadataEntry => m && m.label === 'dagster/uri';
 
 export const TableSchemaAssetContext = createContext<{
   assetKey: AssetKeyInput | undefined;


### PR DESCRIPTION
## Summary

Promotes the URI and Relation identifier metadata fields to the Definitions header in the asset page.

<img width="335" alt="Screenshot 2024-06-04 at 8 24 41 PM" src="https://github.com/dagster-io/dagster/assets/10215173/3f95e9a1-9738-4d09-9609-633d9c970c24">


## Test Plan

Tested locally.
