### PR TITLE
remove AssetLayer.get_spec_for_asset_check

### DIFF
--- a/examples/experimental/dagster-blueprints/dagster_blueprints/blueprint_assets_definition.py
+++ b/examples/experimental/dagster-blueprints/dagster_blueprints/blueprint_assets_definition.py
@@ -34,7 +34,7 @@ class BlueprintAssetsDefinition(Blueprint):
         specs = [spec_model.to_asset_spec() for spec_model in self.assets]
 
         @multi_asset(
-            name=f"assets_{unique_id_from_asset_and_check_keys([spec.key for spec in specs], [])}",
+            name=f"assets_{unique_id_from_asset_and_check_keys([spec.key for spec in specs])}",
             specs=specs,
             required_resource_keys=self.get_required_resource_keys(),
         )

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/utils.py
@@ -273,7 +273,7 @@ def freshness_multi_asset_check(params_metadata: JsonMetadataValue, asset_keys: 
                 for asset_key in asset_keys
             ],
             can_subset=True,
-            name=f"freshness_check_{unique_id_from_asset_and_check_keys(asset_keys, [])}",
+            name=f"freshness_check_{unique_id_from_asset_and_check_keys(asset_keys)}",
         )(fn)
 
     return inner
@@ -287,7 +287,7 @@ def build_multi_asset_check(
     @multi_asset_check(
         specs=check_specs,
         can_subset=True,
-        name=f"asset_check_{unique_id_from_asset_and_check_keys([], [spec.key for spec in check_specs])}",
+        name=f"asset_check_{unique_id_from_asset_and_check_keys([spec.key for spec in check_specs])}",
     )
     def _checks(context):
         for asset_check_key in context.selected_asset_check_keys:

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, AbstractSet, Dict, Iterable, Mapping, NamedTuple, Optional, Set
 
 import dagster._check as check
-from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSpec
+from dagster._core.definitions.asset_check_spec import AssetCheckKey
 
 from ..errors import DagsterInvariantViolationError
 from .dependency import NodeHandle, NodeInputHandle, NodeOutputHandle
@@ -172,12 +172,6 @@ class AssetLayer(NamedTuple):
                 " Multiple asset keys defined."
             )
         return next(iter(asset_keys))
-
-    def get_spec_for_asset_check(
-        self, node_handle: NodeHandle, asset_check_key: AssetCheckKey
-    ) -> Optional[AssetCheckSpec]:
-        assets_def = self.assets_defs_by_node_handle.get(node_handle)
-        return assets_def.get_spec_for_check_key(asset_check_key) if assets_def else None
 
     def get_output_name_for_asset_check(self, asset_check_key: AssetCheckKey) -> str:
         """Output name in the leaf op."""

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1601,7 +1601,7 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
 
     @cached_property
     def unique_id(self) -> str:
-        return unique_id_from_asset_and_check_keys(self.keys, self.check_keys)
+        return unique_id_from_asset_and_check_keys(itertools.chain(self.keys, self.check_keys))
 
     def with_resources(self, resource_defs: Mapping[str, ResourceDefinition]) -> "AssetsDefinition":
         attributes_dict = self.get_attributes_dict()
@@ -2028,18 +2028,13 @@ def get_partition_mappings_from_deps(
     return partition_mappings
 
 
-def unique_id_from_asset_and_check_keys(
-    asset_keys: Iterable[AssetKey], check_keys: Iterable[AssetCheckKey]
-) -> str:
+def unique_id_from_asset_and_check_keys(asset_or_check_keys: Iterable["AssetKeyOrCheckKey"]) -> str:
     """Generate a unique ID from the provided asset keys.
 
     This is useful for generating op names that don't have collisions.
     """
-    sorted_asset_key_strs = sorted(asset_key.to_string() for asset_key in asset_keys)
-    sorted_check_key_strs = sorted(str(check_key) for check_key in check_keys)
-    return non_secure_md5_hash_str(
-        json.dumps(sorted_asset_key_strs + sorted_check_key_strs).encode("utf-8")
-    )[:8]
+    sorted_key_strs = sorted(str(key) for key in asset_or_check_keys)
+    return non_secure_md5_hash_str(json.dumps(sorted_key_strs).encode("utf-8"))[:8]
 
 
 @record

--- a/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/execute_step.py
@@ -111,8 +111,8 @@ def _process_user_event(
     elif isinstance(user_event, AssetCheckResult):
         asset_check_evaluation = user_event.to_asset_check_evaluation(step_context)
         spec = check.not_none(
-            step_context.job_def.asset_layer.get_spec_for_asset_check(
-                step_context.node_handle, asset_check_evaluation.asset_check_key
+            step_context.job_def.asset_layer.asset_graph.get_check_spec(
+                asset_check_evaluation.asset_check_key
             ),
             "If we were able to create an AssetCheckEvaluation from the AssetCheckResult, then"
             " there should be a spec for the check",

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_last_update_freshness.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_last_update_freshness.py
@@ -38,7 +38,7 @@ def test_params() -> None:
     )[0]
     assert (
         check.node_def.name
-        == f"freshness_check_{non_secure_md5_hash_str(json.dumps([my_asset.key.to_string()]).encode())[:8]}"
+        == f"freshness_check_{non_secure_md5_hash_str(json.dumps([str(my_asset.key)]).encode())[:8]}"
     )
     check_specs = list(check.check_specs)
     assert len(check_specs) == 1
@@ -129,10 +129,8 @@ def test_params() -> None:
         lower_bound_delta=datetime.timedelta(minutes=10),
     )[0]
     assert check_multiple_assets.node_def.name == check_multiple_assets_switched_order.node_def.name
-    unique_id = unique_id_from_asset_and_check_keys([my_asset.key, other_asset.key], [])
-    unique_id_switched_order = unique_id_from_asset_and_check_keys(
-        [other_asset.key, my_asset.key], []
-    )
+    unique_id = unique_id_from_asset_and_check_keys([my_asset.key, other_asset.key])
+    unique_id_switched_order = unique_id_from_asset_and_check_keys([other_asset.key, my_asset.key])
     assert check_multiple_assets.node_def.name == f"freshness_check_{unique_id}"
     assert check_multiple_assets.node_def.name == f"freshness_check_{unique_id_switched_order}"
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_time_partition_freshness.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/test_time_partition_freshness.py
@@ -63,7 +63,7 @@ def test_params() -> None:
     }
     assert (
         check.node_def.name
-        == f"freshness_check_{non_secure_md5_hash_str(json.dumps([my_partitioned_asset.key.to_string()]).encode())[:8]}"
+        == f"freshness_check_{non_secure_md5_hash_str(json.dumps([str(my_partitioned_asset.key)]).encode())[:8]}"
     )
 
     @asset(
@@ -191,10 +191,10 @@ def test_params() -> None:
     )[0]
     assert check_multiple_assets.node_def.name == check_multiple_assets_switched_order.node_def.name
     unique_id = unique_id_from_asset_and_check_keys(
-        [my_partitioned_asset.key, my_other_partitioned_asset.key], []
+        [my_partitioned_asset.key, my_other_partitioned_asset.key]
     )
     unique_id_switched_order = unique_id_from_asset_and_check_keys(
-        [my_other_partitioned_asset.key, my_partitioned_asset.key], []
+        [my_other_partitioned_asset.key, my_partitioned_asset.key]
     )
     assert check_multiple_assets.node_def.name == f"freshness_check_{unique_id}"
     assert check_multiple_assets.node_def.name == f"freshness_check_{unique_id_switched_order}"


### PR DESCRIPTION
## Summary & Motivation

The one place that calls it can get the information from the `AssetGraph` instead.

## How I Tested These Changes
