### PR TITLE
feat(dbt): do not invoke the adapter to build the table relation

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -940,7 +940,7 @@ def _fetch_column_metadata(
 
     with adapter.connection_named(f"column_metadata_{dbt_resource_props['unique_id']}"):
         try:
-            relation = adapter.get_relation(
+            relation = adapter.Relation.create(
                 database=dbt_resource_props["database"],
                 schema=dbt_resource_props["schema"],
                 identifier=dbt_resource_props["name"],


### PR DESCRIPTION
## Summary & Motivation
Just construct the relation directly. If an error occurs, it will be caught in the enclosing try/catch.

## How I Tested These Changes
existing pytest