### PR TITLE
[DA] fix observable source asset handling in AutomationCondition.newly_updated

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_newly_updated_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_newly_updated_condition.py
@@ -1,14 +1,12 @@
-import pytest
 from dagster import AutomationCondition
 
-from ..scenario_specs import one_asset, one_observable_asset
+from ..scenario_specs import one_asset, one_upstream_observable_asset
 from .asset_condition_scenario import AutomationConditionScenarioState
 
 
-@pytest.mark.parametrize("scenario", [one_asset, one_observable_asset])
-def test_newly_updated_condition(scenario) -> None:
+def test_newly_updated_condition() -> None:
     state = AutomationConditionScenarioState(
-        scenario, automation_condition=AutomationCondition.newly_updated()
+        one_asset, automation_condition=AutomationCondition.newly_updated()
     )
 
     # not updated
@@ -39,4 +37,45 @@ def test_newly_updated_condition(scenario) -> None:
 
     # not newly updated
     state, result = state.evaluate("A")
+    assert result.true_subset.size == 0
+
+
+def test_newly_updated_condition_data_version() -> None:
+    state = AutomationConditionScenarioState(
+        one_upstream_observable_asset,
+        automation_condition=AutomationCondition.any_deps_match(
+            AutomationCondition.newly_updated()
+        ),
+    )
+
+    # not updated
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # newly updated
+    state = state.with_reported_observation("A", data_version="1")
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 1
+
+    # not newly updated
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # same data version, not newly updated
+    state = state.with_reported_observation("A", data_version="1")
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # new data version
+    state = state.with_reported_observation("A", data_version="2")
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 1
+
+    # new data version
+    state = state.with_reported_observation("A", data_version="3")
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 1
+
+    # no new data version
+    state, result = state.evaluate("B")
     assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_specs.py
@@ -44,14 +44,15 @@ self_partition_mapping = TimeWindowPartitionMapping(start_offset=-1, end_offset=
 ##############
 one_asset = ScenarioSpec(asset_specs=[AssetSpec("A")])
 
-one_observable_asset = ScenarioSpec(
+one_upstream_observable_asset = ScenarioSpec(
     [
         AssetSpec(
             "A",
             metadata={
                 SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE: AssetExecutionType.OBSERVATION.value
             },
-        )
+        ),
+        AssetSpec("B", deps=["A"]),
     ]
 )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_state.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_state.py
@@ -159,7 +159,9 @@ class ScenarioSpec:
                 execution_type = (
                     AssetExecutionType[execution_type_str] if execution_type_str else None
                 )
+                # create an observable_source_asset or regular asset depending on the execution type
                 if execution_type == AssetExecutionType.OBSERVATION:
+                    # strip out the relevant paramters from the spec
                     params = {"key", "group_name", "partitions_def", "metadata"}
 
                     @observable_source_asset(
@@ -169,6 +171,7 @@ class ScenarioSpec:
 
                     assets.append(osa)
                 else:
+                    # strip out the relevant paramters from the spec
                     params = {
                         "key",
                         "deps",

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_state.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/scenario_state.py
@@ -28,8 +28,18 @@ from dagster import (
 )
 from dagster._core.definitions import materialize
 from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_spec import (
+    SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE,
+    AssetExecutionType,
+)
+from dagster._core.definitions.data_version import DATA_VERSION_TAG
+from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
 from dagster._core.definitions.definitions_class import create_repository_using_definitions_args
-from dagster._core.definitions.events import AssetMaterialization, CoercibleToAssetKey
+from dagster._core.definitions.events import (
+    AssetMaterialization,
+    AssetObservation,
+    CoercibleToAssetKey,
+)
 from dagster._core.definitions.executor_definition import in_process_executor
 from dagster._core.definitions.repository_definition.repository_definition import (
     RepositoryDefinition,
@@ -145,22 +155,37 @@ class ScenarioSpec:
 
                 assets.append(_multi_asset)
             else:
-                params = {
-                    "key",
-                    "deps",
-                    "group_name",
-                    "code_version",
-                    "auto_materialize_policy",
-                    "freshness_policy",
-                    "partitions_def",
-                    "metadata",
-                }
-                assets.append(
-                    asset(
-                        compute_fn=compute_fn,
+                execution_type_str = spec.metadata.get(SYSTEM_METADATA_KEY_ASSET_EXECUTION_TYPE)
+                execution_type = (
+                    AssetExecutionType[execution_type_str] if execution_type_str else None
+                )
+                if execution_type == AssetExecutionType.OBSERVATION:
+                    params = {"key", "group_name", "partitions_def", "metadata"}
+
+                    @observable_source_asset(
                         **{k: v for k, v in spec._asdict().items() if k in params},
                     )
-                )
+                    def osa() -> None: ...
+
+                    assets.append(osa)
+                else:
+                    params = {
+                        "key",
+                        "deps",
+                        "group_name",
+                        "code_version",
+                        "auto_materialize_policy",
+                        "freshness_policy",
+                        "partitions_def",
+                        "metadata",
+                    }
+                    assets.append(
+                        asset(
+                            compute_fn=compute_fn,
+                            **{k: v for k, v in spec._asdict().items() if k in params},
+                        )
+                    )
+
         return assets
 
     @property
@@ -335,6 +360,20 @@ class ScenarioState:
             partition=partition_key,
         )
         self.instance.report_runless_asset_event(mat)
+        return self
+
+    def with_reported_observation(
+        self,
+        asset_key: CoercibleToAssetKey,
+        partition_key: Optional[str] = None,
+        data_version: Optional[str] = None,
+    ) -> Self:
+        obs = AssetObservation(
+            asset_key=asset_key,
+            partition=partition_key,
+            tags={DATA_VERSION_TAG: data_version} if data_version else None,
+        )
+        self.instance.report_runless_asset_event(obs)
         return self
 
     def _with_runs_with_status(self, status: DagsterRunStatus) -> Self:


### PR DESCRIPTION
## Summary & Motivation

Resolves: https://github.com/dagster-io/dagster/issues/22850

The method `get_asset_subset_updated_after_cursor` had a somewhat-misguided pattern which I believe was originally intended as a performance optimization. In essence, for unpartitioned assets, it would simply check for the existence of an event after the provided cursor, rather than going through the more explicit `get_asset_partitions_updated_after_cursor` code path.

However, `get_asset_partitions_updated_after_cursor`:
a) already does that same check, and so is able to short-circuit on its own
b) handles data version changes for observable source assets, which is the focus of this fix

Had to make some updates to the testing framework to properly simulate observable source assets (side comment: this is quite rough at the moment).

## How I Tested These Changes
