### PR TITLE
[docs] Remove Dagster+ Pro requirement for Insights metric alerts

### DIFF
--- a/docs/content/dagster-plus/managing-deployments/alerts.mdx
+++ b/docs/content/dagster-plus/managing-deployments/alerts.mdx
@@ -123,7 +123,6 @@ Alert policies are configured on a **per-deployment basis**. This means, for exa
         <strong>Insights metric alert</strong> <Experimental />
       </td>
       <td>
-        <strong>A Dagster+ Pro plan is required to use this feature.</strong>{" "}
         Sends a notification when a{" "}
         <a href="/dagster-plus/insights">Dagster+ Insights</a> metric exceeds or
         falls below a specified threshold over a specified time window. This can


### PR DESCRIPTION
## Summary & Motivation
This type of alert is now available on all Dagster+ plans, as per [this Slack thread](https://dagsterlabs.slack.com/archives/C05K25X1KN1/p1719337936481989)

## How I Tested These Changes
👀