### PR TITLE
use provided logger to log console messages in InstigationLogger

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
+++ b/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
@@ -11,6 +11,7 @@ from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR
 from dagster._core.storage.captured_log_manager import CapturedLogManager
 from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.utils import coerce_valid_log_level
+from dagster._utils.log import create_console_logger
 
 
 class DispatchingLogHandler(logging.Handler):
@@ -88,6 +89,7 @@ class InstigationLogger(logging.Logger):
         instigator_name: Optional[str] = None,
         level: int = logging.NOTSET,
         logger_name: str = "dagster",
+        additional_console_logger: Optional[logging.Logger] = None,
     ):
         super().__init__(name=logger_name, level=coerce_valid_log_level(level))
         self._log_key = log_key
@@ -96,7 +98,9 @@ class InstigationLogger(logging.Logger):
         self._instigator_name = instigator_name
         self._exit_stack = ExitStack()
         self._capture_handler = None
-        self.addHandler(DispatchingLogHandler([logging.getLogger(logger_name)]))
+        if additional_console_logger is None:
+            additional_console_logger = create_console_logger("dagster", logging.INFO)
+        self.addHandler(DispatchingLogHandler([additional_console_logger]))
 
     def __enter__(self):
         if (

--- a/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
+++ b/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
@@ -11,7 +11,6 @@ from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR
 from dagster._core.storage.captured_log_manager import CapturedLogManager
 from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.utils import coerce_valid_log_level
-from dagster._utils.log import create_console_logger
 
 
 class DispatchingLogHandler(logging.Handler):
@@ -97,7 +96,7 @@ class InstigationLogger(logging.Logger):
         self._instigator_name = instigator_name
         self._exit_stack = ExitStack()
         self._capture_handler = None
-        self.addHandler(DispatchingLogHandler([create_console_logger("dagster", logging.INFO)]))
+        self.addHandler(DispatchingLogHandler([logging.getLogger(logger_name)]))
 
     def __enter__(self):
         if (

--- a/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
+++ b/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
@@ -89,7 +89,7 @@ class InstigationLogger(logging.Logger):
         instigator_name: Optional[str] = None,
         level: int = logging.NOTSET,
         logger_name: str = "dagster",
-        additional_console_logger: Optional[logging.Logger] = None,
+        console_logger: Optional[logging.Logger] = None,
     ):
         super().__init__(name=logger_name, level=coerce_valid_log_level(level))
         self._log_key = log_key
@@ -98,9 +98,9 @@ class InstigationLogger(logging.Logger):
         self._instigator_name = instigator_name
         self._exit_stack = ExitStack()
         self._capture_handler = None
-        if additional_console_logger is None:
-            additional_console_logger = create_console_logger("dagster", logging.INFO)
-        self.addHandler(DispatchingLogHandler([additional_console_logger]))
+        if console_logger is None:
+            console_logger = create_console_logger("dagster", logging.INFO)
+        self.addHandler(DispatchingLogHandler([console_logger]))
 
     def __enter__(self):
         if (

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -26,6 +26,7 @@ def _get_instigation_logger_if_log_storage_enabled(
             repository_name=None,
             instigator_name=backfill.backfill_id,
             logger_name=default_logger.name,
+            additional_console_logger=default_logger,
         ) as _logger:
             backfill_logger = cast(logging.Logger, _logger)
             yield backfill_logger

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -26,7 +26,7 @@ def _get_instigation_logger_if_log_storage_enabled(
             repository_name=None,
             instigator_name=backfill.backfill_id,
             logger_name=default_logger.name,
-            additional_console_logger=default_logger,
+            console_logger=default_logger,
         ) as _logger:
             backfill_logger = cast(logging.Logger, _logger)
             yield backfill_logger


### PR DESCRIPTION
## Summary & Motivation
The `InstigationLogger` creates a colored console logger to log messages to the console in addition to storing them in a blob. When we started using the `InstigationLogger` for the backfill daemon, this meant that the log messages were getting logged with the format of the colored console logger, not with the format specified by the dagster-daemon cli. This PR allows you to use the colored console logger or a different logger to additionally log the messages


### Logs before this PR
`dagster-daemon run --log-format json`

```
2024-06-24 11:56:09 -0400 - dagster.daemon.BackfillDaemon - INFO - After BFS-should-backfill filter, asset partitions to request: {AssetKeyPartitionKey(asset_key=AssetKey(['the_hourly_asset']), partition_key='2024-06-02-11:00'), AssetKeyPartitionKey(asset_key=AssetKey(['the_hourly_asset']), partition_key='2024-06-02-10:00'), AssetKeyPartitionKey(asset_key=AssetKey(['the_hourly_asset']), partition_key='2024-06-02-12:00')} 
```

### Logs after this PR 
`dagster-daemon run --log-format json`

```
{"event": "After BFS-should-backfill filter, asset partitions to request: {AssetKeyPartitionKey(asset_key=AssetKey(['the_hourly_asset']), partition_key='2024-06-16-11:00'), AssetKeyPartitionKey(asset_key=AssetKey(['the_hourly_asset']), partition_key='2024-06-16-12:00'), AssetKeyPartitionKey(asset_key=AssetKey(['the_hourly_asset']), partition_key='2024-06-16-10:00'), AssetKeyPartitionKey(asset_key=AssetKey(['the_hourly_asset']), partition_key='2024-06-16-14:00'), AssetKeyPartitionKey(asset_key=AssetKey(['the_hourly_asset']), partition_key='2024-06-16-15:00'), AssetKeyPartitionKey(asset_key=AssetKey(['the_hourly_asset']), partition_key='2024-06-16-13:00')}", "logger": "dagster.daemon.BackfillDaemon", "level": "info", "timestamp": "2024-06-24T15:52:55.800723Z", "backfill_id": "vprwsnlb"} 
```
## How I Tested These Changes
