### PR TITLE
Revert "[PipelineRootExplorer] load by snapshotId when available from WorkspaceContext (#22686)"

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineExplorerRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineExplorerRoot.tsx
@@ -32,7 +32,8 @@ export const PipelineExplorerSnapshotRoot = () => {
   useTrackPageView();
 
   const params = useParams();
-  const explorerPath = explorerPathFromString((params as any)['0']);
+  const pathStr = (params as any)['0'];
+  const explorerPath = useMemo(() => explorerPathFromString(pathStr), [pathStr]);
   const {pipelineName, snapshotId} = explorerPath;
   const history = useHistory();
 
@@ -88,9 +89,10 @@ export const PipelineExplorerContainer = ({
       : explorerPath.snapshotId
       ? explorerPath.snapshotId
       : undefined;
+
     // only add snapshot id from workspace if its loaded when we first render
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [explorerPath]);
+  }, [explorerPath.snapshotId]);
 
   const pipelineResult = useQuery<PipelineExplorerRootQuery, PipelineExplorerRootQueryVariables>(
     PIPELINE_EXPLORER_ROOT_QUERY,

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineExplorerRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineExplorerRoot.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {useMemo, useState} from 'react';
+import {useState} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
 import {explodeCompositesInHandleGraph} from './CompositeSupport';
@@ -25,15 +25,14 @@ import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntryFragment';
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {Loading} from '../ui/Loading';
-import {buildPipelineSelector, useJob} from '../workspace/WorkspaceContext';
+import {buildPipelineSelector} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
 
 export const PipelineExplorerSnapshotRoot = () => {
   useTrackPageView();
 
   const params = useParams();
-  const pathStr = (params as any)['0'];
-  const explorerPath = useMemo(() => explorerPathFromString(pathStr), [pathStr]);
+  const explorerPath = explorerPathFromString((params as any)['0']);
   const {pipelineName, snapshotId} = explorerPath;
   const history = useHistory();
 
@@ -81,25 +80,12 @@ export const PipelineExplorerContainer = ({
   const parentNames = explorerPath.opNames.slice(0, explorerPath.opNames.length - 1);
   const pipelineSelector = buildPipelineSelector(repoAddress || null, explorerPath.pipelineName);
 
-  const snapIdFromContext = useJob(repoAddress || null, explorerPath.pipelineName)
-    ?.pipelineSnapshotId;
-  const snapshotId = useMemo(() => {
-    return snapIdFromContext
-      ? snapIdFromContext
-      : explorerPath.snapshotId
-      ? explorerPath.snapshotId
-      : undefined;
-
-    // only add snapshot id from workspace if its loaded when we first render
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [explorerPath.snapshotId]);
-
   const pipelineResult = useQuery<PipelineExplorerRootQuery, PipelineExplorerRootQueryVariables>(
     PIPELINE_EXPLORER_ROOT_QUERY,
     {
       variables: {
-        snapshotPipelineSelector: snapshotId ? undefined : pipelineSelector,
-        snapshotId,
+        snapshotPipelineSelector: explorerPath.snapshotId ? undefined : pipelineSelector,
+        snapshotId: explorerPath.snapshotId ? explorerPath.snapshotId : undefined,
         rootHandleID: parentNames.join('.'),
         requestScopeHandleID: options.explodeComposites ? undefined : parentNames.join('.'),
       },

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineOverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineOverviewRoot.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useMemo} from 'react';
 import {useHistory, useLocation, useParams} from 'react-router-dom';
 
 import {PipelineExplorerContainer} from './PipelineExplorerRoot';
@@ -28,8 +28,8 @@ export const PipelineOverviewRoot = (props: Props) => {
   const history = useHistory();
   const location = useLocation();
   const params = useParams();
-
-  const explorerPath = explorerPathFromString((params as any)['0']);
+  const pathStr = (params as any)['0'];
+  const explorerPath = useMemo(() => explorerPathFromString(pathStr), [pathStr]);
 
   const repo = useRepository(repoAddress);
   const isJob = isThisThingAJob(repo, explorerPath.pipelineName);

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineOverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineOverviewRoot.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback} from 'react';
 import {useHistory, useLocation, useParams} from 'react-router-dom';
 
 import {PipelineExplorerContainer} from './PipelineExplorerRoot';
@@ -28,8 +28,8 @@ export const PipelineOverviewRoot = (props: Props) => {
   const history = useHistory();
   const location = useLocation();
   const params = useParams();
-  const pathStr = (params as any)['0'];
-  const explorerPath = useMemo(() => explorerPathFromString(pathStr), [pathStr]);
+
+  const explorerPath = explorerPathFromString((params as any)['0']);
 
   const repo = useRepository(repoAddress);
   const isJob = isThisThingAJob(repo, explorerPath.pipelineName);

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
@@ -447,11 +447,6 @@ export const useRepository = (repoAddress: RepoAddress | null) => {
   return findRepositoryAmongOptions(options, repoAddress) || null;
 };
 
-export const useJob = (repoAddress: RepoAddress | null, jobName: string | null) => {
-  const repo = useRepository(repoAddress);
-  return repo?.repository.pipelines.find((pipelineOrJob) => pipelineOrJob.name === jobName) || null;
-};
-
 export const findRepositoryAmongOptions = (
   options: DagsterRepoOption[],
   repoAddress: RepoAddress | null,


### PR DESCRIPTION
missed some behavior differences in oss that cause this scheme to not work

