### PR TITLE
[dagstermill] add asset_tags arg to asset factory

### DIFF
--- a/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
+++ b/python_modules/libraries/dagstermill/dagstermill/asset_factory.py
@@ -86,6 +86,7 @@ def define_dagstermill_asset(
     retry_policy: Optional[RetryPolicy] = None,
     save_notebook_on_failure: bool = False,
     non_argument_deps: Optional[Union[Set[AssetKey], Set[str]]] = None,
+    asset_tags: Optional[Mapping[str, Any]] = None,
 ) -> AssetsDefinition:
     """Creates a Dagster asset for a Jupyter notebook.
 
@@ -124,6 +125,7 @@ def define_dagstermill_asset(
         save_notebook_on_failure (bool): If True and the notebook fails during execution, the failed notebook will be
             written to the Dagster storage directory. The location of the file will be printed in the Dagster logs.
             Defaults to False.
+        asset_tags (Optional[Dict[str, Any]]): A dictionary of tags to apply to the asset.
         non_argument_deps (Optional[Union[Set[AssetKey], Set[str]]]): Deprecated, use deps instead. Set of asset keys that are
             upstream dependencies, but do not pass an input to the asset.
 
@@ -211,6 +213,7 @@ def define_dagstermill_asset(
         io_manager_key=io_mgr_key,
         retry_policy=retry_policy,
         non_argument_deps=non_argument_deps,
+        tags=asset_tags,
     )(
         _make_dagstermill_asset_compute_fn(
             name=name,

--- a/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
+++ b/python_modules/libraries/dagstermill/dagstermill/examples/repository.py
@@ -570,6 +570,7 @@ custom_io_mgr_key_asset = dagstermill.define_dagstermill_asset(
     name="custom_io_mgr_key",
     notebook_path=nb_test_path("hello_world"),
     io_manager_key="my_custom_io_manager",
+    asset_tags={"foo": "bar"},
 )
 
 yield_event_asset = dagstermill.define_dagstermill_asset(

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_assets.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_assets.py
@@ -1,8 +1,10 @@
 import os
 from contextlib import contextmanager
+from typing import cast
 
 import pytest
 from dagster import AssetKey, DagsterEventType
+from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.metadata import NotebookMetadataValue, PathMetadataValue
 from dagster._core.definitions.reconstruct import ReconstructableJob
 from dagster._core.execution.api import execute_job
@@ -107,6 +109,12 @@ def test_add_two_number_asset():
 def test_hello_world_resource_asset():
     with exec_for_test("hello_world_resource_asset_job") as result:
         assert result.success
+
+
+@pytest.mark.notebook_test
+def test_asset_tags() -> None:
+    key = cast(AssetsDefinition, custom_io_mgr_key_asset).key
+    assert cast(AssetsDefinition, custom_io_mgr_key_asset).tags_by_key[key] == {"foo": "bar"}
 
 
 @pytest.mark.notebook_test


### PR DESCRIPTION
## Summary

Adds the ability to specify `asset_tags` on `define_dagstermill_asset`. Could call this param just `tags` too - went with `asset_tags` just to explicitly differentiate from existing `op_tags` arg.


## Test Plan

New unit test.
