### PR TITLE
enable constructing FromLoadableAssets without node_handle and input_name

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/plan/plan.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/plan.py
@@ -445,7 +445,7 @@ def get_step_input_source(
     ):
         # can only load from source asset if assets defs are available
         if asset_layer.asset_key_for_input(handle, input_handle.input_name):
-            return FromLoadableAsset(node_handle=handle, input_name=input_name)
+            return FromLoadableAsset()
         elif input_def.input_manager_key:
             return FromInputManager(node_handle=handle, input_name=input_name)
 

--- a/python_modules/dagster/dagster/_core/execution/resolve_versions.py
+++ b/python_modules/dagster/dagster/_core/execution/resolve_versions.py
@@ -93,7 +93,7 @@ def resolve_step_versions(
 
         input_version_dict = {
             input_name: step_input.source.compute_version(
-                step_versions, pipeline_def, resolved_run_config
+                step_versions, pipeline_def, resolved_run_config, step.node_handle, input_name
             )
             for input_name, step_input in step.step_input_dict.items()
         }

--- a/python_modules/dagster/dagster/_core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/_core/execution/resources_init.py
@@ -402,7 +402,11 @@ def get_required_resource_keys_for_step(
 
         resource_keys = resource_keys.union(input_def.dagster_type.required_resource_keys)
 
-        resource_keys = resource_keys.union(step_input.source.required_resource_keys(job_def))
+        resource_keys = resource_keys.union(
+            step_input.source.required_resource_keys(
+                job_def, execution_step.node_handle, step_input.name
+            )
+        )
 
         if input_def.input_manager_key:
             resource_keys = resource_keys.union([input_def.input_manager_key])


### PR DESCRIPTION
## Summary & Motivation

Like other `StepInputSource` subclasses, `FromLoadableAssets` has properties for node handle and input name, but doesn't actually need them, because how the input gets loaded doesn't actually depend on where the input lives in the composition graph.

## How I Tested These Changes
