### PR TITLE
[dagster-duckdb] include 'custom_user_agent': 'dagster' for use with MotherDuck

### DIFF
--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -285,7 +285,10 @@ class DuckDbClient(DbClient):
             kwargs={
                 "database": context.resource_config["database"],
                 "read_only": False,
-                "config": context.resource_config["connection_config"],
+                "config": {
+                    "custom_user_agent": "dagster",
+                    **context.resource_config["connection_config"],
+                },
             },
             max_retries=10,
         )

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
@@ -54,7 +54,10 @@ class DuckDBResource(ConfigurableResource):
             kwargs={
                 "database": self.database,
                 "read_only": False,
-                "config": self.connection_config,
+                "config": {
+                    "custom_user_agent": "dagster",
+                    **self.connection_config,
+                },
             },
             max_retries=10,
         )


### PR DESCRIPTION
## Summary & Motivation

- MotherDuck would like to know when connections are coming from Dagster through the user of a custom user agent

## How I Tested These Changes

- Tests ran green
