### PR TITLE
Update configuring-running-kubernetes-agent.mdx

### DIFF
--- a/docs/content/dagster-plus/deployment/agents/kubernetes/configuring-running-kubernetes-agent.mdx
+++ b/docs/content/dagster-plus/deployment/agents/kubernetes/configuring-running-kubernetes-agent.mdx
@@ -69,7 +69,7 @@ In this step, you'll spin up the agent with Helm.
 1. Add the [agent chart repository](https://dagster-io.github.io/helm-user-cloud):
 
    ```shell
-   helm repo add dagster-plus https://dagster-io.github.io/helm-user-cloud
+   helm repo add dagster-cloud https://dagster-io.github.io/helm-user-cloud
    helm repo update
    ```
 


### PR DESCRIPTION
Fixing the repo name when adding the Helm repo

## Summary & Motivation
The command does not work because of the repo name  and should have been dagster-cloud instead of dagster-plus

## How I Tested These Changes
I tested by running the command with the new name dagster-cloud which worked