### PR TITLE
fix: Remove usage of deprecated parameter

### DIFF
--- a/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
@@ -468,7 +468,7 @@ class ArtifactsIOManager(IOManager):
                                 output[key] = download_path
                                 continue
 
-                    artifact_dir = artifact.download(root=artifacts_path, recursive=True)
+                    artifact_dir = artifact.download(root=artifacts_path)
                     unpickled_content = unpickle_artifact_content(artifact_dir)
                     if unpickled_content is not None:
                         output[key] = unpickled_content


### PR DESCRIPTION
## Summary & Motivation
Removing a parameter used in the W&B integration that was [deprecated](https://github.com/wandb/wandb/pull/6544). 