### PR TITLE
Fix error when you try to load backfill logs before there are any logs

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -574,7 +574,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
 
         return GrapheneInstigationEventConnection(
             events=events,
-            cursor=new_cursor.to_string() if new_cursor else None,
+            cursor=new_cursor.to_string() if new_cursor else "",
             hasMore=new_cursor.has_more_now if new_cursor else False,
         )
 


### PR DESCRIPTION
Summary:
This is a non-nullable field, make it "" to match the other similar-ish cases

Test Plan: Load a backfill without logs yet, no more error in console

## Summary & Motivation

## How I Tested These Changes
