### PR TITLE
[1.8] error on unselected outputs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -5,8 +5,8 @@ import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 
 from ..errors import DagsterInvariantViolationError
+from .asset_key import AssetKey, AssetKeyOrCheckKey
 from .dependency import NodeHandle, NodeInputHandle, NodeOutputHandle
-from .events import AssetKey
 from .graph_definition import GraphDefinition
 
 if TYPE_CHECKING:
@@ -213,7 +213,9 @@ class AssetLayer(NamedTuple):
             # Can end up here when a non-asset job has an asset as an input
             return None
 
-    def downstream_dep_assets(self, node_handle: NodeHandle, output_name: str) -> Set[AssetKey]:
+    def downstream_dep_assets_and_checks(
+        self, node_handle: NodeHandle, output_name: str
+    ) -> Set[AssetKeyOrCheckKey]:
         """Given the node handle of an op within a graph-backed asset and an output name,
         returns the asset keys dependent on that output.
 
@@ -251,7 +253,6 @@ class AssetLayer(NamedTuple):
             ).asset_or_check_keys_by_dep_op_output_handle[
                 NodeOutputHandle(node_handle=node_handle.pop(), output_name=output_name)
             ]
-            if isinstance(key, AssetKey)
         }
 
     def upstream_dep_op_handles(self, asset_key: AssetKey) -> AbstractSet[NodeHandle]:

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -2,19 +2,7 @@ from abc import ABC, ABCMeta, abstractmethod
 from contextlib import contextmanager
 from contextvars import ContextVar
 from inspect import _empty as EmptyAnnotation
-from typing import (
-    AbstractSet,
-    Any,
-    Dict,
-    Iterator,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Set,
-    Union,
-    cast,
-)
+from typing import AbstractSet, Any, Dict, Iterator, List, Mapping, Optional, Sequence, Union, cast
 
 import dagster._check as check
 from dagster._annotations import deprecated, experimental, public
@@ -623,22 +611,7 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
     @property
     def selected_output_names(self) -> AbstractSet[str]:
         """Get the output names that correspond to the current selection of assets this execution is expected to materialize."""
-        # map selected asset keys to the output names they correspond to
-        selected_asset_keys = self.selected_asset_keys
-        selected_outputs: Set[str] = set()
-        for output_name in self.op.output_dict.keys():
-            asset_key = self.job_def.asset_layer.asset_key_for_output(self.node_handle, output_name)
-            if any(  #  For graph-backed assets, check if a downstream asset is selected
-                [
-                    downstream_asset_key in selected_asset_keys
-                    for downstream_asset_key in self.job_def.asset_layer.downstream_dep_assets(
-                        self.node_handle, output_name
-                    )
-                ]
-            ) or (asset_key in selected_asset_keys):
-                selected_outputs.add(output_name)
-
-        return selected_outputs
+        return self._step_execution_context.selected_output_names
 
     @public
     def asset_key_for_output(self, output_name: str = "result") -> AssetKey:

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -23,6 +23,7 @@ from dagster import (
     In,
     Nothing,
     Out,
+    Output,
     StaticPartitionMapping,
     _seven,
     asset,
@@ -224,9 +225,16 @@ def baz():
     return 10
 
 
-@op(ins={"in1": In(Nothing), "in2": In(Nothing)}, out={"out1": Out(), "out2": Out()})
-def reusable():
-    return 1, 2
+@op(
+    ins={"in1": In(Nothing), "in2": In(Nothing)},
+    out={"out1": Out(is_required=False), "out2": Out(is_required=False)},
+)
+def reusable(context):
+    selected_output_names = context.selected_output_names
+    if "out1" in selected_output_names:
+        yield Output(1, "out1")
+    if "out2" in selected_output_names:
+        yield Output(2, "out2")
 
 
 ab1 = AssetsDefinition(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_defs.py
@@ -331,6 +331,8 @@ def _get_dbt_op(
             kwargs["select"] = [
                 ".".join(fqns_by_output_name[output_name])
                 for output_name in context.selected_output_names
+                # outputs corresponding to asset checks from dbt tests won't be in this dict
+                if output_name in fqns_by_output_name
             ]
         # variables to pass into the command
         if partition_key_to_vars_fn:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cloud/asset_defs.py
@@ -509,6 +509,8 @@ class DbtCloudCacheableAssetsDefinition(CacheableAssetsDefinition):
                 selected_models = [
                     ".".join(fqns_by_output_name[output_name])
                     for output_name in context.op_execution_context.selected_output_names
+                    # outputs corresponding to asset checks from dbt tests won't be in this dict
+                    if output_name in fqns_by_output_name
                 ]
 
                 dbt_options.append(f"--select {' '.join(sorted(selected_models))}")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -2002,20 +2002,24 @@ def get_dbt_resource_names_for_output_names(
     dbt_resource_props_by_output_name: Mapping[str, Any],
     dagster_dbt_translator: DagsterDbtTranslator,
 ) -> Sequence[str]:
+    dbt_resource_props_gen = (
+        dbt_resource_props_by_output_name[output_name]
+        for output_name in output_names
+        # output names corresponding to asset checks won't be in this dict
+        if output_name in dbt_resource_props_by_output_name
+    )
+
     # Explicitly select a dbt resource by its file name.
     # https://docs.getdbt.com/reference/node-selection/methods#the-file-method
     if dagster_dbt_translator.settings.enable_dbt_selection_by_name:
         return [
-            Path(dbt_resource_props_by_output_name[output_name]["original_file_path"]).stem
-            for output_name in output_names
+            Path(dbt_resource_props["original_file_path"]).stem
+            for dbt_resource_props in dbt_resource_props_gen
         ]
 
     # Explictly select a dbt resource by its fully qualified name (FQN).
     # https://docs.getdbt.com/reference/node-selection/methods#the-file-or-fqn-method
-    return [
-        ".".join(dbt_resource_props_by_output_name[output_name]["fqn"])
-        for output_name in output_names
-    ]
+    return [".".join(dbt_resource_props["fqn"]) for dbt_resource_props in dbt_resource_props_gen]
 
 
 def get_dbt_test_names_for_asset_checks(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cloud/test_asset_defs.py
@@ -601,6 +601,11 @@ def test_subsetting(
     # Core command should not be changed by dagster
     core_dbt_materialization_command = f"{dbt_materialization_command} {dbt_materialization_command_non_subsetting_options}".strip()
     full_dbt_materialization_command = f"{core_dbt_materialization_command} {dbt_materialization_command_subsetting_options}".strip()
+
+    expected_dbt_asset_names_list = (
+        expected_dbt_asset_names.split(",") if expected_dbt_asset_names else []
+    )
+
     _add_dbt_cloud_job_responses(
         dbt_cloud_service=dbt_cloud_service,
         dbt_commands=[full_dbt_materialization_command],
@@ -636,16 +641,30 @@ def test_subsetting(
         selection=asset_selection,
     ).resolve(asset_graph=AssetGraph.from_assets([*dbt_cloud_assets, hanger1, hanger2]))
 
+    if expected_dbt_asset_names_list:
+        filtered_results = [
+            result
+            for result in RUN_RESULTS_JSON["results"]
+            if result["unique_id"][len("model.") :] in expected_dbt_asset_names_list
+        ]
+        run_results_json = {**RUN_RESULTS_JSON, "results": filtered_results}
+    else:
+        run_results_json = RUN_RESULTS_JSON
+
+    _add_dbt_cloud_job_responses(
+        dbt_cloud_service=dbt_cloud_service,
+        dbt_commands=[full_dbt_materialization_command],
+        run_results_json=run_results_json,
+    )
     with instance_for_test() as instance:
         result = materialize_cereal_assets.execute_in_process(instance=instance)
 
     assert result.success
 
-    expected_dbt_asset_names = (
-        expected_dbt_asset_names.split(",") if expected_dbt_asset_names else []
-    )
     dbt_filter_option = (
-        f"--select {' '.join(expected_dbt_asset_names)}" if expected_dbt_asset_names else ""
+        f"--select {' '.join(expected_dbt_asset_names_list)}"
+        if expected_dbt_asset_names_list
+        else ""
     )
     mock_run_job_and_poll.assert_called_once_with(
         job_id=DBT_CLOUD_JOB_ID,


### PR DESCRIPTION
## Summary & Motivation

This PR proposes a behavior change, for 1.8, to how we handle yielded outputs that correspond to assets that are unselected in the run. Previously, we would create an `AssetMaterialization` even for an unselected asset. After this change, we raise an error. I believe we should consider the current behavior a bug.

I.e. this now raises an error saying that an output was returned for "asset2" even thought it wasn't selected:
```python
@multi_asset(outs={"asset1": AssetOut(), "asset2": AssetOut()}, can_subset=True)
def assets():
    return 1, 2

materialize([assets], selection=["asset1"])
```

Note that we already raise an error in this case, saying that "asset2" wasn't selected:

```python
@multi_asset(specs=[AssetSpec("asset1"), AssetSpec("asset2")], can_subset=True)
def assets():
    yield MaterializeResult("asset1")
    yield MaterializeResult("asset2")

materialize([assets], selection=["asset1"])
```


Advantages:
- A user clicking "Materialize" on an asset won't unexpectedly also materialize another asset
- Makes it easier to refactor our internals
- Avoids some unintuitive behavior:
  - Materialization without PLANNED event
  - Downstream asset can get materialized before upstream asset within the same run.
- Makes these function the same:

```python
@asset
def asset1(): ...

@asset
def asset2(): ...
```

```python
@multi_asset(outs={"asset1": AssetOut(), "asset2": AssetOut()}, can_subset=True)
def assets(): ...
```

Users can still directly yield `AssetMaterialization` events from their op body if they "force" materializing an unselected asset.

## How I Tested These Changes
