### PR TITLE
[ui] Improvements to the backfill detail page + logs UI FE-406

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -72,6 +72,7 @@ import {
   DaemonNotRunningAlert,
   USING_DEFAULT_LAUNCHER_ALERT_INSTANCE_FRAGMENT,
   UsingDefaultLauncherAlert,
+  isBackfillDaemonHealthy,
   showBackfillErrorToast,
   showBackfillSuccessToast,
 } from '../partitions/BackfillMessaging';
@@ -805,7 +806,7 @@ const Warnings = ({
       selections,
       setSelections,
     }),
-    instance && launchAsBackfill && DaemonNotRunningAlert({instance}),
+    instance && launchAsBackfill && !isBackfillDaemonHealthy(instance) && DaemonNotRunningAlert(),
     instance && launchAsBackfill && UsingDefaultLauncherAlert({instance}),
   ]
     .filter((a) => !!a)

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPartitionsTab.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPartitionsTab.tsx
@@ -21,6 +21,7 @@ import {AssetKey, RunStatus} from '../../graphql/types';
 import {RunFilterToken, runsPathWithFilters} from '../../runs/RunsFilterInput';
 import {testId} from '../../testing/testId';
 import {Container, HeaderCell, HeaderRow, Inner, Row, RowCell} from '../../ui/VirtualizedTable';
+import {numberFormatter} from '../../ui/formatters';
 import {
   BackfillPartitionsForAssetKeyQuery,
   BackfillPartitionsForAssetKeyQueryVariables,
@@ -235,10 +236,10 @@ export const VirtualizedBackfillPartitionsRow = ({
         </RowCell>
         {asset.__typename === 'AssetPartitionsStatusCounts' ? (
           <>
-            <RowCell>{targeted}</RowCell>
-            <RowCell>{inProgress}</RowCell>
-            <RowCell>{completed}</RowCell>
-            <RowCell>{failed}</RowCell>
+            <RowCell>{numberFormatter.format(targeted)}</RowCell>
+            <RowCell>{numberFormatter.format(inProgress)}</RowCell>
+            <RowCell>{numberFormatter.format(completed)}</RowCell>
+            <RowCell>{numberFormatter.format(failed)}</RowCell>
           </>
         ) : (
           <>

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPartitionsTab.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillPartitionsTab.tsx
@@ -13,12 +13,13 @@ import {Link, useHistory} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {BackfillDetailsBackfillFragment} from './types/BackfillPage.types';
-import {displayNameForAssetKey} from '../../asset-graph/Utils';
+import {displayNameForAssetKey, tokenForAssetKey} from '../../asset-graph/Utils';
 import {asAssetKeyInput} from '../../assets/asInput';
 import {assetDetailsPathForKey} from '../../assets/assetDetailsPathForKey';
 import {AssetViewParams} from '../../assets/types';
 import {AssetKey, RunStatus} from '../../graphql/types';
 import {RunFilterToken, runsPathWithFilters} from '../../runs/RunsFilterInput';
+import {testId} from '../../testing/testId';
 import {Container, HeaderCell, HeaderRow, Inner, Row, RowCell} from '../../ui/VirtualizedTable';
 import {
   BackfillPartitionsForAssetKeyQuery,
@@ -205,7 +206,11 @@ export const VirtualizedBackfillPartitionsRow = ({
   };
 
   return (
-    <Row $height={height} $start={start}>
+    <Row
+      $height={height}
+      $start={start}
+      data-testid={testId(`backfill-asset-row-${tokenForAssetKey(asset.assetKey)}`)}
+    >
       <RowGrid border="bottom">
         <RowCell>
           <Box flex={{direction: 'row', justifyContent: 'space-between'}} style={{minWidth: 0}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
@@ -39,6 +39,7 @@ export const BackfillRunsTab = ({backfill}: {backfill: BackfillDetailsBackfillFr
     useTimelineRange({
       maxNowMs: backfill.endTimestamp ? backfill.endTimestamp * 1000 : undefined,
       hourWindowStorageKey: BACKFILL_RUNS_HOUR_WINDOW_KEY,
+      hourWindowDefault: '1',
       lookaheadHours: 0.1, // no ticks, so miminal "future" needed
     });
 
@@ -141,6 +142,15 @@ const ExecutionRunTable = ({
         <StickyTableContainer $top={56}>
           <RunTable
             runs={pipelineRunsOrError.results}
+            emptyState={() => (
+              <Box
+                padding={{vertical: 24}}
+                border="top-and-bottom"
+                flex={{direction: 'column', alignItems: 'center'}}
+              >
+                No runs have been launched.
+              </Box>
+            )}
             actionBarComponents={actionBarComponents}
             actionBarSticky
           />

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/ExecutionTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/ExecutionTimeline.tsx
@@ -1,4 +1,4 @@
-import {Box, useViewport} from '@dagster-io/ui-components';
+import {Box, Colors, Spinner, useViewport} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import React from 'react';
 import {Link} from 'react-router-dom';
@@ -8,7 +8,6 @@ import {
   CONSTANTS,
   RunChunk,
   RunChunks,
-  RunsEmptyOrLoading,
   TimeDividers,
   TimelineRowContainer,
   TimelineRun,
@@ -89,10 +88,42 @@ export const ExecutionTimeline = (props: Props) => {
         </div>
       ) : (
         <div ref={measureRef}>
-          <RunsEmptyOrLoading loading={loading} includesTicks={false} />
+          <ExecutionTimelineEmptyOrLoading loading={loading} />
         </div>
       )}
     </>
+  );
+};
+
+const ExecutionTimelineEmptyOrLoading = (props: {loading: boolean}) => {
+  const {loading} = props;
+
+  const content = () => {
+    if (loading) {
+      return (
+        <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+          <Spinner purpose="body-text" />
+          Loading runs
+        </Box>
+      );
+    }
+
+    return (
+      <Box flex={{direction: 'column', gap: 12, alignItems: 'center'}}>
+        <div>No runs were executing in this time period.</div>
+      </Box>
+    );
+  };
+
+  return (
+    <Box
+      background={Colors.backgroundDefault()}
+      padding={{vertical: 24}}
+      flex={{direction: 'row', justifyContent: 'center'}}
+      border="top-and-bottom"
+    >
+      {content()}
+    </Box>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
@@ -1,5 +1,5 @@
 import {MockedProvider} from '@apollo/client/testing';
-import {getAllByText, getByText, render, screen, waitFor} from '@testing-library/react';
+import {getAllByText, getByText, getByTitle, render, screen, waitFor} from '@testing-library/react';
 import {MemoryRouter, Route} from 'react-router-dom';
 import {RecoilRoot} from 'recoil';
 
@@ -76,7 +76,20 @@ const mocks = [
   }),
 ];
 
+let nativeGBRC: any;
+
 describe('BackfillPage', () => {
+  beforeAll(() => {
+    nativeGBRC = window.Element.prototype.getBoundingClientRect;
+    window.Element.prototype.getBoundingClientRect = jest
+      .fn()
+      .mockReturnValue({height: 400, width: 400});
+  });
+
+  afterAll(() => {
+    window.Element.prototype.getBoundingClientRect = nativeGBRC;
+  });
+
   it('renders the loading state', async () => {
     render(
       <RecoilRoot>
@@ -93,7 +106,7 @@ describe('BackfillPage', () => {
     );
 
     expect(await screen.findByTestId('page-loading-indicator')).toBeInTheDocument();
-    expect(await screen.findByText('assetA')).toBeVisible();
+    expect(await screen.findByTitle('assetA')).toBeVisible();
   });
 
   it('renders the error state', async () => {
@@ -153,14 +166,14 @@ describe('BackfillPage', () => {
 
     const assetARow = await screen.findByTestId('backfill-asset-row-assetA');
     // Check if the correct data is displayed
-    expect(getByText(assetARow, 'assetA')).toBeVisible();
+    expect(getByTitle(assetARow, 'assetA')).toBeVisible();
     expect(getByText(assetARow, '33')).toBeVisible(); // numPartitionsTargeted
     expect(getByText(assetARow, '22')).toBeVisible(); // numPartitionsInProgress
     expect(getByText(assetARow, '11')).toBeVisible(); // numPartitionsMaterialized
     expect(getByText(assetARow, '0')).toBeVisible(); // numPartitionsFailed
 
     const assetBRow = await screen.findByTestId('backfill-asset-row-assetB');
-    expect(getByText(assetBRow, 'assetB')).toBeVisible();
+    expect(getByTitle(assetBRow, 'assetB')).toBeVisible();
     expect(getByText(assetBRow, 'Completed')).toBeVisible();
     expect(getAllByText(assetBRow, '-').length).toBe(3);
   });

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__tests__/BackfillPage.test.tsx
@@ -14,7 +14,11 @@ import {
   buildPythonError,
   buildUnpartitionedAssetStatus,
 } from '../../../graphql/types';
-import {buildQueryMock} from '../../../testing/mocking';
+import {
+  buildQueryMock,
+  mockViewportClientRect,
+  restoreViewportClientRect,
+} from '../../../testing/mocking';
 import {BACKFILL_DETAILS_QUERY, BackfillPage} from '../BackfillPage';
 
 // This file must be mocked because Jest can't handle `import.meta.url`.
@@ -76,18 +80,13 @@ const mocks = [
   }),
 ];
 
-let nativeGBRC: any;
-
 describe('BackfillPage', () => {
   beforeAll(() => {
-    nativeGBRC = window.Element.prototype.getBoundingClientRect;
-    window.Element.prototype.getBoundingClientRect = jest
-      .fn()
-      .mockReturnValue({height: 400, width: 400});
+    mockViewportClientRect();
   });
 
   afterAll(() => {
-    window.Element.prototype.getBoundingClientRect = nativeGBRC;
+    restoreViewportClientRect();
   });
 
   it('renders the loading state', async () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceBackfills.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceBackfills.types.ts
@@ -2,39 +2,6 @@
 
 import * as Types from '../../graphql/types';
 
-export type InstanceHealthForBackfillsQueryVariables = Types.Exact<{[key: string]: never}>;
-
-export type InstanceHealthForBackfillsQuery = {
-  __typename: 'Query';
-  instance: {
-    __typename: 'Instance';
-    id: string;
-    hasInfo: boolean;
-    daemonHealth: {
-      __typename: 'DaemonHealth';
-      id: string;
-      allDaemonStatuses: Array<{
-        __typename: 'DaemonStatus';
-        id: string;
-        daemonType: string;
-        required: boolean;
-        healthy: boolean | null;
-        lastHeartbeatTime: number | null;
-        lastHeartbeatErrors: Array<{
-          __typename: 'PythonError';
-          message: string;
-          stack: Array<string>;
-          errorChain: Array<{
-            __typename: 'ErrorChainLink';
-            isExplicitLink: boolean;
-            error: {__typename: 'PythonError'; message: string; stack: Array<string>};
-          }>;
-        }>;
-      }>;
-    };
-  };
-};
-
 export type InstanceBackfillsQueryVariables = Types.Exact<{
   status?: Types.InputMaybe<Types.BulkActionStatus>;
   cursor?: Types.InputMaybe<Types.Scalars['String']['input']>;

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
@@ -39,13 +39,15 @@ type Props = {
 export function useTimelineRange({
   maxNowMs,
   hourWindowStorageKey,
+  hourWindowDefault = '12',
   lookaheadHours = LOOKAHEAD_HOURS,
 }: {
   maxNowMs?: number;
   hourWindowStorageKey?: string;
+  hourWindowDefault?: HourWindow;
   lookaheadHours?: number;
 }) {
-  const [hourWindow, setHourWindow] = useHourWindow('12', hourWindowStorageKey);
+  const [hourWindow, setHourWindow] = useHourWindow(hourWindowDefault, hourWindowStorageKey);
   const [now, setNow] = React.useState(() => maxNowMs || Date.now());
   const [offsetMsec, setOffsetMsec] = React.useState(() => 0);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillMessaging.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillMessaging.tsx
@@ -1,10 +1,12 @@
-import {gql} from '@apollo/client';
+import {gql, useQuery} from '@apollo/client';
 import {Alert, ButtonLink, Colors, Group, Mono} from '@dagster-io/ui-components';
 import {History} from 'history';
 import * as React from 'react';
 
 import {
   DaemonNotRunningAlertInstanceFragment,
+  DaemonNotRunningAlertQuery,
+  DaemonNotRunningAlertQueryVariables,
   UsingDefaultLauncherAlertInstanceFragment,
 } from './types/BackfillMessaging.types';
 import {showCustomAlert} from '../app/CustomAlertProvider';
@@ -106,13 +108,29 @@ export const DAEMON_NOT_RUNNING_ALERT_INSTANCE_FRAGMENT = gql`
   }
 `;
 
-export const DaemonNotRunningAlert = ({
-  instance,
-}: {
-  instance: DaemonNotRunningAlertInstanceFragment;
-}) => (!instance.daemonHealth.daemonStatus.healthy ? <DaemonNotRunningAlertBody /> : null);
+const DAEMON_NOT_RUNNING_ALERT_QUERY = gql`
+  query DaemonNotRunningAlertQuery {
+    instance {
+      id
+      ...DaemonNotRunningAlertInstanceFragment
+    }
+  }
 
-export const DaemonNotRunningAlertBody = () => (
+  ${DAEMON_NOT_RUNNING_ALERT_INSTANCE_FRAGMENT}
+`;
+
+export function isBackfillDaemonHealthy(instance: DaemonNotRunningAlertInstanceFragment) {
+  return instance.daemonHealth.daemonStatus.healthy;
+}
+
+export function useIsBackfillDaemonHealthy() {
+  const queryData = useQuery<DaemonNotRunningAlertQuery, DaemonNotRunningAlertQueryVariables>(
+    DAEMON_NOT_RUNNING_ALERT_QUERY,
+  );
+  return queryData.data ? isBackfillDaemonHealthy(queryData.data.instance) : true;
+}
+
+export const DaemonNotRunningAlert = () => (
   <Alert
     intent="warning"
     title="The backfill daemon is not running."

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/BackfillSelector.tsx
@@ -21,6 +21,7 @@ import {
   DaemonNotRunningAlert,
   USING_DEFAULT_LAUNCHER_ALERT_INSTANCE_FRAGMENT,
   UsingDefaultLauncherAlert,
+  isBackfillDaemonHealthy,
   showBackfillErrorToast,
   showBackfillSuccessToast,
 } from './BackfillMessaging';
@@ -312,7 +313,7 @@ export const BackfillPartitionSelector = ({
           </Section>
 
           <Box flex={{direction: 'column', gap: 16}}>
-            <DaemonNotRunningAlert instance={instance} />
+            {!isBackfillDaemonHealthy(instance) ? <DaemonNotRunningAlert /> : null}
 
             <UsingDefaultLauncherAlert instance={instance} />
           </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/types/BackfillMessaging.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/types/BackfillMessaging.types.ts
@@ -12,6 +12,21 @@ export type DaemonNotRunningAlertInstanceFragment = {
   };
 };
 
+export type DaemonNotRunningAlertQueryVariables = Types.Exact<{[key: string]: never}>;
+
+export type DaemonNotRunningAlertQuery = {
+  __typename: 'Query';
+  instance: {
+    __typename: 'Instance';
+    id: string;
+    daemonHealth: {
+      __typename: 'DaemonHealth';
+      id: string;
+      daemonStatus: {__typename: 'DaemonStatus'; id: string; healthy: boolean | null};
+    };
+  };
+};
+
 export type UsingDefaultLauncherAlertInstanceFragment = {
   __typename: 'Instance';
   id: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimeline.tsx
@@ -656,7 +656,7 @@ const RunTimelineRow = ({
   );
 };
 
-export const RunsEmptyOrLoading = (props: {loading: boolean; includesTicks: boolean}) => {
+const RunsEmptyOrLoading = (props: {loading: boolean; includesTicks: boolean}) => {
   const {loading, includesTicks} = props;
 
   const content = () => {


### PR DESCRIPTION
## Summary & Motivation

This PR refines the backfill details page based on user feedback:

- The “duration” shown on the page ticks every second instead of every 60s if the backfill is in progress

- The detail page shows the “backfill daemon is not running” notice if needed, which makes it more obvious why the page may not be showing anything. (I also refactored the backfill list page to use a newer mechanism for fetching this info)

- The runs timeline / list no longer have a double scrollbar and their refresh button is visible in the tab bar.

<img width="302" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/a6458303-4017-4712-884b-9d5cd66e71c0">

- The timeline view defaults to a 1 hour time window instead of 12h

- The RunTable and timeline no longer suggest that you materialize or launch runs in the empty state, and the timeline empty state says “no runs /were executing/“, making it more obvious that the timeline does not show queued runs. Showing queued runs in the timeline view would be nice but is a bigger lift because of the way the run timeline loads runs and filters them for display. Seems like a follow-up if we're really interested.

<img width="1712" alt="image" src="https://github.com/dagster-io/dagster/assets/1037212/343ae7d1-1b70-4f29-b959-28228b5002e6">


## How I Tested These Changes

Manually verified with backfills in a handful of states, with the daemon running and stopped