### PR TITLE
[Performance] Partitioned job page - Memoize everything + hide partition graph if large

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -10,6 +10,7 @@ import {WebSocketLink} from '@apollo/client/link/ws';
 import {getMainDefinition} from '@apollo/client/utilities';
 import {CustomTooltipProvider} from '@dagster-io/ui-components';
 import * as React from 'react';
+import {useContext} from 'react';
 import {BrowserRouter} from 'react-router-dom';
 import {CompatRouter} from 'react-router-dom-v5-compat';
 import {SubscriptionClient} from 'subscriptions-transport-ws';
@@ -174,4 +175,9 @@ export const AppProvider = (props: AppProviderProps) => {
       </WebSocketProvider>
     </AppContext.Provider>
   );
+};
+
+export const usePrefixedCacheKey = (key: string) => {
+  const {localCacheIdPrefix} = useContext(AppContext);
+  return `${localCacheIdPrefix}/${key}`;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -40,7 +40,12 @@ import {assetKeyTokensInRange} from './assetKeyTokensInRange';
 import {AssetGraphLayout, GroupLayout} from './layout';
 import {AssetGraphExplorerSidebar} from './sidebar/Sidebar';
 import {AssetNodeForGraphQueryFragment} from './types/useAssetGraphData.types';
-import {AssetGraphFetchScope, AssetGraphQueryItem, useAssetGraphData} from './useAssetGraphData';
+import {
+  AssetGraphFetchScope,
+  AssetGraphQueryItem,
+  useAssetGraphData,
+  useFullAssetGraphData,
+} from './useAssetGraphData';
 import {AssetLocation, useFindAssetLocation} from './useFindAssetLocation';
 import {AssetLiveDataRefreshButton} from '../asset-data/AssetLiveDataProvider';
 import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
@@ -87,11 +92,14 @@ export const MINIMAL_SCALE = 0.6;
 export const GROUPS_ONLY_SCALE = 0.15;
 
 export const AssetGraphExplorer = (props: Props) => {
-  const {fetchResult, assetGraphData, fullAssetGraphData, graphQueryItems, allAssetKeys} =
-    useAssetGraphData(props.explorerPath.opsQuery, {
+  const fullAssetGraphData = useFullAssetGraphData(props.fetchOptions);
+  const {fetchResult, assetGraphData, graphQueryItems, allAssetKeys} = useAssetGraphData(
+    props.explorerPath.opsQuery,
+    {
       ...props.fetchOptions,
       computeKinds: props.assetFilterState?.filters.computeKindTags,
-    });
+    },
+  );
 
   const {explorerPath, onChangeExplorerPath} = props;
 
@@ -100,7 +108,7 @@ export const AssetGraphExplorer = (props: Props) => {
       () => (fullAssetGraphData ? Object.values(fullAssetGraphData.nodes) : []),
       [fullAssetGraphData],
     ),
-    loading: fetchResult.loading ?? true,
+    loading: fetchResult.loading,
     isGlobalGraph: !!props.isGlobalGraph,
     assetFilterState: props.assetFilterState,
     explorerPath: explorerPath.opsQuery,

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useThrottledMemo.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useThrottledMemo.test.tsx
@@ -1,0 +1,99 @@
+import {act, renderHook} from '@testing-library/react-hooks';
+
+import {useThrottledMemo} from '../useThrottledMemo';
+
+jest.useFakeTimers();
+
+describe('useThrottledMemo', () => {
+  it('should compute the memoized value immediately on mount', () => {
+    const factory = jest.fn(() => 42);
+    const {result} = renderHook(() => useThrottledMemo(factory, [], 1000));
+
+    expect(result.current).toBe(42);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('should recompute the memoized value after the delay', () => {
+    let value = 1;
+    const factory = jest.fn(() => value);
+    const {result, rerender} = renderHook(() => useThrottledMemo(factory, [value], 1000));
+
+    expect(result.current).toBe(1);
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    value = 2;
+    rerender();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(result.current).toBe(2);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not recompute the memoized value if delay has not passed', () => {
+    let value = 1;
+    const factory = jest.fn(() => value);
+    const {result, rerender} = renderHook(() => useThrottledMemo(factory, [value], 1000));
+
+    expect(result.current).toBe(1);
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    value = 2;
+    rerender();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(result.current).toBe(1);
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(result.current).toBe(2);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it('should cancel the timeout when the component unmounts', () => {
+    const factory = jest.fn(() => 42);
+    const {unmount} = renderHook(() => useThrottledMemo(factory, [], 1000));
+
+    unmount();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(factory).toHaveBeenCalledTimes(1); // Only the initial call
+  });
+
+  it('should use the latest value when recomputing', () => {
+    let value = 1;
+    const factory = jest.fn(() => value);
+    const {result, rerender} = renderHook(() => useThrottledMemo(factory, [value], 1000));
+
+    expect(result.current).toBe(1);
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    value = 2;
+    rerender();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    value = 3;
+    rerender();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(result.current).toBe(3);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useThrottledMemo.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/useThrottledMemo.test.tsx
@@ -25,7 +25,8 @@ describe('useThrottledMemo', () => {
     rerender();
 
     act(() => {
-      jest.advanceTimersByTime(1000);
+      // 1000 + 200 for batching
+      jest.advanceTimersByTime(1200);
     });
 
     expect(result.current).toBe(2);
@@ -51,7 +52,7 @@ describe('useThrottledMemo', () => {
     expect(factory).toHaveBeenCalledTimes(1);
 
     act(() => {
-      jest.advanceTimersByTime(500);
+      jest.advanceTimersByTime(700);
     });
 
     expect(result.current).toBe(2);
@@ -65,7 +66,7 @@ describe('useThrottledMemo', () => {
     unmount();
 
     act(() => {
-      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(1200);
     });
 
     expect(factory).toHaveBeenCalledTimes(1); // Only the initial call
@@ -90,7 +91,7 @@ describe('useThrottledMemo', () => {
     rerender();
 
     act(() => {
-      jest.advanceTimersByTime(500);
+      jest.advanceTimersByTime(700);
     });
 
     expect(result.current).toBe(3);

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useThrottledMemo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useThrottledMemo.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, useEffect, useRef, useState} from 'react';
+import {createContext, useContext, useEffect, useMemo, useRef, useState} from 'react';
 import {unstable_batchedUpdates} from 'react-dom';
 
 /**
@@ -32,6 +32,8 @@ export const useThrottledMemo = <T,>(
   deps: React.DependencyList,
   delay: number,
 ): T => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(factory, deps);
   const [state, setState] = useState<T>(factory);
   const lastRun = useRef<number>(Date.now());
   const timeoutId = useRef<NodeJS.Timeout | null>(null);

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useThrottledMemo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useThrottledMemo.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, useEffect, useMemo, useRef, useState} from 'react';
+import {createContext, useContext, useEffect, useRef, useState} from 'react';
 import {unstable_batchedUpdates} from 'react-dom';
 
 /**
@@ -32,8 +32,6 @@ export const useThrottledMemo = <T,>(
   deps: React.DependencyList,
   delay: number,
 ): T => {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  return useMemo(factory, deps);
   const [state, setState] = useState<T>(factory);
   const lastRun = useRef<number>(Date.now());
   const timeoutId = useRef<NodeJS.Timeout | null>(null);

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useThrottledMemo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useThrottledMemo.tsx
@@ -1,0 +1,39 @@
+import {useEffect, useRef, useState} from 'react';
+
+export const useThrottledMemo = <T,>(
+  factory: () => T,
+  deps: React.DependencyList,
+  delay: number,
+): T => {
+  const [state, setState] = useState<T>(factory);
+  const lastRun = useRef<number>(Date.now());
+  const timeoutId = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    const now = Date.now();
+    if (now - lastRun.current >= delay) {
+      setState(factory);
+      lastRun.current = now;
+    } else {
+      if (timeoutId.current) {
+        clearTimeout(timeoutId.current);
+      }
+      timeoutId.current = setTimeout(
+        () => {
+          setState(factory);
+          lastRun.current = Date.now();
+        },
+        delay - (now - lastRun.current),
+      );
+    }
+
+    return () => {
+      if (timeoutId.current) {
+        clearTimeout(timeoutId.current);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return state;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useThrottledMemo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useThrottledMemo.tsx
@@ -1,4 +1,5 @@
 import {useEffect, useRef, useState} from 'react';
+import {unstable_batchedUpdates as batchedUpdates} from 'react-dom';
 
 export const useThrottledMemo = <T,>(
   factory: () => T,
@@ -12,7 +13,9 @@ export const useThrottledMemo = <T,>(
   useEffect(() => {
     const now = Date.now();
     if (now - lastRun.current >= delay) {
-      setState(factory);
+      batchedUpdates(() => {
+        setState(factory);
+      });
       lastRun.current = now;
     } else {
       if (timeoutId.current) {
@@ -20,7 +23,9 @@ export const useThrottledMemo = <T,>(
       }
       timeoutId.current = setTimeout(
         () => {
-          setState(factory);
+          batchedUpdates(() => {
+            setState(factory);
+          });
           lastRun.current = Date.now();
         },
         delay - (now - lastRun.current),

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/OpJobPartitionsView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/OpJobPartitionsView.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   useViewport,
 } from '@dagster-io/ui-components';
-import {useCallback, useEffect, useLayoutEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useLayoutEffect, useMemo, useState} from 'react';
 
 import {BackfillPartitionSelector} from './BackfillSelector';
 import {JobBackfillsTable} from './JobBackfillsTable';
@@ -43,100 +43,96 @@ const simpleCache = new Map<
   QueryResult<PartitionsStatusQuery, PartitionsStatusQueryVariables>
 >();
 
-export const OpJobPartitionsView = ({
-  partitionSetName,
-  repoAddress,
-}: {
-  partitionSetName: string;
-  repoAddress: RepoAddress;
-}) => {
-  const repositorySelector = repoAddressToSelector(repoAddress);
-  const variables = useMemo(
-    () => ({partitionSetName, repositorySelector}),
-    [partitionSetName, repositorySelector],
-  );
-  const cacheKey = useMemo(() => JSON.stringify(variables), [variables]);
-  const cachedResult = useMemo(() => simpleCache.get(cacheKey), [cacheKey]);
-  const currentQueryResult = useQuery<PartitionsStatusQuery, PartitionsStatusQueryVariables>(
-    PARTITIONS_STATUS_QUERY,
-    {
-      variables: {partitionSetName, repositorySelector},
-      fetchPolicy: 'no-cache',
-    },
-  );
-  useLayoutEffect(() => {
-    if (currentQueryResult) {
-      simpleCache.set(cacheKey, currentQueryResult);
-    }
-  }, [cacheKey, currentQueryResult]);
-  const queryResult = currentQueryResult.data
-    ? currentQueryResult
-    : cachedResult ?? currentQueryResult;
-  const {data, loading} = queryResult;
-  useBlockTraceOnQueryResult(queryResult, 'PartitionsStatusQuery');
+export const OpJobPartitionsView = React.memo(
+  ({partitionSetName, repoAddress}: {partitionSetName: string; repoAddress: RepoAddress}) => {
+    const repositorySelector = repoAddressToSelector(repoAddress);
+    const variables = useMemo(
+      () => ({partitionSetName, repositorySelector}),
+      [partitionSetName, repositorySelector],
+    );
+    const cacheKey = useMemo(() => JSON.stringify(variables), [variables]);
+    const cachedResult = useMemo(() => simpleCache.get(cacheKey), [cacheKey]);
+    const currentQueryResult = useQuery<PartitionsStatusQuery, PartitionsStatusQueryVariables>(
+      PARTITIONS_STATUS_QUERY,
+      {
+        variables: {partitionSetName, repositorySelector},
+        fetchPolicy: 'no-cache',
+      },
+    );
+    useLayoutEffect(() => {
+      if (currentQueryResult) {
+        simpleCache.set(cacheKey, currentQueryResult);
+      }
+    }, [cacheKey, currentQueryResult]);
+    const queryResult = currentQueryResult.data
+      ? currentQueryResult
+      : cachedResult ?? currentQueryResult;
+    const {data, loading} = queryResult;
+    useBlockTraceOnQueryResult(queryResult, 'PartitionsStatusQuery');
 
-  if (!data) {
-    if (loading) {
-      return (
-        <Box padding={32} flex={{direction: 'column', alignItems: 'center'}}>
-          <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-            <Spinner purpose="body-text" />
-            <div>Loading partitions…</div>
+    if (!data) {
+      if (loading) {
+        return (
+          <Box padding={32} flex={{direction: 'column', alignItems: 'center'}}>
+            <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+              <Spinner purpose="body-text" />
+              <div>Loading partitions…</div>
+            </Box>
           </Box>
+        );
+      }
+
+      return (
+        <Box padding={32}>
+          <NonIdealState
+            icon="error"
+            title="An error occurred"
+            description="An unexpected error occurred."
+          />
         </Box>
       );
     }
 
+    const {partitionSetOrError} = data;
+    if (partitionSetOrError.__typename === 'PartitionSetNotFoundError') {
+      return (
+        <Box padding={32}>
+          <NonIdealState
+            icon="search"
+            title="Partition set not found"
+            description={partitionSetOrError.message}
+          />
+        </Box>
+      );
+    }
+
+    if (partitionSetOrError.__typename === 'PythonError') {
+      return (
+        <Box padding={32}>
+          <PythonErrorInfo error={partitionSetOrError} />
+        </Box>
+      );
+    }
+
+    if (partitionSetOrError.partitionsOrError.__typename === 'PythonError') {
+      return (
+        <Box padding={32}>
+          <PythonErrorInfo error={partitionSetOrError.partitionsOrError} />
+        </Box>
+      );
+    }
+
+    const partitionNames = partitionSetOrError.partitionsOrError.results.map(({name}) => name);
+
     return (
-      <Box padding={32}>
-        <NonIdealState
-          icon="error"
-          title="An error occurred"
-          description="An unexpected error occurred."
-        />
-      </Box>
+      <OpJobPartitionsViewContent
+        partitionNames={partitionNames}
+        partitionSet={partitionSetOrError}
+        repoAddress={repoAddress}
+      />
     );
-  }
-
-  const {partitionSetOrError} = data;
-  if (partitionSetOrError.__typename === 'PartitionSetNotFoundError') {
-    return (
-      <Box padding={32}>
-        <NonIdealState
-          icon="search"
-          title="Partition set not found"
-          description={partitionSetOrError.message}
-        />
-      </Box>
-    );
-  }
-
-  if (partitionSetOrError.__typename === 'PythonError') {
-    return (
-      <Box padding={32}>
-        <PythonErrorInfo error={partitionSetOrError} />
-      </Box>
-    );
-  }
-
-  if (partitionSetOrError.partitionsOrError.__typename === 'PythonError') {
-    return (
-      <Box padding={32}>
-        <PythonErrorInfo error={partitionSetOrError.partitionsOrError} />
-      </Box>
-    );
-  }
-
-  const partitionNames = partitionSetOrError.partitionsOrError.results.map(({name}) => name);
-
-  return (
-    <OpJobPartitionsViewContent
-      partitionNames={partitionNames}
-      partitionSet={partitionSetOrError}
-      repoAddress={repoAddress}
-    />
-  );
-};
+  },
+);
 
 export function usePartitionDurations(partitions: PartitionRuns[]) {
   return useThrottledMemo(
@@ -168,260 +164,262 @@ export function usePartitionDurations(partitions: PartitionRuns[]) {
   );
 }
 
-export const OpJobPartitionsViewContent = ({
-  partitionSet,
-  partitionNames,
-  repoAddress,
-}: {
-  partitionNames: string[];
-  partitionSet: OpJobPartitionSetFragment;
-  repoAddress: RepoAddress;
-}) => {
-  const {
-    permissions: {canLaunchPartitionBackfill},
-    disabledReasons,
-  } = usePermissionsForLocation(repoAddress.location);
-  const {viewport, containerProps} = useViewport();
-
-  const [pageSize, setPageSize] = useState(60);
-  const [offset, setOffset] = useState<number>(0);
-  const [showSteps, setShowSteps] = useState(false);
-  const [showBackfillSetup, setShowBackfillSetup] = useState(false);
-  const [blockDialog, setBlockDialog] = useState(false);
-  const repositorySelector = repoAddressToSelector(repoAddress);
-  const [backfillRefetchCounter, setBackfillRefetchCounter] = useState(0);
-
-  const partitions = usePartitionStepQuery({
-    partitionSetName: partitionSet.name,
-    partitionTagName: DagsterTag.Partition,
+export const OpJobPartitionsViewContent = React.memo(
+  ({
+    partitionSet,
     partitionNames,
-    pageSize,
-    runsFilter: [],
-    repositorySelector,
-    jobName: partitionSet.pipelineName,
-    offset,
-    skipQuery: !showSteps,
-  });
+    repoAddress,
+  }: {
+    partitionNames: string[];
+    partitionSet: OpJobPartitionSetFragment;
+    repoAddress: RepoAddress;
+  }) => {
+    const {
+      permissions: {canLaunchPartitionBackfill},
+      disabledReasons,
+    } = usePermissionsForLocation(repoAddress.location);
+    const {viewport, containerProps} = useViewport();
 
-  useEffect(() => {
-    if (viewport.width && !showSteps) {
-      // magical numbers to approximate the size of the window, which is calculated in the step
-      // status component.  This approximation is to make sure that the window does not jump as
-      // the pageSize gets recalculated
-      const approxPageSize = getVisibleItemCount(viewport.width - GRID_FLOATING_CONTAINER_WIDTH);
-      setPageSize(approxPageSize);
-    }
-  }, [viewport.width, showSteps, setPageSize]);
+    const [pageSize, setPageSize] = useState(60);
+    const [offset, setOffset] = useState<number>(0);
+    const [showSteps, setShowSteps] = useState(false);
+    const [showBackfillSetup, setShowBackfillSetup] = useState(false);
+    const [blockDialog, setBlockDialog] = useState(false);
+    const repositorySelector = repoAddressToSelector(repoAddress);
+    const [backfillRefetchCounter, setBackfillRefetchCounter] = useState(0);
 
-  const selectedPartitions = useThrottledMemo(
-    () => {
-      return showSteps
-        ? partitionNames.slice(
-            Math.max(0, partitionNames.length - 1 - offset - pageSize),
-            partitionNames.length - offset,
-          )
-        : partitionNames;
-    },
-    [offset, pageSize, partitionNames, showSteps],
-    500,
-  );
+    const partitions = usePartitionStepQuery({
+      partitionSetName: partitionSet.name,
+      partitionTagName: DagsterTag.Partition,
+      partitionNames,
+      pageSize,
+      runsFilter: [],
+      repositorySelector,
+      jobName: partitionSet.pipelineName,
+      offset,
+      skipQuery: !showSteps,
+    });
 
-  const stepDurationData = usePartitionDurations(partitions).stepDurationData;
+    useEffect(() => {
+      if (viewport.width && !showSteps) {
+        // magical numbers to approximate the size of the window, which is calculated in the step
+        // status component.  This approximation is to make sure that the window does not jump as
+        // the pageSize gets recalculated
+        const approxPageSize = getVisibleItemCount(viewport.width - GRID_FLOATING_CONTAINER_WIDTH);
+        setPageSize(approxPageSize);
+      }
+    }, [viewport.width, showSteps, setPageSize]);
 
-  const onSubmit = useCallback(() => setBlockDialog(true), []);
+    const selectedPartitions = useThrottledMemo(
+      () => {
+        return showSteps
+          ? partitionNames.slice(
+              Math.max(0, partitionNames.length - 1 - offset - pageSize),
+              partitionNames.length - offset,
+            )
+          : partitionNames;
+      },
+      [offset, pageSize, partitionNames, showSteps],
+      500,
+    );
 
-  const selectPartitionNamesSet = useThrottledMemo(
-    () => new Set(selectedPartitions),
-    [selectedPartitions],
-    1000,
-  );
+    const stepDurationData = usePartitionDurations(partitions).stepDurationData;
 
-  const {partitionStatusesOrError} = partitionSet;
-  const partitionStatuses = useMemo(() => {
-    return partitionStatusesOrError.__typename === 'PartitionStatuses'
-      ? partitionStatusesOrError.results
-      : [];
-  }, [partitionStatusesOrError]);
+    const onSubmit = useCallback(() => setBlockDialog(true), []);
 
-  const {runStatusData, runDurationData} = useThrottledMemo(
-    () => {
-      // Note: This view reads "run duration" from the `partitionStatusesOrError` GraphQL API,
-      // rather than looking at the duration of the most recent run returned in `partitions` above
-      // so that the latter can be loaded when you click "Show per-step status" only.
-      const runStatusData: {[name: string]: RunStatus} = {};
-      const runDurationData: {[name: string]: number | undefined} = {};
+    const selectPartitionNamesSet = useThrottledMemo(
+      () => new Set(selectedPartitions),
+      [selectedPartitions],
+      1000,
+    );
 
-      partitionStatuses.forEach((p) => {
-        runStatusData[p.partitionName] = p.runStatus || RunStatus.NOT_STARTED;
-        if (selectPartitionNamesSet.has(p.partitionName)) {
-          runDurationData[p.partitionName] = p.runDuration || undefined;
-        }
-      });
-      return {runStatusData, runDurationData};
-    },
-    [partitionStatuses, selectPartitionNamesSet],
-    1000,
-  );
+    const {partitionStatusesOrError} = partitionSet;
+    const partitionStatuses = useMemo(() => {
+      return partitionStatusesOrError.__typename === 'PartitionStatuses'
+        ? partitionStatusesOrError.results
+        : [];
+    }, [partitionStatusesOrError]);
 
-  const health = useThrottledMemo(
-    () => {
-      return {runStatusForPartitionKey: (name: string) => runStatusData[name]};
-    },
-    [runStatusData],
-    1000,
-  );
+    const {runStatusData, runDurationData} = useThrottledMemo(
+      () => {
+        // Note: This view reads "run duration" from the `partitionStatusesOrError` GraphQL API,
+        // rather than looking at the duration of the most recent run returned in `partitions` above
+        // so that the latter can be loaded when you click "Show per-step status" only.
+        const runStatusData: {[name: string]: RunStatus} = {};
+        const runDurationData: {[name: string]: number | undefined} = {};
 
-  return (
-    <div>
-      <Dialog
-        canEscapeKeyClose={!blockDialog}
-        canOutsideClickClose={!blockDialog}
-        onClose={() => setShowBackfillSetup(false)}
-        style={{width: 800, zIndex: 1000}}
-        title={`Launch ${partitionSet.pipelineName} backfill`}
-        isOpen={showBackfillSetup}
-      >
-        {showBackfillSetup && (
-          <BackfillPartitionSelector
-            partitionSetName={partitionSet.name}
-            partitionNames={partitionNames}
-            runStatusData={runStatusData}
-            pipelineName={partitionSet.pipelineName}
-            onCancel={() => setShowBackfillSetup(false)}
-            onLaunch={(_backfillId, _stepQuery) => {
-              setBackfillRefetchCounter(backfillRefetchCounter + 1);
-              setShowBackfillSetup(false);
-            }}
-            onSubmit={onSubmit}
-            repoAddress={repoAddress}
-          />
-        )}
-      </Dialog>
+        partitionStatuses.forEach((p) => {
+          runStatusData[p.partitionName] = p.runStatus || RunStatus.NOT_STARTED;
+          if (selectPartitionNamesSet.has(p.partitionName)) {
+            runDurationData[p.partitionName] = p.runDuration || undefined;
+          }
+        });
+        return {runStatusData, runDurationData};
+      },
+      [partitionStatuses, selectPartitionNamesSet],
+      1000,
+    );
 
-      <Box
-        flex={{justifyContent: 'space-between', direction: 'row', alignItems: 'center'}}
-        border="bottom"
-        padding={{vertical: 16, horizontal: 24}}
-      >
-        <Subheading>Status</Subheading>
-        <Box flex={{gap: 8}}>
-          <Button onClick={() => setShowSteps(!showSteps)} active={showBackfillSetup}>
-            {showSteps ? 'Hide per-step status' : 'Show per-step status'}
-          </Button>
-          {canLaunchPartitionBackfill ? (
-            <Button
-              onClick={() => setShowBackfillSetup(!showBackfillSetup)}
-              icon={<Icon name="add_circle" />}
-              active={showBackfillSetup}
-            >
-              Launch backfill…
+    const health = useThrottledMemo(
+      () => {
+        return {runStatusForPartitionKey: (name: string) => runStatusData[name]};
+      },
+      [runStatusData],
+      1000,
+    );
+
+    return (
+      <div>
+        <Dialog
+          canEscapeKeyClose={!blockDialog}
+          canOutsideClickClose={!blockDialog}
+          onClose={() => setShowBackfillSetup(false)}
+          style={{width: 800, zIndex: 1000}}
+          title={`Launch ${partitionSet.pipelineName} backfill`}
+          isOpen={showBackfillSetup}
+        >
+          {showBackfillSetup && (
+            <BackfillPartitionSelector
+              partitionSetName={partitionSet.name}
+              partitionNames={partitionNames}
+              runStatusData={runStatusData}
+              pipelineName={partitionSet.pipelineName}
+              onCancel={() => setShowBackfillSetup(false)}
+              onLaunch={(_backfillId, _stepQuery) => {
+                setBackfillRefetchCounter(backfillRefetchCounter + 1);
+                setShowBackfillSetup(false);
+              }}
+              onSubmit={onSubmit}
+              repoAddress={repoAddress}
+            />
+          )}
+        </Dialog>
+
+        <Box
+          flex={{justifyContent: 'space-between', direction: 'row', alignItems: 'center'}}
+          border="bottom"
+          padding={{vertical: 16, horizontal: 24}}
+        >
+          <Subheading>Status</Subheading>
+          <Box flex={{gap: 8}}>
+            <Button onClick={() => setShowSteps(!showSteps)} active={showBackfillSetup}>
+              {showSteps ? 'Hide per-step status' : 'Show per-step status'}
             </Button>
-          ) : (
-            <Tooltip content={disabledReasons.canLaunchPartitionBackfill}>
-              <Button icon={<Icon name="add_circle" />} disabled>
+            {canLaunchPartitionBackfill ? (
+              <Button
+                onClick={() => setShowBackfillSetup(!showBackfillSetup)}
+                icon={<Icon name="add_circle" />}
+                active={showBackfillSetup}
+              >
                 Launch backfill…
               </Button>
-            </Tooltip>
-          )}
+            ) : (
+              <Tooltip content={disabledReasons.canLaunchPartitionBackfill}>
+                <Button icon={<Icon name="add_circle" />} disabled>
+                  Launch backfill…
+                </Button>
+              </Tooltip>
+            )}
+          </Box>
         </Box>
-      </Box>
-      <Box flex={{direction: 'row', alignItems: 'center'}} border="bottom" padding={{left: 8}}>
-        <CountBox count={partitionNames.length} label="Total partitions" />
-        <CountBox
-          count={partitionNames.filter((x) => runStatusData[x] === RunStatus.FAILURE).length}
-          label="Failed partitions"
-        />
-        <CountBox
-          count={
-            partitionNames.filter(
-              (x) => !runStatusData[x] || runStatusData[x] === RunStatus.NOT_STARTED,
-            ).length
-          }
-          label="Missing partitions"
-        />
-      </Box>
-      <Box padding={{vertical: 16, horizontal: 24}}>
-        <div {...containerProps}>
-          <PartitionStatus
-            partitionNames={partitionNames}
-            health={health}
-            selected={showSteps ? selectedPartitions : undefined}
-            selectionWindowSize={pageSize}
-            onClick={(partitionName) => {
-              const maxIdx = partitionNames.length - 1;
-              const selectedIdx = partitionNames.indexOf(partitionName);
-              const nextOffset = Math.min(
-                maxIdx,
-                Math.max(0, maxIdx - selectedIdx - 0.5 * pageSize),
-              );
-              setOffset(nextOffset);
-              if (!showSteps) {
-                setShowSteps(true);
-              }
-            }}
-            tooltipMessage="Click to view per-step status"
+        <Box flex={{direction: 'row', alignItems: 'center'}} border="bottom" padding={{left: 8}}>
+          <CountBox count={partitionNames.length} label="Total partitions" />
+          <CountBox
+            count={partitionNames.filter((x) => runStatusData[x] === RunStatus.FAILURE).length}
+            label="Failed partitions"
           />
-        </div>
-        {showSteps ? (
-          <Box margin={{top: 16}}>
-            <PartitionPerOpStatus
+          <CountBox
+            count={
+              partitionNames.filter(
+                (x) => !runStatusData[x] || runStatusData[x] === RunStatus.NOT_STARTED,
+              ).length
+            }
+            label="Missing partitions"
+          />
+        </Box>
+        <Box padding={{vertical: 16, horizontal: 24}}>
+          <div {...containerProps}>
+            <PartitionStatus
               partitionNames={partitionNames}
-              partitions={partitions}
-              pipelineName={partitionSet.pipelineName}
-              repoAddress={repoAddress}
-              setPageSize={setPageSize}
-              offset={offset}
-              setOffset={setOffset}
+              health={health}
+              selected={showSteps ? selectedPartitions : undefined}
+              selectionWindowSize={pageSize}
+              onClick={(partitionName) => {
+                const maxIdx = partitionNames.length - 1;
+                const selectedIdx = partitionNames.indexOf(partitionName);
+                const nextOffset = Math.min(
+                  maxIdx,
+                  Math.max(0, maxIdx - selectedIdx - 0.5 * pageSize),
+                );
+                setOffset(nextOffset);
+                if (!showSteps) {
+                  setShowSteps(true);
+                }
+              }}
+              tooltipMessage="Click to view per-step status"
             />
-          </Box>
+          </div>
+          {showSteps ? (
+            <Box margin={{top: 16}}>
+              <PartitionPerOpStatus
+                partitionNames={partitionNames}
+                partitions={partitions}
+                pipelineName={partitionSet.pipelineName}
+                repoAddress={repoAddress}
+                setPageSize={setPageSize}
+                offset={offset}
+                setOffset={setOffset}
+              />
+            </Box>
+          ) : null}
+        </Box>
+        <Box padding={{horizontal: 24, vertical: 16}} border="top-and-bottom">
+          <Subheading>Run duration</Subheading>
+        </Box>
+        <Box margin={24}>
+          <PartitionGraph
+            isJob={true}
+            title="Execution time by partition"
+            yLabel="Execution time (secs)"
+            partitionNames={showSteps ? selectedPartitions : partitionNames}
+            jobDataByPartition={runDurationData}
+          />
+        </Box>
+        {showSteps ? (
+          <>
+            <Box padding={{horizontal: 24, vertical: 16}}>
+              <Subheading>Step duration</Subheading>
+            </Box>
+            <Box margin={24}>
+              <PartitionGraph
+                isJob={true}
+                title="Execution time by partition"
+                yLabel="Execution time (secs)"
+                partitionNames={selectedPartitions}
+                stepDataByPartition={stepDurationData}
+              />
+            </Box>
+          </>
         ) : null}
-      </Box>
-      <Box padding={{horizontal: 24, vertical: 16}} border="top-and-bottom">
-        <Subheading>Run duration</Subheading>
-      </Box>
-      <Box margin={24}>
-        <PartitionGraph
-          isJob={true}
-          title="Execution time by partition"
-          yLabel="Execution time (secs)"
-          partitionNames={showSteps ? selectedPartitions : partitionNames}
-          jobDataByPartition={runDurationData}
-        />
-      </Box>
-      {showSteps ? (
-        <>
-          <Box padding={{horizontal: 24, vertical: 16}}>
-            <Subheading>Step duration</Subheading>
-          </Box>
-          <Box margin={24}>
-            <PartitionGraph
-              isJob={true}
-              title="Execution time by partition"
-              yLabel="Execution time (secs)"
-              partitionNames={selectedPartitions}
-              stepDataByPartition={stepDurationData}
-            />
-          </Box>
-        </>
-      ) : null}
-      <Box
-        padding={{horizontal: 24, vertical: 16}}
-        border="top-and-bottom"
-        style={{marginBottom: -1}}
-      >
-        <Subheading>Backfill history</Subheading>
-      </Box>
-      <Box margin={{bottom: 20}}>
-        <JobBackfillsTable
-          partitionSetName={partitionSet.name}
-          repositorySelector={repositorySelector}
-          partitionNames={partitionNames}
-          refetchCounter={backfillRefetchCounter}
-        />
-      </Box>
-    </div>
-  );
-};
+        <Box
+          padding={{horizontal: 24, vertical: 16}}
+          border="top-and-bottom"
+          style={{marginBottom: -1}}
+        >
+          <Subheading>Backfill history</Subheading>
+        </Box>
+        <Box margin={{bottom: 20}}>
+          <JobBackfillsTable
+            partitionSetName={partitionSet.name}
+            repositorySelector={repositorySelector}
+            partitionNames={partitionNames}
+            refetchCounter={backfillRefetchCounter}
+          />
+        </Box>
+      </div>
+    );
+  },
+);
 
 export const CountBox = ({count, label}: {count: number; label: string}) => (
   <Box padding={16} style={{flex: 1}} border="right">

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/OpJobPartitionsView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/OpJobPartitionsView.tsx
@@ -325,15 +325,20 @@ export const OpJobPartitionsViewContent = React.memo(
         <Box flex={{direction: 'row', alignItems: 'center'}} border="bottom" padding={{left: 8}}>
           <CountBox count={partitionNames.length} label="Total partitions" />
           <CountBox
-            count={partitionNames.filter((x) => runStatusData[x] === RunStatus.FAILURE).length}
+            count={useMemo(
+              () => partitionNames.filter((x) => runStatusData[x] === RunStatus.FAILURE).length,
+              [partitionNames, runStatusData],
+            )}
             label="Failed partitions"
           />
           <CountBox
-            count={
-              partitionNames.filter(
-                (x) => !runStatusData[x] || runStatusData[x] === RunStatus.NOT_STARTED,
-              ).length
-            }
+            count={useMemo(
+              () =>
+                partitionNames.filter(
+                  (x) => !runStatusData[x] || runStatusData[x] === RunStatus.NOT_STARTED,
+                ).length,
+              [partitionNames, runStatusData],
+            )}
             label="Missing partitions"
           />
         </Box>
@@ -344,18 +349,21 @@ export const OpJobPartitionsViewContent = React.memo(
               health={health}
               selected={showSteps ? selectedPartitions : undefined}
               selectionWindowSize={pageSize}
-              onClick={(partitionName) => {
-                const maxIdx = partitionNames.length - 1;
-                const selectedIdx = partitionNames.indexOf(partitionName);
-                const nextOffset = Math.min(
-                  maxIdx,
-                  Math.max(0, maxIdx - selectedIdx - 0.5 * pageSize),
-                );
-                setOffset(nextOffset);
-                if (!showSteps) {
-                  setShowSteps(true);
-                }
-              }}
+              onClick={useCallback(
+                (partitionName: string) => {
+                  const maxIdx = partitionNames.length - 1;
+                  const selectedIdx = partitionNames.indexOf(partitionName);
+                  const nextOffset = Math.min(
+                    maxIdx,
+                    Math.max(0, maxIdx - selectedIdx - 0.5 * pageSize),
+                  );
+                  setOffset(nextOffset);
+                  if (!showSteps) {
+                    setShowSteps(true);
+                  }
+                },
+                [pageSize, partitionNames, showSteps],
+              )}
               tooltipMessage="Click to view per-step status"
             />
           </div>

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/OpJobPartitionsView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/OpJobPartitionsView.tsx
@@ -30,7 +30,6 @@ import {usePermissionsForLocation} from '../app/Permissions';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {RunStatus} from '../graphql/types';
-import {useThrottledMemo} from '../hooks/useThrottledMemo';
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {DagsterTag} from '../runs/RunTag';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
@@ -135,33 +134,29 @@ export const OpJobPartitionsView = React.memo(
 );
 
 export function usePartitionDurations(partitions: PartitionRuns[]) {
-  return useThrottledMemo(
-    () => {
-      const stepDurationData: {[name: string]: {[key: string]: (number | undefined)[]}} = {};
-      const runDurationData: {[name: string]: number | undefined} = {};
+  return useMemo(() => {
+    const stepDurationData: {[name: string]: {[key: string]: (number | undefined)[]}} = {};
+    const runDurationData: {[name: string]: number | undefined} = {};
 
-      partitions.forEach((p) => {
-        if (!p.runsLoaded || p.runs.length === 0) {
-          return;
-        }
-        const sortedRuns = p.runs.sort((a, b) => a.startTime || 0 - (b.startTime || 0));
-        const lastRun = sortedRuns[sortedRuns.length - 1]!;
-        stepDurationData[p.name] = {};
-        runDurationData[p.name] =
-          lastRun?.endTime && lastRun?.startTime ? lastRun.endTime - lastRun.startTime : undefined;
+    partitions.forEach((p) => {
+      if (!p.runsLoaded || p.runs.length === 0) {
+        return;
+      }
+      const sortedRuns = p.runs.sort((a, b) => a.startTime || 0 - (b.startTime || 0));
+      const lastRun = sortedRuns[sortedRuns.length - 1]!;
+      stepDurationData[p.name] = {};
+      runDurationData[p.name] =
+        lastRun?.endTime && lastRun?.startTime ? lastRun.endTime - lastRun.startTime : undefined;
 
-        lastRun.stepStats.forEach((s) => {
-          stepDurationData[p.name]![s.stepKey] = [
-            s.endTime && s.startTime ? s.endTime - s.startTime : undefined,
-          ];
-        });
+      lastRun.stepStats.forEach((s) => {
+        stepDurationData[p.name]![s.stepKey] = [
+          s.endTime && s.startTime ? s.endTime - s.startTime : undefined,
+        ];
       });
+    });
 
-      return {runDurationData, stepDurationData};
-    },
-    [partitions],
-    1000,
-  );
+    return {runDurationData, stepDurationData};
+  }, [partitions]);
 }
 
 export const OpJobPartitionsViewContent = React.memo(
@@ -210,27 +205,22 @@ export const OpJobPartitionsViewContent = React.memo(
       }
     }, [viewport.width, showSteps, setPageSize]);
 
-    const selectedPartitions = useThrottledMemo(
-      () => {
-        return showSteps
-          ? partitionNames.slice(
-              Math.max(0, partitionNames.length - 1 - offset - pageSize),
-              partitionNames.length - offset,
-            )
-          : partitionNames;
-      },
-      [offset, pageSize, partitionNames, showSteps],
-      500,
-    );
+    const selectedPartitions = useMemo(() => {
+      return showSteps
+        ? partitionNames.slice(
+            Math.max(0, partitionNames.length - 1 - offset - pageSize),
+            partitionNames.length - offset,
+          )
+        : partitionNames;
+    }, [offset, pageSize, partitionNames, showSteps]);
 
     const stepDurationData = usePartitionDurations(partitions).stepDurationData;
 
     const onSubmit = useCallback(() => setBlockDialog(true), []);
 
-    const selectPartitionNamesSet = useThrottledMemo(
+    const selectPartitionNamesSet = useMemo(
       () => new Set(selectedPartitions),
       [selectedPartitions],
-      1000,
     );
 
     const {partitionStatusesOrError} = partitionSet;
@@ -240,33 +230,25 @@ export const OpJobPartitionsViewContent = React.memo(
         : [];
     }, [partitionStatusesOrError]);
 
-    const {runStatusData, runDurationData} = useThrottledMemo(
-      () => {
-        // Note: This view reads "run duration" from the `partitionStatusesOrError` GraphQL API,
-        // rather than looking at the duration of the most recent run returned in `partitions` above
-        // so that the latter can be loaded when you click "Show per-step status" only.
-        const runStatusData: {[name: string]: RunStatus} = {};
-        const runDurationData: {[name: string]: number | undefined} = {};
+    const {runStatusData, runDurationData} = useMemo(() => {
+      // Note: This view reads "run duration" from the `partitionStatusesOrError` GraphQL API,
+      // rather than looking at the duration of the most recent run returned in `partitions` above
+      // so that the latter can be loaded when you click "Show per-step status" only.
+      const runStatusData: {[name: string]: RunStatus} = {};
+      const runDurationData: {[name: string]: number | undefined} = {};
 
-        partitionStatuses.forEach((p) => {
-          runStatusData[p.partitionName] = p.runStatus || RunStatus.NOT_STARTED;
-          if (selectPartitionNamesSet.has(p.partitionName)) {
-            runDurationData[p.partitionName] = p.runDuration || undefined;
-          }
-        });
-        return {runStatusData, runDurationData};
-      },
-      [partitionStatuses, selectPartitionNamesSet],
-      1000,
-    );
+      partitionStatuses.forEach((p) => {
+        runStatusData[p.partitionName] = p.runStatus || RunStatus.NOT_STARTED;
+        if (selectPartitionNamesSet.has(p.partitionName)) {
+          runDurationData[p.partitionName] = p.runDuration || undefined;
+        }
+      });
+      return {runStatusData, runDurationData};
+    }, [partitionStatuses, selectPartitionNamesSet]);
 
-    const health = useThrottledMemo(
-      () => {
-        return {runStatusForPartitionKey: (name: string) => runStatusData[name]};
-      },
-      [runStatusData],
-      1000,
-    );
+    const health = useMemo(() => {
+      return {runStatusForPartitionKey: (name: string) => runStatusData[name]};
+    }, [runStatusData]);
 
     return (
       <div>

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionGraph.tsx
@@ -33,9 +33,10 @@ export const PartitionGraph = React.memo(
     const [hiddenPartitions, setHiddenPartitions] = useState<{[name: string]: boolean}>(() => ({}));
     const chart = useRef<any>(null);
 
-    const [showLargeGraphMessage, setShowLargeGraphMessage] = useState(
+    const [_showLargeGraphMessage, setShowLargeGraphMessage] = useState(
       partitionNames.length > 1000,
     );
+    const showLargeGraphMessage = _showLargeGraphMessage && partitionNames.length > 1000;
 
     const onGraphClick = useCallback((event: MouseEvent) => {
       const instance = chart.current;

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionGraph.tsx
@@ -1,5 +1,5 @@
 import {Box, Button, Colors, NonIdealState} from '@dagster-io/ui-components';
-import {useCallback, useRef, useState} from 'react';
+import React, {useCallback, useRef, useState} from 'react';
 import {Line} from 'react-chartjs-2';
 import styled from 'styled-components';
 
@@ -20,204 +20,208 @@ interface PartitionGraphProps {
   hiddenStepKeys?: string[];
 }
 
-export const PartitionGraph = ({
-  partitionNames,
-  jobDataByPartition,
-  stepDataByPartition,
-  title,
-  yLabel,
-  isJob,
-  hiddenStepKeys,
-}: PartitionGraphProps) => {
-  const [hiddenPartitions, setHiddenPartitions] = useState<{[name: string]: boolean}>(() => ({}));
-  const chart = useRef<any>(null);
+export const PartitionGraph = React.memo(
+  ({
+    partitionNames,
+    jobDataByPartition,
+    stepDataByPartition,
+    title,
+    yLabel,
+    isJob,
+    hiddenStepKeys,
+  }: PartitionGraphProps) => {
+    const [hiddenPartitions, setHiddenPartitions] = useState<{[name: string]: boolean}>(() => ({}));
+    const chart = useRef<any>(null);
 
-  const [showLargeGraphMessage, setShowLargeGraphMessage] = useState(partitionNames.length > 1000);
-
-  const onGraphClick = useCallback((event: MouseEvent) => {
-    const instance = chart.current;
-    if (!instance) {
-      return;
-    }
-    const xAxis = instance.scales['x-axis-0'];
-    if (!xAxis) {
-      return;
-    }
-    const {offsetX, offsetY} = event;
-
-    const isChartClick =
-      event.type === 'click' &&
-      offsetX <= instance.chartArea.right &&
-      offsetX >= instance.chartArea.left &&
-      offsetY <= instance.chartArea.bottom &&
-      offsetY >= instance.chartArea.top;
-
-    if (!isChartClick || !event.shiftKey) {
-      return;
-    }
-
-    // category scale returns index here for some reason
-    const labelIndex = xAxis.getValueForPixel(offsetX);
-    const partitionName = instance.data.labels[labelIndex];
-    setHiddenPartitions((current) => ({
-      ...current,
-      [partitionName]: !current[partitionName],
-    }));
-  }, []);
-
-  const defaultOptions = useThrottledMemo(
-    () => {
-      if (showLargeGraphMessage) {
-        return null;
-      }
-      const titleOptions = title ? {display: true, text: title} : undefined;
-      const scales = yLabel
-        ? {
-            y: {
-              id: 'y',
-              title: {display: true, text: yLabel},
-            },
-            x: {
-              id: 'x',
-              title: {display: true, text: title},
-            },
-          }
-        : undefined;
-
-      return {
-        title: titleOptions,
-        animation: false,
-        scales,
-        plugins: {
-          legend: {
-            display: false,
-            onClick: (_e: MouseEvent, _legendItem: any) => {},
-          },
-        },
-        onClick: onGraphClick,
-        maintainAspectRatio: false,
-      };
-    },
-    [onGraphClick, showLargeGraphMessage, title, yLabel],
-    1000,
-  );
-
-  const {jobData, stepData} = useThrottledMemo(
-    () => {
-      if (showLargeGraphMessage) {
-        return {jobData: [], stepData: {}};
-      }
-      const jobData: Point[] = [];
-      const stepData = {};
-
-      partitionNames.forEach((partitionName) => {
-        const hidden = !!hiddenPartitions[partitionName];
-        if (jobDataByPartition) {
-          jobData.push({
-            x: partitionName,
-            y: !hidden ? jobDataByPartition[partitionName] : undefined,
-          });
-        }
-
-        if (stepDataByPartition) {
-          const stepDataByKey = stepDataByPartition[partitionName];
-          Object.entries(stepDataByKey || {}).forEach(([stepKey, step]) => {
-            if (hiddenStepKeys?.includes(stepKey) || !step) {
-              return;
-            }
-            (stepData as any)[stepKey] = [
-              ...((stepData as any)[stepKey] || []),
-              {
-                x: partitionName,
-                y: !hidden ? step : undefined,
-              },
-            ];
-          });
-        }
-      });
-
-      // stepData may have holes due to missing runs or missing steps.  For these to
-      // render properly, fill in the holes with `undefined` values.
-      Object.keys(stepData).forEach((stepKey) => {
-        (stepData as any)[stepKey] = _fillPartitions(partitionNames, (stepData as any)[stepKey]);
-      });
-
-      return {jobData, stepData};
-    },
-    [
-      hiddenPartitions,
-      hiddenStepKeys,
-      jobDataByPartition,
-      partitionNames,
-      showLargeGraphMessage,
-      stepDataByPartition,
-    ],
-    1000,
-  );
-
-  const allLabel = isJob ? 'Total job' : 'Total pipeline';
-  const graphData = useThrottledMemo(
-    () =>
-      showLargeGraphMessage
-        ? null
-        : {
-            labels: partitionNames,
-            datasets: [
-              ...(!jobDataByPartition || (hiddenStepKeys && hiddenStepKeys.includes(allLabel))
-                ? []
-                : [
-                    {
-                      label: allLabel,
-                      data: jobData,
-                      borderColor: Colors.borderDefault(),
-                      backgroundColor: Colors.accentPrimary(),
-                    },
-                  ]),
-              ...Object.keys(stepData).map((stepKey) => ({
-                label: stepKey,
-                data: stepData[stepKey as keyof typeof stepData],
-                borderColor: colorHash(stepKey),
-                backgroundColor: Colors.accentPrimary(),
-              })),
-            ],
-          },
-    [allLabel, hiddenStepKeys, jobData, jobDataByPartition, partitionNames, stepData],
-    5000,
-  );
-
-  if (graphData && defaultOptions) {
-    // Passing graphData as a closure prevents ChartJS from trying to isEqual, which is fairly
-    // unlikely to save a render and is time consuming given the size of the data structure.
-    // We have a useMemo around the entire <PartitionGraphSet /> and there aren't many extra renders.
-    return (
-      <PartitionGraphContainer>
-        <Line data={() => graphData} height={300} options={defaultOptions as any} ref={chart} />
-      </PartitionGraphContainer>
+    const [showLargeGraphMessage, setShowLargeGraphMessage] = useState(
+      partitionNames.length > 1000,
     );
-  }
-  return (
-    <NonIdealState
-      icon="warning"
-      title="Large number of data points"
-      description={
-        <Box flex={{direction: 'column', gap: 8}}>
-          There are {numberFormatter.format(partitionNames.length)} datapoints in this graph. This
-          might crash the browser.
-          <div>
-            <Button
-              intent="primary"
-              onClick={() => {
-                setShowLargeGraphMessage(false);
-              }}
-            >
-              Show anyways
-            </Button>
-          </div>
-        </Box>
+
+    const onGraphClick = useCallback((event: MouseEvent) => {
+      const instance = chart.current;
+      if (!instance) {
+        return;
       }
-    />
-  );
-};
+      const xAxis = instance.scales['x-axis-0'];
+      if (!xAxis) {
+        return;
+      }
+      const {offsetX, offsetY} = event;
+
+      const isChartClick =
+        event.type === 'click' &&
+        offsetX <= instance.chartArea.right &&
+        offsetX >= instance.chartArea.left &&
+        offsetY <= instance.chartArea.bottom &&
+        offsetY >= instance.chartArea.top;
+
+      if (!isChartClick || !event.shiftKey) {
+        return;
+      }
+
+      // category scale returns index here for some reason
+      const labelIndex = xAxis.getValueForPixel(offsetX);
+      const partitionName = instance.data.labels[labelIndex];
+      setHiddenPartitions((current) => ({
+        ...current,
+        [partitionName]: !current[partitionName],
+      }));
+    }, []);
+
+    const defaultOptions = useThrottledMemo(
+      () => {
+        if (showLargeGraphMessage) {
+          return null;
+        }
+        const titleOptions = title ? {display: true, text: title} : undefined;
+        const scales = yLabel
+          ? {
+              y: {
+                id: 'y',
+                title: {display: true, text: yLabel},
+              },
+              x: {
+                id: 'x',
+                title: {display: true, text: title},
+              },
+            }
+          : undefined;
+
+        return {
+          title: titleOptions,
+          animation: false,
+          scales,
+          plugins: {
+            legend: {
+              display: false,
+              onClick: (_e: MouseEvent, _legendItem: any) => {},
+            },
+          },
+          onClick: onGraphClick,
+          maintainAspectRatio: false,
+        };
+      },
+      [onGraphClick, showLargeGraphMessage, title, yLabel],
+      1000,
+    );
+
+    const {jobData, stepData} = useThrottledMemo(
+      () => {
+        if (showLargeGraphMessage) {
+          return {jobData: [], stepData: {}};
+        }
+        const jobData: Point[] = [];
+        const stepData = {};
+
+        partitionNames.forEach((partitionName) => {
+          const hidden = !!hiddenPartitions[partitionName];
+          if (jobDataByPartition) {
+            jobData.push({
+              x: partitionName,
+              y: !hidden ? jobDataByPartition[partitionName] : undefined,
+            });
+          }
+
+          if (stepDataByPartition) {
+            const stepDataByKey = stepDataByPartition[partitionName];
+            Object.entries(stepDataByKey || {}).forEach(([stepKey, step]) => {
+              if (hiddenStepKeys?.includes(stepKey) || !step) {
+                return;
+              }
+              (stepData as any)[stepKey] = [
+                ...((stepData as any)[stepKey] || []),
+                {
+                  x: partitionName,
+                  y: !hidden ? step : undefined,
+                },
+              ];
+            });
+          }
+        });
+
+        // stepData may have holes due to missing runs or missing steps.  For these to
+        // render properly, fill in the holes with `undefined` values.
+        Object.keys(stepData).forEach((stepKey) => {
+          (stepData as any)[stepKey] = _fillPartitions(partitionNames, (stepData as any)[stepKey]);
+        });
+
+        return {jobData, stepData};
+      },
+      [
+        hiddenPartitions,
+        hiddenStepKeys,
+        jobDataByPartition,
+        partitionNames,
+        showLargeGraphMessage,
+        stepDataByPartition,
+      ],
+      1000,
+    );
+
+    const allLabel = isJob ? 'Total job' : 'Total pipeline';
+    const graphData = useThrottledMemo(
+      () =>
+        showLargeGraphMessage
+          ? null
+          : {
+              labels: partitionNames,
+              datasets: [
+                ...(!jobDataByPartition || (hiddenStepKeys && hiddenStepKeys.includes(allLabel))
+                  ? []
+                  : [
+                      {
+                        label: allLabel,
+                        data: jobData,
+                        borderColor: Colors.borderDefault(),
+                        backgroundColor: Colors.accentPrimary(),
+                      },
+                    ]),
+                ...Object.keys(stepData).map((stepKey) => ({
+                  label: stepKey,
+                  data: stepData[stepKey as keyof typeof stepData],
+                  borderColor: colorHash(stepKey),
+                  backgroundColor: Colors.accentPrimary(),
+                })),
+              ],
+            },
+      [allLabel, hiddenStepKeys, jobData, jobDataByPartition, partitionNames, stepData],
+      5000,
+    );
+
+    if (graphData && defaultOptions) {
+      // Passing graphData as a closure prevents ChartJS from trying to isEqual, which is fairly
+      // unlikely to save a render and is time consuming given the size of the data structure.
+      // We have a useMemo around the entire <PartitionGraphSet /> and there aren't many extra renders.
+      return (
+        <PartitionGraphContainer>
+          <Line data={() => graphData} height={300} options={defaultOptions as any} ref={chart} />
+        </PartitionGraphContainer>
+      );
+    }
+    return (
+      <NonIdealState
+        icon="warning"
+        title="Large number of data points"
+        description={
+          <Box flex={{direction: 'column', gap: 8}}>
+            There are {numberFormatter.format(partitionNames.length)} datapoints in this graph. This
+            might crash the browser.
+            <div>
+              <Button
+                intent="primary"
+                onClick={() => {
+                  setShowLargeGraphMessage(false);
+                }}
+              >
+                Show anyways
+              </Button>
+            </div>
+          </Box>
+        }
+      />
+    );
+  },
+);
 
 const _fillPartitions = (partitionNames: string[], points: Point[]) => {
   const pointData = {};

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStatus.tsx
@@ -9,6 +9,7 @@ import {
 } from '../assets/AssetPartitionStatus';
 import {Range} from '../assets/usePartitionHealthData';
 import {RunStatus} from '../graphql/types';
+import {useThrottledMemo} from '../hooks/useThrottledMemo';
 import {RUN_STATUS_COLORS, runStatusToBackfillStateString} from '../runs/RunStatusTag';
 
 type SelectionRange = {
@@ -331,13 +332,17 @@ function useColorSegments(
   const _statusForKey =
     'runStatusForPartitionKey' in health ? health.runStatusForPartitionKey : null;
 
-  return React.useMemo(() => {
-    return _statusForKey
-      ? opRunStatusToColorRanges(partitionNames, splitPartitions, _statusForKey)
-      : _ranges && splitPartitions
-      ? splitColorSegments(partitionNames, assetHealthToColorSegments(_ranges))
-      : assetHealthToColorSegments(_ranges!);
-  }, [splitPartitions, partitionNames, _ranges, _statusForKey]);
+  return useThrottledMemo(
+    () => {
+      return _statusForKey
+        ? opRunStatusToColorRanges(partitionNames, splitPartitions, _statusForKey)
+        : _ranges && splitPartitions
+        ? splitColorSegments(partitionNames, assetHealthToColorSegments(_ranges))
+        : assetHealthToColorSegments(_ranges!);
+    },
+    [splitPartitions, partitionNames, _ranges, _statusForKey],
+    1000,
+  );
 }
 
 // If you ask for each partition to be rendered as a separate segment in the UI, we break the

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStatus.tsx
@@ -1,5 +1,6 @@
 import {Box, Colors, Tooltip, useViewport} from '@dagster-io/ui-components';
 import * as React from 'react';
+import {useMemo} from 'react';
 import styled from 'styled-components';
 
 import {assembleIntoSpans} from './SpanRepresentation';
@@ -9,7 +10,6 @@ import {
 } from '../assets/AssetPartitionStatus';
 import {Range} from '../assets/usePartitionHealthData';
 import {RunStatus} from '../graphql/types';
-import {useThrottledMemo} from '../hooks/useThrottledMemo';
 import {RUN_STATUS_COLORS, runStatusToBackfillStateString} from '../runs/RunStatusTag';
 
 type SelectionRange = {
@@ -345,17 +345,13 @@ function useColorSegments(
   const _statusForKey =
     'runStatusForPartitionKey' in health ? health.runStatusForPartitionKey : null;
 
-  return useThrottledMemo(
-    () => {
-      return _statusForKey
-        ? opRunStatusToColorRanges(partitionNames, splitPartitions, _statusForKey)
-        : _ranges && splitPartitions
-        ? splitColorSegments(partitionNames, assetHealthToColorSegments(_ranges))
-        : assetHealthToColorSegments(_ranges!);
-    },
-    [splitPartitions, partitionNames, _ranges, _statusForKey],
-    1000,
-  );
+  return useMemo(() => {
+    return _statusForKey
+      ? opRunStatusToColorRanges(partitionNames, splitPartitions, _statusForKey)
+      : _ranges && splitPartitions
+      ? splitColorSegments(partitionNames, assetHealthToColorSegments(_ranges))
+      : assetHealthToColorSegments(_ranges!);
+  }, [splitPartitions, partitionNames, _ranges, _statusForKey]);
 }
 
 // If you ask for each partition to be rendered as a separate segment in the UI, we break the

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStatus.tsx
@@ -50,268 +50,281 @@ interface PartitionStatusProps {
   selectionWindowSize?: number;
 }
 
-export const PartitionStatus = ({
-  partitionNames,
-  selected,
-  onSelect,
-  onClick,
-  small,
-  health,
-  selectionWindowSize,
-  hideStatusTooltip,
-  tooltipMessage,
-  splitPartitions = false,
-}: PartitionStatusProps) => {
-  const ref = React.useRef<HTMLDivElement>(null);
-  const [currentSelectionRange, setCurrentSelectionRange] = React.useState<
-    SelectionRange | undefined
-  >();
-  const {viewport, containerProps} = useViewport();
+export const PartitionStatus = React.memo(
+  ({
+    partitionNames,
+    selected,
+    onSelect,
+    onClick,
+    small,
+    health,
+    selectionWindowSize,
+    hideStatusTooltip,
+    tooltipMessage,
+    splitPartitions = false,
+  }: PartitionStatusProps) => {
+    const ref = React.useRef<HTMLDivElement>(null);
+    const [currentSelectionRange, setCurrentSelectionRange] = React.useState<
+      SelectionRange | undefined
+    >();
+    const {viewport, containerProps} = useViewport();
 
-  const segments = useColorSegments(health, splitPartitions, partitionNames);
+    const segments = useColorSegments(health, splitPartitions, partitionNames);
 
-  const toPartitionName = React.useCallback(
-    (e: MouseEvent) => {
-      if (!ref.current) {
-        return null;
-      }
-      const percentage =
-        (e.clientX - ref.current.getBoundingClientRect().left) / ref.current.clientWidth;
-      return partitionNames[Math.floor(percentage * partitionNames.length)];
-    },
-    [partitionNames, ref],
-  );
-  const getRangeSelection = React.useCallback(
-    (start: string, end: string) => {
-      const startIdx = partitionNames.indexOf(start);
-      const endIdx = partitionNames.indexOf(end);
-      return partitionNames.slice(Math.min(startIdx, endIdx), Math.max(startIdx, endIdx) + 1);
-    },
-    [partitionNames],
-  );
+    const toPartitionName = React.useCallback(
+      (e: MouseEvent) => {
+        if (!ref.current) {
+          return null;
+        }
+        const percentage =
+          (e.clientX - ref.current.getBoundingClientRect().left) / ref.current.clientWidth;
+        return partitionNames[Math.floor(percentage * partitionNames.length)];
+      },
+      [partitionNames, ref],
+    );
+    const getRangeSelection = React.useCallback(
+      (start: string, end: string) => {
+        const startIdx = partitionNames.indexOf(start);
+        const endIdx = partitionNames.indexOf(end);
+        return partitionNames.slice(Math.min(startIdx, endIdx), Math.max(startIdx, endIdx) + 1);
+      },
+      [partitionNames],
+    );
 
-  const selectedSet = React.useMemo(() => new Set(selected), [selected]);
+    const selectedSet = React.useMemo(() => new Set(selected), [selected]);
 
-  React.useEffect(() => {
-    if (!currentSelectionRange || !onSelect || !selected) {
-      return;
-    }
-    const onMouseMove = (e: MouseEvent) => {
-      const end = toPartitionName(e) || currentSelectionRange.end;
-      setCurrentSelectionRange({start: currentSelectionRange?.start, end});
-    };
-    const onMouseUp = (e: MouseEvent) => {
-      if (!currentSelectionRange) {
+    React.useEffect(() => {
+      if (!currentSelectionRange || !onSelect || !selected) {
         return;
       }
-      const end = toPartitionName(e) || currentSelectionRange.end;
-      const currentSelection = getRangeSelection(currentSelectionRange.start, end);
+      const onMouseMove = (e: MouseEvent) => {
+        const end = toPartitionName(e) || currentSelectionRange.end;
+        setCurrentSelectionRange({start: currentSelectionRange?.start, end});
+      };
+      const onMouseUp = (e: MouseEvent) => {
+        if (!currentSelectionRange) {
+          return;
+        }
+        const end = toPartitionName(e) || currentSelectionRange.end;
+        const currentSelection = getRangeSelection(currentSelectionRange.start, end);
 
-      const operation = !e.getModifierState('Shift')
-        ? 'replace'
-        : currentSelection.every((name) => selectedSet.has(name))
-        ? 'subtract'
-        : 'add';
+        const operation = !e.getModifierState('Shift')
+          ? 'replace'
+          : currentSelection.every((name) => selectedSet.has(name))
+          ? 'subtract'
+          : 'add';
 
-      if (operation === 'replace') {
-        onSelect(currentSelection);
-      } else if (operation === 'subtract') {
-        onSelect(selected.filter((x) => !currentSelection.includes(x)));
-      } else if (operation === 'add') {
-        onSelect(Array.from(new Set([...selected, ...currentSelection])));
-      }
-      setCurrentSelectionRange(undefined);
-    };
-    window.addEventListener('mousemove', onMouseMove);
-    window.addEventListener('mouseup', onMouseUp);
-    return () => {
-      window.removeEventListener('mousemove', onMouseMove);
-      window.removeEventListener('mouseup', onMouseUp);
-    };
-  }, [onSelect, selected, selectedSet, currentSelectionRange, getRangeSelection, toPartitionName]);
+        if (operation === 'replace') {
+          onSelect(currentSelection);
+        } else if (operation === 'subtract') {
+          onSelect(selected.filter((x) => !currentSelection.includes(x)));
+        } else if (operation === 'add') {
+          onSelect(Array.from(new Set([...selected, ...currentSelection])));
+        }
+        setCurrentSelectionRange(undefined);
+      };
+      window.addEventListener('mousemove', onMouseMove);
+      window.addEventListener('mouseup', onMouseUp);
+      return () => {
+        window.removeEventListener('mousemove', onMouseMove);
+        window.removeEventListener('mouseup', onMouseUp);
+      };
+    }, [
+      onSelect,
+      selected,
+      selectedSet,
+      currentSelectionRange,
+      getRangeSelection,
+      toPartitionName,
+    ]);
 
-  const selectedSpans = React.useMemo(
-    () =>
-      selectedSet.size === 0
-        ? []
-        : selectedSet.size === partitionNames.length
-        ? [{startIdx: 0, endIdx: partitionNames.length - 1, status: true}]
-        : assembleIntoSpans(partitionNames, (key) => selectedSet.has(key)).filter((s) => s.status),
-    [selectedSet, partitionNames],
-  );
+    const selectedSpans = React.useMemo(
+      () =>
+        selectedSet.size === 0
+          ? []
+          : selectedSet.size === partitionNames.length
+          ? [{startIdx: 0, endIdx: partitionNames.length - 1, status: true}]
+          : assembleIntoSpans(partitionNames, (key) => selectedSet.has(key)).filter(
+              (s) => s.status,
+            ),
+      [selectedSet, partitionNames],
+    );
 
-  const highestIndex = segments.map((s) => s.end.idx).reduce((prev, cur) => Math.max(prev, cur), 0);
-  const indexToPct = (idx: number) => `${((idx * 100) / partitionNames.length).toFixed(3)}%`;
-  const showSeparators =
-    splitPartitions && viewport.width > MIN_SPAN_WIDTH * (partitionNames.length + 1);
+    const highestIndex = segments
+      .map((s) => s.end.idx)
+      .reduce((prev, cur) => Math.max(prev, cur), 0);
+    const indexToPct = (idx: number) => `${((idx * 100) / partitionNames.length).toFixed(3)}%`;
+    const showSeparators =
+      splitPartitions && viewport.width > MIN_SPAN_WIDTH * (partitionNames.length + 1);
 
-  const _onClick = onClick
-    ? (e: React.MouseEvent<any, MouseEvent>) => {
-        const partitionName = toPartitionName(e.nativeEvent);
-        partitionName && onClick(partitionName);
-      }
-    : undefined;
+    const _onClick = onClick
+      ? (e: React.MouseEvent<any, MouseEvent>) => {
+          const partitionName = toPartitionName(e.nativeEvent);
+          partitionName && onClick(partitionName);
+        }
+      : undefined;
 
-  const _onMouseDown = onSelect
-    ? (e: React.MouseEvent<any, MouseEvent>) => {
-        const partitionName = toPartitionName(e.nativeEvent);
-        partitionName && setCurrentSelectionRange({start: partitionName, end: partitionName});
-      }
-    : undefined;
+    const _onMouseDown = onSelect
+      ? (e: React.MouseEvent<any, MouseEvent>) => {
+          const partitionName = toPartitionName(e.nativeEvent);
+          partitionName && setCurrentSelectionRange({start: partitionName, end: partitionName});
+        }
+      : undefined;
 
-  return (
-    <div
-      {...containerProps}
-      onMouseDown={(e) => e.preventDefault()}
-      onDragStart={(e) => e.preventDefault()}
-    >
-      {selected && !selectionWindowSize ? (
-        <SelectionSpansContainer>
-          {selectedSpans.map((s) => (
-            <div
-              className="selection-span"
-              key={s.startIdx}
-              style={{
-                left: `min(calc(100% - 2px), ${indexToPct(s.startIdx)})`,
-                width: indexToPct(s.endIdx - s.startIdx + 1),
-              }}
-            />
-          ))}
-        </SelectionSpansContainer>
-      ) : null}
-      <PartitionSpansContainer
-        style={{height: small ? 12 : 24}}
-        ref={ref}
-        onClick={_onClick}
-        onMouseDown={_onMouseDown}
+    return (
+      <div
+        {...containerProps}
+        onMouseDown={(e) => e.preventDefault()}
+        onDragStart={(e) => e.preventDefault()}
       >
-        {segments.map((s) => (
-          <div
-            key={s.start.idx}
-            style={{
-              left: `min(calc(100% - 2px), ${indexToPct(s.start.idx)})`,
-              width: indexToPct(s.end.idx - s.start.idx + 1),
-              minWidth: 1,
-              position: 'absolute',
-              zIndex: s.start.idx === 0 || s.end.idx === highestIndex ? 3 : 2,
-              top: 0,
-            }}
-          >
-            {hideStatusTooltip || tooltipMessage ? (
-              <div className="color-span" style={s.style} title={tooltipMessage} />
-            ) : (
-              <Tooltip
-                display="block"
-                position="top"
-                content={
-                  tooltipMessage
-                    ? tooltipMessage
-                    : s.start.idx === s.end.idx
-                    ? `Partition ${partitionNames[s.start.idx]} is ${s.label.toLowerCase()}`
-                    : `Partitions ${partitionNames[s.start.idx]} through ${
-                        partitionNames[s.end.idx]
-                      } are ${s.label.toLowerCase()}`
-                }
-              >
-                <div className="color-span" style={s.style} />
-              </Tooltip>
-            )}
-          </div>
-        ))}
-        {showSeparators
-          ? segments.slice(1).map((s) => (
+        {selected && !selectionWindowSize ? (
+          <SelectionSpansContainer>
+            {selectedSpans.map((s) => (
               <div
-                className="separator"
-                key={`separator_${s.start.idx}`}
+                className="selection-span"
+                key={s.startIdx}
                 style={{
-                  left: `min(calc(100% - 2px), ${indexToPct(s.start.idx)})`,
-                  height: small ? 14 : 24,
+                  left: `min(calc(100% - 2px), ${indexToPct(s.startIdx)})`,
+                  width: indexToPct(s.endIdx - s.startIdx + 1),
                 }}
               />
-            ))
-          : null}
-        {currentSelectionRange ? (
-          <SelectionHoverHighlight
-            style={{
-              left: `min(calc(100% - 2px), ${indexToPct(
-                Math.min(
-                  partitionNames.indexOf(currentSelectionRange.start),
-                  partitionNames.indexOf(currentSelectionRange.end),
-                ),
-              )})`,
-              width: indexToPct(
-                Math.abs(
-                  partitionNames.indexOf(currentSelectionRange.end) -
-                    partitionNames.indexOf(currentSelectionRange.start),
-                ) + 1,
-              ),
-              height: small ? 14 : 24,
-            }}
-          />
+            ))}
+          </SelectionSpansContainer>
         ) : null}
-        {selected && selected.length && selectionWindowSize ? (
-          <>
-            <SelectionFade
-              key="selectionFadeLeft"
+        <PartitionSpansContainer
+          style={{height: small ? 12 : 24}}
+          ref={ref}
+          onClick={_onClick}
+          onMouseDown={_onMouseDown}
+        >
+          {segments.map((s) => (
+            <div
+              key={s.start.idx}
               style={{
-                left: 0,
-                width: indexToPct(
-                  Math.min(
-                    partitionNames.indexOf(selected[selected.length - 1]!),
-                    partitionNames.indexOf(selected[0]!),
-                  ),
-                ),
-                height: small ? 14 : 24,
+                left: `min(calc(100% - 2px), ${indexToPct(s.start.idx)})`,
+                width: indexToPct(s.end.idx - s.start.idx + 1),
+                minWidth: 1,
+                position: 'absolute',
+                zIndex: s.start.idx === 0 || s.end.idx === highestIndex ? 3 : 2,
+                top: 0,
               }}
-            />
-            <SelectionBorder
+            >
+              {hideStatusTooltip || tooltipMessage ? (
+                <div className="color-span" style={s.style} title={tooltipMessage} />
+              ) : (
+                <Tooltip
+                  display="block"
+                  position="top"
+                  content={
+                    tooltipMessage
+                      ? tooltipMessage
+                      : s.start.idx === s.end.idx
+                      ? `Partition ${partitionNames[s.start.idx]} is ${s.label.toLowerCase()}`
+                      : `Partitions ${partitionNames[s.start.idx]} through ${
+                          partitionNames[s.end.idx]
+                        } are ${s.label.toLowerCase()}`
+                  }
+                >
+                  <div className="color-span" style={s.style} />
+                </Tooltip>
+              )}
+            </div>
+          ))}
+          {showSeparators
+            ? segments.slice(1).map((s) => (
+                <div
+                  className="separator"
+                  key={`separator_${s.start.idx}`}
+                  style={{
+                    left: `min(calc(100% - 2px), ${indexToPct(s.start.idx)})`,
+                    height: small ? 14 : 24,
+                  }}
+                />
+              ))
+            : null}
+          {currentSelectionRange ? (
+            <SelectionHoverHighlight
               style={{
-                left: `min(calc(100% - 3px), ${indexToPct(
+                left: `min(calc(100% - 2px), ${indexToPct(
                   Math.min(
-                    partitionNames.indexOf(selected[0]!),
-                    partitionNames.indexOf(selected[selected.length - 1]!),
+                    partitionNames.indexOf(currentSelectionRange.start),
+                    partitionNames.indexOf(currentSelectionRange.end),
                   ),
                 )})`,
                 width: indexToPct(
                   Math.abs(
-                    partitionNames.indexOf(selected[selected.length - 1]!) -
-                      partitionNames.indexOf(selected[0]!),
+                    partitionNames.indexOf(currentSelectionRange.end) -
+                      partitionNames.indexOf(currentSelectionRange.start),
                   ) + 1,
                 ),
                 height: small ? 14 : 24,
               }}
             />
-            <SelectionFade
-              key="selectionFadeRight"
-              style={{
-                right: 0,
-                width: indexToPct(
-                  partitionNames.length -
-                    1 -
-                    Math.max(
+          ) : null}
+          {selected && selected.length && selectionWindowSize ? (
+            <>
+              <SelectionFade
+                key="selectionFadeLeft"
+                style={{
+                  left: 0,
+                  width: indexToPct(
+                    Math.min(
                       partitionNames.indexOf(selected[selected.length - 1]!),
                       partitionNames.indexOf(selected[0]!),
                     ),
-                ),
-                height: small ? 14 : 24,
-              }}
-            />
-          </>
+                  ),
+                  height: small ? 14 : 24,
+                }}
+              />
+              <SelectionBorder
+                style={{
+                  left: `min(calc(100% - 3px), ${indexToPct(
+                    Math.min(
+                      partitionNames.indexOf(selected[0]!),
+                      partitionNames.indexOf(selected[selected.length - 1]!),
+                    ),
+                  )})`,
+                  width: indexToPct(
+                    Math.abs(
+                      partitionNames.indexOf(selected[selected.length - 1]!) -
+                        partitionNames.indexOf(selected[0]!),
+                    ) + 1,
+                  ),
+                  height: small ? 14 : 24,
+                }}
+              />
+              <SelectionFade
+                key="selectionFadeRight"
+                style={{
+                  right: 0,
+                  width: indexToPct(
+                    partitionNames.length -
+                      1 -
+                      Math.max(
+                        partitionNames.indexOf(selected[selected.length - 1]!),
+                        partitionNames.indexOf(selected[0]!),
+                      ),
+                  ),
+                  height: small ? 14 : 24,
+                }}
+              />
+            </>
+          ) : null}
+        </PartitionSpansContainer>
+        {!splitPartitions ? (
+          <Box
+            flex={{justifyContent: 'space-between'}}
+            margin={{top: 4}}
+            style={{fontSize: '0.8rem', color: Colors.textLight(), minHeight: 17}}
+          >
+            <span>{partitionNames[0]}</span>
+            <span>{partitionNames[partitionNames.length - 1]}</span>
+          </Box>
         ) : null}
-      </PartitionSpansContainer>
-      {!splitPartitions ? (
-        <Box
-          flex={{justifyContent: 'space-between'}}
-          margin={{top: 4}}
-          style={{fontSize: '0.8rem', color: Colors.textLight(), minHeight: 17}}
-        >
-          <span>{partitionNames[0]}</span>
-          <span>{partitionNames[partitionNames.length - 1]}</span>
-        </Box>
-      ) : null}
-    </div>
-  );
-};
+      </div>
+    );
+  },
+);
 
 // This type is similar to a partition health "Range", but this component is also
 // used by backfill UI and backfills can have a wider range of partition states,

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStepStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStepStatus.tsx
@@ -12,7 +12,7 @@ import {
   Popover,
   useViewport,
 } from '@dagster-io/ui-components';
-import {useEffect, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import styled from 'styled-components';
 
 import {PartitionRunList} from './PartitionRunList';
@@ -50,6 +50,7 @@ import {
 import {GanttChartMode} from '../gantt/Constants';
 import {buildLayout} from '../gantt/GanttChartLayout';
 import {RunStatus} from '../graphql/types';
+import {useThrottledMemo} from '../hooks/useThrottledMemo';
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {linkToRunEvent} from '../runs/RunUtils';
 import {RunFilterToken} from '../runs/RunsFilterInput';
@@ -99,58 +100,76 @@ interface PartitionPerAssetStatusProps
   rangeDimension: PartitionHealthDimension;
 }
 
-export const PartitionPerAssetStatus = ({
-  assetHealth,
-  rangeDimension,
-  rangeDimensionIdx,
-  assetQueryItems,
-  ...rest
-}: PartitionPerAssetStatusProps) => {
-  const rangesByAssetKey: {[assetKey: string]: Range[]} = {};
-  for (const a of assetHealth) {
-    if (a.dimensions[rangeDimensionIdx]?.name !== rangeDimension.name) {
-      // Ignore assets in the job / graph that do not have the range partition dimension.
-      continue;
-    }
-    const ranges = a.rangesForSingleDimension(rangeDimensionIdx);
-    rangesByAssetKey[tokenForAssetKey(a.assetKey)] = ranges;
-  }
+export const PartitionPerAssetStatus = React.memo(
+  ({
+    assetHealth,
+    rangeDimension,
+    rangeDimensionIdx,
+    assetQueryItems,
+    ...rest
+  }: PartitionPerAssetStatusProps) => {
+    const rangesByAssetKey = useThrottledMemo(
+      () => {
+        const rangesByAssetKey: {[assetKey: string]: Range[]} = {};
+        for (const a of assetHealth) {
+          if (a.dimensions[rangeDimensionIdx]?.name !== rangeDimension.name) {
+            // Ignore assets in the job / graph that do not have the range partition dimension.
+            continue;
+          }
+          const ranges = a.rangesForSingleDimension(rangeDimensionIdx);
+          rangesByAssetKey[tokenForAssetKey(a.assetKey)] = ranges;
+        }
+        return rangesByAssetKey;
+      },
+      [assetHealth, rangeDimension.name, rangeDimensionIdx],
+      1000,
+    );
 
-  const layout = buildLayout({nodes: assetQueryItems, mode: GanttChartMode.FLAT});
-  const layoutBoxesWithRangeDimension = layout.boxes.filter((b) => !!rangesByAssetKey[b.node.name]);
+    const layoutBoxesWithRangeDimension = useThrottledMemo(
+      () => {
+        const layout = buildLayout({nodes: assetQueryItems, mode: GanttChartMode.FLAT});
+        return layout.boxes.filter((b) => !!rangesByAssetKey[b.node.name]);
+      },
+      [assetQueryItems, rangesByAssetKey],
+      1000,
+    );
 
-  const data: MatrixData = {
-    stepRows: layoutBoxesWithRangeDimension.map((box) => ({
-      x: box.x,
-      name: box.node.name,
-      totalFailurePercent: 0,
-      finalFailurePercent: 0,
-    })),
-    partitions: [],
-    partitionColumns: rangeDimension.partitionKeys.map((partitionKey, partitionKeyIdx) => ({
-      idx: partitionKeyIdx,
-      name: partitionKey,
-      runsLoaded: true,
-      runs: [],
-      steps: layoutBoxesWithRangeDimension.map((box) => ({
-        name: box.node.name,
-        unix: 0,
-        color: assetPartitionStatusToSquareColor(
-          partitionStatusAtIndex(rangesByAssetKey[box.node.name]!, partitionKeyIdx),
-        ),
-      })),
-    })),
-  };
+    const data: MatrixData = useMemo(
+      () => ({
+        stepRows: layoutBoxesWithRangeDimension.map((box) => ({
+          x: box.x,
+          name: box.node.name,
+          totalFailurePercent: 0,
+          finalFailurePercent: 0,
+        })),
+        partitions: [],
+        partitionColumns: rangeDimension.partitionKeys.map((partitionKey, partitionKeyIdx) => ({
+          idx: partitionKeyIdx,
+          name: partitionKey,
+          runsLoaded: true,
+          runs: [],
+          steps: layoutBoxesWithRangeDimension.map((box) => ({
+            name: box.node.name,
+            unix: 0,
+            color: assetPartitionStatusToSquareColor(
+              partitionStatusAtIndex(rangesByAssetKey[box.node.name]!, partitionKeyIdx),
+            ),
+          })),
+        })),
+      }),
+      [layoutBoxesWithRangeDimension, rangeDimension.partitionKeys, rangesByAssetKey],
+    );
 
-  return (
-    <PartitionStepStatus
-      {...rest}
-      partitionNames={rangeDimension.partitionKeys}
-      data={data}
-      showLatestRun={false}
-    />
-  );
-};
+    return (
+      <PartitionStepStatus
+        {...rest}
+        partitionNames={rangeDimension.partitionKeys}
+        data={data}
+        showLatestRun={false}
+      />
+    );
+  },
+);
 
 const assetPartitionStatusToSquareColor = (state: AssetPartitionStatus[]): StatusSquareColor => {
   return state.includes(AssetPartitionStatus.MATERIALIZED) &&
@@ -170,56 +189,53 @@ interface PartitionPerOpStatusProps extends PartitionStepStatusBaseProps {
   partitions: PartitionRuns[];
 }
 
-export const PartitionPerOpStatus = ({
-  repoAddress,
-  pipelineName,
-  partitions,
-  partitionNames,
-  ...rest
-}: PartitionPerOpStatusProps) => {
-  // Retrieve the pipeline's structure
-  const repositorySelector = repoAddressToSelector(repoAddress);
-  const pipelineSelector = {...repositorySelector, pipelineName};
-  const pipeline = useQuery<
-    PartitionStepStatusPipelineQuery,
-    PartitionStepStatusPipelineQueryVariables
-  >(PARTITION_STEP_STATUS_PIPELINE_QUERY, {
-    variables: {pipelineSelector},
-  });
+export const PartitionPerOpStatus = React.memo(
+  ({repoAddress, pipelineName, partitions, partitionNames, ...rest}: PartitionPerOpStatusProps) => {
+    // Retrieve the pipeline's structure
+    const repositorySelector = repoAddressToSelector(repoAddress);
+    const pipelineSelector = {...repositorySelector, pipelineName};
+    const pipeline = useQuery<
+      PartitionStepStatusPipelineQuery,
+      PartitionStepStatusPipelineQueryVariables
+    >(PARTITION_STEP_STATUS_PIPELINE_QUERY, {
+      variables: {pipelineSelector},
+      fetchPolicy: 'no-cache',
+    });
 
-  useBlockTraceOnQueryResult(pipeline, 'PartitionStepStatusPipelineQuery');
+    useBlockTraceOnQueryResult(pipeline, 'PartitionStepStatusPipelineQuery');
 
-  const solidHandles =
-    pipeline.data?.pipelineSnapshotOrError.__typename === 'PipelineSnapshot' &&
-    pipeline.data.pipelineSnapshotOrError.solidHandles;
+    const solidHandles =
+      pipeline.data?.pipelineSnapshotOrError.__typename === 'PipelineSnapshot' &&
+      pipeline.data.pipelineSnapshotOrError.solidHandles;
 
-  const data = useMatrixData({
-    partitionNames,
-    partitions,
-    stepQuery: '',
-    solidHandles,
-  });
+    const data = useMatrixData({
+      partitionNames,
+      partitions,
+      stepQuery: '',
+      solidHandles,
+    });
 
-  if (!data) {
-    return <span />;
-  }
-  return (
-    <PartitionStepStatus
-      {...rest}
-      showLatestRun={true}
-      pipelineName={pipelineName}
-      partitionNames={partitionNames}
-      data={data}
-    />
-  );
-};
+    if (!data) {
+      return <span />;
+    }
+    return (
+      <PartitionStepStatus
+        {...rest}
+        showLatestRun={true}
+        pipelineName={pipelineName}
+        partitionNames={partitionNames}
+        data={data}
+      />
+    );
+  },
+);
 
 interface PartitionStepStatusProps extends PartitionStepStatusBaseProps {
   data: MatrixData;
   showLatestRun: boolean;
 }
 
-const PartitionStepStatus = (props: PartitionStepStatusProps) => {
+const PartitionStepStatus = React.memo((props: PartitionStepStatusProps) => {
   const {viewport, containerProps} = useViewport();
   const [hovered, setHovered] = useState<PartitionRunSelection | null>(null);
   const [focused, setFocused] = useState<PartitionRunSelection | null>(null);
@@ -376,7 +392,7 @@ const PartitionStepStatus = (props: PartitionStepStatusProps) => {
       </div>
     </PartitionRunMatrixContainer>
   );
-};
+});
 
 const PagerControl = styled.div<{$direction: 'left' | 'right'}>`
   width: 30px;
@@ -435,83 +451,85 @@ const TOOLTIP_STYLE = JSON.stringify({
   left: 10,
 });
 
-const PartitionSquare = ({
-  step,
-  runs,
-  runsLoaded,
-  hovered,
-  setHovered,
-  setFocused,
-  partitionName,
-}: {
-  step?: MatrixStep;
-  runs: PartitionMatrixStepRunFragment[];
-  runsLoaded: boolean;
-  hovered: PartitionRunSelection | null;
-  minUnix: number;
-  maxUnix: number;
-  partitionName: string;
-  setHovered: (hovered: PartitionRunSelection | null) => void;
-  setFocused: (hovered: PartitionRunSelection | null) => void;
-}) => {
-  const [opened, setOpened] = useState(false);
-  let squareStatus;
+const PartitionSquare = React.memo(
+  ({
+    step,
+    runs,
+    runsLoaded,
+    hovered,
+    setHovered,
+    setFocused,
+    partitionName,
+  }: {
+    step?: MatrixStep;
+    runs: PartitionMatrixStepRunFragment[];
+    runsLoaded: boolean;
+    hovered: PartitionRunSelection | null;
+    minUnix: number;
+    maxUnix: number;
+    partitionName: string;
+    setHovered: (hovered: PartitionRunSelection | null) => void;
+    setFocused: (hovered: PartitionRunSelection | null) => void;
+  }) => {
+    const [opened, setOpened] = useState(false);
+    let squareStatus;
 
-  if (!runsLoaded) {
-    squareStatus = 'loading';
-  } else if (step) {
-    squareStatus = step.color.toLowerCase();
-  } else if (runs.length === 0) {
-    squareStatus = 'empty';
-  } else {
-    const runStatus = [...runs].reverse().find((r) => r.status !== RunStatus.CANCELED)?.status;
-    if (runStatus) {
-      squareStatus = runStatus.toLowerCase();
-    } else {
+    if (!runsLoaded) {
+      squareStatus = 'loading';
+    } else if (step) {
+      squareStatus = step.color.toLowerCase();
+    } else if (runs.length === 0) {
       squareStatus = 'empty';
+    } else {
+      const runStatus = [...runs].reverse().find((r) => r.status !== RunStatus.CANCELED)?.status;
+      if (runStatus) {
+        squareStatus = runStatus.toLowerCase();
+      } else {
+        squareStatus = 'empty';
+      }
     }
-  }
-  const content = (
-    <div
-      className={`square ${squareStatus}`}
-      onMouseEnter={() => setHovered({stepName: step?.name, partitionName})}
-      onMouseLeave={() => setHovered(null)}
-      data-tooltip={
-        runsLoaded && !step ? (runs.length === 1 ? `1 run` : `${runs.length} runs`) : undefined
-      }
-      data-tooltip-style={TOOLTIP_STYLE}
-    />
-  );
+    const content = (
+      <div
+        className={`square ${squareStatus}`}
+        onMouseEnter={() => setHovered({stepName: step?.name, partitionName})}
+        onMouseLeave={() => setHovered(null)}
+        data-tooltip={
+          runsLoaded && !step ? (runs.length === 1 ? `1 run` : `${runs.length} runs`) : undefined
+        }
+        data-tooltip-style={TOOLTIP_STYLE}
+      />
+    );
 
-  if (
-    !opened &&
-    (!runs.length || hovered?.stepName !== step?.name || hovered?.partitionName !== partitionName)
-  ) {
-    return content;
-  }
+    if (
+      !opened &&
+      (!runs.length || hovered?.stepName !== step?.name || hovered?.partitionName !== partitionName)
+    ) {
+      return content;
+    }
 
-  return (
-    <Popover
-      interactionKind="click"
-      placement="bottom-start"
-      onOpening={() => setOpened(true)}
-      onClosed={() => setOpened(false)}
-      content={
-        <Menu>
-          <MenuLink
-            icon="open_in_new"
-            text="Show logs from last run"
-            to={linkToRunEvent(runs[runs.length - 1]!, {stepKey: step ? step.name : null})}
-          />
-          <MenuItem
-            icon="settings_backup_restore"
-            text={`View runs (${runs.length})`}
-            onClick={() => setFocused({stepName: step?.name, partitionName})}
-          />
-        </Menu>
-      }
-    >
-      {content}
-    </Popover>
-  );
-};
+    return (
+      <Popover
+        interactionKind="click"
+        placement="bottom-start"
+        onOpening={() => setOpened(true)}
+        onClosed={() => setOpened(false)}
+        content={
+          <Menu>
+            <MenuLink
+              icon="open_in_new"
+              text="Show logs from last run"
+              to={linkToRunEvent(runs[runs.length - 1]!, {stepKey: step ? step.name : null})}
+            />
+            <MenuItem
+              icon="settings_backup_restore"
+              text={`View runs (${runs.length})`}
+              onClick={() => setFocused({stepName: step?.name, partitionName})}
+            />
+          </Menu>
+        }
+      >
+        {content}
+      </Popover>
+    );
+  },
+);

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStepStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStepStatus.tsx
@@ -258,9 +258,18 @@ const PartitionStepStatus = React.memo((props: PartitionStepStatusProps) => {
   const visibleCount = getVisibleItemCount(viewport.width);
   const visibleStart = Math.max(0, partitionColumns.length - props.offset - visibleCount);
   const visibleEnd = Math.max(visibleCount, partitionColumns.length - props.offset);
-  const visibleColumns = partitionColumns.slice(visibleStart, visibleEnd);
-  const [minUnix, maxUnix] = timeboundsOfPartitions(partitionColumns);
-  const topLabelHeight = topLabelHeightForLabels(partitionColumns.map((p) => p.name));
+  const visibleColumns = useMemo(
+    () => partitionColumns.slice(visibleStart, visibleEnd),
+    [partitionColumns, visibleEnd, visibleStart],
+  );
+  const [minUnix, maxUnix] = useMemo(
+    () => timeboundsOfPartitions(partitionColumns),
+    [partitionColumns],
+  );
+  const topLabelHeight = useMemo(
+    () => topLabelHeightForLabels(partitionColumns.map((p) => p.name)),
+    [partitionColumns],
+  );
 
   return (
     <PartitionRunMatrixContainer>

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStepStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionStepStatus.tsx
@@ -208,12 +208,17 @@ export const PartitionPerOpStatus = React.memo(
       pipeline.data?.pipelineSnapshotOrError.__typename === 'PipelineSnapshot' &&
       pipeline.data.pipelineSnapshotOrError.solidHandles;
 
-    const data = useMatrixData({
-      partitionNames,
-      partitions,
-      stepQuery: '',
-      solidHandles,
-    });
+    const data = useMatrixData(
+      useMemo(
+        () => ({
+          partitionNames,
+          partitions,
+          stepQuery: '',
+          solidHandles,
+        }),
+        [partitionNames, partitions, solidHandles],
+      ),
+    );
 
     if (!data) {
       return <span />;

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/useMatrixData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/useMatrixData.tsx
@@ -1,6 +1,6 @@
 import {gql} from '@apollo/client';
 import {shallowCompareKeys} from '@blueprintjs/core/lib/cjs/common/utils';
-import {useRef} from 'react';
+import {useMemo, useRef} from 'react';
 
 import {
   PartitionMatrixSolidHandleFragment,
@@ -11,7 +11,6 @@ import {GanttChartLayout} from '../gantt/Constants';
 import {GanttChartMode} from '../gantt/GanttChart';
 import {buildLayout} from '../gantt/GanttChartLayout';
 import {StepEventStatus} from '../graphql/types';
-import {useThrottledMemo} from '../hooks/useThrottledMemo';
 import {explodeCompositesInHandleGraph} from '../pipelines/CompositeSupport';
 import {GRAPH_EXPLORER_SOLID_HANDLE_FRAGMENT} from '../pipelines/GraphExplorer';
 
@@ -201,35 +200,31 @@ export const useMatrixData = (inputs: MatrixDataInputs) => {
     inputs: MatrixDataInputs;
   }>();
 
-  return useThrottledMemo(
-    () => {
-      if (!inputs.solidHandles) {
-        return null;
-      }
-      if (cachedMatrixData.current && shallowCompareKeys(inputs, cachedMatrixData.current.inputs)) {
-        return cachedMatrixData.current.result;
-      }
+  return useMemo(() => {
+    if (!inputs.solidHandles) {
+      return null;
+    }
+    if (cachedMatrixData.current && shallowCompareKeys(inputs, cachedMatrixData.current.inputs)) {
+      return cachedMatrixData.current.result;
+    }
 
-      const nodes = explodeCompositesInHandleGraph(inputs.solidHandles).map((h) => h.solid);
+    const nodes = explodeCompositesInHandleGraph(inputs.solidHandles).map((h) => h.solid);
 
-      // Filter the pipeline's structure and build the flat gantt layout for the left hand side
-      const solidsFiltered = filterByQuery(nodes, inputs.stepQuery);
+    // Filter the pipeline's structure and build the flat gantt layout for the left hand side
+    const solidsFiltered = filterByQuery(nodes, inputs.stepQuery);
 
-      const layout = buildLayout({nodes: solidsFiltered.all, mode: GanttChartMode.FLAT});
+    const layout = buildLayout({nodes: solidsFiltered.all, mode: GanttChartMode.FLAT});
 
-      // Build the matrix of step + partition squares - presorted to match the gantt layout
-      const result = buildMatrixData(
-        layout,
-        inputs.partitionNames,
-        inputs.partitions,
-        inputs.options,
-      );
-      cachedMatrixData.current = {result, inputs};
-      return result;
-    },
-    [inputs],
-    1000,
-  );
+    // Build the matrix of step + partition squares - presorted to match the gantt layout
+    const result = buildMatrixData(
+      layout,
+      inputs.partitionNames,
+      inputs.partitions,
+      inputs.options,
+    );
+    cachedMatrixData.current = {result, inputs};
+    return result;
+  }, [inputs]);
 };
 
 export const PARTITION_MATRIX_STEP_RUN_FRAGMENT = gql`

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/useMatrixData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/useMatrixData.tsx
@@ -227,7 +227,7 @@ export const useMatrixData = (inputs: MatrixDataInputs) => {
       cachedMatrixData.current = {result, inputs};
       return result;
     },
-    [],
+    [inputs],
     1000,
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
@@ -1,5 +1,5 @@
 import {ApolloClient, gql, useApolloClient} from '@apollo/client';
-import {useEffect, useMemo, useRef, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 import {PartitionMatrixStepRunFragment} from './types/useMatrixData.types';
 import {
@@ -77,7 +77,7 @@ export function usePartitionStepQuery({
     1000,
   );
 
-  const partitionNamesSet = useMemo(() => new Set(partitionNames), [partitionNames]);
+  const partitionNamesSet = useThrottledMemo(() => new Set(partitionNames), [partitionNames], 1000);
 
   useEffect(() => {
     // Note: there are several async steps to the loading process - to cancel the previous

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
@@ -61,7 +61,7 @@ export function usePartitionStepQuery({
   const version = useRef(0);
   const [dataState, setDataState] = useState<DataState>(InitialDataState);
 
-  const _serializedRunTags = useMemo(
+  const _serializedRunTags = useThrottledMemo(
     () =>
       JSON.stringify([
         ...runsFilter.map((token) => {
@@ -74,6 +74,7 @@ export function usePartitionStepQuery({
         },
       ]),
     [repositorySelector.repositoryLocationName, repositorySelector.repositoryName, runsFilter],
+    1000,
   );
 
   const partitionNamesSet = useMemo(() => new Set(partitionNames), [partitionNames]);

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
@@ -73,10 +73,9 @@ export function usePartitionStepQuery({
         },
       ]),
     [repositorySelector.repositoryLocationName, repositorySelector.repositoryName, runsFilter],
-    1000,
   );
 
-  const partitionNamesSet = useMemo(() => new Set(partitionNames), [partitionNames], 1000);
+  const partitionNamesSet = useMemo(() => new Set(partitionNames), [partitionNames]);
 
   useEffect(() => {
     // Note: there are several async steps to the loading process - to cancel the previous

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
@@ -10,6 +10,7 @@ import {PARTITION_MATRIX_STEP_RUN_FRAGMENT, PartitionRuns} from './useMatrixData
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment.types';
 import {RepositorySelector, RunStatus} from '../graphql/types';
+import {useThrottledMemo} from '../hooks/useThrottledMemo';
 import {DagsterTag} from '../runs/RunTag';
 import {RunFilterToken} from '../runs/RunsFilterInput';
 
@@ -197,9 +198,10 @@ export function usePartitionStepQuery({
     partitionNamesSet,
   ]);
 
-  return useMemo(
+  return useThrottledMemo(
     () => assemblePartitions(dataState, partitionTagName),
     [dataState, partitionTagName],
+    1000,
   );
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/usePartitionStepQuery.tsx
@@ -1,5 +1,5 @@
 import {ApolloClient, gql, useApolloClient} from '@apollo/client';
-import {useEffect, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 
 import {PartitionMatrixStepRunFragment} from './types/useMatrixData.types';
 import {
@@ -10,7 +10,6 @@ import {PARTITION_MATRIX_STEP_RUN_FRAGMENT, PartitionRuns} from './useMatrixData
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment.types';
 import {RepositorySelector, RunStatus} from '../graphql/types';
-import {useThrottledMemo} from '../hooks/useThrottledMemo';
 import {DagsterTag} from '../runs/RunTag';
 import {RunFilterToken} from '../runs/RunsFilterInput';
 
@@ -61,7 +60,7 @@ export function usePartitionStepQuery({
   const version = useRef(0);
   const [dataState, setDataState] = useState<DataState>(InitialDataState);
 
-  const _serializedRunTags = useThrottledMemo(
+  const _serializedRunTags = useMemo(
     () =>
       JSON.stringify([
         ...runsFilter.map((token) => {
@@ -77,7 +76,7 @@ export function usePartitionStepQuery({
     1000,
   );
 
-  const partitionNamesSet = useThrottledMemo(() => new Set(partitionNames), [partitionNames], 1000);
+  const partitionNamesSet = useMemo(() => new Set(partitionNames), [partitionNames], 1000);
 
   useEffect(() => {
     // Note: there are several async steps to the loading process - to cancel the previous
@@ -199,10 +198,9 @@ export function usePartitionStepQuery({
     partitionNamesSet,
   ]);
 
-  return useThrottledMemo(
+  return useMemo(
     () => assemblePartitions(dataState, partitionTagName),
     [dataState, partitionTagName],
-    1000,
   );
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
@@ -104,6 +104,7 @@ export function useIndexedDBCachedQuery<TQuery, TVariables extends OperationVari
   return {
     data,
     loading,
+    called: true,
     fetch: useCallback(() => fetch(true), [fetch]),
   };
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
@@ -104,7 +104,6 @@ export function useIndexedDBCachedQuery<TQuery, TVariables extends OperationVari
   return {
     data,
     loading,
-    called: true,
     fetch: useCallback(() => fetch(true), [fetch]),
   };
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Loading.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Loading.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import {ERROR_CODES_TO_SURFACE, errorCodeToMessage} from '../app/HTTPErrorCodes';
 
 interface ILoadingProps<TData> {
-  queryResult: QueryResult<TData, any>;
+  queryResult: Pick<QueryResult<TData, any>, 'error' | 'data' | 'loading'>;
   children: (data: TData) => React.ReactNode;
   renderError?: (error: ApolloError) => React.ReactNode;
   allowStaleData?: boolean;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
@@ -181,7 +181,7 @@ export const WorkspaceProvider = ({children}: {children: React.ReactNode}) => {
         },
         bypassCache: true,
       });
-      const entry = locationData?.workspaceLocationEntryOrError;
+      const entry = locationData.data?.workspaceLocationEntryOrError;
       setLocationsData((locationsData) =>
         Object.assign({}, locationsData, {
           [name]: entry,
@@ -293,7 +293,10 @@ export const WorkspaceProvider = ({children}: {children: React.ReactNode}) => {
 
   const refetch = useCallback(async () => {
     return await Promise.all(
-      Object.values(locationsRef.current).map((location) => refetchLocation(location.name)),
+      Object.values(locationsRef.current).map(async (location) => {
+        const result = await refetchLocation(location.name);
+        return result.data;
+      }),
     );
   }, [locationsRef, refetchLocation]);
 


### PR DESCRIPTION
## Summary & Motivation

- Memoized a bunch of stuff to fix a re-render loop caused by references changing. 
- Hide partition graph if large
- Wrote a useThrottledMemo hook that can be used when dependencies are changing often. I wrote it to band-aid the re-render loop but then after more extensive memoization I fixed the actual source of the re-render loop. I'm keeping the hook around though because I think it'll be useful for the Gantt chart on the Runs page when there are a huge number of steps.

<img width="1728" alt="Screenshot 2024-06-20 at 7 02 03 PM" src="https://github.com/dagster-io/dagster/assets/2286579/d13e7bfc-6c9e-44c1-a1bf-98a358cd82f3">

## How I Tested These Changes

Jest tests + used this in partitions view:

Before (2s frames): 
![image](https://github.com/dagster-io/dagster/assets/2286579/94fd3a1f-4f51-4af6-a50f-fcfdbad33c56)


After no re-rendering loop, much smaller frames (biggest frame is 450ms, and its apollo cache, will look into what it is caching):

<img width="1707" alt="Screenshot 2024-06-20 at 10 39 50 PM" src="https://github.com/dagster-io/dagster/assets/2286579/0cda1ce0-9609-4d23-9b2e-5a99be3638e1">


