### PR TITLE
[Run Timeline] Improve rendering performance + Don't wait for future ticks before rendering

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
@@ -169,7 +169,7 @@ const ExecutionRunTimeline = ({
   });
 
   // Use deferred value to allow paginating quickly with the UI feeling more responsive.
-  const {jobs, initialLoading} = useDeferredValue(runsForTimelineRet);
+  const {jobs, loading} = useDeferredValue(runsForTimelineRet);
 
   // Unwrap the timeline to show runs on separate rows, and sort them explicitly by
   // newest => oldest so that they match what you see in the "List" tab.
@@ -192,7 +192,7 @@ const ExecutionRunTimeline = ({
       </Box>
       <ErrorBoundary region="timeline">
         <ExecutionTimeline
-          loading={initialLoading}
+          loading={loading}
           rangeMs={rangeMs}
           annotations={annotations}
           runs={runs}

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
@@ -99,13 +99,13 @@ export const OverviewTimelineRoot = ({Header, TabButton}: Props) => {
   const runsForTimelineRet = useRunsForTimeline({rangeMs});
 
   // Use deferred value to allow paginating quickly with the UI feeling more responsive.
-  const {jobs, initialLoading, refreshState} = useDeferredValue(runsForTimelineRet);
+  const {jobs, loading, refreshState} = useDeferredValue(runsForTimelineRet);
 
   React.useEffect(() => {
-    if (!initialLoading) {
+    if (!loading) {
       trace.endTrace();
     }
-  }, [initialLoading, trace]);
+  }, [loading, trace]);
 
   const visibleJobKeys = React.useMemo(() => {
     const searchLower = searchValue.toLocaleLowerCase().trim();
@@ -160,7 +160,7 @@ export const OverviewTimelineRoot = ({Header, TabButton}: Props) => {
         </Box>
       </Box>
       <ErrorBoundary region="timeline">
-        <RunTimeline loading={initialLoading} rangeMs={rangeMs} jobs={visibleJobs} />
+        <RunTimeline loading={loading} rangeMs={rangeMs} jobs={visibleJobs} />
       </ErrorBoundary>
     </>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/HourlyDataCache.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/HourlyDataCache.tsx
@@ -232,7 +232,7 @@ export class HourlyDataCache<T> {
    * @param callback - The callback function to notify when new data is added.
    */
   subscribe(ts: number, callback: Subscription<T>) {
-    const startHour = Math.ceil(ts / ONE_HOUR_S);
+    const startHour = Math.floor(ts / ONE_HOUR_S);
     const sub = {hour: startHour, callback};
     this.subscriptions.push(sub);
     this.notifyExistingData(startHour, callback);

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/__tests__/HourlyDataCache.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/__tests__/HourlyDataCache.test.tsx
@@ -130,7 +130,7 @@ describe('HourlyDataCache Subscriptions', () => {
     cache.addData(0, ONE_HOUR_S, [1, 2, 3]);
 
     const callback = jest.fn();
-    cache.subscribe(0, callback);
+    cache.subscribe(1, callback);
 
     expect(callback).toHaveBeenCalledWith([1, 2, 3]);
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimeline.tsx
@@ -93,14 +93,18 @@ export const RunTimeline = (props: Props) => {
   const [_, end] = rangeMs;
   const includesTicks = now <= end;
 
-  const buckets = jobs.reduce(
-    (accum, job) => {
-      const {repoAddress} = job;
-      const repoKey = repoAddressAsURLString(repoAddress);
-      const jobsForRepo = accum[repoKey] || [];
-      return {...accum, [repoKey]: [...jobsForRepo, job]};
-    },
-    {} as Record<string, TimelineJob[]>,
+  const buckets = React.useMemo(
+    () =>
+      jobs.reduce(
+        (accum, job) => {
+          const {repoAddress} = job;
+          const repoKey = repoAddressAsURLString(repoAddress);
+          const jobsForRepo = accum[repoKey] || [];
+          return {...accum, [repoKey]: [...jobsForRepo, job]};
+        },
+        {} as Record<string, TimelineJob[]>,
+      ),
+    [jobs],
   );
 
   const allKeys = Object.keys(buckets);

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/fetchPaginatedBucketData.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/fetchPaginatedBucketData.test.tsx
@@ -53,16 +53,20 @@ describe('fetchPaginatedBucketData', () => {
       setQueryDataMock.mock.calls[0][0]!({data: [{id: 1}], hasMore: false, cursor: undefined}),
     ).toEqual({
       called: true,
+      cursor: undefined,
       data: [{id: 1}],
       error: undefined,
+      hasMore: false,
       loading: true,
     });
 
-    expect(setQueryDataMock.mock.calls[1][0]).toEqual({
+    const data = [{id: 999}, {id: 999}];
+
+    expect(setQueryDataMock.mock.calls[1][0]({data})).toEqual({
       loading: false,
       called: true,
       error: undefined,
-      data: [{id: 999}, {id: 999}],
+      data,
     });
   });
 
@@ -124,14 +128,13 @@ describe('fetchPaginatedBucketData', () => {
     expect(fetchDataMock).toHaveBeenCalledWith('bucket1', undefined);
     expect(fetchDataMock).toHaveBeenCalledWith('bucket1', 'cursor1');
 
-    expect(setQueryDataMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: [...dataPage1, ...dataPage2],
-        loading: false,
-        called: true,
-        error: undefined,
-      }),
-    );
+    const calls = setQueryDataMock.mock.calls;
+    expect(calls.length).toEqual(2);
+    expect(calls[calls.length - 1]![0]({})).toEqual({
+      loading: false,
+      called: true,
+      error: undefined,
+    });
   });
 
   it('should handle fetchData returning an error', async () => {
@@ -152,7 +155,9 @@ describe('fetchPaginatedBucketData', () => {
     });
 
     const data = [{id: 1}];
-    expect(setQueryDataMock.mock.calls[1][0]!({data})).toEqual({
+    const calls = setQueryDataMock.mock.calls;
+    expect(calls.length).toEqual(2);
+    expect(calls[calls.length - 1]![0]({data})).toEqual({
       data,
       loading: false,
       called: true,
@@ -177,13 +182,13 @@ describe('fetchPaginatedBucketData', () => {
       setQueryData: setQueryDataMock,
     });
 
-    expect(setQueryDataMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data,
-        loading: false,
-        called: true,
-        error: undefined,
-      }),
-    );
+    const calls = setQueryDataMock.mock.calls;
+    expect(calls.length).toEqual(2);
+    expect(calls[calls.length - 1]![0]({data})).toEqual({
+      data,
+      loading: false,
+      called: true,
+      error: undefined,
+    });
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/fetchPaginatedBucketData.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/fetchPaginatedBucketData.ts
@@ -15,36 +15,38 @@ export async function fetchPaginatedBucketData<BucketType, DataType, CursorType,
     bucket: BucketType,
     cursor: CursorType | undefined,
   ) => Promise<{
-    data: DataType[];
     hasMore: boolean;
     cursor: CursorType | undefined;
     error: ErrorType;
   }>;
   setQueryData: React.Dispatch<React.SetStateAction<QueryResultData<DataType>>>;
 }) {
-  setQueryData(({data}) => ({
-    data, // preserve existing data
+  setQueryData((queryData) => ({
+    ...queryData,
     loading: true,
     called: true,
     error: undefined,
   }));
   try {
-    const results = await Promise.all(
+    await Promise.all(
       buckets.map((bucket) =>
         fetchPaginatedData<DataType, CursorType, ErrorType>({
-          fetchData: (cursor) => fetchData(bucket, cursor),
+          fetchData: async (cursor) => {
+            const res = await fetchData(bucket, cursor);
+            return {...res, data: []};
+          },
         }),
       ),
     );
-    setQueryData({
-      data: results.flat(),
+    setQueryData((queryData) => ({
+      ...queryData,
       loading: false,
       called: true,
       error: undefined,
-    });
+    }));
   } catch (error) {
-    setQueryData(({data}) => ({
-      data, // preserve existing data
+    setQueryData((queryData) => ({
+      ...queryData,
       loading: false,
       called: true,
       error,

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/fetchPaginatedBucketData.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/fetchPaginatedBucketData.ts
@@ -5,6 +5,11 @@ export type QueryResultData<DataType> = {
   called: boolean;
 };
 
+/**
+ * Don't use this function, its an awkward API really meant just for the RunTimeline
+ * setQueryData doesn't actually set any data, you have to do it yourself.
+ * In the case of the RunTimeline it doesn't set any data because it persists it to a cache instead
+ */
 export async function fetchPaginatedBucketData<BucketType, DataType, CursorType, ErrorType>({
   buckets,
   fetchData,

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsForTimeline.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsForTimeline.types.ts
@@ -96,8 +96,6 @@ export type FutureTicksQuery = {
           __typename: 'WorkspaceLocationEntry';
           id: string;
           name: string;
-          loadStatus: Types.RepositoryLocationLoadStatus;
-          displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
           locationOrLoadError:
             | {__typename: 'PythonError'}
             | {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -70,22 +70,27 @@ export const useRunsForTimeline = ({
       localCacheIdPrefix ? `${localCacheIdPrefix}-useRunsForTimeline` : false,
     );
   }, [filter, localCacheIdPrefix]);
-  const [runsNotCapturedByUpdateBuckets, setRunsNotCapturedByUpdateBuckets] = useState<
-    RunTimelineFragment[]
-  >([]);
+  const [completedRuns, setCompletedRuns] = useState<RunTimelineFragment[]>([]);
 
   useLayoutEffect(() => {
-    // We fetch updatedAfter -> updatedBefore buckets but we also need runs that match
-    // updatedAfter (right border) -> createdBefore (right border). Well we rely on the fact
-    // that runs are fetched in adjacent intervals going to the past so we can assume a future bucket that
-    // is being or was fetched will have that run so subscribe to future runs and filter for the ones createdBefore
-    // our right boundary (endSec)
-    return completedRunsCache.subscribe(endSec, (runs) => {
-      setRunsNotCapturedByUpdateBuckets(runs.filter((run) => run.startTime! < endSec));
+    // Fetch runs matching:
+    // 1. updatedAfter (startSec) -> updatedBefore (endSec)
+    // 2. updatedAfter (endSec) -> createdBefore (endSec).
+    // For (2) we rely on the fact that runs are fetched in adjacent intervals from "now" going backwards
+    // so we can assume a future bucket that is being or was fetched will have the runs we need.
+    return completedRunsCache.subscribe(startSec, (runs) => {
+      setCompletedRuns(
+        runs.filter(
+          (run) =>
+            (run.startTime! <= endSec && run.updateTime! >= endSec) ||
+            (run.updateTime! >= startSec && run.updateTime! <= endSec),
+        ),
+      );
     });
-  }, [completedRunsCache, end, endSec]);
+  }, [completedRunsCache, end, endSec, startSec]);
 
   const [completedRunsQueryData, setCompletedRunsData] = useState<{
+    // TODO: Remove data property here since we grab the data from the cache instead of here.
     data: RunTimelineFragment[] | undefined;
     loading: boolean;
     error: any;
@@ -107,42 +112,42 @@ export const useRunsForTimeline = ({
     error: undefined,
     called: false,
   });
-  const {data: ongoingRunsData, loading: loadingOngoingRunsData} = ongoingRunsQueryData;
-  const {data: completedRunsData, loading: loadingCompletedRunsData} = completedRunsQueryData;
+
+  const {data: ongoingRunsData} = ongoingRunsQueryData;
 
   const fetchCompletedRunsQueryData = useCallback(async () => {
     await completedRunsCache.loadCacheFromIndexedDB();
     return await fetchPaginatedBucketData({
-      buckets: buckets.map((bucket) => {
-        let updatedAfter = bucket[0];
-        let updatedBefore = bucket[1];
-        const missingRange = completedRunsCache.getMissingIntervals(updatedAfter);
-        if (missingRange[0]) {
-          // When paginating backwards the missing range will be at the beginning of the hour
-          // When looking the current time the missing range will be at the end of the hour
-          updatedAfter = Math.max(missingRange[0][0], updatedAfter);
-          updatedBefore = Math.min(missingRange[0][1], updatedBefore);
-        }
-        return [updatedAfter, updatedBefore] as [number, number];
-      }),
+      buckets: buckets
+        .filter((bucket) => !completedRunsCache.isCompleteRange(bucket[0], bucket[1]))
+        .map((bucket) => {
+          let updatedAfter = bucket[0];
+          let updatedBefore = bucket[1];
+          const missingRange = completedRunsCache.getMissingIntervals(updatedAfter);
+          if (missingRange[0]) {
+            // When paginating backwards the missing range will be at the beginning of the hour
+            // When looking the current time the missing range will be at the end of the hour
+            updatedAfter = Math.max(missingRange[0][0], updatedAfter);
+            updatedBefore = Math.min(missingRange[0][1], updatedBefore);
+          }
+          return [updatedAfter, updatedBefore] as [number, number];
+        }),
       setQueryData: setCompletedRunsData,
       async fetchData(bucket, cursor: string | undefined) {
         const updatedBefore = bucket[1];
         const updatedAfter = bucket[0];
-        let cacheData: RunTimelineFragment[] = [];
 
         if (completedRunsCache.isCompleteRange(updatedAfter, updatedBefore) && !cursor) {
           // If there's a cursor then that means the current range is being paginated so
           // it is not complete even though there is some data for the time range
 
           return {
-            data: completedRunsCache.getHourData(updatedAfter),
+            // TODO: Remove data property here
+            data: [],
             cursor: undefined,
             hasMore: false,
             error: undefined,
           };
-        } else {
-          cacheData = completedRunsCache.getHourData(updatedAfter);
         }
 
         const {data} = await client.query<
@@ -166,7 +171,7 @@ export const useRunsForTimeline = ({
 
         if (data.completed.__typename !== 'Runs') {
           return {
-            data: [...cacheData],
+            data: [],
             cursor: undefined,
             hasMore: false,
             error: data.completed,
@@ -179,7 +184,7 @@ export const useRunsForTimeline = ({
         const nextCursor = hasMoreData ? runs[runs.length - 1]!.id : undefined;
 
         return {
-          data: [...cacheData, ...runs],
+          data: [],
           cursor: nextCursor,
           hasMore: hasMoreData,
           error: undefined,
@@ -267,38 +272,43 @@ export const useRunsForTimeline = ({
 
   useBlockTraceOnQueryResult(ongoingRunsQueryData, 'OngoingRunTimelineQuery');
   useBlockTraceOnQueryResult(completedRunsQueryData, 'CompletedRunTimelineQuery');
-  useBlockTraceOnQueryResult(futureTicksQueryData, 'FutureTicksQuery');
 
-  const {data: futureTicksData, loading: loadingFutureTicksData} = futureTicksQueryData;
+  const {data: futureTicksData} = futureTicksQueryData;
 
   const {workspaceOrError} = futureTicksData || {workspaceOrError: undefined};
 
-  const runsByJobKey = useMemo(() => {
-    const map: {[jobKey: string]: {[id: string]: TimelineRun}} = {};
+  const [loading, setLoading] = useState(false);
+
+  const previousRunsByJobKey = useRef<{
+    jobInfo: Record<string, {repoAddress: RepoAddress; pipelineName: string; isAdHoc: boolean}>;
+    runsByJobKey: {
+      [jobKey: string]: {
+        [id: string]: TimelineRun;
+      };
+    };
+  }>({jobInfo: {}, runsByJobKey: {}});
+  const {runsByJobKey, jobInfo} = useMemo(() => {
+    if (loading) {
+      // While we're loading data just keep returning the last result so that we're not
+      // re-rendering 24+ times while we populate the cache asynchronously via our batching/chunking.
+      return previousRunsByJobKey.current;
+    }
+    const jobInfo: Record<
+      string,
+      {repoAddress: RepoAddress; pipelineName: string; isAdHoc: boolean}
+    > = {};
+    const map: {
+      [jobKey: string]: {
+        [id: string]: TimelineRun;
+      };
+    } = {};
     const now = Date.now();
 
-    // fetch all the runs in the given range
-    [
-      ...(ongoingRunsData ?? []),
-      ...(completedRunsData ?? []),
-      ...runsNotCapturedByUpdateBuckets,
-    ].forEach((run) => {
+    function saveRunInfo(run: (typeof completedRuns)[0]) {
       if (run.startTime === null) {
         return;
       }
       if (!run.repositoryOrigin) {
-        return;
-      }
-
-      if (
-        !overlap(
-          {start, end},
-          {
-            start: run.startTime * 1000,
-            end: run.endTime ? run.endTime * 1000 : now,
-          },
-        )
-      ) {
         return;
       }
 
@@ -317,16 +327,71 @@ export const useRunsForTimeline = ({
         startTime: run.startTime * 1000,
         endTime: run.endTime ? run.endTime * 1000 : now,
       };
-    });
+      if (!jobInfo[runJobKey] && run.repositoryOrigin) {
+        const pipelineName = run.pipelineName;
+        const isAdHoc = isHiddenAssetGroupJob(pipelineName);
 
-    return map;
-  }, [ongoingRunsData, completedRunsData, runsNotCapturedByUpdateBuckets, start, end]);
-
-  const jobsWithRuns: TimelineJob[] = useMemo(() => {
-    if (!workspaceOrError || workspaceOrError.__typename === 'PythonError') {
-      return [];
+        const repoAddress = buildRepoAddress(
+          run.repositoryOrigin!.repositoryName,
+          run.repositoryOrigin!.repositoryLocationName,
+        );
+        jobInfo[runJobKey] = {
+          repoAddress,
+          isAdHoc,
+          pipelineName,
+        };
+      }
     }
 
+    // fetch all the runs in the given range
+    completedRuns.forEach(saveRunInfo);
+    ongoingRunsData?.forEach(saveRunInfo);
+    const current = {jobInfo, runsByJobKey: map};
+    previousRunsByJobKey.current = current;
+    return current;
+  }, [completedRuns, ongoingRunsData, loading]);
+
+  const jobsWithCompletedRunsAndOngoingRuns = useMemo(() => {
+    const jobs: Record<string, TimelineJob> = {};
+    if (!Object.keys(runsByJobKey).length) {
+      return jobs;
+    }
+
+    Object.entries(runsByJobKey).forEach(([jobKey, jobRunsInfo]) => {
+      const runs = Object.values(jobRunsInfo);
+      const info = jobInfo[jobKey];
+      if (!info) {
+        return;
+      }
+
+      const {pipelineName, isAdHoc, repoAddress} = info;
+
+      jobs[jobKey] = {
+        key: jobKey,
+        jobName: isAdHoc ? 'Ad hoc materializations' : pipelineName,
+        jobType: isAdHoc ? 'asset' : 'job',
+        repoAddress,
+        path: workspacePipelinePath({
+          repoName: repoAddress.name,
+          repoLocation: repoAddress.location,
+          pipelineName,
+          isJob: true,
+        }),
+        runs,
+      } as TimelineJob;
+    });
+
+    return jobs;
+  }, [jobInfo, runsByJobKey]);
+
+  const jobsWithCompletedRunsAndOngoingRunsValues = useMemo(() => {
+    return Object.values(jobsWithCompletedRunsAndOngoingRuns);
+  }, [jobsWithCompletedRunsAndOngoingRuns]);
+
+  const unsortedJobs: TimelineJob[] = useMemo(() => {
+    if (!workspaceOrError || workspaceOrError.__typename === 'PythonError' || _end < Date.now()) {
+      return jobsWithCompletedRunsAndOngoingRunsValues;
+    }
     const jobs: TimelineJob[] = [];
     for (const locationEntry of workspaceOrError.locationEntries) {
       if (
@@ -378,35 +443,47 @@ export const useRunsForTimeline = ({
             continue;
           }
 
-          const jobsAndTicksToAdd = [...jobRuns, ...jobTicks];
-          if (isAdHoc) {
-            const adHocJobs = jobs.find(
-              (job) => job.jobType === 'asset' && job.repoAddress === repoAddress,
-            );
-            if (adHocJobs) {
-              adHocJobs.runs.push(...jobsAndTicksToAdd);
-              continue;
-            }
+          const runs = [...jobRuns, ...jobTicks];
+
+          let job = jobsWithCompletedRunsAndOngoingRuns[jobKey];
+          if (job) {
+            job = {
+              ...job,
+              runs,
+            };
+          } else {
+            job = {
+              key: jobKey,
+              jobName,
+              jobType: isAdHoc ? 'asset' : 'job',
+              repoAddress,
+              path: workspacePipelinePath({
+                repoName: repoAddress.name,
+                repoLocation: repoAddress.location,
+                pipelineName: pipeline.name,
+                isJob: pipeline.isJob,
+              }),
+              runs,
+            } as TimelineJob;
           }
 
-          jobs.push({
-            key: jobKey,
-            jobName,
-            jobType: isAdHoc ? 'asset' : 'job',
-            repoAddress,
-            path: workspacePipelinePath({
-              repoName: repoAddress.name,
-              repoLocation: repoAddress.location,
-              pipelineName: pipeline.name,
-              isJob: pipeline.isJob,
-            }),
-            runs: [...jobRuns, ...jobTicks],
-          } as TimelineJob);
+          jobs.push(job);
         }
       }
     }
+    return jobs;
+    // Don't add start/end time as a dependency here since it changes often.
+    // Instead rely on the underlying runs changing in response to start/end changing
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    workspaceOrError,
+    jobsWithCompletedRunsAndOngoingRunsValues,
+    runsByJobKey,
+    jobsWithCompletedRunsAndOngoingRuns,
+  ]);
 
-    const earliest = jobs.reduce(
+  const jobsWithRuns = useMemo(() => {
+    const earliest = unsortedJobs.reduce(
       (accum, job) => {
         const startTimes = job.runs.map((job) => job.startTime);
         accum[job.key] = Math.min(...startTimes);
@@ -415,8 +492,8 @@ export const useRunsForTimeline = ({
       {} as {[jobKey: string]: number},
     );
 
-    return jobs.sort((a, b) => earliest[a.key]! - earliest[b.key]!);
-  }, [workspaceOrError, runsByJobKey, start, _end]);
+    return unsortedJobs.sort((a, b) => earliest[a.key]! - earliest[b.key]!);
+  }, [unsortedJobs]);
 
   const lastFetchRef = useRef({ongoing: 0, future: 0});
   const lastRangeMs = useRef([0, 0] as readonly [number, number]);
@@ -425,8 +502,14 @@ export const useRunsForTimeline = ({
   }
   lastRangeMs.current = rangeMs;
 
+  const loadingRef = useRef(0);
   const refreshState = useRefreshAtInterval({
     refresh: useCallback(async () => {
+      // If the user paginates backwards quickly then there will be multiple outstanding fetches
+      // but we only want the most recent fetch to change loading back to false.
+      // loadingRef will help us tell if this fetch is the most recent fetch.
+      const loadId = ++loadingRef.current;
+      setLoading(true);
       await Promise.all([
         // Only fetch ongoing runs once every 30 seconds
         (async () => {
@@ -438,31 +521,24 @@ export const useRunsForTimeline = ({
         // Only fetch future ticks on a minute
         (async () => {
           if (lastFetchRef.current.future < Date.now() - 60 * 1000) {
-            await fetchFutureTicks();
-            lastFetchRef.current.future = Date.now();
+            fetchFutureTicks();
           }
         })(),
         fetchCompletedRunsQueryData(),
       ]);
+      if (loadId === loadingRef.current) {
+        setLoading(false);
+      }
     }, [fetchCompletedRunsQueryData, fetchFutureTicks, fetchOngoingRunsQueryData]),
     intervalMs: refreshInterval,
     leading: true,
   });
 
-  const initialLoading =
-    (loadingOngoingRunsData && !ongoingRunsData) ||
-    (loadingCompletedRunsData && !completedRunsData) ||
-    (loadingFutureTicksData && !futureTicksData) ||
-    !workspaceOrError;
-
-  return useMemo(
-    () => ({
-      jobs: jobsWithRuns,
-      initialLoading,
-      refreshState,
-    }),
-    [initialLoading, jobsWithRuns, refreshState],
-  );
+  return {
+    jobs: jobsWithRuns,
+    loading,
+    refreshState,
+  };
 };
 
 export const makeJobKey = (repoAddress: RepoAddress, jobName: string) =>
@@ -520,11 +596,6 @@ export const FUTURE_TICKS_QUERY = gql`
         locationEntries {
           id
           name
-          loadStatus
-          displayMetadata {
-            key
-            value
-          }
           locationOrLoadError {
             ... on RepositoryLocation {
               id

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -196,7 +196,7 @@ export const useRunsForTimeline = ({
   // If the user paginates backwards quickly then there will be multiple outstanding fetches
   // but we only want the most recent fetch to change loading back to false.
   // fetchIdRef will help us tell if this fetch is the most recent fetch.
-  const loadIdRef = useRef(0);
+  const fetchIdRef = useRef(0);
   const ongoingRunFetchIdRef = useRef(0);
   const futureTicksFetchIdRef = useRef(0);
   const fetchOngoingRunsQueryData = useCallback(async () => {
@@ -518,7 +518,7 @@ export const useRunsForTimeline = ({
 
   const refreshState = useRefreshAtInterval({
     refresh: useCallback(async () => {
-      const loadId = ++loadIdRef.current;
+      const loadId = ++fetchIdRef.current;
       setLoading(true);
       await Promise.all([
         // Only fetch ongoing runs once every 30 seconds
@@ -536,7 +536,7 @@ export const useRunsForTimeline = ({
         })(),
         fetchCompletedRunsQueryData(),
       ]);
-      if (loadId === loadIdRef.current) {
+      if (loadId === fetchIdRef.current) {
         setLoading(false);
       }
     }, [fetchCompletedRunsQueryData, fetchFutureTicks, fetchOngoingRunsQueryData]),


### PR DESCRIPTION
## Summary & Motivation

- Don't make the Run Timeline wait for FutureTicks to resolve before considering it complete because future ticks pulls the workspace snapshot and is really slow while the other queries tends to be fast.
- ~75% improvement in rendering performance by fixing needless re-rendering, N^2 isAdHoc job logic, and excessive spread usage

## How I Tested These Changes

Jest tests.
Loaded the Run timeline on various organizations testing both uncached and cached loads and pagination forwards/backwards.


Performance comparison for a cached load of the RunTimeline for a particularly large org 

Before :1,770.62ms
<img width="535" alt="Screenshot 2024-06-10 at 9 09 21 AM" src="https://github.com/dagster-io/dagster/assets/2286579/b8658597-5be7-4b94-8b1b-da9a2f897799">

After: 448ms
<img width="470" alt="Screenshot 2024-06-10 at 9 07 08 AM" src="https://github.com/dagster-io/dagster/assets/2286579/b843f0ec-4888-4f2d-b10e-400c99cf6bc0">


