### PR TITLE
[dagster-aws] :sparkles: add Dagster Pipes integration for AWS Glue

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-aws.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-aws.rst
@@ -100,6 +100,8 @@ Pipes
 
 .. autoclass:: dagster_aws.pipes.PipesLambdaClient
 
+.. autoclass:: dagster_aws.pipes.PipesGlueClient
+
 Legacy
 --------
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/glue/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/glue/dagster_code.py
@@ -10,9 +10,9 @@ from dagster import AssetExecutionContext, Definitions, asset
 
 @asset
 def glue_pipes_asset(
-    context: AssetExecutionContext, glue_pipes_client: PipesGlueClient
+    context: AssetExecutionContext, pipes_glue_client: PipesGlueClient
 ):
-    return glue_pipes_client.run(
+    return pipes_glue_client.run(
         context=context,
         job_name="Example Job",
         arguments={"some_parameter_value": "1"},
@@ -28,7 +28,7 @@ def glue_pipes_asset(
 defs = Definitions(
     assets=[glue_pipes_asset],
     resources={
-        "glue_pipes_client": PipesGlueClient(
+        "pipes_glue_client": PipesGlueClient(
             context_injector=PipesGlueContextInjector(
                 bucket=os.environ["DAGSTER_GLUE_S3_CONTEXT_BUCKET"],
                 client=boto3.client("s3"),

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/glue/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/glue/dagster_code.py
@@ -1,0 +1,40 @@
+# start_asset_marker
+import os
+
+# dagster_lambda_pipes.py
+import boto3
+from dagster_aws.pipes import PipesGlueClient, PipesS3ContextInjector
+
+from dagster import AssetExecutionContext, Definitions, asset
+
+
+@asset
+def glue_pipes_asset(
+    context: AssetExecutionContext, glue_pipes_client: PipesGlueClient
+):
+    return glue_pipes_client.run(
+        context=context,
+        job_name="Example Job",
+        arguments={"some_parameter_value": "1"},
+    ).get_materialize_result()
+
+
+# end_asset_marker
+
+# start_definitions_marker
+
+# dagster_lambda_pipes.py
+
+defs = Definitions(
+    assets=[glue_pipes_asset],
+    resources={
+        "glue_pipes_client": PipesGlueClient(
+            context_injector=PipesS3ContextInjector(
+                bucket=os.environ["DAGSTER_GLUE_S3_CONTEXT_BUCKET"],
+                client=boto3.client("s3"),
+            ),
+            client=boto3.client("glue"),
+        )
+    },
+)
+# end_definitions_marker

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/glue/dagster_code.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/glue/dagster_code.py
@@ -1,9 +1,9 @@
 # start_asset_marker
 import os
 
-# dagster_lambda_pipes.py
+# dagster_glue_pipes.py
 import boto3
-from dagster_aws.pipes import PipesGlueClient, PipesS3ContextInjector
+from dagster_aws.pipes import PipesGlueClient, PipesGlueContextInjector
 
 from dagster import AssetExecutionContext, Definitions, asset
 
@@ -23,13 +23,13 @@ def glue_pipes_asset(
 
 # start_definitions_marker
 
-# dagster_lambda_pipes.py
+# dagster_glue_pipes.py
 
 defs = Definitions(
     assets=[glue_pipes_asset],
     resources={
         "glue_pipes_client": PipesGlueClient(
-            context_injector=PipesS3ContextInjector(
+            context_injector=PipesGlueContextInjector(
                 bucket=os.environ["DAGSTER_GLUE_S3_CONTEXT_BUCKET"],
                 client=boto3.client("s3"),
             ),

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/glue/glue_script.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/glue/glue_script.py
@@ -1,0 +1,18 @@
+import boto3
+from dagster_pipes import (
+    PipesCliArgsParamsLoader,
+    PipesS3ContextLoader,
+    open_dagster_pipes,
+)
+
+
+def main():
+    with open_dagster_pipes(
+        params_loader=PipesCliArgsParamsLoader(),
+        context_loader=PipesS3ContextLoader(client=boto3.client("s3")),
+    ) as pipes:
+        pipes.log.info("Hello from external process!")
+
+
+if __name__ == "__main__":
+    main()

--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -364,7 +364,7 @@ def _normalize_param_metadata(
     return new_metadata
 
 
-def encode_env_var(value: Any) -> str:
+def encode_param(value: Any) -> str:
     """Encode value by serializing to JSON, compressing with zlib, and finally encoding with base64.
     `base64_encode(compress(to_json(value)))` in function notation.
 
@@ -374,13 +374,13 @@ def encode_env_var(value: Any) -> str:
     Returns:
         str: The encoded value.
     """
-    serialized = _json_serialize_param(value, "encode_env_var", "value")
+    serialized = _json_serialize_param(value, "encode_param", "value")
     compressed = zlib.compress(serialized.encode("utf-8"))
     encoded = base64.b64encode(compressed)
     return encoded.decode("utf-8")  # as string
 
 
-def decode_env_var(value: str) -> Any:
+def decode_param(value: str) -> Any:
     """Decode a value by decoding from base64, decompressing with zlib, and finally deserializing from
     JSON. `from_json(decompress(base64_decode(value)))` in function notation.
 
@@ -395,10 +395,9 @@ def decode_env_var(value: str) -> Any:
     return json.loads(decompressed.decode("utf-8"))
 
 
-# make new names for the encode/decode functions that are more descriptive of their purpose
-# and for future-proofing
-encode_cli_argument = encode_env_var
-decode_cli_argument = decode_env_var
+# these aliases are deprecated and will be removed in 2.0
+encode_env_var = encode_param
+decode_env_var = decode_param
 
 
 def _emit_orchestration_inactive_warning() -> None:
@@ -783,11 +782,11 @@ class PipesMappingParamsLoader(PipesParamsLoader):
 
     def load_context_params(self) -> PipesParams:
         raw_value = self._mapping[DAGSTER_PIPES_CONTEXT_ENV_VAR]
-        return decode_env_var(raw_value)
+        return decode_param(raw_value)
 
     def load_messages_params(self) -> PipesParams:
         raw_value = self._mapping[DAGSTER_PIPES_MESSAGES_ENV_VAR]
-        return decode_env_var(raw_value)
+        return decode_param(raw_value)
 
 
 class PipesEnvVarParamsLoader(PipesMappingParamsLoader):
@@ -797,19 +796,23 @@ class PipesEnvVarParamsLoader(PipesMappingParamsLoader):
         super().__init__(mapping=os.environ)
 
 
-DAGSTER_PIPES_CONTEXT_CLI_ARGUMENT = "--dagster-pipes-context"
-DAGSTER_PIPES_MESSAGES_CLI_ARGUMENT = "--dagster-pipes-messages"
+def env_var_to_cli_argument(env_var: str) -> str:
+    return f"--{env_var}".lower().replace("_", "-")
+
+
+DAGSTER_PIPES_CONTEXT_CLI_ARGUMENT = env_var_to_cli_argument(DAGSTER_PIPES_CONTEXT_ENV_VAR)
+DAGSTER_PIPES_MESSAGES_CLI_ARGUMENT = env_var_to_cli_argument(DAGSTER_PIPES_MESSAGES_ENV_VAR)
 
 DAGSTER_PIPES_CLI_PARSER = argparse.ArgumentParser(description="Dagster Pipes CLI interface")
 DAGSTER_PIPES_CLI_PARSER.add_argument(
     DAGSTER_PIPES_CONTEXT_CLI_ARGUMENT,
     type=str,
-    help="Argument with base64 encoded JSON string containing the Pipes context",
+    help="Argument with base64 encoded and zlib-compressed JSON string containing the Pipes context",
 )
 DAGSTER_PIPES_CLI_PARSER.add_argument(
     DAGSTER_PIPES_MESSAGES_CLI_ARGUMENT,
     type=str,
-    help="Argument with base64 encoded JSON string containing the Pipes messages",
+    help="Argument with base64 encoded and zlib-compressed JSON string containing the Pipes messages",
 )
 
 
@@ -825,11 +828,11 @@ class PipesCliArgsParamsLoader(PipesParamsLoader):
 
     def load_context_params(self) -> PipesParams:
         args, _ = self.parser.parse_known_args()
-        return decode_cli_argument(args.dagster_pipes_context)
+        return decode_param(args.dagster_pipes_context)
 
     def load_messages_params(self) -> PipesParams:
         args, _ = self.parser.parse_known_args()
-        return decode_cli_argument(args.dagster_pipes_messages)
+        return decode_param(args.dagster_pipes_messages)
 
 
 # ########################

--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -814,7 +814,7 @@ DAGSTER_PIPES_CLI_PARSER.add_argument(
 
 
 class PipesCliArgsParamsLoader(PipesParamsLoader):
-    """Params loader that extracts params from a given CLI argument value."""
+    """Params loader that extracts params from known CLI arguments."""
 
     def __init__(self):
         self.parser = DAGSTER_PIPES_CLI_PARSER

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -4,7 +4,9 @@ from queue import Queue
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Mapping, Optional, Sequence, Union, cast
 
 from dagster_pipes import (
+    DAGSTER_PIPES_CONTEXT_CLI_ARGUMENT,
     DAGSTER_PIPES_CONTEXT_ENV_VAR,
+    DAGSTER_PIPES_MESSAGES_CLI_ARGUMENT,
     DAGSTER_PIPES_MESSAGES_ENV_VAR,
     PIPES_METADATA_TYPE_INFER,
     Method,
@@ -18,6 +20,7 @@ from dagster_pipes import (
     PipesOpenedData,
     PipesParams,
     PipesTimeWindow,
+    encode_cli_argument,
     encode_env_var,
 )
 from typing_extensions import TypeAlias
@@ -290,6 +293,22 @@ class PipesSession:
         return {
             param_name: encode_env_var(param_value)
             for param_name, param_value in self.get_bootstrap_params().items()
+        }
+
+    @public
+    def get_bootstrap_cli_arguments(self) -> Dict[str, str]:
+        """Encode context injector and message reader params as CLI arguments.
+
+        Passing CLI arguments is an alternative way to expose the pipes I/O parameters to a pipes process.
+        Using environment variables should be preferred when possible.
+
+        Returns:
+            Mapping[str, str]: CLI arguments pass to the external process. The values are
+            serialized as json, compressed with gzip, and then base-64-encoded.
+        """
+        return {
+            DAGSTER_PIPES_CONTEXT_CLI_ARGUMENT: encode_cli_argument(self.context_injector_params),
+            DAGSTER_PIPES_MESSAGES_CLI_ARGUMENT: encode_cli_argument(self.message_reader_params),
         }
 
     @public

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
@@ -286,7 +286,7 @@ class PipesGlueClient(PipesClient, TreatAsResourceParam):
     Args:
         client (boto3.client): The boto Glue client used to call invoke.
         context_injector (Optional[PipesContextInjector]): A context injector to use to inject
-            context into the Glue job. Defaults to :py:class:`PipesGlueContextInjector`.
+            context into the Glue job, for example, :py:class:`PipesGlueContextInjector`.
         message_reader (Optional[PipesMessageReader]): A message reader to use to read messages
             from the glue job run. Defaults to :py:class:`PipesGlueLogsMessageReader`.
     """
@@ -294,7 +294,7 @@ class PipesGlueClient(PipesClient, TreatAsResourceParam):
     def __init__(
         self,
         client: boto3.client,
-        context_injector: PipesS3ContextInjector,
+        context_injector: PipesContextInjector,
         message_reader: Optional[PipesMessageReader] = None,
     ):
         self._client = client
@@ -310,6 +310,7 @@ class PipesGlueClient(PipesClient, TreatAsResourceParam):
         *,
         job_name: str,
         context: OpExecutionContext,
+        extras: Optional[Dict[str, Any]] = None,
         arguments: Optional[Mapping[str, Any]] = None,
         job_run_id: Optional[str] = None,
         allocated_capacity: Optional[int] = None,
@@ -328,6 +329,7 @@ class PipesGlueClient(PipesClient, TreatAsResourceParam):
         Args:
             job_name (str): The name of the job to use.
             context (OpExecutionContext): The context of the currently executing Dagster op or asset.
+            extras (Optional[Dict[str, Any]]): Additional Dagster metadata to pass to the Glue job.
             arguments (Optional[Dict[str, str]]): Arguments to pass to the Glue job Command
             job_run_id (Optional[str]): The ID of the previous job run to retry.
             allocated_capacity (Optional[int]): The amount of DPUs (Glue data processing units) to allocate to this job.
@@ -343,6 +345,7 @@ class PipesGlueClient(PipesClient, TreatAsResourceParam):
             context=context,
             message_reader=self._message_reader,
             context_injector=self._context_injector,
+            extras=extras,
         ) as session:
             arguments = arguments or {}
             assert arguments is not None

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
@@ -5,7 +5,7 @@ import random
 import string
 import time
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Iterator, Literal, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Literal, Mapping, Optional, Sequence
 
 import boto3
 import dagster._check as check
@@ -159,6 +159,31 @@ class PipesLambdaLogsMessageReader(PipesMessageReader):
 
 
 @experimental
+class PipesCloudWatchMessageReader(PipesMessageReader):
+    """Message reader that consumes AWS CloudWatch logs to read pipes messages."""
+
+    @contextmanager
+    def read_messages(
+        self,
+        handler: PipesMessageHandler,
+    ) -> Iterator[PipesParams]:
+        self._handler = handler
+        try:
+            # use buffered stdio to shift the pipes messages to the tail of logs
+            yield {PipesDefaultMessageWriter.BUFFERED_STDIO_KEY: PipesDefaultMessageWriter.STDERR}
+        finally:
+            self._handler = None
+
+    def consume_cloudwatch_logs(
+        self, client: boto3.client, log_group: str, log_stream: str
+    ) -> None:
+        raise NotImplementedError("CloudWatch logs are not yet supported in the pipes protocol.")
+
+    def no_messages_debug_text(self) -> str:
+        return "Attempted to read messages by extracting them from the tail of CloudWatch logs directly."
+
+
+@experimental
 class PipesLambdaEventContextInjector(PipesEnvContextInjector):
     def no_messages_debug_text(self) -> str:
         return "Attempted to inject context via the lambda event input."
@@ -244,38 +269,12 @@ class PipesLambdaClient(PipesClient, TreatAsResourceParam):
         return PipesClientCompletedInvocation(session)
 
 
-@experimental
-class PipesCloudWatchMessageReader(PipesMessageReader):
-    """Message reader that consumes buffered pipes messages that were flushed on exit from the
-    final 4k of logs that are returned from issuing a sync lambda invocation. This means messages
-    emitted during the computation will only be processed once the lambda completes.
+class PipesGlueContextInjector(PipesS3ContextInjector):
+    def no_messages_debug_text(self) -> str:
+        return "Attempted to inject context via Glue job arguments."
 
-    Limitations: If the volume of pipes messages exceeds 4k, messages will be lost and it is
-    recommended to switch to PipesS3MessageWriter & PipesS3MessageReader.
-    """
 
-    @contextmanager
-    def read_messages(
-        self,
-        handler: PipesMessageHandler,
-    ) -> Iterator[PipesParams]:
-        self._handler = handler
-        try:
-            # use buffered stdio to shift the pipes messages to the tail of logs
-            yield {PipesDefaultMessageWriter.BUFFERED_STDIO_KEY: PipesDefaultMessageWriter.STDERR}
-        finally:
-            self._handler = None
-
-    def consume_cloudwatch_logs(self, response) -> None:
-        handler = check.not_none(
-            self._handler, "Can only consume logs within context manager scope."
-        )
-
-        log_events = response["events"]
-
-        for log_event in log_events:
-            extract_message_or_forward_to_stdout(handler, log_event["message"])
-
+class PipesGlueLogsMessageReader(PipesCloudWatchMessageReader):
     def no_messages_debug_text(self) -> str:
         return "Attempted to read messages by extracting them from the tail of CloudWatch logs directly."
 
@@ -312,17 +311,15 @@ class PipesGlueClient(PipesClient, TreatAsResourceParam):
         job_name: str,
         context: OpExecutionContext,
         arguments: Optional[Mapping[str, Any]] = None,
-        # job_run_id: Optional[str] = None,
-        # allocated_capacity: Optional[int] = None,
-        # timeout: Optional[int] = None,
-        # max_capacity: Optional[float] = None,
-        # security_configuration: Optional[str] = None,
-        # notification_property: Optional[Mapping[str, Any]] = None,
-        # worker_type: Optional[
-        #     Literal["Standard", "G.1X", "G.2X", "G.025X", "G.4X", "G.8X", "Z.2X"]
-        # ] = None,
-        # number_of_workers: Optional[int] = None,
-        # execution_class: Optional[Literal["FLEX", "STANDARD"]] = None,
+        job_run_id: Optional[str] = None,
+        allocated_capacity: Optional[int] = None,
+        timeout: Optional[int] = None,
+        max_capacity: Optional[float] = None,
+        security_configuration: Optional[str] = None,
+        notification_property: Optional[Mapping[str, Any]] = None,
+        worker_type: Optional[str] = None,
+        number_of_workers: Optional[int] = None,
+        execution_class: Optional[Literal["FLEX", "STANDARD"]] = None,
     ):
         """Start a Glue job, enriched with the pipes protocol.
 
@@ -331,14 +328,14 @@ class PipesGlueClient(PipesClient, TreatAsResourceParam):
         Args:
             job_name (str): The name of the job to use.
             context (OpExecutionContext): The context of the currently executing Dagster op or asset.
-            arguments (Optional[Dict[str, Any]]): A JSON-serializable arguments to pass to the Glue job Command
+            arguments (Optional[Dict[str, str]]): Arguments to pass to the Glue job Command
             job_run_id (Optional[str]): The ID of the previous job run to retry.
-            allocated_capacity (Optional[int]): The number of Glue data processing units (DPUs) to allocate to this job.
+            allocated_capacity (Optional[int]): The amount of DPUs (Glue data processing units) to allocate to this job.
             timeout (Optional[int]): The job run timeout in minutes.
-            max_capacity (Optional[float]): The maximum capacity for the Glue job.
+            max_capacity (Optional[float]): The maximum capacity for the Glue job in DPUs (Glue data processing units).
             security_configuration (Optional[str]): The name of the Security Configuration to be used with this job run.
             notification_property (Optional[Mapping[str, Any]]): Specifies configuration properties of a job run notification.
-            worker_type (Optional[Literal["Standard", "G.1X", "G.2X", "G.025X", "G.4X", "G.8X", "Z.2X"]]): The type of predefined worker that is allocated when a job runs.
+            worker_type (Optional[str]): The type of predefined worker that is allocated when a job runs.
             number_of_workers (Optional[int]): The number of workers that are allocated when a job runs.
             execution_class (Optional[Literal["FLEX", "STANDARD"]]): The execution property of a job run.
         """
@@ -356,25 +353,33 @@ class PipesGlueClient(PipesClient, TreatAsResourceParam):
                 arguments.update(pipes_args)
 
             try:
-                response = self._client.start_job_run(
-                    JobName=job_name,
-                    Arguments=arguments,
-                    # JobRunId=job_run_id,
-                    # AllocatedCapacity=allocated_capacity,
-                    # Timeout=timeout,
-                    # MaxCapacity=max_capacity,
-                    # SecurityConfiguration=security_configuration,
-                    # NotificationProperty=notification_property,
-                    # WorkerType=worker_type,
-                    # NumberOfWorkers=number_of_workers,
-                    # ExecutionClass=execution_class,
-                )
+                params = {
+                    "JobName": job_name,
+                    "Arguments": arguments,
+                    "JobRunId": job_run_id,
+                    "AllocatedCapacity": allocated_capacity,
+                    "Timeout": timeout,
+                    "MaxCapacity": max_capacity,
+                    "SecurityConfiguration": security_configuration,
+                    "NotificationProperty": notification_property,
+                    "WorkerType": worker_type,
+                    "NumberOfWorkers": number_of_workers,
+                    "ExecutionClass": execution_class,
+                }
+
+                # boto3 does not accept None as defaults for some of the parameters
+                # so we need to filter them out
+                params = {k: v for k, v in params.items() if v is not None}
+
+                response = self._client.start_job_run(**params)
                 run_id = response["JobRunId"]
                 context.log.info(f"Started AWS Glue job {job_name} run: {run_id}")
-                status = self._wait_for_job_run_completion(job_name, run_id)
+                response = self._wait_for_job_run_completion(job_name, run_id)
 
-                if status == "FAILED":
-                    raise RuntimeError(f"Glue job {job_name} run {run_id} failed")
+                if response["JobRun"]["JobRunState"] == "FAILED":
+                    raise RuntimeError(
+                        f"Glue job {job_name} run {run_id} failed:\n{response['JobRun']['ErrorMessage']}"
+                    )
                 else:
                     context.log.info(f"Glue job {job_name} run {run_id} completed successfully")
 
@@ -387,56 +392,16 @@ class PipesGlueClient(PipesClient, TreatAsResourceParam):
                 )
                 raise
 
-        # TODO: get logs from CloudWatch
+        # TODO: get logs from CloudWatch. there are 2 separate streams for stdout and driver stderr to read from
+        # the log group can be found in the response from start_job_run, and the log stream is the job run id
+        # worker logs have log streams like: <job_id>_<worker_id> but we probably don't need to read those
 
         # should probably have a way to return the lambda result payload
         return PipesClientCompletedInvocation(session)
 
-    def _inject_pipes_env_vars(
-        self,
-        arguments: Mapping[str, Any],
-        env_vars: Mapping[str, str],
-        job_type: Literal["spark", "ray"],
-    ) -> Mapping[str, Any]:
-        # this function is not used, it demonstrates how to inject environment variables into Glue job arguments
-        # and how complex this process is
-        if job_type == "spark":
-            # https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-glue-arguments.html#job-parameter-reference
-
-            # string like CUSTOMER_KEY1=value1,CUSTOMER_KEY2=value2
-            formatted_env_string = self._format_environment_variables_for_spark(env_vars)
-
-            # these might already be set by the user, so we need to append to them
-            customer_driver_env_vars = arguments.get("--customer-driver-env-vars") or ""
-            if customer_driver_env_vars:
-                customer_driver_env_vars += ","
-            arguments["--customer-driver-env-vars"] = (
-                customer_driver_env_vars + formatted_env_string
-            )
-
-            # repeat with --customer-executor-env-vars
-            customer_executor_env_vars = arguments.get("--customer-executor-env-vars") or ""
-            if customer_executor_env_vars:
-                customer_executor_env_vars += ","
-            arguments["--customer-executor-env-vars"] = (
-                customer_executor_env_vars + formatted_env_string
-            )
-
-        elif job_type == "ray":
-            # https://docs.aws.amazon.com/glue/latest/dg/author-job-ray-job-parameters.html
-            arguments.update({f"--{k}": v for k, v in env_vars.items()})
-
-    def _format_environment_variables_for_spark(self, env_vars: Mapping[str, str]) -> str:
-        return ",".join([f'CUSTOMER_{k}="{v}"' for k, v in env_vars.items()])
-
-    def _wait_for_job_run_completion(
-        self, job_name: str, run_id: str
-    ) -> Literal["FAILED", "SUCCEEDED"]:
-        # this function is not used, it demonstrates how to poll the status of a Glue job run
-        # until it reaches a desired status
+    def _wait_for_job_run_completion(self, job_name: str, run_id: str) -> Dict[str, Any]:
         while True:
             response = self._client.get_job_run(JobName=job_name, RunId=run_id)
-            status = response["JobRun"]["JobRunState"]
-            if status in ["FAILED", "SUCCEEDED"]:
-                return status
+            if response["JobRun"]["JobRunState"] in ["FAILED", "SUCCEEDED"]:
+                return response
             time.sleep(5)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/fake_glue.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/fake_glue.py
@@ -44,6 +44,8 @@ class LocalGlueMockClient:
             result = subprocess.run(
                 [sys.executable, f.name, *args],
                 check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
             )
 
         # mock the job run with moto

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/fake_glue.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/fake_glue.py
@@ -1,0 +1,62 @@
+import subprocess
+import sys
+import tempfile
+from typing import Dict, Optional
+
+import boto3
+
+
+class LocalGlueMockClient:
+    def __init__(self, s3_client: boto3.client, glue_client: boto3.client):
+        """This class wraps moto3 clients for S3 and Glue, and provides a way to "run" Glue jobs locally.
+        This is necessary because moto3 does not actually run anything when you start a Glue job, so we won't be able
+        to receive any Dagster messages from it.
+        """
+        self.s3_client = s3_client
+        self.glue_client = glue_client
+
+    def get_job_run(self, *args, **kwargs):
+        return self.glue_client.get_job_run(*args, **kwargs)
+
+    def start_job_run(self, JobName: str, Arguments: Optional[Dict[str, str]], *args, **kwargs):
+        params = {
+            "JobName": JobName,
+        }
+
+        if Arguments:
+            params["Arguments"] = Arguments
+
+        script_s3_path = self.glue_client.get_job(JobName=JobName)["Job"]["Command"][
+            "ScriptLocation"
+        ]
+        bucket = script_s3_path.split("/")[2]
+        key = "/".join(script_s3_path.split("/")[3:])
+
+        # load the script and execute it locally
+        with tempfile.NamedTemporaryFile() as f:
+            self.s3_client.download_file(bucket, key, f.name)
+
+            args = []
+            for key, val in (Arguments or {}).items():
+                args.append(key)
+                args.append(val)
+
+            result = subprocess.run(
+                [sys.executable, f.name, *args],
+                check=False,
+            )
+
+        # mock the job run with moto
+        response = self.glue_client.start_job_run(**params)
+
+        # replace run state with actual results
+        response["JobRun"] = {}
+
+        response["JobRun"]["JobRunState"] = "SUCCEEDED" if result.returncode == 0 else "FAILED"
+
+        # add error message if failed
+        if result.returncode != 0:
+            # this actually has to be just the Python exception, but this is good enough for now
+            response["JobRun"]["ErrorMessage"] = result.stderr
+
+        return response

--- a/python_modules/libraries/dagster-aws/setup.py
+++ b/python_modules/libraries/dagster-aws/setup.py
@@ -46,7 +46,7 @@ setup(
         "pyspark": ["dagster-pyspark"],
         "test": [
             "botocore!=1.32.1",
-            "moto[s3,server]>=2.2.8,<5.0",
+            "moto[s3,server,glue]>=2.2.8,<5.0",
             "requests-mock",
             "xmltodict==0.12.0",  # pinned until moto>=3.1.9 (https://github.com/spulec/moto/issues/5112)
         ],


### PR DESCRIPTION
## Summary & Motivation

This PR does 2 things (probably should be split into 2 PRs?): 
- it adds a new `PipesCliArgsParamsLoader` to `dagster_pipes`
- it adds a new `PipesGlueClient` to `dagster_aws.pipes`

A `PipesCliArgsParamsLoader` is required because AWS Glue doesn't have a straightforward way to set environment variables for a job run. 

For example, it's only possible to set `CUSTOMER_*` environment variables for [Spark jobs](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-glue-arguments.html#job-parameter-reference), but Ray jobs can accept any environment variables. The standard `EnvParamsLoader` won't work with variables starting with `CUSTOMER_` out of the box. 

Also, because AWS Glue only really has one `Arguments` parameter with is used for both env and CLI, all runtime parameters will still end up present in both environment and `sys.argv`. Because of this, it's easier to consume them directly from `sys.argv` and not to worry about the `CUSTOMER_` prefix. 

The `PipesCliArgsParamsLoader` could be reused for other Pipes consumers with similar constraints. 

Components: 
- [x] add `PipesCliArgsParamsLoader`
- [x] run AWS Glue jobs from Dagster
- [x] CliArgsParamsLoader works on the process side
- [x] add tests with `moto`

## How I Tested These Changes
Added a test which mocks AWS Glue job execution by running it locally  

fyi @cmpadden 

---

sorry for the random commits being included, sorting this out