### PR TITLE
Add operation name to `[Network Error]` log so that we can pinpoint queries causing OOMs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppError.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppError.tsx
@@ -50,7 +50,8 @@ const showNetworkError = async (statusCode: number) => {
 export const createErrorLink = (toastOnErrors?: boolean) =>
   onError((response) => {
     let didLogError = false;
-    const operationName = response.operation.operationName;
+    // Wrap the operation name in curly braces so that our datadog RUM handler can parse the operation name out easily to add as an attribute.
+    const operationName = `{${response.operation.operationName}}`;
     if (response.graphQLErrors) {
       const {graphQLErrors} = response;
       graphQLErrors.forEach((error) => {


### PR DESCRIPTION
## Summary & Motivation

Add operation name to `[Network Error]` log so that we can pinpoint queries causing OOMs / timeouts / etc.

Also added more logging to make sure we can always pinpoint the operation that is causing an ApolloError since by default it doesn't include the operation name.

## How I Tested These Changes

https://app.datadoghq.com/rum/error-tracking?query=%40application.id%3A6d12cca2-0263-463b-a90e-cc6c524e14bd&fromUser=false&issueId=6c8df1bc-07c3-11ef-9600-da7ad0900002&source=all&view=spans&from_ts=1719512901245&to_ts=1719513801245&live=true

![image](https://github.com/dagster-io/dagster/assets/2286579/2dffa44f-935a-4285-aa9b-bd41e1ed65e9)
