### PR TITLE
fix(dbt): use correct relation identifier when creating `BaseRelation`

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/dbt_project.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/dbt_project.yml
@@ -30,3 +30,6 @@ models:
 seeds:
   +post-hook:
     - "{{ dagster.log_column_level_metadata(enable_parent_relation_metadata_collection=var('dagster_enable_parent_relation_metadata_collection', 'true')) if env_var('DBT_LOG_COLUMN_METADATA', 'true') == 'true' else null }}"
+  test_dagster_metadata:
+    raw_orders:
+      +alias: aliased_raw_orders

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/schema.yml
@@ -32,6 +32,9 @@ models:
   - name: orders
     description: This table has basic information about orders, as well as some derived facts based on payments
 
+    config:
+      alias: aliased_orders
+
     columns:
       - name: order_id
         tests:


### PR DESCRIPTION
## Summary & Motivation
When creating the `BaseRelation`, we want to use the name of the table that's created in the data warehouse so that we can properly query the relation.

Previously, we were using `dbt_resource_props["name"]` as the identifier, which is the dbt's reference to that table. Instead, we should use the underlying identifier name.

For dbt sources, this is `dbt_resource_props["identifier"]`. For dbt models and seeds, this is `dbt_resource_props["alias"]`.

## How I Tested These Changes
pytest: added dbt aliases for source and model in existing `test_dagster_metadata` project