### PR TITLE
chore(buildkite): remove custom package spec for `dagster-blueprints`

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -349,6 +349,9 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         "examples/quickstart_snowflake",
         pytest_tox_factors=["pypi"],
     ),
+    PackageSpec(
+        "examples/experimental/dagster-blueprints",
+    ),
 ]
 
 
@@ -641,9 +644,6 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             "old_kubernetes",
         ],
         pytest_extra_cmds=k8s_extra_cmds,
-    ),
-    PackageSpec(
-        "examples/experimental/dagster-blueprints",
     ),
     PackageSpec(
         "python_modules/libraries/dagster-mlflow",


### PR DESCRIPTION
## Summary & Motivation
Seeing the following error in our build: https://buildkite.com/dagster/dagster-dagster/builds/86064#01900884-603a-40b5-9b3f-b6fca9570ba2/208-418

```
[2024-06-11T18:19:26Z] 2024-06-11 18:19:26 FATAL  Failed to upload and process pipeline: POST https://agent.buildkite.com/v3/jobs/01900884-603a-40b5-9b3f-b6fca9570ba2/pipelines: 422 The key "dagster-blueprints" has already been used by another step in this build
[2024-06-11T18:19:26Z] 🚨 Error: The command exited with status 1
```

We should be specifying the explicit package in the `EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG` instead.

## How I Tested These Changes
bk, see build working: https://buildkite.com/dagster/dagster-dagster/builds/86076