### PR TITLE
[record] defend against problematic collisions

### DIFF
--- a/python_modules/dagster/dagster/_record/__init__.py
+++ b/python_modules/dagster/dagster/_record/__init__.py
@@ -1,3 +1,4 @@
+import inspect
 from abc import ABC
 from functools import partial
 from typing import (
@@ -46,7 +47,24 @@ def _namedtuple_model_transform(
         * creates a run time checked __new__  (optional).
     """
     field_set = getattr(cls, "__annotations__", {})
-    defaults = {name: getattr(cls, name) for name in field_set.keys() if hasattr(cls, name)}
+
+    defaults = {}
+    for name in field_set.keys():
+        if hasattr(cls, name):
+            attr_val = getattr(cls, name)
+            check.invariant(
+                not isinstance(attr_val, property),
+                f"Conflicting @property for field {name} on record {cls.__name__}."
+                "If you are trying to declare an abstract property "
+                "you will have to use a class attribute instead.",
+            )
+            check.invariant(
+                not inspect.isfunction(attr_val),
+                f"Conflicting function for field {name} on record {cls.__name__}. "
+                "If you are trying to set a function as a default value "
+                "you will have to override __new__.",
+            )
+            defaults[name] = attr_val
 
     base = NamedTuple(f"_{cls.__name__}", field_set.items())
     nt_new = base.__new__
@@ -83,9 +101,8 @@ def _namedtuple_model_transform(
         check.failed(f"Expected __new__ on {cls}, add it or switch from the _with_new decorator.")
 
     # clear default values
-    for name in field_set.keys():
-        if hasattr(cls, name):
-            delattr(cls, name)
+    for name in defaults.keys():
+        delattr(cls, name)
 
     new_type = type(
         cls.__name__,


### PR DESCRIPTION
Bumped in to this in https://github.com/dagster-io/dagster/pull/22855, its confusing (and breaks default resolution) to have record fields conflict with methods so defend against it.

## How I Tested These Changes

added test
