### PR TITLE
[Asset graph]  Fix graph data refetch loop in job asset graph page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useIndexedDBCachedQuery.tsx
@@ -113,7 +113,9 @@ export function useIndexedDBCachedQuery<TQuery, TVariables extends OperationVari
       setError(error);
       setLoading(false);
     },
-    [getData, client, key, query, variables, version, dataRef],
+    // exclude variables, instead JSON stringify it to avoid changing this reference if the caller hasn't memoized it
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [getData, client, key, query, JSON.stringify(variables), version, dataRef],
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary & Motivation

The `pipelineSelector` reference is changing every render, to make this less foot gunny I'm making useIndexedDBCachedQuery JSON.stringify the variables instead

## How I Tested These Changes

tested with app proxy