### PR TITLE
[dagster-dbt] clean up unnecessary quotes in relation identifier metadata

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -403,6 +403,7 @@ def default_asset_key_fn(dbt_resource_props: Mapping[str, Any]) -> AssetKey:
     return AssetKey(components)
 
 
+# https://stackoverflow.com/a/70059131
 RELATION_IDENTIFIER_COMPONENT = re.compile(r"(?:\"[^\"]*\"|[^.])+(?:\.+$)?")
 
 COMPONENT_NO_QUOTES = re.compile(r"^\"[a-zA-Z0-9_]+\"$")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_def_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_def_metadata.py
@@ -30,15 +30,15 @@ def test_storage_address(
     # spot check a few storage addresses
     assert (
         storage_address_metas["customers"].relation_identifier
-        == f'"{jaffle_shop_duckdb_dbfile_name}"."dev"."customers"'
+        == f"{jaffle_shop_duckdb_dbfile_name}.dev.customers"
     )
     assert (
         storage_address_metas["raw_customers"].relation_identifier
-        == f'"{jaffle_shop_duckdb_dbfile_name}"."dev"."raw_customers"'
+        == f"{jaffle_shop_duckdb_dbfile_name}.dev.raw_customers"
     )
     assert (
         storage_address_metas["stg_orders"].relation_identifier
-        == f'"{jaffle_shop_duckdb_dbfile_name}"."dev"."stg_orders"'
+        == f"{jaffle_shop_duckdb_dbfile_name}.dev.stg_orders"
     )
 
 
@@ -64,9 +64,9 @@ def test_storage_address_alias(
     # user-defined aliases
     assert (
         storage_address_metas["customers"].relation_identifier
-        == f'"{jaffle_shop_duckdb_dbfile_name}"."main"."dagster.customers"'
+        == f'{jaffle_shop_duckdb_dbfile_name}.main."dagster.customers"'
     )
     assert (
         storage_address_metas["orders"].relation_identifier
-        == f'"{jaffle_shop_duckdb_dbfile_name}"."main"."dagster.orders"'
+        == f'{jaffle_shop_duckdb_dbfile_name}.main."dagster.orders"'
     )


### PR DESCRIPTION


## Summary

By default, dbt's `relation_name` metadata quotes each component of the relation name, e.g. `"my_database"."my_schema"."my_table"`.

This is a defensive measure to deal with cases where one component might have special chars - e.g. in the case of some of our test code, the table name can have a period in it.

Unfortunately, this quoted format doesn't work nicely with many tools out of the box, for example, Snowflake errors trying to query a quoted table name.

This PR adds a helper method to strip these quotes unless a component has special characters.

## Test Plan

Unit tests.
