### PR TITLE
feat(catalog): add `AssetSelection` method to select owners

### DIFF
--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -780,3 +780,20 @@ def test_tag_string():
         AssetKey("asset5"),
         AssetKey("asset6"),
     }
+
+
+def test_owner() -> None:
+    @multi_asset(
+        specs=[
+            AssetSpec("asset1", owners=["owner1@owner.com"]),
+            AssetSpec("asset2", owners=["owner2@owner.com"]),
+            AssetSpec("asset3", owners=["owner1@owner.com"]),
+            AssetSpec("asset4", owners=["owner2@owner.com"]),
+        ]
+    )
+    def assets(): ...
+
+    assert AssetSelection.owner("owner1@owner.com").resolve([assets]) == {
+        AssetKey("asset1"),
+        AssetKey("asset3"),
+    }


### PR DESCRIPTION
## Summary & Motivation
We should be able to serialize an asset selection for owners, as you can select for owners in the catalog UI.

We should also do the same for an asset selection for code locations, but that involves changing how the BaseAssetGraph is constructed. So separating that into its own change.

## How I Tested These Changes
pytest