### PR TITLE
allow multiple `Definitions` objects in a single module

### DIFF
--- a/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
+++ b/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
@@ -9,6 +9,7 @@ from dagster._core.definitions.load_assets_from_modules import assets_from_modul
 from dagster._core.definitions.repository_definition import PendingRepositoryDefinition
 
 LOAD_ALL_ASSETS = "<<LOAD_ALL_ASSETS>>"
+DEFS_PRIMARY_ATTR_NAME = "defs"
 
 
 class LoadableTarget(NamedTuple):
@@ -54,9 +55,19 @@ def loadable_targets_from_loaded_module(module: ModuleType) -> Sequence[Loadable
 
     if loadable_defs:
         if len(loadable_defs) > 1:
-            raise DagsterInvariantViolationError(
-                "Cannot have more than one Definitions object defined at module scope"
-            )
+            loadable_defs_named_defs = [
+                loadable_defs_object
+                for loadable_defs_object in loadable_defs
+                if loadable_defs_object.attribute == DEFS_PRIMARY_ATTR_NAME
+            ]
+
+            if len(loadable_defs_named_defs) == 1:
+                return loadable_defs_named_defs
+            else:
+                raise DagsterInvariantViolationError(
+                    "Cannot have more than one Definitions object defined at module scope, unless "
+                    "one is named 'defs'"
+                )
 
         return loadable_defs
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/double_defs_no_clear_choice.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/double_defs_no_clear_choice.py
@@ -1,0 +1,9 @@
+from dagster import Definitions
+
+
+def _make_defs():
+    return Definitions()
+
+
+defs_foo = _make_defs()
+defs_bar = _make_defs()

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
@@ -195,13 +195,20 @@ def test_single_def_any_name():
     assert symbol == "not_defs"
 
 
-def test_double_defs_in_file():
-    dagster_defs_path = file_relative_path(__file__, "double_defs.py")
+def test_double_defs_in_file_no_clear_choice():
+    dagster_defs_path = file_relative_path(__file__, "double_defs_no_clear_choice.py")
     with pytest.raises(
         DagsterInvariantViolationError,
         match="Cannot have more than one Definitions object defined at module scope",
     ):
         loadable_targets_from_python_file(dagster_defs_path)
+
+
+def test_double_defs_in_file_one_named_defs():
+    dagster_defs_path = file_relative_path(__file__, "double_defs.py")
+    loadable_targets = loadable_targets_from_python_file(dagster_defs_path)
+    assert len(loadable_targets) == 1
+    assert loadable_targets[0].attribute == "defs"
 
 
 def _current_test_directory_paths():


### PR DESCRIPTION
## Summary & Motivation

We recently introduced `Definitions.merge`, with the aim of enabling this kind of pattern:

```python
from marketing import marketing_defs
from sales import sales_defs

defs = Definitions.merge(marketing_defs, sales_defs)
```

However, the above snippet currently fails with
```
DagsterInvariantViolationError("Cannot have more than one Definitions object defined at module scope")
```

This PR makes it no longer fail, by special-casing variables named `defs`.


## How I Tested These Changes
