### PR TITLE
[ui] Update Run duration graph on Job Partitions view

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/PartitionGraph.tsx
@@ -1,9 +1,10 @@
-import {Box, Button, Colors, NonIdealState} from '@dagster-io/ui-components';
+import {Box, Button, Colors, FontFamily, NonIdealState} from '@dagster-io/ui-components';
 import React, {useCallback, useMemo, useRef, useState} from 'react';
 import {Line} from 'react-chartjs-2';
 import styled from 'styled-components';
 
 import {colorHash} from '../app/Util';
+import {useRGBColorsForTheme} from '../app/useRGBColorsForTheme';
 import {numberFormatter} from '../ui/formatters';
 
 type PointValue = number | null | undefined;
@@ -31,6 +32,8 @@ export const PartitionGraph = React.memo(
   }: PartitionGraphProps) => {
     const [hiddenPartitions, setHiddenPartitions] = useState<{[name: string]: boolean}>(() => ({}));
     const chart = useRef<any>(null);
+
+    const rgbColors = useRGBColorsForTheme();
 
     const [_showLargeGraphMessage, setShowLargeGraphMessage] = useState(
       partitionNames.length > 1000,
@@ -77,11 +80,31 @@ export const PartitionGraph = React.memo(
         ? {
             y: {
               id: 'y',
-              title: {display: true, text: yLabel},
+              title: {display: true, text: yLabel, color: rgbColors[Colors.textLighter()]},
+              grid: {
+                color: rgbColors[Colors.keylineDefault()],
+              },
+              ticks: {
+                color: rgbColors[Colors.textLighter()],
+                font: {
+                  size: 12,
+                  family: FontFamily.monospace,
+                },
+              },
             },
             x: {
               id: 'x',
-              title: {display: true, text: title},
+              title: {display: true, text: title, color: rgbColors[Colors.textLighter()]},
+              grid: {
+                color: rgbColors[Colors.keylineDefault()],
+              },
+              ticks: {
+                color: rgbColors[Colors.textLighter()],
+                font: {
+                  size: 12,
+                  family: FontFamily.monospace,
+                },
+              },
             },
           }
         : undefined;
@@ -164,15 +187,15 @@ export const PartitionGraph = React.memo(
                       {
                         label: allLabel,
                         data: jobData,
-                        borderColor: Colors.borderDefault(),
-                        backgroundColor: Colors.accentPrimary(),
+                        borderColor: rgbColors[Colors.borderDefault()],
+                        backgroundColor: rgbColors[Colors.dataVizBlurple()],
                       },
                     ]),
                 ...Object.keys(stepData).map((stepKey) => ({
                   label: stepKey,
                   data: stepData[stepKey as keyof typeof stepData],
                   borderColor: colorHash(stepKey),
-                  backgroundColor: Colors.accentPrimary(),
+                  backgroundColor: rgbColors[Colors.dataVizBlurple()],
                 })),
               ],
             },
@@ -182,6 +205,7 @@ export const PartitionGraph = React.memo(
         jobData,
         jobDataByPartition,
         partitionNames,
+        rgbColors,
         showLargeGraphMessage,
         stepData,
       ],


### PR DESCRIPTION
## Summary & Motivation

Update Run partitions graph to match graph styles elsewhere:

- Use `useRGBColorsForTheme` to pull colors from theme context, since we need raw `rgb` values for chart.js.
- Update monospace font, axis colors
- Use dataviz blurple for main data display color


<img width="1169" alt="Screenshot 2024-06-28 at 14 11 38" src="https://github.com/dagster-io/dagster/assets/2823852/d434f233-f431-477b-bfb5-da68c15fc86a">
<img width="1164" alt="Screenshot 2024-06-28 at 14 11 24" src="https://github.com/dagster-io/dagster/assets/2823852/9a862ac9-4748-417b-bbf8-d960b5167c5a">

## How I Tested These Changes

View a job with partition runs, verify that the graph lines show up correctly in light and dark modes.