### PR TITLE
[WIP][DA] Fix evaluations UI in cases where there are both partitioned an unpartitioned records

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3553,6 +3553,7 @@ type PartitionedAssetConditionEvaluationNode {
   numFalse: Int
   numSkipped: Int
   childUniqueIds: [String!]!
+  status: AssetConditionEvaluationStatus!
 }
 
 type AssetSubset {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -3276,6 +3276,7 @@ export type PartitionedAssetConditionEvaluationNode = {
   numSkipped: Maybe<Scalars['Int']['output']>;
   numTrue: Scalars['Int']['output'];
   startTimestamp: Maybe<Scalars['Float']['output']>;
+  status: AssetConditionEvaluationStatus;
   trueSubset: AssetSubset;
   uniqueId: Scalars['String']['output'];
 };
@@ -11052,6 +11053,10 @@ export const buildPartitionedAssetConditionEvaluationNode = (
     numTrue: overrides && overrides.hasOwnProperty('numTrue') ? overrides.numTrue! : 3015,
     startTimestamp:
       overrides && overrides.hasOwnProperty('startTimestamp') ? overrides.startTimestamp! : 5.96,
+    status:
+      overrides && overrides.hasOwnProperty('status')
+        ? overrides.status!
+        : AssetConditionEvaluationStatus.FALSE,
     trueSubset:
       overrides && overrides.hasOwnProperty('trueSubset')
         ? overrides.trueSubset!

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -236,6 +236,7 @@ fragment evaluationFields on AssetConditionEvaluation {
             }
             uniqueId
             childUniqueIds
+            status
         }
         ... on SpecificPartitionAssetConditionEvaluationNode {
             description


### PR DESCRIPTION
## Summary & Motivation

With Declarative Automation, not all evaluations within the tree need to correspond to the same asset (some sub-evaluations can target the parent asset).

This means that we error if we encounter one of those situations. This PR makes an attempt at handling that, although it still needs some work.


## How I Tested These Changes
