### PR TITLE
rename dagster._core.storage.sql.get_current_timestamp

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/036_add_dynamic_partitions_table.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/036_add_dynamic_partitions_table.py
@@ -9,7 +9,7 @@ Create Date: 2023-01-19 11:41:41.062228
 import sqlalchemy as db
 from alembic import op
 from dagster._core.storage.migration.utils import has_index, has_table
-from dagster._core.storage.sql import get_current_timestamp
+from dagster._core.storage.sql import get_sql_current_timestamp
 from sqlalchemy.dialects import sqlite
 
 # revision identifiers, used by Alembic.
@@ -31,7 +31,7 @@ def upgrade():
             ),
             db.Column("partitions_def_name", db.Text, nullable=False),
             db.Column("partition", db.Text, nullable=False),
-            db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+            db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
         )
         op.create_index(
             "idx_dynamic_partitions",

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/039_d3a4c9e87af3_add_asset_daemon_asset_evaluations_table.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/039_d3a4c9e87af3_add_asset_daemon_asset_evaluations_table.py
@@ -9,7 +9,7 @@ Create Date: 2023-05-09 11:50:38.931820
 import sqlalchemy as db
 from alembic import op
 from dagster._core.storage.migration.utils import has_index, has_table
-from dagster._core.storage.sql import get_current_timestamp
+from dagster._core.storage.sql import get_sql_current_timestamp
 from sqlalchemy.dialects import sqlite
 
 # revision identifiers, used by Alembic.
@@ -39,7 +39,7 @@ def upgrade():
             db.Column("num_requested", db.Integer),
             db.Column("num_skipped", db.Integer),
             db.Column("num_discarded", db.Integer),
-            db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+            db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
         )
         op.create_index(
             "idx_asset_daemon_asset_evaluations_asset_key_evaluation_id",

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/040_add_in_progress_step_table.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/040_add_in_progress_step_table.py
@@ -9,7 +9,7 @@ Create Date: 2023-04-10 19:26:23.232433
 import sqlalchemy as db
 from alembic import op
 from dagster._core.storage.migration.utils import has_index, has_table
-from dagster._core.storage.sql import get_current_timestamp
+from dagster._core.storage.sql import get_sql_current_timestamp
 from sqlalchemy.dialects import sqlite
 
 # revision identifiers, used by Alembic.
@@ -33,7 +33,7 @@ def upgrade():
             db.Column("run_id", db.Text),
             db.Column("step_key", db.Text),
             db.Column("deleted", db.Boolean, nullable=False, default=False),
-            db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+            db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
         )
 
     if not has_table("pending_steps"):
@@ -50,7 +50,7 @@ def upgrade():
             db.Column("step_key", db.Text),
             db.Column("priority", db.Integer),
             db.Column("assigned_timestamp", db.DateTime),
-            db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+            db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
         )
         op.create_index(
             "idx_pending_steps",

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/041_add_asset_check_executions_table.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/041_add_asset_check_executions_table.py
@@ -9,7 +9,7 @@ Create Date: 2023-08-21 12:05:47.817280
 import sqlalchemy as db
 from alembic import op
 from dagster._core.storage.migration.utils import has_index, has_table
-from dagster._core.storage.sql import get_current_timestamp
+from dagster._core.storage.sql import get_sql_current_timestamp
 from sqlalchemy.dialects import sqlite
 
 # revision identifiers, used by Alembic.
@@ -50,7 +50,7 @@ def upgrade():
                 "materialization_event_storage_id",
                 db.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"),
             ),
-            db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+            db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
         )
 
     if not has_index(TABLE_NAME, INDEX_NAME):

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/042_46b412388816_add_concurrency_limits_table.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/042_46b412388816_add_concurrency_limits_table.py
@@ -9,7 +9,7 @@ Create Date: 2023-12-01 14:35:47.622154
 import sqlalchemy as db
 from alembic import op
 from dagster._core.storage.migration.utils import has_table
-from dagster._core.storage.sql import MySQLCompatabilityTypes, get_current_timestamp
+from dagster._core.storage.sql import MySQLCompatabilityTypes, get_sql_current_timestamp
 from sqlalchemy.dialects import sqlite
 
 # revision identifiers, used by Alembic.
@@ -33,8 +33,8 @@ def upgrade():
                 "concurrency_key", MySQLCompatabilityTypes.UniqueText, nullable=False, unique=True
             ),
             db.Column("limit", db.Integer, nullable=False),
-            db.Column("update_timestamp", db.DateTime, server_default=get_current_timestamp()),
-            db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+            db.Column("update_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
+            db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
         )
 
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/schema.py
@@ -1,7 +1,7 @@
 import sqlalchemy as db
 from sqlalchemy.dialects import sqlite
 
-from ..sql import MySQLCompatabilityTypes, get_current_timestamp
+from ..sql import MySQLCompatabilityTypes, get_sql_current_timestamp
 
 SqlEventLogStorageMetadata = db.MetaData()
 
@@ -33,7 +33,7 @@ SecondaryIndexMigrationTable = db.Table(
         autoincrement=True,
     ),
     db.Column("name", MySQLCompatabilityTypes.UniqueText, unique=True),
-    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+    db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
     db.Column("migration_completed", db.DateTime),
 )
 
@@ -65,7 +65,7 @@ AssetKeyTable = db.Table(
         "last_materialization_timestamp", db.types.TIMESTAMP
     ),  # guarded by secondary index check
     db.Column("tags", db.TEXT),  # guarded by secondary index check
-    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+    db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
     db.Column("cached_status_data", db.TEXT),
 )
 
@@ -100,7 +100,7 @@ DynamicPartitionsTable = db.Table(
     ),
     db.Column("partitions_def_name", db.Text, nullable=False),
     db.Column("partition", db.Text, nullable=False),
-    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+    db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
 )
 
 ConcurrencyLimitsTable = db.Table(
@@ -114,8 +114,8 @@ ConcurrencyLimitsTable = db.Table(
     ),
     db.Column("concurrency_key", MySQLCompatabilityTypes.UniqueText, nullable=False, unique=True),
     db.Column("limit", db.Integer, nullable=False),
-    db.Column("update_timestamp", db.DateTime, server_default=get_current_timestamp()),
-    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+    db.Column("update_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
+    db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
 )
 
 ConcurrencySlotsTable = db.Table(
@@ -131,7 +131,7 @@ ConcurrencySlotsTable = db.Table(
     db.Column("run_id", db.Text),
     db.Column("step_key", db.Text),
     db.Column("deleted", db.Boolean, nullable=False, default=False),
-    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+    db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
 )
 
 PendingStepsTable = db.Table(
@@ -148,7 +148,7 @@ PendingStepsTable = db.Table(
     db.Column("step_key", db.Text),
     db.Column("priority", db.Integer),
     db.Column("assigned_timestamp", db.DateTime),
-    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+    db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
 )
 
 AssetCheckExecutionsTable = db.Table(
@@ -177,7 +177,7 @@ AssetCheckExecutionsTable = db.Table(
         "materialization_event_storage_id",
         db.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"),
     ),
-    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+    db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
 )
 
 db.Index(

--- a/python_modules/dagster/dagster/_core/storage/migration/utils.py
+++ b/python_modules/dagster/dagster/_core/storage/migration/utils.py
@@ -8,7 +8,7 @@ from sqlalchemy.dialects import sqlite
 
 import dagster._check as check
 from dagster._core.instance import DagsterInstance
-from dagster._core.storage.sql import get_current_timestamp
+from dagster._core.storage.sql import get_sql_current_timestamp
 
 
 def get_inspector():
@@ -333,8 +333,8 @@ def create_instigators_table() -> None:
             db.Column("status", db.String(63)),
             db.Column("instigator_type", db.String(63), index=True),
             db.Column("instigator_body", db.Text),
-            db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
-            db.Column("update_timestamp", db.DateTime, server_default=get_current_timestamp()),
+            db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
+            db.Column("update_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
         )
 
     if not has_column("jobs", "selector_id"):

--- a/python_modules/dagster/dagster/_core/storage/runs/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/schema.py
@@ -1,7 +1,7 @@
 import sqlalchemy as db
 from sqlalchemy.dialects import sqlite
 
-from ..sql import MySQLCompatabilityTypes, get_current_timestamp
+from ..sql import MySQLCompatabilityTypes, get_sql_current_timestamp
 
 RunStorageSqlMetadata = db.MetaData()
 
@@ -28,8 +28,8 @@ RunsTable = db.Table(
     db.Column("run_body", db.Text),
     db.Column("partition", db.Text),
     db.Column("partition_set", db.Text),
-    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
-    db.Column("update_timestamp", db.DateTime, server_default=get_current_timestamp()),
+    db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
+    db.Column("update_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
     # Added start/end_time in #6038 (12/2021), MySQL fix added in #6451 (2/2022)
     # We are using floats here to store unix timestamps in the database. They are optional perf
     # optimizations, mirroring the timestamps in the event_log for the corresponding events marking
@@ -58,7 +58,7 @@ SecondaryIndexMigrationTable = db.Table(
         autoincrement=True,
     ),
     db.Column("name", MySQLCompatabilityTypes.UniqueText, unique=True),
-    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+    db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
     db.Column("migration_completed", db.DateTime),
 )
 

--- a/python_modules/dagster/dagster/_core/storage/schedules/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/schema.py
@@ -1,7 +1,7 @@
 import sqlalchemy as db
 from sqlalchemy.dialects import sqlite
 
-from ..sql import MySQLCompatabilityTypes, get_current_timestamp
+from ..sql import MySQLCompatabilityTypes, get_sql_current_timestamp
 
 ScheduleStorageSqlMetadata = db.MetaData()
 
@@ -20,8 +20,8 @@ JobTable = db.Table(
     db.Column("status", db.String(63)),
     db.Column("job_type", db.String(63), index=True),
     db.Column("job_body", db.Text),
-    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
-    db.Column("update_timestamp", db.DateTime, server_default=get_current_timestamp()),
+    db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
+    db.Column("update_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
 )
 
 InstigatorsTable = db.Table(
@@ -38,8 +38,8 @@ InstigatorsTable = db.Table(
     db.Column("status", db.String(63)),
     db.Column("instigator_type", db.String(63), index=True),
     db.Column("instigator_body", db.Text),
-    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
-    db.Column("update_timestamp", db.DateTime, server_default=get_current_timestamp()),
+    db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
+    db.Column("update_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
 )
 
 JobTickTable = db.Table(
@@ -57,8 +57,8 @@ JobTickTable = db.Table(
     db.Column("type", db.String(63)),
     db.Column("timestamp", db.types.TIMESTAMP),
     db.Column("tick_body", db.Text),
-    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
-    db.Column("update_timestamp", db.DateTime, server_default=get_current_timestamp()),
+    db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
+    db.Column("update_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
 )
 
 AssetDaemonAssetEvaluationsTable = db.Table(
@@ -78,7 +78,7 @@ AssetDaemonAssetEvaluationsTable = db.Table(
     db.Column("num_requested", db.Integer),
     db.Column("num_skipped", db.Integer),
     db.Column("num_discarded", db.Integer),
-    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+    db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
 )
 
 
@@ -94,7 +94,7 @@ SecondaryIndexMigrationTable = db.Table(
         autoincrement=True,
     ),
     db.Column("name", MySQLCompatabilityTypes.UniqueText, unique=True),
-    db.Column("create_timestamp", db.DateTime, server_default=get_current_timestamp()),
+    db.Column("create_timestamp", db.DateTime, server_default=get_sql_current_timestamp()),
     db.Column("migration_completed", db.DateTime),
 )
 

--- a/python_modules/dagster/dagster/_core/storage/sql.py
+++ b/python_modules/dagster/dagster/_core/storage/sql.py
@@ -166,19 +166,19 @@ def compile_datetime_and_add_precision_mysql(_element, _compiler, **_kw) -> str:
     return f"DATETIME({MYSQL_DATE_PRECISION})"
 
 
-class get_current_timestamp(db.sql.expression.FunctionElement):
+class get_sql_current_timestamp(db.sql.expression.FunctionElement):
     """Like CURRENT_TIMESTAMP, but has the same semantics on MySQL, Postgres, and Sqlite."""
 
     type = db.types.DateTime()  # type: ignore
 
 
-@compiles(get_current_timestamp, "mysql")
-def compiles_get_current_timestamp_mysql(_element, _compiler, **_kw) -> str:
+@compiles(get_sql_current_timestamp, "mysql")
+def compiles_get_sql_current_timestamp_mysql(_element, _compiler, **_kw) -> str:
     return f"CURRENT_TIMESTAMP({MYSQL_DATE_PRECISION})"
 
 
-@compiles(get_current_timestamp)
-def compiles_get_current_timestamp_default(_element, _compiler, **_kw) -> str:
+@compiles(get_sql_current_timestamp)
+def compiles_get_sql_current_timestamp_default(_element, _compiler, **_kw) -> str:
     return "CURRENT_TIMESTAMP"
 
 

--- a/scripts/check_schemas.py
+++ b/scripts/check_schemas.py
@@ -55,7 +55,7 @@ def validate_column(column: Column):
         raise Exception(
             f"Column {column} has a server default of CURRENT_TIMESTAMP without precision"
             " specified. To allow schema compatibility between MySQL, Postgres, and SQLite, use"
-            " dagster._core.storage.sql.py::get_current_timestamp() instead."
+            " dagster._core.storage.sql.py::get_sql_current_timestamp() instead."
         )
 
 


### PR DESCRIPTION
Summary:
I added a get_current_timestamp method in the pendulum refactor before realizing that this method already existed - namespace it a bit better to make it clear that this one is sql-specific.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
