### PR TITLE
[ui] Fix historical events page being closed by background refresh

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AllIndividualEventsButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AllIndividualEventsButton.tsx
@@ -35,16 +35,16 @@ interface AssetEventsTableProps {
   hasPartitions: boolean;
   hasLineage: boolean;
   groups: AssetEventGroup[];
-  focused?: AssetEventGroup;
-  setFocused?: (timestamp: AssetEventGroup | undefined) => void;
+  focusedTimestamp?: string;
+  setFocusedTimestamp?: (timestamp: string | undefined) => void;
 }
 
 const AssetEventsTable = ({
   hasPartitions,
   hasLineage,
   groups,
-  focused,
-  setFocused,
+  focusedTimestamp,
+  setFocusedTimestamp,
 }: AssetEventsTableProps) => {
   return (
     <Table>
@@ -67,17 +67,19 @@ const AssetEventsTable = ({
                 if (e.target instanceof HTMLElement && e.target.closest('a')) {
                   return;
                 }
-                setFocused?.(focused !== group ? group : undefined);
+                setFocusedTimestamp?.(
+                  focusedTimestamp !== group.timestamp ? group.timestamp : undefined,
+                );
               }}
             >
               <EventGroupRow
                 group={group}
                 hasPartitions={hasPartitions}
                 hasLineage={hasLineage}
-                isFocused={focused === group}
+                isFocused={focusedTimestamp === group.timestamp}
               />
             </HoverableRow>
-            {focused === group ? (
+            {focusedTimestamp === group.timestamp ? (
               <MetadataEntriesRow hasLineage={hasLineage} group={group} />
             ) : undefined}
           </React.Fragment>
@@ -309,7 +311,7 @@ export const AllIndividualEventsButton = ({
     decode: (qs) => (qs.showAllEvents === 'true' ? true : false),
     encode: (b) => ({showAllEvents: b || undefined}),
   });
-  const [focused, setFocused] = React.useState<AssetEventGroup | undefined>();
+  const [focusedTimestamp, setFocusedTimestamp] = React.useState<string | undefined>();
   const groups = React.useMemo(
     () =>
       events.map((p) => ({
@@ -351,8 +353,8 @@ export const AllIndividualEventsButton = ({
             <AssetEventsTable
               hasLineage={hasLineage}
               hasPartitions={hasPartitions}
-              focused={focused}
-              setFocused={setFocused}
+              focusedTimestamp={focusedTimestamp}
+              setFocusedTimestamp={setFocusedTimestamp}
               groups={groups}
             />
           </Box>


### PR DESCRIPTION
This was caused by us storing the entire focused event in state, rather than just it’s timestamp. After the events refresh in the background, none of them `===` the focused one.

## Summary & Motivation

## How I Tested These Changes

Tested by visiting /elementl/prod/assets/purina/cloud_reporting/reporting_deduped_internal_asset_materialization_metrics?view=partitions&partition=2024-06-09-21%3A00&showAllEvents=true, going to the most recent materializtion, and opening the modal for column_schema.