### PR TITLE
don't skip steps downstream of non-yielded unselected asset keys

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_computation.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_computation.py
@@ -172,7 +172,22 @@ class AssetGraphComputation(IHaveNew):
             for dep_op_handle in dep_op_handles:
                 op_selection.append(".".join(dep_op_handle.path))
 
-        return get_graph_subset(self.node_def, op_selection)
+        selected_outputs_by_op_handle: Dict[NodeHandle, Set[str]] = defaultdict(set)
+        for (
+            op_output_handle,
+            asset_or_check_keys,
+        ) in self.asset_or_check_keys_by_dep_op_output_handle.items():
+            if any(
+                key in selected_asset_keys or key in selected_asset_check_keys
+                for key in asset_or_check_keys
+            ):
+                selected_outputs_by_op_handle[op_output_handle.node_handle].add(
+                    op_output_handle.output_name
+                )
+
+        return get_graph_subset(
+            self.node_def, op_selection, selected_outputs_by_op_handle=selected_outputs_by_op_handle
+        )
 
     @cached_property
     def dep_op_handles_by_asset_or_check_key(

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -792,7 +792,7 @@ class JobDefinition(IHasInternalInit):
 
     def _get_job_def_for_op_selection(self, op_selection: Iterable[str]) -> "JobDefinition":
         try:
-            sub_graph = get_graph_subset(self.graph, op_selection)
+            sub_graph = get_graph_subset(self.graph, op_selection, selected_outputs_by_op_handle={})
 
             # if explicit config was passed the config_mapping that resolves the defaults implicitly is
             # very unlikely to work. The job will still present the default config in the Dagster UI.


### PR DESCRIPTION
## Summary & Motivation

Consider executing this graph-backed asset with just `asset2` selected:
![image](https://github.com/user-attachments/assets/0afbcc58-48ad-4e8b-9cba-23335c21d61f)

`op1.out1` isn't required to compute `asset2`. We can get its value by just reading `asset1`. So ideally the user wouldn't yield it. However, if they omit it, they have a problem: `op2` will get skipped, because its `in1` is unsatisfied.

When subsetting a graph-backed asset, this PR proposes only including edges from outputs that are required to compute the selected assets.

## How I Tested These Changes
