### PR TITLE
Use asyncio in dagster-graphql cli

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/cli.py
+++ b/python_modules/dagster-graphql/dagster_graphql/cli.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Mapping, Optional
 from urllib.parse import urljoin, urlparse
 
@@ -39,10 +40,12 @@ def execute_query(
 
     context = workspace_process_context.create_request_context()
 
-    result = create_schema().execute(
-        query,
-        context_value=context,
-        variable_values=variables,
+    result = asyncio.run(
+        create_schema().execute_async(
+            query,
+            context_value=context,
+            variable_values=variables,
+        )
     )
 
     result_dict = result.formatted


### PR DESCRIPTION
Summary:
This prevents queries from failing if they use the new async resolvers

Test Plan:
Existing dagster-graphql test suite

## Summary & Motivation

## How I Tested These Changes
