### PR TITLE
Fix `multi_asset` specs arg to accept any sequence

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -580,7 +580,7 @@ def multi_asset(
     args = DecoratorAssetsDefinitionBuilderArgs(
         name=name,
         op_description=description,
-        specs=check.opt_list_param(specs, "specs", of_type=AssetSpec),
+        specs=check.opt_sequence_param(specs, "specs", of_type=AssetSpec),
         check_specs_by_output_name=create_check_specs_by_output_name(check_specs),
         asset_out_map=check.opt_mapping_param(outs, "outs", key_type=str, value_type=AssetOut),
         upstream_asset_deps=_deps_and_non_argument_deps_to_asset_deps(


### PR DESCRIPTION
## Summary & Motivation
https://github.com/dagster-io/dagster/blob/3a990132069004eea64c823bdb7676dca8b006fa/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py#L488

The type signature of `multi_asset` claims to support any sequence, but the type checker expects a list.

Changed to check for sequence instead of list.

## How I Tested These Changes

Ran asset tests.