### PR TITLE
[docs] - Fix typo in Dagster+ code location docs

### DIFF
--- a/docs/content/dagster-plus/managing-deployments/code-locations.mdx
+++ b/docs/content/dagster-plus/managing-deployments/code-locations.mdx
@@ -22,7 +22,7 @@ A [`dagster_cloud.yaml` file](/dagster-plus/managing-deployments/dagster-cloud-y
   , which is set up to run in Dagster+.
 </Note>
 
-A code location specifies a single Python package or file that defines your Dagster code. When you add a code location in Dagster Code, you're instructing the agent where to find your code.
+A code location specifies a single Python package or file that defines your Dagster code. When you add a code location in Dagster+, you're instructing the agent where to find your code.
 
 When you add or update a code location, the agent uses the location configuration to load your code and upload metadata about your jobs to Dagster+. Each full deployment - for example, `prod` - can include code from one or more code locations.
 


### PR DESCRIPTION
## Summary & Motivation

This PR fixes a typo in the Dagster+ code location docs. Copypasta from the rename? The world may never know. 🍭 

## How I Tested These Changes
