### PR TITLE
revert accidental change to build_schedule_from_partitioned_job

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
@@ -144,12 +144,6 @@ def build_schedule_from_partitioned_job(
     )
 
     if isinstance(job, UnresolvedAssetJobDefinition) and job.partitions_def is None:
-        if cron_schedule or execution_timezone:
-            check.failed(
-                "Cannot provide cron_schedule or execution_timezone to"
-                " build_schedule_from_partitioned_job for a time-partitioned job."
-            )
-
         return UnresolvedPartitionedAssetScheduleDefinition(
             job=job,
             default_status=default_status,


### PR DESCRIPTION
## Summary & Motivation

This is a change I was prototyping that accidentally snuck through as part of https://github.com/dagster-io/dagster/commit/066fa220316a1316439cf640c69b9a96363a61d3.

Still potentially worth merging eventually, but this didn't get reviewed and isn't necessarily the right route.

## How I Tested These Changes
