### PR TITLE
Draft: [dagster-polars] Pandera integration for DataFrame schema validation :safety_vest: 

### DIFF
--- a/python_modules/libraries/dagster-polars/dagster_polars/__init__.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/__init__.py
@@ -2,27 +2,14 @@ from dagster._core.libraries import DagsterLibraryRegistry
 
 from dagster_polars.io_managers.base import BasePolarsUPathIOManager
 from dagster_polars.io_managers.parquet import PolarsParquetIOManager
-from dagster_polars.types import (
-    DataFramePartitions,
-    DataFramePartitionsWithMetadata,
-    DataFrameWithMetadata,
-    LazyFramePartitions,
-    LazyFramePartitionsWithMetadata,
-    LazyFrameWithMetadata,
-    StorageMetadata,
-)
+from dagster_polars.types import DataFramePartitions, LazyFramePartitions
 from dagster_polars.version import __version__
 
 __all__ = [
     "PolarsParquetIOManager",
     "BasePolarsUPathIOManager",
-    "StorageMetadata",
-    "DataFrameWithMetadata",
-    "LazyFrameWithMetadata",
     "DataFramePartitions",
     "LazyFramePartitions",
-    "DataFramePartitionsWithMetadata",
-    "LazyFramePartitionsWithMetadata",
     "__version__",
 ]
 

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/__init__.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/__init__.py
@@ -12,8 +12,11 @@ try:
     from dagster_polars.io_managers.delta import DeltaWriteMode, PolarsDeltaIOManager  # noqa
 
     __all__.extend(["DeltaWriteMode", "PolarsDeltaIOManager"])
-except ImportError:
-    pass
+except ImportError as e:
+    if "deltalake" in str(e):
+        pass
+    else:
+        raise e
 
 
 try:
@@ -24,5 +27,8 @@ try:
     )
 
     __all__.extend(["PolarsBigQueryIOManager", "PolarsBigQueryTypeHandler"])
-except ImportError:
-    pass
+except ImportError as e:
+    if "google-cloud-bigquery" in str(e):
+        pass
+    else:
+        raise e

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/base.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/base.py
@@ -1,26 +1,5 @@
-import sys
 from abc import abstractmethod
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Literal,
-    Mapping,
-    Optional,
-    Tuple,
-    Union,
-    cast,
-    get_args,
-    get_origin,
-    overload, Callable, Generic, TypeVar, List,
-
-)
-
-
-if sys.version_info >= (3, 9):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Tuple, Union
 
 import polars as pl
 from dagster import (
@@ -36,200 +15,11 @@ from dagster import (
 from pydantic import PrivateAttr
 from pydantic.fields import Field
 
+from dagster_polars.io_managers.type_routers import resolve_type_router
 from dagster_polars.io_managers.utils import get_polars_metadata
-from dagster_polars.types import (
-    DataFramePartitions,
-    LazyFramePartitions,
-    LazyFrameWithMetadata,
-)
-
-try:
-    import pandera
-
-    PANDERA_INSTALLED = True
-except ImportError:
-    PANDERA_INSTALLED = False
-
 
 if TYPE_CHECKING:
     from upath import UPath
-
-
-T = TypeVar("T")
-
-
-# dump_to_path signature
-F_D: TypeAlias = Callable[[OutputContext, T, "UPath"], None]
-
-# load_from_path signature
-F_L: TypeAlias = Callable[[InputContext, "UPath"], T]
-
-
-class BaseTypeRouter(Generic[T]):
-    """
-    Specifies how to apply a given dump/load operation to a given type annotation.
-    """
-
-    def __init__(self, context: Union[InputContext, OutputContext], type_to_resolve: Any):
-        self.context = context
-        self.type_to_resolve = type_to_resolve
-
-    @abstractmethod
-    def match(self) -> bool:
-        raise NotImplementedError
-
-    @abstractmethod
-    @property
-    def is_root_type(self) -> bool:
-        raise NotImplementedError
-
-    @abstractmethod
-    @property
-    def parent_type(self) -> Any:
-        raise NotImplementedError
-
-    def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
-        dump_fn(self.context, obj, path)
-
-    def load(self, path: "UPath", load_fn: F_L) -> T:
-        return load_fn(self.context, path)
-
-
-class TypeRouter(BaseTypeRouter, Generic[T]):
-    """
-    Specifies how to apply a given dump/load operation to a given type annotation.
-    This base class trivially calls the dump/load functions if the type matches the most simple cases.
-    """
-
-    def match(self) -> bool:
-        return self.type_to_resolve in [
-            pl.DataFrame,
-            pl.LazyFrame,
-            Any,
-            type(None),
-            None,
-        ]
-
-    @property
-    def is_root_type(self) -> bool:
-        return True
-
-
-class OptionalTypeRouter(TypeRouter):
-    """
-    Handles Optional type annotations with a noop if the object is None or missing in storage.
-    """
-
-    def match(self) -> bool:
-        return get_origin(self.type_to_resolve) == Union and type(None) in get_args(self.type_to_resolve)
-
-    @property
-    def is_root_type(self) -> bool:
-        return False
-
-    def parent_type(self) -> Any:
-        return get_args(self.type_to_resolve)[0]
-
-    def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
-        if obj is None:
-            self.context.log.warning(f"Skipping saving optional output at {path} as it is None")
-            return
-        else:
-            router = resolve_type_router(self.context, self.parent_type)
-            router.dump(obj, path, dump_fn)
-
-    def load(self, path: "UPath", load_fn: F_L) -> T:
-        if not path.exists():
-            self.context.log.warning(f"Skipping loading optional input at {path} as it is missing")
-            return None
-        else:
-            router = resolve_type_router(self.context, self.parent_type)
-            return router.load(path, load_fn)
-
-
-class DictTypeRouter(TypeRouter):
-    """
-    Handles loading partitions as dictionaries of DataFrames.
-    """
-
-    def match(self) -> bool:
-        return get_origin(self.type_to_resolve) in (dict, Dict, Mapping)
-
-    @property
-    def is_root_type(self) -> bool:
-        return False
-
-    @property
-    def parent_type(self) -> Any:
-        return get_args(self.type_to_resolve)[1]
-
-
-class PanderaTypeRouter(TypeRouter):
-    """
-    Handles loading Pandera DataFrames.
-    """
-
-    def match(self) -> bool:
-        try:
-            import pandera
-            import pandera.typing.polars
-
-            return (
-                    get_origin(self.type_to_resolve) == pandera.typing.polars.LazyFrame
-                    and issubclass(get_args(self.type_to_resolve)[0], pandera.DataFrameModel)
-            )
-        except ImportError:
-            return False
-
-    @property
-    def is_root_type(self) -> bool:
-        return True
-
-    def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
-        if isinstance()
-        router = resolve_type_router(self.context, self.parent_type)
-        router.dump(obj, path, dump_fn)
-
-    def load(self, path: "UPath", load_fn: F_L) -> T:
-        if not path.exists():
-            self.context.log.warning(f"Skipping loading optional input at {path} as it is missing")
-            return None
-        else:
-            router = resolve_type_router(self.context, self.parent_type)
-            return router.load(path, load_fn)
-
-
-TYPE_ROUTERS = [
-    TypeRouter,
-    OptionalTypeRouter,
-    DictTypeRouter,
-]
-
-if PANDERA_INSTALLED:
-    TYPE_ROUTERS.append(PanderaTypeRo`uter)
-
-
-def resolve_type_router(context: Union[InputContext, OutputContext], type_to_resolve: Any) -> TypeRouter:
-    """
-    Finds the correct TypeRouter for the given context.
-    """
-
-    # try each router class in order of increasing complexity
-    for router_class in [
-        TypeRouter,
-        OptionalTypeRouter,
-        ...
-    ]:
-        router = router_class(context, type_to_resolve)
-
-        if not router.match():
-            continue
-        else:
-            if router.is_root_type:
-                return router
-            else:
-                # recursively resolve the parent type
-                return resolve_type_router(context, router.parent_type)
 
 
 def _process_env_vars(config: Mapping[str, Any]) -> Dict[str, Any]:
@@ -302,22 +92,12 @@ class BasePolarsUPathIOManager(ConfigurableIOManager, UPathIOManager):
         path: "UPath",
     ): ...
 
-    @overload
     @abstractmethod
     def scan_df_from_path(
-        self, path: "UPath", context: InputContext,
+        self,
+        path: "UPath",
+        context: InputContext,
     ) -> pl.LazyFrame: ...
-
-    @overload
-    @abstractmethod
-    def scan_df_from_path(
-        self, path: "UPath", context: InputContext,
-    ) -> LazyFrameWithMetadata: ...
-
-    @abstractmethod
-    def scan_df_from_path(
-        self, path: "UPath", context: InputContext,
-    ) -> Union[pl.LazyFrame, LazyFrameWithMetadata]: ...
 
     def dump_to_path(
         self,
@@ -332,49 +112,18 @@ class BasePolarsUPathIOManager(ConfigurableIOManager, UPathIOManager):
         ],
         path: "UPath",
     ):
-        typing_type = context.dagster_type.typing_type
+        type_router = resolve_type_router(context, context.dagster_type.typing_type)
 
-        if annotation_is_typing_optional(typing_type) and (
-            obj is None or annotation_for_storage_metadata(typing_type) and obj[0] is None
-        ):
-            context.log.warning(self.get_optional_output_none_log_message(context, path))
-            return
+        if type_router.is_eager:
+            dump_fn = self.write_df_to_path
+        elif type_router.is_lazy:
+            dump_fn = self.sink_df_to_path
         else:
-            assert obj is not None, "output should not be None if it's type is not Optional"
-            if not annotation_for_storage_metadata(typing_type):
-                if typing_type in POLARS_EAGER_FRAME_ANNOTATIONS:
-                    obj = cast(pl.DataFrame, obj)
-                    df = obj
-                    self.write_df_to_path(context=context, df=df, path=path)
-                elif typing_type in POLARS_LAZY_FRAME_ANNOTATIONS:
-                    obj = cast(pl.LazyFrame, obj)
-                    df = obj
-                    self.sink_df_to_path(context=context, df=df, path=path)
-                else:
-                    raise NotImplementedError(
-                        f"dump_df_to_path for {typing_type} is not implemented"
-                    )
-            else:
-                if not annotation_is_typing_optional(typing_type):
-                    frame_type = get_args(typing_type)[0]
-                else:
-                    frame_type = get_args(get_args(typing_type)[0])[0]
+            raise NotImplementedError(
+                f"Can't dump object for type annotation {context.dagster_type.typing_type}"
+            )
 
-                if frame_type in POLARS_EAGER_FRAME_ANNOTATIONS:
-                    obj = cast(Tuple[pl.DataFrame, Dict[str, Any]], obj)
-                    df, metadata = obj
-                    self.write_df_to_path(context=context, df=df, path=path, metadata=metadata)
-                elif frame_type in POLARS_LAZY_FRAME_ANNOTATIONS:
-                    obj = cast(Tuple[pl.LazyFrame, Dict[str, Any]], obj)
-                    df, metadata = obj
-                    self.sink_df_to_path(context=context, df=df, path=path, metadata=metadata)
-                else:
-                    raise NotImplementedError(
-                        f"dump_df_to_path for {typing_type} is not implemented"
-                    )
-
-    def needs_output_metadata(self, context: Union[InputContext, OutputContext]) -> bool:
-        return annotation_for_storage_metadata(context.dagster_type.typing_type)
+        type_router.dump(obj, path, dump_fn)
 
     def load_from_path(
         self, context: InputContext, path: "UPath"
@@ -385,38 +134,21 @@ class BasePolarsUPathIOManager(ConfigurableIOManager, UPathIOManager):
         Tuple[pl.LazyFrame, Dict[str, Any]],
         None,
     ]:
-        if annotation_is_typing_optional(context.dagster_type.typing_type) and not path.exists():
-            context.log.warning(self.get_missing_optional_input_log_message(context, path))
-            return None
+        type_router = resolve_type_router(context, context.dagster_type.typing_type)
 
-        assert context.definition_metadata is not None
-
-        metadata: Optional[StorageMetadata] = None
-
-        return_storage_metadata = self.needs_output_metadata(context)
-        if not return_storage_metadata:
-            ldf = self.scan_df_from_path(path=path, context=context)  # type: ignore
-        else:
-            ldf, metadata = self.scan_df_from_path(path=path, context=context, with_metadata=True)
+        ldf = type_router.load(path, self.scan_df_from_path)
 
         columns = context.definition_metadata.get("columns")
         if columns is not None:
             context.log.debug(f"Loading {columns=}")
             ldf = ldf.select(columns)
 
-        if context.dagster_type.typing_type in POLARS_EAGER_FRAME_ANNOTATIONS:
-            if not return_storage_metadata:
-                return ldf.collect()
-            else:
-                assert metadata is not None
-                return ldf.collect(), metadata
-
-        elif context.dagster_type.typing_type in POLARS_LAZY_FRAME_ANNOTATIONS:
-            if not return_storage_metadata:
-                return ldf
-            else:
-                assert metadata is not None
-                return ldf, metadata
+        if ldf is None:
+            return None
+        elif type_router.is_eager and ldf is not None:
+            return ldf.collect()
+        elif type_router.is_lazy:
+            return ldf
         else:
             raise NotImplementedError(
                 f"Can't load object for type annotation {context.dagster_type.typing_type}"
@@ -428,12 +160,8 @@ class BasePolarsUPathIOManager(ConfigurableIOManager, UPathIOManager):
         if obj is None:
             return {"missing": MetadataValue.bool(True)}
         else:
-            if annotation_for_storage_metadata(context.dagster_type.typing_type):
-                df = obj[0]
-            else:
-                df = obj
             return (
-                get_polars_metadata(context, df)
-                if df is not None
+                get_polars_metadata(context, obj)
+                if obj is not None
                 else {"missing": MetadataValue.bool(True)}
             )

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_routers.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_routers.py
@@ -1,0 +1,219 @@
+import sys
+from abc import abstractmethod
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Mapping,
+    Type,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+)
+
+if sys.version_info >= (3, 9):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+
+import polars as pl
+from dagster import InputContext, OutputContext
+
+try:
+    import pandera
+
+    PANDERA_INSTALLED = True
+except ImportError:
+    PANDERA_INSTALLED = False
+
+
+if TYPE_CHECKING:
+    from upath import UPath
+
+
+T = TypeVar("T")
+
+
+# dump_to_path signature
+F_D: TypeAlias = Callable[[OutputContext, T, "UPath"], None]
+
+# load_from_path signature
+F_L: TypeAlias = Callable[["UPath", InputContext], T]
+
+
+class BaseTypeRouter(Generic[T]):
+    """Specifies how to apply a given dump/load operation to a given type annotation."""
+
+    def __init__(self, context: Union[InputContext, OutputContext], typing_type: Any):
+        self.context = context
+        self.typing_type = typing_type
+
+    @abstractmethod
+    def match(self) -> bool:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def is_root_type(self) -> bool:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def parent_type(self) -> Any:
+        raise NotImplementedError
+
+    @property
+    def parent_type_router(self) -> "TypeRouter":
+        return resolve_type_router(self.context, self.parent_type)
+
+    @property
+    def is_eager(self) -> bool:
+        if self.is_root_type:
+            return self.typing_type in [Any, type(None), None] or issubclass(
+                self.typing_type, pl.DataFrame
+            )
+        else:
+            return self.parent_type_router.is_eager
+
+    @property
+    def is_lazy(self) -> bool:
+        if self.is_root_type:
+            return issubclass(self.typing_type, pl.LazyFrame)
+        else:
+            return self.parent_type_router.is_lazy
+
+    def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
+        if self.is_root_type:
+            dump_fn(self.context, obj, path)
+        else:
+            self.parent_type_router.dump(obj, path, dump_fn)
+
+    def load(self, path: "UPath", load_fn: F_L) -> T:
+        if self.is_root_type:
+            return load_fn(path, self.context)
+        else:
+            return self.parent_type_router.load(path, load_fn)
+
+
+class TypeRouter(BaseTypeRouter, Generic[T]):
+    """Specifies how to apply a given dump/load operation to a given type annotation.
+    This base class trivially calls the dump/load functions if the type matches the most simple cases.
+    """
+
+    def match(self) -> bool:
+        return self.typing_type in [
+            pl.DataFrame,
+            pl.LazyFrame,
+            Any,
+            type(None),
+            None,
+        ]
+
+    @property
+    def is_root_type(self) -> bool:
+        return True
+
+
+class OptionalTypeRouter(BaseTypeRouter, Generic[T]):
+    """Handles Optional type annotations with a noop if the object is None or missing in storage."""
+
+    def match(self) -> bool:
+        return get_origin(self.typing_type) == Union and type(None) in get_args(self.typing_type)
+
+    @property
+    def is_root_type(self) -> bool:
+        return False
+
+    @property
+    def parent_type(self) -> Any:
+        return get_args(self.typing_type)[0]
+
+    def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
+        if obj is None:
+            self.context.log.warning(f"Skipping saving optional output at {path} as it is None")
+            return
+        else:
+            self.parent_type_router.dump(obj, path, dump_fn)
+
+    def load(self, path: "UPath", load_fn: F_L) -> T:
+        if not path.exists():
+            self.context.log.warning(f"Skipping loading optional input at {path} as it is missing")
+            return None
+        else:
+            return self.parent_type_router.load(path, load_fn)
+
+
+class DictTypeRouter(BaseTypeRouter, Generic[T]):
+    """Handles loading partitions as dictionaries of DataFrames."""
+
+    def match(self) -> bool:
+        return get_origin(self.typing_type) in (dict, Dict, Mapping)
+
+    @property
+    def is_root_type(self) -> bool:
+        return False
+
+    @property
+    def parent_type(self) -> Any:
+        return get_args(self.typing_type)[1]
+
+
+class PanderaTypeRouter(BaseTypeRouter, Generic[T]):
+    """Handles loading Pandera DataFrames."""
+
+    def match(self) -> bool:
+        try:
+            import pandera
+            import pandera.typing.polars
+
+            return get_origin(self.typing_type) in [
+                pandera.typing.polars.LazyFrame,
+                pandera.typing.polars.DataFrame,
+            ] and issubclass(get_args(self.typing_type)[0], pandera.DataFrameModel)
+        except ImportError:
+            return False
+
+    @property
+    def is_root_type(self) -> bool:
+        return True
+
+    @property
+    def pandera_schema(self) -> Type[pandera.DataFrameModel]:
+        return get_args(self.typing_type)[0]
+
+    def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
+        obj = self.pandera_schema.to_schema().validate(obj)
+        router = resolve_type_router(self.context, self.parent_type)
+        router.dump(obj, path, dump_fn)
+
+    def load(self, path: "UPath", load_fn: F_L) -> T:
+        router = resolve_type_router(self.context, self.parent_type)
+        obj = router.load(path, load_fn)
+        return self.pandera_schema.to_schema().validate(obj)
+
+
+TYPE_ROUTERS = [
+    TypeRouter,
+    OptionalTypeRouter,
+    DictTypeRouter,
+]
+
+if PANDERA_INSTALLED:
+    TYPE_ROUTERS.insert(0, PanderaTypeRouter)  # make sure to add before the base TypeRouter
+
+
+def resolve_type_router(
+    context: Union[InputContext, OutputContext], type_to_resolve: Any
+) -> TypeRouter:
+    """Finds the first matching TypeRouter for the given type."""
+    # try each router class in order of increasing complexity
+    for router_class in TYPE_ROUTERS:
+        router = router_class(context, type_to_resolve)
+
+        if router.match():
+            return router
+
+    raise RuntimeError(f"Could not resolve type router for {type_to_resolve}")

--- a/python_modules/libraries/dagster-polars/dagster_polars/types.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/types.py
@@ -8,7 +8,6 @@ else:
 
 import polars as pl
 
-StorageMetadata: TypeAlias = Dict[str, Any]
 DataFrameWithMetadata: TypeAlias = Tuple[pl.DataFrame, StorageMetadata]
 LazyFrameWithMetadata: TypeAlias = Tuple[pl.LazyFrame, StorageMetadata]
 DataFramePartitions: TypeAlias = Dict[str, pl.DataFrame]
@@ -17,11 +16,6 @@ LazyFramePartitions: TypeAlias = Dict[str, pl.LazyFrame]
 LazyFramePartitionsWithMetadata: TypeAlias = Dict[str, LazyFrameWithMetadata]
 
 __all__ = [
-    "StorageMetadata",
-    "DataFrameWithMetadata",
-    "LazyFrameWithMetadata",
     "DataFramePartitions",
-    "DataFramePartitionsWithMetadata",
     "LazyFramePartitions",
-    "LazyFramePartitionsWithMetadata",
 ]

--- a/python_modules/libraries/dagster-polars/dagster_polars/types.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/types.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Dict, Tuple
+from typing import Dict
 
 if sys.version_info < (3, 10):
     from typing_extensions import TypeAlias
@@ -8,12 +8,8 @@ else:
 
 import polars as pl
 
-DataFrameWithMetadata: TypeAlias = Tuple[pl.DataFrame, StorageMetadata]
-LazyFrameWithMetadata: TypeAlias = Tuple[pl.LazyFrame, StorageMetadata]
 DataFramePartitions: TypeAlias = Dict[str, pl.DataFrame]
-DataFramePartitionsWithMetadata: TypeAlias = Dict[str, DataFrameWithMetadata]
 LazyFramePartitions: TypeAlias = Dict[str, pl.LazyFrame]
-LazyFramePartitionsWithMetadata: TypeAlias = Dict[str, LazyFrameWithMetadata]
 
 __all__ = [
     "DataFramePartitions",


### PR DESCRIPTION
## Summary & Motivation

This PR: 
 - :sparkles: adds Pandera support to dagster-polars (resolve #20584). The goal is to be able to load/save Pandera-validated DataFrames like this: 

```python
from dagster import asset
import pandera
import pandera.typing.polars
import polars as pl

class MySchema(pandera.DataFrameModel):
    foo: str
    bar: int


@asset(io_manager_key="polars_parquet_io_manager")
def upstream() -> pandera.typing.polars.DataFrame[MySchema]:
    return pl.DataFrame({"foo": ["a", "b", "c"], "bar": [1, 2, 3]})


@asset(io_manager_key="polars_parquet_io_manager")
def downstream(upstream: pandera.typing.polars.LazyFrame[MySchema]):
    ...

```

 - :art: refactors logic around loading Optional, Dict, Eager, Lazy, and Pandera-typed DataFrames with new recursive `TypeRouter` (needs a better name?) helper class. This made the base IOManager logic much cleaner while supporting all combinations of these types. Also, `TypeRouter` can potentially be used in the `BigQuery` IOManager, and in general in other non-upath IOManagers.
 - :boom: [TBD] drops support for storing extra metadata in storage as it became too hard to maintain. Extra jsons can be stored in separate assets. This decision is debatable and not final. 

## How I Tested These Changes
Existing tests pass, proving the `TypeRouter` recursive type resolution to be correct. 

New tests for Pandera to be added. 