### PR TITLE
Add overflowY: scroll to backfill page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPage.tsx
@@ -144,7 +144,10 @@ export const BackfillPage = () => {
         {error?.graphQLErrors && (
           <Alert intent="error" title={error.graphQLErrors.map((err) => err.message)} />
         )}
-        <Box flex={{direction: 'column'}} style={{flex: 1, position: 'relative', minHeight: 0}}>
+        <Box
+          flex={{direction: 'column'}}
+          style={{flex: 1, position: 'relative', minHeight: 0, overflowY: 'scroll'}}
+        >
           {selectedTab === 'partitions' && <BackfillPartitionsTab backfill={backfill} />}
           {selectedTab === 'runs' && <BackfillRunsTab backfill={backfill} />}
           {selectedTab === 'logs' && <BackfillLogsTab backfill={backfill} />}


### PR DESCRIPTION
## Summary & Motivation

https://github.com/dagster-io/dagster/pull/22129 changed the behavior here and regressed the scrolling.

## How I Tested These Changes

Tested scrolling on the partitions tab, and the runs timeline tab and the runs list tab