### PR TITLE
[docs] 2/n add airflow migration strategies: TaskFlow, Kubernetes

### DIFF
--- a/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
+++ b/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
@@ -173,7 +173,9 @@ Finally, we create a <PyObject object="Definitions" /> object to register our as
 
 ## Migrating containerized pipelines
 
-If you've elected to containerize your Airflow pipelines by using technologies like Kubernetes using the `KubernetesPodOperator`, or Elastic Container Service using the `EcsRunTaskOperator`, then we recommend that you leverage Dagster Pipes for running these external execution environments from Dagster. For a high level overview of Pipes, please refer to the <a href="/concepts/dagster-pipes">core concept page</a>.
+If you've elected to containerize your Airflow pipelines by using technologies like Kubernetes using the `KubernetesPodOperator`, or Elastic Container Service using the `EcsRunTaskOperator`, you'll need a different approach to migration.
+
+In these cases, we recommend leveraging Dagster Pipes for running these external execution environments from Dagster. Refer to the [Dagster Pipes documentation](/concepts/dagster-pipes) for more information.
 
 Some benefits of containerizing your pipelines are as follows:
 

--- a/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
+++ b/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
@@ -226,7 +226,7 @@ The primary difference between Airflow and Dagster are how the k8s pod specifica
 
 The primary difference between Airflow and Dagster are how the k8s pod specification are expose. In Airflow, they are passed as parameters the `KubernetesPodOperator`, whereas in Dagster they are passed as a `base_pod_spec` dictionary to the `k8s_pipes_client.run` method. Another difference is that in Airflow, `get_logs` is required to capture _stdout_, however, with Dagster they are automatically captured to on the _stdout_ tab of the step output.
 
-### Advanced pipes usage
+In the above example, we demonstrated how to run images on Kubernetes using the `dagster_k8s` library. One of the biggest benefits of Dagster Pipes, however, is that you can leverage the `dagster_pipes` library from within your containerized pipeline to access the full Dagster context, and emit events back to the Dagster UI.
 
 In the above example, we demonstrated how to run images on Kubernetes using the `dagsater_k8s` library. One of the biggest benefits of Dagster Pipes, however, is that you can leverage the `dagster_pipes` library from within your containerized pipeline to access the full Dagster context, and emit events back to the Dagster UI.
 

--- a/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
+++ b/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
@@ -222,7 +222,7 @@ def k8s_pipes_asset(context: AssetExecutionContext, k8s_pipes_client: PipesK8sCl
             ]
         },
     ).get_materialize_result()
-```
+The primary difference between Airflow and Dagster are how the k8s pod specifications are exposed. In Airflow, they are passed as parameters to the `KubernetesPodOperator`, whereas in Dagster they are passed as a `base_pod_spec` dictionary to the `k8s_pipes_client.run` method. Additionally, in Airflow, `get_logs` is required to capture `stdout`. In Dagster, however, they are automatically captured on the `stdout` tab of the step output.
 
 The primary difference between Airflow and Dagster are how the k8s pod specification are expose. In Airflow, they are passed as parameters the `KubernetesPodOperator`, whereas in Dagster they are passed as a `base_pod_spec` dictionary to the `k8s_pipes_client.run` method. Another difference is that in Airflow, `get_logs` is required to capture _stdout_, however, with Dagster they are automatically captured to on the _stdout_ tab of the step output.
 

--- a/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
+++ b/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
@@ -180,7 +180,7 @@ In these cases, we recommend leveraging Dagster Pipes for running these external
 Some benefits of containerizing your pipelines are as follows:
 
 - Dependencies are isolated between execution environments
-- Compute requirements can be easily modified per pipeline (computer, memory, GPU requirements, etc)
+- Compute requirements can be easily modified per pipeline (computer, memory, GPU requirements, and so on)
 - Pipelines can be language agnostic (use R, Rust, Go, etc)
 - Vendor lock-in is limited, and pipelines can be easily migrated to other platforms
 - Pipelines can be versioned using tags on the image repository

--- a/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
+++ b/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
@@ -201,7 +201,7 @@ with DAG(dag_id="example_kubernetes_dag", schedule_interval=None, catchup=False)
     )
 ```
 
-Now, let’s show how the same image would be run on Kubernetes using Dagster pipes and the `dagster_k8s` wrapper.
+Now, let's look at how the same image would be run on Kubernetes using Dagster Pipes and the `dagster_k8s` wrapper.
 
 ```python
 from dagster import AssetExecutionContext, asset

--- a/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
+++ b/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
@@ -181,7 +181,7 @@ Some benefits of containerizing your pipelines are as follows:
 
 - Dependencies are isolated between execution environments
 - Compute requirements can be easily modified per pipeline (computer, memory, GPU requirements, and so on)
-- Pipelines can be language agnostic (use R, Rust, Go, etc)
+- Pipelines can be language agnostic, allowing you to use R, Rust, Go, and so on
 - Vendor lock-in is limited, and pipelines can be easily migrated to other platforms
 - Pipelines can be versioned using tags on the image repository
 

--- a/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
+++ b/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
@@ -5,223 +5,229 @@ description: "Learn how do a lift-and-shift migration of airflow to Dagster."
 
 # Migrating Airflow to Dagster
 
-<Note>
-  Looking for an example of an Airflow to Dagster migration? Check out the{" "}
-  <a href="https://github.com/dagster-io/dagster-airflow-migration-example">
-    dagster-airflow migration example repo on GitHub
-  </a>
-  !
-</Note>
-
-Dagster can convert your Airflow DAGs into Dagster jobs, enabling a lift-and-shift migration from Airflow without any rewriting.
-
-This guide will walk you through the steps of performing this migration.
+There are many strategies that can be employed in migrating an Airflow project to Dagster. Some organization may prefer to migrate all pipelines, or pick and choose workflows while having Airflow and Dagster co-exist. This guide offers a "Choose your own adventure" approach, with a variety of options to assist you in your migration from Apache Airflow.
 
 ---
 
-## Prerequisites
+# Translating Airflow pipelines to Dagster
 
-To complete the migration, you'll need:
+If your organization makes heavy use of the `PythonOperator`, the Airflow TaskFlow API, or the `KubernetesPodOperator`, then migrating to Dagster may be relatively simple!
 
-- **To perform some upfront analysis**. Refer to the [next section](#before-you-begin) for more detail.
+## Migrating pipelines that use the TaskFlow API
 
-- **To know the following about your Airflow setup**:
+The Airflow piplines that are the most simple to migrate to Dagster are those that use Airflow's [TaskFlow](https://airflow.apache.org/docs/apache-airflow/stable/tutorial/taskflow.html) API.
 
-  - What operator types are used in the DAGs you're migrating
-  - What Airflow connections your DAGs depend on
-  - What Airflow variables you've set
-  - What Airflow secrets backend you use
-  - Where the permissions that your DAGs depend on are defined
-
-- **If using Dagster+**, an existing [Dagster+](/dagster-plus) account. While your migrated Airflow DAGs will work with Dagster Open Source, this guide includes setup specific to Dagster+.
-
-  **If you just signed up for a Dagster+ account**, follow the steps in the [Dagster+ Getting Started guide](/dagster-plus/getting-started) before proceeding.
-
-### Before you begin
-
-You may be coming to this document/library in a skeptical frame of mind, having previously been burned by projects that claim to have 100% foolproof, automated migration tools. We want to assure you that we are _not_ making that claim.
-
-The `dagster-airflow` migration library should be viewed as a powerful _accelerant_ of migration, rather than guaranteeing completely _automated_ migration. The amount of work required is proportional to the complexity of your installation. Smaller implementations of less complexity can be trivial to migrate, making it appear virtually automatic; larger, more complicated, or customized implementations require more investment.
-
-For larger installations, teams that already adopt devops practices and/or have standardized usage of Airflow will have a smoother transition.
-
-Some concrete examples:
-
-- If you rely on the usage of the Airflow UI to set production connections or variables, this will require a change of workflow as you will no longer have the Airflow UI at the end of this migration. If instead you rely on code-as-infrastructure patterns to set connections or variables, migration is more straightforward.
-- If you have standardized on a small set or even a single operator type (e.g. the `K8sPodOperator`), migration will be easier. If you use a large number of operator types with a wide range of infrastructure requirements, migration will be more work.
-- If you dynamically generate your Airflow DAGs from a higher-level API or DSL (e.g. yaml), the migration will be more straightforward than all your stakeholders directly creating Airflow DAGs.
-
-Even in the case that requires some infrastructure investment, `dagster-airflow` dramatically eases migration, typically by orders of magnitude. The cost can be borne by a single or small set of infrastructure-oriented engineers, which dramatically reduces coordination costs. You do not have to move all of your stakeholders over to new APIs simultaneously. In our experience, practitioners welcome the change, because of the immediate improvement in tooling, stability, and development speed.
-
----
-
-## Step 1: Prepare your project for a new Dagster Python module
-
-While there are many ways to structure an Airflow git repository, this guide assumes you're using a repository structure that contains a single `./dags` DagBag directory that contains all your DAGs.
-
-In the root of your repository, create a `dagster_migration.py` file.
-
----
-
-## Step 2: Install Dagster Python packages alongside Airflow
-
-<Note>
-  This step may require working through a number of version pins. Specifically,
-  installing Airflow 1.x.x versions may be challenging due to (usually) outdated
-  constraint files.
-  <br />
-  <br />
-  Don't get discouraged if you run into problems! Reach out to the Dagster Slack
-  for help.
-</Note>
-
-In this step, you'll install the `dagster`, `dagster-airflow`, and `dagster-webserver` Python packages alongside Airflow. **We strongly recommend using a virtualenv.**
-
-To install everything, run:
-
-```bash
-pip install dagster dagster-airflow dagster-webserver
-```
-
-We also suggest verifying that you're installing the correct versions of your Airflow dependencies. Verifying the dependency versions will likely save you from debugging tricky errors later.
-
-To check dependency versions, open your Airflow provider's UI and locate the version numbers. When finished, continue to the next step.
-
----
-
-## Step 3: Convert DAGS into Dagster definitions
-
-In this step, you'll start writing Python!
-
-In the `dagster_migration.py` file you created in [Step 1](#step-1-prepare-your-project-for-a-new-dagster-python-module), use <PyObject module="dagster_airflow" object="make_dagster_definitions_from_airflow_dags_path" /> and pass in the file path of your Airflow DagBag. Dagster will load the DagBag and convert all DAGs into Dagster jobs and schedules.
-
-```python file=/integrations/airflow/migrate_repo.py
-import os
-
-from dagster_airflow import make_dagster_definitions_from_airflow_dags_path
-
-migrated_airflow_definitions = make_dagster_definitions_from_airflow_dags_path(
-    os.path.abspath("./dags/"),
-)
-```
-
----
-
-## Step 4: Verify the DAGs are loading
-
-In this step, you'll spin up Dagster's web-based UI, and verify that your migrated DAGs are loading. **Note**: Unless the migrated DAGs depend on no Airflow configuration state or permissions, it's unlikely they'll execute correctly at this point. That's okay - we'll fix it in a bit. Starting the Dagster UI is the first step in our development loop, allowing you to make a local change, view it in the UI, and debug any errors.
-
-1. Run the following to start the UI:
-
-   ```bash
-   dagster dev -f ./migrate_repo.py
-   ```
-
-2. In your browser, navigate to <http://localhost:3001>. You should see a list of Dagster jobs that correspond to the DAGs in your Airflow DagBag.
-
-3. Run one of the simpler jobs, ideally one where you're familiar with the business logic. Note that it's likely to fail due to a configuration or permissions issue.
-
-4. Using logs to identify and making configuration changes to fix the cause of the failure.
-
-Repeat these steps as needed until the jobs run successfully.
-
-### Containerized operator considerations
-
-There are a variety of Airflow Operator types that are used to launch compute in various external execution environments, for example Kubernetes or Amazon ECS. When getting things working locally we'd recommend trying to execute those containers locally unless it's either unrealistic or impossible to emulate the cloud environment. For example if you use the K8sPodOperator, it likely means that you will need to have a local Kubernetes cluster running, and in that case we recommend docker's built-in Kubernetes environment. You also need to be able to pull down the container images that will be needed for execution to your local machine.
-
-If local execution is impossible, we recommend using Branch Deployments in Dagster+, which is a well-supported workflow for cloud-native development.
-
----
-
-## Step 5: Transfer your Airflow configuration
-
-To port your Airflow configuration, we recommend using [environment variables](/guides/dagster/using-environment-variables-and-secrets) as much as possible. Specifically, we recommend using a `.env` file containing Airflow variables and/or a secrets backend configuration in the root of your project.
-
-You'll also need to configure the [Airflow connections](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html) that your DAGs depend on. To accomplish this, use the `connections` parameter instead of URI-encoded environment variables.
-
-```python file=/integrations/airflow/migrate_repo_connections.py
-import os
-
-from airflow.models import Connection
-from dagster_airflow import make_dagster_definitions_from_airflow_dags_path
-
-migrated_airflow_definitions = make_dagster_definitions_from_airflow_dags_path(
-    os.path.abspath("./dags/"),
-    connections=[
-        Connection(conn_id="http_default", conn_type="uri", host="https://google.com")
-    ],
-)
-```
-
-Iterate as needed until all configuration is correctly ported to your local environment.
-
----
-
-## Step 6: Deciding on persistent vs ephemeral Airflow database
-
-The Dagster Airflow migration tooling supports two methods for persisting Airflow metadatabase state. By default, it will use an ephemeral database that is scoped to every job run and thrown away as soon as a job run terminates. You can also configure a persistent database that will be shared by all job runs. This tutorial uses the ephemeral database, but the persistent database option is recommended if you need the following features:
-
-- retry-from-failure support in Dagster
-- Passing Airflow state between DAG runs (i.e., xcoms)
-- `SubDAGOperators`
-- Airflow Pools
-
-If you have complex Airflow DAGs (cross-DAG state sharing, pools) or the ability to retry-from-failure you will need to have a persistent database when making your migration.
-
-You can configure your persistent Airflow database by providing an `airflow_db` to the `resource_defs` parameter of the `dagster-airflow` APIs:
+With this approach, pipelines are constructed using Airflow `@task` decorators that can easily be mapped to a function using the Dagster <PyObject object="asset" decorator /> decorator. For example, given the Airflow task below:
 
 ```python
-from dagster_airflow import (
-    make_dagster_definitions_from_airflow_dags_path,
-    make_persistent_airflow_db_resource,
+from airflow.decorators import task
+
+@task()
+def extract():
+    data_string = '{"1001": 301.27, "1002": 433.21, "1003": 502.22}'
+    order_data_dict = json.loads(data_string)
+    return order_data_dict
+```
+
+This can be directly translated to a Dagster asset like so.
+
+```python
+from dagster import asset
+
+@asset
+def extract():
+    data_string = '{"1001": 301.27, "1002": 433.21, "1003": 502.22}'
+    order_data_dict = json.loads(data_string)
+    return order_data_dict
+```
+
+Now, let’s walk through the full `tutorial_taskflow_api.py` example DAG, and how it would be translated to Dagster assets.
+
+```python
+import json
+
+import pendulum
+
+from airflow.decorators import dag, task
+
+@dag(
+    schedule=None,
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+    catchup=False,
+    tags=["example"],
 )
-postgres_airflow_db = "postgresql+psycopg2://airflow:airflow@localhost:5432/airflow"
-airflow_db = make_persistent_airflow_db_resource(uri=postgres_airflow_db)
-definitions = make_dagster_definitions_from_airflow_example_dags(
-    '/path/to/dags/',
-    resource_defs={"airflow_db": airflow_db}
+def tutorial_taskflow_api():
+    """
+    ### TaskFlow API Tutorial Documentation
+    This is a simple data pipeline example which demonstrates the use of
+    the TaskFlow API using three simple tasks for Extract, Transform, and Load.
+    Documentation that goes along with the Airflow TaskFlow API tutorial is
+    located
+    [here](https://airflow.apache.org/docs/apache-airflow/stable/tutorial_taskflow_api.html)
+    """
+    @task
+    def extract():
+        """
+        #### Extract task
+        A simple Extract task to get data ready for the rest of the data
+        pipeline. In this case, getting data is simulated by reading from a
+        hardcoded JSON string.
+        """
+        data_string = '{"1001": 301.27, "1002": 433.21, "1003": 502.22}'
+
+        order_data_dict = json.loads(data_string)
+        return order_data_dict
+    @task(multiple_outputs=True)
+    def transform(order_data_dict: dict):
+        """
+        #### Transform task
+        A simple Transform task which takes in the collection of order data and
+        computes the total order value.
+        """
+        total_order_value = 0
+
+        for value in order_data_dict.values():
+            total_order_value += value
+
+        return {"total_order_value": total_order_value}
+    @task
+    def load(total_order_value: float):
+        """
+        #### Load task
+        A simple Load task which takes in the result of the Transform task and
+        instead of saving it to end user review, just prints it out.
+        """
+
+        print(f"Total order value is: {total_order_value:.2f}")
+    order_data = extract()
+    order_summary = transform(order_data)
+    load(order_summary["total_order_value"])
+
+
+tutorial_taskflow_api()
+```
+
+By converting the Airflow `task` to a Dagster <PyObject object="asset" decorator />, and our Airflow `dag` to a Dagster <PyObject object="job" decorator />, the resulting code will look like the following.
+
+```python
+import json
+
+from dagster import AssetExecutionContext, Definitions, define_asset_job, asset
+
+
+@asset
+def extract():
+    """Extract task
+
+    A simple Extract task to get data ready for the rest of the data pipeline. In this case, getting
+    data is simulated by reading from a hardcoded JSON string.
+    """
+    data_string = '{"1001": 301.27, "1002": 433.21, "1003": 502.22}'
+
+    order_data_dict = json.loads(data_string)
+
+    return order_data_dict
+
+
+@asset
+def transform(extract):
+    """Transform task
+
+    A simple Transform task which takes in the collection of order data and computes the total order
+    value.
+    """
+    total_order_value = 0
+
+    for value in extract.values():
+        total_order_value += value
+
+    return total_order_value
+
+
+@asset
+def load(context: AssetExecutionContext, transform):
+    """Load task
+
+    A simple Load task which takes in the result of the Transform task and instead of saving it to
+    end user review, just prints it out.
+    """
+    context.log.info(f"Total order value is: {transform:.2f}")
+
+
+airflow_taskflow_example = define_asset_job(
+    name="airflow_taskflow_example",
+    selection=[extract, transform, load]
+)
+
+defs = Definitions(
+    assets=[extract, transform, load],
+    jobs=[airflow_taskflow_example]
 )
 ```
 
----
+In this example, we are using <PyObject object="define_asset_job" /> to define a job in which the selected assets are materialized. Using the `selection` parameter of the function, we specify that we want our `extract`, `transform`, and `load` assets to be materialized. The lineage of dependencies between the assets are automatically determined through the passing of one asset as a parameter to another.
 
-## Step 7: Move to production
-
-<Note>
-  This step is applicable to Dagster+. If deploying to your infrastructure,
-  refer to the <a href="/deployment">Open Source Deployment guides</a> for more
-  info.
-  <br />
-  <br />
-  Additionally, until your Airflow DAGs execute successfully in your local environment,
-  we recommend waiting to move to production.
-</Note>
-
-In this step, you'll set up your project for use with Dagster+.
-
-<!-- Once you have your dagster cloud organization setup you can either choose to adapt your existing airflow repository to use the Dagster+ CI/CD deployment or copy over your code to the quickstart repository you made as part of the Dagster+ onboarding. -->
-
-1. Complete the steps in the [Dagster+ Getting Started guide](/dagster-plus/getting-started), if you haven't already. Proceed to the next step when your account is set up and you have the `dagster-cloud` CLI installed.
-
-2. In the root of your project, create or modify the [`dagster_cloud.yaml` file](/dagster-plus/managing-deployments/dagster-cloud-yaml) with the following code:
-
-   ```yaml
-   locations:
-     - location_name: dagster_migration
-       code_source:
-         python_file: dagster_migration.py
-   ```
-
-3. Push your code and let the CI/CD for Dagster+ run out a deployment of your migrated DAGs to cloud.
+Finally, we create a <PyObject object="Definitions" /> object to register our assets and job and load them by the Dagster tool.
 
 ---
 
-## Step 8: Migrate permissions to Dagster
+## Migrating containerized pipelines
 
-Your Airflow instance likely had specific IAM or Kubernetes permissions that allowed it to successfully run your Airflow DAGs. To run the migrated Dagster jobs, you'll need to duplicate these permissions for Dagster.
+If you've elected to containerize your Airflow pipelines by using technologies like Kubernetes using the `KubernetesPodOperator`, or Elastic Container Service using the `EcsRunTaskOperator`, then we recommend that you leverage Dagster Pipes for running these external execution environments from Dagster. For a high level overview of Pipes, please refer to the <a href="/concepts/dagster-pipes">core concept page</a>.
 
-- **We recommend using [Airflow connections](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html) or [environment variables](/dagster-plus/managing-deployments/environment-variables-and-secrets)** to define permissions whenever possible.
+Some benefits of containerizing your pipelines are as follows:
 
-- **If you're unable to use Airflow connections or environment variables,** you can attach permissions directly to the infrastructure where you're deploying Dagster.
+- Dependencies are isolated between execution environments
+- Compute requirements can be easily modified per pipeline (computer, memory, GPU requirements, etc)
+- Pipelines can be language agnostic (use R, Rust, Go, etc)
+- Vendor lock-in is limited, and pipelines can be easily migrated to other platforms
+- Pipelines can be versioned using tags on the image repository
 
-- **If your Airflow DAGs used [`KubernetesPodOperators`](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/operators.html)**, it's possible that you loaded a `kube_config` file or used the `in_cluster` config. When migrating, we recommend switching to [using connections with a `kube_config` JSON blob](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/connections/kubernetes.html) to make things easier.
+Let’s walk through an example of how a containerized pipeline can be run from Airflow, and then let’s walk through how the same would be done in Dagster. Imagine you have a Dockerized pipeline deployed to your registry of choice with an image named `example-data-pipeline`. In Apache Airflow, you would be able to run the image of that image by using the `KubernetesPodOperator`.
+
+```python
+from airflow import DAG
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from pendulum import datetime
+
+with DAG(dag_id="example_kubernetes_dag", schedule_interval=None, catchup=False) as dag:
+    KubernetesPodOperator(
+        image="example-data-pipeline:latest",
+        name="example-kubernetes-task",
+        task_id="example-kubernetes-task",
+        get_logs=True,
+    )
+```
+
+Now, let’s show how the same image would be run on Kubernetes using Dagster pipes and the `dagster_k8s` wrapper.
+
+```python
+from dagster import AssetExecutionContext, asset
+from dagster_k8s import PipesK8sClient
+
+
+@asset
+def k8s_pipes_asset(context: AssetExecutionContext, k8s_pipes_client: PipesK8sClient):
+    return k8s_pipes_client.run(
+        context=context,
+        image="example-data-pipeline:latest",
+        base_pod_spec={
+            "containers": [
+                {
+                    "name": "data-processing-rs",
+                    "image": "data-processing-rs",
+                }
+            ]
+        },
+    ).get_materialize_result()
+```
+
+The primary difference between Airflow and Dagster are how the k8s pod specification are expose. In Airflow, they are passed as parameters the `KubernetesPodOperator`, whereas in Dagster they are passed as a `base_pod_spec` dictionary to the `k8s_pipes_client.run` method. Another difference is that in Airflow, `get_logs` is required to capture _stdout_, however, with Dagster they are automatically captured to on the _stdout_ tab of the step output.
+
+### Advanced pipes usage
+
+In the above example, we demonstrated how to run images on Kubernetes using the `dagsater_k8s` library. One of the biggest benefits of Dagster Pipes, however, is that you can leverage the `dagster_pipes` library from within your containerized pipeline to access the full Dagster context, and emit events back to the Dagster UI.
+
+A common pattern when building containerized pipelines is to accept a large number of command-line arguments using libraries like `argparse`. However, with Dagster you can pass a dictionary of parameters on the Dagster context using the `extras` parameter. Then, in your pipeline code, you can access the context `PipesContext.get()` if you are using Python.
+
+For a step-by-step walkthrough of using Dagster Pipes, refer to the [Dagster Pipes tutorial](https://docs.dagster.io/concepts/dagster-pipes/subprocess).


### PR DESCRIPTION
## Summary & Motivation

- Removes `dagster-airflow` migration strategy
- Introduces "Choose your own adventure" migrations
    * Pipelines using Airflow TaskFlow API
    * Pipelines using Airflow KubernetesPodOperator

## How I Tested These Changes
