### PR TITLE
Add nightly Snowflake column lineage test

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -1,7 +1,7 @@
 import json
 import os
 import subprocess
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, cast
 
 import pytest
 from dagster import (
@@ -19,6 +19,8 @@ from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.core.resources_v2 import DbtCliResource
 from pytest_mock import MockFixture
 from sqlglot import Dialect
+
+from dagster_dbt_tests.conftest import _create_dbt_invocation
 
 from ...dbt_projects import test_jaffle_shop_path, test_metadata_path
 
@@ -223,6 +225,244 @@ def test_exception_column_lineage(
     )
 
 
+@pytest.fixture(name="test_metadata_manifest_snowflake")
+def test_metadata_manifest_snowflake_fixture() -> Dict[str, Any]:
+    return _create_dbt_invocation(test_metadata_path, target="snowflake").get_artifact(
+        "manifest.json"
+    )
+
+
+@pytest.fixture(name="test_metadata_manifest_bigquery")
+def test_metadata_manifest_bigquery_fixture() -> Dict[str, Any]:
+    return _create_dbt_invocation(test_metadata_path, target="bigquery").get_artifact(
+        "manifest.json"
+    )
+
+
+EXPECTED_COLUMN_LINEAGE_FOR_METADATA_PROJECT = {
+    AssetKey(["raw_customers"]): None,
+    AssetKey(["raw_payments"]): None,
+    AssetKey(["raw_orders"]): None,
+    AssetKey(["stg_payments"]): TableColumnLineage(
+        deps_by_column={
+            "payment_id": [TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="id")],
+            "order_id": [
+                TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="order_id")
+            ],
+            "payment_method": [
+                TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="payment_method")
+            ],
+            "amount": [TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="amount")],
+        }
+    ),
+    AssetKey(["stg_customers"]): TableColumnLineage(
+        deps_by_column={
+            "customer_id": [
+                TableColumnDep(asset_key=AssetKey(["raw_source_customers"]), column_name="id")
+            ],
+            "first_name": [
+                TableColumnDep(
+                    asset_key=AssetKey(["raw_source_customers"]), column_name="first_name"
+                )
+            ],
+            "last_name": [
+                TableColumnDep(
+                    asset_key=AssetKey(["raw_source_customers"]), column_name="last_name"
+                )
+            ],
+        }
+    ),
+    AssetKey(["stg_orders"]): TableColumnLineage(
+        deps_by_column={
+            "order_id": [TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="id")],
+            "customer_id": [
+                TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="user_id")
+            ],
+            "order_date": [
+                TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="order_date")
+            ],
+            "status": [TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="status")],
+        }
+    ),
+    AssetKey(["orders"]): TableColumnLineage(
+        deps_by_column={
+            "order_id": [
+                TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_id")
+            ],
+            "customer_id": [
+                TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="customer_id")
+            ],
+            "order_date": [
+                TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
+            ],
+            "status": [TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="status")],
+            "credit_card_amount": [
+                TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
+                TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="payment_method"),
+            ],
+            "coupon_amount": [
+                TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
+                TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="payment_method"),
+            ],
+            "bank_transfer_amount": [
+                TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
+                TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="payment_method"),
+            ],
+            "gift_card_amount": [
+                TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
+                TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="payment_method"),
+            ],
+            "amount": [
+                TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
+            ],
+        }
+    ),
+    AssetKey(["duplicate_column_dep_orders"]): TableColumnLineage(
+        deps_by_column={
+            "amount_2x": [TableColumnDep(asset_key=AssetKey(["orders"]), column_name="amount")],
+        }
+    ),
+    AssetKey(["incremental_orders"]): TableColumnLineage(
+        deps_by_column={
+            "order_id": [TableColumnDep(asset_key=AssetKey(["orders"]), column_name="order_id")],
+        }
+    ),
+    AssetKey(["customers"]): TableColumnLineage(
+        deps_by_column={
+            "customer_id": [
+                TableColumnDep(asset_key=AssetKey(["stg_customers"]), column_name="customer_id")
+            ],
+            "first_name": [
+                TableColumnDep(asset_key=AssetKey(["stg_customers"]), column_name="first_name")
+            ],
+            "last_name": [
+                TableColumnDep(asset_key=AssetKey(["stg_customers"]), column_name="last_name")
+            ],
+            "first_order": [
+                TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
+            ],
+            "most_recent_order": [
+                TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
+            ],
+            "number_of_orders": [
+                TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_id")
+            ],
+            "customer_lifetime_value": [
+                TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount")
+            ],
+        }
+    ),
+    AssetKey(["select_star_customers"]): TableColumnLineage(
+        deps_by_column={
+            "customer_id": [
+                TableColumnDep(asset_key=AssetKey(["customers"]), column_name="customer_id")
+            ],
+            "first_name": [
+                TableColumnDep(asset_key=AssetKey(["customers"]), column_name="first_name")
+            ],
+            "last_name": [
+                TableColumnDep(asset_key=AssetKey(["customers"]), column_name="last_name")
+            ],
+            "first_order": [
+                TableColumnDep(asset_key=AssetKey(["customers"]), column_name="first_order")
+            ],
+            "most_recent_order": [
+                TableColumnDep(asset_key=AssetKey(["customers"]), column_name="most_recent_order")
+            ],
+            "number_of_orders": [
+                TableColumnDep(asset_key=AssetKey(["customers"]), column_name="number_of_orders")
+            ],
+            "customer_lifetime_value": [
+                TableColumnDep(
+                    asset_key=AssetKey(["customers"]), column_name="customer_lifetime_value"
+                )
+            ],
+        }
+    ),
+    AssetKey(["count_star_customers"]): TableColumnLineage(
+        deps_by_column={
+            "count_star": [],
+        }
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "target, manifest_fixture_name, excluded_models",
+    [
+        pytest.param(
+            "snowflake",
+            "test_metadata_manifest_snowflake",
+            # No implicit alias allowed in Snowflake
+            ["count_star_implicit_alias_customers"],
+            marks=pytest.mark.snowflake,
+            id="snowflake",
+        ),
+        # TODO: test on bigquery
+    ],
+)
+def test_column_lineage_real_warehouse(
+    request: pytest.FixtureRequest,
+    target: str,
+    excluded_models: Optional[List[str]],
+    manifest_fixture_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_metadata_manifest: Dict[str, Any] = cast(
+        Dict[str, Any], request.getfixturevalue(manifest_fixture_name)
+    )
+    sql_dialect = target
+    use_experimental_fetch_column_schema = True
+
+    monkeypatch.setenv(
+        "DBT_LOG_COLUMN_METADATA", str(not use_experimental_fetch_column_schema).lower()
+    )
+    # Simulate the parsing of the SQL into a different dialect.
+    assert Dialect.get_or_raise(sql_dialect)
+
+    manifest = test_metadata_manifest.copy()
+    manifest["metadata"]["adapter_type"] = sql_dialect
+
+    dbt = DbtCliResource(project_dir=os.fspath(test_metadata_path), target=target)
+    dbt.cli(
+        ["--quiet", "build", "--exclude", "resource_type:test", *(excluded_models or [])]
+    ).wait()
+
+    @dbt_assets(manifest=manifest)
+    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+        cli_invocation = dbt.cli(["build"], context=context).stream()
+        if use_experimental_fetch_column_schema:
+            cli_invocation = cli_invocation.fetch_column_metadata()
+        yield from cli_invocation
+
+    result = materialize(
+        [my_dbt_assets],
+        resources={"dbt": dbt},
+        selection=(AssetSelection.all() - AssetSelection.assets(*excluded_models))
+        if excluded_models
+        else AssetSelection.all(),
+    )
+    assert result.success
+
+    column_lineage_by_asset_key = {
+        event.materialization.asset_key: TableMetadataSet.extract(
+            event.materialization.metadata
+        ).column_lineage
+        for event in result.get_asset_materialization_events()
+    }
+
+    expected_column_lineage_by_asset_key = {
+        k: v
+        for k, v in EXPECTED_COLUMN_LINEAGE_FOR_METADATA_PROJECT.items()
+        if k.path[-1] not in (excluded_models or [])
+    }
+    assert column_lineage_by_asset_key == expected_column_lineage_by_asset_key, (
+        str(column_lineage_by_asset_key)
+        + "\n\n"
+        + str(EXPECTED_COLUMN_LINEAGE_FOR_METADATA_PROJECT)
+    )
+
+
 @pytest.mark.parametrize(
     "asset_key_selection",
     [
@@ -296,181 +536,7 @@ def test_column_lineage(
         for event in result.get_asset_materialization_events()
     }
 
-    expected_column_lineage_by_asset_key = {
-        AssetKey(["raw_customers"]): None,
-        AssetKey(["raw_payments"]): None,
-        AssetKey(["raw_orders"]): None,
-        AssetKey(["stg_payments"]): TableColumnLineage(
-            deps_by_column={
-                "payment_id": [
-                    TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="id")
-                ],
-                "order_id": [
-                    TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="order_id")
-                ],
-                "payment_method": [
-                    TableColumnDep(
-                        asset_key=AssetKey(["raw_payments"]), column_name="payment_method"
-                    )
-                ],
-                "amount": [
-                    TableColumnDep(asset_key=AssetKey(["raw_payments"]), column_name="amount")
-                ],
-            }
-        ),
-        AssetKey(["stg_customers"]): TableColumnLineage(
-            deps_by_column={
-                "customer_id": [
-                    TableColumnDep(asset_key=AssetKey(["raw_source_customers"]), column_name="id")
-                ],
-                "first_name": [
-                    TableColumnDep(
-                        asset_key=AssetKey(["raw_source_customers"]), column_name="first_name"
-                    )
-                ],
-                "last_name": [
-                    TableColumnDep(
-                        asset_key=AssetKey(["raw_source_customers"]), column_name="last_name"
-                    )
-                ],
-            }
-        ),
-        AssetKey(["stg_orders"]): TableColumnLineage(
-            deps_by_column={
-                "order_id": [TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="id")],
-                "customer_id": [
-                    TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="user_id")
-                ],
-                "order_date": [
-                    TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="order_date")
-                ],
-                "status": [
-                    TableColumnDep(asset_key=AssetKey(["raw_orders"]), column_name="status")
-                ],
-            }
-        ),
-        AssetKey(["orders"]): TableColumnLineage(
-            deps_by_column={
-                "order_id": [
-                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_id")
-                ],
-                "customer_id": [
-                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="customer_id")
-                ],
-                "order_date": [
-                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
-                ],
-                "status": [
-                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="status")
-                ],
-                "credit_card_amount": [
-                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
-                    TableColumnDep(
-                        asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
-                    ),
-                ],
-                "coupon_amount": [
-                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
-                    TableColumnDep(
-                        asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
-                    ),
-                ],
-                "bank_transfer_amount": [
-                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
-                    TableColumnDep(
-                        asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
-                    ),
-                ],
-                "gift_card_amount": [
-                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
-                    TableColumnDep(
-                        asset_key=AssetKey(["stg_payments"]), column_name="payment_method"
-                    ),
-                ],
-                "amount": [
-                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount"),
-                ],
-            }
-        ),
-        AssetKey(["duplicate_column_dep_orders"]): TableColumnLineage(
-            deps_by_column={
-                "amount_2x": [TableColumnDep(asset_key=AssetKey(["orders"]), column_name="amount")],
-            }
-        ),
-        AssetKey(["incremental_orders"]): TableColumnLineage(
-            deps_by_column={
-                "order_id": [
-                    TableColumnDep(asset_key=AssetKey(["orders"]), column_name="order_id")
-                ],
-            }
-        ),
-        AssetKey(["customers"]): TableColumnLineage(
-            deps_by_column={
-                "customer_id": [
-                    TableColumnDep(asset_key=AssetKey(["stg_customers"]), column_name="customer_id")
-                ],
-                "first_name": [
-                    TableColumnDep(asset_key=AssetKey(["stg_customers"]), column_name="first_name")
-                ],
-                "last_name": [
-                    TableColumnDep(asset_key=AssetKey(["stg_customers"]), column_name="last_name")
-                ],
-                "first_order": [
-                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
-                ],
-                "most_recent_order": [
-                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_date")
-                ],
-                "number_of_orders": [
-                    TableColumnDep(asset_key=AssetKey(["stg_orders"]), column_name="order_id")
-                ],
-                "customer_lifetime_value": [
-                    TableColumnDep(asset_key=AssetKey(["stg_payments"]), column_name="amount")
-                ],
-            }
-        ),
-        AssetKey(["select_star_customers"]): TableColumnLineage(
-            deps_by_column={
-                "customer_id": [
-                    TableColumnDep(asset_key=AssetKey(["customers"]), column_name="customer_id")
-                ],
-                "first_name": [
-                    TableColumnDep(asset_key=AssetKey(["customers"]), column_name="first_name")
-                ],
-                "last_name": [
-                    TableColumnDep(asset_key=AssetKey(["customers"]), column_name="last_name")
-                ],
-                "first_order": [
-                    TableColumnDep(asset_key=AssetKey(["customers"]), column_name="first_order")
-                ],
-                "most_recent_order": [
-                    TableColumnDep(
-                        asset_key=AssetKey(["customers"]), column_name="most_recent_order"
-                    )
-                ],
-                "number_of_orders": [
-                    TableColumnDep(
-                        asset_key=AssetKey(["customers"]), column_name="number_of_orders"
-                    )
-                ],
-                "customer_lifetime_value": [
-                    TableColumnDep(
-                        asset_key=AssetKey(["customers"]), column_name="customer_lifetime_value"
-                    )
-                ],
-            }
-        ),
-        AssetKey(["count_star_customers"]): TableColumnLineage(
-            deps_by_column={
-                "count_star": [],
-            }
-        ),
-        AssetKey(["count_star_implicit_alias_customers"]): TableColumnLineage(
-            deps_by_column={
-                "count_star()": [],
-            }
-        ),
-    }
+    expected_column_lineage_by_asset_key = EXPECTED_COLUMN_LINEAGE_FOR_METADATA_PROJECT
     if asset_key_selection:
         expected_column_lineage_by_asset_key = {
             asset_key: deps_by_column

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -384,6 +384,11 @@ EXPECTED_COLUMN_LINEAGE_FOR_METADATA_PROJECT = {
             "count_star": [],
         }
     ),
+    AssetKey(["count_star_implicit_alias_customers"]): TableColumnLineage(
+        deps_by_column={
+            "count_star()": [],
+        }
+    ),
 }
 
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -421,8 +421,6 @@ def test_column_lineage_real_warehouse(
     sql_dialect = target
 
     monkeypatch.setenv("DBT_LOG_COLUMN_METADATA", str(False).lower())
-    # Simulate the parsing of the SQL into a different dialect.
-    assert Dialect.get_or_raise(sql_dialect)
 
     manifest = test_metadata_manifest.copy()
     assert manifest["metadata"]["adapter_type"] == sql_dialect
@@ -435,6 +433,7 @@ def test_column_lineage_real_warehouse(
     @dbt_assets(manifest=manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
         cli_invocation = dbt.cli(["build"], context=context).stream()
+        # test chaining fetch_row_counts and fetch_column_metadata
         if fetch_row_counts:
             cli_invocation = cli_invocation.fetch_row_counts()
         cli_invocation = cli_invocation.fetch_column_metadata()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/sources.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/sources.yml
@@ -2,6 +2,7 @@ version: 2
 
 sources:
   - name: jaffle_shop
+    schema: "{% if target.name == 'dev' %}main{% else %}{{ target.schema }}{% endif %}"
     tables:
       - name: raw_customers
         meta:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/sources.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/sources.yml
@@ -2,7 +2,6 @@ version: 2
 
 sources:
   - name: jaffle_shop
-    schema: main
     tables:
       - name: raw_customers
         meta:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/profiles.yml
@@ -5,7 +5,6 @@ jaffle_shop:
       type: duckdb
       path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH') }}"
       threads: 24
-      schema: main
     snowflake:
       type: snowflake
       account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/profiles.yml
@@ -5,3 +5,19 @@ jaffle_shop:
       type: duckdb
       path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH') }}"
       threads: 24
+      schema: main
+    snowflake:
+      type: snowflake
+      account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
+      user: "{{ env_var('SNOWFLAKE_USER') }}"
+      password: "{{ env_var('SNOWFLAKE_PASSWORD') }}"
+      client_session_keep_alive: False
+      database: TESTDB
+      schema: TESTSCHEMA
+    bigquery:
+      type: bigquery
+      method: service-account
+      project: "{{ env_var('GCP_PROJECT_ID') }}"
+      dataset: BIGQUERY_IO_MANAGER_SCHEMA
+      threads: 4
+      keyfile: "{{ env_var('GOOGLE_APPLICATION_CREDENTIALS') }}"


### PR DESCRIPTION
## Summary

Runs a test of our deferred fetch of column metadata/lineage on an actual Snowflake instance as part of the nightly build, to ensure that we support other warehouses properly.

Will do the same for BQ in follow-up, but the metadata project as written doesn't run directly on BQ right now.

## Test Plan

https://buildkite.com/dagster/full-moon-with-face-dagster-nightly/builds/53