### PR TITLE
[definition-tags] Merge normalize_tags and validate_tags_strict

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_out.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_out.py
@@ -19,7 +19,7 @@ from dagster._core.definitions.input import NoValueSentinel
 from dagster._core.definitions.output import Out
 from dagster._core.definitions.utils import DEFAULT_IO_MANAGER_KEY, resolve_automation_condition
 from dagster._core.types.dagster_type import DagsterType, resolve_dagster_type
-from dagster._utils.tags import validate_tags_strict
+from dagster._utils.tags import normalize_tags
 from dagster._utils.warnings import disable_dagster_warnings
 
 
@@ -42,7 +42,7 @@ class AssetOut(
             ("automation_condition", PublicAttr[Optional[AutomationCondition]]),
             ("backfill_policy", PublicAttr[Optional[BackfillPolicy]]),
             ("owners", PublicAttr[Optional[Sequence[str]]]),
-            ("tags", PublicAttr[Optional[Mapping[str, str]]]),
+            ("tags", PublicAttr[Mapping[str, str]]),
         ],
     )
 ):
@@ -132,7 +132,7 @@ class AssetOut(
                 backfill_policy, "backfill_policy", BackfillPolicy
             ),
             owners=check.opt_sequence_param(owners, "owners", of_type=str),
-            tags=validate_tags_strict(tags),
+            tags=normalize_tags(tags or {}, strict=True),
         )
 
     def to_out(self) -> Out:

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -21,7 +21,7 @@ from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.storage.tags import KIND_PREFIX
 from dagster._serdes.serdes import whitelist_for_serdes
 from dagster._utils.internal_init import IHasInternalInit
-from dagster._utils.tags import validate_tags_strict
+from dagster._utils.tags import normalize_tags
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_dep import AssetDep, CoercibleToAssetDep
@@ -160,7 +160,7 @@ class AssetSpec(
             validate_asset_owner(owner, key)
 
         tags_with_kinds = {
-            **(validate_tags_strict(tags) or {}),
+            **(normalize_tags(tags or {}, strict=True)),
             **{f"{KIND_PREFIX}{kind}": "" for kind in kinds or []},
         }
 

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -76,7 +76,7 @@ from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariant
 from dagster._utils import IHasInternalInit
 from dagster._utils.merger import merge_dicts
 from dagster._utils.security import non_secure_md5_hash_str
-from dagster._utils.tags import validate_tags_strict
+from dagster._utils.tags import normalize_tags
 from dagster._utils.warnings import ExperimentalWarning, disable_dagster_warnings
 
 if TYPE_CHECKING:
@@ -1711,7 +1711,7 @@ def _asset_specs_from_attr_key_params(
     )
 
     for tags in (tags_by_key or {}).values():
-        validate_tags_strict(tags)
+        normalize_tags(tags, strict=True)
     validated_tags_by_key = tags_by_key or {}
 
     validated_descriptions_by_key = check.opt_mapping_param(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -59,7 +59,7 @@ from dagster._core.definitions.utils import (
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._core.storage.tags import KIND_PREFIX
 from dagster._core.types.dagster_type import DagsterType
-from dagster._utils.tags import validate_tags_strict
+from dagster._utils.tags import normalize_tags
 from dagster._utils.warnings import disable_dagster_warnings
 
 
@@ -254,7 +254,7 @@ def asset(
             "Cannot specify compute_kind and kinds on the @asset decorator."
         )
     tags_with_kinds = {
-        **(validate_tags_strict(tags) or {}),
+        **(normalize_tags(tags, strict=True)),
         **{f"{KIND_PREFIX}{kind}": "" for kind in kinds or []},
     }
 
@@ -469,7 +469,7 @@ def create_assets_def_from_fn_and_decorator_args(
                     automation_condition=args.automation_condition,
                     backfill_policy=args.backfill_policy,
                     owners=args.owners,
-                    tags=validate_tags_strict(args.tags),
+                    tags=normalize_tags(args.tags or {}, strict=True),
                 )
             },
             upstream_asset_deps=args.deps,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -127,7 +127,9 @@ def schedule(
                 " to ScheduleDefinition. Must provide only one of the two."
             )
         elif tags:
-            validated_tags = normalize_tags(tags, allow_reserved_tags=False, warning_stacklevel=3)
+            validated_tags = normalize_tags(
+                tags, allow_private_system_tags=False, warning_stacklevel=3
+            )
 
         context_param_name = get_context_param_name(fn)
         resource_arg_names: Set[str] = {arg.name for arg in get_resource_args(fn)}
@@ -163,7 +165,10 @@ def schedule(
                     evaluated_run_config = copy.deepcopy(result)
                     evaluated_tags = (
                         validated_tags
-                        or (tags_fn and normalize_tags(tags_fn(context), allow_reserved_tags=False))
+                        or (
+                            tags_fn
+                            and normalize_tags(tags_fn(context), allow_private_system_tags=False)
+                        )
                         or None
                     )
                     yield RunRequest(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -20,7 +20,7 @@ from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.source_asset import SourceAsset, SourceAssetObserveFunction
-from dagster._utils.tags import validate_tags_strict
+from dagster._utils.tags import normalize_tags
 from dagster._utils.warnings import disable_dagster_warnings
 
 
@@ -128,7 +128,7 @@ def observable_source_asset(
         auto_observe_interval_minutes,
         freshness_policy,
         op_tags,
-        tags=validate_tags_strict(tags),
+        tags=normalize_tags(tags, strict=True),
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -750,18 +750,16 @@ UserEvent = Union[AssetMaterialization, AssetObservation, ExpectationResult]
 
 
 def validate_asset_event_tags(tags: Optional[Mapping[str, str]]) -> Optional[Mapping[str, str]]:
-    from dagster._utils.tags import validate_tag_strict
+    from dagster._utils.tags import normalize_tags
 
     if tags is None:
         return None
 
-    for key, value in tags.items():
-        # The format of these particular tags does not fit strict validation. E.g.
-        # - Some of the keys have two slashes
-        # - The value for the data/code version tags can be an arbitrary string
-        if not is_system_asset_event_tag(key):
-            validate_tag_strict(key, value)
-
+    # The format of these particular tags does not fit strict validation. E.g.
+    # - Some of the keys have two slashes
+    # - The value for the data/code version tags can be an arbitrary string
+    tags_to_validate = {k: v for k, v in tags.items() if not is_system_asset_event_tag(k)}
+    normalize_tags(tags_to_validate, strict=True)  # performs validation
     return tags
 
 

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -731,7 +731,7 @@ class PartitionedConfig(Generic[T_PartitionsDefinition]):
             user_tags = self._tags_for_partition_key_fn(partition_key)
         else:
             user_tags = {}
-        user_tags = normalize_tags(user_tags, allow_reserved_tags=False)
+        user_tags = normalize_tags(user_tags, allow_private_system_tags=False)
 
         system_tags = {
             **self.partitions_def.get_tags_for_partition_key(partition_key),

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -674,7 +674,7 @@ class ScheduleDefinition(IHasInternalInit):
                 self._execution_fn = execution_fn
             else:
                 self._execution_fn = check.opt_callable_param(execution_fn, "execution_fn")
-            self._tags = normalize_tags(tags, allow_reserved_tags=False, warning_stacklevel=5)
+            self._tags = normalize_tags(tags, allow_private_system_tags=False, warning_stacklevel=5)
             self._tags_fn = None
             self._run_config_fn = None
         else:
@@ -700,7 +700,7 @@ class ScheduleDefinition(IHasInternalInit):
                     "Attempted to provide both tags_fn and tags as arguments"
                     " to ScheduleDefinition. Must provide only one of the two."
                 )
-            self._tags = normalize_tags(tags, allow_reserved_tags=False, warning_stacklevel=5)
+            self._tags = normalize_tags(tags, allow_private_system_tags=False, warning_stacklevel=5)
             if tags_fn:
                 self._tags_fn = check.opt_callable_param(
                     tags_fn, "tags_fn", default=lambda _context: cast(Mapping[str, str], {})
@@ -743,7 +743,9 @@ class ScheduleDefinition(IHasInternalInit):
                     ScheduleExecutionError,
                     lambda: f"Error occurred during the execution of tags_fn for schedule {name}",
                 ):
-                    evaluated_tags = normalize_tags(tags_fn(context), allow_reserved_tags=False)
+                    evaluated_tags = normalize_tags(
+                        tags_fn(context), allow_private_system_tags=False
+                    )
 
                 yield RunRequest(
                     run_key=None,

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -53,7 +53,7 @@ from dagster._core.errors import (
     DagsterInvariantViolationError,
 )
 from dagster._utils.internal_init import IHasInternalInit
-from dagster._utils.tags import validate_tags_strict
+from dagster._utils.tags import normalize_tags
 
 if TYPE_CHECKING:
     from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
@@ -215,7 +215,7 @@ class SourceAsset(ResourceAddable, IHasInternalInit):
     _node_def: Optional[OpDefinition]  # computed lazily
     auto_observe_interval_minutes: Optional[float]
     freshness_policy: Optional[FreshnessPolicy]
-    tags: Optional[Mapping[str, str]]
+    tags: Mapping[str, str]
 
     def __init__(
         self,
@@ -247,7 +247,7 @@ class SourceAsset(ResourceAddable, IHasInternalInit):
         metadata = check.opt_mapping_param(metadata, "metadata", key_type=str)
         self.raw_metadata = metadata
         self.metadata = normalize_metadata(metadata, allow_invalid=True)
-        self.tags = validate_tags_strict(tags) or {}
+        self.tags = normalize_tags(tags or {}, strict=True)
 
         resource_defs_dict = dict(check.opt_mapping_param(resource_defs, "resource_defs"))
         if io_manager_def:

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -1,7 +1,5 @@
 from enum import Enum
 
-import dagster._check as check
-
 SYSTEM_TAG_PREFIX = "dagster/"
 HIDDEN_TAG_PREFIX = ".dagster/"
 
@@ -119,14 +117,3 @@ def get_tag_type(tag):
         return TagType.HIDDEN
     else:
         return TagType.USER_PROVIDED
-
-
-def check_reserved_tags(tags):
-    check.opt_dict_param(tags, "tags", key_type=str, value_type=str)
-
-    for tag in tags.keys():
-        if tag not in USER_EDITABLE_SYSTEM_TAGS:
-            check.invariant(
-                not tag.startswith(SYSTEM_TAG_PREFIX),
-                desc=f"Attempted to set tag with reserved system prefix: {tag}",
-            )

--- a/python_modules/dagster/dagster/_utils/tags.py
+++ b/python_modules/dagster/dagster/_utils/tags.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Sequence, Tuple,
 import dagster._seven as seven
 from dagster import _check as check
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster._core.storage.tags import check_reserved_tags
+from dagster._core.storage.tags import SYSTEM_TAG_PREFIX, USER_EDITABLE_SYSTEM_TAGS
 
 if TYPE_CHECKING:
     from dagster._core.execution.plan.step import ExecutionStep
@@ -103,124 +103,130 @@ def get_boolean_tag_value(tag_value: Optional[str], default_value: bool = False)
 # ##### NORMALIZATION
 # ########################
 
-# There are two variants of tag normalization:
-#
-# 1. Legacy. Uses `normalize_tags`. Accepts a wide range of string keys and JSON-serializable values.
-# 2. Strict. Uses `validate_tags_strict`. Accepts a restricted character set for string keys and
-#    only accepts strings values.
-#
-# Legacy "tags" normalization supports an older vision of tags where potentially large values could
-# be stored in tags to configure runs. It also supports (but issues a warning for) non-standard
-# characters in tag keys like "&". We want to move away from this, but we still need to support it
-# for backcompat.
-#
-# Strict "tags" normalization supports the new vision of tags where they are short string labels
-# used for filtering and grouping in the UI. New tags arguments should generally use this
-# normalization.
-
-
-def normalize_tags(
-    tags: Optional[Mapping[str, Any]],
-    allow_reserved_tags: bool = True,
-    warning_stacklevel: int = 4,
-) -> Mapping[str, str]:
-    """Normalizes JSON-object tags into string tags and warns on deprecated tags.
-
-    New tags properties should _not_ use this function, because it doesn't hard error on tags that
-    are no longer supported.
-    """
-    valid_tags: Dict[str, str] = {}
-    invalid_tag_keys = []
-    for key, value in check.opt_mapping_param(tags, "tags", key_type=str).items():
-        if not isinstance(value, str):
-            valid = False
-            err_reason = f'Could not JSON encode value "{value}"'
-            str_val = None
-            try:
-                str_val = seven.json.dumps(value)
-                err_reason = f'JSON encoding "{str_val}" of value "{value}" is not equivalent to original value'
-
-                valid = seven.json.loads(str_val) == value
-            except Exception:
-                pass
-
-            if not valid:
-                raise DagsterInvalidDefinitionError(
-                    f'Invalid value for tag "{key}", {err_reason}. Tag values must be strings '
-                    "or meet the constraint that json.loads(json.dumps(value)) == value."
-                )
-
-            valid_tags[key] = str_val  # type: ignore  # (possible none)
-        else:
-            valid_tags[key] = value
-
-        if not is_valid_definition_tag_key(key):
-            invalid_tag_keys.append(key)
-
-    if invalid_tag_keys:
-        invalid_tag_keys_sample = invalid_tag_keys[: min(5, len(invalid_tag_keys))]
-        warnings.warn(
-            f"Non-compliant tag keys like {invalid_tag_keys_sample} are deprecated. {VALID_DEFINITION_TAG_KEY_EXPLANATION}",
-            category=DeprecationWarning,
-            stacklevel=warning_stacklevel,
-        )
-
-    if not allow_reserved_tags:
-        check_reserved_tags(valid_tags)
-
-    return valid_tags
-
-
-def validate_tag_strict(key: str, value: str) -> None:
-    if not isinstance(key, str):
-        raise DagsterInvalidDefinitionError("Tag keys must be strings")
-    elif not isinstance(value, str):
-        raise DagsterInvalidDefinitionError("Tag values must be strings")
-    elif not is_valid_definition_tag_key(key):
-        raise DagsterInvalidDefinitionError(
-            f"Invalid tag key: {key}. {VALID_DEFINITION_TAG_KEY_EXPLANATION}"
-        )
-    elif not is_valid_definition_tag_value(value):
-        raise DagsterInvalidDefinitionError(
-            f"Invalid tag value: {value}, for key: {key}. Allowed characters: alpha-numeric, '_', '-', '.'. "
-            "Must have <= 63 characters."
-        )
-
-
-def validate_tags_strict(tags: Optional[Mapping[str, str]]) -> Optional[Mapping[str, str]]:
-    if tags is None:
-        return tags
-
-    for key, value in tags.items():
-        validate_tag_strict(key, value)
-
-    return tags
-
-
-# Inspired by allowed Kubernetes labels:
+# Tag key constraints are inspired by allowed Kubernetes labels:
 # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
 
 # We allow in some cases for users to specify multi-level namespaces for tags,
 # right now we only allow this for the `dagster/kind` namespace, which is how asset kinds are
 # encoded under the hood.
 VALID_NESTED_NAMESPACES_TAG_KEYS = r"dagster/kind/"
-VALID_DEFINITION_TAG_KEY_REGEX_STR = (
+VALID_TAG_KEY_REGEX = re.compile(
     r"^([A-Za-z0-9_.-]{1,63}/|" + VALID_NESTED_NAMESPACES_TAG_KEYS + r")?[A-Za-z0-9_.-]{1,63}$"
 )
-VALID_DEFINITION_TAG_KEY_REGEX = re.compile(VALID_DEFINITION_TAG_KEY_REGEX_STR)
-VALID_DEFINITION_TAG_KEY_EXPLANATION = (
+VALID_TAG_KEY_EXPLANATION = (
     "Allowed characters: alpha-numeric, '_', '-', '.'. "
     "Tag keys can also contain a namespace section, separated by a '/'. Each section "
     "must have <= 63 characters."
 )
 
-VALID_DEFINITION_TAG_VALUE_REGEX_STR = r"^[A-Za-z0-9_.-]{0,63}$"
-VALID_DEFINITION_TAG_VALUE_REGEX = re.compile(VALID_DEFINITION_TAG_VALUE_REGEX_STR)
+VALID_STRICT_TAG_VALUE_REGEX = re.compile(r"^[A-Za-z0-9_.-]{0,63}$")
 
 
-def is_valid_definition_tag_key(key: str) -> bool:
-    return bool(VALID_DEFINITION_TAG_KEY_REGEX.match(key))
+def normalize_tags(
+    tags: Optional[Mapping[str, Any]],
+    strict: bool = False,
+    allow_private_system_tags: bool = True,
+    warning_stacklevel: int = 4,
+) -> Mapping[str, str]:
+    """Normalizes key-value tags attached to definitions throughout Dagster.
+
+    Tag normalization is complicated for backcompat reasons. In the past, tags were permitted to be
+    arbitrary and potentially large JSON-serializable objects. This is inconsistent with the vision
+    we have for tags going forward, which is as short string labels used for filtering and grouping
+    in the UI.
+
+    The `strict` flag controls whether to normalize/validate tags according to the new vision or the
+    old. `strict` should be set whenever we are normalizing a tags parameter that is newly added. It
+    should not be set if we are normalizing an older tags parameter for which we are maintaining old
+    behavior.
+
+    Args:
+        strict (bool):
+            If `strict=True`, we accept a restricted character set and impose length restrictions
+            (<=63 characters) for string keys and values. Violations of these constraints raise
+            errors. If `strict=False` then we run the same test but only warn for keys. Values are
+            permitted to be any JSON-serializable object that is unaffected by JSON round-trip.
+            Unserializable or round-trip-unequal values raise errors. Values are normalized to the
+            JSON string representation in the return value.
+        allow_private_system_tags (bool):
+            Whether to allow non-whitelisted tags that start with the system tag prefix. This should
+            be set to False whenever we are dealing with exclusively user-provided tags.
+        warning_stacklevel (int):
+            The stacklevel to use for warnings. This should be set to the calling function's
+            stacklevel.
+
+    Returns:
+        Mapping[str, str]: A dictionary of normalized tags.
+    """
+    normalized_tags: Dict[str, str] = {}
+    invalid_tag_keys = []
+
+    for key, value in check.opt_mapping_param(tags, "tags", key_type=str).items():
+        # Validate the key
+        if not isinstance(key, str):
+            raise DagsterInvalidDefinitionError("Tag keys must be strings")
+        elif (not allow_private_system_tags) and is_private_system_tag_key(key):
+            raise DagsterInvalidDefinitionError(
+                f"Attempted to set tag with reserved system prefix: {key}"
+            )
+        elif not is_valid_tag_key(key):
+            invalid_tag_keys.append(key)
+
+        # Normalize the value
+        if not isinstance(value, str):
+            if strict:
+                raise DagsterInvalidDefinitionError("Tag values must be strings")
+            else:
+                normalized_tags[key] = _normalize_value(value, key)
+        else:
+            if strict and not is_valid_strict_tag_value(value):
+                raise DagsterInvalidDefinitionError(
+                    f"Invalid tag value: {value}, for key: {key}. Allowed characters: alpha-numeric, '_', '-', '.'. "
+                    "Must have <= 63 characters."
+                )
+            normalized_tags[key] = value
+
+    # Issue errors (strict=True) or warnings (strict=False) for any invalid tag keys that are too
+    # long or contain invalid characters.
+    if invalid_tag_keys:
+        invalid_tag_keys_sample = invalid_tag_keys[: min(5, len(invalid_tag_keys))]
+        if strict:
+            raise DagsterInvalidDefinitionError(
+                f"Found invalid tag keys: {invalid_tag_keys_sample}. {VALID_TAG_KEY_EXPLANATION}"
+            )
+        else:
+            warnings.warn(
+                f"Non-compliant tag keys like {invalid_tag_keys_sample} are deprecated. {VALID_TAG_KEY_EXPLANATION}",
+                category=DeprecationWarning,
+                stacklevel=warning_stacklevel,
+            )
+
+    return normalized_tags
 
 
-def is_valid_definition_tag_value(key: str) -> bool:
-    return bool(VALID_DEFINITION_TAG_VALUE_REGEX.match(key))
+def _normalize_value(value: Any, key: str) -> str:
+    error = None
+    try:
+        serialized_value = seven.json.dumps(value)
+    except TypeError:
+        error = 'Could not JSON encode value "{value}"'
+    if not error and not seven.json.loads(serialized_value) == value:
+        error = f'JSON encoding "{serialized_value}" of value "{value}" is not equivalent to original value'
+    if error:
+        raise DagsterInvalidDefinitionError(
+            f'Invalid value for tag "{key}", {error}. Tag values must be strings '
+            "or meet the constraint that json.loads(json.dumps(value)) == value."
+        )
+    return serialized_value
+
+
+def is_private_system_tag_key(tag) -> bool:
+    return tag.startswith(SYSTEM_TAG_PREFIX) and tag not in USER_EDITABLE_SYSTEM_TAGS
+
+
+def is_valid_tag_key(key: str) -> bool:
+    return bool(VALID_TAG_KEY_REGEX.match(key))
+
+
+def is_valid_strict_tag_value(key: str) -> bool:
+    return bool(VALID_STRICT_TAG_VALUE_REGEX.match(key))

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2257,7 +2257,7 @@ def test_asset_with_tags():
 
     assert asset1.specs_by_key[asset1.key].tags == {"a": "b"}
 
-    with pytest.raises(DagsterInvalidDefinitionError, match="Invalid tag key"):
+    with pytest.raises(DagsterInvalidDefinitionError, match="Found invalid tag keys"):
 
         @asset(tags={"a%": "b"})  # key has illegal character
         def asset2(): ...
@@ -2284,7 +2284,7 @@ def test_asset_spec_with_tags():
 
     assert assets.specs_by_key[AssetKey("asset1")].tags == {"a": "b"}
 
-    with pytest.raises(DagsterInvalidDefinitionError, match="Invalid tag key"):
+    with pytest.raises(DagsterInvalidDefinitionError, match="Found invalid tag key"):
 
         @multi_asset(specs=[AssetSpec("asset1", tags={"a%": "b"})])  # key has illegal character
         def assets(): ...
@@ -2343,7 +2343,7 @@ def test_asset_out_with_tags():
 
     assert assets.specs_by_key[AssetKey("asset1")].tags == {"a": "b"}
 
-    with pytest.raises(DagsterInvalidDefinitionError, match="Invalid tag key"):
+    with pytest.raises(DagsterInvalidDefinitionError, match="Found invalid tag key"):
 
         @multi_asset(outs={"asset1": AssetOut(tags={"a%": "b"})})  # key has illegal character
         def assets(): ...

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_job.py
@@ -113,7 +113,7 @@ def test_job_system_tags():
     def basic_job():
         basic()
 
-    normalize_tags(basic_job.tags, allow_reserved_tags=False)
+    normalize_tags(basic_job.tags, allow_private_system_tags=False)
 
 
 def test_invalid_tag_keys():

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_source_asset_decorator.py
@@ -112,7 +112,7 @@ def test_tags():
 
     assert asset1.tags == tags
 
-    with pytest.raises(DagsterInvalidDefinitionError, match="Invalid tag key"):
+    with pytest.raises(DagsterInvalidDefinitionError, match="Found invalid tag keys"):
 
         @observable_source_asset(tags={"a%": "b"})
         def asset1(): ...
@@ -126,7 +126,7 @@ def test_multi_observable_source_asset_tags():
 
     assert assets.tags_by_key[AssetKey("asset1")] == tags
 
-    with pytest.raises(DagsterInvalidDefinitionError, match="Invalid tag key"):
+    with pytest.raises(DagsterInvalidDefinitionError, match="Found invalid tag keys"):
 
         @multi_observable_source_asset(specs=[AssetSpec("asset1", tags={"a%": "b"})])
         def assets(): ...

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_utils.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_utils.py
@@ -1,48 +1,48 @@
 import pytest
 from dagster._core.definitions.utils import MAX_TITLE_LENGTH, check_valid_title, is_valid_title
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster._utils.tags import is_valid_definition_tag_key, is_valid_definition_tag_value
+from dagster._utils.tags import is_valid_strict_tag_value, is_valid_tag_key
 
 
 def test_is_valid_definition_tag_key_kinds() -> None:
-    assert is_valid_definition_tag_key("dagster/kind/foo") is True
-    assert is_valid_definition_tag_key("dagster/kind/foo.bar") is True
-    assert is_valid_definition_tag_key("dagster/kind/") is False
-    assert is_valid_definition_tag_key("dagster/kind/" + "a" * 63) is True
+    assert is_valid_tag_key("dagster/kind/foo") is True
+    assert is_valid_tag_key("dagster/kind/foo.bar") is True
+    assert is_valid_tag_key("dagster/kind/") is False
+    assert is_valid_tag_key("dagster/kind/" + "a" * 63) is True
 
-    assert is_valid_definition_tag_key("dragster/kind/foo") is False
+    assert is_valid_tag_key("dragster/kind/foo") is False
 
 
 def test_is_valid_definition_tag_key():
-    assert is_valid_definition_tag_key("abc") is True
-    assert is_valid_definition_tag_key("abc.xhz") is True
-    assert is_valid_definition_tag_key("abc-xhz") is True
-    assert is_valid_definition_tag_key("abc/xyz") is True
-    assert is_valid_definition_tag_key("afdjkl.fdskj.-fsdj_lk") is True
-    assert is_valid_definition_tag_key("abc/xyz/fdjks") is False
-    assert is_valid_definition_tag_key("/xyzfdjks") is False
-    assert is_valid_definition_tag_key("xyzfdjks/") is False
-    assert is_valid_definition_tag_key("") is False
-    assert is_valid_definition_tag_key("a" * 63) is True
-    assert is_valid_definition_tag_key("a" * 64) is False
-    assert is_valid_definition_tag_key("a" * 63 + "/" + "b" * 63) is True
-    assert is_valid_definition_tag_key("a" * 64 + "/" + "b" * 63) is False
+    assert is_valid_tag_key("abc") is True
+    assert is_valid_tag_key("abc.xhz") is True
+    assert is_valid_tag_key("abc-xhz") is True
+    assert is_valid_tag_key("abc/xyz") is True
+    assert is_valid_tag_key("afdjkl.fdskj.-fsdj_lk") is True
+    assert is_valid_tag_key("abc/xyz/fdjks") is False
+    assert is_valid_tag_key("/xyzfdjks") is False
+    assert is_valid_tag_key("xyzfdjks/") is False
+    assert is_valid_tag_key("") is False
+    assert is_valid_tag_key("a" * 63) is True
+    assert is_valid_tag_key("a" * 64) is False
+    assert is_valid_tag_key("a" * 63 + "/" + "b" * 63) is True
+    assert is_valid_tag_key("a" * 64 + "/" + "b" * 63) is False
 
 
 def test_is_valid_definition_tag_value():
-    assert is_valid_definition_tag_value("abc") is True
-    assert is_valid_definition_tag_value("abc.xhz") is True
-    assert is_valid_definition_tag_value("abc-xhz") is True
-    assert is_valid_definition_tag_value("abc/xyz") is False
-    assert is_valid_definition_tag_value("afdjkl.fdskj.-fsdj_lk") is True
-    assert is_valid_definition_tag_value("abc/xyz/fdjks") is False
-    assert is_valid_definition_tag_value("/xyzfdjks") is False
-    assert is_valid_definition_tag_value("xyzfdjks/") is False
-    assert is_valid_definition_tag_value("") is True
-    assert is_valid_definition_tag_value("a" * 63) is True
-    assert is_valid_definition_tag_value("a" * 64) is False
-    assert is_valid_definition_tag_value("a" * 63 + "/" + "b" * 63) is False
-    assert is_valid_definition_tag_value("a" * 64 + "/" + "b" * 63) is False
+    assert is_valid_strict_tag_value("abc") is True
+    assert is_valid_strict_tag_value("abc.xhz") is True
+    assert is_valid_strict_tag_value("abc-xhz") is True
+    assert is_valid_strict_tag_value("abc/xyz") is False
+    assert is_valid_strict_tag_value("afdjkl.fdskj.-fsdj_lk") is True
+    assert is_valid_strict_tag_value("abc/xyz/fdjks") is False
+    assert is_valid_strict_tag_value("/xyzfdjks") is False
+    assert is_valid_strict_tag_value("xyzfdjks/") is False
+    assert is_valid_strict_tag_value("") is True
+    assert is_valid_strict_tag_value("a" * 63) is True
+    assert is_valid_strict_tag_value("a" * 64) is False
+    assert is_valid_strict_tag_value("a" * 63 + "/" + "b" * 63) is False
+    assert is_valid_strict_tag_value("a" * 64 + "/" + "b" * 63) is False
 
 
 def test_is_valid_title():

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -10,7 +10,7 @@ from dagster import (
     _check as check,
 )
 from dagster._annotations import experimental, public
-from dagster._utils.tags import is_valid_definition_tag_key
+from dagster._utils.tags import is_valid_tag_key
 
 from dagster_dbt.asset_utils import (
     default_asset_key_fn,
@@ -254,7 +254,7 @@ class DagsterDbtTranslator:
                         return {"custom": "tag"}
         """
         tags = dbt_resource_props.get("tags", [])
-        return {tag: "" for tag in tags if is_valid_definition_tag_key(tag)}
+        return {tag: "" for tag in tags if is_valid_tag_key(tag)}
 
     @public
     def get_group_name(self, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:


### PR DESCRIPTION
## Summary & Motivation

Currently there are two separate tags validation/normalization routines, `normalize_tags` and `validate_tags_strict`. The names do not make clear that one is intended for legacy and one for new use-cases.

This PR merges the two methods and refactors the inner logic. There is now only one method `normalize_tags` that accepts a `strict` param. Also generally cleaned up the terminology and added a solid docstring so that anyone can look at `normalize_tags` now and understand the somewhat complicated tags normalization situation.

## How I Tested These Changes

Existing test suite.