### PR TITLE
[DA] fix automation condition serdes

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/__init__.py
@@ -1,0 +1,21 @@
+from .operands import (
+    CodeVersionChangedCondition as CodeVersionChangedCondition,
+    CronTickPassedCondition as CronTickPassedCondition,
+    FailedAutomationCondition as FailedAutomationCondition,
+    InLatestTimeWindowCondition as InLatestTimeWindowCondition,
+    InProgressAutomationCondition as InProgressAutomationCondition,
+    MissingAutomationCondition as MissingAutomationCondition,
+    NewlyRequestedCondition as NewlyRequestedCondition,
+    NewlyUpdatedCondition as NewlyUpdatedCondition,
+    WillBeRequestedCondition as WillBeRequestedCondition,
+)
+from .operators import (
+    AllDepsCondition as AllDepsCondition,
+    AndAssetCondition as AndAssetCondition,
+    AnyDepsCondition as AnyDepsCondition,
+    AnyDownstreamConditionsCondition as AnyDownstreamConditionsCondition,
+    NewlyTrueCondition as NewlyTrueCondition,
+    NotAssetCondition as NotAssetCondition,
+    OrAssetCondition as OrAssetCondition,
+    SinceCondition as SinceCondition,
+)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -1,14 +1,18 @@
 from abc import abstractmethod
-from typing import AbstractSet, Optional
+from typing import TYPE_CHECKING, AbstractSet, Optional
+
+from typing_extensions import Annotated
 
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
-from dagster._record import copy, record
+from dagster._record import ImportFrom, copy, record
 from dagster._serdes.serdes import whitelist_for_serdes
 
 from ..automation_condition import AutomationCondition, AutomationResult
 from ..automation_context import AutomationContext
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.asset_selection import AssetSelection
 
 
 @record
@@ -45,8 +49,12 @@ class DepConditionWrapperCondition(AutomationCondition):
 @record
 class DepCondition(AutomationCondition):
     operand: AutomationCondition
-    allow_selection: Optional[AssetSelection] = None
-    ignore_selection: Optional[AssetSelection] = None
+    allow_selection: Optional[
+        Annotated["AssetSelection", ImportFrom("dagster._core.definitions.asset_selection")]
+    ] = None
+    ignore_selection: Optional[
+        Annotated["AssetSelection", ImportFrom("dagster._core.definitions.asset_selection")]
+    ] = None
 
     @property
     @abstractmethod
@@ -61,7 +69,7 @@ class DepCondition(AutomationCondition):
             description += f" except for {self.ignore_selection}"
         return description
 
-    def allow(self, selection: AssetSelection) -> "DepCondition":
+    def allow(self, selection: "AssetSelection") -> "DepCondition":
         """Returns a copy of this condition that will only consider dependencies within the provided
         AssetSelection.
         """
@@ -70,7 +78,7 @@ class DepCondition(AutomationCondition):
         )
         return copy(self, allow_selection=allow_selection)
 
-    def ignore(self, selection: AssetSelection) -> "DepCondition":
+    def ignore(self, selection: "AssetSelection") -> "DepCondition":
         """Returns a copy of this condition that will ignore dependencies within the provided
         AssetSelection.
         """

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_automation_condition_serdes.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_automation_condition_serdes.py
@@ -1,0 +1,13 @@
+from dagster import deserialize_value
+
+
+def test_deserialize_no_imports() -> None:
+    serialized = """
+    {"__class__": "AndAssetCondition", "operands": [{"__class__": "InLatestTimeWindowCondition", "serializable_lookback_timedelta": null}, {"__class__": "SinceCondition", "reset_condition": {"__class__": "NewlyRequestedCondition"}, "trigger_condition": {"__class__": "CronTickPassedCondition", "cron_schedule": "0 * * * *", "cron_timezone": "UTC"}}, {"__class__": "AllDepsCondition", "allow_selection": null, "ignore_selection": null, "operand": {"__class__": "OrAssetCondition", "operands": [{"__class__": "SinceCondition", "reset_condition": {"__class__": "CronTickPassedCondition", "cron_schedule": "0 * * * *", "cron_timezone": "UTC"}, "trigger_condition": {"__class__": "NewlyUpdatedCondition"}}, {"__class__": "WillBeRequestedCondition"}]}}]}
+    """
+    deserialized = deserialize_value(serialized)
+
+    # defer import so AutomationCondition doesn't get whitelisted incidentally
+    from dagster import AutomationCondition
+
+    assert isinstance(deserialized, AutomationCondition)


### PR DESCRIPTION
## Summary & Motivation

Because the subclasses of AutomationCondition are not exported from the top-level dagster module, `@whitelist_for_serdes` is not guaranteed to pick them up. In a previous PR, I moved around imports such that these were no longer incidentally imported when importing `AutomationCondition`, which is exported from the top level dagster module (because this helped avoid circular import errors).

This meant that if you deserialized an AutomationCondition before making some specific imports, this would fail.

To fix the circular import errors I needed to use the new ImportFrom mechanism.

Added a test which failed before and passes now.

## How I Tested These Changes
