### PR TITLE
[DA-Internals][2/n] AssetsDefinition updates

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_checks.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_checks.py
@@ -41,7 +41,6 @@ class AssetChecksDefinition(AssetsDefinition):
             metadata_by_key=None,
             tags_by_key=None,
             freshness_policies_by_key=None,
-            auto_materialize_policies_by_key=None,
             backfill_policy=None,
             descriptions_by_key=None,
             check_specs_by_output_name=check_specs_by_output_name,


### PR DESCRIPTION
## Summary & Motivation

As title. Here, we immediately convert input AutoMaterializePolicy objects to AutomationConditions.

## How I Tested These Changes
