### PR TITLE
[prototype] sensors can request backfills via a new class that is constructed via RunRequest

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -322,15 +322,19 @@ class RunRequest(
             return None
 
     @classmethod
-    def from_asset_graph_subset(
+    def for_asset_graph_subset(
         cls,
         asset_graph_subset: "AssetGraphSubset",
         tags: Optional[Mapping[str, str]],
         title: Optional[str],
         description: Optional[str],
     ) -> BackfillDaemonRequest:
-        """Not the final version of this method. will choose a better user api."""
-        # This is where we could introspect on the asset_graph_subset and determine if it should be a backfill or a single run
+        """Constructs a BackfillDaemonRequest from an AssetGraphSubset. When processed by the sensor
+        daemon, this will launch a backfill instead of a run.
+
+        Note: This constructor is intentionally left private since AssetGraphSubset is not part of the
+        public API. Other constructor methods will be public
+        """
         return BackfillDaemonRequest(
             asset_graph_subset=asset_graph_subset, tags=tags, title=title, description=description
         )

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -115,9 +115,7 @@ class DeleteDynamicPartitionsRequest(
 
 
 class IRunRequest(ABC):
-    @property
-    def asset_selection(self) -> AbstractSet[AssetKey]:
-        raise NotImplementedError
+    pass
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -49,6 +49,7 @@ from .job_definition import JobDefinition
 from .sensor_definition import (
     DagsterRunReaction,
     DefaultSensorStatus,
+    IRunRequest,
     RawSensorEvaluationFunctionReturn,
     RunRequest,
     SensorDefinition,
@@ -918,7 +919,7 @@ class RunStatusSensorDefinition(SensorDefinition):
                                 yield sensor_return
                             elif isinstance(
                                 sensor_return,
-                                (RunRequest, SkipReason, DagsterRunReaction),
+                                (IRunRequest, SkipReason, DagsterRunReaction),
                             ):
                                 yield sensor_return
                             else:

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -895,7 +895,8 @@ class SensorDefinition(IHasInternalInit):
                         f" {unexpected_asset_keys}"
                     )
                 resolved_run_requests.append(run_request)
-            else:
+            else:  # RunRequest
+                # we resolve all of the RunRequests at once in resolve_run_requests, so just collect them here
                 run_requests_to_resolve.append(run_request)
 
         resolved_run_requests.extend(
@@ -1084,7 +1085,9 @@ class SensorExecutionData(
             "asset_events",
             (AssetMaterialization, AssetObservation, AssetCheckEvaluation),
         )
-
+        check.invariant(
+            not (run_requests and skip_message), "Found both skip data and run request data"
+        )
         return super(SensorExecutionData, cls).__new__(
             cls,
             run_requests=run_requests,

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -54,6 +54,7 @@ from dagster._core.errors import DagsterUserCodeUnreachableError
 from dagster._core.events import DagsterEvent
 from dagster._core.instance import DagsterInstance
 from dagster._core.launcher import RunLauncher
+from dagster._core.remote_representation import ExternalRepository
 from dagster._core.remote_representation.origin import InProcessCodeLocationOrigin
 from dagster._core.run_coordinator import RunCoordinator, SubmitRunContext
 from dagster._core.secrets import SecretsLoader
@@ -527,6 +528,16 @@ def create_test_daemon_workspace_context(
             grpc_server_registry=grpc_server_registry,
         ) as workspace_process_context:
             yield workspace_process_context
+
+
+def load_external_repo(
+    workspace_context: WorkspaceProcessContext, repo_name: str
+) -> ExternalRepository:
+    code_location_entry = next(
+        iter(workspace_context.create_request_context().get_workspace_snapshot().values())
+    )
+    assert code_location_entry.code_location, code_location_entry.load_error
+    return code_location_entry.code_location.get_repository(repo_name)
 
 
 def remove_none_recursively(obj: T) -> T:

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -27,7 +27,7 @@ from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
 )
-from dagster._core.definitions.run_request import InstigatorType, RunRequest
+from dagster._core.definitions.run_request import InstigatorType, IRunRequest, RunRequest
 from dagster._core.definitions.sensor_definition import DefaultSensorStatus, SensorType
 from dagster._core.errors import DagsterCodeLocationLoadError, DagsterUserCodeUnreachableError
 from dagster._core.execution.submit_asset_runs import submit_asset_run
@@ -1033,7 +1033,7 @@ def invoke_sensor_for_evaluation(
     stored_cursor: AssetDaemonCursor,
     tick: InstigatorTick,
     asset_graph: RemoteAssetGraph,
-) -> Tuple[Sequence[RunRequest], AssetDaemonCursor, Sequence[AssetConditionEvaluation]]:
+) -> Tuple[Sequence[IRunRequest], AssetDaemonCursor, Sequence[AssetConditionEvaluation]]:
     sensor_origin = sensor.get_external_origin()
     request_ctx = workspace_process_context.create_request_context()
     code_loc = request_ctx.get_code_location(sensor_origin.location_name)

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -29,7 +29,6 @@ from dagster._core.definitions.run_request import (
     DagsterRunReaction,
     DeleteDynamicPartitionsRequest,
     InstigatorType,
-    MultiRunRequest,
     RunRequest,
 )
 from dagster._core.definitions.selector import JobSubsetSelector
@@ -761,7 +760,7 @@ def _handle_dynamic_partitions_requests(
 
 
 def _handle_backfill_run_request(
-    multi_run_request: MultiRunRequest,
+    run_request: BackfillDaemonRequest,
     instance: DagsterInstance,
     context: SensorLaunchContext,
 ) -> None:
@@ -771,10 +770,10 @@ def _handle_backfill_run_request(
             backfill_id=backfill_id,
             dynamic_partitions_store=instance,
             backfill_timestamp=get_current_timestamp(),
-            asset_graph_subset=multi_run_request.asset_graph_subset,
-            tags=multi_run_request.tags or {},
-            title=multi_run_request.title,
-            description=multi_run_request.description,
+            asset_graph_subset=run_request.asset_graph_subset,
+            tags=run_request.tags or {},
+            title=run_request.title,
+            description=run_request.description,
         )
     )
     context.add_run_info(run_id=backfill_id)

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -669,7 +669,8 @@ def _evaluate_sensor(
         for run_request in sensor_runtime_data.run_requests:
             if isinstance(run_request, BackfillDaemonRequest):
                 _handle_backfill_run_request(run_request, instance, context)
-            else:
+            else:  # RunRequest
+                # handle RunRequests at once in _handle_run_requests so just collect them here
                 single_runs_to_handle.append(run_request)
         if single_runs_to_handle:
             yield from _handle_run_requests(

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
@@ -9,6 +9,7 @@ from dagster._core.test_utils import (
     SingleThreadPoolExecutor,
     create_test_daemon_workspace_context,
     instance_for_test,
+    load_external_repo,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceProcessContext
@@ -70,11 +71,7 @@ def workspace_fixture(instance_module_scoped: DagsterInstance) -> Iterator[Works
 
 @pytest.fixture(name="external_repo", scope="module")
 def external_repo_fixture(workspace_context: WorkspaceProcessContext) -> ExternalRepository:
-    code_location = next(
-        iter(workspace_context.create_request_context().get_workspace_snapshot().values())
-    ).code_location
-    assert code_location
-    return code_location.get_repository("the_repo")
+    return load_external_repo(workspace_context, "the_repo")
 
 
 def loadable_target_origin() -> LoadableTargetOrigin:

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_daemon.py
@@ -1,0 +1,330 @@
+import os
+
+import pytest
+from dagster import (
+    DagsterInstance,
+    Definitions,
+    DynamicPartitionsDefinition,
+    SensorResult,
+    StaticPartitionsDefinition,
+    asset,
+    load_assets_from_current_module,
+    sensor,
+)
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.definitions.run_request import InstigatorType, RunRequest
+from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus, TickStatus
+from dagster._core.test_utils import create_test_daemon_workspace_context, load_external_repo
+from dagster._core.workspace.load_target import ModuleTarget
+
+from .test_sensor_run import evaluate_sensors, validate_tick
+
+dynamic_partitions_def = DynamicPartitionsDefinition(name="abc")
+
+
+@asset(partitions_def=dynamic_partitions_def)
+def asset1() -> None: ...
+
+
+@asset(deps=[asset1])
+def unpartitioned_child(): ...
+
+
+def make_run_request_uses_backfill_daemon(context) -> RunRequest:
+    ags = AssetGraphSubset.from_asset_partition_set(
+        asset_partitions_set={
+            AssetKeyPartitionKey(asset1.key, "foo"),
+            AssetKeyPartitionKey(asset1.key, "bar"),
+            AssetKeyPartitionKey(unpartitioned_child.key, None),
+        },
+        asset_graph=context.repository_def.asset_graph,
+    )
+    return RunRequest.from_asset_graph_subset(
+        asset_graph_subset=ags,
+        tags={"tagkey": "tagvalue"},
+        title="run_request_uses_backfill_daemon",
+        description=None,
+    )
+
+
+@sensor(asset_selection=[asset1, unpartitioned_child])
+def sensor_result_backfill_request_sensor(context):
+    return SensorResult(
+        dynamic_partitions_requests=[dynamic_partitions_def.build_add_request(["foo", "bar"])],
+        run_requests=[make_run_request_uses_backfill_daemon(context)],
+    )
+
+
+@sensor(asset_selection=[asset1, unpartitioned_child])
+def return_backfill_request_sensor(context):
+    context.instance.add_dynamic_partitions(dynamic_partitions_def.name, ["foo", "bar"])
+    return make_run_request_uses_backfill_daemon(context)
+
+
+@sensor(asset_selection=[asset1, unpartitioned_child])
+def yield_backfill_request_sensor(context):
+    context.instance.add_dynamic_partitions(dynamic_partitions_def.name, ["foo", "bar"])
+    yield make_run_request_uses_backfill_daemon(context)
+
+
+@asset(partitions_def=StaticPartitionsDefinition(["a", "b", "c"]))
+def static_partitioned_asset(): ...
+
+
+@sensor(asset_selection=[asset1, unpartitioned_child])
+def asset_outside_of_selection_backfill_request_sensor(context):
+    ags = AssetGraphSubset.from_asset_partition_set(
+        asset_partitions_set={
+            AssetKeyPartitionKey(static_partitioned_asset.key, "a"),
+            AssetKeyPartitionKey(static_partitioned_asset.key, "b"),
+        },
+        asset_graph=context.repository_def.asset_graph,
+    )
+    return RunRequest.from_asset_graph_subset(
+        asset_graph_subset=ags, tags={"tagkey": "tagvalue"}, title=None, description=None
+    )
+
+
+@sensor(asset_selection=[static_partitioned_asset])
+def invalid_partition_backfill_request_sensor(context):
+    ags = AssetGraphSubset.from_asset_partition_set(
+        asset_partitions_set={
+            AssetKeyPartitionKey(static_partitioned_asset.key, "b"),
+            AssetKeyPartitionKey(static_partitioned_asset.key, "z"),
+        },
+        asset_graph=context.repository_def.asset_graph,
+    )
+    return RunRequest.from_asset_graph_subset(
+        asset_graph_subset=ags, tags={"tagkey": "tagvalue"}, title=None, description=None
+    )
+
+
+@sensor(asset_selection=[static_partitioned_asset])
+def single_partition_run_request_sensor(context):
+    ags = AssetGraphSubset.from_asset_partition_set(
+        asset_partitions_set={AssetKeyPartitionKey(static_partitioned_asset.key, "b")},
+        asset_graph=context.repository_def.asset_graph,
+    )
+    return RunRequest.from_asset_graph_subset(
+        asset_graph_subset=ags, tags={"tagkey": "tagvalue"}, title=None, description=None
+    )
+
+
+@sensor(asset_selection=[static_partitioned_asset])
+def backfill_and_run_request_sensor(context):
+    ags = AssetGraphSubset.from_asset_partition_set(
+        asset_partitions_set={
+            AssetKeyPartitionKey(static_partitioned_asset.key, "a"),
+            AssetKeyPartitionKey(static_partitioned_asset.key, "b"),
+        },
+        asset_graph=context.repository_def.asset_graph,
+    )
+    yield RunRequest.from_asset_graph_subset(
+        asset_graph_subset=ags, tags={"tagkey": "tagvalue"}, title=None, description=None
+    )
+
+    yield RunRequest(asset_selection=[static_partitioned_asset.key], partition_key="c")
+
+
+defs = Definitions(
+    assets=load_assets_from_current_module(),
+    sensors=[
+        sensor_result_backfill_request_sensor,
+        return_backfill_request_sensor,
+        yield_backfill_request_sensor,
+        asset_outside_of_selection_backfill_request_sensor,
+        invalid_partition_backfill_request_sensor,
+        single_partition_run_request_sensor,
+        backfill_and_run_request_sensor,
+    ],
+)
+
+module_target = ModuleTarget(
+    module_name="dagster_tests.daemon_sensor_tests.test_sensor_run_backfill_daemon",
+    attribute=None,
+    working_directory=os.path.join(os.path.dirname(__file__), "..", ".."),
+    location_name="test_location",
+)
+
+
+@pytest.mark.parametrize(
+    "sensor_name",
+    [
+        "sensor_result_backfill_request_sensor",
+        "return_backfill_request_sensor",
+        "yield_backfill_request_sensor",
+    ],
+)
+def test_backfill_request_sensor(instance: DagsterInstance, executor, sensor_name: str):
+    with create_test_daemon_workspace_context(
+        workspace_load_target=module_target, instance=instance
+    ) as workspace_context:
+        external_repo = load_external_repo(workspace_context, "__repository__")
+        external_sensor = external_repo.get_external_sensor(sensor_name)
+
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+
+        assert instance.get_runs_count() == 0
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+        assert len(ticks) == 1
+
+        backfills = instance.get_backfills()
+        assert len(backfills) == 1
+        backfill = backfills[0]
+        assert backfill.tags == {"tagkey": "tagvalue"}
+        assert backfill.is_asset_backfill
+        asset_backfill_data = backfill.asset_backfill_data
+        assert asset_backfill_data
+        assert set(asset_backfill_data.target_subset.iterate_asset_partitions()) == {
+            AssetKeyPartitionKey(asset1.key, "foo"),
+            AssetKeyPartitionKey(asset1.key, "bar"),
+            AssetKeyPartitionKey(unpartitioned_child.key, None),
+        }
+
+        validate_tick(
+            ticks[0],
+            external_sensor,
+            None,
+            TickStatus.SUCCESS,
+            expected_run_ids=[backfill.backfill_id],
+        )
+
+
+def test_asset_selection_outside_of_range(instance, executor):
+    with create_test_daemon_workspace_context(
+        workspace_load_target=module_target, instance=instance
+    ) as workspace_context:
+        external_repo = load_external_repo(workspace_context, "__repository__")
+        external_sensor = external_repo.get_external_sensor(
+            asset_outside_of_selection_backfill_request_sensor.name
+        )
+
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+
+        validate_tick(
+            ticks[0],
+            external_sensor=external_sensor,
+            expected_status=TickStatus.FAILURE,
+            expected_datetime=None,
+            expected_error="RunRequest includes asset keys that are not part of sensor's "
+            "asset_selection: {AssetKey(['static_partitioned_asset'])}",
+        )
+
+
+def test_invalid_partition(instance, executor):
+    with create_test_daemon_workspace_context(
+        workspace_load_target=module_target, instance=instance
+    ) as workspace_context:
+        external_repo = load_external_repo(workspace_context, "__repository__")
+        external_sensor = external_repo.get_external_sensor(
+            invalid_partition_backfill_request_sensor.name
+        )
+
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+
+        # allow creating a backfill with an invalid partition. it will get caught in the daemon
+        # and show up as an error there.
+        validate_tick(ticks[0], external_sensor, None, TickStatus.SUCCESS)
+
+
+def test_single_partition(instance, executor):
+    """Tests requesting a single partition using asset_graph_subset. Currently this will still
+    be run as a backfill, but we could change the behavior to run as a single run.
+    """
+    with create_test_daemon_workspace_context(
+        workspace_load_target=module_target, instance=instance
+    ) as workspace_context:
+        external_repo = load_external_repo(workspace_context, "__repository__")
+        external_sensor = external_repo.get_external_sensor(
+            single_partition_run_request_sensor.name
+        )
+
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+
+        backfills = instance.get_backfills()
+        assert len(backfills) == 1
+        backfill = backfills[0]
+
+        validate_tick(
+            ticks[0],
+            external_sensor,
+            None,
+            TickStatus.SUCCESS,
+            expected_run_ids=[backfill.backfill_id],
+        )
+
+
+def test_backfill_and_run_request(instance, executor):
+    with create_test_daemon_workspace_context(
+        workspace_load_target=module_target, instance=instance
+    ) as workspace_context:
+        external_repo = load_external_repo(workspace_context, "__repository__")
+        external_sensor = external_repo.get_external_sensor(backfill_and_run_request_sensor.name)
+
+        instance.add_instigator_state(
+            InstigatorState(
+                external_sensor.get_external_origin(),
+                InstigatorType.SENSOR,
+                InstigatorStatus.RUNNING,
+            )
+        )
+        evaluate_sensors(workspace_context, executor)
+        ticks = instance.get_ticks(
+            external_sensor.get_external_origin_id(), external_sensor.selector_id
+        )
+
+        backfills = instance.get_backfills()
+        assert len(backfills) == 1
+        backfill = backfills[0]
+
+        runs = instance.get_runs()
+        assert len(runs) == 1
+        run = runs[0]
+
+        validate_tick(
+            ticks[0],
+            external_sensor,
+            None,
+            TickStatus.SUCCESS,
+            expected_run_ids=[backfill.backfill_id, run.run_id],
+        )

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_daemon.py
@@ -40,7 +40,7 @@ def make_run_request_uses_backfill_daemon(context) -> RunRequest:
         },
         asset_graph=context.repository_def.asset_graph,
     )
-    return RunRequest.from_asset_graph_subset(
+    return RunRequest.for_asset_graph_subset(
         asset_graph_subset=ags,
         tags={"tagkey": "tagvalue"},
         title="run_request_uses_backfill_daemon",


### PR DESCRIPTION
## Summary & Motivation
I tried a different approach to adding backfill support to sensors.
Rather than putting the attributes to run a backfill in the `RunRequest` like in https://github.com/dagster-io/dagster/pull/22681, this PR adds a new class `BackfillDaemonRequest` that contains just the attributes that are allowed for backfills. The intention is that this class will remain private and that the public API will look like this 
```python
RunRequest.for_asset_slices(...) 
``` 

I think this approach has a couple benefits:
- clear separation of supported parameters. In #22681 we have to do a lot of checking of parameter combinations to ensure that asset check keys, run keys, partition key, etc are not used when requesting a backfill. 
- Supports backfill specific attributes. You can set a title and a description for a backfill. Maybe we should add this to runs too, but the separation of parameters lets us support these attributes for backfills without adding even more invalid parameter combinations
- The sensor definition and sensor daemon code are more legible. We can check the type of the run request to see how it should be handled. In #22681 we had to either to expensive computations over the partitions in an asset graph subset, or check which of `asset_selection` and `asset_graph_subset` was set to know how to handle the request. We may still want to do some work to determine which kind of request we make when the user calls `RunRequest.from_asset_slices` but that work will happen once at construction time, rather than several times in the sensor execution. it'll also prevent having potentially expensive logic in a function that seems like it should be fast `requires_backfill_daemon`


One concern is how this will affect type checking. If a user writes this 
```python 
@sensor(...)
def my_sensor(context) -> RunRequest:
   ...
   return RunRequest.from_asset_slices(...)
```
there will be a linting error since `BackfillDaemonRequest` is what's actually returned. 

## How I Tested These Changes
