### PR TITLE
[ui] Update asset layout spacing to account for possible checks

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -222,7 +222,7 @@ export const AssetNodeMinimal = ({
 
   return (
     <AssetInsetForHoverEffect>
-      <MinimalAssetNodeContainer $selected={selected} style={{paddingTop: height / 2 - 50}}>
+      <MinimalAssetNodeContainer $selected={selected} style={{paddingTop: height / 2 - 52}}>
         <TooltipStyled
           content={displayName}
           canShow={displayName.length > 14}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/layout.ts
@@ -353,21 +353,22 @@ export const getAssetNodeDimensions = (def: {
 }) => {
   const width = ASSET_NODE_WIDTH;
 
-  let height = 100; // top tags area + name + description
+  let height = 106; // top tags area + name + description
 
   if (def.isSource && def.isObservable) {
     height += 30; // status row
   } else {
-    height += 26; // status row
+    height += 28; // status row
+    height += 28; // checks row
     if (def.isPartitioned) {
-      height += 40;
+      height += 52;
     }
   }
   if (def.changedReasons?.length) {
     height += 30;
   }
 
-  height += 30; // tags beneath
+  height += 36; // tags beneath
 
   return {width, height};
 };


### PR DESCRIPTION
## Summary & Motivation

Fixes FE-263 - The problem here is that we recently added a "Checks" row to the nodes on the asset graph, which appears only if the live data indicates there are checks. Because the live data / checks info isn't loaded as part of the graph definition data, we don't know whether to leave space for the row in the graph layout. 

We'll likely move checks to definition data at some point, but I worry it could have perf implications (ideally maybe we just send a boolean). For now, we're just rendering extra space as if every asset has checks.

I also updated the other constants in the layout calculation to reflect the latest styles.

Before:

![Screenshot 2024-06-25 at 12 54 50 AM](https://github.com/dagster-io/dagster/assets/1037212/cbe3b4e4-7641-442e-bec4-a8b0bc660a80)

After: 

![Screenshot 2024-06-25 at 12 54 40 AM](https://github.com/dagster-io/dagster/assets/1037212/1932a260-99f7-4bda-b418-4278817f5e4a)


Large before:
![image](https://github.com/dagster-io/dagster/assets/1037212/c078c0e4-2a73-4439-ad08-090f15f7e51f)

Large after:
![image](https://github.com/dagster-io/dagster/assets/1037212/51254b52-61d4-408b-8694-079c66fd0014)
