### PR TITLE
Add idempotency-key header to graphql operations

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -45,12 +45,14 @@ import './blueprint.css';
 patchCopyToRemoveZeroWidthUnderscores();
 
 const idempotencyLink = new ApolloLink((operation, forward) => {
-  operation.setContext(({headers = {}}) => ({
-    headers: {
-      ...headers,
-      'Idempotency-Key': uuidv4(),
-    },
-  }));
+  if (/^\s*mutation/.test(operation.query.loc?.source.body ?? '')) {
+    operation.setContext(({headers = {}}) => ({
+      headers: {
+        ...headers,
+        'Idempotency-Key': uuidv4(),
+      },
+    }));
+  }
   return forward(operation);
 });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -48,7 +48,7 @@ const idempotencyLink = new ApolloLink((operation, forward) => {
   operation.setContext(({headers = {}}) => ({
     headers: {
       ...headers,
-      'idempotency-key': uuidv4(),
+      'Idempotency-Key': uuidv4(),
     },
   }));
   return forward(operation);
@@ -109,7 +109,7 @@ export const AppProvider = (props: AppProviderProps) => {
     return new RetryLink({
       attempts: {
         max: 2,
-        retryIf: (error, operation) => {
+        retryIf: (error, _operation) => {
           return error && error.statusCode && [502, 503, 504].includes(error.statusCode);
         },
       },

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppProvider.tsx
@@ -98,7 +98,12 @@ export const AppProvider = (props: AppProviderProps) => {
     return new RetryLink({
       attempts: {
         max: 2,
-        retryIf: (error, _operation) => {
+        retryIf: (error, operation) => {
+          debugger;
+          if (/^\s*mutation/.test(operation.query.loc?.source.body ?? '')) {
+            // Don't retry mutations
+            return false;
+          }
           return error && error.statusCode && [502, 503, 504].includes(error.statusCode);
         },
       },


### PR DESCRIPTION
## Summary & Motivation

Add an idempotency-key header to graphql operations. [[slack link for context](https://dagsterlabs.slack.com/archives/C03CCE471E0/p1720452388539319?thread_ts=1718990436.195549&cid=C03CCE471E0)]


## How I Tested These Changes

Made sure the original operation and the retry of the operation shared the same idempotency-key.


<img width="941" alt="Screenshot 2024-07-08 at 12 42 10 PM" src="https://github.com/dagster-io/dagster/assets/2286579/aef0933f-7c18-4f7f-8ee5-a264f5db72e3">
<img width="874" alt="Screenshot 2024-07-08 at 12 42 19 PM" src="https://github.com/dagster-io/dagster/assets/2286579/550c9a01-894d-4095-b2bc-9ece96786c29">
