### PR TITLE
Properly attach code references to graph-backed assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/graph_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/graph_decorator.py
@@ -97,7 +97,7 @@ class _Graph:
             positional_inputs=positional_inputs,
             tags=self.tags,
             input_assets=input_assets,
-            underlying_fn=fn,
+            composition_fn=fn,
         )
         update_wrapper(graph_def, fn)
         return graph_def

--- a/python_modules/dagster/dagster/_core/definitions/decorators/graph_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/graph_decorator.py
@@ -97,6 +97,7 @@ class _Graph:
             positional_inputs=positional_inputs,
             tags=self.tags,
             input_assets=input_assets,
+            underlying_fn=fn,
         )
         update_wrapper(graph_def, fn)
         return graph_def

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -3,6 +3,7 @@ from typing import (
     TYPE_CHECKING,
     AbstractSet,
     Any,
+    Callable,
     Dict,
     Iterable,
     Iterator,
@@ -164,6 +165,8 @@ class GraphDefinition(NodeDefinition):
             Values that are not strings will be json encoded and must meet the criteria that
             `json.loads(json.dumps(value)) == value`.  These tag values may be overwritten by tag
             values provided at invocation time.
+        underlying_fn (Optional[Callable]): The function that defines this graph. Used to generate
+            code references for this graph.
 
     Examples:
         .. code-block:: python
@@ -216,6 +219,7 @@ class GraphDefinition(NodeDefinition):
         input_assets: Optional[
             Mapping[str, Mapping[str, Union["AssetsDefinition", "SourceAsset"]]]
         ] = None,
+        underlying_fn: Optional[Callable] = None,
         **kwargs: Any,
     ):
         from .external_asset import create_external_asset_from_source_asset
@@ -249,6 +253,8 @@ class GraphDefinition(NodeDefinition):
         )
 
         self._config_mapping = check.opt_inst_param(config, "config", ConfigMapping)
+
+        self._underlying_fn = check.opt_callable_param(underlying_fn, "underlying_fn")
 
         super(GraphDefinition, self).__init__(
             name=name,
@@ -353,6 +359,10 @@ class GraphDefinition(NodeDefinition):
     @property
     def input_assets(self) -> Mapping[str, Mapping[str, "AssetsDefinition"]]:
         return self._input_assets
+
+    @property
+    def underlying_fn(self) -> Optional[Callable]:
+        return self._underlying_fn
 
     def has_node_named(self, name: str) -> bool:
         check.str_param(name, "name")

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -165,7 +165,7 @@ class GraphDefinition(NodeDefinition):
             Values that are not strings will be json encoded and must meet the criteria that
             `json.loads(json.dumps(value)) == value`.  These tag values may be overwritten by tag
             values provided at invocation time.
-        underlying_fn (Optional[Callable]): The function that defines this graph. Used to generate
+        composition_fn (Optional[Callable]): The function that defines this graph. Used to generate
             code references for this graph.
 
     Examples:
@@ -219,7 +219,7 @@ class GraphDefinition(NodeDefinition):
         input_assets: Optional[
             Mapping[str, Mapping[str, Union["AssetsDefinition", "SourceAsset"]]]
         ] = None,
-        underlying_fn: Optional[Callable] = None,
+        composition_fn: Optional[Callable] = None,
         **kwargs: Any,
     ):
         from .external_asset import create_external_asset_from_source_asset
@@ -254,7 +254,7 @@ class GraphDefinition(NodeDefinition):
 
         self._config_mapping = check.opt_inst_param(config, "config", ConfigMapping)
 
-        self._underlying_fn = check.opt_callable_param(underlying_fn, "underlying_fn")
+        self._composition_fn = check.opt_callable_param(composition_fn, "composition_fn")
 
         super(GraphDefinition, self).__init__(
             name=name,
@@ -361,8 +361,8 @@ class GraphDefinition(NodeDefinition):
         return self._input_assets
 
     @property
-    def underlying_fn(self) -> Optional[Callable]:
-        return self._underlying_fn
+    def composition_fn(self) -> Optional[Callable]:
+        return self._composition_fn
 
     def has_node_named(self, name: str) -> bool:
         check.str_param(name, "name")

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -102,6 +102,7 @@ def _with_code_source_single_definition(
     from dagster._core.definitions.graph_definition import GraphDefinition
     from dagster._core.definitions.op_definition import OpDefinition
 
+    base_fn = None
     if isinstance(assets_def.node_def, OpDefinition):
         base_fn = (
             assets_def.node_def.compute_fn.decorated_fn
@@ -112,9 +113,8 @@ def _with_code_source_single_definition(
         # For graph-backed assets, point to the composition fn, e.g. the
         # function decorated by @graph_asset
         base_fn = assets_def.node_def.composition_fn
-        if not base_fn:
-            return assets_def
-    else:
+
+    if not base_fn:
         return assets_def
 
     source_path = local_source_path_from_fn(base_fn)

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -109,7 +109,8 @@ def _with_code_source_single_definition(
             else assets_def.node_def.compute_fn
         )
     elif isinstance(assets_def.node_def, GraphDefinition):
-        # todo - properly handle graph-backed asset code source
+        # For graph-backed assets, point to the composition fn, e.g. the
+        # function decorated by @graph_asset
         base_fn = assets_def.node_def.composition_fn
         if not base_fn:
             return assets_def

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -110,7 +110,7 @@ def _with_code_source_single_definition(
         )
     elif isinstance(assets_def.node_def, GraphDefinition):
         # todo - properly handle graph-backed asset code source
-        base_fn = assets_def.node_def.underlying_fn
+        base_fn = assets_def.node_def.composition_fn
         if not base_fn:
             return assets_def
     else:

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -110,7 +110,9 @@ def _with_code_source_single_definition(
         )
     elif isinstance(assets_def.node_def, GraphDefinition):
         # todo - properly handle graph-backed asset code source
-        return assets_def
+        base_fn = assets_def.node_def.underlying_fn
+        if not base_fn:
+            return assets_def
     else:
         return assets_def
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_defs_source_metadata.py
@@ -35,6 +35,9 @@ EXPECTED_ORIGINS = {
         + PATH_IN_PACKAGE
         + "asset_package/asset_subpackage/another_module_with_assets.py:6"
     ),
+    "graph_backed_asset": (
+        DAGSTER_PACKAGE_PATH + PATH_IN_PACKAGE + "asset_package/module_with_assets.py:39"
+    ),
 }
 
 
@@ -60,9 +63,6 @@ def test_asset_code_origins() -> None:
     for asset in collection_with_source_metadata:
         if isinstance(asset, AssetsDefinition):
             op_name = asset.node_def.name
-
-            if op_name == "graph_backed_asset":
-                continue
 
             assert op_name in EXPECTED_ORIGINS, f"Missing expected origin for op {op_name}"
 
@@ -117,10 +117,7 @@ def test_asset_code_origins_source_control() -> None:
             for key in asset.keys:
                 # `chuck_berry` is the only asset with source code metadata manually
                 # attached to it
-
-                if asset.node_def.name == "graph_backed_asset":
-                    continue
-                elif asset.node_def.name == "chuck_berry":
+                if asset.node_def.name == "chuck_berry":
                     assert "dagster/code_references" in asset.specs_by_key[key].metadata
                 else:
                     assert "dagster/code_references" not in asset.specs_by_key[key].metadata
@@ -139,8 +136,6 @@ def test_asset_code_origins_source_control() -> None:
     for asset in collection_with_source_control_metadata:
         if isinstance(asset, AssetsDefinition):
             op_name = asset.node_def.name
-            if op_name == "graph_backed_asset":
-                continue
 
             assert op_name in EXPECTED_ORIGINS, f"Missing expected origin for op {op_name}"
 
@@ -204,8 +199,6 @@ def test_asset_code_origins_source_control_custom_mapping() -> None:
     for asset in collection_with_source_control_metadata:
         if isinstance(asset, AssetsDefinition):
             op_name = asset.node_def.name
-            if op_name == "graph_backed_asset":
-                continue
 
             assert op_name in EXPECTED_ORIGINS, f"Missing expected origin for op {op_name}"
 


### PR DESCRIPTION

## Summary

Threads through the underlying fn which backs a graph-backed asset, which generated code references will point to.

For example:

```python
@op
def one():
    return 1


@op
def multiply_by_two(input_num):
    return input_num * 2


# code ref will point here
@graph_asset
def graph_backed_asset():
    return multiply_by_two(one())


with_source_code_references([graph_backed_asset])


```


## Test Plan

Unit test.