### PR TITLE
Pin numpy<2 in dagster integration libs that depend on it

### DIFF
--- a/python_modules/libraries/dagster-pandas/setup.py
+++ b/python_modules/libraries/dagster-pandas/setup.py
@@ -47,5 +47,10 @@ setup(
     packages=find_packages(exclude=["dagster_pandas_tests*"]),
     include_package_data=True,
     python_requires=">=3.8,<3.13",
-    install_requires=[f"dagster{pin}", "pandas"],
+    install_requires=[
+        f"dagster{pin}",
+        "pandas",
+        # Pin numpy pending release of pandas that either supports numpy 2 or adds a pin
+        "numpy<2",
+    ],
 )

--- a/python_modules/libraries/dagster-pandera/setup.py
+++ b/python_modules/libraries/dagster-pandera/setup.py
@@ -35,7 +35,13 @@ setup(
     packages=find_packages(exclude=["dagster_pandera_tests*"]),
     include_package_data=True,
     python_requires=">=3.8,<3.13",
-    install_requires=[f"dagster{pin}", "pandas", "pandera>=0.14.2"],
+    install_requires=[
+        f"dagster{pin}",
+        "pandas",
+        "pandera>=0.14.2",
+        # Pin numpy pending release of pandera that either supports numpy 2 or adds a pin
+        "numpy<2",
+    ],
     extras_require={
         "test": [
             "pytest",

--- a/python_modules/libraries/dagster-wandb/setup.py
+++ b/python_modules/libraries/dagster-wandb/setup.py
@@ -36,6 +36,8 @@ setup(
     install_requires=[
         f"dagster{pin}",
         "wandb>=0.15.11,<1.0",
+        # Pin numpy pending release of wandb that either supports numpy 2 or adds a pin
+        "numpy<2",
     ],
     extras_require={"dev": ["cloudpickle", "joblib", "callee", "dill"]},
     zip_safe=False,


### PR DESCRIPTION
## Summary & Motivation

The release of numpy 2 broke several of our integration libraries. This PR pins numpy 2 in those libraries-- we can remove the pins when versions of the third-party libraries are released that either support numpy 2 or add appropriate pins.

## How I Tested These Changes

Existing test suite
