### PR TITLE
[prototype] emit "backfills" from sensors

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -876,7 +876,7 @@ class SensorDefinition(IHasInternalInit):
                 self._asset_selection,
                 "Can only yield NotABackfillRequests for sensors with an asset_selection",
             )
-            asset_keys = item.asset_keys
+            asset_keys = not_a_backfill_request.asset_keys
 
             unexpected_asset_keys = (AssetSelection.keys(*asset_keys) - asset_selection).resolve(
                 check.not_none(context.repository_def).asset_graph

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -352,6 +352,9 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
             )
         )
 
+    def with_not_a_backfill_info(self, backfill_id: str) -> "InstigatorTick":
+        return self._replace(tick_data=self.tick_data.with_not_a_backfill_info(backfill_id))
+
     @property
     def instigator_origin_id(self) -> str:
         return self.tick_data.instigator_origin_id
@@ -383,6 +386,10 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
     @property
     def run_ids(self) -> Sequence[str]:
         return self.tick_data.run_ids
+
+    @property
+    def backfill_ids(self) -> Sequence[str]:
+        return self.tick_data.backfill_ids
 
     @property
     def run_keys(self) -> Sequence[str]:
@@ -507,6 +514,7 @@ class TickData(
             ("run_requests", Optional[Sequence[RunRequest]]),  # run requests created by the tick
             ("auto_materialize_evaluation_id", Optional[int]),
             ("reserved_run_ids", Optional[Sequence[str]]),
+            ("backfill_ids", Sequence[str]),
         ],
     )
 ):
@@ -540,6 +548,7 @@ class TickData(
         reserved_run_ids (Optional[Sequence[str]]): A list of run IDs to use for each of the
             run_requests. Used to ensure that if the tick fails partway through, we don't create
             any duplicate runs for the tick. Currently only used by AUTO_MATERIALIZE ticks.
+        backfill_ids (Optional[Sequence[str]]): A list of backfill ID created by tihs tick.
     """
 
     def __new__(
@@ -565,6 +574,7 @@ class TickData(
         run_requests: Optional[Sequence[RunRequest]] = None,
         auto_materialize_evaluation_id: Optional[int] = None,
         reserved_run_ids: Optional[Sequence[str]] = None,
+        backfill_ids: Optional[Sequence[str]] = None,
     ):
         _validate_tick_args(instigator_type, status, run_ids, error, skip_reason)
         check.opt_list_param(log_key, "log_key", of_type=str)
@@ -593,6 +603,7 @@ class TickData(
             run_requests=check.opt_sequence_param(run_requests, "run_requests"),
             auto_materialize_evaluation_id=auto_materialize_evaluation_id,
             reserved_run_ids=check.opt_sequence_param(reserved_run_ids, "reserved_run_ids"),
+            backfill_ids=check.opt_sequence_param(backfill_ids, "backfill_ids", str),
         )
 
     def with_status(
@@ -608,6 +619,13 @@ class TickData(
                 },
                 kwargs,
             )
+        )
+
+    def with_not_a_backfill_info(self, backfill_id: str) -> "TickData":
+        return self._replace(
+            backfill_ids=[*self.backfill_ids, backfill_id]
+            if backfill_id not in self.backfill_ids
+            else self.backfill_ids
         )
 
     def with_run_info(

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -388,8 +388,8 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
         return self.tick_data.run_ids
 
     @property
-    def backfill_ids(self) -> Sequence[str]:
-        return self.tick_data.backfill_ids
+    def backfill_id(self) -> str:
+        return self.tick_data.backfill_id
 
     @property
     def run_keys(self) -> Sequence[str]:
@@ -514,7 +514,7 @@ class TickData(
             ("run_requests", Optional[Sequence[RunRequest]]),  # run requests created by the tick
             ("auto_materialize_evaluation_id", Optional[int]),
             ("reserved_run_ids", Optional[Sequence[str]]),
-            ("backfill_ids", Sequence[str]),
+            ("backfill_id", Optional[str]),
         ],
     )
 ):
@@ -548,7 +548,7 @@ class TickData(
         reserved_run_ids (Optional[Sequence[str]]): A list of run IDs to use for each of the
             run_requests. Used to ensure that if the tick fails partway through, we don't create
             any duplicate runs for the tick. Currently only used by AUTO_MATERIALIZE ticks.
-        backfill_ids (Optional[Sequence[str]]): A list of backfill ID created by tihs tick.
+        backfill_id (Optional[str]]: The backfill ID created by this tick, if applicable.
     """
 
     def __new__(
@@ -574,7 +574,7 @@ class TickData(
         run_requests: Optional[Sequence[RunRequest]] = None,
         auto_materialize_evaluation_id: Optional[int] = None,
         reserved_run_ids: Optional[Sequence[str]] = None,
-        backfill_ids: Optional[Sequence[str]] = None,
+        backfill_id: Optional[str] = None,
     ):
         _validate_tick_args(instigator_type, status, run_ids, error, skip_reason)
         check.opt_list_param(log_key, "log_key", of_type=str)
@@ -603,7 +603,7 @@ class TickData(
             run_requests=check.opt_sequence_param(run_requests, "run_requests"),
             auto_materialize_evaluation_id=auto_materialize_evaluation_id,
             reserved_run_ids=check.opt_sequence_param(reserved_run_ids, "reserved_run_ids"),
-            backfill_ids=check.opt_sequence_param(backfill_ids, "backfill_ids", str),
+            backfill_id=check.opt_str_param(backfill_id, "backfill_id"),
         )
 
     def with_status(
@@ -622,11 +622,7 @@ class TickData(
         )
 
     def with_not_a_backfill_info(self, backfill_id: str) -> "TickData":
-        return self._replace(
-            backfill_ids=[*self.backfill_ids, backfill_id]
-            if backfill_id not in self.backfill_ids
-            else self.backfill_ids
-        )
+        return self._replace(backfill_id=backfill_id)
 
     def with_run_info(
         self, run_id: Optional[str] = None, run_key: Optional[str] = None

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -54,6 +54,7 @@ from dagster._core.errors import DagsterUserCodeUnreachableError
 from dagster._core.events import DagsterEvent
 from dagster._core.instance import DagsterInstance
 from dagster._core.launcher import RunLauncher
+from dagster._core.remote_representation import ExternalRepository
 from dagster._core.remote_representation.origin import InProcessCodeLocationOrigin
 from dagster._core.run_coordinator import RunCoordinator, SubmitRunContext
 from dagster._core.secrets import SecretsLoader
@@ -527,6 +528,16 @@ def create_test_daemon_workspace_context(
             grpc_server_registry=grpc_server_registry,
         ) as workspace_process_context:
             yield workspace_process_context
+
+
+def load_external_repo(
+    workspace_context: WorkspaceProcessContext, repo_name: str
+) -> ExternalRepository:
+    code_location = next(
+        iter(workspace_context.create_request_context().get_workspace_snapshot().values())
+    ).code_location
+    assert code_location
+    return code_location.get_repository(repo_name)
 
 
 def remove_none_recursively(obj: T) -> T:

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -682,6 +682,7 @@ def _evaluate_sensor(
             )
         if sensor_runtime_data.not_a_backfill_request:
             _handle_backfill_requests(sensor_runtime_data.not_a_backfill_request, instance, context)
+            context.update_state(TickStatus.SUCCESS, cursor=sensor_runtime_data.cursor)
 
 
 def _handle_dynamic_partitions_requests(

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
@@ -9,6 +9,7 @@ from dagster._core.test_utils import (
     SingleThreadPoolExecutor,
     create_test_daemon_workspace_context,
     instance_for_test,
+    load_external_repo,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceProcessContext
@@ -50,9 +51,12 @@ def instance_fixture(instance_module_scoped: DagsterInstance) -> Iterator[Dagste
     yield instance_module_scoped
 
 
-def create_workspace_load_target(attribute: Optional[str] = "the_repo") -> ModuleTarget:
+def create_workspace_load_target(
+    module_name: str = "dagster_tests.daemon_sensor_tests.test_sensor_run",
+    attribute: Optional[str] = "the_repo",
+) -> ModuleTarget:
     return ModuleTarget(
-        module_name="dagster_tests.daemon_sensor_tests.test_sensor_run",
+        module_name=module_name,
         attribute=attribute,
         working_directory=os.path.join(os.path.dirname(__file__), "..", ".."),
         location_name="test_location",
@@ -70,11 +74,7 @@ def workspace_fixture(instance_module_scoped: DagsterInstance) -> Iterator[Works
 
 @pytest.fixture(name="external_repo", scope="module")
 def external_repo_fixture(workspace_context: WorkspaceProcessContext) -> ExternalRepository:
-    code_location = next(
-        iter(workspace_context.create_request_context().get_workspace_snapshot().values())
-    ).code_location
-    assert code_location
-    return code_location.get_repository("the_repo")
+    return load_external_repo(workspace_context, "the_repo")
 
 
 def loadable_target_origin() -> LoadableTargetOrigin:

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -108,7 +108,7 @@ def instance_with_multiple_code_locations(
 ) -> Iterator[Dict[str, CodeLocationInfoForSensorTest]]:
     with instance_for_test(overrides) as instance:
         with create_test_daemon_workspace_context(
-            workspace_load_target or create_workspace_load_target(None), instance=instance
+            workspace_load_target or create_workspace_load_target(attribute=None), instance=instance
         ) as workspace_context:
             location_infos: Dict[str, CodeLocationInfoForSensorTest] = {}
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -6,7 +6,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack
-from typing import Any, Optional, Sequence
+from typing import Any, Optional
 from unittest import mock
 
 import pytest
@@ -1022,7 +1022,7 @@ def validate_tick(
     expected_status=None,
     expected_run_ids=None,
     expected_error=None,
-    expected_backfill_ids: Optional[Sequence[str]] = None,
+    expected_backfill_id: Optional[str] = None,
 ):
     tick_data = tick.tick_data
     assert tick_data.instigator_origin_id == external_sensor.get_external_origin_id()
@@ -1035,8 +1035,8 @@ def validate_tick(
         assert set(tick_data.run_ids) == set(expected_run_ids)
     if expected_error:
         assert expected_error in str(tick_data.error)
-    if expected_backfill_ids:
-        assert set(tick_data.backfill_ids) == set(expected_backfill_ids)
+    if expected_backfill_id:
+        assert tick_data.backfill_id == expected_backfill_id
 
 
 def validate_run_started(run, expected_success=True):

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -6,7 +6,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack
-from typing import Any
+from typing import Any, Optional, Sequence
 from unittest import mock
 
 import pytest
@@ -1018,10 +1018,11 @@ def evaluate_sensors(workspace_context, executor, submit_executor=None, timeout=
 def validate_tick(
     tick,
     external_sensor,
-    expected_datetime,
-    expected_status,
+    expected_datetime=None,
+    expected_status=None,
     expected_run_ids=None,
     expected_error=None,
+    expected_backfill_ids: Optional[Sequence[str]] = None,
 ):
     tick_data = tick.tick_data
     assert tick_data.instigator_origin_id == external_sensor.get_external_origin_id()
@@ -1034,6 +1035,8 @@ def validate_tick(
         assert set(tick_data.run_ids) == set(expected_run_ids)
     if expected_error:
         assert expected_error in str(tick_data.error)
+    if expected_backfill_ids:
+        assert set(tick_data.backfill_ids) == set(expected_backfill_ids)
 
 
 def validate_run_started(run, expected_success=True):

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_request.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_request.py
@@ -1,0 +1,232 @@
+import os
+
+import pytest
+from dagster import (
+    DagsterInstance,
+    Definitions,
+    DynamicPartitionsDefinition,
+    SensorResult,
+    StaticPartitionsDefinition,
+    asset,
+    load_assets_from_current_module,
+    sensor,
+)
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.run_request import InstigatorType, NotABackfillRequest
+from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus, TickStatus
+from dagster._core.test_utils import create_test_daemon_workspace_context, load_external_repo
+from dagster._core.workspace.load_target import ModuleTarget
+
+from .test_sensor_run import evaluate_sensors, validate_tick
+
+dynamic_partitions_def = DynamicPartitionsDefinition(name="abc")
+
+
+@asset(partitions_def=dynamic_partitions_def)
+def asset1() -> None: ...
+
+
+@asset(deps=[asset1])
+def unpartitioned_child(): ...
+
+
+def make_backfill_request(context) -> NotABackfillRequest:
+    ags = AssetGraphSubset.from_asset_partition_set(
+        asset_partitions_set={
+            AssetKeyPartitionKey(asset1.key, "foo"),
+            AssetKeyPartitionKey(asset1.key, "bar"),
+            AssetKeyPartitionKey(unpartitioned_child.key, None),
+        },
+        asset_graph=context.repository_def.asset_graph,
+    )
+    return NotABackfillRequest(
+        asset_graph_subset=ags,
+        tags={"tagkey": "tagvalue"},
+        title="backfill title",
+        description="backfill description",
+    )
+
+
+@sensor(asset_selection=[asset1, unpartitioned_child])
+def sensor_result_backfill_request_sensor(context):
+    return SensorResult(
+        dynamic_partitions_requests=[dynamic_partitions_def.build_add_request(["foo", "bar"])],
+        not_a_backfill_request=make_backfill_request(context),
+    )
+
+
+@sensor(asset_selection=[asset1, unpartitioned_child])
+def return_backfill_request_sensor(context):
+    context.instance.add_dynamic_partitions(dynamic_partitions_def.name, ["foo", "bar"])
+    return make_backfill_request(context)
+
+
+@sensor(asset_selection=[asset1, unpartitioned_child])
+def yield_backfill_request_sensor(context):
+    context.instance.add_dynamic_partitions(dynamic_partitions_def.name, ["foo", "bar"])
+    yield make_backfill_request(context)
+
+
+@asset(partitions_def=StaticPartitionsDefinition(["a", "b"]))
+def static_partitioned_asset(): ...
+
+
+@sensor(asset_selection=[asset1, unpartitioned_child])
+def asset_outside_of_selection_backfill_request_sensor(context):
+    ags = AssetGraphSubset.from_asset_partition_set(
+        asset_partitions_set={
+            AssetKeyPartitionKey(static_partitioned_asset.key, "a"),
+            AssetKeyPartitionKey(static_partitioned_asset.key, "b"),
+        },
+        asset_graph=context.repository_def.asset_graph,
+    )
+    return NotABackfillRequest(
+        asset_graph_subset=ags,
+        tags={"tagkey": "tagvalue"},
+        title=None,
+        description=None,
+    )
+
+
+@sensor(asset_selection=[static_partitioned_asset])
+def invalid_partition_backfill_request_sensor(context):
+    ags = AssetGraphSubset.from_asset_partition_set(
+        asset_partitions_set={AssetKeyPartitionKey(static_partitioned_asset.key, "c")},
+        asset_graph=context.repository_def.asset_graph,
+    )
+    return NotABackfillRequest(
+        asset_graph_subset=ags,
+        tags={"tagkey": "tagvalue"},
+        title=None,
+        description=None,
+    )
+
+
+defs = Definitions(
+    assets=load_assets_from_current_module(),
+    sensors=[
+        sensor_result_backfill_request_sensor,
+        return_backfill_request_sensor,
+        yield_backfill_request_sensor,
+        asset_outside_of_selection_backfill_request_sensor,
+        invalid_partition_backfill_request_sensor,
+    ],
+)
+
+module_target = ModuleTarget(
+    module_name="dagster_tests.daemon_sensor_tests.test_sensor_run_backfill_request",
+    attribute=None,
+    working_directory=os.path.dirname(__file__),
+    location_name="test_location",
+)
+
+
+@pytest.mark.parametrize(
+    "sensor_name",
+    [
+        "sensor_result_backfill_request_sensor",
+        "return_backfill_request_sensor",
+        "yield_backfill_request_sensor",
+    ],
+)
+def test_backfill_request_sensor(instance: DagsterInstance, executor, sensor_name: str):
+    with create_test_daemon_workspace_context(
+        workspace_load_target=module_target, instance=instance
+    ) as workspace_context:
+        external_repo = load_external_repo(workspace_context, "__repository__")
+        external_sensor = external_repo.get_external_sensor(sensor_name)
+
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 1
+
+        backfills = instance.get_backfills()
+        assert len(backfills) == 1
+        backfill = backfills[0]
+        assert backfill.tags == {"tagkey": "tagvalue"}
+        assert backfill.is_asset_backfill
+        asset_backfill_data = backfill.asset_backfill_data
+        assert asset_backfill_data
+        assert set(asset_backfill_data.target_subset.iterate_asset_partitions()) == {
+            AssetKeyPartitionKey(asset1.key, "foo"),
+            AssetKeyPartitionKey(asset1.key, "bar"),
+            AssetKeyPartitionKey(unpartitioned_child.key, None),
+        }
+
+        # wait_for_all_runs_to_finish(instance)
+
+        validate_tick(
+            ticks[0],
+            external_sensor,
+            None,
+            TickStatus.SUCCESS,
+            expected_backfill_ids=[backfill.backfill_id],
+        )
+
+
+def test_asset_selection_outside_of_range(instance, executor):
+    with create_test_daemon_workspace_context(
+        workspace_load_target=module_target, instance=instance
+    ) as workspace_context:
+        external_repo = load_external_repo(workspace_context, "__repository__")
+        external_sensor = external_repo.get_external_sensor(
+            asset_outside_of_selection_backfill_request_sensor.name
+        )
+
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+
+        validate_tick(
+            ticks[0],
+            external_sensor=external_sensor,
+            expected_status=TickStatus.FAILURE,
+            expected_error="BackfillRequest includes asset keys that are not part of sensor's "
+            "asset_selection: {AssetKey(['static_partitioned_asset'])}",
+        )
+
+
+def test_invalid_partition(instance, executor):
+    with create_test_daemon_workspace_context(
+        workspace_load_target=module_target, instance=instance
+    ) as workspace_context:
+        external_repo = load_external_repo(workspace_context, "__repository__")
+        external_sensor = external_repo.get_external_sensor(
+            invalid_partition_backfill_request_sensor.name
+        )
+
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+
+        # allow creating a backfill with an invalid partition. it will get caught in the daemon
+        # and show up as an error there.
+        validate_tick(ticks[0], external_sensor, None, TickStatus.SUCCESS)

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_request.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_request.py
@@ -165,14 +165,12 @@ def test_backfill_request_sensor(instance: DagsterInstance, executor, sensor_nam
             AssetKeyPartitionKey(unpartitioned_child.key, None),
         }
 
-        # wait_for_all_runs_to_finish(instance)
-
         validate_tick(
             ticks[0],
             external_sensor,
             None,
             TickStatus.SUCCESS,
-            expected_backfill_ids=[backfill.backfill_id],
+            expected_backfill_id=backfill.backfill_id,
         )
 
 


### PR DESCRIPTION
## Summary & Motivation
Picks up https://github.com/dagster-io/dagster/pull/18895 to enable sensors to emit backfill requests.

One main difference between this PR and #18895 is that this PR only allows requesting a single NotABackfill in a tick. I'm open to allowing multiple NotABackfill requests! but it's unclear what the use case would be, so i went ahead with the single backfill for now. 

There are several places in the sensors UI that don't make sense when you launch a backfill. For example, if a tick launches a backfill, the row will say "0 runs requested".


## How I Tested These Changes
