### PR TITLE
[rfc] Dedupe definitions by reference equality.

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -22,6 +22,7 @@ from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.events import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.executor_definition import ExecutorDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
+from dagster._core.definitions.utils import dedupe_object_refs
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.build_resources import wrap_resources_for_execution
 from dagster._core.execution.with_resources import with_resources
@@ -254,6 +255,13 @@ def _create_repository_using_definitions_args(
     loggers: Optional[Mapping[str, LoggerDefinition]] = None,
     asset_checks: Optional[Iterable[AssetChecksDefinition]] = None,
 ) -> Union[RepositoryDefinition, PendingRepositoryDefinition]:
+    # First, dedupe all definition types.
+    sensors = dedupe_object_refs(sensors)
+    jobs = dedupe_object_refs(jobs)
+    assets = dedupe_object_refs(assets)
+    schedules = dedupe_object_refs(schedules)
+    asset_checks = dedupe_object_refs(asset_checks)
+
     executor_def = (
         executor
         if isinstance(executor, ExecutorDefinition) or executor is None

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -10,6 +9,7 @@ from typing import (
     Optional,
     Sequence,
     Type,
+    TypedDict,
     Union,
 )
 
@@ -315,6 +315,19 @@ class BindResourcesToJobs(list):
     """
 
 
+class DefinitionsArgs(TypedDict):
+    assets: Optional[Iterable[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]]
+    schedules: Optional[
+        Iterable[Union[ScheduleDefinition, UnresolvedPartitionedAssetScheduleDefinition]]
+    ]
+    sensors: Optional[Iterable[SensorDefinition]]
+    jobs: Optional[Iterable[Union[JobDefinition, UnresolvedAssetJobDefinition]]]
+    resources: Optional[Mapping[str, Any]]
+    executor: Optional[Union[ExecutorDefinition, Executor]]
+    loggers: Optional[Mapping[str, LoggerDefinition]]
+    asset_checks: Optional[Iterable[AssetChecksDefinition]]
+
+
 class Definitions:
     """A set of definitions explicitly available and loadable by Dagster tools.
 
@@ -404,14 +417,8 @@ class Definitions:
       Any other object is coerced to a :py:class:`ResourceDefinition`.
     """
 
-    _assets: Iterable[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]
-    _schedules: Iterable[Union[ScheduleDefinition, UnresolvedPartitionedAssetScheduleDefinition]]
-    _sensors: Iterable[SensorDefinition]
-    _jobs: Iterable[Union[JobDefinition, UnresolvedAssetJobDefinition]]
-    _resources: Mapping[str, Any]
-    _executor: Optional[Union[ExecutorDefinition, Executor]]
-    _loggers: Mapping[str, LoggerDefinition]
-    _asset_checks: Iterable[AssetChecksDefinition]
+    _created_pending_or_normal_repo: Union[RepositoryDefinition, PendingRepositoryDefinition]
+    _original_args: DefinitionsArgs
 
     def __init__(
         self,
@@ -428,105 +435,78 @@ class Definitions:
         loggers: Optional[Mapping[str, LoggerDefinition]] = None,
         asset_checks: Optional[Iterable[AssetChecksDefinition]] = None,
     ):
-        self._assets = check.opt_iterable_param(
-            assets,
-            "assets",
-            (AssetsDefinition, SourceAsset, CacheableAssetsDefinition),
-        )
-        self._schedules = check.opt_iterable_param(
-            schedules,
-            "schedules",
-            (ScheduleDefinition, UnresolvedPartitionedAssetScheduleDefinition),
-        )
-        self._sensors = check.opt_iterable_param(sensors, "sensors", SensorDefinition)
-        self._jobs = check.opt_iterable_param(
-            jobs, "jobs", (JobDefinition, UnresolvedAssetJobDefinition)
-        )
-        # Thee's a bug that means that sometimes it's Dagster's fault when AssetsDefinitions are
-        # passed here instead of AssetChecksDefinitions: https://github.com/dagster-io/dagster/issues/22064.
-        # After we fix the bug, we should remove AssetsDefinition from the set of accepted types.
-        self._asset_checks = check.opt_iterable_param(
-            asset_checks,
-            "asset_checks",
-            (AssetChecksDefinition, AssetsDefinition),
-        )
-        self._resources = check.opt_mapping_param(resources, "resources", key_type=str)
-        self._executor = check.opt_inst_param(executor, "executor", (ExecutorDefinition, Executor))
-        self._loggers = check.opt_mapping_param(
-            loggers, "loggers", key_type=str, value_type=LoggerDefinition
-        )
-
         self._created_pending_or_normal_repo = _create_repository_using_definitions_args(
             name=SINGLETON_REPOSITORY_NAME,
-            assets=assets,
-            schedules=schedules,
-            sensors=sensors,
-            jobs=jobs,
-            resources=resources,
-            executor=executor,
-            loggers=loggers,
-            asset_checks=asset_checks,
+            assets=check.opt_iterable_param(
+                assets,
+                "assets",
+                (AssetsDefinition, SourceAsset, CacheableAssetsDefinition),
+            ),
+            schedules=check.opt_iterable_param(
+                schedules,
+                "schedules",
+                (ScheduleDefinition, UnresolvedPartitionedAssetScheduleDefinition),
+            ),
+            sensors=check.opt_iterable_param(sensors, "sensors", SensorDefinition),
+            jobs=check.opt_iterable_param(
+                jobs, "jobs", (JobDefinition, UnresolvedAssetJobDefinition)
+            ),
+            resources=check.opt_mapping_param(resources, "resources", key_type=str),
+            executor=check.opt_inst_param(executor, "executor", (ExecutorDefinition, Executor)),
+            loggers=check.opt_mapping_param(
+                loggers, "loggers", key_type=str, value_type=LoggerDefinition
+            ),
+            asset_checks=check.opt_iterable_param(
+                asset_checks,
+                "asset_checks",
+                (AssetChecksDefinition, AssetsDefinition),
+            ),
         )
-
-    @cached_property
-    def assets(self) -> Iterable[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
-        inlined_assets: List[Union[AssetsDefinition, SourceAsset]] = []
-        for schedule_def in self._schedules:
-            if isinstance(schedule_def, ScheduleDefinition):
-                inlined_assets.extend(schedule_def.target.assets_defs)
-        for sensor_def in self._sensors:
-            for target in sensor_def.targets:
-                inlined_assets.extend(target.assets_defs)
-        return [*self._assets, *inlined_assets]
+        self._original_args = {
+            "assets": assets,
+            "schedules": schedules,
+            "sensors": sensors,
+            "jobs": jobs,
+            "resources": resources,
+            "executor": executor,
+            "loggers": loggers,
+            "asset_checks": asset_checks,
+        }
 
     @property
-    def schedules(
+    def original_args(self) -> DefinitionsArgs:
+        return self._original_args
+
+    @property
+    def assets(
         self,
-    ) -> Iterable[Union[ScheduleDefinition, UnresolvedPartitionedAssetScheduleDefinition]]:
-        return self._schedules
-
-    @property
-    def sensors(self) -> Iterable[SensorDefinition]:
-        return self._sensors
-
-    @property
-    def jobs(self) -> Iterable[Union[JobDefinition, UnresolvedAssetJobDefinition]]:
-        return self._jobs
-
-    @property
-    def resources(self) -> Mapping[str, Any]:
-        return self._resources
-
-    @property
-    def executor(self) -> Optional[Union[ExecutorDefinition, Executor]]:
-        return self._executor
-
-    @property
-    def loggers(self) -> Mapping[str, LoggerDefinition]:
-        return self._loggers
-
-    @property
-    def asset_checks(self) -> Iterable[AssetChecksDefinition]:
-        return self._asset_checks
+    ) -> Optional[Iterable[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]]:
+        return self._original_args["assets"]
 
     @public
     def get_job_def(self, name: str) -> JobDefinition:
         """Get a job definition by name. If you passed in a an :py:class:`UnresolvedAssetJobDefinition`
         (return value of :py:func:`define_asset_job`) it will be resolved to a :py:class:`JobDefinition` when returned
-        from this function.
+        from this function, with all resource dependencies fully resolved.
         """
         check.str_param(name, "name")
         return self.get_repository_def().get_job(name)
 
     @public
     def get_sensor_def(self, name: str) -> SensorDefinition:
-        """Get a sensor definition by name."""
+        """Get a :py:class:`SensorDefinition` by name.
+        If your passed-in sensor had resource dependencies, or the job targeted by the sensor had
+        resource dependencies, those resource dependencies will be fully resolved on the returned object.
+        """
         check.str_param(name, "name")
         return self.get_repository_def().get_sensor_def(name)
 
     @public
     def get_schedule_def(self, name: str) -> ScheduleDefinition:
-        """Get a schedule definition by name."""
+        """Get a :py:class:`ScheduleDefinition` by name.
+        If your passed-in schedule had resource dependencies, or the job targeted by the schedule had
+        resource dependencies, those resource dependencies will be fully resolved on the returned object.
+        """
         check.str_param(name, "name")
         return self.get_repository_def().get_schedule_def(name)
 
@@ -589,7 +569,10 @@ class Definitions:
         )
 
     def get_all_job_defs(self) -> Sequence[JobDefinition]:
-        """Get all the Job definitions in the code location."""
+        """Get all the Job definitions in the code location.
+        This includes both jobs passed into the Definitions object and any implicit jobs created.
+        All jobs returned from this function will have all resource dependencies resolved.
+        """
         return self.get_repository_def().get_all_jobs()
 
     def has_implicit_global_asset_job_def(self) -> bool:
@@ -619,7 +602,7 @@ class Definitions:
     @cached_method
     def get_repository_def(self) -> RepositoryDefinition:
         """Definitions is implemented by wrapping RepositoryDefinition. Get that underlying object
-        in order to access an functionality which is not exposed on Definitions. This method
+        in order to access any functionality which is not exposed on Definitions. This method
         also resolves a PendingRepositoryDefinition to a RepositoryDefinition.
         """
         return (
@@ -667,13 +650,13 @@ class Definitions:
         executor_index: Optional[int] = None
 
         for i, def_set in enumerate(def_sets):
-            assets.extend(def_set.assets or [])
-            asset_checks.extend(def_set.asset_checks or [])
-            schedules.extend(def_set.schedules or [])
-            sensors.extend(def_set.sensors or [])
-            jobs.extend(def_set.jobs or [])
+            assets.extend(def_set.original_args["assets"] or [])
+            asset_checks.extend(def_set.original_args["asset_checks"] or [])
+            schedules.extend(def_set.original_args["schedules"] or [])
+            sensors.extend(def_set.original_args["sensors"] or [])
+            jobs.extend(def_set.original_args["jobs"] or [])
 
-            for resource_key, resource_value in (def_set.resources or {}).items():
+            for resource_key, resource_value in (def_set.original_args["resources"] or {}).items():
                 if resource_key in resources:
                     raise DagsterInvariantViolationError(
                         f"Definitions objects {resource_key_indexes[resource_key]} and {i} both have a "
@@ -682,7 +665,7 @@ class Definitions:
                 resources[resource_key] = resource_value
                 resource_key_indexes[resource_key] = i
 
-            for logger_key, logger_value in (def_set.loggers or {}).items():
+            for logger_key, logger_value in (def_set.original_args["loggers"] or {}).items():
                 if logger_key in loggers:
                     raise DagsterInvariantViolationError(
                         f"Definitions objects {logger_key_indexes[logger_key]} and {i} both have a "
@@ -691,13 +674,13 @@ class Definitions:
                 loggers[logger_key] = logger_value
                 logger_key_indexes[logger_key] = i
 
-            if def_set.executor is not None:
-                if executor is not None and executor != def_set.executor:
+            if def_set.original_args["executor"] is not None:
+                if executor is not None and executor != def_set.original_args["executor"]:
                     raise DagsterInvariantViolationError(
                         f"Definitions objects {executor_index} and {i} both have an executor"
                     )
 
-                executor = def_set.executor
+                executor = def_set.original_args["executor"]
                 executor_index = i
 
         return Definitions(

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -7,12 +7,14 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    Iterable,
     List,
     Mapping,
     NamedTuple,
     Optional,
     Sequence,
     Tuple,
+    TypeVar,
     Union,
     cast,
 )
@@ -411,3 +413,11 @@ def resolve_automation_condition(
         return auto_materialize_policy.to_automation_condition()
     else:
         return automation_condition
+
+
+T = TypeVar("T")
+
+
+def dedupe_object_refs(objects: Optional[Iterable[T]]) -> Sequence[T]:
+    """Dedupe definitions by reference equality."""
+    return list({id(obj): obj for obj in objects}.values()) if objects is not None else []

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -819,13 +819,16 @@ def test_merge():
     )
 
     merged = Definitions.merge(defs1, defs2)
-    assert merged.assets == [asset1, asset2]
-    assert merged.jobs == [job1, job2]
-    assert merged.schedules == [schedule1, schedule2]
-    assert merged.sensors == [sensor1, sensor2]
-    assert merged.resources == {"resource1": resource1, "resource2": resource2}
-    assert merged.loggers == {"logger1": logger1, "logger2": logger2}
-    assert merged.executor == in_process_executor
+    assert merged.original_args == {
+        "assets": [asset1, asset2],
+        "jobs": [job1, job2],
+        "schedules": [schedule1, schedule2],
+        "sensors": [sensor1, sensor2],
+        "resources": {"resource1": resource1, "resource2": resource2},
+        "loggers": {"logger1": logger1, "logger2": logger2},
+        "executor": in_process_executor,
+        "asset_checks": [],
+    }
 
 
 def test_resource_conflict_on_merge():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -15,6 +15,7 @@ from dagster import (
     ScheduleDefinition,
     SourceAsset,
     asset,
+    asset_check,
     build_schedule_from_partitioned_job,
     create_repository_using_definitions_args,
     define_asset_job,
@@ -27,17 +28,19 @@ from dagster import (
     observable_source_asset,
     op,
     repository,
+    schedule,
     sensor,
     with_resources,
 )
 from dagster._check import CheckError
 from dagster._config.pythonic_config import ConfigurableResource
+from dagster._core.definitions.asset_check_result import AssetCheckResult
+from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
     CacheableAssetsDefinition,
 )
 from dagster._core.definitions.decorators.job_decorator import job
-from dagster._core.definitions.decorators.schedule_decorator import schedule
 from dagster._core.definitions.executor_definition import executor
 from dagster._core.definitions.external_asset import create_external_asset_from_source_asset
 from dagster._core.definitions.job_definition import JobDefinition
@@ -951,3 +954,62 @@ def test_hoist_automation_assets():
 
     # We can define and execute asset jobs that reference assets only defined in targets
     assert defs.get_job_def(foo_job.name).execute_in_process().success
+
+
+def test_definitions_dedupe_reference_equality():
+    """Test that Definitions objects correctly dedupe objects by
+    reference equality.
+    """
+
+    @asset
+    def the_asset():
+        pass
+
+    @asset_check(asset=the_asset)
+    def the_check():
+        return AssetCheckResult(passed=True)
+
+    the_job = define_asset_job(name="the_job", selection="the_asset")
+
+    @sensor(job=the_job)
+    def the_sensor():
+        pass
+
+    @schedule(job=the_job, cron_schedule="* * * * *")
+    def the_schedule():
+        pass
+
+    defs = Definitions(
+        assets=[the_asset, the_asset],
+        asset_checks=[the_check, the_check],
+        jobs=[the_job, the_job],
+        sensors=[the_sensor, the_sensor],
+        schedules=[the_schedule, the_schedule],
+    )
+    underlying_repo = defs.get_repository_def()
+    assert (
+        len(
+            [
+                assets_def
+                for assets_def in underlying_repo.asset_graph.assets_defs
+                if not isinstance(assets_def, AssetChecksDefinition)
+            ]
+        )
+        == 1
+    )
+    assert len(list(underlying_repo.asset_graph._assets_defs_by_check_key)) == 1  # noqa
+    assert (
+        len(
+            [job_def for job_def in underlying_repo.get_all_jobs() if job_def.name != "__ASSET_JOB"]
+        )
+        == 1
+    )
+    assert len(list(underlying_repo.sensor_defs)) == 1
+    assert len(list(underlying_repo.schedule_defs)) == 1
+
+    # properties on the definitions object do not dedupe
+    assert len(defs.original_args["assets"]) == 2
+    assert len(defs.original_args["asset_checks"]) == 2
+    assert len(defs.original_args["jobs"]) == 2
+    assert len(defs.original_args["sensors"]) == 2
+    assert len(defs.original_args["schedules"]) == 2


### PR DESCRIPTION
There are cases where users can easily end up with the same assets definition object floating around in multiple places. Consider the following case:
- asset my_asset is in module module_1
- asset check my_check on my_asset is in module_2. This module imports my_asset from module 1.
- A user calls `load_...` on module_1 and module_2. In their top level `Definitions` object, we will throw an error for duplicate asset keys. 

The typical fix pattern here is actually pretty annoying. You either need to manually import all assets, or completely reorganize your project structure. Instead, we should just perform the deduping for them if there's reference equality across assetsdefinitions objects. We actually already do this in the individual load_... functions.

Added a new test for the deduping behavior and assume I'll need to fix a few test breakages that this will cause.
