### PR TITLE
Fix observation handling for freshness checks

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/last_update.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/last_update.py
@@ -37,7 +37,7 @@ from ..utils import (
     ensure_no_duplicate_assets,
     freshness_multi_asset_check,
     get_last_updated_timestamp,
-    retrieve_latest_record,
+    retrieve_last_update_record,
     seconds_in_words,
 )
 
@@ -186,7 +186,7 @@ def _build_freshness_multi_check(
 
             last_update_time_lower_bound = cast(datetime.datetime, deadline - lower_bound_delta)
 
-            latest_record = retrieve_latest_record(
+            latest_record = retrieve_last_update_record(
                 instance=context.instance, asset_key=asset_key, partition_key=None
             )
             update_timestamp = get_last_updated_timestamp(latest_record, context)

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/time_partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/time_partition.py
@@ -35,7 +35,7 @@ from ..utils import (
     ensure_no_duplicate_assets,
     freshness_multi_asset_check,
     get_last_updated_timestamp,
-    retrieve_latest_record,
+    retrieve_last_update_record,
 )
 
 
@@ -162,7 +162,7 @@ def _build_freshness_multi_check(
             expected_partition_key = partitions_def.get_partition_key_range_for_time_window(
                 last_completed_time_window
             ).start
-            latest_record = retrieve_latest_record(
+            latest_record = retrieve_last_update_record(
                 instance=context.instance, asset_key=asset_key, partition_key=expected_partition_key
             )
             passed = latest_record is not None
@@ -174,7 +174,7 @@ def _build_freshness_multi_check(
 
             # Allows us to distinguish between the case where the asset has never been
             # observed/materialized, and the case where this partition in particular is missing
-            latest_record_any_partition = retrieve_latest_record(
+            latest_record_any_partition = retrieve_last_update_record(
                 instance=context.instance, asset_key=asset_key, partition_key=None
             )
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/utils.py
@@ -98,7 +98,7 @@ def ensure_no_duplicate_asset_checks(
     )
 
 
-def retrieve_latest_record(
+def retrieve_last_update_record(
     instance: DagsterInstance,
     asset_key: AssetKey,
     partition_key: Optional[str],
@@ -106,6 +106,18 @@ def retrieve_latest_record(
     """Retrieve the latest materialization or observation record for the given asset.
 
     If the asset is partitioned, the latest record for the latest partition will be returned.
+
+    There are a few weird edge cases to consider here:
+        - Note that this may not be the latest record overall. We only look for the latest materialization
+        and the latest observation, and return the latest of those two records that we
+        can successfully parse. Take for example, the scenario where we have a materialization, and two
+        obserations after that. If the latest observation is not parseable, we will return the materialization,
+        even though there might be a more recent observation that we can parse. The reason we do
+        this is to avoid an expensive query into the long-tail history of the asset. Retrieving the
+        latest record of a particular type is cheap. Retrieving the latest N records is not.
+        - If the asset has never been materialized and the latest observation is missing
+        `dagster/last_updated_timestamp` metadata, we will return None.
+
     """
     materializations = instance.fetch_materializations(
         records_filter=AssetRecordsFilter(
@@ -120,10 +132,16 @@ def retrieve_latest_record(
         limit=1,
     )
     if materializations.records and observations.records:
-        return max(
-            materializations.records[0],
-            observations.records[0],
-            key=lambda record: retrieve_timestamp_from_record(record),
+        mat_timestamp = retrieve_timestamp_from_record(materializations.records[0])
+        obs_timestamp = retrieve_timestamp_from_record(observations.records[0])
+        if not obs_timestamp:
+            return materializations.records[0]
+        if not mat_timestamp:
+            return observations.records[0]
+        return (
+            materializations.records[0]
+            if mat_timestamp > obs_timestamp
+            else observations.records[0]
         )
     else:
         return (
@@ -135,12 +153,17 @@ def retrieve_latest_record(
         )
 
 
-def retrieve_timestamp_from_record(asset_record: EventLogRecord) -> float:
+def retrieve_timestamp_from_record(asset_record: EventLogRecord) -> Optional[float]:
     """Retrieve the timestamp from the given materialization or observation record."""
     check.inst_param(asset_record, "asset_record", EventLogRecord)
     if asset_record.event_log_entry.dagster_event_type == DagsterEventType.ASSET_MATERIALIZATION:
         return asset_record.timestamp
     else:
+        # If the asset observation does not have a last updated timestamp, return None.
+        if not asset_record.asset_observation or not asset_record.asset_observation.metadata.get(
+            LAST_UPDATED_TIMESTAMP_METADATA_KEY
+        ):
+            return None
         metadata = check.not_none(asset_record.asset_observation).metadata
         value = metadata[LAST_UPDATED_TIMESTAMP_METADATA_KEY].value
         check.invariant(

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/conftest.py
@@ -71,6 +71,7 @@ def add_new_event(
     partition_key: Optional[str] = None,
     is_materialization: bool = True,
     override_timestamp: Optional[float] = None,
+    include_metadata: bool = True,
 ):
     klass = AssetMaterialization if is_materialization else AssetObservation
     metadata = (
@@ -85,7 +86,7 @@ def add_new_event(
     instance.report_runless_asset_event(
         klass(
             asset_key=asset_key,
-            metadata=metadata,
+            metadata=metadata if include_metadata else None,
             partition=partition_key,
         )
     )


### PR DESCRIPTION
When last update timestamp metadata key isn't provided for an observation, prefer the latest materialization.

This has the potential to be wrong occasionally. The second-latest event could actually be an observation with the correct metadata, instead of the materialization, but figuring that out would require us performing an expensive query.