### PR TITLE
Add can_update_asset_cached_status_data to EventLogStorage

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -422,7 +422,7 @@ def get_partition_subsets(
     if not partitions_def:
         return None, None, None
 
-    if instance.can_cache_asset_status_data() and is_cacheable_partition_type(partitions_def):
+    if instance.can_read_asset_status_cache() and is_cacheable_partition_type(partitions_def):
         # When the "cached_status_data" column exists in storage, update the column to contain
         # the latest partition status values
         updated_cache_value = get_and_update_asset_status_cache_value(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -3068,8 +3068,8 @@ def get_partitioned_asset_repo():
 
 def test_1d_subset_backcompat():
     with instance_for_test() as instance:
-        instance.can_cache_asset_status_data = lambda: False
-        assert instance.can_cache_asset_status_data() is False
+        instance.can_read_asset_status_cache = lambda: False
+        assert instance.can_read_asset_status_cache() is False
 
         with define_out_of_process_context(
             __file__, "get_partitioned_asset_repo", instance
@@ -3151,8 +3151,8 @@ def test_1d_subset_backcompat():
 
 def test_2d_subset_backcompat():
     with instance_for_test() as instance:
-        instance.can_cache_asset_status_data = lambda: False
-        assert instance.can_cache_asset_status_data() is False
+        instance.can_read_asset_status_cache = lambda: False
+        assert instance.can_read_asset_status_cache() is False
 
         with define_out_of_process_context(
             __file__, "get_partitioned_asset_repo", instance

--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -182,7 +182,7 @@ def asset_wipe_cache_command(key, **cli_args):
     noprompt = cli_args.get("noprompt")
 
     with get_instance_for_cli() as instance:
-        if instance.can_cache_asset_status_data() is False:
+        if instance.can_read_asset_status_cache() is False:
             raise click.UsageError(
                 "Error, the instance does not support caching asset status. Wiping the cache is not"
                 " supported."

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1912,8 +1912,8 @@ class DagsterInstance(DynamicPartitionsStore):
     # asset storage
 
     @traced
-    def can_cache_asset_status_data(self) -> bool:
-        return self._event_storage.can_cache_asset_status_data()
+    def can_read_asset_status_cache(self) -> bool:
+        return self._event_storage.can_read_asset_status_cache()
 
     @traced
     def update_asset_cached_status_data(

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -306,8 +306,13 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         raise NotImplementedError()
 
     @abstractmethod
-    def can_cache_asset_status_data(self) -> bool:
+    def can_read_asset_status_cache(self) -> bool:
+        """Whether the storage can access cached status information for each asset."""
         pass
+
+    @abstractmethod
+    def can_write_asset_status_cache(self) -> bool:
+        """Whether the storage is able to write to that cache."""
 
     @abstractmethod
     def wipe_asset_cached_status(self, asset_key: AssetKey) -> None:

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -588,8 +588,11 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
             asset_key, filter_tags, filter_event_id
         )
 
-    def can_cache_asset_status_data(self) -> bool:
-        return self._storage.event_log_storage.can_cache_asset_status_data()
+    def can_read_asset_status_cache(self) -> bool:
+        return self._storage.event_log_storage.can_read_asset_status_cache()
+
+    def can_write_asset_status_cache(self) -> bool:
+        return self._storage.event_log_storage.can_write_asset_status_cache()
 
     def wipe_asset_cached_status(self, asset_key: "AssetKey") -> None:
         return self._storage.event_log_storage.wipe_asset_cached_status(asset_key)

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -463,7 +463,11 @@ def get_and_update_asset_status_cache_value(
         stored_cache_value=stored_cache_value if use_cached_value else None,
         asset_record=asset_record,
     )
-    if updated_cache_value is not None and updated_cache_value != stored_cache_value:
+    if (
+        updated_cache_value is not None
+        and instance.event_log_storage.can_write_asset_status_cache()
+        and updated_cache_value != stored_cache_value
+    ):
         instance.update_asset_cached_status_data(asset_key, updated_cache_value)
 
     return updated_cache_value

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1079,7 +1079,7 @@ def test_1_0_17_add_cached_status_data_column():
         assert get_current_alembic_version(db_path) == "958a9495162d"
         assert "cached_status_data" not in set(get_sqlite3_columns(db_path, "asset_keys"))
         with DagsterInstance.from_ref(InstanceRef.from_dir(test_dir)) as instance:
-            assert instance.can_cache_asset_status_data() is False
+            assert instance.can_read_asset_status_cache() is False
             instance.upgrade()
             assert "cached_status_data" in set(get_sqlite3_columns(db_path, "asset_keys"))
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -4813,18 +4813,23 @@ class TestEventLogStorage:
             for field in cache_value._fields:
                 assert getattr(cache_value, field) is not None
 
-            storage.update_asset_cached_status_data(asset_key=asset_key, cache_values=cache_value)
+            if storage.can_write_asset_status_cache():
+                storage.update_asset_cached_status_data(
+                    asset_key=asset_key, cache_values=cache_value
+                )
 
-            assert _get_cached_status_for_asset(storage, asset_key) == cache_value
+                assert _get_cached_status_for_asset(storage, asset_key) == cache_value
 
-            cache_value = AssetStatusCacheValue(
-                latest_storage_id=1,
-                partitions_def_id=None,
-                serialized_materialized_partition_subset=None,
-            )
-            storage.update_asset_cached_status_data(asset_key=asset_key, cache_values=cache_value)
+                cache_value = AssetStatusCacheValue(
+                    latest_storage_id=1,
+                    partitions_def_id=None,
+                    serialized_materialized_partition_subset=None,
+                )
 
-            assert _get_cached_status_for_asset(storage, asset_key) == cache_value
+                storage.update_asset_cached_status_data(
+                    asset_key=asset_key, cache_values=cache_value
+                )
+                assert _get_cached_status_for_asset(storage, asset_key) == cache_value
 
             if self.can_wipe():
                 cache_value = AssetStatusCacheValue(

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/partition_status_cache.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/partition_status_cache.py
@@ -24,7 +24,6 @@ from dagster._core.events import (
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.storage.partition_status_cache import (
     RUN_FETCH_BATCH_SIZE,
-    AssetStatusCacheValue,
     build_failed_and_in_progress_partition_subset,
     get_and_update_asset_status_cache_value,
     get_last_planned_storage_id,
@@ -441,14 +440,6 @@ class TestPartitionStatusCache:
         asset_key = AssetKey("asset1")
         asset_graph = AssetGraph.from_assets([asset1])
         asset_job = define_asset_job("asset_job").resolve(asset_graph=asset_graph)
-
-        instance.update_asset_cached_status_data(
-            asset_key,
-            AssetStatusCacheValue(
-                latest_storage_id=0,
-                partitions_def_id=partitions_def.get_serializable_unique_identifier(),
-            ),
-        )
 
         asset_job.execute_in_process(instance=instance, partition_key="fail1", raise_on_error=False)
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -724,11 +724,11 @@ def test_add_cached_status_data_column(hostname, conn_string):
                 target_fd.write(template)
 
         with DagsterInstance.from_config(tempdir) as instance:
-            assert instance.can_cache_asset_status_data() is False
+            assert instance.can_read_asset_status_cache() is False
             assert {"cached_status_data"} & get_columns(instance, "asset_keys") == set()
 
             instance.upgrade()
-            assert instance.can_cache_asset_status_data() is True
+            assert instance.can_read_asset_status_cache() is True
             assert {"cached_status_data"} <= get_columns(instance, "asset_keys")
 
 


### PR DESCRIPTION
Summary:
Customize whether or not a given storage can write to the asset status cache.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
