### PR TITLE
[ui] Fix build and storybook for ui-components

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/.storybook/blueprint.css
+++ b/js_modules/dagster-ui/packages/ui-components/.storybook/blueprint.css
@@ -1,3 +1,0 @@
-@import '@blueprintjs/core/lib/css/blueprint.css';
-@import '@blueprintjs/select/lib/css/blueprint-select.css';
-@import '@blueprintjs/popover2/lib/css/blueprint-popover2.css';

--- a/js_modules/dagster-ui/packages/ui-components/.storybook/preview.js
+++ b/js_modules/dagster-ui/packages/ui-components/.storybook/preview.js
@@ -17,7 +17,9 @@ import {MemoryRouter} from 'react-router-dom';
 
 import {createGlobalStyle} from 'styled-components';
 
-import './blueprint.css';
+import '@blueprintjs/core/lib/css/blueprint.css';
+import '@blueprintjs/select/lib/css/blueprint-select.css';
+import '@blueprintjs/popover2/lib/css/blueprint-popover2.css';
 
 const GlobalStyle = createGlobalStyle`
   * {

--- a/js_modules/dagster-ui/packages/ui-components/rollup.config.js
+++ b/js_modules/dagster-ui/packages/ui-components/rollup.config.js
@@ -24,7 +24,7 @@ export default {
     // without pulling in the entire library.
     'components/Box': './src/components/Box.tsx',
     'components/Button': './src/components/Button.tsx',
-    'components/Colors': './src/components/Colors.tsx',
+    'components/Color': './src/components/Color.tsx',
     'components/Icon': './src/components/Icon.tsx',
   },
   output: {

--- a/js_modules/dagster-ui/packages/ui-components/src/components/Box.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/Box.tsx
@@ -4,7 +4,7 @@ import {Colors} from './Color';
 import {BorderSetting, BorderSide, DirectionalSpacing, FlexProperties} from './types';
 import {assertUnreachable} from '../util/assertUnreachable';
 
-interface Props {
+export interface Props {
   background?: string | null;
   border?: BorderSide | BorderSetting | null;
   flex?: FlexProperties | null;

--- a/js_modules/dagster-ui/packages/ui-core/.storybook/preview-head.html
+++ b/js_modules/dagster-ui/packages/ui-core/.storybook/preview-head.html
@@ -1,6 +1,0 @@
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link
-  href="https://fonts.googleapis.com/css2?family=Inter:wght@400..600&family=Inconsolata:wght@400..600"
-  rel="stylesheet"
-/>


### PR DESCRIPTION
## Summary & Motivation

A handful of storybook and build fixes:

- In `ui-components`, Blueprint CSS is not being imported properly. I'm not sure when this broke, but it works by just importing directly from the blueprintjs paths.
- Additionally, the `ui-components` build is broken because I didn't update the `Color` filepath. Fixed this.
- In `ui-core` Storybook, we no longer need the `preview-head.html` since we're not using Google fonts.

## How I Tested These Changes

`yarn storybook` on `ui-components`, verify that components like `Menu` now render with the proper imported Blueprint CSS.

`yarn build` on `ui-components`, verify successful output.

`yarn storybook` on `ui-core`, verify that everything still works fine.