### PR TITLE
feat: display compute kind if present on asset node tags

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -21,6 +21,7 @@ import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {
   AssetComputeKindTag,
   AssetStorageKindTag,
+  isCanonicalComputeKindTag,
   isCanonicalStorageKindTag,
 } from '../graph/KindTags';
 import {DefinitionTag} from '../graphql/types';
@@ -39,6 +40,8 @@ export const AssetNode = React.memo(
     const isSource = definition.isSource;
 
     const {liveData} = useAssetLiveData(definition.assetKey);
+    const computeKind =
+      definition.computeKind || definition.tags?.find(isCanonicalComputeKindTag)?.value;
     const storageKindTag = definition.tags?.find(isCanonicalStorageKindTag);
     return (
       <AssetInsetForHoverEffect>
@@ -81,11 +84,13 @@ export const AssetNode = React.memo(
                 currentPageFilter={storageKindTagsFilter}
               />
             )}
-            <AssetComputeKindTag
-              definition={definition}
-              style={{position: 'relative', paddingTop: 7, margin: 0}}
-              currentPageFilter={computeKindTagsFilter}
-            />
+            {computeKind && (
+              <AssetComputeKindTag
+                computeKind={computeKind}
+                style={{position: 'relative', paddingTop: 7, margin: 0}}
+                currentPageFilter={computeKindTagsFilter}
+              />
+            )}
           </Box>
         </AssetNodeContainer>
       </AssetInsetForHoverEffect>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -58,6 +58,7 @@ import {DagsterTypeSummary} from '../dagstertype/DagsterType';
 import {
   AssetComputeKindTag,
   AssetStorageKindTag,
+  isCanonicalComputeKindTag,
   isCanonicalStorageKindTag,
 } from '../graph/KindTags';
 import {CodeReferencesMetadataEntry, IntMetadataEntry} from '../graphql/types';
@@ -230,6 +231,8 @@ export const AssetNodeOverview = ({
     </>
   );
 
+  const computeKind =
+    assetNode.computeKind || assetNode.tags?.find(isCanonicalComputeKindTag)?.value;
   const storageKindTag = assetNode.tags?.find(isCanonicalStorageKindTag);
   const filteredTags = assetNode.tags?.filter((tag) => tag.key !== 'dagster/storage_kind');
   const relationIdentifierMetadata = assetNode.metadataEntries?.find(
@@ -281,10 +284,10 @@ export const AssetNodeOverview = ({
           )}
       </AttributeAndValue>
       <AttributeAndValue label="Compute kind">
-        {assetNode.computeKind && (
+        {computeKind && (
           <AssetComputeKindTag
+            computeKind={computeKind}
             style={{position: 'relative'}}
-            definition={assetNode}
             reduceColor
             linkToFilteredAssetsTable
           />

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
@@ -1,5 +1,6 @@
 import {CaptionMono, Tooltip} from '@dagster-io/ui-components';
 import * as React from 'react';
+import {useHistory} from 'react-router-dom';
 
 import {OpTags} from './OpTags';
 import {DefinitionTag, buildDefinitionTag} from '../graphql/types';
@@ -35,6 +36,8 @@ export const AssetComputeKindTag = ({
   linkToFilteredAssetsTable?: boolean;
   currentPageFilter?: StaticSetFilter<string>;
 }) => {
+  const history = useHistory();
+
   return (
     <Tooltip
       content={
@@ -64,7 +67,7 @@ export const AssetComputeKindTag = ({
               ? () => currentPageFilter.setState(new Set([computeKind || '']))
               : shouldLink
               ? () => {
-                  window.location.href = linkToAssetTableWithComputeKindFilter(computeKind || '');
+                  history.push(linkToAssetTableWithComputeKindFilter(computeKind || ''));
                 }
               : () => {},
           },
@@ -89,6 +92,8 @@ export const AssetStorageKindTag = ({
   linkToFilteredAssetsTable?: boolean;
   currentPageFilter?: StaticSetFilter<DefinitionTag>;
 }) => {
+  const history = useHistory();
+
   return (
     <Tooltip
       content={
@@ -118,7 +123,7 @@ export const AssetStorageKindTag = ({
               ? () => currentPageFilter.setState(new Set([buildStorageKindTag(storageKind)]))
               : shouldLink
               ? () => {
-                  window.location.href = linkToAssetTableWithStorageKindFilter(storageKind);
+                  history.push(linkToAssetTableWithStorageKindFilter(storageKind));
                 }
               : () => {},
           },

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
@@ -21,13 +21,13 @@ export const buildStorageKindTag = (storageKind: string): DefinitionTag =>
   buildDefinitionTag({key: 'dagster/storage_kind', value: storageKind});
 
 export const AssetComputeKindTag = ({
-  definition,
+  computeKind,
   linkToFilteredAssetsTable: shouldLink,
   style,
   currentPageFilter,
   ...rest
 }: {
-  definition: {computeKind: string | null};
+  computeKind: string;
   style: React.CSSProperties;
   reduceColor?: boolean;
   reduceText?: boolean;
@@ -35,23 +35,20 @@ export const AssetComputeKindTag = ({
   linkToFilteredAssetsTable?: boolean;
   currentPageFilter?: StaticSetFilter<string>;
 }) => {
-  if (!definition.computeKind) {
-    return null;
-  }
   return (
     <Tooltip
       content={
         currentPageFilter ? (
           <>
-            Filter to <CaptionMono>{definition.computeKind}</CaptionMono> assets
+            Filter to <CaptionMono>{computeKind}</CaptionMono> assets
           </>
         ) : shouldLink ? (
           <>
-            View all <CaptionMono>{definition.computeKind}</CaptionMono> assets
+            View all <CaptionMono>{computeKind}</CaptionMono> assets
           </>
         ) : (
           <>
-            Compute kind <CaptionMono>{definition.computeKind}</CaptionMono>
+            Compute kind <CaptionMono>{computeKind}</CaptionMono>
           </>
         )
       }
@@ -62,17 +59,14 @@ export const AssetComputeKindTag = ({
         style={{...style, cursor: shouldLink || currentPageFilter ? 'pointer' : 'default'}}
         tags={[
           {
-            label: definition.computeKind,
-            onClick:
-              currentPageFilter && definition.computeKind
-                ? () => currentPageFilter.setState(new Set([definition.computeKind || '']))
-                : shouldLink
-                ? () => {
-                    window.location.href = linkToAssetTableWithComputeKindFilter(
-                      definition.computeKind || '',
-                    );
-                  }
-                : () => {},
+            label: computeKind,
+            onClick: currentPageFilter
+              ? () => currentPageFilter.setState(new Set([computeKind || '']))
+              : shouldLink
+              ? () => {
+                  window.location.href = linkToAssetTableWithComputeKindFilter(computeKind || '');
+                }
+              : () => {},
           },
         ]}
       />

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/ReloadRepositoryLocationButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/ReloadRepositoryLocationButton.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {useHistory} from 'react-router-dom';
 
 import {buildReloadFnForLocation, useRepositoryLocationReload} from './useRepositoryLocationReload';
 import {AppContext} from '../app/AppContext';
@@ -23,6 +24,7 @@ export const ReloadRepositoryLocationButton = (props: Props) => {
   const {ChildComponent, location} = props;
   const [shown, setShown] = React.useState(false);
 
+  const history = useHistory();
   const {basePath} = React.useContext(AppContext);
 
   const {
@@ -51,7 +53,7 @@ export const ReloadRepositoryLocationButton = (props: Props) => {
           // is presented to the user, and so that if the user was previously viewing
           // an object in a failed repo location, they aren't staring at a blank page.
           setShown(false);
-          window.location.href = `${basePath}/locations`;
+          history.push(`${basePath}/locations`);
         }}
       />
     </>

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -24,6 +24,7 @@ import {AssetViewType} from '../assets/useAssetView';
 import {
   AssetComputeKindTag,
   AssetStorageKindTag,
+  isCanonicalComputeKindTag,
   isCanonicalStorageKindTag,
 } from '../graph/KindTags';
 import {AssetKeyInput, DefinitionTag} from '../graphql/types';
@@ -85,6 +86,8 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
     }
   };
 
+  const computeKind =
+    definition?.computeKind || definition?.tags.find(isCanonicalComputeKindTag)?.value;
   const storageKindTag = definition?.tags.find(isCanonicalStorageKindTag);
 
   return (
@@ -106,11 +109,11 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
                 textStyle="middle-truncate"
               />
             </div>
-            {definition && (
+            {computeKind && (
               <AssetComputeKindTag
                 reduceColor
                 reduceText
-                definition={definition}
+                computeKind={computeKind}
                 style={{position: 'relative'}}
                 currentPageFilter={computeKindFilter}
               />


### PR DESCRIPTION
## Summary & Motivation
If the underlying op definition's compute kind is not set, fall back on the compute kind tag is set.

## How I Tested These Changes
local

![Screenshot 2024-06-25 at 2.05.44 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/3paPzMeByK6VgE9uQe4F/f001a13c-547e-45f8-8380-fa1aa659db0d.png)

