### PR TITLE
[6/n] Remove pendulum.instance and pendulum.parse in tests

### DIFF
--- a/examples/assets_dynamic_partitions/assets_dynamic_partitions/assets.py
+++ b/examples/assets_dynamic_partitions/assets_dynamic_partitions/assets.py
@@ -3,9 +3,9 @@ import os
 import urllib.request
 import zipfile
 
-import pendulum
 import requests
 from dagster import DynamicPartitionsDefinition, Output, asset, get_dagster_logger
+from dagster._seven import parse_with_timezone
 from pandas import DataFrame
 
 releases_partitions_def = DynamicPartitionsDefinition(name="releases")
@@ -37,7 +37,7 @@ def releases_metadata(context) -> DataFrame:
                 "zipball_url": response_content["zipball_url"],
                 "id": response_content["id"],
                 "author_login": response_content["author"]["login"],
-                "published_at": pendulum.parse(response_content["published_at"]),
+                "published_at": parse_with_timezone(response_content["published_at"]),
             }
         ]
     )

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -18,7 +18,6 @@ from typing import (
     overload,
 )
 
-import pendulum
 from typing_extensions import TypeAlias
 
 import dagster._check as check
@@ -39,7 +38,7 @@ from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, Runs
 from dagster._serdes import serialize_value, whitelist_for_serdes
 from dagster._serdes.errors import DeserializationError
 from dagster._serdes.serdes import deserialize_value
-from dagster._seven import JSONDecodeError
+from dagster._seven import JSONDecodeError, parse_with_timezone
 from dagster._utils import utc_datetime_from_timestamp
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.warnings import normalize_renamed_param
@@ -729,7 +728,7 @@ class RunStatusSensorDefinition(SensorDefinition):
                     records_filter=RunStatusChangeRecordsFilter(
                         event_type=cast(RunStatusChangeEventType, event_type),
                         after_timestamp=cast(
-                            datetime, pendulum.parse(sensor_cursor.update_timestamp)
+                            datetime, parse_with_timezone(sensor_cursor.update_timestamp)
                         ).timestamp(),
                     ),
                     ascending=True,

--- a/python_modules/dagster/dagster/_core/definitions/timestamp.py
+++ b/python_modules/dagster/dagster/_core/definitions/timestamp.py
@@ -1,7 +1,6 @@
 from typing import NamedTuple
 
 from dagster._serdes import whitelist_for_serdes
-from dagster._seven.compat.pendulum import PendulumDateTime
 
 
 # TimestampWithTimezone is used to preserve IANA timezone information when serializing.
@@ -13,7 +12,3 @@ from dagster._seven.compat.pendulum import PendulumDateTime
 class TimestampWithTimezone(NamedTuple):
     timestamp: float  # Seconds since the Unix epoch
     timezone: str
-
-    @staticmethod
-    def from_pendulum_time(dt: PendulumDateTime):
-        return TimestampWithTimezone(dt.timestamp(), dt.timezone.name)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 import dagster._check as check
-import pendulum
 import pytest
 from dagster import (
     AssetExecutionContext,
@@ -47,7 +46,7 @@ from dagster._core.test_utils import (
     freeze_time,
     raise_exception_on_warnings,
 )
-from dagster._seven import create_datetime
+from dagster._seven import create_datetime, parse_with_timezone
 
 
 @pytest.fixture(autouse=True)
@@ -295,7 +294,7 @@ def test_output_context_asset_partitions_time_window():
     class MyIOManager(IOManager):
         def handle_output(self, context, _obj):
             assert context.asset_partitions_time_window == TimeWindow(
-                pendulum.parse("2021-06-06"), pendulum.parse("2021-06-07")
+                parse_with_timezone("2021-06-06"), parse_with_timezone("2021-06-07")
             )
 
         def load_input(self, context):
@@ -318,12 +317,12 @@ def test_input_context_asset_partitions_time_window():
     class MyIOManager(IOManager):
         def handle_output(self, context, _obj):
             assert context.asset_partitions_time_window == TimeWindow(
-                pendulum.parse("2021-06-06"), pendulum.parse("2021-06-07")
+                parse_with_timezone("2021-06-06"), parse_with_timezone("2021-06-07")
             )
 
         def load_input(self, context):
             assert context.asset_partitions_time_window == TimeWindow(
-                pendulum.parse("2021-06-06"), pendulum.parse("2021-06-07")
+                parse_with_timezone("2021-06-06"), parse_with_timezone("2021-06-07")
             )
 
     @asset(partitions_def=partitions_def)
@@ -333,7 +332,7 @@ def test_input_context_asset_partitions_time_window():
     @asset(partitions_def=partitions_def)
     def downstream_asset(context, upstream_asset):
         assert context.asset_partitions_time_window_for_input("upstream_asset") == TimeWindow(
-            pendulum.parse("2021-06-06"), pendulum.parse("2021-06-07")
+            parse_with_timezone("2021-06-06"), parse_with_timezone("2021-06-07")
         )
         assert upstream_asset is None
 
@@ -699,12 +698,12 @@ def test_multipartitioned_asset_partitions_time_window():
     class CustomIOManager(IOManager):
         def handle_output(self, context: OutputContext, obj):
             assert context.asset_partitions_time_window == TimeWindow(
-                pendulum.parse("2023-01-01"), pendulum.parse("2023-01-02")
+                parse_with_timezone("2023-01-01"), parse_with_timezone("2023-01-02")
             )
 
         def load_input(self, context: InputContext):
             assert context.asset_partitions_time_window == TimeWindow(
-                pendulum.parse("2023-01-01"), pendulum.parse("2023-01-02")
+                parse_with_timezone("2023-01-01"), parse_with_timezone("2023-01-02")
             )
 
     assert materialize(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -135,7 +135,8 @@ def test_time_window_partitions_subset_num_partitions_serialization():
     )
 
     tw = PersistedTimeWindow.from_public_time_window(
-        time_partitions_def.time_window_for_partition_key("2023-01-01")
+        time_partitions_def.time_window_for_partition_key("2023-01-01"),
+        time_partitions_def.timezone,
     )
 
     subset = TimeWindowPartitionsSubset(

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
@@ -2,7 +2,6 @@ import math
 from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
-import pendulum
 import pytest
 from dagster import (
     AssetDep,
@@ -965,7 +964,7 @@ def test_assets_backfill_with_partition_mapping_with_multi_partitions_multi_run_
 
 def test_assets_backfill_with_partition_mapping_with_single_run_backfill_policy():
     daily_partitions_def: DailyPartitionsDefinition = DailyPartitionsDefinition("2023-01-01")
-    test_time = pendulum.parse("2023-03-10T00:00:00", tz="UTC")
+    test_time = parse_with_timezone("2023-03-10T00:00:00")
 
     @asset(
         name="upstream_a",

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from itertools import count
 from typing import Any, List, Optional
 
-import pendulum
 import pytest
 from dagster import (
     ConfigMapping,
@@ -40,6 +39,7 @@ from dagster._core.errors import (
 )
 from dagster._core.test_utils import instance_for_test
 from dagster._loggers import json_console_logger
+from dagster._seven import parse_with_timezone
 
 
 def get_ops():
@@ -970,7 +970,7 @@ def test_job_partitions_def():
         assert context.has_partition_key
         assert context.partition_key == "2020-01-01"
         assert context.partition_time_window == TimeWindow(
-            pendulum.parse("2020-01-01"), pendulum.parse("2020-01-02")
+            parse_with_timezone("2020-01-01"), parse_with_timezone("2020-01-02")
         )
 
     @graph

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_legacy_missing_condition.py
@@ -69,8 +69,8 @@ def test_missing_time_partitioned() -> None:
     # if the partitions definition changes, then we have 1 fewer missing partition
     state = state.with_asset_properties(
         partitions_def=daily_partitions_def._replace(
-            start=TimestampWithTimezone.from_pendulum_time(
-                time_partitions_start_datetime + datetime.timedelta(days=1)
+            start=TimestampWithTimezone(
+                (time_partitions_start_datetime + datetime.timedelta(days=1)).timestamp(), "UTC"
             )
         )
     )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_specs.py
@@ -1,6 +1,5 @@
 import datetime
 
-import pendulum
 from dagster import AssetSpec, MultiPartitionKey, StaticPartitionsDefinition
 from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.asset_spec import (
@@ -15,6 +14,7 @@ from dagster._core.definitions.time_window_partitions import (
     DailyPartitionsDefinition,
     HourlyPartitionsDefinition,
 )
+from dagster._seven import parse_with_timezone
 
 from .scenario_state import MultiAssetSpec, ScenarioSpec
 
@@ -27,7 +27,7 @@ two_partitions_def = StaticPartitionsDefinition(["1", "2"])
 three_partitions_def = StaticPartitionsDefinition(["1", "2", "3"])
 
 time_partitions_start_str = "2013-01-05"
-time_partitions_start_datetime = pendulum.parse(time_partitions_start_str)
+time_partitions_start_datetime = parse_with_timezone(time_partitions_start_str)
 hourly_partitions_def = HourlyPartitionsDefinition(start_date=time_partitions_start_str + "-00:00")
 daily_partitions_def = DailyPartitionsDefinition(start_date=time_partitions_start_str)
 time_multipartitions_def = MultiPartitionsDefinition(

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_state.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_state.py
@@ -50,6 +50,7 @@ from dagster._core.test_utils import (
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.utils import make_new_run_id
 from dagster._serdes.utils import create_snapshot_id
+from dagster._seven import parse_with_timezone
 from typing_extensions import Self
 
 from .base_scenario import run_request
@@ -180,7 +181,7 @@ class ScenarioSpec:
 
     def with_current_time(self, time: Union[str, datetime.datetime]) -> "ScenarioSpec":
         if isinstance(time, str):
-            time = pendulum.parse(time)
+            time = parse_with_timezone(time)
         return dataclasses.replace(self, current_time=time)
 
     def with_current_time_advanced(self, **kwargs) -> "ScenarioSpec":
@@ -245,7 +246,7 @@ class ScenarioState:
     def asset_graph(self) -> AssetGraph:
         return self.scenario_spec.asset_graph
 
-    def with_current_time(self, time: str) -> Self:
+    def with_current_time(self, time: Union[str, datetime.datetime]) -> Self:
         return dataclasses.replace(self, scenario_spec=self.scenario_spec.with_current_time(time))
 
     def with_current_time_advanced(self, **kwargs) -> Self:

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/updated_scenarios/partition_scenarios.py
@@ -394,8 +394,9 @@ partition_scenarios = [
         .with_asset_properties(
             keys=["B"],
             partitions_def=hourly_partitions_def._replace(
-                start=TimestampWithTimezone.from_pendulum_time(
-                    time_partitions_start_datetime + datetime.timedelta(hours=1)
+                start=TimestampWithTimezone(
+                    (time_partitions_start_datetime + datetime.timedelta(hours=1)).timestamp(),
+                    hourly_partitions_def.timezone,
                 )
             ),
         )
@@ -516,8 +517,9 @@ partition_scenarios = [
         .with_current_time_advanced(days=5)
         .with_asset_properties(
             partitions_def=hourly_partitions_def._replace(
-                start=TimestampWithTimezone.from_pendulum_time(
-                    time_partitions_start_datetime + datetime.timedelta(days=5)
+                start=TimestampWithTimezone(
+                    (time_partitions_start_datetime + datetime.timedelta(days=5)).timestamp(),
+                    hourly_partitions_def.timezone,
                 )
             )
         )
@@ -686,8 +688,9 @@ partition_scenarios = [
         initial_spec=three_assets_in_sequence.with_asset_properties(
             keys=["A"],
             partitions_def=daily_partitions_def._replace(
-                start=TimestampWithTimezone.from_pendulum_time(
-                    time_partitions_start_datetime + datetime.timedelta(days=4)
+                start=TimestampWithTimezone(
+                    (time_partitions_start_datetime + datetime.timedelta(days=4)).timestamp(),
+                    daily_partitions_def.timezone,
                 )
             ),
         )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_flatten_time_window_ranges.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_flatten_time_window_ranges.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from typing import cast
 
-import pendulum
 from dagster import DailyPartitionsDefinition, PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import (
     PartitionRangeStatus,
@@ -9,13 +8,15 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
     fetch_flattened_time_window_ranges,
 )
+from dagster._seven import parse_with_timezone
 
 DATE_FORMAT = "%Y-%m-%d"
 
 
 def time_window(start: str, end: str) -> TimeWindow:
     return TimeWindow(
-        cast(datetime, pendulum.parser.parse(start)), cast(datetime, pendulum.parser.parse(end))
+        cast(datetime, parse_with_timezone(start)),
+        cast(datetime, parse_with_timezone(end)),
     )
 
 


### PR DESCRIPTION
## Summary & Motivation
Another largely rote one. Added `parse_with_timezone` to keep the nice property that pendulum had where it always ends up with a tzinfo.

## How I Tested These Changes
BK
