### PR TITLE
[perf] Fix long job partitions page frame when over 100k+ partitions

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionGraph.tsx
@@ -91,7 +91,7 @@ export const PartitionGraph = ({
     };
   }, [onGraphClick, title, yLabel]);
 
-  const buildDatasetData = () => {
+  const {jobData, stepData} = useMemo(() => {
     const jobData: Point[] = [];
     const stepData = {};
 
@@ -128,31 +128,33 @@ export const PartitionGraph = ({
     });
 
     return {jobData, stepData};
-  };
+  }, [hiddenPartitions, hiddenStepKeys, jobDataByPartition, partitionNames, stepDataByPartition]);
 
-  const {jobData, stepData} = buildDatasetData();
   const allLabel = isJob ? 'Total job' : 'Total pipeline';
-  const graphData = {
-    labels: partitionNames,
-    datasets: [
-      ...(!jobDataByPartition || (hiddenStepKeys && hiddenStepKeys.includes(allLabel))
-        ? []
-        : [
-            {
-              label: allLabel,
-              data: jobData,
-              borderColor: Colors.borderDefault(),
-              backgroundColor: Colors.accentPrimary(),
-            },
-          ]),
-      ...Object.keys(stepData).map((stepKey) => ({
-        label: stepKey,
-        data: stepData[stepKey as keyof typeof stepData],
-        borderColor: colorHash(stepKey),
-        backgroundColor: Colors.accentPrimary(),
-      })),
-    ],
-  };
+  const graphData = useMemo(
+    () => ({
+      labels: partitionNames,
+      datasets: [
+        ...(!jobDataByPartition || (hiddenStepKeys && hiddenStepKeys.includes(allLabel))
+          ? []
+          : [
+              {
+                label: allLabel,
+                data: jobData,
+                borderColor: Colors.borderDefault(),
+                backgroundColor: Colors.accentPrimary(),
+              },
+            ]),
+        ...Object.keys(stepData).map((stepKey) => ({
+          label: stepKey,
+          data: stepData[stepKey as keyof typeof stepData],
+          borderColor: colorHash(stepKey),
+          backgroundColor: Colors.accentPrimary(),
+        })),
+      ],
+    }),
+    [allLabel, hiddenStepKeys, jobData, jobDataByPartition, partitionNames, stepData],
+  );
 
   // Passing graphData as a closure prevents ChartJS from trying to isEqual, which is fairly
   // unlikely to save a render and is time consuming given the size of the data structure.

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/RunMatrixUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/RunMatrixUtils.tsx
@@ -188,8 +188,11 @@ const TITLE_MARGIN_BOTTOM = 15;
 const ROTATION_DEGREES = 41;
 
 export function topLabelHeightForLabels(labels: string[]) {
-  const maxlength = Math.max(...labels.map((p) => p.length));
-  return (maxlength > 10 ? maxlength * 4.9 : 55) + TITLE_MARGIN_BOTTOM;
+  let maxLength = 0;
+  for (const label of labels) {
+    maxLength = Math.max(maxLength, label.length);
+  }
+  return (maxLength > 10 ? maxLength * 4.9 : 55) + TITLE_MARGIN_BOTTOM;
 }
 
 export const TopLabelTilted = ({label, $height}: {label: string; $height: number}) => {

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
@@ -194,6 +194,7 @@ export function usePartitionStepQuery({
     offset,
     partitionNames,
     skipQuery,
+    partitionNamesSet,
   ]);
 
   return useMemo(

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
@@ -1,5 +1,5 @@
 import {ApolloClient, gql, useApolloClient} from '@apollo/client';
-import {useEffect, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 
 import {PartitionMatrixStepRunFragment} from './types/useMatrixData.types';
 import {
@@ -60,16 +60,22 @@ export function usePartitionStepQuery({
   const version = useRef(0);
   const [dataState, setDataState] = useState<DataState>(InitialDataState);
 
-  const _serializedRunTags = JSON.stringify([
-    ...runsFilter.map((token) => {
-      const [key, value] = token.value.split('=');
-      return {key, value};
-    }),
-    {
-      key: DagsterTag.RepositoryLabelTag,
-      value: `${repositorySelector.repositoryName}@${repositorySelector.repositoryLocationName}`,
-    },
-  ]);
+  const _serializedRunTags = useMemo(
+    () =>
+      JSON.stringify([
+        ...runsFilter.map((token) => {
+          const [key, value] = token.value.split('=');
+          return {key, value};
+        }),
+        {
+          key: DagsterTag.RepositoryLabelTag,
+          value: `${repositorySelector.repositoryName}@${repositorySelector.repositoryLocationName}`,
+        },
+      ]),
+    [repositorySelector.repositoryLocationName, repositorySelector.repositoryName, runsFilter],
+  );
+
+  const partitionNamesSet = useMemo(() => new Set(partitionNames), [partitionNames]);
 
   useEffect(() => {
     // Note: there are several async steps to the loading process - to cancel the previous
@@ -160,7 +166,7 @@ export function usePartitionStepQuery({
         // Filter detected changes to just runs in our visible range of partitions, and then update
         // local state if changes have been found.
         const relevant = [...pending, ...recent].filter((run) =>
-          run.tags.find((t) => t.key === partitionTagName && partitionNames.includes(t.value)),
+          run.tags.find((t) => t.key === partitionTagName && partitionNamesSet.has(t.value)),
         );
         setDataState((state) => {
           const updated = state.runs
@@ -190,7 +196,10 @@ export function usePartitionStepQuery({
     skipQuery,
   ]);
 
-  return assemblePartitions(dataState, partitionTagName);
+  return useMemo(
+    () => assemblePartitions(dataState, partitionTagName),
+    [dataState, partitionTagName],
+  );
 }
 
 async function fetchRunsForFilter(
@@ -198,7 +207,7 @@ async function fetchRunsForFilter(
   variables: PartitionStepLoaderQueryVariables,
 ) {
   const result = await client.query<PartitionStepLoaderQuery, PartitionStepLoaderQueryVariables>({
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'no-cache',
     query: PARTITION_STEP_LOADER_QUERY,
     variables,
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
@@ -104,6 +104,7 @@ export function useIndexedDBCachedQuery<TQuery, TVariables extends OperationVari
   return {
     data,
     loading,
+    called: true,
     fetch: useCallback(() => fetch(true), [fetch]),
   };
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
@@ -104,7 +104,6 @@ export function useIndexedDBCachedQuery<TQuery, TVariables extends OperationVari
   return {
     data,
     loading,
-    called: true,
     fetch: useCallback(() => fetch(true), [fetch]),
   };
 }


### PR DESCRIPTION
## Summary & Motivation

- Use a set to check if partitionNames array includes a partition  to avoid n^2 logic
- no-cache on queries to avoid long apollo cache frames
- more memoization

## How I Tested These Changes

There's still a lot of work happening on the main thread but this is a big improvement

<img width="1029" alt="Screenshot 2024-06-20 at 5 56 15 PM" src="https://github.com/dagster-io/dagster/assets/2286579/2688c6f5-de8c-42be-8931-f0451d62502d">
