### PR TITLE
Clean up unused indexeddb databases

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -1,5 +1,6 @@
 import {gql, useApolloClient} from '@apollo/client';
 import {Box, ButtonGroup} from '@dagster-io/ui-components';
+import {indexedDB} from 'fake-indexeddb';
 import * as React from 'react';
 import {useCallback, useContext, useEffect, useLayoutEffect, useMemo, useState} from 'react';
 import {useRouteMatch} from 'react-router-dom';
@@ -51,6 +52,8 @@ export function useAllAssets(groupSelector?: AssetGroupSelector) {
     query: ASSET_CATALOG_TABLE_QUERY,
     version: 1,
   });
+  // Delete old database from before the prefix, remove this at some point
+  indexedDB.deleteDatabase('allAssets');
 
   const {data, fetch: fetchAssets} = assetsQuery;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -53,7 +53,7 @@ export function useAllAssets(groupSelector?: AssetGroupSelector) {
     version: 1,
   });
   // Delete old database from before the prefix, remove this at some point
-  indexedDB.deleteDatabase('indexdbQueryCache:/allAssets');
+  indexedDB.deleteDatabase('indexdbQueryCache:allAssets');
 
   const {data, fetch: fetchAssets} = assetsQuery;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -53,7 +53,7 @@ export function useAllAssets(groupSelector?: AssetGroupSelector) {
     version: 1,
   });
   // Delete old database from before the prefix, remove this at some point
-  indexedDB.deleteDatabase('allAssets');
+  indexedDB.deleteDatabase('indexdbQueryCache:/allAssets');
 
   const {data, fetch: fetchAssets} = assetsQuery;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/HourlyDataCache.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/HourlyDataCache.tsx
@@ -23,6 +23,9 @@ export class HourlyDataCache<T> {
   constructor(id?: string | false, keyPrefix = '', keyMaxCount = 1) {
     this.indexedDBKey = keyPrefix ? `${keyPrefix}-hourlyData` : 'hourlyData';
 
+    // Delete old database from before the prefix, remove this at some point
+    indexedDB.deleteDatabase('HourlyDataCache:useRunsForTimeline');
+
     if (id) {
       this.indexedDBCache = cache<string, typeof this.cache>({
         dbName: `HourlyDataCache:${id}`,

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -342,7 +342,7 @@ export const useGlobalSearch = ({includeAssetFilters}: {includeAssetFilters: boo
   });
 
   // Delete old database from before the prefix, remove this at some point
-  indexedDB.deleteDatabase('SearchPrimary');
+  indexedDB.deleteDatabase('indexdbQueryCache:SearchPrimary');
 
   const {
     data: secondaryData,
@@ -355,7 +355,7 @@ export const useGlobalSearch = ({includeAssetFilters}: {includeAssetFilters: boo
   });
 
   // Delete old database from before the prefix, remove this at some point
-  indexedDB.deleteDatabase('SearchSecondary');
+  indexedDB.deleteDatabase('indexdbQueryCache:SearchSecondary');
 
   const consumeBufferEffect = useCallback(
     async (buffer: React.MutableRefObject<IndexBuffer | null>, search: WorkerSearchResult) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -341,6 +341,9 @@ export const useGlobalSearch = ({includeAssetFilters}: {includeAssetFilters: boo
     version: SEARCH_PRIMARY_DATA_VERSION,
   });
 
+  // Delete old database from before the prefix, remove this at some point
+  indexedDB.deleteDatabase('SearchPrimary');
+
   const {
     data: secondaryData,
     fetch: fetchSecondaryData,
@@ -350,6 +353,9 @@ export const useGlobalSearch = ({includeAssetFilters}: {includeAssetFilters: boo
     key: `${localCacheIdPrefix}/SearchSecondary`,
     version: SEARCH_SECONDARY_DATA_VERSION,
   });
+
+  // Delete old database from before the prefix, remove this at some point
+  indexedDB.deleteDatabase('SearchSecondary');
 
   const consumeBufferEffect = useCallback(
     async (buffer: React.MutableRefObject<IndexBuffer | null>, search: WorkerSearchResult) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
@@ -204,7 +204,7 @@ const useWorkspaceState = (): WorkspaceState => {
   });
 
   // Delete old database from before the prefix, remove this at some point
-  indexedDB.deleteDatabase('RootWorkspace');
+  indexedDB.deleteDatabase('indexdbQueryCache:RootWorkspace');
   useMemo(() => refetch(), [refetch]);
 
   const workspaceOrError = data?.workspaceOrError;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
@@ -202,6 +202,9 @@ const useWorkspaceState = (): WorkspaceState => {
     key: `${localCacheIdPrefix}/RootWorkspace`,
     version: 1,
   });
+
+  // Delete old database from before the prefix, remove this at some point
+  indexedDB.deleteDatabase('RootWorkspace');
   useMemo(() => refetch(), [refetch]);
 
   const workspaceOrError = data?.workspaceOrError;


### PR DESCRIPTION
## Summary & Motivation

We recently added a prefix to all of our IndexedDB caches to take the deployment id into account but neglected to clean up the old databases which are just lying around. This PR cleans them up. 

Screenshot of prefixed vs unprefixed keys from production

<img width="521" alt="Screenshot 2024-06-06 at 3 12 07 AM" src="https://github.com/dagster-io/dagster/assets/2286579/8acda509-494d-454f-a44f-f7be7be786cc">

## How I Tested These Changes

Loaded pages and made sure nothing broke even if the database doesn't exist / was already deleted