### PR TITLE
GCS IO manager - update example in doc string

### DIFF
--- a/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
+++ b/python_modules/libraries/dagster-gcp/dagster_gcp/gcs/io_manager.py
@@ -120,9 +120,10 @@ class GCSPickleIOManager(ConfigurableIOManager):
             resources={
                 "io_manager": GCSPickleIOManager(
                     gcs_bucket="my-cool-bucket",
-                    gcs_prefix="my-cool-prefix"
+                    gcs_prefix="my-cool-prefix",
+                    gcs=GCSResource(project="my-cool-project")
                 ),
-                "gcs": GCSResource(project="my-cool-project")
+
             }
         )
 


### PR DESCRIPTION
## Summary & Motivation
Example in the GCS I/O manager doc string incorrectly sets the GCS resource dependency for the I/O manager

## How I Tested These Changes
