### PR TITLE
[useThrottledMemo] Don't Access factory via ref.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useThrottledMemo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useThrottledMemo.tsx
@@ -1,8 +1,6 @@
 import {createContext, useContext, useEffect, useRef, useState} from 'react';
 import {unstable_batchedUpdates} from 'react-dom';
 
-import {useUpdatingRef} from './useUpdatingRef';
-
 /**
  * Context to accumulate updates over 200ms and batch them together to reduce the number of renders
  * Using a context instead of global state to make it easier to reset state across tests.
@@ -36,7 +34,6 @@ export const useThrottledMemo = <T,>(
   delay: number,
 ): T => {
   const [state, setState] = useState<T>(factory);
-  const factoryRef = useUpdatingRef(factory);
   const lastRun = useRef<number>(Date.now());
   const timeoutId = useRef<NodeJS.Timeout | null>(null);
   const {enqueue} = useContext(ThrottledMemoBatchingContext);
@@ -46,7 +43,7 @@ export const useThrottledMemo = <T,>(
     const now = Date.now();
     if (now - lastRun.current >= delay) {
       enqueue(() => {
-        setState(factoryRef.current);
+        setState(factory);
       });
       lastRun.current = now;
     } else {
@@ -59,7 +56,7 @@ export const useThrottledMemo = <T,>(
             if (isCancelled) {
               return;
             }
-            setState(factoryRef.current);
+            setState(factory);
           });
           lastRun.current = Date.now();
         },

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useThrottledMemo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useThrottledMemo.tsx
@@ -46,7 +46,7 @@ export const useThrottledMemo = <T,>(
     const now = Date.now();
     if (now - lastRun.current >= delay) {
       enqueue(() => {
-        setState(factory);
+        setState(factoryRef.current);
       });
       lastRun.current = now;
     } else {


### PR DESCRIPTION
## Summary & Motivation

Feedback on my last PR suggested I used a ref to access `factory` but I realize now that it's wrong because it causes different semantics from `useMemo` which uses stale closures until dependencies change. So I'm reverting that part.

ie. In this case we would want to keep the stale closure:
```
useMemo(() => {
  arg3(arg1, arg2);
  // @ts-ignore intentionally don't include arg3 in memo for xyz reason.
}, [arg1, arg2])
```

## How I Tested These Changes
jest