### PR TITLE
Quote table identifiers for row count query in dbt integration

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -1039,7 +1039,7 @@ def _fetch_row_count_metadata(
                     SELECT
                     count(*) as row_count
                     FROM
-                    {table_str}
+                    {relation_name}
                 """,
                 fetch=True,
             )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -1030,7 +1030,13 @@ def _fetch_row_count_metadata(
 
     unique_id = dbt_resource_props["unique_id"]
     logger.debug("Fetching row count for %s", unique_id)
-    table_str = f"{dbt_resource_props['database']}.{dbt_resource_props['schema']}.{dbt_resource_props['name']}"
+    table_str = ".".join(
+        [adapter.quote(part) for part in [
+            dbt_resource_props["database"],
+            dbt_resource_props["schema"],
+            dbt_resource_props["name"]]
+        ]
+    )
 
     try:
         with adapter.connection_named(f"row_count_{unique_id}"):

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -1030,13 +1030,7 @@ def _fetch_row_count_metadata(
 
     unique_id = dbt_resource_props["unique_id"]
     logger.debug("Fetching row count for %s", unique_id)
-    table_str = ".".join(
-        [adapter.quote(part) for part in [
-            dbt_resource_props["database"],
-            dbt_resource_props["schema"],
-            dbt_resource_props["name"]]
-        ]
-    )
+    relation_name = dbt_resource_props["relation_name"]
 
     try:
         with adapter.connection_named(f"row_count_{unique_id}"):


### PR DESCRIPTION
## Summary & Motivation

Fixes: #22625

Dbt integration fails to add row count materialization metadata when the asset's table
contains characters which require it to be quoted.

## How I Tested These Changes
Modified code and ran locally on asset that is failing with current code from `master`
I would have added unit tests, but I didn't see any for the exising row count feature
so it wasn't clear where to start there/if they were necessary.
