### PR TITLE
change how we compute `upstream_dep_op_handles` and `downstream_dep_assets`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -67,14 +67,20 @@ class AssetLayer(NamedTuple):
                 input_handle = NodeInputHandle(node_handle=node_handle, input_name=input_name)
                 asset_key_by_input[input_handle] = input_asset_key
                 # resolve graph input to list of op inputs that consume it
-                node_input_handles = assets_def.node_def.resolve_input_to_destinations(input_handle)
+                node_input_handles = (
+                    assets_def._computation.full_node_def.resolve_input_to_destinations(
+                        input_handle
+                    )
+                )
                 for node_input_handle in node_input_handles:
                     asset_key_by_input[node_input_handle] = input_asset_key
 
             for output_name, asset_key in assets_def.node_keys_by_output_name.items():
                 # resolve graph output to the op output it comes from
-                inner_output_def, inner_node_handle = assets_def.node_def.resolve_output_to_origin(
-                    output_name, handle=node_handle
+                inner_output_def, inner_node_handle = (
+                    assets_def._computation.full_node_def.resolve_output_to_origin(
+                        output_name, handle=node_handle
+                    )
                 )
                 node_output_handle = NodeOutputHandle(
                     node_handle=inner_node_handle, output_name=inner_output_def.name
@@ -85,7 +91,7 @@ class AssetLayer(NamedTuple):
                 asset_key_by_input.update(
                     {
                         input_handle: asset_key
-                        for input_handle in assets_def.node_def.resolve_output_to_destinations(
+                        for input_handle in assets_def._computation.full_node_def.resolve_output_to_destinations(
                             output_name, node_handle
                         )
                     }
@@ -99,7 +105,7 @@ class AssetLayer(NamedTuple):
                     (
                         inner_output_def,
                         inner_node_handle,
-                    ) = assets_def.node_def.resolve_output_to_origin(
+                    ) = assets_def._computation.node_def.resolve_output_to_origin(
                         output_name, handle=node_handle
                     )
                     node_output_handle = NodeOutputHandle(

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -353,7 +353,7 @@ class NodeHandle(NamedTuple("_NodeHandle", [("name", str), ("parent", Optional["
         return str(self.parent) + "." + self.name if self.parent else self.name
 
     @property
-    def root(self):
+    def root(self) -> "NodeHandle":
         if self.parent:
             return self.parent.root
         else:

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -937,6 +937,7 @@ class GraphDefinition(NodeDefinition):
     def get_op_input_output_handle_pairs(
         self, outer_handle: Optional[NodeHandle]
     ) -> AbstractSet[Tuple[NodeOutputHandle, NodeInputHandle]]:
+        """Get all pairs of op output handles and their downstream op input handles within the graph."""
         result: Set[Tuple[NodeOutputHandle, NodeInputHandle]] = set()
 
         for node in self.nodes:

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -1216,6 +1216,7 @@ def _infer_asset_layer_from_source_asset_deps(job_graph_def: GraphDefinition) ->
         node_output_handles_by_asset_check_key={},
         check_names_by_asset_key_by_node_handle={},
         check_key_by_node_output_handle={},
+        outer_node_names_by_asset_key={},
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/node_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/node_definition.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
     from .asset_layer import AssetLayer
     from .composition import PendingNodeInvocation
-    from .dependency import NodeHandle, NodeInputHandle
+    from .dependency import NodeHandle, NodeInputHandle, NodeOutputHandle
     from .input import InputDefinition
     from .op_definition import OpDefinition
     from .output import OutputDefinition
@@ -237,3 +237,8 @@ class NodeDefinition(NamedConfigurableDefinition):
 
     @abstractmethod
     def get_op_handles(self, parent: "NodeHandle") -> AbstractSet["NodeHandle"]: ...
+
+    @abstractmethod
+    def get_op_output_handles(
+        self, parent: Optional["NodeHandle"]
+    ) -> AbstractSet["NodeOutputHandle"]: ...

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -471,7 +471,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
 
     def get_op_output_handles(self, parent: Optional[NodeHandle]) -> AbstractSet[NodeOutputHandle]:
         return {
-            NodeOutputHandle(check.not_none(parent), output_def.name)
+            NodeOutputHandle(node_handle=parent, output_name=output_def.name)
             for output_def in self.output_defs
         }
 

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -20,7 +20,7 @@ import dagster._check as check
 from dagster._annotations import deprecated, deprecated_param, public
 from dagster._config.config_schema import UserConfigSchema
 from dagster._core.definitions.asset_check_result import AssetCheckResult
-from dagster._core.definitions.dependency import NodeHandle, NodeInputHandle
+from dagster._core.definitions.dependency import NodeHandle, NodeInputHandle, NodeOutputHandle
 from dagster._core.definitions.node_definition import NodeDefinition
 from dagster._core.definitions.op_invocation import direct_invocation_result
 from dagster._core.definitions.policy import RetryPolicy
@@ -468,6 +468,12 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
 
     def get_op_handles(self, parent: NodeHandle) -> AbstractSet[NodeHandle]:
         return {parent}
+
+    def get_op_output_handles(self, parent: Optional[NodeHandle]) -> AbstractSet[NodeOutputHandle]:
+        return {
+            NodeOutputHandle(check.not_none(parent), output_def.name)
+            for output_def in self.output_defs
+        }
 
 
 def _resolve_output_defs_from_outs(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
@@ -1187,7 +1187,8 @@ def test_internal_asset_deps_assets():
         NodeHandle(name="upstream_op", parent=NodeHandle(name="thing", parent=None)),
     }
     assert job.asset_layer.upstream_dep_op_handles(AssetKey("thing_2")) == {
-        NodeHandle("two_outputs", parent=NodeHandle("thing", parent=None))
+        NodeHandle("two_outputs", parent=NodeHandle("thing", parent=None)),
+        NodeHandle(name="upstream_op", parent=NodeHandle(name="thing", parent=None)),
     }
 
     assert job.asset_layer.upstream_dep_op_handles(AssetKey("my_out_name")) == {

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1316,13 +1316,7 @@ def test_graph_backed_asset_subset_context_intermediate_ops(
 
     asset_job = define_asset_job("yay").resolve(
         asset_graph=AssetGraph.from_assets(
-            [
-                AssetsDefinition.from_graph(
-                    graph_asset,
-                    can_subset=True,
-                    internal_asset_deps={"asset_one": {AssetKey("asset_four")}},
-                )
-            ],
+            [AssetsDefinition.from_graph(graph_asset, can_subset=True)],
         )
     )
 


### PR DESCRIPTION
## Summary & Motivation

For graph-backed multi-assets, depending on the asset selection, we sometimes only execute a subset of the ops and expect them to only produce a subset of their outputs.

This PR changes which ops are executed in some of these situations. The goals of this change are four-fold:
- Simplify the logic so that it's easier to understand and reason about (negative LOC, even with new test code).
- Avoid unnecessarily executing ops in some situations.
- Execute ops in some situations they probably should have been executed but were not being executed.
- Make it so that the logic doesn't require looking at asset-level dependencies. This will enable further refactoring of `AssetLayer`.

## How it works after this PR

Op output X will be selected when asset A is selected iff there's at least one path in the graph from X to op output corresponding to A, and no outputs in that path directly correspond to other assets.

## How it worked before this PR

Op output X will be selected when asset A is selected iff there's at least one path in the graph from X to op output corresponding to A, and no outputs in any paths directly correspond to assets that are upstream of A in the `internal_asset_deps` dict.

## Situations that change

Here's one:

<img width="593" alt="image" src="https://github.com/dagster-io/dagster/assets/654855/04cc6d8d-2545-4dea-8f83-367b7090564f">

Prior to this PR, selecting `asset2` would cause all ops to run. Now it only causes `op2` to run. That's because the only path between `op2` and `op1` goes through `op1`'s `result` output, which corresponds to an asset. This behavior change required changing the expected outcome of `test_nested_graph_subset_context` and `test_graph_backed_asset_subset_context_intermediate_ops`.

Here's another one:

<img width="575" alt="image" src="https://github.com/dagster-io/dagster/assets/654855/0b7aa6d5-e6fa-43f0-bde5-79c76ee192cf">

Note that there's an explicit dependency between `asset1` and `asset2` in `internal_asset_deps`.

Prior to this PR, selecting `asset2` would cause only `op2` to run. Now it causes all ops to run. `op2.result` might directly depend on `op2.in1`, which comes from `op1`, so we need to run `op1` to get it.

This behavior change required changing the expected outcome of `test_internal_asset_deps_assets`.

## How I Tested These Changes
