### PR TITLE
terminate running steps when multiprocess / step delegating executors unexpectedly raise an exception

### DIFF
--- a/python_modules/dagster/dagster/_core/executor/child_process_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/child_process_executor.py
@@ -6,6 +6,7 @@ import sys
 from abc import ABC, abstractmethod
 from multiprocessing import Queue
 from multiprocessing.context import BaseContext as MultiprocessingBaseContext
+from multiprocessing.process import BaseProcess
 from typing import TYPE_CHECKING, Iterator, NamedTuple, Optional, Union
 
 from typing_extensions import Literal
@@ -119,7 +120,7 @@ def _poll_for_event(
 
 def execute_child_process_command(
     multiprocessing_ctx: MultiprocessingBaseContext, command: ChildProcessCommand
-) -> Iterator[Optional["DagsterEvent"]]:
+) -> Iterator[Optional[Union["DagsterEvent", ChildProcessEvent, BaseProcess]]]:
     """Execute a ChildProcessCommand in a new process.
 
     This function starts a new process whose execution target is a ChildProcessCommand wrapped by
@@ -130,12 +131,9 @@ def execute_child_process_command(
     executions in flight:
         * None - nothing has happened, yielded to enable cooperative multitasking other iterators
 
-        * ChildProcessEvent - Family of objects that communicates state changes in the child process
+        * multiprocessing.BaseProcess - the child process object.
 
-        * KeyboardInterrupt - Yielded in the case that an interrupt was recieved while
-            polling the child process. Yielded instead of raised to allow forwarding of the
-            interrupt to the child and completion of the iterator for this child and
-            any others that may be executing
+        * ChildProcessEvent - Family of objects that communicates state changes in the child process
 
         * The actual values yielded by the child process command
 
@@ -154,6 +152,7 @@ def execute_child_process_command(
             target=_execute_command_in_child_process, args=(event_queue, command)
         )
         process.start()
+        yield process
 
         completed_properly = False
 

--- a/python_modules/dagster/dagster/_core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/_core/executor/multiprocess.py
@@ -4,6 +4,7 @@ import sys
 import threading
 from contextlib import ExitStack
 from multiprocessing.context import BaseContext as MultiprocessingBaseContext
+from multiprocessing.process import BaseProcess
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Mapping, Optional, Sequence
 
 from dagster import _check as check
@@ -205,91 +206,119 @@ class MultiprocessExecutor(Executor):
             )
             active_iters: Dict[str, Iterator[Optional[DagsterEvent]]] = {}
             errors: Dict[int, SerializableErrorInfo] = {}
+            processes: Dict[str, BaseProcess] = {}
             term_events: Dict[str, Any] = {}
             stopping: bool = False
 
-            while (not stopping and not active_execution.is_complete) or active_iters:
-                if active_execution.check_for_interrupts():
+            try:
+                while (not stopping and not active_execution.is_complete) or active_iters:
+                    if active_execution.check_for_interrupts():
+                        yield DagsterEvent.engine_event(
+                            plan_context,
+                            "Multiprocess executor: received termination signal - "
+                            "forwarding to active child processes",
+                            EngineEventData.interrupted(list(active_iters.keys())),
+                        )
+                        stopping = True
+                        active_execution.mark_interrupted()
+                        for key, term_event in term_events.items():
+                            if processes.get(key) and processes[key].is_alive():
+                                term_event.set()
+
+                    while not stopping:
+                        steps = active_execution.get_steps_to_execute(
+                            limit=(limit - len(active_iters)),
+                        )
+
+                        yield from active_execution.concurrency_event_iterator(plan_context)
+
+                        if not steps:
+                            break
+
+                        for step in steps:
+                            step_context = plan_context.for_step(step)
+                            term_events[step.key] = multiproc_ctx.Event()
+                            active_iters[step.key] = execute_step_out_of_process(
+                                multiproc_ctx,
+                                job,
+                                step_context,
+                                step,
+                                errors,
+                                processes,
+                                term_events,
+                                self.retries,
+                                active_execution.get_known_state(),
+                                execution_plan.repository_load_data,
+                            )
+
+                    # process active iterators
+                    empty_iters = []
+                    for key, step_iter in active_iters.items():
+                        try:
+                            event_or_none = next(step_iter)
+                            if event_or_none is None:
+                                continue
+                            else:
+                                yield event_or_none
+                                active_execution.handle_event(event_or_none)
+
+                        except ChildProcessCrashException as crash:
+                            serializable_error = serializable_error_info_from_exc_info(
+                                sys.exc_info()
+                            )
+                            step_context = plan_context.for_step(
+                                active_execution.get_step_by_key(key)
+                            )
+                            yield DagsterEvent.engine_event(
+                                step_context,
+                                get_run_crash_explanation(
+                                    prefix=f"Multiprocess executor: child process for step {key}",
+                                    exit_code=crash.exit_code,
+                                ),
+                                EngineEventData.engine_error(serializable_error),
+                            )
+                            step_failure_event = DagsterEvent.step_failure_event(
+                                step_context=plan_context.for_step(
+                                    active_execution.get_step_by_key(key)
+                                ),
+                                step_failure_data=StepFailureData(
+                                    error=serializable_error, user_failure_data=None
+                                ),
+                            )
+                            active_execution.handle_event(step_failure_event)
+                            yield step_failure_event
+                            empty_iters.append(key)
+                        except StopIteration:
+                            empty_iters.append(key)
+
+                    # clear and mark complete finished iterators
+                    for key in empty_iters:
+                        del active_iters[key]
+                        del term_events[key]
+                        active_execution.verify_complete(plan_context, key)
+
+                    # process skipped and abandoned steps
+                    yield from active_execution.plan_events_iterator(plan_context)
+            except Exception:
+                if not stopping and active_iters:
+                    serializable_error = serializable_error_info_from_exc_info(sys.exc_info())
                     yield DagsterEvent.engine_event(
                         plan_context,
-                        "Multiprocess executor: received termination signal - "
-                        "forwarding to active child processes",
-                        EngineEventData.interrupted(list(term_events.keys())),
+                        "Unexpected exception while steps were still in-progress - terminating running steps:",
+                        event_specific_data=EngineEventData(
+                            metadata={
+                                "steps_interrupted": MetadataValue.text(
+                                    str(list(active_iters.keys()))
+                                )
+                            },
+                            error=serializable_error,
+                        ),
                     )
-                    stopping = True
-                    active_execution.mark_interrupted()
-                    for key, event in term_events.items():
-                        event.set()
+                    for key, term_event in term_events.items():
+                        if processes.get(key) and processes[key].is_alive():
+                            term_event.set()
 
-                while not stopping:
-                    steps = active_execution.get_steps_to_execute(
-                        limit=(limit - len(active_iters)),
-                    )
-
-                    yield from active_execution.concurrency_event_iterator(plan_context)
-
-                    if not steps:
-                        break
-
-                    for step in steps:
-                        step_context = plan_context.for_step(step)
-                        term_events[step.key] = multiproc_ctx.Event()
-                        active_iters[step.key] = execute_step_out_of_process(
-                            multiproc_ctx,
-                            job,
-                            step_context,
-                            step,
-                            errors,
-                            term_events,
-                            self.retries,
-                            active_execution.get_known_state(),
-                            execution_plan.repository_load_data,
-                        )
-
-                # process active iterators
-                empty_iters = []
-                for key, step_iter in active_iters.items():
-                    try:
-                        event_or_none = next(step_iter)
-                        if event_or_none is None:
-                            continue
-                        else:
-                            yield event_or_none
-                            active_execution.handle_event(event_or_none)
-
-                    except ChildProcessCrashException as crash:
-                        serializable_error = serializable_error_info_from_exc_info(sys.exc_info())
-                        step_context = plan_context.for_step(active_execution.get_step_by_key(key))
-                        yield DagsterEvent.engine_event(
-                            step_context,
-                            get_run_crash_explanation(
-                                prefix=f"Multiprocess executor: child process for step {key}",
-                                exit_code=crash.exit_code,
-                            ),
-                            EngineEventData.engine_error(serializable_error),
-                        )
-                        step_failure_event = DagsterEvent.step_failure_event(
-                            step_context=plan_context.for_step(
-                                active_execution.get_step_by_key(key)
-                            ),
-                            step_failure_data=StepFailureData(
-                                error=serializable_error, user_failure_data=None
-                            ),
-                        )
-                        active_execution.handle_event(step_failure_event)
-                        yield step_failure_event
-                        empty_iters.append(key)
-                    except StopIteration:
-                        empty_iters.append(key)
-
-                # clear and mark complete finished iterators
-                for key in empty_iters:
-                    del active_iters[key]
-                    del term_events[key]
-                    active_execution.verify_complete(plan_context, key)
-
-                # process skipped and abandoned steps
-                yield from active_execution.plan_events_iterator(plan_context)
+                raise
 
             errs = {pid: err for pid, err in errors.items() if err}
 
@@ -336,6 +365,7 @@ def execute_step_out_of_process(
     step_context: IStepContext,
     step: ExecutionStep,
     errors: Dict[int, SerializableErrorInfo],
+    processes: Dict[str, BaseProcess],
     term_events: Dict[str, Any],
     retries: RetryMode,
     known_state: KnownExecutionState,
@@ -365,5 +395,7 @@ def execute_step_out_of_process(
         elif isinstance(ret, ChildProcessEvent):
             if isinstance(ret, ChildProcessSystemErrorEvent):
                 errors[ret.pid] = ret.error_info
+        elif isinstance(ret, BaseProcess):
+            processes[step.key] = ret
         else:
             check.failed(f"Unexpected return value from child process {type(ret)}")

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
@@ -113,9 +113,8 @@ def add(_, num1, num2):
 
 @op
 def op_that_emits_duplicate_step_success_event(context):
-    # emits a duplicate step success event which will mess up the exeuction
+    # emits a duplicate step success event which will mess up the execution
     # machinery and fail the run worker
-    time.sleep(5)
     yield DagsterEvent.step_success_event(
         context._step_execution_context,  # noqa
         StepSuccessData(duration_ms=50.0),

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
@@ -8,8 +8,10 @@ from typing import Any, Mapping
 
 import pytest
 from dagster import (
+    DagsterEvent,
     DagsterEventType,
     DefaultRunLauncher,
+    Output,
     _check as check,
     _seven,
     file_relative_path,
@@ -17,6 +19,7 @@ from dagster import (
 )
 from dagster._core.definitions import op
 from dagster._core.errors import DagsterLaunchFailedError
+from dagster._core.execution.plan.objects import StepSuccessData
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.storage.tags import GRPC_INFO_TAG
@@ -108,6 +111,24 @@ def add(_, num1, num2):
     return num1 + num2
 
 
+@op
+def op_that_emits_duplicate_step_success_event(context):
+    # emits a duplicate step success event which will mess up the exeuction
+    # machinery and fail the run worker
+    time.sleep(5)
+    yield DagsterEvent.step_success_event(
+        context._step_execution_context,  # noqa
+        StepSuccessData(duration_ms=50.0),
+    )
+    yield Output(5)
+
+
+@job
+def job_that_fails_run_worker():
+    sleepy_op()
+    op_that_emits_duplicate_step_success_event()
+
+
 @job
 def math_diamond():
     one = return_one()
@@ -123,6 +144,7 @@ def nope():
         sleepy_job,
         slow_job,
         math_diamond,
+        job_that_fails_run_worker,
     ]
 
 
@@ -671,6 +693,50 @@ def test_multi_op_selection_execution(
         "return_one",
         "multiply_by_2",
     }
+
+
+def test_job_that_fails_run_worker(
+    instance: DagsterInstance,
+    workspace: WorkspaceRequestContext,
+):
+    external_job = (
+        workspace.get_code_location("test")
+        .get_repository("nope")
+        .get_full_external_job("job_that_fails_run_worker")
+    )
+    run = instance.create_run_for_job(
+        job_def=job_that_fails_run_worker,
+        run_config={},
+        external_job_origin=external_job.get_external_origin(),
+        job_code_origin=external_job.get_python_origin(),
+    )
+    run_id = run.run_id
+
+    run = instance.get_run_by_id(run_id)
+    assert run and run.status == DagsterRunStatus.NOT_STARTED
+
+    instance.launch_run(run.run_id, workspace)
+    finished_run = poll_for_finished_run(instance, run_id)
+    assert finished_run.status == DagsterRunStatus.FAILURE
+
+    run_logs = instance.all_logs(run_id)
+    _check_event_log_contains(
+        run_logs,
+        [
+            (
+                "ENGINE_EVENT",
+                "Unexpected exception while steps were still in-progress - terminating running steps:",
+            ),
+            (
+                "STEP_FAILURE",
+                'Execution of step "sleepy_op" failed.',
+            ),
+            (
+                "PIPELINE_FAILURE",
+                'Execution of run for "job_that_fails_run_worker" failed. An exception was thrown during execution.',
+            ),
+        ],
+    )
 
 
 @pytest.mark.parametrize(

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_docker_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_docker_executor.py
@@ -14,6 +14,7 @@ from dagster_test.test_project import (
 )
 
 from . import IS_BUILDKITE, docker_postgres_instance
+from .test_launch_docker import check_event_log_contains
 
 
 @pytest.mark.integration
@@ -80,6 +81,56 @@ def test_docker_executor_check_step_health(aws_env):
             recon_job = get_test_project_recon_job("demo_job_docker", docker_image)
             with execute_job(recon_job, run_config=run_config, instance=instance) as result:
                 assert not result.success
+
+
+@pytest.mark.integration
+def test_docker_executor_job_that_fails_run_worker(aws_env):
+    executor_config = {
+        "execution": {
+            "config": {"networks": ["container:test-postgres-db-docker"], "env_vars": aws_env}
+        }
+    }
+
+    docker_image = get_test_project_docker_image()
+    if IS_BUILDKITE:
+        executor_config["execution"]["config"]["registry"] = get_buildkite_registry_config()
+    else:
+        find_local_test_image(docker_image)
+
+    run_config = merge_dicts(
+        merge_yamls(
+            [
+                #                os.path.join(get_test_project_environments_path(), "env.yaml"),
+                os.path.join(get_test_project_environments_path(), "env_s3.yaml"),
+            ]
+        ),
+        executor_config,
+    )
+
+    with environ({"DOCKER_LAUNCHER_NETWORK": "container:test-postgres-db-docker"}):
+        with docker_postgres_instance() as instance:
+            recon_job = get_test_project_recon_job("fails_run_worker_job_docker", docker_image)
+            with execute_job(recon_job, run_config=run_config, instance=instance) as result:
+                assert not result.success
+                run_logs = instance.all_logs(result.dagster_run.run_id)
+
+                check_event_log_contains(
+                    run_logs,
+                    [
+                        (
+                            "ENGINE_EVENT",
+                            "Unexpected exception while steps were still in-progress - terminating running steps:",
+                        ),
+                        (
+                            "STEP_FAILURE",
+                            'Execution of step "hanging_op" failed.',
+                        ),
+                        (
+                            "PIPELINE_FAILURE",
+                            'Execution of run for "fails_run_worker_job_docker" failed. An exception was thrown during execution.',
+                        ),
+                    ],
+                )
 
 
 @pytest.mark.integration

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
@@ -162,7 +162,7 @@ def test_launch_docker_image_on_job_config(aws_env):
                 assert run.tags[DOCKER_IMAGE_TAG] == docker_image
 
 
-def _check_event_log_contains(event_log, expected_type_and_message):
+def check_event_log_contains(event_log, expected_type_and_message):
     types_and_messages = [
         (e.dagster_event.event_type_value, e.message) for e in event_log if e.is_dagster_event
     ]
@@ -232,7 +232,7 @@ def test_terminate_launched_docker_run(aws_env):
 
             run_logs = instance.all_logs(run_id)
 
-            _check_event_log_contains(
+            check_event_log_contains(
                 run_logs,
                 [
                     ("PIPELINE_CANCELING", "Sending run termination request"),


### PR DESCRIPTION
## Summary & Motivation
If there's a framework error that makes the run fail, terminate any in-progress steps.

## How I Tested These Changes
BK