### PR TITLE
[RFC] check container images before building ExecutionPlan from snapshot

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_base.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_base.py
@@ -53,6 +53,9 @@ class IJob(ABC):
     def resolved_op_selection(self) -> Optional[AbstractSet[str]]:
         return set(self.op_selection) if self.op_selection else None
 
+    def get_container_image(self) -> Optional[str]:
+        pass
+
 
 class InMemoryJob(IJob):
     def __init__(
@@ -94,3 +97,6 @@ class InMemoryJob(IJob):
     @property
     def asset_check_selection(self) -> Optional[AbstractSet[AssetCheckKey]]:
         return self._job_def.asset_check_selection
+
+    def get_container_image(self) -> Optional[None]:
+        return None

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -338,6 +338,9 @@ class ReconstructableJob(
             self._hash = hash_collection(self)
         return self._hash
 
+    def get_container_image(self) -> Optional[str]:
+        return self.repository.container_image
+
 
 def reconstructable(target: Callable[..., "JobDefinition"]) -> ReconstructableJob:
     """Create a :py:class:`~dagster._core.definitions.reconstructable.ReconstructableJob` from a

--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -674,6 +674,7 @@ def _get_execution_plan_from_run(
         and job.resolved_op_selection == dagster_run.resolved_op_selection
         and job.asset_selection == dagster_run.asset_selection
         and job.asset_check_selection == dagster_run.asset_check_selection
+        and job.get_container_image() == dagster_run.get_container_image()
     ):
         return ExecutionPlan.rebuild_from_snapshot(
             dagster_run.job_name,

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -480,6 +480,11 @@ class DagsterRun(
     def tags_for_tick_id(tick_id: str) -> Mapping[str, str]:
         return {TICK_ID_TAG: tick_id}
 
+    def get_container_image(self) -> Optional[str]:
+        if self.job_code_origin and self.job_code_origin.repository_origin:
+            return self.job_code_origin.repository_origin.container_image
+        return None
+
 
 class RunsFilter(
     NamedTuple(


### PR DESCRIPTION
this or maybe just delete this code path entirely

motivated by execution plan desync causing 
```
KeyError: '__subset_input_dbt_model'
  File "/.../venv/lib/python3.10/site-packages/dagster/_grpc/impl.py", line 152, in core_execute_run
    yield from execute_run_iterator(
  File "/.../venv/lib/python3.10/site-packages/dagster/_core/execution/api.py", line 870, in __iter__
    yield from self.execution_context_manager.prepare_context()
  File "/.../venv/lib/python3.10/site-packages/dagster/_utils/__init__.py", line 513, in generate_setup_events
    obj = next(self.generator)
  File "/.../venv/lib/python3.10/site-packages/dagster/_core/execution/context_creation_job.py", line 291, in orchestration_context_event_generator
    context_creation_data = create_context_creation_data(
  File "/.../venv/lib/python3.10/site-packages/dagster/_core/execution/context_creation_job.py", line 116, in create_context_creation_data
    resource_keys_to_init=get_required_resource_keys_to_init(execution_plan, job_def),
  File "/.../venv/lib/python3.10/site-packages/dagster/_core/execution/resources_init.py", line 368, in get_required_resource_keys_to_init
    get_required_resource_keys_for_step(job_def, step, execution_plan)
  File "/.../venv/lib/python3.10/site-packages/dagster/_core/execution/resources_init.py", line 401, in get_required_resource_keys_for_step
    input_def = node_def.input_def_named(step_input.name)
  File "/.../venv/lib/python3.10/site-packages/dagster/_core/definitions/node_definition.py", line 143, in input_def_named
    return self._input_dict[name]
```

where `__subset_input_dbt_model` was not relevant to the current `asset_selection`

## How I Tested These Changes
