### PR TITLE
[ui] show applyLimitPerUniqueValue entries in queue criteria

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunCriteriaDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunCriteriaDialog.tsx
@@ -11,6 +11,7 @@ import {
   Tag,
   Tooltip,
 } from '@dagster-io/ui-components';
+import isPlainObject from 'lodash/isPlainObject';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
 import * as yaml from 'yaml';
@@ -66,7 +67,10 @@ const QueuedRunCriteriaDialogContent = ({run}: {run: RunTableRunFragment}) => {
       return limits.filter(
         (limit) =>
           limit.key in runTagMap &&
-          (limit.value === undefined || limit.value === runTagMap[limit.key]),
+          (limit.value === undefined ||
+            limit.value === runTagMap[limit.key] ||
+            // can be {"applyLimitPerUniqueValue": bool}
+            isPlainObject(limit.value)),
       );
     } catch (err) {
       return undefined;
@@ -119,7 +123,9 @@ const QueuedRunCriteriaDialogContent = ({run}: {run: RunTableRunFragment}) => {
                         </td>
                         <td>
                           <Tag interactive>
-                            {limit.value !== undefined ? `${limit.key}=${limit.value}` : limit.key}
+                            {limit.value !== undefined
+                              ? `${limit.key}=${JSON.stringify(limit.value)}` // might be obj so stringify
+                              : limit.key}
                           </Tag>
                         </td>
                       </tr>


### PR DESCRIPTION
## How I Tested These Changes
get runs queued against `applyLimitPerUniqueValue` rule, previously not displayed now:
![Screenshot 2024-06-13 at 2 46 09 PM](https://github.com/dagster-io/dagster/assets/202219/045add6e-be48-401b-9629-5b4f3b01700f)
