### PR TITLE
[5/n] create_pendulum_time => create_datetime in tests

### DIFF
--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -63,7 +63,9 @@ from dagster._core.workspace.context import WorkspaceProcessContext, WorkspaceRe
 from dagster._core.workspace.load_target import WorkspaceLoadTarget
 from dagster._serdes import ConfigurableClass
 from dagster._serdes.config_class import ConfigurableClassData
-from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_freeze_time
+from dagster._seven import create_datetime
+from dagster._seven.compat.datetime import timezone_from_string
+from dagster._seven.compat.pendulum import pendulum_freeze_time
 from dagster._utils import Counter, get_terminate_signal, traced, traced_counter
 from dagster._utils.log import configure_loggers
 
@@ -311,8 +313,9 @@ def new_cwd(path: str) -> Iterator[None]:
 
 def today_at_midnight(timezone_name="UTC") -> "DateTime":
     check.str_param(timezone_name, "timezone_name")
-    now = pendulum.now(timezone_name)
-    return create_pendulum_time(now.year, now.month, now.day, tz=now.timezone.name)
+    tzinfo = timezone_from_string(timezone_name)
+    now = datetime.datetime.now(tz=tzinfo)
+    return create_datetime(now.year, now.month, now.day, tz=timezone_name)
 
 
 from dagster._core.storage.runs import SqliteRunStorage

--- a/python_modules/dagster/dagster/_seven/__init__.py
+++ b/python_modules/dagster/dagster/_seven/__init__.py
@@ -14,6 +14,8 @@ from typing import Any, Callable, List, Sequence, Type
 from dateutil import parser
 from typing_extensions import TypeGuard
 
+from dagster._seven.compat.datetime import timezone_from_string
+
 from .compat.pendulum import PendulumDateTime as PendulumDateTime  # re-exported
 from .json import (
     JSONDecodeError as JSONDecodeError,
@@ -142,8 +144,15 @@ def get_current_timestamp():
     return _mockable_get_current_timestamp()
 
 
+def create_datetime(year, month, day, *args, **kwargs):
+    tz = kwargs.pop("tz", "UTC")
+    if isinstance(tz, str):
+        tz = timezone_from_string(tz)
+    return datetime(year, month, day, *args, **kwargs, tzinfo=tz)
+
+
 def create_utc_datetime(year, month, day, *args, **kwargs):
-    return datetime(year, month, day, *args, **kwargs, tzinfo=timezone.utc)
+    return create_datetime(year, month, day, *args, **kwargs, tz="UTC")
 
 
 def add_fixed_time(

--- a/python_modules/dagster/dagster/_seven/compat/datetime.py
+++ b/python_modules/dagster/dagster/_seven/compat/datetime.py
@@ -4,13 +4,14 @@ try:
     from zoneinfo import ZoneInfo as _timezone_from_string
 except:
     from dateutil.tz import gettz as _timezone_from_string
-from datetime import tzinfo
+from datetime import timezone, tzinfo
 from typing import Optional
 
 
 def timezone_from_string(timezone_name: str) -> Optional[tzinfo]:
     # Allow case insensitivity for "utc" specifically for back-compat with pendulum 2
     # (plus the fact that some systems can process that timezone and others cannot)
-    if timezone_name == "utc":
-        timezone_name = "UTC"
+    if timezone_name == "utc" or timezone_name == "UTC":
+        return timezone.utc
+
     return _timezone_from_string(timezone_name)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
@@ -1,9 +1,9 @@
-import pendulum
 from dagster import AssetDep, Definitions, asset
 from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
 from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.definitions.partition_mapping import StaticPartitionMapping
 from dagster._core.instance import DagsterInstance
+from dagster._seven import create_datetime
 
 
 def test_basic_construction_and_identity() -> None:
@@ -12,7 +12,7 @@ def test_basic_construction_and_identity() -> None:
 
     defs = Definitions([an_asset])
     instance = DagsterInstance.ephemeral()
-    effective_dt = pendulum.datetime(2020, 1, 1)
+    effective_dt = create_datetime(2020, 1, 1)
     last_event_id = 928348343
     asset_graph_view_t0 = AssetGraphView.for_test(defs, instance, effective_dt, last_event_id)
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_subset.py
@@ -20,8 +20,9 @@ from dagster._core.definitions.time_window_partitions import (
     PersistedTimeWindow,
     TimeWindowPartitionsSubset,
 )
+from dagster._core.definitions.timestamp import TimestampWithTimezone
 from dagster._serdes import deserialize_value, serialize_value
-from dagster._seven.compat.pendulum import create_pendulum_time
+from dagster._seven import create_datetime
 
 partitions_defs = [
     None,
@@ -105,10 +106,12 @@ def test_operations(
             num_partitions=2,
             included_time_windows=[
                 PersistedTimeWindow(
-                    start=create_pendulum_time(2020, 1, 1), end=create_pendulum_time(2020, 1, 2)
+                    start=TimestampWithTimezone(create_datetime(2020, 1, 1).timestamp(), "UTC"),
+                    end=TimestampWithTimezone(create_datetime(2020, 1, 2).timestamp(), "UTC"),
                 ),
                 PersistedTimeWindow(
-                    start=create_pendulum_time(2020, 1, 4), end=create_pendulum_time(2020, 1, 5)
+                    start=TimestampWithTimezone(create_datetime(2020, 1, 4).timestamp(), "UTC"),
+                    end=TimestampWithTimezone(create_datetime(2020, 1, 5).timestamp(), "UTC"),
                 ),
             ],
         ),

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_freshness_policy.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_freshness_policy.py
@@ -1,8 +1,10 @@
+import datetime
+
 import pytest
 from dagster._check import ParameterCheckError
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster._seven.compat.pendulum import create_pendulum_time
+from dagster._seven import create_datetime
 
 
 @pytest.mark.parametrize(
@@ -16,53 +18,53 @@ from dagster._seven.compat.pendulum import create_pendulum_time
     [
         (
             FreshnessPolicy(maximum_lag_minutes=30),
-            create_pendulum_time(2022, 1, 1, 0),
-            create_pendulum_time(2022, 1, 1, 0, 25),
+            create_datetime(2022, 1, 1, 0),
+            create_datetime(2022, 1, 1, 0, 25),
             0,
             25,
         ),
         (
             FreshnessPolicy(maximum_lag_minutes=120),
-            create_pendulum_time(2022, 1, 1, 0),
-            create_pendulum_time(2022, 1, 1, 1),
+            create_datetime(2022, 1, 1, 0),
+            create_datetime(2022, 1, 1, 1),
             0,
             60,
         ),
         (
             FreshnessPolicy(maximum_lag_minutes=30),
-            create_pendulum_time(2022, 1, 1, 0),
-            create_pendulum_time(2022, 1, 1, 1),
+            create_datetime(2022, 1, 1, 0),
+            create_datetime(2022, 1, 1, 1),
             30,
             60,
         ),
         (
             FreshnessPolicy(maximum_lag_minutes=500),
             None,
-            create_pendulum_time(2022, 1, 1, 0, 25),
+            create_datetime(2022, 1, 1, 0, 25),
             None,
             None,
         ),
         # materialization happened before SLA
         (
             FreshnessPolicy(cron_schedule="@daily", maximum_lag_minutes=15),
-            create_pendulum_time(2022, 1, 1, 23, 55),
-            create_pendulum_time(2022, 1, 2, 0, 10),
+            create_datetime(2022, 1, 1, 23, 55),
+            create_datetime(2022, 1, 2, 0, 10),
             0,
             5,
         ),
         # materialization happened after SLA, but is fine now
         (
             FreshnessPolicy(cron_schedule="@daily", maximum_lag_minutes=15),
-            create_pendulum_time(2022, 1, 1, 0, 30),
-            create_pendulum_time(2022, 1, 1, 1, 0),
+            create_datetime(2022, 1, 1, 0, 30),
+            create_datetime(2022, 1, 1, 1, 0),
             0,
             0,
         ),
         # materialization for this data has not happened yet (day before)
         (
             FreshnessPolicy(cron_schedule="@daily", maximum_lag_minutes=60),
-            create_pendulum_time(2022, 1, 1, 22, 0),
-            create_pendulum_time(2022, 1, 2, 2, 0),
+            create_datetime(2022, 1, 1, 22, 0),
+            create_datetime(2022, 1, 2, 2, 0),
             # by midnight, expected data from up to 2022-01-02T23:00, but actual data is from
             # 2022-01-01T22:00, so you are 1 hour late
             60,
@@ -71,15 +73,15 @@ from dagster._seven.compat.pendulum import create_pendulum_time
         # weird one: at the end of each hour, your data should be no more than 5 hours old
         (
             FreshnessPolicy(cron_schedule="@hourly", maximum_lag_minutes=60 * 5),
-            create_pendulum_time(2022, 1, 1, 1, 0),
-            create_pendulum_time(2022, 1, 1, 4, 0),
+            create_datetime(2022, 1, 1, 1, 0),
+            create_datetime(2022, 1, 1, 4, 0),
             0,
             180,
         ),
         (
             FreshnessPolicy(cron_schedule="@hourly", maximum_lag_minutes=60 * 5),
-            create_pendulum_time(2022, 1, 1, 1, 15),
-            create_pendulum_time(2022, 1, 1, 7, 45),
+            create_datetime(2022, 1, 1, 1, 15),
+            create_datetime(2022, 1, 1, 7, 45),
             # schedule is evaluated on the hour, so most recent schedule tick is 7AM. At this point
             # in time, we expect to have the data from at least 5 hours ago (so 2AM), but we only
             # have data from 1:15, so we're 45 minutes late
@@ -93,8 +95,8 @@ from dagster._seven.compat.pendulum import create_pendulum_time
                 cron_schedule_timezone="America/Los_Angeles",
                 maximum_lag_minutes=60,
             ),
-            create_pendulum_time(2022, 1, 1, 1, 0, tz="America/Los_Angeles"),
-            create_pendulum_time(2022, 1, 1, 3, 15, tz="America/Los_Angeles"),
+            create_datetime(2022, 1, 1, 1, 0, tz="America/Los_Angeles"),
+            create_datetime(2022, 1, 1, 3, 15, tz="America/Los_Angeles"),
             # only have data up to 1AM in this timezone, but we need up to 2AM, so we're 1hr late
             60,
             120,
@@ -106,8 +108,12 @@ from dagster._seven.compat.pendulum import create_pendulum_time
                 cron_schedule_timezone="America/Los_Angeles",
                 maximum_lag_minutes=60,
             ),
-            create_pendulum_time(2022, 1, 1, 1, 0, tz="America/Los_Angeles").in_tz("UTC"),
-            create_pendulum_time(2022, 1, 1, 3, 15, tz="America/Los_Angeles").in_tz("UTC"),
+            create_datetime(2022, 1, 1, 1, 0, tz="America/Los_Angeles").astimezone(
+                datetime.timezone.utc
+            ),
+            create_datetime(2022, 1, 1, 3, 15, tz="America/Los_Angeles").astimezone(
+                datetime.timezone.utc
+            ),
             # only have data up to 1AM in this timezone, but we need up to 2AM, so we're 1hr late
             60,
             120,
@@ -118,8 +124,8 @@ from dagster._seven.compat.pendulum import create_pendulum_time
                 cron_schedule_timezone="America/Los_Angeles",
                 maximum_lag_minutes=60,
             ),
-            create_pendulum_time(2022, 1, 1, 0, 0, tz="America/Los_Angeles"),
-            create_pendulum_time(2022, 1, 1, 2, 15, tz="America/Los_Angeles"),
+            create_datetime(2022, 1, 1, 0, 0, tz="America/Los_Angeles"),
+            create_datetime(2022, 1, 1, 2, 15, tz="America/Los_Angeles"),
             # it's not yet 3AM in this timezone, so we're not late
             0,
             0,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -42,8 +42,12 @@ from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
     ASSET_PARTITION_RANGE_START_TAG,
 )
-from dagster._core.test_utils import assert_namedtuple_lists_equal, raise_exception_on_warnings
-from dagster._seven.compat.pendulum import create_pendulum_time, pendulum_freeze_time
+from dagster._core.test_utils import (
+    assert_namedtuple_lists_equal,
+    freeze_time,
+    raise_exception_on_warnings,
+)
+from dagster._seven import create_datetime
 
 
 @pytest.fixture(autouse=True)
@@ -752,7 +756,7 @@ def test_error_on_nonexistent_upstream_partition():
     def downstream_asset(context, upstream_asset):
         return upstream_asset + 1
 
-    with pendulum_freeze_time(create_pendulum_time(2020, 1, 2, 10, 0)):
+    with freeze_time(create_datetime(2020, 1, 2, 10, 0)):
         with pytest.raises(
             DagsterInvariantViolationError,
             match="invalid partition keys",

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
@@ -24,7 +24,12 @@ from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_START_TAG,
 )
 from dagster._core.test_utils import freeze_time
-from dagster._seven import get_current_datetime_in_utc, get_current_timestamp, parse_with_timezone
+from dagster._seven import (
+    create_datetime,
+    get_current_datetime_in_utc,
+    get_current_timestamp,
+    parse_with_timezone,
+)
 
 from dagster_tests.core_tests.execution_tests.test_asset_backfill import (
     execute_asset_backfill_iteration_consume_generator,
@@ -1054,7 +1059,7 @@ def test_run_request_partition_order():
         asset_selection=[foo.key, foo_child.key],
         dynamic_partitions_store=MagicMock(),
         all_partitions=False,
-        backfill_start_timestamp=pendulum.datetime(2023, 10, 7, 0, 0, 0).timestamp(),
+        backfill_start_timestamp=create_datetime(2023, 10, 7, 0, 0, 0).timestamp(),
     )
 
     result = execute_asset_backfill_iteration_consume_generator(

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partitioned_job.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partitioned_job.py
@@ -11,7 +11,7 @@ from dagster import (
     static_partitioned_config,
 )
 from dagster._core.definitions.partition import partitioned_config
-from dagster._seven.compat.pendulum import create_pendulum_time
+from dagster._seven import create_datetime
 
 
 @op
@@ -58,7 +58,7 @@ def test_time_based_partitioned_job():
     def my_job():
         my_op()
 
-    freeze_datetime = create_pendulum_time(
+    freeze_datetime = create_datetime(
         year=2021, month=5, day=6, hour=23, minute=59, second=59, tz="UTC"
     )
     partition_keys = my_daily_partitioned_config.get_partition_keys(freeze_datetime)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -30,8 +30,7 @@ from dagster._core.definitions.time_window_partitions import (
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.test_utils import freeze_time
 from dagster._serdes import deserialize_value, serialize_value
-from dagster._seven import create_utc_datetime
-from dagster._seven.compat.pendulum import create_pendulum_time
+from dagster._seven import create_datetime, create_utc_datetime
 from dagster._utils.partitions import DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
 
 DATE_FORMAT = "%Y-%m-%d"
@@ -358,14 +357,14 @@ def assert_expected_partition_keys(
         (
             datetime(year=2021, month=1, day=1),
             0,
-            create_pendulum_time(2021, 1, 6, 1, 20),
+            create_datetime(2021, 1, 6, 1, 20),
             ["2021-01-01", "2021-01-02", "2021-01-03", "2021-01-04", "2021-01-05"],
             None,
         ),
         (
             datetime(year=2021, month=1, day=1),
             1,
-            create_pendulum_time(2021, 1, 6, 1, 20),
+            create_datetime(2021, 1, 6, 1, 20),
             [
                 "2021-01-01",
                 "2021-01-02",
@@ -379,7 +378,7 @@ def assert_expected_partition_keys(
         (
             datetime(year=2021, month=1, day=1),
             2,
-            create_pendulum_time(2021, 1, 6, 1, 20),
+            create_datetime(2021, 1, 6, 1, 20),
             [
                 "2021-01-01",
                 "2021-01-02",
@@ -394,7 +393,7 @@ def assert_expected_partition_keys(
         (
             datetime(year=2021, month=1, day=1),
             -2,
-            create_pendulum_time(2021, 1, 8, 1, 20),
+            create_datetime(2021, 1, 8, 1, 20),
             [
                 "2021-01-01",
                 "2021-01-02",
@@ -407,21 +406,21 @@ def assert_expected_partition_keys(
         (
             datetime(year=2020, month=12, day=29),
             0,
-            create_pendulum_time(2021, 1, 3, 1, 20),
+            create_datetime(2021, 1, 3, 1, 20),
             ["2020-12-29", "2020-12-30", "2020-12-31", "2021-01-01", "2021-01-02"],
             None,
         ),
         (
             datetime(year=2020, month=2, day=28),
             0,
-            create_pendulum_time(2020, 3, 3, 1, 20),
+            create_datetime(2020, 3, 3, 1, 20),
             ["2020-02-28", "2020-02-29", "2020-03-01", "2020-03-02"],
             None,
         ),
         (
             datetime(year=2021, month=2, day=28),
             0,
-            create_pendulum_time(2021, 3, 3, 1, 20),
+            create_datetime(2021, 3, 3, 1, 20),
             ["2021-02-28", "2021-03-01", "2021-03-02"],
             None,
         ),
@@ -462,31 +461,31 @@ def test_time_partitions_daily_partitions(
         (
             datetime(year=2021, month=1, day=1),
             0,
-            create_pendulum_time(2021, 3, 1, 1, 20),
+            create_datetime(2021, 3, 1, 1, 20),
             ["2021-01-01", "2021-02-01"],
         ),
         (
             datetime(year=2021, month=1, day=1),
             1,
-            create_pendulum_time(2021, 3, 1, 1, 20),
+            create_datetime(2021, 3, 1, 1, 20),
             ["2021-01-01", "2021-02-01", "2021-03-01"],
         ),
         (
             datetime(year=2021, month=1, day=1),
             2,
-            create_pendulum_time(2021, 3, 1, 1, 20),
+            create_datetime(2021, 3, 1, 1, 20),
             ["2021-01-01", "2021-02-01", "2021-03-01", "2021-04-01"],
         ),
         (
             datetime(year=2021, month=1, day=1),
             -1,
-            create_pendulum_time(2021, 3, 27),
+            create_datetime(2021, 3, 27),
             ["2021-01-01"],
         ),
         (
             datetime(year=2021, month=1, day=3),
             0,
-            create_pendulum_time(2021, 1, 31),
+            create_datetime(2021, 1, 31),
             [],
         ),
     ],
@@ -525,19 +524,19 @@ def test_time_partitions_monthly_partitions(
         (
             datetime(year=2021, month=1, day=1),
             0,
-            create_pendulum_time(2021, 1, 31, 1, 20),
+            create_datetime(2021, 1, 31, 1, 20),
             ["2021-01-03", "2021-01-10", "2021-01-17", "2021-01-24"],
         ),
         (
             datetime(year=2021, month=1, day=1),
             1,
-            create_pendulum_time(2021, 1, 31, 1, 20),
+            create_datetime(2021, 1, 31, 1, 20),
             ["2021-01-03", "2021-01-10", "2021-01-17", "2021-01-24", "2021-01-31"],
         ),
         (
             datetime(year=2021, month=1, day=1),
             2,
-            create_pendulum_time(2021, 1, 31, 1, 20),
+            create_datetime(2021, 1, 31, 1, 20),
             [
                 "2021-01-03",
                 "2021-01-10",
@@ -550,13 +549,13 @@ def test_time_partitions_monthly_partitions(
         (
             datetime(year=2021, month=1, day=1),
             -2,
-            create_pendulum_time(2021, 1, 24, 1, 20),
+            create_datetime(2021, 1, 24, 1, 20),
             ["2021-01-03"],
         ),
         (
             datetime(year=2021, month=1, day=4),
             0,
-            create_pendulum_time(2021, 1, 9),
+            create_datetime(2021, 1, 9),
             [],
         ),
     ],
@@ -599,7 +598,7 @@ def test_time_partitions_weekly_partitions(
             datetime(year=2021, month=1, day=1, hour=0),
             None,
             0,
-            create_pendulum_time(2021, 1, 1, 4, 1),
+            create_datetime(2021, 1, 1, 4, 1),
             [
                 "2021-01-01-00:00",
                 "2021-01-01-01:00",
@@ -611,7 +610,7 @@ def test_time_partitions_weekly_partitions(
             datetime(year=2021, month=1, day=1, hour=0),
             None,
             1,
-            create_pendulum_time(2021, 1, 1, 4, 1),
+            create_datetime(2021, 1, 1, 4, 1),
             [
                 "2021-01-01-00:00",
                 "2021-01-01-01:00",
@@ -624,7 +623,7 @@ def test_time_partitions_weekly_partitions(
             datetime(year=2021, month=1, day=1, hour=0),
             None,
             2,
-            create_pendulum_time(2021, 1, 1, 4, 1),
+            create_datetime(2021, 1, 1, 4, 1),
             [
                 "2021-01-01-00:00",
                 "2021-01-01-01:00",
@@ -638,21 +637,21 @@ def test_time_partitions_weekly_partitions(
             datetime(year=2021, month=1, day=1, hour=0),
             None,
             -1,
-            create_pendulum_time(2021, 1, 1, 3, 30),
+            create_datetime(2021, 1, 1, 3, 30),
             ["2021-01-01-00:00", "2021-01-01-01:00"],
         ),
         (
             datetime(year=2021, month=1, day=1, hour=0, minute=2),
             None,
             0,
-            create_pendulum_time(2021, 1, 1, 0, 59),
+            create_datetime(2021, 1, 1, 0, 59),
             [],
         ),
         (
             datetime(year=2021, month=3, day=14, hour=1),
             None,
             0,
-            create_pendulum_time(2021, 3, 14, 4, 1),
+            create_datetime(2021, 3, 14, 4, 1),
             [
                 "2021-03-14-01:00",
                 "2021-03-14-02:00",
@@ -663,14 +662,14 @@ def test_time_partitions_weekly_partitions(
             datetime(year=2021, month=3, day=14, hour=1),
             "US/Central",
             0,
-            create_pendulum_time(2021, 3, 14, 4, 1, tz="US/Central"),
+            create_datetime(2021, 3, 14, 4, 1, tz="US/Central"),
             ["2021-03-14-01:00", "2021-03-14-03:00"],
         ),
         (
             datetime(year=2021, month=11, day=7, hour=0),
             None,
             0,
-            create_pendulum_time(2021, 11, 7, 4, 1),
+            create_datetime(2021, 11, 7, 4, 1),
             [
                 "2021-11-07-00:00",
                 "2021-11-07-01:00",
@@ -682,7 +681,7 @@ def test_time_partitions_weekly_partitions(
             datetime(year=2021, month=11, day=7, hour=0),
             "US/Central",
             0,
-            create_pendulum_time(2021, 11, 7, 4, 1, tz="US/Central"),
+            create_datetime(2021, 11, 7, 4, 1, tz="US/Central"),
             [
                 "2021-11-07-00:00",
                 "2021-11-07-01:00",

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_metadata.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from pathlib import Path
 
-import pendulum
 import pytest
 import pytz
 from dagster import (
@@ -42,6 +41,7 @@ from dagster._core.definitions.metadata.table import (
 )
 from dagster._core.execution.execution_result import ExecutionResult
 from dagster._core.snap.node import build_node_defs_snapshot
+from dagster._seven import create_datetime
 
 
 def step_events_of_type(result: ExecutionResult, node_name: str, event_type: DagsterEventType):
@@ -139,12 +139,12 @@ def test_metadata_asset_observation():
 
 
 def test_metadata_value_timestamp():
-    pendulum_dt_with_timezone = pendulum.datetime(2024, 3, 6, 12, 0, 0, tz="America/New_York")
+    pendulum_dt_with_timezone = create_datetime(2024, 3, 6, 12, 0, 0, tz="America/New_York")
     assert (
         MetadataValue.timestamp(pendulum_dt_with_timezone).value
         == pendulum_dt_with_timezone.timestamp()
     )
-    pendulum_dt_without_timezone = pendulum.datetime(2024, 3, 6, 12, 0, 0)
+    pendulum_dt_without_timezone = create_datetime(2024, 3, 6, 12, 0, 0)
     assert (
         MetadataValue.timestamp(pendulum_dt_without_timezone).value
         == pendulum_dt_without_timezone.timestamp()

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_cron_string_iterator.py
@@ -2,12 +2,8 @@ import calendar
 
 import pendulum
 import pytest
-from dagster._seven.compat.pendulum import (
-    POST_TRANSITION,
-    PRE_TRANSITION,
-    create_pendulum_time,
-    to_timezone,
-)
+from dagster._seven import create_datetime
+from dagster._seven.compat.pendulum import to_timezone
 from dagster._utils.schedules import (
     _croniter_string_iterator,
     cron_string_iterator,
@@ -18,7 +14,7 @@ from dagster._utils.schedules import (
 def test_cron_iterator_always_advances():
     tz = "Europe/Berlin"
 
-    start_timestamp = create_pendulum_time(2023, 3, 26, 2, 0, 0, tz=tz).timestamp() + 1
+    start_timestamp = create_datetime(2023, 3, 26, 2, 0, 0, tz=tz).timestamp() + 1
 
     expected_next_timestamp = 1679875200  # 2023-03-272:00+2:00
 
@@ -41,7 +37,7 @@ def test_cron_iterator_always_advances():
 def test_cron_iterator_leap_day():
     tz = "Europe/Berlin"
 
-    start_timestamp = create_pendulum_time(2023, 3, 27, 1, 0, 0, tz=tz).timestamp()
+    start_timestamp = create_datetime(2023, 3, 27, 1, 0, 0, tz=tz).timestamp()
 
     cron_iter = cron_string_iterator(
         start_timestamp + 1,
@@ -57,8 +53,8 @@ def test_cron_iterator_leap_day():
         assert next_datetime.minute == 2
 
 
-# Fall back: In Europe/Berlin on Sunday 10/29, 2AM-3AM happen twice (first with dst_rule=PRE_TRANSITION / +2 offset,
-# then dst_rule=POST_TRANSITION, +1 offset)
+# Fall back: In Europe/Berlin on Sunday 10/29, 2AM-3AM happen twice (first with fold=0 / +2 offset,
+# then fold=1, +1 offset)
 # Spring forward: In Europe/Berlin on Sunday 3/26, 2AM jumps ahead to 3AM
 # https://www.timeanddate.com/time/change/germany/berlin?year=2023
 DST_PARAMS = [
@@ -67,73 +63,59 @@ DST_PARAMS = [
         "Europe/Berlin",
         "45 1 * * *",
         [
-            create_pendulum_time(2023, 10, 27, 1, 45, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 28, 1, 45, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 29, 1, 45, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 30, 1, 45, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 31, 1, 45, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 11, 1, 1, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 27, 1, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 28, 1, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 1, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 30, 1, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 31, 1, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 11, 1, 1, 45, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Australia/Lord_Howe",
         "0 2 * * *",
         [
-            create_pendulum_time(2023, 9, 29, 2, 0, 0, tz="Australia/Lord_Howe"),
-            create_pendulum_time(2023, 9, 30, 2, 0, 0, tz="Australia/Lord_Howe"),
-            create_pendulum_time(2023, 10, 1, 2, 30, 0, tz="Australia/Lord_Howe"),
-            create_pendulum_time(2023, 10, 2, 2, 0, 0, tz="Australia/Lord_Howe"),
-            create_pendulum_time(2023, 10, 3, 2, 0, 0, tz="Australia/Lord_Howe"),
+            create_datetime(2023, 9, 29, 2, 0, 0, tz="Australia/Lord_Howe"),
+            create_datetime(2023, 9, 30, 2, 0, 0, tz="Australia/Lord_Howe"),
+            create_datetime(2023, 10, 1, 2, 30, 0, tz="Australia/Lord_Howe"),
+            create_datetime(2023, 10, 2, 2, 0, 0, tz="Australia/Lord_Howe"),
+            create_datetime(2023, 10, 3, 2, 0, 0, tz="Australia/Lord_Howe"),
         ],
     ),
     (
         "Europe/Berlin",
         "0 2 * * *",
         [
-            create_pendulum_time(2023, 10, 27, 2, 0, 0, tz="Europe/Berlin"),  # +2:00
-            create_pendulum_time(2023, 10, 28, 2, 0, 0, tz="Europe/Berlin"),  # +2:00
-            create_pendulum_time(
-                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),  # +1:00
-            create_pendulum_time(2023, 10, 30, 2, 0, 0, tz="Europe/Berlin"),  # +1:00
-            create_pendulum_time(2023, 10, 31, 2, 0, 0, tz="Europe/Berlin"),  # +1:00
-            create_pendulum_time(2023, 11, 1, 2, 0, 0, tz="Europe/Berlin"),  # +1:00
+            create_datetime(2023, 10, 27, 2, 0, 0, tz="Europe/Berlin"),  # +2:00
+            create_datetime(2023, 10, 28, 2, 0, 0, tz="Europe/Berlin"),  # +2:00
+            create_datetime(2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", fold=1),  # +1:00
+            create_datetime(2023, 10, 30, 2, 0, 0, tz="Europe/Berlin"),  # +1:00
+            create_datetime(2023, 10, 31, 2, 0, 0, tz="Europe/Berlin"),  # +1:00
+            create_datetime(2023, 11, 1, 2, 0, 0, tz="Europe/Berlin"),  # +1:00
         ],
     ),
     (
         "Europe/Berlin",
         "30 2 * * *",
         [
-            create_pendulum_time(
-                2023, 10, 27, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 28, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 29, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 30, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 31, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 11, 1, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
+            create_datetime(2023, 10, 27, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 28, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 2, 30, 0, tz="Europe/Berlin", fold=1),
+            create_datetime(2023, 10, 30, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 31, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 11, 1, 2, 30, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "0 3 * * *",
         [
-            create_pendulum_time(2023, 10, 27, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 28, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 29, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 30, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 31, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 11, 1, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 27, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 28, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 30, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 31, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 11, 1, 3, 0, 0, tz="Europe/Berlin"),
         ],
     ),
     # Hourly / fall back
@@ -141,30 +123,22 @@ DST_PARAMS = [
         "Europe/Berlin",
         "45 * * * *",
         [
-            create_pendulum_time(2023, 10, 29, 0, 45, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 29, 1, 45, 0, tz="Europe/Berlin"),
-            create_pendulum_time(
-                2023, 10, 29, 2, 45, 0, tz="Europe/Berlin", dst_rule=PRE_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 29, 2, 45, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(2023, 10, 29, 3, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 0, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 1, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 2, 45, 0, tz="Europe/Berlin", fold=0),
+            create_datetime(2023, 10, 29, 2, 45, 0, tz="Europe/Berlin", fold=1),
+            create_datetime(2023, 10, 29, 3, 45, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "0 * * * *",
         [
-            create_pendulum_time(2023, 10, 29, 0, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 29, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(
-                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=PRE_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(2023, 10, 29, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 0, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", fold=0),
+            create_datetime(2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", fold=1),
+            create_datetime(2023, 10, 29, 3, 0, 0, tz="Europe/Berlin"),
         ],
     ),
     # Weekly / fall back
@@ -172,72 +146,48 @@ DST_PARAMS = [
         "Europe/Berlin",
         "45 1 * * 0",  # Every sunday at 1:45 AM
         [
-            create_pendulum_time(2023, 10, 15, 1, 45, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 22, 1, 45, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 29, 1, 45, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 11, 5, 1, 45, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 11, 12, 1, 45, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 11, 19, 1, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 15, 1, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 22, 1, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 1, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 11, 5, 1, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 11, 12, 1, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 11, 19, 1, 45, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "0 2 * * 0",  # Every sunday at 2 AM
         [
-            create_pendulum_time(
-                2023, 10, 15, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 22, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 11, 5, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 11, 12, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 11, 19, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
+            create_datetime(2023, 10, 15, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 22, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", fold=1),
+            create_datetime(2023, 11, 5, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 11, 12, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 11, 19, 2, 0, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "30 2 * * 0",  # Every sunday at 2:30 AM
         [
-            create_pendulum_time(
-                2023, 10, 15, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 22, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 29, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 11, 5, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 11, 12, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 11, 19, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
+            create_datetime(2023, 10, 15, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 22, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 2, 30, 0, tz="Europe/Berlin", fold=1),
+            create_datetime(2023, 11, 5, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 11, 12, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 11, 19, 2, 30, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "0 3 * * 0",  # Every sunday at 3:00 AM
         [
-            create_pendulum_time(2023, 10, 15, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 22, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 29, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 11, 5, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 11, 12, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 11, 19, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 15, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 22, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 11, 5, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 11, 12, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 11, 19, 3, 0, 0, tz="Europe/Berlin"),
         ],
     ),
     # Monthly / fall back (11/5 2AM is turned back to 1AM)
@@ -245,44 +195,44 @@ DST_PARAMS = [
         "US/Central",
         "45 0 5 * *",  # 5th of each month at 00:45 (No DST issues)
         [
-            create_pendulum_time(2023, 9, 5, 0, 45, 0, tz="US/Central"),
-            create_pendulum_time(2023, 10, 5, 0, 45, 0, tz="US/Central"),
-            create_pendulum_time(2023, 11, 5, 0, 45, 0, tz="US/Central"),
-            create_pendulum_time(2023, 12, 5, 0, 45, 0, tz="US/Central"),
-            create_pendulum_time(2024, 1, 5, 0, 45, 0, tz="US/Central"),
+            create_datetime(2023, 9, 5, 0, 45, 0, tz="US/Central"),
+            create_datetime(2023, 10, 5, 0, 45, 0, tz="US/Central"),
+            create_datetime(2023, 11, 5, 0, 45, 0, tz="US/Central"),
+            create_datetime(2023, 12, 5, 0, 45, 0, tz="US/Central"),
+            create_datetime(2024, 1, 5, 0, 45, 0, tz="US/Central"),
         ],
     ),
     (
         "US/Central",
         "0 1 5 * *",  # 5th of each month at 1AM
         [
-            create_pendulum_time(2023, 9, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
-            create_pendulum_time(2023, 10, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
-            create_pendulum_time(2023, 11, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
-            create_pendulum_time(2023, 12, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
-            create_pendulum_time(2024, 1, 5, 1, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
+            create_datetime(2023, 9, 5, 1, 0, 0, tz="US/Central"),
+            create_datetime(2023, 10, 5, 1, 0, 0, tz="US/Central"),
+            create_datetime(2023, 11, 5, 1, 0, 0, tz="US/Central", fold=1),
+            create_datetime(2023, 12, 5, 1, 0, 0, tz="US/Central"),
+            create_datetime(2024, 1, 5, 1, 0, 0, tz="US/Central"),
         ],
     ),
     (
         "US/Central",
         "30 1 5 * *",  # 5th of each month at 130AM
         [
-            create_pendulum_time(2023, 9, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION),
-            create_pendulum_time(2023, 10, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION),
-            create_pendulum_time(2023, 11, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION),
-            create_pendulum_time(2023, 12, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION),
-            create_pendulum_time(2024, 1, 5, 1, 30, 0, tz="US/Central", dst_rule=POST_TRANSITION),
+            create_datetime(2023, 9, 5, 1, 30, 0, tz="US/Central"),
+            create_datetime(2023, 10, 5, 1, 30, 0, tz="US/Central"),
+            create_datetime(2023, 11, 5, 1, 30, 0, tz="US/Central", fold=1),
+            create_datetime(2023, 12, 5, 1, 30, 0, tz="US/Central"),
+            create_datetime(2024, 1, 5, 1, 30, 0, tz="US/Central"),
         ],
     ),
     (
         "US/Central",
         "0 2 5 * *",  # 5th of each month at 2AM
         [
-            create_pendulum_time(2023, 9, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
-            create_pendulum_time(2023, 10, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
-            create_pendulum_time(2023, 11, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
-            create_pendulum_time(2023, 12, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
-            create_pendulum_time(2024, 1, 5, 2, 0, 0, tz="US/Central", dst_rule=POST_TRANSITION),
+            create_datetime(2023, 9, 5, 2, 0, 0, tz="US/Central"),
+            create_datetime(2023, 10, 5, 2, 0, 0, tz="US/Central"),
+            create_datetime(2023, 11, 5, 2, 0, 0, tz="US/Central", fold=1),
+            create_datetime(2023, 12, 5, 2, 0, 0, tz="US/Central"),
+            create_datetime(2024, 1, 5, 2, 0, 0, tz="US/Central"),
         ],
     ),
     # Daily / spring forward
@@ -290,52 +240,52 @@ DST_PARAMS = [
         "Europe/Berlin",
         "0 1 * * *",
         [
-            create_pendulum_time(2023, 3, 24, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 25, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 27, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 28, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 29, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 24, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 25, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 27, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 28, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 29, 1, 0, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "0 2 * * *",
         [
-            create_pendulum_time(2023, 3, 24, 2, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 25, 2, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(  # 2AM on 3/26 does not exist, move forward
+            create_datetime(2023, 3, 24, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 25, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(  # 2AM on 3/26 does not exist, move forward
                 2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"
             ),
-            create_pendulum_time(2023, 3, 27, 2, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 28, 2, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 29, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 27, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 28, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 29, 2, 0, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "30 2 * * *",
         [
-            create_pendulum_time(2023, 3, 24, 2, 30, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 25, 2, 30, 0, tz="Europe/Berlin"),
-            create_pendulum_time(  # 2AM on 3/26 does not exist, move forward to 3AM
+            create_datetime(2023, 3, 24, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 25, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(  # 2AM on 3/26 does not exist, move forward to 3AM
                 2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"
             ),
-            create_pendulum_time(2023, 3, 27, 2, 30, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 28, 2, 30, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 29, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 27, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 28, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 29, 2, 30, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "0 3 * * *",
         [
-            create_pendulum_time(2023, 3, 24, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 25, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 27, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 28, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 29, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 24, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 25, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 27, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 28, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 29, 3, 0, 0, tz="Europe/Berlin"),
         ],
     ),
     # Weekly / spring forward
@@ -343,62 +293,62 @@ DST_PARAMS = [
         "Europe/Berlin",
         "0 1 * * 0",
         [
-            create_pendulum_time(2023, 3, 12, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 19, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 4, 2, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 4, 9, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 4, 16, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 12, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 19, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 4, 2, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 4, 9, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 4, 16, 1, 0, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "0 2 * * 0",
         [
-            create_pendulum_time(2023, 3, 12, 2, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 19, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 12, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 19, 2, 0, 0, tz="Europe/Berlin"),
             # 2AM on 3/26 does not exist, move forward
-            create_pendulum_time(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 4, 2, 2, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 4, 9, 2, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 4, 16, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 4, 2, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 4, 9, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 4, 16, 2, 0, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "30 2 * * 0",
         [
-            create_pendulum_time(2023, 3, 12, 2, 30, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 19, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 12, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 19, 2, 30, 0, tz="Europe/Berlin"),
             # 2:30AM on 3/26 does not exist, move forward
-            create_pendulum_time(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 4, 2, 2, 30, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 4, 9, 2, 30, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 4, 16, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 4, 2, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 4, 9, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 4, 16, 2, 30, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "0 3 * * 0",
         [
-            create_pendulum_time(2023, 3, 12, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 19, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 4, 2, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 4, 9, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 4, 16, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 12, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 19, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 4, 2, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 4, 9, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 4, 16, 3, 0, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "0 3 * * *",
         [
-            create_pendulum_time(2023, 3, 24, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 25, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 27, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 28, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 29, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 24, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 25, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 27, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 28, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 29, 3, 0, 0, tz="Europe/Berlin"),
         ],
     ),
     # Monthly / spring forward
@@ -406,46 +356,46 @@ DST_PARAMS = [
         "Europe/Berlin",
         "0 1 26 * *",
         [
-            create_pendulum_time(2023, 1, 26, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 2, 26, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 4, 26, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 5, 26, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 1, 26, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 2, 26, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 4, 26, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 5, 26, 1, 0, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "0 2 26 * *",
         [
-            create_pendulum_time(2023, 1, 26, 2, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 2, 26, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 1, 26, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 2, 26, 2, 0, 0, tz="Europe/Berlin"),
             # 2AM on 3/26 does not exist, move forward to 3AM
-            create_pendulum_time(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 4, 26, 2, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 5, 26, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 4, 26, 2, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 5, 26, 2, 0, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "30 2 26 * *",
         [
-            create_pendulum_time(2023, 1, 26, 2, 30, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 2, 26, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 1, 26, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 2, 26, 2, 30, 0, tz="Europe/Berlin"),
             # 230AM on 3/26 does not exist, move forward to 3AM
-            create_pendulum_time(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 4, 26, 2, 30, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 5, 26, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 4, 26, 2, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 5, 26, 2, 30, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "0 3 26 * *",
         [
-            create_pendulum_time(2023, 1, 26, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 2, 26, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 4, 26, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 5, 26, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 1, 26, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 2, 26, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 4, 26, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 5, 26, 3, 0, 0, tz="Europe/Berlin"),
         ],
     ),
     # Hourly / spring forward
@@ -453,73 +403,57 @@ DST_PARAMS = [
         "Europe/Berlin",
         "45 * * * *",
         [
-            create_pendulum_time(2023, 3, 26, 0, 45, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 1, 45, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 3, 45, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 4, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 0, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 1, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 3, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 4, 45, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "0 * * * *",
         [
-            create_pendulum_time(2023, 3, 26, 0, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 4, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 0, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 4, 0, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "*/15 * * * *",
         [
-            create_pendulum_time(2023, 3, 26, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 1, 15, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 1, 30, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 1, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 1, 15, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 1, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 1, 45, 0, tz="Europe/Berlin"),
             # 2 AM does not exist
-            create_pendulum_time(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 3, 15, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 3, 30, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 3, 26, 3, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 3, 15, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 3, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 3, 26, 3, 45, 0, tz="Europe/Berlin"),
         ],
     ),
     (
         "Europe/Berlin",
         "*/15 * * * *",
         [
-            create_pendulum_time(2023, 10, 29, 1, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 29, 1, 15, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 29, 1, 30, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 29, 1, 45, 0, tz="Europe/Berlin"),
-            create_pendulum_time(
-                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=PRE_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 29, 2, 15, 0, tz="Europe/Berlin", dst_rule=PRE_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 29, 2, 30, 0, tz="Europe/Berlin", dst_rule=PRE_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 29, 2, 45, 0, tz="Europe/Berlin", dst_rule=PRE_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 29, 2, 15, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 29, 2, 30, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(
-                2023, 10, 29, 2, 45, 0, tz="Europe/Berlin", dst_rule=POST_TRANSITION
-            ),
-            create_pendulum_time(2023, 10, 29, 3, 0, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 29, 3, 15, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 29, 3, 30, 0, tz="Europe/Berlin"),
-            create_pendulum_time(2023, 10, 29, 3, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 1, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 1, 15, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 1, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 1, 45, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", fold=0),
+            create_datetime(2023, 10, 29, 2, 15, 0, tz="Europe/Berlin", fold=0),
+            create_datetime(2023, 10, 29, 2, 30, 0, tz="Europe/Berlin", fold=0),
+            create_datetime(2023, 10, 29, 2, 45, 0, tz="Europe/Berlin", fold=0),
+            create_datetime(2023, 10, 29, 2, 0, 0, tz="Europe/Berlin", fold=1),
+            create_datetime(2023, 10, 29, 2, 15, 0, tz="Europe/Berlin", fold=1),
+            create_datetime(2023, 10, 29, 2, 30, 0, tz="Europe/Berlin", fold=1),
+            create_datetime(2023, 10, 29, 2, 45, 0, tz="Europe/Berlin", fold=1),
+            create_datetime(2023, 10, 29, 3, 0, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 3, 15, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 3, 30, 0, tz="Europe/Berlin"),
+            create_datetime(2023, 10, 29, 3, 45, 0, tz="Europe/Berlin"),
         ],
     ),
 ]

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_schedule_iterator.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_schedule_iterator.py
@@ -1,13 +1,13 @@
 import pytest
 from dagster._check import CheckError
-from dagster._seven.compat.pendulum import create_pendulum_time
+from dagster._seven import create_datetime
 from dagster._utils.schedules import schedule_execution_time_iterator
 
 
 def test_cron_schedule_advances_past_dst():
     # In Australia/Sydney, DST is at 2AM on 10/3/21. Verify that we don't
     # get stuck on the DST boundary.
-    start_time = create_pendulum_time(
+    start_time = create_datetime(
         year=2021, month=10, day=3, hour=1, minute=30, second=1, tz="Australia/Sydney"
     )
 
@@ -21,14 +21,12 @@ def test_cron_schedule_advances_past_dst():
 
     assert (
         next_time.timestamp()
-        == create_pendulum_time(
-            year=2021, month=10, day=3, hour=4, tz="Australia/Sydney"
-        ).timestamp()
+        == create_datetime(year=2021, month=10, day=3, hour=4, tz="Australia/Sydney").timestamp()
     )
 
 
 def test_vixie_cronstring_schedule():
-    start_time = create_pendulum_time(
+    start_time = create_datetime(
         year=2022, month=2, day=21, hour=1, minute=30, second=1, tz="US/Pacific"
     )
 
@@ -38,7 +36,7 @@ def test_vixie_cronstring_schedule():
         next_time = next(time_iter)
     assert (
         next_time.timestamp()
-        == create_pendulum_time(year=2022, month=2, day=21, hour=7, tz="US/Pacific").timestamp()
+        == create_datetime(year=2022, month=2, day=21, hour=7, tz="US/Pacific").timestamp()
     )
 
     time_iter = schedule_execution_time_iterator(start_time.timestamp(), "@daily", "US/Pacific")
@@ -47,7 +45,7 @@ def test_vixie_cronstring_schedule():
         next_time = next(time_iter)
     assert (
         next_time.timestamp()
-        == create_pendulum_time(year=2022, month=2, day=27, tz="US/Pacific").timestamp()
+        == create_datetime(year=2022, month=2, day=27, tz="US/Pacific").timestamp()
     )
 
     time_iter = schedule_execution_time_iterator(start_time.timestamp(), "@weekly", "US/Pacific")
@@ -56,7 +54,7 @@ def test_vixie_cronstring_schedule():
         next_time = next(time_iter)
     assert (
         next_time.timestamp()
-        == create_pendulum_time(year=2022, month=4, day=3, tz="US/Pacific").timestamp()
+        == create_datetime(year=2022, month=4, day=3, tz="US/Pacific").timestamp()
     )
 
     time_iter = schedule_execution_time_iterator(start_time.timestamp(), "@monthly", "US/Pacific")
@@ -65,7 +63,7 @@ def test_vixie_cronstring_schedule():
         next_time = next(time_iter)
     assert (
         next_time.timestamp()
-        == create_pendulum_time(year=2022, month=8, day=1, tz="US/Pacific").timestamp()
+        == create_datetime(year=2022, month=8, day=1, tz="US/Pacific").timestamp()
     )
 
     time_iter = schedule_execution_time_iterator(start_time.timestamp(), "@yearly", "US/Pacific")
@@ -74,13 +72,13 @@ def test_vixie_cronstring_schedule():
         next_time = next(time_iter)
     assert (
         next_time.timestamp()
-        == create_pendulum_time(year=2028, month=1, day=1, tz="US/Pacific").timestamp()
+        == create_datetime(year=2028, month=1, day=1, tz="US/Pacific").timestamp()
     )
 
 
 def test_union_of_cron_strings_schedule():
     # Saturday
-    start_time = create_pendulum_time(year=2022, month=1, day=1, hour=2, tz="UTC")
+    start_time = create_datetime(year=2022, month=1, day=1, hour=2, tz="UTC")
 
     time_iter = schedule_execution_time_iterator(
         start_time.timestamp(),
@@ -97,21 +95,21 @@ def test_union_of_cron_strings_schedule():
     expected_next_timestamps = [
         dt.timestamp()
         for dt in [
-            create_pendulum_time(year=2022, month=1, day=1, hour=2, tz="UTC"),
-            create_pendulum_time(year=2022, month=1, day=2, hour=9, tz="UTC"),
-            create_pendulum_time(year=2022, month=1, day=2, hour=9, minute=30, tz="UTC"),
-            create_pendulum_time(year=2022, month=1, day=3, hour=2, tz="UTC"),
-            create_pendulum_time(year=2022, month=1, day=3, hour=8, tz="UTC"),
-            create_pendulum_time(year=2022, month=1, day=7, hour=2, tz="UTC"),
-            create_pendulum_time(year=2022, month=1, day=7, hour=8, tz="UTC"),
-            create_pendulum_time(year=2022, month=1, day=8, hour=2, tz="UTC"),
+            create_datetime(year=2022, month=1, day=1, hour=2, tz="UTC"),
+            create_datetime(year=2022, month=1, day=2, hour=9, tz="UTC"),
+            create_datetime(year=2022, month=1, day=2, hour=9, minute=30, tz="UTC"),
+            create_datetime(year=2022, month=1, day=3, hour=2, tz="UTC"),
+            create_datetime(year=2022, month=1, day=3, hour=8, tz="UTC"),
+            create_datetime(year=2022, month=1, day=7, hour=2, tz="UTC"),
+            create_datetime(year=2022, month=1, day=7, hour=8, tz="UTC"),
+            create_datetime(year=2022, month=1, day=8, hour=2, tz="UTC"),
         ]
     ]
     assert next_timestamps == expected_next_timestamps
 
 
 def test_invalid_cron_string():
-    start_time = create_pendulum_time(
+    start_time = create_datetime(
         year=2022, month=2, day=21, hour=1, minute=30, second=1, tz="US/Pacific"
     )
 
@@ -120,7 +118,7 @@ def test_invalid_cron_string():
 
 
 def test_empty_cron_string_union():
-    start_time = create_pendulum_time(
+    start_time = create_datetime(
         year=2022, month=2, day=21, hour=1, minute=30, second=1, tz="US/Pacific"
     )
 
@@ -130,21 +128,21 @@ def test_empty_cron_string_union():
 
 def test_first_monday():
     # start sunday 1/1/2023
-    start_time = create_pendulum_time(year=2023, month=1, day=1, tz="US/Pacific")
+    start_time = create_datetime(year=2023, month=1, day=1, tz="US/Pacific")
     iterator = schedule_execution_time_iterator(
         start_time.timestamp(), "0 0 * * mon#1", "US/Pacific"
     )
     # monday 1/2
-    assert next(iterator) == create_pendulum_time(year=2023, month=1, day=2, tz="US/Pacific")
+    assert next(iterator) == create_datetime(year=2023, month=1, day=2, tz="US/Pacific")
     # monday 2/6
-    assert next(iterator) == create_pendulum_time(year=2023, month=2, day=6, tz="US/Pacific")
+    assert next(iterator) == create_datetime(year=2023, month=2, day=6, tz="US/Pacific")
     # monday 3/6
-    assert next(iterator) == create_pendulum_time(year=2023, month=3, day=6, tz="US/Pacific")
+    assert next(iterator) == create_datetime(year=2023, month=3, day=6, tz="US/Pacific")
 
 
 def test_on_tick_boundary_simple():
     # Saturday
-    start_time = create_pendulum_time(year=2022, month=1, day=1, hour=2, tz="UTC")
+    start_time = create_datetime(year=2022, month=1, day=1, hour=2, tz="UTC")
 
     time_iter = schedule_execution_time_iterator(
         start_time.timestamp(),
@@ -157,7 +155,7 @@ def test_on_tick_boundary_simple():
     next_timestamps = [next(time_iter).timestamp() for _ in range(8)]
 
     expected_next_timestamps = [
-        create_pendulum_time(year=2022, month=1, day=i + 1, hour=3, tz="UTC").timestamp()
+        create_datetime(year=2022, month=1, day=i + 1, hour=3, tz="UTC").timestamp()
         for i in range(8)
     ]
     assert next_timestamps == expected_next_timestamps
@@ -165,7 +163,7 @@ def test_on_tick_boundary_simple():
 
 def test_on_tick_boundary_complex():
     # Saturday
-    start_time = create_pendulum_time(year=2022, month=1, day=1, hour=2, tz="UTC")
+    start_time = create_datetime(year=2022, month=1, day=1, hour=2, tz="UTC")
 
     time_iter = schedule_execution_time_iterator(
         start_time.timestamp(),
@@ -178,7 +176,7 @@ def test_on_tick_boundary_complex():
     next_timestamps = [next(time_iter).timestamp() for _ in range(10)]
 
     expected_next_timestamps = [
-        create_pendulum_time(year=2022, month=1, day=i + 1, hour=3, tz="UTC").timestamp()
+        create_datetime(year=2022, month=1, day=i + 1, hour=3, tz="UTC").timestamp()
         for i in (*range(2, 7), *range(9, 14))  # skip SAT and SUN
     ]
     assert next_timestamps == expected_next_timestamps


### PR DESCRIPTION
## Summary & Motivation
Another largely rote replacement - create_datetime has the same API as create_pendulum_time for ease of transition. POST_TRANSITION is replaced with fold=1. 

## How I Tested These Changes
BK