### PR TITLE
Add cached_property to PersistedTimeWindow and TimeWindowPartitionsDefinition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -267,14 +267,14 @@ class PersistedTimeWindow(
             ),
         )
 
-    @property
+    @cached_property
     def start(self) -> datetime:
         start_timestamp_with_timezone = self._asdict()["start"]
         return pendulum.from_timestamp(
             start_timestamp_with_timezone.timestamp, start_timestamp_with_timezone.timezone
         )
 
-    @property
+    @cached_property
     def end(self) -> datetime:
         end_timestamp_with_timezone = self._asdict()["end"]
         return pendulum.from_timestamp(
@@ -432,7 +432,7 @@ class TimeWindowPartitionsDefinition(
         )
 
     @public
-    @property
+    @cached_property
     def start(self) -> datetime:
         start_timestamp_with_timezone = self._asdict()["start"]
         return pendulum.from_timestamp(
@@ -440,7 +440,7 @@ class TimeWindowPartitionsDefinition(
         )
 
     @public
-    @property
+    @cached_property
     def end(self) -> Optional[datetime]:
         end_timestamp_with_timezone = self._asdict()["end"]
 

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -174,6 +174,10 @@ class TimestampWithTimezone(NamedTuple):
     timestamp: float  # Seconds since the Unix epoch
     timezone: str
 
+    @staticmethod
+    def from_pendulum_time(dt: PendulumDateTime):
+        return TimestampWithTimezone(dt.timestamp(), dt.timezone.name)
+
 
 class DatetimeFieldSerializer(FieldSerializer):
     """Serializes datetime objects to and from floats."""
@@ -234,15 +238,48 @@ class TimeWindow(NamedTuple):
 
 @whitelist_for_serdes(
     storage_name="TimeWindow",  # For back-compat with existing serdes
-    field_serializers={"start": DatetimeFieldSerializer, "end": DatetimeFieldSerializer},
 )
-class PersistedTimeWindow(NamedTuple):
+class PersistedTimeWindow(
+    NamedTuple(
+        "_PersistedTimeWindow", [("start", TimestampWithTimezone), ("end", TimestampWithTimezone)]
+    )
+):
     """Internal serialized representation of a time interval that is closed at the
     start and open at the end.
     """
 
-    start: datetime
-    end: datetime
+    def __new__(
+        cls,
+        start: Union[TimestampWithTimezone, PendulumDateTime],
+        end: Union[TimestampWithTimezone, PendulumDateTime],
+    ):
+        return super(cls, PersistedTimeWindow).__new__(
+            cls,
+            start=(
+                start
+                if isinstance(start, TimestampWithTimezone)
+                else TimestampWithTimezone.from_pendulum_time(start)
+            ),
+            end=(
+                end
+                if isinstance(end, TimestampWithTimezone)
+                else TimestampWithTimezone.from_pendulum_time(end)
+            ),
+        )
+
+    @property
+    def start(self) -> datetime:
+        start_timestamp_with_timezone = self._asdict()["start"]
+        return pendulum.from_timestamp(
+            start_timestamp_with_timezone.timestamp, start_timestamp_with_timezone.timezone
+        )
+
+    @property
+    def end(self) -> datetime:
+        end_timestamp_with_timezone = self._asdict()["end"]
+        return pendulum.from_timestamp(
+            end_timestamp_with_timezone.timestamp, end_timestamp_with_timezone.timezone
+        )
 
     @staticmethod
     def from_public_time_window(tw: TimeWindow):
@@ -276,18 +313,15 @@ class PersistedTimeWindow(NamedTuple):
         return TimeWindow(start=self.start, end=self.end)
 
 
-@whitelist_for_serdes(
-    field_serializers={"start": DatetimeFieldSerializer, "end": DatetimeFieldSerializer},
-    is_pickleable=False,
-)
+@whitelist_for_serdes(is_pickleable=False)
 class TimeWindowPartitionsDefinition(
     PartitionsDefinition,
     NamedTuple(
         "_TimeWindowPartitionsDefinition",
         [
-            ("start", PublicAttr[datetime]),
+            ("start", TimestampWithTimezone),
             ("timezone", PublicAttr[str]),
-            ("end", PublicAttr[Optional[datetime]]),
+            ("end", Optional[TimestampWithTimezone]),
             ("fmt", PublicAttr[str]),
             ("end_offset", PublicAttr[int]),
             ("cron_schedule", PublicAttr[str]),
@@ -332,9 +366,9 @@ class TimeWindowPartitionsDefinition(
 
     def __new__(
         cls,
-        start: Union[datetime, str],
+        start: Union[datetime, str, TimestampWithTimezone],
         fmt: str,
-        end: Union[datetime, str, None] = None,
+        end: Union[datetime, str, TimestampWithTimezone, None] = None,
         schedule_type: Optional[ScheduleType] = None,
         timezone: Optional[str] = None,
         end_offset: int = 0,
@@ -346,25 +380,29 @@ class TimeWindowPartitionsDefinition(
         check.opt_str_param(timezone, "timezone")
         timezone = timezone or "UTC"
 
-        if isinstance(start, datetime):
+        if isinstance(start, str):
+            start_dt = dst_safe_strptime(start, timezone, fmt)
+            start = TimestampWithTimezone(start_dt.timestamp(), timezone)
+        elif isinstance(start, datetime):
             start_dt = pendulum.instance(start, tz=timezone)
             if start.tzinfo:
                 # Pendulum.instance does not override the timezone of the datetime object,
                 # so we convert it to the provided timezone
                 start_dt = to_timezone(start_dt, timezone)
-        else:
-            start_dt = dst_safe_strptime(start, timezone, fmt)
+            start = TimestampWithTimezone(start_dt.timestamp(), timezone)
 
         if not end:
-            end_dt = None
+            end = None
+        elif isinstance(end, str):
+            end_dt = dst_safe_strptime(end, timezone, fmt)
+            end = TimestampWithTimezone(end_dt.timestamp(), timezone)
         elif isinstance(end, datetime):
             end_dt = pendulum.instance(end, tz=timezone)
             if end.tzinfo:
                 # Pendulum.instance does not override the timezone of the datetime object,
                 # so we convert it to the provided timezone
                 end_dt = to_timezone(end_dt, timezone)
-        else:
-            end_dt = dst_safe_strptime(end, timezone, fmt)
+            end = TimestampWithTimezone(end_dt.timestamp(), timezone)
 
         if cron_schedule is not None:
             check.invariant(
@@ -390,7 +428,27 @@ class TimeWindowPartitionsDefinition(
             )
 
         return super(TimeWindowPartitionsDefinition, cls).__new__(
-            cls, start_dt, timezone, end_dt, fmt, end_offset, cron_schedule
+            cls, start, timezone, end, fmt, end_offset, cron_schedule
+        )
+
+    @public
+    @property
+    def start(self) -> datetime:
+        start_timestamp_with_timezone = self._asdict()["start"]
+        return pendulum.from_timestamp(
+            start_timestamp_with_timezone.timestamp, start_timestamp_with_timezone.timezone
+        )
+
+    @public
+    @property
+    def end(self) -> Optional[datetime]:
+        end_timestamp_with_timezone = self._asdict()["end"]
+
+        if not end_timestamp_with_timezone:
+            return None
+
+        return pendulum.from_timestamp(
+            end_timestamp_with_timezone.timestamp, end_timestamp_with_timezone.timezone
         )
 
     def get_current_timestamp(self, current_time: Optional[datetime] = None) -> float:

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
@@ -2,6 +2,7 @@ import datetime
 
 from dagster import AutoMaterializePolicy, Definitions, asset
 from dagster._core.definitions.declarative_automation.legacy.asset_condition import AssetCondition
+from dagster._core.definitions.time_window_partitions import TimestampWithTimezone
 from dagster._core.remote_representation.external_data import external_repository_data_from_def
 from dagster._serdes import serialize_value
 
@@ -68,7 +69,9 @@ def test_missing_time_partitioned() -> None:
     # if the partitions definition changes, then we have 1 fewer missing partition
     state = state.with_asset_properties(
         partitions_def=daily_partitions_def._replace(
-            start=time_partitions_start_datetime + datetime.timedelta(days=1)
+            start=TimestampWithTimezone.from_pendulum_time(
+                time_partitions_start_datetime + datetime.timedelta(days=1)
+            )
         )
     )
     state, result = state.evaluate("A")

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
@@ -12,6 +12,7 @@ from dagster import (
 from dagster._core.definitions.auto_materialize_rule_impls import (
     DiscardOnMaxMaterializationsExceededRule,
 )
+from dagster._core.definitions.time_window_partitions import TimestampWithTimezone
 
 from ..base_scenario import run_request
 from ..scenario_specs import (
@@ -393,7 +394,9 @@ partition_scenarios = [
         .with_asset_properties(
             keys=["B"],
             partitions_def=hourly_partitions_def._replace(
-                start=time_partitions_start_datetime + datetime.timedelta(hours=1)
+                start=TimestampWithTimezone.from_pendulum_time(
+                    time_partitions_start_datetime + datetime.timedelta(hours=1)
+                )
             ),
         )
         # allow nonexistent partitions
@@ -513,7 +516,9 @@ partition_scenarios = [
         .with_current_time_advanced(days=5)
         .with_asset_properties(
             partitions_def=hourly_partitions_def._replace(
-                start=time_partitions_start_datetime + datetime.timedelta(days=5)
+                start=TimestampWithTimezone.from_pendulum_time(
+                    time_partitions_start_datetime + datetime.timedelta(days=5)
+                )
             )
         )
         .evaluate_tick("BAR")
@@ -681,7 +686,9 @@ partition_scenarios = [
         initial_spec=three_assets_in_sequence.with_asset_properties(
             keys=["A"],
             partitions_def=daily_partitions_def._replace(
-                start=time_partitions_start_datetime + datetime.timedelta(days=4)
+                start=TimestampWithTimezone.from_pendulum_time(
+                    time_partitions_start_datetime + datetime.timedelta(days=4)
+                )
             ),
         )
         .with_asset_properties(keys=["B"], partitions_def=daily_partitions_def)


### PR DESCRIPTION
Summary:
I'm confused how I previously managed to convince myself that this did not work, but it appears to work in this situation at least - some simple testing suggests that this is computed exactly once per instance if I add this decorator.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
