### PR TITLE
kwargs_fields in whitelist_for_serdes overload

### DIFF
--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -247,6 +247,7 @@ def whitelist_for_serdes(
     skip_when_empty_fields: Optional[AbstractSet[str]] = ...,
     field_serializers: Optional[Mapping[str, Type["FieldSerializer"]]] = None,
     is_pickleable: bool = True,
+    kwargs_fields: Optional[AbstractSet[str]] = None,
 ) -> Callable[[T_Type], T_Type]: ...
 
 


### PR DESCRIPTION
## Summary & Motivation
i goofed and forgot another spot for  `kwargs_fields`

## How I Tested These Changes
