### PR TITLE
[Websocket - SubscriptionClient] Set timeout of 10s

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -87,6 +87,7 @@ export const AppProvider = (props: AppProviderProps) => {
     () =>
       new SubscriptionClient(websocketURI, {
         reconnect: true,
+        timeout: 10000,
         connectionParams: {...headerObject},
       }),
     [headerObject, websocketURI],


### PR DESCRIPTION
## Summary & Motivation

https://linear.app/dagster-labs/issue/FOU-215/tweak-frontend-retry-behavior-on-websocket-failure


## How I Tested These Changes

shadow dagit  - confirmed we wait 10s between these attempts
<img width="1509" alt="Screenshot 2024-06-10 at 12 22 43 PM" src="https://github.com/dagster-io/dagster/assets/2286579/4eb2aafa-c399-4ed1-ba6a-9fc8bf122ed8">

