### PR TITLE
fix docs for execute_query and execute_queries

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -547,7 +547,7 @@ class SnowflakeConnection:
             .. code-block:: python
 
                 @op
-                def drop_database(snowflake: SnowflakeResource):
+                def drop_database(snowflake: snowflake_resource):
                     snowflake.execute_query(
                         "DROP DATABASE IF EXISTS MY_DATABASE"
                     )
@@ -600,7 +600,7 @@ class SnowflakeConnection:
             .. code-block:: python
 
                 @op
-                def create_fresh_database(snowflake: SnowflakeResource):
+                def create_fresh_database(snowflake: snowflake_resource):
                     queries = ["DROP DATABASE IF EXISTS MY_DATABASE", "CREATE DATABASE MY_DATABASE"]
                     snowflake.execute_queries(
                         sql_queries=queries


### PR DESCRIPTION
## Summary & Motivation

`execute_query` and `execute_queries` are methods in SnowflakeConnection, which is used by `snowflake_resource` but _not_  using by the Pythonic SnowflakeResource.



## How I Tested These Changes
