### PR TITLE
[DA] Create any_downstream_conditions AutomationCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from collections import deque
+from collections import defaultdict, deque
 from datetime import datetime
 from functools import cached_property, total_ordering
 from heapq import heapify, heappop, heappush
@@ -47,6 +47,7 @@ from .time_window_partitions import get_time_partition_key, get_time_partitions_
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
     from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+    from dagster._core.definitions.declarative_automation import AutomationCondition
 
 AssetKeyOrCheckKey = Union[AssetKey, AssetCheckKey]
 
@@ -618,6 +619,21 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
             downstream_policies.add(asset.freshness_policy)
 
         return downstream_policies
+
+    @cached_method
+    def get_downstream_automation_conditions(
+        self, *, asset_key: AssetKey
+    ) -> Mapping["AutomationCondition", AbstractSet[AssetKey]]:
+        asset = self.get(asset_key)
+        downstream_conditions = defaultdict(set)
+        for child_key in asset.child_keys:
+            child_policy = self.get(child_key).auto_materialize_policy
+            child_condition = child_policy.asset_condition if child_policy else None
+            if child_condition:
+                downstream_conditions[child_condition].add(child_key)
+            for c, aks in self.get_downstream_automation_conditions(asset_key=child_key).items():
+                downstream_conditions[c].update(aks)
+        return downstream_conditions
 
     def bfs_filter_subsets(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
@@ -10,6 +10,7 @@ from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_time import CachingDataTimeResolver
+from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
 from dagster._core.definitions.declarative_automation.automation_condition_evaluator import (
     AutomationConditionEvaluator,
 )
@@ -24,9 +25,11 @@ class EvaluateAutomationConditionsResult:
         self,
         requested_asset_partitions: AbstractSet[AssetKeyPartitionKey],
         cursor: AssetDaemonCursor,
+        results: Sequence[AutomationResult],
     ):
         self._requested_asset_partitions = requested_asset_partitions
         self.cursor = cursor
+        self.results = results
 
     @cached_property
     def _requested_partitions_by_asset_key(self) -> Mapping[AssetKey, AbstractSet[Optional[str]]]:
@@ -134,4 +137,5 @@ def evaluate_automation_conditions(
     return EvaluateAutomationConditionsResult(
         cursor=cursor,
         requested_asset_partitions=requested_asset_partitions,
+        results=results,
     )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/__init__.py
@@ -1,3 +1,6 @@
+from .any_downstream_conditions_operator import (
+    AnyDownstreamConditionsCondition as AnyDownstreamConditionsCondition,
+)
 from .boolean_operators import (
     AndAssetCondition as AndAssetCondition,
     NotAssetCondition as NotAssetCondition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
@@ -1,0 +1,84 @@
+from typing import AbstractSet, Sequence
+
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._serdes.serdes import whitelist_for_serdes
+
+from ..automation_condition import AutomationCondition, AutomationResult
+from ..automation_context import AutomationContext
+
+
+class DownstreamConditionWrapperCondition(AutomationCondition):
+    """Wrapper object which evaluates a condition against a dependency and returns a subset
+    representing the subset of downstream asset which has at least one parent which evaluated to
+    True.
+    """
+
+    downstream_keys: Sequence[AssetKey]
+    operand: AutomationCondition
+
+    @property
+    def description(self) -> str:
+        return ",".join(key.to_user_string() for key in self.downstream_keys)
+
+    @property
+    def children(self) -> Sequence[AutomationCondition]:
+        return [self.operand]
+
+    def evaluate(self, context: AutomationContext) -> AutomationResult:
+        child_result = self.operand.evaluate(
+            context.for_child_condition(
+                child_condition=self.operand, child_index=0, candidate_slice=context.candidate_slice
+            )
+        )
+        return AutomationResult.create_from_children(
+            context=context, true_slice=child_result.true_slice, child_results=[child_result]
+        )
+
+
+@whitelist_for_serdes
+class AnyDownstreamConditionsCondition(AutomationCondition):
+    @property
+    def description(self) -> str:
+        return "Any downstream conditions"
+
+    def _get_ignored_conditions(
+        self, context: AutomationContext
+    ) -> AbstractSet[AutomationCondition]:
+        """To avoid infinite recursion, we do not expand conditions which are already part of the
+        evaluation hierarchy.
+        """
+        ignored_conditions = {context.condition}
+        while context.parent_context is not None:
+            context = context.parent_context
+            ignored_conditions.add(context.condition)
+        return ignored_conditions
+
+    def evaluate(self, context: AutomationContext) -> AutomationResult:
+        ignored_conditions = self._get_ignored_conditions(context)
+        downstream_conditions = context.asset_graph.get_downstream_automation_conditions(
+            asset_key=context.asset_key
+        )
+
+        true_slice = context.asset_graph_view.create_empty_slice(asset_key=context.asset_key)
+        child_results = []
+        for i, (downstream_condition, asset_keys) in enumerate(
+            sorted(downstream_conditions.items(), key=lambda x: sorted(x[1]))
+        ):
+            if downstream_condition in ignored_conditions:
+                continue
+            child_condition = DownstreamConditionWrapperCondition(
+                downstream_keys=list(sorted(asset_keys)), operand=downstream_condition
+            )
+            child_context = context.for_child_condition(
+                child_condition=child_condition,
+                child_index=i,
+                candidate_slice=context.candidate_slice,
+            )
+            child_result = child_condition.evaluate(child_context)
+
+            child_results.append(child_result)
+            true_slice = true_slice.compute_union(child_result.true_slice)
+
+        return AutomationResult.create_from_children(
+            context=context, true_slice=true_slice, child_results=child_results
+        )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_any_downstream_conditions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_any_downstream_conditions.py
@@ -1,0 +1,123 @@
+from typing import Sequence
+
+from dagster import (
+    AssetKey,
+    AutomationCondition,
+    DagsterInstance,
+    asset,
+    evaluate_automation_conditions,
+)
+from dagster._core.definitions.asset_key import CoercibleToAssetKey
+from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
+from dagster._core.definitions.declarative_automation.operators.boolean_operators import (
+    AndAssetCondition,
+)
+
+
+def _get_result(key: CoercibleToAssetKey, results: Sequence[AutomationResult]) -> AutomationResult:
+    key = AssetKey.from_coercible(key)
+    for result in results:
+        if result.asset_key == key:
+            return result
+    assert False
+
+
+def test_basic() -> None:
+    cond1 = AutomationCondition.any_downstream_conditions()
+    cond2 = AutomationCondition.eager()
+
+    @asset(auto_materialize_policy=cond1.as_auto_materialize_policy())
+    def a(): ...
+
+    @asset(auto_materialize_policy=cond2.as_auto_materialize_policy(), deps=[a])
+    def b(): ...
+
+    result = evaluate_automation_conditions([a, b], instance=DagsterInstance.ephemeral())
+
+    a_result = _get_result(a.key, result.results)
+    assert len(a_result.child_results) == 1
+    assert a_result.child_results[0].child_results[0].condition == cond2
+
+
+def test_multiple_downstreams() -> None:
+    cond1 = AutomationCondition.any_downstream_conditions()
+    cond2 = AutomationCondition.in_progress()
+    cond3 = AutomationCondition.missing()
+
+    @asset(auto_materialize_policy=cond1.as_auto_materialize_policy())
+    def a(): ...
+
+    # Left hand side, chain of lazy into two different policies
+    @asset(auto_materialize_policy=cond1.as_auto_materialize_policy(), deps=[a])
+    def left1(): ...
+
+    @asset(auto_materialize_policy=cond1.as_auto_materialize_policy(), deps=[left1])
+    def left2(): ...
+
+    @asset(auto_materialize_policy=cond2.as_auto_materialize_policy(), deps=[left2])
+    def b(): ...
+
+    @asset(auto_materialize_policy=cond3.as_auto_materialize_policy(), deps=[left2])
+    def c(): ...
+
+    # Right hand side, same policy as b
+    @asset(auto_materialize_policy=cond2.as_auto_materialize_policy(), deps=[a])
+    def d(): ...
+
+    result = evaluate_automation_conditions(
+        [a, left1, left2, b, c, d], instance=DagsterInstance.ephemeral()
+    )
+
+    # make sure a has all downstreams
+    a_result = _get_result(a.key, result.results)
+    assert len(a_result.child_results) == 2
+
+    res1 = a_result.child_results[0]
+    assert res1.condition.description == "b,d"
+    assert res1.child_results[0].condition == cond2
+
+    res2 = a_result.child_results[1]
+    assert res2.condition.description == "c"
+    assert res2.child_results[0].condition == cond3
+
+
+def test_multiple_downstreams_nested() -> None:
+    cond1 = AutomationCondition.any_downstream_conditions()
+    # combine the lazy condition with another condition, ensure we don't infinite loop
+    cond2 = AutomationCondition.any_downstream_conditions() & ~AutomationCondition.in_progress()
+    cond3 = AutomationCondition.eager()
+
+    @asset(auto_materialize_policy=cond1.as_auto_materialize_policy())
+    def a(): ...
+
+    @asset(auto_materialize_policy=cond2.as_auto_materialize_policy(), deps=[a])
+    def b(): ...
+
+    @asset(auto_materialize_policy=cond1.as_auto_materialize_policy(), deps=[b])
+    def c(): ...
+
+    # Right hand side, same policy as b
+    @asset(auto_materialize_policy=cond3.as_auto_materialize_policy(), deps=[c])
+    def d(): ...
+
+    result = evaluate_automation_conditions([a, b, c, d], instance=DagsterInstance.ephemeral())
+
+    # make sure a has all downstreams
+    a_result = _get_result(a.key, result.results)
+    assert len(a_result.child_results) == 2
+
+    # the first condition is a bit gnarly, but it should resolve to b: ((d: eager) & ~in_progress)
+    res1 = a_result.child_results[0]
+    assert res1.condition.description == "b"
+    res1_and = res1.child_results[0]
+    assert isinstance(res1_and.condition, AndAssetCondition)
+    res1_1 = res1_and.child_results[0].child_results[0]
+    assert res1_1.condition.description == "d"
+    assert res1_1.child_results[0].condition == cond3
+    res1_2 = res1_and.child_results[1]
+    assert res1_2.condition == ~AutomationCondition.in_progress()
+
+    # the second condition resolves to just (d: eager)
+    res2 = a_result.child_results[1]
+    assert res2.condition.description == "d"
+    assert res2.child_results[0].condition == cond3


### PR DESCRIPTION
## Summary & Motivation

This creates the "`lazy`" AutomationCondition. I have not fully decided on a name, but I felt like this was potentially more descriptive of what it's actually doing.

Handling the weird recursive cases is a bit tricky, hence the odd structure of the tests. Basically if you have:

A: any_downstream_conditions
B: any_downstream_conditions & foo
C: bar

, A->B->C, and you want to evaluate A, the naive approach would result in the following infinite loop behavior:

1. convert any_downstream_conditions to (any_downstream_conditions & foo, bar)
2. this expands to ((any_downstream_conditions & foo, bar) & foo, bar)
3. etc.

The way I avoid this is by not including a condition in the expansion if it's already part of the "call stack". So in this case, in step 2 we would just expand `any_downstream_conditions & foo` to ((bar) & foo), resulting in a full expression of:

(((bar) & foo), bar)

This is certainly a bit duplicative, but it at least feels somewhat logical and prevents the infinite recursion issue pretty nicely. Generally this is the sort of danger when you have a mix of regular `any_downstream_conditions and stuff that combines that with other filters. Not sure if we would even recommend that pattern, just trying to get ahead of the flat-out errors

## How I Tested These Changes
