### PR TITLE
improve assets.py::get_partition_mappings_from_deps

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -514,7 +514,6 @@ class DecoratorAssetsDefinitionBuilder:
         return get_partition_mappings_from_deps(
             partition_mappings=partition_mappings,
             deps=self.args.upstream_asset_deps,
-            asset_name=self.op_name,
         )
 
     @cached_property


### PR DESCRIPTION
## Summary & Motivation

Followup from https://github.com/dagster-io/dagster/pull/22165/files#r1639027524.

The existing error message was actually misleading, because it called the node name the "asset" name. I spent 5 minutes trying to figure out a better name for the parameter / way to frame the error message, but struggled to come up with one and think in most cases the stack will point to a clear offender. This PR takes it out and updates the error message accordingly. Open to revisiting if others feel strongly that we need more specifity.

I also took the liberty of changing the function to not mutate its input.

## How I Tested These Changes
