### PR TITLE
[dagster-dbt] Keep dagster-dbt project prepare-for-deployment alias for backcompat

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/cli/app.py
@@ -359,6 +359,7 @@ def sync_project_to_packaged_dir(
     console.print("Sync complete.")
 
 
+@project_app.command(name="prepare-for-deployment", hidden=True)
 @project_app.command(name="prepare-and-package")
 def project_prepare_and_package_command(
     file: Annotated[

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_prepare_and_package.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/cli/test_prepare_and_package.py
@@ -16,7 +16,10 @@ from typer.testing import CliRunner
 runner = CliRunner()
 
 
-def test_prepare_and_package(monkeypatch: pytest.MonkeyPatch, dbt_project_dir: Path) -> None:
+@pytest.mark.parametrize("prepare_command_name", ["prepare-for-deployment", "prepare-and-package"])
+def test_prepare_and_package(
+    monkeypatch: pytest.MonkeyPatch, dbt_project_dir: Path, prepare_command_name: str
+) -> None:
     monkeypatch.chdir(dbt_project_dir)
 
     project_name = "jaffle_dagster"
@@ -47,7 +50,7 @@ def test_prepare_and_package(monkeypatch: pytest.MonkeyPatch, dbt_project_dir: P
         app,
         [
             "project",
-            "prepare-and-package",
+            prepare_command_name,
             "--file",
             os.fspath(dagster_project_dir.joinpath(project_name, "project.py")),
         ],


### PR DESCRIPTION
## Summary

We refer to this command as `prepare-for-deployment` as part of our dbt GitHub actions that we drop in users' repositories as part of cloud setup (https://github.com/dagster-io/dagster-cloud-action/blob/main/github/serverless/dbt/deploy.yml#L70). While we can update the command name in the GitHub action going forward to match the recent rename, it won't carry over users who have already cloned the set of actions.

This PR leaves the old name as a hidden alias to support existing users.

## Test Plan

Unit test for boht names.

