### PR TITLE
Fix navigating to folders in asset catalog 

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -290,7 +290,7 @@ export const AssetView = ({
 
   if (definitionQueryResult.data?.assetOrError.__typename === 'AssetNotFoundError') {
     // Redirect to the asset catalog
-    return <Redirect to="/assets" />;
+    return <Redirect to={`/assets/${currentPath.join('/')}?view=folder`} />;
   }
 
   return (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverviewRoot.tsx
@@ -9,10 +9,11 @@ import {AssetGlobalLineageLink, AssetPageHeader} from './AssetPageHeader';
 import {AssetView} from './AssetView';
 import {AssetsCatalogTable} from './AssetsCatalogTable';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
-import {AssetKey} from './types';
+import {AssetKey, AssetViewParams} from './types';
 import {useTrackPageView} from '../app/analytics';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
+import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {usePageLoadTrace} from '../performance';
 import {ReloadAllButton} from '../workspace/ReloadAllButton';
 
@@ -28,6 +29,7 @@ export const AssetsOverviewRoot = ({
   useTrackPageView();
 
   const params = useParams();
+  const [searchParams] = useQueryPersistedState<AssetViewParams>({});
   const history = useHistory();
 
   const currentPathStr = (params as any)['0'];
@@ -51,7 +53,7 @@ export const AssetsOverviewRoot = ({
     currentPath && currentPath.length === 0 ? 'AssetsOverviewRoot' : 'AssetCatalogAssetView',
   );
 
-  if (currentPath.length === 0) {
+  if (currentPath.length === 0 || searchParams.view === 'folder') {
     return (
       <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
         <AssetPageHeader


### PR DESCRIPTION
## Summary & Motivation

https://github.com/dagster-io/dagster/pull/22589/ broke the behavior for navigating to folders within the asset catalog. Previously on an `AssetNotFoundError` we would assume the path was a folder and render the asset catalog with that path set, after that PR we would instead always redirect to the root of the catalog. After this PR we instead redirect to the catalog at that current path

## How I Tested These Changes

tests locally with app proxy