### PR TITLE
make PartitionBackfill from AssetGraphSubset

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -567,6 +567,12 @@ class AssetBackfillData(NamedTuple):
 
         return cls.empty(target_subset, backfill_start_timestamp, dynamic_partitions_store)
 
+    @classmethod
+    def from_asset_graph_subset(
+        cls, asset_graph_subset, backfill_start_timestamp, dynamic_partitions_store
+    ):
+        return cls.empty(asset_graph_subset, backfill_start_timestamp, dynamic_partitions_store)
+
     def serialize(
         self, dynamic_partitions_store: DynamicPartitionsStore, asset_graph: BaseAssetGraph
     ) -> str:

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -569,8 +569,11 @@ class AssetBackfillData(NamedTuple):
 
     @classmethod
     def from_asset_graph_subset(
-        cls, asset_graph_subset, backfill_start_timestamp, dynamic_partitions_store
-    ):
+        cls,
+        asset_graph_subset: AssetGraphSubset,
+        dynamic_partitions_store: DynamicPartitionsStore,
+        backfill_start_timestamp: float,
+    ) -> "AssetBackfillData":
         return cls.empty(asset_graph_subset, backfill_start_timestamp, dynamic_partitions_store)
 
     def serialize(

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -3,6 +3,7 @@ from typing import Mapping, NamedTuple, Optional, Sequence, Union
 
 from dagster import _check as check
 from dagster._core.definitions import AssetKey
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.utils import check_valid_title
@@ -454,6 +455,34 @@ class PartitionBackfill(
             serialized_asset_backfill_data=None,
             asset_backfill_data=asset_backfill_data,
             asset_selection=[selector.asset_key for selector in partitions_by_assets],
+            title=title,
+            description=description,
+        )
+
+    @classmethod
+    def from_asset_graph_subset(
+        cls,
+        backfill_id: str,
+        asset_graph: BaseAssetGraph,
+        backfill_timestamp: float,
+        tags: Mapping[str, str],
+        dynamic_partitions_store: DynamicPartitionsStore,
+        asset_graph_subset: AssetGraphSubset,
+        title: Optional[str],
+        description: Optional[str],
+    ):
+        asset_backfill_data = AssetBackfillData.empty(
+            asset_graph_subset, backfill_timestamp, dynamic_partitions_store
+        )
+        return cls(
+            backfill_id=backfill_id,
+            status=BulkActionStatus.REQUESTED,
+            from_failure=False,
+            tags=tags,
+            backfill_timestamp=backfill_timestamp,
+            serialized_asset_backfill_data=None,
+            asset_backfill_data=asset_backfill_data,
+            asset_selection=asset_graph_subset.asset_keys,
             title=title,
             description=description,
         )

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -463,7 +463,6 @@ class PartitionBackfill(
     def from_asset_graph_subset(
         cls,
         backfill_id: str,
-        asset_graph: BaseAssetGraph,
         backfill_timestamp: float,
         tags: Mapping[str, str],
         dynamic_partitions_store: DynamicPartitionsStore,
@@ -482,7 +481,7 @@ class PartitionBackfill(
             backfill_timestamp=backfill_timestamp,
             serialized_asset_backfill_data=None,
             asset_backfill_data=asset_backfill_data,
-            asset_selection=asset_graph_subset.asset_keys,
+            asset_selection=list(asset_graph_subset.asset_keys),
             title=title,
             description=description,
         )

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -470,8 +470,10 @@ class PartitionBackfill(
         title: Optional[str],
         description: Optional[str],
     ):
-        asset_backfill_data = AssetBackfillData.empty(
-            asset_graph_subset, backfill_timestamp, dynamic_partitions_store
+        asset_backfill_data = AssetBackfillData.from_asset_graph_subset(
+            asset_graph_subset=asset_graph_subset,
+            backfill_start_timestamp=backfill_timestamp,
+            dynamic_partitions_store=dynamic_partitions_store,
         )
         return cls(
             backfill_id=backfill_id,

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -472,8 +472,8 @@ class PartitionBackfill(
     ):
         asset_backfill_data = AssetBackfillData.from_asset_graph_subset(
             asset_graph_subset=asset_graph_subset,
-            backfill_start_timestamp=backfill_timestamp,
             dynamic_partitions_store=dynamic_partitions_store,
+            backfill_start_timestamp=backfill_timestamp,
         )
         return cls(
             backfill_id=backfill_id,


### PR DESCRIPTION
## Summary & Motivation
Adds methods to make a backfill from an `AssetGraphSubset`. This will make emitting backfills from DA easier. 

## How I Tested These Changes
new unit tests