### PR TITLE
Fix custom `job_image` in helm for `K8sRunLauncher`

### DIFF
--- a/helm/dagster/templates/helpers/instance/_run-launcher.tpl
+++ b/helm/dagster/templates/helpers/instance/_run-launcher.tpl
@@ -77,7 +77,7 @@ config:
   service_account_name: {{ include "dagster.serviceAccountName" . }}
 
   {{- if (hasKey $k8sRunLauncherConfig "image") }}
-  job_image: {{ include "dagster.dagsterImage.name" (list $ $k8sRunLauncherConfig.image) | quote }}
+  job_image: {{ include "dagster.externalImage.name" $k8sRunLauncherConfig.image | quote }}
   {{- end }}
   dagster_home: {{ .Values.global.dagsterHome | quote }}
   instance_config_map: "{{ template "dagster.fullname" .}}-instance"

--- a/helm/dagster/templates/helpers/instance/_run-launcher.tpl
+++ b/helm/dagster/templates/helpers/instance/_run-launcher.tpl
@@ -77,7 +77,7 @@ config:
   service_account_name: {{ include "dagster.serviceAccountName" . }}
 
   {{- if (hasKey $k8sRunLauncherConfig "image") }}
-  job_image: {{ include "dagster.externalImage.name" (list $ $k8sRunLauncherConfig.image) | quote }}
+  job_image: {{ include "dagster.dagsterImage.name" (list $ $k8sRunLauncherConfig.image) | quote }}
   {{- end }}
   dagster_home: {{ .Values.global.dagsterHome | quote }}
   instance_config_map: "{{ template "dagster.fullname" .}}-instance"


### PR DESCRIPTION
## Summary & Motivation
When passing custom image config for the `k8sRunLauncher` in Helm values [here](https://github.com/dagster-io/dagster/blob/e25ecea78aa46ed357c16fbd55539f620bebd7bf/helm/dagster/values.yaml#L476-L479)
```yaml
runLauncher:
  type: K8sRunLauncher
  config:
    k8sRunLauncher:
      imagePullPolicy: "IfNotPresent"
      image:
        repository: "custom-image"
        tag: "0.1"
        pullPolicy: IfNotPresent
```

Helm fails with this error:
```shell
Error: INSTALLATION FAILED: template: dagster/templates/deployment-webserver.yaml:3:4: executing "dagster/templates/deployment-webserver.yaml" at <include "deployment-webserver" $data>:
error calling include: template: dagster/templates/helpers/_deployment-webserver.tpl:36:38: executing "deployment-webserver" at <include (print $.Template.BasePath "/configmap-instance.yaml") .>:
error calling include: template: dagster/templates/configmap-instance.yaml:33:12:
executing "dagster/templates/configmap-instance.yaml" at <include "dagsterYaml.runLauncher.k8s" .>:
error calling include: template: dagster/templates/helpers/instance/_run-launcher.tpl:80:16: executing "dagsterYaml.runLauncher.k8s" at <include "dagster.externalImage.name"
(list $ $k8sRunLauncherConfig.image)>: error calling include: template: dagster/templates/helpers/_helpers.tpl:30:4: executing "dagster.externalImage.name" at <.repository>: can't evaluate field repository in type []interface {}
```

The `dagster.externalImage.name` named template is used. This named template doesn't support list as an argument https://github.com/dagster-io/dagster/blob/e25ecea78aa46ed357c16fbd55539f620bebd7bf/helm/dagster/templates/helpers/instance/_run-launcher.tpl#L79-L81

However, `dagster.dagsterImage.name` does: https://github.com/dagster-io/dagster/blob/e25ecea78aa46ed357c16fbd55539f620bebd7bf/helm/dagster/templates/helpers/_helpers.tpl#L33-L41

## How I Tested These Changes
Changed the helm chart and installed it successfully locally:
```shell
helm install dagster ./dagster/helm/dagster \
    --namespace dagster \
    -f values.yaml \
    --set dagsterWebserver.image.tag=1719334175 \
    --set dagsterDaemon.image.tag=1719334175 \
    --set runLauncher.config.k8sRunLauncher.image.tag=1719334175
```
