### PR TITLE
Move check spec validation into asset-decorator-only creation pathways

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -599,8 +599,8 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         owners_by_output_name: Optional[Mapping[str, Sequence[str]]] = None,
     ) -> "AssetsDefinition":
         from dagster._core.definitions.decorators.decorator_assets_definition_builder import (
-            _assign_output_names_to_check_specs,
             _validate_check_specs_target_relevant_asset_keys,
+            create_check_specs_by_output_name,
         )
 
         node_def = check.inst_param(node_def, "node_def", NodeDefinition)
@@ -632,7 +632,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
                 )
                 transformed_internal_asset_deps[keys_by_output_name[output_name]] = asset_keys
 
-        check_specs_by_output_name = _assign_output_names_to_check_specs(check_specs)
+        check_specs_by_output_name = create_check_specs_by_output_name(check_specs)
 
         keys_by_output_name = _infer_keys_by_output_names(
             node_def, keys_by_output_name or {}, check_specs_by_output_name

--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -598,6 +598,13 @@ class DecoratorAssetsDefinitionBuilder:
         return specs
 
 
+def validate_and_assign_output_names_to_check_specs(
+    check_specs: Optional[Sequence[AssetCheckSpec]], valid_asset_keys: Sequence[AssetKey]
+) -> Mapping[str, AssetCheckSpec]:
+    _validate_check_specs_target_relevant_asset_keys(check_specs, valid_asset_keys)
+    return create_check_specs_by_output_name(check_specs)
+
+
 def create_check_specs_by_output_name(
     check_specs: Optional[Sequence[AssetCheckSpec]],
 ) -> Mapping[str, AssetCheckSpec]:
@@ -614,13 +621,6 @@ def create_check_specs_by_output_name(
         raise DagsterInvalidDefinitionError(f"Duplicate check specs: {duplicates}")
 
     return checks_by_output_name
-
-
-def validate_and_assign_output_names_to_check_specs(
-    check_specs: Optional[Sequence[AssetCheckSpec]], valid_asset_keys: Sequence[AssetKey]
-) -> Mapping[str, AssetCheckSpec]:
-    _validate_check_specs_target_relevant_asset_keys(check_specs, valid_asset_keys)
-    return create_check_specs_by_output_name(check_specs)
 
 
 def _validate_check_specs_target_relevant_asset_keys(


### PR DESCRIPTION
## Summary & Motivation

Right now we call `validate_and_assign_output_names_to_check_specs` when we get `check_specs_by_output_name` out of the builder. However this only is relevant to asset-decorator-based (as opposed to the asset checks) use cases so hoisting it to there and removing it from the general path.

## How I Tested These Changes

BK