### PR TITLE
in Definitions docstring, remove discussion of repository

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -254,6 +254,8 @@ def repository(
 ) -> Union[RepositoryDefinition, PendingRepositoryDefinition, _Repository]:
     """Create a repository from the decorated function.
 
+    In most cases, :py:class:`Definitions` should be used instead.
+
     The decorated function should take no arguments and its return value should one of:
 
     1. ``List[Union[JobDefinition, ScheduleDefinition, SensorDefinition]]``.

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -386,21 +386,6 @@ class Definitions:
 
     A Python module is loadable by Dagster tools if there is a top-level variable
     that is an instance of :py:class:`Definitions`.
-
-    Before the introduction of :py:class:`Definitions`,
-    :py:func:`@repository <repository>` was the API for organizing defintions.
-    :py:class:`Definitions` provides a few conveniences for dealing with resources
-    that do not apply to old-style :py:func:`@repository <repository>` declarations:
-
-    * It takes a dictionary of top-level resources which are automatically bound
-      (via :py:func:`with_resources <with_resources>`) to any asset passed to it.
-      If you need to apply different resources to different assets, use legacy
-      :py:func:`@repository <repository>` and use
-      :py:func:`with_resources <with_resources>` as before.
-    * The resources dictionary takes raw Python objects, not just instances
-      of :py:class:`ResourceDefinition`. If that raw object inherits from
-      :py:class:`IOManager`, it gets coerced to an :py:class:`IOManagerDefinition`.
-      Any other object is coerced to a :py:class:`ResourceDefinition`.
     """
 
     _assets: Iterable[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]


### PR DESCRIPTION
## Summary & Motivation

Now that `Definitions` is the solidified default way of doing things, I don't think we need to spend words comparing it to a legacy API.

## How I Tested These Changes
