### PR TITLE
[ui] Use newer virtualizer for logs scrolling table

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/CellTruncationProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/CellTruncationProvider.tsx
@@ -2,6 +2,8 @@ import {Button, Dialog, DialogFooter, Icon} from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled from 'styled-components';
 
+import {MAX_ROW_HEIGHT_PX} from './LogsRowComponents';
+
 const OverflowFade = styled.div`
   position: absolute;
   bottom: 0;
@@ -54,8 +56,7 @@ export class CellTruncationProvider extends React.Component<
       return;
     }
 
-    const isOverflowing =
-      typeof this.props.style.height === 'number' && child.scrollHeight > this.props.style.height;
+    const isOverflowing = child.scrollHeight > MAX_ROW_HEIGHT_PX;
     if (isOverflowing !== this.state.isOverflowing) {
       this.setState({isOverflowing});
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRow.tsx
@@ -25,12 +25,12 @@ import {autolinkTextContent} from '../ui/autolinking';
 interface StructuredProps {
   node: LogsRowStructuredFragment;
   metadata: IRunMetadataDict;
-  style: React.CSSProperties;
+  style?: React.CSSProperties;
   highlighted: boolean;
 }
 
 export const Structured = (props: StructuredProps) => {
-  const {node, metadata, style, highlighted} = props;
+  const {node, metadata, style = {}, highlighted} = props;
   const [expanded, setExpanded] = useState(false);
 
   const {title, body} = useMemo(() => {
@@ -256,7 +256,7 @@ StructuredMemoizedContent.displayName = 'StructuredMemoizedContent';
 
 interface UnstructuredProps {
   node: LogsRowUnstructuredFragment;
-  style: React.CSSProperties;
+  style?: React.CSSProperties;
   highlighted: boolean;
   metadata: IRunMetadataDict;
 }
@@ -286,7 +286,7 @@ export class Unstructured extends React.Component<UnstructuredProps> {
 
   render() {
     return (
-      <CellTruncationProvider style={this.props.style} onExpand={this.onExpand}>
+      <CellTruncationProvider style={this.props.style || {}} onExpand={this.onExpand}>
         <UnstructuredMemoizedContent
           node={this.props.node}
           highlighted={this.props.highlighted}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowComponents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowComponents.tsx
@@ -23,11 +23,13 @@ const bgcolorForLevel = (level: LogLevel) =>
     [LogLevel.CRITICAL]: Colors.backgroundRed(),
   })[level];
 
+export const MAX_ROW_HEIGHT_PX = 200;
+
 export const Row = styled.div<{level: LogLevel; highlighted: boolean}>`
   font-size: 12px;
   width: 100%;
   height: 100%;
-  max-height: 17em;
+  max-height: ${MAX_ROW_HEIGHT_PX}px;
   word-break: break-word;
   white-space: pre-wrap;
   color: ${Colors.textDefault()};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTable.tsx
@@ -30,7 +30,7 @@ const LOGS_PADDING_BOTTOM = 50;
 const List: any = _List;
 const CellMeasurer: any = _CellMeasurer;
 
-interface ILogsScrollingTableProps {
+export interface ILogsScrollingTableProps {
   logs: LogsProviderLogs;
   filter: LogFilter;
   filterStepKeys: string[];
@@ -56,7 +56,7 @@ interface ILogsScrollingTableSizedProps {
   metadata: IRunMetadataDict;
 }
 
-function filterLogs(logs: LogsProviderLogs, filter: LogFilter, filterStepKeys: string[]) {
+export function filterLogs(logs: LogsProviderLogs, filter: LogFilter, filterStepKeys: string[]) {
   const filteredNodes = logs.allNodes.filter((node) => {
     // These events are used to determine which assets a run will materialize and are not intended
     // to be displayed in the Dagster UI. Pagination is offset based, so we remove these logs client-side.
@@ -409,7 +409,7 @@ class AutoSizer extends React.Component<{
   }
 }
 
-const ListEmptyState = styled.div`
+export const ListEmptyState = styled.div`
   background-color: ${Colors.backgroundDefault()};
   z-index: 100;
   position: absolute;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTableHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTableHeader.tsx
@@ -22,14 +22,14 @@ export const ColumnWidthsContext = React.createContext({
 });
 
 export class ColumnWidthsProvider extends React.Component<
-  {children: React.ReactNode; onWidthsChanged: (widths: typeof ColumnWidths) => void},
+  {children: React.ReactNode; onWidthsChanged?: (widths: typeof ColumnWidths) => void},
   typeof ColumnWidths
 > {
   state = ColumnWidths;
 
   onWidthsChangedFromContext = (columnWidths: typeof ColumnWidths) => {
     window.localStorage.setItem(ColumnWidthsStorageKey, JSON.stringify(columnWidths));
-    this.props.onWidthsChanged(columnWidths);
+    this.props.onWidthsChanged && this.props.onWidthsChanged(columnWidths);
     this.setState(columnWidths);
   };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTableNew.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTableNew.tsx
@@ -1,0 +1,112 @@
+import {Box, NonIdealState} from '@dagster-io/ui-components';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import {useEffect, useRef} from 'react';
+
+import {Structured, Unstructured} from './LogsRow';
+import {ILogsScrollingTableProps, ListEmptyState, filterLogs} from './LogsScrollingTable';
+import {ColumnWidthsProvider, Headers} from './LogsScrollingTableHeader';
+import {Container, DynamicRowContainer, Inner} from '../ui/VirtualizedTable';
+
+const BOTTOM_SCROLL_THRESHOLD_PX = 60;
+
+export const LogsScrollingTableNew = (props: ILogsScrollingTableProps) => {
+  const {filterStepKeys, metadata, filter, logs} = props;
+
+  const parentRef = useRef<HTMLDivElement>(null);
+  const pinToBottom = useRef(true);
+
+  const {filteredNodes, textMatchNodes} = filterLogs(logs, filter, filterStepKeys);
+
+  const virtualizer = useVirtualizer({
+    count: filteredNodes.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 64,
+    overscan: 20,
+    paddingEnd: 40,
+  });
+
+  const totalHeight = virtualizer.getTotalSize();
+  const items = virtualizer.getVirtualItems();
+
+  // Determine whether the user has scrolled away from the bottom of the log list.
+  // If so, we no longer pin to the bottom of the list as new logs arrive. If they
+  // scroll back to the bottom, we go back to pinning.
+  useEffect(() => {
+    const parent = parentRef.current;
+
+    const onScroll = () => {
+      const totalHeight = virtualizer.getTotalSize();
+      const rectHeight = virtualizer.scrollRect.height;
+      const scrollOffset = virtualizer.scrollOffset;
+
+      // If we're within a certain threshold of the maximum scroll depth, consider this
+      // to mean that the user wants to pin scrolling to the bottom.
+      const maxScrollOffset = totalHeight - rectHeight;
+      const shouldPin = scrollOffset > maxScrollOffset - BOTTOM_SCROLL_THRESHOLD_PX;
+
+      pinToBottom.current = shouldPin;
+    };
+
+    parent && parent.addEventListener('scroll', onScroll);
+    return () => {
+      parent && parent.removeEventListener('scroll', onScroll);
+    };
+  }, [virtualizer]);
+
+  // If we should pin to the bottom, do so when the height of the virtualized table changes.
+  useEffect(() => {
+    if (pinToBottom.current) {
+      virtualizer.scrollToOffset(totalHeight, {align: 'end'});
+    }
+  }, [totalHeight, virtualizer]);
+
+  const content = () => {
+    if (logs.loading) {
+      return (
+        <Box margin={{top: 32}}>
+          <ListEmptyState>
+            <NonIdealState icon="spinner" title="Fetching logs..." />
+          </ListEmptyState>
+        </Box>
+      );
+    }
+
+    return (
+      <Inner $totalHeight={totalHeight}>
+        <DynamicRowContainer $start={items[0]?.start ?? 0}>
+          {items.map(({index, key}) => {
+            const node = filteredNodes[index]!;
+            const textMatch = textMatchNodes.includes(node);
+            const focusedTimeMatch = Number(node.timestamp) === filter.focusedTime;
+            const highlighted = textMatch || focusedTimeMatch;
+
+            const row =
+              node.__typename === 'LogMessageEvent' ? (
+                <Unstructured node={node} metadata={metadata} highlighted={highlighted} />
+              ) : (
+                <Structured node={node} metadata={metadata} highlighted={highlighted} />
+              );
+
+            return (
+              <div
+                ref={virtualizer.measureElement}
+                key={key}
+                data-index={index}
+                style={{position: 'relative'}}
+              >
+                {row}
+              </div>
+            );
+          })}
+        </DynamicRowContainer>
+      </Inner>
+    );
+  };
+
+  return (
+    <ColumnWidthsProvider>
+      <Headers />
+      <Container ref={parentRef}>{content()}</Container>
+    </ColumnWidthsProvider>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/Run.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/Run.tsx
@@ -16,7 +16,7 @@ import styled from 'styled-components';
 import {CapturedOrExternalLogPanel} from './CapturedLogPanel';
 import {ComputeLogPanel} from './ComputeLogPanel';
 import {LogFilter, LogsProvider, LogsProviderLogs} from './LogsProvider';
-import {LogsScrollingTable} from './LogsScrollingTable';
+import {LogsScrollingTableNew} from './LogsScrollingTableNew';
 import {LogType, LogsToolbar} from './LogsToolbar';
 import {RunActionButtons} from './RunActionButtons';
 import {RunContext} from './RunContext';
@@ -385,7 +385,7 @@ const RunWithData = ({
                   />
                 )
               ) : (
-                <LogsScrollingTable
+                <LogsScrollingTableNew
                   logs={logs}
                   filter={logsFilter}
                   filterStepKeys={logsFilterStepKeys}


### PR DESCRIPTION
## Summary & Motivation

Use `@tanstack/react-virtual` for the logs scrolling table instead of `react-virtualized`. If I've done this correctly and haven't overlooked any features, the implementation of this component is now *much* simpler.

This was prompted by wanting to add some empty stats for cases where the filter settings yield no results, which was surprisingly difficult and buggy with our `react-virtualized` implementation. It should be much simpler with `@tanstack/react-virtual`.

There are only a couple of `react-virtualized` callsites left in the codebase.

We'll want to stress test this quite a bit just to make sure it doesn't introduce unexpected bugs.

## How I Tested These Changes

View an existing run, verify that the virtualized scroll works correctly in the log table. Verify that:

- Filtering behaves correctly.
- Highlighting for text and timestamp works correctly.
- The loading state is correct.

Kick off a `log_spew` run, verify that logs are appended correctly, and that the scroll state remains pinned to the bottom. Scroll up manually, verify that pinning is undone. Scroll back to the bottom, verify that pinning resumes.