### PR TITLE
[code links] more flexible local->git filepath  mapping in link_to_git fn

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -48,7 +48,9 @@ from .source_code import (
     CodeReferencesMetadataSet as CodeReferencesMetadataSet,
     CodeReferencesMetadataValue as CodeReferencesMetadataValue,
     LocalFileCodeReference as LocalFileCodeReference,
+    SourceControlFilePathMapping as SourceControlFilePathMapping,
     UrlCodeReference as UrlCodeReference,
+    link_to_git as link_to_git,
     link_to_source_control as link_to_source_control,
     with_source_code_references as with_source_code_references,
 )

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -45,10 +45,10 @@ from .metadata_value import (
 )
 from .source_code import (
     DEFAULT_SOURCE_FILE_KEY as DEFAULT_SOURCE_FILE_KEY,
+    AnchorBasedFilePathMappingFn as AnchorBasedFilePathMappingFn,
     CodeReferencesMetadataSet as CodeReferencesMetadataSet,
     CodeReferencesMetadataValue as CodeReferencesMetadataValue,
     LocalFileCodeReference as LocalFileCodeReference,
-    SourceControlFilePathMapping as SourceControlFilePathMapping,
     UrlCodeReference as UrlCodeReference,
     link_to_git as link_to_git,
     with_source_code_references as with_source_code_references,

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -51,7 +51,6 @@ from .source_code import (
     SourceControlFilePathMapping as SourceControlFilePathMapping,
     UrlCodeReference as UrlCodeReference,
     link_to_git as link_to_git,
-    link_to_source_control as link_to_source_control,
     with_source_code_references as with_source_code_references,
 )
 from .table import (  # re-exported

--- a/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/__init__.py
@@ -45,7 +45,7 @@ from .metadata_value import (
 )
 from .source_code import (
     DEFAULT_SOURCE_FILE_KEY as DEFAULT_SOURCE_FILE_KEY,
-    AnchorBasedFilePathMappingFn as AnchorBasedFilePathMappingFn,
+    AnchorBasedFilePathMapping as AnchorBasedFilePathMapping,
     CodeReferencesMetadataSet as CodeReferencesMetadataSet,
     CodeReferencesMetadataValue as CodeReferencesMetadataValue,
     LocalFileCodeReference as LocalFileCodeReference,

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -255,7 +255,7 @@ def link_to_git(
         git_url (str): The base URL for the source control system. For example,
             "https://github.com/dagster-io/dagster".
         git_branch (str): The branch in the source control system, such as "master".
-        file_path_mapping (FilePathMappingFn):
+        file_path_mapping (Callable[[Path], str]):
             Specifies the mapping between local file paths and their corresponding paths in a source control repository.
             Simple usage is to provide a `AnchorBasedFilePathMappingFn` instance, which specifies an anchor file in the
             repository and the corresponding local file path, which is extrapolated to all other local file paths.

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -1,13 +1,13 @@
 import inspect
 import os
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._annotations import experimental
 from dagster._model import DagsterModel
-from dagster._model.decorator import dagster_model
 from dagster._serdes import whitelist_for_serdes
 
 from .metadata_set import (
@@ -153,7 +153,7 @@ class FilePathMapping(ABC):
 
 
 @experimental
-@dagster_model
+@dataclass
 class AnchorBasedFilePathMapping(FilePathMapping):
     """Specifies the mapping between local file paths and their corresponding paths in a source control repository,
     using a specific file "anchor" as a reference point. All other paths are calculated relative to this anchor file.

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -140,7 +140,13 @@ FilePathMappingFn = Callable[[Path], str]
 
 class AnchorBasedFilePathMappingFn(NamedTuple):
     """Specifies the mapping between local file paths and their corresponding paths in a source control repository,
-    using a specific anchor file as a reference point. All other paths are calculated relative to this anchor file.
+    using a specific file "anchor" as a reference point. All other paths are calculated relative to this anchor file.
+
+    For example, if the chosen anchor file is `/Users/dagster/Documents/python_modules/my_module/my-module/__init__.py`
+    locally, and `python_modules/my_module/my-module/__init__.py` in a source control repository, in order to map a
+    different file `/Users/dagster/Documents/python_modules/my_module/my-module/my_asset.py` to the repository path,
+    the mapping function will position the file in the repository relative to the anchor file's position in the repository,
+    resulting in `python_modules/my_module/my-module/my_asset.py`.
 
     Args:
         local_file_anchor (Path): The path to a local file that is present in the repository.

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -1,8 +1,9 @@
 import abc
 import inspect
 import os
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, NamedTuple, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._annotations import experimental
@@ -150,7 +151,8 @@ class FilePathMapping(abc.ABC):
     def convert_to_source_control_path(self, local_path: Path) -> str: ...
 
 
-class AnchorBasedFilePathMapping(NamedTuple):
+@dataclass(frozen=True)
+class AnchorBasedFilePathMapping(FilePathMapping):
     """Specifies the mapping between local file paths and their corresponding paths in a source control repository,
     using a specific file "anchor" as a reference point. All other paths are calculated relative to this anchor file.
 

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -273,6 +273,20 @@ def link_to_git(
             repository and the corresponding local file path, which is extrapolated to all other local file paths.
             Alternatively, a function can be provided which takes a local file path and returns the corresponding path in
             the repository, allowing for more complex mappings.
+
+    Example:
+        .. code-block:: python
+                defs = Definitions(
+                    assets=link_to_git(
+                        with_source_code_references([my_dbt_assets]),
+                        source_control_url="https://github.com/dagster-io/dagster",
+                        source_control_branch="master",
+                        source_control_file_path_mapping=SourceControlFilePathMapping(
+                            local_file_anchor=Path(__file__),
+                            file_anchor_path_in_repository="python_modules/my_module/my-module/__init__.py",
+                        ),
+                    )
+                )
     """
     if "gitlab.com" in source_control_url:
         source_control_url = _build_gitlab_url(source_control_url, source_control_branch)

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -173,10 +173,10 @@ class AnchorBasedFilePathMappingFn(NamedTuple):
 
 def convert_local_path_to_git_path(
     base_git_url: str,
-    git_file_path_mapping_fn: FilePathMappingFn,
+    file_path_mapping_fn: FilePathMappingFn,
     local_path: LocalFileCodeReference,
 ) -> UrlCodeReference:
-    source_file_from_repo_root = git_file_path_mapping_fn(Path(local_path.file_path))
+    source_file_from_repo_root = file_path_mapping_fn(Path(local_path.file_path))
     line_number_suffix = f"#L{local_path.line_number}" if local_path.line_number else ""
 
     return UrlCodeReference(
@@ -187,7 +187,7 @@ def convert_local_path_to_git_path(
 
 def _convert_local_path_to_git_path_single_definition(
     base_git_url: str,
-    git_file_path_mapping_fn: FilePathMappingFn,
+    file_path_mapping_fn: FilePathMappingFn,
     assets_def: Union["AssetsDefinition", "SourceAsset", "CacheableAssetsDefinition"],
 ) -> Union["AssetsDefinition", "SourceAsset", "CacheableAssetsDefinition"]:
     from dagster._core.definitions.assets import AssetsDefinition
@@ -209,7 +209,7 @@ def _convert_local_path_to_git_path_single_definition(
         sources_for_asset: List[Union[LocalFileCodeReference, UrlCodeReference]] = [
             convert_local_path_to_git_path(
                 base_git_url,
-                git_file_path_mapping_fn,
+                file_path_mapping_fn,
                 source,
             )
             if isinstance(source, LocalFileCodeReference)
@@ -242,7 +242,7 @@ def link_to_git(
     assets_defs: Sequence[Union["AssetsDefinition", "SourceAsset", "CacheableAssetsDefinition"]],
     git_url: str,
     git_branch: str,
-    git_file_path_mapping: FilePathMappingFn,
+    file_path_mapping: FilePathMappingFn,
 ) -> Sequence[Union["AssetsDefinition", "SourceAsset", "CacheableAssetsDefinition"]]:
     """Wrapper function which converts local file path code references to source control URLs
     based on the provided source control URL and branch.
@@ -255,7 +255,7 @@ def link_to_git(
         git_url (str): The base URL for the source control system. For example,
             "https://github.com/dagster-io/dagster".
         git_branch (str): The branch in the source control system, such as "master".
-        git_file_path_mapping (FilePathMappingFn):
+        file_path_mapping (FilePathMappingFn):
             Specifies the mapping between local file paths and their corresponding paths in a source control repository.
             Simple usage is to provide a `AnchorBasedFilePathMappingFn` instance, which specifies an anchor file in the
             repository and the corresponding local file path, which is extrapolated to all other local file paths.
@@ -269,7 +269,7 @@ def link_to_git(
                         with_source_code_references([my_dbt_assets]),
                         git_url="https://github.com/dagster-io/dagster",
                         git_branch="master",
-                        git_file_path_mapping=AnchorBasedFilePathMappingFn(
+                        file_path_mapping=AnchorBasedFilePathMappingFn(
                             local_file_anchor=Path(__file__),
                             file_anchor_path_in_repository="python_modules/my_module/my-module/__init__.py",
                         ),
@@ -289,7 +289,7 @@ def link_to_git(
     return [
         _convert_local_path_to_git_path_single_definition(
             base_git_url=git_url,
-            git_file_path_mapping_fn=git_file_path_mapping,
+            file_path_mapping_fn=file_path_mapping,
             assets_def=assets_def,
         )
         for assets_def in assets_defs

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -1,13 +1,13 @@
-import abc
 import inspect
 import os
-from dataclasses import dataclass
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._annotations import experimental
 from dagster._model import DagsterModel
+from dagster._model.decorator import dagster_model
 from dagster._serdes import whitelist_for_serdes
 
 from .metadata_set import (
@@ -137,9 +137,10 @@ def _with_code_source_single_definition(
     )
 
 
-class FilePathMapping(abc.ABC):
-    """Base class for file path mapping functions. These functions are used to map local file paths to their corresponding
-    paths in a source control repository.
+@experimental
+class FilePathMapping(ABC):
+    """Base class which defines a file path mapping function. These functions are used to map local file paths
+    to their corresponding paths in a source control repository.
 
     In many cases where a source control repository is reproduced exactly on a local machine, the included
     AnchorBasedFilePathMapping class can be used to specify a direct mapping between the local file paths and the
@@ -147,11 +148,12 @@ class FilePathMapping(abc.ABC):
     mapping function can be provided to handle these cases.
     """
 
-    @abc.abstractmethod
+    @abstractmethod
     def convert_to_source_control_path(self, local_path: Path) -> str: ...
 
 
-@dataclass(frozen=True)
+@experimental
+@dagster_model
 class AnchorBasedFilePathMapping(FilePathMapping):
     """Specifies the mapping between local file paths and their corresponding paths in a source control repository,
     using a specific file "anchor" as a reference point. All other paths are calculated relative to this anchor file.

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
@@ -1,6 +1,8 @@
 import os
+from pathlib import Path
 from typing import cast
 
+import pytest
 from dagster import AssetsDefinition, load_assets_from_modules
 from dagster._core.definitions.metadata import (
     LocalFileCodeReference,
@@ -8,6 +10,7 @@ from dagster._core.definitions.metadata import (
     link_to_source_control,
     with_source_code_references,
 )
+from dagster._core.definitions.metadata.source_code import SourceControlFilePathMapping, link_to_git
 from dagster._utils import file_relative_path
 
 # path of the `dagster` package on the filesystem
@@ -96,7 +99,11 @@ def test_asset_code_origins() -> None:
                 assert meta.line_number == int(expected_line_number)
 
 
-def test_asset_code_origins_source_control() -> None:
+@pytest.mark.parametrize(
+    "use_old_source_control_link_fn",
+    [False, True],
+)
+def test_asset_code_origins_source_control(use_old_source_control_link_fn: bool) -> None:
     from dagster_tests.asset_defs_tests import asset_package
 
     from .asset_package import module_with_assets
@@ -114,12 +121,23 @@ def test_asset_code_origins_source_control() -> None:
                     assert "dagster/code_references" not in asset.specs_by_key[key].metadata
 
     collection_with_source_metadata = with_source_code_references(collection)
-    collection_with_source_control_metadata = link_to_source_control(
-        collection_with_source_metadata,
-        source_control_url="https://github.com/dagster-io/dagster",
-        source_control_branch="master",
-        repository_root_absolute_path=GIT_ROOT_PATH,
-    )
+
+    if use_old_source_control_link_fn:
+        collection_with_source_control_metadata = link_to_source_control(
+            collection_with_source_metadata,
+            source_control_url="https://github.com/dagster-io/dagster",
+            source_control_branch="master",
+            repository_root_absolute_path=GIT_ROOT_PATH,
+        )
+    else:
+        collection_with_source_control_metadata = link_to_git(
+            collection_with_source_metadata,
+            source_control_url="https://github.com/dagster-io/dagster",
+            source_control_branch="master",
+            source_control_file_path_mapping=SourceControlFilePathMapping(
+                local_file_anchor=Path(GIT_ROOT_PATH), file_anchor_path_in_repository=""
+            ),
+        )
 
     for asset in collection_with_source_control_metadata:
         if isinstance(asset, AssetsDefinition):
@@ -145,3 +163,65 @@ def test_asset_code_origins_source_control() -> None:
                     + (expected_file_path[len(DAGSTER_PACKAGE_PATH) :])
                     + f"#L{expected_line_number}"
                 )
+
+
+def test_asset_code_origins_source_control_custom_mapping() -> None:
+    # test custom source_control_file_path_mapping fn
+
+    from dagster_tests.asset_defs_tests import asset_package
+
+    from .asset_package import module_with_assets
+
+    collection = load_assets_from_modules([asset_package, module_with_assets])
+
+    for asset in collection:
+        if isinstance(asset, AssetsDefinition):
+            for key in asset.keys:
+                # `chuck_berry` is the only asset with source code metadata manually
+                # attached to it
+                if asset.op.name == "chuck_berry":
+                    assert "dagster/code_references" in asset.metadata_by_key[key]
+                else:
+                    assert "dagster/code_references" not in asset.metadata_by_key[key]
+
+    collection_with_source_metadata = with_source_code_references(collection)
+
+    collection_with_source_control_metadata = link_to_git(
+        collection_with_source_metadata,
+        source_control_url="https://github.com/dagster-io/dagster",
+        source_control_branch="master",
+        source_control_file_path_mapping=lambda file_path: "override.py"
+        if os.fspath(file_path).endswith("module_with_assets.py")
+        else os.path.normpath(os.path.relpath(file_path, GIT_ROOT_PATH)),
+    )
+
+    for asset in collection_with_source_control_metadata:
+        if isinstance(asset, AssetsDefinition):
+            op_name = asset.op.name
+            assert op_name in EXPECTED_ORIGINS, f"Missing expected origin for op {op_name}"
+
+            expected_file_path, expected_line_number = EXPECTED_ORIGINS[op_name].split(":")
+            expected_url = (
+                "https://github.com/dagster-io/dagster/tree/master/python_modules/dagster"
+                + (expected_file_path[len(DAGSTER_PACKAGE_PATH) :])
+                + f"#L{expected_line_number}"
+            )
+            if expected_file_path.endswith("module_with_assets.py"):
+                expected_url = (
+                    "https://github.com/dagster-io/dagster/tree/master/override.py"
+                    + f"#L{expected_line_number}"
+                )
+
+            for key in asset.keys:
+                assert "dagster/code_references" in asset.metadata_by_key[key]
+
+                assert isinstance(
+                    asset.metadata_by_key[key]["dagster/code_references"].code_references[-1],
+                    UrlCodeReference,
+                )
+                meta = cast(
+                    UrlCodeReference,
+                    asset.metadata_by_key[key]["dagster/code_references"].code_references[-1],
+                )
+
+                assert meta.url == expected_url

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
@@ -120,7 +120,7 @@ def test_asset_code_origins_source_control() -> None:
         collection_with_source_metadata,
         git_url="https://github.com/dagster-io/dagster",
         git_branch="master",
-        git_file_path_mapping=AnchorBasedFilePathMappingFn(
+        file_path_mapping=AnchorBasedFilePathMappingFn(
             local_file_anchor=Path(GIT_ROOT_PATH), file_anchor_path_in_repository=""
         ),
     )
@@ -176,7 +176,7 @@ def test_asset_code_origins_source_control_custom_mapping() -> None:
         collection_with_source_metadata,
         git_url="https://github.com/dagster-io/dagster",
         git_branch="master",
-        git_file_path_mapping=lambda file_path: "override.py"
+        file_path_mapping=lambda file_path: "override.py"
         if os.fspath(file_path).endswith("module_with_assets.py")
         else os.path.normpath(os.path.relpath(file_path, GIT_ROOT_PATH)),
     )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
@@ -8,7 +8,7 @@ from dagster._core.definitions.metadata import (
     UrlCodeReference,
     with_source_code_references,
 )
-from dagster._core.definitions.metadata.source_code import SourceControlFilePathMapping, link_to_git
+from dagster._core.definitions.metadata.source_code import AnchorBasedFilePathMappingFn, link_to_git
 from dagster._utils import file_relative_path
 
 # path of the `dagster` package on the filesystem
@@ -120,7 +120,7 @@ def test_asset_code_origins_source_control() -> None:
         collection_with_source_metadata,
         git_url="https://github.com/dagster-io/dagster",
         git_branch="master",
-        git_file_path_mapping=SourceControlFilePathMapping(
+        git_file_path_mapping=AnchorBasedFilePathMappingFn(
             local_file_anchor=Path(GIT_ROOT_PATH), file_anchor_path_in_repository=""
         ),
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
@@ -6,8 +6,8 @@ from typing import Any, Dict
 import pytest
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.metadata.source_code import (
+    AnchorBasedFilePathMappingFn,
     LocalFileCodeReference,
-    SourceControlFilePathMapping,
     UrlCodeReference,
     link_to_git,
     with_source_code_references,
@@ -102,7 +102,7 @@ def test_link_to_git_wrapper(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
             with_source_code_references([my_dbt_assets]),
             git_url="https://github.com/dagster-io/jaffle_shop",
             git_branch="master",
-            git_file_path_mapping=SourceControlFilePathMapping(
+            git_file_path_mapping=AnchorBasedFilePathMappingFn(
                 local_file_anchor=Path(JAFFLE_SHOP_ROOT_PATH), file_anchor_path_in_repository=""
             ),
         )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
@@ -100,9 +100,9 @@ def test_link_to_git_wrapper(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
     defs = Definitions(
         assets=link_to_git(
             with_source_code_references([my_dbt_assets]),
-            source_control_url="https://github.com/dagster-io/jaffle_shop",
-            source_control_branch="master",
-            source_control_file_path_mapping=SourceControlFilePathMapping(
+            git_url="https://github.com/dagster-io/jaffle_shop",
+            git_branch="master",
+            git_file_path_mapping=SourceControlFilePathMapping(
                 local_file_anchor=Path(JAFFLE_SHOP_ROOT_PATH), file_anchor_path_in_repository=""
             ),
         )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
@@ -1,13 +1,15 @@
 import inspect
 import os
+from pathlib import Path
 from typing import Any, Dict
 
 import pytest
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.metadata.source_code import (
     LocalFileCodeReference,
+    SourceControlFilePathMapping,
     UrlCodeReference,
-    link_to_source_control,
+    link_to_git,
     with_source_code_references,
 )
 from dagster._core.errors import DagsterInvalidDefinitionError
@@ -85,7 +87,7 @@ def test_with_source_code_references_wrapper(test_jaffle_shop_manifest: Dict[str
         assert code_reference.file_path.endswith("test_code_references.py")
 
 
-def test_link_to_source_control_wrapper(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
+def test_link_to_git_wrapper(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
     @dbt_assets(
         manifest=test_jaffle_shop_manifest,
         dagster_dbt_translator=DagsterDbtTranslator(
@@ -96,11 +98,13 @@ def test_link_to_source_control_wrapper(test_jaffle_shop_manifest: Dict[str, Any
     def my_dbt_assets(): ...
 
     defs = Definitions(
-        assets=link_to_source_control(
+        assets=link_to_git(
             with_source_code_references([my_dbt_assets]),
             source_control_url="https://github.com/dagster-io/jaffle_shop",
             source_control_branch="master",
-            repository_root_absolute_path=JAFFLE_SHOP_ROOT_PATH,
+            source_control_file_path_mapping=SourceControlFilePathMapping(
+                local_file_anchor=Path(JAFFLE_SHOP_ROOT_PATH), file_anchor_path_in_repository=""
+            ),
         )
     )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
@@ -102,7 +102,7 @@ def test_link_to_git_wrapper(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
             with_source_code_references([my_dbt_assets]),
             git_url="https://github.com/dagster-io/jaffle_shop",
             git_branch="master",
-            git_file_path_mapping=AnchorBasedFilePathMappingFn(
+            file_path_mapping=AnchorBasedFilePathMappingFn(
                 local_file_anchor=Path(JAFFLE_SHOP_ROOT_PATH), file_anchor_path_in_repository=""
             ),
         )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 import pytest
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.metadata.source_code import (
-    AnchorBasedFilePathMappingFn,
+    AnchorBasedFilePathMapping,
     LocalFileCodeReference,
     UrlCodeReference,
     link_to_git,
@@ -102,7 +102,7 @@ def test_link_to_git_wrapper(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
             with_source_code_references([my_dbt_assets]),
             git_url="https://github.com/dagster-io/jaffle_shop",
             git_branch="master",
-            file_path_mapping=AnchorBasedFilePathMappingFn(
+            file_path_mapping=AnchorBasedFilePathMapping(
                 local_file_anchor=Path(JAFFLE_SHOP_ROOT_PATH), file_anchor_path_in_repository=""
             ),
         )


### PR DESCRIPTION
## Summary

Deprecates the old `link_to_source_control` code references wrapper (should just be used internally) and creates the new `link_to_git` wrapper (to match `link_to_git_in_cloud`) which now can be provided with a more flexible local file->source control path mapping.

This mapping can either be specified as a pair of (path to a reference 'anchor' file locally, path to that 'anchor' file in source control), which is used to map all other files, or a custom user-provided fn.

## Test Plan

Unit tests.
