### PR TITLE
[docs] - Update Dagster+ CI/CD files into single deploy.yml

### DIFF
--- a/docs/content/dagster-plus/references/ci-cd-file-reference.mdx
+++ b/docs/content/dagster-plus/references/ci-cd-file-reference.mdx
@@ -11,6 +11,93 @@ When you import a project into Dagster+ from GitHub or Gitlab, a few `.yml` file
 
 ---
 
+## deploy.yml
+
+<table
+  className="table"
+  style={{
+    width: "100%",
+  }}
+>
+  <tbody>
+    <tr>
+      <td
+        style={{
+          width: "15%",
+        }}
+      >
+        <strong>Name</strong>
+      </td>
+      <td>deploy.yml</td>
+    </tr>
+    <tr>
+      <td
+        style={{
+          width: "15%",
+        }}
+      >
+        <strong>Status</strong>
+      </td>
+      <td>Active</td>
+    </tr>
+    <tr>
+      <td
+        style={{
+          width: "15%",
+        }}
+      >
+        <strong>Required</strong>
+      </td>
+      <td>Required for Dagster+</td>
+    </tr>
+    <tr>
+      <td
+        style={{
+          width: "15%",
+        }}
+      >
+        <strong>Description</strong>
+      </td>
+      <td>
+        This file defines the steps required to:
+        <ul>
+          <li>
+            Deploy a project in Dagster+, including running checks, checking out
+            the project directory, and deploying the project.
+          </li>
+          <li>
+            Use{" "}
+            <a href="/dagster-plus/managing-deployments/branch-deployments">
+              Branch Deployments
+            </a>{" "}
+            (For Dagster+ accounts created after [TODO])
+          </li>
+        </ul>
+        Additionally, note the following:
+        <ul>
+          <li>
+            <strong>
+              If using a{" "}
+              <a href="/dagster-plus/deployment/hybrid">Hybrid deployment</a>
+            </strong>
+            , this file must be manually added to the repository.
+          </li>
+          <li>
+            <strong>If using dbt</strong>, some steps may need to be added to
+            successfully deploy your project. Refer to the{" "}
+            <a href="/integrations/dbt/using-dbt-with-dagster-plus#step-3-update-the-cicd-files">
+              Using dbt with Dagster+ guide
+            </a>{" "}
+            for more information.
+          </li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+---
+
 ## branch_deployments.yml
 
 <table
@@ -64,86 +151,16 @@ When you import a project into Dagster+ from GitHub or Gitlab, a few `.yml` file
         <strong>Description</strong>
       </td>
       <td>
-        Defines the steps required to use Branch Deployments. <br />
+        Defines the steps required to use Branch Deployments.{" "}
+        <strong>For Dagster+ accounts created after [TODO]</strong>, the
+        contents of this file will be consolidated into the{" "}
+        <code>deploy.yml</code> file.
         <br />
-        <strong>Note</strong>: This file must be manually added to the
-        repository if using a{" "}
-        <a href="/dagster-plus/deployment/hybrid">Hybrid deployment</a>.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
----
-
-## deploy.yml
-
-<table
-  className="table"
-  style={{
-    width: "100%",
-  }}
->
-  <tbody>
-    <tr>
-      <td
-        style={{
-          width: "15%",
-        }}
-      >
-        <strong>Name</strong>
-      </td>
-      <td>deploy.yml</td>
-    </tr>
-    <tr>
-      <td
-        style={{
-          width: "15%",
-        }}
-      >
-        <strong>Status</strong>
-      </td>
-      <td>Active</td>
-    </tr>
-    <tr>
-      <td
-        style={{
-          width: "15%",
-        }}
-      >
-        <strong>Required</strong>
-      </td>
-      <td>Required for Dagster+</td>
-    </tr>
-    <tr>
-      <td
-        style={{
-          width: "15%",
-        }}
-      >
-        <strong>Description</strong>
-      </td>
-      <td>
-        Defines the steps required to deploy a project in Dagster+, including
-        running checks, checking out the project directory, and deploying the
-        project. Additionally, note the following:
-        <ul>
-          <li>
-            <strong>
-              If using a{" "}
-              <a href="/dagster-plus/deployment/hybrid">Hybrid deployment</a>
-            </strong>
-            , this file must be manually added to the repository.
-          </li>
-          <li>
-            <strong>If using dbt</strong>, some steps may need to be added to
-            successfully deploy your project. Refer to the{" "}
-            <a href="/integrations/dbt/using-dbt-with-dagster-plus#step-3-update-the-cicd-files">
-              Using dbt with Dagster+ guide
-            </a>{" "}
-            for more information.
-          </li>
-        </ul>
+        <br />
+        <strong>Note</strong>: This file must be manually added to the repository
+        if using a <a href="/dagster-plus/deployment/hybrid">
+          Hybrid deployment
+        </a>.
       </td>
     </tr>
   </tbody>

--- a/docs/content/guides/dagster/branch_deployments.mdx
+++ b/docs/content/guides/dagster/branch_deployments.mdx
@@ -272,13 +272,19 @@ defs = Definitions(
 ## Step 4: Create our database clone upon opening a branch
 
 <TabGroup>
-  <TabItem name="Using GitHub Actions">
+<TabItem name="Using GitHub Actions">
 
-The `branch_deployments.yml` file located in `.github/workflows/branch_deployments.yml` defines a `dagster_cloud_build_push` job with a series of steps that launch a branch deployment. Because we want to queue a run of `clone_prod` within each deployment after it launches, we'll add an additional step at the end `dagster_cloud_build_push`. This job is triggered on multiple pull request events: `opened`, `synchronize`, `reopen`, and `closed`. This means that upon future pushes to the branch, we'll trigger a run of `clone_prod`. The `if` condition below ensures that `clone_prod` will not run if the pull request is closed:
+<Note>
+  <strong>Heads up!</strong> If your Dagster+ account was created before [TODO],
+  refer to your repository's <code>branch_deployments.yml</code> instead of{" "}
+  <code>deploy.yml</code>.
+</Note>
+
+The `deploy.yml` file located in `.github/workflows/deploy.yml` defines a `dagster_cloud_build_push` job with a series of steps that launch a branch deployment. Because we want to queue a run of `clone_prod` within each deployment after it launches, we'll add an additional step at the end `dagster_cloud_build_push`.
+
+This job is triggered on multiple pull request events: `opened`, `synchronize`, `reopen`, and `closed`. This means that upon future pushes to the branch, we'll trigger a run of `clone_prod`. The `if` condition below ensures that `clone_prod` will not run if the pull request is closed:
 
 ```yaml file=/guides/dagster/development_to_production/branch_deployments/clone_prod.yaml
-# .github/workflows/branch_deployments.yml
-
 name: Dagster Branch Deployments
   on:
     pull_request:
@@ -327,7 +333,7 @@ width={1431}
 height={537}
 /> </TabItem>
 
-  <TabItem name="Using Gitlab CI/CD">
+<TabItem name="Using Gitlab CI/CD">
 
 The `.gitlab-ci.yaml` script contains a `deploy` job that defines a series of steps that launch a branch deployment. Because we want to queue a run of `clone_prod` within each deployment after it launches, we'll add an additional step at the end of `deploy`. This job is triggered on when a merge request is created or updated. This means that upon future pushes to the branch, we'll trigger a run of `clone_prod`.
 
@@ -408,11 +414,15 @@ height={537}
 <TabGroup>
 <TabItem name="Using GitHub Actions">
 
-Finally, we can add a step to our `branch_deployments.yml` file that queues a run of our `drop_prod_clone` job:
+<Note>
+  <strong>Heads up!</strong> If your Dagster+ account was created before [TODO],
+  refer to your repository's <code>branch_deployments.yml</code> instead of{" "}
+  <code>deploy.yml</code>.
+</Note>
+
+Finally, we can add a step to our `deploy.yml` file that queues a run of our `drop_prod_clone` job:
 
 ```yaml file=/guides/dagster/development_to_production/branch_deployments/drop_db_clone.yaml
-# .github/workflows/branch_deployments.yml
-
 name: Dagster Branch Deployments
   on:
     pull_request:

--- a/docs/content/integrations/dbt/using-dbt-with-dagster-plus.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster-plus.mdx
@@ -72,7 +72,7 @@ Once Dagster+ finishes importing the project, move onto the next step.
 The file structure of the repository will change the first time a project is deployed using Dagster+. For dbt projects, a few things will happen:
 
 - **A [`dagster_cloud.yaml` file](/dagster-plus/managing-deployments/dagster-cloud-yaml) will be created.** This file defines the project as a Dagster+ code location.
-- **A few `.yml` files, used for CI/CD, will be created in `.github/workflows`.** [These files](/dagster-plus/references/ci-cd-file-reference), named `branch_deployments.yml` and `deploy.yml`, manage the deployments of the repository.
+- **CI/CD will be automatically set up**, using the contents of `.github/workflows`.\*\* [The files in this directory](/dagster-plus/references/ci-cd-file-reference) manage the deployments of the repository.
 - **For dbt-only projects being deployed for the first time**, Dagster+ will create a new Dagster project in the repository using the [`dagster-dbt scaffold`](/integrations/dbt/reference#scaffolding-a-dagster-project-from-a-dbt-project) command. This will result in a Dagster project that matches the dbt project. For example, a dbt project named `my_dbt_project` will contain a Dagster project in `my_dbt_project/my_dbt_project` after the process completes. Refer to the [Dagster project files reference](/guides/understanding-dagster-project-files) to learn more about the files in a Dagster project.
 
 **Use the following tabs** to see how the repository will change for a [dbt-only project](#dbt-only-projects) and a [dbt and Dagster project](#dbt-and-dagster-projects) being deployed for the first time.
@@ -112,9 +112,8 @@ When the Dagster+ deployment process completes, the repository will now look lik
 ## after Dagster+ deployment
 
 my_dbt_project
-├── .github                                                ## CI/CD files
+├── .github                                                ## CI/CD setup
 │   ├── workflows
-│   │   ├── branch_deployments.yml
 │   │   ├── deploy.yml
 ├── models
 │   ├── my_model.sql
@@ -156,7 +155,6 @@ After the Dagster+ changes, a dbt and Dagster project will include the files req
 my_dbt_and_dagster_project
 ├── .github                                                ## CI/CD files
 │   ├── workflows
-│   │   ├── branch_deployments.yml
 │   │   ├── deploy.yml
 ├── dbt
 │   ├── models
@@ -220,7 +218,7 @@ The last step is to update the [CI/CD files](/dagster-plus/references/ci-cd-file
 
 5. Save the changes.
 
-6. Open the `branch_deployments.yml` file and repeat steps 3 - 5.
+6. **If your Dagster+ account was created before \[TODO]**, open the `branch_deployments.yml` file and repeat steps 3 - 5.
 
 7. Commit the changes to the repository.
 

--- a/docs/content/integrations/dbt/using-dbt-with-dagster-plus.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster-plus.mdx
@@ -72,7 +72,7 @@ Once Dagster+ finishes importing the project, move onto the next step.
 The file structure of the repository will change the first time a project is deployed using Dagster+. For dbt projects, a few things will happen:
 
 - **A [`dagster_cloud.yaml` file](/dagster-plus/managing-deployments/dagster-cloud-yaml) will be created.** This file defines the project as a Dagster+ code location.
-- **CI/CD will be automatically set up**, using the contents of `.github/workflows`.\*\* [The files in this directory](/dagster-plus/references/ci-cd-file-reference) manage the deployments of the repository.
+- **CI/CD will be automatically set up**, using the contents of `.github/workflows`. [The files in this directory](/dagster-plus/references/ci-cd-file-reference) manage the deployments of the repository.
 - **For dbt-only projects being deployed for the first time**, Dagster+ will create a new Dagster project in the repository using the [`dagster-dbt scaffold`](/integrations/dbt/reference#scaffolding-a-dagster-project-from-a-dbt-project) command. This will result in a Dagster project that matches the dbt project. For example, a dbt project named `my_dbt_project` will contain a Dagster project in `my_dbt_project/my_dbt_project` after the process completes. Refer to the [Dagster project files reference](/guides/understanding-dagster-project-files) to learn more about the files in a Dagster project.
 
 **Use the following tabs** to see how the repository will change for a [dbt-only project](#dbt-only-projects) and a [dbt and Dagster project](#dbt-and-dagster-projects) being deployed for the first time.

--- a/docs/dagster-university/pages/dagster-dbt/lesson-7/3-setting-up-dagster-cloud.md
+++ b/docs/dagster-university/pages/dagster-dbt/lesson-7/3-setting-up-dagster-cloud.md
@@ -32,6 +32,8 @@ When Dagster deploys the code, a few things happen:
     - `.github/workflows/deploy.yml` - This file sets up Continuous Deployment (CD) for the repository. We won’t talk through all the steps here, but a high-level summary is that every time a change is made to the `main` branch of your repository, this GitHub Action will build your Dagster project and deploy it to Dagster+.
     - `.github/workflows/branch_deployments.yml` - This file enables the use of [Branch Deployments](https://docs.dagster.io/dagster-cloud/managing-deployments/branch-deployments), a Dagster+ feature that automatically creates staging environments for your Dagster code with every pull request. We won’t work with Branch Deployments during this lesson, but we highly recommend trying them out!
 
+    **Note**: This file is only created if your Dagster+ account was created before [TODO]. If your account was created on or after this date, the `branch_deployments.yml` file will be consolidated into `deploy.yml`.
+
 ---
 
 ## Checking deployment status

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/branch_deployments/clone_prod.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/branch_deployments/clone_prod.yaml
@@ -1,5 +1,3 @@
-# .github/workflows/branch_deployments.yml
-
 name: Dagster Branch Deployments
   on:
     pull_request:

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/branch_deployments/drop_db_clone.yaml
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/branch_deployments/drop_db_clone.yaml
@@ -1,5 +1,3 @@
-# .github/workflows/branch_deployments.yml
-
 name: Dagster Branch Deployments
   on:
     pull_request:


### PR DESCRIPTION
## Summary & Motivation

This PR updates the docs to reflect the changes in https://github.com/dagster-io/dagster-cloud-action/pull/187 and https://github.com/dagster-io/dagster-cloud-action/pull/188. Serverless deployments will now have a single `deploy.yml` for GitHub Actions, matching Hybrid.

## How I Tested These Changes
