### PR TITLE
[pre-commit] Only run pyright in pre-push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+default_stages: [pre-commit] # don't run on push by default
 repos:
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: v0.4.5


### PR DESCRIPTION
Internal companion PR: https://github.com/dagster-io/internal/pull/10219

## Summary & Motivation

Currently pre-commit will run all of our defined hooks pre-push. There is no point re-running hooks that also run pre-commit. This PR makes it so that only the pyright hook runs pre-push.

## How I Tested These Changes

Pushed and observed executed hooks