### PR TITLE
Fix "Attempt to use history.pushState() more than 100 times per 10 seconds" issue

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
@@ -1,5 +1,5 @@
 import {Box, ButtonLink, Colors} from '@dagster-io/ui-components';
-import {useCallback, useContext, useLayoutEffect, useState} from 'react';
+import {useCallback, useContext, useLayoutEffect, useRef, useState} from 'react';
 import {useHistory} from 'react-router-dom';
 import {atom, useRecoilValue} from 'recoil';
 import styled from 'styled-components';
@@ -28,12 +28,14 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
   const [previousEntriesById, setPreviousEntriesById] = useState<EntriesById | null>(null);
 
   const history = useHistory();
+  const historyRef = useRef<typeof history>(history);
+  historyRef.current = history;
 
   const [showSpinner, setShowSpinner] = useState(false);
 
   const onClickViewButton = useCallback(() => {
-    history.push('/locations');
-  }, [history]);
+    historyRef.current.push('/locations');
+  }, []);
 
   // Reload the workspace, but don't toast about it.
 


### PR DESCRIPTION
## Summary & Motivation

I have no idea why this fixes it but I was able to repro only in Safari with a particular org who has a failing code location and this seems to fix it. Might be a bug in react-router-dom.

https://app.datadoghq.com/rum/error-tracking?query=%40application.id%3A7edc09bb-51d0-4555-90cd-b19ca483d1fe&fromUser=true&issueId=d9f40514-21a1-11ef-91cb-da7ad0900002&source=all&view=spans&from_ts=1717426770824&to_ts=1718031570824&live=true

## How I Tested These Changes

Loaded insights in Safari for org with code location that is currently erroring