### PR TITLE
create serializable run reexecution info, to enable cached retry / reexecution info

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -124,6 +124,7 @@ if TYPE_CHECKING:
     from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
     from dagster._core.execution.plan.plan import ExecutionPlan
     from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
+    from dagster._core.execution.plan.state import RunReexecutionInfo
     from dagster._core.execution.stats import RunStepKeyStatsSnapshot
     from dagster._core.launcher import RunLauncher
     from dagster._core.remote_representation import (
@@ -3230,3 +3231,16 @@ class DagsterInstance(DynamicPartitionsStore):
 
     def backfill_log_storage_enabled(self) -> bool:
         return False
+
+    def get_reexecution_info(self, run_id: str) -> "RunReexecutionInfo":
+        from dagster._core.errors import DagsterRunNotFoundError
+        from dagster._core.execution.plan.state import RunReexecutionInfo
+
+        run = self.get_run_by_id(run_id)
+        if not run:
+            raise DagsterRunNotFoundError(
+                f"Could not load run {run_id} for re-execution",
+                invalid_run_id=run_id,
+            )
+
+        return RunReexecutionInfo.build_from_logs(self, run)


### PR DESCRIPTION
## Summary & Motivation
There's an opportunity to cache retry/reexecution info, so that we can pre-calculate them without incurring a potentially expensive db query upon a user-action.

In order to do this, we need
A) a serializable info object containing the known state (already serializable), and the retry steps.
B) we also need a new instance API to fetch this info from some durable storage.

The naive implementation of B) just recalculates the info from event logs, which is the current behavior.

## How I Tested These Changes
BK