### PR TITLE
[PipelineRootExplorer] load by snapshotId when available from WorkspaceContext

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineExplorerRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineExplorerRoot.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {useState} from 'react';
+import {useMemo, useState} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
 import {explodeCompositesInHandleGraph} from './CompositeSupport';
@@ -25,7 +25,7 @@ import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntryFragment';
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {Loading} from '../ui/Loading';
-import {buildPipelineSelector} from '../workspace/WorkspaceContext';
+import {buildPipelineSelector, useJob} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
 
 export const PipelineExplorerSnapshotRoot = () => {
@@ -80,12 +80,24 @@ export const PipelineExplorerContainer = ({
   const parentNames = explorerPath.opNames.slice(0, explorerPath.opNames.length - 1);
   const pipelineSelector = buildPipelineSelector(repoAddress || null, explorerPath.pipelineName);
 
+  const snapIdFromContext = useJob(repoAddress || null, explorerPath.pipelineName)
+    ?.pipelineSnapshotId;
+  const snapshotId = useMemo(() => {
+    return snapIdFromContext
+      ? snapIdFromContext
+      : explorerPath.snapshotId
+      ? explorerPath.snapshotId
+      : undefined;
+    // only add snapshot id from workspace if its loaded when we first render
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [explorerPath]);
+
   const pipelineResult = useQuery<PipelineExplorerRootQuery, PipelineExplorerRootQueryVariables>(
     PIPELINE_EXPLORER_ROOT_QUERY,
     {
       variables: {
-        snapshotPipelineSelector: explorerPath.snapshotId ? undefined : pipelineSelector,
-        snapshotId: explorerPath.snapshotId ? explorerPath.snapshotId : undefined,
+        snapshotPipelineSelector: snapshotId ? undefined : pipelineSelector,
+        snapshotId,
         rootHandleID: parentNames.join('.'),
         requestScopeHandleID: options.explodeComposites ? undefined : parentNames.join('.'),
       },

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
@@ -447,6 +447,11 @@ export const useRepository = (repoAddress: RepoAddress | null) => {
   return findRepositoryAmongOptions(options, repoAddress) || null;
 };
 
+export const useJob = (repoAddress: RepoAddress | null, jobName: string | null) => {
+  const repo = useRepository(repoAddress);
+  return repo?.repository.pipelines.find((pipelineOrJob) => pipelineOrJob.name === jobName) || null;
+};
+
 export const findRepositoryAmongOptions = (
   options: DagsterRepoOption[],
   repoAddress: RepoAddress | null,


### PR DESCRIPTION
loading by snapshot id is faster in environments where the workspace is loaded from scratch to find the job by selector 

## How I Tested These Changes

fresh page load on a job -> uses selector
in app navigation once `WorkspaceContext` is ready -> uses snapshot id and loads faster
