### PR TITLE
Remove debug log lines from asset backfill

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -326,8 +326,6 @@ def submit_asset_runs_in_chunks(
         chunk_submitted_runs: List[Tuple[RunRequest, DagsterRun]] = []
         retryable_error_raised = False
 
-        logger.debug(f"{chunk_size}, {chunk_start}, {len(run_request_chunk)}")
-
         # submit each run in the chunk
         for chunk_idx, run_request in enumerate(run_request_chunk):
             run_request_idx = chunk_start + chunk_idx


### PR DESCRIPTION
Summary:
These are showing up in the user-facing logs in a way that may be confusing, I don't think we need them?

Test Plan: Launch a backfill, no more debug line in logs

## Summary & Motivation

## How I Tested These Changes
