### PR TITLE
[docs] dlt add examples for translator, sourceasset, partitions

### DIFF
--- a/docs/content/integrations/embedded-elt/dlt.mdx
+++ b/docs/content/integrations/embedded-elt/dlt.mdx
@@ -228,9 +228,122 @@ And that's it! You should now have two assets that load data to corresponding Sn
 
 ---
 
+## Advanced Usage
+
+### Overriding the translator to customize dlt assets
+
+The <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" /> object can be used to customize how the dlt attributes map to Dagster concepts.
+
+For example, if you would like to change how the name of the asset is derived, you can override the <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" method="get_asset_key" /> method, or if you would like to change the key of the upstream asset, you can use the <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" method="get_deps_assets_keys" /> method.
+
+```python
+from dagster import AssetExecutionContext, Definitions
+from dagster_embedded_elt.dlt import DagsterDltResource, DagsterDltTranslator, dlt_assets
+from dlt import pipeline
+from dlt_sources.github import github_reactions
+
+
+class CustomDagsterDltTranslator(DagsterDltTranslator):
+    def get_asset_key(self, resource: DltResource) -> AssetKey:
+        """Overrides asset key to be the dlt resource name."""
+        return f"{resource.name}"
+
+    def get_deps_asset_keys(self, resource: DltResource) -> Iterable[AssetKey]:
+        """Overrides upstream asset key to be a single source asset."""
+        return [AssetKey("common_upstream_dlt_dependency")]
+
+
+@dlt_assets(
+    name="example_dlt_assets",
+    dlt_source=example_dlt_source(),
+    dlt_pipeline=pipeline(
+        pipeline_name="example_pipeline_name",
+        dataset_name="example_dataset_name",
+        destination="snowflake",
+        progress="log",
+    ),
+    dlt_dagster_translator=CustomDagsterDltTranslator(),
+)
+def dlt_example_assets(context: AssetExecutionContext, dlt: DagsterDltResource):
+    yield from dlt.run(context=context)
+```
+
+In this example we overrode the translator to customize how the dlt assets name is defined, and we also hard-coded the asset dependency that is upstream of our assets. This allowed us to define a fan-out operation from a single dependency to our dlt assets.
+
+### Assigning metadata to source assets
+
+A common question is how to add metadata to source assets that area upstream to your dlt assets.
+
+This can be accomplished by defining a <PyObject object="SourceAsset" /> with a key that matches the one defined in the <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" method="get_deps_assets_keys" /> method.
+
+For example, let's say we have defined a set of dlt assets named `thinkific_assets`, we can iterate over those assets and derive a <PyObject object="SourceAsset" /> with attributes like `group_name`.
+
+```python
+@dlt_assets(
+    dlt_source=thinkific(),
+    dlt_pipeline=pipeline(
+        pipeline_name="thinkific",
+        dataset_name="thinkific",
+        destination="snowflake",
+        progress="log",
+    ),
+    group_name="thinkific",
+    dlt_dagster_translator=ThinkificDagsterDltTranslator(),
+)
+def thinkific_assets(context: AssetExecutionContext, dlt: DagsterDltResource):
+    yield from dlt.run(context=context)
+
+
+thinkific_source_assets = [
+    SourceAsset(key, group_name="thinkific") for key in thinkific_assets.dependency_keys
+]
+```
+
+### Using partitions in your dlt_assets
+
+While still experimental, it is possible to use partitions with your dlt assets. However, it should be noted that this may result in concurrency related issues to how state is managed by dlt. For this reason, it is recommended to set concurrency limits for your partitioned dlt assets.
+
+```python
+import dlt
+
+from dagster import AssetExecutionContext, StaticPartitionsDefinition
+from dagster_embedded_elt.dlt import DagsterDltResource, dlt_assets
+from dlt import pipeline
+from typing import Optional
+
+
+color_partitions = StaticPartitionsDefinition(["red", "green", "blue"])
+
+
+@dlt.source
+def example_dlt_source(color: Optional[str] = None):
+    def load_colors():
+        if color:
+            # partition-specific processing
+            ...
+        else:
+            # non-partitioned processing
+            ...
+
+
+@dlt_assets(
+    dlt_source=example_dlt_source(),
+    name="example_dlt_assets",
+    dlt_pipeline=pipeline(
+        pipeline_name="example_pipeline_name",
+        dataset_name="example_dataset_name",
+        destination="snowflake",
+    ),
+    partitions_def=color_partitions,
+)
+def compute(context: AssetExecutionContext, dlt: DagsterDltResource):
+    color = context.partition_key
+    yield from dlt.run(context=context, dlt_source=example_dlt_source(color=color))
+```
+
 ## What's next?
 
-Want to see more real-world examples of dlt in production? Check out how we use it internally at Dagster in [Dagster Open Platform](https://github.com/dagster-io/dagster-open-platform).
+Want to see real-world examples of dlt in production? Check out how we use it internally at Dagster in the [Dagster Open Platform](https://github.com/dagster-io/dagster-open-platform) project.
 
 ---
 

--- a/docs/content/integrations/embedded-elt/dlt.mdx
+++ b/docs/content/integrations/embedded-elt/dlt.mdx
@@ -285,7 +285,7 @@ In this example, we customized the translator to change how the dlt assets' name
 
 ### Assigning metadata to upstream source assets
 
-A common question is how to define metadata on the source assets that area upstream of the dlt assets.
+A common question is how to define metadata on the source assets upstream of the dlt assets.
 
 This can be accomplished by defining a <PyObject object="SourceAsset" /> with a key that matches the one defined in the <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" method="get_deps_assets_keys" /> method.
 

--- a/docs/content/integrations/embedded-elt/dlt.mdx
+++ b/docs/content/integrations/embedded-elt/dlt.mdx
@@ -259,7 +259,7 @@ def example_dlt_source():
 class CustomDagsterDltTranslator(DagsterDltTranslator):
     def get_asset_key(self, resource: DagsterDltResource) -> AssetKey:
         """Overrides asset key to be the dlt resource name."""
-        return f"{resource.name}"
+        return AssetKey(f"{resource.name}")
 
     def get_deps_asset_keys(self, resource: DagsterDltResource) -> Iterable[AssetKey]:
         """Overrides upstream asset key to be a single source asset."""

--- a/docs/content/integrations/embedded-elt/dlt.mdx
+++ b/docs/content/integrations/embedded-elt/dlt.mdx
@@ -236,19 +236,32 @@ The <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" />
 
 For example, to change how the name of the asset is derived, you can override the <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" method="get_asset_key" /> method, or if you would like to change the key of the upstream source asset, you can override the <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" method="get_deps_assets_keys" /> method.
 
-```python
-from dagster import AssetExecutionContext, Definitions
-from dagster_embedded_elt.dlt import DagsterDltResource, DagsterDltTranslator, dlt_assets
-from dlt import pipeline
-from dlt_sources.github import github_reactions
+```python file=/integrations/embedded_elt/dlt_dagster_translator.py
+from collections.abc import Iterable
+
+import dlt
+from dagster_embedded_elt.dlt import (
+    DagsterDltResource,
+    DagsterDltTranslator,
+    dlt_assets,
+)
+
+from dagster import AssetExecutionContext, AssetKey
+
+
+@dlt.source
+def example_dlt_source():
+    def example_resource(): ...
+
+    return example_resource
 
 
 class CustomDagsterDltTranslator(DagsterDltTranslator):
-    def get_asset_key(self, resource: DltResource) -> AssetKey:
+    def get_asset_key(self, resource: DagsterDltResource) -> AssetKey:
         """Overrides asset key to be the dlt resource name."""
         return f"{resource.name}"
 
-    def get_deps_asset_keys(self, resource: DltResource) -> Iterable[AssetKey]:
+    def get_deps_asset_keys(self, resource: DagsterDltResource) -> Iterable[AssetKey]:
         """Overrides upstream asset key to be a single source asset."""
         return [AssetKey("common_upstream_dlt_dependency")]
 
@@ -256,7 +269,7 @@ class CustomDagsterDltTranslator(DagsterDltTranslator):
 @dlt_assets(
     name="example_dlt_assets",
     dlt_source=example_dlt_source(),
-    dlt_pipeline=pipeline(
+    dlt_pipeline=dlt.pipeline(
         pipeline_name="example_pipeline_name",
         dataset_name="example_dataset_name",
         destination="snowflake",
@@ -322,7 +335,6 @@ from typing import Optional
 
 import dlt
 from dagster_embedded_elt.dlt import DagsterDltResource, dlt_assets
-from dlt import pipeline
 
 from dagster import AssetExecutionContext, StaticPartitionsDefinition
 
@@ -343,7 +355,7 @@ def example_dlt_source(color: Optional[str] = None):
 @dlt_assets(
     dlt_source=example_dlt_source(),
     name="example_dlt_assets",
-    dlt_pipeline=pipeline(
+    dlt_pipeline=dlt.pipeline(
         pipeline_name="example_pipeline_name",
         dataset_name="example_dataset_name",
         destination="snowflake",

--- a/docs/content/integrations/embedded-elt/dlt.mdx
+++ b/docs/content/integrations/embedded-elt/dlt.mdx
@@ -281,7 +281,7 @@ def dlt_example_assets(context: AssetExecutionContext, dlt: DagsterDltResource):
     yield from dlt.run(context=context)
 ```
 
-In this example we customized the translator to change how the dlt assets name is defined, and we also hard-coded the asset dependency that is upstream of our assets to provide a fan-out model from a single dependency to our dlt assets.
+In this example, we customized the translator to change how the dlt assets' names are defined. We also hard-coded the asset dependency upstream of our assets to provide a fan-out model from a single dependency to our dlt assets.
 
 ### Assigning metadata to upstream source assets
 

--- a/docs/content/integrations/embedded-elt/dlt.mdx
+++ b/docs/content/integrations/embedded-elt/dlt.mdx
@@ -305,14 +305,14 @@ While still an experimental feature, it is possible to use partitions within you
 
 That being said, here is an example of using statically named partitions from a dlt source.
 
-```python
-import dlt
-
-from dagster import AssetExecutionContext, StaticPartitionsDefinition
-from dagster_embedded_elt.dlt import DagsterDltResource, dlt_assets
-from dlt import pipeline
+```python file=/integrations/embedded_elt/dlt_partitions.py
 from typing import Optional
 
+import dlt
+from dagster_embedded_elt.dlt import DagsterDltResource, dlt_assets
+from dlt import pipeline
+
+from dagster import AssetExecutionContext, StaticPartitionsDefinition
 
 color_partitions = StaticPartitionsDefinition(["red", "green", "blue"])
 

--- a/docs/content/integrations/embedded-elt/dlt.mdx
+++ b/docs/content/integrations/embedded-elt/dlt.mdx
@@ -326,7 +326,7 @@ thinkific_source_assets = [
 
 ### Using partitions in your dlt assets
 
-While still an experimental feature, it is possible to use partitions within your dlt assets. However, it should be noted that this may result in concurrency related issues as state is managed by dlt. For this reason, it is recommended to set concurrency limits for your partitioned dlt assets.
+While still an experimental feature, it is possible to use partitions within your dlt assets. However, it should be noted that this may result in concurrency related issues as state is managed by dlt. For this reason, it is recommended to set concurrency limits for your partitioned dlt assets. See the [Limiting concurrency in data pipelines](/guides/limiting-concurrency-in-data-pipelines#limiting-concurrency-in-data-pipelines) guide for more details.
 
 That said, here is an example of using static named partitions from a dlt source.
 

--- a/docs/content/integrations/embedded-elt/dlt.mdx
+++ b/docs/content/integrations/embedded-elt/dlt.mdx
@@ -326,7 +326,7 @@ thinkific_source_assets = [
 
 ### Using partitions in your dlt assets
 
-While still an experimental feature, it is possible to use partitions within your dlt assets. However, it should be noted that this may result in concurrency related issues as state is managed by dlt. For this reason, it is recommended to set concurrency limits for your partitioned dlt assets. See the [Limiting concurrency in data pipelines](/guides/limiting-concurrency-in-data-pipelines#limiting-concurrency-in-data-pipelines) guide for more details.
+While still an experimental feature, it is possible to use partitions within your dlt assets. However, it should be noted that this may result in concurrency related issues as state is managed by dlt. For this reason, it is recommended to set concurrency limits for your partitioned dlt assets. See the [Limiting concurrency in data pipelines](/guides/limiting-concurrency-in-data-pipelines) guide for more details.
 
 That said, here is an example of using static named partitions from a dlt source.
 

--- a/docs/content/integrations/embedded-elt/dlt.mdx
+++ b/docs/content/integrations/embedded-elt/dlt.mdx
@@ -328,7 +328,7 @@ thinkific_source_assets = [
 
 While still an experimental feature, it is possible to use partitions within your dlt assets. However, it should be noted that this may result in concurrency related issues as state is managed by dlt. For this reason, it is recommended to set concurrency limits for your partitioned dlt assets.
 
-That being said, here is an example of using statically named partitions from a dlt source.
+That said, here is an example of using static named partitions from a dlt source.
 
 ```python file=/integrations/embedded_elt/dlt_partitions.py
 from typing import Optional

--- a/docs/content/integrations/embedded-elt/dlt.mdx
+++ b/docs/content/integrations/embedded-elt/dlt.mdx
@@ -278,24 +278,36 @@ This can be accomplished by defining a <PyObject object="SourceAsset" /> with a 
 
 For example, let's say we have defined a set of dlt assets named `thinkific_assets`, we can iterate over those assets and derive a <PyObject object="SourceAsset" /> with attributes like `group_name`.
 
-```python
+```python file=/integrations/embedded_elt/dlt_source_assets.py
+import dlt
+from dagster_embedded_elt.dlt import DagsterDltResource, dlt_assets
+
+from dagster import AssetExecutionContext, SourceAsset
+
+
+@dlt.source
+def example_dlt_source():
+    def example_resource(): ...
+
+    return example_resource
+
+
 @dlt_assets(
-    dlt_source=thinkific(),
-    dlt_pipeline=pipeline(
-        pipeline_name="thinkific",
-        dataset_name="thinkific",
+    dlt_source=example_dlt_source(),
+    dlt_pipeline=dlt.pipeline(
+        pipeline_name="example_pipeline_name",
+        dataset_name="example_dataset_name",
         destination="snowflake",
         progress="log",
     ),
-    group_name="thinkific",
-    dlt_dagster_translator=ThinkificDagsterDltTranslator(),
 )
-def thinkific_assets(context: AssetExecutionContext, dlt: DagsterDltResource):
+def example_dlt_assets(context: AssetExecutionContext, dlt: DagsterDltResource):
     yield from dlt.run(context=context)
 
 
 thinkific_source_assets = [
-    SourceAsset(key, group_name="thinkific") for key in thinkific_assets.dependency_keys
+    SourceAsset(key, group_name="thinkific")
+    for key in example_dlt_assets.dependency_keys
 ]
 ```
 

--- a/docs/content/integrations/embedded-elt/dlt.mdx
+++ b/docs/content/integrations/embedded-elt/dlt.mdx
@@ -228,13 +228,13 @@ And that's it! You should now have two assets that load data to corresponding Sn
 
 ---
 
-## Advanced Usage
+## Advanced usage
 
 ### Overriding the translator to customize dlt assets
 
-The <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" /> object can be used to customize how the dlt attributes map to Dagster concepts.
+The <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" /> object can be used to customize how dlt properties map to Dagster concepts.
 
-For example, if you would like to change how the name of the asset is derived, you can override the <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" method="get_asset_key" /> method, or if you would like to change the key of the upstream asset, you can use the <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" method="get_deps_assets_keys" /> method.
+For example, to change how the name of the asset is derived, you can override the <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" method="get_asset_key" /> method, or if you would like to change the key of the upstream source asset, you can override the <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" method="get_deps_assets_keys" /> method.
 
 ```python
 from dagster import AssetExecutionContext, Definitions
@@ -268,11 +268,11 @@ def dlt_example_assets(context: AssetExecutionContext, dlt: DagsterDltResource):
     yield from dlt.run(context=context)
 ```
 
-In this example we overrode the translator to customize how the dlt assets name is defined, and we also hard-coded the asset dependency that is upstream of our assets. This allowed us to define a fan-out operation from a single dependency to our dlt assets.
+In this example we customized the translator to change how the dlt assets name is defined, and we also hard-coded the asset dependency that is upstream of our assets to provide a fan-out model from a single dependency to our dlt assets.
 
-### Assigning metadata to source assets
+### Assigning metadata to upstream source assets
 
-A common question is how to add metadata to source assets that area upstream to your dlt assets.
+A common question is how to define metadata on the source assets that area upstream of the dlt assets.
 
 This can be accomplished by defining a <PyObject object="SourceAsset" /> with a key that matches the one defined in the <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" method="get_deps_assets_keys" /> method.
 
@@ -299,9 +299,11 @@ thinkific_source_assets = [
 ]
 ```
 
-### Using partitions in your dlt_assets
+### Using partitions in your dlt assets
 
-While still experimental, it is possible to use partitions with your dlt assets. However, it should be noted that this may result in concurrency related issues to how state is managed by dlt. For this reason, it is recommended to set concurrency limits for your partitioned dlt assets.
+While still an experimental feature, it is possible to use partitions within your dlt assets. However, it should be noted that this may result in concurrency related issues as state is managed by dlt. For this reason, it is recommended to set concurrency limits for your partitioned dlt assets.
+
+That being said, here is an example of using statically named partitions from a dlt source.
 
 ```python
 import dlt

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/dlt_dagster_translator.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/dlt_dagster_translator.py
@@ -1,0 +1,42 @@
+from collections.abc import Iterable
+
+import dlt
+from dagster_embedded_elt.dlt import (
+    DagsterDltResource,
+    DagsterDltTranslator,
+    dlt_assets,
+)
+
+from dagster import AssetExecutionContext, AssetKey
+
+
+@dlt.source
+def example_dlt_source():
+    def example_resource(): ...
+
+    return example_resource
+
+
+class CustomDagsterDltTranslator(DagsterDltTranslator):
+    def get_asset_key(self, resource: DagsterDltResource) -> AssetKey:
+        """Overrides asset key to be the dlt resource name."""
+        return f"{resource.name}"
+
+    def get_deps_asset_keys(self, resource: DagsterDltResource) -> Iterable[AssetKey]:
+        """Overrides upstream asset key to be a single source asset."""
+        return [AssetKey("common_upstream_dlt_dependency")]
+
+
+@dlt_assets(
+    name="example_dlt_assets",
+    dlt_source=example_dlt_source(),
+    dlt_pipeline=dlt.pipeline(
+        pipeline_name="example_pipeline_name",
+        dataset_name="example_dataset_name",
+        destination="snowflake",
+        progress="log",
+    ),
+    dlt_dagster_translator=CustomDagsterDltTranslator(),
+)
+def dlt_example_assets(context: AssetExecutionContext, dlt: DagsterDltResource):
+    yield from dlt.run(context=context)

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/dlt_dagster_translator.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/dlt_dagster_translator.py
@@ -20,7 +20,7 @@ def example_dlt_source():
 class CustomDagsterDltTranslator(DagsterDltTranslator):
     def get_asset_key(self, resource: DagsterDltResource) -> AssetKey:
         """Overrides asset key to be the dlt resource name."""
-        return f"{resource.name}"
+        return AssetKey(f"{resource.name}")
 
     def get_deps_asset_keys(self, resource: DagsterDltResource) -> Iterable[AssetKey]:
         """Overrides upstream asset key to be a single source asset."""

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/dlt_partitions.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/dlt_partitions.py
@@ -1,0 +1,35 @@
+from typing import Optional
+
+import dlt
+from dagster_embedded_elt.dlt import DagsterDltResource, dlt_assets
+from dlt import pipeline
+
+from dagster import AssetExecutionContext, StaticPartitionsDefinition
+
+color_partitions = StaticPartitionsDefinition(["red", "green", "blue"])
+
+
+@dlt.source
+def example_dlt_source(color: Optional[str] = None):
+    def load_colors():
+        if color:
+            # partition-specific processing
+            ...
+        else:
+            # non-partitioned processing
+            ...
+
+
+@dlt_assets(
+    dlt_source=example_dlt_source(),
+    name="example_dlt_assets",
+    dlt_pipeline=pipeline(
+        pipeline_name="example_pipeline_name",
+        dataset_name="example_dataset_name",
+        destination="snowflake",
+    ),
+    partitions_def=color_partitions,
+)
+def compute(context: AssetExecutionContext, dlt: DagsterDltResource):
+    color = context.partition_key
+    yield from dlt.run(context=context, dlt_source=example_dlt_source(color=color))

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/dlt_partitions.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/dlt_partitions.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 import dlt
 from dagster_embedded_elt.dlt import DagsterDltResource, dlt_assets
-from dlt import pipeline
 
 from dagster import AssetExecutionContext, StaticPartitionsDefinition
 
@@ -23,7 +22,7 @@ def example_dlt_source(color: Optional[str] = None):
 @dlt_assets(
     dlt_source=example_dlt_source(),
     name="example_dlt_assets",
-    dlt_pipeline=pipeline(
+    dlt_pipeline=dlt.pipeline(
         pipeline_name="example_pipeline_name",
         dataset_name="example_dataset_name",
         destination="snowflake",

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/dlt_source_assets.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/dlt_source_assets.py
@@ -1,0 +1,30 @@
+import dlt
+from dagster_embedded_elt.dlt import DagsterDltResource, dlt_assets
+
+from dagster import AssetExecutionContext, SourceAsset
+
+
+@dlt.source
+def example_dlt_source():
+    def example_resource(): ...
+
+    return example_resource
+
+
+@dlt_assets(
+    dlt_source=example_dlt_source(),
+    dlt_pipeline=dlt.pipeline(
+        pipeline_name="example_pipeline_name",
+        dataset_name="example_dataset_name",
+        destination="snowflake",
+        progress="log",
+    ),
+)
+def example_dlt_assets(context: AssetExecutionContext, dlt: DagsterDltResource):
+    yield from dlt.run(context=context)
+
+
+thinkific_source_assets = [
+    SourceAsset(key, group_name="thinkific")
+    for key in example_dlt_assets.dependency_keys
+]


### PR DESCRIPTION
## Summary & Motivation

- Adds "Advanced usage" section to dlt docs
- Introduces new examples:
    * Using the translator to customize dlt -> dagster mapping
    * Customizing metadata of source assets
    * Using partitions with dlt_assets

## How I Tested These Changes
