### PR TITLE
don't include outer node handle in AssetsDefinition asset/op deps

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -394,7 +394,14 @@ class NodeHandle(NamedTuple("_NodeHandle", [("name", str), ("parent", Optional["
                 return False
         return True
 
-    def pop(self, ancestor: "NodeHandle") -> Optional["NodeHandle"]:
+    def pop(self) -> Optional["NodeHandle"]:
+        """Return a copy of the handle with some its root pruned."""
+        if self.parent is None:
+            return None
+        else:
+            return NodeHandle.from_path(self.path[1:])
+
+    def pop_ancestor(self, ancestor: "NodeHandle") -> Optional["NodeHandle"]:
         """Return a copy of the handle with some of its ancestors pruned.
 
         Args:
@@ -408,7 +415,7 @@ class NodeHandle(NamedTuple("_NodeHandle", [("name", str), ("parent", Optional["
 
             handle = NodeHandle('baz', NodeHandle('bar', NodeHandle('foo', None)))
             ancestor = NodeHandle('bar', NodeHandle('foo', None))
-            assert handle.pop(ancestor) == NodeHandle('baz', None)
+            assert handle.pop_ancestor(ancestor) == NodeHandle('baz', None)
         """
         check.inst_param(ancestor, "ancestor", NodeHandle)
         check.invariant(
@@ -418,11 +425,11 @@ class NodeHandle(NamedTuple("_NodeHandle", [("name", str), ("parent", Optional["
 
         return NodeHandle.from_path(self.path[len(ancestor.path) :])
 
-    def with_ancestor(self, ancestor: Optional["NodeHandle"]) -> "NodeHandle":
-        """Returns a copy of the handle with an ancestor grafted on.
+    def with_child(self, child: Optional["NodeHandle"]) -> "NodeHandle":
+        """Returns a copy of the handle with a child grafted on.
 
         Args:
-            ancestor (NodeHandle): Handle to the new ancestor.
+            child (NodeHandle): Handle to the new ancestor.
 
         Returns:
             NodeHandle:
@@ -430,15 +437,18 @@ class NodeHandle(NamedTuple("_NodeHandle", [("name", str), ("parent", Optional["
         Example:
         .. code-block:: python
 
-            handle = NodeHandle('baz', NodeHandle('bar', NodeHandle('foo', None)))
-            ancestor = NodeHandle('quux' None)
-            assert handle.with_ancestor(ancestor) == NodeHandle(
+            handle = NodeHandle('quux' None)
+            child = NodeHandle('baz', NodeHandle('bar', NodeHandle('foo', None)))
+            assert str(child) == "foo.baz.bar"
+            assert handle.with_child(child) == NodeHandle(
                 'baz', NodeHandle('bar', NodeHandle('foo', NodeHandle('quux', None)))
             )
+            assert str(handle.with_child(child)) == "quux.foo.baz.bar""
         """
-        check.opt_inst_param(ancestor, "ancestor", NodeHandle)
-
-        return NodeHandle.from_path([*(ancestor.path if ancestor else []), *self.path])
+        if child is None:
+            return self
+        else:
+            return NodeHandle.from_path([*self.path, *child.path])
 
     @staticmethod
     def from_path(path: Sequence[str]) -> "NodeHandle":

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1402,6 +1402,13 @@ def test_graph_backed_asset_reused():
                 ),
             )
         )
+        asset_one_dep_op_handles = asset_job.asset_layer.upstream_dep_op_handles(
+            AssetKey("asset_one")
+        )
+        duplicate_one_dep_op_handles = asset_job.asset_layer.upstream_dep_op_handles(
+            AssetKey("duplicate_one")
+        )
+        assert asset_one_dep_op_handles != duplicate_one_dep_op_handles
 
         with instance_for_test() as instance:
             asset_job.execute_in_process(instance=instance, asset_selection=[AssetKey("upstream")])

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_node_handle.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_node_handle.py
@@ -60,18 +60,22 @@ def test_is_or_descends_from():
 
 def test_pop():
     handle = NodeHandle("baz", NodeHandle("bar", NodeHandle("foo", None)))
-    assert handle.pop(NodeHandle("foo", None)) == NodeHandle("baz", NodeHandle("bar", None))
-    assert handle.pop(NodeHandle("bar", NodeHandle("foo", None))) == NodeHandle("baz", None)
+    assert handle.pop_ancestor(NodeHandle("foo", None)) == NodeHandle(
+        "baz", NodeHandle("bar", None)
+    )
+    assert handle.pop_ancestor(NodeHandle("bar", NodeHandle("foo", None))) == NodeHandle(
+        "baz", None
+    )
 
     with pytest.raises(CheckError, match="does not descend from"):
         handle = NodeHandle("baz", NodeHandle("bar", NodeHandle("foo", None)))
-        handle.pop(NodeHandle("quux", None))
+        handle.pop_ancestor(NodeHandle("quux", None))
 
 
-def test_with_ancestor():
+def test_with_child():
     handle = NodeHandle("baz", NodeHandle("bar", NodeHandle("foo", None)))
-    assert handle.with_ancestor(None) == handle
-    assert handle.with_ancestor(NodeHandle("quux", None)) == NodeHandle(
+    assert handle.with_child(None) == handle
+    assert NodeHandle("quux", None).with_child(handle) == NodeHandle(
         "baz", NodeHandle("bar", NodeHandle("foo", NodeHandle("quux", None)))
     )
 


### PR DESCRIPTION
## Summary & Motivation

The `asset_or_check_keys_by_dep_op_output_handle` and `dep_op_handles_by_asset_or_check_key` properties on `AssetsDefinition` return dictionaries that relate asset keys to ops within the `AssetsDefinition`.

We use `NodeHandle`s to identify the ops within the `AssetsDefinition`, but the way that we do so is non-standard way:
- A `NodeHandle` represents a path down the composition tree to a node within a graph, from the root of that graph. They do _not_ include the name of the outer graph definition, because that name might be aliased if it's embedded in a larger graph.
- The `NodeHandle`s returned in these dictionaries _do_ contain the name of the root graph definition.

We in fact do embed these asset-level graph definitions within a larger graph - the asset-job level graph. This means that op handles within that job-level graph can point to the wrong op within that graph.

## How I Tested These Changes

Added an assert to `test_graph_backed_asset_reused`, which fails before this PR and passes with it.