### PR TITLE
Remove pendulum from dagster core - non-breaking changes

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, List, Sequence, Union, cast
 
 import dagster._check as check
-import pendulum
 from dagster._core.definitions.selector import PartitionsByAssetSelector, RepositorySelector
 from dagster._core.definitions.utils import is_valid_title_and_reason
 from dagster._core.errors import (
@@ -16,7 +15,7 @@ from dagster._core.execution.job_backfill import submit_backfill_runs
 from dagster._core.remote_representation.external_data import ExternalPartitionExecutionErrorData
 from dagster._core.utils import make_new_backfill_id
 from dagster._core.workspace.permissions import Permissions
-from dagster._time import datetime_from_timestamp
+from dagster._time import datetime_from_timestamp, get_current_timestamp
 from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 from ..utils import (
@@ -111,7 +110,7 @@ def create_and_launch_partition_backfill(
 
     tags = {**tags, **graphene_info.context.get_viewer_tags()}
 
-    backfill_timestamp = pendulum.now("UTC").timestamp()
+    backfill_timestamp = get_current_timestamp()
 
     if backfill_params.get("selector") is not None:  # job backfill
         partition_set_selector = backfill_params["selector"]

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_ticks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_ticks.py
@@ -1,8 +1,9 @@
 import warnings
+from datetime import timedelta
 from typing import TYPE_CHECKING, Optional, Sequence
 
-import pendulum
 from dagster._core.scheduler.instigation import InstigatorType, TickStatus
+from dagster._time import get_current_datetime
 
 if TYPE_CHECKING:
     from ..schema.util import ResolveInfo
@@ -27,7 +28,7 @@ def get_instigation_ticks(
 
     if before is None:
         if dayOffset:
-            before = pendulum.now("UTC").subtract(days=dayOffset).timestamp()
+            before = (get_current_datetime() - timedelta(days=dayOffset)).timestamp()
         elif cursor:
             parts = cursor.split(":")
             if parts:
@@ -38,7 +39,7 @@ def get_instigation_ticks(
 
     if after is None:
         after = (
-            pendulum.now("UTC").subtract(days=dayRange + (dayOffset or 0)).timestamp()
+            (get_current_datetime() - timedelta(days=dayRange + (dayOffset or 0))).timestamp()
             if dayRange
             else None
         )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -1,7 +1,7 @@
 import graphene
-import pendulum
 from dagster._core.events import DagsterEventType
 from dagster._core.storage.dagster_run import DagsterRunStatus, RunsFilter
+from dagster._time import datetime_from_timestamp
 from dagster._utils import check
 
 from .pipelines.status import GrapheneRunStatus
@@ -60,10 +60,10 @@ class GrapheneRunsFilter(graphene.InputObjectType):
         else:
             statuses = None
 
-        updated_before = pendulum.from_timestamp(self.updatedBefore) if self.updatedBefore else None
-        updated_after = pendulum.from_timestamp(self.updatedAfter) if self.updatedAfter else None
-        created_before = pendulum.from_timestamp(self.createdBefore) if self.createdBefore else None
-        created_after = pendulum.from_timestamp(self.createdAfter) if self.createdAfter else None
+        updated_before = datetime_from_timestamp(self.updatedBefore) if self.updatedBefore else None
+        updated_after = datetime_from_timestamp(self.updatedAfter) if self.updatedAfter else None
+        created_before = datetime_from_timestamp(self.createdBefore) if self.createdBefore else None
+        created_after = datetime_from_timestamp(self.createdAfter) if self.createdAfter else None
 
         return RunsFilter(
             run_ids=self.runIds if self.runIds else None,

--- a/python_modules/dagster-test/dagster_test/toys/repo.py
+++ b/python_modules/dagster-test/dagster_test/toys/repo.py
@@ -1,11 +1,11 @@
 import warnings
 
 from dagster import ExperimentalWarning
+from dagster._time import get_current_timestamp
 
 # squelch experimental warnings since we often include experimental things in toys for development
 warnings.filterwarnings("ignore", category=ExperimentalWarning)
 
-import pendulum
 from dagster import AssetMaterialization, Output, graph, load_assets_from_modules, op, repository
 
 from dagster_test.toys import big_honkin_asset_graph as big_honkin_asset_graph_module
@@ -67,7 +67,7 @@ from .sensors import get_toys_sensors
 
 @op
 def materialization_op():
-    timestamp = pendulum.now("UTC").timestamp()
+    timestamp = get_current_timestamp()
     yield AssetMaterialization(asset_key="model", metadata={"timestamp": timestamp})
     yield Output(1)
 

--- a/python_modules/dagster-test/dagster_test/toys/schedules.py
+++ b/python_modules/dagster-test/dagster_test/toys/schedules.py
@@ -9,6 +9,7 @@ from dagster._core.definitions.time_window_partitions import (
     monthly_partitioned_config,
     weekly_partitioned_config,
 )
+from dagster._utils.partitions import DEFAULT_DATE_FORMAT
 
 from dagster_test.toys.longitudinal import longitudinal
 from dagster_test.toys.many_events import many_events
@@ -98,7 +99,7 @@ def longitudinal_schedule():
     def longitudinal_config(start, _end):
         return {
             "ops": {
-                op.name: {"config": {"partition": start.to_date_string()}}
+                op.name: {"config": {"partition": start.strftime(DEFAULT_DATE_FORMAT)}}
                 for op in longitudinal_job.nodes
             }
         }

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -5,7 +5,6 @@ import textwrap
 from typing import Any, Callable, Iterator, Mapping, Optional, Sequence, Tuple, TypeVar, cast
 
 import click
-import pendulum
 from tabulate import tabulate
 
 import dagster._check as check
@@ -54,6 +53,7 @@ from dagster._core.telemetry import log_external_repo_stats, telemetry_wrapper
 from dagster._core.utils import make_new_backfill_id
 from dagster._core.workspace.workspace import IWorkspace
 from dagster._seven import IS_WINDOWS, JSONDecodeError, json
+from dagster._time import get_current_timestamp
 from dagster._utils import DEFAULT_WORKSPACE_YAML_FILENAME, PrintFn
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.hosted_user_process import recon_job_from_origin
@@ -744,7 +744,7 @@ def _execute_backfill_command_at_location(
             from_failure=False,
             reexecution_steps=None,
             tags=run_tags,
-            backfill_timestamp=pendulum.now("UTC").timestamp(),
+            backfill_timestamp=get_current_timestamp(),
         )
         try:
             partition_execution_data = (

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -17,8 +17,6 @@ from typing import (
     cast,
 )
 
-import pendulum
-
 import dagster._check as check
 from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView, TemporalContext
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
@@ -29,6 +27,7 @@ from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.time_window_partitions import get_time_partitions_def
 from dagster._core.instance import DynamicPartitionsStore
+from dagster._time import get_current_timestamp
 
 from ... import PartitionKeyRange
 from ..storage.tags import ASSET_PARTITION_RANGE_END_TAG, ASSET_PARTITION_RANGE_START_TAG
@@ -178,7 +177,7 @@ class AssetDaemonContext:
     def evaluate(
         self,
     ) -> Tuple[Sequence[RunRequest], AssetDaemonCursor, Sequence[AssetConditionEvaluation]]:
-        observe_request_timestamp = pendulum.now().timestamp()
+        observe_request_timestamp = get_current_timestamp()
         auto_observe_run_requests = (
             get_auto_observe_run_requests(
                 asset_graph=self.asset_graph,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -2,8 +2,6 @@ import datetime
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Mapping, NamedTuple, Optional, Sequence, Union
 
-import pendulum
-
 from dagster._annotations import experimental
 from dagster._core.asset_graph_view.asset_graph_view import AssetSlice, TemporalContext
 from dagster._core.definitions.asset_key import AssetKey
@@ -19,6 +17,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
 from dagster._core.definitions.partition import AllPartitionsSubset
 from dagster._core.definitions.time_window_partitions import BaseTimeWindowPartitionsSubset
 from dagster._model import DagsterModel
+from dagster._time import get_current_timestamp
 from dagster._utils.security import non_secure_md5_hash_str
 
 if TYPE_CHECKING:
@@ -320,7 +319,7 @@ class AutomationResult(NamedTuple):
         child_results: Sequence["AutomationResult"],
     ) -> "AutomationResult":
         start_timestamp = context.create_time.timestamp()
-        end_timestamp = pendulum.now("UTC").timestamp()
+        end_timestamp = get_current_timestamp()
 
         return AutomationResult(
             condition=context.condition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
@@ -18,8 +18,6 @@ from typing import (
     TypeVar,
 )
 
-import pendulum
-
 from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     HistoricalAllPartitionsSubsetSentinel,
@@ -27,6 +25,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.partition import PartitionsDefinition
+from dagster._time import get_current_timestamp
 
 from ...asset_subset import AssetSubset, ValidAssetSubset
 from ..serialized_objects import (
@@ -140,7 +139,7 @@ class LegacyRuleEvaluationContext:
             instance_queryer=instance_queryer,
             current_results_by_key=current_results_by_key,
             expected_data_time_mapping=expected_data_time_mapping,
-            start_timestamp=pendulum.now("UTC").timestamp(),
+            start_timestamp=get_current_timestamp(),
             respect_materialization_data_versions=respect_materialization_data_versions,
             auto_materialize_run_tags=auto_materialize_run_tags,
             logger=logger,
@@ -160,7 +159,7 @@ class LegacyRuleEvaluationContext:
             else None,
             candidate_subset=candidate_subset,
             root_ref=self.root_context,
-            start_timestamp=pendulum.now("UTC").timestamp(),
+            start_timestamp=get_current_timestamp(),
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -5,7 +5,7 @@ import dagster._check as check
 from dagster._annotations import deprecated
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._serdes import whitelist_for_serdes
-from dagster._seven.compat.pendulum import pendulum_create_timezone
+from dagster._time import get_timezone
 from dagster._utils.schedules import is_valid_cron_schedule, reverse_cron_string_iterator
 
 from .events import AssetKey
@@ -123,7 +123,7 @@ class FreshnessPolicy(
             )
             try:
                 # Verify that the timezone can be loaded
-                pendulum_create_timezone(cron_schedule_timezone)
+                get_timezone(cron_schedule_timezone)
             except Exception as e:
                 raise DagsterInvalidDefinitionError(
                     "Invalid cron schedule timezone '{cron_schedule_timezone}'.   "

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -32,7 +32,7 @@ from dagster._core.definitions.run_config import CoercibleToRunConfig
 from dagster._core.definitions.scoped_resources_builder import Resources, ScopedResourcesBuilder
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 from dagster._serdes import whitelist_for_serdes
-from dagster._seven.compat.pendulum import pendulum_create_timezone
+from dagster._time import get_timezone
 from dagster._utils import IHasInternalInit, ensure_gen
 from dagster._utils.merger import merge_dicts
 from dagster._utils.schedules import has_out_of_range_cron_interval, is_valid_cron_schedule
@@ -704,7 +704,7 @@ class ScheduleDefinition(IHasInternalInit):
         if self._execution_timezone:
             try:
                 # Verify that the timezone can be loaded
-                pendulum_create_timezone(self._execution_timezone)
+                get_timezone(self._execution_timezone)
             except Exception as e:
                 raise DagsterInvalidDefinitionError(
                     f"Invalid execution timezone {self._execution_timezone} for {name}"

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -23,7 +23,6 @@ from typing import (
     cast,
 )
 
-import pendulum
 from typing_extensions import TypeAlias
 
 import dagster._check as check
@@ -47,6 +46,7 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.instance.ref import InstanceRef
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._serdes import whitelist_for_serdes
+from dagster._time import get_current_datetime
 from dagster._utils import IHasInternalInit, normalize_to_repository
 from dagster._utils.merger import merge_dicts
 from dagster._utils.warnings import normalize_renamed_param
@@ -202,7 +202,7 @@ class SensorEvaluationContext:
             self._log_key = [
                 repository_name,
                 sensor_name,
-                pendulum.now("UTC").strftime("%Y%m%d_%H%M%S"),
+                get_current_datetime().strftime("%Y%m%d_%H%M%S"),
             ]
 
         self._logger: Optional[InstigationLogger] = None

--- a/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
@@ -3,8 +3,6 @@ import sys
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, cast
 
-import pendulum
-
 import dagster._check as check
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.event_api import EventLogCursor
@@ -18,6 +16,7 @@ from dagster._core.execution.retries import RetryMode
 from dagster._core.executor.step_delegating.step_handler.base import StepHandler, StepHandlerContext
 from dagster._core.instance import DagsterInstance
 from dagster._grpc.types import ExecuteStepArgs
+from dagster._time import get_current_datetime
 from dagster._utils.error import serializable_error_info_from_exc_info
 
 from ..base import Executor
@@ -226,7 +225,7 @@ class StepDelegatingExecutor(Executor):
 
                         running_steps[step.key] = step
 
-                last_check_step_health_time = pendulum.now("UTC")
+                last_check_step_health_time = get_current_datetime()
 
                 # Order of events is important here. During an interation, we call handle_event, then get_steps_to_execute,
                 # then is_complete. get_steps_to_execute updates the state of ActiveExecution, and without it
@@ -298,7 +297,7 @@ class StepDelegatingExecutor(Executor):
                     # process skips from failures or uncovered inputs
                     list(active_execution.plan_events_iterator(plan_context))
 
-                    curr_time = pendulum.now("UTC")
+                    curr_time = get_current_datetime()
                     if (
                         curr_time - last_check_step_health_time
                     ).total_seconds() >= self._check_step_health_interval_seconds:

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -28,7 +28,6 @@ from typing import (
     cast,
 )
 
-import pendulum
 import yaml
 from typing_extensions import Protocol, Self, TypeAlias, TypeVar, runtime_checkable
 
@@ -2803,7 +2802,7 @@ class DagsterInstance(DynamicPartitionsStore):
                     InstigatorStatus.RUNNING,
                     SensorInstigatorData(
                         min_interval=external_sensor.min_interval_seconds,
-                        last_sensor_start_timestamp=pendulum.now("UTC").timestamp(),
+                        last_sensor_start_timestamp=get_current_timestamp(),
                         sensor_type=external_sensor.sensor_type,
                     ),
                 )
@@ -2812,7 +2811,7 @@ class DagsterInstance(DynamicPartitionsStore):
             data = cast(SensorInstigatorData, stored_state.instigator_data)
             return self.update_instigator_state(
                 stored_state.with_status(InstigatorStatus.RUNNING).with_data(
-                    data.with_sensor_start_timestamp(pendulum.now("UTC").timestamp())
+                    data.with_sensor_start_timestamp(get_current_timestamp())
                 )
             )
 

--- a/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
+++ b/python_modules/dagster/dagster/_core/op_concurrency_limits_counter.py
@@ -2,9 +2,8 @@ import os
 from collections import defaultdict
 from typing import Mapping, Optional, Sequence
 
-import pendulum
-
 from dagster._core.snap.execution_plan_snapshot import ExecutionPlanSnapshot
+from dagster._time import get_current_timestamp
 
 from .instance import DagsterInstance
 from .storage.dagster_run import DagsterRun, DagsterRunStatus, RunOpConcurrency, RunRecord
@@ -85,7 +84,7 @@ class GlobalOpConcurrencyLimitsCounter:
             return True
         if status != DagsterRunStatus.STARTED or not record.start_time:
             return False
-        time_elapsed = pendulum.now("UTC").timestamp() - record.start_time
+        time_elapsed = get_current_timestamp() - record.start_time
         if time_elapsed < self._started_run_concurrency_keys_allotted_seconds:
             return True
 

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -67,7 +67,6 @@ from dagster._grpc.impl import (
 )
 from dagster._grpc.types import GetCurrentImageResult, GetCurrentRunsResult
 from dagster._serdes import deserialize_value
-from dagster._seven.compat.pendulum import PendulumDateTime
 from dagster._utils.merger import merge_dicts
 
 if TYPE_CHECKING:
@@ -512,7 +511,9 @@ class InProcessCodeLocation(CodeLocation):
         check.inst_param(instance, "instance", DagsterInstance)
         check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
         check.str_param(schedule_name, "schedule_name")
-        check.opt_inst_param(scheduled_execution_time, "scheduled_execution_time", PendulumDateTime)
+        check.opt_inst_param(
+            scheduled_execution_time, "scheduled_execution_time", TimestampWithTimezone
+        )
         check.opt_list_param(log_key, "log_key", of_type=str)
 
         result = get_external_schedule_execution(

--- a/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
@@ -4,7 +4,6 @@ import uuid
 from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Union, cast
 
-import pendulum
 from typing_extensions import TypeGuard
 
 import dagster._check as check
@@ -16,6 +15,7 @@ from dagster._core.remote_representation.origin import (
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.server import GrpcServerProcess
+from dagster._time import get_current_timestamp
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
 if TYPE_CHECKING:
@@ -198,14 +198,14 @@ class GrpcServerRegistry(AbstractContextManager):
                 self._active_entries[origin_id] = ServerRegistryEntry(
                     process=server_process,
                     loadable_target_origin=loadable_target_origin,
-                    creation_timestamp=pendulum.now("UTC").timestamp(),
+                    creation_timestamp=get_current_timestamp(),
                     server_id=new_server_id,
                 )
             except Exception:
                 self._active_entries[origin_id] = ErrorRegistryEntry(
                     error=serializable_error_info_from_exc_info(sys.exc_info()),
                     loadable_target_origin=loadable_target_origin,
-                    creation_timestamp=pendulum.now("UTC").timestamp(),
+                    creation_timestamp=get_current_timestamp(),
                 )
 
         active_entry = self._active_entries[origin_id]

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from typing import AbstractSet, Any, List, Mapping, NamedTuple, Optional, Sequence, Union
 
-import pendulum
 from typing_extensions import TypeAlias
 
 import dagster._check as check
@@ -26,7 +25,7 @@ from dagster._core.remote_representation.origin import RemoteInstigatorOrigin
 from dagster._serdes import create_snapshot_id
 from dagster._serdes.errors import DeserializationError
 from dagster._serdes.serdes import EnumSerializer, deserialize_value, whitelist_for_serdes
-from dagster._time import utc_datetime_from_naive
+from dagster._time import get_current_timestamp, utc_datetime_from_naive
 from dagster._utils import xor
 from dagster._utils.error import SerializableErrorInfo
 from dagster._utils.merger import merge_dicts
@@ -318,7 +317,7 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
 
     def with_status(self, status: TickStatus, **kwargs: Any):
         check.inst_param(status, "status", TickStatus)
-        end_timestamp = pendulum.now("UTC").timestamp() if status != TickStatus.STARTED else None
+        end_timestamp = get_current_timestamp() if status != TickStatus.STARTED else None
         kwargs["end_timestamp"] = end_timestamp
         return self._replace(tick_data=self.tick_data.with_status(status, **kwargs))
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -23,7 +23,6 @@ from typing import (
     cast,
 )
 
-import pendulum
 import sqlalchemy as db
 import sqlalchemy.exc as db_exc
 from sqlalchemy.engine import Connection
@@ -70,7 +69,7 @@ from dagster._core.storage.sqlalchemy_compat import (
 )
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._serdes.errors import DeserializationError
-from dagster._time import datetime_from_timestamp, utc_datetime_from_naive
+from dagster._time import datetime_from_timestamp, get_current_timestamp, utc_datetime_from_naive
 from dagster._utils import PrintFn
 from dagster._utils.concurrency import (
     ClaimedSlotInfo,
@@ -1756,7 +1755,7 @@ class SqlEventLogStorage(EventLogStorage):
         return event_or_materialization.dagster_event.step_materialization_data.materialization  # type: ignore
 
     def _get_asset_key_values_on_wipe(self) -> Mapping[str, Any]:
-        wipe_timestamp = pendulum.now("UTC").timestamp()
+        wipe_timestamp = get_current_timestamp()
         values = {
             "asset_details": serialize_value(AssetDetails(last_wipe_timestamp=wipe_timestamp)),
             "last_run_id": None,

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -21,7 +21,6 @@ from typing import (
     cast,
 )
 
-import pendulum
 import sqlalchemy as db
 import sqlalchemy.exc as db_exc
 from sqlalchemy.engine import Connection
@@ -64,7 +63,7 @@ from dagster._core.storage.tags import (
 from dagster._daemon.types import DaemonHeartbeat
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._seven import JSONDecodeError
-from dagster._time import datetime_from_timestamp, utc_datetime_from_naive
+from dagster._time import datetime_from_timestamp, get_current_datetime, utc_datetime_from_naive
 from dagster._utils import PrintFn
 from dagster._utils.merger import merge_dicts
 
@@ -186,7 +185,7 @@ class SqlRunStorage(RunStorage):
 
         # consider changing the `handle_run_event` signature to get timestamp off of the
         # EventLogEntry instead of the DagsterEvent, for consistency
-        now = pendulum.now("UTC")
+        now = get_current_datetime()
 
         if run_stats_cols_in_index and event.event_type == DagsterEventType.PIPELINE_START:
             kwargs["start_time"] = now.timestamp()
@@ -496,7 +495,7 @@ class SqlRunStorage(RunStorage):
                     run_body=serialize_value(run.with_tags(merge_dicts(current_tags, new_tags))),
                     partition=partition,
                     partition_set=partition_set,
-                    update_timestamp=pendulum.now("UTC"),
+                    update_timestamp=get_current_datetime(),
                 )
             )
 

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -14,7 +14,6 @@ from typing import (
     TypeVar,
 )
 
-import pendulum
 import sqlalchemy as db
 import sqlalchemy.exc as db_exc
 from sqlalchemy.engine import Connection
@@ -38,7 +37,7 @@ from dagster._core.storage.sql import SqlAlchemyQuery, SqlAlchemyRow
 from dagster._core.storage.sqlalchemy_compat import db_fetch_mappings, db_select, db_subquery
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
-from dagster._time import datetime_from_timestamp
+from dagster._time import datetime_from_timestamp, get_current_datetime
 from dagster._utils import PrintFn
 
 from .base import ScheduleStorage
@@ -166,7 +165,7 @@ class SqlScheduleStorage(ScheduleStorage):
                     status=state.status.value,
                     instigator_type=state.instigator_type.value,
                     instigator_body=serialize_value(state),
-                    update_timestamp=pendulum.now("UTC"),
+                    update_timestamp=get_current_datetime(),
                 )
             )
 
@@ -204,7 +203,7 @@ class SqlScheduleStorage(ScheduleStorage):
         values = {
             "status": state.status.value,
             "job_body": serialize_value(state),
-            "update_timestamp": pendulum.now("UTC"),
+            "update_timestamp": get_current_datetime(),
         }
         if self.has_instigators_table():
             values["selector_id"] = state.selector_id

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -8,7 +8,6 @@ from contextlib import AbstractContextManager, ExitStack, contextmanager
 from types import TracebackType
 from typing import Callable, Dict, Iterable, Iterator, Mapping, Optional, Sequence, Type
 
-import pendulum
 from typing_extensions import Self
 
 import dagster._check as check
@@ -27,6 +26,7 @@ from dagster._daemon.daemon import (
 )
 from dagster._daemon.run_coordinator.queued_run_coordinator_daemon import QueuedRunCoordinatorDaemon
 from dagster._daemon.types import DaemonHeartbeat, DaemonStatus
+from dagster._time import get_current_datetime, get_current_timestamp
 from dagster._utils.interrupts import raise_interrupts_as
 from dagster._utils.log import configure_loggers
 
@@ -197,7 +197,7 @@ class DagsterDaemonController(AbstractContextManager):
             self._last_healthy_heartbeat_times[daemon_type] = time.time()
             self._daemon_threads[daemon_type].start()
 
-        self._start_time = pendulum.now("UTC")
+        self._start_time = get_current_datetime()
 
     def __enter__(self) -> Self:
         return self
@@ -269,13 +269,13 @@ class DagsterDaemonController(AbstractContextManager):
             )
 
     def check_workspace_freshness(self, last_workspace_update_time: float) -> float:
-        nowish = pendulum.now("UTC").float_timestamp
+        nowish = get_current_timestamp()
         try:
             if (nowish - last_workspace_update_time) > RELOAD_WORKSPACE_INTERVAL:
                 if self._grpc_server_registry:
                     self._grpc_server_registry.clear_all_grpc_endpoints()
                 self._workspace_process_context.refresh_workspace()
-                return pendulum.now("UTC").float_timestamp
+                return get_current_timestamp()
         except Exception:
             if (nowish - last_workspace_update_time) > DEFAULT_WORKSPACE_FRESHNESS_TOLERANCE:
                 self._logger.exception("Daemon controller surpassed workspace freshness tolerance.")
@@ -305,7 +305,7 @@ class DagsterDaemonController(AbstractContextManager):
                     # If there's no errors, the daemons won't be writing heartbeats.
                     continue
 
-                now = pendulum.now("UTC").float_timestamp
+                now = get_current_timestamp()
                 # Give the daemon enough time to send an initial heartbeat before checking
                 if (
                     (now - start_time) < 2 * self._heartbeat_interval_seconds
@@ -314,7 +314,7 @@ class DagsterDaemonController(AbstractContextManager):
                     continue
 
                 self.check_daemon_heartbeats()
-                last_heartbeat_check_time = pendulum.now("UTC").float_timestamp
+                last_heartbeat_check_time = get_current_timestamp()
 
     def __exit__(
         self,
@@ -424,7 +424,7 @@ def get_daemon_statuses(
     heartbeat_tolerance_seconds: float = DEFAULT_DAEMON_HEARTBEAT_TOLERANCE_SECONDS,
 ) -> Mapping[str, DaemonStatus]:
     curr_time_seconds = check.opt_float_param(
-        curr_time_seconds, "curr_time_seconds", default=pendulum.now("UTC").float_timestamp
+        curr_time_seconds, "curr_time_seconds", default=get_current_timestamp()
     )
 
     daemon_statuses_by_type: Dict[str, DaemonStatus] = {}
@@ -449,7 +449,7 @@ def get_daemon_statuses(
                 maximum_tolerated_time = (
                     hearbeat_timestamp + heartbeat_interval_seconds + heartbeat_tolerance_seconds
                 )
-                healthy = curr_time_seconds <= maximum_tolerated_time  # type: ignore  # (possible none)
+                healthy = curr_time_seconds <= maximum_tolerated_time
 
                 if not ignore_errors and latest_heartbeat.errors:
                     healthy = False
@@ -466,7 +466,7 @@ def get_daemon_statuses(
 
 def debug_daemon_heartbeats(instance: DagsterInstance) -> None:
     daemon = SensorDaemon(settings=instance.get_sensor_settings())
-    timestamp = pendulum.now("UTC").float_timestamp
+    timestamp = get_current_timestamp()
     instance.add_daemon_heartbeat(DaemonHeartbeat(timestamp, daemon.daemon_type(), None, None))
     returned_timestamp = instance.get_daemon_heartbeats()[daemon.daemon_type()].timestamp
     print(f"Written timestamp: {timestamp}\nRead timestamp: {returned_timestamp}")  # noqa: T201

--- a/python_modules/dagster/dagster/_daemon/daemon.py
+++ b/python_modules/dagster/dagster/_daemon/daemon.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import os
 import random
@@ -9,9 +10,8 @@ from collections import deque
 from contextlib import AbstractContextManager, ExitStack
 from enum import Enum
 from threading import Event
-from typing import TYPE_CHECKING, Any, Generator, Generic, Mapping, Optional, TypeVar, Union
+from typing import Any, Generator, Generic, Mapping, Optional, TypeVar, Union
 
-import pendulum
 from typing_extensions import TypeAlias
 
 from dagster import (
@@ -31,10 +31,8 @@ from dagster._daemon.sensor import execute_sensor_iteration_loop
 from dagster._daemon.types import DaemonHeartbeat
 from dagster._daemon.utils import DaemonErrorCapture
 from dagster._scheduler.scheduler import execute_scheduler_iteration_loop
+from dagster._time import get_current_datetime
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
-
-if TYPE_CHECKING:
-    from pendulum.datetime import DateTime
 
 
 def get_default_daemon_logger(daemon_name) -> logging.Logger:
@@ -66,7 +64,7 @@ TContext = TypeVar("TContext", bound=IWorkspaceProcessContext)
 
 class DagsterDaemon(AbstractContextManager, ABC, Generic[TContext]):
     _logger: logging.Logger
-    _last_heartbeat_time: Optional["DateTime"]
+    _last_heartbeat_time: Optional[datetime.datetime]
 
     def __init__(self):
         self._logger = get_default_daemon_logger(type(self).__name__)
@@ -120,7 +118,7 @@ class DagsterDaemon(AbstractContextManager, ABC, Generic[TContext]):
                     try:
                         result = next(daemon_generator)
                         if isinstance(result, SerializableErrorInfo):
-                            self._errors.appendleft((result, pendulum.now("UTC")))
+                            self._errors.appendleft((result, get_current_datetime()))
                     except StopIteration:
                         self._logger.error(
                             "Daemon loop finished without raising an error - daemon loops should"
@@ -133,7 +131,7 @@ class DagsterDaemon(AbstractContextManager, ABC, Generic[TContext]):
                             logger=self._logger,
                             log_message="Caught error, daemon loop will restart",
                         )
-                        self._errors.appendleft((error_info, pendulum.now("UTC")))
+                        self._errors.appendleft((error_info, get_current_datetime()))
                         daemon_generator.close()
 
                         # Wait a bit to ensure that errors don't happen in a tight loop
@@ -153,7 +151,7 @@ class DagsterDaemon(AbstractContextManager, ABC, Generic[TContext]):
         heartbeat_interval_seconds: float,
         error_interval_seconds: int,
     ) -> None:
-        error_max_time = pendulum.now("UTC").subtract(seconds=error_interval_seconds)
+        error_max_time = get_current_datetime() - datetime.timedelta(seconds=error_interval_seconds)
 
         while len(self._errors):
             _earliest_error, earliest_timestamp = self._errors[-1]
@@ -165,7 +163,7 @@ class DagsterDaemon(AbstractContextManager, ABC, Generic[TContext]):
             # no errors to report, so we don't write a heartbeat
             return
 
-        curr_time = pendulum.now("UTC")
+        curr_time = get_current_datetime()
 
         if (
             self._last_heartbeat_time
@@ -195,7 +193,7 @@ class DagsterDaemon(AbstractContextManager, ABC, Generic[TContext]):
 
         instance.add_daemon_heartbeat(
             DaemonHeartbeat(
-                curr_time.float_timestamp,
+                curr_time.timestamp(),
                 daemon_type,
                 daemon_uuid,
                 errors=[error for (error, timestamp) in self._errors],

--- a/python_modules/dagster/dagster/_daemon/monitoring/concurrency.py
+++ b/python_modules/dagster/dagster/_daemon/monitoring/concurrency.py
@@ -1,10 +1,10 @@
+import datetime
 import logging
 from typing import Iterator, Optional
 
-import pendulum
-
 from dagster._core.storage.dagster_run import FINISHED_STATUSES, RunsFilter
 from dagster._core.workspace.context import IWorkspaceProcessContext
+from dagster._time import get_current_datetime
 from dagster._utils import DebugCrashFlags
 from dagster._utils.error import SerializableErrorInfo
 
@@ -31,12 +31,12 @@ def execute_concurrency_slots_iteration(
         yield
         return
 
-    now = pendulum.now("UTC")
+    now = get_current_datetime()
     run_records = instance.get_run_records(
         filters=RunsFilter(
             run_ids=list(run_ids),
             statuses=FINISHED_STATUSES,
-            updated_before=now.subtract(seconds=timeout_seconds),
+            updated_before=(now - datetime.timedelta(seconds=timeout_seconds)),
         ),
         limit=RUN_BATCH_SIZE,
     )

--- a/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
+++ b/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
@@ -3,8 +3,6 @@ import sys
 import time
 from typing import Iterator, Optional
 
-import pendulum
-
 from dagster import (
     DagsterInstance,
     _check as check,
@@ -20,6 +18,7 @@ from dagster._core.storage.dagster_run import (
 from dagster._core.storage.tags import MAX_RUNTIME_SECONDS_TAG
 from dagster._core.workspace.context import IWorkspace, IWorkspaceProcessContext
 from dagster._daemon.utils import DaemonErrorCapture
+from dagster._time import get_current_timestamp
 from dagster._utils import DebugCrashFlags
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
@@ -218,7 +217,7 @@ def check_run_timeout(
 
     if (
         run_record.start_time is not None
-        and pendulum.now("UTC").timestamp() - run_record.start_time > max_time
+        and get_current_timestamp() - run_record.start_time > max_time
     ):
         logger.info(
             f"Run {run_record.dagster_run.run_id} has exceeded maximum runtime of"

--- a/python_modules/dagster/dagster/_utils/container.py
+++ b/python_modules/dagster/dagster/_utils/container.py
@@ -3,7 +3,7 @@ import os
 from enum import Enum
 from typing import Optional, TypedDict
 
-import pendulum
+from dagster._time import get_current_timestamp
 
 
 def cpu_usage_path_cgroup_v1():
@@ -125,7 +125,7 @@ def retrieve_containerized_utilization_metrics(
         "cpu_cfs_period_us": _retrieve_containerized_cpu_cfs_period_us(logger, cgroup_version),
         "memory_usage": _retrieve_containerized_memory_usage(logger, cgroup_version),
         "memory_limit": _retrieve_containerized_memory_limit(logger, cgroup_version),
-        "measurement_timestamp": pendulum.now("UTC").float_timestamp,
+        "measurement_timestamp": get_current_timestamp(),
         "cgroup_version": cgroup_version.value if cgroup_version else None,
     }
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/captured_log_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/captured_log_manager.py
@@ -3,10 +3,10 @@ import string
 import sys
 import time
 
-import pendulum
 import pytest
 from dagster._core.execution.compute_logs import should_disable_io_stream_redirect
 from dagster._core.storage.compute_log_manager import ComputeIOType
+from dagster._time import get_current_datetime
 
 
 class TestCapturedLogManager:
@@ -44,7 +44,7 @@ class TestCapturedLogManager:
         should_disable_io_stream_redirect(), reason="compute logs disabled for win / py3.6+"
     )
     def test_capture(self, captured_log_manager):
-        now = pendulum.now("UTC")
+        now = get_current_datetime()
         log_key = ["arbitrary", "log", "key", now.strftime("%Y_%m_%d__%H_%M_%S")]
 
         with captured_log_manager.capture_logs(log_key) as context:
@@ -106,7 +106,7 @@ class TestCapturedLogManager:
         ):
             pytest.skip("does not support streaming")
 
-        now = pendulum.now("UTC")
+        now = get_current_datetime()
         log_key = ["streaming", "log", "key", now.strftime("%Y_%m_%d__%H_%M_%S")]
         with write_manager.capture_logs(log_key):
             print("hello stdout")  # noqa: T201
@@ -143,7 +143,7 @@ class TestCapturedLogManager:
         ):
             pytest.skip("unnecessary check since write/read manager should have the same behavior")
 
-        now = pendulum.now("UTC")
+        now = get_current_datetime()
         log_key = ["complete", "test", "log", "key", now.strftime("%Y_%m_%d__%H_%M_%S")]
         with write_manager.capture_logs(log_key):
             print("hello stdout")  # noqa: T201

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -10,7 +10,6 @@ from contextlib import ExitStack, contextmanager
 from typing import List, Optional, Sequence, Tuple, cast
 
 import mock
-import pendulum
 import pytest
 import sqlalchemy as db
 from dagster import (
@@ -113,6 +112,7 @@ from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.utils import make_new_run_id
 from dagster._loggers import colored_console_logger
 from dagster._serdes.serdes import deserialize_value
+from dagster._time import get_current_datetime
 from dagster._utils.concurrency import ConcurrencySlotStatus
 
 # py36 & 37 list.append not hashable
@@ -387,7 +387,7 @@ def cursor_datetime_args():
     # parametrization function to test constructing run-sharded event log cursors, with both
     # timezone-aware and timezone-naive datetimes
     yield None
-    yield pendulum.now()
+    yield get_current_datetime()
     yield datetime.datetime.now()
 
 

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -1,7 +1,6 @@
 from typing import ContextManager, Optional, Sequence, cast
 
 import dagster._check as check
-import pendulum
 import sqlalchemy as db
 import sqlalchemy.dialects as db_dialects
 import sqlalchemy.pool as db_pool
@@ -23,6 +22,7 @@ from dagster._core.storage.sql import (
     stamp_alembic_rev,
 )
 from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_value
+from dagster._time import get_current_datetime
 from sqlalchemy.engine import Connection
 
 from ..utils import (
@@ -167,7 +167,7 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
                 status=state.status.value,
                 instigator_type=state.instigator_type.value,
                 instigator_body=serialize_value(state),
-                update_timestamp=pendulum.now("UTC"),
+                update_timestamp=get_current_datetime(),
             )
         )
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -1,7 +1,6 @@
 from typing import ContextManager, Optional, Sequence
 
 import dagster._check as check
-import pendulum
 import sqlalchemy as db
 import sqlalchemy.dialects as db_dialects
 import sqlalchemy.pool as db_pool
@@ -24,6 +23,7 @@ from dagster._core.storage.sql import (
     stamp_alembic_rev,
 )
 from dagster._serdes import ConfigurableClass, ConfigurableClassData, serialize_value
+from dagster._time import get_current_datetime
 from sqlalchemy import event
 from sqlalchemy.engine import Connection
 
@@ -175,7 +175,7 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
                     "status": state.status.value,
                     "instigator_type": state.instigator_type.value,
                     "instigator_body": serialize_value(state),
-                    "update_timestamp": pendulum.now("UTC"),
+                    "update_timestamp": get_current_datetime(),
                 },
             )
         )


### PR DESCRIPTION
Summary:
This removes a sizeable portion of pendulum from the dagster core codebase - but leaves out the removals that would affect the public API (e.g. partitions and schedules).

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
