### PR TITLE
Lazily import from dateutil.tz to work around default EMR python environment issue

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -93,7 +93,7 @@ setup(
         "pendulum>=0.7.0,<3; python_version<'3.9'",  # https://github.com/dagster-io/dagster/issues/19500
         "protobuf>=3.20.0,<5; python_version<'3.11'",  # min protobuf version to be compatible with both protobuf 3 and 4
         "protobuf>=4,<5; python_version>='3.11'",
-        "python-dateutil",
+        "python-dateutil>=2.7.0",
         "python-dotenv",
         "pytz",
         "requests",


### PR DESCRIPTION
Summary:
Workaround for the issue identified in https://github.com/dagster-io/dagster/issues/22586 where EMR has two different versions of dateutil installed in the default python environment - generally in an EMR context we are just running an op and won't need this import to resolve correctly anyway.

Also add a pin for the dateutil version that we actually depend on now.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
