### PR TITLE
fix unexpected type in JobExecutionResult._get_value()

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/job_execution_result.py
+++ b/python_modules/dagster/dagster/_core/execution/job_execution_result.py
@@ -1,4 +1,4 @@
-from typing import Any, Sequence
+from typing import Any, Dict, Sequence, cast
 
 import dagster._check as check
 from dagster._annotations import public
@@ -6,8 +6,11 @@ from dagster._core.definitions import JobDefinition, NodeHandle
 from dagster._core.definitions.utils import DEFAULT_OUTPUT
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.events import DagsterEvent
+from dagster._core.execution.context.system import StepExecutionContext
+from dagster._core.execution.plan.outputs import StepOutputData
 from dagster._core.execution.plan.utils import build_resources_for_manager
 from dagster._core.storage.dagster_run import DagsterRun
+from dagster._core.types.dagster_type import DagsterType
 
 from .execution_result import ExecutionResult
 
@@ -126,7 +129,7 @@ class JobExecutionResult(ExecutionResult):
                     if result is None:
                         result = {mapping_key: value}
                     else:
-                        result[mapping_key] = value  # pylint:disable=unsupported-assignment-operation
+                        cast(Dict, result)[mapping_key] = value
                 else:
                     result = value
 
@@ -138,13 +141,18 @@ class JobExecutionResult(ExecutionResult):
             f"Did not find result {output_name} in {node.describe_node()}"
         )
 
-    def _get_value(self, context, step_output_data, dagster_type):
+    def _get_value(
+        self,
+        context: StepExecutionContext,
+        step_output_data: StepOutputData,
+        dagster_type: DagsterType,
+    ) -> object:
         step_output_handle = step_output_data.step_output_handle
         manager = context.get_io_manager(step_output_handle)
         manager_key = context.execution_plan.get_manager_key(step_output_handle, self.job_def)
         res = manager.load_input(
             context.for_input_manager(
-                name=None,
+                name="dummy_input_name",
                 config=None,
                 definition_metadata=None,
                 dagster_type=dagster_type,


### PR DESCRIPTION
## Summary & Motivation

The `input_name` param of `StepExecutionContext.for_input_manager` has a `str` type annotation. However when I made a change elsewhere that enforced this type deeper in the stack, I found a callsite where a `None` value is passed in for this parameter.

I considered adding a constant for the value that's being passed in, but it's not referenced elsewhere. Can still do so though if preferred.

## How I Tested These Changes

- Added type annotations to `_get_value`
- Observed that the type checker started to complain about the value passed to the `input_name` argument in `for_input_manager`
- Added my "fix"
- Observed that the type checker stopped complaining