### PR TITLE
feat: adding ability to pass mlflow run_id to mlflow integration to alleviate ...

### DIFF
--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -558,6 +558,8 @@ tomli==2.0.1
 tomlkit==0.12.5
 toolz==0.12.1
 toposort==1.10
+torch==2.3.0
+torchvision==0.18.0
 tornado==6.4
 tox==3.25.0
 tqdm==4.66.4

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -558,8 +558,6 @@ tomli==2.0.1
 tomlkit==0.12.5
 toolz==0.12.1
 toposort==1.10
-torch==2.3.0
-torchvision==0.18.0
 tornado==6.4
 tox==3.25.0
 tqdm==4.66.4

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
@@ -275,6 +275,33 @@ def test_setup(mock_atexit, context):
     mock_atexit.assert_called_once_with(mlf.end_run)
 
 
+@patch("atexit.unregister")
+def test_setup_with_passed_run_id(mock_atexit, context):
+    # Given: a mlflow_run_id of zero
+    context.resource_config["mlflow_run_id"] = 0
+
+    with patch.object(MlFlow, "_setup"):
+        # Given: a context  passed into the __init__ for MlFlow
+        mlf = MlFlow(context)
+
+    with patch.object(
+        MlFlow, "_get_current_run_id", return_value="run_id_mock"
+    ) as mock_get_current_run_id, patch.object(
+        MlFlow, "_set_active_run"
+    ) as mock_set_active_run, patch.object(MlFlow, "_set_all_tags") as mock_set_all_tags:
+        # When _setup is called
+        mlf._setup()  # noqa: SLF001
+        # Then
+        # - _get_current_run_id is called once with the experiment object
+        mock_get_current_run_id.assert_not_called()
+        # - _set_active_run is called once with the run_id returned from _get_current_run_id
+        mock_set_active_run.assert_called_once_with(run_id=0)
+        # - _set_all_tags is called once
+        mock_set_all_tags.assert_called_once()
+    # - atexit.unregister is called with mlf.end_run as an argument
+    mock_atexit.assert_called_once_with(mlf.end_run)
+
+
 @pytest.mark.parametrize("run_id", [None, 0, "12"])
 def test_set_active_run(context, run_id):
     with patch.object(MlFlow, "_setup"):


### PR DESCRIPTION
… 429 issues (22633)

## Summary & Motivation
The mlflow qps for searches is very low and if you have a flow with multiple ops run in docker containers that you run in parallel you quickly hit the qps. This adds a method to avoid searching for the run ids multiple times in a run.

## How I Tested These Changes
I added units tests. Also I deployed a version locally which I tested with a sensor and jobs that I created to interface with mlflow. I tested passing the run_id in the resource dynamically and letting the resource create it.