### PR TITLE
Add compute_kind arg to `AssetSpec` constructor

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -1,6 +1,7 @@
 from collections import Counter
 from functools import cached_property
 from inspect import Parameter
+from itertools import groupby
 from typing import (
     AbstractSet,
     Any,
@@ -298,6 +299,19 @@ class DecoratorAssetsDefinitionBuilder:
         args: DecoratorAssetsDefinitionBuilderArgs,
     ) -> "DecoratorAssetsDefinitionBuilder":
         check.param_invariant(args.specs, "args", "Must use specs in this codepath")
+
+        specs_by_compute_kind = dict(
+            groupby(args.specs, key=lambda spec: spec.tags.get(COMPUTE_KIND_TAG))
+        )
+        if len(specs_by_compute_kind) > 1:
+            asset_keys_by_compute_kind = {
+                ck: [spec.key.to_user_string() for spec in specs]
+                for ck, specs in specs_by_compute_kind.items()
+            }
+            raise DagsterInvalidDefinitionError(
+                "Cannot specify multiple compute kinds in the same multi_asset."
+                f" Found multiple compute kinds:\n\n{asset_keys_by_compute_kind}"
+            )
 
         named_outs_by_asset_key: Mapping[AssetKey, NamedOut] = {}
         for asset_spec in args.specs:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -36,6 +36,7 @@ from dagster import (
 from dagster._check import CheckError
 from dagster._config.pythonic_config import Config
 from dagster._core.definitions import AssetIn, AssetsDefinition, asset, multi_asset
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.decorators.config_mapping_decorator import config_mapping
 from dagster._core.definitions.policy import RetryPolicy
@@ -1375,3 +1376,24 @@ def test_graph_inputs_error():
 
     except DagsterInvalidDefinitionError as err:
         assert "except for Ins that have the Nothing dagster_type" not in str(err)
+
+
+def test_multi_asset_multiple_compute_kind():
+    with pytest.raises(
+        DagsterInvalidDefinitionError, match="Cannot specify multiple compute kinds"
+    ):
+
+        @multi_asset(
+            specs=[AssetSpec("foo", compute_kind="alpha"), AssetSpec("bar", compute_kind="beta")]
+        )
+        def foo_bar():
+            pass
+
+    # With a null compute kind
+    with pytest.raises(
+        DagsterInvalidDefinitionError, match="Cannot specify multiple compute kinds"
+    ):
+
+        @multi_asset(specs=[AssetSpec("foo", compute_kind="alpha"), AssetSpec("bar")])
+        def foo_bar_2():
+            pass

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
@@ -1,8 +1,14 @@
 import pytest
 from dagster import AssetSpec
 from dagster._core.errors import DagsterInvalidDefinitionError
+from dagster._core.storage.tags import COMPUTE_KIND_TAG
 
 
 def test_validate_asset_owner():
     with pytest.raises(DagsterInvalidDefinitionError, match="Invalid owner"):
         AssetSpec(key="asset1", owners=["owner@$#&*1"])
+
+
+def test_compute_kind():
+    asset_spec = AssetSpec(key="foo", compute_kind="bar")
+    assert asset_spec.tags[COMPUTE_KIND_TAG] == "bar"


### PR DESCRIPTION
## Summary & Motivation

Fixes https://linear.app/dagster-labs/issue/FOU-228/assetspec-accepts-compute-kind.

Add a `compute_kind` parameter to `AssetSpec` constructor (which gets wrapped into the tags), matching the analogous parameter on `@asset`.

## How I Tested These Changes

New unit test.