### PR TITLE
[ui] Fix Storybook memory bug

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/.storybook/main.js
+++ b/js_modules/dagster-ui/packages/ui-components/.storybook/main.js
@@ -21,9 +21,8 @@ const config = {
     name: getAbsolutePath('@storybook/nextjs'),
     options: {},
   },
-  // https://github.com/hipstersmoothie/react-docgen-typescript-plugin/issues/78#issuecomment-1409224863
   typescript: {
-    reactDocgen: 'react-docgen-typescript-plugin',
+    reactDocgen: false,
   },
   docs: {},
   env: (config) => ({

--- a/js_modules/dagster-ui/packages/ui-core/.storybook/main.js
+++ b/js_modules/dagster-ui/packages/ui-core/.storybook/main.js
@@ -17,9 +17,11 @@ const config = {
     getAbsolutePath('@storybook/addon-mdx-gfm'),
     '@chromatic-com/storybook',
   ],
+  typescript: {
+    reactDocgen: false,
+  },
   framework: {
     name: getAbsolutePath('@storybook/nextjs'),
-    options: {},
   },
   // https://github.com/storybookjs/storybook/issues/16690#issuecomment-971579785
   webpackFinal: async (config) => {


### PR DESCRIPTION
## Summary & Motivation

Disable react-docgen in Storybook build, because pulling in massive generated GraphQL types is causing memory failures in CI/Vercel.

## How I Tested These Changes

Add a memory-limited build command to package.json:

```
"build-storybook-limited": "NODE_OPTIONS=--max_old_space_size=2048 storybook build"
```
Run this to repro the memory failure. Kill docgen (as in the PR), rerun. Verify that the build completes correctly.