### PR TITLE
add get_log_keys_for_log_key_prefix to gcs compute log manager

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
@@ -263,10 +263,10 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
             self._s3_session.download_fileobj(self._s3_bucket, s3_key, fileobj)
 
     def get_log_keys_for_log_key_prefix(
-        self, log_key_prefix: Sequence[str]
+        self, log_key_prefix: Sequence[str], io_type: ComputeIOType
     ) -> Sequence[Sequence[str]]:
-        directory = self._resolve_path_for_namespace(log_key_prefix, legacy=False)
-        objects = self.s3_session.list_objects_v2(
+        directory = self._resolve_path_for_namespace(log_key_prefix)
+        objects = self._s3_session.list_objects_v2(
             Bucket=self._s3_bucket, Prefix="/".join(directory)
         )
         results = []
@@ -275,9 +275,7 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
         for obj in objects["Contents"]:
             full_key = obj["Key"]
             filename, obj_io_type = full_key.split("/")[-1].split(".")
-            # Currently, this method is only used for fetching backfill daemon logs, which are stored as
-            # .err files. If this method gets used for other log types, the io_type can become a parameter.
-            if obj_io_type != IO_TYPE_EXTENSION[ComputeIOType.STDERR]:
+            if obj_io_type != IO_TYPE_EXTENSION[io_type]:
                 continue
             results.append(list_key_prefix + [filename])
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
@@ -272,6 +272,9 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
         results = []
         list_key_prefix = list(log_key_prefix)
 
+        if objects["KeyCount"] == 0:
+            return []
+
         for obj in objects["Contents"]:
             full_key = obj["Key"]
             filename, obj_io_type = full_key.split("/")[-1].split(".")

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/compute_log_manager.py
@@ -156,6 +156,9 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
         parts = prefix.split("/")
         return "/".join([part for part in parts if part])
 
+    def _resolve_path_for_namespace(self, namespace):
+        return [self._s3_prefix, "storage", *namespace]
+
     def _s3_key(self, log_key, io_type, partial=False):
         check.inst_param(io_type, "io_type", ComputeIOType)
         extension = IO_TYPE_EXTENSION[io_type]
@@ -163,7 +166,7 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
         filename = f"{filebase}.{extension}"
         if partial:
             filename = f"{filename}.partial"
-        paths = [self._s3_prefix, "storage", *namespace, filename]
+        paths = [*self._resolve_path_for_namespace(namespace), filename]
         return "/".join(paths)  # s3 path delimiter
 
     @contextmanager
@@ -258,6 +261,27 @@ class S3ComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
         s3_key = self._s3_key(log_key, io_type, partial=partial)
         with open(path, "wb") as fileobj:
             self._s3_session.download_fileobj(self._s3_bucket, s3_key, fileobj)
+
+    def get_log_keys_for_log_key_prefix(
+        self, log_key_prefix: Sequence[str]
+    ) -> Sequence[Sequence[str]]:
+        directory = self._resolve_path_for_namespace(log_key_prefix, legacy=False)
+        objects = self.s3_session.list_objects_v2(
+            Bucket=self._s3_bucket, Prefix="/".join(directory)
+        )
+        results = []
+        list_key_prefix = list(log_key_prefix)
+
+        for obj in objects["Contents"]:
+            full_key = obj["Key"]
+            filename, obj_io_type = full_key.split("/")[-1].split(".")
+            # Currently, this method is only used for fetching backfill daemon logs, which are stored as
+            # .err files. If this method gets used for other log types, the io_type can become a parameter.
+            if obj_io_type != IO_TYPE_EXTENSION[ComputeIOType.STDERR]:
+                continue
+            results.append(list_key_prefix + [filename])
+
+        return results
 
     def on_subscribe(self, subscription):
         self._subscription_manager.add_subscription(subscription)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
@@ -214,13 +214,13 @@ def test_get_log_keys_for_log_key_prefix(mock_s3_bucket):
         )
         log_key_prefix = ["test_log_bucket", evaluation_time.strftime("%Y%m%d_%H%M%S")]
 
-        def write_log_file(file_id: int):
+        def write_log_file(file_id: int, io_type: ComputeIOType):
             full_log_key = [*log_key_prefix, f"{file_id}"]
-            with manager.open_log_stream(full_log_key, ComputeIOType.STDERR) as f:
+            with manager.open_log_stream(full_log_key, io_type) as f:
                 f.write("foo")
 
     for i in range(4):
-        write_log_file(i)
+        write_log_file(i, ComputeIOType.STDERR)
 
     log_keys = manager.get_log_keys_for_log_key_prefix(log_key_prefix, io_type=ComputeIOType.STDERR)
     assert sorted(log_keys) == [

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
@@ -219,6 +219,9 @@ def test_get_log_keys_for_log_key_prefix(mock_s3_bucket):
             with manager.open_log_stream(full_log_key, io_type) as f:
                 f.write("foo")
 
+    log_keys = manager.get_log_keys_for_log_key_prefix(log_key_prefix, io_type=ComputeIOType.STDERR)
+    assert len(log_keys) == 0
+
     for i in range(4):
         write_log_file(i, ComputeIOType.STDERR)
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
@@ -230,6 +230,17 @@ def test_get_log_keys_for_log_key_prefix(mock_s3_bucket):
         [*log_key_prefix, "3"],
     ]
 
+    # write a different file type
+    write_log_file(4, ComputeIOType.STDOUT)
+
+    log_keys = manager.get_log_keys_for_log_key_prefix(log_key_prefix, io_type=ComputeIOType.STDERR)
+    assert sorted(log_keys) == [
+        [*log_key_prefix, "0"],
+        [*log_key_prefix, "1"],
+        [*log_key_prefix, "2"],
+        [*log_key_prefix, "3"],
+    ]
+
 
 class TestS3ComputeLogManager(TestCapturedLogManager):
     __test__ = True

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
@@ -2,6 +2,7 @@ import os
 import sys
 import tempfile
 
+import pendulum
 import pytest
 from botocore.exceptions import ClientError
 from dagster import DagsterEventType, job, op
@@ -201,6 +202,33 @@ def test_prefix_filter(mock_s3_bucket):
         s3_object = mock_s3_bucket.Object(key="foo/bar/storage/arbitrary/log/key.err")
         logs = s3_object.get()["Body"].read().decode("utf-8")
         assert logs == "hello hello"
+
+
+def test_get_log_keys_for_log_key_prefix(mock_s3_bucket):
+    evaluation_time = pendulum.now()
+    s3_prefix = "foo/bar/"  # note the trailing slash
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        manager = S3ComputeLogManager(
+            bucket=mock_s3_bucket.name, prefix=s3_prefix, local_dir=temp_dir
+        )
+        log_key_prefix = ["test_log_bucket", evaluation_time.strftime("%Y%m%d_%H%M%S")]
+
+        def write_log_file(file_id: int):
+            full_log_key = [*log_key_prefix, f"{file_id}"]
+            with manager.open_log_stream(full_log_key, ComputeIOType.STDERR) as f:
+                f.write("foo")
+
+    for i in range(4):
+        write_log_file(i)
+
+    log_keys = manager.get_log_keys_for_log_key_prefix(log_key_prefix, io_type=ComputeIOType.STDERR)
+    assert sorted(log_keys) == [
+        [*log_key_prefix, "0"],
+        [*log_key_prefix, "1"],
+        [*log_key_prefix, "2"],
+        [*log_key_prefix, "3"],
+    ]
 
 
 class TestS3ComputeLogManager(TestCapturedLogManager):

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_compute_log_manager.py
@@ -210,7 +210,7 @@ def test_get_log_keys_for_log_key_prefix(mock_s3_bucket):
 
     with tempfile.TemporaryDirectory() as temp_dir:
         manager = S3ComputeLogManager(
-            bucket=mock_s3_bucket.name, prefix=s3_prefix, local_dir=temp_dir
+            bucket=mock_s3_bucket.name, prefix=s3_prefix, local_dir=temp_dir, skip_empty_files=True
         )
         log_key_prefix = ["test_log_bucket", evaluation_time.strftime("%Y%m%d_%H%M%S")]
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/compute_log_manager.py
@@ -139,7 +139,7 @@ class GCSComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
         filename = f"{filebase}.{extension}"
         if partial:
             filename = f"{filename}.partial"
-        paths = [self._resolve_path_for_namespace(namespace), filename]
+        paths = [*self._resolve_path_for_namespace(namespace), filename]
         return "/".join(paths)
 
     @contextmanager

--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/compute_log_manager.py
@@ -235,7 +235,7 @@ class GCSComputeLogManager(CloudStorageComputeLogManager, ConfigurableClass):
         self, log_key_prefix: Sequence[str], io_type: ComputeIOType
     ) -> Sequence[Sequence[str]]:
         directory = self._resolve_path_for_namespace(log_key_prefix)
-        blobs = self._client.list_blobs(self._bucket, prefix="/".join(directory), delimeter="/")
+        blobs = self._client.list_blobs(self._bucket, prefix="/".join(directory))
         results = []
         list_key_prefix = list(log_key_prefix)
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
@@ -323,8 +323,13 @@ def test_get_log_keys_for_log_key_prefix(gcs_bucket):
         [*log_key_prefix, "3"],
     ]
 
-    # write a different file type
-    write_log_file(4, ComputeIOType.STDOUT)
+    # gcs creates and stores empty files for both IOTYPES when open_log_stream is used, so make the next file
+    # manually so we can test that files with different IOTYPES are not considered
+
+    log_key = [*log_key_prefix, "4"]
+    with manager.local_manager.open_log_stream(log_key, ComputeIOType.STDOUT) as f:
+        f.write("foo")
+    manager.upload_to_cloud_storage(log_key, ComputeIOType.STDOUT)
 
     log_keys = manager.get_log_keys_for_log_key_prefix(log_key_prefix, io_type=ComputeIOType.STDERR)
     assert sorted(log_keys) == [

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
@@ -323,6 +323,17 @@ def test_get_log_keys_for_log_key_prefix(gcs_bucket):
         [*log_key_prefix, "3"],
     ]
 
+    # write a different file type
+    write_log_file(4, ComputeIOType.STDOUT)
+
+    log_keys = manager.get_log_keys_for_log_key_prefix(log_key_prefix, io_type=ComputeIOType.STDERR)
+    assert sorted(log_keys) == [
+        [*log_key_prefix, "0"],
+        [*log_key_prefix, "1"],
+        [*log_key_prefix, "2"],
+        [*log_key_prefix, "3"],
+    ]
+
 
 @pytest.mark.integration
 def test_storage_download_url_fallback(gcs_bucket):

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
@@ -296,6 +296,35 @@ def test_prefix_filter(gcs_bucket):
 
 
 @pytest.mark.integration
+def test_get_log_keys_for_log_key_prefix(gcs_bucket):
+    evaluation_time = pendulum.now()
+    gcs_prefix = "foo/bar/"  # note the trailing slash
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        manager = GCSComputeLogManager(bucket=gcs_bucket, prefix=gcs_prefix, local_dir=temp_dir)
+        log_key_prefix = ["test_log_bucket", evaluation_time.strftime("%Y%m%d_%H%M%S")]
+
+        def write_log_file(file_id: int):
+            full_log_key = [*log_key_prefix, f"{file_id}"]
+            with manager.open_log_stream(full_log_key, ComputeIOType.STDERR) as f:
+                f.write("foo")
+
+    log_keys = manager.get_log_keys_for_log_key_prefix(log_key_prefix, io_type=ComputeIOType.STDERR)
+    assert len(log_keys) == 0
+
+    for i in range(4):
+        write_log_file(i)
+
+    log_keys = manager.get_log_keys_for_log_key_prefix(log_key_prefix, io_type=ComputeIOType.STDERR)
+    assert sorted(log_keys) == [
+        [*log_key_prefix, "0"],
+        [*log_key_prefix, "1"],
+        [*log_key_prefix, "2"],
+        [*log_key_prefix, "3"],
+    ]
+
+
+@pytest.mark.integration
 def test_storage_download_url_fallback(gcs_bucket):
     with tempfile.TemporaryDirectory() as temp_dir:
         manager = GCSComputeLogManager(bucket=gcs_bucket, local_dir=temp_dir)

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
@@ -304,16 +304,16 @@ def test_get_log_keys_for_log_key_prefix(gcs_bucket):
         manager = GCSComputeLogManager(bucket=gcs_bucket, prefix=gcs_prefix, local_dir=temp_dir)
         log_key_prefix = ["test_log_bucket", evaluation_time.strftime("%Y%m%d_%H%M%S")]
 
-        def write_log_file(file_id: int):
+        def write_log_file(file_id: int, io_type: ComputeIOType):
             full_log_key = [*log_key_prefix, f"{file_id}"]
-            with manager.open_log_stream(full_log_key, ComputeIOType.STDERR) as f:
+            with manager.open_log_stream(full_log_key, io_type) as f:
                 f.write("foo")
 
     log_keys = manager.get_log_keys_for_log_key_prefix(log_key_prefix, io_type=ComputeIOType.STDERR)
     assert len(log_keys) == 0
 
     for i in range(4):
-        write_log_file(i)
+        write_log_file(i, ComputeIOType.STDERR)
 
     log_keys = manager.get_log_keys_for_log_key_prefix(log_key_prefix, io_type=ComputeIOType.STDERR)
     assert sorted(log_keys) == [


### PR DESCRIPTION
## Summary & Motivation
implements `get_log_keys_for_log_key_prefix` for the GCS compute log manager so that it can support storing and loading backfill logs

## How I Tested These Changes
