### PR TITLE
whitelist_for_serdes kwargs_fields

### DIFF
--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -261,6 +261,7 @@ def whitelist_for_serdes(
     skip_when_empty_fields: Optional[AbstractSet[str]] = None,
     field_serializers: Optional[Mapping[str, Type["FieldSerializer"]]] = None,
     is_pickleable: bool = True,
+    kwargs_fields: Optional[AbstractSet[str]] = None,
 ) -> Union[T_Type, Callable[[T_Type], T_Type]]:
     """Decorator to whitelist an object (NamedTuple / dataclass / pydantic model) or
     Enum subclass to be serializable. Various arguments can be passed to alter
@@ -307,6 +308,7 @@ def whitelist_for_serdes(
           The canonical example is `MetadataFieldSerializer`.  Note that if the field needs to be
           stored under a different name, then it still needs an entry in `storage_field_names` even
           if a `FieldSerializer` is provided. Does not apply to enums.
+        kwargs_fields (Optional[AbstractSet[str]]): A set of fields that will be passed to the constructor in kwargs.
     """
     if storage_field_names or old_fields or skip_when_empty_fields:
         check.invariant(
@@ -333,6 +335,7 @@ def whitelist_for_serdes(
             skip_when_empty_fields=skip_when_empty_fields,
             field_serializers=field_serializers,
             is_pickleable=is_pickleable,
+            kwargs_fields=kwargs_fields,
         )
 
 


### PR DESCRIPTION
## Summary & Motivation
I missed this when i reviewed https://github.com/dagster-io/dagster/pull/22881 but `kwargs_fields` was only added to `_whitelist_for_serdes` but not `whitelist_for_serdes`

## How I Tested These Changes
