### PR TITLE
FE-414: Fix invalid links to resources on the resource page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/ResourceRoot.tsx
@@ -388,15 +388,18 @@ const ResourceUses = (props: {
               </tr>
             </thead>
             <tbody>
-              {parentResources.map((resource) => {
+              {parentResources.map((ref) => {
                 return (
-                  resource.resource && (
-                    <tr key={resource.name}>
+                  ref.resource && (
+                    <tr key={ref.resource.name}>
                       <td>
                         <ResourceEntry
-                          url={workspacePathFromAddress(repoAddress, `/resources/${resource.name}`)}
-                          name={resourceDisplayName(resource.resource) || ''}
-                          description={resource.resource.description || undefined}
+                          url={workspacePathFromAddress(
+                            repoAddress,
+                            `/resources/${ref.resource.name}`,
+                          )}
+                          name={resourceDisplayName(ref.resource) || ''}
+                          description={ref.resource.description || undefined}
                         />
                       </td>
                     </tr>


### PR DESCRIPTION
## Summary & Motivation

The core issue here was `resource.name` instead of `resource.resource.name`, but I renamed the top level var to make it more clear.
