### PR TITLE
Create exapndedLabel GQL field for AutomationConditionEvaluationNode

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3598,8 +3598,8 @@ type AssetConditionEvaluationRecord {
 
 type AutomationConditionEvaluationNode {
   uniqueId: String!
-  description: String!
-  label: String
+  userLabel: String
+  expandedLabel: String!
   startTimestamp: Float
   endTimestamp: Float
   numTrue: Int!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3599,7 +3599,7 @@ type AssetConditionEvaluationRecord {
 type AutomationConditionEvaluationNode {
   uniqueId: String!
   userLabel: String
-  expandedLabel: String!
+  expandedLabel: [String!]!
   startTimestamp: Float
   endTimestamp: Float
   numTrue: Int!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -693,14 +693,14 @@ export type AutomationConditionEvaluationNode = {
   __typename: 'AutomationConditionEvaluationNode';
   candidateSubset: Maybe<AssetSubset>;
   childUniqueIds: Array<Scalars['String']['output']>;
-  description: Scalars['String']['output'];
   endTimestamp: Maybe<Scalars['Float']['output']>;
+  expandedLabel: Scalars['String']['output'];
   isPartitioned: Scalars['Boolean']['output'];
-  label: Maybe<Scalars['String']['output']>;
   numTrue: Scalars['Int']['output'];
   startTimestamp: Maybe<Scalars['Float']['output']>;
   trueSubset: AssetSubset;
   uniqueId: Scalars['String']['output'];
+  userLabel: Maybe<Scalars['String']['output']>;
 };
 
 export type BackfillNotFoundError = Error & {
@@ -6868,15 +6868,12 @@ export const buildAutomationConditionEvaluationNode = (
         : buildAssetSubset({}, relationshipsToOmit),
     childUniqueIds:
       overrides && overrides.hasOwnProperty('childUniqueIds') ? overrides.childUniqueIds! : [],
-    description:
-      overrides && overrides.hasOwnProperty('description')
-        ? overrides.description!
-        : 'exercitationem',
     endTimestamp:
       overrides && overrides.hasOwnProperty('endTimestamp') ? overrides.endTimestamp! : 4.53,
+    expandedLabel:
+      overrides && overrides.hasOwnProperty('expandedLabel') ? overrides.expandedLabel! : 'sunt',
     isPartitioned:
       overrides && overrides.hasOwnProperty('isPartitioned') ? overrides.isPartitioned! : true,
-    label: overrides && overrides.hasOwnProperty('label') ? overrides.label! : 'itaque',
     numTrue: overrides && overrides.hasOwnProperty('numTrue') ? overrides.numTrue! : 5212,
     startTimestamp:
       overrides && overrides.hasOwnProperty('startTimestamp') ? overrides.startTimestamp! : 5.42,
@@ -6887,6 +6884,8 @@ export const buildAutomationConditionEvaluationNode = (
         ? ({} as AssetSubset)
         : buildAssetSubset({}, relationshipsToOmit),
     uniqueId: overrides && overrides.hasOwnProperty('uniqueId') ? overrides.uniqueId! : 'sit',
+    userLabel:
+      overrides && overrides.hasOwnProperty('userLabel') ? overrides.userLabel! : 'dolorem',
   };
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -694,7 +694,7 @@ export type AutomationConditionEvaluationNode = {
   candidateSubset: Maybe<AssetSubset>;
   childUniqueIds: Array<Scalars['String']['output']>;
   endTimestamp: Maybe<Scalars['Float']['output']>;
-  expandedLabel: Scalars['String']['output'];
+  expandedLabel: Array<Scalars['String']['output']>;
   isPartitioned: Scalars['Boolean']['output'];
   numTrue: Scalars['Int']['output'];
   startTimestamp: Maybe<Scalars['Float']['output']>;
@@ -6871,7 +6871,7 @@ export const buildAutomationConditionEvaluationNode = (
     endTimestamp:
       overrides && overrides.hasOwnProperty('endTimestamp') ? overrides.endTimestamp! : 4.53,
     expandedLabel:
-      overrides && overrides.hasOwnProperty('expandedLabel') ? overrides.expandedLabel! : 'sunt',
+      overrides && overrides.hasOwnProperty('expandedLabel') ? overrides.expandedLabel! : [],
     isPartitioned:
       overrides && overrides.hasOwnProperty('isPartitioned') ? overrides.isPartitioned! : true,
     numTrue: overrides && overrides.hasOwnProperty('numTrue') ? overrides.numTrue! : 5212,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
@@ -268,7 +268,7 @@ class GrapheneAssetConditionEvaluation(graphene.ObjectType):
 class GrapheneAutomationConditionEvaluationNode(graphene.ObjectType):
     uniqueId = graphene.NonNull(graphene.String)
     userLabel = graphene.Field(graphene.String)
-    expandedLabel = graphene.NonNull(graphene.String)
+    expandedLabel = non_null_list(graphene.String)
 
     startTimestamp = graphene.Field(graphene.Float)
     endTimestamp = graphene.Field(graphene.Float)
@@ -392,17 +392,20 @@ def _coerce_subset(maybe_subset):
     )
 
 
-def _get_expanded_label(evaluation: AssetConditionEvaluation, root: bool = True) -> str:
-    # don't use the user-provided label for the root of the expanded expression
-    if not root and evaluation.condition_snapshot.label is not None:
-        return evaluation.condition_snapshot.label
-
+def _get_expanded_label(evaluation: AssetConditionEvaluation, use_label=False) -> Sequence[str]:
+    if use_label and evaluation.condition_snapshot.label is not None:
+        return [evaluation.condition_snapshot.label]
     node_text = evaluation.condition_snapshot.name or evaluation.condition_snapshot.description
-    if len(evaluation.child_evaluations) == 0:
-        return node_text
-    elif len(evaluation.child_evaluations) == 1:
-        return f"{node_text} ({_get_expanded_label(evaluation.child_evaluations[0], root=False)})"
+    child_labels = [
+        f'({" ".join(_get_expanded_label(ce, use_label=True))})'
+        for ce in evaluation.child_evaluations
+    ]
+    if len(child_labels) == 0:
+        return [node_text]
+    elif len(child_labels) == 1:
+        return [node_text, f"{child_labels[0]}"]
     else:
-        return f" {node_text} ".join(
-            f"({_get_expanded_label(ce, root=False)})" for ce in evaluation.child_evaluations
-        )
+        # intersperses node_text (e.g. AND) between each child label
+        return list(itertools.chain(*itertools.zip_longest(child_labels, [], fillvalue=node_text)))[
+            :-1
+        ]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -339,8 +339,8 @@ query GetEvaluationsQuery($assetKey: AssetKeyInput!, $limit: Int!, $cursor: Stri
                 }
                 rootUniqueId
                 evaluationNodes {
-                    description
-                    label
+                    userLabel
+                    expandedLabel
                     startTimestamp
                     endTimestamp
                     numTrue
@@ -784,6 +784,7 @@ class TestAssetConditionEvaluations(ExecutingGraphQLContextTestMatrix):
         @asset(
             partitions_def=StaticPartitionsDefinition(["a", "b", "c", "d"]),
             automation_condition=AutomationCondition.eager().with_label("blah"),
+            deps=["up"],
         )
         def A() -> None: ...
 
@@ -818,21 +819,25 @@ class TestAssetConditionEvaluations(ExecutingGraphQLContextTestMatrix):
         assert len(records) == 1
 
         record = records[0]
-        assert record["numRequested"] == 4
+        assert record["numRequested"] == 0
 
         # all nodes in the tree
-        assert len(record["evaluationNodes"]) == 16
+        assert len(record["evaluationNodes"]) == 27
 
         rootNode = record["evaluationNodes"][0]
         assert rootNode["uniqueId"] == record["rootUniqueId"]
-        assert rootNode["description"] == "All of"
-        assert rootNode["label"] == "blah"
-        assert rootNode["numTrue"] == 4
-        assert set(rootNode["trueSubset"]["subsetValue"]["partitionKeys"]) == {"a", "b", "c", "d"}
+        assert rootNode["userLabel"] == "blah"
+        assert (
+            rootNode["expandedLabel"]
+            == "(in_latest_time_window) AND (((became missing) OR (any parents updated)) SINCE ((newly_requested) OR (newly_updated))) AND (NOT (any parents missing)) AND (NOT (any parents in progress)) AND (NOT (in_progress))"
+        )
+        assert rootNode["numTrue"] == 0
+        assert set(rootNode["trueSubset"]["subsetValue"]["partitionKeys"]) == set()
         assert len(rootNode["childUniqueIds"]) == 5
 
         childNode = record["evaluationNodes"][1]
-        assert childNode["description"] == "Within latest time window"
-        assert childNode["label"] is None
+        assert childNode["userLabel"] is None
+        assert childNode["expandedLabel"] == "in_latest_time_window"
         assert childNode["numTrue"] == 4
+        assert set(childNode["trueSubset"]["subsetValue"]["partitionKeys"]) == {"a", "b", "c", "d"}
         assert len(childNode["childUniqueIds"]) == 0

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -827,17 +827,24 @@ class TestAssetConditionEvaluations(ExecutingGraphQLContextTestMatrix):
         rootNode = record["evaluationNodes"][0]
         assert rootNode["uniqueId"] == record["rootUniqueId"]
         assert rootNode["userLabel"] == "blah"
-        assert (
-            rootNode["expandedLabel"]
-            == "(in_latest_time_window) AND (((became missing) OR (any parents updated)) SINCE ((newly_requested) OR (newly_updated))) AND (NOT (any parents missing)) AND (NOT (any parents in progress)) AND (NOT (in_progress))"
-        )
+        assert rootNode["expandedLabel"] == [
+            "(in_latest_time_window)",
+            "AND",
+            "(((became missing) OR (any parents updated)) SINCE ((newly_requested) OR (newly_updated)))",
+            "AND",
+            "(NOT (any parents missing))",
+            "AND",
+            "(NOT (any parents in progress))",
+            "AND",
+            "(NOT (in_progress))",
+        ]
         assert rootNode["numTrue"] == 0
         assert set(rootNode["trueSubset"]["subsetValue"]["partitionKeys"]) == set()
         assert len(rootNode["childUniqueIds"]) == 5
 
         childNode = record["evaluationNodes"][1]
         assert childNode["userLabel"] is None
-        assert childNode["expandedLabel"] == "in_latest_time_window"
+        assert childNode["expandedLabel"] == ["in_latest_time_window"]
         assert childNode["numTrue"] == 4
         assert set(childNode["trueSubset"]["subsetValue"]["partitionKeys"]) == {"a", "b", "c", "d"}
         assert len(childNode["childUniqueIds"]) == 0

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -60,12 +60,19 @@ class AutomationCondition(ABC):
     @property
     @abstractmethod
     def description(self) -> str:
+        """Human-readable description of when this condition is true."""
         raise NotImplementedError()
 
     @property
     @abstractmethod
     def label(self) -> Optional[str]:
+        """User-provided label subjectively describing the purpose of this condition in the broader evaluation tree."""
         raise NotImplementedError()
+
+    @property
+    def name(self) -> Optional[str]:
+        """Formal name of this specific condition, generally aligning with its static constructor."""
+        return None
 
     def get_snapshot(self, unique_id: str) -> AssetConditionSnapshot:
         """Returns a snapshot of this condition that can be used for serialization."""
@@ -74,6 +81,7 @@ class AutomationCondition(ABC):
             description=self.description,
             unique_id=unique_id,
             label=self.label,
+            name=self.name,
         )
 
     def get_unique_id(self, *, parent_unique_id: Optional[str], index: Optional[int]) -> str:
@@ -278,26 +286,26 @@ class AutomationCondition(ABC):
         - None of its parent partitions are currently part of an in-progress run
         """
         with disable_dagster_warnings():
-            became_missing_or_any_deps_updated = (
-                AutomationCondition.missing().newly_true()
+            became_missing_or_any_parents_updated = (
+                AutomationCondition.missing().newly_true().with_label("became missing")
                 | AutomationCondition.any_deps_match(
                     AutomationCondition.newly_updated() | AutomationCondition.will_be_requested()
-                )
+                ).with_label("any parents updated")
             )
 
-            any_parent_missing = AutomationCondition.any_deps_match(
+            any_parents_missing = AutomationCondition.any_deps_match(
                 AutomationCondition.missing() & ~AutomationCondition.will_be_requested()
-            )
-            any_parent_in_progress = AutomationCondition.any_deps_match(
+            ).with_label("any parents missing")
+            any_parents_in_progress = AutomationCondition.any_deps_match(
                 AutomationCondition.in_progress()
-            )
+            ).with_label("any parents in progress")
             return (
                 AutomationCondition.in_latest_time_window()
-                & became_missing_or_any_deps_updated.since(
+                & became_missing_or_any_parents_updated.since(
                     AutomationCondition.newly_requested() | AutomationCondition.newly_updated()
                 )
-                & ~any_parent_missing
-                & ~any_parent_in_progress
+                & ~any_parents_missing
+                & ~any_parents_in_progress
                 & ~AutomationCondition.in_progress()
             )
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
@@ -17,6 +17,10 @@ class CodeVersionChangedCondition(AutomationCondition):
         return "Asset code version changed since previous tick"
 
     @property
+    def name(self) -> str:
+        return "code_version_changed"
+
+    @property
     def requires_cursor(self) -> bool:
         return True
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
@@ -37,6 +37,10 @@ class MissingAutomationCondition(SliceAutomationCondition):
     def description(self) -> str:
         return "Missing"
 
+    @property
+    def name(self) -> str:
+        return "missing"
+
     def compute_slice(self, context: AutomationContext) -> AssetSlice:
         return context.asset_graph_view.compute_missing_subslice(
             context.asset_key, from_slice=context.candidate_slice
@@ -52,6 +56,10 @@ class InProgressAutomationCondition(SliceAutomationCondition):
     def description(self) -> str:
         return "Part of an in-progress run"
 
+    @property
+    def name(self) -> str:
+        return "in_progress"
+
     def compute_slice(self, context: AutomationContext) -> AssetSlice:
         return context.asset_graph_view.compute_in_progress_asset_slice(asset_key=context.asset_key)
 
@@ -65,6 +73,10 @@ class FailedAutomationCondition(SliceAutomationCondition):
     def description(self) -> str:
         return "Latest run failed"
 
+    @property
+    def name(self) -> str:
+        return "failed"
+
     def compute_slice(self, context: AutomationContext) -> AssetSlice:
         return context.asset_graph_view.compute_failed_asset_slice(asset_key=context.asset_key)
 
@@ -77,6 +89,10 @@ class WillBeRequestedCondition(SliceAutomationCondition):
     @property
     def description(self) -> str:
         return "Will be requested this tick"
+
+    @property
+    def name(self) -> str:
+        return "will_be_requested"
 
     def _executable_with_root_context_key(self, context: AutomationContext) -> bool:
         # TODO: once we can launch backfills via the asset daemon, this can be removed
@@ -110,6 +126,10 @@ class NewlyRequestedCondition(SliceAutomationCondition):
     def description(self) -> str:
         return "Was requested on the previous tick"
 
+    @property
+    def name(self) -> str:
+        return "newly_requested"
+
     def compute_slice(self, context: AutomationContext) -> AssetSlice:
         return context.previous_requested_slice or context.asset_graph_view.create_empty_slice(
             asset_key=context.asset_key
@@ -124,6 +144,10 @@ class NewlyUpdatedCondition(SliceAutomationCondition):
     @property
     def description(self) -> str:
         return "Updated since previous tick"
+
+    @property
+    def name(self) -> str:
+        return "newly_updated"
 
     def compute_slice(self, context: AutomationContext) -> AssetSlice:
         # if it's the first time evaluating, just return the empty slice
@@ -145,6 +169,10 @@ class CronTickPassedCondition(SliceAutomationCondition):
     @property
     def description(self) -> str:
         return f"New tick of {self.cron_schedule} ({self.cron_timezone})"
+
+    @property
+    def name(self) -> str:
+        return "cron_tick_passed"
 
     def _get_previous_cron_tick(self, effective_dt: datetime.datetime) -> datetime.datetime:
         previous_ticks = reverse_cron_string_iterator(
@@ -198,6 +226,10 @@ class InLatestTimeWindowCondition(SliceAutomationCondition):
             if self.lookback_timedelta
             else "Within latest time window"
         )
+
+    @property
+    def name(self) -> str:
+        return "in_latest_time_window"
 
     def compute_slice(self, context: AutomationContext) -> AssetSlice:
         return context.asset_graph_view.compute_latest_time_window_slice(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
@@ -47,6 +47,10 @@ class AnyDownstreamConditionsCondition(AutomationCondition):
     def description(self) -> str:
         return "Any downstream conditions"
 
+    @property
+    def name(self) -> str:
+        return "ANY_DOWNSTREAM_CONDITIONS"
+
     def _get_ignored_conditions(
         self, context: AutomationContext
     ) -> AbstractSet[AutomationCondition]:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -23,6 +23,10 @@ class AndAssetCondition(AutomationCondition):
     def description(self) -> str:
         return "All of"
 
+    @property
+    def name(self) -> str:
+        return "AND"
+
     def evaluate(self, context: AutomationContext) -> AutomationResult:
         child_results: List[AutomationResult] = []
         true_slice = context.candidate_slice
@@ -52,6 +56,10 @@ class OrAssetCondition(AutomationCondition):
     def description(self) -> str:
         return "Any of"
 
+    @property
+    def name(self) -> str:
+        return "OR"
+
     def evaluate(self, context: AutomationContext) -> AutomationResult:
         child_results: List[AutomationResult] = []
         true_slice = context.asset_graph_view.create_empty_slice(asset_key=context.asset_key)
@@ -77,6 +85,10 @@ class NotAssetCondition(AutomationCondition):
     @property
     def description(self) -> str:
         return "Not"
+
+    @property
+    def name(self) -> str:
+        return "NOT"
 
     @property
     def children(self) -> Sequence[AutomationCondition]:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -106,6 +106,10 @@ class AnyDepsCondition(DepCondition):
     def base_description(self) -> str:
         return "Any"
 
+    @property
+    def name(self) -> str:
+        return "ANY_DEPS_MATCH"
+
     def evaluate(self, context: AutomationContext) -> AutomationResult:
         dep_results = []
         true_slice = context.asset_graph_view.create_empty_slice(asset_key=context.asset_key)
@@ -135,6 +139,10 @@ class AllDepsCondition(DepCondition):
     @property
     def base_description(self) -> str:
         return "All"
+
+    @property
+    def name(self) -> str:
+        return "ALL_DEPS_MATCH"
 
     def evaluate(self, context: AutomationContext) -> AutomationResult:
         dep_results = []

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
@@ -24,6 +24,10 @@ class NewlyTrueCondition(AutomationCondition):
         return "Condition newly became true."
 
     @property
+    def name(self) -> str:
+        return "NEWLY_TRUE"
+
+    @property
     def children(self) -> Sequence[AutomationCondition]:
         return [self.operand]
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
@@ -25,6 +25,10 @@ class SinceCondition(AutomationCondition):
         )
 
     @property
+    def name(self) -> str:
+        return "SINCE"
+
+    @property
     def children(self) -> Sequence[AutomationCondition]:
         return [self.trigger_condition, self.reset_condition]
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
@@ -60,6 +60,7 @@ class AssetConditionSnapshot(NamedTuple):
     description: str
     unique_id: str
     label: Optional[str] = None
+    name: Optional[str] = None
 
 
 @whitelist_for_serdes


### PR DESCRIPTION
## Summary & Motivation

As title, this creates an expanded label field which recursively builds a string to be rendered in the UI. The logic is that an "expandedLabel" will ditch the user-provided label for that node (if any), and then render the full expression based on the in-code names of the underlying conditions.

It adds in a new "name" property to AutomationCondition, which is necessary because we can't repurpose "description" because that's meant to be a human-readable description of the precise situations under which the condition is true (i.e. it also contains information about the specific parameters of the computation), whereas the name is meant to be more of a machine / system property. The label needs to be fully user-customizable and rather than referring to a single node, it actually refers to the entire subtree underneath that node as well.

By convention, the names of operators are all-caps, and the names of operands are all lower-case.

In the future, the existing description would likely be rendered in the UI behind some sort of tooltip, but we can punt on that for now.

## How I Tested These Changes
