### PR TITLE
[bug] Fix issue where metadata got discarded in SourceAsset conversion

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1507,9 +1507,9 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
 
             return SourceAsset(
                 key=key,
-                metadata=output_def.metadata,
+                metadata=spec.metadata,
                 io_manager_key=output_def.io_manager_key,
-                description=output_def.description,
+                description=spec.description,
                 resource_defs=self.resource_defs,
                 partitions_def=self.partitions_def,
                 group_name=spec.group_name,

--- a/python_modules/dagster/dagster_tests/storage_tests/test_input_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_input_manager.py
@@ -6,6 +6,7 @@ from dagster import (
     AssetKey,
     DagsterInstance,
     DagsterInvalidDefinitionError,
+    DataVersion,
     In,
     InputManager,
     IOManager,
@@ -16,6 +17,7 @@ from dagster import (
     io_manager,
     job,
     materialize,
+    observable_source_asset,
     op,
     resource,
 )
@@ -365,6 +367,32 @@ def test_input_manager_with_assets():
     )
 
     assert output._get_output_for_handle("downstream", "result") == 3  # noqa: SLF001
+
+
+def test_input_manager_with_observable_source_asset() -> None:
+    fancy_metadata = {"foo": "bar", "baz": 1.23}
+
+    @observable_source_asset(metadata=fancy_metadata)
+    def upstream():
+        return DataVersion("1")
+
+    @asset(ins={"upstream": AssetIn(input_manager_key="special_io_manager")})
+    def downstream(upstream) -> int:
+        return upstream + 1
+
+    class MyIOManager(IOManager):
+        def load_input(self, context) -> int:
+            assert context.upstream_output is not None
+            assert context.upstream_output.asset_key == AssetKey(["upstream"])
+            # the process of converting assets to source assets leaves an extra metadata entry
+            # of dagster/io_manager_key in the dictionary, so we can't use simple equality here
+            for k, v in fancy_metadata.items():
+                assert context.upstream_output.definition_metadata[k] == v
+            return 2
+
+        def handle_output(self, context, obj) -> None: ...
+
+    materialize(assets=[upstream, downstream], resources={"special_io_manager": MyIOManager()})
 
 
 def test_input_manager_with_assets_no_default_io_manager():


### PR DESCRIPTION
## Summary & Motivation

Resolves: https://github.com/dagster-io/dagster/issues/22789

Fixes issue which I believe was introduced by: https://github.com/dagster-io/dagster/issues/22165 (didn't dig that hard)

The core problem is this conversion: https://sourcegraph.com/github.com/dagster-io/dagster/-/blob/python_modules/dagster/dagster/_core/definitions/external_asset.py?L176

`observable_source_asset` does not set metadata on the `OutputDefinition` of its internal op. So when we initially convert a SourceAsset into an ol' fashioned `AssetsDefinition`, then call `to_source_assets()` on that, we end up losing the metadata field, as we were trying to pull it off of the `OutputDefinition`. This PR just pulls it off of the spec instead.

## How I Tested These Changes

Added test fails before, passes now.