### PR TITLE
fix(dlt) do not append to pipeline name as results in unintended side-effects

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
@@ -169,11 +169,6 @@ class DagsterDltResource(ConfigurableResource):
                 ]
             )
 
-        # https://github.com/dagster-io/dagster/issues/21022
-        if isinstance(context, AssetExecutionContext):
-            if context.assets_def.partitions_def is not None:
-                dlt_pipeline.pipeline_name += f"_{context.partition_key}"
-
         load_info = dlt_pipeline.run(dlt_source, **kwargs)
 
         load_info.raise_on_failed_jobs()


### PR DESCRIPTION
## Summary & Motivation

Appending to the _dlt_ pipeline name results in unintended consequences in that _filesystem_ destinations will have file names that do not adhere to typical _dlt_ usage. This removes the appended partition to the pipeline name. For more context see the discussion below:

https://github.com/dagster-io/dagster/pull/22000#issuecomment-2174983213

## How I Tested These Changes

- pytest