### PR TITLE
read_only parameter for DuckDBResource.connection()

### DIFF
--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
@@ -47,13 +47,13 @@ class DuckDBResource(ConfigurableResource):
         return True
 
     @contextmanager
-    def get_connection(self):
+    def get_connection(self, read_only: bool = False):
         conn = backoff(
             fn=duckdb.connect,
             retry_on=(RuntimeError, duckdb.IOException),
             kwargs={
                 "database": self.database,
-                "read_only": False,
+                "read_only": read_only,
                 "config": {
                     "custom_user_agent": "dagster",
                     **self.connection_config,


### PR DESCRIPTION
## Summary & Motivation
> DuckDB has two configurable options for concurrency:
>
> 1. One process can both read and write to the database.
> 2. Multiple processes can read from the database, but no processes can write ([access_mode = 'READ_ONLY'](https://duckdb.org/docs/configuration/overview.html#configuration-reference)).
>
> [(source)](https://duckdb.org/docs/connect/concurrency.html)

The python library `dagster_duckdb` connects always in read _and_ write mode to duckdb databases.
In one of my pipelines I have multiple assets which use the resource `DuckDBResource` which have queries that take longer but only need to read from the database. Currently, those queries from the assets are executed sequentially (due to `read_only=False` and `backoff`). However, I want to parallelize the execution of the queries to accelerate my pipeline.

Therefore, I introduced the parameter `read_only` in the method `DuckDBResource.connection()` which allows multiple assets to use the same duckdb resource, while being able to decide for each connection if it should be opened in read-only mode. To be backwards compatible this parameter has `False` as default value.

Is there interest to merge this extension?

- [x] Implement parameter `read_only` for `DuckDBResource.connection()`
- [x] Tests
- [ ] Documentation

It would also be interesting to implement this for the IO-manager `DuckDBIOManager` but this seems rather complex because the abstract class `ConfigurableIOManagerFactory` does not seem to support custom arguments for reading and writing from the database. Thus, I don't plan to tackle this in this PR.

## How I Tested These Changes
With adjusting the unittest `test_resource.test_resource`