### PR TITLE
[perf] Remove n^2 logic in asset catalog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -346,7 +346,7 @@ function buildFlatProps(assets: Asset[], _: string[]) {
 }
 
 function buildNamespaceProps(assets: Asset[], prefixPath: string[]) {
-  // Return all assets from the next PAGE_SIZE namespaces - the AssetTable component will later
+  // Return all assets matching prefixPath - the AssetTable component will later
   // group them by namespace
 
   const namespaceForAsset = (asset: Asset) => {
@@ -355,7 +355,7 @@ function buildNamespaceProps(assets: Asset[], prefixPath: string[]) {
 
   // Only consider assets that start with the prefix path
   const assetsWithPathPrefix = assets.filter((asset) =>
-    asset.key.path.join(',').startsWith(prefixPath.join(',')),
+    prefixPath.every((part, index) => part === asset.key.path[index]),
   );
 
   return {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -358,23 +358,8 @@ function buildNamespaceProps(assets: Asset[], prefixPath: string[]) {
     asset.key.path.join(',').startsWith(prefixPath.join(',')),
   );
 
-  const namespaces = Array.from(
-    new Set(assetsWithPathPrefix.map((asset) => JSON.stringify(namespaceForAsset(asset)))),
-  )
-    .map((x) => JSON.parse(x))
-    .sort();
-
   return {
     displayPathForAsset: namespaceForAsset,
-    displayed: filterAssetsByNamespace(
-      assetsWithPathPrefix,
-      namespaces.map((ns) => [...prefixPath, ...ns]),
-    ),
+    displayed: assetsWithPathPrefix,
   };
 }
-
-const filterAssetsByNamespace = (assets: Asset[], paths: string[][]) => {
-  return assets.filter((asset) =>
-    paths.some((path) => path.every((part, i) => part === asset.key.path[i])),
-  );
-};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -353,7 +353,6 @@ function buildNamespaceProps(assets: Asset[], prefixPath: string[]) {
     return asset.key.path.slice(prefixPath.length, prefixPath.length + 1);
   };
 
-  // Only consider assets that start with the prefix path
   const assetsWithPathPrefix = assets.filter((asset) =>
     prefixPath.every((part, index) => part === asset.key.path[index]),
   );


### PR DESCRIPTION
## Summary & Motivation

I'm not really sure what the original code was trying to do, it seems to have morphed a bit over the years. I believe just filtering by prefixPath is all we need to do here so removing all of the extraneous logic. It's totally possible I'm missing something but from my testing this works the same.

## How I Tested These Changes


Loaded an asset catalog with 100k assets and saw that loading a folder view in that catalog didn't cause the page to hang. Also confirmed that the assets displayed for that folder were correct.