### PR TITLE
fix: add `dagster-sdf` to automation tox suite dependencies

### DIFF
--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -38,6 +38,7 @@ deps =
   -e ../libraries/dagster-postgres
   -e ../libraries/dagster-prometheus
   -e ../libraries/dagster-pyspark
+  -e ../libraries/dagster-sdf
   -e ../libraries/dagster-shell
   -e ../libraries/dagster-slack
   -e ../libraries/dagster-spark


### PR DESCRIPTION
## Summary & Motivation
There has to be a better way than just installing all of these dependencies. But just cargo-culting for now to fix the build.

## How I Tested These Changes
bk