### PR TITLE
support io types in captured log manager read_log_lines_for_log_key_prefix

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -17,6 +17,7 @@ from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.external import ExternalPartitionSet
 from dagster._core.storage.captured_log_manager import CapturedLogManager
+from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.storage.dagster_run import DagsterRun, RunPartitionData, RunRecord, RunsFilter
 from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
@@ -547,7 +548,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             return GrapheneInstigationEventConnection(events=[], cursor="", hasMore=False)
 
         records, new_cursor = instance.compute_log_manager.read_log_lines_for_log_key_prefix(
-            backfill_log_key_prefix, cursor
+            backfill_log_key_prefix, cursor, io_type=ComputeIOType.STDERR
         )
 
         events = []

--- a/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
@@ -244,7 +244,7 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
         self.on_unsubscribe(subscription)
 
     def get_log_keys_for_log_key_prefix(
-        self, log_key_prefix: Sequence[str]
+        self, log_key_prefix: Sequence[str], io_type: ComputeIOType
     ) -> Sequence[Sequence[str]]:
         """Returns the logs keys for a given log key prefix. This is determined by looking at the
         directory defined by the log key prefix and creating a log_key for each file in the directory.
@@ -256,10 +256,7 @@ class LocalComputeLogManager(CapturedLogManager, ComputeLogManager, Configurable
         list_key_prefix = list(log_key_prefix)
 
         for obj in objects:
-            # Note: This method was implemented to support backfill logs, which are always stored as .err files.
-            # If other file extensions need to be supported, this method will need to be updated to look at the
-            # correct part of log_data based on an io_type parameter
-            if obj.is_file() and obj.suffix == "." + IO_TYPE_EXTENSION[ComputeIOType.STDERR]:
+            if obj.is_file() and obj.suffix == "." + IO_TYPE_EXTENSION[io_type]:
                 results.append(list_key_prefix + [obj.stem])
 
         return results

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -2347,8 +2347,7 @@ def test_asset_backfill_logs(
     # set num_lines high so we know we get all of the remaining logs
     os.environ["DAGSTER_CAPTURED_LOG_CHUNK_SIZE"] = "100"
     logs, cursor = cm.read_log_lines_for_log_key_prefix(
-        ["backfill", backfill.backfill_id],
-        cursor=cursor.to_string(),
+        ["backfill", backfill.backfill_id], cursor=cursor.to_string(), io_type=ComputeIOType.STDERR
     )
 
     assert cursor is not None

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -54,6 +54,7 @@ from dagster._core.remote_representation import (
     RemoteRepositoryOrigin,
 )
 from dagster._core.storage.captured_log_manager import CapturedLogManager
+from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.storage.dagster_run import IN_PROGRESS_RUN_STATUSES, DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
@@ -2325,7 +2326,7 @@ def test_asset_backfill_logs(
     assert isinstance(cm, CapturedLogManager)
 
     logs, cursor = cm.read_log_lines_for_log_key_prefix(
-        ["backfill", backfill.backfill_id], cursor=None
+        ["backfill", backfill.backfill_id], cursor=None, io_type=ComputeIOType.STDERR
     )
     assert cursor is not None
     assert logs

--- a/python_modules/dagster/dagster_tests/storage_tests/test_captured_log_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_captured_log_manager.py
@@ -105,7 +105,7 @@ def test_get_log_keys_for_log_key_prefix():
         for i in range(4):
             write_log_file(i)
 
-        log_keys = cm.get_log_keys_for_log_key_prefix(log_key_prefix)
+        log_keys = cm.get_log_keys_for_log_key_prefix(log_key_prefix, io_type=ComputeIOType.STDERR)
         assert sorted(log_keys) == [
             [*log_key_prefix, "0"],
             [*log_key_prefix, "1"],
@@ -141,7 +141,9 @@ def test_read_log_lines_for_log_key_prefix():
 
         os.environ["DAGSTER_CAPTURED_LOG_CHUNK_SIZE"] = "10"
         # read the entirety of the first file
-        log_lines, cursor = cm.read_log_lines_for_log_key_prefix(log_key_prefix, cursor=None)
+        log_lines, cursor = cm.read_log_lines_for_log_key_prefix(
+            log_key_prefix, cursor=None, io_type=ComputeIOType.STDERR
+        )
         assert len(log_lines) == 10
         assert cursor.has_more_now
         assert cursor.log_key == [*log_key_prefix, "1"]

--- a/python_modules/dagster/dagster_tests/storage_tests/test_captured_log_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_captured_log_manager.py
@@ -154,8 +154,7 @@ def test_read_log_lines_for_log_key_prefix():
         # read half of the next log file
         os.environ["DAGSTER_CAPTURED_LOG_CHUNK_SIZE"] = "5"
         log_lines, cursor = cm.read_log_lines_for_log_key_prefix(
-            log_key_prefix,
-            cursor=cursor.to_string(),
+            log_key_prefix, cursor=cursor.to_string(), io_type=ComputeIOType.STDERR
         )
         assert len(log_lines) == 5
         assert cursor.has_more_now
@@ -167,7 +166,7 @@ def test_read_log_lines_for_log_key_prefix():
         # read the next ten lines, five will be in the second file, five will be in the third
         os.environ["DAGSTER_CAPTURED_LOG_CHUNK_SIZE"] = "10"
         log_lines, cursor = cm.read_log_lines_for_log_key_prefix(
-            log_key_prefix, cursor=cursor.to_string()
+            log_key_prefix, cursor=cursor.to_string(), io_type=ComputeIOType.STDERR
         )
         assert len(log_lines) == 10
         assert cursor.has_more_now
@@ -179,8 +178,7 @@ def test_read_log_lines_for_log_key_prefix():
         # read the remaining 15 lines, but request 20
         os.environ["DAGSTER_CAPTURED_LOG_CHUNK_SIZE"] = "20"
         log_lines, cursor = cm.read_log_lines_for_log_key_prefix(
-            log_key_prefix,
-            cursor=cursor.to_string(),
+            log_key_prefix, cursor=cursor.to_string(), io_type=ComputeIOType.STDERR
         )
         assert len(log_lines) == 15
         assert not cursor.has_more_now
@@ -196,8 +194,7 @@ def test_read_log_lines_for_log_key_prefix():
 
         os.environ["DAGSTER_CAPTURED_LOG_CHUNK_SIZE"] = "15"
         log_lines, cursor = cm.read_log_lines_for_log_key_prefix(
-            log_key_prefix,
-            cursor=cursor.to_string(),
+            log_key_prefix, cursor=cursor.to_string(), io_type=ComputeIOType.STDERR
         )
         assert len(log_lines) == 10
         assert not cursor.has_more_now


### PR DESCRIPTION
## Summary & Motivation

adds support for IO types in the functions to `read_log_lines_for_log_key_prefix` and related methods

related internal pr https://github.com/dagster-io/internal/pull/10087

## How I Tested These Changes
bk