### PR TITLE
[ui] Move mocks for viewportClientRect to mocking utils

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetTables.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetTables.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import {MemoryRouter} from 'react-router';
 import {RecoilRoot} from 'recoil';
 
+import {mockViewportClientRect, restoreViewportClientRect} from '../../testing/mocking';
 import {WorkspaceProvider} from '../../workspace/WorkspaceContext';
 import {buildWorkspaceMocks} from '../../workspace/__fixtures__/Workspace.fixtures';
 import {AssetsCatalogTable} from '../AssetsCatalogTable';
@@ -32,17 +33,12 @@ const MOCKS = [
 jest.mock('../../graph/asyncGraphLayout', () => ({}));
 
 describe('AssetTable', () => {
-  let nativeGBRC: any;
-
   beforeAll(() => {
-    nativeGBRC = window.Element.prototype.getBoundingClientRect;
-    window.Element.prototype.getBoundingClientRect = jest
-      .fn()
-      .mockReturnValue({height: 400, width: 400});
+    mockViewportClientRect();
   });
 
   afterAll(() => {
-    window.Element.prototype.getBoundingClientRect = nativeGBRC;
+    restoreViewportClientRect();
   });
 
   describe('Materialize button', () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/LeftNavRepositorySection.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/LeftNavRepositorySection.test.tsx
@@ -5,6 +5,7 @@ import {useContext} from 'react';
 import {MemoryRouter} from 'react-router-dom';
 
 import {__resetForJest} from '../../search/useIndexedDBCachedQuery';
+import {mockViewportClientRect, restoreViewportClientRect} from '../../testing/mocking';
 import {
   HIDDEN_REPO_KEYS,
   WorkspaceContext,
@@ -27,18 +28,13 @@ describe('Repository options', () => {
   const locationOne = 'ipsum';
   const repoOne = 'lorem';
 
-  let nativeGBRC: any;
-
   beforeEach(() => {
     window.localStorage.clear();
-    nativeGBRC = window.Element.prototype.getBoundingClientRect;
-    window.Element.prototype.getBoundingClientRect = jest
-      .fn()
-      .mockReturnValue({height: 400, width: 400});
+    mockViewportClientRect();
   });
 
   afterEach(() => {
-    window.Element.prototype.getBoundingClientRect = nativeGBRC;
+    restoreViewportClientRect();
     window.localStorage.clear();
     __resetForJest();
     jest.resetModules();

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/RunFilterInput.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/RunFilterInput.test.tsx
@@ -11,6 +11,7 @@ import {
   buildRunTagKeys,
   buildWorkspaceLocationEntry,
 } from '../../graphql/types';
+import {mockViewportClientRect, restoreViewportClientRect} from '../../testing/mocking';
 import {calculateTimeRanges} from '../../ui/Filters/useTimeRangeFilter';
 import {WorkspaceProvider} from '../../workspace/WorkspaceContext';
 import {buildWorkspaceMocks} from '../../workspace/__fixtures__/Workspace.fixtures';
@@ -65,17 +66,12 @@ const backfillRunTagsValuesMock = buildRunTagValuesQueryMockedResponse(DagsterTa
   'value2',
 ]);
 
-let nativeGBRC: any;
-
 beforeAll(() => {
-  nativeGBRC = window.Element.prototype.getBoundingClientRect;
-  window.Element.prototype.getBoundingClientRect = jest
-    .fn()
-    .mockReturnValue({height: 400, width: 400});
+  mockViewportClientRect();
 });
 
 afterAll(() => {
-  window.Element.prototype.getBoundingClientRect = nativeGBRC;
+  restoreViewportClientRect();
 });
 
 describe('useTagDataFilterValues', () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/testing/mocking.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/testing/mocking.ts
@@ -146,3 +146,26 @@ function removeDefaultValues<T extends Record<string | number, any> | Array<any>
 
   return dataWithoutDefaultValues as T; // Cast to the original type 'T'
 }
+
+let nativeGBRC: any;
+
+/* simulate getBoundingCLientRect returning a > 0x0 size, important for
+testing React trees that useVirtualized()
+*/
+export function mockViewportClientRect() {
+  if (nativeGBRC) {
+    return;
+  }
+  nativeGBRC = window.Element.prototype.getBoundingClientRect;
+  window.Element.prototype.getBoundingClientRect = jest
+    .fn()
+    .mockReturnValue({height: 400, width: 400});
+}
+
+export function restoreViewportClientRect() {
+  if (!nativeGBRC) {
+    return;
+  }
+  window.Element.prototype.getBoundingClientRect = nativeGBRC;
+  nativeGBRC = null;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/__tests__/FilterDropdown.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/__tests__/FilterDropdown.test.tsx
@@ -1,6 +1,7 @@
 import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import {mockViewportClientRect, restoreViewportClientRect} from '../../../testing/mocking';
 import {FilterDropdown, FilterDropdownButton} from '../FilterDropdown';
 import {FilterObject} from '../useFilter';
 
@@ -36,17 +37,12 @@ beforeEach(() => {
   ] as any;
 });
 
-let nativeGBRC: any;
-
 beforeAll(() => {
-  nativeGBRC = window.Element.prototype.getBoundingClientRect;
-  window.Element.prototype.getBoundingClientRect = jest
-    .fn()
-    .mockReturnValue({height: 400, width: 400});
+  mockViewportClientRect();
 });
 
 afterAll(() => {
-  window.Element.prototype.getBoundingClientRect = nativeGBRC;
+  restoreViewportClientRect();
 });
 
 describe('FilterDropdown', () => {


### PR DESCRIPTION
## Summary & Motivation

Just added a 5th test file that needed this code, figured I'd move it to a shared helper. The shape of the function is a bit different than other mocks but I think that's required for this particular case.

## How I Tested These Changes

Tests still pass