### PR TITLE
fix(dbt): divest from the quoted `relation_name` when building column lineage

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -955,32 +955,11 @@ def _fetch_column_metadata(
                 exc_info=True,
             )
             return {}
-        column_schema_data = {col.name: {"data_type": col.data_type} for col in cols}
-
-        if with_column_lineage:
-            parents = {}
-            dependent_unique_ids = invocation.manifest["parent_map"].get(
-                dbt_resource_props["unique_id"], []
-            )
-            for dep_unique_id in dependent_unique_ids:
-                dep_node = invocation.manifest["nodes"].get(dep_unique_id) or invocation.manifest[
-                    "sources"
-                ].get(dep_unique_id)
-
-                dep_relation_name = dep_node["relation_name"]
-                dep_relation_components = [
-                    component.strip('"') for component in dep_relation_name.split(".")
-                ]
-                dep_relation = adapter.get_relation(*dep_relation_components)
-
-                dep_cols: List[BaseColumn] = adapter.get_columns_in_relation(relation=dep_relation)
-                dep_name = str(dep_relation)
-                parents[dep_name] = {col.name: {"data_type": col.data_type} for col in dep_cols}
-
-        col_data = {"columns": column_schema_data}
 
         schema_metadata = {}
         try:
+            column_schema_data = {col.name: {"data_type": col.data_type} for col in cols}
+            col_data = {"columns": column_schema_data}
             schema_metadata = default_metadata_from_dbt_resource_props(col_data)
         except Exception as e:
             logger.warning(
@@ -995,6 +974,28 @@ def _fetch_column_metadata(
         lineage_metadata = {}
         if with_column_lineage:
             try:
+                parents = {}
+                parent_unique_ids = invocation.manifest["parent_map"].get(
+                    dbt_resource_props["unique_id"], []
+                )
+                for parent_unique_id in parent_unique_ids:
+                    dbt_parent_resource_props = invocation.manifest["nodes"].get(
+                        parent_unique_id
+                    ) or invocation.manifest["sources"].get(parent_unique_id)
+
+                    parent_relation = adapter.Relation.create(
+                        database=dbt_parent_resource_props["database"],
+                        schema=dbt_parent_resource_props["schema"],
+                        identifier=dbt_parent_resource_props["name"],
+                    )
+                    parent_columns: List[BaseColumn] = adapter.get_columns_in_relation(
+                        relation=parent_relation
+                    )
+
+                    parents[str(parent_relation)] = {
+                        col.name: {"data_type": col.data_type} for col in parent_columns
+                    }
+
                 lineage_metadata = _build_column_lineage_metadata(
                     event_history_metadata=EventHistoryMetadata(
                         columns=column_schema_data,


### PR DESCRIPTION
## Summary & Motivation

- Consolidate the column lineage metadata logic together in a single conditional with a try/except similar to https://github.com/dagster-io/dagster/pull/22641.
- Divest from using the quoted `relation_name`, and just use the `database`, `schema`, `name`.
- Apply https://github.com/dagster-io/dagster/pull/22642 when building the column lineage.

## How I Tested These Changes
This should probably be under nightly test against a real bigquery instance.

Locally, things work now.

### Before

Materializing with `.fetch_column_metadata()` resulted in:

```
dagster._core.errors.DagsterExecutionStepExecutionError: Error occurred while executing op "jaffle_shop_dbt_assets":
The above exception was caused by the following exception:
google.api_core.exceptions.BadRequest: 400 GET https://bigquery.googleapis.com/bigquery/v2/projects/%60dagster-cloud-local-test%60/datasets/%60toys%60/tables/%60raw_customers%60?prettyPrint=false: Invalid resource name projects/`dagster-cloud-local-test`; Project id: `dagster-cloud-local-test`
```


### After

Bigquery assets materialize successfully with metadata:
![image](https://github.com/dagster-io/dagster/assets/16431325/63867fcf-d404-44ca-a06c-60989c79b744)
