### PR TITLE
support prefixed asset keys in blueprints, via `AssetKey.from_user_string`

### DIFF
--- a/examples/experimental/dagster-blueprints/dagster_blueprints/blueprint_assets_definition.py
+++ b/examples/experimental/dagster-blueprints/dagster_blueprints/blueprint_assets_definition.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 from typing import AbstractSet, Any, Mapping, Optional, Sequence
 
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.assets import unique_id_from_asset_and_check_keys
 from dagster._core.definitions.decorators.asset_decorator import multi_asset
@@ -22,7 +23,12 @@ class AssetSpecModel(DagsterModel):
     tags: Mapping[str, str] = {}
 
     def to_asset_spec(self) -> AssetSpec:
-        return AssetSpec(**self.__dict__)
+        return AssetSpec(
+            **{
+                **self.__dict__,
+                "key": AssetKey.from_user_string(self.key),
+            },
+        )
 
 
 class BlueprintAssetsDefinition(Blueprint):

--- a/examples/experimental/dagster-blueprints/dagster_blueprints_tests/test_shell_command_blueprint.py
+++ b/examples/experimental/dagster-blueprints/dagster_blueprints_tests/test_shell_command_blueprint.py
@@ -39,6 +39,15 @@ def test_single_asset_shell_command_blueprint() -> None:
     ).success
 
 
+def test_single_asset_shell_command_blueprint_key_prefix() -> None:
+    single_asset_blueprint = ShellCommandBlueprint(
+        assets=[AssetSpecModel(key="prefix/asset1")], command=["echo", '"hello"']
+    )
+    defs = single_asset_blueprint.build_defs()
+    asset1 = cast(AssetsDefinition, next(iter(defs.assets)))
+    assert asset1.key == AssetKey(["prefix", "asset1"])
+
+
 def test_single_asset_shell_command_blueprint_str_command() -> None:
     single_asset_blueprint = ShellCommandBlueprint(
         assets=[AssetSpecModel(key="asset1")], command='echo "hello world"'


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes
