### PR TITLE
Compare asset key paths instead of comparing the entire asset key object

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
@@ -17,7 +17,9 @@ interface Props {
 
 export const PartitionHealthSummary = memo((props: Props) => {
   const {showAssetKey, assetKey, data, selections} = props;
-  const assetData = data.find((d) => JSON.stringify(d.assetKey) === JSON.stringify(assetKey));
+  const assetData = data.find(
+    (d) => JSON.stringify(d.assetKey.path) === JSON.stringify(assetKey.path),
+  );
 
   if (!assetData) {
     return (


### PR DESCRIPTION
## Summary & Motivation

Looks like something changed on the backend and the __typename field isn't first in the object anymore. Instead lets compare the paths.


<img width="589" alt="Screenshot 2024-07-01 at 4 26 34 PM" src="https://github.com/dagster-io/dagster/assets/2286579/7792d6f2-b4b7-4181-81be-141700aec0be">


## How I Tested These Changes

app-proxy

<img width="410" alt="Screenshot 2024-07-01 at 4 33 28 PM" src="https://github.com/dagster-io/dagster/assets/2286579/364bf6dc-7a72-4481-bc72-290f6cfb3bc6">

