### PR TITLE
remove AssetsDefinitions from external_data.py

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -53,7 +53,6 @@ from dagster._core.definitions.asset_spec import (
     SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE,
     AssetExecutionType,
 )
-from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.auto_materialize_sensor_definition import (
     AutoMaterializeSensorDefinition,
@@ -69,7 +68,6 @@ from dagster._core.definitions.dependency import (
 )
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
-from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.metadata import (
     MetadataFieldSerializer,
     MetadataMapping,
@@ -1632,7 +1630,7 @@ def external_repository_data_from_def(
             ],
             key=lambda rd: rd.name,
         ),
-        external_asset_checks=external_asset_checks_from_defs(jobs),
+        external_asset_checks=external_asset_checks_from_defs(jobs, repository_def.asset_graph),
         metadata=repository_def.metadata,
         utilized_env_vars={
             env_var: [
@@ -1646,42 +1644,25 @@ def external_repository_data_from_def(
 
 def external_asset_checks_from_defs(
     job_defs: Sequence[JobDefinition],
+    asset_graph: AssetGraph,
 ) -> Sequence[ExternalAssetCheck]:
-    nodes_by_check_key: Dict[AssetCheckKey, List[AssetsDefinition]] = {}
-    job_names_by_check_key: Dict[AssetCheckKey, List[str]] = {}
+    job_names_by_check_key: Dict[AssetCheckKey, List[str]] = defaultdict(list)
 
     for job_def in job_defs:
         asset_layer = job_def.asset_layer
-        for asset_def in asset_layer.assets_defs_by_node_handle.values():
-            for spec in asset_def.check_specs:
-                nodes_by_check_key.setdefault(spec.key, []).append(asset_def)
-                job_names_by_check_key.setdefault(spec.key, []).append(job_def.name)
+        for check_key in asset_layer.asset_graph.asset_check_keys:
+            job_names_by_check_key[check_key].append(job_def.name)
 
     external_checks = []
-    for check_key, nodes in nodes_by_check_key.items():
-        first_node = nodes[0]
-        # The same check may appear multiple times in different jobs, but it should come from the
-        # same definition.
-        check.is_list(
-            nodes,
-            of_type=AssetsDefinition,
-            additional_message=f"Check {check_key} is redefined in an AssetsDefinition and an AssetChecksDefinition",
-        )
-
-        # Executing individual checks isn't supported in graph assets
-        if isinstance(first_node.node_def, GraphDefinition):
-            execution_set_identifier = first_node.unique_id
-        else:
-            execution_set_identifier = first_node.unique_id if not first_node.can_subset else None
-
-        spec = first_node.get_spec_for_check_key(check_key)
+    for check_key, job_names in job_names_by_check_key.items():
+        spec = asset_graph.get_check_spec(check_key)
         external_checks.append(
             ExternalAssetCheck(
                 name=check_key.name,
                 asset_key=check_key.asset_key,
                 description=spec.description,
-                execution_set_identifier=execution_set_identifier,
-                job_names=job_names_by_check_key[check_key],
+                execution_set_identifier=asset_graph.get_execution_set_identifier(check_key),
+                job_names=job_names,
                 blocking=spec.blocking,
                 additional_asset_keys=[dep.asset_key for dep in spec.additional_deps],
             )
@@ -1708,15 +1689,6 @@ def external_asset_nodes_from_defs(
             if asset_key not in primary_node_pairs_by_asset_key:
                 primary_node_pairs_by_asset_key[asset_key] = (node_output_handle, job_def)
             job_defs_by_asset_key.setdefault(asset_key, []).append(job_def)
-
-    # Build index of execution set identifiers. Only assets that are part of non-subsettable assets
-    # have a defined execution set identifier.
-    execution_set_identifiers_by_asset_key: Dict[AssetKey, str] = {}
-    for assets_def in asset_graph.assets_defs:
-        if (len(assets_def.keys) > 1 or assets_def.check_keys) and not assets_def.can_subset:
-            execution_set_identifiers_by_asset_key.update(
-                {k: assets_def.unique_id for k in assets_def.keys}
-            )
 
     external_asset_nodes: List[ExternalAssetNode] = []
     for key in sorted(asset_graph.all_asset_keys):
@@ -1809,7 +1781,7 @@ def external_asset_nodes_from_defs(
                 freshness_policy=asset_node.freshness_policy,
                 is_source=asset_node.is_external,
                 is_observable=asset_node.is_observable,
-                execution_set_identifier=execution_set_identifiers_by_asset_key.get(key),
+                execution_set_identifier=asset_graph.get_execution_set_identifier(key),
                 required_top_level_resources=required_top_level_resources,
                 auto_materialize_policy=asset_node.auto_materialize_policy,
                 backfill_policy=asset_node.backfill_policy,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -53,7 +53,9 @@ def to_external_asset_graph(assets, asset_checks=None) -> BaseAssetGraph:
     external_asset_nodes = external_asset_nodes_from_defs(repo.get_all_jobs(), repo.asset_graph)
     return RemoteAssetGraph.from_repository_handles_and_external_asset_nodes(
         [(MagicMock(), asset_node) for asset_node in external_asset_nodes],
-        external_asset_checks=external_asset_checks_from_defs(repo.get_all_jobs()),
+        external_asset_checks=external_asset_checks_from_defs(
+            repo.get_all_jobs(), repo.asset_graph
+        ),
     )
 
 


### PR DESCRIPTION
## Summary & Motivation

Another step on my slow crusade to transition from `AssetsDefinition` to `AssetGraph` in our internals.

## How I Tested These Changes
