### PR TITLE
Publicize AssetCheckSummaryRecord + instance method

### DIFF
--- a/docs/sphinx/sections/api/apidocs/asset-checks.rst
+++ b/docs/sphinx/sections/api/apidocs/asset-checks.rst
@@ -36,3 +36,5 @@ Dagster allows you to define and execute checks on your software-defined assets.
 .. autofunction:: build_column_schema_change_checks
 
 .. autofunction:: build_metadata_bounds_checks
+
+.. autoclass:: AssetCheckSummaryRecord

--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -547,6 +547,9 @@ from dagster._core.run_coordinator.queued_run_coordinator import (
     QueuedRunCoordinator as QueuedRunCoordinator,
     SubmitRunContext as SubmitRunContext,
 )
+from dagster._core.storage.asset_check_summary_record import (
+    AssetCheckSummaryRecord as AssetCheckSummaryRecord,
+)
 from dagster._core.storage.asset_value_loader import AssetValueLoader as AssetValueLoader
 from dagster._core.storage.dagster_run import (
     DagsterRun as DagsterRun,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -159,6 +159,7 @@ if TYPE_CHECKING:
     from dagster._core.storage.daemon_cursor import DaemonCursorStorage
     from dagster._core.storage.event_log import EventLogStorage
     from dagster._core.storage.event_log.base import (
+        AssetCheckSummaryRecord,
         AssetRecord,
         EventLogConnection,
         EventLogRecord,
@@ -2111,6 +2112,24 @@ class DagsterInstance(DynamicPartitionsStore):
             EventRecordsResult: Object containing a list of event log records and a cursor string
         """
         return self._event_storage.fetch_observations(records_filter, limit, cursor, ascending)
+
+    @experimental
+    @public
+    @traced
+    def get_asset_check_summary_records(
+        self, asset_check_keys: Sequence["AssetCheckKey"]
+    ) -> Mapping["AssetCheckKey", "AssetCheckSummaryRecord"]:
+        """For a given set of asset check keys, return an :py:class:`AssetCheckSummaryRecord` for
+        each.
+
+        Args:
+            asset_check_keys (Sequence[AssetCheckKey]): The asset check keys to retrieve records for.
+
+        Returns:
+            Mapping[AssetCheckKey, AssetCheckSummaryRecord]: A mapping of asset check keys to
+                :py:class:`AssetCheckSummaryRecord` objects.
+        """
+        return self._event_storage.get_asset_check_summary_records(asset_check_keys)
 
     @public
     @traced

--- a/python_modules/dagster/dagster/_core/storage/asset_check_summary_record.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_check_summary_record.py
@@ -1,0 +1,18 @@
+from typing import NamedTuple, Optional
+
+from dagster._annotations import experimental
+from dagster._core.definitions.asset_check_spec import AssetCheckKey
+from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecord
+
+
+@experimental
+class AssetCheckSummaryRecord(NamedTuple):
+    """A representation of the current state of an asset check. Contains the most recent execution record,
+    and the most recent run id that the check was executed in.
+
+    Users should not instantiate this class directly.
+    """
+
+    asset_check_key: AssetCheckKey
+    last_check_execution_record: Optional[AssetCheckExecutionRecord]
+    last_run_id: Optional[str]

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -42,6 +42,7 @@ from dagster._utils.warnings import deprecation_warning
 
 if TYPE_CHECKING:
     from dagster._core.events.log import EventLogEntry
+    from dagster._core.storage.asset_check_summary_record import AssetCheckSummaryRecord
     from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
 
@@ -132,12 +133,6 @@ class AssetRecord(NamedTuple):
 
     storage_id: int
     asset_entry: AssetEntry
-
-
-class AssetCheckSummaryRecord(NamedTuple):
-    asset_check_key: AssetCheckKey
-    last_check_execution_record: Optional[AssetCheckExecutionRecord]
-    last_run_id: Optional[str]
 
 
 class PlannedMaterializationInfo(NamedTuple):
@@ -327,7 +322,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     @abstractmethod
     def get_asset_check_summary_records(
         self, asset_check_keys: Sequence[AssetCheckKey]
-    ) -> Mapping[AssetCheckKey, AssetCheckSummaryRecord]:
+    ) -> Mapping[AssetCheckKey, "AssetCheckSummaryRecord"]:
         pass
 
     @property


### PR DESCRIPTION
Publicize AssetCheckSummaryRecord and kin. This API is quite useful for creating sensors that might make use of an asset check's result. See: https://github.com/dagster-io/dagster/discussions/22176
