### PR TITLE
Correctly return None if there are no base asset jobs that exist for a given asset key

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -34,7 +34,7 @@ def _get_implicit_job_name_for_assets(
     for asset_key in asset_keys[1:]:
         job_names &= set(asset_graph.get_materialization_job_names(asset_key))
 
-    return next(job_name for job_name in job_names if is_base_asset_job_name(job_name))
+    return next((job_name for job_name in job_names if is_base_asset_job_name(job_name)), None)
 
 
 def _get_execution_plan_asset_keys(


### PR DESCRIPTION
Summary:
The intention here appears to have been to return None if there were no jobs, but right now this is returning a StopIteration if the list is empty. Add a default.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
