### PR TITLE
Add GTM to docs

### DIFF
--- a/docs/next/pages/_document.js
+++ b/docs/next/pages/_document.js
@@ -1,6 +1,6 @@
 import Document, {Head, Html, Main, NextScript} from 'next/document';
 
-import {GA_TRACKING_ID} from '../util/gtag';
+import {GA_TRACKING_ID, GTM_ID} from '../util/gtag';
 
 export default class MyDocument extends Document {
   render() {
@@ -17,9 +17,10 @@ export default class MyDocument extends Document {
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
+            gtag('config', ${GTM_ID}); // GTM
             gtag('config', '${GA_TRACKING_ID}', {
               page_path: window.location.pathname,
-            });
+            }); // GA
           `,
                 }}
               />

--- a/docs/next/util/gtag.js
+++ b/docs/next/util/gtag.js
@@ -1,4 +1,5 @@
 export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_DOCS_GA_ID;
+export const GTM_ID = process.env.NEXT_PUBLIC_DOCS_GTM_ID;
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
 export const pageview = (url) => {


### PR DESCRIPTION
## Summary & Motivation

Adding google tag manager to docs so that it can manage inserting things like Leadfeeder, Linkedin marketing tags, etc. only if the user has given consent for the specific types of cookies they use so that we can be GDPR compliant.
