### PR TITLE
chore: add `zoneinfo` dependency for `dagster-polars` tests

### DIFF
--- a/python_modules/libraries/dagster-polars/setup.py
+++ b/python_modules/libraries/dagster-polars/setup.py
@@ -47,7 +47,7 @@ setup(
         "gcp": ["dagster-gcp>=0.19.5"],
         "test": [
             "pytest>=7.3.1,<8.0.0",
-            "hypothesis>=6.89.0",
+            "hypothesis[zoneinfo]>=6.89.0",
             "deepdiff>=6.3.0",
             "pytest-cases>=3.6.14",
         ],


### PR DESCRIPTION
## Summary & Motivation
https://buildkite.com/dagster/dagster-dagster/builds/86076#019008a4-2d77-45ab-8366-db8de4760ec5

> ModuleNotFoundError: The zoneinfo module is required, but could not be imported.  Run `pip install hypothesis[zoneinfo]` and try again.

## How I Tested These Changes
bk