### PR TITLE
[ui] Modernize Description component, handle async rendering of Markdown

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/Description.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/Description.tsx
@@ -1,4 +1,5 @@
 import {Button} from '@dagster-io/ui-components';
+import useResizeObserver from '@react-hook/resize-observer';
 import * as React from 'react';
 import styled from 'styled-components';
 
@@ -8,11 +9,6 @@ interface IDescriptionProps {
   description: string | null;
   maxHeight?: number;
   fontSize?: string | number;
-}
-
-interface IDescriptionState {
-  hasMore: boolean;
-  expanded: boolean;
 }
 
 const DEFAULT_MAX_HEIGHT = 320;
@@ -35,71 +31,71 @@ function removeLeadingSpaces(input: string) {
   return lines.map((l) => l.substr(leadingSpaces[1]!.length)).join('\n');
 }
 
-export class Description extends React.Component<IDescriptionProps, IDescriptionState> {
-  private _container: React.RefObject<HTMLDivElement> = React.createRef();
+export const Description = ({maxHeight, description, fontSize}: IDescriptionProps) => {
+  const container = React.createRef<HTMLDivElement>();
+  const [hasMore, setHasMore] = React.useState(false);
+  const [expanded, setExpanded] = React.useState(false);
 
-  public state: IDescriptionState = {
-    hasMore: false,
-    expanded: false,
-  };
-
-  componentDidMount() {
-    this.updateHandleState();
-  }
-
-  componentDidUpdate() {
-    this.updateHandleState();
-  }
-
-  updateHandleState() {
-    if (!this._container.current) {
+  const updateHasMore = React.useCallback(() => {
+    if (!container.current) {
       return;
     }
-    const hasMore =
-      this._container.current.clientHeight > (this.props.maxHeight || DEFAULT_MAX_HEIGHT);
-    if (hasMore !== this.state.hasMore) {
-      this.setState({hasMore});
+    setHasMore(container.current.clientHeight > (maxHeight || DEFAULT_MAX_HEIGHT));
+  }, [container, maxHeight]);
+
+  // On mount, recalculate whether to show "show more"
+  React.useLayoutEffect(updateHasMore, [updateHasMore]);
+
+  // If the container has been resized, recalculate.
+  useResizeObserver(container.current, updateHasMore);
+
+  // If the content has changed, recalculate. This is necessary because our Markdown
+  // support is lazy-loaded and seems to take one React render to populate after it loads,
+  // and also means you can change the `description` prop.
+  React.useLayoutEffect(() => {
+    if (!container.current || !('MutationObserver' in window)) {
+      return;
     }
+    const mutationObserver = new MutationObserver(updateHasMore);
+    mutationObserver.observe(container.current, {subtree: true, childList: true});
+    return () => mutationObserver.disconnect();
+  }, [container, updateHasMore]);
+
+  if (!description || description.length === 0) {
+    return null;
   }
 
-  render() {
-    if (!this.props.description || this.props.description.length === 0) {
-      return null;
-    }
+  return (
+    <Container
+      onDoubleClick={() => {
+        const sel = document.getSelection();
+        if (!sel || !container.current) {
+          return;
+        }
+        const range = document.createRange();
+        range.selectNodeContents(container.current);
+        sel.removeAllRanges();
+        sel.addRange(range);
+      }}
+      $fontSize={fontSize || '0.8rem'}
+      style={{
+        maxHeight: expanded ? undefined : maxHeight || DEFAULT_MAX_HEIGHT,
+      }}
+    >
+      {hasMore && (
+        <ShowMoreHandle>
+          <Button intent="primary" onClick={() => setExpanded(!expanded)}>
+            {expanded ? 'Show less' : 'Show more'}
+          </Button>
+        </ShowMoreHandle>
+      )}
 
-    const {expanded, hasMore} = this.state;
-    return (
-      <Container
-        onDoubleClick={() => {
-          const sel = document.getSelection();
-          if (!sel || !this._container.current) {
-            return;
-          }
-          const range = document.createRange();
-          range.selectNodeContents(this._container.current);
-          sel.removeAllRanges();
-          sel.addRange(range);
-        }}
-        $fontSize={this.props.fontSize || '0.8rem'}
-        style={{
-          maxHeight: expanded ? undefined : this.props.maxHeight || DEFAULT_MAX_HEIGHT,
-        }}
-      >
-        {hasMore && (
-          <ShowMoreHandle>
-            <Button intent="primary" onClick={() => this.setState({expanded: !expanded})}>
-              {expanded ? 'Show less' : 'Show more'}
-            </Button>
-          </ShowMoreHandle>
-        )}
-
-        <div ref={this._container} style={{overflowX: 'auto'}}>
-          <Markdown>{removeLeadingSpaces(this.props.description)}</Markdown>
-        </div>
-      </Container>
-    );
-  }
-}
+      <div ref={container} style={{overflowX: 'auto'}}>
+        <Markdown>{removeLeadingSpaces(description)}</Markdown>
+      </div>
+    </Container>
+  );
+};
 
 const Container = styled.div<{$fontSize: string | number}>`
   overflow: hidden;


### PR DESCRIPTION
Fixes https://linear.app/dagster-labs/issue/FE-392/issue-with-cut-off-asset-descriptions-and-no-expandscroll-option

## Summary & Motivation

Was able to reliably reproduce this loading http://localhost:3001/elementl/prod/assets/purina/cloud_reporting/reporting_deduped_internal_asset_materialization_metrics?view=overview&partition=2024-06-09-21%3A00. 

It appears that this happens because our markdown support is lazy-loaded, and if you navigate to this page and then hard-refresh, the Description element renders empty on the first render, and then fills with markdown content a few renders later. It's possible there's also some React 18 deferred rendering stuff going on, but I'm less sure.

This component is old and less sophisticated than MiddleTruncate. I updated it to use both a resize observer and a mutation observer (to detect both the markdown render finishing and potentially the description prop changing, which was also not supported before).