### PR TITLE
[docs] 4/n dagster as single-pane-of-glass for organization workflows

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -1153,7 +1153,12 @@
           {
             "title": "Migrating from Airflow",
             "path": "/guides/migrations/migrating-airflow-to-dagster"
+          },
+          {
+            "title": "Observe your Airflow pipelines with Dagster",
+            "path": "/guides/migrations/observe-your-airflow-pipelines-with-dagster"
           }
+
         ]
       },
       {

--- a/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
+++ b/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Migrating Airflow to Dagster | Dagster Docs"
-description: "Learn how do a lift-and-shift migration of airflow to Dagster."
+description: "Learn how to a lift-and-shift migration of airflow to Dagster."
 ---
 
 # Migrating Airflow to Dagster

--- a/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
+++ b/docs/content/guides/migrations/migrating-airflow-to-dagster.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Migrating Airflow to Dagster | Dagster Docs"
-description: "Learn how to a lift-and-shift migration of airflow to Dagster."
+description: "Learn how to perform a lift-and-shift migration of Airflow to Dagster."
 ---
 
 # Migrating Airflow to Dagster

--- a/docs/content/guides/migrations/observe-your-airflow-pipelines-with-dagster.mdx
+++ b/docs/content/guides/migrations/observe-your-airflow-pipelines-with-dagster.mdx
@@ -9,7 +9,7 @@ Dagster can act as a single entry point to all orchestration platforms in use at
 
 ### Emitting materialization events from Airflow to Dagster
 
-Imagine you have a large number of pipelines written in Apache Airflow, and you wish to introduce Dagster into your stack. You can continue to run your existing pipelines, while building new pipelines in Dagster that are tightly integrated to your legacy systems by using custom Airflow operators.
+Imagine you have a large number of pipelines written in Apache Airflow and wish to introduce Dagster into your stack. By using custom Airflow operators, you can continue to run your existing pipelines while you work toward migrating them off Airflow, or while building new pipelines in Dagster that are tightly integrated with your legacy systems.
 
 To do this, we will define a `DagsterAssetOperator` operator that can be appended to the end of your Airflow DAG to indicate the processing of the pipeline has concluded. The HTTP endpoint of Dagster server, the `asset_key` and additional metadata and descriptions are to be specified to inform Dagster of the materialization.
 

--- a/docs/content/guides/migrations/observe-your-airflow-pipelines-with-dagster.mdx
+++ b/docs/content/guides/migrations/observe-your-airflow-pipelines-with-dagster.mdx
@@ -11,7 +11,7 @@ Dagster can act as a single entry point to all orchestration platforms in use at
 
 Imagine you have a large number of pipelines written in Apache Airflow and wish to introduce Dagster into your stack. By using custom Airflow operators, you can continue to run your existing pipelines while you work toward migrating them off Airflow, or while building new pipelines in Dagster that are tightly integrated with your legacy systems.
 
-To do this, we will define a `DagsterAssetOperator` operator that can be appended to the end of your Airflow DAG to indicate the processing of the pipeline has concluded. The HTTP endpoint of Dagster server, the `asset_key` and additional metadata and descriptions are to be specified to inform Dagster of the materialization.
+To do this, we will define a `DagsterAssetOperator` operator downstream of your Airflow DAG to indicate that the pipeline's processing has concluded. The HTTP endpoint of the Dagster server, the `asset_key`, and additional metadata and descriptions are to be specified to inform Dagster of the materialization.
 
 ```python
 from typing import Dict, Optional

--- a/docs/content/guides/migrations/observe-your-airflow-pipelines-with-dagster.mdx
+++ b/docs/content/guides/migrations/observe-your-airflow-pipelines-with-dagster.mdx
@@ -69,7 +69,7 @@ dagster_op = DagsterAssetOperator(
 )
 ```
 
-Once the events are being emit from Airflow, there are two options for scheduling Dagster processing from the external Airflow materialization event: asset sensors, and auto materialization policies.
+Once the events are emitted from Airflow, there are two options for scheduling Dagster materializations following the external Airflow materialization event: asset sensors and auto materialization policies.
 
 An external asset is created in Dagster, and an `asset_sensor` is used to identify the materialization events that are being sent from Airflow.
 

--- a/docs/content/guides/migrations/observe-your-airflow-pipelines-with-dagster.mdx
+++ b/docs/content/guides/migrations/observe-your-airflow-pipelines-with-dagster.mdx
@@ -52,7 +52,7 @@ class DagsterAssetOperator(BaseOperator):
         )
 ```
 
-Then, we can append this to our Airflow DAG to indicate that a pipeline has run to success.
+Then, we can append this to our Airflow DAG to indicate that a pipeline has run successfully.
 
 ```python
 import os

--- a/docs/content/guides/migrations/observe-your-airflow-pipelines-with-dagster.mdx
+++ b/docs/content/guides/migrations/observe-your-airflow-pipelines-with-dagster.mdx
@@ -1,0 +1,105 @@
+---
+title: "Observe your Airflow pipelines with Dagster | Dagster Docs"
+description: "Learn how to leverage the features of Dagster and Airflow together."
+---
+
+# Observe your Airflow pipelines with Dagster
+
+Dagster can act as a single entry point to all orchestration platforms in use at your organization. By injecting a small amount of code into your existing pipelines, you can report events to Dagster, where you can then visualize the full lineage of pipelines. This can be particularly useful if you have multiple Apache Airflow environments, and hope to build a catalog and observation platform through Dagster.
+
+### Emitting materialization events from Airflow to Dagster
+
+Imagine you have a large number of pipelines written in Apache Airflow, and you wish to introduce Dagster into your stack. You can continue to run your existing pipelines, while building new pipelines in Dagster that are tightly integrated to your legacy systems by using custom Airflow operators.
+
+To do this, we will define a `DagsterAssetOperator` operator that can be appended to the end of your Airflow DAG to indicate the processing of the pipeline has concluded. The HTTP endpoint of Dagster server, the `asset_key` and additional metadata and descriptions are to be specified to inform Dagster of the materialization.
+
+```python
+from typing import Dict, Optional
+
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+import requests
+
+class DagsterAssetOperator(BaseOperator):
+    @apply_defaults
+    def __init__(
+        self,
+        dagster_webserver_host: str,
+        dagster_webserver_port: str,
+        asset_key: str,
+        metadata: Optional[Dict] = None,
+        description: Optional[str] = None,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.dagster_webserver_host = dagster_webserver_host
+        self.dagster_webserver_port = dagster_webserver_port
+        self.asset_key = asset_key
+        self.metadata = metadata or {}
+        self.description = description
+
+    def execute(self, context):
+        url = f"http://{dagster_webserver_host}:{dagster_webserver_port}/report_asset_materialization/{self.asset_key}"
+        payload = {"metadata": self.metadata, "description": self.description}
+        headers = {"Content-Type": "application/json"}
+
+        response = requests.post(url, json=payload, headers=headers)
+        response.raise_for_status()
+
+        self.log.info(
+            f"Reported asset materialization to Dagster. Response: {response.text}"
+        )
+```
+
+Then, we can append this to our Airflow DAG to indicate that a pipeline has run to success.
+
+```python
+import os
+
+dagster_webserver_host = os.environ.get("DAGSTER_WEBSERVER_HOST", "localhost")
+dagster_webserver_port = os.environ.get("DAGSTER_WEBSERVER_PORT", "3000")
+
+dagster_op = DagsterAssetOperator(
+    task_id="report_dagster_asset_materialization",
+    dagster_webserver_host=dagster_webserver_host,
+    dagster_webserver_port=dagster_webserver_port,
+    asset_key="example_external_airflow_asset",
+    metadata={"airflow/tag": "example", "source": "external"},
+)
+```
+
+Once the events are being emit from Airflow, there are two options for scheduling Dagster processing from the external Airflow materialization event: asset sensors, and auto materialization policies.
+
+An external asset is created in Dagster, and an `asset_sensor` is used to identify the materialization events that are being sent from Airflow.
+
+```python
+from dagster import external_asset_from_spec
+
+example_external_airflow_asset = external_asset_from_spec(
+    AssetSpec("example_external_airflow_asset",
+    group_name="External")
+)
+```
+
+```python
+from dagster import (
+    AssetKey,
+    EventLogEntry,
+    RunRequest,
+    SensorEvaluationContext,
+    asset_sensor
+)
+
+@asset_sensor(
+    asset_key=AssetKey("example_external_airflow_asset"),
+    job=example_external_airflow_asset_job
+)
+def example_external_airflow_asset_sensor(
+    context: SensorEvaluationContext, asset_event: EventLogEntry
+):
+    assert asset_event.dagster_event and asset_event.dagster_event.asset_key
+    yield RunRequest(run_key=context.cursor)
+```
+
+Now, when a materialization event occurs on the external `example_external_airflow_asset` asset, the `example_external_airflow_asset_job` job will be triggered. Here, you can define logic that can build upon the DAG from your Airflow environment.

--- a/docs/content/integrations/airflow.mdx
+++ b/docs/content/integrations/airflow.mdx
@@ -273,4 +273,3 @@ While Airflow and Dagster have some significant differences, there are many conc
     </tr>
   </tbody>
 </table>
->>>>>>> bd51840130 ([docs] 4/n dagster as single-pane-of-glass for organization workflows)

--- a/docs/content/integrations/airflow.mdx
+++ b/docs/content/integrations/airflow.mdx
@@ -9,3 +9,268 @@ Migrating from Airflow to Dagster, or integrating Dagster into your existing wor
 
 - [Learning Dagster from Airflow](/integrations/airflow/from-airflow-to-dagster) - a step-by-step tutorial of mapping concepts from Airflow to Dagster
 - [Migrating from Airflow](/guides/migrations/migrating-airflow-to-dagster) - migration patterns for translating Airflow code to Dagster
+- [Observe your Airflow pipelines with Dagster](/guides/migrations/observe-your-airflow-pipelines-with-dagster) - See how Dagster can act as the observation layer over all pipelines in your organization
+
+---
+
+## Mapping Airflow concepts to Dagster
+
+While Airflow and Dagster have some significant differences, there are many concepts that overlap. Use this cheatsheet to understand how Airflow concepts map to Dagster.
+
+**Want a look at this in code?** Check out the [Learning Dagster from Airflow](/integrations/airflow/from-airflow-to-dagster) guide.
+
+<table
+  className="table"
+  style={{
+    width: "100%",
+  }}
+>
+  <thead>
+    <tr>
+      <th
+        style={{
+          width: "25%",
+        }}
+      >
+        Airflow concept
+      </th>
+      <th
+        style={{
+          width: "30%",
+        }}
+      >
+        Dagster concept
+      </th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Directed Acyclic Graphs (DAG)</td>
+      <td>
+        <a href="/concepts/ops-jobs-graphs/jobs">Jobs</a>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Task</td>
+      <td>
+        <a href="/concepts/ops-jobs-graphs/ops">Ops</a>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Datasets</td>
+      <td>
+        <a href="/concepts/assets/software-defined-assets">Assets</a>
+      </td>
+      <td>
+        Dagster assets are more powerful and mature than datasets and include
+        support for things like{" "}
+        <a href="/concepts/partitions-schedules-sensors/partitioning-assets">
+          partitioning
+        </a>
+        .
+      </td>
+    </tr>
+    <tr>
+      <td>Connections/Variables</td>
+      <td>
+        <ul style={{ marginTop: "0em" }}>
+          <li style={{ marginTop: "0em" }}>
+            <a href="/concepts/configuration/config-schema">
+              Run configuration
+            </a>
+          </li>
+          <li>
+            <a href="/concepts/configuration/configured">Configured API</a>{" "}
+            (Legacy)
+          </li>
+          <li>
+            <a href="/guides/dagster/using-environment-variables-and-secrets">
+              Environment variables
+            </a>{" "}
+            (Dagster+ only)
+          </li>
+        </ul>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>DagBags</td>
+      <td>
+        <a href="/concepts/code-locations">Code locations</a>
+      </td>
+      <td>
+        Multiple isolated code locations with different system and Python
+        dependencies can exist within the same Dagster instance.
+      </td>
+    </tr>
+    <tr>
+      <td>DAG runs</td>
+      <td>Job runs</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>
+        <code>depends_on_past</code>
+      </td>
+      <td>
+        <ul style={{ marginTop: "0em" }}>
+          <li style={{ marginTop: "0em" }}>
+            <a href="/concepts/partitions-schedules-sensors/partitions">
+              Partitions
+            </a>
+          </li>
+          <li>
+            <a href="/concepts/partitions-schedules-sensors/backfills">
+              Backfills
+            </a>
+          </li>
+          <li>
+            <a href="/concepts/assets/asset-auto-execution">
+              Auto-materialization
+            </a>
+          </li>
+        </ul>
+      </td>
+      <td>
+        An asset can{" "}
+        <a
+          href="https://github.com/dagster-io/dagster/discussions/11829"
+          target="new"
+        >
+          depend on earlier partitions of itself
+        </a>
+        . When this is the case, <a href="/concepts/partitions-schedules-sensors/backfills">
+          backfills
+        </a> and <a href="/concepts/assets/asset-auto-execution">
+          auto-materialize
+        </a> will only materialize later partitions after earlier partitions have
+        completed.
+      </td>
+    </tr>
+    <tr>
+      <td>Executors</td>
+      <td>
+        <a href="/deployment/executors">Executors</a>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Hooks</td>
+      <td>
+        <a href="/concepts/resources">Resources</a>
+      </td>
+      <td>
+        Dagster <a href="/concepts/resources">resource</a> contain a superset of
+        the functionality of hooks and have much stronger composition
+        guarantees.
+      </td>
+    </tr>
+    <tr>
+      <td>Instances</td>
+      <td>
+        <a href="/deployment/dagster-instance">Instances</a>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Operators</td>
+      <td>None</td>
+      <td>
+        Dagster uses normal Python functions instead of framework-specific
+        operator classes. For off-the-shelf functionality with third-party
+        tools, Dagster provides{" "}
+        <a href="/integrations">integration libraries</a>.
+      </td>
+    </tr>
+    <tr>
+      <td>Pools</td>
+      <td>
+        <a href="/deployment/run-coordinator">Run coordinators</a>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Plugins/Providers</td>
+      <td>
+        <a href="/integrations">Integrations</a>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Schedulers</td>
+      <td>
+        <a href="/concepts/automation/schedules">Schedules</a>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Sensors</td>
+      <td>
+        <a href="/concepts/partitions-schedules-sensors/sensors">Sensors</a>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>SubDAGs/TaskGroups</td>
+      <td>
+        <ul style={{ marginTop: "0em" }}>
+          <li style={{ marginTop: "0em" }}>
+            <a href="/concepts/ops-jobs-graphs/graphs">Graphs</a>
+          </li>
+          <li>
+            <a href="/concepts/metadata-tags/tags">Tags</a>
+          </li>
+          <li>
+            <a href="/concepts/assets/software-defined-assets#grouping-assets">
+              Asset groups
+            </a>
+          </li>
+        </ul>
+      </td>
+      <td>
+        Dagster provides rich, searchable{" "}
+        <a href="/concepts/metadata-tags">
+          metadata and <a href="/concepts/metadata-tags/tags">tagging</a>
+        </a>{" "}
+        support beyond what’s offered by Airflow.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <code>task_concurrency</code>
+      </td>
+      <td>
+        <a href="/guides/limiting-concurrency-in-data-pipelines#limiting-opasset-concurrency-across-runs">
+          Asset/op-level concurrency limits
+        </a>
+      </td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Trigger</td>
+      <td>
+        <a href="/concepts/webserver/ui">Dagster UI Launchpad</a>
+      </td>
+      <td>
+        Triggering and configuring ad-hoc runs is easier in Dagster which allows
+        them to be initiated through the{" "}
+        <a href="/concepts/webserver/ui">Dagster UI</a>, the{" "}
+        <a href="/concepts/webserver/graphql">GraphQL API</a>, or the CLI.
+      </td>
+    </tr>
+    <tr>
+      <td>XComs</td>
+      <td>
+        <a href="/concepts/io-management/io-managers">I/O managers</a>
+      </td>
+      <td>
+        I/O managers are more powerful than XComs and allow the passing large
+        datasets between jobs.
+      </td>
+    </tr>
+  </tbody>
+</table>
+>>>>>>> bd51840130 ([docs] 4/n dagster as single-pane-of-glass for organization workflows)


### PR DESCRIPTION
## Summary & Motivation

[DRAFT]

- Adds tutorial on coexisting Airflow and Dagster through the emission of events from Airflow to Dagster -- allowing Dagster to act as the single pane of glass for all orchestration in an organization

## How I Tested These Changes
