### PR TITLE
Retry parallelized dbt tests

### DIFF
--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -57,7 +57,6 @@ setup(
             "dbt-duckdb",
             "dagster-duckdb",
             "dagster-duckdb-pandas",
-            "pytest-retry",
         ]
     },
     entry_points={

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -57,6 +57,7 @@ setup(
             "dbt-duckdb",
             "dagster-duckdb",
             "dagster-duckdb-pandas",
+            "pytest-retry",
         ]
     },
     entry_points={

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -29,9 +29,9 @@ allowlist_externals =
   uv
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-  cloud: pytest --numprocesses 6 --durations 10 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
-  core-main: pytest --numprocesses 6 --durations 10 -c ../../../pyproject.toml -m "core and not snowflake and not bigquery and not derived_metadata" -vv {posargs}
-  core-derived-metadata: pytest --numprocesses 6 --durations 10 -c ../../../pyproject.toml -m "derived_metadata and not snowflake and not bigquery" -vv {posargs}
+  cloud: pytest --numprocesses 6 --durations 10 --retries 2 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
+  core-main: pytest --numprocesses 6 --durations 10 --retries 2 -c ../../../pyproject.toml -m "core and not snowflake and not bigquery and not derived_metadata" -vv {posargs}
+  core-derived-metadata: pytest --numprocesses 6 --durations 10 --retries 2 -c ../../../pyproject.toml -m "derived_metadata and not snowflake and not bigquery" -vv {posargs}
   legacy: pytest --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
   snowflake: pytest -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'snowflake'
   bigquery: pytest -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'bigquery'

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -29,9 +29,9 @@ allowlist_externals =
   uv
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-  cloud: pytest --numprocesses 6 --durations 10 --retries 2 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
-  core-main: pytest --numprocesses 6 --durations 10 --retries 2 -c ../../../pyproject.toml -m "core and not snowflake and not bigquery and not derived_metadata" -vv {posargs}
-  core-derived-metadata: pytest --numprocesses 6 --durations 10 --retries 2 -c ../../../pyproject.toml -m "derived_metadata and not snowflake and not bigquery" -vv {posargs}
+  cloud: pytest --numprocesses 6 --durations 10 --reruns 2 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
+  core-main: pytest --numprocesses 6 --durations 10 --reruns 2 -c ../../../pyproject.toml -m "core and not snowflake and not bigquery and not derived_metadata" -vv {posargs}
+  core-derived-metadata: pytest --numprocesses 6 --durations 10 --reruns 2 -c ../../../pyproject.toml -m "derived_metadata and not snowflake and not bigquery" -vv {posargs}
   legacy: pytest --durations 10 -c ../../../pyproject.toml -m "legacy" -vv {posargs}
   snowflake: pytest -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'snowflake'
   bigquery: pytest -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'bigquery'


### PR DESCRIPTION
We sometimes see flakes related to file locking across processes in our dbt tests:

https://buildkite.com/dagster/dagster-dagster/builds/85277#018fec98-397c-4dfb-806c-03189319e07c

I haven't dug very deep but naively I assume this is related to running these tests with higher parallelism. So this adds a [pytest-rerunfailures](https://pypi.org/project/pytest-rerunfailures/) retry to smooth out the flakiness.