### PR TITLE
RFC: We should allow arbitrary metadata on all definitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
@@ -10,7 +10,6 @@ from ..graph_definition import GraphDefinition
 from ..hook_definition import HookDefinition
 from ..job_definition import JobDefinition
 from ..logger_definition import LoggerDefinition
-from ..metadata import RawMetadataValue
 from ..policy import RetryPolicy
 from ..resource_definition import ResourceDefinition
 from ..utils import normalize_tags
@@ -28,7 +27,7 @@ class _Job:
         name: Optional[str] = None,
         description: Optional[str] = None,
         tags: Optional[Mapping[str, Any]] = None,
-        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
+        metadata: Optional[Mapping[str, object]] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         config: Optional[
             Union[ConfigMapping, Mapping[str, Any], "RunConfig", "PartitionedConfig"]
@@ -126,7 +125,7 @@ def job(
     resource_defs: Optional[Mapping[str, object]] = ...,
     config: Union[ConfigMapping, Mapping[str, Any], "RunConfig", "PartitionedConfig"] = ...,
     tags: Optional[Mapping[str, Any]] = ...,
-    metadata: Optional[Mapping[str, RawMetadataValue]] = ...,
+    metadata: Optional[Mapping[str, object]] = ...,
     logger_defs: Optional[Mapping[str, LoggerDefinition]] = ...,
     executor_def: Optional["ExecutorDefinition"] = ...,
     hooks: Optional[AbstractSet[HookDefinition]] = ...,
@@ -152,7 +151,7 @@ def job(
         Union[ConfigMapping, Mapping[str, Any], "RunConfig", "PartitionedConfig"]
     ] = None,
     tags: Optional[Mapping[str, Any]] = None,
-    metadata: Optional[Mapping[str, RawMetadataValue]] = None,
+    metadata: Optional[Mapping[str, object]] = None,
     logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
     executor_def: Optional["ExecutorDefinition"] = None,
     hooks: Optional[AbstractSet[HookDefinition]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -48,7 +48,6 @@ from .dependency import (
 from .hook_definition import HookDefinition
 from .input import FanInInputPointer, InputDefinition, InputMapping, InputPointer
 from .logger_definition import LoggerDefinition
-from .metadata import RawMetadataValue
 from .node_container import create_execution_structure, normalize_dependency_dict
 from .node_definition import NodeDefinition
 from .output import OutputDefinition, OutputMapping
@@ -599,7 +598,7 @@ class GraphDefinition(NodeDefinition):
             Union["RunConfig", ConfigMapping, Mapping[str, object], "PartitionedConfig"]
         ] = None,
         tags: Union[NormalizedTags, Optional[Mapping[str, str]]] = None,
-        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
+        metadata: Optional[Mapping[str, object]] = None,
         logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
         executor_def: Optional["ExecutorDefinition"] = None,
         hooks: Optional[AbstractSet[HookDefinition]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -65,7 +65,7 @@ from .executor_definition import ExecutorDefinition, multi_or_in_process_executo
 from .graph_definition import GraphDefinition, SubselectedGraphDefinition
 from .hook_definition import HookDefinition
 from .logger_definition import LoggerDefinition
-from .metadata import MetadataValue, RawMetadataValue, normalize_metadata
+from .metadata import normalize_definition_metadata
 from .partition import PartitionedConfig, PartitionsDefinition
 from .resource_definition import ResourceDefinition
 from .run_request import RunRequest
@@ -95,7 +95,7 @@ class JobDefinition(IHasInternalInit):
     _graph_def: GraphDefinition
     _description: Optional[str]
     _tags: Mapping[str, str]
-    _metadata: Mapping[str, MetadataValue]
+    _metadata: Mapping[str, object]
     _current_level_node_defs: Sequence[NodeDefinition]
     _hook_defs: AbstractSet[HookDefinition]
     _op_retry_policy: Optional[RetryPolicy]
@@ -121,7 +121,7 @@ class JobDefinition(IHasInternalInit):
         description: Optional[str] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
         tags: Union[NormalizedTags, Optional[Mapping[str, Any]]] = None,
-        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
+        metadata: Optional[Mapping[str, object]] = None,
         hook_defs: Optional[AbstractSet[HookDefinition]] = None,
         op_retry_policy: Optional[RetryPolicy] = None,
         version_strategy: Optional[VersionStrategy] = None,
@@ -164,7 +164,7 @@ class JobDefinition(IHasInternalInit):
         # same graph may be in multiple jobs, keep separate layer
         self._description = check.opt_str_param(description, "description")
         self._tags = normalize_tags(tags).tags
-        self._metadata = normalize_metadata(
+        self._metadata = normalize_definition_metadata(
             check.opt_mapping_param(metadata, "metadata", key_type=str)
         )
         self._hook_defs = check.opt_set_param(hook_defs, "hook_defs")
@@ -256,7 +256,7 @@ class JobDefinition(IHasInternalInit):
         description: Optional[str],
         partitions_def: Optional[PartitionsDefinition],
         tags: Union[NormalizedTags, Optional[Mapping[str, Any]]],
-        metadata: Optional[Mapping[str, RawMetadataValue]],
+        metadata: Optional[Mapping[str, object]],
         hook_defs: Optional[AbstractSet[HookDefinition]],
         op_retry_policy: Optional[RetryPolicy],
         version_strategy: Optional[VersionStrategy],
@@ -294,7 +294,7 @@ class JobDefinition(IHasInternalInit):
         return merge_dicts(self._graph_def.tags, self._tags)
 
     @property
-    def metadata(self) -> Mapping[str, MetadataValue]:
+    def metadata(self) -> Mapping[str, object]:
         return self._metadata
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -88,6 +88,30 @@ T_Packable = TypeVar("T_Packable", bound=PackableValue, default=PackableValue, c
 # ########################
 
 
+def normalize_definition_metadata(metadata: Mapping[str, object]) -> Mapping[str, object]:
+    def_metadata = {}
+    for k, v in metadata.items():
+        try:
+            normalized_value = normalize_metadata_value(v)  # type: ignore
+        except DagsterInvalidMetadata:
+            normalized_value = v
+        def_metadata[k] = normalized_value
+    return def_metadata
+
+
+def serialize_definition_metadata_for_snaps(
+    metadata: Mapping[str, object],
+) -> Mapping[str, RawMetadataValue]:
+    normed_metadata = {}
+    for k, v in metadata.items():
+        try:
+            normalize_metadata[k] = normalize_metadata_value(v)  # type: ignore
+        except DagsterInvalidMetadata:
+            ...
+            # Just hide it
+    return normed_metadata
+
+
 def normalize_metadata(
     metadata: Mapping[str, RawMetadataValue],
     allow_invalid: bool = False,

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -1,4 +1,5 @@
 import os
+from abc import ABC
 from datetime import datetime
 from typing import Any, Dict, Generic, List, Mapping, NamedTuple, Optional, Sequence, Union, cast
 
@@ -88,6 +89,10 @@ T_Packable = TypeVar("T_Packable", bound=PackableValue, default=PackableValue, c
 # ########################
 
 
+class IHasSerializedMetadataRepresentation(ABC):
+    def serialized_representation(self) -> MetadataValue[Any]: ...
+
+
 def normalize_definition_metadata(metadata: Mapping[str, object]) -> Mapping[str, object]:
     def_metadata = {}
     for k, v in metadata.items():
@@ -105,7 +110,11 @@ def serialize_definition_metadata_for_snaps(
     normed_metadata = {}
     for k, v in metadata.items():
         try:
-            normalize_metadata[k] = normalize_metadata_value(v)  # type: ignore
+            normed_metadata[k] = (
+                v.serialized_representation()
+                if isinstance(v, IHasSerializedMetadataRepresentation)
+                else normalize_metadata_value(v)  # type: ignore
+            )
         except DagsterInvalidMetadata:
             ...
             # Just hide it

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -179,6 +179,8 @@ def normalize_metadata_value(raw_value: RawMetadataValue) -> "MetadataValue[Any]
         return MetadataValue.table_schema(raw_value)
     elif isinstance(raw_value, TableColumnLineage):
         return MetadataValue.column_lineage(raw_value)
+    elif isinstance(raw_value, HasSerializedMetadataRepresentation):
+        return raw_value.serialized_representation()
     elif raw_value is None:
         return MetadataValue.null()
 

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -89,7 +89,7 @@ T_Packable = TypeVar("T_Packable", bound=PackableValue, default=PackableValue, c
 # ########################
 
 
-class IHasSerializedMetadataRepresentation(ABC):
+class HasSerializedMetadataRepresentation(ABC):
     def serialized_representation(self) -> MetadataValue[Any]: ...
 
 
@@ -112,7 +112,7 @@ def serialize_definition_metadata_for_snaps(
         try:
             normed_metadata[k] = (
                 v.serialized_representation()
-                if isinstance(v, IHasSerializedMetadataRepresentation)
+                if isinstance(v, HasSerializedMetadataRepresentation)
                 else normalize_metadata_value(v)  # type: ignore
             )
         except DagsterInvalidMetadata:

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -97,7 +97,12 @@ def normalize_definition_metadata(metadata: Mapping[str, object]) -> Mapping[str
     def_metadata = {}
     for k, v in metadata.items():
         try:
-            normalized_value = normalize_metadata_value(v)  # type: ignore
+            # do not serialize metadata values for the in-memory representation
+            normalized_value = (
+                v
+                if isinstance(v, HasSerializedMetadataRepresentation)
+                else normalize_metadata_value(v)  # type: ignore
+            )
         except DagsterInvalidMetadata:
             normalized_value = v
         def_metadata[k] = normalized_value
@@ -116,8 +121,7 @@ def serialize_definition_metadata_for_snaps(
                 else normalize_metadata_value(v)  # type: ignore
             )
         except DagsterInvalidMetadata:
-            ...
-            # Just hide it
+            normed_metadata[k] = TextMetadataValue(f"[{v.__class__.__name__}] (unserializable)")
     return normed_metadata
 
 

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -179,8 +179,6 @@ def normalize_metadata_value(raw_value: RawMetadataValue) -> "MetadataValue[Any]
         return MetadataValue.table_schema(raw_value)
     elif isinstance(raw_value, TableColumnLineage):
         return MetadataValue.column_lineage(raw_value)
-    elif isinstance(raw_value, HasSerializedMetadataRepresentation):
-        return raw_value.serialized_representation()
     elif raw_value is None:
         return MetadataValue.null()
 

--- a/python_modules/dagster/dagster/_core/snap/job_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/job_snapshot.py
@@ -29,6 +29,7 @@ from dagster._core.definitions.metadata import (
     MetadataValue,
     RawMetadataValue,
     normalize_metadata,
+    serialize_definition_metadata_for_snaps,
 )
 from dagster._core.utils import toposort_flatten
 from dagster._serdes import create_snapshot_id, deserialize_value, whitelist_for_serdes
@@ -170,7 +171,7 @@ class JobSnapshot(
             name=job_def.name,
             description=job_def.description,
             tags=job_def.tags,
-            metadata=job_def.metadata,
+            metadata=serialize_definition_metadata_for_snaps(job_def.metadata),
             config_schema_snapshot=build_config_schema_snapshot(job_def),
             dagster_type_namespace_snapshot=build_dagster_type_namespace_snapshot(job_def),
             node_defs_snapshot=build_node_defs_snapshot(job_def),

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_job.py
@@ -16,7 +16,7 @@ from dagster import (
     usable_as_dagster_type,
     validate_run_config,
 )
-from dagster._core.definitions.metadata import IHasSerializedMetadataRepresentation
+from dagster._core.definitions.metadata import HasSerializedMetadataRepresentation
 from dagster._core.definitions.metadata.metadata_value import (
     JsonMetadataValue,
     MetadataValue as MetadataValue,
@@ -340,7 +340,7 @@ def test_job_recreation_works() -> None:
 
 
 def test_arbitrary_metadata() -> None:
-    class SomeCustomObjectForUserFramework(IHasSerializedMetadataRepresentation):
+    class SomeCustomObjectForUserFramework(HasSerializedMetadataRepresentation):
         def serialized_representation(self) -> MetadataValue[Any]:
             return MetadataValue.json({"foo": "bar"})
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_job.py
@@ -16,6 +16,7 @@ from dagster import (
     usable_as_dagster_type,
     validate_run_config,
 )
+from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.metadata import HasSerializedMetadataRepresentation
 from dagster._core.definitions.metadata.metadata_value import (
     JsonMetadataValue,
@@ -356,6 +357,10 @@ def test_arbitrary_metadata() -> None:
     @job(metadata={"custom_object": SomeCustomObjectForUserFramework()})
     def a_job() -> None:
         an_op()
+
+    assert isinstance(a_job, JobDefinition)
+    assert isinstance(a_job.metadata["custom_object"], SomeCustomObjectForUserFramework)
+    assert isinstance(a_job.get_job_snapshot().metadata["custom_object"], JsonMetadataValue)
 
     assert a_job.execute_in_process().success
     assert executed["yes"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -13,7 +13,10 @@ from dagster._core.definitions.asset_key import (
     CoercibleToAssetKeyPrefix,
     check_opt_coercible_to_asset_key_prefix_param,
 )
+from dagster._core.definitions.metadata import HasSerializedMetadataRepresentation
+from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._core.definitions.utils import is_valid_definition_tag_key
+from deltalake import Metadata
 
 from .asset_utils import (
     default_asset_key_fn,
@@ -47,7 +50,7 @@ class DagsterDbtTranslatorSettings:
     enable_dbt_selection_by_name: bool = False
 
 
-class DagsterDbtTranslator:
+class DagsterDbtTranslator(HasSerializedMetadataRepresentation):
     """Holds a set of methods that derive Dagster asset definition metadata given a representation
     of a dbt resource (models, tests, sources, etc).
 
@@ -62,6 +65,9 @@ class DagsterDbtTranslator:
             settings (Optional[DagsterDbtTranslatorSettings]): Settings for the translator.
         """
         self._settings = settings or DagsterDbtTranslatorSettings()
+
+    def serialized_representation(self) -> MetadataValue[Any]:
+        return MetadataValue.text(repr(self._settings))
 
     @property
     def settings(self) -> DagsterDbtTranslatorSettings:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -16,7 +16,6 @@ from dagster._core.definitions.asset_key import (
 from dagster._core.definitions.metadata import HasSerializedMetadataRepresentation
 from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._core.definitions.utils import is_valid_definition_tag_key
-from deltalake import Metadata
 
 from .asset_utils import (
     default_asset_key_fn,


### PR DESCRIPTION
## Summary & Motivation

I'm proposing that we loosen the rules on metadata to explicitly allow for arbitrary objects. We already do this for the "translator" objects in the dbt integration, and I think this is perfectly valid and desirable use cases.

By allowing arbitrary objects as metadata on all definitions types, we enable the framework to be more customizable. It enables users to build their own abstractions and frameworks on top of dagster. They can attach arbitrary metadata, and then have factories that depend on the existence of that metadata to provide customer behavior. This is a good pattern.

This kick tests this on `JobDefinition` only

This adds support for a marker interface to allow for a serialized metadata representation that differs from the raw object.

I added this to `DagsterDbtTranslator` as an example but then it turns out that it looks like we no longer do that, but you can see how it would have worked.

## How I Tested These Changes
