### PR TITLE
Remove setCurrentPage call in `useTrackPageView`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/CloudOSSContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/CloudOSSContext.tsx
@@ -14,7 +14,6 @@ type FeatureContext = {
 export const CloudOSSContext = React.createContext<{
   isBranchDeployment: boolean;
   featureContext: FeatureContext;
-  onViewChange: (view: {path: string}) => void;
   useAugmentSearchResults: () => (results: SearchResult[]) => SearchResult[];
 }>({
   isBranchDeployment: false,
@@ -26,6 +25,5 @@ export const CloudOSSContext = React.createContext<{
     canSeeExecuteChecksAction: true,
     canSeeBackfillCoordinatorLogs: false,
   },
-  onViewChange: () => {},
   useAugmentSearchResults: () => (results) => results,
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/app/analytics.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/analytics.tsx
@@ -1,9 +1,6 @@
 import {createContext, useCallback, useContext, useLayoutEffect} from 'react';
 import {useLocation, useRouteMatch} from 'react-router-dom';
-import {atom, useRecoilValue, useSetRecoilState} from 'recoil';
-
-import {CloudOSSContext} from './CloudOSSContext';
-import {useDangerousRenderEffect} from '../hooks/useDangerousRenderEffect';
+import {atom, useRecoilValue} from 'recoil';
 
 export const currentPageAtom = atom<{path: string; specificPath: string}>({
   key: 'currentPageAtom',
@@ -62,27 +59,16 @@ export const useTrackPageView = () => {
   const {pathname: specificPath} = useLocation();
   const {path} = match;
 
-  const setCurrentPage = useSetRecoilState(currentPageAtom);
-
   useLayoutEffect(() => {
     // Wait briefly to allow redirects.
     const timer = setTimeout(() => {
       analytics.page(path, specificPath);
     }, PAGEVIEW_DELAY);
-    setCurrentPage({path, specificPath});
 
     return () => {
       clearTimeout(timer);
     };
-  }, [analytics, path, setCurrentPage, specificPath]);
-
-  const {onViewChange} = useContext(CloudOSSContext);
-
-  useDangerousRenderEffect(() => {
-    // Update Cloud synchronously that the view is changing in order to
-    // better capture the dependencies of the view
-    onViewChange({path});
-  }, [path]);
+  }, [analytics, path, specificPath]);
 };
 
 export const useTrackEvent = () => {


### PR DESCRIPTION
## Summary & Motivation

We don't rely on useTrackPageView setting the current page anymore since we landed https://github.com/dagster-io/dagster/pull/21720 so lets remove the call here.

This fixes an issue where useTrackPageView ends up overriding the route set by our wrapped Route components.

## How I Tested These Changes
Recorded a correct initial_load trace for an asset view route.

<img width="1036" alt="Screenshot 2024-07-08 at 4 51 27 PM" src="https://github.com/dagster-io/dagster/assets/2286579/f21fe9e1-04ec-4029-9294-ef1757d72676">
