### PR TITLE
[perf] Overview pages - don't show loading state when workspace cache available

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
@@ -145,8 +145,6 @@ export const JobsPageContent = () => {
     return <OverviewJobsTable repos={filteredBySearch} />;
   };
 
-  const showSearchSpinner = workspaceLoading && !repoCount && loading && !data;
-
   return (
     <>
       <Box
@@ -159,7 +157,7 @@ export const JobsPageContent = () => {
             icon="search"
             value={searchValue}
             rightElement={
-              showSearchSpinner ? <SearchInputSpinner tooltipContent="Loading jobs…" /> : undefined
+              loading ? <SearchInputSpinner tooltipContent="Loading jobs…" /> : undefined
             }
             onChange={(e) => setSearchValue(e.target.value)}
             placeholder="Filter by job name…"

--- a/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
@@ -51,7 +51,7 @@ export const JobsPageContent = () => {
       notifyOnNetworkStatusChange: true,
     },
   );
-  const {data, loading} = queryResultOverview;
+  const {data} = queryResultOverview;
 
   const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
@@ -72,7 +72,9 @@ export const JobsPageContent = () => {
     );
   }, [cachedData, data, visibleRepos]);
 
-  useBlockTraceUntilTrue('OverviewJobs', !!data || !workspaceLoading);
+  const loading = !!data || !workspaceLoading;
+
+  useBlockTraceUntilTrue('OverviewJobs', !loading);
 
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
   const anySearch = sanitizedSearch.length > 0;
@@ -88,7 +90,7 @@ export const JobsPageContent = () => {
   }, [repoBuckets, sanitizedSearch]);
 
   const content = () => {
-    if (loading && !data) {
+    if (loading && !data && !cachedData) {
       return (
         <Box flex={{direction: 'row', justifyContent: 'center'}} style={{paddingTop: '100px'}}>
           <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
@@ -143,7 +145,7 @@ export const JobsPageContent = () => {
     return <OverviewJobsTable repos={filteredBySearch} />;
   };
 
-  const showSearchSpinner = (workspaceLoading && !repoCount) || (loading && !data);
+  const showSearchSpinner = workspaceLoading && !repoCount && loading && !data;
 
   return (
     <>

--- a/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
@@ -51,7 +51,7 @@ export const JobsPageContent = () => {
       notifyOnNetworkStatusChange: true,
     },
   );
-  const {data} = queryResultOverview;
+  const {data, loading: queryLoading} = queryResultOverview;
 
   const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
@@ -145,6 +145,8 @@ export const JobsPageContent = () => {
     return <OverviewJobsTable repos={filteredBySearch} />;
   };
 
+  const showSearchSpinner = queryLoading && !data;
+
   return (
     <>
       <Box
@@ -157,7 +159,7 @@ export const JobsPageContent = () => {
             icon="search"
             value={searchValue}
             rightElement={
-              loading ? <SearchInputSpinner tooltipContent="Loading jobs…" /> : undefined
+              showSearchSpinner ? <SearchInputSpinner tooltipContent="Loading jobs…" /> : undefined
             }
             onChange={(e) => setSearchValue(e.target.value)}
             placeholder="Filter by job name…"

--- a/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
@@ -72,7 +72,7 @@ export const JobsPageContent = () => {
     );
   }, [cachedData, data, visibleRepos]);
 
-  const loading = !!data || !workspaceLoading;
+  const loading = !data && workspaceLoading;
 
   useBlockTraceUntilTrue('OverviewJobs', !loading);
 
@@ -90,7 +90,7 @@ export const JobsPageContent = () => {
   }, [repoBuckets, sanitizedSearch]);
 
   const content = () => {
-    if (loading && !data && !cachedData) {
+    if (loading) {
       return (
         <Box flex={{direction: 'row', justifyContent: 'center'}} style={{paddingTop: '100px'}}>
           <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewResourcesRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewResourcesRoot.tsx
@@ -50,7 +50,7 @@ export const OverviewResourcesRoot = () => {
       notifyOnNetworkStatusChange: true,
     },
   );
-  const {data, loading: queryLoading} = queryResultOverview;
+  const {data, loading} = queryResultOverview;
   useBlockTraceOnQueryResult(queryResultOverview, 'OverviewResourcesQuery');
   const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
@@ -71,7 +71,7 @@ export const OverviewResourcesRoot = () => {
     );
   }, [cachedData, data, visibleRepos]);
 
-  const loading = !data && queryLoading && workspaceLoading;
+  const showSearchSpinner = workspaceLoading && !repoCount && loading && !data;
 
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
   const anySearch = sanitizedSearch.length > 0;
@@ -87,7 +87,7 @@ export const OverviewResourcesRoot = () => {
   }, [repoBuckets, sanitizedSearch]);
 
   const content = () => {
-    if (loading) {
+    if (showSearchSpinner) {
       return (
         <Box flex={{direction: 'row', justifyContent: 'center'}} style={{paddingTop: '100px'}}>
           <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
@@ -143,8 +143,6 @@ export const OverviewResourcesRoot = () => {
     return <OverviewResourcesTable repos={filteredBySearch} />;
   };
 
-  const showSearchSpinner = (workspaceLoading && !repoCount) || (loading && !data);
-
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
       <OverviewPageHeader tab="resources" refreshState={refreshState} />
@@ -166,7 +164,7 @@ export const OverviewResourcesRoot = () => {
           style={{width: '340px'}}
         />
       </Box>
-      {loading && !repoCount ? (
+      {showSearchSpinner && !repoCount ? (
         <Box padding={64}>
           <Spinner purpose="page" />
         </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewResourcesRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewResourcesRoot.tsx
@@ -50,7 +50,7 @@ export const OverviewResourcesRoot = () => {
       notifyOnNetworkStatusChange: true,
     },
   );
-  const {data, loading} = queryResultOverview;
+  const {data, loading: queryLoading} = queryResultOverview;
   useBlockTraceOnQueryResult(queryResultOverview, 'OverviewResourcesQuery');
   const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
@@ -71,7 +71,7 @@ export const OverviewResourcesRoot = () => {
     );
   }, [cachedData, data, visibleRepos]);
 
-  const showSearchSpinner = workspaceLoading && !repoCount && loading && !data;
+  const loading = !data && queryLoading && workspaceLoading;
 
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
   const anySearch = sanitizedSearch.length > 0;
@@ -87,7 +87,7 @@ export const OverviewResourcesRoot = () => {
   }, [repoBuckets, sanitizedSearch]);
 
   const content = () => {
-    if (showSearchSpinner) {
+    if (loading) {
       return (
         <Box flex={{direction: 'row', justifyContent: 'center'}} style={{paddingTop: '100px'}}>
           <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
@@ -143,6 +143,8 @@ export const OverviewResourcesRoot = () => {
     return <OverviewResourcesTable repos={filteredBySearch} />;
   };
 
+  const showSearchSpinner = queryLoading && !data;
+
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
       <OverviewPageHeader tab="resources" refreshState={refreshState} />
@@ -164,7 +166,7 @@ export const OverviewResourcesRoot = () => {
           style={{width: '340px'}}
         />
       </Box>
-      {showSearchSpinner && !repoCount ? (
+      {loading && !repoCount ? (
         <Box padding={64}>
           <Spinner purpose="page" />
         </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSchedules.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSchedules.tsx
@@ -61,7 +61,7 @@ export const OverviewSchedules = () => {
       notifyOnNetworkStatusChange: true,
     },
   );
-  const {data, loading} = queryResultOverview;
+  const {data, loading: queryLoading} = queryResultOverview;
   useBlockTraceOnQueryResult(queryResultOverview, 'OverviewSchedulesQuery');
 
   const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
@@ -166,10 +166,10 @@ export const OverviewSchedules = () => {
   const viewerHasAnyInstigationPermission = allPermissionedScheduleKeys.length > 0;
   const checkedCount = checkedSchedules.length;
 
-  const showSearchSpinner = workspaceLoading && !repoCount && loading && !data;
+  const loading = workspaceLoading && !repoCount && queryLoading && !data;
 
   const content = () => {
-    if (showSearchSpinner) {
+    if (loading) {
       return (
         <Box flex={{direction: 'row', justifyContent: 'center'}} style={{paddingTop: '100px'}}>
           <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
@@ -239,6 +239,8 @@ export const OverviewSchedules = () => {
       />
     );
   };
+
+  const showSearchSpinner = queryLoading && !data;
 
   return (
     <>

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSchedules.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSchedules.tsx
@@ -166,8 +166,10 @@ export const OverviewSchedules = () => {
   const viewerHasAnyInstigationPermission = allPermissionedScheduleKeys.length > 0;
   const checkedCount = checkedSchedules.length;
 
+  const showSearchSpinner = workspaceLoading && !repoCount && loading && !data;
+
   const content = () => {
-    if (loading && !data) {
+    if (showSearchSpinner) {
       return (
         <Box flex={{direction: 'row', justifyContent: 'center'}} style={{paddingTop: '100px'}}>
           <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
@@ -237,8 +239,6 @@ export const OverviewSchedules = () => {
       />
     );
   };
-
-  const showSearchSpinner = (workspaceLoading && !repoCount) || (loading && !data);
 
   return (
     <>

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSensors.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSensors.tsx
@@ -215,8 +215,10 @@ export const OverviewSensors = () => {
   const viewerHasAnyInstigationPermission = allPermissionedSensorKeys.length > 0;
   const checkedCount = checkedSensors.length;
 
+  const showSearchSpinner = workspaceLoading && !repoCount && loading && !data;
+
   const content = () => {
-    if (loading && !data) {
+    if (showSearchSpinner) {
       return (
         <Box flex={{direction: 'row', justifyContent: 'center'}} style={{paddingTop: '100px'}}>
           <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
@@ -286,8 +288,6 @@ export const OverviewSensors = () => {
       />
     );
   };
-
-  const showSearchSpinner = (workspaceLoading && !repoCount) || (loading && !data);
 
   return (
     <>

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSensors.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSensors.tsx
@@ -103,7 +103,7 @@ export const OverviewSensors = () => {
       notifyOnNetworkStatusChange: true,
     },
   );
-  const {data, loading} = queryResultOverview;
+  const {data, loading: queryLoading} = queryResultOverview;
 
   useBlockTraceOnQueryResult(queryResultOverview, 'OverviewSensorsQuery');
 
@@ -215,10 +215,9 @@ export const OverviewSensors = () => {
   const viewerHasAnyInstigationPermission = allPermissionedSensorKeys.length > 0;
   const checkedCount = checkedSensors.length;
 
-  const showSearchSpinner = workspaceLoading && !repoCount && loading && !data;
-
+  const loading = workspaceLoading && queryLoading && !data;
   const content = () => {
-    if (showSearchSpinner) {
+    if (loading) {
       return (
         <Box flex={{direction: 'row', justifyContent: 'center'}} style={{paddingTop: '100px'}}>
           <Box flex={{direction: 'row', alignItems: 'center', gap: 16}}>
@@ -289,6 +288,8 @@ export const OverviewSensors = () => {
     );
   };
 
+  const showSearchSpinner = queryLoading && !data;
+
   return (
     <>
       <Box
@@ -337,7 +338,7 @@ export const OverviewSensors = () => {
           {activeFiltersJsx}
         </Box>
       ) : null}
-      {loading && !repoCount ? (
+      {loading ? (
         <Box padding={64}>
           <Spinner purpose="page" />
         </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceJobsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceJobsRoot.tsx
@@ -17,6 +17,7 @@ import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {usePageLoadTrace} from '../performance';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
+import {SearchInputSpinner} from '../ui/SearchInputSpinner';
 
 const NO_REPOS_EMPTY_ARR: any[] = [];
 
@@ -43,7 +44,7 @@ export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => 
       variables: {selector},
     },
   );
-  const {data} = queryResultOverview;
+  const {data, loading: queryLoading} = queryResultOverview;
 
   const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
@@ -119,6 +120,8 @@ export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => 
     return <VirtualizedJobTable repoAddress={repoAddress} jobs={filteredBySearch} />;
   };
 
+  const showSearchSpinner = !data && queryLoading;
+
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
       <WorkspaceHeader
@@ -134,6 +137,9 @@ export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => 
           onChange={(e) => setSearchValue(e.target.value)}
           placeholder="Filter by job name…"
           style={{width: '340px'}}
+          rightElement={
+            showSearchSpinner ? <SearchInputSpinner tooltipContent="Loading jobs…" /> : undefined
+          }
         />
       </Box>
       {loading && !data ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceJobsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceJobsRoot.tsx
@@ -51,11 +51,11 @@ export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => 
   const anySearch = sanitizedSearch.length > 0;
 
   const jobs = useMemo(() => {
-    if (repo) {
-      return repo.repository.pipelines;
-    }
     if (data?.repositoryOrError.__typename === 'Repository') {
       return data.repositoryOrError.pipelines;
+    }
+    if (repo) {
+      return repo.repository.pipelines;
     }
     return NO_REPOS_EMPTY_ARR;
   }, [data, repo]);

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceJobsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceJobsRoot.tsx
@@ -43,7 +43,7 @@ export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => 
       variables: {selector},
     },
   );
-  const {data, loading} = queryResultOverview;
+  const {data} = queryResultOverview;
 
   useLayoutEffect(() => {
     if (!loading) {
@@ -66,7 +66,8 @@ export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => 
     return NO_REPOS_EMPTY_ARR;
   }, [data, repo]);
 
-  useBlockTraceUntilTrue('WorkspaceJobs', jobs !== NO_REPOS_EMPTY_ARR);
+  const loading = jobs === NO_REPOS_EMPTY_ARR;
+  useBlockTraceUntilTrue('WorkspaceJobs', !loading);
 
   const filteredBySearch = useMemo(() => {
     const searchToLower = sanitizedSearch.toLocaleLowerCase();

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceJobsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceJobsRoot.tsx
@@ -45,12 +45,6 @@ export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => 
   );
   const {data} = queryResultOverview;
 
-  useLayoutEffect(() => {
-    if (!loading) {
-      trace.endTrace();
-    }
-  }, [loading, trace]);
-
   const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
@@ -67,6 +61,12 @@ export const WorkspaceJobsRoot = ({repoAddress}: {repoAddress: RepoAddress}) => 
   }, [data, repo]);
 
   const loading = jobs === NO_REPOS_EMPTY_ARR;
+
+  useLayoutEffect(() => {
+    if (!loading) {
+      trace.endTrace();
+    }
+  }, [loading, trace]);
   useBlockTraceUntilTrue('WorkspaceJobs', !loading);
 
   const filteredBySearch = useMemo(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceSchedulesRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceSchedulesRoot.tsx
@@ -26,6 +26,7 @@ import {makeScheduleKey} from '../schedules/makeScheduleKey';
 import {CheckAllBox} from '../ui/CheckAllBox';
 import {useFilters} from '../ui/Filters';
 import {useInstigationStatusFilter} from '../ui/Filters/useInstigationStatusFilter';
+import {SearchInputSpinner} from '../ui/SearchInputSpinner';
 
 // Reuse this reference to distinguish no sensors case from data is still loading case;
 const NO_DATA_EMPTY_ARR: any[] = [];
@@ -57,7 +58,7 @@ export const WorkspaceSchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}
     },
   );
   useBlockTraceOnQueryResult(queryResultOverview, 'WorkspaceSchedulesQuery');
-  const {data} = queryResultOverview;
+  const {data, loading: queryLoading} = queryResultOverview;
   const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
@@ -176,6 +177,8 @@ export const WorkspaceSchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}
     );
   };
 
+  const showSearchSpinner = queryLoading && !data;
+
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
       <WorkspaceHeader
@@ -196,6 +199,11 @@ export const WorkspaceSchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}
             }}
             placeholder="Filter by schedule name…"
             style={{width: '340px'}}
+            rightElement={
+              showSearchSpinner ? (
+                <SearchInputSpinner tooltipContent="Loading schedules…" />
+              ) : undefined
+            }
           />
         </Box>
         <Tooltip

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceSchedulesRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceSchedulesRoot.tsx
@@ -64,11 +64,11 @@ export const WorkspaceSchedulesRoot = ({repoAddress}: {repoAddress: RepoAddress}
   const anySearch = sanitizedSearch.length > 0;
 
   const schedules = useMemo(() => {
-    if (repo) {
-      return repo.repository.schedules;
-    }
     if (data?.repositoryOrError.__typename === 'Repository') {
       return data.repositoryOrError.schedules;
+    }
+    if (repo) {
+      return repo.repository.schedules;
     }
     return NO_DATA_EMPTY_ARR;
   }, [data, repo]);

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceSensorsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceSensorsRoot.tsx
@@ -64,11 +64,11 @@ export const WorkspaceSensorsRoot = ({repoAddress}: {repoAddress: RepoAddress}) 
   const anySearch = sanitizedSearch.length > 0;
 
   const sensors = useMemo(() => {
-    if (repo) {
-      return repo.repository.sensors;
-    }
     if (data?.repositoryOrError.__typename === 'Repository') {
       return data.repositoryOrError.sensors;
+    }
+    if (repo) {
+      return repo.repository.sensors;
     }
     return NO_DATA_EMPTY_ARR;
   }, [repo, data]);

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceSensorsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceSensorsRoot.tsx
@@ -26,6 +26,7 @@ import {makeSensorKey} from '../sensors/makeSensorKey';
 import {CheckAllBox} from '../ui/CheckAllBox';
 import {useFilters} from '../ui/Filters';
 import {useInstigationStatusFilter} from '../ui/Filters/useInstigationStatusFilter';
+import {SearchInputSpinner} from '../ui/SearchInputSpinner';
 
 // Reuse this reference to distinguish no sensors case from data is still loading case;
 const NO_DATA_EMPTY_ARR: any[] = [];
@@ -57,7 +58,7 @@ export const WorkspaceSensorsRoot = ({repoAddress}: {repoAddress: RepoAddress}) 
     },
   );
   useBlockTraceOnQueryResult(queryResultOverview, 'WorkspaceSensorsQuery');
-  const {data} = queryResultOverview;
+  const {data, loading: queryLoading} = queryResultOverview;
   const refreshState = useQueryRefreshAtInterval(queryResultOverview, FIFTEEN_SECONDS);
 
   const sanitizedSearch = searchValue.trim().toLocaleLowerCase();
@@ -176,6 +177,8 @@ export const WorkspaceSensorsRoot = ({repoAddress}: {repoAddress: RepoAddress}) 
     );
   };
 
+  const showSearchSpinner = queryLoading && !data;
+
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
       <WorkspaceHeader
@@ -193,6 +196,11 @@ export const WorkspaceSensorsRoot = ({repoAddress}: {repoAddress: RepoAddress}) 
             onChange={(e) => setSearchValue(e.target.value)}
             placeholder="Filter by sensor name…"
             style={{width: '340px'}}
+            rightElement={
+              showSearchSpinner ? (
+                <SearchInputSpinner tooltipContent="Loading sensors…" />
+              ) : undefined
+            }
           />
         </Box>
         <Tooltip


### PR DESCRIPTION
## Summary & Motivation

Lost some loading state stuff while rebasing these changes... adds back skipping the loading state if the workspace cache has data for us to use in it.

Also made WorkspaceSensors/WorkspaceSchedules pages use the workspace cache if available.

## How I Tested These Changes

Load OverviewJobs/Sensors/Schedules/Resources for a large customer and see these pages load immediately.