### PR TITLE
[docs] - Clean up dagster-plus/dagster-cloud rename (DOC-272)

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -733,7 +733,7 @@
         ]
       },
       {
-        "title": "dagster-plus CLI",
+        "title": "dagster-cloud CLI",
         "path": "/dagster-plus/managing-deployments/dagster-plus-cli"
       },
       {

--- a/docs/content/dagster-plus/managing-deployments/alerts.mdx
+++ b/docs/content/dagster-plus/managing-deployments/alerts.mdx
@@ -191,7 +191,7 @@ Managing alert policies can be accomplished by using:
     href="/dagster-plus/managing-deployments/alerts/managing-alerts-in-ui"
   ></ArticleListItem>
   <ArticleListItem
-    title="Managing alerts using the dagster-plus CLI"
+    title="Managing alerts using the dagster-cloud CLI"
     href="/dagster-plus/managing-deployments/alerts/managing-alerts-cli"
   ></ArticleListItem>
   <ArticleListItem

--- a/docs/content/dagster-plus/managing-deployments/setting-environment-variables-agents.mdx
+++ b/docs/content/dagster-plus/managing-deployments/setting-environment-variables-agents.mdx
@@ -160,7 +160,7 @@ To make environment variables accessible to a full deployment with an Amazon ECS
        env_vars:
          - SNOWFLAKE_USERNAME=dev
          - SNOWFLAKE_PASSWORD       ## pulled from agent environment
-   ' > $DAGSTER_HOME/dagster.yaml && cat $DAGSTER_HOME/dagster.yaml && dagster-plus agent run"
+   ' > $DAGSTER_HOME/dagster.yaml && cat $DAGSTER_HOME/dagster.yaml && dagster-cloud agent run"
    ```
 
 8. When finished, click the **Create Stack** button:


### PR DESCRIPTION
## Summary & Motivation

This PR cleans up a few mentions of `dagster-plus` in the docs where it should be `dagster-cloud`, which came about as a result of stepping back from the product rename. **Note**: I'm opting not to rename URLs, as this will introduce more redirects and link updates that could break things.

## How I Tested These Changes
