### PR TITLE
[daggy-u] include SensorEvaluationContext import in full code example

### DIFF
--- a/docs/dagster-university/pages/dagster-essentials/lesson-9/building-the-sensor.md
+++ b/docs/dagster-university/pages/dagster-essentials/lesson-9/building-the-sensor.md
@@ -157,6 +157,7 @@ Putting everything together, you should have the following code in `sensors/__in
 ```python
 from dagster import (
     RunRequest,
+    SensorEvaluationContext,
     SensorResult,
     sensor,
 )


### PR DESCRIPTION
## Summary & Motivation

- Includes SensorEvaluationContext import in full example at end of "Lesson 9: Building the sensor"

Comment from community member, Joseph:
> Hi, I'm going through the Dagster Essentials course and noticed the SensorEvaluationContext import is missing from the last code block of [Building the sensor](https://courses.dagster.io/courses/take/dagster-essentials/multimedia/48127179-building-the-sensor). Just thought y'all should know
