### PR TITLE
[docs] user deployment env config doc fix

### DIFF
--- a/docs/content/deployment/guides/kubernetes/deploying-with-helm.mdx
+++ b/docs/content/deployment/guides/kubernetes/deploying-with-helm.mdx
@@ -364,9 +364,9 @@ dagster-user-deployments:
         - "/example_project/example_repo/repo.py"
       port: 3030
       envConfigMaps:
-        - my-config-map
+        - name: my-config-map
       envSecrets:
-        - my-secret
+        - name: my-secret
       labels:
         foo_label: bar_value
       volumes:

--- a/examples/docs_snippets/docs_snippets/deploying/kubernetes/user_code_deployment_config.yaml
+++ b/examples/docs_snippets/docs_snippets/deploying/kubernetes/user_code_deployment_config.yaml
@@ -11,9 +11,9 @@ dagster-user-deployments:
         - "/example_project/example_repo/repo.py"
       port: 3030
       envConfigMaps:
-        - my-config-map
+        - name: my-config-map
       envSecrets:
-        - my-secret
+        - name: my-secret
       labels:
         foo_label: bar_value
       volumes:


### PR DESCRIPTION
## Summary & Motivation
While customizing the env vars for my codelocations I found the following small discrepancy within the docs. If you put secrets in the format the docs suggest, you get the following error.

```bash
Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
dagster:
- dagster-user-deployments.deployments.1.envSecrets.0: Invalid type. Expected: object, given: string
```

## How I Tested These Changes

This is the change I had to make to get my helm chart to work. Validated by looking at the helm chart to see the actual implementation of the template [vars](https://github.com/dagster-io/dagster/blob/master/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml#L84-L87). The helm chart injects the yaml objects, not just the strings. Hence they need to be properly formatted [configmapref's](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables) and secretrefs

To implement the changes, I ran the following:

```bash
cd docs/
make next-dev-install
make mdx-format
```