### PR TITLE
[record] pass through *args in JitCheckedNew

### DIFF
--- a/python_modules/dagster/dagster/_record/__init__.py
+++ b/python_modules/dagster/dagster/_record/__init__.py
@@ -339,7 +339,7 @@ class JitCheckedNew:
         self._eval_ctx = eval_ctx
         self._new_frames = new_frames  # how many frames of __new__ there are
 
-    def __call__(self, cls, **kwargs):
+    def __call__(self, cls, *args, **kwargs):
         # update the context with callsite locals/globals to resolve
         # ForwardRefs that were unavailable at definition time.
         self._eval_ctx.update_from_frame(1 + self._new_frames)
@@ -354,7 +354,7 @@ class JitCheckedNew:
             _CHECKED_NEW,
         )
 
-        return self._nt_base.__new__(cls, **kwargs)
+        return self._nt_base.__new__(cls, *args, **kwargs)
 
     def _build_checked_new_str(self) -> str:
         kw_args_str, set_calls_str = build_args_and_assignment_strs(self._field_set, self._defaults)

--- a/python_modules/dagster/dagster_tests/general_tests/test_record.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_record.py
@@ -21,6 +21,15 @@ if TYPE_CHECKING:
     from dagster._core.test_utils import TestType
 
 
+def test_kwargs_only() -> None:
+    @record
+    class MyClass:
+        foo: str
+
+    with pytest.raises(TypeError, match="takes 1 positional argument but 2 were given"):
+        MyClass("fdslk")  # type: ignore # good job type checker
+
+
 def test_runtime_typecheck() -> None:
     @record
     class MyClass:


### PR DESCRIPTION
avoids weird error if you use positional args

## How I Tested These Changes

added test that was failing before change