### PR TITLE
Fix per-location permissions checks for asset backfills using the "partitionsByAssets" parameter

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/selector.py
+++ b/python_modules/dagster/dagster/_core/definitions/selector.py
@@ -403,7 +403,7 @@ class PartitionsByAssetSelector(
         }
 
     @staticmethod
-    def from_graphql_input(graphql_data):
+    def from_graphql_input(graphql_data) -> "PartitionsByAssetSelector":
         asset_key = graphql_data["assetKey"]
         partitions = graphql_data.get("partitions")
         return PartitionsByAssetSelector(


### PR DESCRIPTION
Summary:
Asset backfills were incorrectly only letting you submit backfills with the partitionsByAssets field set if you were a deployment-wide Launcher, unlike the other codepaths which correctly look at the specific assets being backfilled and checking per-location permissions.

Test Plan: New test case that was failing before
