### PR TITLE
Explicit hidden_param

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -16,8 +16,8 @@ from typing import (
 
 import dagster._check as check
 from dagster._annotations import (
-    deprecated_param,
     experimental_param,
+    hidden_param,
     only_allow_hidden_params_in_kwargs,
 )
 from dagster._config.config_schema import UserConfigSchema
@@ -123,11 +123,10 @@ def _validate_hidden_non_argument_dep_param(
 @experimental_param(param="backfill_policy")
 @experimental_param(param="owners")
 @experimental_param(param="tags")
-@deprecated_param(
+@hidden_param(
     param="non_argument_deps",
     breaking_version="2.0.0",
     additional_warn_text="use `deps` instead.",
-    hidden=True,
 )
 def asset(
     compute_fn: Optional[Callable[..., Any]] = None,
@@ -495,11 +494,10 @@ def create_assets_def_from_fn_and_decorator_args(
 
 
 @experimental_param(param="resource_defs")
-@deprecated_param(
+@hidden_param(
     param="non_argument_deps",
     breaking_version="2.0.0",
     additional_warn_text="use `deps` instead.",
-    hidden=True,
 )
 def multi_asset(
     *,

--- a/python_modules/dagster/dagster_tests/test_annotations.py
+++ b/python_modules/dagster/dagster_tests/test_annotations.py
@@ -15,6 +15,7 @@ from dagster._annotations import (
     experimental_param,
     get_deprecated_info,
     get_experimental_info,
+    hidden_param,
     is_deprecated,
     is_deprecated_param,
     is_experimental,
@@ -765,7 +766,7 @@ def test_all_annotations():
 
 
 def test_hidden_annotations() -> None:
-    @deprecated_param(param="baz", breaking_version="2.0", hidden=True)
+    @hidden_param(param="baz", breaking_version="2.0")
     def with_hidden_args(**kwargs) -> bool:
         only_allow_hidden_params_in_kwargs(with_hidden_args, kwargs)
         return True

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import os
 from pathlib import Path
@@ -33,7 +34,7 @@ from dagster import (
     get_dagster_logger,
     op,
 )
-from dagster._annotations import deprecated_param
+from dagster._annotations import hidden_param, only_allow_hidden_params_in_kwargs
 from dagster._core.definitions.events import (
     AssetMaterialization,
     AssetObservation,
@@ -633,39 +634,41 @@ def load_assets_from_dbt_project(
     )
 
 
-@deprecated_param(
-    param="manifest_json", breaking_version="0.21", additional_warn_text="Use manifest instead"
-)
-@deprecated_param(
-    param="selected_unique_ids",
+# declare hidden parameter that will break at 2.0
+def hidden_until_20_param(param: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    return functools.partial(hidden_param, param=param, breaking_version="2.0")
+
+
+@hidden_param(
+    param="manifest_json",
     breaking_version="0.21",
-    additional_warn_text="Use the select parameter instead.",
+    additional_warn_text="Use manifest instead",
 )
-@deprecated_param(
+@hidden_param(
     param="dbt_resource_key",
     breaking_version="0.21",
     additional_warn_text=(
         "Use the `@dbt_assets` decorator if you need to customize your resource key."
     ),
 )
-@deprecated_param(
+@hidden_param(
     param="use_build_command",
     breaking_version="0.21",
     additional_warn_text=(
         "Use the `@dbt_assets` decorator if you need to customize the underlying dbt commands."
     ),
 )
-@deprecated_param(
+@hidden_param(
     param="partitions_def",
     breaking_version="0.21",
     additional_warn_text="Use the `@dbt_assets` decorator to define partitioned dbt assets.",
 )
-@deprecated_param(
+@hidden_param(
     param="partition_key_to_vars_fn",
     breaking_version="0.21",
     additional_warn_text="Use the `@dbt_assets` decorator to define partitioned dbt assets.",
 )
-@deprecated_param(
+@hidden_param(
     param="runtime_metadata_fn",
     breaking_version="0.21",
     additional_warn_text=(


### PR DESCRIPTION
## Summary & Motivation

A further extension to #22385, this proposes making an explicit `hidden_param` rather just a boolean flag on `deprecated_param`.

Two reasons why this could be a good idea.

1) This is more greppable. We could audit our uses of hidden versus deprecated trivially, rather than having to inspect every callsite.
2) We could use hidden params for the experimental use case as well, as a way to _introduce_ capabilities in our releases without polluting public signatures.

I think #2 potentially pretty compelling. I'm not super high conviction on this but writing this out made my think this is the right approach.

## How I Tested These Changes

BK
