### PR TITLE
refactor: prefer `history.pushState` over assignment of `window.location.href`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
@@ -1,5 +1,6 @@
 import {CaptionMono, Tooltip} from '@dagster-io/ui-components';
 import * as React from 'react';
+import {useHistory} from 'react-router-dom';
 
 import {OpTags} from './OpTags';
 import {DefinitionTag, buildDefinitionTag} from '../graphql/types';
@@ -35,6 +36,8 @@ export const AssetComputeKindTag = ({
   linkToFilteredAssetsTable?: boolean;
   currentPageFilter?: StaticSetFilter<string>;
 }) => {
+  const history = useHistory();
+
   return (
     <Tooltip
       content={
@@ -64,7 +67,7 @@ export const AssetComputeKindTag = ({
               ? () => currentPageFilter.setState(new Set([computeKind || '']))
               : shouldLink
               ? () => {
-                  window.location.href = linkToAssetTableWithComputeKindFilter(computeKind || '');
+                  history.push(linkToAssetTableWithComputeKindFilter(computeKind || ''));
                 }
               : () => {},
           },
@@ -89,6 +92,8 @@ export const AssetStorageKindTag = ({
   linkToFilteredAssetsTable?: boolean;
   currentPageFilter?: StaticSetFilter<DefinitionTag>;
 }) => {
+  const history = useHistory();
+
   return (
     <Tooltip
       content={
@@ -118,7 +123,7 @@ export const AssetStorageKindTag = ({
               ? () => currentPageFilter.setState(new Set([buildStorageKindTag(storageKind)]))
               : shouldLink
               ? () => {
-                  window.location.href = linkToAssetTableWithStorageKindFilter(storageKind);
+                  history.push(linkToAssetTableWithStorageKindFilter(storageKind));
                 }
               : () => {},
           },

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/ReloadRepositoryLocationButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/ReloadRepositoryLocationButton.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {useHistory} from 'react-router-dom';
 
 import {buildReloadFnForLocation, useRepositoryLocationReload} from './useRepositoryLocationReload';
 import {AppContext} from '../app/AppContext';
@@ -23,6 +24,7 @@ export const ReloadRepositoryLocationButton = (props: Props) => {
   const {ChildComponent, location} = props;
   const [shown, setShown] = React.useState(false);
 
+  const history = useHistory();
   const {basePath} = React.useContext(AppContext);
 
   const {
@@ -51,7 +53,7 @@ export const ReloadRepositoryLocationButton = (props: Props) => {
           // is presented to the user, and so that if the user was previously viewing
           // an object in a failed repo location, they aren't staring at a blank page.
           setShown(false);
-          window.location.href = `${basePath}/locations`;
+          history.push(`${basePath}/locations`);
         }}
       />
     </>


### PR DESCRIPTION
## Summary & Motivation
https://github.com/dagster-io/dagster/pull/22705#discussion_r1653337561

Clean up all references that assign `window.location.href`.

## How I Tested These Changes
bk