### PR TITLE
make get_log_keys_for_log_key_prefix an abstractmethod

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
@@ -261,13 +261,13 @@ class CapturedLogManager(ABC):
         """Legacy adapter to translate run_id/key to captured log manager-based log_key."""
         return [run_id, "compute_logs", step_key]
 
+    @abstractmethod
     def get_log_keys_for_log_key_prefix(
         self, log_key_prefix: Sequence[str], io_type: ComputeIOType
     ) -> Sequence[Sequence[str]]:
         """Returns the logs keys for a given log key prefix. This is determined by looking at the
         directory defined by the log key prefix and creating a log_key for each file in the directory.
         """
-        raise NotImplementedError("Must implement get_log_keys_for_log_key_prefix")
 
     def _get_log_lines_for_log_key(
         self, log_key: Sequence[str], io_type: ComputeIOType

--- a/python_modules/dagster/dagster/_core/storage/noop_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/noop_compute_log_manager.py
@@ -109,3 +109,8 @@ class NoOpComputeLogManager(CapturedLogManager, ComputeLogManager, ConfigurableC
 
     def unsubscribe(self, subscription: CapturedLogSubscription):
         pass
+
+    def get_log_keys_for_log_key_prefix(
+        self, log_key_prefix: Sequence[str], io_type: ComputeIOType
+    ) -> Sequence[Sequence[str]]:
+        return []

--- a/python_modules/dagster/dagster_tests/storage_tests/test_compute_log_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_compute_log_manager.py
@@ -109,6 +109,11 @@ class BrokenCapturedLogManager(CapturedLogManager, ComputeLogManager):
     def on_unsubscribe(self, subscription):
         pass
 
+    def get_log_keys_for_log_key_prefix(
+        self, log_key_prefix: Sequence[str], io_type: ComputeIOType
+    ) -> Sequence[Sequence[str]]:
+        return []
+
 
 class BrokenComputeLogManager(ComputeLogManager):
     def __init__(self, fail_on_setup=False, fail_on_teardown=False):


### PR DESCRIPTION
## Summary & Motivation
moves `get_log_keys_for_log_key_prefix` to an abstract method to follow convention for the captured log manager.

It's unclear to me if we can actually merge this PR - do we expect users to have custom Captured/ComputeLogManagers?

## How I Tested These Changes
