### PR TITLE
[DbtProject] Mark `preparer` as experimental param

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Optional, Sequence, Union
 
 import yaml
-from dagster._annotations import experimental, public
+from dagster._annotations import experimental, experimental_param, public
 from dagster._model import IHaveNew, dagster_model_custom
 from dagster._utils import run_with_concurrent_update_guard
 
@@ -103,6 +103,7 @@ class DagsterDbtManifestPreparer(DbtManifestPreparer):
 
 
 @experimental
+@experimental_param(param="preparer")
 @dagster_model_custom
 class DbtProject(IHaveNew):
     """Representation of a dbt project and related settings that assist with managing the project preparation.


### PR DESCRIPTION
## Summary & Motivation

This PR marks the preparer attribute of DbtProject as experimental. 

This is in anticipation of removing the experimental tag for DbtProject. Since we'll keep DagsterDbtManifestPreparer and DbtManifestPreparer as experimental, we want the attribute corresponding to theses classes in DbtProject to be experimental as well.

## How I Tested These Changes
N/A