### PR TITLE
[check] fix build_check_call_str Union handling

### DIFF
--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -1598,6 +1598,7 @@ BUILD_CASES = [
     (PublicAttr[Optional[Mapping[str, int]]], {"a": 1}, {1: "a"}),
     (PublicAttr[Bar], Bar(), Foo()),
     (Union[bool, Foo], True, None),
+    (Union[Foo, "Bar"], Bar(), None),
     # fwd refs
     ("Foo", Foo(), Bar()),
     (Optional["Foo"], Foo(), Bar()),


### PR DESCRIPTION
Fix mishandling of processing `Union[A, B, C]` in to `check.inst_param(x, "x", of_type=(A, B, C))` 

## How I Tested These Changes

added test

