### PR TITLE
[bugfix] Show actual creation timestamp instead of `start_time` in runs table

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRunsTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRunsTable.types.ts
@@ -27,6 +27,7 @@ export type AutomaterializeRunsQuery = {
           id: string;
           runId: string;
           status: Types.RunStatus;
+          creationTime: number;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;
@@ -39,6 +40,7 @@ export type AutomaterializeRunFragment = {
   id: string;
   runId: string;
   status: Types.RunStatus;
+  creationTime: number;
   startTime: number | null;
   endTime: number | null;
   updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/types/RunGroupPanel.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/types/RunGroupPanel.types.ts
@@ -29,6 +29,7 @@ export type RunGroupPanelQuery = {
           status: Types.RunStatus;
           stepKeysToExecute: Array<string> | null;
           pipelineName: string;
+          creationTime: number;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;
@@ -45,6 +46,7 @@ export type RunGroupPanelRunFragment = {
   status: Types.RunStatus;
   stepKeysToExecute: Array<string> | null;
   pipelineName: string;
+  creationTime: number;
   startTime: number | null;
   endTime: number | null;
   updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -1415,6 +1415,7 @@ type Run implements PipelineRun {
   assetCheckSelection: [AssetCheckhandle!]
   resolvedOpSelection: [String!]
   assetMaterializations: [MaterializationEvent!]!
+  creationTime: Float!
   startTime: Float
   endTime: Float
   updateTime: Float

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -4355,6 +4355,7 @@ export type Run = PipelineRun & {
   canTerminate: Scalars['Boolean']['output'];
   capturedLogs: CapturedLogs;
   computeLogs: ComputeLogs;
+  creationTime: Scalars['Float']['output'];
   endTime: Maybe<Scalars['Float']['output']>;
   eventConnection: EventConnection;
   executionPlan: Maybe<ExecutionPlan>;
@@ -12730,6 +12731,8 @@ export const buildRun = (
         : relationshipsToOmit.has('ComputeLogs')
         ? ({} as ComputeLogs)
         : buildComputeLogs({}, relationshipsToOmit),
+    creationTime:
+      overrides && overrides.hasOwnProperty('creationTime') ? overrides.creationTime! : 5.95,
     endTime: overrides && overrides.hasOwnProperty('endTime') ? overrides.endTime! : 7.08,
     eventConnection:
       overrides && overrides.hasOwnProperty('eventConnection')

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/types/InstigationTick.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/types/InstigationTick.types.ts
@@ -57,6 +57,7 @@ export type LaunchedRunListQuery = {
           pipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
+          creationTime: number;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/types/InstigationUtils.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/types/InstigationUtils.types.ts
@@ -24,6 +24,7 @@ export type InstigationStateFragment = {
     __typename: 'Run';
     id: string;
     status: Types.RunStatus;
+    creationTime: number;
     startTime: number | null;
     endTime: number | null;
     updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/types/JobMetadata.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/types/JobMetadata.types.ts
@@ -66,6 +66,7 @@ export type JobMetadataQuery = {
           __typename: 'Run';
           id: string;
           status: Types.RunStatus;
+          creationTime: number;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;
@@ -128,6 +129,7 @@ export type RunMetadataFragment = {
   __typename: 'Run';
   id: string;
   status: Types.RunStatus;
+  creationTime: number;
   startTime: number | null;
   endTime: number | null;
   updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/types/LatestRunTag.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/types/LatestRunTag.types.ts
@@ -17,6 +17,7 @@ export type LatestRunTagQuery = {
           __typename: 'Run';
           id: string;
           status: Types.RunStatus;
+          creationTime: number;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/types/PartitionRunList.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/types/PartitionRunList.types.ts
@@ -37,6 +37,7 @@ export type PartitionRunListQuery = {
           pipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
+          creationTime: number;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/PipelineRunsRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/PipelineRunsRoot.types.ts
@@ -39,6 +39,7 @@ export type PipelineRunsRootQuery = {
           pipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
+          creationTime: number;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunUtils.tsx
@@ -290,15 +290,11 @@ interface RunTimeProps {
 }
 
 export const RunTime = memo(({run}: RunTimeProps) => {
-  const {startTime, updateTime} = run;
+  const {creationTime} = run;
 
   return (
     <div>
-      {startTime ? (
-        <Timestamp timestamp={{unix: startTime}} />
-      ) : updateTime ? (
-        <Timestamp timestamp={{unix: updateTime}} />
-      ) : null}
+      <Timestamp timestamp={{unix: creationTime}} />
     </div>
   );
 });
@@ -328,6 +324,7 @@ export const RUN_TIME_FRAGMENT = gql`
   fragment RunTimeFragment on Run {
     id
     status
+    creationTime
     startTime
     endTime
     updateTime

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__stories__/RunStatusPez.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__stories__/RunStatusPez.stories.tsx
@@ -50,6 +50,7 @@ export const List = () => {
       id: string;
       status: RunStatus;
       startTime: number;
+      creationTime: number;
       endTime: number;
     }[],
   ): RunTimeFragment[] =>
@@ -57,7 +58,6 @@ export const List = () => {
 
   const fakeRepo = 'a_repo.py';
   const fakeId = useCallback(() => faker.datatype.uuid(), []);
-
   return (
     <StorybookProvider apolloProps={{mocks}}>
       <Box flex={{direction: 'column', gap: 8}}>
@@ -87,6 +87,7 @@ export const List = () => {
                   id,
                   runId: id,
                   status: RunStatus.STARTING,
+                  creationTime: Date.now() - (idx + 1) * 60 * 60 * 1000,
                   startTime: Date.now() - (idx + 1) * 60 * 60 * 1000,
                   endTime: Date.now() - idx * 60 * 60 * 1000,
                   updateTime: null,

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunTable.types.ts
@@ -19,6 +19,7 @@ export type RunTableRunFragment = {
   pipelineSnapshotId: string | null;
   pipelineName: string;
   solidSelection: Array<string> | null;
+  creationTime: number;
   startTime: number | null;
   endTime: number | null;
   updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunUtils.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunUtils.types.ts
@@ -160,6 +160,7 @@ export type RunTimeFragment = {
   __typename: 'Run';
   id: string;
   status: Types.RunStatus;
+  creationTime: number;
   startTime: number | null;
   endTime: number | null;
   updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsRoot.types.ts
@@ -39,6 +39,7 @@ export type RunsRootQuery = {
           pipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
+          creationTime: number;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsForTimeline.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsForTimeline.types.ts
@@ -7,6 +7,7 @@ export type RunTimelineFragment = {
   id: string;
   pipelineName: string;
   status: Types.RunStatus;
+  creationTime: number;
   startTime: number | null;
   endTime: number | null;
   updateTime: number | null;
@@ -36,6 +37,7 @@ export type OngoingRunTimelineQuery = {
           id: string;
           pipelineName: string;
           status: Types.RunStatus;
+          creationTime: number;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;
@@ -67,6 +69,7 @@ export type CompletedRunTimelineQuery = {
           id: string;
           pipelineName: string;
           status: Types.RunStatus;
+          creationTime: number;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleRoot.types.ts
@@ -52,6 +52,7 @@ export type ScheduleRootQuery = {
             __typename: 'Run';
             id: string;
             status: Types.RunStatus;
+            creationTime: number;
             startTime: number | null;
             endTime: number | null;
             updateTime: number | null;
@@ -140,6 +141,7 @@ export type PreviousRunsForScheduleQuery = {
           pipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
+          creationTime: number;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleUtils.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleUtils.types.ts
@@ -35,6 +35,7 @@ export type ScheduleFragment = {
       __typename: 'Run';
       id: string;
       status: Types.RunStatus;
+      creationTime: number;
       startTime: number | null;
       endTime: number | null;
       updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorFragment.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorFragment.types.ts
@@ -33,6 +33,7 @@ export type SensorFragment = {
       __typename: 'Run';
       id: string;
       status: Types.RunStatus;
+      creationTime: number;
       startTime: number | null;
       endTime: number | null;
       updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorPreviousRuns.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorPreviousRuns.types.ts
@@ -30,6 +30,7 @@ export type PreviousRunsForSensorQuery = {
           pipelineSnapshotId: string | null;
           pipelineName: string;
           solidSelection: Array<string> | null;
+          creationTime: number;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorRoot.types.ts
@@ -50,6 +50,7 @@ export type SensorRootQuery = {
             __typename: 'Run';
             id: string;
             status: Types.RunStatus;
+            creationTime: number;
             startTime: number | null;
             endTime: number | null;
             updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/testing/generateRunMocks.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/testing/generateRunMocks.ts
@@ -14,10 +14,12 @@ export const generateRunMocks = (runCount: number, range: [number, number]) => {
           ? RunStatus.STARTED
           : faker.random.arrayElement([RunStatus.SUCCESS, RunStatus.FAILURE]);
 
+      const startTime = startDate.getTime();
       return {
         id: faker.datatype.uuid(),
+        creationTime: startTime,
+        startTime,
         status,
-        startTime: startDate.getTime(),
         endTime,
       };
     });

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedJobRow.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedJobRow.types.ts
@@ -21,6 +21,7 @@ export type SingleJobQuery = {
           __typename: 'Run';
           id: string;
           status: Types.RunStatus;
+          creationTime: number;
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedScheduleRow.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedScheduleRow.types.ts
@@ -47,6 +47,7 @@ export type SingleScheduleQuery = {
             __typename: 'Run';
             id: string;
             status: Types.RunStatus;
+            creationTime: number;
             startTime: number | null;
             endTime: number | null;
             updateTime: number | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedSensorRow.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedSensorRow.types.ts
@@ -52,6 +52,7 @@ export type SingleSensorQuery = {
             __typename: 'Run';
             id: string;
             status: Types.RunStatus;
+            creationTime: number;
             startTime: number | null;
             endTime: number | null;
             updateTime: number | null;

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -365,6 +365,7 @@ class GrapheneRun(graphene.ObjectType):
         graphene.NonNull(GrapheneEventConnection),
         afterCursor=graphene.Argument(graphene.String),
     )
+    creationTime = graphene.NonNull(graphene.Float)
     startTime = graphene.Float()
     endTime = graphene.Float()
     updateTime = graphene.Float()
@@ -585,6 +586,10 @@ class GrapheneRun(graphene.ObjectType):
     def resolve_updateTime(self, graphene_info: ResolveInfo):
         run_record = self._get_run_record(graphene_info.context.instance)
         return datetime_as_float(run_record.update_timestamp)
+
+    def resolve_creationTime(self, graphene_info: ResolveInfo):
+        run_record = self._get_run_record(graphene_info.context.instance)
+        return datetime_as_float(run_record.create_timestamp)
 
     def resolve_hasConcurrencyKeySlots(self, graphene_info: ResolveInfo):
         instance = graphene_info.context.instance


### PR DESCRIPTION
## Summary & Motivation

A recent user inquiry about the sorting of runs in the backfill runs table
(https://dagsterlabs.slack.com/archives/C064933ANQL/p1719328567183329) led to the discovery that what is listed as the "Create date" in the runs table UI is not actually the "Create time" of the underlying run record, but rather the `start_time` (when the run was launched) if it was defined, or if not the `update_time`.

This is both inaccurate and also causes the sorting in the table to be inscrutable in some cases, where there is a subtle deviation from sorting by "Created date".

This PR updates the UI to use the run record `creation_time` instead of `start_time` or `updated_time`. `creation_time` is always defined since it is set on record creation. This change both fixes the inaccuracy on the runs page and results in more straightforward sorting.

Note that creation time was not exposed on the `GrapheneRun` GQL type so it is added here.

## How I Tested These Changes

Viewed backfill runs page linked by user in shadow dagit with this applied, confirmed sorting was fixed.

Before:

<img width="270" alt="image" src="https://github.com/dagster-io/dagster/assets/1531373/46db88a2-6f9e-4f5a-a550-19f831dc2233">

After:

<img width="270" alt="image" src="https://github.com/dagster-io/dagster/assets/1531373/ad8e002a-1574-4ec7-a098-f9eea8db51e9">
