### PR TITLE
[1.8.0][config] change who gets mypy errors from pydantic 2 to pydantic 1 users

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -8,11 +8,11 @@ from dagster._core.errors import DagsterInvalidDagsterTypeInPythonicConfigDefini
 from .type_check_utils import safe_is_subclass
 
 try:
-    # Pydantic 2.x
-    from pydantic.main import ModelMetaclass
-except ImportError:
     # Pydantic 1.x
     from pydantic._internal._model_construction import ModelMetaclass  # type: ignore
+except ImportError:
+    # Pydantic 2.x
+    from pydantic.main import ModelMetaclass
 
 if TYPE_CHECKING:
     from dagster._config.pythonic_config import PartialResource

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -10,7 +10,7 @@ setenv =
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE* DAGSTER_DOCKER_* GRPC_SERVER_HOST
 install_command =
   ; pyright/mypy invocations type_signature_tests in need commpat mode installs to find types correctly
-  type_signature_tests: python -m pip install {opts} {packages} --config-settings editable_mode=compat
+  type_signature_tests: uv pip install {opts} {packages} --config-settings editable_mode=compat
   !type_signature_tests: uv pip install {opts} {packages}
 
 deps =
@@ -27,7 +27,7 @@ deps =
   core_tests_pydantic2:  pydantic>=2.0.0
   model_tests_pydantic1:  pydantic!=1.10.7,<2.0.0
   model_tests_pydantic2:  pydantic>=2.0.0
-  type_signature_tests:  pydantic!=1.10.7,<2.0.0
+  type_signature_tests:  pydantic>=2.0.0
   -e ../dagster-test
   -e .[mypy,test,pyright]
   -e ../dagster-pipes


### PR DESCRIPTION
context https://github.com/dagster-io/dagster/issues/17443, specifically

> Unless someone is able to find a clever solution it appears the only choice is to flip who gets the errors at some point.

looking at [pypi download stats](https://www.pepy.tech/projects/pydantic?versions=2.*&versions=1.*) pydantic 2 downloads are ballpark 30% more than pydantic 1

so opening this PR to discuss if now / `1.8.0` is the time


## How I Tested These Changes

run `mypy` on
```
from dagster import Config


class MyConfig(Config): ...
```

pydantic 2: no error
pydantic 1: `error: Metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases  [misc]`
