### PR TITLE
[ui] Use relative links for manifest/favicon.

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/src/pages/_document.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/pages/_document.tsx
@@ -15,6 +15,17 @@ function getSecurityPolicy() {
   return fs.readFileSync(path.join(__dirname, '../../../csp-header-dev.txt'), {encoding: 'utf8'});
 }
 
+function getPrefix(): string {
+  const next_public_url = process.env.NEXT_PUBLIC_URL;
+  if (next_public_url === undefined || next_public_url === '') {
+    return PREFIX_PLACEHOLDER;
+  }
+  if (next_public_url.endsWith('/')) {
+    return `${next_public_url}${PREFIX_PLACEHOLDER}`;
+  }
+  return `${next_public_url}/${PREFIX_PLACEHOLDER}`;
+}
+
 // eslint-disable-next-line import/no-default-export
 export default function Document() {
   const isDev = process.env.NODE_ENV === 'development';
@@ -24,6 +35,7 @@ export default function Document() {
     liveDataPollRate: LIVE_DATA_POLL_RATE_PLACEHOLDER,
     instanceId: isDev ? 'dev' : INSTANCE_ID_PLACEHOLDER,
   };
+  const prefix = getPrefix();
   return (
     <Html lang="en">
       <Head nonce="NONCE-PLACEHOLDER">
@@ -48,21 +60,9 @@ export default function Document() {
           // format the json...
           dangerouslySetInnerHTML={{__html: JSON.stringify(values, null, 2)}}
         />
-        <link
-          rel="manifest"
-          href={`${process.env.NEXT_PUBLIC_URL ?? PREFIX_PLACEHOLDER}/manifest.json`}
-          crossOrigin="use-credentials"
-        />
-        <link
-          rel="icon"
-          type="image/png"
-          href={`${process.env.NEXT_PUBLIC_URL ?? PREFIX_PLACEHOLDER}/favicon.png`}
-        />
-        <link
-          rel="icon"
-          type="image/svg+xml"
-          href={`${process.env.NEXT_PUBLIC_URL ?? PREFIX_PLACEHOLDER}/favicon.svg`}
-        />
+        <link rel="manifest" href={`${prefix}/manifest.json`} crossOrigin="use-credentials" />
+        <link rel="icon" type="image/png" href={`${prefix}/favicon.png`} />
+        <link rel="icon" type="image/svg+xml" href={`${prefix}/favicon.svg`} />
       </Head>
       <body>
         <Main />

--- a/js_modules/dagster-ui/packages/app-oss/src/pages/_document.tsx
+++ b/js_modules/dagster-ui/packages/app-oss/src/pages/_document.tsx
@@ -50,18 +50,18 @@ export default function Document() {
         />
         <link
           rel="manifest"
-          href={`${process.env.NEXT_PUBLIC_URL ?? ''}/manifest.json`}
+          href={`${process.env.NEXT_PUBLIC_URL ?? PREFIX_PLACEHOLDER}/manifest.json`}
           crossOrigin="use-credentials"
         />
         <link
           rel="icon"
           type="image/png"
-          href={`${process.env.NEXT_PUBLIC_URL ?? ''}/favicon.png`}
+          href={`${process.env.NEXT_PUBLIC_URL ?? PREFIX_PLACEHOLDER}/favicon.png`}
         />
         <link
           rel="icon"
           type="image/svg+xml"
-          href={`${process.env.NEXT_PUBLIC_URL ?? ''}/favicon.svg`}
+          href={`${process.env.NEXT_PUBLIC_URL ?? PREFIX_PLACEHOLDER}/favicon.svg`}
         />
       </Head>
       <body>


### PR DESCRIPTION
Right now, this renders to e.g. `/manfiest.json` which does not load correctly when using a `path-prefix`.

## Summary & Motivation
I noticed when running with a `path-prefix`, I was getting 404 errors for the manifest and favicon specified from the top level, which were using absolute paths without the prefix.

## How I Tested These Changes
In my local environment, I made the change, ran `./build_js.sh` then `pip install -e .` from the `python_modules/dagster-webserver` directory. Then I launched `dagster-webserver  --path-prefix /dagster-testing` and verified the correct behavior. The generated HTML now contains the following:
```
<link rel="manifest" href="/dagster-testing/manifest.json" crossorigin="use-credentials"/><link rel="icon" type="image/png" href="/dagster-testing/favicon.png"/><link rel="icon" type="image/svg+xml" href="/dagster-testing/favicon.svg"/
```
