### PR TITLE
[ui] click kind tag to open filtered asset list

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -276,7 +276,12 @@ export const AssetNodeOverview = ({
       </AttributeAndValue>
       <AttributeAndValue label="Compute kind">
         {assetNode.computeKind && (
-          <AssetComputeKindTag style={{position: 'relative'}} definition={assetNode} reduceColor />
+          <AssetComputeKindTag
+            style={{position: 'relative'}}
+            definition={assetNode}
+            reduceColor
+            linkToFilter
+          />
         )}
       </AttributeAndValue>
       <AttributeAndValue label="Storage">
@@ -311,6 +316,7 @@ export const AssetNodeOverview = ({
                 style={{position: 'relative'}}
                 storageKind={storageKindTag.value}
                 reduceColor
+                linkToFilter
               />
             )}
           </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
@@ -33,7 +33,7 @@ export const AssetComputeKindTag = ({
       content={
         shouldLink ? (
           <>
-            View all assets with compute kind <CaptionMono>{definition.computeKind}</CaptionMono>
+            View all <CaptionMono>{definition.computeKind}</CaptionMono> assets
           </>
         ) : (
           <>
@@ -82,7 +82,7 @@ export const AssetStorageKindTag = ({
       content={
         shouldLink ? (
           <>
-            View all assets with storage kind <CaptionMono>{storageKind}</CaptionMono>
+            View all <CaptionMono>{storageKind}</CaptionMono> assets
           </>
         ) : (
           <>

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
@@ -3,6 +3,10 @@ import * as React from 'react';
 
 import {OpTags} from './OpTags';
 import {DefinitionTag, buildDefinitionTag} from '../graphql/types';
+import {
+  linkToAssetTableWithComputeKindFilter,
+  linkToAssetTableWithStorageKindFilter,
+} from '../search/useGlobalSearch';
 
 export const isCanonicalStorageKindTag = (tag: DefinitionTag) => tag.key === 'dagster/storage_kind';
 export const buildStorageKindTag = (storageKind: string): DefinitionTag =>
@@ -10,6 +14,8 @@ export const buildStorageKindTag = (storageKind: string): DefinitionTag =>
 
 export const AssetComputeKindTag = ({
   definition,
+  linkToFilter: shouldLink,
+  style,
   ...rest
 }: {
   definition: {computeKind: string | null};
@@ -17,6 +23,7 @@ export const AssetComputeKindTag = ({
   reduceColor?: boolean;
   reduceText?: boolean;
   reversed?: boolean;
+  linkToFilter?: boolean;
 }) => {
   if (!definition.computeKind) {
     return null;
@@ -24,22 +31,32 @@ export const AssetComputeKindTag = ({
   return (
     <Tooltip
       content={
-        <>
-          Compute kind <CaptionMono>{definition.computeKind}</CaptionMono>
-        </>
+        shouldLink ? (
+          <>
+            View all assets with compute kind <CaptionMono>{definition.computeKind}</CaptionMono>
+          </>
+        ) : (
+          <>
+            Compute kind <CaptionMono>{definition.computeKind}</CaptionMono>
+          </>
+        )
       }
       placement="bottom"
     >
       <OpTags
         {...rest}
+        style={{...style, cursor: shouldLink ? 'pointer' : 'default'}}
         tags={[
           {
             label: definition.computeKind,
-            onClick: () => {
-              window.requestAnimationFrame(() =>
-                document.dispatchEvent(new Event('show-kind-info')),
-              );
-            },
+            onClick:
+              shouldLink && definition.computeKind
+                ? () => {
+                    window.location.href = linkToAssetTableWithComputeKindFilter(
+                      definition.computeKind || '',
+                    );
+                  }
+                : () => {},
           },
         ]}
       />
@@ -49,6 +66,8 @@ export const AssetComputeKindTag = ({
 
 export const AssetStorageKindTag = ({
   storageKind,
+  style,
+  linkToFilter: shouldLink,
   ...rest
 }: {
   storageKind: string;
@@ -56,22 +75,34 @@ export const AssetStorageKindTag = ({
   reduceColor?: boolean;
   reduceText?: boolean;
   reversed?: boolean;
+  linkToFilter?: boolean;
 }) => {
   return (
     <Tooltip
       content={
-        <>
-          Storage kind <CaptionMono>{storageKind}</CaptionMono>
-        </>
+        shouldLink ? (
+          <>
+            View all assets with storage kind <CaptionMono>{storageKind}</CaptionMono>
+          </>
+        ) : (
+          <>
+            Storage kind <CaptionMono>{storageKind}</CaptionMono>
+          </>
+        )
       }
       placement="bottom"
     >
       <OpTags
+        style={{...style, cursor: shouldLink ? 'pointer' : 'default'}}
         {...rest}
         tags={[
           {
             label: storageKind,
-            onClick: () => {},
+            onClick: shouldLink
+              ? () => {
+                  window.location.href = linkToAssetTableWithStorageKindFilter(storageKind);
+                }
+              : () => {},
           },
         ]}
       />


### PR DESCRIPTION
## Summary

Adds an optional prop to the kind tag component to make it a clickable link to the asset list, filtered to that kind tag.

Enables this functionality on the asset details page, so you can easily navigate to peer assets w/ the same compute or storage kind.

<img width="339" alt="Screenshot 2024-06-06 at 9 27 35 AM" src="https://github.com/dagster-io/dagster/assets/10215173/5d0656ce-dbb8-4628-ad20-f007264a7243">


## Test Plan

Tested locally.
