### PR TITLE
Bump up langchain dependencies in with_openai example

### DIFF
--- a/examples/with_openai/setup.py
+++ b/examples/with_openai/setup.py
@@ -6,14 +6,12 @@ setup(
     install_requires=[
         "dagster",
         "dagster-aws",
-        # Commented to avoid version conflicts with Pyright in the Dagster repo, uncomment when using Dagster+
-        # "dagster-cloud",
         "dagster-openai",
         "faiss-cpu==1.8.0",
         "filelock",
-        "langchain==0.1.11",
-        "langchain-community==0.0.34",
-        "langchain-openai==0.1.3",
+        "langchain==0.2.7",
+        "langchain-community==0.2.7",
+        "langchain-openai==0.1.14",
     ],
     extras_require={"dev": ["dagster-webserver", "pytest"]},
 )

--- a/examples/with_openai/with_openai/assets.py
+++ b/examples/with_openai/with_openai/assets.py
@@ -75,12 +75,20 @@ def completion(
     search_index: Dict[str, Any],
 ):
     merged_index: Any = None
+    # allow_dangerous_deserialization set to True since since we created the search index ourselves
+    # in the search_index asset
     for index in search_index.values():
-        curr = FAISS.deserialize_from_bytes(index, OpenAIEmbeddings())
+        curr = FAISS.deserialize_from_bytes(
+            index, OpenAIEmbeddings(), allow_dangerous_deserialization=True
+        )
         if not merged_index:
             merged_index = curr
         else:
-            merged_index.merge_from(FAISS.deserialize_from_bytes(index, OpenAIEmbeddings()))
+            merged_index.merge_from(
+                FAISS.deserialize_from_bytes(
+                    index, OpenAIEmbeddings(), allow_dangerous_deserialization=True
+                )
+            )
     with openai.get_client(context) as client:
         prompt = stuff_prompt.PROMPT
         model = ChatOpenAI(client=client.chat.completions, model=config.model, temperature=0)


### PR DESCRIPTION
Summary:
Resolves a dependabot issue with the old version of langchain we are currently using in this example. Had to add a flag to indicate that the bytes that we are deserializing are from a trusted source (ourselves), but maybe there's a less scary-looking way to accomplish that.

Test Plan: Run example locally

## Summary & Motivation

## How I Tested These Changes
