### PR TITLE
[ui] Show run queue criteria on Run page header

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/types/InstigationTick.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/types/InstigationTick.types.ts
@@ -57,8 +57,6 @@ export type LaunchedRunListQuery = {
           pipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
-          rootConcurrencyKeys: Array<string> | null;
-          hasUnconstrainedRootNodes: boolean;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSensors.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewSensors.tsx
@@ -62,7 +62,6 @@ export const OverviewSensors = () => {
     data: cachedData,
   } = useContext(WorkspaceContext);
 
-  const repoCount = allRepos.length;
   const [searchValue, setSearchValue] = useQueryPersistedState<string>({
     queryKey: 'search',
     defaults: {search: ''},

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/types/PartitionRunList.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/types/PartitionRunList.types.ts
@@ -37,8 +37,6 @@ export type PartitionRunListQuery = {
           pipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
-          rootConcurrencyKeys: Array<string> | null;
-          hasUnconstrainedRootNodes: boolean;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/PipelineRunsRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/PipelineRunsRoot.types.ts
@@ -39,8 +39,6 @@ export type PipelineRunsRootQuery = {
           pipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
-          rootConcurrencyKeys: Array<string> | null;
-          hasUnconstrainedRootNodes: boolean;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunCriteriaQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/QueuedRunCriteriaQuery.tsx
@@ -1,0 +1,13 @@
+import {gql} from '@apollo/client';
+
+export const QUEUED_RUN_CRITERIA_QUERY = gql`
+  query QueuedRunCriteriaQuery($runId: ID!) {
+    runOrError(runId: $runId) {
+      ... on Run {
+        id
+        rootConcurrencyKeys
+        hasUnconstrainedRootNodes
+      }
+    }
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
@@ -220,8 +220,6 @@ export const RUN_TABLE_RUN_FRAGMENT = gql`
       ...RunTagsFragment
     }
     ...RunTimeFragment
-    rootConcurrencyKeys
-    hasUnconstrainedRootNodes
   }
 
   ${RUN_TIME_FRAGMENT}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/QueuedRunCriteriaQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/QueuedRunCriteriaQuery.types.ts
@@ -1,0 +1,20 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type QueuedRunCriteriaQueryVariables = Types.Exact<{
+  runId: Types.Scalars['ID']['input'];
+}>;
+
+export type QueuedRunCriteriaQuery = {
+  __typename: 'Query';
+  runOrError:
+    | {__typename: 'PythonError'}
+    | {
+        __typename: 'Run';
+        id: string;
+        rootConcurrencyKeys: Array<string> | null;
+        hasUnconstrainedRootNodes: boolean;
+      }
+    | {__typename: 'RunNotFoundError'};
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunTable.types.ts
@@ -19,8 +19,6 @@ export type RunTableRunFragment = {
   pipelineSnapshotId: string | null;
   pipelineName: string;
   solidSelection: Array<string> | null;
-  rootConcurrencyKeys: Array<string> | null;
-  hasUnconstrainedRootNodes: boolean;
   startTime: number | null;
   endTime: number | null;
   updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsRoot.types.ts
@@ -39,8 +39,6 @@ export type RunsRootQuery = {
           pipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
-          rootConcurrencyKeys: Array<string> | null;
-          hasUnconstrainedRootNodes: boolean;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleRoot.types.ts
@@ -140,8 +140,6 @@ export type PreviousRunsForScheduleQuery = {
           pipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
-          rootConcurrencyKeys: Array<string> | null;
-          hasUnconstrainedRootNodes: boolean;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorPreviousRuns.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorPreviousRuns.types.ts
@@ -30,8 +30,6 @@ export type PreviousRunsForSensorQuery = {
           pipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
-          rootConcurrencyKeys: Array<string> | null;
-          hasUnconstrainedRootNodes: boolean;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/SectionedLeftNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/SectionedLeftNav.tsx
@@ -49,7 +49,7 @@ type RowType =
     };
 
 export const SectionedLeftNav = () => {
-  const {loading, visibleRepos} = React.useContext(WorkspaceContext);
+  const {visibleRepos} = React.useContext(WorkspaceContext);
   const {basePath} = React.useContext(AppContext);
   const parentRef = React.useRef<HTMLDivElement | null>(null);
 


### PR DESCRIPTION
## Summary & Motivation

Add "View queue criteria" to the overflow menu on the Run detail page header. This reuses the existing dialog from the Runs page, with a bit of refactoring:

- Strip down what the dialog requires from the `Run` object
- Query for the values needed for the dialog, which allows us to reuse the component without needing the exact same fragment object in both places.
- More context for the loading state
- An empty state when the dialog query fails

Overflow menu item:

<img width="235" alt="Screenshot 2024-06-28 at 15 35 58" src="https://github.com/dagster-io/dagster/assets/2823852/c11bfdcc-861a-41cc-971e-961cb75a69ab">

Loading state:

<img width="735" alt="Screenshot 2024-06-28 at 16 30 29" src="https://github.com/dagster-io/dagster/assets/2823852/8c3c03c6-806e-419d-bc6f-d1808fc04f5b">

Error state:

<img width="739" alt="Screenshot 2024-06-28 at 16 30 43" src="https://github.com/dagster-io/dagster/assets/2823852/67f85024-1619-4037-b1a1-6ab388310a42">

## How I Tested These Changes

Queue some runs, verify that the dialog works from the Runs page and from the Run detail header.

Verify that the menu item is not present in the run is not queued.