### PR TITLE
[fix] fix err when trying to attach code references to graph-backed assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -99,12 +99,21 @@ def _with_code_source_single_definition(
     metadata_by_key = dict(assets_def.metadata_by_key) or {}
 
     from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
+    from dagster._core.definitions.graph_definition import GraphDefinition
+    from dagster._core.definitions.op_definition import OpDefinition
 
-    base_fn = (
-        assets_def.op.compute_fn.decorated_fn
-        if isinstance(assets_def.op.compute_fn, DecoratedOpFunction)
-        else assets_def.op.compute_fn
-    )
+    if isinstance(assets_def.node_def, OpDefinition):
+        base_fn = (
+            assets_def.node_def.compute_fn.decorated_fn
+            if isinstance(assets_def.node_def.compute_fn, DecoratedOpFunction)
+            else assets_def.node_def.compute_fn
+        )
+    elif isinstance(assets_def.node_def, GraphDefinition):
+        # todo - properly handle graph-backed asset code source
+        return assets_def
+    else:
+        return assets_def
+
     source_path = local_source_path_from_fn(base_fn)
 
     if source_path:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_package/module_with_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_package/module_with_assets.py
@@ -1,4 +1,4 @@
-from dagster import AssetKey, SourceAsset, asset
+from dagster import AssetKey, SourceAsset, asset, graph_asset, op
 from dagster._core.definitions.metadata import (
     CodeReferencesMetadataSet,
     CodeReferencesMetadataValue,
@@ -24,3 +24,18 @@ elvis_presley = SourceAsset(key=AssetKey("elvis_presley"))
 )
 def chuck_berry(elvis_presley, miles_davis):
     pass
+
+
+@op
+def one():
+    return 1
+
+
+@op
+def multiply_by_two(input_num):
+    return input_num * 2
+
+
+@graph_asset
+def graph_backed_asset():
+    return multiply_by_two(one())

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
@@ -50,7 +50,7 @@ def test_asset_code_origins() -> None:
             for key in asset.keys:
                 # `chuck_berry` is the only asset with source code metadata manually
                 # attached to it
-                if asset.op.name == "chuck_berry":
+                if asset.node_def.name == "chuck_berry":
                     assert "dagster/code_references" in asset.metadata_by_key[key]
                 else:
                     assert "dagster/code_references" not in asset.metadata_by_key[key]
@@ -59,7 +59,11 @@ def test_asset_code_origins() -> None:
 
     for asset in collection_with_source_metadata:
         if isinstance(asset, AssetsDefinition):
-            op_name = asset.op.name
+            op_name = asset.node_def.name
+
+            if op_name == "graph_backed_asset":
+                continue
+
             assert op_name in EXPECTED_ORIGINS, f"Missing expected origin for op {op_name}"
 
             expected_file_path, expected_line_number = EXPECTED_ORIGINS[op_name].split(":")
@@ -113,7 +117,10 @@ def test_asset_code_origins_source_control() -> None:
             for key in asset.keys:
                 # `chuck_berry` is the only asset with source code metadata manually
                 # attached to it
-                if asset.op.name == "chuck_berry":
+
+                if asset.node_def.name == "graph_backed_asset":
+                    continue
+                elif asset.node_def.name == "chuck_berry":
                     assert "dagster/code_references" in asset.specs_by_key[key].metadata
                 else:
                     assert "dagster/code_references" not in asset.specs_by_key[key].metadata
@@ -131,7 +138,10 @@ def test_asset_code_origins_source_control() -> None:
 
     for asset in collection_with_source_control_metadata:
         if isinstance(asset, AssetsDefinition):
-            op_name = asset.op.name
+            op_name = asset.node_def.name
+            if op_name == "graph_backed_asset":
+                continue
+
             assert op_name in EXPECTED_ORIGINS, f"Missing expected origin for op {op_name}"
 
             expected_file_path, expected_line_number = EXPECTED_ORIGINS[op_name].split(":")
@@ -169,7 +179,7 @@ def test_asset_code_origins_source_control_custom_mapping() -> None:
             for key in asset.keys:
                 # `chuck_berry` is the only asset with source code metadata manually
                 # attached to it
-                if asset.op.name == "chuck_berry":
+                if asset.node_def.name == "chuck_berry":
                     assert "dagster/code_references" in asset.metadata_by_key[key]
                 else:
                     assert "dagster/code_references" not in asset.metadata_by_key[key]
@@ -193,7 +203,10 @@ def test_asset_code_origins_source_control_custom_mapping() -> None:
 
     for asset in collection_with_source_control_metadata:
         if isinstance(asset, AssetsDefinition):
-            op_name = asset.op.name
+            op_name = asset.node_def.name
+            if op_name == "graph_backed_asset":
+                continue
+
             assert op_name in EXPECTED_ORIGINS, f"Missing expected origin for op {op_name}"
 
             expected_file_path, expected_line_number = EXPECTED_ORIGINS[op_name].split(":")

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets_from_modules.py
@@ -18,7 +18,7 @@ from dagster._core.definitions.auto_materialize_policy import AutoMaterializePol
 from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 
 get_unique_asset_identifier = lambda asset: (
-    asset.op.name if isinstance(asset, AssetsDefinition) else asset.key
+    asset.node_def.name if isinstance(asset, AssetsDefinition) else asset.key
 )
 
 
@@ -90,12 +90,12 @@ def test_load_assets_from_package_name():
     from . import asset_package
 
     assets_defs = load_assets_from_package_name(asset_package.__name__)
-    assert len(assets_defs) == 10
+    assert len(assets_defs) == 11
 
     assets_1 = [get_unique_asset_identifier(asset) for asset in assets_defs]
 
     assets_defs_2 = load_assets_from_package_name(asset_package.__name__)
-    assert len(assets_defs_2) == 10
+    assert len(assets_defs_2) == 11
 
     assets_2 = [get_unique_asset_identifier(asset) for asset in assets_defs]
 
@@ -106,12 +106,12 @@ def test_load_assets_from_package_module():
     from . import asset_package
 
     assets_1 = load_assets_from_package_module(asset_package)
-    assert len(assets_1) == 10
+    assert len(assets_1) == 11
 
     assets_1 = [get_unique_asset_identifier(asset) for asset in assets_1]
 
     assets_2 = load_assets_from_package_module(asset_package)
-    assert len(assets_2) == 10
+    assert len(assets_2) == 11
 
     assets_2 = [get_unique_asset_identifier(asset) for asset in assets_2]
 


### PR DESCRIPTION
## Summary & Motivation


Avoids trying to attach code references automatically to graph-backed assets, which previously errored. Puts that case under test. Subsequent PR will actually properly attach a reference to the underlying graph to the asset metadata.

## How I Tested These Changes

New test case.
