### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/content/concepts/assets/asset-jobs.mdx
+++ b/docs/content/concepts/assets/asset-jobs.mdx
@@ -12,7 +12,7 @@ description: Asset jobs are the main unit for materializing and monitoring asset
   <a href="/concepts/ops-jobs-graphs/op-jobs">Op jobs</a> documentation.
 </Note>
 
-[Jobs](/concepts/ops-jobs-graphs/jobs) are the main unit for executing and monitoring [asset definitions](/concepts/assets/software-defined-assets) in Dagster. An asset job is a type of \[job]\(/concepts/ops-jobs-graphs/jobs] that targets a selection of assets and can be launched:
+[Jobs](/concepts/ops-jobs-graphs/jobs) are the main unit for executing and monitoring [asset definitions](/concepts/assets/software-defined-assets) in Dagster. An asset job is a type of [job](/concepts/ops-jobs-graphs/jobs) that targets a selection of assets and can be launched:
 
 - Manually from the Dagster UI
 - At fixed intervals, by [schedules](/concepts/automation/schedules)


### PR DESCRIPTION
## Summary & Motivation
Just fix a boken link in a doc page
## How I Tested These Changes
the preview now shoes the link