### PR TITLE
Bugfix handle string source key prefix

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -396,7 +396,6 @@ def prefix_assets(
     
     if isinstance(source_key_prefix, str):
         source_key_prefix = [source_key_prefix]
-    #source_key_prefix = check.is_list(source_key_prefix, of_type=str)
 
     result_assets: List[AssetsDefinition] = []
     for assets_def in assets_defs:

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -393,6 +393,10 @@ def prefix_assets(
     if isinstance(key_prefix, str):
         key_prefix = [key_prefix]
     key_prefix = check.is_list(key_prefix, of_type=str)
+    
+    if isinstance(source_key_prefix, str):
+        source_key_prefix = [source_key_prefix]
+    #source_key_prefix = check.is_list(source_key_prefix, of_type=str)
 
     result_assets: List[AssetsDefinition] = []
     for assets_def in assets_defs:

--- a/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
+++ b/python_modules/dagster/dagster/_core/definitions/load_assets_from_modules.py
@@ -393,7 +393,7 @@ def prefix_assets(
     if isinstance(key_prefix, str):
         key_prefix = [key_prefix]
     key_prefix = check.is_list(key_prefix, of_type=str)
-    
+
     if isinstance(source_key_prefix, str):
         source_key_prefix = [source_key_prefix]
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
@@ -260,7 +260,7 @@ def test_source_key_prefix(load_fn):
         AssetKey(["elvis_presley"]),
         AssetKey(["foo", "my_cool_prefix", "miles_davis"]),
     }
-    
+
     assets_with_prefix_sources = load_fn(
         key_prefix=prefix, source_key_prefix=["bar", "cooler_prefix"]
     )
@@ -274,9 +274,7 @@ def test_source_key_prefix(load_fn):
         AssetKey(["foo", "my_cool_prefix", "miles_davis"]),
     }
 
-    assets_with_str_prefix_sources = load_fn(
-        key_prefix=prefix, source_key_prefix="string_prefix"
-    )
+    assets_with_str_prefix_sources = load_fn(key_prefix=prefix, source_key_prefix="string_prefix")
     assert get_source_asset_with_key(
         assets_with_str_prefix_sources, AssetKey(["string_prefix", "elvis_presley"])
     )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
@@ -260,7 +260,7 @@ def test_source_key_prefix(load_fn):
         AssetKey(["elvis_presley"]),
         AssetKey(["foo", "my_cool_prefix", "miles_davis"]),
     }
-
+    
     assets_with_prefix_sources = load_fn(
         key_prefix=prefix, source_key_prefix=["bar", "cooler_prefix"]
     )
@@ -273,6 +273,13 @@ def test_source_key_prefix(load_fn):
         AssetKey(["bar", "cooler_prefix", "elvis_presley"]),
         AssetKey(["foo", "my_cool_prefix", "miles_davis"]),
     }
+
+    assets_with_str_prefix_sources = load_fn(
+        key_prefix=prefix, source_key_prefix="string_prefix"
+    )
+    assert get_source_asset_with_key(
+        assets_with_str_prefix_sources, AssetKey(["string_prefix", "elvis_presley"])
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary & Motivation
To my understanding, it should be possible to provide the `source_key_prefix` argument to `load_assets_from_modules` as a string and not only as a list of strings, just as is the case for `key_prefix`. However, this was not the case. Although passing validation checks, loading a SourceAsset with key `source_asset_key` with `source_key_prefix="prefix"` resulted in `AssetKey(['p', 'r', 'e', 'f', 'i', 'x', 'source_asset_key'])`.
Fixed the behavior by checking that `source_asset_key` is a list before applying it.

## How I Tested These Changes
Added an additional assert to function `test_source_key_prefix` in `test_assets_from_modules.py`.