### PR TITLE
Augment dagster dev sanity check test to actually verify that it could load the toys code location

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
+++ b/integration_tests/test_suites/daemon-test-suite/dagster_dev_command_tests/test_dagster_dev_command.py
@@ -78,6 +78,14 @@ def test_dagster_dev_command_loads_toys():
                 )
                 try:
                     _wait_for_dagit_running(dagit_port)
+
+                    client = DagsterGraphQLClient(hostname="localhost", port_number=dagit_port)
+                    locations_and_names = client._get_repo_locations_and_names_with_pipeline(  # noqa
+                        "hammer"
+                    )
+                    assert (
+                        len(locations_and_names) > 0
+                    ), "toys repo failed to load or was missing a job called 'hammer'"
                 finally:
                     dev_process.send_signal(signal.SIGINT)
                     dev_process.communicate()

--- a/integration_tests/test_suites/daemon-test-suite/tox.ini
+++ b/integration_tests/test_suites/daemon-test-suite/tox.ini
@@ -22,6 +22,8 @@ deps =
   -e ../../../python_modules/libraries/dagster-celery-k8s
   -e ../../../python_modules/libraries/dagster-postgres
   -e ../../../python_modules/libraries/dagster-docker
+  -e ../../../python_modules/libraries/dagstermill
+  -e ../../../python_modules/libraries/dagster-slack
 allowlist_externals =
   /bin/bash
   uv


### PR DESCRIPTION
Summary:
This test previously detected dagit crashes on startup, but not issues with loading the toys repo. Now it does both.

Test Plan: BK (this test is failing in master currently due to an issue introduced by https://github.com/dagster-io/dagster/pull/22890)

## Summary & Motivation

## How I Tested These Changes
