### PR TITLE
[ui] update code locations table to source from status and entries

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryLocationsList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryLocationsList.tsx
@@ -4,8 +4,8 @@ import {useRef} from 'react';
 
 import {
   CodeLocationRowType,
-  VirtualizedCodeLocationErrorRow,
   VirtualizedCodeLocationHeader,
+  VirtualizedCodeLocationRepositoryRow,
   VirtualizedCodeLocationRow,
 } from './VirtualizedCodeLocationRow';
 import {Container, DynamicRowContainer, Inner} from '../ui/VirtualizedTable';
@@ -73,22 +73,23 @@ export const RepositoryLocationsList = ({loading, codeLocations, searchValue}: P
         <DynamicRowContainer $start={items[0]?.start ?? 0}>
           {items.map(({index, key}) => {
             const row: CodeLocationRowType = codeLocations[index]!;
-            if (row.type === 'error') {
+            if (row.type === 'location') {
               return (
-                <VirtualizedCodeLocationErrorRow
+                <VirtualizedCodeLocationRow
                   key={key}
                   index={index}
-                  locationNode={row.node}
+                  locationEntry={row.locationEntry}
+                  locationStatus={row.locationStatus}
                   ref={virtualizer.measureElement}
                 />
               );
             }
-
             return (
-              <VirtualizedCodeLocationRow
+              <VirtualizedCodeLocationRepositoryRow
                 key={key}
                 index={index}
-                codeLocation={row.codeLocation}
+                locationStatus={row.locationStatus}
+                locationEntry={row.locationEntry}
                 repository={row.repository}
                 ref={virtualizer.measureElement}
               />

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceQueries.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceQueries.tsx
@@ -134,12 +134,16 @@ export const CODE_LOCATION_STATUS_QUERY = gql`
     locationStatusesOrError {
       ... on WorkspaceLocationStatusEntries {
         entries {
-          id
-          name
-          loadStatus
-          updateTimestamp
+          ...LocationStatusEntryFragment
         }
       }
     }
+  }
+
+  fragment LocationStatusEntryFragment on WorkspaceLocationStatusEntry {
+    id
+    name
+    loadStatus
+    updateTimestamp
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceQueries.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceQueries.types.ts
@@ -453,3 +453,11 @@ export type CodeLocationStatusQuery = {
         }>;
       };
 };
+
+export type LocationStatusEntryFragment = {
+  __typename: 'WorkspaceLocationStatusEntry';
+  id: string;
+  name: string;
+  loadStatus: Types.RepositoryLocationLoadStatus;
+  updateTimestamp: number;
+};


### PR DESCRIPTION
Each code location has a status representation and full entry representation with all the definitions. We poll the small cheap status frequently and when changes are detected update the large entries. 

This PR brings this modeling to the code locations table by explicitly passing down status and entry objects. 

## How I Tested These Changes

viewed and refreshed locations loading dagster dev at repo root 
