### PR TITLE
[perf] Fix waterfall on asset partitions tab

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
@@ -49,6 +49,7 @@ interface Props {
 
   repository?: RepositorySelector;
   opName?: string | null;
+  isLoadingDefinition: boolean;
 }
 
 const DISPLAYED_STATUSES = [
@@ -71,6 +72,7 @@ export const AssetPartitions = ({
   params,
   setParams,
   dataRefreshHint,
+  isLoadingDefinition,
 }: Props) => {
   const assetHealth = usePartitionHealthData([assetKey], dataRefreshHint)[0]!;
   const [selections, setSelections] = usePartitionDimensionSelections({
@@ -184,6 +186,17 @@ export const AssetPartitions = ({
 
   const countsByStateInSelection = keyCountByStateInSelection(assetHealth, selections);
   const countsFiltered = statusFilters.reduce((a, b) => a + countsByStateInSelection[b], 0);
+
+  if (isLoadingDefinition) {
+    return (
+      <Box
+        style={{height: 390}}
+        flex={{direction: 'row', justifyContent: 'center', alignItems: 'center'}}
+      >
+        <Spinner purpose="page" />
+      </Box>
+    );
+  }
 
   return (
     <>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/AssetPartitions.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/AssetPartitions.stories.tsx
@@ -31,6 +31,7 @@ export const SingleDimensionStaticAsset = () => {
           paramsTimeWindowOnly={false}
           assetPartitionDimensions={['default']}
           dataRefreshHint={undefined}
+          isLoadingDefinition={false}
         />
       </MockedProvider>
     </StorybookProvider>
@@ -50,6 +51,7 @@ export const SingleDimensionTimeAsset = () => {
           paramsTimeWindowOnly={false}
           assetPartitionDimensions={['default']}
           dataRefreshHint={undefined}
+          isLoadingDefinition={false}
         />
       </MockedProvider>
     </StorybookProvider>
@@ -69,6 +71,7 @@ export const MultiDimensionStaticAsset = () => {
           paramsTimeWindowOnly={false}
           assetPartitionDimensions={['month', 'state']}
           dataRefreshHint={undefined}
+          isLoadingDefinition={false}
         />
       </MockedProvider>
     </StorybookProvider>
@@ -88,6 +91,7 @@ export const MultiDimensionTimeFirstAsset = () => {
           paramsTimeWindowOnly={false}
           assetPartitionDimensions={['date', 'zstate']}
           dataRefreshHint={undefined}
+          isLoadingDefinition={false}
         />
       </MockedProvider>
     </StorybookProvider>
@@ -107,6 +111,7 @@ export const MultiDimensionTimeSecondAsset = () => {
           paramsTimeWindowOnly={false}
           assetPartitionDimensions={['astate', 'date']}
           dataRefreshHint={undefined}
+          isLoadingDefinition={false}
         />
       </MockedProvider>
     </StorybookProvider>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetPartitions.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetPartitions.test.tsx
@@ -59,6 +59,7 @@ const SingleDimensionAssetPartitions = ({
           paramsTimeWindowOnly={false}
           assetPartitionDimensions={['default']}
           dataRefreshHint={undefined}
+          isLoadingDefinition={false}
         />
       </MockedProvider>
       <Route
@@ -157,6 +158,7 @@ describe('AssetPartitions', () => {
               paramsTimeWindowOnly={false}
               assetPartitionDimensions={['date', 'zstate']}
               dataRefreshHint={undefined}
+              isLoadingDefinition={false}
             />
           </MockedProvider>
         </MemoryRouter>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetView.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetView.test.tsx
@@ -78,7 +78,7 @@ describe('AssetView', () => {
           <WorkspaceProvider>
             <AssetLiveDataProvider>
               <MemoryRouter initialEntries={[path]}>
-                <AssetView assetKey={assetKey} headerBreadcrumbs={[]} />
+                <AssetView assetKey={assetKey} headerBreadcrumbs={[]} currentPath={assetKey.path} />
               </MemoryRouter>
             </AssetLiveDataProvider>
           </WorkspaceProvider>


### PR DESCRIPTION
## Summary & Motivation

1. Removed the AssetOverviewRootQuery because it's a subset of what AssetViewDefinitionQuery fetches and it's only used to render the catalog if an asset doesn't exist. Instead I made AssetView redirect to the catalog table if the asset doesn't exist. This means that we do render the chrome of the AssetView while loading and then redirect to the catalog if the asset doesn't exist, IMO this trade off is worth making to avoid the waterfall. In a future PR I can update all of the tabs to show a loading state while their definition query is loading instead (I did this for the partitions tab).

2. Render the partitions tab while the definition query is loading so that it can fetch partition data in parallel

## How I Tested These Changes



1. Loaded a url for an asset that doesn't exist and made sure we redirected to the catalog table
2. Loaded an asset that does exist and confirmed query waterfall is fixed

Before:
<img width="965" alt="Screenshot 2024-06-25 at 1 51 18 PM" src="https://github.com/dagster-io/dagster/assets/2286579/5bed3b7d-2a4c-49bf-8b4e-f5dca3002251">

After:

<img width="903" alt="Screenshot 2024-06-25 at 1 53 58 PM" src="https://github.com/dagster-io/dagster/assets/2286579/375a2f9d-aa72-4ec1-bd96-1aa9a7e8e70c">
