### PR TITLE
[RFC] change hourly/daily/weekly/monthly partitions defs to functions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -21,7 +21,7 @@ class AssetSubsetSerializer(NamedTupleSerializer):
     """Ensures that the inner PartitionsSubset is converted to a serializable form if necessary."""
 
     def get_storage_name(self) -> str:
-        # override this method so all ValidAssetSubsets are serialzied as AssetSubsets
+        # override this method so all ValidAssetSubsets are serialized as AssetSubsets
         return "AssetSubset"
 
     def before_pack(self, value: "AssetSubset") -> "AssetSubset":

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partitions.py
@@ -1053,7 +1053,15 @@ class TimeWindowPartitionsDefinition(
         return is_basic_hourly(self.cron_schedule)
 
 
-class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
+def DailyPartitionsDefinition(
+    start_date: Union[datetime, str],
+    end_date: Union[datetime, str, None] = None,
+    minute_offset: int = 0,
+    hour_offset: int = 0,
+    timezone: Optional[str] = None,
+    fmt: Optional[str] = None,
+    end_offset: int = 0,
+) -> TimeWindowPartitionsDefinition:
     """A set of daily partitions.
 
     The first partition in the set will start at the start_date at midnight. The last partition
@@ -1086,30 +1094,18 @@ class DailyPartitionsDefinition(TimeWindowPartitionsDefinition):
         DailyPartitionsDefinition(start_date="2022-03-12", minute_offset=15, hour_offset=16)
         # creates partitions (2022-03-12-16:15, 2022-03-13-16:15), (2022-03-13-16:15, 2022-03-14-16:15), ...
     """
+    _fmt = fmt or DEFAULT_DATE_FORMAT
 
-    def __new__(
-        cls,
-        start_date: Union[datetime, str],
-        end_date: Union[datetime, str, None] = None,
-        minute_offset: int = 0,
-        hour_offset: int = 0,
-        timezone: Optional[str] = None,
-        fmt: Optional[str] = None,
-        end_offset: int = 0,
-    ):
-        _fmt = fmt or DEFAULT_DATE_FORMAT
-
-        return super(DailyPartitionsDefinition, cls).__new__(
-            cls,
-            schedule_type=ScheduleType.DAILY,
-            start=start_date,
-            end=end_date,
-            minute_offset=minute_offset,
-            hour_offset=hour_offset,
-            timezone=timezone,
-            fmt=_fmt,
-            end_offset=end_offset,
-        )
+    return TimeWindowPartitionsDefinition(
+        schedule_type=ScheduleType.DAILY,
+        start=start_date,
+        end=end_date,
+        minute_offset=minute_offset,
+        hour_offset=hour_offset,
+        timezone=timezone,
+        fmt=_fmt,
+        end_offset=end_offset,
+    )
 
 
 def wrap_time_window_run_config_fn(
@@ -1148,7 +1144,7 @@ def daily_partitioned_config(
     tags_for_partition_fn: Optional[Callable[[datetime, datetime], Mapping[str, str]]] = None,
 ) -> Callable[
     [Callable[[datetime, datetime], Mapping[str, Any]]],
-    PartitionedConfig[DailyPartitionsDefinition],
+    PartitionedConfig[TimeWindowPartitionsDefinition],
 ]:
     """Defines run config over a set of daily partitions.
 
@@ -1192,7 +1188,7 @@ def daily_partitioned_config(
 
     def inner(
         fn: Callable[[datetime, datetime], Mapping[str, Any]],
-    ) -> PartitionedConfig[DailyPartitionsDefinition]:
+    ) -> PartitionedConfig[TimeWindowPartitionsDefinition]:
         check.callable_param(fn, "fn")
 
         partitions_def = DailyPartitionsDefinition(
@@ -1216,7 +1212,14 @@ def daily_partitioned_config(
     return inner
 
 
-class HourlyPartitionsDefinition(TimeWindowPartitionsDefinition):
+def HourlyPartitionsDefinition(
+    start_date: Union[datetime, str],
+    end_date: Union[datetime, str, None] = None,
+    minute_offset: int = 0,
+    timezone: Optional[str] = None,
+    fmt: Optional[str] = None,
+    end_offset: int = 0,
+) -> TimeWindowPartitionsDefinition:
     """A set of hourly partitions.
 
     The first partition in the set will start on the start_date at midnight. The last partition
@@ -1252,28 +1255,17 @@ class HourlyPartitionsDefinition(TimeWindowPartitionsDefinition):
         HourlyPartitionsDefinition(start_date=datetime(2022, 03, 12), minute_offset=15)
         # creates partitions (2022-03-12-00:15, 2022-03-12-01:15), (2022-03-12-01:15, 2022-03-12-02:15), ...
     """
+    _fmt = fmt or DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
 
-    def __new__(
-        cls,
-        start_date: Union[datetime, str],
-        end_date: Union[datetime, str, None] = None,
-        minute_offset: int = 0,
-        timezone: Optional[str] = None,
-        fmt: Optional[str] = None,
-        end_offset: int = 0,
-    ):
-        _fmt = fmt or DEFAULT_HOURLY_FORMAT_WITHOUT_TIMEZONE
-
-        return super(HourlyPartitionsDefinition, cls).__new__(
-            cls,
-            schedule_type=ScheduleType.HOURLY,
-            start=start_date,
-            end=end_date,
-            minute_offset=minute_offset,
-            timezone=timezone,
-            fmt=_fmt,
-            end_offset=end_offset,
-        )
+    return TimeWindowPartitionsDefinition(
+        schedule_type=ScheduleType.HOURLY,
+        start=start_date,
+        end=end_date,
+        minute_offset=minute_offset,
+        timezone=timezone,
+        fmt=_fmt,
+        end_offset=end_offset,
+    )
 
 
 def hourly_partitioned_config(
@@ -1285,7 +1277,7 @@ def hourly_partitioned_config(
     tags_for_partition_fn: Optional[Callable[[datetime, datetime], Mapping[str, str]]] = None,
 ) -> Callable[
     [Callable[[datetime, datetime], Mapping[str, Any]]],
-    PartitionedConfig[HourlyPartitionsDefinition],
+    PartitionedConfig[TimeWindowPartitionsDefinition],
 ]:
     """Defines run config over a set of hourly partitions.
 
@@ -1328,7 +1320,7 @@ def hourly_partitioned_config(
 
     def inner(
         fn: Callable[[datetime, datetime], Mapping[str, Any]],
-    ) -> PartitionedConfig[HourlyPartitionsDefinition]:
+    ) -> PartitionedConfig[TimeWindowPartitionsDefinition]:
         check.callable_param(fn, "fn")
 
         partitions_def = HourlyPartitionsDefinition(
@@ -1497,7 +1489,16 @@ def monthly_partitioned_config(
     return inner
 
 
-class WeeklyPartitionsDefinition(TimeWindowPartitionsDefinition):
+def WeeklyPartitionsDefinition(
+    start_date: Union[datetime, str],
+    end_date: Union[datetime, str, None] = None,
+    minute_offset: int = 0,
+    hour_offset: int = 0,
+    day_offset: int = 0,
+    timezone: Optional[str] = None,
+    fmt: Optional[str] = None,
+    end_offset: int = 0,
+) -> TimeWindowPartitionsDefinition:
     """Defines a set of weekly partitions.
 
     The first partition in the set will start at the start_date. The last partition in the set will
@@ -1534,32 +1535,19 @@ class WeeklyPartitionsDefinition(TimeWindowPartitionsDefinition):
         WeeklyPartitionsDefinition(start_date="2022-03-12", minute_offset=15, hour_offset=3, day_offset=6)
         # creates partitions (2022-03-12-03:15, 2022-03-19-03:15), (2022-03-19-03:15, 2022-03-26-03:15), ...
     """
+    _fmt = fmt or DEFAULT_DATE_FORMAT
 
-    def __new__(
-        cls,
-        start_date: Union[datetime, str],
-        end_date: Union[datetime, str, None] = None,
-        minute_offset: int = 0,
-        hour_offset: int = 0,
-        day_offset: int = 0,
-        timezone: Optional[str] = None,
-        fmt: Optional[str] = None,
-        end_offset: int = 0,
-    ):
-        _fmt = fmt or DEFAULT_DATE_FORMAT
-
-        return super(WeeklyPartitionsDefinition, cls).__new__(
-            cls,
-            schedule_type=ScheduleType.WEEKLY,
-            start=start_date,
-            end=end_date,
-            minute_offset=minute_offset,
-            hour_offset=hour_offset,
-            day_offset=day_offset,
-            timezone=timezone,
-            fmt=_fmt,
-            end_offset=end_offset,
-        )
+    return TimeWindowPartitionsDefinition(
+        schedule_type=ScheduleType.WEEKLY,
+        start=start_date,
+        end=end_date,
+        minute_offset=minute_offset,
+        hour_offset=hour_offset,
+        day_offset=day_offset,
+        timezone=timezone,
+        fmt=_fmt,
+        end_offset=end_offset,
+    )
 
 
 def weekly_partitioned_config(
@@ -1573,7 +1561,7 @@ def weekly_partitioned_config(
     tags_for_partition_fn: Optional[Callable[[datetime, datetime], Mapping[str, str]]] = None,
 ) -> Callable[
     [Callable[[datetime, datetime], Mapping[str, Any]]],
-    PartitionedConfig[WeeklyPartitionsDefinition],
+    PartitionedConfig[TimeWindowPartitionsDefinition],
 ]:
     """Defines run config over a set of weekly partitions.
 
@@ -1621,7 +1609,7 @@ def weekly_partitioned_config(
 
     def inner(
         fn: Callable[[datetime, datetime], Mapping[str, Any]],
-    ) -> PartitionedConfig[WeeklyPartitionsDefinition]:
+    ) -> PartitionedConfig[TimeWindowPartitionsDefinition]:
         check.callable_param(fn, "fn")
 
         partitions_def = WeeklyPartitionsDefinition(
@@ -2107,20 +2095,8 @@ class PartitionKeysTimeWindowPartitionsSubset(BaseTimeWindowPartitionsSubset):
         return f"PartitionKeysTimeWindowPartitionsSubset({self.get_partition_key_ranges(self.partitions_def)})"
 
     def to_serializable_subset(self) -> "TimeWindowPartitionsSubset":
-        from dagster._core.remote_representation.external_data import (
-            external_time_window_partitions_definition_from_def,
-        )
-
-        # in cases where we're dealing with (e.g.) HourlyPartitionsDefinition, we need to convert
-        # this partitions definition into a raw TimeWindowPartitionsDefinition to make it
-        # serializable. to do this, we just convert it to its external representation and back.
-        partitions_def = self.partitions_def
-        if type(self.partitions_def) != TimeWindowPartitionsSubset:
-            partitions_def = external_time_window_partitions_definition_from_def(
-                partitions_def
-            ).get_partitions_definition()
         return TimeWindowPartitionsSubset(
-            partitions_def, self.num_partitions, self.included_time_windows
+            self.partitions_def, self.num_partitions, self.included_time_windows
         )
 
     def __or__(self, other: "PartitionsSubset") -> "PartitionsSubset":
@@ -2448,21 +2424,6 @@ class TimeWindowPartitionsSubset(
         )
 
     def to_serializable_subset(self) -> "TimeWindowPartitionsSubset":
-        from dagster._core.remote_representation.external_data import (
-            external_time_window_partitions_definition_from_def,
-        )
-
-        # in cases where we're dealing with (e.g.) HourlyPartitionsDefinition, we need to convert
-        # this partitions definition into a raw TimeWindowPartitionsDefinition to make it
-        # serializable. to do this, we just convert it to its external representation and back.
-        # note that we rarely serialize subsets on the user code side of a serialization boundary,
-        # and so this conversion is rarely necessary.
-        partitions_def = self.partitions_def
-        if type(self.partitions_def) != TimeWindowPartitionsSubset:
-            partitions_def = external_time_window_partitions_definition_from_def(
-                partitions_def
-            ).get_partitions_definition()
-            return self.with_partitions_def(partitions_def)
         return self
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -79,7 +79,7 @@ composite = MultiPartitionsDefinition({"date": time_window_partitions, "abc": st
 def test_get_subset_type():
     assert composite.__class__.__name__ == MultiPartitionsDefinition.__name__
     assert static_partitions.__class__.__name__ == StaticPartitionsDefinition.__name__
-    assert time_window_partitions.__class__.__name__ == DailyPartitionsDefinition.__name__
+    assert time_window_partitions.__class__.__name__ == TimeWindowPartitionsDefinition.__name__
 
 
 def test_empty_subsets():
@@ -95,7 +95,7 @@ def test_empty_subsets():
     ],
 )
 def test_time_window_partitions_subset_serialization_deserialization(
-    partitions_def: DailyPartitionsDefinition,
+    partitions_def: TimeWindowPartitionsDefinition,
 ):
     time_window_partitions_def = TimeWindowPartitionsDefinition(
         start=partitions_def.start,

--- a/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_upath_io_manager.py
@@ -27,6 +27,7 @@ from dagster import (
     OutputContext,
     StaticPartitionsDefinition,
     TimeWindowPartitionMapping,
+    TimeWindowPartitionsDefinition,
     asset,
     build_init_resource_context,
     build_input_context,
@@ -184,8 +185,8 @@ def test_upath_io_manager_with_non_any_type_annotation(tmp_path: Path):
 
 
 def test_upath_io_manager_multiple_time_partitions(
-    daily: DailyPartitionsDefinition,
-    hourly: HourlyPartitionsDefinition,
+    daily: TimeWindowPartitionsDefinition,
+    hourly: TimeWindowPartitionsDefinition,
     start: datetime,
     dummy_io_manager: DummyIOManager,
 ):
@@ -355,7 +356,7 @@ def test_upath_io_manager_with_extension_static_partitions_with_dot():
 
 
 def test_partitioned_io_manager_preserves_single_partition_dependency(
-    daily: DailyPartitionsDefinition, dummy_io_manager: DummyIOManager
+    daily: TimeWindowPartitionsDefinition, dummy_io_manager: DummyIOManager
 ):
     @asset(partitions_def=daily)
     def upstream_asset():
@@ -375,8 +376,8 @@ def test_partitioned_io_manager_preserves_single_partition_dependency(
 
 def test_skip_type_check_for_multiple_partitions_with_no_type_annotation(
     start: datetime,
-    daily: DailyPartitionsDefinition,
-    hourly: HourlyPartitionsDefinition,
+    daily: TimeWindowPartitionsDefinition,
+    hourly: TimeWindowPartitionsDefinition,
     dummy_io_manager: DummyIOManager,
 ):
     @asset(partitions_def=hourly)
@@ -399,8 +400,8 @@ def test_skip_type_check_for_multiple_partitions_with_no_type_annotation(
 
 def test_skip_type_check_for_multiple_partitions_with_any_type(
     start: datetime,
-    daily: DailyPartitionsDefinition,
-    hourly: HourlyPartitionsDefinition,
+    daily: TimeWindowPartitionsDefinition,
+    hourly: TimeWindowPartitionsDefinition,
     dummy_io_manager: DummyIOManager,
 ):
     @asset(partitions_def=hourly)
@@ -541,7 +542,7 @@ def test_upath_io_manager_async_load_from_path(tmp_path: Path, json_data: Any):
 @requires_python38
 def test_upath_io_manager_async_multiple_time_partitions(
     tmp_path: Path,
-    daily: DailyPartitionsDefinition,
+    daily: TimeWindowPartitionsDefinition,
     start: datetime,
 ):
     manager = AsyncJSONIOManager(base_dir=str(tmp_path))
@@ -577,7 +578,7 @@ def test_upath_io_manager_async_multiple_time_partitions(
 @requires_python38
 def test_upath_io_manager_async_fail_on_missing_partitions(
     tmp_path: Path,
-    daily: DailyPartitionsDefinition,
+    daily: TimeWindowPartitionsDefinition,
     start: datetime,
 ):
     manager = AsyncJSONIOManager(base_dir=str(tmp_path))
@@ -611,7 +612,7 @@ def test_upath_io_manager_async_fail_on_missing_partitions(
 @requires_python38
 def test_upath_io_manager_async_allow_missing_partitions(
     tmp_path: Path,
-    daily: DailyPartitionsDefinition,
+    daily: TimeWindowPartitionsDefinition,
     start: datetime,
 ):
     manager = AsyncJSONIOManager(base_dir=str(tmp_path))
@@ -647,7 +648,7 @@ def test_upath_io_manager_async_allow_missing_partitions(
 
 
 def test_upath_can_transition_from_non_partitioned_to_partitioned(
-    tmp_path: Path, daily: DailyPartitionsDefinition, start: datetime
+    tmp_path: Path, daily: TimeWindowPartitionsDefinition, start: datetime
 ):
     my_io_manager = PickleIOManager(UPath(tmp_path))
 


### PR DESCRIPTION
Exploring this idea which fell out of this conversation https://github.com/dagster-io/dagster/pull/22884#discussion_r1674613887 on the PR that attempts to move `TimeWindowPartitionsDefinition` to `@record`

It seems the utility of these classes being classes is near zero, but their set-up as classes does cause a fair bit of complexity. 

Turning them in to functions shouldn't break any existing call sites, just potentially some typehints. 

## How I Tested These Changes

bk