### PR TITLE
Make run record datetime fields in UTC instead of naive datetimes, remove datetime_as_float

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -15,7 +15,6 @@ from dagster._core.storage.dagster_run import (
 )
 from dagster._core.storage.tags import REPOSITORY_LABEL_TAG, TagType, get_tag_type
 from dagster._core.workspace.permissions import Permissions
-from dagster._utils import datetime_as_float
 from dagster._utils.yaml_utils import dump_run_config_yaml
 
 from dagster_graphql.implementation.events import iterate_metadata_entries
@@ -584,7 +583,7 @@ class GrapheneRun(graphene.ObjectType):
 
     def resolve_updateTime(self, graphene_info: ResolveInfo):
         run_record = self._get_run_record(graphene_info.context.instance)
-        return datetime_as_float(run_record.update_timestamp)
+        return run_record.update_timestamp.timestamp()
 
     def resolve_hasConcurrencyKeySlots(self, graphene_info: ResolveInfo):
         instance = graphene_info.context.instance

--- a/python_modules/dagster/dagster/_core/definitions/data_time.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_time.py
@@ -34,7 +34,8 @@ from dagster._core.definitions.time_window_partitions import (
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import EventLogRecord
 from dagster._core.storage.dagster_run import FINISHED_STATUSES, DagsterRunStatus, RunsFilter
-from dagster._utils import datetime_as_float, make_hashable
+from dagster._time import datetime_from_timestamp
+from dagster._utils import make_hashable
 from dagster._utils.cached_method import cached_method
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
@@ -453,9 +454,8 @@ class CachingDataTimeResolver:
         ):
             return current_data_time
 
-        run_failure_time = datetime.datetime.fromtimestamp(
-            latest_run_record.end_time or datetime_as_float(latest_run_record.create_timestamp),
-            datetime.timezone.utc,
+        run_failure_time = datetime_from_timestamp(
+            latest_run_record.end_time or latest_run_record.create_timestamp.timestamp(),
         )
         return self._get_in_progress_data_time_in_run(
             run_id=run_id, asset_key=asset_key, current_time=run_failure_time

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -26,7 +26,8 @@ from dagster._core.remote_representation.origin import RemoteInstigatorOrigin
 from dagster._serdes import create_snapshot_id
 from dagster._serdes.errors import DeserializationError
 from dagster._serdes.serdes import EnumSerializer, deserialize_value, whitelist_for_serdes
-from dagster._utils import datetime_as_float, xor
+from dagster._time import utc_datetime_from_naive
+from dagster._utils import xor
 from dagster._utils.error import SerializableErrorInfo
 from dagster._utils.merger import merge_dicts
 
@@ -743,7 +744,7 @@ class AutoMaterializeAssetEvaluationRecord(NamedTuple):
             id=row["id"],
             serialized_evaluation_body=row["asset_evaluation_body"],
             evaluation_id=row["evaluation_id"],
-            timestamp=datetime_as_float(row["create_timestamp"]),
+            timestamp=utc_datetime_from_naive(row["create_timestamp"]).timestamp(),
             asset_key=check.not_none(AssetKey.from_db_string(row["asset_key"])),
         )
 

--- a/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
@@ -4,7 +4,7 @@ from typing import NamedTuple, Optional
 import dagster._check as check
 from dagster._core.events.log import DagsterEventType, EventLogEntry
 from dagster._serdes.serdes import deserialize_value
-from dagster._utils import datetime_as_float
+from dagster._time import utc_datetime_from_naive
 
 
 class AssetCheckInstanceSupport(enum.Enum):
@@ -99,5 +99,5 @@ class AssetCheckExecutionRecord(
                 if row["evaluation_event"]
                 else None
             ),
-            create_timestamp=datetime_as_float(row["create_timestamp"]),
+            create_timestamp=utc_datetime_from_naive(row["create_timestamp"]).timestamp(),
         )

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -71,7 +71,7 @@ from dagster._core.storage.sqlalchemy_compat import (
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._serdes.errors import DeserializationError
 from dagster._time import datetime_from_timestamp, utc_datetime_from_naive
-from dagster._utils import PrintFn, datetime_as_float
+from dagster._utils import PrintFn
 from dagster._utils.concurrency import (
     ClaimedSlotInfo,
     ConcurrencyClaimStatus,
@@ -603,10 +603,16 @@ class SqlEventLogStorage(EventLogStorage):
                 steps_failed=counts.get(DagsterEventType.STEP_FAILURE.value, 0),
                 materializations=counts.get(DagsterEventType.ASSET_MATERIALIZATION.value, 0),
                 expectations=counts.get(DagsterEventType.STEP_EXPECTATION_RESULT.value, 0),
-                enqueued_time=datetime_as_float(enqueued_time) if enqueued_time else None,
-                launch_time=datetime_as_float(launch_time) if launch_time else None,
-                start_time=datetime_as_float(start_time) if start_time else None,
-                end_time=datetime_as_float(end_time) if end_time else None,
+                enqueued_time=(
+                    utc_datetime_from_naive(enqueued_time).timestamp() if enqueued_time else None
+                ),
+                launch_time=(
+                    utc_datetime_from_naive(launch_time).timestamp() if launch_time else None
+                ),
+                start_time=(
+                    utc_datetime_from_naive(start_time).timestamp() if start_time else None
+                ),
+                end_time=(utc_datetime_from_naive(end_time).timestamp() if end_time else None),
             )
         except (seven.JSONDecodeError, DeserializationError) as err:
             raise DagsterEventLogInvalidForRun(run_id=run_id) from err

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -64,7 +64,7 @@ from dagster._core.storage.tags import (
 from dagster._daemon.types import DaemonHeartbeat
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._seven import JSONDecodeError
-from dagster._time import datetime_from_timestamp
+from dagster._time import datetime_from_timestamp, utc_datetime_from_naive
 from dagster._utils import PrintFn
 from dagster._utils.merger import merge_dicts
 
@@ -272,16 +272,24 @@ class SqlRunStorage(RunStorage):
             query = query.where(RunsTable.c.snapshot_id == filters.snapshot_id)
 
         if filters.updated_after:
-            query = query.where(RunsTable.c.update_timestamp > filters.updated_after)
+            query = query.where(
+                RunsTable.c.update_timestamp > filters.updated_after.replace(tzinfo=None)
+            )
 
         if filters.updated_before:
-            query = query.where(RunsTable.c.update_timestamp < filters.updated_before)
+            query = query.where(
+                RunsTable.c.update_timestamp < filters.updated_before.replace(tzinfo=None)
+            )
 
         if filters.created_after:
-            query = query.where(RunsTable.c.create_timestamp > filters.created_after)
+            query = query.where(
+                RunsTable.c.create_timestamp > filters.created_after.replace(tzinfo=None)
+            )
 
         if filters.created_before:
-            query = query.where(RunsTable.c.create_timestamp < filters.created_before)
+            query = query.where(
+                RunsTable.c.create_timestamp < filters.created_before.replace(tzinfo=None)
+            )
 
         if filters.tags:
             query = self._apply_tags_table_filters(query, filters.tags)
@@ -424,8 +432,12 @@ class SqlRunStorage(RunStorage):
             RunRecord(
                 storage_id=check.int_param(row["id"], "id"),
                 dagster_run=self._row_to_run(row),
-                create_timestamp=check.inst(row["create_timestamp"], datetime),
-                update_timestamp=check.inst(row["update_timestamp"], datetime),
+                create_timestamp=utc_datetime_from_naive(
+                    check.inst(row["create_timestamp"], datetime)
+                ),
+                update_timestamp=utc_datetime_from_naive(
+                    check.inst(row["update_timestamp"], datetime)
+                ),
                 start_time=(
                     check.opt_inst(row["start_time"], float) if "start_time" in row else None
                 ),

--- a/python_modules/dagster/dagster/_utils/__init__.py
+++ b/python_modules/dagster/dagster/_utils/__init__.py
@@ -472,11 +472,6 @@ def iterate_with_context(
         yield next_output
 
 
-def datetime_as_float(dt: datetime.datetime) -> float:
-    check.inst_param(dt, "dt", datetime.datetime)
-    return float((dt - EPOCH).total_seconds())
-
-
 T_GeneratedContext = TypeVar("T_GeneratedContext")
 
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -113,7 +113,6 @@ from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.utils import make_new_run_id
 from dagster._loggers import colored_console_logger
 from dagster._serdes.serdes import deserialize_value
-from dagster._utils import datetime_as_float
 from dagster._utils.concurrency import ConcurrencySlotStatus
 
 # py36 & 37 list.append not hashable
@@ -2083,14 +2082,13 @@ class TestEventLogStorage:
                 storage.store_event(event)
 
             update_timestamp = run_records[-1].update_timestamp
-            tzaware_dt = pendulum.from_timestamp(datetime_as_float(update_timestamp), tz="UTC")
 
             # use tz-aware cursor
             filtered_records = storage.get_event_records(
                 EventRecordsFilter(
                     event_type=DagsterEventType.RUN_SUCCESS,
                     after_cursor=RunShardedEventsCursor(
-                        id=0, run_updated_after=tzaware_dt
+                        id=0, run_updated_after=update_timestamp
                     ),  # events after first run
                 ),
                 ascending=True,
@@ -2107,7 +2105,7 @@ class TestEventLogStorage:
                 EventRecordsFilter(
                     event_type=DagsterEventType.RUN_SUCCESS,
                     after_cursor=RunShardedEventsCursor(
-                        id=0, run_updated_after=tzaware_dt.naive()
+                        id=0, run_updated_after=update_timestamp.replace(tzinfo=None)
                     ),  # events after first run
                 ),
                 ascending=True,


### PR DESCRIPTION
Summary:
This brings run records in OSS in line with run records that are returned over our API in that it has non-naive datetimes - UTC datetimes are strictly better than naive datetimes. It also allows us to remove this datetime_as_float utiliyt method which was designed as a way to reliably handle these naive datetimes coming out of sqlite - my claim is that the new syntax that I have replaced it with (utc_datetime_from_naive(...).timestamp()) is much clearer about what is going on.

Somewhat unfortunate that the field on RunRecord is "update_timestamp" and not "update_time", but that would be a breaking change.

## Summary & Motivation

## How I Tested These Changes
