### PR TITLE
Don't raise an error if assetNodes is called on a code location that does not exist or is in an error state

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -912,7 +912,11 @@ class GrapheneQuery(graphene.ObjectType):
         if group is not None:
             group_name = group.groupName
             repo_sel = RepositorySelector.from_graphql_input(group)
-            repo_loc = graphene_info.context.get_code_location(repo_sel.location_name)
+            repo_loc_entry = graphene_info.context.get_location_entry(repo_sel.location_name)
+            repo_loc = repo_loc_entry.code_location if repo_loc_entry else None
+            if not repo_loc or not repo_loc.has_repository(repo_sel.repository_name):
+                return []
+
             repo = repo_loc.get_repository(repo_sel.repository_name)
             external_asset_nodes = repo.get_external_asset_nodes()
             asset_checks_loader = AssetChecksLoader(
@@ -937,8 +941,13 @@ class GrapheneQuery(graphene.ObjectType):
         elif pipeline is not None:
             job_name = pipeline.pipelineName
             repo_sel = RepositorySelector.from_graphql_input(pipeline)
-            repo_loc = graphene_info.context.get_code_location(repo_sel.location_name)
+            repo_loc_entry = graphene_info.context.get_location_entry(repo_sel.location_name)
+            repo_loc = repo_loc_entry.code_location if repo_loc_entry else None
+            if not repo_loc or not repo_loc.has_repository(repo_sel.repository_name):
+                return []
+
             repo = repo_loc.get_repository(repo_sel.repository_name)
+
             external_asset_nodes = repo.get_external_asset_nodes(job_name)
             asset_checks_loader = AssetChecksLoader(
                 context=graphene_info.context,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -1064,6 +1064,23 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         assert len(materializations) == 1
         assert second_timestamp == int(materializations[0]["timestamp"])
 
+    def test_asset_node_in_pipeline_that_does_not_exist(
+        self, graphql_context: WorkspaceRequestContext
+    ):
+        selector = infer_job_selector(graphql_context, "two_assets_job")
+        selector["repositoryLocationName"] = "does_not_exist"
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_ASSET_NODES_FROM_KEYS,
+            variables={
+                "pipelineSelector": selector,
+                "assetKeys": [{"path": ["asset_one"]}],
+            },
+        )
+        assert result.data
+        assert len(result.data["assetNodes"]) == 0
+
     def test_asset_node_in_pipeline(self, graphql_context: WorkspaceRequestContext):
         selector = infer_job_selector(graphql_context, "two_assets_job")
         result = execute_dagster_graphql(


### PR DESCRIPTION
Summary:
Similar to if you call assetNodes on asset keys that do not exist in the graph anymore, or on a job that no longer exists in the repor return an empty list of nodes if you pass in a selector for a code location that does not exist.

Test Plan: New test case

## Summary & Motivation

## How I Tested These Changes
