### PR TITLE
[DA][perf] Avoid recomputing in progress subset

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -170,7 +170,7 @@ class AssetStatusCacheValue(
 
     def is_materialized_subset_up_to_date(
         self,
-        asset_record: AssetRecord,
+        asset_record: "AssetRecord",
         partitions_def: Optional[PartitionsDefinition],
         dynamic_partitions_store: DynamicPartitionsStore,
     ) -> bool:

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -166,6 +166,8 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
                 and stored_cache_value
                 and (stored_cache_value.latest_storage_id or 0)
                 >= (asset_record.asset_entry.last_materialization_storage_id or 0)
+                and stored_cache_value.partitions_def_id
+                == partitions_def.get_serializable_unique_identifier(dynamic_partitions_store=self)
             ):
                 cache_value = stored_cache_value
             else:

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -164,10 +164,9 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             if (
                 asset_record
                 and stored_cache_value
-                and (stored_cache_value.latest_storage_id or 0)
-                >= (asset_record.asset_entry.last_materialization_storage_id or 0)
-                and stored_cache_value.partitions_def_id
-                == partitions_def.get_serializable_unique_identifier(dynamic_partitions_store=self)
+                and stored_cache_value.is_materialized_subset_up_to_date(
+                    asset_record, partitions_def, dynamic_partitions_store=self
+                )
             ):
                 cache_value = stored_cache_value
             else:


### PR DESCRIPTION
## Summary & Motivation

We have a simple an efficient way of avoiding doing work when the "materialize" subset is fully up-to-date in the partition status cache. Because we don't have an ASSET_MATERIALIZATION_FAILED event, the same cannot be said regarding the in-progress subset.

So if you have any in-progress runs targeting an asset `get_and_update_asset_status_cache_value` will always be expensive, even if you only care about the "materialized_susbet" value, which is cheap to calculate. This adds a bit of code to avoid updating the entire asset status cache in cases where the materialized_subset is known to be up to date.

## How I Tested These Changes
