### PR TITLE
[docs] make quickstart self contained in assets.py

### DIFF
--- a/docs/content/getting-started/quickstart.mdx
+++ b/docs/content/getting-started/quickstart.mdx
@@ -133,9 +133,13 @@ import json
 import pandas as pd
 import requests
 
-from dagster import MaterializeResult, MetadataValue, asset
+from dagster import Config, MaterializeResult, MetadataValue, asset
 
-from .configurations import HNStoriesConfig
+
+class HNStoriesConfig(Config):
+    top_stories_limit: int = 10
+    hn_top_story_ids_path: str = "hackernews_top_story_ids.json"
+    hn_top_stories_path: str = "hackernews_top_stories.csv"
 
 
 @asset

--- a/examples/docs_snippets/docs_snippets/getting-started/quickstart/assets.py
+++ b/examples/docs_snippets/docs_snippets/getting-started/quickstart/assets.py
@@ -3,9 +3,13 @@ import json
 import pandas as pd
 import requests
 
-from dagster import MaterializeResult, MetadataValue, asset
+from dagster import Config, MaterializeResult, MetadataValue, asset
 
-from .configurations import HNStoriesConfig
+
+class HNStoriesConfig(Config):
+    top_stories_limit: int = 10
+    hn_top_story_ids_path: str = "hackernews_top_story_ids.json"
+    hn_top_stories_path: str = "hackernews_top_stories.csv"
 
 
 @asset

--- a/examples/docs_snippets/docs_snippets/getting-started/quickstart/configurations.py
+++ b/examples/docs_snippets/docs_snippets/getting-started/quickstart/configurations.py
@@ -1,7 +1,0 @@
-from dagster import Config
-
-
-class HNStoriesConfig(Config):
-    top_stories_limit: int = 10
-    hn_top_story_ids_path: str = "hackernews_top_story_ids.json"
-    hn_top_stories_path: str = "hackernews_top_stories.csv"


### PR DESCRIPTION
## Summary & Motivation

- For ease of copying, make it so that the assets.py file is self contained

## How I Tested These Changes

`dagster dev -f assets.py`