### PR TITLE
[ui] Add a coordinator logs tab to the backfill detail page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/CloudOSSContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/CloudOSSContext.tsx
@@ -8,6 +8,7 @@ type FeatureContext = {
   canSeeToggleScheduleAction: boolean;
   canSeeToggleSensorAction: boolean;
   canSeeExecuteChecksAction: boolean;
+  canSeeBackfillCoordinatorLogs: boolean;
 };
 
 export const CloudOSSContext = React.createContext<{
@@ -23,6 +24,7 @@ export const CloudOSSContext = React.createContext<{
     canSeeToggleSensorAction: true,
     canSeeWipeMaterializationAction: true,
     canSeeExecuteChecksAction: true,
+    canSeeBackfillCoordinatorLogs: false,
   },
   onViewChange: () => {},
   useAugmentSearchResults: () => (results) => results,

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillLogsTab.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillLogsTab.tsx
@@ -1,0 +1,76 @@
+import {gql} from '@apollo/client';
+import {Box, NonIdealState} from '@dagster-io/ui-components';
+import React from 'react';
+
+import {BackfillLogsPageQuery, BackfillLogsPageQueryVariables} from './types/BackfillLogsTab.types';
+import {BackfillDetailsBackfillFragment} from './types/BackfillPage.types';
+import {QueryRefreshCountdown} from '../../app/QueryRefresh';
+import {useCursorAccumulatedQuery} from '../../runs/useCursorAccumulatedQuery';
+import {
+  INSTIGATION_EVENT_LOG_FRAGMENT,
+  InstigationEventLogTable,
+} from '../../ticks/InstigationEventLogTable';
+import {InstigationEventLogFragment} from '../../ticks/types/InstigationEventLogTable.types';
+
+const getResultsForBackfillLogsPage = (e?: BackfillLogsPageQuery) => {
+  return e?.partitionBackfillOrError.__typename === 'PartitionBackfill'
+    ? e.partitionBackfillOrError.logEvents.events
+    : [];
+};
+const getFetchStateForBackfillLogsPage = (e?: BackfillLogsPageQuery) => {
+  return e?.partitionBackfillOrError.__typename === 'PartitionBackfill'
+    ? e.partitionBackfillOrError.logEvents
+    : null;
+};
+
+export const BackfillLogsTab = ({backfill}: {backfill: BackfillDetailsBackfillFragment}) => {
+  const {fetched: events, refreshState} = useCursorAccumulatedQuery<
+    BackfillLogsPageQuery,
+    BackfillLogsPageQueryVariables,
+    InstigationEventLogFragment
+  >({
+    query: BACKFILL_LOGS_PAGE_QUERY,
+    variables: {backfillId: backfill.id},
+    getResultArray: getResultsForBackfillLogsPage,
+    getNextFetchState: getFetchStateForBackfillLogsPage,
+  });
+
+  return (
+    <>
+      <div style={{position: 'absolute', right: 16, top: -32}}>
+        <QueryRefreshCountdown refreshState={refreshState} />
+      </div>
+      {events && events.length ? (
+        <InstigationEventLogTable events={events} />
+      ) : (
+        <Box flex={{justifyContent: 'center', alignItems: 'center'}} style={{flex: 1}}>
+          <NonIdealState
+            title="No logs available"
+            description="If backfill log storage is enabled, logs will appear as they are emitted by the backfill daemon."
+          />
+        </Box>
+      )}
+    </>
+  );
+};
+
+export const BACKFILL_LOGS_PAGE_QUERY = gql`
+  query BackfillLogsPageQuery($backfillId: String!, $cursor: String) {
+    partitionBackfillOrError(backfillId: $backfillId) {
+      __typename
+      ... on PartitionBackfill {
+        id
+        logEvents(cursor: $cursor) {
+          ... on InstigationEventConnection {
+            cursor
+            hasMore
+            events {
+              ...InstigationEventLog
+            }
+          }
+        }
+      }
+    }
+  }
+  ${INSTIGATION_EVENT_LOG_FRAGMENT}
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillLogsTab.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillLogsTab.tsx
@@ -1,5 +1,5 @@
 import {gql} from '@apollo/client';
-import {Box, NonIdealState} from '@dagster-io/ui-components';
+import {Box, NonIdealState, Spinner} from '@dagster-io/ui-components';
 import React from 'react';
 
 import {BackfillLogsPageQuery, BackfillLogsPageQueryVariables} from './types/BackfillLogsTab.types';
@@ -40,7 +40,11 @@ export const BackfillLogsTab = ({backfill}: {backfill: BackfillDetailsBackfillFr
       <div style={{position: 'absolute', right: 16, top: -32}}>
         <QueryRefreshCountdown refreshState={refreshState} />
       </div>
-      {events && events.length ? (
+      {events === null ? (
+        <Box flex={{justifyContent: 'center', alignItems: 'center'}} style={{flex: 1}}>
+          <Spinner purpose="page" />
+        </Box>
+      ) : events.length > 0 ? (
         <InstigationEventLogTable events={events} />
       ) : (
         <Box flex={{justifyContent: 'center', alignItems: 'center'}} style={{flex: 1}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
@@ -13,7 +13,7 @@ import {
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import {useEffect, useReducer} from 'react';
+import {useContext, useEffect, useReducer} from 'react';
 import {Link, useParams} from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -27,6 +27,7 @@ import {
   BackfillStatusesByAssetQuery,
   BackfillStatusesByAssetQueryVariables,
 } from './types/BackfillPage.types';
+import {CloudOSSContext} from '../../app/CloudOSSContext';
 import {PYTHON_ERROR_FRAGMENT} from '../../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../../app/PythonErrorInfo';
 import {QueryRefreshCountdown, useQueryRefreshAtInterval} from '../../app/QueryRefresh';
@@ -42,6 +43,7 @@ dayjs.extend(duration);
 dayjs.extend(relativeTime);
 
 export const BackfillPage = () => {
+  const {featureContext} = useContext(CloudOSSContext);
   const {backfillId} = useParams<{backfillId: string}>();
   useTrackPageView();
   useDocumentTitle(`Backfill | ${backfillId}`);
@@ -133,7 +135,9 @@ export const BackfillPage = () => {
           <Tabs size="large" selectedTabId={selectedTab}>
             <Tab id="partitions" title="Partitions" onClick={() => setSelectedTab('partitions')} />
             <Tab id="runs" title="Runs" onClick={() => setSelectedTab('runs')} />
-            <Tab id="logs" title="Coordinator logs" onClick={() => setSelectedTab('logs')} />
+            {featureContext.canSeeBackfillCoordinatorLogs ? (
+              <Tab id="logs" title="Coordinator logs" onClick={() => setSelectedTab('logs')} />
+            ) : null}
           </Tabs>
         </Box>
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
@@ -133,7 +133,7 @@ export const BackfillPage = () => {
           <Tabs size="large" selectedTabId={selectedTab}>
             <Tab id="partitions" title="Partitions" onClick={() => setSelectedTab('partitions')} />
             <Tab id="runs" title="Runs" onClick={() => setSelectedTab('runs')} />
-            <Tab id="logs" title="Coordinator Logs" onClick={() => setSelectedTab('logs')} />
+            <Tab id="logs" title="Coordinator logs" onClick={() => setSelectedTab('logs')} />
           </Tabs>
         </Box>
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
@@ -18,6 +18,7 @@ import {Link, useParams} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {BACKFILL_ACTIONS_BACKFILL_FRAGMENT, BackfillActionsMenu} from './BackfillActionsMenu';
+import {BackfillLogsTab} from './BackfillLogsTab';
 import {BackfillPartitionsTab} from './BackfillPartitionsTab';
 import {BackfillRunsTab} from './BackfillRunsTab';
 import {BackfillStatusTagForPage} from './BackfillStatusTagForPage';
@@ -45,7 +46,7 @@ export const BackfillPage = () => {
   useTrackPageView();
   useDocumentTitle(`Backfill | ${backfillId}`);
 
-  const [selectedTab, setSelectedTab] = useQueryPersistedState({
+  const [selectedTab, setSelectedTab] = useQueryPersistedState<'partitions' | 'logs' | 'runs'>({
     queryKey: 'tab',
     defaults: {tab: 'partitions'},
   });
@@ -132,14 +133,18 @@ export const BackfillPage = () => {
           <Tabs size="large" selectedTabId={selectedTab}>
             <Tab id="partitions" title="Partitions" onClick={() => setSelectedTab('partitions')} />
             <Tab id="runs" title="Runs" onClick={() => setSelectedTab('runs')} />
+            <Tab id="logs" title="Coordinator Logs" onClick={() => setSelectedTab('logs')} />
           </Tabs>
         </Box>
 
         {error?.graphQLErrors && (
           <Alert intent="error" title={error.graphQLErrors.map((err) => err.message)} />
         )}
-        {selectedTab === 'partitions' && <BackfillPartitionsTab backfill={backfill} />}
-        {selectedTab === 'runs' && <BackfillRunsTab backfill={backfill} />}
+        <Box flex={{direction: 'column'}} style={{flex: 1, position: 'relative', minHeight: 0}}>
+          {selectedTab === 'partitions' && <BackfillPartitionsTab backfill={backfill} />}
+          {selectedTab === 'runs' && <BackfillRunsTab backfill={backfill} />}
+          {selectedTab === 'logs' && <BackfillLogsTab backfill={backfill} />}
+        </Box>
       </>
     );
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillLogsTab.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillLogsTab.test.tsx
@@ -1,0 +1,103 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {render, screen} from '@testing-library/react';
+import {MemoryRouter, Route} from 'react-router-dom';
+import {RecoilRoot} from 'recoil';
+
+import {AnalyticsContext} from '../../../app/analytics';
+import {
+  buildInstigationEvent,
+  buildInstigationEventConnection,
+  buildPartitionBackfill,
+} from '../../../graphql/types';
+import {BACKFILL_LOGS_PAGE_QUERY, BackfillLogsTab} from '../BackfillLogsTab';
+
+// This file must be mocked because Jest can't handle `import.meta.url`.
+jest.mock('../../../graph/asyncGraphLayout', () => ({}));
+jest.mock('../../../app/QueryRefresh', () => {
+  return {
+    useQueryRefreshAtInterval: jest.fn(),
+    QueryRefreshCountdown: jest.fn(() => <div />),
+  };
+});
+
+const mockBackfillId = 'mockBackfillId';
+
+const mocks = [
+  {
+    request: {
+      query: BACKFILL_LOGS_PAGE_QUERY,
+      variables: {backfillId: mockBackfillId, cursor: undefined},
+    },
+    delay: 10,
+    result: {
+      __typename: 'CloudQuery',
+      data: {
+        partitionBackfillOrError: buildPartitionBackfill({
+          logEvents: buildInstigationEventConnection({
+            hasMore: true,
+            cursor: 'next-cursor-value',
+            events: [
+              buildInstigationEvent({
+                message: 'Event 1',
+                timestamp: '1717962300001',
+              }),
+              buildInstigationEvent({
+                message: 'Event 2',
+                timestamp: '1717962300002',
+              }),
+            ],
+          }),
+        }),
+      },
+    },
+  },
+  {
+    request: {
+      query: BACKFILL_LOGS_PAGE_QUERY,
+      variables: {backfillId: mockBackfillId, cursor: 'next-cursor-value'},
+    },
+    delay: 10,
+    result: {
+      __typename: 'CloudQuery',
+      data: {
+        partitionBackfillOrError: buildPartitionBackfill({
+          logEvents: buildInstigationEventConnection({
+            hasMore: false,
+            cursor: 'final-cursor-value',
+            events: [
+              buildInstigationEvent({
+                message: 'Event 3',
+                timestamp: `1717962300003`,
+              }),
+              buildInstigationEvent({
+                message: 'Event 4',
+                timestamp: `1717962300004`,
+              }),
+            ],
+          }),
+        }),
+      },
+    },
+  },
+];
+
+describe('BackfillLogsTab', () => {
+  it('paginates through the logs to load them all', async () => {
+    render(
+      <RecoilRoot>
+        <AnalyticsContext.Provider value={{page: () => {}} as any}>
+          <MemoryRouter initialEntries={[`/backfills/${mockBackfillId}?tab=logs`]}>
+            <Route path="/backfills/:backfillId">
+              <MockedProvider mocks={mocks}>
+                <BackfillLogsTab backfill={buildPartitionBackfill({id: mockBackfillId})} />
+              </MockedProvider>
+            </Route>
+          </MemoryRouter>
+        </AnalyticsContext.Provider>
+      </RecoilRoot>,
+    );
+
+    expect(await screen.findByText('Event 1')).toBeVisible();
+    expect(await screen.findByText('Event 4')).toBeVisible();
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillLogsTab.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillLogsTab.test.tsx
@@ -9,6 +9,7 @@ import {
   buildInstigationEventConnection,
   buildPartitionBackfill,
 } from '../../../graphql/types';
+import {buildQueryMock} from '../../../testing/mocking';
 import {BACKFILL_LOGS_PAGE_QUERY, BackfillLogsTab} from '../BackfillLogsTab';
 
 // This file must be mocked because Jest can't handle `import.meta.url`.
@@ -23,62 +24,52 @@ jest.mock('../../../app/QueryRefresh', () => {
 const mockBackfillId = 'mockBackfillId';
 
 const mocks = [
-  {
-    request: {
-      query: BACKFILL_LOGS_PAGE_QUERY,
-      variables: {backfillId: mockBackfillId, cursor: undefined},
-    },
+  buildQueryMock({
+    query: BACKFILL_LOGS_PAGE_QUERY,
+    variables: {backfillId: mockBackfillId, cursor: undefined},
     delay: 10,
-    result: {
-      __typename: 'CloudQuery',
-      data: {
-        partitionBackfillOrError: buildPartitionBackfill({
-          logEvents: buildInstigationEventConnection({
-            hasMore: true,
-            cursor: 'next-cursor-value',
-            events: [
-              buildInstigationEvent({
-                message: 'Event 1',
-                timestamp: '1717962300001',
-              }),
-              buildInstigationEvent({
-                message: 'Event 2',
-                timestamp: '1717962300002',
-              }),
-            ],
-          }),
+    data: {
+      partitionBackfillOrError: buildPartitionBackfill({
+        logEvents: buildInstigationEventConnection({
+          hasMore: true,
+          cursor: 'next-cursor-value',
+          events: [
+            buildInstigationEvent({
+              message: 'Event 1',
+              timestamp: '1717962300001',
+            }),
+            buildInstigationEvent({
+              message: 'Event 2',
+              timestamp: '1717962300002',
+            }),
+          ],
         }),
-      },
+      }),
     },
-  },
-  {
-    request: {
-      query: BACKFILL_LOGS_PAGE_QUERY,
-      variables: {backfillId: mockBackfillId, cursor: 'next-cursor-value'},
-    },
+  }),
+  buildQueryMock({
+    query: BACKFILL_LOGS_PAGE_QUERY,
+    variables: {backfillId: mockBackfillId, cursor: 'next-cursor-value'},
     delay: 10,
-    result: {
-      __typename: 'CloudQuery',
-      data: {
-        partitionBackfillOrError: buildPartitionBackfill({
-          logEvents: buildInstigationEventConnection({
-            hasMore: false,
-            cursor: 'final-cursor-value',
-            events: [
-              buildInstigationEvent({
-                message: 'Event 3',
-                timestamp: `1717962300003`,
-              }),
-              buildInstigationEvent({
-                message: 'Event 4',
-                timestamp: `1717962300004`,
-              }),
-            ],
-          }),
+    data: {
+      partitionBackfillOrError: buildPartitionBackfill({
+        logEvents: buildInstigationEventConnection({
+          hasMore: false,
+          cursor: 'final-cursor-value',
+          events: [
+            buildInstigationEvent({
+              message: 'Event 3',
+              timestamp: `1717962300003`,
+            }),
+            buildInstigationEvent({
+              message: 'Event 4',
+              timestamp: `1717962300004`,
+            }),
+          ],
         }),
-      },
+      }),
     },
-  },
+  }),
 ];
 
 describe('BackfillLogsTab', () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillLogsTab.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillLogsTab.test.tsx
@@ -1,5 +1,5 @@
 import {MockedProvider} from '@apollo/client/testing';
-import {render, screen} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import {MemoryRouter, Route} from 'react-router-dom';
 import {RecoilRoot} from 'recoil';
 
@@ -97,7 +97,9 @@ describe('BackfillLogsTab', () => {
       </RecoilRoot>,
     );
 
-    expect(await screen.findByText('Event 1')).toBeVisible();
-    expect(await screen.findByText('Event 4')).toBeVisible();
+    waitFor(async () => {
+      expect(await screen.findByText('Event 1')).toBeVisible();
+      expect(await screen.findByText('Event 4')).toBeVisible();
+    });
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillLogsTab.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillLogsTab.types.ts
@@ -1,0 +1,30 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../../graphql/types';
+
+export type BackfillLogsPageQueryVariables = Types.Exact<{
+  backfillId: Types.Scalars['String']['input'];
+  cursor?: Types.InputMaybe<Types.Scalars['String']['input']>;
+}>;
+
+export type BackfillLogsPageQuery = {
+  __typename: 'Query';
+  partitionBackfillOrError:
+    | {__typename: 'BackfillNotFoundError'}
+    | {
+        __typename: 'PartitionBackfill';
+        id: string;
+        logEvents: {
+          __typename: 'InstigationEventConnection';
+          cursor: string;
+          hasMore: boolean;
+          events: Array<{
+            __typename: 'InstigationEvent';
+            message: string;
+            timestamp: string;
+            level: Types.LogLevel;
+          }>;
+        };
+      }
+    | {__typename: 'PythonError'};
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useCursorAccumulatedQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useCursorAccumulatedQuery.tsx
@@ -38,8 +38,8 @@ export function useCursorAccumulatedQuery<T, TVars extends {cursor?: string | nu
     }
   }, [queryResult, getResultArray, getNextFetchState]);
 
-  // When we have reached the last event, switch to refreshing every 5s
-  const refreshState = useQueryRefreshAtInterval(queryResult, 5 * 1000, !fetchState.hasMore);
+  // When we have reached the last event, switch to refreshing every 10s
+  const refreshState = useQueryRefreshAtInterval(queryResult, 10 * 1000, !fetchState.hasMore);
 
   return {fetched, refreshState};
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useCursorAccumulatedQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useCursorAccumulatedQuery.tsx
@@ -1,0 +1,45 @@
+import {useQuery} from '@apollo/client';
+import {DocumentNode} from 'graphql';
+import {useEffect, useState} from 'react';
+
+import {useQueryRefreshAtInterval} from '../app/QueryRefresh';
+
+type FetchState = {
+  hasMore: boolean;
+  cursor: string | null | undefined;
+};
+
+export function useCursorAccumulatedQuery<T, TVars extends {cursor?: string | null}, U>(options: {
+  query: DocumentNode;
+  skip?: boolean;
+  variables: Omit<TVars, 'cursor'>;
+  getResultArray: (result: T | undefined) => U[];
+  getNextFetchState: (result: T | undefined) => FetchState | null;
+}) {
+  const [fetched, setFetched] = useState<U[] | null>(null);
+  const [fetchState, setFetchState] = useState<FetchState>({hasMore: true, cursor: undefined});
+  const {query, skip, variables, getResultArray, getNextFetchState} = options;
+
+  const queryResult = useQuery<T, TVars>(query, {
+    variables: {...variables, cursor: fetchState.cursor} as TVars,
+    notifyOnNetworkStatusChange: true,
+    skip,
+  });
+
+  useEffect(() => {
+    if (!queryResult.data) {
+      return;
+    }
+    const result = getResultArray(queryResult.data);
+    setFetched((fetched) => (fetched || []).concat(result));
+    const next = getNextFetchState(queryResult.data);
+    if (next) {
+      setFetchState(next);
+    }
+  }, [queryResult, getResultArray, getNextFetchState]);
+
+  // When we have reached the last event, switch to refreshing every 5s
+  const refreshState = useQueryRefreshAtInterval(queryResult, 5 * 1000, !fetchState.hasMore);
+
+  return {fetched, refreshState};
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/InstigationEventLogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/InstigationEventLogTable.tsx
@@ -1,0 +1,72 @@
+import {gql} from '@apollo/client';
+import {Box} from '@dagster-io/ui-components';
+import {useContext} from 'react';
+
+import {InstigationEventLogFragment} from './types/InstigationEventLogTable.types';
+import {EventTypeColumn, Row, TimestampColumn} from '../runs/LogsRowComponents';
+import {
+  ColumnWidthsContext,
+  ColumnWidthsProvider,
+  Header,
+  HeaderContainer,
+  HeadersContainer,
+} from '../runs/LogsScrollingTableHeader';
+
+const Headers = () => {
+  const widths = useContext(ColumnWidthsContext);
+  return (
+    <HeadersContainer>
+      <Header
+        width={widths.eventType}
+        onResize={(width) => widths.onChange({...widths, eventType: width})}
+      >
+        Event Type
+      </Header>
+      <HeaderContainer style={{flex: 1}}>Info</HeaderContainer>
+      <Header
+        handleSide="left"
+        width={widths.timestamp}
+        onResize={(width) => widths.onChange({...widths, timestamp: width})}
+      >
+        Timestamp
+      </Header>
+    </HeadersContainer>
+  );
+};
+
+const InstigationEventLogRow = ({event}: {event: InstigationEventLogFragment}) => {
+  return (
+    <Row level={event.level} highlighted={false} style={{height: 'auto'}}>
+      <EventTypeColumn>
+        <span style={{marginLeft: 8}}>{event.level}</span>
+      </EventTypeColumn>
+      <Box padding={{horizontal: 12}} style={{flex: 1}}>
+        {event.message}
+      </Box>
+      <TimestampColumn time={event.timestamp} />
+    </Row>
+  );
+};
+
+export const InstigationEventLogTable = ({events}: {events: InstigationEventLogFragment[]}) => {
+  return (
+    <ColumnWidthsProvider onWidthsChanged={() => {}}>
+      <div style={{height: 500, position: 'relative', zIndex: 0}}>
+        <Headers />
+        <div style={{height: 468, overflowY: 'auto'}}>
+          {events.map((event, idx) => (
+            <InstigationEventLogRow event={event} key={idx} />
+          ))}
+        </div>
+      </div>
+    </ColumnWidthsProvider>
+  );
+};
+
+export const INSTIGATION_EVENT_LOG_FRAGMENT = gql`
+  fragment InstigationEventLog on InstigationEvent {
+    message
+    timestamp
+    level
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/InstigationEventLogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/InstigationEventLogTable.tsx
@@ -50,8 +50,8 @@ export const InstigationEventLogTable = ({events}: {events: InstigationEventLogF
 
   useEffect(() => {
     const el = parentRef.current;
-    if (!el) {
-      return;
+    if (!el || !('scrollTo' in el)) {
+      return; // scrollTo is not present in jest test
     }
     if (isAtBottom.current && events.length) {
       el.scrollTo(0, el.scrollHeight);

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/InstigationEventLogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/InstigationEventLogTable.tsx
@@ -1,7 +1,7 @@
 import {gql} from '@apollo/client';
 import {Box} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
-import {useContext, useRef} from 'react';
+import {useContext, useEffect, useRef} from 'react';
 
 import {InstigationEventLogFragment} from './types/InstigationEventLogTable.types';
 import {EventTypeColumn, Row as LogsRow, TimestampColumn} from '../runs/LogsRowComponents';
@@ -46,6 +46,22 @@ export const InstigationEventLogTable = ({events}: {events: InstigationEventLogF
   });
   const totalHeight = rowVirtualizer.getTotalSize();
   const items = rowVirtualizer.getVirtualItems();
+  const isAtBottom = useRef(true);
+
+  useEffect(() => {
+    const el = parentRef.current;
+    if (!el) {
+      return;
+    }
+    if (isAtBottom.current && events.length) {
+      el.scrollTo(0, el.scrollHeight);
+    }
+    const onScroll = () => {
+      isAtBottom.current = el.scrollTop >= el.scrollHeight - el.clientHeight;
+    };
+    el.addEventListener('scroll', onScroll);
+    return () => el.removeEventListener('scroll', onScroll);
+  });
 
   return (
     <ColumnWidthsProvider onWidthsChanged={() => {}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/TickLogDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/TickLogDialog.tsx
@@ -10,23 +10,11 @@ import {
   Icon,
   NonIdealState,
 } from '@dagster-io/ui-components';
-import {useContext} from 'react';
 
-import {
-  TickLogEventFragment,
-  TickLogEventsQuery,
-  TickLogEventsQueryVariables,
-} from './types/TickLogDialog.types';
+import {INSTIGATION_EVENT_LOG_FRAGMENT, InstigationEventLogTable} from './InstigationEventLogTable';
+import {TickLogEventsQuery, TickLogEventsQueryVariables} from './types/TickLogDialog.types';
 import {InstigationSelector} from '../graphql/types';
 import {HistoryTickFragment} from '../instigation/types/InstigationUtils.types';
-import {EventTypeColumn, Row, TimestampColumn} from '../runs/LogsRowComponents';
-import {
-  ColumnWidthsContext,
-  ColumnWidthsProvider,
-  Header,
-  HeaderContainer,
-  HeadersContainer,
-} from '../runs/LogsScrollingTableHeader';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 
 export const TickLogDialog = ({
@@ -58,7 +46,7 @@ export const TickLogDialog = ({
     >
       <DialogBody>
         {events && events.length ? (
-          <TickLogsTable events={events} />
+          <InstigationEventLogTable events={events} />
         ) : (
           <Box
             flex={{justifyContent: 'center', alignItems: 'center'}}
@@ -97,7 +85,7 @@ export const QueryfulTickLogsTable = ({instigationSelector, tick}: TickLogTableP
       : undefined;
 
   if (events && events.length) {
-    return <TickLogsTable events={events} />;
+    return <InstigationEventLogTable events={events} />;
   }
 
   const tickStatus =
@@ -160,57 +148,6 @@ export const QueryfulTickLogsTable = ({instigationSelector, tick}: TickLogTableP
   );
 };
 
-const TickLogsTable = ({events}: {events: TickLogEventFragment[]}) => {
-  return (
-    <ColumnWidthsProvider onWidthsChanged={() => {}}>
-      <div style={{height: 500, position: 'relative', zIndex: 0}}>
-        <Headers />
-        <div style={{height: 468, overflowY: 'auto'}}>
-          {events.map((event, idx) => (
-            <TickLogRow event={event} key={idx} />
-          ))}
-        </div>
-      </div>
-    </ColumnWidthsProvider>
-  );
-};
-
-const Headers = () => {
-  const widths = useContext(ColumnWidthsContext);
-  return (
-    <HeadersContainer>
-      <Header
-        width={widths.eventType}
-        onResize={(width) => widths.onChange({...widths, eventType: width})}
-      >
-        Event Type
-      </Header>
-      <HeaderContainer style={{flex: 1}}>Info</HeaderContainer>
-      <Header
-        handleSide="left"
-        width={widths.timestamp}
-        onResize={(width) => widths.onChange({...widths, timestamp: width})}
-      >
-        Timestamp
-      </Header>
-    </HeadersContainer>
-  );
-};
-
-const TickLogRow = ({event}: {event: TickLogEventFragment}) => {
-  return (
-    <Row level={event.level} highlighted={false} style={{height: 'auto'}}>
-      <EventTypeColumn>
-        <span style={{marginLeft: 8}}>{event.level}</span>
-      </EventTypeColumn>
-      <Box padding={{horizontal: 12}} style={{flex: 1}}>
-        {event.message}
-      </Box>
-      <TimestampColumn time={event.timestamp} />
-    </Row>
-  );
-};
-
 const TICK_LOG_EVENTS_QUERY = gql`
   query TickLogEventsQuery($instigationSelector: InstigationSelector!, $tickId: BigInt!) {
     instigationStateOrError(instigationSelector: $instigationSelector) {
@@ -223,17 +160,12 @@ const TICK_LOG_EVENTS_QUERY = gql`
           timestamp
           logEvents {
             events {
-              ...TickLogEvent
+              ...InstigationEventLog
             }
           }
         }
       }
     }
   }
-
-  fragment TickLogEvent on InstigationEvent {
-    message
-    timestamp
-    level
-  }
+  ${INSTIGATION_EVENT_LOG_FRAGMENT}
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/TickLogDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/TickLogDialog.tsx
@@ -85,7 +85,11 @@ export const QueryfulTickLogsTable = ({instigationSelector, tick}: TickLogTableP
       : undefined;
 
   if (events && events.length) {
-    return <InstigationEventLogTable events={events} />;
+    return (
+      <Box style={{height: 500}} flex={{direction: 'column'}}>
+        <InstigationEventLogTable events={events} />
+      </Box>
+    );
   }
 
   const tickStatus =

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/types/InstigationEventLogTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/types/InstigationEventLogTable.types.ts
@@ -1,0 +1,10 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type InstigationEventLogFragment = {
+  __typename: 'InstigationEvent';
+  message: string;
+  timestamp: string;
+  level: Types.LogLevel;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/types/TickLogDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/types/TickLogDialog.types.ts
@@ -33,10 +33,3 @@ export type TickLogEventsQuery = {
     | {__typename: 'InstigationStateNotFoundError'}
     | {__typename: 'PythonError'};
 };
-
-export type TickLogEventFragment = {
-  __typename: 'InstigationEvent';
-  message: string;
-  timestamp: string;
-  level: Types.LogLevel;
-};


### PR DESCRIPTION
## Summary & Motivation

The backfill logs are implemented as a cursor-paginated resolver on partitionBackfill. To get the latest logs, you have to start at the first log (no cursor) and paginate to get to the last log. When you reach the last log, it returns `hasMore: false`, and we switch to polling that final cursor for additional logs and advancing it as they come in.

This does mean that showing the "tail" of the logs requires loading them all, but we're not super worried about this -- because the backend implementation stores the logs as files on S3, the underlying implementation doesn't support a "last N" retrieval.

I created a new query hook `useCursorAccumulatedQuery` which is similar to `useCursorPaginatedQuery` but effectively auto-pages and accumulates the data rather than returning a single page at a time.

Misc:

- I also added the refresh countdown components to all the backfill tabs

Important note:

- This feature is shipping in OSS this week but has not yet shipped - backfill logs are currently only available in cloud when an org setting is enabled.

## How I Tested These Changes

- Because the OSS backend for this is still in-flight I wrote a test to cover the front-end logic