### PR TITLE
[graphql] instigation state by id

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3209,7 +3209,11 @@ type Query {
     repositorySelector: RepositorySelector!
     sensorStatus: InstigationStatus
   ): SensorsOrError!
-  instigationStateOrError(instigationSelector: InstigationSelector!): InstigationStateOrError!
+  instigationStateOrError(
+    instigationSelector: InstigationSelector
+    id: String
+  ): InstigationStateOrError!
+  instigationStatesOrError(repositoryID: String!): InstigationStatesOrError!
   partitionSetsOrError(
     repositorySelector: RepositorySelector!
     pipelineName: String!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -3679,6 +3679,7 @@ export type Query = {
   graphOrError: GraphOrError;
   instance: Instance;
   instigationStateOrError: InstigationStateOrError;
+  instigationStatesOrError: InstigationStatesOrError;
   isPipelineConfigValid: PipelineConfigValidationResult;
   locationStatusesOrError: WorkspaceLocationStatusEntriesOrError;
   logsForRun: EventConnectionOrError;
@@ -3819,7 +3820,12 @@ export type QueryGraphOrErrorArgs = {
 };
 
 export type QueryInstigationStateOrErrorArgs = {
-  instigationSelector: InstigationSelector;
+  id?: InputMaybe<Scalars['String']['input']>;
+  instigationSelector?: InputMaybe<InstigationSelector>;
+};
+
+export type QueryInstigationStatesOrErrorArgs = {
+  repositoryID: Scalars['String']['input'];
 };
 
 export type QueryIsPipelineConfigValidArgs = {
@@ -11848,6 +11854,12 @@ export const buildQuery = (
         : relationshipsToOmit.has('InstigationState')
         ? ({} as InstigationState)
         : buildInstigationState({}, relationshipsToOmit),
+    instigationStatesOrError:
+      overrides && overrides.hasOwnProperty('instigationStatesOrError')
+        ? overrides.instigationStatesOrError!
+        : relationshipsToOmit.has('InstigationStates')
+        ? ({} as InstigationStates)
+        : buildInstigationStates({}, relationshipsToOmit),
     isPipelineConfigValid:
       overrides && overrides.hasOwnProperty('isPipelineConfigValid')
         ? overrides.isPipelineConfigValid!

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -286,8 +286,8 @@ class GrapheneRepository(graphene.ObjectType):
             )
         super().__init__(name=repository.name)
 
-    def resolve_id(self, _graphene_info: ResolveInfo):
-        return self._repository.get_external_origin_id()
+    def resolve_id(self, _graphene_info: ResolveInfo) -> str:
+        return self._repository.get_compound_id().to_string()
 
     def resolve_origin(self, _graphene_info: ResolveInfo):
         origin = self._repository.get_external_origin()

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -727,10 +727,10 @@ class GrapheneInstigationStateNotFoundError(graphene.ObjectType):
 
     name = graphene.NonNull(graphene.String)
 
-    def __init__(self, name):
+    def __init__(self, target):
         super().__init__()
-        self.name = check.str_param(name, "name")
-        self.message = f"Could not find `{name}` in the currently loaded repository."
+        self.name = check.str_param(target, "target")
+        self.message = f"Could not find instigation state for `{target}`"
 
 
 class GrapheneInstigationStateOrError(graphene.Union):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -91,8 +91,8 @@ class GrapheneSchedule(graphene.ObjectType):
             description=external_schedule.description,
         )
 
-    def resolve_id(self, _graphene_info: ResolveInfo):
-        return self._external_schedule.get_external_origin_id()
+    def resolve_id(self, _graphene_info: ResolveInfo) -> str:
+        return self._external_schedule.get_compound_id().to_string()
 
     def resolve_defaultStatus(self, _graphene_info: ResolveInfo):
         default_schedule_status = self._external_schedule.default_status

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -125,8 +125,8 @@ class GrapheneSensor(graphene.ObjectType):
             else None,
         )
 
-    def resolve_id(self, _):
-        return self._external_sensor.get_external_origin_id()
+    def resolve_id(self, _) -> str:
+        return self._external_sensor.get_compound_id().to_string()
 
     def resolve_defaultStatus(self, _graphene_info: ResolveInfo):
         default_sensor_status = self._external_sensor.default_status

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
@@ -10,8 +10,8 @@ from dagster_graphql.test.utils import (
 from .graphql_context_test_suite import NonLaunchableGraphQLContextTestMatrix
 
 INSTIGATION_QUERY = """
-query JobQuery($instigationSelector: InstigationSelector!) {
-  instigationStateOrError(instigationSelector: $instigationSelector) {
+query JobQuery($instigationSelector: InstigationSelector $id: String) {
+  instigationStateOrError(instigationSelector: $instigationSelector id: $id) {
     __typename
     ... on PythonError {
       message
@@ -22,6 +22,24 @@ query JobQuery($instigationSelector: InstigationSelector!) {
         nextTick {
             timestamp
         }
+    }
+  }
+}
+"""
+
+INSTIGATION_STATES_QUERY = """
+query InstigationStatesQuery($id: String!) {
+  instigationStatesOrError(repositoryID: $id) {
+    __typename
+    ... on PythonError {
+      message
+      stack
+    }
+    ... on InstigationStates {
+      results {
+        name
+        instigationType
+      }
     }
   }
 }
@@ -44,7 +62,7 @@ def _create_sensor_tick(graphql_context):
 
 
 class TestNextTickRepository(NonLaunchableGraphQLContextTestMatrix):
-    def test_schedule_next_tick(self, graphql_context):
+    def test_schedule_next_tick(self, graphql_context) -> None:
         repository_selector = infer_repository_selector(graphql_context)
         external_repository = graphql_context.get_code_location(
             repository_selector["repositoryLocationName"]
@@ -52,10 +70,23 @@ class TestNextTickRepository(NonLaunchableGraphQLContextTestMatrix):
 
         schedule_name = "no_config_job_hourly_schedule"
         external_schedule = external_repository.get_external_schedule(schedule_name)
-        selector = infer_instigation_selector(graphql_context, schedule_name)
 
         # need to be running in order to generate a future tick
         graphql_context.instance.start_schedule(external_schedule)
+        result = execute_dagster_graphql(
+            graphql_context,
+            INSTIGATION_QUERY,
+            variables={"id": external_schedule.get_compound_id().to_string()},
+        )
+
+        assert result.data
+        assert result.data["instigationStateOrError"]["__typename"] == "InstigationState"
+        next_tick = result.data["instigationStateOrError"]["nextTick"]
+        assert next_tick
+
+        # ensure legacy selector based impl works until removal
+
+        selector = infer_instigation_selector(graphql_context, schedule_name)
         result = execute_dagster_graphql(
             graphql_context, INSTIGATION_QUERY, variables={"instigationSelector": selector}
         )
@@ -81,10 +112,51 @@ class TestNextTickRepository(NonLaunchableGraphQLContextTestMatrix):
         _create_sensor_tick(graphql_context)
 
         result = execute_dagster_graphql(
+            graphql_context,
+            INSTIGATION_QUERY,
+            variables={"id": external_sensor.get_compound_id().to_string()},
+        )
+
+        assert result.data
+        assert (
+            result.data["instigationStateOrError"]["__typename"] == "InstigationState"
+        ), result.data["instigationStateOrError"]
+        next_tick = result.data["instigationStateOrError"]["nextTick"]
+        assert next_tick
+
+        # ensure legacy selector based lookup continues to work until removed
+
+        result = execute_dagster_graphql(
             graphql_context, INSTIGATION_QUERY, variables={"instigationSelector": selector}
         )
 
         assert result.data
-        assert result.data["instigationStateOrError"]["__typename"] == "InstigationState"
+        assert (
+            result.data["instigationStateOrError"]["__typename"] == "InstigationState"
+        ), result.data["instigationStateOrError"]
         next_tick = result.data["instigationStateOrError"]["nextTick"]
         assert next_tick
+
+    def test_instigation_states(self, graphql_context) -> None:
+        repository_selector = infer_repository_selector(graphql_context)
+        external_repository = graphql_context.get_code_location(
+            repository_selector["repositoryLocationName"]
+        ).get_repository(repository_selector["repositoryName"])
+
+        schedule_name = "no_config_job_hourly_schedule"
+        external_schedule = external_repository.get_external_schedule(schedule_name)
+        graphql_context.instance.start_schedule(external_schedule)
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            INSTIGATION_STATES_QUERY,
+            variables={"id": external_repository.get_compound_id().to_string()},
+        )
+
+        assert result.data
+        assert (
+            result.data["instigationStatesOrError"]["__typename"] == "InstigationStates"
+        ), result.data["instigationStatesOrError"]
+
+        results = result.data["instigationStatesOrError"]["results"]
+        assert results == [{"name": schedule_name, "instigationType": "SCHEDULE"}]

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -36,6 +36,7 @@ from dagster._core.definitions.sensor_definition import (
     DefaultSensorStatus,
     SensorType,
 )
+from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.plan.handle import ResolvedFromDynamicStepHandle, StepHandle
 from dagster._core.instance import DagsterInstance
 from dagster._core.origin import JobPythonOrigin, RepositoryPythonOrigin
@@ -48,6 +49,7 @@ from dagster._core.remote_representation.origin import (
 from dagster._core.snap import ExecutionPlanSnapshot
 from dagster._core.snap.job_snapshot import JobSnapshot
 from dagster._core.utils import toposort
+from dagster._model.decorator import dagster_model
 from dagster._serdes import create_snapshot_id
 from dagster._utils.cached_method import cached_method
 from dagster._utils.schedules import schedule_execution_time_iterator
@@ -79,6 +81,30 @@ if TYPE_CHECKING:
     from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
     from dagster._core.scheduler.instigation import InstigatorState
     from dagster._core.snap.execution_plan_snapshot import ExecutionStepSnap
+
+_DELIMITER = "::"
+
+
+@dagster_model
+class CompoundID:
+    """Compound ID object for the two id schemes that state is recorded in the database against."""
+
+    external_origin_id: str
+    selector_id: str
+
+    def to_string(self) -> str:
+        return f"{self.external_origin_id}{_DELIMITER}{self.selector_id}"
+
+    @staticmethod
+    def from_string(serialized: str):
+        parts = serialized.split(_DELIMITER)
+        if len(parts) != 2:
+            raise DagsterInvariantViolationError(f"Invalid serialized InstigatorID: {serialized}")
+
+        return CompoundID(
+            external_origin_id=parts[0],
+            selector_id=parts[1],
+        )
 
 
 class ExternalRepository:
@@ -331,6 +357,12 @@ class ExternalRepository:
     def selector_id(self) -> str:
         return create_snapshot_id(
             RepositorySelector(self._handle.location_name, self._handle.repository_name)
+        )
+
+    def get_compound_id(self) -> CompoundID:
+        return CompoundID(
+            external_origin_id=self.get_external_origin_id(),
+            selector_id=self.selector_id,
         )
 
     def get_external_origin(self) -> RemoteRepositoryOrigin:
@@ -784,6 +816,12 @@ class ExternalSchedule:
     def selector_id(self) -> str:
         return create_snapshot_id(self.selector)
 
+    def get_compound_id(self) -> CompoundID:
+        return CompoundID(
+            external_origin_id=self.get_external_origin_id(),
+            selector_id=self.selector_id,
+        )
+
     @property
     def default_status(self) -> DefaultScheduleStatus:
         return self._external_schedule_data.default_status or DefaultScheduleStatus.STOPPED
@@ -927,6 +965,12 @@ class ExternalSensor:
     @property
     def selector_id(self) -> str:
         return create_snapshot_id(self.selector)
+
+    def get_compound_id(self) -> CompoundID:
+        return CompoundID(
+            external_origin_id=self.get_external_origin_id(),
+            selector_id=self.selector_id,
+        )
 
     @property
     def sensor_type(self) -> SensorType:

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -110,7 +110,6 @@ class SqlScheduleStorage(ScheduleStorage):
                 query = query.where(
                     JobTable.c.status.in_([status.value for status in instigator_statuses])
                 )
-
         rows = self.execute(query)
         return self._deserialize_rows(rows, InstigatorState)
 


### PR DESCRIPTION
* add `CompoundID` to wrap external origin + selector id components 
* change the `Schedule` `Sensor` and `Repository` id fields to return serialized CompoundIDs 
* update the `instigationStateOrError` to be able to fetch by id
* add `instigationStatesOrError` and support fetching all instigation states by their containing repository ID

## How I Tested These Changes

Added tests