### PR TITLE
Make display done wait for indexeddb cache to load 

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -296,7 +296,7 @@ export const useRunsForTimeline = ({
 
   const {workspaceOrError} = futureTicksData || {workspaceOrError: undefined};
 
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   const previousRunsByJobKey = useRef<{
     jobInfo: Record<string, {repoAddress: RepoAddress; pipelineName: string; isAdHoc: boolean}>;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -290,7 +290,7 @@ export const useRunsForTimeline = ({
   }, [startSec, _end, client, showTicks]);
 
   useBlockTraceOnQueryResult(ongoingRunsQueryData, 'OngoingRunTimelineQuery');
-  useBlockTraceOnQueryResult(completedRunsQueryData, 'CompletedRunTimelineQuery');
+  useBlockTraceUntilTrue('CompletedRunTimelineQuery', !completedRunsQueryData.loading);
 
   const {data: futureTicksData} = futureTicksQueryData;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -21,7 +21,7 @@ import {FIFTEEN_SECONDS, useRefreshAtInterval} from '../app/QueryRefresh';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {InstigationStatus, RunStatus, RunsFilter} from '../graphql/types';
 import {SCHEDULE_FUTURE_TICKS_FRAGMENT} from '../instance/NextTick';
-import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
+import {useBlockTraceOnQueryResult, useBlockTraceUntilTrue} from '../performance/TraceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
@@ -115,8 +115,13 @@ export const useRunsForTimeline = ({
 
   const {data: ongoingRunsData} = ongoingRunsQueryData;
 
+  const [didLoadCache, setDidLoadCache] = useState(false);
+  useBlockTraceUntilTrue('IndexedDBCache', didLoadCache);
+
   const fetchCompletedRunsQueryData = useCallback(async () => {
     await completedRunsCache.loadCacheFromIndexedDB();
+    setDidLoadCache(true);
+
     return await fetchPaginatedBucketData({
       buckets: buckets
         .filter((bucket) => !completedRunsCache.isCompleteRange(bucket[0], bucket[1]))


### PR DESCRIPTION
## Summary & Motivation

There's a missing dependency here since we stopped blocked on the future ticks query which would normally fill the gap while indexeddb loaded. Without this dependency we end up logging display done too early.

## How I Tested These Changes

Take a sample locally: https://app.datadoghq.com/rum/sessions?query=%40application.id%3A6d12cca2-0263-463b-a90e-cc6c524e14bd%20%40usr.email%3Amarco%40dagsterlabs.com%20%40type%3Aaction&agg_m=count&agg_m_source=base&agg_q=%40issue.id&agg_q_source=base&agg_t=count&cols=&event=AgAAAZAn4VnigTg1mwAAAAAAAAAYAAAAAEFaQW40WXhoQUFERVNFNm1DeVo1blFBRAAAACQAAAAAMDE5MDI3ZTEtYmUyNS00ODZjLThkYTEtMDFlYzg3ZWM1YjFh&fromUser=false&tab=error&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1718569637424&to_ts=1718656037424&live=true

