### PR TITLE
in blueprints CLI, echo checking whether redhat.vscode-yaml extension is installed

### DIFF
--- a/examples/experimental/dagster-blueprints/dagster_blueprints/cli.py
+++ b/examples/experimental/dagster-blueprints/dagster_blueprints/cli.py
@@ -191,6 +191,7 @@ def recommend_yaml_extension() -> None:
         )
         return
 
+    click.echo("Checking whether redhat.vscode-yaml extension is installed.")
     extensions = run_vscode_cli_command(["--list-extensions"]).decode("utf-8").split("\n")
     if "redhat.vscode-yaml" in extensions:
         click.echo("redhat.vscode-yaml extension is already installed.")


### PR DESCRIPTION
## Summary & Motivation

I noticed that, after running `dagster-blueprints configure-vscode`, there was a long pause before anything happened. Upon inspection, this occurred while running `code --list-extensions`.

This PR adds an echo to make it clear that to users that this is what's happening behind the scenes.

## How I Tested These Changes
