### PR TITLE
consolidate graph asset op handle dependency logic

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -32,10 +32,6 @@ class AssetLayer(NamedTuple):
     asset_keys_by_node_input_handle: Mapping[NodeInputHandle, AssetKey]
     asset_keys_by_node_output_handle: Mapping[NodeOutputHandle, AssetKey]
     check_key_by_node_output_handle: Mapping[NodeOutputHandle, AssetCheckKey]
-    dependency_node_handles_by_asset_key: Mapping[AssetKey, Set[NodeHandle]]
-    # Used to store the asset key dependencies of op node handles within graph backed assets
-    # See AssetLayer.downstream_dep_assets for more information
-    dep_asset_keys_by_node_output_handle: Mapping[NodeOutputHandle, Set[AssetKey]]
     node_output_handles_by_asset_check_key: Mapping[AssetCheckKey, NodeOutputHandle]
     check_names_by_asset_key_by_node_handle: Mapping[
         NodeHandle, Mapping[AssetKey, AbstractSet[str]]
@@ -56,27 +52,9 @@ class AssetLayer(NamedTuple):
             assets_defs_by_outer_node_handle (Mapping[NodeHandle, AssetsDefinition]): A mapping from
                 a NodeHandle pointing to the node in the graph where the AssetsDefinition ended up.
         """
-        from .assets import asset_or_check_key_to_dep_node_handles
-
         asset_key_by_input: Dict[NodeInputHandle, AssetKey] = {}
         asset_keys_by_node_output_handle: Dict[NodeOutputHandle, AssetKey] = {}
         check_key_by_output: Dict[NodeOutputHandle, AssetCheckKey] = {}
-
-        (
-            dep_node_handles_by_asset_or_check_key,
-            dep_node_output_handles_by_asset_or_check_key,
-        ) = asset_or_check_key_to_dep_node_handles(graph_def, assets_defs_by_outer_node_handle)
-
-        dep_node_handles_by_asset_key = {
-            key: handles
-            for key, handles in dep_node_handles_by_asset_or_check_key.items()
-            if isinstance(key, AssetKey)
-        }
-        dep_node_output_handles_by_asset_key = {
-            key: handles
-            for key, handles in dep_node_output_handles_by_asset_or_check_key.items()
-            if isinstance(key, AssetKey)
-        }
 
         node_output_handles_by_asset_check_key: Mapping[AssetCheckKey, NodeOutputHandle] = {}
         check_names_by_asset_key_by_node_handle: Dict[NodeHandle, Dict[AssetKey, Set[str]]] = {}
@@ -132,35 +110,20 @@ class AssetLayer(NamedTuple):
 
                 assets_defs_by_check_key.update({k: assets_def for k in assets_def.check_keys})
 
-        dep_asset_keys_by_node_output_handle = defaultdict(set)
-        for asset_key, node_output_handles in dep_node_output_handles_by_asset_key.items():
-            for node_output_handle in node_output_handles:
-                dep_asset_keys_by_node_output_handle[node_output_handle].add(asset_key)
-
-        assets_defs_by_node_handle: Dict[NodeHandle, "AssetsDefinition"] = {
-            # nodes for assets
-            **{
-                node_handle: asset_graph.get(asset_key).assets_def
-                for asset_key, node_handles in dep_node_handles_by_asset_key.items()
-                for node_handle in node_handles
-            },
-            # nodes for asset checks. Required for AssetsDefs that have selected checks
-            # but not assets
-            **{
-                node_handle: assets_def
-                for node_handle, assets_def in assets_defs_by_outer_node_handle.items()
-                if assets_def.check_keys
-            },
-        }
+        assets_defs_by_op_handle: Dict[NodeHandle, "AssetsDefinition"] = {}
+        for outer_node_handle, assets_def in assets_defs_by_outer_node_handle.items():
+            if assets_def.computation is not None:
+                for op_handle in assets_def.computation.node_def.get_op_handles(
+                    parent=outer_node_handle
+                ):
+                    assets_defs_by_op_handle[op_handle] = assets_def
 
         return AssetLayer(
             asset_graph=asset_graph,
             asset_keys_by_node_input_handle=asset_key_by_input,
             asset_keys_by_node_output_handle=asset_keys_by_node_output_handle,
             check_key_by_node_output_handle=check_key_by_output,
-            assets_defs_by_node_handle=assets_defs_by_node_handle,
-            dependency_node_handles_by_asset_key=dep_node_handles_by_asset_key,
-            dep_asset_keys_by_node_output_handle=dep_asset_keys_by_node_output_handle,
+            assets_defs_by_node_handle=assets_defs_by_op_handle,
             node_output_handles_by_asset_check_key=node_output_handles_by_asset_check_key,
             check_names_by_asset_key_by_node_handle=check_names_by_asset_key_by_node_handle,
         )
@@ -275,6 +238,15 @@ class AssetLayer(NamedTuple):
         Calling downstream_dep_assets with node handle add_one will return:
         - {AssetKey("asset_two")} if output_name="result"
         """
-        return self.dep_asset_keys_by_node_output_handle.get(
-            NodeOutputHandle(node_handle, output_name), set()
-        )
+        assets_def = self.assets_defs_by_node_handle[node_handle]
+        return {
+            key
+            for key in assets_def.asset_or_check_keys_by_dep_op_output_handle[
+                NodeOutputHandle(node_handle, output_name)
+            ]
+            if isinstance(key, AssetKey)
+        }
+
+    def upstream_dep_op_handles(self, asset_key: AssetKey) -> AbstractSet[NodeHandle]:
+        assets_def = self.asset_graph.get(asset_key).assets_def
+        return assets_def.dep_op_handles_by_asset_or_check_key[asset_key]

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -914,6 +914,13 @@ class GraphDefinition(NodeDefinition):
 
         return all_destinations
 
+    def get_op_handles(self, parent: NodeHandle) -> AbstractSet[NodeHandle]:
+        return {
+            op_handle
+            for node in self.nodes
+            for op_handle in node.definition.get_op_handles(NodeHandle(node.name, parent=parent))
+        }
+
 
 class SubselectedGraphDefinition(GraphDefinition):
     """Defines a subselected graph.

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -1213,8 +1213,6 @@ def _infer_asset_layer_from_source_asset_deps(job_graph_def: GraphDefinition) ->
         assets_defs_by_node_handle={},
         asset_keys_by_node_input_handle=asset_keys_by_node_input_handle,
         asset_keys_by_node_output_handle={},
-        dependency_node_handles_by_asset_key={},
-        dep_asset_keys_by_node_output_handle={},
         node_output_handles_by_asset_check_key={},
         check_names_by_asset_key_by_node_handle={},
         check_key_by_node_output_handle={},

--- a/python_modules/dagster/dagster/_core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/node_definition.py
@@ -234,3 +234,6 @@ class NodeDefinition(NamedConfigurableDefinition):
     def resolve_output_to_destinations(
         self, output_name: str, handle: Optional["NodeHandle"]
     ) -> Sequence["NodeInputHandle"]: ...
+
+    @abstractmethod
+    def get_op_handles(self, parent: "NodeHandle") -> AbstractSet["NodeHandle"]: ...

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -466,6 +466,9 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
 
         return direct_invocation_result(self, *args, **kwargs)
 
+    def get_op_handles(self, parent: NodeHandle) -> AbstractSet[NodeHandle]:
+        return {parent}
+
 
 def _resolve_output_defs_from_outs(
     compute_fn: Union[Callable[..., Any], "DecoratedOpFunction"],

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -112,7 +112,7 @@ def _process_user_event(
         asset_check_evaluation = user_event.to_asset_check_evaluation(step_context)
         spec = check.not_none(
             step_context.job_def.asset_layer.get_spec_for_asset_check(
-                step_context.node_handle.root, asset_check_evaluation.asset_check_key
+                step_context.node_handle, asset_check_evaluation.asset_check_key
             ),
             "If we were able to create an AssetCheckEvaluation from the AssetCheckResult, then"
             " there should be a spec for the check",

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -1734,7 +1734,7 @@ def external_asset_nodes_from_defs(
                     break
                 root_node_handle = root_node_handle.parent
             node_def = job_def.graph.get_node(output_handle.node_handle).definition
-            node_handles = job_def.asset_layer.dependency_node_handles_by_asset_key.get(key, [])
+            node_handles = job_def.asset_layer.upstream_dep_op_handles(key)
 
             # graph_name is only set for assets that are produced by nested ops.
             graph_name = (


### PR DESCRIPTION
## Summary & Motivation

In graph-backed assets, there ops that directly produce assets often depend on ops that don't directly produce assets. In various situations, we need to find all the ops within a graph-backed asset that need to be executed to materialize a particular asset. Or the inverse.

This PR aims to simplify the way we track this correspondence by consolidating it inside `AssetsDefinition`. Prior to this PR, it's tracked with a big dictionary in the asset layer, which is a little confusing because it makes it seems like these dependencies can cross `AssetsDefinition`.

The motivation for this PR is to have a smooth base for simplifications to this logic, which will ultimately help with refactoring the relationship between `AssetLayer` and `AssetGraph`.

Direct effects of this PR:
- `AssetLayer` loses the `dependency_node_handles_by_asset_key` and `dep_asset_keys_by_node_output_handle` properties
- The `AssetLayer. downstream_dep_assets` method delegates to the underlying `AssetsDefinition`
- `asset_or_check_key_to_dep_node_handles` becomes a method of `AssetsDefinition`, and operates on a single `AssetsDefinition` instead of a dictionary of them

## How I Tested These Changes
