### PR TITLE
[ruff] 0.4.5 -> 0.5.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_stages: [pre-commit] # don't run on push by default
 repos:
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.4.5
+  rev: v0.5.1
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ruff:
 	ruff format .
 
 check_ruff:
-	ruff .
+	ruff check .
 	ruff format --check .
 
 check_prettier:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ extend-exclude = [
 line-length = 100
 
 # Fail if Ruff is not running this version.
-required-version = "0.4.5"
+required-version = "0.5.0"
 
 [tool.ruff.lint]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ extend-exclude = [
 line-length = 100
 
 # Fail if Ruff is not running this version.
-required-version = "0.5.0"
+required-version = "0.5.1"
 
 [tool.ruff.lint]
 

--- a/python_modules/dagster/dagster/_core/definitions/op_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_invocation.py
@@ -310,8 +310,7 @@ def _resolve_inputs(
     unassigned_kwargs = {k: v for k, v in kwargs.items() if k not in input_dict}
     # If there are unassigned inputs, then they may be intended for use with a variadic keyword argument.
     if unassigned_kwargs and cast("DecoratedOpFunction", op_def.compute_fn).has_var_kwargs():
-        for k, v in unassigned_kwargs.items():
-            input_dict[k] = v
+        input_dict.update(unassigned_kwargs)
 
     # Type check inputs
     op_label = context.per_invocation_properties.step_description

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -274,13 +274,14 @@ def build_caching_repository_data_from_list(
         key: checks_def for checks_def in asset_checks_defs for key in checks_def.check_keys
     }
     if assets_defs or asset_checks_defs or source_assets:
-        for job_name, job_def in get_base_asset_jobs(
-            asset_graph=asset_graph,
-            executor_def=default_executor_def,
-            resource_defs=top_level_resources,
-            logger_defs=default_logger_defs,
-        ).items():
-            jobs[job_name] = job_def
+        jobs.update(
+            get_base_asset_jobs(
+                asset_graph=asset_graph,
+                executor_def=default_executor_def,
+                resource_defs=top_level_resources,
+                logger_defs=default_logger_defs,
+            )
+        )
 
     for name, sensor_def in sensors.items():
         for target in sensor_def.targets:

--- a/python_modules/dagster/dagster/_core/workspace/load.py
+++ b/python_modules/dagster/dagster/_core/workspace/load.py
@@ -44,8 +44,9 @@ def location_origins_from_yaml_paths(
             ),
         )
 
-        for k, v in location_origins_from_config(cast(Dict, workspace_config), yaml_path).items():
-            origins_by_name[k] = v
+        origins_by_name.update(
+            location_origins_from_config(cast(Dict, workspace_config), yaml_path)
+        )
 
     return list(origins_by_name.values())
 

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_lifecycle_methods.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_lifecycle_methods.py
@@ -656,7 +656,7 @@ def test_direct_invocation_from_context_cm() -> None:
 
     # need to use a context manager to ensure teardown is called
     with pytest.raises(CheckError):
-        res = AWSCredentialsResource.from_resource_context(
+        AWSCredentialsResource.from_resource_context(
             build_init_resource_context(config={"access_key": "my_key", "secret_key": "my_secret"})
         )
 

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -164,7 +164,7 @@ setup(
             "types-toml",  # version will be resolved against toml
         ],
         "ruff": [
-            "ruff==0.5.0",
+            "ruff==0.5.1",
         ],
     },
     entry_points={

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -164,7 +164,7 @@ setup(
             "types-toml",  # version will be resolved against toml
         ],
         "ruff": [
-            "ruff==0.4.5",
+            "ruff==0.5.0",
         ],
     },
     entry_points={

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
@@ -297,7 +297,6 @@ def test_fetch_last_updated_timestamps_empty():
 @pytest.mark.parametrize("db_str", [None, "TESTDB"], ids=["db_from_resource", "db_from_param"])
 def test_fetch_last_updated_timestamps(db_str: str):
     start_time = get_current_timestamp()
-    table_name = "the_table"
     with temporary_snowflake_table() as table_name:
 
         @observable_source_asset

--- a/python_modules/libraries/dagstermill/dagstermill_tests/test_ops.py
+++ b/python_modules/libraries/dagstermill/dagstermill_tests/test_ops.py
@@ -397,7 +397,6 @@ def test_resources_notebook():
 @pytest.mark.skip
 @pytest.mark.notebook_test
 def test_resources_notebook_with_exception():
-    result = None
     with safe_tempfile_path() as path:
         with exec_for_test(
             "resource_with_exception_job",


### PR DESCRIPTION
Internal companion PR: https://github.com/dagster-io/internal/pull/10447

## Summary & Motivation

Bump ruff from 0.4.5 -> 0.5.1.

Some minor lint fixes due to rule updates.

## How I Tested These Changes

Existing test suite.