### PR TITLE
Set `RunRequest.partition_key` when backfilling with policy with `max_partitions_per_run=1`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -421,7 +421,8 @@ def _build_run_request_for_partition_key_range(
         ASSET_PARTITION_RANGE_START_TAG: partition_range_start,
         ASSET_PARTITION_RANGE_END_TAG: partition_range_end,
     }
-    return RunRequest(asset_selection=asset_keys, tags=tags)
+    partition_key = partition_range_start if partition_range_start == partition_range_end else None
+    return RunRequest(asset_selection=asset_keys, partition_key=partition_key, tags=tags)
 
 
 def get_auto_observe_run_requests(


### PR DESCRIPTION
## Summary & Motivation

When backfills runs are launched using `BackfillPolicy(max_partitions_per_run=1)`, ensure that `RunRequest.partition_key` gets set. This makes these run requests _almost_ equivalent to runs launched with `BackfillPolicy=None`-- the difference is that `BackfillPolicy(max_partitions_per_run=1)` will _also_ set the range tags.

This allows us to do away with null backfill policies in the backfill machinery, instead defaulting to `BackfillPolicy(max_partitions_per_run=1)` (upstack).

## How I Tested These Changes

New unit test