### PR TITLE
drop default event chunk size to 1000

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -211,7 +211,7 @@ def delete_pipeline_run(
 def get_chunk_size() -> int:
     return int(
         os.getenv(
-            "DAGSTER_UI_EVENT_LOAD_CHUNK_SIZE", os.getenv("DAGIT_EVENT_LOAD_CHUNK_SIZE", "10000")
+            "DAGSTER_UI_EVENT_LOAD_CHUNK_SIZE", os.getenv("DAGIT_EVENT_LOAD_CHUNK_SIZE", "1000")
         )
     )
 


### PR DESCRIPTION
Summary:
websocket equivalent to https://github.com/dagster-io/dagster/pull/22791

Test Plan:
View streaming run logs in the UI

## Summary & Motivation

## How I Tested These Changes
