### PR TITLE
[ui] Don't use UTC in per-event bar chart times

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsBarChart.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/insights/InsightsBarChart.tsx
@@ -208,7 +208,6 @@ export const InsightsBarChart = (props: Props) => {
                 day: 'numeric',
                 hour: 'numeric',
                 minute: 'numeric',
-                timeZone: 'UTC',
               });
             },
           },


### PR DESCRIPTION
## Summary & Motivation

Not sure why this is set to UTC as the timezone, but that's wrong.

## How I Tested These Changes

View per-event asset insights, verify that timestamp labels on the x axis and tooltip are correct for my timezone.