### PR TITLE
[Run Timeline Perf] Don't reset timer for fetching ongoing runs / future ticks when time range changes

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -510,6 +510,11 @@ export const useRunsForTimeline = ({
   }, [unsortedJobs]);
 
   const lastFetchRef = useRef({ongoing: 0, future: 0});
+  const lastRangeMs = useRef([0, 0] as readonly [number, number]);
+  if (Math.abs(lastRangeMs.current[0] - rangeMs[0]) > 30000) {
+    lastFetchRef.current.future = 0;
+  }
+  lastRangeMs.current = rangeMs;
 
   const refreshState = useRefreshAtInterval({
     refresh: useCallback(async () => {
@@ -525,7 +530,8 @@ export const useRunsForTimeline = ({
         })(),
         // Only fetch future ticks on a minute
         (async () => {
-          if (lastFetchRef.current.future < Date.now() - 60 * 1000) {
+          // If the end of this time range isn't past "Now" then future ticks are not visible on the timeline
+          if (_end > Date.now() && lastFetchRef.current.future < Date.now() - 60 * 1000) {
             fetchFutureTicks();
           }
         })(),

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -510,11 +510,6 @@ export const useRunsForTimeline = ({
   }, [unsortedJobs]);
 
   const lastFetchRef = useRef({ongoing: 0, future: 0});
-  const lastRangeMs = useRef([0, 0] as readonly [number, number]);
-  if (Math.abs(lastRangeMs.current[0] - rangeMs[0]) > 30000) {
-    lastFetchRef.current = {ongoing: 0, future: 0};
-  }
-  lastRangeMs.current = rangeMs;
 
   const refreshState = useRefreshAtInterval({
     refresh: useCallback(async () => {


### PR DESCRIPTION
## Summary & Motivation

ongoing runs doesn't depend on the time range so don't make it refetch when the time range passed to `useRunsForTimeline` changes significantly. 

Also future ticks aren't visible if the end time range isn't past "now" so dont make that query if the time range is in the past.

## How I Tested These Changes

Paginate forward/backwards on the RunTimeline and see it doesn't wait for ongoing runs query.