### PR TITLE
Refetch indexeddb cached query immediately

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
@@ -68,6 +68,7 @@ export function useIndexedDBCachedQuery<TQuery, TVariables extends OperationVari
   const [loading, setLoading] = React.useState(true);
 
   const getData = useGetData();
+  const getCachedData = useGetCachedData();
 
   const fetch = useCallback(
     async (bypassCache = false) => {
@@ -87,7 +88,16 @@ export function useIndexedDBCachedQuery<TQuery, TVariables extends OperationVari
   );
 
   React.useEffect(() => {
-    fetch();
+    getCachedData<TQuery>({key, version}).then((data) => {
+      if (data) {
+        setData(data);
+        setLoading(false);
+      }
+    });
+  }, [key, version, getCachedData]);
+
+  React.useEffect(() => {
+    fetch(true);
   }, [fetch]);
 
   return {


### PR DESCRIPTION
## Summary & Motivation

Recent changes to this file regressed the immediate fetch from the server in favor of only fetching from cache. This PR adds back the fetching from the server behavior to update the cache.

## How I Tested These Changes

App proxy, see requests fire in the network panel:

<img width="682" alt="Screenshot 2024-06-12 at 7 51 09 PM" src="https://github.com/dagster-io/dagster/assets/2286579/f1301542-e542-4cd8-96cd-262776671e65">


