### PR TITLE
in AssetsDefinition construction, enforce single key per output name

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -59,7 +59,7 @@ from dagster._core.errors import (
     DagsterInvalidInvocationError,
     DagsterInvariantViolationError,
 )
-from dagster._model import dagster_model
+from dagster._model import IHaveNew, dagster_model_custom
 from dagster._utils import IHasInternalInit
 from dagster._utils.merger import merge_dicts
 from dagster._utils.security import non_secure_md5_hash_str
@@ -87,8 +87,8 @@ if TYPE_CHECKING:
 ASSET_SUBSET_INPUT_PREFIX = "__subset_input__"
 
 
-@dagster_model
-class AssetGraphComputation:
+@dagster_model_custom
+class AssetGraphComputation(IHaveNew):
     """A computation whose purpose is to materialize assets, observe assets, and/or evaluate asset
     checks.
 
@@ -103,10 +103,40 @@ class AssetGraphComputation:
     is_subset: bool
     selected_asset_keys: AbstractSet[AssetKey]
     selected_asset_check_keys: AbstractSet[AssetCheckKey]
+    output_names_by_key: Mapping[AssetKey, str]
 
-    @cached_property
-    def output_names_by_key(self):
-        return {key: name for name, key in self.keys_by_output_name.items()}
+    def __new__(
+        cls,
+        node_def: NodeDefinition,
+        keys_by_input_name: Mapping[str, AssetKey],
+        keys_by_output_name: Mapping[str, AssetKey],
+        backfill_policy: Optional[BackfillPolicy],
+        can_subset: bool,
+        is_subset: bool,
+        selected_asset_keys: AbstractSet[AssetKey],
+        selected_asset_check_keys: AbstractSet[AssetCheckKey],
+    ):
+        output_names_by_key: Dict[AssetKey, str] = {}
+        for output_name, key in keys_by_output_name.items():
+            if key in output_names_by_key:
+                check.failed(
+                    f"Outputs '{output_names_by_key[key]}' and '{output_name}' both target the "
+                    "same asset key. Each asset key should correspond to a single output."
+                )
+            output_names_by_key[key] = output_name
+
+        return super().__new__(
+            cls,
+            node_def=node_def,
+            keys_by_input_name=keys_by_input_name,
+            keys_by_output_name=keys_by_output_name,
+            backfill_policy=backfill_policy,
+            can_subset=can_subset,
+            is_subset=is_subset,
+            selected_asset_keys=selected_asset_keys,
+            selected_asset_check_keys=selected_asset_check_keys,
+            output_names_by_key=output_names_by_key,
+        )
 
 
 class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2209,3 +2209,14 @@ def test_construct_assets_definition_without_node_def_with_bad_param_combo() -> 
 
     with pytest.raises(CheckError):
         AssetsDefinition(specs=[spec], can_subset=True)
+
+
+def test_multiple_keys_per_output_name():
+    @op(out={"out1": Out(), "out2": Out()})
+    def op1():
+        pass
+
+    with pytest.raises(CheckError, match="Each asset key should correspond to a single output."):
+        AssetsDefinition(
+            node_def=op1, keys_by_output_name={"out1": AssetKey("a"), "out2": AssetKey("a")}
+        )


### PR DESCRIPTION
## Summary & Motivation

We already implicitly expect this in various places in our code. E.g.:
- https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/_core/definitions/assets.py#L328.
- https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/_core/definitions/asset_layer.py#L294

I believe we assume a single materialization per asset (per partition) per run.

## How I Tested These Changes
