### PR TITLE
Fix duplicate code location error toasts + Add status filter to code locations page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/CodeLocationsPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/CodeLocationsPage.tsx
@@ -3,12 +3,11 @@ import * as React from 'react';
 
 import {InstancePageContext} from './InstancePageContext';
 import {InstanceTabs} from './InstanceTabs';
-import {flattenCodeLocationRows} from './flattenCodeLocationRows';
+import {useCodeLocationPageFilters} from './useCodeLocationPageFilters';
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {ReloadAllButton} from '../workspace/ReloadAllButton';
 import {RepositoryLocationsList} from '../workspace/RepositoryLocationsList';
-import {WorkspaceContext} from '../workspace/WorkspaceContext';
 
 const SEARCH_THRESHOLD = 10;
 
@@ -16,18 +15,8 @@ export const CodeLocationsPageContent = () => {
   useTrackPageView();
   useDocumentTitle('Code locations');
 
-  const {locationEntries, loading} = React.useContext(WorkspaceContext);
-
-  const [searchValue, setSearchValue] = React.useState('');
-
-  const onChangeSearch = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchValue(e.target.value);
-  }, []);
-
-  const queryString = searchValue.toLocaleLowerCase();
-  const {flattened, filtered} = React.useMemo(() => {
-    return flattenCodeLocationRows(locationEntries, queryString);
-  }, [locationEntries, queryString]);
+  const {activeFiltersJsx, flattened, button, loading, filtered, onChangeSearch, searchValue} =
+    useCodeLocationPageFilters();
 
   const entryCount = flattened.length;
   const showSearch = entryCount > SEARCH_THRESHOLD;
@@ -47,17 +36,20 @@ export const CodeLocationsPageContent = () => {
         flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
         style={{height: '64px'}}
       >
-        {showSearch ? (
-          <TextInput
-            icon="search"
-            value={searchValue}
-            onChange={onChangeSearch}
-            placeholder="Filter code locations by name…"
-            style={{width: '400px'}}
-          />
-        ) : (
-          <Subheading id="repository-locations">{subheadingText()}</Subheading>
-        )}
+        <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+          {button}
+          {showSearch ? (
+            <TextInput
+              icon="search"
+              value={searchValue}
+              onChange={onChangeSearch}
+              placeholder="Filter code locations by name…"
+              style={{width: '400px'}}
+            />
+          ) : (
+            <Subheading id="repository-locations">{subheadingText()}</Subheading>
+          )}
+        </Box>
         <Box flex={{direction: 'row', gap: 12, alignItems: 'center'}}>
           {showSearch ? <div>{`${entryCount} code locations`}</div> : null}
           <ReloadAllButton />
@@ -68,6 +60,14 @@ export const CodeLocationsPageContent = () => {
         codeLocations={filtered}
         searchValue={searchValue}
       />
+      {activeFiltersJsx.length ? (
+        <Box
+          flex={{direction: 'row', alignItems: 'center', gap: 4}}
+          padding={{top: 8, horizontal: 24}}
+        >
+          {activeFiltersJsx}
+        </Box>
+      ) : null}
     </>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/flattenCodeLocationRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/flattenCodeLocationRows.tsx
@@ -1,4 +1,7 @@
-import {CodeLocationRowType} from '../workspace/VirtualizedCodeLocationRow';
+import {
+  CodeLocationRowStatusType,
+  CodeLocationRowType,
+} from '../workspace/VirtualizedCodeLocationRow';
 import {WorkspaceLocationNodeFragment} from '../workspace/types/WorkspaceQueries.types';
 
 const flatten = (locationEntries: WorkspaceLocationNodeFragment[]) => {
@@ -6,20 +9,48 @@ const flatten = (locationEntries: WorkspaceLocationNodeFragment[]) => {
   const all: CodeLocationRowType[] = [];
   for (const locationNode of locationEntries) {
     const {locationOrLoadError} = locationNode;
+    let status: CodeLocationRowStatusType;
+    if (locationNode.loadStatus === 'LOADING') {
+      if (locationOrLoadError) {
+        status = 'Updating';
+      } else {
+        status = 'Loading';
+      }
+    } else {
+      if (locationOrLoadError?.__typename === 'PythonError') {
+        status = 'Failed';
+      } else {
+        status = 'Loaded';
+      }
+    }
     if (!locationOrLoadError || locationOrLoadError?.__typename === 'PythonError') {
-      all.push({type: 'error' as const, node: locationNode});
+      all.push({type: 'error' as const, node: locationNode, status});
     } else {
       locationOrLoadError.repositories.forEach((repo) => {
-        all.push({type: 'repository' as const, codeLocation: locationNode, repository: repo});
+        all.push({
+          type: 'repository' as const,
+          codeLocation: locationNode,
+          repository: repo,
+          status,
+        });
       });
     }
   }
   return all;
 };
 
-const filterBySearch = (flattened: CodeLocationRowType[], searchValue: string) => {
+const filterRows = (
+  flattened: CodeLocationRowType[],
+  searchValue: string,
+  filters: CodeLocationFilters,
+) => {
   const queryString = searchValue.toLocaleLowerCase();
   return flattened.filter((row) => {
+    if (filters.status?.length) {
+      if (!filters.status.includes(row.status)) {
+        return false;
+      }
+    }
     if (row.type === 'error') {
       return row.node.name.toLocaleLowerCase().includes(queryString);
     }
@@ -30,12 +61,15 @@ const filterBySearch = (flattened: CodeLocationRowType[], searchValue: string) =
   });
 };
 
+export type CodeLocationFilters = Partial<{status: CodeLocationRowStatusType[]}>;
+
 export const flattenCodeLocationRows = (
   locationEntries: WorkspaceLocationNodeFragment[],
   searchValue: string = '',
+  filters: CodeLocationFilters = {},
 ) => {
   const flattened = flatten(locationEntries);
-  const filtered = filterBySearch(flattened, searchValue);
+  const filtered = filterRows(flattened, searchValue, filters);
 
   return {
     flattened,

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/useCodeLocationPageFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/useCodeLocationPageFilters.tsx
@@ -53,7 +53,6 @@ export const useCodeLocationPageFilters = () => {
     getStringValue: (value) => value,
     state: filters.status,
     onStateChanged: (values) => {
-      console.log({values});
       setFilters({status: Array.from(values)});
     },
     matchType: 'all-of',

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/useCodeLocationPageFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/useCodeLocationPageFilters.tsx
@@ -1,0 +1,75 @@
+import React, {useCallback, useContext, useMemo, useState} from 'react';
+
+import {CodeLocationFilters, flattenCodeLocationRows} from './flattenCodeLocationRows';
+import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
+import {TruncatedTextWithFullTextOnHover} from '../nav/getLeftNavItemsForOption';
+import {useFilters} from '../ui/Filters';
+import {useStaticSetFilter} from '../ui/Filters/useStaticSetFilter';
+import {CodeLocationRowStatusType} from '../workspace/VirtualizedCodeLocationRow';
+import {WorkspaceContext} from '../workspace/WorkspaceContext';
+
+export const useCodeLocationPageFilters = () => {
+  const {locationEntries, loading} = useContext(WorkspaceContext);
+
+  const [searchValue, setSearchValue] = useState('');
+
+  const onChangeSearch = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchValue(e.target.value);
+  }, []);
+
+  const queryString = searchValue.toLocaleLowerCase();
+
+  const [filters, setFilters] = useQueryPersistedState<CodeLocationFilters>({
+    encode: ({status}) => ({
+      status: status?.length ? JSON.stringify(status) : undefined,
+    }),
+    decode: (qs) => {
+      return {
+        status: qs.status ? JSON.parse(qs.status) : [],
+      };
+    },
+  });
+
+  const {flattened, filtered} = useMemo(() => {
+    return flattenCodeLocationRows(locationEntries, queryString, filters);
+  }, [locationEntries, queryString, filters]);
+
+  const statusFilter = useStaticSetFilter<CodeLocationRowStatusType>({
+    name: 'Status',
+    icon: 'tag',
+    allValues: useMemo(
+      () =>
+        (['Failed', 'Loaded', 'Updating', 'Loading'] as const).map((value) => ({
+          key: value,
+          value,
+          match: [value],
+        })),
+      [],
+    ),
+    menuWidth: '300px',
+    renderLabel: ({value}) => {
+      return <TruncatedTextWithFullTextOnHover text={value} />;
+    },
+    getStringValue: (value) => value,
+    state: filters.status,
+    onStateChanged: (values) => {
+      console.log({values});
+      setFilters({status: Array.from(values)});
+    },
+    matchType: 'all-of',
+    canSelectAll: false,
+    allowMultipleSelections: true,
+  });
+
+  const {button, activeFiltersJsx} = useFilters({filters: [statusFilter]});
+
+  return {
+    button,
+    activeFiltersJsx,
+    onChangeSearch,
+    loading,
+    flattened,
+    filtered,
+    searchValue,
+  };
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
@@ -93,7 +93,6 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
         icon: 'check_circle',
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [erroredLocationEntries, loading, onClickViewButton]);
 
   useLayoutEffect(() => {
@@ -133,7 +132,7 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
             <div>Definitions reloaded</div>
             <ViewCodeLocationsButton
               onClick={() => {
-                onClickViewButton(['Loaded']);
+                onClickViewButton([]);
               }}
             />
           </Box>
@@ -223,7 +222,7 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
             {toastContent()}
             <ViewCodeLocationsButton
               onClick={() => {
-                onClickViewButton(['Loaded']);
+                onClickViewButton([]);
               }}
             />
           </Box>
@@ -256,7 +255,7 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
             )}
             <ViewCodeLocationsButton
               onClick={() => {
-                onClickViewButton(['Updating']);
+                onClickViewButton([]);
               }}
             />
           </Box>
@@ -293,8 +292,6 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
 
   return null;
 };
-
-const alreadyViewingCodeLocations = () => document.location.pathname.endsWith('/locations');
 
 const ViewCodeLocationsButton = ({onClick}: {onClick: () => void}) => {
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
@@ -66,7 +66,7 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
     previousErroredLocationEntries.current = erroredLocationEntries;
   } else {
     // We need preserve the previous reference to avoid firing the error layout effect more than necessary.
-    // This is due to their being multiple updates to `data` to locations being fetched individually
+    // This is due to their being multiple updates to `data` due to locations being fetched individually
     // and each updating `data` as they come in.
     erroredLocationEntries = previousErroredLocationEntries.current;
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
@@ -1,5 +1,5 @@
 import {Box, ButtonLink, Colors} from '@dagster-io/ui-components';
-import {useCallback, useContext, useLayoutEffect, useRef, useState} from 'react';
+import {useCallback, useContext, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {useHistory} from 'react-router-dom';
 import {atom, useRecoilValue} from 'recoil';
 import styled from 'styled-components';
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import {showSharedToaster} from '../app/DomUtils';
 import {RepositoryLocationLoadStatus} from '../graphql/types';
 import {StatusAndMessage} from '../instance/DeploymentStatusType';
+import {CodeLocationRowStatusType} from '../workspace/VirtualizedCodeLocationRow';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 import {CodeLocationStatusQuery} from '../workspace/types/WorkspaceQueries.types';
 
@@ -24,7 +25,7 @@ export const codeLocationStatusAtom = atom<CodeLocationStatusQuery | undefined>(
 });
 
 export const useCodeLocationsStatus = (): StatusAndMessage | null => {
-  const {locationEntries, data} = useContext(WorkspaceContext);
+  const {locationEntries, loading, data} = useContext(WorkspaceContext);
   const [previousEntriesById, setPreviousEntriesById] = useState<EntriesById | null>(null);
 
   const history = useHistory();
@@ -33,35 +34,72 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
 
   const [showSpinner, setShowSpinner] = useState(false);
 
-  const onClickViewButton = useCallback(() => {
-    historyRef.current.push('/locations');
+  const onClickViewButton = useCallback((statuses: CodeLocationRowStatusType[]) => {
+    historyRef.current.push(`/locations?status=${JSON.stringify(statuses)}`);
   }, []);
 
   // Reload the workspace, but don't toast about it.
 
+  const previousErroredLocationEntries = useRef<typeof erroredLocationEntries | null>(null);
+  let erroredLocationEntries = useMemo(
+    () =>
+      Object.values(data)
+        .map((entry) => {
+          if (entry.__typename === 'PythonError') {
+            return entry.__typename;
+          }
+          if (entry.locationOrLoadError?.__typename === 'PythonError') {
+            return entry.updatedTimestamp;
+          }
+          return null;
+        })
+        .filter(Boolean),
+    [data],
+  );
+  if (
+    !previousErroredLocationEntries.current ||
+    previousErroredLocationEntries.current.length !== erroredLocationEntries.length ||
+    previousErroredLocationEntries.current?.some(
+      (entry, index) => entry !== erroredLocationEntries[index],
+    )
+  ) {
+    previousErroredLocationEntries.current = erroredLocationEntries;
+  } else {
+    // We need preserve the previous reference to avoid firing the error layout effect more than necessary.
+    // This is due to their being multiple updates to `data` to locations being fetched individually
+    // and each updating `data` as they come in.
+    erroredLocationEntries = previousErroredLocationEntries.current;
+  }
+
   // Reload the workspace, and show a success or error toast upon completion.
   useLayoutEffect(() => {
-    const anyErrors = Object.values(data).some(
-      (entry) =>
-        entry.__typename === 'PythonError' ||
-        entry.locationOrLoadError?.__typename === 'PythonError',
-    );
+    if (loading) {
+      return;
+    }
 
-    const showViewButton = !alreadyViewingCodeLocations();
-
-    if (anyErrors) {
+    if (erroredLocationEntries.length) {
       showSharedToaster({
         intent: 'warning',
         message: (
           <Box flex={{direction: 'row', justifyContent: 'space-between', gap: 24, grow: 1}}>
             <div>Definitions loaded with errors</div>
-            {showViewButton ? <ViewCodeLocationsButton onClick={onClickViewButton} /> : null}
+            <ViewCodeLocationsButton
+              onClick={() => {
+                onClickViewButton(['Failed']);
+              }}
+            />
           </Box>
         ),
         icon: 'check_circle',
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [erroredLocationEntries, loading, onClickViewButton]);
 
+  useLayoutEffect(() => {
+    if (loading) {
+      return;
+    }
     const anyLoading = Object.values(data).some(
       (entry) =>
         entry.__typename === 'WorkspaceLocationEntry' &&
@@ -70,14 +108,12 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
     if (!anyLoading) {
       setShowSpinner(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, onClickViewButton]);
+  }, [loading, data]);
 
   const codeLocationStatusQueryData = useRecoilValue(codeLocationStatusAtom);
 
   useLayoutEffect(() => {
     const isFreshPageload = previousEntriesById === null;
-    const showViewButton = !alreadyViewingCodeLocations();
 
     // Given the previous and current code locations, determine whether to show a) a loading spinner
     // and/or b) a toast indicating that a code location is being reloaded.
@@ -95,7 +131,11 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
         message: (
           <Box flex={{direction: 'row', justifyContent: 'space-between', gap: 24, grow: 1}}>
             <div>Definitions reloaded</div>
-            {showViewButton ? <ViewCodeLocationsButton onClick={onClickViewButton} /> : null}
+            <ViewCodeLocationsButton
+              onClick={() => {
+                onClickViewButton(['Loaded']);
+              }}
+            />
           </Box>
         ),
         icon: 'check_circle',
@@ -181,7 +221,11 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
         message: (
           <Box flex={{direction: 'row', justifyContent: 'space-between', gap: 24, grow: 1}}>
             {toastContent()}
-            {showViewButton ? <ViewCodeLocationsButton onClick={onClickViewButton} /> : null}
+            <ViewCodeLocationsButton
+              onClick={() => {
+                onClickViewButton(['Loaded']);
+              }}
+            />
           </Box>
         ),
         icon: 'add_circle',
@@ -210,7 +254,11 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
             ) : (
               <span>Updating {currentlyLoading.length} code locations</span>
             )}
-            {showViewButton ? <ViewCodeLocationsButton onClick={onClickViewButton} /> : null}
+            <ViewCodeLocationsButton
+              onClick={() => {
+                onClickViewButton(['Updating']);
+              }}
+            />
           </Box>
         ),
         icon: 'refresh',

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedCodeLocationRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedCodeLocationRow.tsx
@@ -17,13 +17,16 @@ import {workspacePathFromAddress} from './workspacePath';
 import {TimeFromNow} from '../ui/TimeFromNow';
 import {HeaderCell, HeaderRow, RowCell} from '../ui/VirtualizedTable';
 
+export type CodeLocationRowStatusType = 'Failed' | 'Updating' | 'Loaded' | 'Loading';
+
 export type CodeLocationRowType =
   | {
       type: 'repository';
       codeLocation: WorkspaceLocationNodeFragment;
       repository: WorkspaceRepositoryFragment;
+      status: CodeLocationRowStatusType;
     }
-  | {type: 'error'; node: WorkspaceLocationNodeFragment};
+  | {type: 'error'; node: WorkspaceLocationNodeFragment; status: CodeLocationRowStatusType};
 
 const TEMPLATE_COLUMNS = '3fr 1fr 1fr 240px 160px';
 


### PR DESCRIPTION
## Summary & Motivation

Recent changes to the WorkspaceContext where we split fetched by location caused us show the code location error toast multiple times. Once for each code location update after we've detected an errored code location. The fix is to instead fire the effect off of the errored code locations and preserve the reference if they haven't changed. 

Also adding a "state" filter to the code locations page for use in the error toast so that if you have 132 locations you can easily see which ones failed.


## How I Tested These Changes

Loaded an org with 132 code locations and saw a single error toast. Clicked on "view definitions" and saw it took me to the code location page with status = Failed as the filter.

<img width="394" alt="Screenshot 2024-06-13 at 4 25 03 PM" src="https://github.com/dagster-io/dagster/assets/2286579/92fcadc6-f844-4cd9-a48c-100eec9aba42">
<img width="1724" alt="Screenshot 2024-06-13 at 4 24 53 PM" src="https://github.com/dagster-io/dagster/assets/2286579/fb000b48-d778-4d06-b339-8fc96816c9de">
