### PR TITLE
Use Process.terminate instead of a multiprocessing Event in the multiprocess executor

### DIFF
--- a/python_modules/dagster/dagster/_core/executor/child_process_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/child_process_executor.py
@@ -6,6 +6,7 @@ import sys
 from abc import ABC, abstractmethod
 from multiprocessing import Queue
 from multiprocessing.context import BaseContext as MultiprocessingBaseContext
+from multiprocessing.process import BaseProcess
 from typing import TYPE_CHECKING, Iterator, NamedTuple, Optional, Union
 
 from typing_extensions import Literal
@@ -119,7 +120,7 @@ def _poll_for_event(
 
 def execute_child_process_command(
     multiprocessing_ctx: MultiprocessingBaseContext, command: ChildProcessCommand
-) -> Iterator[Optional["DagsterEvent"]]:
+) -> Iterator[Optional[Union["DagsterEvent", ChildProcessEvent, BaseProcess]]]:
     """Execute a ChildProcessCommand in a new process.
 
     This function starts a new process whose execution target is a ChildProcessCommand wrapped by
@@ -130,12 +131,9 @@ def execute_child_process_command(
     executions in flight:
         * None - nothing has happened, yielded to enable cooperative multitasking other iterators
 
-        * ChildProcessEvent - Family of objects that communicates state changes in the child process
+        * multiprocessing.BaseProcess - the child process object.
 
-        * KeyboardInterrupt - Yielded in the case that an interrupt was recieved while
-            polling the child process. Yielded instead of raised to allow forwarding of the
-            interrupt to the child and completion of the iterator for this child and
-            any others that may be executing
+        * ChildProcessEvent - Family of objects that communicates state changes in the child process
 
         * The actual values yielded by the child process command
 
@@ -154,6 +152,7 @@ def execute_child_process_command(
             target=_execute_command_in_child_process, args=(event_queue, command)
         )
         process.start()
+        yield process
 
         completed_properly = False
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/multi_file_target_workspace/example_one/jobs.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/multi_file_target_workspace/example_one/jobs.py
@@ -1,5 +1,6 @@
 # type: ignore
 from dagster import job
+
 from ops import example_one_op
 
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/multi_file_target_workspace/example_two/jobs.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/multi_file_target_workspace/example_two/jobs.py
@@ -1,6 +1,7 @@
 # type: ignore
 
 from dagster import job
+
 from ops import example_two_op
 
 

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -57,7 +57,7 @@ commands =
   execution_tests__versioning_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/execution_tests/versioning_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
   general_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/general_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
   general_tests_old_protobuf: pytest -c ../../pyproject.toml -vv ./dagster_tests/general_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
-  launcher_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/launcher_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
+  launcher_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/launcher_tests  {env:COVERAGE_ARGS} --durations 10 {posargs} -s
   logging_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/logging_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   model_tests_pydantic1: pytest -c ../../pyproject.toml -vv ./dagster_tests/model_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   model_tests_pydantic2: pytest -c ../../pyproject.toml -vv ./dagster_tests/model_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}


### PR DESCRIPTION
Summary:
Attempt to resolve a race condition where when you set the termination event after the subprocess has already finished, it hangs. Instead, terminate the subprocess directly - since we are catching SIGTERMS in a custom signal handler the child subprocess should be able to intercept the signal and cleanly terminate.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
