### PR TITLE
[pandera] pin < 0.20.0

### DIFF
--- a/python_modules/libraries/dagster-pandera/setup.py
+++ b/python_modules/libraries/dagster-pandera/setup.py
@@ -38,7 +38,7 @@ setup(
     install_requires=[
         f"dagster{pin}",
         "pandas",
-        "pandera>=0.14.2",
+        "pandera>=0.14.2,<0.20.0",
         # Pin numpy pending release of pandera that either supports numpy 2 or adds a pin
         "numpy<2",
     ],


### PR DESCRIPTION
our code and doc strings make heavy use of `SchemaModel` which was deprecated and no longer top level exported in `0.20.0` 

## How I Tested These Changes

bk
