### PR TITLE
[record] 3.8/3.9 fixes

### DIFF
--- a/python_modules/dagster/dagster/_check/builder.py
+++ b/python_modules/dagster/dagster/_check/builder.py
@@ -184,7 +184,13 @@ def _name(target: Optional[TypeOrTupleOfTypes]) -> str:
     if isinstance(target, tuple):
         return f"({', '.join(tup_type.__name__ if tup_type is not NoneType else 'check.NoneType' for tup_type in target)})"
 
-    return target.__name__
+    if hasattr(target, "__name__"):
+        return target.__name__
+
+    if hasattr(target, "_name"):
+        return getattr(target, "_name")
+
+    failed(f"Could not calculate string name for {target}")
 
 
 def build_check_call_str(
@@ -283,6 +289,11 @@ def build_check_call_str(
                         return f'check.opt_nullable_iterable_param({name}, "{name}", {_name(inner_single)})'
                     elif inner_origin is collections.abc.Mapping:
                         return f'check.opt_nullable_mapping_param({name}, "{name}", {_name(inner_pair_left)}, {_name(inner_pair_right)})'
+                    elif inner_origin is collections.abc.Set:
+                        return (
+                            f'check.opt_nullable_set_param({name}, "{name}", {_name(inner_single)})'
+                        )
+
             # union
             else:
                 tuple_types = _coerce_type(ttype, eval_ctx)

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -1598,6 +1598,19 @@ BUILD_CASES = [
     (Iterable[str], [["a", "b"]], [[1, 2]]),
     (Set[str], [{"a", "b"}], [{1, 2}]),
     (AbstractSet[str], [{"a", "b"}], [{1, 2}]),
+    (Optional[AbstractSet[str]], [{"a", "b"}, None], [{1, 2}]),
+    (
+        Mapping[str, AbstractSet[str]],
+        [
+            {"letters": {"a", "b"}},
+            # should fail, but we do not yet handle inner collection types,
+            # check.mapping_param(..., key_type=str, value_type=AbstractSet)
+            {"numbers": {1, 2}},
+        ],
+        [
+            {"letters": ["a", "b"]},
+        ],
+    ),
     (Dict[str, int], [{"a": 1}], [{1: "a"}]),
     (Mapping[str, int], [{"a": 1}], [{1: "a"}]),
     (Optional[int], [None], ["4"]),


### PR DESCRIPTION
some typing types do not have `__name__` in 3.8 / 3.9 but they do have `_name` 

## How I Tested These Changes

updated tests
