### PR TITLE
[RFC] `partitions_def` on `AssetSpec`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_checks.py
@@ -125,7 +125,7 @@ def build_asset_with_blocking_check(
         key_prefix=None,
         key=asset_def.key,
         group_name=spec.group_name,
-        partitions_def=asset_def.partitions_def,
+        partitions_def=spec.partitions_def,
         check_specs=check_specs,
         description=spec.description,
         ins={name: AssetIn(key) for name, key in asset_def.keys_by_input_name.items()},

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -81,11 +81,11 @@ class AssetNode(BaseAssetNode):
 
     @property
     def is_partitioned(self) -> bool:
-        return self.assets_def.partitions_def is not None
+        return self.partitions_def is not None
 
     @property
     def partitions_def(self) -> Optional[PartitionsDefinition]:
-        return self.assets_def.partitions_def
+        return self.assets_def.specs_by_key[self.key].partitions_def
 
     @property
     def partition_mappings(self) -> Mapping[AssetKey, PartitionMapping]:

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -465,10 +465,11 @@ class AssetLayer(NamedTuple):
                         )
                     )
 
+                spec = assets_def.specs_by_key[asset_key]
                 asset_info_by_output[node_output_handle] = AssetOutputInfo(
                     asset_key,
-                    partitions_fn=partitions_fn if assets_def.partitions_def else None,
-                    partitions_def=assets_def.partitions_def,
+                    partitions_fn=partitions_fn if spec.partitions_def else None,
+                    partitions_def=spec.partitions_def,
                     is_required=asset_key in assets_def.keys,
                     code_version=inner_output_def.code_version,
                 )

--- a/python_modules/dagster/dagster/_core/definitions/asset_out.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_out.py
@@ -153,4 +153,5 @@ class AssetOut(
                 owners=self.owners,
                 tags=self.tags,
                 deps=deps,
+                partitions_def=None,
             )

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -10,6 +10,7 @@ from dagster._utils.internal_init import IHasInternalInit
 from .auto_materialize_policy import AutoMaterializePolicy
 from .events import AssetKey, CoercibleToAssetKey
 from .freshness_policy import FreshnessPolicy
+from .partition import PartitionsDefinition
 from .utils import validate_tags_strict
 
 if TYPE_CHECKING:
@@ -70,6 +71,7 @@ class AssetSpec(
             ("auto_materialize_policy", PublicAttr[Optional[AutoMaterializePolicy]]),
             ("owners", PublicAttr[Sequence[str]]),
             ("tags", PublicAttr[Mapping[str, str]]),
+            ("partitions_def", PublicAttr[Optional[PartitionsDefinition]]),
         ],
     ),
     IHasInternalInit,
@@ -117,6 +119,7 @@ class AssetSpec(
         auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
         owners: Optional[Sequence[str]] = None,
         tags: Optional[Mapping[str, str]] = None,
+        partitions_def: Optional[PartitionsDefinition] = None,
     ):
         from dagster._core.definitions.asset_dep import coerce_to_deps_and_check_duplicates
 
@@ -148,6 +151,9 @@ class AssetSpec(
             ),
             owners=owners,
             tags=validate_tags_strict(tags) or {},
+            partitions_def=check.opt_inst_param(
+                partitions_def, "partitions_def", PartitionsDefinition
+            ),
         )
 
     @staticmethod
@@ -164,6 +170,7 @@ class AssetSpec(
         auto_materialize_policy: Optional[AutoMaterializePolicy],
         owners: Optional[Sequence[str]],
         tags: Optional[Mapping[str, str]],
+        partitions_def: Optional[PartitionsDefinition],
     ) -> "AssetSpec":
         return AssetSpec(
             key=key,
@@ -177,4 +184,5 @@ class AssetSpec(
             auto_materialize_policy=auto_materialize_policy,
             owners=owners,
             tags=tags,
+            partitions_def=partitions_def,
         )

--- a/python_modules/dagster/dagster/_core/definitions/external_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset.py
@@ -125,6 +125,7 @@ def external_assets_from_specs(specs: Sequence[AssetSpec]) -> List[AssetsDefinit
                         skippable=False,
                         code_version=None,
                         auto_materialize_policy=None,
+                        partitions_def=None,
                     )
                 ],
             )

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -266,13 +266,11 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         self._partitions_def_by_asset_key: Dict[AssetKey, Optional[PartitionsDefinition]] = {}
         asset_graph = self._repository_def.asset_graph
         for asset_key in self._monitored_asset_keys:
-            assets_def = (
-                asset_graph.get(asset_key).assets_def if asset_graph.has(asset_key) else None
-            )
-            self._assets_by_key[asset_key] = assets_def
+            asset_node = asset_graph.get(asset_key) if asset_graph.has(asset_key) else None
+            self._assets_by_key[asset_key] = asset_node.assets_def if asset_node else None
 
             self._partitions_def_by_asset_key[asset_key] = (
-                assets_def.partitions_def if assets_def else None
+                asset_node.partitions_def if asset_node else None
             )
 
         # Cursor object with utility methods for updating and retrieving cursor information.
@@ -745,24 +743,25 @@ class MultiAssetSensorEvaluationContext(SensorEvaluationContext):
         to_asset = self._get_asset(to_asset_key, fn_name="get_downstream_partition_keys")
         from_asset = self._get_asset(from_asset_key, fn_name="get_downstream_partition_keys")
 
-        to_partitions_def = to_asset.partitions_def
+        to_partitions_def = to_asset.specs_by_key[to_asset_key].partitions_def
+        from_partitions_def = from_asset.specs_by_key[from_asset_key].partitions_def
 
         if not isinstance(to_partitions_def, PartitionsDefinition):
             raise DagsterInvalidInvocationError(
                 f"Asset key {to_asset_key} is not partitioned. Cannot get partition keys."
             )
-        if not isinstance(from_asset.partitions_def, PartitionsDefinition):
+        if not isinstance(from_partitions_def, PartitionsDefinition):
             raise DagsterInvalidInvocationError(
                 f"Asset key {from_asset_key} is not partitioned. Cannot get partition keys."
             )
 
         partition_mapping = to_asset.infer_partition_mapping(
-            from_asset_key, from_asset.partitions_def
+            to_asset_key, from_asset_key, from_partitions_def
         )
         downstream_partition_key_subset = (
             partition_mapping.get_downstream_partitions_for_partitions(
-                from_asset.partitions_def.empty_subset().with_partition_keys([partition_key]),
-                from_asset.partitions_def,
+                from_partitions_def.empty_subset().with_partition_keys([partition_key]),
+                from_partitions_def,
                 downstream_partitions_def=to_partitions_def,
                 dynamic_partitions_store=self.instance,
             )

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -246,14 +246,15 @@ def build_caching_repository_data_from_list(
             asset_check_keys.update(definition.check_keys)
             asset_checks_defs.append(definition)
         elif isinstance(definition, AssetsDefinition):
-            for key in definition.keys:
-                if key in asset_keys:
-                    raise DagsterInvalidDefinitionError(f"Duplicate asset key: {key}")
+            for spec in definition.specs:
+                if spec.key in asset_keys:
+                    raise DagsterInvalidDefinitionError(f"Duplicate asset key: {spec.key}")
+
+                if spec.partitions_def is not None:
+                    partitions_defs.add(spec.partitions_def)
             for key in definition.check_keys:
                 if key in asset_check_keys:
                     raise DagsterInvalidDefinitionError(f"Duplicate asset check key: {key}")
-            if definition.partitions_def is not None:
-                partitions_defs.add(definition.partitions_def)
 
             asset_keys.update(definition.keys)
             asset_check_keys.update(definition.check_keys)

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -337,7 +337,7 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
                 #   ["2023-08-21", "2023-08-22", "2023-08-23", "2023-08-24", "2023-08-25"]
         """
         key_range = self.partition_key_range
-        partitions_def = self.assets_def.partitions_def
+        partitions_def = self._step_execution_context.partitions_def
         if partitions_def is None:
             raise DagsterInvariantViolationError(
                 "Cannot access partition_keys for a non-partitioned run"

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -84,6 +84,7 @@ def assert_namedtuple_lists_equal(
     t2_list: Sequence[T_NamedTuple],
     exclude_fields: Optional[Sequence[str]] = None,
 ) -> None:
+    assert len(t1_list) == len(t2_list)
     for t1, t2 in zip(t1_list, t2_list):
         assert_namedtuples_equal(t1, t2, exclude_fields)
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -528,7 +528,7 @@ def get_asset_graph(
     ) as get_builtin_partition_mapping_types:
         get_builtin_partition_mapping_types.return_value = tuple(
             assets_def.infer_partition_mapping(
-                dep_key, assets_defs_by_key[dep_key].partitions_def
+                next(iter(assets_def.keys)), dep_key, assets_defs_by_key[dep_key].partitions_def
             ).__class__
             for assets in assets_by_repo_name.values()
             for assets_def in assets


### PR DESCRIPTION
## Summary & Motivation

Adds a `partitions_def` property to `AssetSpec`. This means that different assets within a multi-asset can have different `PartitionsDefinition`s.

This is only permitted when `can_subset=True`. This restriction means that this change doesn't require any changes to our execution machinery.  I.e. we can still retain the restriction that each run targets a single partition from a single `PartitionsDefinition`.

In the future, we could relax the `can_subset` constraint after relaxing the single-PartitionsDefinition-per-run constraint.

Depends on https://github.com/dagster-io/dagster/pull/223762, which allows multiple `PartitionsDefinition`s per implicit asset job.

## How I Tested These Changes
