### PR TITLE
[docs] - Update dbt quickstart

### DIFF
--- a/docs/content/integrations/dbt/quickstart.mdx
+++ b/docs/content/integrations/dbt/quickstart.mdx
@@ -1,44 +1,50 @@
 ---
-title: "Quickstart: Run your dbt project with Dagster"
-description: Get started swiftly with this simple dbt & Dagster example.
+title: "Dagster and dbt quickstart | Dagster Docs"
+description: Get started quickly with this simple dbt & Dagster example.
 ---
 
-# Quickstart: Run your dbt project with Dagster
+# Dagster & dbt quickstart
 
-<Note>
-  <strong>Note</strong>: This guide uses the <code>DbtProject</code> class,
-  which is an experimental feature. Visit the{" "}
-  <a href="/\_apidocs/libraries/dagster-dbt#dagster_dbt.DbtProject">
-    dagster-dbt library API reference
-  </a>{" "}
-  for more info.
-</Note>
+This quickstart will get your dbt project up and running quickly with Dagster. By the end of this guide, you'll have an integrated Dagster and dbt project and be able to view it in the Dagster UI.
 
 ---
 
-## Setup your environment
+## Step 1: Set up your environment
 
 <Note>
   <strong>Note</strong>: We strongly recommend installing Dagster inside a
-  Python virtualenv. Visit the{" "}
+  Python virtualenv. Refer to the{" "}
   <a href="/getting-started/install">Dagster installation docs</a> for more
-  info.
+  information.
 </Note>
 
-Install dbt, Dagster, and the Dagster webserver. Run the following to install everything using pip:
+Install dbt, Dagster, and the Dagster webserver by running the following:
 
 ```shell
 pip install dagster-dbt dagster-webserver
 ```
 
-The `dagster-dbt` library installs both `dbt-core` and `dagster` as dependencies. Refer to the [dbt](https://docs.getdbt.com/dbt-cli/install/overview) and [Dagster](/getting-started/install) installation docs for more info.
+The `dagster-dbt` library installs both `dbt-core` and `dagster` as dependencies. Refer to the [dbt](https://docs.getdbt.com/dbt-cli/install/overview) and [Dagster](/getting-started/install) installation docs for more information.
 
 ---
 
-## Load your dbt project in Dagster
+## Step 2: Load your dbt project into Dagster
+
+Next, you'll load your dbt project into Dagster. Use the tabs to view instructions for how to accomplish this.
 
 <TabGroup>
+<TabItem name="Select an option">
+
+Select one of the following to load your dbt project into Dagster:
+
+- [**Option 1:**](#option-1-create-a-single-dagster-file) Create a Dagster project in a single file
+- [**Option 2:**](#option-2-create-a-new-dagster-project) Create a new Dagster project that wraps a dbt project by using the `dagster-dbt` command line interface (CLI)
+- [**Option 3:**](#option-3-use-an-existing-dagster-project) Use an existing Dagster project
+
+</TabItem>
 <TabItem name="Option 1: Create a single Dagster file">
+
+### Option 1: Create a single Dagster file
 
 Running your dbt project with Dagster can be easily done after creating a single file. For this example, let's consider a basic use case - say you want to represent your dbt models as Dagster assets and run them daily at midnight.
 
@@ -90,25 +96,41 @@ defs = Definitions(
 </TabItem>
 <TabItem name="Option 2: Create a new Dagster project">
 
-You can create a Dagster project that wraps your dbt project by using the `dagster-dbt` command line interface.
+### Option 2: Create a new Dagster project
 
-To use the command, you'll need to provide two options:
+<Note>
+  <strong>Heads up!</strong>: This approach uses the <code>DbtProject</code>{" "}
+  class, which is an experimental feature. Refer to the{" "}
+  <a href="/\_apidocs/libraries/dagster-dbt#dagster_dbt.DbtProject">
+    dagster-dbt API reference
+  </a>{" "}
+  for more information.
+</Note>
 
-- `--project-name`, the name of your Dagster project to be created, and
-- `--dbt-project-dir`, the path to your dbt project.
+This approach creates a new Dagster project and wraps a dbt project by using the `dagster-dbt` command line interface. Two options must be provided to run the command:
 
-In our example, our Dagster project is named `my_dagster_project` and the relative path to our dbt project is `./my_dbt_project`, meaning that we are in the directory where `my_dbt_project` is located.
+- `--project-name` - The name of the Dagster project to be created. In our example, this will be `my_dagster_project`.
+- `--dbt-project-dir` - The path to the dbt project. In our example, this will be `./my_dbt_project`, which means our current location is in the directory where `my_dbt_project` is located.
+
+In our example, our command would look like this:
 
 ```shell
 dagster-dbt project scaffold --project-name my_dagster_project --dbt-project-dir ./my_dbt_project --use-experimental-dbt-project
 ```
 
-This command creates a new directory called `my_dagster_project/` inside the current directory. The new `my_dagster_project/` directory will contain a set of files that define a Dagster project to load the dbt project provided in `./my_dbt_project`.
+This command will create a new directory called `my_dagster_project/` inside the current directory. The new `my_dagster_project/` directory will contain a set of files that define a Dagster project to load the dbt project provided in `./my_dbt_project`.
 
 </TabItem>
 <TabItem name="Option 3: Use an existing Dagster project">
 
-You can use an existing Dagster project to run your dbt project. To do so, you'll need to add some objects using the [dagster-dbt library](/\_apidocs/libraries/dagster-dbt) and update your `Definitions` object. This example assumes that your existing Dagster project includes both `assets.py` and `definitions.py` files, among other required files.
+### Option 3: Use an existing Dagster project
+
+Existing Dagster projects can also be used to run a dbt project. To do this, you'll need to:
+
+1. Use the [`dagster-dbt` library](/\_apidocs/libraries/dagster-dbt) to add <PyObject object="DbtProject" module="dagster_dbt" /> and <PyObject object="dbt_assets" module="dagster_dbt" decorator /> objects
+2. Add the new objects to your Dagster project's <PyObject object="Definitions" /> object
+
+**Note**: This example assumes that your existing Dagster project includes both `assets.py` and `definitions.py` files, among other required files like `setup.py` and `pyproject.toml`. For example, your project might look like this:
 
 ```shell
 my_dagster_project
@@ -126,7 +148,7 @@ my_dagster_project
    cd my_dagster_project/
    ```
 
-2. Create a Python file named `project.py` and add the following code. The DbtProject object is a representation of your dbt project that assist with managing `manifest.json` preparation.
+2. Create a Python file named `project.py` and add the following code:
 
    ```python file=/integrations/dbt/quickstart/with_project.py startafter=start_dbt_project_example endbefore=end_dbt_project_example
    from pathlib import Path
@@ -142,7 +164,9 @@ my_dagster_project
    )
    ```
 
-3. In your `assets.py` file, add the following code. Using the `dbt_assets` decorator allows Dagster to create a definition for how to compute a set of dbt resources, described by a `manifest.json`.
+   The <PyObject object="DbtProject" module="dagster_dbt" /> object is a representation of the dbt project that assists with `manifest.json` preparation.
+
+3. In your project's `assets.py` file, add the following code:
 
    ```python file=/integrations/dbt/quickstart/with_project.py startafter=start_dbt_assets_example endbefore=end_dbt_assets_example
    from dagster import AssetExecutionContext
@@ -155,7 +179,9 @@ my_dagster_project
        yield from dbt.cli(["build"], context=context).stream()
    ```
 
-4. In your `definitions.py` file, update your Definitions object to include the newly created objects.
+   The <PyObject object="dbt_assets" module="dagster_dbt" decorator /> decorator allows Dagster to create a definition for how to compute a set of dbt resources, described by a `manifest.json`.
+
+4. In your project's `definitions.py` file, update the <PyObject object="Definitions" /> object to include the newly created objects:
 
    ```python file=/integrations/dbt/quickstart/with_project.py startafter=start_dbt_definitions_example endbefore=end_dbt_definitions_example
    from dagster import Definitions
@@ -186,14 +212,24 @@ With these changes, your existing Dagster project is ready to run your dbt proje
 
 ---
 
-## Run your dbt project in Dagster's UI
+## Step 3: Run your dbt project in the Dagster UI
 
-Now that your code is ready, you can run Dagster's UI to take a look at your dbt project.
+Now that your code is ready, you can use the [Dagster UI](/concepts/webserver/ui) to take a look at your dbt project. Use the tabs to view instructions for starting the UI.
 
 <TabGroup>
+<TabItem name="Select an option">
+
+How you [start the UI](/guides/running-dagster-locally) depends on which approach you took to load your dbt project into Dagster:
+
+- **If you created a single Dagster file**, [use Option 1](#option-1-from-a-dagster-file)
+- **If you created a new Dagster project or used an existing project**, [use Option 2](#option-2-from-a-dagster-project)
+
+</TabItem>
 <TabItem name="Option 1: From a Dagster file">
 
-1. Locate the Dagster file containing your definitions. If you followed our example to create a single Dagster file in the [previous section](#load-your-dbt-project-in-dagster), your file should be named `definitions.py`.
+### Option 1: From a Dagster file
+
+1. Locate the Dagster file containing your definitions. If you created a single Dagster file in the [previous section (Option 1)](#option-1-create-a-single-dagster-file), this file will be `definitions.py`.
 
 2. To start Dagster's UI, run the following:
 
@@ -209,6 +245,8 @@ Now that your code is ready, you can run Dagster's UI to take a look at your dbt
 
 </TabItem>
 <TabItem name="Option 2: From a Dagster project">
+
+### Option 2: From a Dagster project
 
 1. Change directories to the Dagster project directory:
 
@@ -244,7 +282,9 @@ width={2688}
 height={1680}
 />
 
-In Dagster, running a dbt model corresponds to _materializing_ an asset. Because a schedule definition has been added to your code location, your assets will be materialized at the next cron tick. The assets can also be materialized manually by click the **Materialize all** button near the top right corner of the page. This will launch a run to materialize the assets.
+In Dagster, running a dbt model corresponds to _materializing_ an asset. The [schedule definition](/concepts/automation/schedules) included in your Dagster project's code location (<PyObject object="Definitions" /> object) will materialize the assets at its next cron tick.
+
+Assets can also be materialized manually by clicking the **Materialize all** button near the top right corner of the page.
 
 ---
 
@@ -252,7 +292,31 @@ In Dagster, running a dbt model corresponds to _materializing_ an asset. Because
 
 Congratulations on successfully running your dbt project in Dagster!
 
-In this example, we created a single file to handle a simple use case and run your dbt project. To learn more about our dbt integrations and how to handle more complex use cases, consider the following options:
+To learn more about Dagster's dbt integration and how to handle more complex use cases, you can:
 
-- To find out more about integrating dbt with Dagster, begin the official dbt scaffold tutorial, like the [dbt & Dagster project](/integrations/dbt/using-dbt-with-dagster).
-- For an end-to-end example, from the project creation to the deployment to Dagster+, checkout out the Dagster & dbt course in [Dagster University](https://courses.dagster.io).
+- Complete the [Dagster & dbt tutorial](/integrations/dbt/using-dbt-with-dagster)
+- Learn how to [use dbt with Dagster+](/integrations/dbt/using-dbt-with-dagster-plus)
+- Check out the official [Dagster & dbt course on Dagster University](https://courses.dagster.io)
+
+---
+
+## Related
+
+<ArticleList>
+  <ArticleListItem
+    title="Dagster & dbt tutorial"
+    href="/integrations/dbt/using-dbt-with-dagster"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Using dbt with Dagster+"
+    href="/integrations/dbt/using-dbt-with-dagster-plus"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="dagster-dbt reference"
+    href="/integrations/dbt/reference"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Running Dagster locally"
+    href="/guides/running-dagster-locally"
+  ></ArticleListItem>
+</ArticleList>

--- a/docs/content/integrations/dbt/quickstart.mdx
+++ b/docs/content/integrations/dbt/quickstart.mdx
@@ -5,6 +5,15 @@ description: Get started quickly with this simple dbt & Dagster example.
 
 # Dagster & dbt quickstart
 
+<Note>
+  <strong>Heads up!</strong>: This approach uses the <code>DbtProject</code>{" "}
+  class, which is an experimental feature. Refer to the{" "}
+  <a href="/\_apidocs/libraries/dagster-dbt#dagster_dbt.DbtProject">
+    dagster-dbt API reference
+  </a>{" "}
+  for more information.
+</Note>
+
 This quickstart will get your dbt project up and running quickly with Dagster. By the end of this guide, you'll have an integrated Dagster and dbt project and be able to view it in the Dagster UI.
 
 ---
@@ -97,15 +106,6 @@ defs = Definitions(
 <TabItem name="Option 2: Create a new Dagster project">
 
 ### Option 2: Create a new Dagster project
-
-<Note>
-  <strong>Heads up!</strong>: This approach uses the <code>DbtProject</code>{" "}
-  class, which is an experimental feature. Refer to the{" "}
-  <a href="/\_apidocs/libraries/dagster-dbt#dagster_dbt.DbtProject">
-    dagster-dbt API reference
-  </a>{" "}
-  for more information.
-</Note>
 
 This approach uses the `dagster-dbt` CLI to create a new Dagster project and wrap it around a dbt project. Running this command requires two arguments:
 

--- a/docs/content/integrations/dbt/quickstart.mdx
+++ b/docs/content/integrations/dbt/quickstart.mdx
@@ -5,15 +5,6 @@ description: Get started quickly with this simple dbt & Dagster example.
 
 # Dagster & dbt quickstart
 
-<Note>
-  <strong>Heads up!</strong>: This approach uses the <code>DbtProject</code>{" "}
-  class, which is an experimental feature. Refer to the{" "}
-  <a href="/\_apidocs/libraries/dagster-dbt#dagster_dbt.DbtProject">
-    dagster-dbt API reference
-  </a>{" "}
-  for more information.
-</Note>
-
 This quickstart will get your dbt project up and running quickly with Dagster. By the end of this guide, you'll have an integrated Dagster and dbt project and be able to view it in the Dagster UI.
 
 ---
@@ -38,6 +29,16 @@ The `dagster-dbt` library installs both `dbt-core` and `dagster` as dependencies
 ---
 
 ## Step 2: Load your dbt project into Dagster
+
+<Note>
+  <strong>Heads up!</strong> Some of the methods described in this section may
+  use the <code>DbtProject</code> class, which is an experimental feature. Refer
+  to the{" "}
+  <a href="/\_apidocs/libraries/dagster-dbt#dagster_dbt.DbtProject">
+    dagster-dbt API reference
+  </a>{" "}
+  for more information.
+</Note>
 
 Next, you'll load your dbt project into Dagster. Use the tabs to view instructions for how to accomplish this.
 

--- a/docs/content/integrations/dbt/quickstart.mdx
+++ b/docs/content/integrations/dbt/quickstart.mdx
@@ -107,7 +107,7 @@ defs = Definitions(
   for more information.
 </Note>
 
-This approach creates a new Dagster project and wraps a dbt project by using the `dagster-dbt` command line interface. Two options must be provided to run the command:
+This approach uses the `dagster-dbt` CLI to create a new Dagster project and wrap it around a dbt project. Running this command requires two arguments:
 
 - `--project-name` - The name of the Dagster project to be created. In our example, this will be `my_dagster_project`.
 - `--dbt-project-dir` - The path to the dbt project. In our example, this will be `./my_dbt_project`, which means our current location is in the directory where `my_dbt_project` is located.


### PR DESCRIPTION
## Summary & Motivation

This PR fixes some typos and formatting in the Dagster & dbt quickstart, including:

- Add headings to subsections to make them easy to find + linkable
- Put sections for different options into tabs
- Add a **Related** section with relevant links
- Update H2 headings to include `Step`, which matches our other guides

## How I Tested These Changes

👀 
