### PR TITLE
fix #22665 - support ephemeral asset job in run_status_sensor

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -830,12 +830,15 @@ class RunStatusSensorDefinition(SensorDefinition):
                     else:
                         job_match = True
 
-                if not job_match:
+                if (
+                    not job_match
+                    and
+                    # the job has a repository (not manually executed)
+                    dagster_run.external_job_origin
+                ):
                     # check if the run is one of the jobs specified by JobSelector or RepositorySelector (ie in another repo)
                     # make a JobSelector for the run in question
-                    external_repository_origin = check.not_none(
-                        dagster_run.external_job_origin
-                    ).repository_origin
+                    external_repository_origin = dagster_run.external_job_origin
                     run_job_selector = JobSelector(
                         location_name=external_repository_origin.code_location_origin.location_name,
                         repository_name=external_repository_origin.repository_name,

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -838,7 +838,7 @@ class RunStatusSensorDefinition(SensorDefinition):
                 ):
                     # check if the run is one of the jobs specified by JobSelector or RepositorySelector (ie in another repo)
                     # make a JobSelector for the run in question
-                    external_repository_origin = dagster_run.external_job_origin
+                    external_repository_origin = dagster_run.external_job_origin.repository_origin
                     run_job_selector = JobSelector(
                         location_name=external_repository_origin.code_location_origin.location_name,
                         repository_name=external_repository_origin.repository_name,


### PR DESCRIPTION
## Summary & Motivation

An ephemeral asset job created with `materialize()` that fails, causes the `RunStatusSensorDefinition` to fail.

## How I Tested These Changes

I modified the file in and ran locally.
