### PR TITLE
in AssetNode, get partition mapping from spec

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -89,7 +89,7 @@ class AssetNode(BaseAssetNode):
 
     @property
     def partition_mappings(self) -> Mapping[AssetKey, PartitionMapping]:
-        return self.assets_def.partition_mappings
+        return self._spec.partition_mappings
 
     @property
     def freshness_policy(self) -> Optional[FreshnessPolicy]:

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, NamedTuple, Optional, Sequence
 
 import dagster._check as check
@@ -10,6 +11,7 @@ from dagster._utils.internal_init import IHasInternalInit
 from .auto_materialize_policy import AutoMaterializePolicy
 from .events import AssetKey, CoercibleToAssetKey
 from .freshness_policy import FreshnessPolicy
+from .partition_mapping import PartitionMapping
 from .utils import validate_tags_strict
 
 if TYPE_CHECKING:
@@ -184,3 +186,11 @@ class AssetSpec(
             owners=owners,
             tags=tags,
         )
+
+    @cached_property
+    def partition_mappings(self) -> Mapping[AssetKey, PartitionMapping]:
+        return {
+            dep.asset_key: dep.partition_mapping
+            for dep in self.deps
+            if dep.partition_mapping is not None
+        }

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1078,10 +1078,6 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         return {key: spec.code_version for key, spec in self._specs_by_key.items()}
 
     @property
-    def partition_mappings(self) -> Mapping[AssetKey, PartitionMapping]:
-        return self._partition_mappings
-
-    @property
     def owners_by_key(self) -> Mapping[AssetKey, Sequence[str]]:
         return {key: spec.owners or [] for key, spec in self._specs_by_key.items()}
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -597,9 +597,9 @@ def test_partition_mapping_with_asset_deps():
 
     materialize([upstream, downstream], partition_key="2023-08-20")
 
-    assert downstream.partition_mappings == {
-        AssetKey("upstream"): TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
-    }
+    assert downstream.get_partition_mapping(AssetKey("upstream")) == TimeWindowPartitionMapping(
+        start_offset=-1, end_offset=-1
+    )
 
     ### With @multi_asset and AssetSpec
     asset_1 = AssetSpec(key="asset_1")
@@ -656,10 +656,8 @@ def test_partition_mapping_with_asset_deps():
 
     materialize([multi_asset_1, multi_asset_2], partition_key="2023-08-20")
 
-    assert multi_asset_2.partition_mappings == {
-        AssetKey("asset_1"): asset_1_partition_mapping,
-        AssetKey("asset_2"): asset_2_partition_mapping,
-    }
+    assert multi_asset_2.get_partition_mapping(AssetKey("asset_1")) == asset_1_partition_mapping
+    assert multi_asset_2.get_partition_mapping(AssetKey("asset_2")) == asset_2_partition_mapping
 
 
 def test_conflicting_mappings_with_asset_deps():
@@ -756,9 +754,9 @@ def test_self_dependent_partition_mapping_with_asset_deps():
 
     materialize([self_dependent], partition_key="2023-08-20")
 
-    assert self_dependent.partition_mappings == {
-        AssetKey("self_dependent"): TimeWindowPartitionMapping(start_offset=-1, end_offset=-1),
-    }
+    assert self_dependent.get_partition_mapping(
+        AssetKey("self_dependent")
+    ) == TimeWindowPartitionMapping(start_offset=-1, end_offset=-1)
 
     ### With @multi_asset and AssetSpec
     asset_1 = AssetSpec(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -830,9 +830,7 @@ def test_multi_partition_mapping_with_asset_deps():
         [upstream, downstream], partition_key=MultiPartitionKey({"123": "1", "time": "2023-08-05"})
     )
 
-    assert downstream.partition_mappings == {
-        AssetKey("upstream"): mapping,
-    }
+    assert downstream.get_partition_mapping(AssetKey("upstream")) == mapping
 
     ### With @multi_asset and AssetSpec
     asset_1 = AssetSpec(key="asset_1")
@@ -926,10 +924,8 @@ def test_multi_partition_mapping_with_asset_deps():
         partition_key=MultiPartitionKey({"123": "1", "time": "2023-08-05"}),
     )
 
-    assert multi_asset_2.partition_mappings == {
-        AssetKey("asset_1"): asset_1_partition_mapping,
-        AssetKey("asset_2"): asset_2_partition_mapping,
-    }
+    assert multi_asset_2.get_partition_mapping(AssetKey("asset_1")) == asset_1_partition_mapping
+    assert multi_asset_2.get_partition_mapping(AssetKey("asset_2")) == asset_2_partition_mapping
 
 
 def test_dynamic_dimension_multipartition_mapping():


### PR DESCRIPTION
## Summary & Motivation

This is an incremental step towards both:
- Removing `AssetsDefinition` from internals
- Enabling partitioning per-asset rather than per-`AssetsDefinition`

## How I Tested These Changes
