### PR TITLE
target refactor

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -154,15 +154,15 @@ def _attach_resources_to_jobs_and_instigator_jobs(
             schedule.job
             for schedule in schedules
             if isinstance(schedule, ScheduleDefinition)
-            and schedule.has_loadable_target()
+            and schedule.target.has_executable_def
             and isinstance(schedule.job, (JobDefinition, UnresolvedAssetJobDefinition))
         ],
         *[
-            job
+            target.executable_def
             for sensor in sensors
-            if sensor.has_loadable_targets()
-            for job in sensor.jobs
-            if isinstance(job, (JobDefinition, UnresolvedAssetJobDefinition))
+            for target in sensor.targets
+            if target.has_executable_def
+            and isinstance(target.executable_def, (JobDefinition, UnresolvedAssetJobDefinition))
         ],
     ]
     # Dedupe
@@ -209,7 +209,7 @@ def _attach_resources_to_jobs_and_instigator_jobs(
             schedule.with_updated_job(unsatisfied_job_to_resource_bound_job[id(schedule.job)])
             if (
                 isinstance(schedule, ScheduleDefinition)
-                and schedule.has_loadable_target()
+                and schedule.target.has_executable_def
                 and schedule.job in unsatisfied_jobs
             )
             else schedule
@@ -228,7 +228,8 @@ def _attach_resources_to_jobs_and_instigator_jobs(
                     for job in sensor.jobs
                 ]
             )
-            if sensor.has_loadable_targets() and any(job in unsatisfied_jobs for job in sensor.jobs)
+            if any(target.has_executable_def for target in sensor.targets)
+            and any(job in unsatisfied_jobs for job in sensor.jobs)
             else sensor
         )
         for sensor in sensors

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -476,7 +476,7 @@ class ScheduleSnap(
             name=schedule_def.name,
             cron_schedule=schedule_def.cron_schedule,
             job_name=schedule_def.job_name,
-            op_selection=schedule_def._target.op_selection,  # noqa: SLF001
+            op_selection=schedule_def.target.op_selection,
             mode=DEFAULT_MODE_NAME,
             environment_vars=schedule_def.environment_vars,
             partition_set_name=None,
@@ -1997,7 +1997,7 @@ def external_schedule_data_from_def(schedule_def: ScheduleDefinition) -> Schedul
         name=schedule_def.name,
         cron_schedule=schedule_def.cron_schedule,
         job_name=schedule_def.job_name,
-        op_selection=schedule_def._target.op_selection,  # noqa: SLF001
+        op_selection=schedule_def.target.op_selection,
         mode=DEFAULT_MODE_NAME,
         environment_vars=schedule_def.environment_vars,
         partition_set_name=None,


### PR DESCRIPTION
## Summary & Motivation

Refactor/clean up of schedule/sensor "target" abstractions.

- Consolidate `DirectTarget` and `RepoRelativeTarget` into a new `AutomationTarget` class. Existing names were inaccurate name since unresolved asset job defs are also repo-relative but were stored as `DirectTarget` instead of `RepoRelativeTarget`. The new class stores a `job_resolvable` (a job def, graph def, or job name) and an optional op selection. It exposes  `executable_def` and `has_executable_def` properties. Note that upstack we convert these into `job_def` and `has_job_def` respectively. `AutomationTarget` is also what the `target` parameter added upstack is resolved into.
- Delete methods on schedules/sensors around "loading" targets. These methods didn't actually load anything, they just returned the underlying definition.
- Correct a mismatch in sensor target logic, where accessing `SensorDefinition.jobs`, which errors unless _all_ targets are "direct", is sometimes gated on `has_loadable_targets`, which only ensures _some_ targets are direct.

## How I Tested These Changes

Existing test suite
