### PR TITLE
Fix type annotation on defns util method

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -251,7 +251,7 @@ def _create_repository_using_definitions_args(
     executor: Optional[Union[ExecutorDefinition, Executor]] = None,
     loggers: Optional[Mapping[str, LoggerDefinition]] = None,
     asset_checks: Optional[Iterable[AssetChecksDefinition]] = None,
-) -> RepositoryDefinition:
+) -> Union[RepositoryDefinition, PendingRepositoryDefinition]:
     executor_def = (
         executor
         if isinstance(executor, ExecutorDefinition) or executor is None


### PR DESCRIPTION
This bad type annotation was hiding the complexity that I think underlies why we chose to pull defns off of the inputs rather than the repository definition;
because for a pending repository definition, we need to "force it to load" in order to retrieve assets defs.

Downstream PRs will attempt to address this state of affairs, but for now let's make this more clear.
