### PR TITLE
Move get_current_datetime_in_utc off of pendulum

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -1,3 +1,4 @@
+import time
 from typing import TYPE_CHECKING, Optional, Sequence, Set
 
 import dagster._check as check
@@ -9,7 +10,6 @@ from dagster._core.definitions.selector import (
 )
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus
 from dagster._core.workspace.permissions import Permissions
-from dagster._seven import get_current_datetime_in_utc, get_timestamp_from_utc_datetime
 
 from dagster_graphql.schema.util import ResolveInfo
 
@@ -222,9 +222,7 @@ def get_schedule_next_tick(
         return None
 
     external_schedule = repository.get_external_schedule(schedule_state.name)
-    time_iter = external_schedule.execution_time_iterator(
-        get_timestamp_from_utc_datetime(get_current_datetime_in_utc())
-    )
+    time_iter = external_schedule.execution_time_iterator(time.time())
 
     next_timestamp = next(time_iter).timestamp()
     return GrapheneDryRunInstigationTick(external_schedule.schedule_selector, next_timestamp)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -1,3 +1,4 @@
+import time
 from typing import TYPE_CHECKING, Optional, Sequence, Set
 
 import dagster._check as check
@@ -9,7 +10,6 @@ from dagster._core.scheduler.instigation import (
     SensorInstigatorData,
 )
 from dagster._core.workspace.permissions import Permissions
-from dagster._seven import get_current_datetime_in_utc, get_timestamp_from_utc_datetime
 
 from dagster_graphql.schema.util import ResolveInfo
 
@@ -212,7 +212,7 @@ def get_sensor_next_tick(
     latest_tick = ticks[0]
 
     next_timestamp = latest_tick.timestamp + external_sensor.min_interval_seconds
-    if next_timestamp < get_timestamp_from_utc_datetime(get_current_datetime_in_utc()):
+    if next_timestamp < time.time():
         return None
     return GrapheneDryRunInstigationTick(external_sensor.sensor_selector, next_timestamp)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -1,3 +1,4 @@
+import time
 from typing import List, Optional
 
 import dagster._check as check
@@ -135,7 +136,7 @@ class GrapheneSchedule(graphene.ObjectType):
         limit: Optional[int] = None,
         until: Optional[float] = None,
     ):
-        cursor = cursor or get_timestamp_from_utc_datetime(get_current_datetime_in_utc())
+        cursor = cursor or time.time()
 
         tick_times: List[float] = []
         time_iter = self._external_schedule.execution_time_iterator(cursor)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 
 import pendulum
 import pytest
@@ -12,7 +13,6 @@ from dagster._core.scheduler.instigation import (
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceRequestContext
-from dagster._seven import get_current_datetime_in_utc, get_timestamp_from_utc_datetime
 from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_freeze_time
 from dagster._utils import Counter, traced_counter
 from dagster_graphql.implementation.utils import UserFacingGraphQLError
@@ -367,7 +367,7 @@ def test_schedule_dry_run(graphql_context):
 
     schedule_selector = infer_schedule_selector(context, "provide_config_schedule")
 
-    timestamp = get_timestamp_from_utc_datetime(get_current_datetime_in_utc())
+    timestamp = time.time()
     result = execute_dagster_graphql(
         context,
         SCHEDULE_DRY_RUN_MUTATION,
@@ -391,7 +391,7 @@ def test_schedule_dry_run_errors(graphql_context):
 
     schedule_selector = infer_schedule_selector(context, "always_error")
 
-    timestamp = get_timestamp_from_utc_datetime(get_current_datetime_in_utc())
+    timestamp = time.time()
     result = execute_dagster_graphql(
         context,
         SCHEDULE_DRY_RUN_MUTATION,
@@ -417,7 +417,7 @@ def test_dry_run_nonexistent_schedule(graphql_context):
 
     unknown_instigator_selector = infer_schedule_selector(context, "schedule_doesnt_exist")
 
-    timestamp = get_timestamp_from_utc_datetime(get_current_datetime_in_utc())
+    timestamp = time.time()
     with pytest.raises(UserFacingGraphQLError, match="GrapheneScheduleNotFoundError"):
         execute_dagster_graphql(
             context,
@@ -627,7 +627,7 @@ def test_ticks_from_timestamp(graphql_context):
     schedule_selector = infer_schedule_selector(graphql_context, "past_tick_schedule")
 
     # get schedule past ticks
-    cur_timestamp = get_timestamp_from_utc_datetime(get_current_datetime_in_utc())
+    cur_timestamp = time.time()
     result = execute_dagster_graphql(
         graphql_context,
         GET_SCHEDULE_QUERY,

--- a/python_modules/dagster/dagster/_core/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_core/scheduler/scheduler.py
@@ -1,5 +1,6 @@
 import abc
 import os
+import time
 from typing import Any, Mapping, NamedTuple, Optional, Sequence
 
 from typing_extensions import Self
@@ -17,7 +18,6 @@ from dagster._core.scheduler.instigation import (
 )
 from dagster._serdes import ConfigurableClass
 from dagster._serdes.config_class import ConfigurableClassData
-from dagster._seven import get_current_datetime_in_utc
 from dagster._utils import mkdir_p
 
 
@@ -87,7 +87,7 @@ class Scheduler(abc.ABC):
 
         new_instigator_data = ScheduleInstigatorData(
             external_schedule.cron_schedule,
-            get_current_datetime_in_utc().timestamp(),
+            time.time(),
         )
 
         if not stored_state:

--- a/python_modules/dagster/dagster/_seven/__init__.py
+++ b/python_modules/dagster/dagster/_seven/__init__.py
@@ -11,7 +11,6 @@ from datetime import datetime, timezone
 from types import ModuleType
 from typing import Any, Callable, List, Sequence, Type
 
-import pendulum
 from typing_extensions import TypeGuard
 
 from .compat.pendulum import PendulumDateTime as PendulumDateTime  # re-exported
@@ -125,7 +124,7 @@ def builtin_print() -> str:
 
 
 def get_current_datetime_in_utc() -> Any:
-    return pendulum.now("UTC")
+    return datetime.now(tz=timezone.utc)
 
 
 def get_timestamp_from_utc_datetime(utc_datetime: datetime) -> float:

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -26,7 +26,6 @@ from dagster._core.scheduler.instigation import (
     TickStatus,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
-from dagster._seven import get_current_datetime_in_utc
 from dagster._seven.compat.pendulum import pendulum_freeze_time
 from dagster._utils.error import SerializableErrorInfo
 
@@ -207,7 +206,7 @@ class TestScheduleStorage:
         schedule = self.build_schedule("my_schedule", "* * * * *")
         storage.add_instigator_state(schedule)
 
-        now_time = get_current_datetime_in_utc().timestamp()
+        now_time = time.time()
 
         new_schedule = schedule.with_status(InstigatorStatus.RUNNING).with_data(
             ScheduleInstigatorData(

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_schedule_execution_data.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_schedule_execution_data.py
@@ -1,4 +1,5 @@
 import os
+import time
 from typing import Optional
 from unittest import mock
 
@@ -119,6 +120,7 @@ def test_include_execution_time_grpc():
     with instance_for_test() as instance:
         with get_bar_repo_handle(instance) as repository_handle:
             execution_time = get_current_datetime_in_utc()
+
             execution_data = sync_get_external_schedule_execution_data_ephemeral_grpc(
                 instance,
                 repository_handle,
@@ -137,12 +139,11 @@ def test_include_execution_time_grpc():
 def test_run_request_partition_key_schedule_grpc():
     with instance_for_test() as instance:
         with get_bar_repo_handle(instance) as repository_handle:
-            execution_time = get_current_datetime_in_utc()
             execution_data = sync_get_external_schedule_execution_data_ephemeral_grpc(
                 instance,
                 repository_handle,
                 "partitioned_run_request_schedule",
-                TimestampWithTimezone(execution_time.timestamp(), "UTC"),
+                TimestampWithTimezone(time.time(), "UTC"),
                 None,
             )
 


### PR DESCRIPTION
Summary:
To try to have something roughly as succinct as pendulum.now("UTC") - none of the existing callsites of this required pendulum, many of them were extremely complex ways to write time.time() instead

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
