### PR TITLE
Fix retry logic when setting dagster/retry_on_asset_or_op_failure to False in a job tag

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
+++ b/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
@@ -120,6 +120,37 @@ def test_filter_runs_no_retry_on_asset_or_op_failure(instance_no_retry_on_asset_
     run = create_run(
         instance,
         status=DagsterRunStatus.STARTED,
+        tags={MAX_RETRIES_TAG: "2", RETRY_ON_ASSET_OR_OP_FAILURE_TAG: False},
+    )
+
+    dagster_event = DagsterEvent(
+        event_type_value=DagsterEventType.PIPELINE_FAILURE.value,
+        job_name=run.job_name,
+        message="oops step failure",
+        event_specific_data=JobFailureData(
+            error=None, failure_reason=RunFailureReason.STEP_FAILURE
+        ),
+    )
+    instance.report_dagster_event(dagster_event, run_id=run.run_id, log_level=logging.ERROR)
+
+    # does not retry due to the RETRY_ON_ASSET_OR_OP_FAILURE_TAG tag being false
+
+    assert (
+        len(
+            list(
+                filter_runs_to_should_retry(
+                    instance.get_runs(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+                    instance,
+                    2,
+                )
+            )
+        )
+        == 0
+    )
+
+    run = create_run(
+        instance,
+        status=DagsterRunStatus.STARTED,
         tags={MAX_RETRIES_TAG: "2", RETRY_ON_ASSET_OR_OP_FAILURE_TAG: True},
     )
 
@@ -133,7 +164,7 @@ def test_filter_runs_no_retry_on_asset_or_op_failure(instance_no_retry_on_asset_
     )
     instance.report_dagster_event(dagster_event, run_id=run.run_id, log_level=logging.ERROR)
 
-    # does retry because due to the RETRY_ON_ASSET_OR_OP_FAILURE_TAG tag
+    # does retry due to the RETRY_ON_ASSET_OR_OP_FAILURE_TAG tag being true
 
     assert (
         len(

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -39,6 +39,7 @@ from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.hosted_user_process import recon_job_from_origin
 from dagster._utils.interrupts import capture_interrupts, setup_interrupt_handlers
 from dagster._utils.log import configure_loggers
+from dagster._utils.tags import get_boolean_tag_value
 
 from .._core.execution.run_metrics_thread import (
     DEFAULT_RUN_METRICS_POLL_INTERVAL_SECONDS,
@@ -84,20 +85,12 @@ def execute_run_command(input_json):
                 sys.exit(return_code)
 
 
-def _truthy_tag_value(dagster_run: DagsterRun, tag: str, default: str = "false") -> bool:
-    return dagster_run.tags.get(tag, default).casefold() not in ["false", "0", "off", "no", ""]
-
-
 def _should_start_metrics_thread(dagster_run: DagsterRun) -> bool:
-    return _truthy_tag_value(dagster_run, "dagster/run_metrics")
+    return get_boolean_tag_value(dagster_run.tags.get("dagster/run_metrics"))
 
 
 def _enable_python_runtime_metrics(dagster_run: DagsterRun) -> bool:
-    return _truthy_tag_value(dagster_run, "dagster/python_runtime_metrics")
-
-
-def _report_container_metrics_as_engine_events(dagster_run: DagsterRun) -> bool:
-    return _truthy_tag_value(dagster_run, "dagster/container_metrics_engine_events")
+    return get_boolean_tag_value(dagster_run.tags.get("dagster/python_runtime_metrics"))
 
 
 def _metrics_polling_interval(

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -16,6 +16,7 @@ from dagster._core.storage.tags import (
 )
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._daemon.utils import DaemonErrorCapture
+from dagster._utils.tags import get_boolean_tag_value
 
 DEFAULT_REEXECUTION_POLICY = ReexecutionStrategy.FROM_FAILURE
 
@@ -62,14 +63,15 @@ def filter_runs_to_should_retry(
         else:
             return 1
 
-    default_retry_on_asset_or_op_failure = instance.get_settings("run_retries").get(
+    default_retry_on_asset_or_op_failure: bool = instance.get_settings("run_retries").get(
         "retry_on_asset_or_op_failure", True
     )
 
     for run in runs:
         retry_number = get_retry_number(run)
-        retry_on_asset_or_op_failure = run.tags.get(
-            RETRY_ON_ASSET_OR_OP_FAILURE_TAG, default_retry_on_asset_or_op_failure
+        retry_on_asset_or_op_failure = get_boolean_tag_value(
+            run.tags.get(RETRY_ON_ASSET_OR_OP_FAILURE_TAG),
+            default_value=default_retry_on_asset_or_op_failure,
         )
         if retry_number is not None:
             if (

--- a/python_modules/dagster/dagster/_utils/tags.py
+++ b/python_modules/dagster/dagster/_utils/tags.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Dict, Mapping, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Sequence, Tuple, Union
 
 from dagster import _check as check
 
@@ -85,3 +85,10 @@ class TagConcurrencyLimitsCounter:
 
             if key in self._unique_value_limits:
                 self._unique_value_counts[tag_tuple] += 1
+
+
+def get_boolean_tag_value(tag_value: Optional[str], default_value: bool = False) -> bool:
+    if tag_value is None:
+        return default_value
+
+    return tag_value.lower() not in {"false", "none", "0", ""}


### PR DESCRIPTION
Summary:
The logic here was checking for the non-None-ness of the tag value rather than the truthiness of the string tag value.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
