### PR TITLE
Add missing QUEUED state to DatabricksRunLifeCycleState

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/types.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/types.py
@@ -21,6 +21,7 @@ class DatabricksRunLifeCycleState(str, Enum):
 
     BLOCKED = "BLOCKED"
     INTERNAL_ERROR = "INTERNAL_ERROR"
+    QUEUED = "QUEUED"
     PENDING = "PENDING"
     RUNNING = "RUNNING"
     SKIPPED = "SKIPPED"


### PR DESCRIPTION
## Summary & Motivation

The `QUEUED` state is a possible lifecycle state for runs that have queueing enabled and are queried using Jobs API 2.0.

## How I Tested These Changes

Existing tests pass. `QUEUED` is a non-terminal state, similar to `PENDING`.