### PR TITLE
move AssetKeyOrCheckKey and AssetCheckKey to asset_key.py

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping, NamedTuple, Optional, 
 
 import dagster._check as check
 from dagster._annotations import PublicAttr
-from dagster._core.definitions.asset_key import AssetKey, CoercibleToAssetKey
+from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.metadata import RawMetadataMapping
 from dagster._serdes.serdes import whitelist_for_serdes
 
@@ -25,31 +25,6 @@ class AssetCheckSeverity(Enum):
 
     WARN = "WARN"
     ERROR = "ERROR"
-
-
-@whitelist_for_serdes(old_storage_names={"AssetCheckHandle"})
-class AssetCheckKey(NamedTuple):
-    """Check names are expected to be unique per-asset. Thus, this combination of asset key and
-    check name uniquely identifies an asset check within a deployment.
-    """
-
-    asset_key: PublicAttr[AssetKey]
-    name: PublicAttr[str]
-
-    @staticmethod
-    def from_graphql_input(graphql_input: Mapping[str, Any]) -> "AssetCheckKey":
-        return AssetCheckKey(
-            asset_key=AssetKey.from_graphql_input(graphql_input["assetKey"]),
-            name=graphql_input["name"],
-        )
-
-    def to_user_string(self) -> str:
-        return f"{self.asset_key.to_user_string()}:{self.name}"
-
-    @staticmethod
-    def from_user_string(user_string: str) -> "AssetCheckKey":
-        asset_key_str, name = user_string.split(":")
-        return AssetCheckKey(AssetKey.from_user_string(asset_key_str), name)
 
 
 class AssetCheckSpec(

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -25,9 +25,9 @@ from typing import (
 
 import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
+from dagster._core.definitions.asset_key import AssetKey, AssetKeyOrCheckKey
 from dagster._core.definitions.asset_subset import ValidAssetSubset
 from dagster._core.definitions.backfill_policy import BackfillPolicy
-from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
 from dagster._core.definitions.partition import PartitionsDefinition
@@ -48,8 +48,6 @@ if TYPE_CHECKING:
     from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
     from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
     from dagster._core.definitions.declarative_automation import AutomationCondition
-
-AssetKeyOrCheckKey = Union[AssetKey, AssetCheckKey]
 
 
 class ParentsPartitionsResult(NamedTuple):


### PR DESCRIPTION
## Summary & Motivation

This makes it easier to avoid circular imports

## How I Tested These Changes
