### PR TITLE
[ui] Use newer virtualizer for Suggest

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/package.json
+++ b/js_modules/dagster-ui/packages/ui-components/package.json
@@ -26,6 +26,7 @@
     "@blueprintjs/core": "^4.20.2",
     "@blueprintjs/popover2": "1.13.12",
     "@blueprintjs/select": "^4.9.12",
+    "@tanstack/react-virtual": "^3.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-is": "^18.2.0",
@@ -36,7 +37,6 @@
     "amator": "^1.1.0",
     "codemirror": "^5.65.2",
     "deepmerge": "^4.2.2",
-    "react-virtualized": "^9.22.3",
     "yaml": "2.4.0"
   },
   "devDependencies": {

--- a/js_modules/dagster-ui/packages/ui-components/rollup.config.js
+++ b/js_modules/dagster-ui/packages/ui-components/rollup.config.js
@@ -54,10 +54,10 @@ export default {
     '@blueprintjs/core',
     '@blueprintjs/popover2',
     '@blueprintjs/select',
+    '@tanstack/react-virtual',
     'react',
     'react-dom',
     'react-is',
-    'react-virtualized',
     'styled-components',
   ],
 };

--- a/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Suggest.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/__stories__/Suggest.stories.tsx
@@ -1,6 +1,8 @@
 import {Meta} from '@storybook/react';
 import {useState} from 'react';
 
+import {Box} from '../Box';
+import {Colors} from '../Color';
 import {MenuItem} from '../Menu';
 import {Suggest} from '../Suggest';
 
@@ -70,7 +72,7 @@ export const Default = () => {
       key="loading"
       inputProps={{
         placeholder: 'Type the name of a US state…',
-        style: {width: '250px'},
+        style: {width: '260px'},
       }}
       icon="search"
       items={US_STATES}
@@ -84,7 +86,11 @@ export const Default = () => {
           text={item}
         />
       )}
-      noResults={<MenuItem disabled={true} text="No presets." />}
+      noResults={
+        <Box padding={4} style={{color: Colors.textDisabled()}}>
+          No matching states
+        </Box>
+      }
       onItemSelect={(item) => setSelectedItem(item)}
       selectedItem={selectedItem}
     />

--- a/js_modules/dagster-ui/yarn.lock
+++ b/js_modules/dagster-ui/yarn.lock
@@ -3702,7 +3702,6 @@ __metadata:
     react: "npm:^18.2.0"
     react-docgen-typescript-plugin: "npm:^1.0.8"
     react-dom: "npm:^18.2.0"
-    react-virtualized: "npm:^9.22.3"
     regenerator-runtime: "npm:^0.13.9"
     rollup: "npm:^2.70.1"
     rollup-plugin-node-globals: "npm:^1.4.0"
@@ -3716,6 +3715,7 @@ __metadata:
     "@blueprintjs/core": ^4.20.2
     "@blueprintjs/popover2": 1.13.12
     "@blueprintjs/select": ^4.9.12
+    "@tanstack/react-virtual": ^3.0.1
     react: ^18.2.0
     react-dom: ^18.2.0
     react-is: ^18.2.0


### PR DESCRIPTION
## Summary & Motivation

Replace `react-virtualized` with the tanstack virtualizer in the Suggest component. This eliminates `react-virtualized` as a peer dep in `ui-components`.

## How I Tested These Changes

View `Suggest` storybook example, verify correct rendering and behavior of input, list, list items. Includes hovering, clicking, keyboard navigation and selecting.

View use cases of `Suggest` in the app, verify same: launchpad config partition picker, asset graph sidebar search, compute log toolbar filter.