### PR TITLE
[check builder] 3.12.4 fix

### DIFF
--- a/python_modules/dagster/dagster/_check/builder.py
+++ b/python_modules/dagster/dagster/_check/builder.py
@@ -120,9 +120,16 @@ class EvalContext(NamedTuple):
             return type(ref.__forward_arg__, (_LazyImportPlaceholder,), {})
         try:
             if sys.version_info <= (3, 9):
-                return ref._evaluate(self.get_merged_ns(), {})  # noqa
+                return ref._evaluate(  # noqa
+                    globalns=self.get_merged_ns(),
+                    localns={},
+                )
             else:
-                return ref._evaluate(self.get_merged_ns(), {}, frozenset())  # noqa
+                return ref._evaluate(  # noqa
+                    globalns=self.get_merged_ns(),
+                    localns={},
+                    recursive_guard=frozenset(),
+                )
         except NameError as e:
             raise CheckError(
                 f"Unable to resolve {ref}, could not map string name to actual type using captured frames. "


### PR DESCRIPTION
`recursive_guard` got made keyword arg only in https://github.com/python/cpython/pull/118009 which released in `3.12.4` (we run an older version in buildkite so we missed it)

fixes https://github.com/dagster-io/dagster/issues/22985

## How I Tested These Changes

on a fresh 3.12.4 venv
`pytest python_modules/dagster/dagster_tests/general_tests/test_record.py python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py`
which was failing before fix