### PR TITLE
[ui] Sensors: Disable "Test sensor" button instead of hiding it

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
@@ -8,6 +8,7 @@ import {
   MetadataTableWIP,
   PageHeader,
   Tag,
+  Tooltip,
 } from '@dagster-io/ui-components';
 import {useState} from 'react';
 
@@ -107,15 +108,20 @@ export const SensorDetails = ({
         right={
           <Box margin={{top: 4}} flex={{direction: 'row', alignItems: 'center', gap: 8}}>
             <QueryRefreshCountdown refreshState={refreshState} />
-            {sensor.sensorType === SensorType.STANDARD ? (
+            <Tooltip
+              canShow={sensor.sensorType !== SensorType.STANDARD}
+              content="Testing not available for this sensor type"
+              placement="top-end"
+            >
               <Button
+                disabled={sensor.sensorType !== SensorType.STANDARD}
                 onClick={() => {
                   setShowTestTickDialog(true);
                 }}
               >
-                Test Sensor
+                Test sensor
               </Button>
-            ) : null}
+            </Tooltip>
           </Box>
         }
       />


### PR DESCRIPTION
## Summary & Motivation

Instead of hiding the "Test sensor" button for sensors that are not `STANDARD` type, disable it and show a tooltip.

<img width="288" alt="Screenshot 2024-06-28 at 14 21 04" src="https://github.com/dagster-io/dagster/assets/2823852/4c62f234-2b12-46a6-ab44-cb838a9de04e">

## How I Tested These Changes

View sensors, verify that the button is visible in all cases, and disabled (with tooltip) for sensors that are not `STANDARD`.