### PR TITLE
[perf] Simple partition perf fixes

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -342,7 +342,9 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
         parent_partitions_def = self.get(parent_asset_key).partitions_def
 
         if parent_partitions_def is None:
-            return ValidAssetSubset(asset_key=parent_asset_key, value=child_asset_subset.size > 0)
+            return ValidAssetSubset(
+                asset_key=parent_asset_key, value=not child_asset_subset.is_empty
+            )
 
         partition_mapping = self.get_partition_mapping(child_asset_key, parent_asset_key)
         parent_partitions_subset = (

--- a/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition_mapping.py
@@ -26,6 +26,7 @@ from dagster._core.definitions.multi_dimensional_partitions import (
     MultiPartitionsDefinition,
 )
 from dagster._core.definitions.partition import (
+    AllPartitionsSubset,
     PartitionsDefinition,
     PartitionsSubset,
     StaticPartitionsDefinition,
@@ -190,10 +191,19 @@ class AllPartitionMapping(PartitionMapping, NamedTuple("_AllPartitionMapping", [
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> UpstreamPartitionsResult:
-        upstream_subset = upstream_partitions_def.subset_with_all_partitions(
-            current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
+        if dynamic_partitions_store is not None and current_time is not None:
+            partitions_subset = AllPartitionsSubset(
+                partitions_def=upstream_partitions_def,
+                dynamic_partitions_store=dynamic_partitions_store,
+                current_time=current_time,
+            )
+        else:
+            partitions_subset = upstream_partitions_def.subset_with_all_partitions(
+                current_time=current_time, dynamic_partitions_store=dynamic_partitions_store
+            )
+        return UpstreamPartitionsResult(
+            partitions_subset=partitions_subset, required_but_nonexistent_partition_keys=[]
         )
-        return UpstreamPartitionsResult(upstream_subset, [])
 
     def get_downstream_partitions_for_partitions(
         self,


### PR DESCRIPTION
## Summary & Motivation

Was just doing some dry run spot checking and noticed two silly things. One is that `subset.size > 0` is far more expensive than `subset.empty`, and the other is that if you have an AllPartitionMapping (the default when you have an unpartitioned asset downstream of a partitioned asset), the mapping function calls `partitions_def.subset_with_all_partitions`, which does the inefficient thing of calculating every single partition key of an asset. This makes it so that we just use the efficient AllPartitionsSubset class when possible.

Took a representative trial run from 180s -> 25s.

## How I Tested These Changes
