### PR TITLE
stop rebuilding execution plan from snapshot in execute_run

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -103,7 +103,7 @@ def create_valid_pipeline_run(
             else None
         ),
         run_config=execution_params.run_config,
-        step_keys_to_execute=step_keys_to_execute,
+        step_keys_to_execute=external_execution_plan.execution_plan_snapshot.step_keys_to_execute,
         tags=tags,
         root_run_id=execution_params.execution_metadata.root_run_id,
         parent_run_id=execution_params.execution_metadata.parent_run_id,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_retry_execution.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_retry_execution.ambr
@@ -1,6 +1,0 @@
-# serializer version: 1
-# name: TestRetryExecution.test_pipeline_reexecution_info_query[0]
-  list([
-    'sum_sq_op',
-  ])
-# ---

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
@@ -404,7 +404,7 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
         )
         query_result_one = info_result_one.data["pipelineRunOrError"]
         assert query_result_one["__typename"] == "Run"
-        assert query_result_one["stepKeysToExecute"] is None
+        assert query_result_one["stepKeysToExecute"] == ["sum_op", "sum_sq_op"]  # full execution
 
         info_result_two = execute_dagster_graphql_and_finish_runs(
             context, PIPELINE_REEXECUTION_INFO_QUERY, variables={"runId": new_run_id}
@@ -412,8 +412,7 @@ class TestRetryExecution(ExecutingGraphQLContextTestMatrix):
         query_result_two = info_result_two.data["pipelineRunOrError"]
         assert query_result_two["__typename"] == "Run"
         stepKeysToExecute = query_result_two["stepKeysToExecute"]
-        assert stepKeysToExecute is not None
-        snapshot.assert_match(stepKeysToExecute)
+        assert stepKeysToExecute == ["sum_sq_op"]  # selected key
 
     def test_pipeline_reexecution_invalid_step_in_subset(
         self, graphql_context: WorkspaceRequestContext

--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -667,24 +667,12 @@ def _get_execution_plan_from_run(
         else None
     )
 
-    # Rebuild from snapshot if able and selection has not changed
-    if (
-        execution_plan_snapshot is not None
-        and execution_plan_snapshot.can_reconstruct_plan
-        and job.resolved_op_selection == dagster_run.resolved_op_selection
-        and job.asset_selection == dagster_run.asset_selection
-        and job.asset_check_selection == dagster_run.asset_check_selection
-    ):
-        return ExecutionPlan.rebuild_from_snapshot(
-            dagster_run.job_name,
-            execution_plan_snapshot,
-        )
-
     return create_execution_plan(
         job,
         run_config=dagster_run.run_config,
         step_keys_to_execute=dagster_run.step_keys_to_execute,
         instance_ref=instance.get_ref() if instance.is_persistent else None,
+        tags=dagster_run.tags,
         repository_load_data=(
             execution_plan_snapshot.repository_load_data if execution_plan_snapshot else None
         ),

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -824,24 +824,6 @@ def get_output_context(
     )
 
 
-def step_output_version(
-    job_def: "JobDefinition",
-    execution_plan: "ExecutionPlan",
-    resolved_run_config: "ResolvedRunConfig",
-    step_output_handle: "StepOutputHandle",
-) -> Optional[str]:
-    from dagster._core.execution.resolve_versions import resolve_step_output_versions
-
-    step_output_versions = resolve_step_output_versions(
-        job_def, execution_plan, resolved_run_config
-    )
-    return (
-        step_output_versions[step_output_handle]
-        if step_output_handle in step_output_versions
-        else None
-    )
-
-
 @deprecated_param(
     param="metadata",
     breaking_version="2.0",

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -56,7 +56,6 @@ from dagster._core.execution.plan.compute import execute_core_compute
 from dagster._core.execution.plan.inputs import StepInputData
 from dagster._core.execution.plan.objects import StepSuccessData, TypeCheckData
 from dagster._core.execution.plan.outputs import StepOutputData, StepOutputHandle
-from dagster._core.execution.resolve_versions import resolve_step_output_versions
 from dagster._core.storage.tags import BACKFILL_ID_TAG, MEMOIZED_RUN_TAG
 from dagster._core.types.dagster_type import DagsterType
 from dagster._utils import iterate_with_context
@@ -550,9 +549,7 @@ def _type_check_and_store_output(
         step_context.step_output_metadata_capture[step_output_handle] = output.metadata
 
     version = (
-        resolve_step_output_versions(
-            step_context.job_def, step_context.execution_plan, step_context.resolved_run_config
-        ).get(step_output_handle)
+        step_context.execution_plan.known_state.step_output_versions.get(step_output_handle)
         if MEMOIZED_RUN_TAG in step_context.job.get_definition().tags
         else None
     )

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -156,7 +156,7 @@ class _PlanBuilder:
         root_inputs: List[
             Union[StepInput, UnresolvedMappedStepInput, UnresolvedCollectStepInput]
         ] = []
-        # Recursively bjob_defd the execution plan starting at the root pipeline
+        # Recursively build the execution plan starting at the root pipeline
         for input_def in self.job_def.graph.input_defs:
             input_name = input_def.name
 
@@ -197,7 +197,6 @@ class _PlanBuilder:
         )
 
         executor_name = self.resolved_run_config.execution.execution_engine_name
-        step_output_versions = self.known_state.step_output_versions if self.known_state else []
 
         plan = ExecutionPlan(
             step_dict,
@@ -217,23 +216,28 @@ class _PlanBuilder:
             repository_load_data=self.repository_load_data,
         )
 
-        if self.step_keys_to_execute is not None:
+        if (
+            self.step_keys_to_execute is not None
+            # no need to subset if plan already matches request
+            and self.step_keys_to_execute != plan.step_keys_to_execute
+        ):
             plan = plan.build_subset_plan(
                 self.step_keys_to_execute, self.job_def, self.resolved_run_config
             )
 
-        # Expects that if step_keys_to_execute was set, that the `plan` variable will have the
-        # reflected step_keys_to_execute
-        if self.job_def.is_using_memoization(self._tags) and len(step_output_versions) == 0:
+        if (
+            self.job_def.is_using_memoization(self._tags)
+            # step_output_versions being filled out indicates if the memoization has already been calculated
+            and self.known_state.step_output_versions == {}
+        ):
             if self._instance_ref is None:
                 raise DagsterInvariantViolationError(
                     "Attempted to build memoized execution plan without providing a persistent "
                     "DagsterInstance to create_execution_plan."
                 )
             instance = DagsterInstance.from_ref(self._instance_ref)
-            plan = plan.build_memoized_plan(
-                self.job_def, self.resolved_run_config, instance, self.step_keys_to_execute
-            )
+
+            plan = plan.build_memoized_plan(self.job_def, self.resolved_run_config, instance)
 
         return plan
 
@@ -815,13 +819,21 @@ class ExecutionPlan(
             step_output_versions, "step_output_versions", key_type=StepOutputHandle, value_type=str
         )
 
-        step_handles_to_validate_set: Set[StepHandleUnion] = {
-            StepHandle.parse_from_key(key) for key in step_keys_to_execute
-        }
+        step_handles_to_validate: Sequence[StepHandleUnion] = []
+        step_handles_to_validate_set: Set[StepHandleUnion] = set()
+
+        # preserve order of step_keys_to_execute since we build the new step_keys_to_execute
+        # from iterating step_handles_to_validate
+        for key in step_keys_to_execute:
+            handle = StepHandle.parse_from_key(key)
+            if handle not in step_handles_to_validate_set:
+                step_handles_to_validate_set.add(handle)
+                step_handles_to_validate.append(handle)
+
         step_handles_to_execute: List[StepHandleUnion] = []
         bad_keys = []
 
-        for handle in step_handles_to_validate_set:
+        for handle in step_handles_to_validate:
             if handle not in self.step_dict:
                 # Ok if the entire dynamic step is selected to execute.
                 # https://github.com/dagster-io/dagster/issues/8000
@@ -864,13 +876,9 @@ class ExecutionPlan(
 
         # If step output versions were provided when constructing the subset plan, add them to the
         # known state.
+        known_state = self.known_state
         if len(step_output_versions) > 0:
-            if self.known_state:
-                known_state = self.known_state._replace(step_output_versions=step_output_versions)
-            else:
-                known_state = KnownExecutionState(step_output_versions=step_output_versions)  # type: ignore  # (possible none)
-        else:
-            known_state = self.known_state
+            known_state = self.known_state._replace(step_output_versions=step_output_versions)
 
         return ExecutionPlan(
             self.step_dict,
@@ -900,7 +908,6 @@ class ExecutionPlan(
         job_def: JobDefinition,
         resolved_run_config: ResolvedRunConfig,
         instance: DagsterInstance,
-        selected_step_keys: Optional[Sequence[str]],
     ) -> "ExecutionPlan":
         """Returns:
         ExecutionPlan: Execution plan that runs only unmemoized steps.
@@ -908,6 +915,11 @@ class ExecutionPlan(
         from ...storage.memoizable_io_manager import MemoizableIOManager
         from ..build_resources import build_resources, initialize_console_manager
         from ..resources_init import get_dependencies, resolve_resource_dependencies
+
+        check.invariant(
+            self.known_state.step_output_versions == {},
+            "Should not be building memoized plan twice.",
+        )
 
         # Memoization cannot be used with dynamic orchestration yet.
         # Tracking: https://github.com/dagster-io/dagster/issues/4451
@@ -979,11 +991,10 @@ class ExecutionPlan(
                 if not io_manager.has_output(context):
                     unmemoized_step_keys.add(step_output_handle.step_key)
 
-        if selected_step_keys is not None:
-            # Take the intersection unmemoized steps and selected steps
-            step_keys_to_execute = list(unmemoized_step_keys & set(selected_step_keys))
-        else:
-            step_keys_to_execute = list(unmemoized_step_keys)
+        step_keys_to_execute = [
+            key for key in self.step_keys_to_execute if key in unmemoized_step_keys
+        ]
+
         return self.build_subset_plan(
             step_keys_to_execute,
             job_def,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1169,12 +1169,8 @@ class DagsterInstance(DynamicPartitionsStore):
                 asset_selection=asset_selection,
                 op_selection=op_selection,
             )
-        step_keys_to_execute = None
 
-        if execution_plan:
-            step_keys_to_execute = execution_plan.step_keys_to_execute
-
-        else:
+        if not execution_plan:
             execution_plan = create_execution_plan(
                 job=job_def,
                 run_config=run_config,
@@ -1191,7 +1187,7 @@ class DagsterInstance(DynamicPartitionsStore):
             asset_selection=asset_selection,
             asset_check_selection=None,
             resolved_op_selection=resolved_op_selection,
-            step_keys_to_execute=step_keys_to_execute,
+            step_keys_to_execute=execution_plan.step_keys_to_execute,
             status=DagsterRunStatus(status) if status else None,
             tags=tags,
             root_run_id=root_run_id,


### PR DESCRIPTION
This was originally put here as part of a project to be able to execute runs from a host process which we ended up moving away from. The only real utilty this serves is keeping that capability excercised on a critical path. Unfortunately, this can be the source of a class of desync issues when the execution plan is created on version N and then the run starts on version N+1. We also always build the execution plan from scratch in execute_step, so this puts the run code path back in line with that.

The changes that were required to make this work mostly fall out of the rebuild_from_snapshot code path effectively acting as a way to pass through `step_keys_to_execute` so we now just store that resolved value on `DagsterRun` where previously we would record `None` to mean "execute everything". 

## How I Tested These Changes

existing coverage