### PR TITLE
avoid internal use of AssetsDefinition.asset_deps

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -982,7 +982,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         AssetsDefinition.
         """
         # the input asset keys that are directly upstream of a selected asset key
-        return {dep_key for key in self.keys for dep_key in self.asset_deps[key]}
+        return {dep.asset_key for key in self.keys for dep in self._specs_by_key[key].deps}
 
     @property
     def node_keys_by_output_name(self) -> Mapping[str, AssetKey]:
@@ -1033,7 +1033,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
     @property
     def keys_by_input_name(self) -> Mapping[str, AssetKey]:
         upstream_keys = {
-            *(dep_key for key in self.keys for dep_key in self.asset_deps[key]),
+            *(dep.asset_key for key in self.keys for dep in self._specs_by_key[key].deps),
             *(spec.asset_key for spec in self.check_specs if spec.asset_key not in self.keys),
         }
 

--- a/python_modules/dagster/dagster/_core/definitions/resolved_asset_deps.py
+++ b/python_modules/dagster/dagster/_core/definitions/resolved_asset_deps.py
@@ -27,10 +27,9 @@ class ResolvedAssetDependencies:
         self, assets_def: AssetsDefinition, asset_key: AssetKey
     ) -> AbstractSet[AssetKey]:
         resolved_keys_by_unresolved_key = self._deps_by_assets_def_id.get(id(assets_def), {})
-        unresolved_upstream_keys = assets_def.asset_deps[asset_key]
         return {
-            resolved_keys_by_unresolved_key.get(unresolved_key, unresolved_key)
-            for unresolved_key in unresolved_upstream_keys
+            resolved_keys_by_unresolved_key.get(unresolved_dep.asset_key, unresolved_dep.asset_key)
+            for unresolved_dep in assets_def.specs_by_key[asset_key].deps
         }
 
     def get_resolved_asset_key_for_input(

--- a/python_modules/dagster/dagster/_core/selector/subset_selector.py
+++ b/python_modules/dagster/dagster/_core/selector/subset_selector.py
@@ -122,9 +122,9 @@ def generate_asset_dep_graph(
             upstream[asset_key] = set()
             downstream[asset_key] = downstream.get(asset_key, set())
             # for each asset upstream of this one, set that as upstream, and this downstream of it
-            for upstream_key in assets_def.asset_deps[asset_key]:
-                upstream[asset_key].add(upstream_key)
-                downstream[upstream_key] = downstream.get(upstream_key, set()) | {asset_key}
+            for dep in assets_def.specs_by_key[asset_key].deps:
+                upstream[asset_key].add(dep.asset_key)
+                downstream[dep.asset_key] = downstream.get(dep.asset_key, set()) | {asset_key}
     return {"upstream": upstream, "downstream": downstream}
 
 


### PR DESCRIPTION
## Summary & Motivation

Now that specs are the source of truth on an `AssetsDefinition`'s dependencies, the `asset_deps` property is a derived property that's O(N) to compute, instead of its previous constant time.

This is a source of performance regressions: https://github.com/dagster-io/dagster/issues/22709.

This PR avoids using this property in favor of directly getting dependencies from the asset specs, which is a constant time operation.

## How I Tested These Changes
