### PR TITLE
[graphql] prevent repeated subscription starts

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/graphql.py
+++ b/python_modules/dagster-webserver/dagster_webserver/graphql.py
@@ -194,6 +194,10 @@ class GraphQLServer(ABC):
                 elif message_type == GraphQLWS.CONNECTION_TERMINATE:
                     await websocket.close()
                 elif message_type == GraphQLWS.START:
+                    # Ignore if same operation id attempts to get restarted
+                    if operation_id in tasks:
+                        continue
+
                     data = message["payload"]
 
                     task, error_payload = await self.execute_graphql_subscription(
@@ -213,7 +217,7 @@ class GraphQLServer(ABC):
 
                 elif message_type == GraphQLWS.STOP:
                     if operation_id not in tasks:
-                        return
+                        continue
 
                     tasks[operation_id].cancel()
                     del tasks[operation_id]

--- a/python_modules/dagster-webserver/dagster_webserver_tests/test_subscriptions.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/test_subscriptions.py
@@ -53,24 +53,27 @@ def send_subscription_message(ws, op, payload=None):
     ws.send_json({"id": 1, "type": op, "payload": payload or {}})
 
 
+def start_connection(ws):
+    send_subscription_message(ws, GraphQLWS.CONNECTION_INIT)
+    ws.receive_json()
+
+
+def end_connection(ws):
+    send_subscription_message(ws, GraphQLWS.CONNECTION_TERMINATE)
+    ws.close()
+
+
 def start_subscription(ws, query, variables=None):
     start_payload = {
         "query": query,
         "variables": variables or {},
     }
 
-    send_subscription_message(ws, GraphQLWS.CONNECTION_INIT)
-    ws.receive_json()
     send_subscription_message(ws, GraphQLWS.START, start_payload)
-    rx = ws.receive_json()
-    assert rx["type"] != GraphQLWS.ERROR, rx
-    return rx
 
 
 def end_subscription(ws):
     send_subscription_message(ws, GraphQLWS.STOP)
-    send_subscription_message(ws, GraphQLWS.CONNECTION_TERMINATE)
-    ws.close()
 
 
 @op
@@ -83,71 +86,100 @@ def example_job():
     example_op()
 
 
-def test_event_log_subscription() -> None:
+@pytest.fixture(scope="module")
+def instance():
     with instance_for_test() as instance:
-        run = example_job.execute_in_process(instance=instance)
-        assert run.success
-        assert run.run_id
+        yield instance
 
-        with create_asgi_client(instance) as client:
-            with client.websocket_connect("/graphql", GraphQLWS.PROTOCOL) as ws:
-                assert str(ws.accepted_subprotocol) == "graphql-ws"
-                start_subscription(ws, EVENT_LOG_SUBSCRIPTION, {"runId": run.run_id})
-                gc.collect()
-                assert len(objgraph.by_type("async_generator")) == 1
-                end_subscription(ws)
 
-            gc.collect()
-            assert len(objgraph.by_type("async_generator")) == 0
+@pytest.fixture(scope="module")
+def asgi_client(instance):
+    with create_asgi_client(instance) as client:
+        yield client
+
+
+@pytest.fixture(scope="module")
+def run_id(instance):
+    run = example_job.execute_in_process(instance=instance)
+    assert run.success
+    assert run.run_id
+    return run.run_id
+
+
+def test_event_log_subscription(asgi_client, run_id) -> None:
+    with asgi_client.websocket_connect("/graphql", GraphQLWS.PROTOCOL) as ws:
+        assert str(ws.accepted_subprotocol) == "graphql-ws"
+        start_connection(ws)
+        start_subscription(ws, EVENT_LOG_SUBSCRIPTION, {"runId": run_id})
+
+        rx = ws.receive_json()
+        assert rx["type"] != GraphQLWS.ERROR, rx
+
+        start_subscription(
+            ws, EVENT_LOG_SUBSCRIPTION, {"runId": run_id}
+        )  # duplicate starts ignored
+
+        gc.collect()
+        assert len(objgraph.by_type("async_generator")) == 1
+        end_subscription(ws)
+
+        # can restart on the same connection
+        start_subscription(ws, EVENT_LOG_SUBSCRIPTION, {"runId": run_id})
+        rx = ws.receive_json()
+        assert rx["type"] != GraphQLWS.ERROR, rx
+        end_subscription(ws)
+
+        end_connection(ws)
+
+    gc.collect()
+    assert len(objgraph.by_type("async_generator")) == 0
 
 
 @pytest.mark.skipif(
     sys.version_info < (3, 8),
     reason="Inconsistent GC on the async_generator in 3.7",
 )
-def test_event_log_subscription_chunked():
-    with instance_for_test() as instance, environ({"DAGSTER_WEBSERVER_EVENT_LOAD_CHUNK_SIZE": "2"}):
-        run = example_job.execute_in_process(instance=instance)
-        assert run.success
-        assert run.run_id
-
-        with create_asgi_client(instance) as client:
-            with client.websocket_connect("/graphql", GraphQLWS.PROTOCOL) as ws:
-                start_subscription(ws, EVENT_LOG_SUBSCRIPTION, {"runId": run.run_id})
-                gc.collect()
-                assert len(objgraph.by_type("async_generator")) == 1
-
-                end_subscription(ws)
-
+def test_event_log_subscription_chunked(asgi_client, run_id):
+    with environ({"DAGSTER_WEBSERVER_EVENT_LOAD_CHUNK_SIZE": "2"}), asgi_client.websocket_connect(
+        "/graphql", GraphQLWS.PROTOCOL
+    ) as ws:
+        start_connection(ws)
+        start_subscription(ws, EVENT_LOG_SUBSCRIPTION, {"runId": run_id})
+        rx = ws.receive_json()
+        assert rx["type"] != GraphQLWS.ERROR, rx
         gc.collect()
-        assert len(objgraph.by_type("async_generator")) == 0
+        assert len(objgraph.by_type("async_generator")) == 1
+
+        end_subscription(ws)
+        end_connection(ws)
+
+    gc.collect()
+    assert len(objgraph.by_type("async_generator")) == 0
 
 
 @mock.patch(
     "dagster._core.storage.local_compute_log_manager.LocalComputeLogManager.is_watch_completed"
 )
-def test_compute_log_subscription(mock_watch_completed):
+def test_compute_log_subscription(mock_watch_completed, asgi_client, run_id):
     mock_watch_completed.return_value = False
 
-    with instance_for_test() as instance:
-        run = example_job.execute_in_process(instance=instance)
-        assert run.success
-        assert run.run_id
+    with asgi_client.websocket_connect("/graphql", GraphQLWS.PROTOCOL) as ws:
+        start_connection(ws)
+        start_subscription(
+            ws,
+            COMPUTE_LOG_SUBSCRIPTION,
+            {
+                "runId": run_id,
+                "stepKey": "example_op",
+                "ioType": "STDERR",
+            },
+        )
+        rx = ws.receive_json()
+        assert rx["type"] != GraphQLWS.ERROR, rx
 
-        with create_asgi_client(instance) as client:
-            with client.websocket_connect("/graphql", GraphQLWS.PROTOCOL) as ws:
-                start_subscription(
-                    ws,
-                    COMPUTE_LOG_SUBSCRIPTION,
-                    {
-                        "runId": run.run_id,
-                        "stepKey": "example_op",
-                        "ioType": "STDERR",
-                    },
-                )
-                gc.collect()
-                assert len(objgraph.by_type("ComputeLogSubscription")) == 1
-                end_subscription(ws)
+        gc.collect()
+        assert len(objgraph.by_type("ComputeLogSubscription")) == 1
+        end_subscription(ws)
 
-            gc.collect()
-            assert len(objgraph.by_type("ComputeLogSubscription")) == 0
+    gc.collect()
+    assert len(objgraph.by_type("ComputeLogSubscription")) == 0


### PR DESCRIPTION
Seen some logs that seem to indicate we might be receiving multiple `START` messages and piling asyncio tasks. Just ignore these duplicate starts for the same operation id.

## How I Tested These Changes

updated tests that failed before fixes

`dagster dev -f python_modules/dagster-test/dagster_test/toys/log_spew.py`
launch log_spew and monitor web socket in network tab of browser dev tools 