### PR TITLE
Change default websocket-less event log batch size to 1000

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsProvider.tsx
@@ -69,7 +69,7 @@ const pipelineStatusFromMessages = (messages: RunDagsterRunEventFragment[]) => {
 };
 
 const BATCH_INTERVAL = 100;
-const QUERY_LOG_LIMIT = 10000;
+const QUERY_LOG_LIMIT = 1000;
 
 type State = {
   nodes: LogNode[];


### PR DESCRIPTION
Summary:
This matches the new default in the websocket case.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
