### PR TITLE
remove NodeHandle.to_string()

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -506,7 +506,7 @@ def construct_basic_params(event_record: EventLogEntry) -> Any:
         ),
         "stepKey": event_record.step_key,
         "solidHandleID": (
-            event_record.dagster_event.node_handle.to_string()  # type: ignore
+            str(event_record.dagster_event.node_handle)  # type: ignore
             if dagster_event and dagster_event.node_handle
             else None
         ),

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_solids.py
@@ -43,7 +43,7 @@ def get_used_solid_map(repo):
                 definition=definition,
                 invocations=sorted(
                     inv_by_def_name[definition.name],
-                    key=lambda i: i.solidHandle.handleID.to_string(),
+                    key=lambda i: str(i.solidHandle.handleID),
                 ),
             ),
         )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -733,7 +733,7 @@ class GrapheneIPipelineSnapshotMixin:
             handles = {
                 key: handle
                 for key, handle in handles.items()
-                if handle.parent and handle.parent.handleID.to_string() == parentHandleID
+                if handle.parent and str(handle.parent.handleID) == parentHandleID
             }
 
         return [handles[key] for key in sorted(handles)]
@@ -985,7 +985,7 @@ class GrapheneGraph(graphene.ObjectType):
             handles = {
                 key: handle
                 for key, handle in handles.items()
-                if handle.parent and handle.parent.handleID.to_string() == parentHandleID
+                if handle.parent and str(handle.parent.handleID) == parentHandleID
             }
 
         return [handles[key] for key in sorted(handles)]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -744,7 +744,7 @@ class GrapheneCompositeSolidDefinition(graphene.ObjectType, ISolidDefinitionMixi
             handles = {
                 key: handle
                 for key, handle in handles.items()
-                if handle.parent and handle.parent.handleID.to_string() == parentHandleID
+                if handle.parent and str(handle.parent.handleID) == parentHandleID
             }
 
         return [handles[key] for key in sorted(handles)]

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -344,7 +344,11 @@ class NodeHandle(NamedTuple("_NodeHandle", [("name", str), ("parent", Optional["
         )
 
     def __str__(self):
-        return self.to_string()
+        """Return a unique string representation of the handle.
+
+        Inverse of NodeHandle.from_string.
+        """
+        return str(self.parent) + "." + self.name if self.parent else self.name
 
     @property
     def root(self):
@@ -369,13 +373,6 @@ class NodeHandle(NamedTuple("_NodeHandle", [("name", str), ("parent", Optional["
             cur = cur.parent
         path.reverse()
         return path
-
-    def to_string(self) -> str:
-        """Return a unique string representation of the handle.
-
-        Inverse of NodeHandle.from_string.
-        """
-        return self.parent.to_string() + "." + self.name if self.parent else self.name
 
     def is_or_descends_from(self, handle: "NodeHandle") -> bool:
         """Check if the handle is or descends from another handle.
@@ -414,7 +411,7 @@ class NodeHandle(NamedTuple("_NodeHandle", [("name", str), ("parent", Optional["
         check.inst_param(ancestor, "ancestor", NodeHandle)
         check.invariant(
             self.is_or_descends_from(ancestor),
-            f"Handle {self.to_string()} does not descend from {ancestor.to_string()}",
+            f"Handle {self} does not descend from {ancestor}",
         )
 
         return NodeHandle.from_path(self.path[len(ancestor.path) :])

--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -763,7 +763,7 @@ def get_output_context(
     """
     step = execution_plan.get_step_by_key(step_output_handle.step_key)
     # get config
-    op_config = resolved_run_config.ops[step.node_handle.to_string()]
+    op_config = resolved_run_config.ops[str(step.node_handle)]
     outputs_config = op_config.outputs
 
     if outputs_config:

--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -63,7 +63,7 @@ def create_step_outputs(
     config_output_names: Set[str] = set()
     current_handle = handle
     while current_handle:
-        op_config = resolved_run_config.ops[current_handle.to_string()]
+        op_config = resolved_run_config.ops[str(current_handle)]
         current_handle = current_handle.parent
         config_output_names = config_output_names.union(op_config.outputs.output_names)
 

--- a/python_modules/dagster/dagster/_core/execution/plan/handle.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/handle.py
@@ -16,7 +16,7 @@ class StepHandle(NamedTuple("_StepHandle", [("node_handle", NodeHandle), ("key",
             cls,
             node_handle=check.inst_param(node_handle, "node_handle", NodeHandle),
             # mypy can't tell that if default is set, this is guaranteed to be a str
-            key=cast(str, check.opt_str_param(key, "key", default=node_handle.to_string())),
+            key=cast(str, check.opt_str_param(key, "key", default=str(node_handle))),
         )
 
     def to_key(self) -> str:
@@ -51,7 +51,7 @@ class UnresolvedStepHandle(NamedTuple("_UnresolvedStepHandle", [("node_handle", 
         )
 
     def to_key(self):
-        return f"{self.node_handle.to_string()}[?]"
+        return f"{self.node_handle}[?]"
 
     def resolve(self, map_key) -> "ResolvedFromDynamicStepHandle":
         return ResolvedFromDynamicStepHandle(self.node_handle, map_key)
@@ -78,9 +78,7 @@ class ResolvedFromDynamicStepHandle(
             # mypy can't tell that if default is set, this is guaranteed to be a str
             key=cast(
                 str,
-                check.opt_str_param(
-                    key, "key", default=f"{node_handle.to_string()}[{mapping_key}]"
-                ),
+                check.opt_str_param(key, "key", default=f"{node_handle}[{mapping_key}]"),
             ),
         )
 

--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -140,11 +140,11 @@ class _PlanBuilder:
             keys = list(self._steps.keys())
             check.failed(f"Duplicated key {step.key}. Full list seen so far: {keys}.")
         self._seen_handles.add(step.handle)
-        self._steps[step.node_handle.to_string()] = step
+        self._steps[str(step.node_handle)] = step
 
     def get_step_by_node_handle(self, handle: NodeHandle) -> IExecutionStep:
         check.inst_param(handle, "handle", NodeHandle)
-        return self._steps[handle.to_string()]
+        return self._steps[str(handle)]
 
     def build(self) -> "ExecutionPlan":
         """Builds the execution plan."""

--- a/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/execution_plan_snapshot.py
@@ -279,7 +279,7 @@ def _snapshot_from_execution_step(execution_step: IExecutionStep) -> ExecutionSt
             list(map(_snapshot_from_step_output, execution_step.step_outputs)),
             key=lambda so: so.name,
         ),
-        node_handle_id=execution_step.node_handle.to_string(),
+        node_handle_id=str(execution_step.node_handle),
         kind=execution_step.kind,
         metadata_items=(
             sorted(

--- a/python_modules/dagster/dagster/_core/system_config/composite_descent.py
+++ b/python_modules/dagster/dagster/_core/system_config/composite_descent.py
@@ -62,7 +62,7 @@ class DescentStack(
 
     @property
     def current_handle_str(self) -> str:
-        return check.not_none(self.handle).to_string()
+        return str(check.not_none(self.handle))
 
     def descend(self, node: Node) -> "DescentStack":
         parent = self.handle if self.handle != _ROOT_HANDLE else None
@@ -102,7 +102,7 @@ def composite_descent(
         )
 
     return {
-        handle.to_string(): op_config
+        str(handle): op_config
         for handle, op_config in _composite_descent(
             parent_stack=DescentStack(job_def, _ROOT_HANDLE),
             ops_config_dict=ops_config,

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -475,8 +475,7 @@ def test_repository_snap_definitions_function_style_resources_assets_usage() -> 
 
 def _to_dict(entries: List[ResourceJobUsageEntry]) -> Dict[str, List[str]]:
     return {
-        entry.job_name: sorted([handle.to_string() for handle in entry.node_handles])
-        for entry in entries
+        entry.job_name: sorted([str(handle) for handle in entry.node_handles]) for entry in entries
     }
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_node_handle.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_node_handle.py
@@ -16,12 +16,12 @@ def test_handle_path():
 
 def test_handle_to_from_string():
     handle = NodeHandle("baz", NodeHandle("bar", NodeHandle("foo", None)))
-    assert handle.to_string() == "foo.bar.baz"
-    assert NodeHandle.from_string(handle.to_string()) == handle
+    assert str(handle) == "foo.bar.baz"
+    assert NodeHandle.from_string(str(handle)) == handle
 
     handle = NodeHandle("foo", None)
-    assert handle.to_string() == "foo"
-    assert NodeHandle.from_string(handle.to_string()) == handle
+    assert str(handle) == "foo"
+    assert NodeHandle.from_string(str(handle)) == handle
 
 
 def test_is_or_descends_from():


### PR DESCRIPTION
## Summary & Motivation

Typical python practice is to implement `__str__` instead of `to_string`. `NodeHandle` currently has both, and they do the same thing. This removes `to_string`.

## How I Tested These Changes
