### PR TITLE
Pass a TimestampWithTimezone into scheduler methods rather than a pendulum datetime

### DIFF
--- a/python_modules/dagster/dagster/_api/snapshot_schedule.py
+++ b/python_modules/dagster/dagster/_api/snapshot_schedule.py
@@ -1,14 +1,14 @@
-from typing import TYPE_CHECKING, Any, Optional, Sequence
+from typing import TYPE_CHECKING, Optional, Sequence
 
 import dagster._check as check
 from dagster._core.definitions.schedule_definition import ScheduleExecutionData
+from dagster._core.definitions.timestamp import TimestampWithTimezone
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.external_data import ExternalScheduleExecutionErrorData
 from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._grpc.types import ExternalScheduleExecutionArgs
 from dagster._serdes import deserialize_value
-from dagster._seven.compat.pendulum import PendulumDateTime
 
 if TYPE_CHECKING:
     from dagster._grpc.client import DagsterGrpcClient
@@ -18,7 +18,7 @@ def sync_get_external_schedule_execution_data_ephemeral_grpc(
     instance: DagsterInstance,
     repository_handle: RepositoryHandle,
     schedule_name: str,
-    scheduled_execution_time: Any,
+    scheduled_execution_time: Optional[TimestampWithTimezone],
     log_key: Optional[Sequence[str]],
     timeout: Optional[int] = None,
 ) -> ScheduleExecutionData:
@@ -44,13 +44,15 @@ def sync_get_external_schedule_execution_data_grpc(
     instance: DagsterInstance,
     repository_handle: RepositoryHandle,
     schedule_name: str,
-    scheduled_execution_time: Any,
+    scheduled_execution_time: Optional[TimestampWithTimezone],
     log_key: Optional[Sequence[str]],
     timeout: Optional[int] = None,
 ) -> ScheduleExecutionData:
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
     check.str_param(schedule_name, "schedule_name")
-    check.opt_inst_param(scheduled_execution_time, "scheduled_execution_time", PendulumDateTime)
+    check.opt_inst_param(
+        scheduled_execution_time, "scheduled_execution_time", TimestampWithTimezone
+    )
 
     origin = repository_handle.get_external_origin()
     result = deserialize_value(
@@ -60,10 +62,10 @@ def sync_get_external_schedule_execution_data_grpc(
                 instance_ref=instance.get_ref(),
                 schedule_name=schedule_name,
                 scheduled_execution_timestamp=(
-                    scheduled_execution_time.timestamp() if scheduled_execution_time else None
+                    scheduled_execution_time.timestamp if scheduled_execution_time else None
                 ),
                 scheduled_execution_timezone=(
-                    scheduled_execution_time.timezone.name if scheduled_execution_time else None
+                    scheduled_execution_time.timezone if scheduled_execution_time else None
                 ),
                 log_key=log_key,
                 timeout=timeout,

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -58,6 +58,7 @@ from .partition import (
     cron_schedule_from_schedule_type_and_offsets,
 )
 from .partition_key_range import PartitionKeyRange
+from .timestamp import TimestampWithTimezone
 
 
 def is_second_ambiguous_time(dt: datetime, tz: Optional[str]):
@@ -154,21 +155,6 @@ def dst_safe_strptime(date_string: str, tz: str, fmt: str) -> PendulumDateTime:
         if _IS_PENDULUM_1:
             dt = dt.add(microseconds=-1)
         return dt
-
-
-# TimestampWithTimezone is used to preserve IANA timezone information when serializing.
-# Serializing with the UTC offset (i.e. via datetime.isoformat) is insufficient because offsets vary
-# depending on daylight savings time. This causes timedelta operations to be inexact, since the
-# exact timezone is not preserved. To prevent any lossy serialization, ths implementation
-# serializes both the datetime float and the IANA timezone.
-@whitelist_for_serdes
-class TimestampWithTimezone(NamedTuple):
-    timestamp: float  # Seconds since the Unix epoch
-    timezone: str
-
-    @staticmethod
-    def from_pendulum_time(dt: PendulumDateTime):
-        return TimestampWithTimezone(dt.timestamp(), dt.timezone.name)
 
 
 class TimeWindow(NamedTuple):

--- a/python_modules/dagster/dagster/_core/definitions/timestamp.py
+++ b/python_modules/dagster/dagster/_core/definitions/timestamp.py
@@ -1,0 +1,19 @@
+from typing import NamedTuple
+
+from dagster._serdes import whitelist_for_serdes
+from dagster._seven.compat.pendulum import PendulumDateTime
+
+
+# TimestampWithTimezone is used to preserve IANA timezone information when serializing.
+# Serializing with the UTC offset (i.e. via datetime.isoformat) is insufficient because offsets vary
+# depending on daylight savings time. This causes timedelta operations to be inexact, since the
+# exact timezone is not preserved. To prevent any lossy serialization, ths implementation
+# serializes both the datetime float and the IANA timezone.
+@whitelist_for_serdes
+class TimestampWithTimezone(NamedTuple):
+    timestamp: float  # Seconds since the Unix epoch
+    timezone: str
+
+    @staticmethod
+    def from_pendulum_time(dt: PendulumDateTime):
+        return TimestampWithTimezone(dt.timestamp(), dt.timezone.name)

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -39,10 +39,8 @@ from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.selector import PartitionsByAssetSelector
 from dagster._core.definitions.time_window_partition_mapping import TimeWindowPartitionMapping
-from dagster._core.definitions.time_window_partitions import (
-    TimestampWithTimezone,
-    TimeWindowPartitionsSubset,
-)
+from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsSubset
+from dagster._core.definitions.timestamp import TimestampWithTimezone
 from dagster._core.errors import (
     DagsterAssetBackfillDataLoadError,
     DagsterBackfillFailedError,

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -27,6 +27,7 @@ import dagster._check as check
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.schedule_definition import DefaultScheduleStatus
 from dagster._core.definitions.selector import JobSubsetSelector
+from dagster._core.definitions.timestamp import TimestampWithTimezone
 from dagster._core.definitions.utils import normalize_tags
 from dagster._core.errors import DagsterCodeLocationLoadError, DagsterUserCodeUnreachableError
 from dagster._core.instance import DagsterInstance
@@ -621,6 +622,7 @@ def launch_scheduled_runs_for_schedule_iterator(
                     logger,
                     external_schedule,
                     schedule_time,
+                    timezone_str,
                     tick_context,
                     submit_threadpool_executor,
                     schedule_debug_crash_flags,
@@ -783,6 +785,7 @@ def _schedule_runs_at_time(
     logger: logging.Logger,
     external_schedule: ExternalSchedule,
     schedule_time: datetime.datetime,
+    timezone_str: str,
     tick_context: _ScheduleLaunchContext,
     submit_threadpool_executor: Optional[ThreadPoolExecutor],
     debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags] = None,
@@ -796,7 +799,10 @@ def _schedule_runs_at_time(
         instance=instance,
         repository_handle=repository_handle,
         schedule_name=external_schedule.name,
-        scheduled_execution_time=schedule_time,
+        scheduled_execution_time=TimestampWithTimezone(
+            schedule_time.timestamp(),
+            timezone_str,
+        ),
         log_key=tick_context.log_key,
     )
     yield None

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_schedule_execution_data.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_schedule_execution_data.py
@@ -8,6 +8,7 @@ from dagster._api.snapshot_schedule import (
     sync_get_external_schedule_execution_data_grpc,
 )
 from dagster._core.definitions.schedule_definition import ScheduleExecutionData
+from dagster._core.definitions.timestamp import TimestampWithTimezone
 from dagster._core.errors import DagsterUserCodeUnreachableError
 from dagster._core.remote_representation.external_data import ExternalScheduleExecutionErrorData
 from dagster._core.test_utils import instance_for_test
@@ -122,7 +123,7 @@ def test_include_execution_time_grpc():
                 instance,
                 repository_handle,
                 "foo_schedule_echo_time",
-                execution_time,
+                TimestampWithTimezone(execution_time.timestamp(), "UTC"),
                 None,
             )
 
@@ -141,7 +142,7 @@ def test_run_request_partition_key_schedule_grpc():
                 instance,
                 repository_handle,
                 "partitioned_run_request_schedule",
-                execution_time,
+                TimestampWithTimezone(execution_time.timestamp(), "UTC"),
                 None,
             )
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_mask_user_code_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_mask_user_code_errors.py
@@ -1,12 +1,13 @@
 import re
 import sys
+import time
 from typing import Any
 
 import pytest
 from dagster import Config, RunConfig, config_mapping, job, op
+from dagster._core.definitions.timestamp import TimestampWithTimezone
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.test_utils import environ, instance_for_test
-from dagster._seven import get_current_datetime_in_utc
 from dagster._utils.error import serializable_error_info_from_exc_info
 
 from ..api_tests.utils import get_bar_repo_handle
@@ -85,7 +86,7 @@ def test_masking_schedule_execution(instance, enable_masking_user_code_errors, c
                 instance,
                 repository_handle,
                 "schedule_error",
-                get_current_datetime_in_utc(),
+                TimestampWithTimezone(time.time(), "UTC"),
                 None,
                 None,
             )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
@@ -2,7 +2,7 @@ import datetime
 
 from dagster import AutoMaterializePolicy, Definitions, asset
 from dagster._core.definitions.declarative_automation.legacy.asset_condition import AssetCondition
-from dagster._core.definitions.time_window_partitions import TimestampWithTimezone
+from dagster._core.definitions.timestamp import TimestampWithTimezone
 from dagster._core.remote_representation.external_data import external_repository_data_from_def
 from dagster._serdes import serialize_value
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/base_scenario.py
@@ -65,7 +65,7 @@ from dagster._core.definitions.events import CoercibleToAssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.partition import PartitionsSubset
-from dagster._core.definitions.time_window_partitions import TimestampWithTimezone
+from dagster._core.definitions.timestamp import TimestampWithTimezone
 from dagster._core.events import AssetMaterializationPlannedData, DagsterEvent, DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.asset_backfill import AssetBackfillData

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
@@ -12,7 +12,7 @@ from dagster import (
 from dagster._core.definitions.auto_materialize_rule_impls import (
     DiscardOnMaxMaterializationsExceededRule,
 )
-from dagster._core.definitions.time_window_partitions import TimestampWithTimezone
+from dagster._core.definitions.timestamp import TimestampWithTimezone
 
 from ..base_scenario import run_request
 from ..scenario_specs import (


### PR DESCRIPTION
Summary:
Inching towards pendulum removal by passing around a different object that allows IANA timezone extraction in a similar fashion.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
