### PR TITLE
[2/n] Move all freeze_pendulum_time callsites into a helper function, part 2: sensor tests

### DIFF
--- a/python_modules/dagster/dagster/_seven/__init__.py
+++ b/python_modules/dagster/dagster/_seven/__init__.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from types import ModuleType
 from typing import Any, Callable, List, Sequence, Type
 
+from dateutil import parser
 from typing_extensions import TypeGuard
 
 from .compat.pendulum import PendulumDateTime as PendulumDateTime  # re-exported
@@ -191,6 +192,16 @@ def subtract_fixed_time(
             hours=hours,
         )
     ).astimezone(dt.tzinfo)
+
+
+def parse_with_timezone(datetime_str) -> datetime:
+    """Like dateutil.parser.parse, but always includes a timezone."""
+    dt = parser.parse(datetime_str)
+
+    if not dt.tzinfo:
+        dt = dt.replace(tzinfo=timezone.utc)
+
+    return dt
 
 
 def get_timestamp_from_utc_datetime(utc_datetime: datetime) -> float:

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -15,7 +15,6 @@ from typing import (
 from unittest.mock import MagicMock, patch
 
 import mock
-import pendulum
 import pytest
 from dagster import (
     AssetIn,
@@ -64,9 +63,9 @@ from dagster._core.storage.tags import (
     BACKFILL_ID_TAG,
     PARTITION_NAME_TAG,
 )
-from dagster._core.test_utils import environ, instance_for_test
+from dagster._core.test_utils import environ, freeze_time, instance_for_test
 from dagster._serdes import deserialize_value, serialize_value
-from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_freeze_time
+from dagster._seven import create_utc_datetime, get_current_datetime_in_utc, get_current_timestamp
 from dagster._utils import Counter, traced_counter
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
@@ -113,7 +112,7 @@ def scenario(
 
     return AssetBackfillScenario(
         assets_by_repo_name=cast(Mapping[str, Sequence[AssetsDefinition]], assets_by_repo_name),
-        evaluation_time=evaluation_time if evaluation_time else pendulum.now("UTC"),
+        evaluation_time=evaluation_time if evaluation_time else get_current_datetime_in_utc(),
         target_root_partition_keys=target_root_partition_keys,
         last_storage_id_cursor_offset=last_storage_id_cursor_offset,
     )
@@ -148,20 +147,20 @@ scenarios = {
         two_assets_in_sequence_fan_out_partitions
     ),
     "one_asset_self_dependency": scenario(
-        one_asset_self_dependency, create_pendulum_time(year=2020, month=1, day=7, hour=4)
+        one_asset_self_dependency, create_utc_datetime(year=2020, month=1, day=7, hour=4)
     ),
     "non_partitioned_after_partitioned": scenario(
-        non_partitioned_after_partitioned, create_pendulum_time(year=2020, month=1, day=7, hour=4)
+        non_partitioned_after_partitioned, create_utc_datetime(year=2020, month=1, day=7, hour=4)
     ),
     "partitioned_after_non_partitioned": scenario(
         partitioned_after_non_partitioned,
-        create_pendulum_time(year=2020, month=1, day=7, hour=4),
+        create_utc_datetime(year=2020, month=1, day=7, hour=4),
     ),
     "unpartitioned_after_dynamic_asset": scenario(unpartitioned_after_dynamic_asset),
     "two_dynamic_assets": scenario(two_dynamic_assets),
     "hourly_to_daily_partiitons": scenario(
         hourly_to_daily_partitions,
-        create_pendulum_time(year=2013, month=1, day=7, hour=0),
+        create_utc_datetime(year=2013, month=1, day=7, hour=0),
         target_root_partition_keys=[
             "2013-01-05-22:00",
             "2013-01-05-23:00",
@@ -172,13 +171,13 @@ scenarios = {
     "root_assets_different_partitions": scenario(root_assets_different_partitions_same_downstream),
     "hourly_with_nonexistent_downstream_daily_partition": scenario(
         hourly_to_daily_partitions,
-        create_pendulum_time(year=2013, month=1, day=7, hour=10),
+        create_utc_datetime(year=2013, month=1, day=7, hour=10),
         target_root_partition_keys=[
             "2013-01-07-05:00",
         ],
     ),
     "multipartitioned_self_dependency": scenario(
-        multipartitioned_self_dependency, create_pendulum_time(year=2020, month=1, day=7, hour=4)
+        multipartitioned_self_dependency, create_utc_datetime(year=2020, month=1, day=7, hour=4)
     ),
 }
 
@@ -288,7 +287,7 @@ def test_scenario_to_completion(scenario: AssetBackfillScenario, failures: str, 
     ):
         instance.add_dynamic_partitions("foo", ["a", "b"])
 
-        with pendulum_freeze_time(scenario.evaluation_time):
+        with freeze_time(scenario.evaluation_time):
             assets_by_repo_name = scenario.assets_by_repo_name
 
             asset_graph = get_asset_graph(assets_by_repo_name)
@@ -394,7 +393,7 @@ def test_do_not_rerequest_while_existing_run_in_progress():
         asset_selection=[downstream.key],
         dynamic_partitions_store=MagicMock(),
         all_partitions=False,
-        backfill_start_timestamp=pendulum.datetime(2023, 1, 9, 0, 0, 0).timestamp(),
+        backfill_start_timestamp=create_utc_datetime(2023, 1, 9, 0, 0, 0).timestamp(),
     )
 
     do_run(
@@ -453,7 +452,7 @@ def make_backfill_data(
 
     return AssetBackfillData.empty(
         target_subset,
-        current_time.timestamp() if current_time else pendulum.now("UTC").timestamp(),
+        current_time.timestamp() if current_time else get_current_timestamp(),
         dynamic_partitions_store=instance,
     )
 
@@ -879,7 +878,7 @@ def test_asset_backfill_status_counts():
         ],
         dynamic_partitions_store=MagicMock(),
         all_partitions=False,
-        backfill_start_timestamp=pendulum.now("UTC").timestamp(),
+        backfill_start_timestamp=get_current_timestamp(),
     )
 
     (
@@ -941,7 +940,7 @@ def test_asset_backfill_status_counts_with_reexecution():
         ],
         dynamic_partitions_store=MagicMock(),
         all_partitions=False,
-        backfill_start_timestamp=pendulum.now("UTC").timestamp(),
+        backfill_start_timestamp=get_current_timestamp(),
     )
 
     backfill_data = _single_backfill_iteration(
@@ -1002,7 +1001,7 @@ def test_asset_backfill_selects_only_existent_partitions():
         ],
         dynamic_partitions_store=MagicMock(),
         all_partitions=False,
-        backfill_start_timestamp=pendulum.datetime(2023, 1, 9, 0, 0, 0).timestamp(),
+        backfill_start_timestamp=create_utc_datetime(2023, 1, 9, 0, 0, 0).timestamp(),
     )
 
     target_subset = backfill_data.target_subset
@@ -1044,7 +1043,7 @@ def test_asset_backfill_throw_error_on_invalid_upstreams():
         ],
         dynamic_partitions_store=MagicMock(),
         all_partitions=False,
-        backfill_start_timestamp=pendulum.datetime(2023, 5, 15, 0, 0, 0).timestamp(),
+        backfill_start_timestamp=create_utc_datetime(2023, 5, 15, 0, 0, 0).timestamp(),
     )
 
     instance = DagsterInstance.ephemeral()
@@ -1074,7 +1073,7 @@ def test_asset_backfill_cancellation():
     asset_graph = get_asset_graph(assets_by_repo_name)
 
     backfill_id = "dummy_backfill_id"
-    backfill_start_datetime = pendulum.datetime(2023, 1, 9, 0, 0, 0)
+    backfill_start_datetime = create_utc_datetime(2023, 1, 9, 0, 0, 0)
     asset_selection = [
         upstream_hourly_partitioned_asset.key,
         downstream_daily_partitioned_asset.key,
@@ -1149,7 +1148,7 @@ def test_asset_backfill_cancels_without_fetching_downstreams_of_failed_partition
     asset_graph = get_asset_graph(assets_by_repo_name)
 
     backfill_id = "dummy_backfill_id"
-    backfill_start_datetime = pendulum.datetime(2023, 1, 10, 0, 0, 0)
+    backfill_start_datetime = create_utc_datetime(2023, 1, 10, 0, 0, 0)
     asset_selection = [
         upstream_hourly_partitioned_asset.key,
         downstream_daily_partitioned_asset.key,
@@ -1240,7 +1239,7 @@ def test_asset_backfill_target_asset_and_same_partitioning_grandchild():
         asset_selection=asset_selection,
         dynamic_partitions_store=MagicMock(),
         all_partitions=True,
-        backfill_start_timestamp=pendulum.datetime(2023, 10, 5, 0, 0, 0).timestamp(),
+        backfill_start_timestamp=create_utc_datetime(2023, 10, 5, 0, 0, 0).timestamp(),
     )
     assert set(asset_backfill_data.target_subset.iterate_asset_partitions()) == {
         AssetKeyPartitionKey(asset_key, partition_key)
@@ -1289,7 +1288,7 @@ def test_asset_backfill_target_asset_and_differently_partitioned_grandchild():
         asset_selection=asset_selection,
         dynamic_partitions_store=MagicMock(),
         all_partitions=True,
-        backfill_start_timestamp=pendulum.datetime(2023, 10, 8, 0, 0, 0).timestamp(),
+        backfill_start_timestamp=create_utc_datetime(2023, 10, 8, 0, 0, 0).timestamp(),
     )
 
     expected_targeted_partitions = {
@@ -1348,7 +1347,7 @@ def test_asset_backfill_nonexistent_parent_partitions():
         asset_selection=[foo.key, foo_child.key],
         dynamic_partitions_store=MagicMock(),
         all_partitions=True,
-        backfill_start_timestamp=pendulum.datetime(2023, 10, 8, 0, 0, 0).timestamp(),
+        backfill_start_timestamp=create_utc_datetime(2023, 10, 8, 0, 0, 0).timestamp(),
     )
 
     backfill_data, _, _ = run_backfill_to_completion(
@@ -1392,7 +1391,7 @@ def test_connected_assets_disconnected_partitions():
     assets_by_repo_name = {"repo": [foo, foo_child, foo_grandchild]}
     asset_graph = get_asset_graph(assets_by_repo_name)
 
-    backfill_start_datetime = pendulum.datetime(2023, 10, 30, 0, 0, 0)
+    backfill_start_datetime = create_utc_datetime(2023, 10, 30, 0, 0, 0)
     instance_queryer = CachingInstanceQueryer(instance, asset_graph, backfill_start_datetime)
     asset_backfill_data = AssetBackfillData.from_partitions_by_assets(
         asset_graph,
@@ -1450,7 +1449,7 @@ def test_partition_outside_backfill_materialized():
         asset_selection=[foo.key, foo_child.key],
         dynamic_partitions_store=MagicMock(),
         all_partitions=False,
-        backfill_start_timestamp=pendulum.datetime(2023, 10, 3, 0, 0, 0).timestamp(),
+        backfill_start_timestamp=create_utc_datetime(2023, 10, 3, 0, 0, 0).timestamp(),
     )
 
     backfill_data, _, _ = run_backfill_to_completion(
@@ -1516,7 +1515,7 @@ def test_asset_backfill_unpartitioned_downstream_of_partitioned():
         asset_selection=[foo.key, foo_child.key],
         dynamic_partitions_store=MagicMock(),
         all_partitions=False,
-        backfill_start_timestamp=pendulum.datetime(2023, 10, 8, 0, 0, 0).timestamp(),
+        backfill_start_timestamp=create_utc_datetime(2023, 10, 8, 0, 0, 0).timestamp(),
     )
 
     assert asset_backfill_data.target_subset.partitions_subsets_by_asset_key == {
@@ -1557,7 +1556,7 @@ def test_asset_backfill_serialization_deserialization():
         asset_selection=[upstream.key, middle.key, downstream.key],
         dynamic_partitions_store=MagicMock(),
         all_partitions=False,
-        backfill_start_timestamp=pendulum.datetime(2023, 1, 9, 0, 0, 0).timestamp(),
+        backfill_start_timestamp=create_utc_datetime(2023, 1, 9, 0, 0, 0).timestamp(),
     )
 
     assert (
@@ -1589,7 +1588,7 @@ def test_asset_backfill_unpartitioned_root_turned_to_partitioned():
         asset_selection=[first.key, second.key],
         dynamic_partitions_store=MagicMock(),
         all_partitions=False,
-        backfill_start_timestamp=pendulum.datetime(2024, 1, 9, 0, 0, 0).timestamp(),
+        backfill_start_timestamp=create_utc_datetime(2024, 1, 9, 0, 0, 0).timestamp(),
     )
 
     repo_with_partitioned_root = {"repo": [first_partitioned, second]}
@@ -1616,7 +1615,7 @@ def test_multi_asset_internal_deps_asset_backfill():
         asset_selection=[AssetKey("a"), AssetKey("b"), AssetKey("c")],
         dynamic_partitions_store=MagicMock(),
         all_partitions=False,
-        backfill_start_timestamp=pendulum.datetime(2024, 1, 9, 0, 0, 0).timestamp(),
+        backfill_start_timestamp=create_utc_datetime(2024, 1, 9, 0, 0, 0).timestamp(),
     )
     backfill_data = _single_backfill_iteration(
         "fake_id", asset_backfill_data, asset_graph, instance, repo_with_unpartitioned_root
@@ -1655,7 +1654,7 @@ def test_multi_asset_internal_and_external_deps_asset_backfill() -> None:
         asset_selection=[AssetKey("a"), AssetKey("b"), AssetKey("c")],
         dynamic_partitions_store=MagicMock(),
         all_partitions=False,
-        backfill_start_timestamp=pendulum.datetime(2024, 1, 9, 0, 0, 0).timestamp(),
+        backfill_start_timestamp=create_utc_datetime(2024, 1, 9, 0, 0, 0).timestamp(),
     )
     backfill_data = _single_backfill_iteration(
         "fake_id", asset_backfill_data, asset_graph, instance, repo_with_unpartitioned_root
@@ -1683,7 +1682,7 @@ def test_run_request_partition_order():
         asset_selection=[foo.key, foo_child.key],
         dynamic_partitions_store=MagicMock(),
         all_partitions=False,
-        backfill_start_timestamp=pendulum.datetime(2023, 10, 4, 0, 0, 0).timestamp(),
+        backfill_start_timestamp=create_utc_datetime(2023, 10, 4, 0, 0, 0).timestamp(),
     )
 
     result = execute_asset_backfill_iteration_consume_generator(

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
@@ -23,7 +23,8 @@ from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
     ASSET_PARTITION_RANGE_START_TAG,
 )
-from dagster._seven.compat.pendulum import pendulum_freeze_time
+from dagster._core.test_utils import freeze_time
+from dagster._seven import get_current_datetime_in_utc, parse_with_timezone
 
 from dagster_tests.core_tests.execution_tests.test_asset_backfill import (
     execute_asset_backfill_iteration_consume_generator,
@@ -639,9 +640,9 @@ def test_assets_backfill_with_partition_mapping(same_partitions):
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
     if same_partitions:
         # time at which there will be an identical set of partitions for the downstream asset
-        test_time = pendulum.parse("2023-03-04T00:00:00", tz="UTC")
+        test_time = parse_with_timezone("2023-03-04T00:00:00")
     else:
-        test_time = pendulum.now("UTC")
+        test_time = get_current_datetime_in_utc()
 
     @asset(
         name="upstream_a",
@@ -684,7 +685,7 @@ def test_assets_backfill_with_partition_mapping(same_partitions):
         all_partitions=False,
     )
     assert backfill_data
-    with pendulum_freeze_time(test_time):
+    with freeze_time(test_time):
         result = execute_asset_backfill_iteration_consume_generator(
             backfill_id="test_backfill_id",
             asset_backfill_data=backfill_data,
@@ -707,9 +708,9 @@ def test_assets_backfill_with_partition_mapping_run_to_complete(same_partitions)
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
     if same_partitions:
         # time at which there will be an identical set of partitions for the downstream asset
-        test_time = pendulum.parse("2023-03-04T00:00:00", tz="UTC")
+        test_time = parse_with_timezone("2023-03-04T00:00:00")
     else:
-        test_time = pendulum.now("UTC")
+        test_time = get_current_datetime_in_utc()
 
     @asset(
         name="upstream_a",
@@ -1007,7 +1008,7 @@ def test_assets_backfill_with_partition_mapping_with_single_run_backfill_policy(
         all_partitions=False,
     )
     assert backfill_data
-    with pendulum_freeze_time(test_time):
+    with freeze_time(test_time):
         result = execute_asset_backfill_iteration_consume_generator(
             backfill_id="test_backfill_id",
             asset_backfill_data=backfill_data,

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from typing import List, NamedTuple, Optional
 
 import mock
-import pendulum
 import pytest
 from dagster import (
     AssetKey,
@@ -25,8 +24,8 @@ from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.materialize import materialize_to_memory
 from dagster._core.definitions.observe import observe
 from dagster._core.definitions.time_window_partitions import DailyPartitionsDefinition
-from dagster._core.test_utils import create_test_asset_job
-from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_freeze_time
+from dagster._core.test_utils import create_test_asset_job, freeze_time
+from dagster._seven import create_utc_datetime, get_current_datetime_in_utc
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 
@@ -265,9 +264,7 @@ scenarios = {
 
 @pytest.mark.parametrize("scenario", list(scenarios.values()), ids=list(scenarios.keys()))
 def test_partitioned_data_time(scenario):
-    with DagsterInstance.ephemeral() as instance, pendulum_freeze_time(
-        create_pendulum_time(2023, 1, 7)
-    ):
+    with DagsterInstance.ephemeral() as instance, freeze_time(create_utc_datetime(2023, 1, 7)):
         _materialize_partitions(instance, scenario.before_partitions)
         record = _get_record(instance=instance)
         _materialize_partitions(instance, scenario.after_partitions)
@@ -456,5 +453,5 @@ def test_non_volatile_data_time(timeline):
             action(
                 instance=instance,
                 times_by_key=times_by_key,
-                evaluation_time=pendulum.now("UTC"),
+                evaluation_time=get_current_datetime_in_utc(),
             )

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import random
 import string
@@ -8,7 +9,6 @@ from contextlib import ExitStack
 from typing import Any
 from unittest import mock
 
-import pendulum
 import pytest
 from dagster import (
     AssetKey,
@@ -83,6 +83,7 @@ from dagster._core.storage.captured_log_manager import CapturedLogManager
 from dagster._core.test_utils import (
     BlockingThreadPoolExecutor,
     create_test_daemon_workspace_context,
+    freeze_time,
     instance_for_test,
     wait_for_futures,
 )
@@ -90,12 +91,8 @@ from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._daemon import get_default_daemon_logger
 from dagster._daemon.daemon import SpanMarker
 from dagster._daemon.sensor import execute_sensor_iteration, execute_sensor_iteration_loop
-from dagster._seven.compat.pendulum import (
-    _IS_PENDULUM_3,
-    create_pendulum_time,
-    pendulum_freeze_time,
-    to_timezone,
-)
+from dagster._seven import create_utc_datetime, get_current_datetime_in_utc
+from dateutil.relativedelta import relativedelta
 
 from .conftest import create_workspace_load_target
 
@@ -1093,12 +1090,9 @@ def get_planned_asset_keys_for_run(instance: DagsterInstance, run_id: str):
 
 
 def test_ignore_auto_materialize_sensor(instance, workspace_context, external_repo, executor):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
-        "US/Central",
-    )
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("my_auto_materialize_sensor")
         assert external_sensor
         instance.add_instigator_state(
@@ -1120,12 +1114,9 @@ def test_ignore_auto_materialize_sensor(instance, workspace_context, external_re
 
 
 def test_simple_sensor(instance, workspace_context, external_repo, executor):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
-        "US/Central",
-    )
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -1154,9 +1145,9 @@ def test_simple_sensor(instance, workspace_context, external_repo, executor):
             TickStatus.SKIPPED,
         )
 
-        freeze_datetime = freeze_datetime.add(seconds=30)
+        freeze_datetime = freeze_datetime + relativedelta(seconds=30)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         wait_for_all_runs_to_start(instance)
         assert instance.get_runs_count() == 1
@@ -1167,7 +1158,7 @@ def test_simple_sensor(instance, workspace_context, external_repo, executor):
         )
         assert len(ticks) == 2
 
-        expected_datetime = create_pendulum_time(
+        expected_datetime = create_utc_datetime(
             year=2019, month=2, day=28, hour=0, minute=0, second=29
         )
         validate_tick(
@@ -1185,12 +1176,9 @@ def test_sensors_keyed_on_selector_not_origin(
     external_repo: ExternalRepository,
     executor: ThreadPoolExecutor,
 ):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
-        "US/Central",
-    )
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
 
         existing_origin = external_sensor.get_external_origin()
@@ -1233,12 +1221,9 @@ def test_bad_load_sensor_repository(
     workspace_context: WorkspaceProcessContext,
     external_repo: ExternalRepository,
 ):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
-        "US/Central",
-    )
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
 
         valid_origin = external_sensor.get_external_origin()
@@ -1268,12 +1253,9 @@ def test_bad_load_sensor_repository(
 
 
 def test_bad_load_sensor(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
-        "US/Central",
-    )
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
 
         valid_origin = external_sensor.get_external_origin()
@@ -1300,11 +1282,8 @@ def test_bad_load_sensor(executor, instance, workspace_context, external_repo):
 
 
 def test_error_sensor(caplog, executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("error_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -1356,18 +1335,15 @@ def test_error_sensor(caplog, executor, instance, workspace_context, external_re
 
 
 def test_wrong_config_sensor(caplog, executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(
-            year=2019,
-            month=2,
-            day=27,
-            hour=23,
-            minute=59,
-            second=59,
-        ),
-        "US/Central",
+    freeze_datetime = create_utc_datetime(
+        year=2019,
+        month=2,
+        day=27,
+        hour=23,
+        minute=59,
+        second=59,
     )
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("wrong_config_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -1400,9 +1376,9 @@ def test_wrong_config_sensor(caplog, executor, instance, workspace_context, exte
 
         assert "Error in config for job" in caplog.text
 
-    freeze_datetime = freeze_datetime.add(seconds=60)
+    freeze_datetime = freeze_datetime + relativedelta(seconds=60)
     caplog.clear()
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         # Error repeats on subsequent ticks
 
         evaluate_sensors(workspace_context, executor)
@@ -1425,10 +1401,7 @@ def test_wrong_config_sensor(caplog, executor, instance, workspace_context, exte
 
 
 def test_launch_failure(caplog, executor, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
-        "US/Central",
-    )
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
     with instance_for_test(
         overrides={
             "run_launcher": {
@@ -1437,7 +1410,7 @@ def test_launch_failure(caplog, executor, workspace_context, external_repo):
             },
         },
     ) as instance:
-        with pendulum_freeze_time(freeze_datetime):
+        with freeze_time(freeze_datetime):
             exploding_workspace_context = workspace_context.copy_for_test_instance(instance)
             external_sensor = external_repo.get_external_sensor("always_on_sensor")
             instance.add_instigator_state(
@@ -1475,20 +1448,16 @@ def test_launch_failure(caplog, executor, workspace_context, external_repo):
 
 
 def test_launch_once(caplog, executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(
-            year=2019,
-            month=2,
-            day=27,
-            hour=23,
-            minute=59,
-            second=59,
-            tz="UTC",
-        ),
-        "US/Central",
+    freeze_datetime = create_utc_datetime(
+        year=2019,
+        month=2,
+        day=27,
+        hour=23,
+        minute=59,
+        second=59,
     )
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("run_key_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -1521,8 +1490,8 @@ def test_launch_once(caplog, executor, instance, workspace_context, external_rep
         )
 
     # run again (after 30 seconds), to ensure that the run key maintains idempotence
-    freeze_datetime = freeze_datetime.add(seconds=30)
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = freeze_datetime + relativedelta(seconds=30)
+    with freeze_time(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         assert instance.get_runs_count() == 1
         ticks = instance.get_ticks(
@@ -1554,8 +1523,8 @@ def test_launch_once(caplog, executor, instance, workspace_context, external_rep
         )
 
         # Sensor loop still executes
-    freeze_datetime = freeze_datetime.add(seconds=30)
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = freeze_datetime + relativedelta(seconds=30)
+    with freeze_time(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
@@ -1571,10 +1540,8 @@ def test_launch_once(caplog, executor, instance, workspace_context, external_rep
 
 
 def test_custom_interval_sensor(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=28, tz="UTC"), "US/Central"
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=28)
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("custom_interval_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -1595,9 +1562,9 @@ def test_custom_interval_sensor(executor, instance, workspace_context, external_
         assert len(ticks) == 1
         validate_tick(ticks[0], external_sensor, freeze_datetime, TickStatus.SKIPPED)
 
-        freeze_datetime = freeze_datetime.add(seconds=30)
+        freeze_datetime = freeze_datetime + relativedelta(seconds=30)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
@@ -1605,16 +1572,16 @@ def test_custom_interval_sensor(executor, instance, workspace_context, external_
         # no additional tick created after 30 seconds
         assert len(ticks) == 1
 
-        freeze_datetime = freeze_datetime.add(seconds=30)
+        freeze_datetime = freeze_datetime + relativedelta(seconds=30)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 2
 
-        expected_datetime = create_pendulum_time(year=2019, month=2, day=28, hour=0, minute=1)
+        expected_datetime = create_utc_datetime(year=2019, month=2, day=28, hour=0, minute=1)
         validate_tick(ticks[0], external_sensor, expected_datetime, TickStatus.SKIPPED)
 
 
@@ -1637,26 +1604,27 @@ def test_sensor_spans(workspace_context):
             break
 
 
-@pytest.mark.skipif(_IS_PENDULUM_3, reason="pendulum.set_test_now not supported in pendulum 3")
 def test_custom_interval_sensor_with_offset(
     monkeypatch, executor, instance, workspace_context, external_repo
 ):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=28, tz="UTC"), "US/Central"
-    )
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=28)
 
-    sleeps = []
+    with ExitStack() as stack:
+        stack.enter_context(freeze_time(freeze_datetime))
+        sleeps = []
 
-    def fake_sleep(s):
-        sleeps.append(s)
-        pendulum.set_test_now(pendulum.now().add(seconds=s))
+        def fake_sleep(s):
+            sleeps.append(s)
 
-    monkeypatch.setattr(time, "sleep", fake_sleep)
+            stack.enter_context(
+                freeze_time(get_current_datetime_in_utc() + datetime.timedelta(seconds=s))
+            )
 
-    shutdown_event = mock.MagicMock()
-    shutdown_event.wait.side_effect = fake_sleep
+        monkeypatch.setattr(time, "sleep", fake_sleep)
 
-    with pendulum_freeze_time(freeze_datetime):
+        shutdown_event = mock.MagicMock()
+        shutdown_event.wait.side_effect = fake_sleep
+
         # 60 second custom interval
         external_sensor = external_repo.get_external_sensor("custom_interval_sensor")
 
@@ -1690,11 +1658,11 @@ def test_custom_interval_sensor_with_offset(
                 workspace_context,
                 get_default_daemon_logger("dagster.daemon.SensorDaemon"),
                 shutdown_event=shutdown_event,
-                until=freeze_datetime.add(seconds=65).timestamp(),
+                until=(freeze_datetime + relativedelta(seconds=65)).timestamp(),
             )
         )
 
-        assert pendulum.now() == freeze_datetime.add(seconds=65)
+        assert get_current_datetime_in_utc() == freeze_datetime + relativedelta(seconds=65)
         ticks = instance.get_ticks(
             external_sensor.get_external_origin_id(), external_sensor.selector_id
         )
@@ -1703,11 +1671,8 @@ def test_custom_interval_sensor_with_offset(
 
 
 def test_sensor_start_stop(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("always_on_sensor")
         external_origin_id = external_sensor.get_external_origin_id()
         instance.start_sensor(external_sensor)
@@ -1730,9 +1695,9 @@ def test_sensor_start_stop(executor, instance, workspace_context, external_repo)
             [run.run_id],
         )
 
-        freeze_datetime = freeze_datetime.add(seconds=15)
+        freeze_datetime = freeze_datetime + relativedelta(seconds=15)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         # no new ticks, no new runs, we are below the 30 second min interval
         assert instance.get_runs_count() == 1
@@ -1749,9 +1714,9 @@ def test_sensor_start_stop(executor, instance, workspace_context, external_repo)
         ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
         assert len(ticks) == 1
 
-        freeze_datetime = freeze_datetime.add(seconds=16)
+        freeze_datetime = freeze_datetime + relativedelta(seconds=16)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         # should have new tick, new run, we are after the 30 second min interval
         assert instance.get_runs_count() == 2
@@ -1760,11 +1725,8 @@ def test_sensor_start_stop(executor, instance, workspace_context, external_repo)
 
 
 def test_large_sensor(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("large_sensor")
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor, timeout=300)
@@ -1781,11 +1743,8 @@ def test_large_sensor(executor, instance, workspace_context, external_repo):
 
 
 def test_many_request_sensor(executor, submit_executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("many_request_sensor")
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor, submit_executor=submit_executor)
@@ -1802,11 +1761,8 @@ def test_many_request_sensor(executor, submit_executor, instance, workspace_cont
 
 
 def test_cursor_sensor(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         skip_sensor = external_repo.get_external_sensor("skip_cursor_sensor")
         run_sensor = external_repo.get_external_sensor("run_cursor_sensor")
         instance.start_sensor(skip_sensor)
@@ -1835,8 +1791,8 @@ def test_cursor_sensor(executor, instance, workspace_context, external_repo):
         )
         assert run_ticks[0].cursor == "1"
 
-    freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = freeze_datetime + relativedelta(seconds=60)
+    with freeze_time(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
 
         skip_ticks = instance.get_ticks(
@@ -1863,11 +1819,8 @@ def test_cursor_sensor(executor, instance, workspace_context, external_repo):
 
 
 def test_run_request_asset_selection_sensor(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("run_request_asset_selection_sensor")
         external_origin_id = external_sensor.get_external_origin_id()
         instance.start_sensor(external_sensor)
@@ -1899,11 +1852,8 @@ def test_run_request_asset_selection_sensor(executor, instance, workspace_contex
 def test_run_request_check_selection_only_sensor(
     executor, instance: DagsterInstance, workspace_context, external_repo
 ) -> None:
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("run_request_check_only_sensor")
         external_origin_id = external_sensor.get_external_origin_id()
         instance.start_sensor(external_sensor)
@@ -1941,12 +1891,9 @@ def test_run_request_check_selection_only_sensor(
 def test_run_request_stale_asset_selection_sensor_never_materialized(
     executor, instance, workspace_context, external_repo
 ):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("run_request_stale_asset_sensor")
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor)
@@ -1958,14 +1905,11 @@ def test_run_request_stale_asset_selection_sensor_never_materialized(
 def test_run_request_stale_asset_selection_sensor_empty(
     executor, instance, workspace_context, external_repo
 ):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
 
     materialize([a, b, c], instance=instance)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("run_request_stale_asset_sensor")
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor)
@@ -1976,14 +1920,11 @@ def test_run_request_stale_asset_selection_sensor_empty(
 def test_run_request_stale_asset_selection_sensor_subset(
     executor, instance, workspace_context, external_repo
 ):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
 
     materialize([a], instance=instance)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("run_request_stale_asset_sensor")
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor)
@@ -1993,11 +1934,8 @@ def test_run_request_stale_asset_selection_sensor_subset(
 
 
 def test_targets_asset_selection_sensor(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("targets_asset_selection_sensor")
         external_origin_id = external_sensor.get_external_origin_id()
         instance.start_sensor(external_sensor)
@@ -2039,11 +1977,8 @@ def test_targets_asset_selection_sensor(executor, instance, workspace_context, e
 
 
 def test_partitioned_asset_selection_sensor(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("partitioned_asset_selection_sensor")
         external_origin_id = external_sensor.get_external_origin_id()
         instance.start_sensor(external_sensor)
@@ -2072,11 +2007,8 @@ def test_partitioned_asset_selection_sensor(executor, instance, workspace_contex
 
 
 def test_asset_sensor(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         foo_sensor = external_repo.get_external_sensor("asset_foo_sensor")
         instance.start_sensor(foo_sensor)
 
@@ -2091,8 +2023,8 @@ def test_asset_sensor(executor, instance, workspace_context, external_repo):
             TickStatus.SKIPPED,
         )
 
-        freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum_freeze_time(freeze_datetime):
+        freeze_datetime = freeze_datetime + relativedelta(seconds=60)
+    with freeze_time(freeze_datetime):
         # should generate the foo asset
         foo_job.execute_in_process(instance=instance)
 
@@ -2113,11 +2045,8 @@ def test_asset_sensor(executor, instance, workspace_context, external_repo):
 
 
 def test_asset_job_sensor(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         job_sensor = external_repo.get_external_sensor("asset_job_sensor")
         instance.start_sensor(job_sensor)
 
@@ -2133,8 +2062,8 @@ def test_asset_job_sensor(executor, instance, workspace_context, external_repo):
         )
         assert "No new materialization events" in ticks[0].tick_data.skip_reason
 
-        freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum_freeze_time(freeze_datetime):
+        freeze_datetime = freeze_datetime + relativedelta(seconds=60)
+    with freeze_time(freeze_datetime):
         # should generate the foo asset
         foo_job.execute_in_process(instance=instance)
 
@@ -2157,11 +2086,8 @@ def test_asset_job_sensor(executor, instance, workspace_context, external_repo):
 def test_asset_sensor_not_triggered_on_observation(
     executor, instance, workspace_context, external_repo
 ):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         foo_sensor = external_repo.get_external_sensor("asset_foo_sensor")
         instance.start_sensor(foo_sensor)
 
@@ -2180,8 +2106,8 @@ def test_asset_sensor_not_triggered_on_observation(
             TickStatus.SKIPPED,
         )
 
-        freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum_freeze_time(freeze_datetime):
+        freeze_datetime = freeze_datetime + relativedelta(seconds=60)
+    with freeze_time(freeze_datetime):
         # should generate the foo asset
         foo_job.execute_in_process(instance=instance)
 
@@ -2202,11 +2128,8 @@ def test_asset_sensor_not_triggered_on_observation(
 
 
 def test_multi_asset_sensor(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         a_and_b_sensor = external_repo.get_external_sensor("asset_a_and_b_sensor")
         instance.start_sensor(a_and_b_sensor)
 
@@ -2223,8 +2146,8 @@ def test_multi_asset_sensor(executor, instance, workspace_context, external_repo
             TickStatus.SKIPPED,
         )
 
-        freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum_freeze_time(freeze_datetime):
+        freeze_datetime = freeze_datetime + relativedelta(seconds=60)
+    with freeze_time(freeze_datetime):
         # should generate asset_a
         materialize([asset_a], instance=instance)
 
@@ -2242,9 +2165,9 @@ def test_multi_asset_sensor(executor, instance, workspace_context, external_repo
             TickStatus.SKIPPED,
         )
 
-        freeze_datetime = freeze_datetime.add(seconds=60)
+        freeze_datetime = freeze_datetime + relativedelta(seconds=60)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         # should generate asset_b
         materialize([asset_b], instance=instance)
 
@@ -2267,11 +2190,8 @@ def test_multi_asset_sensor(executor, instance, workspace_context, external_repo
 
 
 def test_asset_selection_sensor(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         asset_selection_sensor = external_repo.get_external_sensor("asset_selection_sensor")
         instance.start_sensor(asset_selection_sensor)
 
@@ -2292,11 +2212,8 @@ def test_asset_selection_sensor(executor, instance, workspace_context, external_
 def test_multi_asset_sensor_targets_asset_selection(
     executor, instance, workspace_context, external_repo
 ):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         multi_asset_sensor_targets_asset_selection = external_repo.get_external_sensor(
             "multi_asset_sensor_targets_asset_selection"
         )
@@ -2316,8 +2233,8 @@ def test_multi_asset_sensor_targets_asset_selection(
             TickStatus.SKIPPED,
         )
 
-        freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum_freeze_time(freeze_datetime):
+        freeze_datetime = freeze_datetime + relativedelta(seconds=60)
+    with freeze_time(freeze_datetime):
         # should generate asset_a
         materialize([asset_a], instance=instance)
 
@@ -2336,9 +2253,9 @@ def test_multi_asset_sensor_targets_asset_selection(
             TickStatus.SKIPPED,
         )
 
-        freeze_datetime = freeze_datetime.add(seconds=60)
+        freeze_datetime = freeze_datetime + relativedelta(seconds=60)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         # should generate asset_b
         materialize([asset_b], instance=instance)
 
@@ -2363,11 +2280,8 @@ def test_multi_asset_sensor_targets_asset_selection(
 
 
 def test_multi_asset_sensor_w_many_events(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         backlog_sensor = external_repo.get_external_sensor("backlog_sensor")
         instance.start_sensor(backlog_sensor)
 
@@ -2384,8 +2298,8 @@ def test_multi_asset_sensor_w_many_events(executor, instance, workspace_context,
             TickStatus.SKIPPED,
         )
 
-        freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum_freeze_time(freeze_datetime):
+        freeze_datetime = freeze_datetime + relativedelta(seconds=60)
+    with freeze_time(freeze_datetime):
         # should generate asset_a
         materialize([asset_a], instance=instance)
 
@@ -2402,9 +2316,9 @@ def test_multi_asset_sensor_w_many_events(executor, instance, workspace_context,
             TickStatus.SKIPPED,
         )
 
-        freeze_datetime = freeze_datetime.add(seconds=60)
+        freeze_datetime = freeze_datetime + relativedelta(seconds=60)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         # should generate asset_a
         materialize([asset_a], instance=instance)
 
@@ -2429,11 +2343,8 @@ def test_multi_asset_sensor_w_many_events(executor, instance, workspace_context,
 def test_multi_asset_sensor_w_no_cursor_update(
     executor, instance, workspace_context, external_repo
 ):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         cursor_sensor = external_repo.get_external_sensor("doesnt_update_cursor_sensor")
         instance.start_sensor(cursor_sensor)
 
@@ -2450,8 +2361,8 @@ def test_multi_asset_sensor_w_no_cursor_update(
             TickStatus.SKIPPED,
         )
 
-        freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum_freeze_time(freeze_datetime):
+        freeze_datetime = freeze_datetime + relativedelta(seconds=60)
+    with freeze_time(freeze_datetime):
         # should generate asset_a
         materialize([asset_a], instance=instance)
 
@@ -2469,11 +2380,8 @@ def test_multi_asset_sensor_w_no_cursor_update(
 
 
 def test_multi_asset_sensor_hourly_to_weekly(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2022, month=8, day=2, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2022, month=8, day=2)
+    with freeze_time(freeze_datetime):
         materialize([hourly_asset], instance=instance, partition_key="2022-08-01-00:00")
         cursor_sensor = external_repo.get_external_sensor("multi_asset_sensor_hourly_to_weekly")
         instance.start_sensor(cursor_sensor)
@@ -2498,11 +2406,8 @@ def test_multi_asset_sensor_hourly_to_weekly(executor, instance, workspace_conte
 
 
 def test_multi_asset_sensor_hourly_to_hourly(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2022, month=8, day=3, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2022, month=8, day=3)
+    with freeze_time(freeze_datetime):
         materialize([hourly_asset], instance=instance, partition_key="2022-08-02-00:00")
         cursor_sensor = external_repo.get_external_sensor("multi_asset_sensor_hourly_to_hourly")
         instance.start_sensor(cursor_sensor)
@@ -2526,9 +2431,9 @@ def test_multi_asset_sensor_hourly_to_hourly(executor, instance, workspace_conte
         assert run.tags.get("dagster/sensor_name") == "multi_asset_sensor_hourly_to_hourly"
         assert run.tags.get("dagster/partition") == "2022-08-02-00:00"
 
-        freeze_datetime = freeze_datetime.add(seconds=30)
+        freeze_datetime = freeze_datetime + relativedelta(seconds=30)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         cursor_sensor = external_repo.get_external_sensor("multi_asset_sensor_hourly_to_hourly")
         instance.start_sensor(cursor_sensor)
 
@@ -2542,11 +2447,8 @@ def test_multi_asset_sensor_hourly_to_hourly(executor, instance, workspace_conte
 
 
 def test_sensor_result_multi_asset_sensor(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2022, month=8, day=3, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2022, month=8, day=3)
+    with freeze_time(freeze_datetime):
         cursor_sensor = external_repo.get_external_sensor("sensor_result_multi_asset_sensor")
         instance.start_sensor(cursor_sensor)
 
@@ -2567,11 +2469,8 @@ def test_sensor_result_multi_asset_sensor(executor, instance, workspace_context,
 def test_cursor_update_sensor_result_multi_asset_sensor(
     executor, instance, workspace_context, external_repo
 ):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2022, month=8, day=3, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2022, month=8, day=3)
+    with freeze_time(freeze_datetime):
         cursor_sensor = external_repo.get_external_sensor("cursor_sensor_result_multi_asset_sensor")
         instance.start_sensor(cursor_sensor)
 
@@ -2591,11 +2490,8 @@ def test_cursor_update_sensor_result_multi_asset_sensor(
 
 
 def test_multi_job_sensor(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         job_sensor = external_repo.get_external_sensor("two_job_sensor")
         instance.start_sensor(job_sensor)
 
@@ -2615,8 +2511,8 @@ def test_multi_job_sensor(executor, instance, workspace_context, external_repo):
         assert run.tags.get("dagster/sensor_name") == "two_job_sensor"
         assert run.job_name == "the_job"
 
-        freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum_freeze_time(freeze_datetime):
+        freeze_datetime = freeze_datetime + relativedelta(seconds=60)
+    with freeze_time(freeze_datetime):
         # should fire the asset sensor
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(job_sensor.get_external_origin_id(), job_sensor.selector_id)
@@ -2635,11 +2531,8 @@ def test_multi_job_sensor(executor, instance, workspace_context, external_repo):
 
 
 def test_bad_run_request_untargeted(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         job_sensor = external_repo.get_external_sensor("bad_request_untargeted")
         instance.start_sensor(job_sensor)
 
@@ -2660,11 +2553,8 @@ def test_bad_run_request_untargeted(executor, instance, workspace_context, exter
 
 
 def test_bad_run_request_mismatch(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         job_sensor = external_repo.get_external_sensor("bad_request_mismatch")
         instance.start_sensor(job_sensor)
 
@@ -2684,11 +2574,8 @@ def test_bad_run_request_mismatch(executor, instance, workspace_context, externa
 
 
 def test_bad_run_request_unspecified(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         job_sensor = external_repo.get_external_sensor("bad_request_unspecified")
         instance.start_sensor(job_sensor)
 
@@ -2709,10 +2596,7 @@ def test_bad_run_request_unspecified(executor, instance, workspace_context, exte
 
 
 def test_status_in_code_sensor(executor, instance):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
-        "US/Central",
-    )
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
     with create_test_daemon_workspace_context(
         create_workspace_load_target(attribute="the_status_in_code_repo"),
         instance=instance,
@@ -2721,7 +2605,7 @@ def test_status_in_code_sensor(executor, instance):
             iter(workspace_context.create_request_context().get_workspace_snapshot().values())
         ).code_location.get_repository("the_status_in_code_repo")
 
-        with pendulum_freeze_time(freeze_datetime):
+        with freeze_time(freeze_datetime):
             running_sensor = external_repo.get_external_sensor("always_running_sensor")
             not_running_sensor = external_repo.get_external_sensor("never_running_sensor")
 
@@ -2816,8 +2700,8 @@ def test_status_in_code_sensor(executor, instance):
             )
             assert len(ticks) == 1
 
-        freeze_datetime = freeze_datetime.add(seconds=30)
-        with pendulum_freeze_time(freeze_datetime):
+        freeze_datetime = freeze_datetime + relativedelta(seconds=30)
+        with freeze_time(freeze_datetime):
             evaluate_sensors(workspace_context, executor)
             wait_for_all_runs_to_start(instance)
             assert instance.get_runs_count() == 1
@@ -2829,7 +2713,7 @@ def test_status_in_code_sensor(executor, instance):
 
             assert len(ticks) == 2
 
-            expected_datetime = create_pendulum_time(
+            expected_datetime = create_utc_datetime(
                 year=2019, month=2, day=28, hour=0, minute=0, second=29
             )
             validate_tick(
@@ -2852,11 +2736,8 @@ def test_status_in_code_sensor(executor, instance):
 
 
 def test_run_request_list_sensor(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("request_list_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -2881,11 +2762,8 @@ def test_run_request_list_sensor(executor, instance, workspace_context, external
 
 
 def test_sensor_purge(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -2906,9 +2784,9 @@ def test_sensor_purge(executor, instance, workspace_context, external_repo):
             external_sensor.get_external_origin_id(), external_sensor.selector_id
         )
         assert len(ticks) == 1
-        freeze_datetime = freeze_datetime.add(days=6)
+        freeze_datetime = freeze_datetime + relativedelta(days=6)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         # create another tick
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
@@ -2916,9 +2794,9 @@ def test_sensor_purge(executor, instance, workspace_context, external_repo):
         )
         assert len(ticks) == 2
 
-        freeze_datetime = freeze_datetime.add(days=2)
+        freeze_datetime = freeze_datetime + relativedelta(days=2)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         # create another tick, but the first tick should be purged
         evaluate_sensors(workspace_context, executor)
         ticks = instance.get_ticks(
@@ -2928,10 +2806,7 @@ def test_sensor_purge(executor, instance, workspace_context, external_repo):
 
 
 def test_sensor_custom_purge(executor, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
-        "US/Central",
-    )
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
     with instance_for_test(
         overrides={
             "retention": {"sensor": {"purge_after_days": {"skipped": 14}}},
@@ -2939,7 +2814,7 @@ def test_sensor_custom_purge(executor, workspace_context, external_repo):
         },
     ) as instance:
         purge_ws_ctx = workspace_context.copy_for_test_instance(instance)
-        with pendulum_freeze_time(freeze_datetime):
+        with freeze_time(freeze_datetime):
             external_sensor = external_repo.get_external_sensor("simple_sensor")
             instance.add_instigator_state(
                 InstigatorState(
@@ -2960,9 +2835,9 @@ def test_sensor_custom_purge(executor, workspace_context, external_repo):
                 external_sensor.get_external_origin_id(), external_sensor.selector_id
             )
             assert len(ticks) == 1
-            freeze_datetime = freeze_datetime.add(days=8)
+            freeze_datetime = freeze_datetime + relativedelta(days=8)
 
-        with pendulum_freeze_time(freeze_datetime):
+        with freeze_time(freeze_datetime):
             # create another tick, and the first tick should not be purged despite the fact that the
             # default purge day offset is 7
             evaluate_sensors(purge_ws_ctx, executor)
@@ -2971,9 +2846,9 @@ def test_sensor_custom_purge(executor, workspace_context, external_repo):
             )
             assert len(ticks) == 2
 
-            freeze_datetime = freeze_datetime.add(days=7)
+            freeze_datetime = freeze_datetime + relativedelta(days=7)
 
-        with pendulum_freeze_time(freeze_datetime):
+        with freeze_time(freeze_datetime):
             # create another tick, but the first tick should be purged
             evaluate_sensors(purge_ws_ctx, executor)
             ticks = instance.get_ticks(
@@ -2983,17 +2858,13 @@ def test_sensor_custom_purge(executor, workspace_context, external_repo):
 
 
 def test_repository_namespacing(executor):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(
-            year=2019,
-            month=2,
-            day=27,
-            hour=23,
-            minute=59,
-            second=59,
-            tz="UTC",
-        ),
-        "US/Central",
+    freeze_datetime = create_utc_datetime(
+        year=2019,
+        month=2,
+        day=27,
+        hour=23,
+        minute=59,
+        second=59,
     )
     with ExitStack() as exit_stack:
         instance = exit_stack.enter_context(instance_for_test())
@@ -3020,7 +2891,7 @@ def test_repository_namespacing(executor):
         external_sensor = external_repo.get_external_sensor("run_key_sensor")
         other_sensor = other_repo.get_external_sensor("run_key_sensor")
 
-        with pendulum_freeze_time(freeze_datetime):
+        with freeze_time(freeze_datetime):
             instance.start_sensor(external_sensor)
             assert instance.get_runs_count() == 0
             ticks = instance.get_ticks(
@@ -3053,8 +2924,8 @@ def test_repository_namespacing(executor):
             assert len(ticks) == 1
 
         # run again (after 30 seconds), to ensure that the run key maintains idempotence
-        freeze_datetime = freeze_datetime.add(seconds=30)
-        with pendulum_freeze_time(freeze_datetime):
+        freeze_datetime = freeze_datetime + relativedelta(seconds=30)
+        with freeze_time(freeze_datetime):
             evaluate_sensors(full_workspace_context, executor)
             assert instance.get_runs_count() == 2  # still 2
             ticks = instance.get_ticks(
@@ -3216,20 +3087,16 @@ def test_add_delete_skip_dynamic_partitions(
     )
     assert len(ticks) == 0
 
-    freeze_datetime = to_timezone(
-        create_pendulum_time(
-            year=2023,
-            month=2,
-            day=27,
-            hour=23,
-            minute=59,
-            second=59,
-            tz="UTC",
-        ),
-        "US/Central",
+    freeze_datetime = create_utc_datetime(
+        year=2023,
+        month=2,
+        day=27,
+        hour=23,
+        minute=59,
+        second=59,
     )
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
@@ -3262,8 +3129,8 @@ def test_add_delete_skip_dynamic_partitions(
         assert run.tags
         assert run.tags.get("dagster/partition") == "1"
 
-    freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = freeze_datetime + relativedelta(seconds=60)
+    with freeze_time(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
 
         ticks = instance.get_ticks(
@@ -3428,15 +3295,12 @@ def test_code_location_construction():
 
 
 def test_stale_request_context(instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, hour=23, minute=59, second=59, tz="UTC"),
-        "US/Central",
-    )
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
 
     executor = ThreadPoolExecutor()
     blocking_executor = BlockingThreadPoolExecutor()
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         external_sensor = external_repo.get_external_sensor("simple_sensor")
         instance.add_instigator_state(
             InstigatorState(
@@ -3477,9 +3341,9 @@ def test_stale_request_context(instance, workspace_context, external_repo):
         )
 
     blocking_executor.block()
-    freeze_datetime = freeze_datetime.add(seconds=30)
+    freeze_datetime = freeze_datetime + relativedelta(seconds=30)
 
-    with pendulum_freeze_time(freeze_datetime):
+    with freeze_time(freeze_datetime):
         futures = {}
         list(
             execute_sensor_iteration(
@@ -3511,7 +3375,7 @@ def test_stale_request_context(instance, workspace_context, external_repo):
         run = instance.get_runs()[0]
         validate_run_started(run)
 
-        expected_datetime = create_pendulum_time(
+        expected_datetime = create_utc_datetime(
             year=2019, month=2, day=28, hour=0, minute=0, second=29
         )
         validate_tick(
@@ -3524,11 +3388,8 @@ def test_stale_request_context(instance, workspace_context, external_repo):
 
 
 def test_start_tick_sensor(executor, instance, workspace_context, external_repo):
-    freeze_datetime = to_timezone(
-        create_pendulum_time(year=2019, month=2, day=27, tz="UTC"),
-        "US/Central",
-    )
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = create_utc_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
         start_skip_sensor = external_repo.get_external_sensor("start_skip_sensor")
         instance.start_sensor(start_skip_sensor)
         evaluate_sensors(workspace_context, executor)
@@ -3537,15 +3398,15 @@ def test_start_tick_sensor(executor, instance, workspace_context, external_repo)
         last_sensor_start_time = last_tick.tick_data.cursor
         assert last_sensor_start_time
 
-    freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = freeze_datetime + relativedelta(seconds=60)
+    with freeze_time(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         last_tick = _get_last_tick(instance, start_skip_sensor)
         validate_tick(last_tick, start_skip_sensor, freeze_datetime, TickStatus.SUCCESS)
         assert last_sensor_start_time == last_tick.cursor
 
-    freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = freeze_datetime + relativedelta(seconds=60)
+    with freeze_time(freeze_datetime):
         instance.stop_sensor(
             start_skip_sensor.get_external_origin_id(),
             start_skip_sensor.selector_id,
@@ -3559,8 +3420,8 @@ def test_start_tick_sensor(executor, instance, workspace_context, external_repo)
         assert last_tick.cursor != last_sensor_start_time
         last_sensor_start_time = last_tick.cursor
 
-    freeze_datetime = freeze_datetime.add(seconds=60)
-    with pendulum_freeze_time(freeze_datetime):
+    freeze_datetime = freeze_datetime + relativedelta(seconds=60)
+    with freeze_time(freeze_datetime):
         evaluate_sensors(workspace_context, executor)
         last_tick = _get_last_tick(instance, start_skip_sensor)
         validate_tick(last_tick, start_skip_sensor, freeze_datetime, TickStatus.SUCCESS)


### PR DESCRIPTION
## Summary & Motivation
More of the same - moving test callsites off of pendulum and into the new freeze_time helper function instead.

## How I Tested These Changes
