### PR TITLE
[docs] remove support paragraph in PG alert doc

### DIFF
--- a/docs/content/dagster-plus/managing-deployments/alerts/pagerduty.mdx
+++ b/docs/content/dagster-plus/managing-deployments/alerts/pagerduty.mdx
@@ -39,10 +39,6 @@ To integrate PagerDuty with Dagster+, you'll need:
   - **A Pro plan**
   - **Organization, Admin, or Editor permissions**, which are required to create and manage alerts
 
-### Support
-
-If you need help with this integration, [contact Dagster+ support](https://dagster.io/contact) by selecting **Contact support** in the contact form's **Request type**.
-
 ---
 
 ## Integration walkthrough


### PR DESCRIPTION
## Summary & Motivation

I don't think this callout to contact support is necessary/good optically now that the feature has been available for a while. Also the contact method given is going to be deprecated in the near future. 

## How I Tested These Changes
👀