### PR TITLE
remove pydantic 2 tests from windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,6 @@ parameters:
       - api_tests
       - cli_tests
       - core_tests_pydantic1
-      - core_tests_pydantic2
       - general_tests
       - daemon_tests
       - daemon_sensor_tests


### PR DESCRIPTION
Summary:
the pydantic 2 test suite is reliably timing out on windows - pydantic 1 appears to be notably faster, it seems more important to run the core suite on windows than test every permutation of pydantic dependencies.

Test Plan: BK,azure

## Summary & Motivation

## How I Tested These Changes
