### PR TITLE
[AMP][bug] Fix previous parent subset logic

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -815,9 +815,8 @@ class SkipOnNotAllParentsUpdatedSinceCronRule(
         else:
             # previous state still valid
             previous_parent_subsets = context.legacy_context.node_cursor.get_extra_state(list) or []
-            previous_parent_subset = next(
-                (s for s in previous_parent_subsets if s.asset_key == parent_asset_key),
-                context.legacy_context.empty_subset(),
+            previous_parent_subset: Optional[AssetSubset] = next(
+                (s for s in previous_parent_subsets if s.asset_key == parent_asset_key), None
             )
 
             # the set of asset partitions that have been updated since the previous evaluation
@@ -827,6 +826,8 @@ class SkipOnNotAllParentsUpdatedSinceCronRule(
                     after_cursor=context.legacy_context.previous_max_storage_id,
                 )
             )
+            if previous_parent_subset is None:
+                return new_parent_subset
             return new_parent_subset | previous_parent_subset
 
     def get_parent_subsets_updated_since_cron_by_key(


### PR DESCRIPTION
## Summary & Motivation

Previously, we were generating "ValidAssetSubsets" as the default values when no previous information existed. However, these were valid asset subsets for the wrong asset (the child instead of the parent), which could cause errors.

## How I Tested These Changes
