### PR TITLE
[Workspace] Stop showing spinner when code locations are no longer loading

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
@@ -61,6 +61,15 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
         icon: 'check_circle',
       });
     }
+
+    const anyLoading = Object.values(data).some(
+      (entry) =>
+        entry.__typename === 'WorkspaceLocationEntry' &&
+        entry.loadStatus === RepositoryLocationLoadStatus.LOADING,
+    );
+    if (!anyLoading) {
+      setShowSpinner(false);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data, onClickViewButton]);
 


### PR DESCRIPTION
## Summary & Motivation

Now that useCodeLocationsStatus isn't in charge of the actual refetch it needs to manually check if any code location is not loading in order to stop showing the spinner

## How I Tested These Changes
Update a code location and make sure the spinner next to the deployment tab stops showing when its done
