### PR TITLE
fix warnings contextvar in asyncio

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute_generator.py
@@ -351,13 +351,16 @@ def validate_and_coerce_op_result_to_iterator(
                 _check_output_object_name(element, output_def, position)
 
                 with disable_dagster_warnings():
-                    yield Output(
+                    output = Output(
                         output_name=output_def.name,
                         value=element.value,
                         metadata=element.metadata,
                         data_version=element.data_version,
                         tags=element.tags,
                     )
+
+                yield output
+
             else:
                 # If annotation indicates a generic output annotation, and an
                 # output object was not received, throw an error.

--- a/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_async.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/misc_execution_tests/test_async.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from dagster import Output
+from dagster import Output, asset, materialize
 from dagster._core.definitions.decorators import op
 from dagster._utils.test import wrap_op_in_graph_and_execute
 
@@ -13,6 +13,16 @@ def test_aio_op():
 
     result = wrap_op_in_graph_and_execute(aio_op)
     assert result.output_value() == "done"
+
+
+def test_aio_asset():
+    @asset
+    async def aio_asset(_):
+        await asyncio.sleep(0.01)
+        return Output("done")
+
+    result = materialize([aio_asset])
+    assert result.success
 
 
 def test_aio_gen_op():


### PR DESCRIPTION
context managers around yields in generators leads to extremely bizarre behavior, so avoid it.

fixes https://github.com/dagster-io/dagster/issues/22606

## How I Tested These Changes

added test that was previously failing