### PR TITLE
[perf] Fix request waterfalls in asset overview

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetLiveDataProvider.tsx
@@ -6,12 +6,12 @@ import {
   AssetStaleStatusData,
   __resetForJest as __resetStaleData,
 } from './AssetStaleStatusDataProvider';
-import {SUBSCRIPTION_MAX_POLL_RATE} from './util';
 import {observeAssetEventsInRuns} from '../asset-graph/AssetRunLogObserver';
 import {LiveDataForNodeWithStaleData, tokenForAssetKey} from '../asset-graph/Utils';
 import {AssetKeyInput} from '../graphql/types';
 import {LiveDataPollRateContext} from '../live-data-provider/LiveDataProvider';
 import {LiveDataThreadID} from '../live-data-provider/LiveDataThread';
+import {SUBSCRIPTION_MAX_POLL_RATE} from '../live-data-provider/util';
 import {useDidLaunchEvent} from '../runs/RunUtils';
 
 export function useAssetLiveData(assetKey: AssetKeyInput, thread: LiveDataThreadID = 'default') {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
@@ -7,10 +7,10 @@ import {GraphQLError} from 'graphql/error';
 import {buildMockedAssetGraphLiveQuery} from './util';
 import {AssetKey, AssetKeyInput, buildAssetKey} from '../../graphql/types';
 import {LiveDataThreadID} from '../../live-data-provider/LiveDataThread';
+import {BATCH_SIZE, SUBSCRIPTION_IDLE_POLL_RATE} from '../../live-data-provider/util';
 import {getMockResultFn} from '../../testing/mocking';
 import {useAssetsBaseData} from '../AssetBaseDataProvider';
 import {AssetLiveDataProvider, __resetForJest} from '../AssetLiveDataProvider';
-import {BATCH_SIZE, SUBSCRIPTION_IDLE_POLL_RATE} from '../util';
 
 Object.defineProperty(document, 'visibilityState', {value: 'visible', writable: true});
 Object.defineProperty(document, 'hidden', {value: false, writable: true});
@@ -362,7 +362,7 @@ describe('AssetLiveDataProvider', () => {
     });
   });
 
-  it.only('Skips over asset keys that fail to fetch', async () => {
+  it('Skips over asset keys that fail to fetch', async () => {
     const assetKeys = [buildAssetKey({path: ['key1']})];
     const mockedQuery = buildMockedAssetGraphLiveQuery(assetKeys, undefined, [
       new GraphQLError('500'),

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
@@ -362,7 +362,7 @@ describe('AssetLiveDataProvider', () => {
     });
   });
 
-  it('Skips over asset keys that fail to fetch', async () => {
+  it.only('Skips over asset keys that fail to fetch', async () => {
     const assetKeys = [buildAssetKey({path: ['key1']})];
     const mockedQuery = buildMockedAssetGraphLiveQuery(assetKeys, undefined, [
       new GraphQLError('500'),

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/util.ts
@@ -1,8 +1,0 @@
-// How many assets to fetch at once
-export const BATCH_SIZE = 10;
-
-// Milliseconds we wait until sending a batched query
-export const BATCHING_INTERVAL = 250;
-
-export const SUBSCRIPTION_IDLE_POLL_RATE = 30 * 1000;
-export const SUBSCRIPTION_MAX_POLL_RATE = 2 * 1000;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMetadata.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetMetadata.tsx
@@ -9,10 +9,10 @@ import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntryFragment';
 import {MetadataEntryFragment} from '../metadata/types/MetadataEntryFragment.types';
 
 export const metadataForAssetNode = (
-  assetNode: AssetNodeOpMetadataFragment,
+  assetNode: AssetNodeOpMetadataFragment | null | undefined,
 ): {assetType?: DagsterTypeFragment; assetMetadata: MetadataEntryFragment[]} => {
-  const assetType = assetNode.type ? assetNode.type : undefined;
-  const assetMetadata = assetNode.metadataEntries || [];
+  const assetType = assetNode?.type ? assetNode.type : undefined;
+  const assetMetadata = assetNode?.metadataEntries || [];
   return {assetType, assetMetadata};
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeInstigatorTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeInstigatorTag.tsx
@@ -9,14 +9,16 @@ import {SENSOR_SWITCH_FRAGMENT} from '../sensors/SensorSwitch';
 import {SensorSwitchFragment} from '../sensors/types/SensorSwitch.types';
 import {RepoAddress} from '../workspace/types';
 
-export const insitigatorsByType = (assetNode: AssetNodeInstigatorsFragment) => {
-  const instigators = assetNode.targetingInstigators;
-  const schedules = instigators?.filter(
-    (instigator): instigator is ScheduleSwitchFragment => instigator.__typename === 'Schedule',
-  );
-  const sensors = instigators?.filter(
-    (instigator): instigator is SensorSwitchFragment => instigator.__typename === 'Sensor',
-  );
+export const insitigatorsByType = (assetNode: AssetNodeInstigatorsFragment | undefined | null) => {
+  const instigators = assetNode?.targetingInstigators;
+  const schedules =
+    instigators?.filter(
+      (instigator): instigator is ScheduleSwitchFragment => instigator.__typename === 'Schedule',
+    ) ?? [];
+  const sensors =
+    instigators?.filter(
+      (instigator): instigator is SensorSwitchFragment => instigator.__typename === 'Sensor',
+    ) ?? [];
 
   return {schedules, sensors};
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -17,7 +17,7 @@ import {
   Tooltip,
 } from '@dagster-io/ui-components';
 import dayjs from 'dayjs';
-import React, {useMemo, useState} from 'react';
+import React, {useCallback, useMemo, useState} from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -25,6 +25,7 @@ import {AssetDefinedInMultipleReposNotice} from './AssetDefinedInMultipleReposNo
 import {AssetEventMetadataEntriesTable} from './AssetEventMetadataEntriesTable';
 import {metadataForAssetNode} from './AssetMetadata';
 import {insitigatorsByType} from './AssetNodeInstigatorTag';
+import {useCachedAssets} from './AssetsCatalogTable';
 import {DependsOnSelfBanner} from './DependsOnSelfBanner';
 import {LargeCollapsibleSection} from './LargeCollapsibleSection';
 import {MaterializationTag} from './MaterializationTag';
@@ -38,12 +39,14 @@ import {buildConsolidatedColumnSchema} from './buildConsolidatedColumnSchema';
 import {globalAssetGraphPathForAssetsAndDescendants} from './globalAssetGraphPathToString';
 import {AssetKey} from './types';
 import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinition.types';
+import {AssetTableFragment} from './types/AssetTableFragment.types';
 import {useLatestPartitionEvents} from './useLatestPartitionEvents';
 import {useRecentAssetEvents} from './useRecentAssetEvents';
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {showSharedToaster} from '../app/DomUtils';
 import {COMMON_COLLATOR} from '../app/Util';
 import {useCopyToClipboard} from '../app/browser';
+import {useAssetsLiveData} from '../asset-data/AssetLiveDataProvider';
 import {
   LiveDataForNode,
   displayNameForAssetKey,
@@ -81,34 +84,50 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 export const AssetNodeOverview = ({
+  assetKey,
   assetNode,
   upstream,
   downstream,
   liveData,
   dependsOnSelf,
 }: {
-  assetNode: AssetNodeDefinitionFragment;
+  assetKey: AssetKey;
+  assetNode: AssetNodeDefinitionFragment | undefined | null;
   upstream: AssetNodeForGraphQueryFragment[] | null;
   downstream: AssetNodeForGraphQueryFragment[] | null;
   liveData: LiveDataForNode | undefined;
   dependsOnSelf: boolean;
 }) => {
-  const repoAddress = buildRepoAddress(
-    assetNode.repository.name,
-    assetNode.repository.location.name,
-  );
+  const repoAddress = assetNode
+    ? buildRepoAddress(assetNode.repository.name, assetNode.repository.location.name)
+    : buildRepoAddress('', '');
   const location = useRepositoryLocationForAddress(repoAddress);
 
   const {assetType, assetMetadata} = metadataForAssetNode(assetNode);
   const {schedules, sensors} = useMemo(() => insitigatorsByType(assetNode), [assetNode]);
-  const configType = assetNode.configField?.configType;
+  const configType = assetNode?.configField?.configType;
   const assetConfigSchema = configType && configType.key !== 'Any' ? configType : null;
-  const visibleJobNames = assetNode.jobNames.filter((jobName) => !isHiddenAssetGroupJob(jobName));
+  const visibleJobNames =
+    assetNode?.jobNames.filter((jobName) => !isHiddenAssetGroupJob(jobName)) || [];
 
   const assetNodeLoadTimestamp = location ? location.updatedTimestamp * 1000 : undefined;
 
+  const [cachedAsset, setCachedAsset] = useState<AssetTableFragment | undefined>();
+  useCachedAssets({
+    onAssets: useCallback(
+      (data) => {
+        for (const asset of data) {
+          if (JSON.stringify(asset.key.path) === JSON.stringify(assetKey.path)) {
+            setCachedAsset(asset);
+          }
+        }
+      },
+      [assetKey.path],
+    ),
+  });
+
   const {materialization, observation, loading} = useLatestPartitionEvents(
-    assetNode,
+    assetKey,
     assetNodeLoadTimestamp,
     liveData,
   );
@@ -119,12 +138,27 @@ export const AssetNodeOverview = ({
     observations,
     loading: materializationsLoading,
   } = useRecentAssetEvents(
-    assetNode.isPartitioned ? undefined : assetNode.assetKey,
+    (!cachedAsset && !assetNode) ||
+      cachedAsset?.definition?.partitionDefinition ||
+      assetNode?.isPartitioned
+      ? undefined
+      : assetNode?.assetKey,
     {},
     {assetHasDefinedPartitions: false},
   );
 
-  if (loading) {
+  // Start loading neighboring assets data immediately to avoid waterfall.
+  useAssetsLiveData(
+    useMemo(
+      () => [
+        ...(downstream || []).map((node) => node.assetKey),
+        ...(upstream || []).map((node) => node.assetKey),
+      ],
+      [downstream, upstream],
+    ),
+  );
+
+  if (loading || !assetNode) {
     return <AssetNodeOverviewLoading />;
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -100,7 +100,7 @@ export const AssetNodeOverview = ({
 }) => {
   const repoAddress = assetNode
     ? buildRepoAddress(assetNode.repository.name, assetNode.repository.location.name)
-    : buildRepoAddress('', '');
+    : null;
   const location = useRepositoryLocationForAddress(repoAddress);
 
   const {assetType, assetMetadata} = metadataForAssetNode(assetNode);
@@ -114,11 +114,12 @@ export const AssetNodeOverview = ({
 
   const [cachedAsset, setCachedAsset] = useState<AssetTableFragment | undefined>();
   useCachedAssets({
-    onAssets: useCallback(
+    onAssetsLoaded: useCallback(
       (data) => {
         for (const asset of data) {
           if (JSON.stringify(asset.key.path) === JSON.stringify(assetKey.path)) {
             setCachedAsset(asset);
+            return;
           }
         }
       },
@@ -279,7 +280,7 @@ export const AssetNodeOverview = ({
     <Box flex={{direction: 'column', gap: 12}}>
       <AttributeAndValue label="Group">
         <Tag icon="asset_group">
-          <Link to={workspacePathFromAddress(repoAddress, `/asset-groups/${assetNode.groupName}`)}>
+          <Link to={workspacePathFromAddress(repoAddress!, `/asset-groups/${assetNode.groupName}`)}>
             {assetNode.groupName}
           </Link>
         </Tag>
@@ -289,9 +290,9 @@ export const AssetNodeOverview = ({
         <Box flex={{direction: 'column'}}>
           <AssetDefinedInMultipleReposNotice
             assetKey={assetNode.assetKey}
-            loadedFromRepo={repoAddress}
+            loadedFromRepo={repoAddress!}
           />
-          <RepositoryLink repoAddress={repoAddress} />
+          <RepositoryLink repoAddress={repoAddress!} />
           {location && (
             <Caption color={Colors.textLighter()}>
               Loaded {dayjs.unix(location.updatedTimestamp).fromNow()}
@@ -387,20 +388,24 @@ export const AssetNodeOverview = ({
             isJob
             showIcon
             pipelineName={jobName}
-            pipelineHrefContext={repoAddress}
+            pipelineHrefContext={repoAddress!}
           />
         )),
       },
       {
         label: 'Sensors',
         children: sensors.length > 0 && (
-          <ScheduleOrSensorTag repoAddress={repoAddress} sensors={sensors} showSwitch={false} />
+          <ScheduleOrSensorTag repoAddress={repoAddress!} sensors={sensors} showSwitch={false} />
         ),
       },
       {
         label: 'Schedules',
         children: schedules.length > 0 && (
-          <ScheduleOrSensorTag repoAddress={repoAddress} schedules={schedules} showSwitch={false} />
+          <ScheduleOrSensorTag
+            repoAddress={repoAddress!}
+            schedules={schedules}
+            showSwitch={false}
+          />
         ),
       },
       {
@@ -439,7 +444,7 @@ export const AssetNodeOverview = ({
         <Tag>
           <UnderlyingOpsOrGraph
             assetNode={assetNode}
-            repoAddress={repoAddress}
+            repoAddress={repoAddress!}
             hideIfRedundant={false}
           />
         </Tag>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -11,11 +11,7 @@ import {AssetFeatureContext} from './AssetFeatureContext';
 import {ASSET_NODE_DEFINITION_FRAGMENT, AssetNodeDefinition} from './AssetNodeDefinition';
 import {ASSET_NODE_INSTIGATORS_FRAGMENT} from './AssetNodeInstigatorTag';
 import {AssetNodeLineage} from './AssetNodeLineage';
-import {
-  AssetNodeOverview,
-  AssetNodeOverviewLoading,
-  AssetNodeOverviewNonSDA,
-} from './AssetNodeOverview';
+import {AssetNodeOverview, AssetNodeOverviewNonSDA} from './AssetNodeOverview';
 import {AssetPageHeader} from './AssetPageHeader';
 import {AssetPartitions} from './AssetPartitions';
 import {AssetPlotsPage} from './AssetPlotsPage';
@@ -80,9 +76,9 @@ export const AssetView = ({
       definitionQueryResult.data?.assetOrError.__typename === 'Asset' &&
       writeAssetVisit
     ) {
-      writeAssetVisit({path: currentPath});
+      writeAssetVisit({path: assetKey.path});
     }
-  }, [definitionQueryResult, writeAssetVisit, currentPath]);
+  }, [definitionQueryResult, writeAssetVisit, assetKey.path]);
 
   const tabList = useTabBuilder({definition, params});
 
@@ -119,17 +115,20 @@ export const AssetView = ({
     }
   }, [definitionQueryResult, liveData, trace]);
 
+  const isLoading =
+    definitionQueryResult.loading &&
+    !definitionQueryResult.previousData &&
+    !definitionQueryResult.data;
+
   const renderOverviewTab = () => {
-    if (definitionQueryResult.loading && !definitionQueryResult.previousData) {
-      return <AssetNodeOverviewLoading />;
-    }
-    if (!definition) {
+    if (!definition && !isLoading) {
       return (
         <AssetNodeOverviewNonSDA assetKey={assetKey} lastMaterialization={lastMaterialization} />
       );
     }
     return (
       <AssetNodeOverview
+        assetKey={assetKey}
         assetNode={definition}
         upstream={upstream}
         downstream={downstream}
@@ -140,7 +139,7 @@ export const AssetView = ({
   };
 
   const renderDefinitionTab = () => {
-    if (definitionQueryResult.loading && !definitionQueryResult.previousData) {
+    if (isLoading) {
       return <AssetLoadingDefinitionState />;
     }
     if (!definition) {
@@ -195,7 +194,7 @@ export const AssetView = ({
   };
 
   const renderEventsTab = () => {
-    if (definitionQueryResult.loading && !definitionQueryResult.previousData) {
+    if (isLoading) {
       return <AssetLoadingDefinitionState />;
     }
     return (
@@ -212,7 +211,7 @@ export const AssetView = ({
   };
 
   const renderPlotsTab = () => {
-    if (definitionQueryResult.loading && !definitionQueryResult.previousData) {
+    if (isLoading) {
       return <AssetLoadingDefinitionState />;
     }
     return (
@@ -226,14 +225,14 @@ export const AssetView = ({
   };
 
   const renderAutomaterializeHistoryTab = () => {
-    if (definitionQueryResult.loading && !definitionQueryResult.previousData) {
+    if (isLoading) {
       return <AssetLoadingDefinitionState />;
     }
     return <AssetAutomaterializePolicyPage assetKey={assetKey} definition={definition} />;
   };
 
   const renderChecksTab = () => {
-    if (definitionQueryResult.loading && !definitionQueryResult.previousData) {
+    if (isLoading) {
       return <AssetLoadingDefinitionState />;
     }
     return (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -39,7 +39,11 @@ const groupTableCache = new Map();
 export const ASSET_CATALOG_TABLE_QUERY_VERSION = 1;
 const DEFAULT_BATCH_LIMIT = 10000;
 
-export function useCachedAssets({onAssets}: {onAssets: (data: AssetTableFragment[]) => void}) {
+export function useCachedAssets({
+  onAssetsLoaded,
+}: {
+  onAssetsLoaded: (data: AssetTableFragment[]) => void;
+}) {
   const {localCacheIdPrefix} = useContext(AppContext);
   const cacheManager = useMemo(
     () => new CacheManager<AssetTableFragment[]>(`${localCacheIdPrefix}/allAssetNodes`),
@@ -49,10 +53,10 @@ export function useCachedAssets({onAssets}: {onAssets: (data: AssetTableFragment
   useLayoutEffect(() => {
     cacheManager.get(ASSET_CATALOG_TABLE_QUERY_VERSION).then((data) => {
       if (data) {
-        onAssets(data);
+        onAssetsLoaded(data);
       }
     });
-  }, [cacheManager, onAssets]);
+  }, [cacheManager, onAssetsLoaded]);
 
   return {cacheManager};
 }
@@ -70,7 +74,7 @@ export function useAllAssets({
   const assetsRef = useUpdatingRef(assets);
 
   const {cacheManager} = useCachedAssets({
-    onAssets: useCallback(
+    onAssetsLoaded: useCallback(
       (data) => {
         if (!assetsRef.current) {
           setErrorAndAssets({

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useLatestPartitionEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useLatestPartitionEvents.tsx
@@ -30,21 +30,21 @@ export function useLatestPartitionEvents(
   const {data, refetch} = queryResult;
 
   const refreshHint = usePredicateChangeSignal(
-    (prevHints, [lastMaterializationTimestamp, assetNodeLoadTimestamp], signalChanged) => {
+    (prevHints, [lastMaterializationTimestamp, assetNodeLoadTimestamp]) => {
       const [prevLastMaterializationTimestamp, prevAssetNodeLoadTimestamp] =
         prevHints || ([undefined, undefined] as const);
 
-      if (
+      return !!(
         /**
          * Trigger a refetch only if a previous a timestamp hint existed and has changed.
          * This avoids redundant queries since these timestamps are fetched in parallel.
          */
-        (prevLastMaterializationTimestamp &&
-          lastMaterializationTimestamp !== prevLastMaterializationTimestamp) ||
-        (prevAssetNodeLoadTimestamp && prevAssetNodeLoadTimestamp !== assetNodeLoadTimestamp)
-      ) {
-        signalChanged();
-      }
+        (
+          (prevLastMaterializationTimestamp &&
+            lastMaterializationTimestamp !== prevLastMaterializationTimestamp) ||
+          (prevAssetNodeLoadTimestamp && prevAssetNodeLoadTimestamp !== assetNodeLoadTimestamp)
+        )
+      );
     },
     [lastMaterializationTimestamp, assetNodeLoadTimestamp],
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useLatestPartitionEvents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useLatestPartitionEvents.tsx
@@ -2,36 +2,56 @@ import {gql, useQuery} from '@apollo/client';
 // eslint-disable-next-line no-restricted-imports
 import React from 'react';
 
-import {asAssetKeyInput} from './asInput';
-import {AssetNodeDefinitionFragment} from './types/AssetNodeDefinition.types';
+import {AssetKey} from './types';
 import {
   AssetOverviewMetadataEventsQuery,
   AssetOverviewMetadataEventsQueryVariables,
 } from './types/useLatestPartitionEvents.types';
 import {LiveDataForNode} from '../asset-graph/Utils';
+import {usePredicateChangeSignal} from '../hooks/usePredicateChangeSignal';
 import {METADATA_ENTRY_FRAGMENT} from '../metadata/MetadataEntryFragment';
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
 export function useLatestPartitionEvents(
-  assetNode: AssetNodeDefinitionFragment,
+  assetKey: AssetKey,
   assetNodeLoadTimestamp: number | undefined,
   liveData: LiveDataForNode | undefined,
 ) {
-  const refreshHint = liveData?.lastMaterialization?.timestamp;
+  const lastMaterializationTimestamp = liveData?.lastMaterialization?.timestamp;
 
   const queryResult = useQuery<
     AssetOverviewMetadataEventsQuery,
     AssetOverviewMetadataEventsQueryVariables
   >(ASSET_OVERVIEW_METADATA_EVENTS_QUERY, {
-    variables: {assetKey: asAssetKeyInput(assetNode)},
+    variables: {assetKey: {path: assetKey.path}},
   });
   useBlockTraceOnQueryResult(queryResult, 'AssetOverviewMetadataEventsQuery');
 
   const {data, refetch} = queryResult;
 
+  const refreshHint = usePredicateChangeSignal(
+    (prevHints, [lastMaterializationTimestamp, assetNodeLoadTimestamp], signalChanged) => {
+      const [prevLastMaterializationTimestamp, prevAssetNodeLoadTimestamp] =
+        prevHints || ([undefined, undefined] as const);
+
+      if (
+        /**
+         * Trigger a refetch only if a previous a timestamp hint existed and has changed.
+         * This avoids redundant queries since these timestamps are fetched in parallel.
+         */
+        (prevLastMaterializationTimestamp &&
+          lastMaterializationTimestamp !== prevLastMaterializationTimestamp) ||
+        (prevAssetNodeLoadTimestamp && prevAssetNodeLoadTimestamp !== assetNodeLoadTimestamp)
+      ) {
+        signalChanged();
+      }
+    },
+    [lastMaterializationTimestamp, assetNodeLoadTimestamp],
+  );
+
   React.useEffect(() => {
     refetch();
-  }, [refetch, refreshHint, assetNodeLoadTimestamp]);
+  }, [refetch, refreshHint]);
 
   const materialization =
     data?.assetOrError.__typename === 'Asset'

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsModal.tsx
@@ -59,7 +59,7 @@ export function useReportEventsModal(asset: Asset | null, onEventReported?: () =
   );
 
   const element = asset ? (
-    <ReportEventDialogBody
+    <ReportEventsDialog
       asset={asset}
       isOpen={isOpen}
       setIsOpen={setIsOpen}
@@ -74,7 +74,7 @@ export function useReportEventsModal(asset: Asset | null, onEventReported?: () =
   };
 }
 
-const ReportEventDialogBody = ({
+const ReportEventsDialog = ({
   asset,
   repoAddress,
   isOpen,
@@ -84,6 +84,35 @@ const ReportEventDialogBody = ({
   asset: Asset;
   repoAddress: RepoAddress;
   isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  onEventReported?: () => void;
+}) => {
+  return (
+    <Dialog
+      style={{width: 700}}
+      isOpen={isOpen}
+      canEscapeKeyClose
+      canOutsideClickClose
+      onClose={() => setIsOpen(false)}
+    >
+      <ReportEventDialogBody
+        asset={asset}
+        setIsOpen={setIsOpen}
+        repoAddress={repoAddress}
+        onEventReported={onEventReported}
+      />
+    </Dialog>
+  );
+};
+
+const ReportEventDialogBody = ({
+  asset,
+  repoAddress,
+  setIsOpen,
+  onEventReported,
+}: {
+  asset: Asset;
+  repoAddress: RepoAddress;
   setIsOpen: (open: boolean) => void;
   onEventReported?: () => void;
 }) => {
@@ -165,13 +194,7 @@ const ReportEventDialogBody = ({
   };
 
   return (
-    <Dialog
-      style={{width: 700}}
-      isOpen={isOpen}
-      canEscapeKeyClose
-      canOutsideClickClose
-      onClose={() => setIsOpen(false)}
-    >
+    <>
       <DialogHeader
         icon="info"
         label={
@@ -268,7 +291,7 @@ const ReportEventDialogBody = ({
           </Button>
         </Tooltip>
       </DialogFooter>
-    </Dialog>
+    </>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/usePredicateChangeSignal.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/usePredicateChangeSignal.test.tsx
@@ -1,0 +1,47 @@
+import {renderHook} from '@testing-library/react-hooks';
+
+import {usePredicateChangeSignal} from '../usePredicateChangeSignal';
+
+describe('usePredicateChangeSignal', () => {
+  it('should alternate between 0 and 1 when the predicate signals a change', () => {
+    const predicate = jest.fn((prev, curr, signalChanged) => {
+      if (!prev || prev[0] !== curr[0]) {
+        signalChanged();
+      }
+    });
+
+    const {result, rerender} = renderHook(({deps}) => usePredicateChangeSignal(predicate, deps), {
+      initialProps: {deps: [1]},
+    });
+
+    expect(result.current).toBe(0);
+    expect(predicate).toHaveBeenCalledWith(null, [1], expect.any(Function));
+
+    rerender({deps: [2]});
+    expect(result.current).toBe(1);
+    expect(predicate).toHaveBeenCalledWith([1], [2], expect.any(Function));
+
+    rerender({deps: [3]});
+    expect(result.current).toBe(0);
+    expect(predicate).toHaveBeenCalledWith([2], [3], expect.any(Function));
+  });
+
+  it('should not change the value if the predicate does not signal a change', () => {
+    const predicate = jest.fn((prev, curr, signalChanged) => {
+      if (!prev || prev[0] !== curr[0]) {
+        signalChanged();
+      }
+    });
+
+    const {result, rerender} = renderHook(({deps}) => usePredicateChangeSignal(predicate, deps), {
+      initialProps: {deps: [1]},
+    });
+
+    expect(result.current).toBe(0);
+    expect(predicate).toHaveBeenCalledWith(null, [1], expect.any(Function));
+
+    rerender({deps: [1]});
+    expect(result.current).toBe(0); // No change since deps are the same
+    expect(predicate).toHaveBeenCalledWith([1], [1], expect.any(Function));
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/usePredicateChangeSignal.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/__tests__/usePredicateChangeSignal.test.tsx
@@ -4,10 +4,8 @@ import {usePredicateChangeSignal} from '../usePredicateChangeSignal';
 
 describe('usePredicateChangeSignal', () => {
   it('should alternate between 0 and 1 when the predicate signals a change', () => {
-    const predicate = jest.fn((prev, curr, signalChanged) => {
-      if (!prev || prev[0] !== curr[0]) {
-        signalChanged();
-      }
+    const predicate = jest.fn((prev, curr) => {
+      return !prev || prev[0] !== curr[0];
     });
 
     const {result, rerender} = renderHook(({deps}) => usePredicateChangeSignal(predicate, deps), {
@@ -15,22 +13,20 @@ describe('usePredicateChangeSignal', () => {
     });
 
     expect(result.current).toBe(0);
-    expect(predicate).toHaveBeenCalledWith(null, [1], expect.any(Function));
+    expect(predicate).toHaveBeenCalledWith(null, [1]);
 
     rerender({deps: [2]});
     expect(result.current).toBe(1);
-    expect(predicate).toHaveBeenCalledWith([1], [2], expect.any(Function));
+    expect(predicate).toHaveBeenCalledWith([1], [2]);
 
     rerender({deps: [3]});
     expect(result.current).toBe(0);
-    expect(predicate).toHaveBeenCalledWith([2], [3], expect.any(Function));
+    expect(predicate).toHaveBeenCalledWith([2], [3]);
   });
 
   it('should not change the value if the predicate does not signal a change', () => {
-    const predicate = jest.fn((prev, curr, signalChanged) => {
-      if (!prev || prev[0] !== curr[0]) {
-        signalChanged();
-      }
+    const predicate = jest.fn((prev, curr) => {
+      return !prev || prev[0] !== curr[0];
     });
 
     const {result, rerender} = renderHook(({deps}) => usePredicateChangeSignal(predicate, deps), {
@@ -38,10 +34,10 @@ describe('usePredicateChangeSignal', () => {
     });
 
     expect(result.current).toBe(0);
-    expect(predicate).toHaveBeenCalledWith(null, [1], expect.any(Function));
+    expect(predicate).toHaveBeenCalledWith(null, [1]);
 
     rerender({deps: [1]});
     expect(result.current).toBe(0); // No change since deps are the same
-    expect(predicate).toHaveBeenCalledWith([1], [1], expect.any(Function));
+    expect(predicate).toHaveBeenCalledWith(null, [1]);
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/usePredicateChangeSignal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/usePredicateChangeSignal.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+// Alternates between 0 / 1, switching whenever the predicate calls `signalChanged`.
+export const usePredicateChangeSignal = <T extends ReadonlyArray<unknown>>(
+  predicate: (previousDeps: T | null, currentDeps: T, signalChanged: () => void) => any,
+  currentDeps: T,
+) => {
+  const previousDepsRef = React.useRef<T | null>(null);
+
+  let didChange = false;
+  const signalChanged = () => {
+    didChange = true;
+  };
+  predicate(previousDepsRef.current, currentDeps, signalChanged);
+
+  const resultValueRef = React.useRef<1 | 0>(1);
+
+  if (didChange) {
+    previousDepsRef.current = currentDeps;
+    resultValueRef.current = resultValueRef.current === 1 ? 0 : 1;
+  }
+  return resultValueRef.current;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/usePredicateChangeSignal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/usePredicateChangeSignal.tsx
@@ -1,17 +1,17 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 
 // Alternates between 0 / 1, switching whenever the predicate calls `signalChanged`.
 export const usePredicateChangeSignal = <T extends ReadonlyArray<unknown>>(
-  predicate: (previousDeps: T | null, currentDeps: T, signalChanged: () => void) => any,
+  predicate: (previousDeps: T | null, currentDeps: T) => true | false | void,
   currentDeps: T,
 ) => {
   const previousDepsRef = React.useRef<T | null>(null);
 
-  let didChange = false;
-  const signalChanged = () => {
-    didChange = true;
-  };
-  predicate(previousDepsRef.current, currentDeps, signalChanged);
+  let didChange: void | boolean = false;
+  useMemo(() => {
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    didChange = predicate(previousDepsRef.current, currentDeps);
+  }, currentDeps);
 
   const resultValueRef = React.useRef<1 | 0>(1);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/usePredicateChangeSignal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/usePredicateChangeSignal.tsx
@@ -1,6 +1,6 @@
 import React, {useMemo} from 'react';
 
-// Alternates between 0 / 1, switching whenever the predicate calls `signalChanged`.
+// Alternates between 0 / 1, switching whenever the predicate evaluates to true.
 export const usePredicateChangeSignal = <T extends ReadonlyArray<unknown>>(
   predicate: (previousDeps: T | null, currentDeps: T) => true | false | void,
   currentDeps: T,

--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThread.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThread.tsx
@@ -66,13 +66,17 @@ export class LiveDataThread<T> {
     if (this.activeFetches === this.parallelFetches) {
       return;
     }
-    const fetch = () => {
-      this._batchedQueryKeys();
-    };
-    setTimeout(fetch, BATCHING_INTERVAL);
-    if (this.intervals.length !== this.parallelFetches) {
-      this.intervals.push(setInterval(fetch, 5000));
+    setTimeout(this._batchedQueryKeys, BATCHING_INTERVAL);
+    if (this.intervals.length === this.parallelFetches) {
+      return;
     }
+    console.log('pushed interval');
+    this.intervals.push(
+      setInterval(() => {
+        console.log('interval');
+        this._batchedQueryKeys();
+      }, 5000),
+    );
   }
 
   public stopFetchLoop() {
@@ -82,14 +86,17 @@ export class LiveDataThread<T> {
     this.intervals = [];
   }
 
-  private async _batchedQueryKeys() {
+  private _batchedQueryKeys = async () => {
+    console.log(this.activeFetches, this.parallelFetches);
     if (this.activeFetches >= this.parallelFetches) {
+      console.log('return');
       return;
     }
     const keys = this.manager.determineKeysToFetch(this.getObservedKeys(), this.batchSize);
     if (!keys.length) {
       return;
     }
+    console.log('query', keys);
     this.activeFetches += 1;
     this.manager._markKeysRequested(keys);
 
@@ -122,5 +129,5 @@ export class LiveDataThread<T> {
         Math.min(this.pollRate, 5000),
       );
     }
-  }
+  };
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThread.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/LiveDataThread.tsx
@@ -63,14 +63,16 @@ export class LiveDataThread<T> {
   }
 
   public startFetchLoop() {
-    if (this.intervals.length === this.parallelFetches) {
+    if (this.activeFetches === this.parallelFetches) {
       return;
     }
     const fetch = () => {
       this._batchedQueryKeys();
     };
     setTimeout(fetch, BATCHING_INTERVAL);
-    this.intervals.push(setInterval(fetch, 5000));
+    if (this.intervals.length !== this.parallelFetches) {
+      this.intervals.push(setInterval(fetch, 5000));
+    }
   }
 
   public stopFetchLoop() {

--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/util.ts
@@ -1,13 +1,13 @@
 // How many assets to fetch at once
 const urlParams = new URLSearchParams(window.location.search);
 const liveDataBatchSize = parseInt(urlParams.get('live-data-batch-size') ?? '10', 10);
-const batchThreads = parseInt(urlParams.get('live-data-parallel-fetches') ?? '1', 10);
+const batchThreads = parseInt(urlParams.get('live-data-parallel-fetches') ?? '2', 10);
 
 export const BATCH_SIZE = isNaN(liveDataBatchSize) ? 10 : liveDataBatchSize;
-export const BATCH_PARALLEL_FETCHES = isNaN(batchThreads) ? 1 : batchThreads;
+export const BATCH_PARALLEL_FETCHES = isNaN(batchThreads) ? 2 : batchThreads;
 
 // Milliseconds we wait until sending a batched query
-export const BATCHING_INTERVAL = 250;
+export const BATCHING_INTERVAL = 50;
 
 export const SUBSCRIPTION_IDLE_POLL_RATE = 30 * 1000;
 export const SUBSCRIPTION_MAX_POLL_RATE = 2 * 1000;

--- a/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/util.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/live-data-provider/util.ts
@@ -6,9 +6,6 @@ const batchThreads = parseInt(urlParams.get('live-data-parallel-fetches') ?? '2'
 export const BATCH_SIZE = isNaN(liveDataBatchSize) ? 10 : liveDataBatchSize;
 export const BATCH_PARALLEL_FETCHES = isNaN(batchThreads) ? 2 : batchThreads;
 
-// Milliseconds we wait until sending a batched query
-export const BATCHING_INTERVAL = 50;
-
 export const SUBSCRIPTION_IDLE_POLL_RATE = 30 * 1000;
 export const SUBSCRIPTION_MAX_POLL_RATE = 2 * 1000;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/useRepositoryLocationForAddress.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/useRepositoryLocationForAddress.ts
@@ -3,13 +3,15 @@ import {useContext} from 'react';
 import {WorkspaceContext} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
 
-export function useRepositoryLocationForAddress(repoAddress: RepoAddress) {
+export function useRepositoryLocationForAddress(repoAddress: RepoAddress | null) {
   const {locationEntries} = useContext(WorkspaceContext);
-  return locationEntries.find(
-    (r) =>
-      r.locationOrLoadError?.__typename === 'RepositoryLocation' &&
-      r.locationOrLoadError.repositories.some(
-        (repo) => repo.name === repoAddress.name && repo.location.name === repoAddress.location,
-      ),
-  );
+  return repoAddress
+    ? locationEntries.find(
+        (r) =>
+          r.locationOrLoadError?.__typename === 'RepositoryLocation' &&
+          r.locationOrLoadError.repositories.some(
+            (repo) => repo.name === repoAddress.name && repo.location.name === repoAddress.location,
+          ),
+      )
+    : undefined;
 }


### PR DESCRIPTION
## Summary & Motivation
Fix a bunch of request waterfalls in the Asset Overview page.

1. Stop gating the overview tab on the definition loading, instead allow the overview tab to handle a null definition (indicating it is loading)
2. Allow a few utilities to take handle `null` / `undefined` while the assetNode is loading.
3. If available, use the all assets cache to figure out if an asset is partitioned to avoid waterfall for events query
4. Fix an issue where the ReportEvents dialog was querying for all partitions as soon as you loaded the page even if you the dialog wasn't open.
5. Increased the default number of parallel live data threads from 1 to 2 (to avoid waterfall on loading the main assets live data and its neighboring asset's live data which comes in after via the indexeddb cache or via ASSET_GRAPH_QUERY request waterfall if not in the cache).
6. Fixed timing issue in live data provider which caused us to unnecessarily wait up to 5 seconds before fetching a subsequent batch if it was requested separately


## How I Tested These Changes

Loaded the asset overview page and made sure loading states were shown and recorded below traces

13.07s -> 4.84s (62.97% improvement)

Before ([link](https://app.datadoghq.com/rum/sessions?query=%40application.id%3A6d12cca2-0263-463b-a90e-cc6c524e14bd%20%40type%3Aview%20%40context.organization%3Adiscord%20%40view.name%3A%22%2Fassets%28%2F%3F.%2A%29%3Fview%3Doverview%22&agg_m=count&agg_m_source=base&agg_t=count&cols=has_replay%2Cstatus%2Ctimestamp%2C%40view.name%2C%40view.loading_type%2C%40view.url_path%2C%40view.custom_timings.display-done%2C%40view.loading_time%2C%40view.custom_timings.display-done-clean%2C%40view.url_path_group&event=AgAAAZB5US_XubxAzwAAAAAAAAAYAAAAAEFaQjVVU19YQUFCTldKUFpFSzNoeF9QTwAAACQAAAAAMDE5MDc5NTItZmE4Yi00NDExLTg4MWUtNjY0ODhhNTMyZDZk&fromUser=true&refresh_mode=sliding&sort_by=%40view.custom_timings.display-done-clean&sort_order=desc&track=rum&type=rum&viz=stream&from_ts=1719421161137&to_ts=1720025961137&live=true)):
<img width="1205" alt="Screenshot 2024-07-03 at 12 38 14 PM" src="https://github.com/dagster-io/dagster/assets/2286579/451a62ed-8181-48e6-a371-a4c9fc565c94">


After ([link](https://app.datadoghq.com/rum/sessions?query=%40type%3Aview%20%40application.id%3A6d12cca2-0263-463b-a90e-cc6c524e14bd%20%40usr.email%3Amarco%40dagsterlabs.com%20%40view.url_path_group%3A%22%2Fdiscord%2Fprd%2Fassets%2Finsights%2Fcaptcha_user_day_client%22&agg_m=count&agg_m_source=base&agg_q=%40issue.id&agg_q_source=base&agg_t=count&cols=&event=AgAAAZB5e-o7-z0IzQAAAAAAAAAYAAAAAEFaQjVlLW83QUFDeXBMajZBVU1IZlN1NAAAACQAAAAAMDE5MDc5N2MtM2VkYi00MGMyLWFkNjQtOGNlMDY2OWQ0OTA0&fromUser=false&p_tab_from=1720025082351&p_tab_to=1720025087276&tab=error&top_n=10&top_o=top&track=rum&viz=stream&x_missing=true&from_ts=1720024893925&to_ts=1720025793925&live=true)):
<img width="1198" alt="Screenshot 2024-07-03 at 12 50 36 PM" src="https://github.com/dagster-io/dagster/assets/2286579/5c108145-450c-476d-9027-f61a7b1b1acd">


