### PR TITLE
[ui] Fix two small CSS issues in asset overview sidebar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -292,10 +292,10 @@ export const AssetNodeOverview = ({
       </AttributeAndValue>
       <AttributeAndValue label="Storage">
         {(relationIdentifierMetadata || uriMetadata || storageKindTag) && (
-          <Box flex={{direction: 'column', gap: 4}}>
+          <Box flex={{direction: 'column', gap: 4}} style={{minWidth: 0}}>
             {relationIdentifierMetadata && (
               <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
-                {relationIdentifierMetadata.text}
+                <MiddleTruncate text={relationIdentifierMetadata.text} />
                 <CopyButton value={relationIdentifierMetadata.text} />
               </Box>
             )}

--- a/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLink.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLink.tsx
@@ -31,7 +31,7 @@ const getCodeReferenceEntryLabel = (codeReference: SourceLocation): React.ReactE
         codeReference.label || (codeReference.url.split('/').pop()?.split('#')[0] as string);
       const sourceControlName = codeReference.url.includes('github') ? 'GitHub' : 'GitLab';
       return (
-        <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+        <Box flex={{direction: 'row', alignItems: 'center', gap: 4}} style={{whiteSpace: 'nowrap'}}>
           Open <MiddleTruncate text={labelOrUrl} /> in {sourceControlName}
         </Box>
       );
@@ -86,18 +86,23 @@ export const CodeLink = ({sourceLocation}: {sourceLocation: SourceLocation}) => 
   const [codeLinkProtocol, _] = React.useContext(CodeLinkProtocolContext);
 
   return (
-    <Tooltip content={getCodeReferenceTooltip(sourceLocation)} position="bottom">
-      <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-        <Icon name={getCodeReferenceIcon(sourceLocation)} />
-        <a
-          target="_blank"
-          rel="noreferrer"
-          href={getCodeReferenceLink(codeLinkProtocol, sourceLocation)}
+    <Box style={{minWidth: 0}} flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+      <Icon name={getCodeReferenceIcon(sourceLocation)} />
+      <a
+        target="_blank"
+        rel="noreferrer"
+        style={{minWidth: 0}}
+        href={getCodeReferenceLink(codeLinkProtocol, sourceLocation)}
+      >
+        <Tooltip
+          display="block"
+          content={getCodeReferenceTooltip(sourceLocation)}
+          position="bottom"
         >
           {getCodeReferenceEntryLabel(sourceLocation)}
-        </a>
-        <Icon name="open_in_new" />
-      </Box>
-    </Tooltip>
+        </Tooltip>
+      </a>
+      <Icon name="open_in_new" />
+    </Box>
   );
 };


### PR DESCRIPTION
## Summary & Motivation

Before:

<img width="534" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/e4f8b85d-c6e0-4657-ae8a-fff1670f9b12">

After:

<img width="518" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/d6a7d927-70b9-421f-aec6-7a5f3ed49bd8">
