### PR TITLE
[DA] add code_version_changed AutomationCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -209,6 +209,15 @@ class AutomationCondition(ABC, DagsterModel):
         return NewlyRequestedCondition()
 
     @staticmethod
+    def code_version_newly_updated() -> "NewlyRequestedCondition":
+        """Returns a AutomationCondition that is true for an asset partition if its asset's code
+        version has been updated since the previous tick.
+        """
+        from .operands import NewlyRequestedCondition
+
+        return NewlyRequestedCondition()
+
+    @staticmethod
     def cron_tick_passed(
         cron_schedule: str, cron_timezone: str = "UTC"
     ) -> "CronTickPassedCondition":

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
     from .automation_context import AutomationContext
     from .operands import (
+        CodeVersionChangedCondition,
         CronTickPassedCondition,
         FailedAutomationCondition,
         InLatestTimeWindowCondition,
@@ -209,13 +210,13 @@ class AutomationCondition(ABC, DagsterModel):
         return NewlyRequestedCondition()
 
     @staticmethod
-    def code_version_newly_updated() -> "NewlyRequestedCondition":
+    def code_version_changed() -> "CodeVersionChangedCondition":
         """Returns a AutomationCondition that is true for an asset partition if its asset's code
-        version has been updated since the previous tick.
+        version has been changed since the previous tick.
         """
-        from .operands import NewlyRequestedCondition
+        from .operands import CodeVersionChangedCondition
 
-        return NewlyRequestedCondition()
+        return CodeVersionChangedCondition()
 
     @staticmethod
     def cron_tick_passed(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/__init__.py
@@ -1,4 +1,5 @@
 from .slice_conditions import (
+    CodeVersionNewlyUpdated as CodeVersionNewlyUpdated,
     CronTickPassedCondition as CronTickPassedCondition,
     FailedAutomationCondition as FailedAutomationCondition,
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/__init__.py
@@ -1,5 +1,7 @@
+from .code_version_changed_condition import (
+    CodeVersionChangedCondition as CodeVersionChangedCondition,
+)
 from .slice_conditions import (
-    CodeVersionNewlyUpdated as CodeVersionNewlyUpdated,
     CronTickPassedCondition as CronTickPassedCondition,
     FailedAutomationCondition as FailedAutomationCondition,
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
@@ -1,0 +1,32 @@
+from typing import Optional
+
+from dagster._serdes.serdes import whitelist_for_serdes
+
+from ..automation_condition import AutomationCondition, AutomationResult
+from ..automation_context import AutomationContext
+
+
+@whitelist_for_serdes
+class CodeVersionChangedCondition(AutomationCondition):
+    @property
+    def description(self) -> str:
+        return "Asset code version changed since previous tick"
+
+    @property
+    def requires_cursor(self) -> bool:
+        return True
+
+    def _get_previous_code_version(self, context: AutomationContext) -> Optional[str]:
+        if context.node_cursor is None:
+            return None
+        return context.node_cursor.get_extra_state(as_type=str)
+
+    def evaluate(self, context: AutomationContext) -> AutomationResult:
+        previous_code_version = self._get_previous_code_version(context)
+        current_code_version = context.asset_graph.get(context.asset_key).code_version
+        if previous_code_version is None or previous_code_version == current_code_version:
+            true_slice = context.asset_graph_view.create_empty_slice(asset_key=context.asset_key)
+        else:
+            true_slice = context.candidate_slice
+
+        return AutomationResult.create(context, true_slice, extra_state=current_code_version)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
@@ -180,27 +180,3 @@ class InLatestTimeWindowCondition(SliceAutomationCondition):
         return context.asset_graph_view.compute_latest_time_window_slice(
             context.asset_key, lookback_delta=self.lookback_timedelta
         )
-
-
-@whitelist_for_serdes
-class CodeVersionNewlyUpdated(SliceAutomationCondition):
-    @property
-    def description(self) -> str:
-        return "Asset code version updated since previous tick"
-
-    @property
-    def requires_cursor(self) -> bool:
-        return True
-
-    def _get_previous_code_version(self, context: AutomationContext) -> Optional[str]:
-        if context.node_cursor is None:
-            return None
-        return context.node_cursor.get_extra_state(as_type=str)
-
-    def compute_slice(self, context: AutomationContext) -> AssetSlice:
-        previous_code_version = self._get_previous_code_version(context)
-        current_code_version = context.asset_graph.get(context.asset_key).code_version
-        if previous_code_version is None or previous_code_version == current_code_version:
-            return context.asset_graph_view.create_empty_slice(asset_key=context.asset_key)
-        else:
-            return context.candidate_slice

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
@@ -180,3 +180,27 @@ class InLatestTimeWindowCondition(SliceAutomationCondition):
         return context.asset_graph_view.compute_latest_time_window_slice(
             context.asset_key, lookback_delta=self.lookback_timedelta
         )
+
+
+@whitelist_for_serdes
+class CodeVersionNewlyUpdated(SliceAutomationCondition):
+    @property
+    def description(self) -> str:
+        return "Asset code version updated since previous tick"
+
+    @property
+    def requires_cursor(self) -> bool:
+        return True
+
+    def _get_previous_code_version(self, context: AutomationContext) -> Optional[str]:
+        if context.node_cursor is None:
+            return None
+        return context.node_cursor.get_extra_state(as_type=str)
+
+    def compute_slice(self, context: AutomationContext) -> AssetSlice:
+        previous_code_version = self._get_previous_code_version(context)
+        current_code_version = context.asset_graph.get(context.asset_key).code_version
+        if previous_code_version is None or previous_code_version == current_code_version:
+            return context.asset_graph_view.create_empty_slice(asset_key=context.asset_key)
+        else:
+            return context.candidate_slice

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_code_version_changed_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_code_version_changed_condition.py
@@ -1,0 +1,41 @@
+from dagster import AutomationCondition
+
+from ..scenario_specs import one_asset
+from .asset_condition_scenario import AutomationConditionScenarioState
+
+
+def test_code_version_changed_condition() -> None:
+    state = AutomationConditionScenarioState(
+        one_asset, automation_condition=AutomationCondition.code_version_changed()
+    ).with_asset_properties(code_version="1")
+
+    # not changed
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 0
+
+    # still not changed
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 0
+
+    # newly changed
+    state = state.with_asset_properties(code_version="2")
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+    # not newly changed
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 0
+
+    # newly changed
+    state = state.with_asset_properties(code_version="3")
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+    # newly changed
+    state = state.with_asset_properties(code_version="2")
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 1
+
+    # not newly changed
+    state, result = state.evaluate("A")
+    assert result.true_subset.size == 0


### PR DESCRIPTION
## Summary & Motivation

Resolves a long-standing request to allow our asset automation system to respond to code version changes. Implementation is quite simple, it just detects when the code version has changed since the previous ticks.

All "memory" (required to keep track of cases where we're not able to immediately request a materialization in response to this stimulus) is delegated to the `since()` condition, leaving this implementation pretty clean.

## How I Tested These Changes
