### PR TITLE
AssetGraphComputation.execution_type

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -232,6 +232,7 @@ def asset_check(
             asset_deps={},
             asset_in_map={},
             asset_out_map={},
+            execution_type=None,
         )
 
         builder = DecoratorAssetsDefinitionBuilder(

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -33,7 +33,7 @@ from dagster._utils.warnings import disable_dagster_warnings
 from ..asset_check_spec import AssetCheckSpec
 from ..asset_in import AssetIn
 from ..asset_out import AssetOut
-from ..asset_spec import AssetSpec
+from ..asset_spec import AssetExecutionType, AssetSpec
 from ..assets import AssetsDefinition
 from ..backfill_policy import BackfillPolicy, BackfillPolicyType
 from ..decorators.graph_decorator import graph
@@ -446,6 +446,7 @@ def create_assets_def_from_fn_and_decorator_args(
             asset_deps={},
             can_subset=False,
             decorator_name="@asset",
+            execution_type=AssetExecutionType.MATERIALIZATION,
         )
 
         builder = DecoratorAssetsDefinitionBuilder.from_asset_outs_in_asset_centric_decorator(
@@ -612,6 +613,7 @@ def multi_asset(
         ),
         backfill_policy=backfill_policy,
         decorator_name="@multi_asset",
+        execution_type=AssetExecutionType.MATERIALIZATION,
     )
 
     def inner(fn: Callable[..., Any]) -> AssetsDefinition:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -24,7 +24,7 @@ from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.asset_in import AssetIn
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_out import AssetOut
-from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.asset_spec import AssetExecutionType, AssetSpec
 from dagster._core.definitions.assets import (
     ASSET_SUBSET_INPUT_PREFIX,
     AssetsDefinition,
@@ -229,6 +229,7 @@ class DecoratorAssetsDefinitionBuilderArgs(NamedTuple):
     retry_policy: Optional[RetryPolicy]
     specs: Sequence[AssetSpec]
     upstream_asset_deps: Optional[Iterable[AssetDep]]
+    execution_type: Optional[AssetExecutionType]
 
     @property
     def check_specs(self) -> Sequence[AssetCheckSpec]:
@@ -556,6 +557,7 @@ class DecoratorAssetsDefinitionBuilder:
             is_subset=False,
             selected_asset_keys=None,  # not a subset so this is None
             selected_asset_check_keys=None,  # not a subset so this is none
+            execution_type=self.args.execution_type,
         )
 
     @cached_property

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -1,16 +1,17 @@
-from typing import AbstractSet, Any, Mapping, Optional, Sequence, Set, Union, overload
+from typing import AbstractSet, Any, Callable, Mapping, Optional, Sequence, Set, Union, overload
 
 import dagster._check as check
 from dagster._annotations import experimental
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
-from dagster._core.definitions.asset_spec import (
-    SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE,
-    AssetExecutionType,
-    AssetSpec,
-)
+from dagster._core.definitions.asset_spec import AssetExecutionType, AssetSpec
+from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.decorators.asset_decorator import (
-    multi_asset,
     resolve_asset_key_and_name_for_decorator,
+)
+from dagster._core.definitions.decorators.decorator_assets_definition_builder import (
+    DecoratorAssetsDefinitionBuilder,
+    DecoratorAssetsDefinitionBuilderArgs,
+    create_check_specs_by_output_name,
 )
 from dagster._core.definitions.events import CoercibleToAssetKey, CoercibleToAssetKeyPrefix
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
@@ -20,6 +21,7 @@ from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.source_asset import SourceAsset, SourceAssetObserveFunction
 from dagster._core.definitions.utils import validate_tags_strict
+from dagster._utils.warnings import disable_dagster_warnings
 
 
 @overload
@@ -250,22 +252,50 @@ def multi_observable_source_asset(
                 yield ObserveResult(asset_key="asset2", metadata={"baz": "qux"})
 
     """
-    return multi_asset(
-        specs=[
-            spec._replace(
-                metadata={
-                    **(spec.metadata or {}),
-                    SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: AssetExecutionType.OBSERVATION.value,
-                }
-            )
-            for spec in specs
-        ],
+    from dagster._core.execution.build_resources import wrap_resources_for_execution
+
+    args = DecoratorAssetsDefinitionBuilderArgs(
         name=name,
-        description=description,
-        partitions_def=partitions_def,
+        op_description=description,
+        specs=check.opt_list_param(specs, "specs", of_type=AssetSpec),
+        check_specs_by_output_name=create_check_specs_by_output_name(check_specs),
+        asset_out_map={},
+        upstream_asset_deps=None,
+        asset_deps={},
+        asset_in_map={},
         can_subset=can_subset,
-        required_resource_keys=required_resource_keys,
-        resource_defs=resource_defs,
         group_name=group_name,
-        check_specs=check_specs,
+        partitions_def=partitions_def,
+        retry_policy=None,
+        code_version=None,
+        op_tags=None,
+        config_schema={},
+        compute_kind=None,
+        required_resource_keys=check.opt_set_param(
+            required_resource_keys, "required_resource_keys", of_type=str
+        ),
+        op_def_resource_defs=wrap_resources_for_execution(
+            check.opt_mapping_param(resource_defs, "resource_defs", key_type=str)
+        ),
+        assets_def_resource_defs=wrap_resources_for_execution(
+            check.opt_mapping_param(resource_defs, "resource_defs", key_type=str)
+        ),
+        backfill_policy=None,
+        decorator_name="@multi_observable_source_asset",
+        execution_type=AssetExecutionType.OBSERVATION,
     )
+
+    def inner(fn: Callable[..., Any]) -> AssetsDefinition:
+        builder = DecoratorAssetsDefinitionBuilder.from_multi_asset_specs(
+            can_subset=can_subset,
+            asset_specs=specs,
+            op_name=name or fn.__name__,
+            asset_in_map={},
+            passed_args=args,
+            fn=fn,
+        )
+
+        with disable_dagster_warnings():
+            return builder.create_assets_definition()
+
+    return inner

--- a/python_modules/dagster/dagster/_core/definitions/external_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset.py
@@ -2,7 +2,6 @@ from typing import List, Sequence
 
 from dagster import _check as check
 from dagster._core.definitions.asset_spec import (
-    SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE,
     SYSTEM_METADATA_KEY_AUTO_OBSERVE_INTERVAL_MINUTES,
     SYSTEM_METADATA_KEY_IO_MANAGER_KEY,
     AssetExecutionType,
@@ -117,9 +116,8 @@ def create_external_asset_from_source_asset(source_asset: SourceAsset) -> Assets
             required_resource_keys=source_asset._required_resource_keys,  # noqa: SLF001,
             outs={"result": Out(io_manager_key=source_asset.io_manager_key)},
         )
-        extra_metadata_entries = {
-            SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: AssetExecutionType.OBSERVATION.value
-        }
+        extra_metadata_entries = {}
+        execution_type = AssetExecutionType.OBSERVATION
     else:
         keys_by_output_name = {}
         node_def = None
@@ -128,6 +126,7 @@ def create_external_asset_from_source_asset(source_asset: SourceAsset) -> Assets
             if source_asset.io_manager_key is not None
             else {}
         )
+        execution_type = None
 
     observe_interval = source_asset.auto_observe_interval_minutes
     metadata = {
@@ -160,6 +159,7 @@ def create_external_asset_from_source_asset(source_asset: SourceAsset) -> Assets
             # We don't pass the `io_manager_def` because it will already be present in
             # `resource_defs` (it is added during `SourceAsset` initialization).
             resource_defs=source_asset.resource_defs,
+            execution_type=execution_type,
         )
 
 

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -49,10 +49,7 @@ from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_job import is_base_asset_job_name
 from dagster._core.definitions.asset_sensor_definition import AssetSensorDefinition
-from dagster._core.definitions.asset_spec import (
-    SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE,
-    AssetExecutionType,
-)
+from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.auto_materialize_sensor_definition import (
     AutoMaterializeSensorDefinition,
@@ -103,6 +100,10 @@ from dagster._utils.error import SerializableErrorInfo
 
 DEFAULT_MODE_NAME = "default"
 DEFAULT_PRESET_NAME = "default"
+
+# Historically, SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE could on the metadata of an asset
+# to encode the execution type of the asset.
+SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE = "dagster/asset_execution_type"
 
 
 @whitelist_for_serdes(storage_field_names={"external_job_datas": "external_pipeline_datas"})

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -898,11 +898,7 @@ def test_get_all_asset_specs():
         group_name="default",
         tags={"biz": "boz"},
     )
-    assert asset_specs_by_key[AssetKey("asset6")] == AssetSpec(
-        "asset6",
-        group_name="blag",
-        metadata={"dagster/asset_execution_type": "OBSERVATION"},
-    )
+    assert asset_specs_by_key[AssetKey("asset6")] == AssetSpec("asset6", group_name="blag")
 
 
 @pytest.mark.skip(reason="Failing BK")


### PR DESCRIPTION
## Summary & Motivation

This gets rid of the SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE metadata value (except for backcompat) and instead introduces an `execution_type` field on `AssetGraphComputation`.

## How I Tested These Changes
