### PR TITLE
add job name filter support for run status sensors

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -766,6 +766,42 @@ class RunStatusSensorDefinition(SensorDefinition):
                     ascending=True,
                     limit=fetch_limit,
                 ).records
+            elif (
+                context.instance.event_log_storage.supports_run_status_change_job_name_filter
+                and monitored_jobs
+                and all(
+                    [
+                        not isinstance(monitored, (RepositorySelector, CodeLocationSelector))
+                        for monitored in monitored_jobs
+                    ]
+                )
+            ):
+                # the event log storage supports run status change selectors... we should construct
+                # the appropriate job selectors so that we can filter the events by jobs in the
+                # storage layer instead of in memory.  This should improve throughput since we will
+                # avoid fetching events that we will filter out later on.
+                job_names = _job_names_for_monitored(
+                    cast(
+                        Sequence[
+                            Union[
+                                JobDefinition,
+                                GraphDefinition,
+                                UnresolvedAssetJobDefinition,
+                                "JobSelector",
+                            ]
+                        ],
+                        monitored_jobs,
+                    )
+                )
+                event_records = context.instance.fetch_run_status_changes(
+                    records_filter=RunStatusChangeRecordsFilter(
+                        event_type=cast(RunStatusChangeEventType, event_type),
+                        after_storage_id=sensor_cursor.record_id,
+                        job_names=job_names,
+                    ),
+                    ascending=True,
+                    limit=fetch_limit,
+                ).records
             else:
                 # the cursor storage id is globally unique, either because the event log storage is
                 # not run sharded or because the cursor was set from an event returned from the
@@ -1126,3 +1162,24 @@ def run_status_sensor(
         )
 
     return inner
+
+
+def _job_names_for_monitored(
+    monitored: Sequence[
+        Union[
+            JobDefinition,
+            GraphDefinition,
+            UnresolvedAssetJobDefinition,
+            "JobSelector",
+        ]
+    ],
+) -> Sequence[str]:
+    from dagster._core.definitions.selector import JobSelector
+
+    job_names = []
+    for m in monitored:
+        if isinstance(m, JobSelector):
+            job_names.append(m.job_name)
+        else:
+            job_names.append(m.name)
+    return job_names

--- a/python_modules/dagster/dagster/_core/event_api.py
+++ b/python_modules/dagster/dagster/_core/event_api.py
@@ -349,6 +349,7 @@ class RunStatusChangeRecordsFilter(
             ("after_storage_id", PublicAttr[Optional[int]]),
             ("before_storage_id", PublicAttr[Optional[int]]),
             ("storage_ids", PublicAttr[Optional[Sequence[int]]]),
+            ("job_names", Optional[Sequence[str]]),
         ],
     )
 ):
@@ -376,6 +377,7 @@ class RunStatusChangeRecordsFilter(
         after_storage_id: Optional[int] = None,
         before_storage_id: Optional[int] = None,
         storage_ids: Optional[Sequence[int]] = None,
+        job_names: Optional[Sequence[str]] = None,
     ):
         if event_type not in EVENT_TYPE_TO_PIPELINE_RUN_STATUS:
             check.failed("Invalid event type for run status change event filter")
@@ -388,9 +390,10 @@ class RunStatusChangeRecordsFilter(
             after_storage_id=check.opt_int_param(after_storage_id, "after_storage_id"),
             before_storage_id=check.opt_int_param(before_storage_id, "before_storage_id"),
             storage_ids=check.opt_nullable_sequence_param(storage_ids, "storage_ids", of_type=int),
+            job_names=check.opt_nullable_sequence_param(job_names, "job_names", of_type=str),
         )
 
-    def to_event_records_filter(
+    def to_event_records_filter_without_job_names(
         self, cursor: Optional[str] = None, ascending: bool = False
     ) -> EventRecordsFilter:
         before_cursor_storage_id, after_cursor_storage_id = EventRecordsFilter.get_cursor_params(

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -648,6 +648,10 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     ) -> EventRecordsResult:
         raise NotImplementedError()
 
+    @property
+    def supports_run_status_change_job_name_filter(self) -> bool:
+        return False
+
     @abstractmethod
     def fetch_run_status_changes(
         self,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -1112,12 +1112,19 @@ class SqlEventLogStorage(EventLogStorage):
 
         before_cursor, after_cursor = EventRecordsFilter.get_cursor_params(cursor, ascending)
         event_records_filter = (
-            records_filter.to_event_records_filter(cursor, ascending)
+            records_filter.to_event_records_filter_without_job_names(cursor, ascending)
             if isinstance(records_filter, RunStatusChangeRecordsFilter)
             else EventRecordsFilter(
                 event_type, before_cursor=before_cursor, after_cursor=after_cursor
             )
         )
+        has_job_name_filter = (
+            isinstance(records_filter, RunStatusChangeRecordsFilter) and records_filter.job_names
+        )
+        if has_job_name_filter and not self.supports_run_status_change_job_name_filter:
+            check.failed(
+                "Called fetch_run_status_changes with selectors, which are not supported with this storage."
+            )
         return self._get_event_records_result(event_records_filter, limit, cursor, ascending)
 
     def get_logs_for_all_runs_by_log_id(

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -412,7 +412,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
         before_cursor, after_cursor = EventRecordsFilter.get_cursor_params(cursor, ascending)
         event_records_filter = (
-            records_filter.to_event_records_filter(cursor, ascending)
+            records_filter.to_event_records_filter_without_job_names(cursor, ascending)
             if isinstance(records_filter, RunStatusChangeRecordsFilter)
             else EventRecordsFilter(
                 event_type, before_cursor=before_cursor, after_cursor=after_cursor

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -271,7 +271,13 @@ def _default_loggers(event_callback):
 
 # This exists to create synthetic events to test the store
 def _synthesize_events(
-    ops_fn_or_assets, run_id=None, check_success=True, instance=None, run_config=None, tags=None
+    ops_fn_or_assets,
+    run_id=None,
+    check_success=True,
+    instance=None,
+    run_config=None,
+    tags=None,
+    job_name=None,
 ) -> Tuple[List[EventLogEntry], JobExecutionResult]:
     events = []
 
@@ -290,6 +296,7 @@ def _synthesize_events(
     else:  # op_fn
 
         @job(
+            name=job_name,
             resource_defs=_default_resources(),
             logger_defs=_default_loggers(_append_event),
             executor_def=in_process_executor,
@@ -2057,6 +2064,61 @@ class TestEventLogStorage:
                 limit=100,
             )
             assert _get_storage_ids(result) == [storage_id_3, storage_id_1]
+
+    def test_fetch_run_status_monitor_filters(self, storage, instance):
+        if not storage.supports_run_status_change_job_name_filter:
+            # test sqlite in test_get_event_records_sqlite
+            pytest.skip()
+
+        @op
+        def my_op(_):
+            yield Output(1)
+
+        def _ops():
+            my_op()
+
+        def _store_run_events(run_id, job_name=None):
+            events, _ = _synthesize_events(_ops, run_id=run_id, job_name=job_name)
+            for event in events:
+                storage.store_event(event)
+
+        # store events for three runs
+        [run_id_1, run_id_2, run_id_3] = [
+            make_new_run_id(),
+            make_new_run_id(),
+            make_new_run_id(),
+        ]
+
+        with create_and_delete_test_runs(instance, [run_id_1, run_id_2, run_id_3]):
+            _store_run_events(run_id_1, "job_one")
+            _store_run_events(run_id_2, "job_two")
+            _store_run_events(run_id_3, "job_three")
+
+            result = storage.fetch_run_status_changes(
+                DagsterEventType.RUN_SUCCESS,
+                limit=100,
+            )
+            assert [r.event_log_entry.run_id for r in result.records] == [
+                run_id_3,
+                run_id_2,
+                run_id_1,
+            ]
+            result = storage.fetch_run_status_changes(
+                RunStatusChangeRecordsFilter(
+                    DagsterEventType.RUN_SUCCESS,
+                    job_names=["job_one"],
+                ),
+                limit=100,
+            )
+            assert [r.event_log_entry.run_id for r in result.records] == [run_id_1]
+            result = storage.fetch_run_status_changes(
+                RunStatusChangeRecordsFilter(
+                    DagsterEventType.RUN_SUCCESS,
+                    job_names=["job_one", "job_two"],
+                ),
+                limit=100,
+            )
+            assert [r.event_log_entry.run_id for r in result.records] == [run_id_2, run_id_1]
 
     def test_get_event_records_sqlite(self, storage, instance):
         if not self.is_sqlite(storage):


### PR DESCRIPTION
## Summary & Motivation
We want to be able to increase the throughput of run status sensors that target specific jobs by filtering in the run status event DB query instead of filtering in memory, against storages that support such filtering



## How I Tested These Changes
BK