### PR TITLE
[ui] Provide an explicit Refresh button to update op partition status FE-411

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
@@ -1,5 +1,6 @@
 import {gql, useMutation, useQuery} from '@apollo/client';
 import {
+  Body2,
   Box,
   Button,
   Checkbox,
@@ -60,12 +61,14 @@ export const BackfillPartitionSelector = ({
   onSubmit,
   repoAddress,
   runStatusData,
+  refreshing,
   pipelineName,
   partitionNames,
 }: {
   partitionSetName: string;
   partitionNames: string[];
   runStatusData: {[partitionName: string]: RunStatus};
+  refreshing: boolean;
   pipelineName: string;
   onLaunch?: (backfillId: string, stepQuery: string) => void;
   onCancel?: () => void;
@@ -177,7 +180,19 @@ export const BackfillPartitionSelector = ({
     <>
       <DialogBody>
         <Box flex={{direction: 'column', gap: 24}}>
-          <Section title="Partitions">
+          <Section
+            title={
+              <Box flex={{justifyContent: 'space-between'}}>
+                <div>Partitions</div>
+                {refreshing && (
+                  <Box flex={{gap: 4, alignItems: 'center'}}>
+                    <Spinner purpose="body-text" />
+                    <Body2 color={Colors.textLight()}>Refreshing...</Body2>
+                  </Box>
+                )}
+              </Box>
+            }
+          >
             <Box>
               Select partitions to materialize. Click and drag to select a range on the timeline.
             </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionGraph.tsx
@@ -236,7 +236,7 @@ export const PartitionGraph = React.memo(
                   setShowLargeGraphMessage(false);
                 }}
               >
-                Show anyways
+                Show anyway
               </Button>
             </div>
           </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/__tests__/OpJobPartitionsViewContent.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/__tests__/OpJobPartitionsViewContent.test.tsx
@@ -19,11 +19,17 @@ jest.mock('../../graph/asyncGraphLayout', () => ({}));
 describe('OpJobPartitionsViewContent', () => {
   it('does not error when partition statuses are in an error state', async () => {
     const fragment = buildOpJobPartitionSetFragmentWithError();
+    const mockResult: any = {
+      refresh: () => {},
+      loading: false,
+    };
+
     render(
       <MockedProvider>
         <OpJobPartitionsViewContent
           partitionNames={['lorem', 'ipsum']}
           partitionSet={fragment}
+          partitionsQueryResult={mockResult}
           repoAddress={buildRepoAddress('foo', 'bar')}
         />
       </MockedProvider>,


### PR DESCRIPTION
## Summary & Motivation

A user reported internal inconsistencies on the op job partitions page here: https://linear.app/dagster-labs/issue/FE-411/reporting-an-issue-with-the-backfill-launcher-ui-not-consistently

There are a few things going on:

- This page never updates the overall partition status bar after page load
- This page DOES update the run+step statuses, but only in the selected range
- This page DOES update the backfill status shown at the very bottom of the page in the table

This means that if a backfill is running, it's easy to get this page into a state where it's reporting different information in different places, especially the top bar. This is bad because it doesn't even refresh when you click "Launch backfill", and causes the UI elements in the modal (eg: failed checkbox) to behave incorrectly.

My guess is that we originally periodically refreshed the overall partition status bar and took it out for performance reasons.  We just invested more into perf + caching in #22629 due to backend load, so I think the best solution for now is a tried-and-true explicit refresh button, and triggering a refresh when you open the launchpad.

![image](https://github.com/dagster-io/dagster/assets/1037212/480bc6f7-9cc1-4cf7-bba6-efdf66fcbac6)


## How I Tested These Changes

Tested this by launching a long-running backfill and playing with the page extensively while it was running.