### PR TITLE
[PipelineRootExplorer] load by snapshotId when available from WorkspaceContext (take 2)

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineExplorerRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineExplorerRoot.tsx
@@ -1,5 +1,5 @@
 import {gql, useQuery} from '@apollo/client';
-import {useState} from 'react';
+import {useMemo, useState} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
 import {explodeCompositesInHandleGraph} from './CompositeSupport';
@@ -25,14 +25,15 @@ import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntryFragment';
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {Loading} from '../ui/Loading';
-import {buildPipelineSelector} from '../workspace/WorkspaceContext';
+import {buildPipelineSelector, useJob} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
 
 export const PipelineExplorerSnapshotRoot = () => {
   useTrackPageView();
 
   const params = useParams();
-  const explorerPath = explorerPathFromString((params as any)['0']);
+  const pathStr = (params as any)['0'];
+  const explorerPath = useMemo(() => explorerPathFromString(pathStr), [pathStr]);
   const {pipelineName, snapshotId} = explorerPath;
   const history = useHistory();
 
@@ -80,12 +81,24 @@ export const PipelineExplorerContainer = ({
   const parentNames = explorerPath.opNames.slice(0, explorerPath.opNames.length - 1);
   const pipelineSelector = buildPipelineSelector(repoAddress || null, explorerPath.pipelineName);
 
+  const snapIdFromContext = useJob(repoAddress || null, explorerPath.pipelineName)
+    ?.pipelineSnapshotId;
+  const snapshotId = useMemo(() => {
+    return snapIdFromContext
+      ? snapIdFromContext
+      : explorerPath.snapshotId
+      ? explorerPath.snapshotId
+      : undefined;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [explorerPath]); // memoize only against explorerPath so that we use the snapshot id
+  // from the context if it was available initially, but we don't rerender if it loads after.
+
   const pipelineResult = useQuery<PipelineExplorerRootQuery, PipelineExplorerRootQueryVariables>(
     PIPELINE_EXPLORER_ROOT_QUERY,
     {
       variables: {
-        snapshotPipelineSelector: explorerPath.snapshotId ? undefined : pipelineSelector,
-        snapshotId: explorerPath.snapshotId ? explorerPath.snapshotId : undefined,
+        snapshotPipelineSelector: pipelineSelector,
+        snapshotId,
         rootHandleID: parentNames.join('.'),
         requestScopeHandleID: options.explodeComposites ? undefined : parentNames.join('.'),
       },

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineOverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineOverviewRoot.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useMemo} from 'react';
 import {useHistory, useLocation, useParams} from 'react-router-dom';
 
 import {PipelineExplorerContainer} from './PipelineExplorerRoot';
@@ -28,8 +28,8 @@ export const PipelineOverviewRoot = (props: Props) => {
   const history = useHistory();
   const location = useLocation();
   const params = useParams();
-
-  const explorerPath = explorerPathFromString((params as any)['0']);
+  const pathStr = (params as any)['0'];
+  const explorerPath = useMemo(() => explorerPathFromString(pathStr), [pathStr]);
 
   const repo = useRepository(repoAddress);
   const isJob = isThisThingAJob(repo, explorerPath.pipelineName);

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
@@ -447,6 +447,11 @@ export const useRepository = (repoAddress: RepoAddress | null) => {
   return findRepositoryAmongOptions(options, repoAddress) || null;
 };
 
+export const useJob = (repoAddress: RepoAddress | null, jobName: string | null) => {
+  const repo = useRepository(repoAddress);
+  return repo?.repository.pipelines.find((pipelineOrJob) => pipelineOrJob.name === jobName) || null;
+};
+
 export const findRepositoryAmongOptions = (
   options: DagsterRepoOption[],
   repoAddress: RepoAddress | null,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_pipelines.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_pipelines.py
@@ -28,7 +28,23 @@ def get_job_snapshot_or_error_from_snapshot_id(
     graphene_info: ResolveInfo, snapshot_id: str
 ) -> "GraphenePipelineSnapshot":
     check.str_param(snapshot_id, "snapshot_id")
+
     return _get_job_snapshot_from_instance(graphene_info.context.instance, snapshot_id)
+
+
+def get_job_snapshot_or_error_from_snap_or_selector(
+    graphene_info: ResolveInfo,
+    job_selector: JobSubsetSelector,
+    snapshot_id: str,
+):
+    from ..schema.pipelines.snapshot import GraphenePipelineSnapshot
+
+    if graphene_info.context.instance.has_job_snapshot(snapshot_id):
+        job_snapshot = graphene_info.context.instance.get_historical_job(snapshot_id)
+        if job_snapshot:
+            return GraphenePipelineSnapshot(job_snapshot)
+
+    return get_job_snapshot_or_error_from_job_selector(graphene_info, job_selector)
 
 
 # extracted this out to test


### PR DESCRIPTION
second pass of #22686 that also
* memoizes `explorerPath` to avoid re-renders
* updates the server to allow both snap and selector (preferring snap) 

## How I Tested These Changes

added server tests
launched dagit and clicked through jobs ensuring they all load 