### PR TITLE
[rfc] Add earliest step failure event to job failure event

### DIFF
--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -1089,6 +1089,7 @@ class DagsterEvent(
         context_msg: str,
         failure_reason: RunFailureReason,
         error_info: Optional[SerializableErrorInfo] = None,
+        first_step_failure_event: Optional["DagsterEvent"] = None,
     ) -> "DagsterEvent":
         check.str_param(context_msg, "context_msg")
         if isinstance(job_context_or_name, IPlanContext):
@@ -1098,7 +1099,11 @@ class DagsterEvent(
                 message=(
                     f'Execution of run for "{job_context_or_name.job_name}" failed. {context_msg}'
                 ),
-                event_specific_data=JobFailureData(error_info, failure_reason=failure_reason),
+                event_specific_data=JobFailureData(
+                    error_info,
+                    failure_reason=failure_reason,
+                    first_step_failure_event=first_step_failure_event,
+                ),
             )
         else:
             # when the failure happens trying to bring up context, the job_context hasn't been
@@ -1737,6 +1742,7 @@ class JobFailureData(
         [
             ("error", Optional[SerializableErrorInfo]),
             ("failure_reason", Optional[RunFailureReason]),
+            ("first_step_failure_event", Optional["DagsterEvent"]),
         ],
     )
 ):
@@ -1744,11 +1750,15 @@ class JobFailureData(
         cls,
         error: Optional[SerializableErrorInfo],
         failure_reason: Optional[RunFailureReason] = None,
+        first_step_failure_event: Optional["DagsterEvent"] = None,
     ):
         return super(JobFailureData, cls).__new__(
             cls,
             error=check.opt_inst_param(error, "error", SerializableErrorInfo),
             failure_reason=check.opt_inst_param(failure_reason, "failure_reason", RunFailureReason),
+            first_step_failure_event=check.opt_inst_param(
+                first_step_failure_event, "first_step_failure_event", DagsterEvent
+            ),
         )
 
 


### PR DESCRIPTION
This will allow us to retrieve step failure information in a performant way for large runs. I chose to retrieve "earliest" step failure event, since that's the one relevant to the state transition from "in progress" to "failed" run.

Some concern for if, in the future, we want to include more than just the latest step failure, we'll need to have some serdes logic to switch this new field to a list that includes more than just the latest event. It's also possible we can choose some non-comprehensive N of step failure events to occur, but I think I prefer just retrieving the earliest for now to keep it simple.

Added a test to ensure that we actually receive the earliest step failure.
