### PR TITLE
[ui] add click-to-filter behavior in asset graph, list

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -55,6 +55,7 @@ import {AssetFilterState} from '../assets/useAssetDefinitionFilterState';
 import {DEFAULT_MAX_ZOOM, SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
 import {closestNodeInDirection, isNodeOffscreen} from '../graph/common';
+import {DefinitionTag} from '../graphql/types';
 import {useQueryAndLocalStoragePersistedState} from '../hooks/useQueryAndLocalStoragePersistedState';
 import {PageLoadTrace} from '../performance';
 import {
@@ -65,6 +66,7 @@ import {
 } from '../pipelines/GraphExplorer';
 import {EmptyDAGNotice, EntirelyFilteredDAGNotice, LoadingNotice} from '../pipelines/GraphNotices';
 import {ExplorerPath} from '../pipelines/PipelinePathUtils';
+import {StaticSetFilter} from '../ui/Filters/useStaticSetFilter';
 import {GraphQueryInput} from '../ui/GraphQueryInput';
 import {Loading} from '../ui/Loading';
 
@@ -103,25 +105,26 @@ export const AssetGraphExplorer = (props: Props) => {
 
   const {explorerPath, onChangeExplorerPath} = props;
 
-  const {button, filterBar} = useAssetGraphExplorerFilters({
-    nodes: React.useMemo(
-      () => (fullAssetGraphData ? Object.values(fullAssetGraphData.nodes) : []),
-      [fullAssetGraphData],
-    ),
-    loading: fetchResult.loading,
-    isGlobalGraph: !!props.isGlobalGraph,
-    assetFilterState: props.assetFilterState,
-    explorerPath: explorerPath.opsQuery,
-    clearExplorerPath: React.useCallback(() => {
-      onChangeExplorerPath(
-        {
-          ...explorerPath,
-          opsQuery: '',
-        },
-        'push',
-      );
-    }, [explorerPath, onChangeExplorerPath]),
-  });
+  const {button, filterBar, computeKindTagsFilter, storageKindTagsFilter} =
+    useAssetGraphExplorerFilters({
+      nodes: React.useMemo(
+        () => (fullAssetGraphData ? Object.values(fullAssetGraphData.nodes) : []),
+        [fullAssetGraphData],
+      ),
+      loading: fetchResult.loading,
+      isGlobalGraph: !!props.isGlobalGraph,
+      assetFilterState: props.assetFilterState,
+      explorerPath: explorerPath.opsQuery,
+      clearExplorerPath: React.useCallback(() => {
+        onChangeExplorerPath(
+          {
+            ...explorerPath,
+            opsQuery: '',
+          },
+          'push',
+        );
+      }, [explorerPath, onChangeExplorerPath]),
+    });
 
   return (
     <Loading allowStaleData queryResult={fetchResult}>
@@ -150,6 +153,8 @@ export const AssetGraphExplorer = (props: Props) => {
             graphQueryItems={graphQueryItems}
             filterBar={filterBar}
             filterButton={button}
+            computeKindTagsFilter={computeKindTagsFilter}
+            storageKindTagsFilter={storageKindTagsFilter}
             {...props}
           />
         );
@@ -168,6 +173,8 @@ type WithDataProps = Props & {
   filterBar?: React.ReactNode;
   isGlobalGraph?: boolean;
   trace?: PageLoadTrace;
+  computeKindTagsFilter?: StaticSetFilter<string>;
+  storageKindTagsFilter?: StaticSetFilter<DefinitionTag>;
 };
 
 const AssetGraphExplorerWithData = ({
@@ -185,6 +192,8 @@ const AssetGraphExplorerWithData = ({
   filterBar,
   assetFilterState,
   isGlobalGraph = false,
+  storageKindTagsFilter,
+  computeKindTagsFilter,
   trace,
 }: WithDataProps) => {
   const findAssetLocation = useFindAssetLocation();
@@ -624,6 +633,8 @@ const AssetGraphExplorerWithData = ({
                       <AssetNode
                         definition={graphNode.definition}
                         selected={selectedGraphNodes.includes(graphNode)}
+                        computeKindTagsFilter={computeKindTagsFilter}
+                        storageKindTagsFilter={storageKindTagsFilter}
                       />
                     </AssetNodeContextMenuWrapper>
                   )}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorerFilters.tsx
@@ -211,6 +211,8 @@ export function useAssetGraphExplorerFilters({
   }
 
   return {
+    computeKindTagsFilter: kindTagsFilter,
+    storageKindTagsFilter,
     button,
     filterBar:
       activeFiltersJsx.length || explorerPath ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -23,67 +23,76 @@ import {
   AssetStorageKindTag,
   isCanonicalStorageKindTag,
 } from '../graph/KindTags';
+import {DefinitionTag} from '../graphql/types';
+import {StaticSetFilter} from '../ui/Filters/useStaticSetFilter';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';
 
 interface Props {
   definition: AssetNodeFragment;
   selected: boolean;
+  computeKindTagsFilter?: StaticSetFilter<string>;
+  storageKindTagsFilter?: StaticSetFilter<DefinitionTag>;
 }
 
-export const AssetNode = React.memo(({definition, selected}: Props) => {
-  const isSource = definition.isSource;
+export const AssetNode = React.memo(
+  ({definition, selected, computeKindTagsFilter, storageKindTagsFilter}: Props) => {
+    const isSource = definition.isSource;
 
-  const {liveData} = useAssetLiveData(definition.assetKey);
-  const storageKindTag = definition.tags?.find(isCanonicalStorageKindTag);
-  return (
-    <AssetInsetForHoverEffect>
-      <Box
-        flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
-        style={{minHeight: 24}}
-      >
-        <StaleReasonsTag liveData={liveData} assetKey={definition.assetKey} />
-        <ChangedReasonsTag
-          changedReasons={definition.changedReasons}
-          assetKey={definition.assetKey}
-        />
-      </Box>
-      <AssetNodeContainer $selected={selected}>
-        <AssetNodeBox $selected={selected} $isSource={isSource}>
-          <AssetNameRow definition={definition} />
-          <Box style={{padding: '6px 8px'}} flex={{direction: 'column', gap: 4}} border="top">
-            {definition.description ? (
-              <AssetDescription $color={Colors.textDefault()}>
-                {markdownToPlaintext(definition.description).split('\n')[0]}
-              </AssetDescription>
-            ) : (
-              <AssetDescription $color={Colors.textLight()}>No description</AssetDescription>
-            )}
-            {definition.isPartitioned && !definition.isSource && (
-              <PartitionCountTags definition={definition} liveData={liveData} />
-            )}
-          </Box>
-
-          <AssetNodeStatusRow definition={definition} liveData={liveData} />
-          {(liveData?.assetChecks || []).length > 0 && (
-            <AssetNodeChecksRow definition={definition} liveData={liveData} />
-          )}
-        </AssetNodeBox>
-        <Box flex={{direction: 'row-reverse', gap: 8}}>
-          {storageKindTag && (
-            <AssetStorageKindTag
-              storageKind={storageKindTag.value}
-              style={{position: 'relative', paddingTop: 7, margin: 0}}
-            />
-          )}
-          <AssetComputeKindTag
-            definition={definition}
-            style={{position: 'relative', paddingTop: 7, margin: 0}}
+    const {liveData} = useAssetLiveData(definition.assetKey);
+    const storageKindTag = definition.tags?.find(isCanonicalStorageKindTag);
+    return (
+      <AssetInsetForHoverEffect>
+        <Box
+          flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
+          style={{minHeight: 24}}
+        >
+          <StaleReasonsTag liveData={liveData} assetKey={definition.assetKey} />
+          <ChangedReasonsTag
+            changedReasons={definition.changedReasons}
+            assetKey={definition.assetKey}
           />
         </Box>
-      </AssetNodeContainer>
-    </AssetInsetForHoverEffect>
-  );
-}, isEqual);
+        <AssetNodeContainer $selected={selected}>
+          <AssetNodeBox $selected={selected} $isSource={isSource}>
+            <AssetNameRow definition={definition} />
+            <Box style={{padding: '6px 8px'}} flex={{direction: 'column', gap: 4}} border="top">
+              {definition.description ? (
+                <AssetDescription $color={Colors.textDefault()}>
+                  {markdownToPlaintext(definition.description).split('\n')[0]}
+                </AssetDescription>
+              ) : (
+                <AssetDescription $color={Colors.textLight()}>No description</AssetDescription>
+              )}
+              {definition.isPartitioned && !definition.isSource && (
+                <PartitionCountTags definition={definition} liveData={liveData} />
+              )}
+            </Box>
+
+            <AssetNodeStatusRow definition={definition} liveData={liveData} />
+            {(liveData?.assetChecks || []).length > 0 && (
+              <AssetNodeChecksRow definition={definition} liveData={liveData} />
+            )}
+          </AssetNodeBox>
+          <Box flex={{direction: 'row-reverse', gap: 8}}>
+            {storageKindTag && (
+              <AssetStorageKindTag
+                storageKind={storageKindTag.value}
+                style={{position: 'relative', paddingTop: 7, margin: 0}}
+                currentPageFilter={storageKindTagsFilter}
+              />
+            )}
+            <AssetComputeKindTag
+              definition={definition}
+              style={{position: 'relative', paddingTop: 7, margin: 0}}
+              currentPageFilter={computeKindTagsFilter}
+            />
+          </Box>
+        </AssetNodeContainer>
+      </AssetInsetForHoverEffect>
+    );
+  },
+  isEqual,
+);
 
 export const AssetNameRow = ({definition}: {definition: AssetNodeFragment}) => {
   const displayName = definition.assetKey.path[definition.assetKey.path.length - 1]!;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -286,7 +286,7 @@ export const AssetNodeOverview = ({
             style={{position: 'relative'}}
             definition={assetNode}
             reduceColor
-            linkToFilter
+            linkToFilteredAssetsTable
           />
         )}
       </AttributeAndValue>
@@ -322,7 +322,7 @@ export const AssetNodeOverview = ({
                 style={{position: 'relative'}}
                 storageKind={storageKindTag.value}
                 reduceColor
-                linkToFilter
+                linkToFilteredAssetsTable
               />
             )}
           </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
@@ -22,9 +22,10 @@ import {AssetViewType} from './useAssetView';
 import {CloudOSSContext} from '../app/CloudOSSContext';
 import {useUnscopedPermissions} from '../app/Permissions';
 import {QueryRefreshCountdown, RefreshState} from '../app/QueryRefresh';
-import {AssetKeyInput} from '../graphql/types';
+import {AssetKeyInput, DefinitionTag} from '../graphql/types';
 import {useSelectionReducer} from '../hooks/useSelectionReducer';
 import {testId} from '../testing/testId';
+import {StaticSetFilter} from '../ui/Filters/useStaticSetFilter';
 import {VirtualizedAssetTable} from '../workspace/VirtualizedAssetTable';
 
 type Asset = AssetTableFragment;
@@ -40,6 +41,8 @@ interface Props {
   requery?: RefetchQueriesFunction;
   searchPath: string;
   isFiltered: boolean;
+  computeKindFilter?: StaticSetFilter<string>;
+  storageKindFilter?: StaticSetFilter<DefinitionTag>;
 }
 
 export const AssetTable = ({
@@ -53,6 +56,8 @@ export const AssetTable = ({
   searchPath,
   isFiltered,
   view,
+  computeKindFilter,
+  storageKindFilter,
 }: Props) => {
   const [toWipe, setToWipe] = React.useState<AssetKeyInput[] | undefined>();
 
@@ -131,6 +136,8 @@ export const AssetTable = ({
         showRepoColumn
         view={view}
         onWipe={(assetKeys: AssetKeyInput[]) => setToWipe(assetKeys)}
+        computeKindFilter={computeKindFilter}
+        storageKindFilter={storageKindFilter}
       />
     );
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -182,8 +182,16 @@ export const AssetsCatalogTable = ({
   const [view, setView] = useAssetView();
 
   const {assets, query, error} = useAllAssets({groupSelector});
-  const {searchPath, filtered, isFiltered, filterButton, filterInput, activeFiltersJsx} =
-    useAssetCatalogFiltering(assets, prefixPath);
+  const {
+    searchPath,
+    filtered,
+    isFiltered,
+    filterButton,
+    filterInput,
+    activeFiltersJsx,
+    computeKindFilter,
+    storageKindFilter,
+  } = useAssetCatalogFiltering(assets, prefixPath);
 
   useBlockTraceUntilTrue('useAllAssets', !!assets?.length);
 
@@ -267,6 +275,8 @@ export const AssetsCatalogTable = ({
       searchPath={searchPath}
       displayPathForAsset={displayPathForAsset}
       requery={(_) => [{query: ASSET_CATALOG_TABLE_QUERY, fetchPolicy: 'no-cache'}]}
+      computeKindFilter={computeKindFilter}
+      storageKindFilter={storageKindFilter}
     />
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetCatalogFiltering.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetCatalogFiltering.tsx
@@ -129,6 +129,7 @@ export function useAssetCatalogFiltering(
   const isFiltered: boolean = !!(
     filters.changedInBranch?.length ||
     filters.computeKindTags?.length ||
+    filters.storageKindTags?.length ||
     filters.groups?.length ||
     filters.owners?.length ||
     filters.repos?.length

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetCatalogFiltering.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetCatalogFiltering.tsx
@@ -141,5 +141,7 @@ export function useAssetCatalogFiltering(
     filterInput,
     isFiltered,
     filtered,
+    computeKindFilter,
+    storageKindFilter,
   };
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
@@ -7,6 +7,7 @@ import {
   linkToAssetTableWithComputeKindFilter,
   linkToAssetTableWithStorageKindFilter,
 } from '../search/useGlobalSearch';
+import {StaticSetFilter} from '../ui/Filters/useStaticSetFilter';
 
 export const LEGACY_COMPUTE_KIND_TAG = 'kind';
 export const COMPUTE_KIND_TAG = 'dagster/compute_kind';
@@ -21,8 +22,9 @@ export const buildStorageKindTag = (storageKind: string): DefinitionTag =>
 
 export const AssetComputeKindTag = ({
   definition,
-  linkToFilter: shouldLink,
+  linkToFilteredAssetsTable: shouldLink,
   style,
+  currentPageFilter,
   ...rest
 }: {
   definition: {computeKind: string | null};
@@ -30,7 +32,8 @@ export const AssetComputeKindTag = ({
   reduceColor?: boolean;
   reduceText?: boolean;
   reversed?: boolean;
-  linkToFilter?: boolean;
+  linkToFilteredAssetsTable?: boolean;
+  currentPageFilter?: StaticSetFilter<string>;
 }) => {
   if (!definition.computeKind) {
     return null;
@@ -38,7 +41,11 @@ export const AssetComputeKindTag = ({
   return (
     <Tooltip
       content={
-        shouldLink ? (
+        currentPageFilter ? (
+          <>
+            Filter to <CaptionMono>{definition.computeKind}</CaptionMono> assets
+          </>
+        ) : shouldLink ? (
           <>
             View all <CaptionMono>{definition.computeKind}</CaptionMono> assets
           </>
@@ -52,12 +59,14 @@ export const AssetComputeKindTag = ({
     >
       <OpTags
         {...rest}
-        style={{...style, cursor: shouldLink ? 'pointer' : 'default'}}
+        style={{...style, cursor: shouldLink || currentPageFilter ? 'pointer' : 'default'}}
         tags={[
           {
             label: definition.computeKind,
             onClick:
-              shouldLink && definition.computeKind
+              currentPageFilter && definition.computeKind
+                ? () => currentPageFilter.setState(new Set([definition.computeKind || '']))
+                : shouldLink
                 ? () => {
                     window.location.href = linkToAssetTableWithComputeKindFilter(
                       definition.computeKind || '',
@@ -74,7 +83,8 @@ export const AssetComputeKindTag = ({
 export const AssetStorageKindTag = ({
   storageKind,
   style,
-  linkToFilter: shouldLink,
+  linkToFilteredAssetsTable: shouldLink,
+  currentPageFilter,
   ...rest
 }: {
   storageKind: string;
@@ -82,12 +92,17 @@ export const AssetStorageKindTag = ({
   reduceColor?: boolean;
   reduceText?: boolean;
   reversed?: boolean;
-  linkToFilter?: boolean;
+  linkToFilteredAssetsTable?: boolean;
+  currentPageFilter?: StaticSetFilter<DefinitionTag>;
 }) => {
   return (
     <Tooltip
       content={
-        shouldLink ? (
+        currentPageFilter ? (
+          <>
+            Filter to <CaptionMono>{storageKind}</CaptionMono> assets
+          </>
+        ) : shouldLink ? (
           <>
             View all <CaptionMono>{storageKind}</CaptionMono> assets
           </>
@@ -100,12 +115,14 @@ export const AssetStorageKindTag = ({
       placement="bottom"
     >
       <OpTags
-        style={{...style, cursor: shouldLink ? 'pointer' : 'default'}}
+        style={{...style, cursor: shouldLink || currentPageFilter ? 'pointer' : 'default'}}
         {...rest}
         tags={[
           {
             label: storageKind,
-            onClick: shouldLink
+            onClick: currentPageFilter
+              ? () => currentPageFilter.setState(new Set([buildStorageKindTag(storageKind)]))
+              : shouldLink
               ? () => {
                   window.location.href = linkToAssetTableWithStorageKindFilter(storageKind);
                 }

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -26,11 +26,12 @@ import {
   AssetStorageKindTag,
   isCanonicalStorageKindTag,
 } from '../graph/KindTags';
-import {AssetKeyInput} from '../graphql/types';
+import {AssetKeyInput, DefinitionTag} from '../graphql/types';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {testId} from '../testing/testId';
+import {StaticSetFilter} from '../ui/Filters/useStaticSetFilter';
 import {HeaderCell, HeaderRow, Row, RowCell} from '../ui/VirtualizedTable';
 
 const TEMPLATE_COLUMNS = '1.3fr 1fr 80px';
@@ -50,6 +51,8 @@ interface AssetRowProps {
   height: number;
   start: number;
   onWipe: (assets: AssetKeyInput[]) => void;
+  computeKindFilter?: StaticSetFilter<string>;
+  storageKindFilter?: StaticSetFilter<DefinitionTag>;
 }
 
 export const VirtualizedAssetRow = (props: AssetRowProps) => {
@@ -66,6 +69,8 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
     showCheckboxColumn = false,
     showRepoColumn,
     view = 'flat',
+    computeKindFilter,
+    storageKindFilter,
   } = props;
 
   const liveData = useLiveDataOrLatestMaterializationDebounced(path, type);
@@ -107,6 +112,7 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
                 reduceText
                 definition={definition}
                 style={{position: 'relative'}}
+                currentPageFilter={computeKindFilter}
               />
             )}
             {storageKindTag && (
@@ -115,6 +121,7 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
                 reduceText
                 storageKind={storageKindTag.value}
                 style={{position: 'relative'}}
+                currentPageFilter={storageKindFilter}
               />
             )}
           </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetTable.tsx
@@ -21,6 +21,8 @@ interface Props {
   onWipe: (assets: AssetKeyInput[]) => void;
   showRepoColumn: boolean;
   view?: AssetViewType;
+  computeKindFilter?: StaticSetFilter<string>;
+  storageKindFilter?: StaticSetFilter<DefinitionTag>;
 }
 
 export const VirtualizedAssetTable = (props: Props) => {
@@ -33,6 +35,8 @@ export const VirtualizedAssetTable = (props: Props) => {
     onWipe,
     showRepoColumn,
     view = 'flat',
+    computeKindFilter,
+    storageKindFilter,
   } = props;
   const parentRef = React.useRef<HTMLDivElement | null>(null);
   const count = Object.keys(groups).length;
@@ -96,6 +100,8 @@ export const VirtualizedAssetTable = (props: Props) => {
                 checked={checkedDisplayKeys.has(row.displayKey)}
                 onToggleChecked={onToggleFactory(row.displayKey)}
                 onWipe={() => onWipe(wipeableAssets.map((a) => a.key))}
+                computeKindFilter={computeKindFilter}
+                storageKindFilter={storageKindFilter}
               />
             );
           })}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetTable.tsx
@@ -5,7 +5,8 @@ import {VirtualizedAssetCatalogHeader, VirtualizedAssetRow} from './VirtualizedA
 import {buildRepoAddress} from './buildRepoAddress';
 import {AssetTableFragment} from '../assets/types/AssetTableFragment.types';
 import {AssetViewType} from '../assets/useAssetView';
-import {AssetKeyInput} from '../graphql/types';
+import {AssetKeyInput, DefinitionTag} from '../graphql/types';
+import {StaticSetFilter} from '../ui/Filters/useStaticSetFilter';
 import {Container, Inner} from '../ui/VirtualizedTable';
 
 type Row =


### PR DESCRIPTION
## Summary

Adds the ability to click on a compute kind or storage kind tag in the asset graph or asset list to filter to that kind.


<img width="758" alt="Screenshot 2024-06-18 at 11 16 57 AM" src="https://github.com/dagster-io/dagster/assets/10215173/3f5fc308-e274-4cd4-b05d-3f506231b146">
<img width="1116" alt="Screenshot 2024-06-18 at 11 16 48 AM" src="https://github.com/dagster-io/dagster/assets/10215173/e23fb7d1-1387-4f67-9848-6ac2a13cc093">

## Test Plan

Tested locally.
