### PR TITLE
Eliminate seven.wait_for_process

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/test_monitoring.py
+++ b/integration_tests/test_suites/daemon-test-suite/monitoring_daemon_tests/test_monitoring.py
@@ -2,7 +2,6 @@ import os
 import time
 from contextlib import contextmanager
 
-from dagster import _seven
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.test_utils import instance_for_test, poll_for_finished_run
 from dagster._daemon.controller import all_daemons_healthy
@@ -41,7 +40,7 @@ def start_daemon(timeout=60):
         yield
     finally:
         interrupt_ipc_subprocess(p)
-        _seven.wait_for_process(p, timeout=timeout)
+        p.communicate(timeout=timeout)
 
 
 @contextmanager

--- a/integration_tests/test_suites/daemon-test-suite/utils.py
+++ b/integration_tests/test_suites/daemon-test-suite/utils.py
@@ -1,6 +1,5 @@
 import contextlib
 
-from dagster import _seven
 from dagster._serdes.ipc import interrupt_ipc_subprocess, open_ipc_subprocess
 
 
@@ -15,4 +14,4 @@ def start_daemon(timeout=60, workspace_file=None, log_level=None):
         yield
     finally:
         interrupt_ipc_subprocess(p)
-        _seven.wait_for_process(p, timeout=timeout)
+        p.communicate(timeout=timeout)

--- a/python_modules/dagster/dagster/_core/execution/compute_logs.py
+++ b/python_modules/dagster/dagster/_core/execution/compute_logs.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 
 from dagster._core.execution.scripts import poll_compute_logs, watch_orphans
 from dagster._serdes.ipc import interrupt_ipc_subprocess, open_ipc_subprocess
-from dagster._seven import IS_WINDOWS, wait_for_process
+from dagster._seven import IS_WINDOWS
 from dagster._utils import ensure_file
 
 WIN_PY36_COMPUTE_LOG_DISABLED_MSG = """\u001b[33mWARNING: Compute log capture is disabled for the current environment. Set the environment variable `PYTHONLEGACYWINDOWSSTDIO` to enable.\n\u001b[0m"""
@@ -111,7 +111,7 @@ def execute_windows_tail(path, stream):
                 # Now that we know the tail process has started, tell it to terminate once there is
                 # nothing more to output
                 interrupt_ipc_subprocess(tail_process)
-                wait_for_process(tail_process)
+                tail_process.communicate(timeout=30)
 
 
 @contextmanager
@@ -150,7 +150,7 @@ def _clean_up_subprocess(subprocess_obj):
     try:
         if subprocess_obj:
             subprocess_obj.terminate()
-            wait_for_process(subprocess_obj)
+            subprocess_obj.communicate(timeout=30)
     except OSError:
         pass
 

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -1499,7 +1499,7 @@ class GrpcServerProcess:
     def wait(self, timeout=30):
         self._waited = True
         if self.server_process.poll() is None:
-            seven.wait_for_process(self.server_process, timeout=timeout)
+            self.server_process.wait(timeout=timeout)
 
     def __enter__(self):
         return self

--- a/python_modules/dagster/dagster/_seven/__init__.py
+++ b/python_modules/dagster/dagster/_seven/__init__.py
@@ -57,15 +57,6 @@ def get_arg_names(callable_: Callable[..., Any]) -> Sequence[str]:
     ]
 
 
-def wait_for_process(process, timeout=30) -> None:
-    # Using Popen.communicate instead of Popen.wait since the latter
-    # can deadlock, see https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait
-    if not timeout:
-        process.communicate()
-    else:
-        process.communicate(timeout=timeout)
-
-
 # https://stackoverflow.com/a/58437485/324449
 def is_module_available(module_name: str) -> bool:
     # python 3.4 and above

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_ping.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_ping.py
@@ -222,7 +222,7 @@ def test_detect_server_restart():
     finally:
         _cleanup_process(server_process)
 
-    seven.wait_for_process(server_process, timeout=5)
+    server_process.communicate(timeout=5)
     with pytest.raises(DagsterUserCodeUnreachableError):
         api_client.get_server_id()
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -63,7 +63,6 @@ from dagster._daemon import get_default_daemon_logger
 from dagster._grpc.client import DagsterGrpcClient
 from dagster._grpc.server import open_server_process
 from dagster._scheduler.scheduler import ScheduleIterationTimes, launch_scheduled_runs
-from dagster._seven import wait_for_process
 from dagster._time import create_datetime, get_current_datetime, get_current_timestamp, get_timezone
 from dagster._utils import DebugCrashFlags
 from dagster._utils.error import SerializableErrorInfo
@@ -705,7 +704,7 @@ def _grpc_server_external_repo(port: int, scheduler_instance: DagsterInstance):
     finally:
         DagsterGrpcClient(port=port, socket=None).shutdown_server()
         if server_process.poll() is None:
-            wait_for_process(server_process, timeout=30)
+            server_process.communicate(timeout=30)
 
 
 @pytest.mark.parametrize("executor", get_schedule_executors())


### PR DESCRIPTION
## Summary & Motivation

Eliminate `wait_for_process` in favor of `.communicate`. Note we no longer get the `timeout=30` default.

## How I Tested These Changes

BK