### PR TITLE
Normalize asset job backfill policies

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
@@ -1132,7 +1132,10 @@
     "external_partition_set_datas": [
       {
         "__class__": "ExternalPartitionSetData",
-        "backfill_policy": null,
+        "backfill_policy": {
+          "__class__": "BackfillPolicy",
+          "max_partitions_per_run": 1
+        },
         "external_partitions_data": {
           "__class__": "ExternalTimeWindowPartitionsDefinitionData",
           "cron_schedule": "15 0 * * *",


### PR DESCRIPTION
## Summary & Motivation

Fixes #22254.

- When an unresolved asset job has multiple backfill policies in constituent assets, use the one with the lowest max partitions per run and print a warning. This replaces previous behavior of hard error for conflicting backfill policies.
- Ensure `JobDefinition.backfill_policy` is always non-null by normalizing null values to `BackfillPolicy.multi_run(max_partitions_per_run=1)`. This is handled by backfill machinery in the same way as a null policy, but has a more explicit display in the UI.

A longer term solution will involve allowing asset job backfills to actually use multiple backfill policies.

## How I Tested These Changes

Modified existing tests.