### PR TITLE
Fix warnings

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -901,7 +901,6 @@ def test_get_all_asset_specs():
     assert asset_specs_by_key[AssetKey("asset6")] == AssetSpec("asset6", group_name="blag")
 
 
-@pytest.mark.skip(reason="Failing BK")
 def test_invalid_partitions_subclass():
     class CustomPartitionsDefinition(PartitionsDefinition):
         def get_partition_keys(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_schedule.py
@@ -130,10 +130,8 @@ def test_coerce_graph_def_to_job():
     def bar():
         foo()
 
-    # Skipping this assertion until we can figure out what is causing warning non-determinism in
-    # pytest
-    # with pytest.warns(DeprecationWarning, match="Passing GraphDefinition"):
-    my_schedule = ScheduleDefinition(cron_schedule="* * * * *", job=bar)
+    with pytest.warns(DeprecationWarning, match="Passing GraphDefinition"):
+        my_schedule = ScheduleDefinition(cron_schedule="* * * * *", job=bar)
 
     assert isinstance(my_schedule.job, JobDefinition)
     assert my_schedule.job.name == "bar"

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor.py
@@ -78,10 +78,8 @@ def test_coerce_graph_def_to_job():
     def bar():
         foo()
 
-    # Skipping this assertion until we can figure out what is causing warning non-determinism in
-    # pytest
-    # with pytest.warns(DeprecationWarning, match="Passing GraphDefinition"):
-    my_sensor = SensorDefinition(job=bar, evaluation_fn=lambda _: ...)
+    with pytest.warns(DeprecationWarning, match="Passing GraphDefinition"):
+        my_sensor = SensorDefinition(job=bar, evaluation_fn=lambda _: ...)
 
     assert isinstance(my_sensor.job, JobDefinition)
     assert my_sensor.job.name == "bar"


### PR DESCRIPTION
## Summary & Motivation

Limit nesting of manipulation of the `_warnings_on` context variable to one level. The motivation here is that, in certain niche cases (in particular observed in pytest), nested `finally` resets of the token sometimes occur out-of-order, which leads to the `_warnings_on` context variable being "permanently" reset to `False`. By avoiding this nesting, we can avoid this bug (whether it's a problem in python, pytest, or our own code, which is unclear).

This also re-enables the skipped assertions that surfaced this bug before.

## How I Tested These Changes

Pushed this 5 times and did not observe previous inconsistently failing tests to fail.