### PR TITLE
include OpExecutionContext in snippet

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -43,7 +43,7 @@ To define a sensor, use the <PyObject object="sensor" decorator /> decorator. Th
 Let's say you have a job that logs a filename that is specified in the op configuration of the `process_file` op:
 
 ```python file=concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_sensor_job_marker endbefore=end_sensor_job_marker
-from dagster import op, job, Config
+from dagster import op, job, Config, OpExecutionContext
 
 
 class FileConfig(Config):

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -12,12 +12,11 @@ from dagster import (
     DagsterRunStatus,
     run_status_sensor,
     run_failure_sensor,
-    OpExecutionContext,
 )
 
 
 # start_sensor_job_marker
-from dagster import op, job, Config
+from dagster import op, job, Config, OpExecutionContext
 
 
 class FileConfig(Config):


### PR DESCRIPTION
## Summary & Motivation

OpExecutionContext is missing in the imports for dagster in this particular snippet, so copy-pasting fails on import

## How I Tested These Changes

Make sure I can copy-paste the snippet and things work