### PR TITLE
Eliminate seven.nullcontext

### DIFF
--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
@@ -65,7 +65,6 @@ from dagster._core.storage.dagster_run import DagsterRun
 from dagster._grpc.types import ExecutionPlanSnapshotArgs
 from dagster._serdes import deserialize_value
 from dagster._serdes.ipc import IPCErrorMessage
-from dagster._seven import nullcontext
 from dagster._utils import start_termination_thread
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.interrupts import capture_interrupts

--- a/python_modules/dagster/dagster/_seven/__init__.py
+++ b/python_modules/dagster/dagster/_seven/__init__.py
@@ -5,7 +5,6 @@ import os
 import shlex
 import sys
 import time
-from contextlib import contextmanager
 from types import ModuleType
 from typing import Any, Callable, List, Sequence, Type
 
@@ -102,12 +101,6 @@ def xplat_shlex_split(s: str) -> List[str]:
 
 def get_import_error_message(import_error: ImportError) -> str:
     return import_error.msg
-
-
-# Stand-in for contextlib.nullcontext, but available in python 3.6
-@contextmanager
-def nullcontext():
-    yield
 
 
 def is_subclass(child_type: Type[Any], parent_type: Type[Any]):


### PR DESCRIPTION
## Summary & Motivation

Underlying contextlib.nullcontext available in all supported versions

## How I Tested These Changes

BK
