### PR TITLE
remove vestigial T_Handle

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -466,8 +466,6 @@ class GraphDefinition(NodeDefinition):
                 return mapping
         check.failed(f"Could not find output mapping {output_name}")
 
-    T_Handle = TypeVar("T_Handle", bound=Optional[NodeHandle])
-
     def resolve_output_to_origin(
         self, output_name: str, handle: Optional[NodeHandle]
     ) -> Tuple[OutputDefinition, Optional[NodeHandle]]:

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -9,7 +9,6 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
-    TypeVar,
     Union,
     cast,
 )
@@ -323,11 +322,9 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
     def iterate_op_defs(self) -> Iterator["OpDefinition"]:
         yield self
 
-    T_Handle = TypeVar("T_Handle", bound=Optional[NodeHandle])
-
     def resolve_output_to_origin(
-        self, output_name: str, handle: T_Handle
-    ) -> Tuple[OutputDefinition, T_Handle]:
+        self, output_name: str, handle: Optional[NodeHandle]
+    ) -> Tuple[OutputDefinition, Optional[NodeHandle]]:
         return self.output_def_named(output_name), handle
 
     def resolve_output_to_origin_op_def(self, output_name: str) -> "OpDefinition":


### PR DESCRIPTION
## Summary & Motivation

This `TypeVar` is unused in `graph_definition.py` and has no effect in `op_definition.py`.

## How I Tested These Changes
