### PR TITLE
Cache AssetsDefinition.asset_deps

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1320,6 +1320,10 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
             selected_asset_keys (AbstractSet[AssetKey]): The total set of asset keys
             selected_asset_check_keys (AbstractSet[AssetCheckKey]): The selected asset checks
         """
+        check.invariant(
+            self.can_subset or not self.is_executable,
+            f"Attempted to subset an executable AssetsDefinition for {self.node_def.name}, but can_subset=False.",
+        )
         subsetted_computation = check.not_none(self._computation).subset_for(
             selected_asset_keys, selected_asset_check_keys
         )


### PR DESCRIPTION
## Summary & Motivation

Cache `AssetsDefinition.asset_deps`. This gets called many times during `AssetGraph` construction for large multi-assets. Caching it results in 1-to-2 orders of magnitude perf improvement for loading `Definitions` with many assets.

I considered caching other properties relying on a comprehension over asset keys as insurance against similar perf issues in the future, but chose to make this PR as conservative as possible (caching the other properties I tested resulted in no additional perf improvements for the test specified below).

## How I Tested These Changes

`auto_materialize_perf_tests` in internal prepare a large number of assets. The "collection" phase of running pytest on this alone takes a long time. I identified `AssetsDefinition.asset_deps` by speed-scoping `pytest dagster-cloud/integration_tests/test_suites/auto_materialize_perf_tests/test_asset_daemon_perf.py`.

- Before this PR: 149.21s
- After this PR: 3.90s

That's a ~40x speedup.