### PR TITLE
fix(dbt): ensure `external_assets_from_specs` composes with `build_dbt_asset_specs`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_specs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_specs.py
@@ -61,6 +61,11 @@ def build_dbt_asset_specs(
             key=check.inst(asset_out.key, AssetKey),
             deps=[AssetDep(asset=dep) for dep in internal_asset_deps.get(output_name, set())],
         )
+        # Allow specs to be represented as external assets by adhering to external asset invariants.
+        ._replace(
+            skippable=False,
+            code_version=None,
+        )
         for output_name, asset_out in outs.items()
     ]
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_specs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_specs.py
@@ -1,0 +1,18 @@
+from typing import Any, Dict
+
+from dagster import Definitions, external_assets_from_specs
+from dagster_dbt.asset_specs import build_dbt_asset_specs
+
+
+def test_build_dbt_asset_specs_as_external_assets(
+    test_jaffle_shop_manifest: Dict[str, Any],
+) -> None:
+    assert Definitions(
+        assets=[
+            *external_assets_from_specs(
+                build_dbt_asset_specs(
+                    manifest=test_jaffle_shop_manifest,
+                )
+            )
+        ]
+    )


### PR DESCRIPTION
## Summary & Motivation
Looks like `external_assets_from_specs` enforces that some properties on `AssetSpec` are set to the defaults before converting them to `AssetsDefinition`. So ensure that `build_dbt_asset_specs` follows this invariant.

## How I Tested These Changes
pytest