### PR TITLE
Add `target` param to `{Schedule,Sensor}Definition`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from functools import reduce
 from typing import AbstractSet, Iterable, List, Optional, Sequence, Union, cast
 
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, TypeGuard
 
 import dagster._check as check
 from dagster._annotations import deprecated, experimental, experimental_param, public
@@ -38,6 +38,13 @@ CoercibleToAssetSelection: TypeAlias = Union[
     Sequence[Union["AssetsDefinition", "SourceAsset"]],
     "AssetSelection",
 ]
+
+
+def is_coercible_to_asset_selection(obj: object) -> TypeGuard[CoercibleToAssetSelection]:
+    return isinstance(obj, (str, AssetSelection)) or (
+        isinstance(obj, Sequence)
+        and all(isinstance(x, (str, AssetKey, AssetsDefinition, SourceAsset)) for x in obj)
+    )
 
 
 class AssetSelection(ABC, DagsterModel):

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -1,8 +1,9 @@
 import copy
 from functools import update_wrapper
-from typing import Callable, List, Mapping, Optional, Sequence, Set, Union, cast
+from typing import TYPE_CHECKING, Callable, List, Mapping, Optional, Sequence, Set, Union, cast
 
 import dagster._check as check
+from dagster._annotations import experimental_param
 from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.sensor_definition import get_context_param_name
 from dagster._core.errors import (
@@ -26,7 +27,16 @@ from ..schedule_definition import (
 from ..target import ExecutableDefinition
 from ..utils import normalize_tags
 
+if TYPE_CHECKING:
+    from dagster._core.definitions.asset_selection import CoercibleToAssetSelection
+    from dagster._core.definitions.assets import AssetsDefinition
+    from dagster._core.definitions.job_definition import JobDefinition
+    from dagster._core.definitions.unresolved_asset_job_definition import (
+        UnresolvedAssetJobDefinition,
+    )
 
+
+@experimental_param(param="target")
 def schedule(
     cron_schedule: Union[str, Sequence[str]],
     *,
@@ -41,6 +51,14 @@ def schedule(
     job: Optional[ExecutableDefinition] = None,
     default_status: DefaultScheduleStatus = DefaultScheduleStatus.STOPPED,
     required_resource_keys: Optional[Set[str]] = None,
+    target: Optional[
+        Union[
+            "CoercibleToAssetSelection",
+            "AssetsDefinition",
+            "JobDefinition",
+            "UnresolvedAssetJobDefinition",
+        ]
+    ] = None,
 ) -> Callable[[RawScheduleEvaluationFunction], ScheduleDefinition]:
     """Creates a schedule following the provided cron schedule and requests runs for the provided job.
 
@@ -82,6 +100,8 @@ def schedule(
             that should execute when the schedule runs.
         default_status (DefaultScheduleStatus): If set to ``RUNNING``, the schedule will immediately be active when starting Dagster. The default status can be overridden from the `Dagster UI </concepts/webserver/ui>`_ or via the `GraphQL API </concepts/webserver/graphql>`_.
         required_resource_keys (Optional[Set[str]]): The set of resource keys required by the schedule.
+        target (Optional[Union[CoercibleToAssetSelection, AssetsDefinition, JobDefinition, UnresolvedAssetJobDefinition]]):
+            The target that the schedule will execute.
     """
 
     def inner(fn: RawScheduleEvaluationFunction) -> ScheduleDefinition:
@@ -174,6 +194,7 @@ def schedule(
             tags=None,  # cannot supply tags or tags_fn to decorator
             tags_fn=None,
             should_execute=None,  # already encompassed in evaluation_fn
+            target=target,
         )
 
         update_wrapper(schedule_def, wrapped=fn)

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -1,10 +1,10 @@
 import collections.abc
 import inspect
 from functools import update_wrapper
-from typing import Any, Callable, Optional, Sequence, Set, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Set, Union
 
 import dagster._check as check
-from dagster._annotations import experimental
+from dagster._annotations import experimental, experimental_param
 from dagster._core.definitions.asset_selection import AssetSelection, CoercibleToAssetSelection
 
 from ...errors import DagsterInvariantViolationError
@@ -25,7 +25,15 @@ from ..sensor_definition import (
 )
 from ..target import ExecutableDefinition
 
+if TYPE_CHECKING:
+    from dagster._core.definitions.assets import AssetsDefinition
+    from dagster._core.definitions.job_definition import JobDefinition
+    from dagster._core.definitions.unresolved_asset_job_definition import (
+        UnresolvedAssetJobDefinition,
+    )
 
+
+@experimental_param(param="target")
 def sensor(
     job_name: Optional[str] = None,
     *,
@@ -37,6 +45,14 @@ def sensor(
     default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
     asset_selection: Optional[CoercibleToAssetSelection] = None,
     required_resource_keys: Optional[Set[str]] = None,
+    target: Optional[
+        Union[
+            "CoercibleToAssetSelection",
+            "AssetsDefinition",
+            "JobDefinition",
+            "UnresolvedAssetJobDefinition",
+        ]
+    ] = None,
 ) -> Callable[[RawSensorEvaluationFunction], SensorDefinition]:
     """Creates a sensor where the decorated function is used as the sensor's evaluation function.
 
@@ -65,6 +81,8 @@ def sensor(
         asset_selection (Optional[Union[str, Sequence[str], Sequence[AssetKey], Sequence[Union[AssetsDefinition, SourceAsset]], AssetSelection]]):
             (Experimental) an asset selection to launch a run for if the sensor condition is met.
             This can be provided instead of specifying a job.
+        target (Optional[Union[CoercibleToAssetSelection, AssetsDefinition, JobDefinition, UnresolvedAssetJobDefinition]]):
+            The target that the sensor will execute.
     """
     check.opt_str_param(name, "name")
 
@@ -82,6 +100,7 @@ def sensor(
             default_status=default_status,
             asset_selection=asset_selection,
             required_resource_keys=required_resource_keys,
+            target=target,
         )
 
         update_wrapper(sensor_def, wrapped=fn)

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -467,9 +468,16 @@ class Definitions:
             asset_checks=asset_checks,
         )
 
-    @property
+    @cached_property
     def assets(self) -> Iterable[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
-        return self._assets
+        inlined_assets: List[Union[AssetsDefinition, SourceAsset]] = []
+        for schedule_def in self._schedules:
+            if isinstance(schedule_def, ScheduleDefinition):
+                inlined_assets.extend(schedule_def.target.assets_defs)
+        for sensor_def in self._sensors:
+            for target in sensor_def.targets:
+                inlined_assets.extend(target.assets_defs)
+        return [*self._assets, *inlined_assets]
 
     @property
     def schedules(

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -25,6 +25,7 @@ from dagster._config.pythonic_config import (
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_job import get_base_asset_jobs, is_base_asset_job_name
+from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.auto_materialize_sensor_definition import (
     AutoMaterializeSensorDefinition,
 )
@@ -267,12 +268,55 @@ def build_caching_repository_data_from_list(
     for partitions_def in partitions_defs:
         _validate_partitions_definition(partitions_def)
 
-    asset_graph = AssetGraph.from_assets([*assets_defs, *asset_checks_defs, *source_assets])
     source_assets_by_key = {source_asset.key: source_asset for source_asset in source_assets}
     assets_defs_by_key = {key: asset for asset in assets_defs for key in asset.keys}
     asset_checks_defs_by_key = {
         key: checks_def for checks_def in asset_checks_defs for key in checks_def.check_keys
     }
+
+    for name, sensor_def in sensors.items():
+        for target in sensor_def.targets:
+            if target.has_job_def:
+                _process_and_validate_target_job(sensor_def, unresolved_jobs, jobs, target.job_def)
+            if target.assets_defs:
+                _process_and_validate_target_assets(
+                    sensor_def, assets_defs_by_key, source_assets_by_key, target.assets_defs
+                )
+
+    for name, schedule_def in schedules.items():
+        if schedule_def.target.has_job_def:
+            _process_and_validate_target_job(
+                schedule_def, unresolved_jobs, jobs, schedule_def.target.job_def
+            )
+        if schedule_def.target.assets_defs:
+            _process_and_validate_target_assets(
+                schedule_def,
+                assets_defs_by_key,
+                source_assets_by_key,
+                schedule_def.target.assets_defs,
+            )
+
+    if unresolved_partitioned_asset_schedules:
+        for (
+            name,
+            unresolved_partitioned_asset_schedule,
+        ) in unresolved_partitioned_asset_schedules.items():
+            _process_and_validate_target_job(
+                unresolved_partitioned_asset_schedule,
+                unresolved_jobs,
+                jobs,
+                unresolved_partitioned_asset_schedule.job,
+            )
+
+    assets_without_keys = [ad for ad in assets_defs if not ad.keys]
+    asset_graph = AssetGraph.from_assets(
+        [
+            *assets_defs_by_key.values(),
+            *assets_without_keys,
+            *asset_checks_defs,
+            *source_assets_by_key.values(),
+        ]
+    )
     if assets_defs or asset_checks_defs or source_assets:
         jobs.update(
             get_base_asset_jobs(
@@ -283,30 +327,7 @@ def build_caching_repository_data_from_list(
             )
         )
 
-    for name, sensor_def in sensors.items():
-        for target in sensor_def.targets:
-            if target.has_job_def:
-                _process_and_validate_target(sensor_def, unresolved_jobs, jobs, target.job_def)
-
-    for name, schedule_def in schedules.items():
-        if schedule_def.target.has_job_def:
-            _process_and_validate_target(
-                schedule_def, unresolved_jobs, jobs, schedule_def.target.job_def
-            )
-
     _validate_auto_materialize_sensors(sensors.values(), asset_graph)
-
-    if unresolved_partitioned_asset_schedules:
-        for (
-            name,
-            unresolved_partitioned_asset_schedule,
-        ) in unresolved_partitioned_asset_schedules.items():
-            _process_and_validate_target(
-                unresolved_partitioned_asset_schedule,
-                unresolved_jobs,
-                jobs,
-                unresolved_partitioned_asset_schedule.job,
-            )
 
     # resolve all the UnresolvedAssetJobDefinitions using the full set of assets
     # resolving jobs is potentially time-consuming if there are many of them,
@@ -418,8 +439,8 @@ def build_caching_repository_data_from_dict(
     )
 
 
-def _process_and_validate_target(
-    schedule_or_sensor_def: Union[
+def _process_and_validate_target_job(
+    instigator_def: Union[
         SensorDefinition, ScheduleDefinition, UnresolvedPartitionedAssetScheduleDefinition
     ],
     unresolved_jobs: Dict[str, UnresolvedAssetJobDefinition],
@@ -428,9 +449,9 @@ def _process_and_validate_target(
 ):
     """This function modifies the state of unresolved_jobs, and jobs."""
     targeter = (
-        f"schedule '{schedule_or_sensor_def.name}'"
-        if isinstance(schedule_or_sensor_def, ScheduleDefinition)
-        else f"sensor '{schedule_or_sensor_def.name}'"
+        f"schedule '{instigator_def.name}'"
+        if isinstance(instigator_def, ScheduleDefinition)
+        else f"sensor '{instigator_def.name}'"
     )
     if isinstance(job_def, UnresolvedAssetJobDefinition):
         if job_def.name not in unresolved_jobs:
@@ -458,11 +479,46 @@ def _process_and_validate_target(
         jobs[job_def.name] = job_def
 
 
+def _process_and_validate_target_assets(
+    instigator_def: Union[
+        SensorDefinition, ScheduleDefinition, UnresolvedPartitionedAssetScheduleDefinition
+    ],
+    assets_defs_by_key: Dict["AssetKey", AssetsDefinition],
+    source_assets_by_key: Dict["AssetKey", SourceAsset],
+    target_assets_defs: Sequence[Union[AssetsDefinition, SourceAsset]],
+) -> None:
+    for ad in target_assets_defs:
+        keys = ad.keys if isinstance(ad, AssetsDefinition) else [ad.key]
+        for key in keys:
+            if isinstance(ad, AssetsDefinition):
+                existing_ad = assets_defs_by_key.get(key)
+                if not existing_ad:
+                    assets_defs_by_key[key] = ad
+                elif not existing_ad.computation == ad.computation:
+                    raise DagsterInvalidDefinitionError(
+                        _get_error_msg_for_target_asset_conflict(
+                            _get_instigator_str(instigator_def), key.to_user_string()
+                        )
+                    )
+            elif isinstance(ad, SourceAsset):
+                existing_sa = source_assets_by_key.get(key)
+                if not existing_sa:
+                    source_assets_by_key[key] = ad
+                elif not ad == existing_sa:
+                    raise DagsterInvalidDefinitionError(
+                        _get_error_msg_for_target_asset_conflict(
+                            _get_instigator_str(instigator_def), key.to_user_string()
+                        )
+                    )
+            else:
+                check.failed(f"Unexpected asset definition {ad}")
+
+
 def _validate_auto_materialize_sensors(
     sensors: Iterable[SensorDefinition], asset_graph: BaseAssetGraph
 ) -> None:
     """Raises an error if two or more automation policy sensors target the same asset."""
-    sensor_names_by_asset_key: Dict[AssetKey, str] = {}
+    sensor_names_by_asset_key: Dict["AssetKey", str] = {}
     for sensor in sensors:
         if isinstance(sensor, AutoMaterializeSensorDefinition):
             asset_keys = sensor.asset_selection.resolve(asset_graph)
@@ -490,9 +546,33 @@ def _validate_partitions_definition(partitions_def: PartitionsDefinition) -> Non
         )
 
 
-def _get_error_msg_for_target_conflict(targeter, target_type, target_name, dupe_target_type):
+def _get_instigator_str(
+    instigator_def: Union[
+        SensorDefinition, ScheduleDefinition, UnresolvedPartitionedAssetScheduleDefinition
+    ],
+) -> str:
     return (
-        f"{targeter} targets {target_type} '{target_name}', but a different {dupe_target_type} with"
+        f"schedule '{instigator_def.name}'"
+        if isinstance(
+            instigator_def,
+            (ScheduleDefinition, UnresolvedPartitionedAssetScheduleDefinition),
+        )
+        else f"sensor '{instigator_def.name}'"
+    )
+
+
+def _get_error_msg_for_target_conflict(
+    instigator: str, target_type: str, target_name: str, dupe_target_type: str
+) -> str:
+    return (
+        f"{instigator} targets {target_type} '{target_name}', but a different {dupe_target_type} with"
         " the same name was provided. Disambiguate between these by providing a separate name to"
         " one of them."
+    )
+
+
+def _get_error_msg_for_target_asset_conflict(instigator: str, target_name: str) -> str:
+    return (
+        f"{instigator} targets asset '{target_name}', but a different asset with"
+        " the same key was provided. Assets must have unique keys."
     )

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -24,7 +24,7 @@ from typing import (
 from typing_extensions import TypeAlias
 
 import dagster._check as check
-from dagster._annotations import deprecated, deprecated_param, public
+from dagster._annotations import deprecated, deprecated_param, experimental_param, public
 from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.resource_annotation import get_resource_args
@@ -49,13 +49,16 @@ from ..instance import DagsterInstance
 from ..instance.ref import InstanceRef
 from ..storage.dagster_run import DagsterRun
 from .run_request import RunRequest, SkipReason
-from .target import AutomationTarget, ExecutableDefinition, normalize_automation_target_def
+from .target import AutomationTarget, ExecutableDefinition
 from .utils import NormalizedTags, check_valid_name, normalize_tags
 
 if TYPE_CHECKING:
     from dagster import ResourceDefinition
+    from dagster._core.definitions.asset_selection import CoercibleToAssetSelection
+    from dagster._core.definitions.assets import AssetsDefinition
     from dagster._core.definitions.repository_definition import RepositoryDefinition
     from dagster._core.definitions.run_config import RunConfig
+
 T = TypeVar("T")
 
 RunRequestIterator: TypeAlias = Iterator[Union[RunRequest, SkipReason]]
@@ -479,6 +482,7 @@ def validate_and_get_schedule_resource_dict(
         " the containing environment, and can safely be deleted."
     ),
 )
+@experimental_param(param="target")
 class ScheduleDefinition(IHasInternalInit):
     """Defines a schedule that targets a job.
 
@@ -518,6 +522,8 @@ class ScheduleDefinition(IHasInternalInit):
             schedule runs.
         default_status (DefaultScheduleStatus): If set to ``RUNNING``, the schedule will start as running. The default status can be overridden from the `Dagster UI </concepts/webserver/ui>`_ or via the `GraphQL API </concepts/webserver/graphql>`_.
         required_resource_keys (Optional[Set[str]]): The set of resource keys required by the schedule.
+        target (Optional[Union[CoercibleToAssetSelection, AssetsDefinition, JobDefinition, UnresolvedAssetJobDefinition]]):
+            The target that the schedule will execute.
     """
 
     def with_updated_job(self, new_job: ExecutableDefinition) -> "ScheduleDefinition":
@@ -530,7 +536,7 @@ class ScheduleDefinition(IHasInternalInit):
         return ScheduleDefinition.dagster_internal_init(
             name=self.name,
             cron_schedule=self._cron_schedule,
-            job_name=self.job_name,
+            job_name=None,  # job name will be derived from the passed job
             execution_timezone=self.execution_timezone,
             execution_fn=self._execution_fn,
             description=self.description,
@@ -543,6 +549,7 @@ class ScheduleDefinition(IHasInternalInit):
             tags=None,
             tags_fn=None,
             should_execute=None,
+            target=None,
         )
 
     def __init__(
@@ -563,6 +570,14 @@ class ScheduleDefinition(IHasInternalInit):
         job: Optional[ExecutableDefinition] = None,
         default_status: DefaultScheduleStatus = DefaultScheduleStatus.STOPPED,
         required_resource_keys: Optional[Set[str]] = None,
+        target: Optional[
+            Union[
+                "CoercibleToAssetSelection",
+                "AssetsDefinition",
+                "JobDefinition",
+                "UnresolvedAssetJobDefinition",
+            ]
+        ] = None,
     ):
         from dagster._core.definitions.run_config import convert_config_input
 
@@ -584,16 +599,36 @@ class ScheduleDefinition(IHasInternalInit):
                 " https://github.com/dagster-io/dagster/issues/15294 for more information."
             )
 
-        if job:
-            job_def = normalize_automation_target_def(job)
-            self._target = AutomationTarget(job_def)
+        if (
+            sum(
+                [
+                    int(target is not None),
+                    int(job_name is not None),
+                    int(job is not None),
+                ]
+            )
+            > 1
+        ):
+            raise DagsterInvalidDefinitionError(
+                "Attempted to provide more than one of 'job', 'job_name', and 'target'"
+                "params to ScheduleDefinition. Must provide only one."
+            )
+
+        if target:
+            self._target = AutomationTarget.from_coercible(
+                target,
+                automation_name=check.not_none(
+                    name, "If you specify target you must specify schedule name"
+                ),
+            )
+        elif job:
+            self._target = AutomationTarget.from_coercible(job)
         elif job_name:
             self._target = AutomationTarget(
                 resolvable_to_job=check.str_param(job_name, "job_name"),
-                op_selection=None,
             )
         else:
-            check.failed("Must provide job or job_name")
+            check.failed("Must provide target, job, or job_name")
 
         if name:
             self._name = check_valid_name(name)
@@ -648,7 +683,7 @@ class ScheduleDefinition(IHasInternalInit):
                     " to ScheduleDefinition. Must provide only one of the two."
                 )
             elif tags:
-                tags = normalize_tags(tags, allow_reserved_tags=False).tags
+                tags = normalize_tags(tags, allow_reserved_tags=False, warning_stacklevel=5).tags
                 tags_fn = lambda _context: tags
             else:
                 tags_fn = check.opt_callable_param(
@@ -749,6 +784,14 @@ class ScheduleDefinition(IHasInternalInit):
         job: Optional[ExecutableDefinition],
         default_status: DefaultScheduleStatus,
         required_resource_keys: Optional[Set[str]],
+        target: Optional[
+            Union[
+                "CoercibleToAssetSelection",
+                "AssetsDefinition",
+                "JobDefinition",
+                "UnresolvedAssetJobDefinition",
+            ]
+        ],
     ) -> "ScheduleDefinition":
         return ScheduleDefinition(
             name=name,
@@ -766,6 +809,7 @@ class ScheduleDefinition(IHasInternalInit):
             job=job,
             default_status=default_status,
             required_resource_keys=required_resource_keys,
+            target=target,
         )
 
     def __call__(self, *args, **kwargs) -> ScheduleEvaluationFunctionReturn:

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -26,9 +26,8 @@ from typing import (
 from typing_extensions import TypeAlias
 
 import dagster._check as check
-from dagster._annotations import deprecated, deprecated_param, public
+from dagster._annotations import deprecated, deprecated_param, experimental_param, public
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
-from dagster._core.definitions.asset_selection import CoercibleToAssetSelection
 from dagster._core.definitions.events import AssetMaterialization, AssetObservation
 from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.definitions.job_definition import JobDefinition
@@ -52,16 +51,20 @@ from dagster._utils.merger import merge_dicts
 from dagster._utils.warnings import normalize_renamed_param
 
 from ..decorator_utils import get_function_params
-from .asset_selection import AssetSelection, KeysAssetSelection
+from .asset_selection import AssetSelection, CoercibleToAssetSelection, KeysAssetSelection
 from .dynamic_partitions_request import AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest
 from .run_request import DagsterRunReaction, RunRequest, SensorResult, SkipReason
-from .target import AutomationTarget, ExecutableDefinition, normalize_automation_target_def
+from .target import AutomationTarget, ExecutableDefinition
 from .utils import check_valid_name
 
 if TYPE_CHECKING:
     from dagster import ResourceDefinition
+    from dagster._core.definitions.assets import AssetsDefinition
     from dagster._core.definitions.definitions_class import Definitions
     from dagster._core.definitions.repository_definition import RepositoryDefinition
+    from dagster._core.definitions.unresolved_asset_job_definition import (
+        UnresolvedAssetJobDefinition,
+    )
     from dagster._core.remote_representation.origin import CodeLocationOrigin
 
 
@@ -540,6 +543,7 @@ def split_run_requests(
     return run_requests_for_backfill_daemon, run_requests_for_single_runs
 
 
+@experimental_param(param="target")
 class SensorDefinition(IHasInternalInit):
     """Define a sensor that initiates a set of runs based on some external state.
 
@@ -561,6 +565,8 @@ class SensorDefinition(IHasInternalInit):
         asset_selection (Optional[Union[str, Sequence[str], Sequence[AssetKey], Sequence[Union[AssetsDefinition, SourceAsset]], AssetSelection]]):
             (Experimental) an asset selection to launch a run for if the sensor condition is met.
             This can be provided instead of specifying a job.
+        target (Optional[Union[CoercibleToAssetSelection, AssetsDefinition, JobDefinition, UnresolvedAssetJobDefinition]]):
+            The target that the sensor will execute.
     """
 
     def with_updated_jobs(self, new_jobs: Sequence[ExecutableDefinition]) -> "SensorDefinition":
@@ -581,6 +587,7 @@ class SensorDefinition(IHasInternalInit):
             default_status=self.default_status,
             asset_selection=self.asset_selection,
             required_resource_keys=self._raw_required_resource_keys,
+            target=None,
         )
 
     def with_updated_job(self, new_job: ExecutableDefinition) -> "SensorDefinition":
@@ -605,6 +612,14 @@ class SensorDefinition(IHasInternalInit):
         default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
         asset_selection: Optional[CoercibleToAssetSelection] = None,
         required_resource_keys: Optional[Set[str]] = None,
+        target: Optional[
+            Union[
+                "CoercibleToAssetSelection",
+                "AssetsDefinition",
+                "JobDefinition",
+                "UnresolvedAssetJobDefinition",
+            ]
+        ] = None,
     ):
         from dagster._config.pythonic_config import validate_resource_annotated_function
 
@@ -614,9 +629,10 @@ class SensorDefinition(IHasInternalInit):
         if (
             sum(
                 [
+                    int(target is not None),
                     int(job is not None),
-                    int(jobs is not None),
                     int(job_name is not None),
+                    int(jobs is not None),
                     int(asset_selection is not None),
                 ]
             )
@@ -627,21 +643,24 @@ class SensorDefinition(IHasInternalInit):
                 "'asset_selection' params to SensorDefinition. Must provide only one."
             )
 
-        jobs = jobs if jobs else [job] if job else None
-
-        targets: Optional[List[AutomationTarget]] = None
-        if job_name:
+        if target:
             targets = [
-                AutomationTarget(
-                    resolvable_to_job=check.str_param(job_name, "job_name"),
-                    op_selection=None,
+                AutomationTarget.from_coercible(
+                    target,
+                    automation_name=check.not_none(
+                        name, "If you specify target you must specify sensor name"
+                    ),
                 )
             ]
         elif job:
-            targets = [AutomationTarget(normalize_automation_target_def(job))]
+            targets = [AutomationTarget.from_coercible(job)]
+        elif job_name:
+            targets = [
+                AutomationTarget(resolvable_to_job=check.str_param(job_name, "job_name")),
+            ]
         elif jobs:
-            targets = [AutomationTarget(normalize_automation_target_def(job)) for job in jobs]
-        elif asset_selection:
+            targets = [AutomationTarget.from_coercible(job) for job in jobs]
+        else:
             targets = []
 
         if name:
@@ -698,6 +717,14 @@ class SensorDefinition(IHasInternalInit):
         default_status: DefaultSensorStatus,
         asset_selection: Optional[CoercibleToAssetSelection],
         required_resource_keys: Optional[Set[str]],
+        target: Optional[
+            Union[
+                "CoercibleToAssetSelection",
+                "AssetsDefinition",
+                "JobDefinition",
+                "UnresolvedAssetJobDefinition",
+            ]
+        ],
     ) -> "SensorDefinition":
         return SensorDefinition(
             name=name,
@@ -710,6 +737,7 @@ class SensorDefinition(IHasInternalInit):
             default_status=default_status,
             asset_selection=asset_selection,
             required_resource_keys=required_resource_keys,
+            target=target,
         )
 
     def __call__(self, *args, **kwargs) -> RawSensorEvaluationFunctionReturn:

--- a/python_modules/dagster/dagster/_core/definitions/target.py
+++ b/python_modules/dagster/dagster/_core/definitions/target.py
@@ -1,18 +1,30 @@
 from typing import NamedTuple, Optional, Sequence, Union
 
-from typing_extensions import TypeAlias
+from typing_extensions import Self, TypeAlias
 
 import dagster._check as check
+from dagster._core.definitions.asset_selection import (
+    AssetSelection,
+    CoercibleToAssetSelection,
+    is_coercible_to_asset_selection,
+)
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.source_asset import SourceAsset
 from dagster._utils.warnings import deprecation_warning
 
 from .graph_definition import GraphDefinition
 from .job_definition import JobDefinition
-from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition
+from .unresolved_asset_job_definition import UnresolvedAssetJobDefinition, define_asset_job
 
 ExecutableDefinition: TypeAlias = Union[
     JobDefinition, GraphDefinition, UnresolvedAssetJobDefinition
 ]
 
+CoercibleToAutomationTarget: TypeAlias = Union[
+    CoercibleToAssetSelection,
+    AssetsDefinition,
+    ExecutableDefinition,
+]
 
 ResolvableToJob: TypeAlias = Union[JobDefinition, UnresolvedAssetJobDefinition, str]
 """
@@ -33,6 +45,7 @@ class AutomationTarget(
         [
             ("resolvable_to_job", ResolvableToJob),
             ("op_selection", Optional[Sequence[str]]),
+            ("assets_defs", Sequence[Union[AssetsDefinition, SourceAsset]]),
         ],
     )
 ):
@@ -48,14 +61,58 @@ class AutomationTarget(
         cls,
         resolvable_to_job: Union[JobDefinition, UnresolvedAssetJobDefinition, str],
         op_selection: Optional[Sequence[str]] = None,
+        assets_defs: Optional[Sequence[Union[AssetsDefinition, SourceAsset]]] = None,
     ):
-        check.inst_param(
-            resolvable_to_job,
-            "resolvable_to_job",
-            (JobDefinition, UnresolvedAssetJobDefinition, str),
+        return super().__new__(
+            cls,
+            resolvable_to_job=check.inst_param(
+                resolvable_to_job,
+                "resolvable_to_job",
+                (JobDefinition, UnresolvedAssetJobDefinition, str),
+            ),
+            op_selection=check.opt_nullable_sequence_param(
+                op_selection, "op_selection", of_type=str
+            ),
+            assets_defs=check.opt_sequence_param(
+                assets_defs, "assets_defs", of_type=AssetsDefinition
+            ),
         )
 
-        return super().__new__(cls, resolvable_to_job, op_selection=op_selection)
+    @classmethod
+    def from_coercible(
+        cls,
+        coercible: CoercibleToAutomationTarget,
+        automation_name: Optional[str] = None,  # only needed if we are generating an anonymous job
+    ) -> Self:
+        if isinstance(coercible, (JobDefinition, UnresolvedAssetJobDefinition)):
+            return cls(coercible)
+        elif isinstance(coercible, GraphDefinition):
+            deprecation_warning(
+                "Passing GraphDefinition as a job/target argument to ScheduleDefinition and SensorDefinition",
+                breaking_version="2.0",
+            )
+            return cls(coercible.to_job())
+        else:
+            if isinstance(coercible, AssetsDefinition):
+                asset_selection = AssetSelection.assets(coercible)
+                assets_defs = [coercible]
+            elif is_coercible_to_asset_selection(coercible):
+                asset_selection = AssetSelection.from_coercible(coercible)
+                assets_defs = (
+                    [x for x in coercible if isinstance(x, (AssetsDefinition, SourceAsset))]
+                    if isinstance(coercible, Sequence)
+                    else []
+                )
+            else:
+                check.failed(_make_invalid_target_error_message(coercible))
+
+            job_name = _make_anonymous_asset_job_name(
+                check.not_none(automation_name, "Must provide automation_name")
+            )
+            return cls(
+                resolvable_to_job=define_asset_job(name=job_name, selection=asset_selection),
+                assets_defs=assets_defs,
+            )
 
     @property
     def job_name(self) -> str:
@@ -77,16 +134,13 @@ class AutomationTarget(
         return isinstance(self.resolvable_to_job, (JobDefinition, UnresolvedAssetJobDefinition))
 
 
-def normalize_automation_target_def(
-    target_def: "ExecutableDefinition",
-) -> Union["JobDefinition", "UnresolvedAssetJobDefinition"]:
-    from dagster._core.definitions.graph_definition import GraphDefinition
+def _make_anonymous_asset_job_name(automation_name: str) -> str:
+    return f"__anonymous_asset_job_{automation_name}"
 
-    if isinstance(target_def, GraphDefinition):
-        deprecation_warning(
-            "Passing GraphDefinition as a job argument to ScheduleDefinition and SensorDefinition",
-            breaking_version="2.0",
-        )
-        return target_def.to_job()
+
+def _make_invalid_target_error_message(target: object) -> str:
+    if isinstance(target, Sequence):
+        additional_message = " If you pass a sequence to a schedule, it must be a sequence of strings, AssetKeys, AssetsDefinitions, or SourceAssets."
     else:
-        return target_def
+        additional_message = ""
+    return f"Invalid target passed to schedule/sensor.{additional_message} Target: {target}"

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -55,7 +55,7 @@ def boring_observable_asset():
     pass
 
 
-@sensor()
+@sensor(asset_selection=[auto_materialize_asset])
 def normal_sensor():
     yield SkipReason("OOPS")
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/automation_tests/test_basic_automations.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/automation_tests/test_basic_automations.py
@@ -1,0 +1,129 @@
+from typing import TYPE_CHECKING, List, Optional, Sequence, Union
+
+from dagster import ScheduleDefinition, asset, job, op, sensor
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.decorators.schedule_decorator import schedule
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.job_definition import JobDefinition
+from dagster._core.definitions.sensor_definition import SensorDefinition
+from dagster._core.definitions.target import _make_anonymous_asset_job_name
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.source_asset import SourceAsset
+    from dagster._core.definitions.unresolved_asset_job_definition import (
+        UnresolvedAssetJobDefinition,
+    )
+
+
+def make_automations_aware_definitions(
+    schedules: Optional[Sequence[ScheduleDefinition]] = None,
+    sensors: Optional[Sequence[SensorDefinition]] = None,
+):
+    job_defs: List[Union[JobDefinition, UnresolvedAssetJobDefinition]] = []
+    assets_defs: List[Union[AssetsDefinition, SourceAsset]] = []
+    for schedule_def in schedules or []:
+        job_defs.append(schedule_def.target.job_def)
+        assets_defs.extend(schedule_def.target.assets_defs)
+
+    for sensor_def in sensors or []:
+        for target in sensor_def.targets:
+            job_defs.append(target.job_def)
+            assets_defs.extend(target.assets_defs)
+
+    return Definitions(schedules=schedules, sensors=sensors, assets=assets_defs)
+
+
+def test_basic_schedule_single_asset() -> None:
+    @asset
+    def my_asset() -> None: ...
+
+    schedule = ScheduleDefinition(name="a_schedule", cron_schedule="* * * * *", target=my_asset)
+
+    defs = make_automations_aware_definitions([schedule])
+
+    assert isinstance(defs, Definitions)
+
+    assert isinstance(
+        defs.get_job_def(_make_anonymous_asset_job_name(schedule.name)), JobDefinition
+    )
+    assert isinstance(defs.get_assets_def("my_asset"), AssetsDefinition)
+
+
+def test_basic_schedule_multiple_assets() -> None:
+    @asset
+    def asset_one() -> None: ...
+
+    @asset(deps=[asset_one])
+    def asset_two() -> None: ...
+
+    schedule = ScheduleDefinition(
+        name="a_schedule", cron_schedule="* * * * *", target=[asset_one, asset_two]
+    )
+
+    defs = make_automations_aware_definitions([schedule])
+
+    assert isinstance(defs, Definitions)
+
+    assert isinstance(
+        defs.get_job_def(_make_anonymous_asset_job_name(schedule.name)), JobDefinition
+    )
+    assert isinstance(defs.get_assets_def("asset_one"), AssetsDefinition)
+    assert isinstance(defs.get_assets_def("asset_two"), AssetsDefinition)
+    assert not defs.get_asset_graph().has(AssetKey.from_coercible("slkjdfklsjdfl"))
+
+
+def test_decorator_schedule() -> None:
+    @asset
+    def my_asset() -> None: ...
+
+    @schedule(cron_schedule="* * * * *", target=my_asset)
+    def a_schedule(_) -> dict:
+        return {}
+
+    defs = make_automations_aware_definitions(schedules=[a_schedule])
+    assert isinstance(defs.get_schedule_def("a_schedule"), ScheduleDefinition)
+
+
+def test_legacy_job() -> None:
+    @op
+    def an_op() -> None: ...
+    @job
+    def a_job() -> None:
+        an_op()
+
+    schedule = ScheduleDefinition(name="a_schedule", cron_schedule="* * * * *", target=a_job)
+
+    defs = make_automations_aware_definitions([schedule])
+
+    assert isinstance(defs, Definitions)
+
+    assert isinstance(defs.get_job_def("a_job"), JobDefinition)
+
+
+def test_basic_sensor_definition() -> None:
+    @asset
+    def my_asset() -> None: ...
+
+    defs = make_automations_aware_definitions(
+        sensors=[
+            SensorDefinition(
+                name="a_sensor",
+                target=my_asset,
+                evaluation_fn=lambda _: ...,
+            )
+        ]
+    )
+    assert isinstance(defs, Definitions)
+    assert isinstance(defs.get_sensor_def("a_sensor"), SensorDefinition)
+
+
+def test_sensor_decorator() -> None:
+    @asset
+    def my_asset() -> None: ...
+
+    @sensor(target=my_asset, name="a_sensor")
+    def a_sensor() -> None: ...
+
+    defs = make_automations_aware_definitions(sensors=[a_sensor])
+    assert isinstance(defs.get_sensor_def("a_sensor"), SensorDefinition)


### PR DESCRIPTION
## Summary & Motivation

Add new `target` param to `{Schedule,Sensor}Definition` and their associated decorators. A target is an executable entity that can be targeted by a schedule/sensor. This is intended as a replacement for the `job`/`job_name` parameters.

This PR builds off downstack work that consolidated `DirectTarget` and `RepoRelativeTarget` into a single `AutomationTarget` class. The primary addition here is an `AutomationTarget.from_coercible` class method that will accept an `AssetsDefinition` or `CoercibleToAssetSelection` and generate an anonymous asset job from it which is used as the job def for the `AutomationTarget`.

`AssetsDefinitions` that are passed directly as a target, rather than as `Definitions.assets`, are automatically included in the pool of assets for the `Definitions` object. This means that if asset "foo" is embedded as an automation target as some sensor, and an unrelated job is defined by `AssetSelection.assets("foo")`, the job will successfully resolve foo.

## How I Tested These Changes

New unit tests.