### PR TITLE
allow other logger names in InstigationLogger

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
+++ b/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
@@ -79,9 +79,6 @@ class InstigationLogger(logging.Logger):
 
     The instigation logger also adds a console logger to emit the logs in a structured way from the
     evaluation process.
-
-    Note: the logger_name is passed to the super class, and will be set as the name attribute. This is
-    distinct from the name parameter that is set as the _name attribute on this class.
     """
 
     def __init__(

--- a/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
+++ b/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
@@ -88,8 +88,9 @@ class InstigationLogger(logging.Logger):
         repository_name: Optional[str] = None,
         name: Optional[str] = None,
         level: int = logging.NOTSET,
+        logger_name: str = "dagster",
     ):
-        super().__init__(name="dagster", level=coerce_valid_log_level(level))
+        super().__init__(name=logger_name, level=coerce_valid_log_level(level))
         self._log_key = log_key
         self._instance = instance
         self._repository_name = repository_name

--- a/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
+++ b/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
@@ -79,6 +79,9 @@ class InstigationLogger(logging.Logger):
 
     The instigation logger also adds a console logger to emit the logs in a structured way from the
     evaluation process.
+
+    Note: the logger_name is passed to the super class, and will be set as the name attribute. This is
+    distinct from the name parameter that is set as the _name attribute on this class.
     """
 
     def __init__(

--- a/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
+++ b/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
@@ -89,7 +89,7 @@ class InstigationLogger(logging.Logger):
         log_key: Optional[Sequence[str]] = None,
         instance: Optional[DagsterInstance] = None,
         repository_name: Optional[str] = None,
-        name: Optional[str] = None,
+        instigator_name: Optional[str] = None,
         level: int = logging.NOTSET,
         logger_name: str = "dagster",
     ):
@@ -97,7 +97,7 @@ class InstigationLogger(logging.Logger):
         self._log_key = log_key
         self._instance = instance
         self._repository_name = repository_name
-        self._name = name
+        self._instigator_name = instigator_name
         self._exit_stack = ExitStack()
         self._capture_handler = None
         self.addHandler(DispatchingLogHandler([create_console_logger("dagster", logging.INFO)]))
@@ -122,18 +122,18 @@ class InstigationLogger(logging.Logger):
         self._exit_stack.close()
 
     def _annotate_record(self, record: logging.LogRecord) -> logging.LogRecord:
-        if self._repository_name and self._name:
+        if self._repository_name and self._instigator_name:
             message = record.getMessage()
             setattr(
                 record,
                 LOG_RECORD_METADATA_ATTR,
                 {
                     "repository_name": self._repository_name,
-                    "name": self._name,
+                    "name": self._instigator_name,
                     "orig_message": message,
                 },
             )
-            record.msg = " - ".join([self._repository_name, self._name, message])
+            record.msg = " - ".join([self._repository_name, self._instigator_name, message])
             record.args = tuple()
         return record
 

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -339,7 +339,7 @@ class ScheduleEvaluationContext:
                     InstigationLogger(
                         self._log_key,
                         repository_name=self._repository_name,
-                        name=self._schedule_name,
+                        instigator_name=self._schedule_name,
                     )
                 )
             else:
@@ -348,7 +348,7 @@ class ScheduleEvaluationContext:
                         self._log_key,
                         self.instance,
                         repository_name=self._repository_name,
-                        name=self._schedule_name,
+                        instigator_name=self._schedule_name,
                     )
                 )
 

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -418,7 +418,7 @@ class SensorEvaluationContext:
                 InstigationLogger(
                     self._log_key,
                     repository_name=self._repository_name,
-                    name=self._sensor_name,
+                    instigator_name=self._sensor_name,
                 )
             )
             return cast(logging.Logger, self._logger)
@@ -428,7 +428,7 @@ class SensorEvaluationContext:
                 self._log_key,
                 self.instance,
                 repository_name=self._repository_name,
-                name=self._sensor_name,
+                instigator_name=self._sensor_name,
             )
         )
         return cast(logging.Logger, self._logger)

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -26,6 +26,7 @@ def _get_instigation_logger_if_log_storage_enabled(
             instance,
             repository_name=None,
             name=backfill.backfill_id,
+            logger_name=default_logger.name,
         ) as _logger:
             backfill_logger = cast(logging.Logger, _logger)
             yield backfill_logger

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -25,7 +25,7 @@ def _get_instigation_logger_if_log_storage_enabled(
             log_key,
             instance,
             repository_name=None,
-            name=backfill.backfill_id,
+            instigator_name=backfill.backfill_id,
             logger_name=default_logger.name,
         ) as _logger:
             backfill_logger = cast(logging.Logger, _logger)

--- a/python_modules/dagster/dagster_tests/storage_tests/test_instigation_logger.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_instigation_logger.py
@@ -9,8 +9,3 @@ def test_gets_correct_logger():
 
     instigation_logger = InstigationLogger(logger_name=custom_logger_name)
     assert instigation_logger.name == custom_logger_name
-
-    # name parameter is passed to metadata
-    instigation_logger = InstigationLogger(name="bar", logger_name=custom_logger_name)
-    assert instigation_logger.name == custom_logger_name
-    assert instigation_logger._name == "bar"  # noqa: SLF001

--- a/python_modules/dagster/dagster_tests/storage_tests/test_instigation_logger.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_instigation_logger.py
@@ -1,11 +1,8 @@
-import logging
-
 from dagster._core.definitions.instigation_logger import InstigationLogger
 
 
-def test_gets_correct_logger(caplog):
+def test_gets_correct_logger():
     custom_logger_name = "foo"
-    caplog.set_level(logging.INFO, logger=custom_logger_name)
 
     instigation_logger = InstigationLogger()
     assert instigation_logger.name == "dagster"
@@ -17,7 +14,3 @@ def test_gets_correct_logger(caplog):
     instigation_logger = InstigationLogger(name="bar", logger_name=custom_logger_name)
     assert instigation_logger.name == custom_logger_name
     assert instigation_logger._name == "bar"  # noqa: SLF001
-
-    instigation_logger.info("this is a test message")
-
-    assert len(caplog.records) == 1

--- a/python_modules/dagster/dagster_tests/storage_tests/test_instigation_logger.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_instigation_logger.py
@@ -1,0 +1,23 @@
+import logging
+
+from dagster._core.definitions.instigation_logger import InstigationLogger
+
+
+def test_gets_correct_logger(caplog):
+    custom_logger_name = "foo"
+    caplog.set_level(logging.INFO, logger=custom_logger_name)
+
+    instigation_logger = InstigationLogger()
+    assert instigation_logger.name == "dagster"
+
+    instigation_logger = InstigationLogger(logger_name=custom_logger_name)
+    assert instigation_logger.name == custom_logger_name
+
+    # name parameter is passed to metadata
+    instigation_logger = InstigationLogger(name="bar", logger_name=custom_logger_name)
+    assert instigation_logger.name == custom_logger_name
+    assert instigation_logger._name == "bar"  # noqa: SLF001
+
+    instigation_logger.info("this is a test message")
+
+    assert len(caplog.records) == 1


### PR DESCRIPTION
## Summary & Motivation
Adds a param to InstigationLogger to allow the user to pass in a custom logger name. For use with the backfill daemon so that we can continue to use the backfill daemon logger when storing backfill logs

## How I Tested These Changes
manually ran a backfill and saw the logger change from `dagster` to `dagster.daemon.BackfillDaemon` with this change