### PR TITLE
Retry buildkite on additional error codes

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/step_builder.py
@@ -42,6 +42,8 @@ class CommandStepBuilder:
             "retry": {
                 "automatic": [
                     {"exit_status": -1, "limit": 2},  # agent lost
+                    {"exit_status": 143, "limit": 2},  # agent lost
+                    {"exit_status": 2, "limit": 2},  # often a uv read timeout
                     {"exit_status": 255, "limit": 2},  # agent forced shut down
                 ],
                 "manual": {"permit_on_passed": True},


### PR DESCRIPTION
We're seeing some upticks in Buildkite flakes. I think it's safe to retry around them more systematically:

- [Exit 2 is showing up a occasionally](https://buildkite.com/dagster/dagster-dagster/builds/85297#018fedf7-f1d3-4826-90c6-f562e8c79307) on network related uv install failures.
- [Exit 143 is showing up occasionally](https://buildkite.com/dagster/dagster-dagster/builds/85751#018ffdff-32c9-49e6-a17f-712ac8e3edc8) when the [autoscaling group the cloudformation template provisions is removing an agent from rotation while it's in the middle of running a step](https://dagsterlabs.slack.com/archives/C03EQ628RS7/p1717428269503689?thread_ts=1717427551.865789&cid=C03EQ628RS7).

https://buildkite.com/docs/pipelines/command-step

## Summary & Motivation

## How I Tested These Changes
