### PR TITLE
[DA] Add with_label to AutomationCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/rule_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/rule_condition.py
@@ -18,6 +18,7 @@ class RuleCondition(AssetCondition):
     """This class represents the condition that a particular AutoMaterializeRule is satisfied."""
 
     rule: AutoMaterializeRule
+    label: Optional[str] = None
 
     def get_unique_id(self, *, parent_unique_id: Optional[str], index: Optional[str]) -> str:
         # preserves old (bad) behavior of not including the parent_unique_id to avoid inavlidating

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
@@ -10,6 +10,8 @@ from ..automation_context import AutomationContext
 @whitelist_for_serdes
 @record
 class CodeVersionChangedCondition(AutomationCondition):
+    label: Optional[str] = None
+
     @property
     def description(self) -> str:
         return "Asset code version changed since previous tick"

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
@@ -31,6 +31,8 @@ class SliceAutomationCondition(AutomationCondition):
 @whitelist_for_serdes
 @record
 class MissingAutomationCondition(SliceAutomationCondition):
+    label: Optional[str] = None
+
     @property
     def description(self) -> str:
         return "Missing"
@@ -44,6 +46,8 @@ class MissingAutomationCondition(SliceAutomationCondition):
 @whitelist_for_serdes
 @record
 class InProgressAutomationCondition(SliceAutomationCondition):
+    label: Optional[str] = None
+
     @property
     def description(self) -> str:
         return "Part of an in-progress run"
@@ -55,6 +59,8 @@ class InProgressAutomationCondition(SliceAutomationCondition):
 @whitelist_for_serdes
 @record
 class FailedAutomationCondition(SliceAutomationCondition):
+    label: Optional[str] = None
+
     @property
     def description(self) -> str:
         return "Latest run failed"
@@ -66,6 +72,8 @@ class FailedAutomationCondition(SliceAutomationCondition):
 @whitelist_for_serdes
 @record
 class WillBeRequestedCondition(SliceAutomationCondition):
+    label: Optional[str] = None
+
     @property
     def description(self) -> str:
         return "Will be requested this tick"
@@ -96,6 +104,8 @@ class WillBeRequestedCondition(SliceAutomationCondition):
 @whitelist_for_serdes
 @record
 class NewlyRequestedCondition(SliceAutomationCondition):
+    label: Optional[str] = None
+
     @property
     def description(self) -> str:
         return "Was requested on the previous tick"
@@ -109,6 +119,8 @@ class NewlyRequestedCondition(SliceAutomationCondition):
 @whitelist_for_serdes
 @record
 class NewlyUpdatedCondition(SliceAutomationCondition):
+    label: Optional[str] = None
+
     @property
     def description(self) -> str:
         return "Updated since previous tick"
@@ -128,6 +140,7 @@ class NewlyUpdatedCondition(SliceAutomationCondition):
 class CronTickPassedCondition(SliceAutomationCondition):
     cron_schedule: str
     cron_timezone: str
+    label: Optional[str] = None
 
     @property
     def description(self) -> str:
@@ -158,6 +171,7 @@ class CronTickPassedCondition(SliceAutomationCondition):
 @record
 class InLatestTimeWindowCondition(SliceAutomationCondition):
     serializable_lookback_timedelta: Optional[SerializableTimeDelta] = None
+    label: Optional[str] = None
 
     @staticmethod
     def from_lookback_delta(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
@@ -1,4 +1,4 @@
-from typing import AbstractSet, Sequence
+from typing import AbstractSet, Optional, Sequence
 
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._record import record
@@ -17,6 +17,7 @@ class DownstreamConditionWrapperCondition(AutomationCondition):
 
     downstream_keys: Sequence[AssetKey]
     operand: AutomationCondition
+    label: Optional[str] = None
 
     @property
     def description(self) -> str:
@@ -40,6 +41,8 @@ class DownstreamConditionWrapperCondition(AutomationCondition):
 @whitelist_for_serdes
 @record
 class AnyDownstreamConditionsCondition(AutomationCondition):
+    label: Optional[str] = None
+
     @property
     def description(self) -> str:
         return "Any downstream conditions"

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -1,4 +1,4 @@
-from typing import List, Sequence
+from typing import List, Optional, Sequence
 
 from dagster._record import record
 from dagster._serdes.serdes import whitelist_for_serdes
@@ -13,6 +13,7 @@ class AndAssetCondition(AutomationCondition):
     """This class represents the condition that all of its children evaluate to true."""
 
     operands: Sequence[AutomationCondition]
+    label: Optional[str] = None
 
     @property
     def children(self) -> Sequence[AutomationCondition]:
@@ -41,6 +42,7 @@ class OrAssetCondition(AutomationCondition):
     """This class represents the condition that any of its children evaluate to true."""
 
     operands: Sequence[AutomationCondition]
+    label: Optional[str] = None
 
     @property
     def children(self) -> Sequence[AutomationCondition]:
@@ -70,6 +72,7 @@ class NotAssetCondition(AutomationCondition):
     """This class represents the condition that none of its children evaluate to true."""
 
     operand: AutomationCondition
+    label: Optional[str] = None
 
     @property
     def description(self) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -24,6 +24,7 @@ class DepConditionWrapperCondition(AutomationCondition):
 
     dep_key: AssetKey
     operand: AutomationCondition
+    label: Optional[str] = None
 
     @property
     def description(self) -> str:
@@ -55,6 +56,7 @@ class DepCondition(AutomationCondition):
     ignore_selection: Optional[
         Annotated["AssetSelection", ImportFrom("dagster._core.definitions.asset_selection")]
     ] = None
+    label: Optional[str] = None
 
     @property
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
@@ -13,6 +13,7 @@ from ..automation_context import AutomationContext
 @record
 class NewlyTrueCondition(AutomationCondition):
     operand: AutomationCondition
+    label: Optional[str] = None
 
     @property
     def requires_cursor(self) -> bool:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Optional, Sequence
 
 from dagster._record import record
 from dagster._serdes.serdes import whitelist_for_serdes
@@ -12,6 +12,7 @@ from ..automation_context import AutomationContext
 class SinceCondition(AutomationCondition):
     trigger_condition: AutomationCondition
     reset_condition: AutomationCondition
+    label: Optional[str] = None
 
     @property
     def requires_cursor(self) -> bool:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
@@ -59,6 +59,7 @@ class AssetConditionSnapshot(NamedTuple):
     class_name: str
     description: str
     unique_id: str
+    label: Optional[str] = None
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/asset_condition_scenario.py
@@ -36,6 +36,8 @@ from ..scenario_state import ScenarioState
 class FalseAssetCondition(AutomationCondition):
     """Always returns the empty subset."""
 
+    label: Optional[str] = None
+
     @property
     def description(self) -> str:
         return ""

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_asset_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_asset_condition.py
@@ -92,3 +92,13 @@ def test_deserialize_definitions_with_asset_condition() -> None:
 
     deserialized = deserialize_value(serialized, AutoMaterializePolicy)
     assert isinstance(deserialized, AutoMaterializePolicy)
+
+
+def test_label_automation_condition() -> None:
+    not_missing = (~AutomationCondition.missing()).with_label("Not missing")
+    not_in_progress = (~AutomationCondition.in_progress()).with_label("Not in progress")
+    not_missing_and_not_in_progress = (not_missing & not_in_progress).with_label("Blah")
+    assert not_missing_and_not_in_progress.label == "Blah"
+    assert not_missing_and_not_in_progress.get_snapshot("").label == "Blah"
+    assert not_missing_and_not_in_progress.children[0].label == "Not missing"
+    assert not_missing_and_not_in_progress.children[1].label == "Not in progress"

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Optional, Sequence
 
 import dagster._check as check
 import pytest
@@ -22,6 +22,10 @@ def get_hardcoded_condition():
     true_set = set()
 
     class HardcodedCondition(AutomationCondition):
+        @property
+        def label(self) -> Optional[str]:
+            return None
+
         @property
         def description(self) -> str:
             return "..."


### PR DESCRIPTION
## Summary & Motivation

Adds the ability to apply an arbitrary string label to an AutomationCondition.

For now, this requires adding an explicit `label` property to all AutomationCondition subclasses, but this can be simplified with an update to the @record system

## How I Tested These Changes

Added unit test
