### PR TITLE
[serdes] handle record subclasses

### DIFF
--- a/python_modules/dagster/dagster/_record/__init__.py
+++ b/python_modules/dagster/dagster/_record/__init__.py
@@ -23,10 +23,11 @@ TType = TypeVar("TType", bound=Type)
 TVal = TypeVar("TVal")
 
 
-_MODEL_MARKER_VALUE = object()
-_MODEL_MARKER_FIELD = (
+_RECORD_MARKER_VALUE = object()
+_RECORD_MARKER_FIELD = (
     "__checkrepublic__"  # "I do want to release this as checkrepublic one day" - schrockn
 )
+_RECORD_ANNOTATIONS_FIELD = "__record_annotations__"
 _CHECKED_NEW = "__checked_new__"
 _DEFAULTS_NEW = "__defaults_new__"
 _INJECTED_DEFAULT_VALS_LOCAL_VAR = "__dm_defaults__"
@@ -93,8 +94,8 @@ def _namedtuple_model_transform(
             "__iter__": _banned_iter,
             "__getitem__": _banned_idx,
             "__hidden_iter__": base.__iter__,
-            _MODEL_MARKER_FIELD: _MODEL_MARKER_VALUE,
-            "__annotations__": field_set,
+            _RECORD_MARKER_FIELD: _RECORD_MARKER_VALUE,
+            _RECORD_ANNOTATIONS_FIELD: field_set,
             "__nt_new__": nt_new,
             "__bool__": _true,
         },
@@ -216,11 +217,15 @@ class IHaveNew:
 
 def is_record(obj) -> bool:
     """Whether or not this object was produced by a record decorator."""
-    return getattr(obj, _MODEL_MARKER_FIELD, None) == _MODEL_MARKER_VALUE
+    return getattr(obj, _RECORD_MARKER_FIELD, None) == _RECORD_MARKER_VALUE
 
 
 def has_generated_new(obj) -> bool:
     return obj.__new__.__name__ in (_DEFAULTS_NEW, _CHECKED_NEW)
+
+
+def get_record_annotations(obj) -> Mapping[str, Type]:
+    return getattr(obj, _RECORD_ANNOTATIONS_FIELD)
 
 
 def as_dict(obj) -> Mapping[str, Any]:

--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -48,7 +48,7 @@ from typing_extensions import Final, Self, TypeAlias, TypeVar
 import dagster._check as check
 import dagster._seven as seven
 from dagster._model.pydantic_compat_layer import ModelFieldCompat, model_fields
-from dagster._record import as_dict, has_generated_new, is_record
+from dagster._record import as_dict, get_record_annotations, has_generated_new, is_record
 from dagster._utils import is_named_tuple_instance, is_named_tuple_subclass
 from dagster._utils.warnings import disable_dagster_warnings
 
@@ -648,9 +648,8 @@ class NamedTupleSerializer(ObjectSerializer[T_NamedTuple]):
 
     @cached_property
     def constructor_param_names(self) -> Sequence[str]:
-        # if its an @record generated new, just use annotations
         if has_generated_new(self.klass):
-            return list(self.klass.__annotations__.keys())
+            return list(get_record_annotations(self.klass).keys())
 
         return list(signature(self.klass.__new__).parameters.keys())
 

--- a/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
@@ -977,3 +977,18 @@ def test_record_fwd_ref():
         )
 
     assert _out_of_scope()
+
+
+def test_record_subclass() -> None:
+    test_env = WhitelistMap.create()
+
+    @record
+    class MyRecord:
+        name: str
+
+    @_whitelist_for_serdes(test_env)
+    class Child(MyRecord): ...
+
+    c = Child(name="kiddo")
+    r_str = serialize_value(c, whitelist_map=test_env)
+    assert deserialize_value(r_str, whitelist_map=test_env) == c


### PR DESCRIPTION
`__annotations__` will get set in subclasses, so use a different field. Also update some names from model to record

## How I Tested These Changes

added test
