### PR TITLE
[asset differ] add "asset removed" change reason

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -72,6 +72,7 @@ export const AssetNodeFragmentBasic: AssetNodeFragment = buildAssetNode({
     ChangeReason.PARTITIONS_DEFINITION,
     ChangeReason.TAGS,
     ChangeReason.METADATA,
+    ChangeReason.REMOVED,
   ],
 });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/ChangedReasons.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/ChangedReasons.tsx
@@ -45,10 +45,13 @@ export const ChangedReasonsPopover = ({
   assetKey: AssetKeyInput;
   children: React.ReactNode;
 }) => {
-  const modifiedChanges = changedReasons.filter((reason) => reason !== ChangeReason.NEW);
+  const modifiedChanges = changedReasons.filter(
+    (reason) => reason !== ChangeReason.NEW && reason !== ChangeReason.REMOVED,
+  );
   function getDescription(change: ChangeReason) {
     switch (change) {
       case ChangeReason.NEW:
+      case ChangeReason.REMOVED:
         return '';
       case ChangeReason.CODE_VERSION:
         return 'has a changed code version';

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -720,6 +720,7 @@ enum ChangeReason {
   PARTITIONS_DEFINITION
   TAGS
   METADATA
+  REMOVED
 }
 
 type AssetDependency {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -749,6 +749,7 @@ export enum ChangeReason {
   METADATA = 'METADATA',
   NEW = 'NEW',
   PARTITIONS_DEFINITION = 'PARTITIONS_DEFINITION',
+  REMOVED = 'REMOVED',
   TAGS = 'TAGS',
 }
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -18,6 +18,7 @@ class ChangeReason(Enum):
     PARTITIONS_DEFINITION = "PARTITIONS_DEFINITION"
     TAGS = "TAGS"
     METADATA = "METADATA"
+    REMOVED = "REMOVED"
 
 
 def _get_external_repo_from_context(
@@ -118,6 +119,9 @@ class AssetGraphDiffer:
 
         if asset_key not in self.base_asset_graph.all_asset_keys:
             return [ChangeReason.NEW]
+
+        if asset_key not in self.branch_asset_graph.all_asset_keys:
+            return [ChangeReason.REMOVED]
 
         branch_asset = self.branch_asset_graph.get(asset_key)
         base_asset = self.base_asset_graph.get(asset_key)

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/basic_asset_graph/branch_deployment_removed_asset.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/basic_asset_graph/branch_deployment_removed_asset.py
@@ -1,0 +1,9 @@
+from dagster import Definitions, asset
+
+
+@asset
+def upstream():
+    return 1
+
+
+defs = Definitions(assets=[upstream])

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -116,6 +116,20 @@ def test_new_asset(instance):
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
 
 
+def test_removed_asset(instance) -> None:
+    differ = get_asset_graph_differ(
+        instance=instance,
+        code_location_to_diff="basic_asset_graph",
+        base_code_locations=["basic_asset_graph"],
+        branch_code_location_to_definitions={
+            "basic_asset_graph": "branch_deployment_removed_asset"
+        },
+    )
+
+    assert differ.get_changes_for_asset(AssetKey("downstream")) == [ChangeReason.REMOVED]
+    assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
+
+
 def test_new_asset_connected(instance):
     differ = get_asset_graph_differ(
         instance=instance,


### PR DESCRIPTION
## Summary

Allows the asset graph differ to mark an asset as removed in the case that an asset is present in the base branch but not the comparison branch.

In the branch deploymenet case this is currently not used, but is helpful to make the asset differ useful in other use-cases (e.g. tracking change history on a prod branch).

## Test Plan

New unit test.
