### PR TITLE
Checkpoint requested_subset before re-raising when there is an error in the middle of an asset backfill

### DIFF
--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -1560,16 +1560,21 @@ def test_asset_backfill_mid_iteration_code_location_unreachable_error(
     assert (
         updated_backfill.failure_count == 0
     )  # because of the nature of the error, failure count not incremented
-    assert len(updated_backfill.submitting_run_requests) == 3
-    assert len(updated_backfill.reserved_run_ids) == 3
+
+    # Runs were still removed off the list of submitting run requests because the error was
+    # caught and the backfill data updated
+    assert len(updated_backfill.submitting_run_requests) == 2
+    assert len(updated_backfill.reserved_run_ids) == 2
     assert updated_backfill.asset_backfill_data
     assert (
         updated_backfill.asset_backfill_data.materialized_subset.num_partitions_and_non_partitioned_assets
         == 1
     )
+
+    # Requested subset still updated since the error was caught and the backfill data updated
     assert (
         updated_backfill.asset_backfill_data.requested_subset.num_partitions_and_non_partitioned_assets
-        == 1
+        == 2
     )
 
     # Execute backfill iteration again, confirming that the two partitions that did not submit runs
@@ -1757,11 +1762,12 @@ def test_asset_backfill_first_iteration_code_location_unreachable_error_some_run
     assert updated_backfill
     assert updated_backfill.asset_backfill_data
 
-    # chunk did not finish so requested_subset did not yet update
-    assert len(updated_backfill.submitting_run_requests or []) == 2
+    # error was caught and the submitting run requests and backfill data were updated with
+    # what was submitted before the failure
+    assert len(updated_backfill.submitting_run_requests or []) == 1
     assert (
         updated_backfill.asset_backfill_data.requested_subset.num_partitions_and_non_partitioned_assets
-        == 0
+        == 1
     )
     assert updated_backfill.asset_backfill_data.requested_runs_for_target_roots
 


### PR DESCRIPTION
Summary:
Followup from https://github.com/dagster-io/dagster/pull/22538 - which expands our retry behavior, but loses a nice property where if there was an error in the middle of a 25 run chunk, we would still correctly update the list of requested partitions (of course this wouldn't happen if there was a hard crash, but in a more 'expected' error like a user code server being down or an agent being unavailable, it's nice to keep the list of requested partitions up to date)

This PR brings back that behavior by simplifying the chunking behavior / removing submit_asset_runs_in_chunks entirely - instead, we check hte number of runs that have been submitted and update the written backfill every 25 runs. If there's an error, we do that write as well before re-raising the exception so that the retry logic can take over.

Test Plan: BK, launch a backfill with 100 runs and shut down the code server halfway through, observe that the backfill pauses and the correct set of requested partitions are shown

## Summary & Motivation

## How I Tested These Changes
