### PR TITLE
`AssetGraphComputation` inside `AssetsDefinition`

### DIFF
--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2179,7 +2179,7 @@ def test_asset_spec_skippable():
 
 
 def test_construct_assets_definition_no_args() -> None:
-    with pytest.raises(CheckError, match="Must provide node_def if not providing specs"):
+    with pytest.raises(CheckError, match="If specs are not provided, a node_def must be provided"):
         AssetsDefinition()
 
 


### PR DESCRIPTION
## Summary & Motivation

Sprouting off of Nick's comment [here](https://github.com/dagster-io/dagster/pull/22165#discussion_r1638984982), this moves all the computation-related properties of `AssetsDefinition` into their own class.

While in this PR it's restricted to the internals of `AssetsDefinition`, I think that this object could eventually take on a wider role. It basically corresponds to the nodes on the right in this diagram I've been bandying about:

<img width="860" alt="image" src="https://github.com/dagster-io/dagster/assets/654855/69161dc4-dc23-4a35-a798-73e5548eb216">


## How I Tested These Changes
