### PR TITLE
Refactor asset backfill retry behavior to cover more classes of failures

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -14,7 +14,7 @@ from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.execution.asset_backfill import (
-    AssetBackfillIterationResult,
+    AssetBackfillData,
     execute_asset_backfill_iteration,
     execute_asset_backfill_iteration_inner,
 )
@@ -241,14 +241,13 @@ def _execute_asset_backfill_iteration_no_side_effects(
         ):
             pass
 
-    if not isinstance(result, AssetBackfillIterationResult):
+    if not isinstance(result, AssetBackfillData):
         check.failed(
-            "Expected execute_asset_backfill_iteration_inner to return an"
-            " AssetBackfillIterationResult"
+            "Expected execute_asset_backfill_iteration_inner to return an" " AssetBackfillData"
         )
 
     updated_backfill = backfill.with_asset_backfill_data(
-        cast(AssetBackfillIterationResult, result).backfill_data,
+        cast(AssetBackfillData, result),
         dynamic_partitions_store=graphql_context.instance,
         asset_graph=asset_graph,
     )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -14,7 +14,7 @@ from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.execution.asset_backfill import (
-    AssetBackfillData,
+    AssetBackfillIterationResult,
     execute_asset_backfill_iteration,
     execute_asset_backfill_iteration_inner,
 )
@@ -235,19 +235,19 @@ def _execute_asset_backfill_iteration_no_side_effects(
                 graphql_context.instance, asset_graph, asset_backfill_data.backfill_start_datetime
             ),
             asset_graph=asset_graph,
-            run_tags=backfill.tags,
             backfill_start_timestamp=asset_backfill_data.backfill_start_timestamp,
             logger=logging.getLogger("fake_logger"),
         ):
             pass
 
-    if not isinstance(result, AssetBackfillData):
+    if not isinstance(result, AssetBackfillIterationResult):
         check.failed(
-            "Expected execute_asset_backfill_iteration_inner to return an" " AssetBackfillData"
+            "Expected execute_asset_backfill_iteration_inner to return an"
+            " AssetBackfillIterationResult"
         )
 
     updated_backfill = backfill.with_asset_backfill_data(
-        cast(AssetBackfillData, result),
+        cast(AssetBackfillIterationResult, result).backfill_data,
         dynamic_partitions_store=graphql_context.instance,
         asset_graph=asset_graph,
     )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import time
-from typing import List, Optional, Tuple, Union, cast
+from typing import List, Optional, Tuple, Union
 
 from dagster import (
     AssetKey,
@@ -227,13 +227,14 @@ def _execute_asset_backfill_iteration_no_side_effects(
     backfill = graphql_context.instance.get_backfill(backfill_id)
     asset_backfill_data = backfill.asset_backfill_data
     result = None
+    instance_queryer = CachingInstanceQueryer(
+        graphql_context.instance, asset_graph, asset_backfill_data.backfill_start_datetime
+    )
     with environ({"ASSET_BACKFILL_CURSOR_DELAY_TIME": "0"}):
         for result in execute_asset_backfill_iteration_inner(
             backfill_id=backfill_id,
             asset_backfill_data=asset_backfill_data,
-            instance_queryer=CachingInstanceQueryer(
-                graphql_context.instance, asset_graph, asset_backfill_data.backfill_start_datetime
-            ),
+            instance_queryer=instance_queryer,
             asset_graph=asset_graph,
             backfill_start_timestamp=asset_backfill_data.backfill_start_timestamp,
             logger=logging.getLogger("fake_logger"),
@@ -247,7 +248,9 @@ def _execute_asset_backfill_iteration_no_side_effects(
         )
 
     updated_backfill = backfill.with_asset_backfill_data(
-        cast(AssetBackfillIterationResult, result).backfill_data,
+        result.backfill_data.with_run_requests_submitted(
+            result.run_requests, asset_graph=asset_graph, instance_queryer=instance_queryer
+        ),
         dynamic_partitions_store=graphql_context.instance,
         asset_graph=asset_graph,
     )

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -279,7 +279,6 @@ def build_run_requests(
 def build_run_requests_with_backfill_policies(
     asset_partitions: Iterable[AssetKeyPartitionKey],
     asset_graph: BaseAssetGraph,
-    run_tags: Optional[Mapping[str, str]],
     dynamic_partitions_store: DynamicPartitionsStore,
 ) -> Sequence[RunRequest]:
     """If all assets have backfill policies, we should respect them and materialize them according
@@ -312,14 +311,13 @@ def build_run_requests_with_backfill_policies(
         partition_keys,
         backfill_policy,
     ), asset_keys in assets_to_reconcile_by_partitions_def_partition_keys_backfill_policy.items():
-        tags = {**(run_tags or {})}
         if partitions_def is None and partition_keys is not None:
             check.failed("Partition key provided for unpartitioned asset")
         if partitions_def is not None and partition_keys is None:
             check.failed("Partition key missing for partitioned asset")
         if partitions_def is None and partition_keys is None:
             # non partitioned assets will be backfilled in a single run
-            run_requests.append(RunRequest(asset_selection=list(asset_keys), tags=tags))
+            run_requests.append(RunRequest(asset_selection=list(asset_keys), tags={}))
         else:
             run_requests.extend(
                 _build_run_requests_with_backfill_policy(
@@ -327,7 +325,7 @@ def build_run_requests_with_backfill_policies(
                     check.not_none(backfill_policy),
                     check.not_none(partition_keys),
                     check.not_none(partitions_def),
-                    tags,
+                    tags={},
                     dynamic_partitions_store=dynamic_partitions_store,
                 )
             )

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -31,6 +31,7 @@ class BulkActionStatus(Enum):
     FAILED = "FAILED"
     CANCELING = "CANCELING"
     CANCELED = "CANCELED"
+    #    RETRYING = "RETRYING"
 
     @staticmethod
     def from_graphql_input(graphql_str):
@@ -59,6 +60,7 @@ class PartitionBackfill(
             # only used by asset backfills
             ("serialized_asset_backfill_data", Optional[str]),
             ("asset_backfill_data", Optional[AssetBackfillData]),
+            ("failure_count", int),
         ],
     ),
 ):
@@ -79,6 +81,7 @@ class PartitionBackfill(
         reexecution_steps: Optional[Sequence[str]] = None,
         serialized_asset_backfill_data: Optional[str] = None,
         asset_backfill_data: Optional[AssetBackfillData] = None,
+        failure_count: Optional[int] = None,
     ):
         check.invariant(
             not (asset_selection and reexecution_steps),
@@ -122,6 +125,8 @@ class PartitionBackfill(
             asset_backfill_data=check.opt_inst_param(
                 asset_backfill_data, "asset_backfill_data", AssetBackfillData
             ),
+            # TODO MOVE THE RUN REQUESTS AND RUN IDS HERE RATHER THAN ASSET BACKFILL DATA
+            failure_count=check.opt_int_param(failure_count, "failure_count", 0),
         )
 
     @property
@@ -335,6 +340,9 @@ class PartitionBackfill(
             title=self.title,
             description=self.description,
         )
+
+    def with_failure_count(self, new_failure_count: int):
+        return self._replace(failure_count=new_failure_count)
 
     def with_error(self, error):
         check.opt_inst_param(error, "error", SerializableErrorInfo)

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -61,7 +61,7 @@ class PartitionBackfill(
             ("serialized_asset_backfill_data", Optional[str]),
             ("asset_backfill_data", Optional[AssetBackfillData]),
             ("failure_count", int),
-            ("in_progress_run_requests", Sequence[RunRequest]),
+            ("submitting_run_requests", Sequence[RunRequest]),
             ("reserved_run_ids", Sequence[str]),
         ],
     ),
@@ -84,7 +84,7 @@ class PartitionBackfill(
         serialized_asset_backfill_data: Optional[str] = None,
         asset_backfill_data: Optional[AssetBackfillData] = None,
         failure_count: Optional[int] = None,
-        in_progress_run_requests: Optional[Sequence[RunRequest]] = None,
+        submitting_run_requests: Optional[Sequence[RunRequest]] = None,
         reserved_run_ids: Optional[Sequence[str]] = None,
     ):
         check.invariant(
@@ -130,8 +130,8 @@ class PartitionBackfill(
                 asset_backfill_data, "asset_backfill_data", AssetBackfillData
             ),
             failure_count=check.opt_int_param(failure_count, "failure_count", 0),
-            in_progress_run_requests=check.opt_sequence_param(
-                in_progress_run_requests, "in_progress_run_requests", of_type=RunRequest
+            submitting_run_requests=check.opt_sequence_param(
+                submitting_run_requests, "submitting_run_requests", of_type=RunRequest
             ),
             reserved_run_ids=check.opt_sequence_param(
                 reserved_run_ids, "reserved_run_ids", of_type=str
@@ -318,11 +318,11 @@ class PartitionBackfill(
         check.str_param(last_submitted_partition_name, "last_submitted_partition_name")
         return self._replace(last_submitted_partition_name=last_submitted_partition_name)
 
-    def with_in_progress_run_requests(
-        self, in_progress_run_requests: Sequence[RunRequest], reserved_run_ids: Sequence[str]
+    def with_submitting_run_requests(
+        self, submitting_run_requests: Sequence[RunRequest], reserved_run_ids: Sequence[str]
     ) -> "PartitionBackfill":
         return self._replace(
-            in_progress_run_requests=in_progress_run_requests,
+            submitting_run_requests=submitting_run_requests,
             reserved_run_ids=reserved_run_ids,
         )
 

--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -1,7 +1,18 @@
 import logging
 import sys
 import time
-from typing import AbstractSet, Dict, Iterator, List, NamedTuple, Optional, Sequence, Tuple, cast
+from typing import (
+    AbstractSet,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    cast,
+)
 
 import dagster._check as check
 from dagster._core.definitions.asset_job import is_base_asset_job_name
@@ -304,6 +315,7 @@ def submit_asset_runs_in_chunks(
     asset_graph: RemoteAssetGraph,
     debug_crash_flags: SingleInstigatorDebugCrashFlags,
     logger: logging.Logger,
+    run_tags: Mapping[str, str],
 ) -> Iterator[Optional[SubmitRunRequestChunkResult]]:
     """Submits runs for a sequence of run requests that target asset selections in chunks. Yields
     None after each run is submitted to allow the daemon to heartbeat, and yields a list of tuples
@@ -324,7 +336,12 @@ def submit_asset_runs_in_chunks(
             run_id = reserved_run_ids[run_request_idx] if reserved_run_ids else None
             submitted_run = submit_asset_run(
                 run_id,
-                run_request,
+                run_request._replace(
+                    tags={
+                        **run_request.tags,
+                        **run_tags,
+                    }
+                ),
                 run_request_idx,
                 instance,
                 workspace_process_context,

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -132,11 +132,7 @@ def execute_backfill_jobs(
                                 logger=backfill_logger,
                                 log_message=f"Backfill failed for {backfill.backfill_id} due to unreachable code server and will retry",
                             )
-                            instance.update_backfill(
-                                backfill.with_status(BulkActionStatus.REQUESTED).with_error(
-                                    error_info
-                                )
-                            )
+                            instance.update_backfill(backfill.with_error(error_info))
                     else:
                         error_info = DaemonErrorCapture.on_exception(
                             sys.exc_info(),
@@ -144,9 +140,9 @@ def execute_backfill_jobs(
                             log_message=f"Backfill failed for {backfill.backfill_id} and will retry.",
                         )
                         instance.update_backfill(
-                            backfill.with_status(BulkActionStatus.REQUESTED)
-                            .with_error(error_info)
-                            .with_failure_count(backfill.failure_count + 1)
+                            backfill.with_error(error_info).with_failure_count(
+                                backfill.failure_count + 1
+                            )
                         )
                 else:
                     error_info = DaemonErrorCapture.on_exception(

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill_with_backfill_policies.py
@@ -123,13 +123,11 @@ def test_asset_backfill_parent_and_children_have_different_backfill_policy():
         asset_graph=asset_graph,
         instance=DagsterInstance.ephemeral(),
     )
-    assert result1 != backfill_data
-    assert len(result1.in_progress_run_requests) == 1
+    assert result1.backfill_data != backfill_data
+    assert len(result1.run_requests) == 1
     # The first iteration of backfill should only create run request for the upstream asset since
     # the downstream does not have same backfill policy as the upstream.
-    assert result1.in_progress_run_requests[0].asset_selection == [
-        upstream_daily_partitioned_asset.key
-    ]
+    assert result1.run_requests[0].asset_selection == [upstream_daily_partitioned_asset.key]
 
 
 def test_asset_backfill_parent_and_children_have_same_backfill_policy():
@@ -176,10 +174,10 @@ def test_asset_backfill_parent_and_children_have_same_backfill_policy():
         asset_graph=asset_graph,
         instance=DagsterInstance.ephemeral(),
     )
-    assert result != backfill_data
-    assert len(result.in_progress_run_requests) == 2
+    assert result.backfill_data != backfill_data
+    assert len(result.run_requests) == 2
 
-    for run_request in result.in_progress_run_requests:
+    for run_request in result.run_requests:
         if run_request.tags.__contains__(ASSET_PARTITION_RANGE_START_TAG):
             # single run request for partitioned asset, both parent and the children somce they share same
             # partitions def and backfill policy
@@ -249,10 +247,10 @@ def test_asset_backfill_parent_and_children_have_same_backfill_policy_but_third_
         asset_graph=asset_graph,
         instance=DagsterInstance.ephemeral(),
     )
-    assert result != backfill_data
-    assert len(result.in_progress_run_requests) == 2
+    assert result.backfill_data != backfill_data
+    assert len(result.run_requests) == 2
 
-    for run_request in result.in_progress_run_requests:
+    for run_request in result.run_requests:
         if upstream_daily_partitioned_asset.key in run_request.asset_selection:
             assert downstream_daily_partitioned_asset.key in run_request.asset_selection
             assert has_different_backfill_policy.key not in run_request.asset_selection
@@ -287,10 +285,10 @@ def test_asset_backfill_return_single_run_request_for_non_partitioned():
         asset_graph=asset_graph,
         instance=DagsterInstance.ephemeral(),
     )
-    assert result != backfill_data
-    assert len(result.in_progress_run_requests) == 1
-    assert result.in_progress_run_requests[0].partition_key is None
-    assert result.in_progress_run_requests[0].tags == {"dagster/backfill": backfill_id}
+    assert result.backfill_data != backfill_data
+    assert len(result.run_requests) == 1
+    assert result.run_requests[0].partition_key is None
+    assert result.run_requests[0].tags == {}
 
 
 def test_asset_backfill_return_single_run_request_for_partitioned():
@@ -325,14 +323,12 @@ def test_asset_backfill_return_single_run_request_for_partitioned():
         asset_graph=asset_graph,
         instance=DagsterInstance.ephemeral(),
     )
-    assert result != backfill_data
-    assert len(result.in_progress_run_requests) == 1
-    assert result.in_progress_run_requests[0].partition_key is None
+    assert result.backfill_data != backfill_data
+    assert len(result.run_requests) == 1
+    assert result.run_requests[0].partition_key is None
+    assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "2023-01-01"
     assert (
-        result.in_progress_run_requests[0].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "2023-01-01"
-    )
-    assert (
-        result.in_progress_run_requests[0].tags.get(ASSET_PARTITION_RANGE_END_TAG)
+        result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_END_TAG)
         == daily_partitions_def.get_partition_keys(time_now)[-1]
     )
 
@@ -372,14 +368,12 @@ def test_asset_backfill_return_multiple_run_request_for_partitioned():
         asset_graph=asset_graph,
         instance=DagsterInstance.ephemeral(),
     )
-    assert result != backfill_data
-    assert len(result.in_progress_run_requests) == math.ceil(num_of_daily_partitions / 7)
-    assert result.in_progress_run_requests[0].partition_key is None
+    assert result.backfill_data != backfill_data
+    assert len(result.run_requests) == math.ceil(num_of_daily_partitions / 7)
+    assert result.run_requests[0].partition_key is None
+    assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "2023-01-01"
     assert (
-        result.in_progress_run_requests[0].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "2023-01-01"
-    )
-    assert (
-        result.in_progress_run_requests[-1].tags.get(ASSET_PARTITION_RANGE_END_TAG)
+        result.run_requests[-1].tags.get(ASSET_PARTITION_RANGE_END_TAG)
         == daily_partitions_def.get_partition_keys(time_now)[-1]
     )
 
@@ -597,17 +591,17 @@ def test_dynamic_partitions_multi_run_backfill_policy():
         asset_graph=asset_graph,
         instance=instance,
     )
-    assert result != backfill_data
-    assert len(result.in_progress_run_requests) == 2
+    assert result.backfill_data != backfill_data
+    assert len(result.run_requests) == 2
     assert any(
         run_request.tags.get(ASSET_PARTITION_RANGE_START_TAG) == "foo"
         and run_request.tags.get(ASSET_PARTITION_RANGE_END_TAG) == "foo"
-        for run_request in result.in_progress_run_requests
+        for run_request in result.run_requests
     )
     assert any(
         run_request.tags.get(ASSET_PARTITION_RANGE_START_TAG) == "bar"
         and run_request.tags.get(ASSET_PARTITION_RANGE_END_TAG) == "bar"
-        for run_request in result.in_progress_run_requests
+        for run_request in result.run_requests
     )
 
 
@@ -639,10 +633,10 @@ def test_dynamic_partitions_single_run_backfill_policy():
         asset_graph=asset_graph,
         instance=instance,
     )
-    assert result != backfill_data
-    assert len(result.in_progress_run_requests) == 1
-    assert result.in_progress_run_requests[0].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "foo"
-    assert result.in_progress_run_requests[0].tags.get(ASSET_PARTITION_RANGE_END_TAG) == "bar"
+    assert result.backfill_data != backfill_data
+    assert len(result.run_requests) == 1
+    assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "foo"
+    assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_END_TAG) == "bar"
 
 
 @pytest.mark.parametrize("same_partitions", [True, False])
@@ -702,22 +696,15 @@ def test_assets_backfill_with_partition_mapping(same_partitions):
             asset_graph=asset_graph,
             instance=instance,
         )
-    assert len(result.in_progress_run_requests) == 1
+    assert len(result.run_requests) == 1
 
     if same_partitions:
-        assert set(result.in_progress_run_requests[0].asset_selection) == {
-            upstream_a.key,
-            downstream_b.key,
-        }
+        assert set(result.run_requests[0].asset_selection) == {upstream_a.key, downstream_b.key}
     else:
-        assert set(result.in_progress_run_requests[0].asset_selection) == {upstream_a.key}
+        assert set(result.run_requests[0].asset_selection) == {upstream_a.key}
 
-    assert (
-        result.in_progress_run_requests[0].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "2023-03-01"
-    )
-    assert (
-        result.in_progress_run_requests[0].tags.get(ASSET_PARTITION_RANGE_END_TAG) == "2023-03-03"
-    )
+    assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "2023-03-01"
+    assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_END_TAG) == "2023-03-03"
 
 
 @pytest.mark.parametrize("same_partitions", [True, False])
@@ -846,9 +833,9 @@ def test_assets_backfill_with_partition_mapping_without_backfill_policy():
         asset_graph=asset_graph,
         instance=instance,
     )
-    assert len(result.in_progress_run_requests) == 2
+    assert len(result.run_requests) == 2
 
-    for run_request in result.in_progress_run_requests:
+    for run_request in result.run_requests:
         # b should not be materialized in the same run as a
         if run_request.partition_key == "2023-03-02":
             assert set(run_request.asset_selection) == {upstream_a.key}
@@ -909,7 +896,7 @@ def test_assets_backfill_with_partition_mapping_with_one_partition_multi_run_bac
         asset_graph=asset_graph,
         instance=instance,
     )
-    assert len(result.in_progress_run_requests) == 2
+    assert len(result.run_requests) == 2
 
 
 def test_assets_backfill_with_partition_mapping_with_multi_partitions_multi_run_backfill_policy():
@@ -968,9 +955,9 @@ def test_assets_backfill_with_partition_mapping_with_multi_partitions_multi_run_
         asset_graph=asset_graph,
         instance=instance,
     )
-    assert len(result.in_progress_run_requests) == 4
+    assert len(result.run_requests) == 4
 
-    for run_request in result.in_progress_run_requests:
+    for run_request in result.run_requests:
         # there is no parallel runs for downstream_b before upstream_a's targeted partitions are materialized
         assert set(run_request.asset_selection) == {upstream_a.key}
 
@@ -1033,17 +1020,10 @@ def test_assets_backfill_with_partition_mapping_with_single_run_backfill_policy(
             instance=instance,
         )
 
-    assert len(result.in_progress_run_requests) == 1
-    assert set(result.in_progress_run_requests[0].asset_selection) == {
-        upstream_a.key,
-        downstream_b.key,
-    }
-    assert (
-        result.in_progress_run_requests[0].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "2023-03-02"
-    )
-    assert (
-        result.in_progress_run_requests[0].tags.get(ASSET_PARTITION_RANGE_END_TAG) == "2023-03-09"
-    )
+    assert len(result.run_requests) == 1
+    assert set(result.run_requests[0].asset_selection) == {upstream_a.key, downstream_b.key}
+    assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_START_TAG) == "2023-03-02"
+    assert result.run_requests[0].tags.get(ASSET_PARTITION_RANGE_END_TAG) == "2023-03-09"
 
 
 def test_run_request_partition_order():
@@ -1085,7 +1065,7 @@ def test_run_request_partition_order():
         "apple", asset_backfill_data, asset_graph, DagsterInstance.ephemeral()
     )
 
-    assert [run_request.partition_key_range for run_request in result.in_progress_run_requests] == [
+    assert [run_request.partition_key_range for run_request in result.run_requests] == [
         PartitionKeyRange("2023-10-01", "2023-10-02"),
         PartitionKeyRange("2023-10-03", "2023-10-04"),
         PartitionKeyRange("2023-10-05", "2023-10-06"),
@@ -1118,12 +1098,12 @@ def test_max_partitions_per_range_1_sets_run_request_partition_key():
         "apple", asset_backfill_data, asset_graph, DagsterInstance.ephemeral()
     )
 
-    assert [run_request.partition_key for run_request in result.in_progress_run_requests] == [
+    assert [run_request.partition_key for run_request in result.run_requests] == [
         "2023-10-05",
         "2023-10-06",
     ]
 
-    assert [run_request.partition_key_range for run_request in result.in_progress_run_requests] == [
+    assert [run_request.partition_key_range for run_request in result.run_requests] == [
         PartitionKeyRange("2023-10-05", "2023-10-05"),
         PartitionKeyRange("2023-10-06", "2023-10-06"),
     ]

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -1581,7 +1581,7 @@ def test_asset_backfill_first_iteration_code_location_unreachable_error_some_run
     assert updated_backfill.asset_backfill_data
 
     # backfill has the updated data that it will have once the runs finish submitting
-    assert len(updated_backfill.asset_backfill_data.in_progress_run_requests or []) == 2
+    assert len(updated_backfill.in_progress_run_requests or []) == 2
     assert (
         updated_backfill.asset_backfill_data.requested_subset.num_partitions_and_non_partitioned_assets
         == 2


### PR DESCRIPTION
Summary:
This replaces the retry logic in asset backfills from being code-server/agent faiure-specific to cover more classes of failures. It now works more like AMP retry logic, where the sequence of events is;

a) generate a candidate set of runs to launch, reserve run IDs for them, update the backfill data with those run IDs
b) launch each run one by one, at each step making sure that no run with that ID has previously been launched
c) once you're done, write that you're finished and are ready to move on

This guarantees idempotency because we're resilient to failures at any stage in the above:
- If we fail before the write in a), no writes have been done, so we're good and can start over
- If we fail partway through b), we have persisted which runs we want to launch, so we can check if they exist and have been launched to ensure idempotency

This also should let us remove some kinda gnarly existing retry logic that was specific to user code failures and had to kind of backtrack to try to recover (instead of bubbling up the failure and relying on idempotency in the next tick).

## Summary & Motivation

## How I Tested These Changes
