### PR TITLE
[docs] Add `dbt parse` troubleshooting to dbt reference

### DIFF
--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -85,6 +85,7 @@ When deploying your Dagster project to production, **we recommend generating the
 Creating the manifest at runtime in production is known to cause issues and is not recommended. This is often caused by the following code and should be avoided.
 
 ```python startafter=start_troubleshooting_dbt_manifest endbefore=end_troubleshooting_dbt_manifest file=/integrations/dbt/dbt.py dedent=4
+"""❌ This is not recommended."""
 import os
 from pathlib import Path
 
@@ -92,15 +93,24 @@ from dagster_dbt import DbtCliResource
 
 dbt_project_dir = Path(__file__).joinpath("..", "..", "..").resolve()
 dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
-dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
-dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
+
+# A manifest will always be created at runtime.
+dbt_manifest_path = (
+    dbt.cli(
+        ["--quiet", "parse"],
+        target_path=Path("target"),
+    )
+    .wait()
+    .target_path.joinpath("manifest.json")
+)
 ```
 
-In this example, the command `dbt parse` is invoked at run time. To avoid any issues, it is recommended to create the manifest at build time, like in the following example.
+To avoid any issues, we recommend that the manifest is created at run time only during local development. In production, the manifest should be created at build time.
 
 In the Dagster project created by the [`dagster-dbt project scaffold`](/\_apidocs/libraries/dagster-dbt#dagster-dbt-project-scaffold) command line interface, we offer you both ways to load your dbt models:
 
 ```python startafter=start_compile_dbt_manifest endbefore=end_compile_dbt_manifest file=/integrations/dbt/dbt.py dedent=4
+"""✅ This is recommended!"""
 import os
 from pathlib import Path
 

--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -121,6 +121,24 @@ DAGSTER_DBT_PARSE_PROJECT_ON_LOAD=1 dagster dev
 
 In production, `DAGSTER_DBT_PARSE_PROJECT_ON_LOAD` should be unset so that your project uses the precompiled manifest.
 
+### Troubleshooting
+
+Creating the manifest at runtime in production is known to cause issues and is not recommended. This is often cause by the following code:
+
+```python startafter=start_troubleshooting_dbt_manifest endbefore=end_troubleshooting_dbt_manifest file=/integrations/dbt/dbt.py dedent=4
+import os
+from pathlib import Path
+
+from dagster_dbt import DbtCliResource
+
+dbt_project_dir = Path(__file__).joinpath("..", "..", "..").resolve()
+dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
+dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
+dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
+```
+
+In this example, the command `dbt parse` is invoked at run time. To avoid any issues, it is recommended to create the manifest at build time and to use the same code as that created by the `dagster-dbt project scaffold` command line interface, which is displayed in the previous example of this section.
+
 ---
 
 ## Deploying a Dagster project with a dbt project

--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -82,6 +82,22 @@ The manifest can be created in two ways:
 
 When deploying your Dagster project to production, **we recommend generating the manifest at build time** to avoid the overhead of recompiling your dbt project every time your Dagster code is executed. A `manifest.json` should be precompiled and included in the Python package for your Dagster code.
 
+Creating the manifest at runtime in production is known to cause issues and is not recommended. This is often caused by the following code and should be avoided.
+
+```python startafter=start_troubleshooting_dbt_manifest endbefore=end_troubleshooting_dbt_manifest file=/integrations/dbt/dbt.py dedent=4
+import os
+from pathlib import Path
+
+from dagster_dbt import DbtCliResource
+
+dbt_project_dir = Path(__file__).joinpath("..", "..", "..").resolve()
+dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
+dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
+dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
+```
+
+In this example, the command `dbt parse` is invoked at run time. To avoid any issues, it is recommended to create the manifest at build time, like in the following example.
+
 In the Dagster project created by the [`dagster-dbt project scaffold`](/\_apidocs/libraries/dagster-dbt#dagster-dbt-project-scaffold) command line interface, we offer you both ways to load your dbt models:
 
 ```python startafter=start_compile_dbt_manifest endbefore=end_compile_dbt_manifest file=/integrations/dbt/dbt.py dedent=4
@@ -120,24 +136,6 @@ DAGSTER_DBT_PARSE_PROJECT_ON_LOAD=1 dagster dev
 ```
 
 In production, `DAGSTER_DBT_PARSE_PROJECT_ON_LOAD` should be unset so that your project uses the precompiled manifest.
-
-### Troubleshooting
-
-Creating the manifest at runtime in production is known to cause issues and is not recommended. This is often cause by the following code:
-
-```python startafter=start_troubleshooting_dbt_manifest endbefore=end_troubleshooting_dbt_manifest file=/integrations/dbt/dbt.py dedent=4
-import os
-from pathlib import Path
-
-from dagster_dbt import DbtCliResource
-
-dbt_project_dir = Path(__file__).joinpath("..", "..", "..").resolve()
-dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
-dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
-dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
-```
-
-In this example, the command `dbt parse` is invoked at run time. To avoid any issues, it is recommended to create the manifest at build time and to use the same code as that created by the `dagster-dbt project scaffold` command line interface, which is displayed in the previous example of this section.
 
 ---
 

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -29,6 +29,20 @@ def scope_compile_dbt_manifest(manifest):
     # end_compile_dbt_manifest
 
 
+def scope_troubleshooting_dbt_manifest(manifest):
+    # start_troubleshooting_dbt_manifest
+    import os
+    from pathlib import Path
+
+    from dagster_dbt import DbtCliResource
+
+    dbt_project_dir = Path(__file__).joinpath("..", "..", "..").resolve()
+    dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
+    dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
+    dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
+    # end_troubleshooting_dbt_manifest
+
+
 def scope_schedule_assets_dbt_only(manifest):
     from dagster import Config, RunConfig
 

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -5,6 +5,7 @@ MANIFEST_PATH = ""
 
 def scope_compile_dbt_manifest(manifest):
     # start_compile_dbt_manifest
+    """✅ This is recommended!"""
     import os
     from pathlib import Path
 
@@ -31,6 +32,7 @@ def scope_compile_dbt_manifest(manifest):
 
 def scope_troubleshooting_dbt_manifest(manifest):
     # start_troubleshooting_dbt_manifest
+    """❌ This is not recommended."""
     import os
     from pathlib import Path
 
@@ -38,8 +40,16 @@ def scope_troubleshooting_dbt_manifest(manifest):
 
     dbt_project_dir = Path(__file__).joinpath("..", "..", "..").resolve()
     dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
-    dbt_parse_invocation = dbt.cli(["parse"], target_path=Path("target")).wait()
-    dbt_manifest_path = dbt_parse_invocation.target_path.joinpath("manifest.json")
+
+    # A manifest will always be created at runtime.
+    dbt_manifest_path = (
+        dbt.cli(
+            ["--quiet", "parse"],
+            target_path=Path("target"),
+        )
+        .wait()
+        .target_path.joinpath("manifest.json")
+    )
     # end_troubleshooting_dbt_manifest
 
 


### PR DESCRIPTION
## Summary & Motivation

This PR adds an example on what to avoid when it comes to dbt parse and creating `manifest.json`.

This error is pretty common and comes up a lot in support. Another PR specific to DbtProject across dbt docs will also mentions it as an option.

## How I Tested These Changes

BK 
+
local
```
make mdx-full-format
make next-watch-build
```
