### PR TITLE
Only render left nav if visible

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/nav/LeftNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/LeftNav.tsx
@@ -10,7 +10,7 @@ export const LeftNav = () => {
 
   return (
     <LeftNavContainer $open={nav.isOpen} $smallScreen={nav.isSmallScreen}>
-      <LeftNavRepositorySection />
+      {nav.isOpen ? <LeftNavRepositorySection /> : null}
     </LeftNavContainer>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/LeftNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/LeftNav.tsx
@@ -1,5 +1,5 @@
 import {Colors} from '@dagster-io/ui-components';
-import {useContext} from 'react';
+import {useContext, useRef} from 'react';
 import styled from 'styled-components';
 
 import {LeftNavRepositorySection} from './LeftNavRepositorySection';
@@ -8,9 +8,14 @@ import {LayoutContext} from '../app/LayoutProvider';
 export const LeftNav = () => {
   const {nav} = useContext(LayoutContext);
 
+  const wasEverOpen = useRef(nav.isOpen);
+  if (nav.isOpen) {
+    wasEverOpen.current = true;
+  }
+
   return (
     <LeftNavContainer $open={nav.isOpen} $smallScreen={nav.isSmallScreen}>
-      {nav.isOpen ? <LeftNavRepositorySection /> : null}
+      {wasEverOpen.current ? <LeftNavRepositorySection /> : null}
     </LeftNavContainer>
   );
 };


### PR DESCRIPTION
## Summary & Motivation

This thing is super slow to render (~2s!!) (For one of our exceptionally large customers). I will investigate and fix in a follow up PR but for now lets not even render it if its not visible.

<img width="699" alt="Screenshot 2024-06-10 at 9 40 18 AM" src="https://github.com/dagster-io/dagster/assets/2286579/0b1b4473-07bc-4941-9c67-cf169fe8ec38">


## How I Tested These Changes

locally