### PR TITLE
[ui] Make asset compute kind grouping and filtering case-insensitive

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -84,9 +84,11 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
     // get to leverage the useQuery cache almost 100% of the time above, making this
     // super fast after the first load vs a network fetch on every page view.
     const {all: allFilteredByOpQuery} = filterByQuery(graphQueryItems, opsQuery);
-    const computeKinds = options.computeKinds;
+    const computeKinds = options.computeKinds?.map((c) => c.toLowerCase());
     const all = computeKinds?.length
-      ? allFilteredByOpQuery.filter((item) => computeKinds.includes(item.node.computeKind ?? ''))
+      ? allFilteredByOpQuery.filter(
+          ({node}) => node.computeKind && computeKinds.includes(node.computeKind.toLowerCase()),
+        )
       : allFilteredByOpQuery;
 
     // Assemble the response into the data structure used for layout, traversal, etc.

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.tsx
@@ -173,10 +173,8 @@ export function filterAssetDefinition(
       return false;
     }
   } else if (filters.computeKindTags?.length) {
-    if (
-      !definition?.computeKind?.length ||
-      !filters.computeKindTags.includes(definition.computeKind)
-    ) {
+    const lowercased = new Set(filters.computeKindTags.map((c) => c.toLowerCase()));
+    if (!definition?.computeKind || !lowercased.has(definition.computeKind.toLowerCase())) {
       return false;
     }
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useComputeKindTagFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useComputeKindTagFilter.tsx
@@ -1,4 +1,5 @@
 import {Box, Icon} from '@dagster-io/ui-components';
+import uniqBy from 'lodash/uniqBy';
 import {useMemo} from 'react';
 
 import {useStaticSetFilter} from './useStaticSetFilter';
@@ -46,9 +47,10 @@ export function useAssetKindTagsForAssets(
 ): string[] {
   return useMemo(
     () =>
-      Array.from(
-        new Set(assets.map((a) => a.definition?.computeKind).filter((x) => x)),
-      ) as string[],
+      uniqBy(
+        assets.map((a) => a.definition?.computeKind).filter((x): x is string => !!x),
+        (c) => c.toLowerCase(),
+      ),
     [assets],
   );
 }


### PR DESCRIPTION
## Summary & Motivation

Fixes https://linear.app/dagster-labs/issue/FE-357/bug-compute-kind-tags-should-ignore-capitalization

This is actually a bit nuanced -- once I updated the catalog home page to show `Airtable` and `airtable` compute kinds as a single option, I realized that clicking it led to the filtered catalog view where the filters were case-sensitive. 

This PR currently updates the grouping behavior for all groupings, but only makes compute kind search case insensitive. I think the `CaseInsensitiveCounters` may essentially be a no-op for other things, but are worth using for consistency. 

## How I Tested These Changes

I tested this by making some mis-capitalized and lowercased compute kinds in my local repo, and also used the app-proxy to connect to prod and verify that dogfood's catalog landing page looks identical before and after.