### PR TITLE
Don't show error toast on a code location if its updating

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
@@ -48,7 +48,10 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
           if (entry.__typename === 'PythonError') {
             return entry.__typename;
           }
-          if (entry.locationOrLoadError?.__typename === 'PythonError') {
+          if (
+            entry.locationOrLoadError?.__typename === 'PythonError' &&
+            entry.loadStatus !== RepositoryLocationLoadStatus.LOADING
+          ) {
             return entry.updatedTimestamp;
           }
           return null;


### PR DESCRIPTION
## Summary & Motivation

https://linear.app/dagster-labs/issue/FE-408/bug-error-popup-is-displayed-when-loading-the-code-locations-tab-with

## How I Tested These Changes

Force a code location to error, then update it and refresh the page, make sure we don't show the error toast in this case.