### PR TITLE
AssetsDefinition.map_asset_specs

### DIFF
--- a/examples/experimental/dagster-blueprints/dagster_blueprints/load_from_yaml.py
+++ b/examples/experimental/dagster-blueprints/dagster_blueprints/load_from_yaml.py
@@ -69,16 +69,8 @@ def _attach_code_references_to_definitions(
             }
 
         new_assets_defs.append(
-            AssetsDefinition.dagster_internal_init(
-                **{
-                    **assets_def.get_attributes_dict(),
-                    **{
-                        "specs": [
-                            spec._replace(metadata=new_metadata_by_key[spec.key])
-                            for spec in assets_def.specs
-                        ]
-                    },
-                }
+            assets_def.map_asset_specs(
+                lambda spec: spec._replace(metadata=new_metadata_by_key[spec.key])
             )
         )
     return defs._replace(assets=new_assets_defs)

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -6,6 +6,7 @@ from typing import (
     TYPE_CHECKING,
     AbstractSet,
     Any,
+    Callable,
     Dict,
     Iterable,
     Iterator,
@@ -1303,6 +1304,30 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
 
         merged_attrs = merge_dicts(self.get_attributes_dict(), replaced_attributes)
         return self.__class__.dagster_internal_init(**merged_attrs)
+
+    def map_asset_specs(self, fn: Callable[[AssetSpec], AssetSpec]) -> "AssetsDefinition":
+        mapped_specs = []
+        for spec in self.specs:
+            mapped_spec = fn(spec)
+            if mapped_spec.key != spec.key:
+                raise DagsterInvalidDefinitionError(
+                    f"Asset key {spec.key.to_user_string()} was changed to "
+                    f"{mapped_spec.key.to_user_string()}. Mapping function must not change keys."
+                )
+            if (
+                # check reference equality first for performance
+                mapped_spec.deps is not spec.deps and mapped_spec.deps != spec.deps
+            ):
+                raise DagsterInvalidDefinitionError(
+                    f"Asset deps {spec.deps} were changed to {mapped_spec.deps}. Mapping function "
+                    "must not change deps."
+                )
+
+            mapped_specs.append(mapped_spec)
+
+        return self.__class__.dagster_internal_init(
+            **{**self.get_attributes_dict(), "specs": mapped_specs}
+        )
 
     def _subset_graph_backed_asset(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -130,15 +130,8 @@ def _with_code_source_single_definition(
                 ),
             }
 
-    return AssetsDefinition.dagster_internal_init(
-        **{
-            **assets_def.get_attributes_dict(),
-            **{
-                "specs": [
-                    spec._replace(metadata=metadata_by_key[spec.key]) for spec in assets_def.specs
-                ]
-            },
-        }
+    return assets_def.map_asset_specs(
+        lambda spec: spec._replace(metadata=metadata_by_key[spec.key])
     )
 
 
@@ -197,15 +190,8 @@ def _convert_local_path_to_source_control_path_single_definition(
             ),
         }
 
-    return AssetsDefinition.dagster_internal_init(
-        **{
-            **assets_def.get_attributes_dict(),
-            **{
-                "specs": [
-                    spec._replace(metadata=metadata_by_key[spec.key]) for spec in assets_def.specs
-                ]
-            },
-        }
+    return assets_def.map_asset_specs(
+        lambda spec: spec._replace(metadata=metadata_by_key[spec.key])
     )
 
 


### PR DESCRIPTION
## Summary & Motivation

Adds a utility that makes it easier to replace asset-level attributes on `AssetsDefinition`s.

## How I Tested These Changes
