### PR TITLE
[DA] Fix evaluation history UI

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_condition_evaluations.py
@@ -86,9 +86,7 @@ def fetch_asset_condition_evaluation_record_for_partition(
         else None
     )
     return GrapheneAssetConditionEvaluation(
-        record.get_evaluation_with_run_ids(partitions_def).evaluation,
-        partitions_def,
-        partition_key,
+        record.get_evaluation_with_run_ids(partitions_def).evaluation, partition_key
     )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
@@ -155,7 +155,7 @@ class GraphenePartitionedAssetConditionEvaluationNode(graphene.ObjectType):
             elif maybe_subset.is_partitioned:
                 return GrapheneAssetSubset(maybe_subset)
 
-            # TODO: Remove on redesign
+            # TODO: Remove on redesign (FOU-242)
             # We create a fake partitioned asset subset out of an unpartitioned asset subset in
             # order to allow unpartitioned rows to not error when used in the partition-focused UI.
             if maybe_subset.size == 0:
@@ -198,7 +198,7 @@ class GrapheneSpecificPartitionAssetConditionEvaluationNode(graphene.ObjectType)
         self._partition_key = partition_key
 
         if not evaluation.true_subset.is_partitioned:
-            # TODO: Remove on redesign
+            # TODO: Remove on redesign (FOU-242)
             # This code allows the page to not error when displaying a specific partition's results
             # where a sub-condition is not partitioned. In these cases, we can treat the expression
             # as SKIPPED


### PR DESCRIPTION
## Summary & Motivation

Resolves: https://github.com/dagster-io/dagster/issues/22787

The new Declarative Automation framework allows conditions which are evaluated against parents of a given asset. Those parents do not necessarily have the same partitions definition as the child.

The current UI was designed with the expectation that all sub-evaluations would reference the same PartitionsDefinition, and so results in errors when we (e.g.) try to construct a`GraphenePartitionedAssetConditionEvaluationNode` from an evaluation that was actually executed against an unpartitioned asset.

We are working on a larger redesign which should help remove this assumption from the core UI model, but for now we can prevent these errors by making it possible to construct a `...PartitionedEvaluationNode` from an unpartitioned evaluation and vice-versa.

The end result is a comprehensible UI without errors, although compromises needed to be made (e.g. an unpartitioned row in the partitioned UI ends up being represented as having a "partition key" of the string "None"). This feels like an acceptable state for the short term.

## How I Tested These Changes
