### PR TITLE
Add serverless io manager appropriate usage for baa

### DIFF
--- a/docs/content/dagster-plus/deployment/serverless.mdx
+++ b/docs/content/dagster-plus/deployment/serverless.mdx
@@ -306,10 +306,19 @@ After changing the deployment type, you will need to update your code locations'
 
 Unlike Hybrid, Serverless Deployments on Dagster+ require direct access to your data, secrets and source code.
 
-- Dagster+ Serverless does not provide persistent storage. Ephemeral storage is deleted when a run concludes.
 - Secrets and source code are built into the image directly. Images are stored in a per-customer container registry with restricted access.
 - User code is securely sandboxed using modern container sandboxing techniques.
 - All production access is governed by industry-standard best practices which are regularly audited.
+
+### IO Management on Serverless
+
+<Warning>
+If you are a Serverless customer who is working on personally identifiable information (PII), private health information (PHI), has signed a business association agreement (BAA), or are otherwise working with data subject to GDPR or other such regulations, you must not use the default IO manager.
+</Warning> 
+
+In Serverless, code that uses the default [IO Manager](/concepts/io-management/io-managers#built-in-io-managers) is automatically adjusted to save data in Dagster Plus managed storage. This automatic change is useful because the default file system in Serverless is ephemeral which means the default IO manager would not work as expected. However, this automatic change means potentially sensitive data is being stored, not just processed or orchestrated, by Dagster Plus. To avoid this behavior:
+- Use an IO manager that stores data in your infrastructure
+- Write code that does not use an IO manager
 
 ---
 

--- a/docs/content/dagster-plus/deployment/serverless.mdx
+++ b/docs/content/dagster-plus/deployment/serverless.mdx
@@ -313,16 +313,18 @@ Unlike Hybrid, Serverless Deployments on Dagster+ require direct access to your 
 ### I/O management on Serverless
 
 <Note>
-The default I/O manager cannot be used if you are a Serverless user who:
-<ul>
-<li>Works with personally identifiable information (PII)</li>
-<li>Works with private health information (PHI)</li>
-<li>Has signed a business association agreement (BAA), or</li>
-<li>Are otherwise working with data subject to GDPR or other such regulations</li>
-</ul>
-</Note> 
+  The default I/O manager cannot be used if you are a Serverless user who:
+  <ul>
+    <li>Works with personally identifiable information (PII)</li>
+    <li>Works with private health information (PHI)</li>
+    <li>Has signed a business association agreement (BAA), or</li>
+    <li>
+      Are otherwise working with data subject to GDPR or other such regulations
+    </li>
+  </ul>
+</Note>{" "}
 
-In Serverless, code that uses the default [I/O manager](/concepts/io-management/io-managers#built-in-io-managers) is automatically adjusted to save data in Dagster+ managed storage. This automatic change is useful because the default file system in Serverless is ephemeral, which means the default I/O manager wouldn't work as expected. However, this automatic change means potentially sensitive data is being stored, not just processed or orchestrated, by Dagster+. 
+In Serverless, code that uses the default [I/O manager](/concepts/io-management/io-managers#built-in-io-managers) is automatically adjusted to save data in Dagster+ managed storage. This automatic change is useful because the default file system in Serverless is ephemeral, which means the default I/O manager wouldn't work as expected. However, this automatic change means potentially sensitive data is being stored, not just processed or orchestrated, by Dagster+.
 
 To avoid this behavior, you can:
 

--- a/docs/content/dagster-plus/deployment/serverless.mdx
+++ b/docs/content/dagster-plus/deployment/serverless.mdx
@@ -310,15 +310,24 @@ Unlike Hybrid, Serverless Deployments on Dagster+ require direct access to your 
 - User code is securely sandboxed using modern container sandboxing techniques.
 - All production access is governed by industry-standard best practices which are regularly audited.
 
-### IO Management on Serverless
+### I/O management on Serverless
 
-<Warning>
-If you are a Serverless customer who is working on personally identifiable information (PII), private health information (PHI), has signed a business association agreement (BAA), or are otherwise working with data subject to GDPR or other such regulations, you must not use the default IO manager.
-</Warning> 
+<Note>
+The default I/O manager cannot be used if you are a Serverless user who:
+<ul>
+<li>Works with personally identifiable information (PII)</li>
+<li>Works with private health information (PHI)</li>
+<li>Has signed a business association agreement (BAA), or</li>
+<li>Are otherwise working with data subject to GDPR or other such regulations</li>
+</ul>
+</Note> 
 
-In Serverless, code that uses the default [IO Manager](/concepts/io-management/io-managers#built-in-io-managers) is automatically adjusted to save data in Dagster Plus managed storage. This automatic change is useful because the default file system in Serverless is ephemeral which means the default IO manager would not work as expected. However, this automatic change means potentially sensitive data is being stored, not just processed or orchestrated, by Dagster Plus. To avoid this behavior:
-- Use an IO manager that stores data in your infrastructure
-- Write code that does not use an IO manager
+In Serverless, code that uses the default [I/O manager](/concepts/io-management/io-managers#built-in-io-managers) is automatically adjusted to save data in Dagster+ managed storage. This automatic change is useful because the default file system in Serverless is ephemeral, which means the default I/O manager wouldn't work as expected. However, this automatic change means potentially sensitive data is being stored, not just processed or orchestrated, by Dagster+. 
+
+To avoid this behavior, you can:
+
+- Use an I/O manager that stores data in your infrastructure
+- Write code that doesn't use an I/O manager
 
 ---
 


### PR DESCRIPTION
## Summary & Motivation

Explain how the default filesystem IO manager is replaced in Serverless which could surprise users. Also address that this replacement is not appropriate for sensitive data, specifically warning certain customers (like those with a BAA) that appropriate use of the system forgoes using the default serverless io manager.

## How I Tested These Changes
- reviewed the docs preview and link