### PR TITLE
[dagster-pipes] add PipesCliArgsParamsLoader

### DIFF
--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -1,3 +1,4 @@
+import argparse
 import base64
 import datetime
 import json
@@ -363,7 +364,7 @@ def _normalize_param_metadata(
     return new_metadata
 
 
-def encode_env_var(value: Any) -> str:
+def encode_param(value: Any) -> str:
     """Encode value by serializing to JSON, compressing with zlib, and finally encoding with base64.
     `base64_encode(compress(to_json(value)))` in function notation.
 
@@ -373,13 +374,13 @@ def encode_env_var(value: Any) -> str:
     Returns:
         str: The encoded value.
     """
-    serialized = _json_serialize_param(value, "encode_env_var", "value")
+    serialized = _json_serialize_param(value, "encode_param", "value")
     compressed = zlib.compress(serialized.encode("utf-8"))
     encoded = base64.b64encode(compressed)
     return encoded.decode("utf-8")  # as string
 
 
-def decode_env_var(value: str) -> Any:
+def decode_param(value: str) -> Any:
     """Decode a value by decoding from base64, decompressing with zlib, and finally deserializing from
     JSON. `from_json(decompress(base64_decode(value)))` in function notation.
 
@@ -392,6 +393,11 @@ def decode_env_var(value: str) -> Any:
     decoded = base64.b64decode(value)
     decompressed = zlib.decompress(decoded)
     return json.loads(decompressed.decode("utf-8"))
+
+
+# these aliases are deprecated and will be removed in 2.0
+encode_env_var = encode_param
+decode_env_var = decode_param
 
 
 def _emit_orchestration_inactive_warning() -> None:
@@ -776,11 +782,11 @@ class PipesMappingParamsLoader(PipesParamsLoader):
 
     def load_context_params(self) -> PipesParams:
         raw_value = self._mapping[DAGSTER_PIPES_CONTEXT_ENV_VAR]
-        return decode_env_var(raw_value)
+        return decode_param(raw_value)
 
     def load_messages_params(self) -> PipesParams:
         raw_value = self._mapping[DAGSTER_PIPES_MESSAGES_ENV_VAR]
-        return decode_env_var(raw_value)
+        return decode_param(raw_value)
 
 
 class PipesEnvVarParamsLoader(PipesMappingParamsLoader):
@@ -788,6 +794,45 @@ class PipesEnvVarParamsLoader(PipesMappingParamsLoader):
 
     def __init__(self):
         super().__init__(mapping=os.environ)
+
+
+def env_var_to_cli_argument(env_var: str) -> str:
+    return f"--{env_var}".lower().replace("_", "-")
+
+
+DAGSTER_PIPES_CONTEXT_CLI_ARGUMENT = env_var_to_cli_argument(DAGSTER_PIPES_CONTEXT_ENV_VAR)
+DAGSTER_PIPES_MESSAGES_CLI_ARGUMENT = env_var_to_cli_argument(DAGSTER_PIPES_MESSAGES_ENV_VAR)
+
+DAGSTER_PIPES_CLI_PARSER = argparse.ArgumentParser(description="Dagster Pipes CLI interface")
+DAGSTER_PIPES_CLI_PARSER.add_argument(
+    DAGSTER_PIPES_CONTEXT_CLI_ARGUMENT,
+    type=str,
+    help="Argument with base64 encoded and zlib-compressed JSON string containing the Pipes context",
+)
+DAGSTER_PIPES_CLI_PARSER.add_argument(
+    DAGSTER_PIPES_MESSAGES_CLI_ARGUMENT,
+    type=str,
+    help="Argument with base64 encoded and zlib-compressed JSON string containing the Pipes messages",
+)
+
+
+class PipesCliArgsParamsLoader(PipesParamsLoader):
+    """Params loader that extracts params from known CLI arguments."""
+
+    def __init__(self):
+        self.parser = DAGSTER_PIPES_CLI_PARSER
+
+    def is_dagster_pipes_process(self) -> bool:
+        # use the presence of --dagster-pipes-context to discern if we are in a pipes process
+        return DAGSTER_PIPES_CONTEXT_CLI_ARGUMENT in sys.argv
+
+    def load_context_params(self) -> PipesParams:
+        args, _ = self.parser.parse_known_args()
+        return decode_param(args.dagster_pipes_context)
+
+    def load_messages_params(self) -> PipesParams:
+        args, _ = self.parser.parse_known_args()
+        return decode_param(args.dagster_pipes_messages)
 
 
 # ########################

--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -796,12 +796,12 @@ class PipesEnvVarParamsLoader(PipesMappingParamsLoader):
         super().__init__(mapping=os.environ)
 
 
-def env_var_to_cli_argument(env_var: str) -> str:
+def _env_var_to_cli_argument(env_var: str) -> str:
     return f"--{env_var}".lower().replace("_", "-")
 
 
-DAGSTER_PIPES_CONTEXT_CLI_ARGUMENT = env_var_to_cli_argument(DAGSTER_PIPES_CONTEXT_ENV_VAR)
-DAGSTER_PIPES_MESSAGES_CLI_ARGUMENT = env_var_to_cli_argument(DAGSTER_PIPES_MESSAGES_ENV_VAR)
+DAGSTER_PIPES_CONTEXT_CLI_ARGUMENT = _env_var_to_cli_argument(DAGSTER_PIPES_CONTEXT_ENV_VAR)
+DAGSTER_PIPES_MESSAGES_CLI_ARGUMENT = _env_var_to_cli_argument(DAGSTER_PIPES_MESSAGES_ENV_VAR)
 
 DAGSTER_PIPES_CLI_PARSER = argparse.ArgumentParser(description="Dagster Pipes CLI interface")
 DAGSTER_PIPES_CLI_PARSER.add_argument(

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -18,8 +18,8 @@ from dagster_pipes import (
     PipesOpenedData,
     PipesParams,
     PipesTimeWindow,
+    _env_var_to_cli_argument,
     encode_param,
-    env_var_to_cli_argument,
 )
 from typing_extensions import TypeAlias
 
@@ -305,7 +305,7 @@ class PipesSession:
             serialized as json, compressed with zlib, and then base64-encoded.
         """
         return {
-            env_var_to_cli_argument(param_name): encode_param(param_value)
+            _env_var_to_cli_argument(param_name): encode_param(param_value)
             for param_name, param_value in self.get_bootstrap_params().items()
         }
 

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
 from queue import Queue
-from typing import TYPE_CHECKING, Any, Dict, Iterator, Mapping, Optional, Sequence, Union, cast
+from typing import TYPE_CHECKING, Any, Iterator, Mapping, Optional, Sequence, Union, cast
 
 from dagster_pipes import (
     DAGSTER_PIPES_CONTEXT_ENV_VAR,
@@ -18,7 +18,8 @@ from dagster_pipes import (
     PipesOpenedData,
     PipesParams,
     PipesTimeWindow,
-    encode_env_var,
+    encode_param,
+    env_var_to_cli_argument,
 )
 from typing_extensions import TypeAlias
 
@@ -277,7 +278,7 @@ class PipesSession:
     context: OpExecutionContext
 
     @public
-    def get_bootstrap_env_vars(self) -> Dict[str, str]:
+    def get_bootstrap_env_vars(self) -> Mapping[str, str]:
         """Encode context injector and message reader params as environment variables.
 
         Passing environment variables is the typical way to expose the pipes I/O parameters
@@ -288,12 +289,28 @@ class PipesSession:
             serialized as json, compressed with gzip, and then base-64-encoded.
         """
         return {
-            param_name: encode_env_var(param_value)
+            param_name: encode_param(param_value)
             for param_name, param_value in self.get_bootstrap_params().items()
         }
 
     @public
-    def get_bootstrap_params(self) -> Dict[str, Any]:
+    def get_bootstrap_cli_arguments(self) -> Mapping[str, str]:
+        """Encode context injector and message reader params as CLI arguments.
+
+        Passing CLI arguments is an alternative way to expose the pipes I/O parameters to a pipes process.
+        Using environment variables should be preferred when possible.
+
+        Returns:
+            Mapping[str, str]: CLI arguments pass to the external process. The values are
+            serialized as json, compressed with zlib, and then base64-encoded.
+        """
+        return {
+            env_var_to_cli_argument(param_name): encode_param(param_value)
+            for param_name, param_value in self.get_bootstrap_params().items()
+        }
+
+    @public
+    def get_bootstrap_params(self) -> Mapping[str, Any]:
         """Get the params necessary to bootstrap a launched pipes process. These parameters are typically
         are as environment variable. See `get_bootstrap_env_vars`. It is the context injector's
         responsibility to decide how to pass these parameters to the external environment.

--- a/python_modules/libraries/dagster-sdf/tox.ini
+++ b/python_modules/libraries/dagster-sdf/tox.ini
@@ -6,10 +6,11 @@ download = True
 passenv = CI_* COVERALLS_REPO_TOKEN BUILDKITE*
 install_command = uv pip install {opts} {packages}
 deps =
+  -e ../../dagster-pipes
   -e ../../dagster[test]
   -e .[test]
 allowlist_externals =
   /bin/bash
   uv
 commands =
-  pytest -c ../../../pyproject.toml -vv {posargs}
+  pytest -c ../../../pyproject.toml -vv {posargs} --pdb

--- a/python_modules/libraries/dagster-sdf/tox.ini
+++ b/python_modules/libraries/dagster-sdf/tox.ini
@@ -13,4 +13,4 @@ allowlist_externals =
   /bin/bash
   uv
 commands =
-  pytest -c ../../../pyproject.toml -vv {posargs} --pdb
+  pytest -c ../../../pyproject.toml -vv {posargs}


### PR DESCRIPTION
## Summary & Motivation

This PR adds PipesCliArgsParamsLoader to dagster_pipes. 

This ParamsLoader is needed for some external processes which do not support setting environment variables. 

## How I Tested These Changes
Added tests with subprocess