### PR TITLE
make AssetsDefinition.asset_deps a cached_property

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -918,7 +918,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
         return check.not_none(self._computation, "This AssetsDefinition has no node_def").node_def
 
     @public
-    @property
+    @cached_property
     def asset_deps(self) -> Mapping[AssetKey, AbstractSet[AssetKey]]:
         """Maps assets that are produced by this definition to assets that they depend on. The
         dependencies can be either "internal", meaning that they refer to other assets that are


### PR DESCRIPTION
## Summary & Motivation

Now that specs are the source of truth on an AssetsDefinition's dependencies, the asset_deps property is a derived property that's O(N) to compute, instead of its previous constant time.

This is a source of performance regressions: https://github.com/dagster-io/dagster/issues/22709.

While https://github.com/dagster-io/dagster/pull/22874 moves away from using it internally, users could still be expecting constant time behavior.

More background here: https://github.com/dagster-io/dagster/pull/22874#pullrequestreview-2163916957

## How I Tested These Changes
