### PR TITLE
[dagster-dbt] simplify relation name generation

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -430,13 +430,11 @@ def default_metadata_from_dbt_resource_props(
             ]
         )
 
-    relation_name = (
-        dbt_resource_props["database"]
-        + "."
-        + dbt_resource_props["schema"]
-        + "."
-        + dbt_resource_props["alias"]
-    )
+    relation_name = ".".join([
+        dbt_resource_props["database"],
+        dbt_resource_props["schema"],
+        dbt_resource_props["alias"],
+    ])
 
     return {
         **TableMetadataSet(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -430,15 +430,20 @@ def default_metadata_from_dbt_resource_props(
             ]
         )
 
-    # all nodes should have these props defined, but just in case
-    relation_identifier = dbt_resource_props.get("relation_name")
+    relation_name = (
+        dbt_resource_props["database"]
+        + "."
+        + dbt_resource_props["schema"]
+        + "."
+        + dbt_resource_props["alias"]
+    )
 
     metadata: Dict[str, Any] = {}
-    if column_schema or relation_identifier:
+    if column_schema or relation_name:
         metadata = {
             **TableMetadataSet(
                 column_schema=column_schema,
-                relation_identifier=relation_identifier,
+                relation_identifier=(relation_name),
             ),
         }
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -438,16 +438,12 @@ def default_metadata_from_dbt_resource_props(
         + dbt_resource_props["alias"]
     )
 
-    metadata: Dict[str, Any] = {}
-    if column_schema or relation_name:
-        metadata = {
-            **TableMetadataSet(
-                column_schema=column_schema,
-                relation_identifier=(relation_name),
-            ),
-        }
-
-    return metadata
+    return {
+        **TableMetadataSet(
+            column_schema=column_schema,
+            relation_identifier=relation_name,
+        ),
+    }
 
 
 def default_group_from_dbt_resource_props(dbt_resource_props: Mapping[str, Any]) -> Optional[str]:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -430,11 +430,20 @@ def default_metadata_from_dbt_resource_props(
             ]
         )
 
-    relation_name = ".".join([
-        dbt_resource_props["database"],
-        dbt_resource_props["schema"],
-        dbt_resource_props["alias"],
-    ])
+    relation_name: Optional[str] = None
+
+    if (
+        "database" in dbt_resource_props
+        and "schema" in dbt_resource_props
+        and "alias" in dbt_resource_props
+    ):
+        relation_name = ".".join(
+            [
+                dbt_resource_props["database"],
+                dbt_resource_props["schema"],
+                dbt_resource_props["alias"],
+            ]
+        )
 
     return {
         **TableMetadataSet(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_def_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_def_metadata.py
@@ -30,15 +30,15 @@ def test_storage_address(
     # spot check a few storage addresses
     assert (
         storage_address_metas["customers"].relation_identifier
-        == f'"{jaffle_shop_duckdb_dbfile_name}"."dev"."customers"'
+        == f"{jaffle_shop_duckdb_dbfile_name}.dev.customers"
     )
     assert (
         storage_address_metas["raw_customers"].relation_identifier
-        == f'"{jaffle_shop_duckdb_dbfile_name}"."dev"."raw_customers"'
+        == f"{jaffle_shop_duckdb_dbfile_name}.dev.raw_customers"
     )
     assert (
         storage_address_metas["stg_orders"].relation_identifier
-        == f'"{jaffle_shop_duckdb_dbfile_name}"."dev"."stg_orders"'
+        == f"{jaffle_shop_duckdb_dbfile_name}.dev.stg_orders"
     )
 
 
@@ -64,9 +64,9 @@ def test_storage_address_alias(
     # user-defined aliases
     assert (
         storage_address_metas["customers"].relation_identifier
-        == f'"{jaffle_shop_duckdb_dbfile_name}"."main"."dagster.customers"'
+        == f"{jaffle_shop_duckdb_dbfile_name}.main.dagster.customers"
     )
     assert (
         storage_address_metas["orders"].relation_identifier
-        == f'"{jaffle_shop_duckdb_dbfile_name}"."main"."dagster.orders"'
+        == f"{jaffle_shop_duckdb_dbfile_name}.main.dagster.orders"
     )


### PR DESCRIPTION
## Summary

Alternative to #22304 - simplify impl of dbt relation name generation by just concatenating db name, schema, and alias.

This doesn't make an effort to wrap aliases with special chars (e.g. dots), but does look nicer to the eye. The logic here is less complex than in #22304.

## Test Plan

Unit test.