### PR TITLE
[1.8] don't validate `Definitions` on construction

### DIFF
--- a/examples/experimental/dagster-blueprints/dagster_blueprints_tests/test_load_defs_from_yaml.py
+++ b/examples/experimental/dagster-blueprints/dagster_blueprints_tests/test_load_defs_from_yaml.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import List, Literal, Sequence, Union
 
 import pytest
-from dagster import AssetKey, asset, job
+from dagster import AssetKey, Definitions, asset, job
 from dagster._check import CheckError
 from dagster._core.definitions.metadata.source_code import (
     CodeReferencesMetadataSet,
@@ -227,9 +227,11 @@ def test_additional_resources() -> None:
         DagsterInvalidDefinitionError,
         match="resource with key 'some_resource' required by op 'asset1' was not provided",
     ):
-        load_defs_from_yaml(
-            path=Path(__file__).parent / "yaml_files" / "single_blueprint.yaml",
-            per_file_blueprint_type=SimpleAssetBlueprintNeedsResource,
+        Definitions.validate_loadable(
+            load_defs_from_yaml(
+                path=Path(__file__).parent / "yaml_files" / "single_blueprint.yaml",
+                per_file_blueprint_type=SimpleAssetBlueprintNeedsResource,
+            )
         )
 
     defs = load_defs_from_yaml(
@@ -246,10 +248,12 @@ def test_yaml_blueprints_loader_additional_resources() -> None:
         DagsterInvalidDefinitionError,
         match="resource with key 'some_resource' required by op 'asset1' was not provided",
     ):
-        YamlBlueprintsLoader(
-            path=Path(__file__).parent / "yaml_files" / "single_blueprint.yaml",
-            per_file_blueprint_type=SimpleAssetBlueprintNeedsResource,
-        ).load_defs()
+        Definitions.validate_loadable(
+            YamlBlueprintsLoader(
+                path=Path(__file__).parent / "yaml_files" / "single_blueprint.yaml",
+                per_file_blueprint_type=SimpleAssetBlueprintNeedsResource,
+            ).load_defs()
+        )
 
     defs = YamlBlueprintsLoader(
         path=Path(__file__).parent / "yaml_files" / "single_blueprint.yaml",

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -709,7 +709,7 @@ def repository_def_from_target_def(
 
     if isinstance(target, Definitions):
         # reassign to handle both repository and pending repo case
-        target = target.get_inner_repository_for_loading_process()
+        target = target.get_inner_repository()
 
     # special case - we can wrap a single job in a repository
     if isinstance(target, (JobDefinition, GraphDefinition)):

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps_error_informative.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps_error_informative.py
@@ -42,7 +42,7 @@ def test_typo_upstream_asset_one_similar(group_name, asset_key_prefix) -> None:
             rf"\n\t{re.escape(asset1.key.to_string())}"
         ),
     ):
-        Definitions(assets=[asset1, asset2])
+        Definitions.validate_loadable(Definitions(assets=[asset1, asset2]))
 
 
 def test_typo_upstream_asset_no_similar() -> None:
@@ -59,7 +59,7 @@ def test_typo_upstream_asset_no_similar() -> None:
             r" ops and is not one of the provided sources."
         ),
     ):
-        Definitions(assets=[asset1, asset2])
+        Definitions.validate_loadable(Definitions(assets=[asset1, asset2]))
 
 
 def test_typo_upstream_asset_many_similar() -> None:
@@ -85,7 +85,7 @@ def test_typo_upstream_asset_many_similar() -> None:
             rf" {re.escape(asst.key.to_string())}"
         ),
     ):
-        Definitions(assets=[asst, asset1, assets1, asset2])
+        Definitions.validate_loadable(Definitions(assets=[asst, asset1, assets1, asset2]))
 
 
 def test_typo_upstream_asset_wrong_prefix() -> None:
@@ -103,7 +103,7 @@ def test_typo_upstream_asset_wrong_prefix() -> None:
             rf"\n\t{re.escape(asset1.key.to_string())}"
         ),
     ):
-        Definitions(assets=[asset1, asset2])
+        Definitions.validate_loadable(Definitions(assets=[asset1, asset2]))
 
 
 def test_typo_upstream_asset_wrong_prefix_and_wrong_key() -> None:
@@ -122,7 +122,7 @@ def test_typo_upstream_asset_wrong_prefix_and_wrong_key() -> None:
             r" not one of the provided sources."
         ),
     ):
-        Definitions(assets=[asset1, asset2])
+        Definitions.validate_loadable(Definitions(assets=[asset1, asset2]))
 
 
 def test_one_off_component_prefix() -> None:
@@ -141,7 +141,7 @@ def test_one_off_component_prefix() -> None:
             rf"\n\t{re.escape(asset1.key.to_string())}"
         ),
     ):
-        Definitions(assets=[asset1, asset2])
+        Definitions.validate_loadable(Definitions(assets=[asset1, asset2]))
 
     # One fewer component in the prefix
     @asset(ins={"asset1": AssetIn(key=AssetKey(["my", "asset1"]))})
@@ -155,7 +155,7 @@ def test_one_off_component_prefix() -> None:
             rf"\n\t{re.escape(asset1.key.to_string())}"
         ),
     ):
-        Definitions(assets=[asset1, asset3])
+        Definitions.validate_loadable(Definitions(assets=[asset1, asset3]))
 
 
 def test_accidentally_using_slashes() -> None:
@@ -174,7 +174,7 @@ def test_accidentally_using_slashes() -> None:
             rf"\n\t{re.escape(asset1.key.to_string())}"
         ),
     ):
-        Definitions(assets=[asset1, asset2])
+        Definitions.validate_loadable(Definitions(assets=[asset1, asset2]))
 
 
 NUM_ASSETS_TO_TEST_PERF = 5000

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_source_asset_observation_job.py
@@ -172,8 +172,10 @@ def test_source_asset_observation_job_with_pythonic_resource(is_valid, resource_
             DagsterInvalidDefinitionError,
             match="resource with key 'bar' required by op 'foo' was not provided",
         ):
-            Definitions(
-                assets=[foo],
-                jobs=[define_asset_job("source_asset_job", [foo])],
-                resources=resource_defs,
+            Definitions.validate_loadable(
+                Definitions(
+                    assets=[foo],
+                    jobs=[define_asset_job("source_asset_job", [foo])],
+                    resources=resource_defs,
+                )
             )

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_binding.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_binding.py
@@ -62,9 +62,7 @@ def test_bind_resource_to_job_at_defn_time_err() -> None:
         DagsterInvalidDefinitionError,
         match="resource with key 'writer' required by op 'hello_world_op' was not provided",
     ):
-        Definitions(
-            jobs=[hello_world_job],
-        )
+        Definitions.validate_loadable(Definitions(jobs=[hello_world_job]))
 
 
 def test_bind_resource_to_job_at_defn_time() -> None:
@@ -193,9 +191,7 @@ def test_bind_resource_to_job_with_job_config() -> None:
         DagsterInvalidDefinitionError,
         match="resource with key 'writer' required by op 'hello_world_op' was not provided",
     ):
-        Definitions(
-            jobs=[hello_world_job],
-        )
+        Definitions.validate_loadable(Definitions(jobs=[hello_world_job]))
 
 
 def test_bind_resource_to_job_at_defn_time_override() -> None:

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_nesting.py
@@ -395,11 +395,13 @@ def test_nested_function_resource_runtime_config() -> None:
     ):
         # errors b/c writer_resource is not configured
         # and not provided as a top-level resource to Definitions
-        defs = Definitions(
-            assets=[my_asset],
-            resources={
-                "writer": PostfixWriterResource(writer=writer_resource, postfix="!"),
-            },
+        Definitions.validate_loadable(
+            Definitions(
+                assets=[my_asset],
+                resources={
+                    "writer": PostfixWriterResource(writer=writer_resource, postfix="!"),
+                },
+            )
         )
 
     defs = Definitions(

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -63,7 +63,7 @@ def test_repository_snap_all_props():
 
 
 def resolve_pending_repo_if_required(definitions: Definitions) -> RepositoryDefinition:
-    repo_or_caching_repo = definitions.get_inner_repository_for_loading_process()
+    repo_or_caching_repo = definitions.get_inner_repository()
     return (
         repo_or_caching_repo.compute_repository_definition()
         if isinstance(repo_or_caching_repo, PendingRepositoryDefinition)

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
@@ -416,7 +416,7 @@ def test_definitions_conflicting_checks() -> None:
         DagsterInvalidDefinitionError,
         match="Duplicate asset check key.+asset1.+check1",
     ):
-        Definitions(asset_checks=[make_check(), make_check()])
+        Definitions.validate_loadable(Definitions(asset_checks=[make_check(), make_check()]))
 
 
 def test_definitions_same_name_different_asset() -> None:
@@ -427,7 +427,9 @@ def test_definitions_same_name_different_asset() -> None:
 
         return check1
 
-    Definitions(asset_checks=[make_check_for_asset("asset1"), make_check_for_asset("asset2")])
+    Definitions.validate_loadable(
+        Definitions(asset_checks=[make_check_for_asset("asset1"), make_check_for_asset("asset2")])
+    )
 
 
 def test_definitions_same_asset_different_name() -> None:
@@ -438,7 +440,9 @@ def test_definitions_same_asset_different_name() -> None:
 
         return _check
 
-    Definitions(asset_checks=[make_check("check1"), make_check("check2")])
+    Definitions.validate_loadable(
+        Definitions(asset_checks=[make_check("check1"), make_check("check2")])
+    )
 
 
 def test_resource_params() -> None:


### PR DESCRIPTION
## Summary & Motivation

This PR proposes turning Definitions into a "dumb" data class for passing around diverse sets of definitions. This means that users won't encounter any validation errors for unsatisfied resources, duplicate asset keys, etc., until either:
- They run a code server to load the definitions
- They invoke `Definitions.validate_loadable`

Why do this?
- Less work will happen at module import time. This gives users more flexibility to determine where they want to incur the cost of this validation. It also helps enable a future world where run/step workers only need to load/validate the subset of definitions that they need to execute.
- Less repetition of resources. This was sited as an issue by the developers of our internal platform: https://dagsterlabs.slack.com/archives/C03AF3MMEEN/p1720546166484669?thread_ts=1720545875.842949&cid=C03AF3MMEEN.
- Makes it possible to define asset jobs / schedules in separate `Definitions` objects from the assets they target. I encountered this when trying to write an [example that that allows using blueprints to define dbt selection jobs](https://github.com/dagster-io/dagster/pull/22908).

The original Definitions.merge PR contains some discussion on this topic: https://github.com/dagster-io/dagster/pull/21746.

## How I Tested These Changes
