### PR TITLE
strip special chars from build_metadata_bounds_checks check name

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/metadata_bounds_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/metadata_bounds_checks.py
@@ -1,8 +1,10 @@
+import re
 from typing import Optional, Sequence, Tuple, Union, cast
 
 import dagster._check as check
 from dagster._annotations import experimental
 from dagster._core.definitions.events import AssetMaterialization
+from dagster._core.definitions.utils import INVALID_NAME_CHARS
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.instance import DagsterInstance
 
@@ -98,7 +100,7 @@ def build_metadata_bounds_checks(
     return build_multi_asset_check(
         check_specs=[
             AssetCheckSpec(
-                f"{metadata_key.replace(' ','_')}_bounds_check",
+                f"{re.sub(INVALID_NAME_CHARS, '_', metadata_key)}_bounds_check",
                 asset=asset_key,
                 description=description,
             )

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -51,6 +51,7 @@ DISALLOWED_NAMES = set(
     + list(keyword.kwlist)  # just disallow all python keywords
 )
 
+INVALID_NAME_CHARS = r"[^A-Za-z0-9_]"
 VALID_NAME_REGEX_STR = r"^[A-Za-z0-9_]+$"
 VALID_NAME_REGEX = re.compile(VALID_NAME_REGEX_STR)
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_metadata_bounds_checks.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_metadata_bounds_checks.py
@@ -188,3 +188,12 @@ def test_two_assets():
     check_eval = check_evals_by_key[my_other_asset.key]
     assert not check_eval.passed
     assert check_eval.description == "Value `-5` is less than 1"
+
+
+def test_name_special_chars() -> None:
+    checks = build_metadata_bounds_checks(
+        assets=[my_asset], metadata_key="dagster/row_count", min_value=1, max_value=10
+    )
+    assert len(checks) == 1
+    assert len(list(checks[0].check_specs)) == 1
+    assert next(iter(checks[0].check_specs)).name == "dagster_row_count_bounds_check"

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_metadata_bounds_checks.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_metadata_bounds_checks.py
@@ -197,3 +197,10 @@ def test_name_special_chars() -> None:
     assert len(checks) == 1
     assert len(list(checks[0].check_specs)) == 1
     assert next(iter(checks[0].check_specs)).name == "dagster_row_count_bounds_check"
+
+    checks = build_metadata_bounds_checks(
+        assets=[my_asset], metadata_key="my key with spaces", min_value=1, max_value=10
+    )
+    assert len(checks) == 1
+    assert len(list(checks[0].check_specs)) == 1
+    assert next(iter(checks[0].check_specs)).name == "my_key_with_spaces_bounds_check"


### PR DESCRIPTION
## Summary

Removes any disallowed characters from the asset check name generated by `build_metadata_bounds_checks`.

This came up specifically with namespaced metadata, e.g. `dagster/row_count`.


## Test Plan

New unit test.
