### PR TITLE
Begin stack to use DecoratorAssetsDefinitionBuilder for asset-check-related decorators 

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -507,18 +507,22 @@ class DecoratorAssetsDefinitionBuilder:
             asset_name=self.op_name,
         )
 
+    @cached_property
+    def required_resource_keys(self) -> AbstractSet[str]:
+        return compute_required_resource_keys(
+            required_resource_keys=self.args.required_resource_keys,
+            resource_defs=self.args.op_def_resource_defs,
+            fn=self.fn,
+            decorator_name=self.args.decorator_name,
+        )
+
     def _create_op_definition(self) -> OpDefinition:
         return _Op(
             name=self.op_name,
             description=self.args.description,
             ins=self.ins_by_input_names,
             out=self.combined_outs_by_output_name,
-            required_resource_keys=compute_required_resource_keys(
-                required_resource_keys=self.args.required_resource_keys,
-                resource_defs=self.args.op_def_resource_defs,
-                fn=self.fn,
-                decorator_name=self.args.decorator_name,
-            ),
+            required_resource_keys=self.required_resource_keys,
             tags={
                 **({COMPUTE_KIND_TAG: self.args.compute_kind} if self.args.compute_kind else {}),
                 **(self.args.op_tags or {}),


### PR DESCRIPTION
## Summary & Motivation

The general approach here will be to incrementally "eat" the current implementation of these decorators by creating the builders and then using their interior methods to incrementally replace the entire body of decorator-based construction.

In this case we will replace the call to `compute_required_resource_keys` with the one in the builder.

## How I Tested These Changes

BK
