### PR TITLE
[4/n] Replace pendulum.now() with get_current_datetime and get_current_timestamp

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -3,7 +3,6 @@ from typing import Any, Mapping, Optional, Sequence
 from unittest.mock import PropertyMock, patch
 
 import dagster._check as check
-import pendulum
 from dagster import AssetKey, RunRequest
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.asset_subset import AssetSubset
@@ -36,7 +35,9 @@ from dagster._daemon.asset_daemon import (
     asset_daemon_cursor_to_instigator_serialized_cursor,
 )
 from dagster._serdes.serdes import serialize_value
+from dagster._seven import get_current_datetime_in_utc
 from dagster_graphql.test.utils import execute_dagster_graphql, infer_repository
+from dateutil.relativedelta import relativedelta
 
 from dagster_graphql_tests.graphql.graphql_context_test_suite import (
     ExecutingGraphQLContextTestMatrix,
@@ -91,7 +92,7 @@ class TestAutoMaterializeTicks(ExecutingGraphQLContextTestMatrix):
         )
         assert len(result.data["autoMaterializeTicks"]) == 0
 
-        now = pendulum.now("UTC")
+        now = get_current_datetime_in_utc()
         end_timestamp = now.timestamp() + 20
 
         success_1 = _create_tick(
@@ -110,14 +111,14 @@ class TestAutoMaterializeTicks(ExecutingGraphQLContextTestMatrix):
         success_2 = _create_tick(
             graphql_context.instance,
             TickStatus.SUCCESS,
-            now.subtract(days=1, hours=1).timestamp(),
+            (now - relativedelta(days=1, hours=1)).timestamp(),
             evaluation_id=2,
         )
 
         _create_tick(
             graphql_context.instance,
             TickStatus.SKIPPED,
-            now.subtract(days=2, hours=1).timestamp(),
+            (now - relativedelta(days=2, hours=1)).timestamp(),
             evaluation_id=1,
         )
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
@@ -24,7 +24,7 @@ from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_START_TAG,
 )
 from dagster._core.test_utils import freeze_time
-from dagster._seven import get_current_datetime_in_utc, parse_with_timezone
+from dagster._seven import get_current_datetime_in_utc, get_current_timestamp, parse_with_timezone
 
 from dagster_tests.core_tests.execution_tests.test_asset_backfill import (
     execute_asset_backfill_iteration_consume_generator,
@@ -62,7 +62,7 @@ def test_asset_backfill_not_all_asset_have_backfill_policy():
         ],
         dynamic_partitions_store=MagicMock(),
         all_partitions=True,
-        backfill_start_timestamp=pendulum.now("UTC").timestamp(),
+        backfill_start_timestamp=get_current_timestamp(),
     )
 
     with pytest.raises(
@@ -81,7 +81,7 @@ def test_asset_backfill_not_all_asset_have_backfill_policy():
 
 
 def test_asset_backfill_parent_and_children_have_different_backfill_policy():
-    time_now = pendulum.now("UTC")
+    time_now = get_current_datetime_in_utc()
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
 
     @asset(partitions_def=daily_partitions_def, backfill_policy=BackfillPolicy.single_run())
@@ -127,7 +127,7 @@ def test_asset_backfill_parent_and_children_have_different_backfill_policy():
 
 
 def test_asset_backfill_parent_and_children_have_same_backfill_policy():
-    time_now = pendulum.now("UTC")
+    time_now = get_current_datetime_in_utc()
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
 
     @asset(backfill_policy=BackfillPolicy.single_run())
@@ -196,7 +196,7 @@ def test_asset_backfill_parent_and_children_have_same_backfill_policy_but_third_
     """Tests that when a backfill contains multiple backfill policies, we still group assets with the
     same backfill policy in a single run.
     """
-    time_now = pendulum.now("UTC")
+    time_now = get_current_datetime_in_utc()
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
 
     @asset(partitions_def=daily_partitions_def, backfill_policy=BackfillPolicy.multi_run(10))
@@ -272,7 +272,7 @@ def test_asset_backfill_return_single_run_request_for_non_partitioned():
         ],
         dynamic_partitions_store=MagicMock(),
         all_partitions=True,
-        backfill_start_timestamp=pendulum.now("UTC").timestamp(),
+        backfill_start_timestamp=get_current_timestamp(),
     )
     backfill_id = "test_backfill_id"
     result = execute_asset_backfill_iteration_consume_generator(
@@ -288,7 +288,7 @@ def test_asset_backfill_return_single_run_request_for_non_partitioned():
 
 
 def test_asset_backfill_return_single_run_request_for_partitioned():
-    time_now = pendulum.now("UTC")
+    time_now = get_current_datetime_in_utc()
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
 
     @asset(partitions_def=daily_partitions_def, backfill_policy=BackfillPolicy.single_run())
@@ -330,7 +330,7 @@ def test_asset_backfill_return_single_run_request_for_partitioned():
 
 
 def test_asset_backfill_return_multiple_run_request_for_partitioned():
-    time_now = pendulum.now("UTC")
+    time_now = get_current_datetime_in_utc()
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition(
         "2023-01-01", end_date="2023-08-11"
     )
@@ -378,7 +378,7 @@ def test_asset_backfill_status_count_with_backfill_policies():
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
     weekly_partitions_def = WeeklyPartitionsDefinition("2023-01-01")
 
-    time_now = pendulum.now("UTC")
+    time_now = get_current_datetime_in_utc()
     num_of_daily_partitions = daily_partitions_def.get_num_partitions(time_now)
     num_of_weekly_partitions = weekly_partitions_def.get_num_partitions(time_now)
 
@@ -462,7 +462,7 @@ def test_backfill_run_contains_more_than_one_asset():
     upstream_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
     downstream_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-02")
 
-    time_now = pendulum.now("UTC")
+    time_now = get_current_datetime_in_utc()
     upstream_num_of_partitions = upstream_partitions_def.get_num_partitions(time_now)
     downstream_num_of_partitions = downstream_partitions_def.get_num_partitions(time_now)
 
@@ -577,7 +577,7 @@ def test_dynamic_partitions_multi_run_backfill_policy():
         asset_selection=[asset1.key],
         dynamic_partitions_store=instance,
         partition_names=["foo", "bar"],
-        backfill_start_timestamp=pendulum.now("UTC").timestamp(),
+        backfill_start_timestamp=get_current_timestamp(),
         all_partitions=False,
     )
 
@@ -619,7 +619,7 @@ def test_dynamic_partitions_single_run_backfill_policy():
         asset_selection=[asset1.key],
         dynamic_partitions_store=instance,
         partition_names=["foo", "bar"],
-        backfill_start_timestamp=pendulum.now("UTC").timestamp(),
+        backfill_start_timestamp=get_current_timestamp(),
         all_partitions=False,
     )
 
@@ -783,7 +783,7 @@ def test_assets_backfill_with_partition_mapping_run_to_complete(same_partitions)
 
 def test_assets_backfill_with_partition_mapping_without_backfill_policy():
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
-    time_now = pendulum.now("UTC")
+    time_now = get_current_datetime_in_utc()
 
     @asset(
         name="upstream_a",
@@ -844,7 +844,7 @@ def test_assets_backfill_with_partition_mapping_without_backfill_policy():
 
 def test_assets_backfill_with_partition_mapping_with_one_partition_multi_run_backfill_policy():
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
-    time_now = pendulum.now("UTC")
+    time_now = get_current_datetime_in_utc()
 
     @asset(
         name="upstream_a",
@@ -897,7 +897,7 @@ def test_assets_backfill_with_partition_mapping_with_one_partition_multi_run_bac
 
 def test_assets_backfill_with_partition_mapping_with_multi_partitions_multi_run_backfill_policy():
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
-    time_now = pendulum.now("UTC")
+    time_now = get_current_datetime_in_utc()
 
     @asset(
         name="upstream_a",
@@ -1076,7 +1076,7 @@ def test_run_request_partition_order():
 def test_single_run_backfill_full_execution(
     batch_size: int, throw_store_event_batch_error: bool, capsys, monkeypatch
 ):
-    time_now = pendulum.now("UTC")
+    time_now = get_current_datetime_in_utc()
 
     partitions_def = StaticPartitionsDefinition(["a", "b", "c", "d"])
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_active_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_active_data.py
@@ -2,7 +2,6 @@ from concurrent.futures import ThreadPoolExecutor, wait
 from datetime import datetime
 from unittest import mock
 
-import pendulum
 from dagster import daily_partitioned_config, job, op, repository
 from dagster._core.definitions.decorators.schedule_decorator import schedule
 from dagster._core.remote_representation import (
@@ -16,6 +15,7 @@ from dagster._core.snap.job_snapshot import create_job_snapshot_id
 from dagster._core.test_utils import in_process_test_workspace, instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._serdes import serialize_pp
+from dagster._seven import get_current_datetime_in_utc
 
 
 @op
@@ -64,7 +64,7 @@ def test_external_repository_data(snapshot):
         job_partition_set_data.external_partitions_data, ExternalTimeWindowPartitionsDefinitionData
     )
 
-    now = pendulum.now()
+    now = get_current_datetime_in_utc()
 
     assert (
         job_partition_set_data.external_partitions_data.get_partitions_definition().get_partition_keys(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -7,7 +7,6 @@ import time
 
 import dagster._check as check
 import mock
-import pendulum
 import pytest
 from dagster import (
     AllPartitionMapping,
@@ -67,7 +66,7 @@ from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceProcessContext
 from dagster._daemon import get_default_daemon_logger
 from dagster._daemon.backfill import execute_backfill_iteration
-from dagster._seven import IS_WINDOWS, get_system_temp_directory
+from dagster._seven import IS_WINDOWS, get_current_timestamp, get_system_temp_directory
 from dagster._utils import touch_file
 from dagster._utils.error import SerializableErrorInfo
 
@@ -482,7 +481,7 @@ def test_simple_backfill(
             from_failure=False,
             reexecution_steps=None,
             tags=None,
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
         )
     )
     assert instance.get_runs_count() == 0
@@ -515,7 +514,7 @@ def test_canceled_backfill(
             from_failure=False,
             reexecution_steps=None,
             tags=None,
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
         )
     )
     assert instance.get_runs_count() == 0
@@ -553,7 +552,7 @@ def test_failure_backfill(
             from_failure=False,
             reexecution_steps=None,
             tags=None,
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
         )
     )
     assert instance.get_runs_count() == 0
@@ -602,7 +601,7 @@ def test_failure_backfill(
             from_failure=True,
             reexecution_steps=None,
             tags=None,
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
         )
     )
 
@@ -657,7 +656,7 @@ def test_partial_backfill(
             from_failure=False,
             reexecution_steps=None,
             tags=None,
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
         )
     )
     assert instance.get_runs_count() == 0
@@ -704,7 +703,7 @@ def test_partial_backfill(
             from_failure=False,
             reexecution_steps=["step_one"],
             tags=None,
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
         )
     )
     list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
@@ -747,7 +746,7 @@ def test_large_backfill(
             from_failure=False,
             reexecution_steps=None,
             tags=None,
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
         )
     )
     assert instance.get_runs_count() == 0
@@ -768,7 +767,7 @@ def test_unloadable_backfill(instance, workspace_context):
             from_failure=False,
             reexecution_steps=None,
             tags=None,
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
         )
     )
     assert instance.get_runs_count() == 0
@@ -792,7 +791,7 @@ def test_unloadable_backfill_retry(
             asset_graph=workspace_context.create_request_context().asset_graph,
             backfill_id="retry_backfill",
             tags={"custom_tag_key": "custom_tag_value"},
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
             asset_selection=asset_selection,
             partition_names=partition_keys,
             dynamic_partitions_store=instance,
@@ -851,7 +850,7 @@ def test_backfill_from_partitioned_job(
             from_failure=False,
             reexecution_steps=None,
             tags=None,
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
         )
     )
     assert instance.get_runs_count() == 0
@@ -886,7 +885,7 @@ def test_backfill_with_asset_selection(
             from_failure=False,
             reexecution_steps=None,
             tags=None,
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
             asset_selection=asset_selection,
         )
     )
@@ -926,7 +925,7 @@ def test_pure_asset_backfill_with_multiple_assets_selected(
             asset_graph=workspace_context.create_request_context().asset_graph,
             backfill_id="backfill_with_multiple_assets_selected",
             tags={"custom_tag_key": "custom_tag_value"},
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
             asset_selection=asset_selection,
             partition_names=partition_keys,
             dynamic_partitions_store=instance,
@@ -991,7 +990,7 @@ def test_pure_asset_backfill(
             asset_graph=workspace_context.create_request_context().asset_graph,
             backfill_id="backfill_with_asset_selection",
             tags={"custom_tag_key": "custom_tag_value"},
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
             asset_selection=asset_selection,
             partition_names=partition_keys,
             dynamic_partitions_store=instance,
@@ -1056,7 +1055,7 @@ def test_backfill_from_failure_for_subselection(
             from_failure=True,
             reexecution_steps=None,
             tags=None,
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
         )
     )
 
@@ -1081,7 +1080,7 @@ def test_asset_backfill_cancellation(
             asset_graph=workspace_context.create_request_context().asset_graph,
             backfill_id=backfill_id,
             tags={"custom_tag_key": "custom_tag_value"},
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
             asset_selection=asset_selection,
             partition_names=partition_keys,
             dynamic_partitions_store=instance,
@@ -1142,7 +1141,7 @@ def test_asset_backfill_submit_runs_in_chunks(
             asset_graph=workspace_context.create_request_context().asset_graph,
             backfill_id=backfill_id,
             tags={},
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
             asset_selection=asset_selection,
             partition_names=target_partitions,
             dynamic_partitions_store=instance,
@@ -1182,7 +1181,7 @@ def test_asset_backfill_mid_iteration_cancel(
         asset_graph=asset_graph,
         backfill_id=backfill_id,
         tags={},
-        backfill_timestamp=pendulum.now().timestamp(),
+        backfill_timestamp=get_current_timestamp(),
         asset_selection=asset_selection,
         partition_names=target_partitions,
         dynamic_partitions_store=instance,
@@ -1250,7 +1249,7 @@ def test_asset_backfill_forcible_mark_as_canceled_during_canceling_iteration(
         asset_graph=asset_graph,
         backfill_id=backfill_id,
         tags={},
-        backfill_timestamp=pendulum.now().timestamp(),
+        backfill_timestamp=get_current_timestamp(),
         asset_selection=asset_selection,
         partition_names=["2023-01-01"],
         dynamic_partitions_store=instance,
@@ -1322,7 +1321,7 @@ def test_asset_backfill_mid_iteration_code_location_unreachable_error(
         asset_graph=asset_graph,
         backfill_id=backfill_id,
         tags={},
-        backfill_timestamp=pendulum.now().timestamp(),
+        backfill_timestamp=get_current_timestamp(),
         asset_selection=asset_selection,
         partition_names=target_partitions,
         dynamic_partitions_store=instance,
@@ -1435,7 +1434,7 @@ def test_asset_backfill_first_iteration_code_location_unreachable_error_no_runs_
         asset_graph=asset_graph,
         backfill_id=backfill_id,
         tags={},
-        backfill_timestamp=pendulum.now().timestamp(),
+        backfill_timestamp=get_current_timestamp(),
         asset_selection=asset_selection,
         partition_names=target_partitions,
         dynamic_partitions_store=instance,
@@ -1516,7 +1515,7 @@ def test_asset_backfill_first_iteration_code_location_unreachable_error_some_run
         asset_graph=asset_graph,
         backfill_id=backfill_id,
         tags={},
-        backfill_timestamp=pendulum.now().timestamp(),
+        backfill_timestamp=get_current_timestamp(),
         asset_selection=asset_selection,
         partition_names=target_partitions,
         dynamic_partitions_store=instance,
@@ -1605,7 +1604,7 @@ def test_fail_backfill_when_runs_completed_but_partitions_marked_as_in_progress(
         asset_graph=asset_graph,
         backfill_id=backfill_id,
         tags={},
-        backfill_timestamp=pendulum.now().timestamp(),
+        backfill_timestamp=get_current_timestamp(),
         asset_selection=asset_selection,
         partition_names=target_partitions,
         dynamic_partitions_store=instance,
@@ -1683,7 +1682,7 @@ def _get_abcd_job_backfill(external_repo: ExternalRepository, job_name: str) -> 
         from_failure=False,
         reexecution_steps=None,
         tags=None,
-        backfill_timestamp=pendulum.now().timestamp(),
+        backfill_timestamp=get_current_timestamp(),
     )
 
 
@@ -1760,7 +1759,7 @@ def test_asset_backfill_with_single_run_backfill_policy(
     backfill = PartitionBackfill.from_partitions_by_assets(
         backfill_id=backfill_id,
         asset_graph=asset_graph,
-        backfill_timestamp=pendulum.now().timestamp(),
+        backfill_timestamp=get_current_timestamp(),
         tags={},
         dynamic_partitions_store=instance,
         partitions_by_assets=[
@@ -1805,7 +1804,7 @@ def test_asset_backfill_with_multi_run_backfill_policy(
         asset_graph=asset_graph,
         backfill_id=backfill_id,
         tags={},
-        backfill_timestamp=pendulum.now().timestamp(),
+        backfill_timestamp=get_current_timestamp(),
         asset_selection=[asset_with_multi_run_backfill_policy.key],
         partition_names=partitions,
         dynamic_partitions_store=instance,
@@ -1855,7 +1854,7 @@ def test_error_code_location(
             asset_graph=workspace_context.create_request_context().asset_graph,
             backfill_id=backfill_id,
             tags={},
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
             asset_selection=asset_selection,
             partition_names=partition_keys,
             dynamic_partitions_store=instance,
@@ -1899,7 +1898,7 @@ def test_raise_error_on_asset_backfill_partitions_defs_changes(
         asset_graph=asset_graph,
         backfill_id=backfill_id,
         tags={},
-        backfill_timestamp=pendulum.now().timestamp(),
+        backfill_timestamp=get_current_timestamp(),
         asset_selection=asset_selection,
         partition_names=partition_keys,
         dynamic_partitions_store=instance,
@@ -1951,7 +1950,7 @@ def test_raise_error_on_partitions_defs_removed(
         asset_graph=asset_graph,
         backfill_id=backfill_id,
         tags={},
-        backfill_timestamp=pendulum.now().timestamp(),
+        backfill_timestamp=get_current_timestamp(),
         asset_selection=asset_selection,
         partition_names=partition_keys,
         dynamic_partitions_store=instance,
@@ -1998,7 +1997,7 @@ def test_raise_error_on_target_static_partition_removed(
         asset_graph=asset_graph,
         backfill_id="dummy_backfill",
         tags={},
-        backfill_timestamp=pendulum.now().timestamp(),
+        backfill_timestamp=get_current_timestamp(),
         asset_selection=asset_selection,
         partition_names=partition_keys,
         dynamic_partitions_store=instance,
@@ -2023,7 +2022,7 @@ def test_raise_error_on_target_static_partition_removed(
         asset_graph=asset_graph,
         backfill_id="dummy_backfill_2",
         tags={},
-        backfill_timestamp=pendulum.now().timestamp(),
+        backfill_timestamp=get_current_timestamp(),
         asset_selection=asset_selection,
         partition_names=["c"],
         dynamic_partitions_store=instance,
@@ -2063,7 +2062,7 @@ def test_partitions_def_changed_backfill_retry_envvar_set(
         asset_graph=asset_graph,
         backfill_id=backfill_id,
         tags={},
-        backfill_timestamp=pendulum.now().timestamp(),
+        backfill_timestamp=get_current_timestamp(),
         asset_selection=asset_selection,
         partition_names=partition_keys,
         dynamic_partitions_store=instance,
@@ -2100,7 +2099,7 @@ def test_asset_backfill_logging(caplog, instance, workspace_context):
             asset_graph=workspace_context.create_request_context().asset_graph,
             backfill_id=backfill_id,
             tags={"custom_tag_key": "custom_tag_value"},
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
             asset_selection=asset_selection,
             partition_names=partition_keys,
             dynamic_partitions_store=instance,
@@ -2148,7 +2147,7 @@ def test_asset_backfill_asset_graph_out_of_sync_with_workspace(
         asset_graph=location_1_asset_graph,
         backfill_id=backfill_id,
         tags={},
-        backfill_timestamp=pendulum.now().timestamp(),
+        backfill_timestamp=get_current_timestamp(),
         asset_selection=[AssetKey(["hourly_asset"])],
         partition_names=["2023-01-01-00:00"],
         dynamic_partitions_store=instance,
@@ -2216,7 +2215,7 @@ def test_backfill_with_title_and_description(
             asset_graph=workspace_context.create_request_context().asset_graph,
             backfill_id="backfill_with_title",
             tags={"custom_tag_key": "custom_tag_value"},
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
             asset_selection=asset_selection,
             partition_names=partition_keys,
             dynamic_partitions_store=instance,
@@ -2299,7 +2298,7 @@ def test_asset_backfill_logs(
             asset_graph=workspace_context.create_request_context().asset_graph,
             backfill_id="backfill_with_asset_selection",
             tags={"custom_tag_key": "custom_tag_value"},
-            backfill_timestamp=pendulum.now().timestamp(),
+            backfill_timestamp=get_current_timestamp(),
             asset_selection=asset_selection,
             partition_names=partition_keys,
             dynamic_partitions_store=instance,

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_schedule.py
@@ -4,7 +4,6 @@ import re
 import warnings
 from datetime import datetime
 
-import pendulum
 import pytest
 from dagster import (
     DagsterInvalidDefinitionError,
@@ -17,6 +16,7 @@ from dagster import (
     validate_run_config,
 )
 from dagster._core.errors import ScheduleExecutionError
+from dagster._seven import get_current_datetime_in_utc
 from dagster._utils.merger import merge_dicts
 
 # This file tests a lot of parameter name stuff, so these warnings are spurious
@@ -177,7 +177,7 @@ def test_schedule_with_nested_tags():
         return {}
 
     assert my_tag_schedule.evaluate_tick(
-        build_schedule_context(scheduled_execution_time=pendulum.now())
+        build_schedule_context(scheduled_execution_time=get_current_datetime_in_utc())
     )[0][0].tags == merge_dicts(
         {key: json.dumps(val) for key, val in nested_tags.items()},
         {"dagster/schedule_name": "my_tag_schedule"},
@@ -203,7 +203,7 @@ def test_invalid_tag_keys():
         assert warning.filename.endswith("test_schedule.py")
 
     assert my_tag_schedule.evaluate_tick(
-        build_schedule_context(scheduled_execution_time=pendulum.now())
+        build_schedule_context(scheduled_execution_time=get_current_datetime_in_utc())
     )[0][0].tags == merge_dicts(tags, {"dagster/schedule_name": "my_tag_schedule"})
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/conftest.py
@@ -1,7 +1,6 @@
 # pyright: reportPrivateImportUsage=false
 from typing import Iterator, Optional, Sequence
 
-import pendulum
 import pytest
 from dagster import define_asset_job
 from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
@@ -14,6 +13,7 @@ from dagster._core.definitions.metadata import TimestampMetadataValue
 from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance_for_test import instance_for_test
+from dagster._seven import get_current_timestamp
 
 
 @pytest.fixture(name="instance")
@@ -76,7 +76,7 @@ def add_new_event(
     metadata = (
         {
             "dagster/last_updated_timestamp": TimestampMetadataValue(
-                pendulum.now("UTC").timestamp() if not override_timestamp else override_timestamp
+                get_current_timestamp() if not override_timestamp else override_timestamp
             )
         }
         if not is_materialization

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -10,7 +10,6 @@ from enum import Enum
 from gzip import GzipFile
 from typing import NamedTuple, Optional, Union
 
-import pendulum
 import pytest
 import sqlalchemy as db
 from dagster import (
@@ -57,6 +56,7 @@ from dagster._serdes.serdes import (
     pack_value,
     serialize_value,
 )
+from dagster._seven import get_current_timestamp
 from dagster._utils.error import SerializableErrorInfo
 from dagster._utils.test import copy_directory
 
@@ -979,7 +979,7 @@ def test_add_bulk_actions_columns():
                     from_failure=False,
                     reexecution_steps=None,
                     tags=None,
-                    backfill_timestamp=pendulum.now().timestamp(),
+                    backfill_timestamp=get_current_timestamp(),
                 )
             )
             unmigrated_row_count = instance._run_storage.fetchone(

--- a/python_modules/dagster/dagster_tests/storage_tests/test_captured_log_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_captured_log_manager.py
@@ -4,7 +4,6 @@ import tempfile
 from contextlib import contextmanager
 from typing import Any, Generator, Mapping, Sequence
 
-import pendulum
 import pytest
 from dagster import job, op
 from dagster._core.events import DagsterEventType
@@ -14,6 +13,7 @@ from dagster._core.storage.local_compute_log_manager import LocalComputeLogManag
 from dagster._core.storage.noop_compute_log_manager import NoOpComputeLogManager
 from dagster._core.test_utils import instance_for_test
 from dagster._serdes import ConfigurableClassData
+from dagster._seven import get_current_datetime_in_utc
 from typing_extensions import Self
 
 from .utils.captured_log_manager import TestCapturedLogManager
@@ -94,7 +94,7 @@ def test_external_captured_log_manager():
 def test_get_log_keys_for_log_key_prefix():
     with tempfile.TemporaryDirectory() as tmpdir_path:
         cm = LocalComputeLogManager(tmpdir_path)
-        evaluation_time = pendulum.now()
+        evaluation_time = get_current_datetime_in_utc()
         log_key_prefix = ["test_log_bucket", evaluation_time.strftime("%Y%m%d_%H%M%S")]
 
         def write_log_file(file_id: int):
@@ -118,7 +118,7 @@ def test_read_log_lines_for_log_key_prefix():
     """Tests that we can read a sequence of files in a bucket as if they are a single file."""
     with tempfile.TemporaryDirectory() as tmpdir_path:
         cm = LocalComputeLogManager(tmpdir_path)
-        evaluation_time = pendulum.now()
+        evaluation_time = get_current_datetime_in_utc()
         log_key_prefix = ["test_log_bucket", evaluation_time.strftime("%Y%m%d_%H%M%S")]
 
         all_logs = []

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_resource.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/bigquery_tests/test_resource.py
@@ -1,7 +1,6 @@
 import base64
 import os
 
-import pendulum
 import pytest
 from dagster import (
     DagsterInstance,
@@ -15,6 +14,7 @@ from dagster import (
 from dagster._check import CheckError
 from dagster._core.definitions.data_version import DataVersion
 from dagster._core.definitions.observe import observe
+from dagster._seven import get_current_timestamp
 from dagster_gcp import BigQueryResource, bigquery_resource, fetch_last_updated_timestamps
 
 from .conftest import IS_BUILDKITE, SHARED_BUILDKITE_BQ_CONFIG, temporary_bigquery_table
@@ -141,7 +141,7 @@ def test_fetch_last_updated_timestamps_no_table():
 @pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE bigquery DB")
 @pytest.mark.integration
 def test_fetch_last_updated_timestamps():
-    start_timestamp = pendulum.now("UTC").timestamp()
+    start_timestamp = get_current_timestamp()
     dataset_name = "BIGQUERY_IO_MANAGER_SCHEMA"
     with temporary_bigquery_table(schema_name=dataset_name, column_str="FOO string") as table_name:
 

--- a/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp_tests/gcs_tests/test_compute_log_manager.py
@@ -4,7 +4,6 @@ import tempfile
 from typing import cast
 from unittest import mock
 
-import pendulum
 import pytest
 from dagster import DagsterEventType, job, op
 from dagster._core.instance import DagsterInstance, InstanceType
@@ -16,6 +15,7 @@ from dagster._core.storage.event_log import SqliteEventLogStorage
 from dagster._core.storage.root import LocalArtifactStorage
 from dagster._core.storage.runs import SqliteRunStorage
 from dagster._core.test_utils import ensure_dagster_tests_import, environ, instance_for_test
+from dagster._seven import get_current_datetime_in_utc
 from dagster_gcp.gcs import GCSComputeLogManager
 from google.cloud import storage
 
@@ -280,7 +280,7 @@ def test_prefix_filter(gcs_bucket):
 
     with tempfile.TemporaryDirectory() as temp_dir:
         manager = GCSComputeLogManager(bucket=gcs_bucket, prefix=gcs_prefix, local_dir=temp_dir)
-        time_str = pendulum.now("UTC").strftime("%Y_%m_%d__%H_%M_%S")
+        time_str = get_current_datetime_in_utc().strftime("%Y_%m_%d__%H_%M_%S")
         log_key = ["arbitrary", "log", "key", time_str]
         with manager.open_log_stream(log_key, ComputeIOType.STDERR) as write_stream:
             write_stream.write("hello hello")
@@ -344,7 +344,7 @@ def test_get_log_keys_for_log_key_prefix(gcs_bucket):
 def test_storage_download_url_fallback(gcs_bucket):
     with tempfile.TemporaryDirectory() as temp_dir:
         manager = GCSComputeLogManager(bucket=gcs_bucket, local_dir=temp_dir)
-        time_str = pendulum.now("UTC").strftime("%Y_%m_%d__%H_%M_%S")
+        time_str = get_current_datetime_in_utc().strftime("%Y_%m_%d__%H_%M_%S")
         log_key = ["arbitrary", "log", "key", time_str]
 
         orig_blob_fn = manager._bucket.blob  # noqa: SLF001

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 from typing import Iterator
 from unittest import mock
 
-import pendulum
 import pytest
 from dagster import (
     DagsterInstance,
@@ -21,6 +20,7 @@ from dagster._check import CheckError
 from dagster._core.definitions.metadata import FloatMetadataValue
 from dagster._core.definitions.observe import observe
 from dagster._core.test_utils import environ
+from dagster._seven import get_current_timestamp
 from dagster_snowflake import SnowflakeResource, fetch_last_updated_timestamps, snowflake_resource
 
 from .utils import create_mock_connector
@@ -296,7 +296,7 @@ def test_fetch_last_updated_timestamps_empty():
 @pytest.mark.integration
 @pytest.mark.parametrize("db_str", [None, "TESTDB"], ids=["db_from_resource", "db_from_param"])
 def test_fetch_last_updated_timestamps(db_str: str):
-    start_time = pendulum.now("UTC").timestamp()
+    start_time = get_current_timestamp()
     table_name = "the_table"
     with temporary_snowflake_table() as table_name:
 


### PR DESCRIPTION
Summary:
Rote replacement of the pendulum version for the (mockable) non-pendulum version

## Summary & Motivation

## How I Tested These Changes
