### PR TITLE
Fix page crash in asset catalog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -35,6 +35,7 @@ import {LoadingSpinner} from '../ui/Loading';
 type Asset = AssetTableFragment;
 
 const groupTableCache = new Map();
+const emptyArray: string[] = [];
 
 export const ASSET_CATALOG_TABLE_QUERY_VERSION = 1;
 const DEFAULT_BATCH_LIMIT = 10000;
@@ -60,6 +61,7 @@ export function useCachedAssets({
 
   return {cacheManager};
 }
+const requery = () => [{query: ASSET_CATALOG_TABLE_QUERY, fetchPolicy: 'no-cache' as const}];
 
 export function useAllAssets({
   batchLimit = DEFAULT_BATCH_LIMIT,
@@ -209,12 +211,15 @@ export const AssetsCatalogTable = ({
 
   useBlockTraceUntilTrue('useAllAssets', !!assets?.length);
 
-  const {displayPathForAsset, displayed} =
-    view === 'flat'
-      ? buildFlatProps(filtered, prefixPath)
-      : buildNamespaceProps(filtered, prefixPath);
+  const {displayPathForAsset, displayed} = useMemo(
+    () =>
+      view === 'flat'
+        ? buildFlatProps(filtered, prefixPath)
+        : buildNamespaceProps(filtered, prefixPath),
+    [filtered, prefixPath, view],
+  );
 
-  const refreshState = useRefreshAtInterval<any>({
+  const refreshState = useRefreshAtInterval({
     refresh: query,
     intervalMs: FIFTEEN_SECONDS,
     leading: true,
@@ -285,10 +290,10 @@ export const AssetsCatalogTable = ({
         ) : null
       }
       refreshState={refreshState}
-      prefixPath={prefixPath || []}
+      prefixPath={prefixPath || emptyArray}
       searchPath={searchPath}
       displayPathForAsset={displayPathForAsset}
-      requery={(_) => [{query: ASSET_CATALOG_TABLE_QUERY, fetchPolicy: 'no-cache'}]}
+      requery={requery}
       computeKindFilter={computeKindFilter}
       storageKindFilter={storageKindFilter}
     />


### PR DESCRIPTION
## Summary & Motivation

The source of the page crash is using `.push(...items)` with an array of over 100k items.

## How I Tested These Changes

Ticked the checkbox for a folder with over 100k items that would previously cause the page to crash and observe the page no longer crashes.