### PR TITLE
[WIP][dagster-airbyte] RFC: Prototype `airbyte_assets` asset decorator

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/airbyte_project.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/airbyte_project.py
@@ -1,12 +1,19 @@
+import json
 import logging
 import os
 from pathlib import Path
-from typing import Optional, Union
+from typing import Dict, List, Optional, Union, cast
 
-from dagster import ResourceDefinition
+import yaml
+from dagster import (
+    ResourceDefinition,
+    _check as check,
+)
 from dagster._annotations import public
 from dagster._record import IHaveNew, record_custom
+from dagster._utils import run_with_concurrent_update_guard
 
+from dagster_airbyte.asset_defs import AirbyteConnectionMetadata
 from dagster_airbyte.resources import AirbyteResource
 
 logger = logging.getLogger("dagster-airbyte.project")
@@ -37,36 +44,120 @@ class AirbyteProjectPreparer:
 
 
 class AirbyteInstanceProjectPreparer(AirbyteProjectPreparer):
-    def __init__(
-        self,
-        instance: Union[AirbyteResource, ResourceDefinition],
-    ):
-        pass
+    def prepare_if_dev(self, project: "AirbyteProject"):
+        raise NotImplementedError()
+
+    def prepare(self, project: "AirbyteProject") -> None:
+        raise NotImplementedError()
 
 
-class AirbyteOctaviaProjectPreparer(AirbyteProjectPreparer):
-    def __init__(
-        self,
-        project_dir: Path,
-    ):
-        pass
+class AirbyteLocalProjectPreparer(AirbyteProjectPreparer):
+    def prepare_if_dev(self, project: "AirbyteProject"):
+        if self.using_dagster_dev():
+            self.prepare(project)
+            if not project.connections_metadata_path.exists():
+                # TODO: implement custom errors
+                raise FileNotFoundError(
+                    f"Did not find connections metadata at expected path {project.connections_metadata_path} "
+                    f"after running '{self.prepare.__qualname__}'. Ensure the implementation respects "
+                    "all Airbyte configuration properties."
+                )
+
+    def prepare(self, project: "AirbyteProject") -> None:
+        # guard against multiple Dagster processes trying to update this at the same time
+        run_with_concurrent_update_guard(
+            project.connections_metadata_path,
+            self._prepare_connections_metadata,
+            project=project,
+        )
+
+    def _prepare_connections_metadata(self, project: "AirbyteProject") -> None:
+        connections_dir = Path(os.path.join(project.configuration_dir, "connections"))
+        if not connections_dir.exists():
+            # TODO: implement custom errors
+            raise FileNotFoundError(
+                f"Did not find connections directory at expected path {connections_dir} "
+                f"after running '{self.prepare.__qualname__}'. Ensure the implementation respects "
+                "all Airbyte configuration properties."
+            )
+
+        output_connections: List[Dict[str, AirbyteConnectionMetadata]] = []
+
+        connection_directories = os.listdir(connections_dir)
+        for connection_name in connection_directories:
+            connection_dir = os.path.join(connections_dir, connection_name)
+            with open(os.path.join(connection_dir, "configuration.yaml"), encoding="utf-8") as f:
+                connection = AirbyteConnectionMetadata.from_config(yaml.safe_load(f.read()))
+
+            if project.workspace_id:
+                state_file = f"state_{project.workspace_id}.yaml"
+                check.invariant(
+                    state_file in os.listdir(connection_dir),
+                    f"Workspace state file {state_file} not found",
+                )
+            else:
+                state_files = [
+                    filename
+                    for filename in os.listdir(connection_dir)
+                    if filename.startswith("state_")
+                ]
+                check.invariant(
+                    len(state_files) > 0,
+                    f"No state files found for connection {connection_name} in {connection_dir}",
+                )
+                check.invariant(
+                    len(state_files) <= 1,
+                    f"More than one state file found for connection {connection_name} in {connection_dir}, "
+                    "specify a workspace_id to disambiguate",
+                )
+                state_file = state_files[0]
+
+            with open(os.path.join(connection_dir, cast(str, state_file)), encoding="utf-8") as f:
+                state = yaml.safe_load(f.read())
+                connection_id = state.get("resource_id")
+
+            output_connections.append({connection_id: connection})
+
+        with open(project.connections_metadata_path, encoding="utf-8") as f:
+            json.dump(output_connections, f)
 
 
 @record_custom
 class AirbyteProject(IHaveNew):
+    configuration_dir: Path
     preparer: AirbyteProjectPreparer
     workspace_id: Optional[str]
+    output_path: Path
+    connections_metadata_path: Path
 
     def __new__(
         cls,
+        configuration_dir: Path,
         preparer: AirbyteProjectPreparer,
         workspace_id: Optional[str] = None,
     ) -> "AirbyteProject":
         return super().__new__(
             cls,
+            configuration_dir=configuration_dir,
             workspace_id=workspace_id,
             preparer=preparer,
         )
+
+    @property
+    def connections_metadata(self) -> List[Dict[str, AirbyteConnectionMetadata]]:
+        if not self.connections_metadata_path.exists():
+            # TODO: implement custom errors
+            raise FileNotFoundError(
+                f"Did not find connections metadata at expected path {self.connections_metadata_path}. "
+                f"Ensure the Airbyte project was prepared."
+            )
+        with open(self.connections_metadata_path, encoding="utf-8") as f:
+            connections_metadata_json = json.load(f)
+
+        return [
+            {connection_id: AirbyteConnectionMetadata(**connection_metadata)}
+            for connection_id, connection_metadata in connections_metadata_json
+        ]
 
     @public
     def prepare_if_dev(self) -> None:
@@ -78,21 +169,23 @@ class AirbyteProject(IHaveNew):
         instance: Union[AirbyteResource, ResourceDefinition],
         workspace_id: Optional[str] = None,
     ) -> "AirbyteProject":
-        return AirbyteProject(
-            preparer=AirbyteInstanceProjectPreparer(instance=instance), workspace_id=workspace_id
-        )
+        raise NotImplementedError()
+        # return AirbyteProject(
+        #     preparer=AirbyteInstanceProjectPreparer(instance=instance), workspace_id=workspace_id
+        # )
 
     @staticmethod
-    def from_octavia_project(
-        project_dir: Union[Path, str],
+    def from_local_configuration(
+        configuration_dir: Union[Path, str],
         workspace_id: Optional[str] = None,
     ) -> "AirbyteProject":
-        project_dir = Path(project_dir)
-        if not project_dir.exists():
+        configuration_dir = Path(configuration_dir)
+        if not configuration_dir.exists():
             # TODO: implement custom errors
-            raise FileNotFoundError(f"project_dir {project_dir} does not exist.")
+            raise FileNotFoundError(f"configuration_dir {configuration_dir} does not exist.")
 
         return AirbyteProject(
-            preparer=AirbyteOctaviaProjectPreparer(project_dir=project_dir),
+            configuration_dir=configuration_dir,
+            preparer=AirbyteLocalProjectPreparer(),
             workspace_id=workspace_id,
         )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/airbyte_project.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/airbyte_project.py
@@ -1,0 +1,98 @@
+import logging
+import os
+from pathlib import Path
+from typing import Optional, Union
+
+from dagster import ResourceDefinition
+from dagster._annotations import public
+from dagster._record import IHaveNew, record_custom
+
+from dagster_airbyte.resources import AirbyteResource
+
+logger = logging.getLogger("dagster-airbyte.project")
+
+
+# TODO: duplicate from dbt_project.py, projects could inherit from one common project?
+def using_dagster_dev() -> bool:
+    return bool(os.getenv("DAGSTER_IS_DEV_CLI"))
+
+
+class AirbyteProjectPreparer:
+    """The abstract class of a preparer for an AirbyteProject representation."""
+
+    @public
+    def prepare_if_dev(self, project: "AirbyteProject") -> None:
+        """Invoked in the `prepare_if_dev` method of AirbyteProject,
+        when Airbyte needs preparation during development.
+        """
+
+    @public
+    def prepare(self, project: "AirbyteProject") -> None:
+        """Called explicitly to prepare the connection metadata for this the project."""
+
+    @public
+    def using_dagster_dev(self) -> bool:
+        """Returns true if Dagster is running using the `dagster dev` command."""
+        return using_dagster_dev()
+
+
+class AirbyteInstanceProjectPreparer(AirbyteProjectPreparer):
+    def __init__(
+        self,
+        instance: Union[AirbyteResource, ResourceDefinition],
+    ):
+        pass
+
+
+class AirbyteOctaviaProjectPreparer(AirbyteProjectPreparer):
+    def __init__(
+        self,
+        project_dir: Path,
+    ):
+        pass
+
+
+@record_custom
+class AirbyteProject(IHaveNew):
+    preparer: AirbyteProjectPreparer
+    workspace_id: Optional[str]
+
+    def __new__(
+        cls,
+        preparer: AirbyteProjectPreparer,
+        workspace_id: Optional[str] = None,
+    ) -> "AirbyteProject":
+        return super().__new__(
+            cls,
+            workspace_id=workspace_id,
+            preparer=preparer,
+        )
+
+    @public
+    def prepare_if_dev(self) -> None:
+        if self.preparer:
+            self.preparer.prepare_if_dev(self)
+
+    @staticmethod
+    def from_instance(
+        instance: Union[AirbyteResource, ResourceDefinition],
+        workspace_id: Optional[str] = None,
+    ) -> "AirbyteProject":
+        return AirbyteProject(
+            preparer=AirbyteInstanceProjectPreparer(instance=instance), workspace_id=workspace_id
+        )
+
+    @staticmethod
+    def from_octavia_project(
+        project_dir: Union[Path, str],
+        workspace_id: Optional[str] = None,
+    ) -> "AirbyteProject":
+        project_dir = Path(project_dir)
+        if not project_dir.exists():
+            # TODO: implement custom errors
+            raise FileNotFoundError(f"project_dir {project_dir} does not exist.")
+
+        return AirbyteProject(
+            preparer=AirbyteOctaviaProjectPreparer(project_dir=project_dir),
+            workspace_id=workspace_id,
+        )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
@@ -134,6 +134,7 @@ def airbyte_assets(
     if not dagster_airbyte_translator:
         dagster_airbyte_translator = DagsterAirbyteTranslator()
 
+    # TODO: update to assets specs
     (
         deps,
         outs,
@@ -272,17 +273,22 @@ def build_airbyte_multi_asset_args(
         deps.append(*list((keys_by_input_name or {}).values()))
 
         # TODO: Update will work if collisions are handled
+        # TODO: update extra metadata after cleaning code
+        # TODO: update to asset specs
         outs.update(
             {
                 k: AssetOut(
                     key=v,
                     metadata=(
                         {
-                            k: cast(TableSchemaMetadataValue, v)
-                            for k, v in metadata_by_output_name.get(k, {}).items()
+                            **extra_metadata,
+                            **{
+                                k: cast(TableSchemaMetadataValue, v)
+                                for k, v in metadata_by_output_name.get(k, {}).items()
+                            },
                         }
                         if metadata_by_output_name
-                        else None
+                        else extra_metadata
                     ),
                     io_manager_key=io_manager_key,
                     freshness_policy=(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
@@ -18,6 +18,9 @@ from dagster._core.definitions.events import CoercibleToAssetKey
 from dagster._utils.warnings import suppress_dagster_warnings
 
 
+# TODO: pass all connections, then add connection filter or selection
+# TODO: add bool to materialize normalization table
+# TODO: add DagsterAirbyteTranslator
 @suppress_dagster_warnings
 def airbyte_assets(
     *,
@@ -25,6 +28,7 @@ def airbyte_assets(
     destination_tables: Sequence[str],
     asset_key_prefix: Optional[Sequence[str]] = None,
     group_name: Optional[str] = None,
+    io_manager_key: Optional[str] = None,
     normalization_tables: Optional[Mapping[str, Set[str]]] = None,
     deps: Optional[Iterable[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]]] = None,
     upstream_assets: Optional[Set[AssetKey]] = None,
@@ -94,4 +98,5 @@ def airbyte_assets(
         internal_asset_deps=internal_deps,
         compute_kind="airbyte",
         group_name=group_name,
+        io_manager_key=io_manager_key,
     )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
@@ -1,0 +1,97 @@
+from itertools import chain
+from typing import Any, Callable, Iterable, Mapping, Optional, Sequence, Set, Union
+
+from dagster import (
+    AssetKey,
+    AssetOut,
+    AssetsDefinition,
+    AutoMaterializePolicy,
+    DagsterInvalidDefinitionError,
+    FreshnessPolicy,
+    MetadataValue,
+    SourceAsset,
+    TableSchema,
+    _check as check,
+    multi_asset,
+)
+from dagster._core.definitions.events import CoercibleToAssetKey
+from dagster._utils.warnings import suppress_dagster_warnings
+
+
+@suppress_dagster_warnings
+def airbyte_assets(
+    *,
+    connection_id: str,
+    destination_tables: Sequence[str],
+    asset_key_prefix: Optional[Sequence[str]] = None,
+    group_name: Optional[str] = None,
+    normalization_tables: Optional[Mapping[str, Set[str]]] = None,
+    deps: Optional[Iterable[Union[CoercibleToAssetKey, AssetsDefinition, SourceAsset]]] = None,
+    upstream_assets: Optional[Set[AssetKey]] = None,
+    schema_by_table_name: Optional[Mapping[str, TableSchema]] = None,
+    freshness_policy: Optional[FreshnessPolicy] = None,
+    stream_to_asset_map: Optional[Mapping[str, str]] = None,
+    auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
+) -> Callable[[Callable[..., Any]], AssetsDefinition]:
+    if upstream_assets is not None and deps is not None:
+        raise DagsterInvalidDefinitionError(
+            "Cannot specify both deps and upstream_assets to build_airbyte_assets. Use only deps"
+            " instead."
+        )
+
+    asset_key_prefix = check.opt_sequence_param(asset_key_prefix, "asset_key_prefix", of_type=str)
+
+    # Generate a list of outputs, the set of destination tables plus any affiliated
+    # normalization tables
+    tables = chain.from_iterable(
+        chain([destination_tables], normalization_tables.values() if normalization_tables else [])
+    )
+
+    metadata = {
+        "connection_id": connection_id,
+        "destination_tables": destination_tables,
+        "normalization_tables": normalization_tables,
+    }
+
+    outputs = {
+        table: AssetOut(
+            key=AssetKey([*asset_key_prefix, table]),
+            metadata=(
+                {
+                    **metadata,
+                    "table_schema": MetadataValue.table_schema(schema_by_table_name[table]),
+                }
+                if schema_by_table_name
+                else metadata
+            ),
+            freshness_policy=freshness_policy,
+            auto_materialize_policy=auto_materialize_policy,
+        )
+        for table in tables
+    }
+
+    internal_deps = {}
+
+    # If normalization tables are specified, we need to add a dependency from the destination table
+    # to the affilitated normalization table
+    if normalization_tables:
+        for base_table, derived_tables in normalization_tables.items():
+            for derived_table in derived_tables:
+                internal_deps[derived_table] = {AssetKey([*asset_key_prefix, base_table])}
+
+    upstream_deps = deps
+    if upstream_assets is not None:
+        upstream_deps = list(upstream_assets)
+
+    # All non-normalization tables depend on any user-provided upstream assets
+    for table in destination_tables:
+        internal_deps[table] = set(upstream_deps) if upstream_deps else set()
+
+    return multi_asset(
+        name=f"airbyte_sync_{connection_id[:5]}",
+        deps=upstream_deps,
+        outs=outputs,
+        internal_asset_deps=internal_deps,
+        compute_kind="airbyte",
+        group_name=group_name,
+    )

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_decorator.py
@@ -1,28 +1,47 @@
+from functools import partial
 from itertools import chain
-from typing import Any, Callable, Iterable, Mapping, Optional, Sequence, Set, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Union,
+    cast,
+)
 
 from dagster import (
+    AssetDep,
     AssetKey,
     AssetOut,
     AssetsDefinition,
     AutoMaterializePolicy,
     DagsterInvalidDefinitionError,
     FreshnessPolicy,
-    MetadataValue,
+    Nothing,
     SourceAsset,
     TableSchema,
     _check as check,
     multi_asset,
 )
 from dagster._core.definitions.events import CoercibleToAssetKey
+from dagster._core.definitions.metadata import MetadataValue, TableSchemaMetadataValue
 from dagster._utils.warnings import suppress_dagster_warnings
+
+from dagster_airbyte.airbyte_project import AirbyteProject
+from dagster_airbyte.dagster_airbyte_translator import DagsterAirbyteTranslator
+from dagster_airbyte.utils import get_schema_by_table_name, table_to_output_name_fn
 
 
 # TODO: pass all connections, then add connection filter or selection
 # TODO: add bool to materialize normalization table
 # TODO: add DagsterAirbyteTranslator
 @suppress_dagster_warnings
-def airbyte_assets(
+def airbyte_single_connection_asset(
     *,
     connection_id: str,
     destination_tables: Sequence[str],
@@ -36,6 +55,7 @@ def airbyte_assets(
     freshness_policy: Optional[FreshnessPolicy] = None,
     stream_to_asset_map: Optional[Mapping[str, str]] = None,
     auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
+    dagster_airbyte_translator: Optional[DagsterAirbyteTranslator] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     if upstream_assets is not None and deps is not None:
         raise DagsterInvalidDefinitionError(
@@ -100,3 +120,187 @@ def airbyte_assets(
         group_name=group_name,
         io_manager_key=io_manager_key,
     )
+
+
+@suppress_dagster_warnings
+def airbyte_assets(
+    *,
+    name: Optional[str] = None,
+    project: AirbyteProject,
+    dagster_airbyte_translator: Optional[DagsterAirbyteTranslator] = None,
+    create_assets_for_normalization_tables: bool = True,
+    required_resource_keys: Optional[Set[str]] = None,
+) -> Callable[[Callable[..., Any]], AssetsDefinition]:
+    if not dagster_airbyte_translator:
+        dagster_airbyte_translator = DagsterAirbyteTranslator()
+
+    (
+        deps,
+        outs,
+        internal_asset_deps,
+    ) = build_airbyte_multi_asset_args(
+        project=project,
+        translator=dagster_airbyte_translator,
+        create_assets_for_normalization_tables=create_assets_for_normalization_tables,
+    )
+
+    return multi_asset(
+        name=name,
+        deps=deps,
+        outs=outs,
+        internal_asset_deps=internal_asset_deps,
+        compute_kind="airbyte",
+        required_resource_keys=required_resource_keys,
+    )
+
+
+def build_airbyte_multi_asset_args(
+    project: AirbyteProject,
+    translator: DagsterAirbyteTranslator,
+    create_assets_for_normalization_tables: bool,
+):
+    # TODO: support AssetKey prefix
+
+    deps: List[AssetDep] = []
+    outs: Dict[str, AssetOut] = {}
+    internal_asset_deps: Dict[str, Set[AssetKey]] = {}
+
+    for connection_id, connection_metadata in project.connections_metadata:
+        stream_table_metadata = connection_metadata.parse_stream_tables(
+            create_assets_for_normalization_tables
+        )
+        schema_by_table_name = get_schema_by_table_name(stream_table_metadata)
+
+        table_to_asset_key = partial(translator.get_asset_key, connection_metadata)
+
+        destination_tables = list(stream_table_metadata.keys())
+        normalization_tables = {
+            table: set(metadata.normalization_tables.keys())
+            for table, metadata in stream_table_metadata.items()
+        }
+        group_name = translator.get_group_name_from_connection_metadata(connection_metadata)
+        io_manager_key = translator.get_io_manager_key(connection_metadata.name)
+        # schema_by_table_name = schema_by_table_name
+        table_to_asset_key_fn = table_to_asset_key
+        freshness_policy = translator.get_freshness_policy(connection_metadata)
+        auto_materialize_policy = translator.get_auto_materialize_policy(connection_metadata)
+        asset_key_prefix = translator.get_asset_key_prefix(connection_metadata)
+
+        # Generate a list of outputs, the set of destination tables plus any affiliated
+        # normalization tables
+        tables = list(
+            chain.from_iterable(
+                chain(
+                    [destination_tables],
+                    normalization_tables.values() if normalization_tables else [],
+                )
+            )
+        )
+
+        # TODO: manage collisions with group_name
+        outputs = {
+            table_to_output_name_fn(table): AssetKey(
+                [*asset_key_prefix, *table_to_asset_key_fn(table).path]
+            )
+            for table in tables
+        }
+
+        internal_deps: Dict[str, Set[AssetKey]] = {}
+
+        metadata_encodable_normalization_tables = (
+            {k: list(v) for k, v in normalization_tables.items()} if normalization_tables else {}
+        )
+
+        # If normalization tables are specified, we need to add a dependency from the destination table
+        # to the affiliated normalization table
+        if len(metadata_encodable_normalization_tables) > 0:
+            for base_table, derived_tables in metadata_encodable_normalization_tables.items():
+                for derived_table in derived_tables:
+                    # TODO: manage collisions with group_name
+                    internal_deps[derived_table] = {
+                        AssetKey([*asset_key_prefix, *table_to_asset_key_fn(base_table).path])
+                    }
+
+        # upstream_assets is None by default in the original code, meaning there were no deps.
+        # TODO: Confirm deps and upstream_assets are None by default
+        keys_by_input_name = {}
+
+        keys_by_output_name = outputs
+        internal_asset_deps = internal_deps
+        # group_name = group_name
+
+        # TODO: not used?
+        # key_prefix = asset_key_prefix
+        # can_subset = False
+
+        metadata_by_output_name = (
+            {
+                table: {"table_schema": MetadataValue.table_schema(schema_by_table_name[table])}
+                for table in tables
+            }
+            if schema_by_table_name
+            else None
+        )
+        freshness_policies_by_output_name = (
+            {output: freshness_policy for output in outputs} if freshness_policy else None
+        )
+        auto_materialize_policies_by_output_name = (
+            {output: auto_materialize_policy for output in outputs}
+            if auto_materialize_policy
+            else None
+        )
+
+        # TODO: Add to asset out
+        extra_metadata = {
+            "connection_id": connection_id,
+            "group_name": group_name,
+            "destination_tables": destination_tables,
+            "normalization_tables": metadata_encodable_normalization_tables,
+            "io_manager_key": io_manager_key,
+        }
+
+        metadata = cast(Mapping[str, Any], extra_metadata)
+        group_name = cast(Optional[str], metadata["group_name"])
+        io_manager_key = cast(Optional[str], metadata["io_manager_key"])
+
+        # TODO: should be added to metadata of asset out
+        # connection_id = cast(str, metadata["connection_id"])
+        # destination_tables = cast(List[str], metadata["destination_tables"])
+        # normalization_tables = cast(Mapping[str, List[str]], metadata["normalization_tables"])
+
+        # TODO: collisions?
+        deps.append(*list((keys_by_input_name or {}).values()))
+
+        # TODO: Update will work if collisions are handled
+        outs.update(
+            {
+                k: AssetOut(
+                    key=v,
+                    metadata=(
+                        {
+                            k: cast(TableSchemaMetadataValue, v)
+                            for k, v in metadata_by_output_name.get(k, {}).items()
+                        }
+                        if metadata_by_output_name
+                        else None
+                    ),
+                    io_manager_key=io_manager_key,
+                    freshness_policy=(
+                        freshness_policies_by_output_name.get(k)
+                        if freshness_policies_by_output_name
+                        else None
+                    ),
+                    dagster_type=Nothing,
+                    auto_materialize_policy=auto_materialize_policies_by_output_name.get(k, None)
+                    if auto_materialize_policies_by_output_name
+                    else None,
+                    group_name=group_name,
+                )
+                for k, v in (keys_by_output_name or {}).items()
+            }
+        )
+
+        # TODO: Same as above, update will work if collisions are handled
+        internal_asset_deps.update({k: set(v) for k, v in (internal_asset_deps or {}).items()})
+
+    return deps, outs, internal_asset_deps

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -52,11 +52,10 @@ from dagster_airbyte.utils import (
     generate_materializations,
     generate_table_schema,
     is_basic_normalization_operation,
+    table_to_output_name_fn,
 )
 
-
-def _table_to_output_name_fn(table: str) -> str:
-    return table.replace("-", "_")
+_table_to_output_name_fn = table_to_output_name_fn
 
 
 def _build_airbyte_asset_defn_metadata(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -51,11 +51,13 @@ from dagster_airbyte.types import AirbyteTableMetadata
 from dagster_airbyte.utils import (
     generate_materializations,
     generate_table_schema,
+    get_schema_by_table_name,
     is_basic_normalization_operation,
     table_to_output_name_fn,
 )
 
 _table_to_output_name_fn = table_to_output_name_fn
+_get_schema_by_table_name = get_schema_by_table_name()
 
 
 def _build_airbyte_asset_defn_metadata(
@@ -501,27 +503,6 @@ class AirbyteConnectionMetadata(
             )
 
         return tables
-
-
-def _get_schema_by_table_name(
-    stream_table_metadata: Mapping[str, AirbyteTableMetadata],
-) -> Mapping[str, TableSchema]:
-    schema_by_base_table_name = [(k, v.schema) for k, v in stream_table_metadata.items()]
-    schema_by_normalization_table_name = list(
-        chain.from_iterable(
-            [
-                [
-                    (k, v.schema)
-                    for k, v in cast(
-                        Dict[str, AirbyteTableMetadata], meta.normalization_tables
-                    ).items()
-                ]
-                for meta in stream_table_metadata.values()
-            ]
-        )
-    )
-
-    return dict(schema_by_normalization_table_name + schema_by_base_table_name)
 
 
 class AirbyteCoreCacheableAssetsDefinition(CacheableAssetsDefinition):

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/dagster_airbyte_translator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/dagster_airbyte_translator.py
@@ -1,36 +1,67 @@
-class DagsterAirbyteTranslator:
-    def get_group_name_from_connection(self):
-        # Based on
-        # connection_to_group_fn: Optional[Callable[[str], Optional[str]]] = (_clean_name,)
-        raise NotImplementedError
+from dagster import AssetKey
 
-    def get_group_name_from_connection_metadata(self):
+from dagster_airbyte.asset_defs import AirbyteConnectionMetadata
+
+
+class DagsterAirbyteTranslator:
+    def get_group_name_from_connection_metadata(
+        self, connection_metadata: AirbyteConnectionMetadata
+    ):
         # Based on
         # connection_meta_to_group_fn: Optional[Callable[[AirbyteConnectionMetadata], Optional[str]]] = (
         #    None,
         # )
-        raise NotImplementedError
+        return default_group_name_fn(connection_metadata)
 
-    def get_asset_key(self):
+    def get_asset_key(self, connection_metadata: AirbyteConnectionMetadata, table_name: str):
         # Based on
         # connection_to_asset_key_fn: Optional[Callable[[AirbyteConnectionMetadata, str], AssetKey]] = (None,)
-        raise NotImplementedError
+        return default_asset_key_fn(connection_metadata, table_name)
 
-    def get_auto_materialize_policy(self):
+    def get_asset_key_prefix(self, connection_metadata: AirbyteConnectionMetadata):
+        # Based on
+        # connection_to_asset_key_fn: Optional[Callable[[AirbyteConnectionMetadata, str], AssetKey]] = (None,)
+        return default_asset_key_prefix_fn(connection_metadata)
+
+    def get_auto_materialize_policy(self, connection_metadata: AirbyteConnectionMetadata):
         # Based on
         # connection_to_auto_materialize_policy_fn: Optional[
         #    Callable[[AirbyteConnectionMetadata], Optional[AutoMaterializePolicy]]
         # ] = (None,)
-        raise NotImplementedError
+        return default_auto_materialize_policy_fn(connection_metadata)
 
-    def get_freshness_policy(self):
+    def get_freshness_policy(self, connection_metadata: AirbyteConnectionMetadata):
         # Based on
         # connection_to_freshness_policy_fn: Optional[
         #    Callable[[AirbyteConnectionMetadata], Optional[FreshnessPolicy]]
         # ] = (None,)
-        raise NotImplementedError
+        return default_freshness_policy_fn(connection_metadata)
 
-    def get_io_manager_key(self):
+    def get_io_manager_key(self, connection_metadata: AirbyteConnectionMetadata):
         # Based on
         # connection_to_io_manager_key_fn: Optional[Callable[[str], Optional[str]]] = (None,)
-        raise NotImplementedError
+        return default_io_manager_key_fn(connection_metadata)
+
+
+def default_group_name_fn(connection_metadata: AirbyteConnectionMetadata):
+    return connection_metadata.name
+
+
+def default_asset_key_fn(connection_metadata: AirbyteConnectionMetadata, table_name: str):
+    return AssetKey([connection_metadata.name, table_name])
+
+
+def default_asset_key_prefix_fn(connection_metadata: AirbyteConnectionMetadata):
+    return [connection_metadata.name]
+
+
+def default_auto_materialize_policy_fn(connection_metadata: AirbyteConnectionMetadata):
+    return None
+
+
+def default_freshness_policy_fn(connection_metadata: AirbyteConnectionMetadata):
+    return None
+
+
+def default_io_manager_key_fn(connection_metadata: AirbyteConnectionMetadata):
+    return "io_manager"

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/dagster_airbyte_translator.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/dagster_airbyte_translator.py
@@ -1,0 +1,36 @@
+class DagsterAirbyteTranslator:
+    def get_group_name_from_connection(self):
+        # Based on
+        # connection_to_group_fn: Optional[Callable[[str], Optional[str]]] = (_clean_name,)
+        raise NotImplementedError
+
+    def get_group_name_from_connection_metadata(self):
+        # Based on
+        # connection_meta_to_group_fn: Optional[Callable[[AirbyteConnectionMetadata], Optional[str]]] = (
+        #    None,
+        # )
+        raise NotImplementedError
+
+    def get_asset_key(self):
+        # Based on
+        # connection_to_asset_key_fn: Optional[Callable[[AirbyteConnectionMetadata, str], AssetKey]] = (None,)
+        raise NotImplementedError
+
+    def get_auto_materialize_policy(self):
+        # Based on
+        # connection_to_auto_materialize_policy_fn: Optional[
+        #    Callable[[AirbyteConnectionMetadata], Optional[AutoMaterializePolicy]]
+        # ] = (None,)
+        raise NotImplementedError
+
+    def get_freshness_policy(self):
+        # Based on
+        # connection_to_freshness_policy_fn: Optional[
+        #    Callable[[AirbyteConnectionMetadata], Optional[FreshnessPolicy]]
+        # ] = (None,)
+        raise NotImplementedError
+
+    def get_io_manager_key(self):
+        # Based on
+        # connection_to_io_manager_key_fn: Optional[Callable[[str], Optional[str]]] = (None,)
+        raise NotImplementedError

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -5,7 +5,7 @@ import sys
 import time
 from abc import abstractmethod
 from contextlib import contextmanager, suppress
-from typing import Any, Dict, List, Mapping, Optional, Union, cast, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union, cast
 
 import requests
 from dagster import (
@@ -27,10 +27,8 @@ from dagster._utils.merger import deep_merge_dicts
 from pydantic import Field
 from requests.exceptions import RequestException
 
-#TODO that function should be called from util, move it
-from dagster_airbyte.asset_defs import _table_to_output_name_fn
 from dagster_airbyte.types import AirbyteOutput
-from dagster_airbyte.utils import generate_materializations
+from dagster_airbyte.utils import generate_materializations, table_to_output_name_fn
 
 DEFAULT_POLL_INTERVAL_SECONDS = 10
 
@@ -275,13 +273,13 @@ class BaseAirbyteResource(ConfigurableResource):
                 for table_name in destination_tables:
                     yield Output(
                         value=None,
-                        output_name=_table_to_output_name_fn(table_name),
+                        output_name=table_to_output_name_fn(table_name),
                     )
                     if normalization_tables:
                         for dependent_table in normalization_tables.get(table_name, set()):
                             yield Output(
                                 value=None,
-                                output_name=_table_to_output_name_fn(dependent_table),
+                                output_name=table_to_output_name_fn(dependent_table),
                             )
             else:
                 for materialization in generate_materializations(ab_output):
@@ -289,7 +287,7 @@ class BaseAirbyteResource(ConfigurableResource):
                     if table_name in destination_tables:
                         yield Output(
                             value=None,
-                            output_name=_table_to_output_name_fn(table_name),
+                            output_name=table_to_output_name_fn(table_name),
                             metadata=materialization.metadata,
                         )
                         # Also materialize any normalization tables affiliated with this destination
@@ -298,7 +296,7 @@ class BaseAirbyteResource(ConfigurableResource):
                             for dependent_table in normalization_tables.get(table_name, set()):
                                 yield Output(
                                     value=None,
-                                    output_name=_table_to_output_name_fn(dependent_table),
+                                    output_name=table_to_output_name_fn(dependent_table),
                                 )
                     else:
                         yield materialization

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/utils.py
@@ -74,3 +74,7 @@ def generate_materializations(
             all_stream_stats.get(stream_name, {}),
             asset_key_prefix=asset_key_prefix,
         )
+
+
+def table_to_output_name_fn(table: str) -> str:
+    return table.replace("-", "_")


### PR DESCRIPTION
## Summary & Motivation

*Note: **The code is still WIP**

### Background

As part of the integration overhaul, we want to explore how we can improve our already existing integration.

Namely, we want to explore how using an approach combining a project, a translator and a decorator would help improving an integration and making it easier to use.

This PR is a RFC and implements a prototype for `dagster-airbyte`, using the a project, a translator and a decorator.

Goals of this RFC:

- Understand frictions in the current dagster-airbyte integration.
  - Does an approach using a project, decorator and translator is better at enabling users than the previous approach?
- Understand whether some patterns makes sense for tools like Airbyte
  - Does the translator pattern makes sense?
  - What about the project pattern?

### Current state

Currently, users can create their Airbyte assets in three different ways in Dagster.

- `load_assets_from_airbyte_instance`
  - Gets all connections from an Airbyte assets and creates Dagster assets for each of them
  - Uses `CacheableAssetsDefinition`
- `load_assets_from_airbyte_project`
  - Gets all connections from an Octavia project directory and local YAML files. Creates Dagster assets for each of the connections.
  - Uses `CacheableAssetsDefinition`
- `build_airbyte_assets`
  - Creates a multi-asset for a single Airbyte connection.
  - Does not use `CacheableAssetsDefinition`, but multi-asset

Looks like this, assuming no overlap in Airbyte connection between approaches:

```python
from dagster import job, EnvVar
from dagster_airbyte import AirbyteResource

my_airbyte_resource = AirbyteResource(
    host=EnvVar("AIRBYTE_HOST"),
    port=EnvVar("AIRBYTE_PORT"),
    # If using basic auth
    username=EnvVar("AIRBYTE_USERNAME"),
    password=EnvVar("AIRBYTE_PASSWORD"),
)

my_connection_assets = with_resources(
    build_airbyte_assets(
        connection_id="87b7fe85-a22c-420e-8d74-b30e7ede77df",
        destination_tables=["releases", "tags", "teams"],
    ),
    {"airbyte": airbyte_instance},
)

my_project_assets  = with_resources(
    [load_assets_from_airbyte_project(project_dir="path/to/airbyte/project")],
    {"airbyte": airbyte_instance},
)

my_instance_assets = load_assets_from_airbyte_instance(
    airbyte = my_airbyte_resource,
)

defs = Definitions(
    assets=[my_connection_assets, my_project_assets, my_instance_assets],
    resources={"airbyte": my_airbyte_resource},
)
```

### Proposition

Use one asset decorator to manage all connections. Use a resource, project and translator in the process.

This proposition
- Prepare the connections in advance, at run time during development and at build time during deployment. Create the assets based on these connections.
- Remove the cacheable assets previously used in `load_assets_from_airbyte_instance` and `load_assets_from_airbyte_project` and adopt a project object with multi-assets
  - like for `DbtProject`, the `AirbyteProject` can be prepared at run time (development) and build time (deployment)

Introduced in this proposition
- `AirbyteProject` object
  - the internal representation of the Airbyte project/configuration.
    - can be created in two ways
      - from_local_configuration(), which takes an Airbyte configuration directory, that was already imported by users with Octavia CLI, see [here](https://airbyte.com/tutorials/version-control-airbyte-configurations).
      - from_resource(), which would import the Airbyte configuration directory using the resource/credentials. (not implemented yet)
  - is used to prepare a connections metadata file, used by the asset decorator.
  - is created based on a single `workspace_id`.
- `airbyte_assets` decorator
  - the decorator that creates all assets for each connection of the airbyte project
  - can `select` and `exclude` connections in the asset decorator (not implemented yet)
- `DagsterAirbyteTranslator` object
  - represent all translation functions required
    - currently represents the connection_to_*_fn passed to `load_assets_from_airbyte_project` and `load_assets_from_airbyte_instance`.
- `materialize_from_sync` method added to the AirbyteResource
  -  it encapsulates the previously existing AirbyteResource.sync_and_poll, and materialize the assets based on the context.
    - though, maybe decoupling the materialization from the resource would be better

```python
from dagster import job, EnvVar
from dagster_airbyte import (
    AirbyteProject, 
    DagsterAirbyteTranslator, 
    AirbyteResource, 
    airbyte_assets
)

my_airbyte_resource = AirbyteResource(
    host=EnvVar("AIRBYTE_HOST"),
    port=EnvVar("AIRBYTE_PORT"),
    # If using basic auth
    username=EnvVar("AIRBYTE_USERNAME"),
    password=EnvVar("AIRBYTE_PASSWORD"),
)

airbyte_project = AirbyteProject.from_local_configuration(
    configuration_dir="path/to/configuration",
    workspace_id="my-workspace-id",
)
airbyte_project.prepare_if_dev()

@airbyte_assets(
    name="my_airbyte_assets",
    project=airbyte_project,
    dagster_airbyte_translator=DagsterAirbyteTranslator(),
)
def my_airbyte_assets(context, airbyte: AirbyteResource):
    # Do something with my resource
    yield from airbyte.materialize_from_sync(context=context)

defs = Definitions(
    assets=[my_airbyte_assets],
    resources={"airbyte": my_airbyte_resource},
)
```

## Request for comments

1. The API
- Any feedback on the API, including the project, decorator, translator and resource is welcome.
  - Does the current implementation make sense in terms of usage?
  - Allowing users to select and exclude connections at the asset decorator level seems like a good idea to make usage more flexible. Other opinions or thoughts?

2. Naming
- `AirbyteProject` vs `AirbyteConfiguration`
  - The proposition includes a AirbyteProject, which respect the `Project` convention that we want to enforce in the integration overhaul.
  - The object represents the configuration more than an actual Airbyte project.
  - Do we still want to name it `AirbyteProject`?

3. Who's responsible for the workspace_id
- In this proposition, the `workspace_id` is passed that the project level, meaning that the project object would represent only one `workspace_id`, if many.
  - Should `workspace_id` be passed in the asset decorator instead, to represent the all the connections of a single workspace?

4. Importing the Airbyte configuration via Octavia CLI for the user
- For this proposition, we need the configuration directory that can be imported via Octavia CLI
  - When using `AirbyteProject.from_local_configuration()`
    - Easy to use to extract the connections and workspaces from the local configuration directory
  - When using `AirbyteProject.from_resource()`
    - Using the resource attributes (credentials), we could import the Airbyte configuration via Octavia CLI
      - We could avoid using the partially initialized resource and the REST API
      - the credentials could be decoupled from the resource to avoid using the resource object here.
      - the configuration directory could then be packaged at build time when deploying, similarly to what we are doing for dbt.
    - Is importing the configuration directory using the credentials a good strategy?

5. Is the configuration directory enough?
- In this proposition, the `AirbyteProject` creates a file when prepared, `connections_metadata.json`, that is what Dagster needs to create the assets.
  - This was created to replicate the cache behiavor previously implemented
  - This is an intermediate step that could be eliminated.
    - The assets could be created using only configuration directory.
      - No need to "prepare" the Airbyte project created with `AirbyteProject.from_local_configuration()`
      - We would still need to either import the configuration directory via Octavia CLI or fetch the connections via the REST API when using `AirbyteProject.from_resource()`.
    - Any objection with removing that intermediate step?


## Additional thoughts

1. One of the initial propositions for this prototype was to only refactor the current `build_airbyte_assets` in an asset decorator. This approach should be dropped.
  - In this approach, we would keep `load_assets_from_airbyte_instance` and `load_assets_from_airbyte_project` as-is, which does not make much sense in hindsight.
  - the asset decorator was initially `airbyte_assets` , now named `airbyte_single_connection_asset` in this PR. A method was added to the resource as well, initially `materialize_from_sync`, now named `materialize_single_connection_from_sync`.
    - I'm just waiting for the first round of feedback to confirm the main proposition before removing this.

## To-do

- [x] Implement the translator to replace the function passed to `load_assets_from_airbyte_instance` and `load_assets_from_airbyte_project`
- [x] Implement a `AirbyteProject.from_local_configuration()` to reflect the project and connections 
- [x] Implement a `AirbyteProject.from_resource()` to reflect the project and connections 
- [ ] Update code to use `AssetSpec` instead of `AssetOut`
- [ ] Update code to `select` and `exclude` connections in the asset decorator.
- [ ] Update and add tests
