### PR TITLE
RunRequest can request backfills

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -156,7 +156,7 @@ class RunRequest(IHaveNew, LegacyNamedTupleMixin):
             stale_assets_only=stale_assets_only,
             partition_key=partition_key,
             asset_check_keys=asset_check_keys,
-            asset_graph_subset=asset_graph_subset,
+            asset_graph_subset=None,
         )
 
     @classmethod

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -134,7 +134,7 @@ class RunRequest(IHaveNew, LegacyNamedTupleMixin):
             return super().__new__(
                 cls,
                 run_key=None,
-                run_config=None,
+                run_config={},
                 tags=normalize_tags(tags).tags,
                 job_name=None,
                 asset_selection=None,
@@ -170,6 +170,10 @@ class RunRequest(IHaveNew, LegacyNamedTupleMixin):
         Note: This constructor is intentionally left private since AssetGraphSubset is not part of the
         public API. Other constructor methods will be public.
         """
+        from dagster._core.definitions.asset_graph_subset import (
+            AssetGraphSubset,  # noqa: F401 need to import this here to avoid a ForwardRef exception
+        )
+
         return RunRequest(tags=tags, asset_graph_subset=asset_graph_subset)
 
     def with_replaced_attrs(self, **kwargs: Any) -> "RunRequest":

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -80,6 +80,7 @@ class RunRequest(IHaveNew, LegacyNamedTupleMixin):
     stale_assets_only: bool
     partition_key: Optional[str]
     asset_check_keys: Optional[Sequence[AssetCheckKey]]
+    asset_graph_subset: Optional["AssetGraphSubset"]
     """Represents all the information required to launch a single run.  Must be returned by a
     SensorDefinition or ScheduleDefinition's evaluation function for a run to be launched.
 
@@ -124,10 +125,26 @@ class RunRequest(IHaveNew, LegacyNamedTupleMixin):
         stale_assets_only: bool = False,
         partition_key: Optional[str] = None,
         asset_check_keys: Optional[Sequence[AssetCheckKey]] = None,
-        asset_graph_subset: Optional["AssetGraphSubset"] = None,
+        **kwargs,
     ):
         from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
         from dagster._core.definitions.run_config import convert_config_input
+
+        if kwargs.get("asset_graph_subset") is not None:
+            return super().__new__(
+                cls,
+                run_key=None,
+                run_config=None,
+                tags=normalize_tags(tags).tags,
+                job_name=None,
+                asset_selection=None,
+                stale_assets_only=False,
+                partition_key=None,
+                asset_check_keys=None,
+                asset_graph_subset=check.inst_param(
+                    kwargs["asset_graph_subset"], "asset_graph_subset", AssetGraphSubset
+                ),
+            )
 
         return super().__new__(
             cls,

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -130,6 +130,8 @@ class RunRequest(IHaveNew, LegacyNamedTupleMixin):
         from dagster._core.definitions.run_config import convert_config_input
 
         if kwargs.get("asset_graph_subset") is not None:
+            # asset_graph_subset is only passed if you use the RunRequest.for_asset_graph_subset helper
+            # constructor, so we assume that no other parameters were passed.
             return super().__new__(
                 cls,
                 run_key=None,

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -896,7 +896,7 @@ class SensorDefinition(IHasInternalInit):
                     self._asset_selection,
                     dynamic_partitions_requests,
                 ),
-                *self.resolve_backfill_requests(
+                *self.validate_backfill_requests(
                     run_requests_for_backfill_daemon,
                     context,
                 ),
@@ -987,7 +987,7 @@ class SensorDefinition(IHasInternalInit):
 
         return resolved_run_requests
 
-    def resolve_backfill_requests(
+    def validate_backfill_requests(
         self,
         run_requests: Sequence[RunRequest],
         context: SensorEvaluationContext,
@@ -997,7 +997,14 @@ class SensorDefinition(IHasInternalInit):
                 self._asset_selection,
                 "Can only yield RunRequests with asset_graph_subset for sensors with an asset_selection",
             )
-            asset_keys = run_request.asset_graph_subset.asset_keys
+
+            if run_request.asset_graph_subset:
+                asset_keys = run_request.asset_graph_subset.asset_keys
+            else:
+                check.invariant(
+                    False,
+                    "RunRequest must have an asset_graph_subset to launch a backfill.",
+                )
 
             unexpected_asset_keys = (AssetSelection.keys(*asset_keys) - asset_selection).resolve(
                 check.not_none(context.repository_def).asset_graph

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -523,6 +523,23 @@ def _check_dynamic_partitions_requests(
             check.failed(f"Unexpected dynamic partition request type: {req}")
 
 
+def split_run_requests(
+    run_requests: Sequence[RunRequest],
+) -> Tuple[Sequence[RunRequest], Sequence[RunRequest]]:
+    """Splits RunRequests into those that must be handled by the backfill daemon and those
+    that can be handled by launching a single run.
+    """
+    run_requests_for_backfill_daemon = []
+    run_requests_for_single_runs = []
+    for run_request in run_requests:
+        if run_request.requires_backfill_daemon():
+            run_requests_for_backfill_daemon.append(run_request)
+        else:
+            run_requests_for_single_runs.append(run_request)
+
+    return run_requests_for_backfill_daemon, run_requests_for_single_runs
+
+
 class SensorDefinition(IHasInternalInit):
     """Define a sensor that initiates a set of runs based on some external state.
 
@@ -864,13 +881,26 @@ class SensorDefinition(IHasInternalInit):
                     check.failed("Expected a single SkipReason: received multiple SkipReasons")
 
         _check_dynamic_partitions_requests(dynamic_partitions_requests)
+
+        run_requests_for_backfill_daemon, run_requests_for_single_runs = split_run_requests(
+            run_requests
+        )
         resolved_run_requests = [
             run_request.with_replaced_attrs(
                 tags=merge_dicts(run_request.tags, DagsterRun.tags_for_sensor(self)),
             )
-            for run_request in self.resolve_run_requests(
-                run_requests, context, self._asset_selection, dynamic_partitions_requests
-            )
+            for run_request in [
+                *self.resolve_run_requests(
+                    run_requests_for_single_runs,
+                    context,
+                    self._asset_selection,
+                    dynamic_partitions_requests,
+                ),
+                *self.resolve_backfill_requests(
+                    run_requests_for_backfill_daemon,
+                    context,
+                ),
+            ]
         ]
 
         return SensorExecutionData(
@@ -956,6 +986,28 @@ class SensorDefinition(IHasInternalInit):
                 resolved_run_requests.append(run_request)
 
         return resolved_run_requests
+
+    def resolve_backfill_requests(
+        self,
+        run_requests: Sequence[RunRequest],
+        context: SensorEvaluationContext,
+    ) -> Sequence[RunRequest]:
+        for run_request in run_requests:
+            asset_selection = check.not_none(
+                self._asset_selection,
+                "Can only yield RunRequests with asset_graph_subset for sensors with an asset_selection",
+            )
+            asset_keys = run_request.asset_graph_subset.asset_keys
+
+            unexpected_asset_keys = (AssetSelection.keys(*asset_keys) - asset_selection).resolve(
+                check.not_none(context.repository_def).asset_graph
+            )
+            if unexpected_asset_keys:
+                raise DagsterInvalidSubsetError(
+                    "RunRequest includes asset keys that are not part of sensor's asset_selection:"
+                    f" {unexpected_asset_keys}"
+                )
+        return run_requests
 
     @property
     def _target(self) -> Optional[AutomationTarget]:

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -55,6 +55,7 @@ from dagster._core.errors import DagsterUserCodeUnreachableError
 from dagster._core.events import DagsterEvent
 from dagster._core.instance import DagsterInstance
 from dagster._core.launcher import RunLauncher
+from dagster._core.remote_representation import ExternalRepository
 from dagster._core.remote_representation.origin import InProcessCodeLocationOrigin
 from dagster._core.run_coordinator import RunCoordinator, SubmitRunContext
 from dagster._core.secrets import SecretsLoader
@@ -528,6 +529,16 @@ def create_test_daemon_workspace_context(
             grpc_server_registry=grpc_server_registry,
         ) as workspace_process_context:
             yield workspace_process_context
+
+
+def load_external_repo(
+    workspace_context: WorkspaceProcessContext, repo_name: str
+) -> ExternalRepository:
+    code_location_entry = next(
+        iter(workspace_context.create_request_context().get_workspace_snapshot().values())
+    )
+    assert code_location_entry.code_location, code_location_entry.load_error
+    return code_location_entry.code_location.get_repository(repo_name)
 
 
 def remove_none_recursively(obj: T) -> T:

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -885,9 +885,6 @@ def _handle_backfill_requests(
     context: SensorLaunchContext,
 ) -> None:
     for run_request in run_requests:
-        # TODO handling of duplicate run_keys so the same backfill isn't submitted twice
-        # issue with this is that we determine run_key duplicates based on tags
-        # and we dont have an efficient way to query backfills by tags
         backfill_id = make_new_backfill_id()
         instance.add_backfill(
             PartitionBackfill.from_asset_graph_subset(

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -29,9 +29,10 @@ from dagster._core.definitions.dynamic_partitions_request import (
 )
 from dagster._core.definitions.run_request import DagsterRunReaction, InstigatorType, RunRequest
 from dagster._core.definitions.selector import JobSubsetSelector
-from dagster._core.definitions.sensor_definition import DefaultSensorStatus
+from dagster._core.definitions.sensor_definition import DefaultSensorStatus, split_run_requests
 from dagster._core.definitions.utils import normalize_tags
 from dagster._core.errors import DagsterError
+from dagster._core.execution.backfill import PartitionBackfill
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.code_location import CodeLocation
 from dagster._core.remote_representation.external import ExternalJob, ExternalSensor
@@ -48,6 +49,7 @@ from dagster._core.scheduler.instigation import (
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import RUN_KEY_TAG, SENSOR_NAME_TAG
 from dagster._core.telemetry import SENSOR_RUN_CREATED, hash_name, log_action
+from dagster._core.utils import make_new_backfill_id
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._daemon.utils import DaemonErrorCapture
 from dagster._scheduler.stale import resolve_stale_or_missing_assets
@@ -660,16 +662,28 @@ def _evaluate_sensor(
 
         yield
     else:
-        yield from _handle_run_requests(
-            run_requests=sensor_runtime_data.run_requests,
-            cursor=sensor_runtime_data.cursor,
-            context=context,
-            instance=instance,
-            external_sensor=external_sensor,
-            workspace_process_context=workspace_process_context,
-            submit_threadpool_executor=submit_threadpool_executor,
-            sensor_debug_crash_flags=sensor_debug_crash_flags,
+        run_requests_for_backfill_daemon, run_requests_for_single_runs = split_run_requests(
+            sensor_runtime_data.run_requests
         )
+
+        if run_requests_for_single_runs:
+            yield from _handle_run_requests(
+                run_requests=run_requests_for_single_runs,
+                context=context,
+                instance=instance,
+                external_sensor=external_sensor,
+                workspace_process_context=workspace_process_context,
+                submit_threadpool_executor=submit_threadpool_executor,
+                sensor_debug_crash_flags=sensor_debug_crash_flags,
+            )
+        if run_requests_for_backfill_daemon:
+            _handle_backfill_requests(
+                run_requests=run_requests_for_backfill_daemon, instance=instance, context=context
+            )
+        if context.run_count:
+            context.update_state(TickStatus.SUCCESS, cursor=sensor_runtime_data.cursor)
+        else:
+            context.update_state(TickStatus.SKIPPED, cursor=sensor_runtime_data.cursor)
 
 
 def _handle_dynamic_partitions_requests(
@@ -794,7 +808,6 @@ def _handle_run_requests(
     instance: DagsterInstance,
     context: SensorLaunchContext,
     external_sensor: ExternalSensor,
-    cursor: Optional[str],
     workspace_process_context: IWorkspaceProcessContext,
     submit_threadpool_executor: Optional[ThreadPoolExecutor],
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags] = None,
@@ -863,13 +876,32 @@ def _handle_run_requests(
             f"Skipping {skipped_count} {'run' if skipped_count == 1 else 'runs'} for sensor "
             f"{external_sensor.name} already completed with run keys: {seven.json.dumps(run_keys)}"
         )
-
-    if context.run_count:
-        context.update_state(TickStatus.SUCCESS, cursor=cursor)
-    else:
-        context.update_state(TickStatus.SKIPPED, cursor=cursor)
-
     yield
+
+
+def _handle_backfill_requests(
+    run_requests: Sequence[RunRequest],
+    instance: DagsterInstance,
+    context: SensorLaunchContext,
+) -> None:
+    for run_request in run_requests:
+        # TODO handling of duplicate run_keys so the same backfill isn't submitted twice
+        # issue with this is that we determine run_key duplicates based on tags
+        # and we dont have an efficient way to query backfills by tags
+        backfill_id = make_new_backfill_id()
+        instance.add_backfill(
+            PartitionBackfill.from_asset_graph_subset(
+                backfill_id=backfill_id,
+                dynamic_partitions_store=instance,
+                backfill_timestamp=get_current_timestamp(),
+                asset_graph_subset=run_request.asset_graph_subset,
+                tags=run_request.tags or {},
+                # would need to add these as params to RunRequest
+                title=None,
+                description=None,
+            )
+        )
+        context.add_run_info(run_id=backfill_id, run_key=run_request.run_key)
 
 
 def is_under_min_interval(state: InstigatorState, external_sensor: ExternalSensor) -> bool:

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -23,6 +23,7 @@ from typing_extensions import Self
 
 import dagster._check as check
 import dagster._seven as seven
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.dynamic_partitions_request import (
     AddDynamicPartitionsRequest,
     DeleteDynamicPartitionsRequest,
@@ -891,7 +892,7 @@ def _handle_backfill_requests(
                 backfill_id=backfill_id,
                 dynamic_partitions_store=instance,
                 backfill_timestamp=get_current_timestamp(),
-                asset_graph_subset=run_request.asset_graph_subset,
+                asset_graph_subset=check.inst(run_request.asset_graph_subset, AssetGraphSubset),
                 tags=run_request.tags or {},
                 # would need to add these as params to RunRequest
                 title=None,

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
@@ -9,6 +9,7 @@ from dagster._core.test_utils import (
     SingleThreadPoolExecutor,
     create_test_daemon_workspace_context,
     instance_for_test,
+    load_external_repo,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceProcessContext
@@ -70,11 +71,7 @@ def workspace_fixture(instance_module_scoped: DagsterInstance) -> Iterator[Works
 
 @pytest.fixture(name="external_repo", scope="module")
 def external_repo_fixture(workspace_context: WorkspaceProcessContext) -> ExternalRepository:
-    code_location = next(
-        iter(workspace_context.create_request_context().get_workspace_snapshot().values())
-    ).code_location
-    assert code_location
-    return code_location.get_repository("the_repo")
+    return load_external_repo(workspace_context, "the_repo")
 
 
 def loadable_target_origin() -> LoadableTargetOrigin:

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_daemon.py
@@ -1,0 +1,330 @@
+import os
+
+import pytest
+from dagster import (
+    DagsterInstance,
+    Definitions,
+    DynamicPartitionsDefinition,
+    SensorResult,
+    StaticPartitionsDefinition,
+    asset,
+    load_assets_from_current_module,
+    sensor,
+)
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.run_request import InstigatorType, RunRequest
+from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus, TickStatus
+from dagster._core.test_utils import create_test_daemon_workspace_context, load_external_repo
+from dagster._core.workspace.load_target import ModuleTarget
+
+from .test_sensor_run import evaluate_sensors, validate_tick
+
+dynamic_partitions_def = DynamicPartitionsDefinition(name="abc")
+
+
+@asset(partitions_def=dynamic_partitions_def)
+def asset1() -> None: ...
+
+
+@asset(deps=[asset1])
+def unpartitioned_child(): ...
+
+
+def make_run_request_uses_backfill_daemon(context) -> RunRequest:
+    ags = AssetGraphSubset.from_asset_partition_set(
+        asset_partitions_set={
+            AssetKeyPartitionKey(asset1.key, "foo"),
+            AssetKeyPartitionKey(asset1.key, "bar"),
+            AssetKeyPartitionKey(unpartitioned_child.key, None),
+        },
+        asset_graph=context.repository_def.asset_graph,
+    )
+    return RunRequest.for_asset_graph_subset(
+        asset_graph_subset=ags,
+        tags={"tagkey": "tagvalue"},
+    )
+
+
+@sensor(asset_selection=[asset1, unpartitioned_child])
+def sensor_result_backfill_request_sensor(context):
+    return SensorResult(
+        dynamic_partitions_requests=[dynamic_partitions_def.build_add_request(["foo", "bar"])],
+        run_requests=[make_run_request_uses_backfill_daemon(context)],
+    )
+
+
+@sensor(asset_selection=[asset1, unpartitioned_child])
+def return_backfill_request_sensor(context):
+    context.instance.add_dynamic_partitions(dynamic_partitions_def.name, ["foo", "bar"])
+    return make_run_request_uses_backfill_daemon(context)
+
+
+@sensor(asset_selection=[asset1, unpartitioned_child])
+def yield_backfill_request_sensor(context):
+    context.instance.add_dynamic_partitions(dynamic_partitions_def.name, ["foo", "bar"])
+    yield make_run_request_uses_backfill_daemon(context)
+
+
+@asset(partitions_def=StaticPartitionsDefinition(["a", "b", "c"]))
+def static_partitioned_asset(): ...
+
+
+@sensor(asset_selection=[asset1, unpartitioned_child])
+def asset_outside_of_selection_backfill_request_sensor(context):
+    ags = AssetGraphSubset.from_asset_partition_set(
+        asset_partitions_set={
+            AssetKeyPartitionKey(static_partitioned_asset.key, "a"),
+            AssetKeyPartitionKey(static_partitioned_asset.key, "b"),
+        },
+        asset_graph=context.repository_def.asset_graph,
+    )
+    return RunRequest.for_asset_graph_subset(
+        asset_graph_subset=ags,
+        tags={"tagkey": "tagvalue"},
+    )
+
+
+@sensor(asset_selection=[static_partitioned_asset])
+def invalid_partition_backfill_request_sensor(context):
+    ags = AssetGraphSubset.from_asset_partition_set(
+        asset_partitions_set={
+            AssetKeyPartitionKey(static_partitioned_asset.key, "b"),
+            AssetKeyPartitionKey(static_partitioned_asset.key, "z"),
+        },
+        asset_graph=context.repository_def.asset_graph,
+    )
+    return RunRequest.for_asset_graph_subset(
+        asset_graph_subset=ags,
+        tags={"tagkey": "tagvalue"},
+    )
+
+
+@sensor(asset_selection=[static_partitioned_asset])
+def single_partition_run_request_sensor(context):
+    ags = AssetGraphSubset.from_asset_partition_set(
+        asset_partitions_set={AssetKeyPartitionKey(static_partitioned_asset.key, "b")},
+        asset_graph=context.repository_def.asset_graph,
+    )
+    return RunRequest.for_asset_graph_subset(
+        asset_graph_subset=ags,
+        tags={"tagkey": "tagvalue"},
+    )
+
+
+@sensor(asset_selection=[static_partitioned_asset])
+def backfill_and_run_request_sensor(context):
+    ags = AssetGraphSubset.from_asset_partition_set(
+        asset_partitions_set={
+            AssetKeyPartitionKey(static_partitioned_asset.key, "a"),
+            AssetKeyPartitionKey(static_partitioned_asset.key, "b"),
+        },
+        asset_graph=context.repository_def.asset_graph,
+    )
+    yield RunRequest.for_asset_graph_subset(asset_graph_subset=ags, tags={"tagkey": "tagvalue"})
+
+    yield RunRequest(asset_selection=[static_partitioned_asset.key], partition_key="c")
+
+
+defs = Definitions(
+    assets=load_assets_from_current_module(),
+    sensors=[
+        sensor_result_backfill_request_sensor,
+        return_backfill_request_sensor,
+        yield_backfill_request_sensor,
+        asset_outside_of_selection_backfill_request_sensor,
+        invalid_partition_backfill_request_sensor,
+        single_partition_run_request_sensor,
+        backfill_and_run_request_sensor,
+    ],
+)
+
+module_target = ModuleTarget(
+    module_name="dagster_tests.daemon_sensor_tests.test_sensor_run_backfill_daemon",
+    attribute=None,
+    working_directory=os.path.join(os.path.dirname(__file__), "..", ".."),
+    location_name="test_location",
+)
+
+
+@pytest.mark.parametrize(
+    "sensor_name",
+    [
+        "sensor_result_backfill_request_sensor",
+        "return_backfill_request_sensor",
+        "yield_backfill_request_sensor",
+    ],
+)
+def test_backfill_request_sensor(instance: DagsterInstance, executor, sensor_name: str):
+    with create_test_daemon_workspace_context(
+        workspace_load_target=module_target, instance=instance
+    ) as workspace_context:
+        external_repo = load_external_repo(workspace_context, "__repository__")
+        external_sensor = external_repo.get_external_sensor(sensor_name)
+
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 1
+
+        backfills = instance.get_backfills()
+        assert len(backfills) == 1
+        backfill = backfills[0]
+        assert backfill.tags.get("tagkey") == "tagvalue"
+        assert backfill.is_asset_backfill
+        asset_backfill_data = backfill.asset_backfill_data
+        assert asset_backfill_data
+        assert set(asset_backfill_data.target_subset.iterate_asset_partitions()) == {
+            AssetKeyPartitionKey(asset1.key, "foo"),
+            AssetKeyPartitionKey(asset1.key, "bar"),
+            AssetKeyPartitionKey(unpartitioned_child.key, None),
+        }
+
+        validate_tick(
+            ticks[0],
+            external_sensor,
+            None,
+            TickStatus.SUCCESS,
+            expected_run_ids=[backfill.backfill_id],
+        )
+
+
+def test_asset_selection_outside_of_range(instance, executor):
+    with create_test_daemon_workspace_context(
+        workspace_load_target=module_target, instance=instance
+    ) as workspace_context:
+        external_repo = load_external_repo(workspace_context, "__repository__")
+        external_sensor = external_repo.get_external_sensor(
+            asset_outside_of_selection_backfill_request_sensor.name
+        )
+
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+
+        validate_tick(
+            ticks[0],
+            external_sensor=external_sensor,
+            expected_status=TickStatus.FAILURE,
+            expected_datetime=None,
+            expected_error="RunRequest includes asset keys that are not part of sensor's "
+            "asset_selection: {AssetKey(['static_partitioned_asset'])}",
+        )
+
+
+def test_invalid_partition(instance, executor):
+    with create_test_daemon_workspace_context(
+        workspace_load_target=module_target, instance=instance
+    ) as workspace_context:
+        external_repo = load_external_repo(workspace_context, "__repository__")
+        external_sensor = external_repo.get_external_sensor(
+            invalid_partition_backfill_request_sensor.name
+        )
+
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+
+        # allow creating a backfill with an invalid partition. it will get caught in the daemon
+        # and show up as an error there.
+        validate_tick(ticks[0], external_sensor, None, TickStatus.SUCCESS)
+
+
+def test_single_partition(instance, executor):
+    """Tests requesting a single partition using asset_graph_subset, which will be executed as a backfill.
+    However, when we add additional introspection on the asset_graph_subset to determine how each request
+    should be executed, this test should launch a single run instead.
+    """
+    with create_test_daemon_workspace_context(
+        workspace_load_target=module_target, instance=instance
+    ) as workspace_context:
+        external_repo = load_external_repo(workspace_context, "__repository__")
+        external_sensor = external_repo.get_external_sensor(
+            single_partition_run_request_sensor.name
+        )
+
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+
+        backfills = instance.get_backfills()
+        assert len(backfills) == 1
+        backfill = backfills[0]
+
+        validate_tick(
+            ticks[0],
+            external_sensor,
+            None,
+            TickStatus.SUCCESS,
+            expected_run_ids=[backfill.backfill_id],
+        )
+
+
+def test_backfill_and_run_request(instance, executor):
+    with create_test_daemon_workspace_context(
+        workspace_load_target=module_target, instance=instance
+    ) as workspace_context:
+        external_repo = load_external_repo(workspace_context, "__repository__")
+        external_sensor = external_repo.get_external_sensor(backfill_and_run_request_sensor.name)
+
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+
+        backfills = instance.get_backfills()
+        assert len(backfills) == 1
+        backfill = backfills[0]
+
+        runs = instance.get_runs()
+        assert len(runs) == 1
+        run = runs[0]
+
+        validate_tick(
+            ticks[0],
+            external_sensor,
+            None,
+            TickStatus.SUCCESS,
+            expected_run_ids=[backfill.backfill_id, run.run_id],
+        )


### PR DESCRIPTION
## Summary & Motivation
Modifies `RunRequest` to accept an `AssetGraphSubset`. If a `RunRequest` contains an `AssetGraphSubset`, the sensor daemon will launch a backfill for the `AssetGraphSubset` 

based on https://github.com/dagster-io/dagster/pull/18895

other iterations of this PR that got closed 
https://github.com/dagster-io/dagster/pull/22827
https://github.com/dagster-io/dagster/pull/22488

## How I Tested These Changes
new tests