### PR TITLE
Virtualize, chunk, and show progress in "wipe materializations" dialog 

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
@@ -186,7 +186,6 @@ export const AssetTable = ({
         assetKeys={toWipe || []}
         isOpen={!!toWipe}
         onClose={() => setToWipe(undefined)}
-        onComplete={() => setToWipe(undefined)}
         requery={requery}
       />
     </>
@@ -241,7 +240,6 @@ const MoreActionsDropdown = React.memo((props: MoreActionsDropdownProps) => {
         isOpen={showBulkWipeDialog}
         onClose={() => setShowBulkWipeDialog(false)}
         onComplete={() => {
-          setShowBulkWipeDialog(false);
           clearSelection();
         }}
         requery={requery}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetWipeDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetWipeDialog.tsx
@@ -131,8 +131,8 @@ export const AssetWipeDialogInner = memo(
       if (isDone) {
         return (
           <Box flex={{direction: 'column'}}>
-            {wipedCount ? <Body1>Wiped {numberFormatter.format(wipedCount)}</Body1> : null}
-            {failedCount ? <Body1>Failed {numberFormatter.format(failedCount)}</Body1> : null}
+            {wipedCount ? <Body1>{numberFormatter.format(wipedCount)} Wiped</Body1> : null}
+            {failedCount ? <Body1>{numberFormatter.format(failedCount)} Failed</Body1> : null}
           </Box>
         );
       } else if (!isWiping) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetWipeDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetWipeDialog.tsx
@@ -1,24 +1,62 @@
 import {RefetchQueriesFunction, gql, useMutation} from '@apollo/client';
-import {Button, Dialog, DialogBody, DialogFooter, Group} from '@dagster-io/ui-components';
+// eslint-disable-next-line no-restricted-imports
+import {ProgressBar} from '@blueprintjs/core';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogBody,
+  DialogFooter,
+  Group,
+  ifPlural,
+} from '@dagster-io/ui-components';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import {memo, useLayoutEffect, useMemo, useRef, useState} from 'react';
 
 import {asAssetKeyInput} from './asInput';
 import {AssetWipeMutation, AssetWipeMutationVariables} from './types/AssetWipeDialog.types';
+import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
+import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {displayNameForAssetKey} from '../asset-graph/Utils';
+import {NavigationBlock} from '../runs/NavigationBlock';
+import {Inner, Row} from '../ui/VirtualizedTable';
+import {numberFormatter} from '../ui/formatters';
 
 interface AssetKey {
   path: string[];
 }
 
-export const AssetWipeDialog = ({
+const CHUNK_SIZE = 100;
+
+export const AssetWipeDialog = memo(
+  (props: {
+    assetKeys: AssetKey[];
+    isOpen: boolean;
+    onClose: () => void;
+    onComplete: (assetKeys: AssetKey[]) => void;
+    requery?: RefetchQueriesFunction;
+  }) => {
+    return (
+      <Dialog
+        isOpen={props.isOpen}
+        title="Wipe materializations"
+        onClose={props.onClose}
+        style={{width: '80vw', maxWidth: '1200px', minWidth: '600px'}}
+      >
+        <AssetWipeDialogInner {...props} />
+      </Dialog>
+    );
+  },
+);
+
+export const AssetWipeDialogInner = ({
   assetKeys,
-  isOpen,
   onClose,
   onComplete,
   requery,
 }: {
   assetKeys: AssetKey[];
-  isOpen: boolean;
   onClose: () => void;
   onComplete: (assetKeys: AssetKey[]) => void;
   requery?: RefetchQueriesFunction;
@@ -26,50 +64,123 @@ export const AssetWipeDialog = ({
   const [requestWipe] = useMutation<AssetWipeMutation, AssetWipeMutationVariables>(
     ASSET_WIPE_MUTATION,
     {
-      variables: {assetKeys: assetKeys.map(asAssetKeyInput)},
       refetchQueries: requery,
     },
   );
 
+  const [isWiping, setIsWiping] = useState(false);
+  const [wiped, setWiped] = useState(0);
+
+  const didCancel = useRef(false);
   const wipe = async () => {
     if (!assetKeys.length) {
       return;
     }
-    await requestWipe();
+    setIsWiping(true);
+    for (let i = 0, l = assetKeys.length; i < l; i += CHUNK_SIZE) {
+      if (didCancel.current) {
+        return;
+      }
+      const nextChunk = assetKeys.slice(i, i + CHUNK_SIZE);
+      const result = await requestWipe({variables: {assetKeys: nextChunk.map(asAssetKeyInput)}});
+      const data = result.data?.wipeAssets;
+      switch (data?.__typename) {
+        case 'AssetNotFoundError':
+          showCustomAlert({
+            title: 'Could not wipe asset materializations',
+            body: 'Asset not found.',
+          });
+          break;
+        case 'AssetWipeSuccess':
+          setWiped((wiped) => wiped + nextChunk.length);
+          break;
+        case 'PythonError':
+          showCustomAlert({
+            title: 'Could not wipe asset materializations',
+            body: <PythonErrorInfo error={data} />,
+          });
+          break;
+        case 'UnauthorizedError':
+          showCustomAlert({
+            title: 'Could not wipe asset materializations',
+            body: 'You do not have permission to do this.',
+          });
+          break;
+      }
+    }
     onComplete(assetKeys);
+    setIsWiping(false);
   };
 
-  return (
-    <Dialog isOpen={isOpen} title="Wipe materializations" onClose={onClose} style={{width: 600}}>
-      <DialogBody>
+  useLayoutEffect(() => {
+    return () => {
+      didCancel.current = true;
+    };
+  }, []);
+
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: assetKeys.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 24,
+    overscan: 10,
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const items = rowVirtualizer.getVirtualItems();
+
+  const content = useMemo(() => {
+    if (!isWiping) {
+      return (
         <Group direction="column" spacing={16}>
-          <div>Are you sure you want to wipe materializations for these assets?</div>
-          <ul style={{paddingLeft: 32, margin: 0}}>
-            {assetKeys.map((assetKey) => {
-              const name = displayNameForAssetKey(assetKey);
-              return (
-                <li style={{marginBottom: 4}} key={name}>
-                  {name}
-                </li>
-              );
-            })}
-          </ul>
+          <div>
+            Are you sure you want to wipe materializations for{' '}
+            {numberFormatter.format(assetKeys.length)}{' '}
+            {ifPlural(assetKeys.length, 'asset', 'assets')}?
+          </div>
+          <div style={{maxHeight: '50vh', overflowY: 'scroll'}} ref={parentRef}>
+            <Inner $totalHeight={totalHeight}>
+              {items.map(({index, key, size, start}) => {
+                const assetKey = assetKeys[index]!;
+                return (
+                  <Row key={key} $height={size} $start={start}>
+                    {displayNameForAssetKey(assetKey)}
+                  </Row>
+                );
+              })}
+            </Inner>
+          </div>
           <div>
             Assets defined only by their historical materializations will disappear from the Asset
             Catalog. Software-defined assets will remain unless their definition is also deleted.
           </div>
           <strong>This action cannot be undone.</strong>
         </Group>
-      </DialogBody>
+      );
+    }
+    const value = assetKeys.length > 0 ? wiped / assetKeys.length : 1;
+    return (
+      <Box flex={{gap: 8, direction: 'column'}}>
+        <div>Wiping...</div>
+        <ProgressBar intent="primary" value={Math.max(0.1, value)} animate={value < 1} />
+        <NavigationBlock message="Termination in progress, please do not navigate away yet." />
+      </Box>
+    );
+  }, [assetKeys, isWiping, items, totalHeight, wiped]);
+
+  return (
+    <>
+      <DialogBody>{content}</DialogBody>
       <DialogFooter topBorder>
         <Button intent="none" onClick={onClose}>
           Cancel
         </Button>
-        <Button intent="danger" onClick={wipe}>
+        <Button intent="danger" onClick={wipe} disabled={isWiping} loading={isWiping}>
           Wipe
         </Button>
       </DialogFooter>
-    </Dialog>
+    </>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/testing/StorybookProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/testing/StorybookProvider.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {MemoryRouter, MemoryRouterProps} from 'react-router-dom';
+import {RecoilRoot} from 'recoil';
 
 import {ApolloTestProps, ApolloTestProvider} from './ApolloTestProvider';
 import {CustomAlertProvider} from '../app/CustomAlertProvider';
@@ -16,11 +17,13 @@ export const StorybookProvider = (props: Props) => {
   const {apolloProps, routerProps} = props;
 
   return (
-    <MemoryRouter {...routerProps}>
-      <ApolloTestProvider {...apolloProps} typeDefs={typeDefs as any}>
-        <CustomAlertProvider />
-        <WorkspaceProvider>{props.children}</WorkspaceProvider>
-      </ApolloTestProvider>
-    </MemoryRouter>
+    <RecoilRoot>
+      <MemoryRouter {...routerProps}>
+        <ApolloTestProvider {...apolloProps} typeDefs={typeDefs as any}>
+          <CustomAlertProvider />
+          <WorkspaceProvider>{props.children}</WorkspaceProvider>
+        </ApolloTestProvider>
+      </MemoryRouter>
+    </RecoilRoot>
   );
 };


### PR DESCRIPTION
## Summary & Motivation

1. Virtualize the AssetWipeDialog so that it doesn't make the page unresponsive
2. Add a container with a max height to make it easier to scroll
3. Show progress via progress bar + loading spinner on wipe button.

## How I Tested These Changes

Confirmed in network panel that chunking progresses through all assets
<img width="771" alt="Screenshot 2024-07-10 at 4 15 40 AM" src="https://github.com/dagster-io/dagster/assets/2286579/2da25b65-ab35-43f3-83ab-3126d894db21">

Progress indicator
<img width="1272" alt="Screenshot 2024-07-10 at 4 15 19 AM" src="https://github.com/dagster-io/dagster/assets/2286579/78a40cb2-e62f-4a3b-b719-d7bbd6953879">

Virtualized list
<img width="1274" alt="Screenshot 2024-07-10 at 4 13 49 AM" src="https://github.com/dagster-io/dagster/assets/2286579/b83cabad-a1f8-41f6-a0d0-118b64780e99">
