### PR TITLE
[Perf monitoring] Don't update path using nesting route

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/BaseFallthroughRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/BaseFallthroughRoot.tsx
@@ -10,7 +10,7 @@ import {workspacePath, workspacePipelinePath} from '../workspace/workspacePath';
 export const BaseFallthroughRoot = () => {
   return (
     <Switch>
-      <Route path="*">
+      <Route path="*" isNestingRoute>
         <FinalRedirectOrLoadingRoot />
       </Route>
     </Switch>

--- a/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
@@ -89,7 +89,7 @@ export const ContentRoot = memo(() => {
           <Route path="/settings">
             <SettingsRoot />
           </Route>
-          <Route path="*">
+          <Route path="*" isNestingRoute>
             <FallthroughRoot />
           </Route>
         </Switch>

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Route.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Route.tsx
@@ -4,8 +4,13 @@ import {useSetRecoilState} from 'recoil';
 
 import {currentPageAtom} from './analytics';
 
-export const Route = memo((props: ComponentProps<typeof ReactRouterRoute>) => {
-  const {render, children, component: Component} = props;
+type Props = ComponentProps<typeof ReactRouterRoute> & {
+  // Set to true if this route should contain more routes.
+  isNestingRoute?: boolean;
+};
+
+export const Route = memo((props: Props) => {
+  const {render, children, isNestingRoute, component: Component} = props;
 
   const renderFn = useMemo(() => {
     if (!render) {
@@ -44,18 +49,22 @@ export const Route = memo((props: ComponentProps<typeof ReactRouterRoute>) => {
   }
   return (
     <ReactRouterRoute {...props}>
-      <Wrapper>{children}</Wrapper>
+      <Wrapper isNestingRoute={isNestingRoute}>{children}</Wrapper>
     </ReactRouterRoute>
   );
 });
 
-const Wrapper = memo(({children}: {children: ReactNode}) => {
-  const {path} = useRouteMatch();
+const Wrapper = memo(
+  ({children, isNestingRoute}: {children: ReactNode; isNestingRoute?: boolean}) => {
+    const {path} = useRouteMatch();
 
-  const setCurrentPage = useSetRecoilState(currentPageAtom);
-  useLayoutEffect(() => {
-    setCurrentPage(({specificPath}) => ({specificPath, path}));
-  }, [path, setCurrentPage]);
+    const setCurrentPage = useSetRecoilState(currentPageAtom);
+    useLayoutEffect(() => {
+      if (path !== '*' && !isNestingRoute) {
+        setCurrentPage(({specificPath}) => ({specificPath, path}));
+      }
+    }, [path, isNestingRoute, setCurrentPage]);
 
-  return children;
-});
+    return children;
+  },
+);

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewActivityRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewActivityRoot.tsx
@@ -65,6 +65,7 @@ export const OverviewActivityRoot = () => {
         </Route>
         <Route
           path="*"
+          isNestingRoute
           render={React.useCallback(
             () =>
               defaultTab === 'timeline' ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
@@ -15,7 +15,7 @@ export const OverviewRoot = () => {
   const {flagSettingsPage} = useFeatureFlags();
   return (
     <Switch>
-      <Route path="/overview/activity">
+      <Route path="/overview/activity" isNestingRoute>
         <OverviewActivityRoot />
       </Route>
       <Route
@@ -60,7 +60,7 @@ export const OverviewRoot = () => {
       <Route path="/overview/resources">
         <OverviewResourcesRoot />
       </Route>
-      <Route path="*" render={() => <Redirect to="/overview/activity" />} />
+      <Route path="*" isNestingRoute render={() => <Redirect to="/overview/activity" />} />
     </Switch>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/settings/SettingsMainPane.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/settings/SettingsMainPane.tsx
@@ -29,7 +29,7 @@ export const SettingsMainPane = () => {
         <Route path="/settings/config">
           <InstanceConfigContent />
         </Route>
-        <Route path="*">
+        <Route path="*" isNestingRoute>
           <Redirect to="/settings/locations" />
         </Route>
       </Switch>


### PR DESCRIPTION
## Summary & Motivation

Some of our routes nest other routes. Eg: `/overview/activity` nests 3 other routes. Currently if a component rendering a nested route re-renders it ends up changing the path back to its nested route path (eg. `/overview/activity`) and if display-done happens at that point then we end up using that as the view name. To avoid that just never use the path of a route the nests other routes.

## How I Tested These Changes

Haven't been able to repro the issue myself but you can see this in the go/ux dashboard. Seems to happen for a particularly large org with slow and expensive renders