### PR TITLE
Remove DatetimeFieldSerializer from time window partitions classes

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
@@ -2,6 +2,7 @@ import datetime
 
 from dagster import AutoMaterializePolicy, Definitions, asset
 from dagster._core.definitions.declarative_automation.legacy.asset_condition import AssetCondition
+from dagster._core.definitions.time_window_partitions import TimestampWithTimezone
 from dagster._core.remote_representation.external_data import external_repository_data_from_def
 from dagster._serdes import serialize_value
 
@@ -68,7 +69,9 @@ def test_missing_time_partitioned() -> None:
     # if the partitions definition changes, then we have 1 fewer missing partition
     state = state.with_asset_properties(
         partitions_def=daily_partitions_def._replace(
-            start=time_partitions_start_datetime + datetime.timedelta(days=1)
+            start=TimestampWithTimezone.from_pendulum_time(
+                time_partitions_start_datetime + datetime.timedelta(days=1)
+            )
         )
     )
     state, result = state.evaluate("A")

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
@@ -12,6 +12,7 @@ from dagster import (
 from dagster._core.definitions.auto_materialize_rule_impls import (
     DiscardOnMaxMaterializationsExceededRule,
 )
+from dagster._core.definitions.time_window_partitions import TimestampWithTimezone
 
 from ..base_scenario import run_request
 from ..scenario_specs import (
@@ -393,7 +394,9 @@ partition_scenarios = [
         .with_asset_properties(
             keys=["B"],
             partitions_def=hourly_partitions_def._replace(
-                start=time_partitions_start_datetime + datetime.timedelta(hours=1)
+                start=TimestampWithTimezone.from_pendulum_time(
+                    time_partitions_start_datetime + datetime.timedelta(hours=1)
+                )
             ),
         )
         # allow nonexistent partitions
@@ -513,7 +516,9 @@ partition_scenarios = [
         .with_current_time_advanced(days=5)
         .with_asset_properties(
             partitions_def=hourly_partitions_def._replace(
-                start=time_partitions_start_datetime + datetime.timedelta(days=5)
+                start=TimestampWithTimezone.from_pendulum_time(
+                    time_partitions_start_datetime + datetime.timedelta(days=5)
+                )
             )
         )
         .evaluate_tick("BAR")
@@ -681,7 +686,9 @@ partition_scenarios = [
         initial_spec=three_assets_in_sequence.with_asset_properties(
             keys=["A"],
             partitions_def=daily_partitions_def._replace(
-                start=time_partitions_start_datetime + datetime.timedelta(days=4)
+                start=TimestampWithTimezone.from_pendulum_time(
+                    time_partitions_start_datetime + datetime.timedelta(days=4)
+                )
             ),
         )
         .with_asset_properties(keys=["B"], partitions_def=daily_partitions_def)


### PR DESCRIPTION
Summary:
This is a prereq to removing pendulum, because non-pendulum datetimes do not have a direct way to fetch the timezone information back from a datetime object. So to keep hte objects deserializable post-transition this serialization scheme will not work.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
