### PR TITLE
[ui] IA: Settings -> Deployment

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavLinks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavLinks.tsx
@@ -6,9 +6,9 @@ import {TopNavLink} from './AppTopNav';
 import {
   assetsPathMatcher,
   automationPathMatcher,
+  deploymentPathMatcher,
   jobsPathMatcher,
   locationPathMatcher,
-  settingsPathMatcher,
 } from './activePathMatchers';
 import {DeploymentStatusIcon} from '../../nav/DeploymentStatusIcon';
 import {FeatureFlag, featureEnabled} from '../Flags';
@@ -96,21 +96,28 @@ export const navLinks = () => {
     ),
   };
 
-  const settings = {
-    key: 'settings',
-    path: '/settings',
-    element: (
-      <TopNavLink to="/settings" data-cy="AppTopNav_SettingsLink" isActive={settingsPathMatcher}>
-        <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
-          Settings
-          <DeploymentStatusIcon />
-        </Box>
-      </TopNavLink>
-    ),
-  };
+  if (featureEnabled(FeatureFlag.flagSettingsPage)) {
+    const deployment = {
+      key: 'deployment',
+      path: '/deployment',
+      element: (
+        <TopNavLink
+          to="/deployment"
+          data-cy="AppTopNav_DeploymentLink"
+          isActive={deploymentPathMatcher}
+        >
+          <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
+            Deployment
+            <DeploymentStatusIcon />
+          </Box>
+        </TopNavLink>
+      ),
+    };
+    return [overview, assets, jobs, automation, runs, deployment];
+  }
 
   const deployment = {
-    key: 'deployment',
+    key: 'locations',
     path: '/locations',
     element: (
       <TopNavLink to="/locations" data-cy="AppTopNav_StatusLink" isActive={locationPathMatcher}>
@@ -121,10 +128,6 @@ export const navLinks = () => {
       </TopNavLink>
     ),
   };
-
-  if (featureEnabled(FeatureFlag.flagSettingsPage)) {
-    return [overview, assets, jobs, automation, runs, settings];
-  }
 
   return [overview, runs, assets, deployment];
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/activePathMatchers.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/activePathMatchers.tsx
@@ -20,10 +20,10 @@ export const assetsPathMatcher: MatcherFn = (_, currentLocation) => {
   );
 };
 
-export const settingsPathMatcher: MatcherFn = (_, currentLocation) => {
+export const deploymentPathMatcher: MatcherFn = (_, currentLocation) => {
   const {pathname} = currentLocation;
   return (
-    pathname.startsWith('/settings') ||
+    pathname.startsWith('/deployment') ||
     (pathname.startsWith('/locations') &&
       !pathname.includes('/asset-groups/') &&
       !automationPathMatcher(_, currentLocation) &&
@@ -36,6 +36,7 @@ export const locationPathMatcher: MatcherFn = (_, currentLocation) => {
   return (
     (pathname.startsWith('/locations') && !pathname.includes('/asset-groups/')) ||
     pathname.startsWith('/health') ||
+    pathname.startsWith('/concurrency') ||
     pathname.startsWith('/config')
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
@@ -86,7 +86,7 @@ export const ContentRoot = memo(() => {
           <Route path="/automation">
             <AutomationRoot />
           </Route>
-          <Route path="/settings">
+          <Route path="/deployment">
             <SettingsRoot />
           </Route>
           <Route path="*" isNestingRoute>

--- a/js_modules/dagster-ui/packages/ui-core/src/settings/SettingsLeftPane.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/settings/SettingsLeftPane.tsx
@@ -12,28 +12,28 @@ const items: SideNavItemConfig[] = [
     type: 'link',
     icon: <Icon name="code_location" />,
     label: 'Code locations',
-    path: '/settings/locations',
+    path: '/deployment/locations',
   },
   {
     key: 'daemons',
     type: 'link',
     icon: <Icon name="sync_alt" />,
     label: 'Daemons',
-    path: '/settings/daemons',
+    path: '/deployment/daemons',
   },
   {
     key: 'concurrency-limits',
     type: 'link',
     icon: <Icon name="stacks" />,
     label: 'Concurrency limits',
-    path: '/settings/concurrency',
+    path: '/deployment/concurrency',
   },
   {
     key: 'config',
     type: 'link',
     icon: <Icon name="tune" />,
     label: 'Configuration (read-only)',
-    path: '/settings/config',
+    path: '/deployment/config',
   },
 ];
 

--- a/js_modules/dagster-ui/packages/ui-core/src/settings/SettingsMainPane.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/settings/SettingsMainPane.tsx
@@ -17,20 +17,20 @@ export const SettingsMainPane = () => {
   return (
     <Box flex={{direction: 'column', alignItems: 'stretch'}} style={{flex: 1, overflow: 'hidden'}}>
       <Switch>
-        <Route path="/settings/locations">
+        <Route path="/deployment/locations">
           <CodeLocationsPageContent />
         </Route>
-        <Route path="/settings/daemons">
+        <Route path="/deployment/daemons">
           <InstanceHealthPageContent />
         </Route>
-        <Route path="/settings/concurrency">
+        <Route path="/deployment/concurrency">
           <InstanceConcurrencyPageContent />
         </Route>
-        <Route path="/settings/config">
+        <Route path="/deployment/config">
           <InstanceConfigContent />
         </Route>
         <Route path="*" isNestingRoute>
-          <Redirect to="/settings/locations" />
+          <Redirect to="/deployment/locations" />
         </Route>
       </Switch>
     </Box>


### PR DESCRIPTION
## Summary & Motivation

For the IA flag, rename "Settings" to "Deployment". This includes changing `/settings` routes to `/deployment`.

There is a corresponding internal change as well.

## How I Tested These Changes

Inside and outside IA feature flag, verify correct rendering and behavior of the top nav item and all routes and pages within that section of the app.