### PR TITLE
Non-transitive sync status

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/data_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_version.py
@@ -521,18 +521,7 @@ class CachingStaleStatusResolver:
         partition_deps = self._get_partition_dependencies(key=key)
         for dep_key in sorted(partition_deps):
             dep_asset = self.asset_graph.get(dep_key.asset_key)
-            if (
-                self._instance.use_transitive_stale_causes
-                and self._get_status(key=dep_key) == StaleStatus.STALE
-            ):
-                yield StaleCause(
-                    key,
-                    StaleCauseCategory.DATA,
-                    "stale dependency",
-                    dep_key,
-                    self._get_stale_causes(key=dep_key),
-                )
-            elif provenance:
+            if provenance:
                 if not provenance.has_input_asset(dep_key.asset_key):
                     yield StaleCause(
                         key,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -962,10 +962,6 @@ class DagsterInstance(DynamicPartitionsStore):
     def global_op_concurrency_default_limit(self) -> Optional[int]:
         return self.get_settings("concurrency").get("default_op_concurrency_limit")
 
-    @property
-    def use_transitive_stale_causes(self) -> bool:
-        return False
-
     # python logs
 
     @property


### PR DESCRIPTION
## Summary & Motivation

Internal companion PR: https://github.com/dagster-io/internal/pull/10427

Non-transitive sync status calculation is toggled by an org setting. This has been turned off by default for everyone for a few months now. We have had no need to revert, so this PR cleans non-transitive sync status completely out of the codebase.

## How I Tested These Changes

Existing test suite.
