### PR TITLE
[ui] IA: Batch timeline by automation

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
@@ -87,7 +87,7 @@ export const BackfillRunsTab = ({backfill}: {backfill: BackfillDetailsBackfillFr
       {view === 'timeline' && (
         <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
           <Button onClick={onPageEarlier}>&larr;</Button>
-          <Button onClick={onPageNow}>{backfill.endTimestamp ? 'Jump to End' : 'Now'}</Button>
+          <Button onClick={onPageNow}>{backfill.endTimestamp ? 'Jump to end' : 'Now'}</Button>
           <Button onClick={onPageLater}>&rarr;</Button>
         </Box>
       )}
@@ -128,7 +128,7 @@ const ExecutionRunTable = ({
   if (pipelineRunsOrError.__typename !== 'Runs') {
     return (
       <Box padding={{vertical: 64}}>
-        <NonIdealState icon="error" title="Query Error" description={pipelineRunsOrError.message} />
+        <NonIdealState icon="error" title="Query error" description={pipelineRunsOrError.message} />
       </Box>
     );
   }
@@ -188,13 +188,13 @@ const ExecutionRunTimeline = ({
 
   // Unwrap the timeline to show runs on separate rows, and sort them explicitly by
   // newest => oldest so that they match what you see in the "List" tab.
-  const job = jobs[0];
+  const row = jobs[0];
   const {runs, now} = React.useMemo(() => {
     const now = Date.now();
-    return job
-      ? {runs: [...job.runs].sort((a, b) => b.startTime - a.startTime), now}
+    return row
+      ? {runs: [...row.runs].sort((a, b) => b.startTime - a.startTime), now}
       : {runs: [], now};
-  }, [job]);
+  }, [row]);
 
   return (
     <>

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/ExecutionTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/ExecutionTimeline.tsx
@@ -10,8 +10,8 @@ import {
   RunChunks,
   TimeDividers,
   TimelineRowContainer,
-  TimelineRun,
 } from '../../runs/RunTimeline';
+import {TimelineRun} from '../../runs/RunTimelineTypes';
 import {TimeElapsed} from '../../runs/TimeElapsed';
 import {RunBatch, batchRunsForTimeline} from '../../runs/batchRunsForTimeline';
 import {mergeStatusToBackground} from '../../runs/mergeStatusToBackground';

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/groupRunsByAutomation.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/groupRunsByAutomation.tsx
@@ -1,0 +1,77 @@
+import {assertUnreachable} from '../app/Util';
+import {RowObjectType, RunAutomation, TimelineRow} from '../runs/RunTimelineTypes';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
+import {RepoAddress} from '../workspace/types';
+import {workspacePathFromAddress} from '../workspace/workspacePath';
+
+export const groupRunsByAutomation = (jobRows: TimelineRow[]): TimelineRow[] => {
+  const byAutomation: Record<string, TimelineRow> = {};
+  for (const jobRow of jobRows) {
+    const {repoAddress, runs} = jobRow;
+    runs.forEach((run) => {
+      const {automation} = run;
+      const key = makeAutomationKey(repoAddress, automation);
+
+      if (!byAutomation[key]) {
+        const name = automationName(automation);
+        byAutomation[key] = {
+          key,
+          name,
+          type: automation?.type || 'manual',
+          path: makeAutomationPath(repoAddress, automation?.type, name),
+          repoAddress,
+          runs: [],
+        };
+      }
+
+      byAutomation[key]!.runs.push(run);
+    });
+  }
+
+  return Object.values(byAutomation);
+};
+
+const automationName = (automation: RunAutomation | null) => {
+  if (!automation) {
+    return 'Launched manually';
+  }
+
+  const {type} = automation;
+  switch (type) {
+    case 'legacy-amp':
+      return 'Auto-materialized';
+    case 'schedule':
+    case 'sensor':
+      return automation.name;
+    default:
+      return assertUnreachable(type);
+  }
+};
+
+const makeAutomationKey = (repoAddress: RepoAddress, automation: RunAutomation | null) => {
+  const repo = repoAddressAsHumanString(repoAddress);
+  if (!automation) {
+    return `MANUAL-${repo}`;
+  }
+
+  const {type} = automation;
+  switch (type) {
+    case 'legacy-amp':
+      return `AMP-${repo}`;
+    case 'schedule':
+    case 'sensor':
+      return `${automation.name}-${type}-${repo}`;
+    default:
+      return assertUnreachable(type);
+  }
+};
+
+const makeAutomationPath = (repoAddress: RepoAddress, type?: RowObjectType, name?: string) => {
+  if (type === 'schedule') {
+    return workspacePathFromAddress(repoAddress, `/schedules/${name}`);
+  }
+  if (type === 'sensor') {
+    return workspacePathFromAddress(repoAddress, `/sensors/${name}`);
+  }
+  return '';
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimeline.tsx
@@ -18,11 +18,12 @@ import styled from 'styled-components';
 
 import {RunStatusDot} from './RunStatusDots';
 import {failedStatuses, inProgressStatuses, successStatuses} from './RunStatuses';
+import {RunTimelineRowIcon} from './RunTimelineRowIcon';
+import {RowObjectType, TimelineRow, TimelineRun} from './RunTimelineTypes';
 import {TimeElapsed} from './TimeElapsed';
 import {RunBatch, batchRunsForTimeline} from './batchRunsForTimeline';
 import {mergeStatusToBackground} from './mergeStatusToBackground';
 import {COMMON_COLLATOR} from '../app/Util';
-import {RunStatus} from '../graphql/types';
 import {OVERVIEW_COLLAPSED_KEY} from '../overview/OverviewExpansionKey';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
 import {AnchorButton} from '../ui/AnchorButton';
@@ -55,34 +56,27 @@ export const CONSTANTS = {
   LEFT_SIDE_SPACE_ALLOTTED,
 };
 
-export type TimelineRun = {
-  id: string;
-  status: RunStatus | 'SCHEDULED';
-  startTime: number;
-  endTime: number;
-};
-
-export type TimelineJob = {
-  key: string;
-  repoAddress: RepoAddress;
-  jobName: string;
-  jobType: 'job' | 'asset';
-  path: string;
-  runs: TimelineRun[];
+const SORT_PRIORITY: Record<RowObjectType, number> = {
+  asset: 0,
+  manual: 0,
+  'legacy-amp': 0,
+  schedule: 1,
+  sensor: 1,
+  job: 2,
 };
 
 type RowType =
-  | {type: 'header'; repoAddress: RepoAddress; jobCount: number}
-  | {type: 'job'; repoAddress: RepoAddress; job: TimelineJob};
+  | {type: 'header'; repoAddress: RepoAddress; rowCount: number}
+  | {type: RowObjectType; repoAddress: RepoAddress; row: TimelineRow};
 
 interface Props {
   loading?: boolean;
-  jobs: TimelineJob[];
+  rows: TimelineRow[];
   rangeMs: [number, number];
 }
 
 export const RunTimeline = (props: Props) => {
-  const {loading = false, jobs, rangeMs} = props;
+  const {loading = false, rows, rangeMs} = props;
   const parentRef = React.useRef<HTMLDivElement | null>(null);
   const {
     viewport: {width},
@@ -95,17 +89,17 @@ export const RunTimeline = (props: Props) => {
 
   const buckets = React.useMemo(
     () =>
-      jobs.reduce(
-        (accum, job) => {
-          const {repoAddress} = job;
+      rows.reduce(
+        (accum, row) => {
+          const {repoAddress} = row;
           const repoKey = repoAddressAsURLString(repoAddress);
           accum[repoKey] = accum[repoKey] || [];
-          accum[repoKey]!.push(job);
+          accum[repoKey]!.push(row);
           return accum;
         },
-        {} as Record<string, TimelineJob[]>,
+        {} as Record<string, TimelineRow[]>,
       ),
-    [jobs],
+    [rows],
   );
 
   const allKeys = Object.keys(buckets);
@@ -124,12 +118,17 @@ export const RunTimeline = (props: Props) => {
           return;
         }
 
-        flat.push({type: 'header', repoAddress, jobCount: bucket.length});
+        flat.push({type: 'header', repoAddress, rowCount: bucket.length});
         if (expandedKeys.includes(repoKey)) {
           bucket
-            .sort((a, b) => COMMON_COLLATOR.compare(a.jobName, b.jobName))
-            .forEach((job) => {
-              flat.push({type: 'job', repoAddress, job});
+            .sort((a, b) => {
+              return (
+                SORT_PRIORITY[a.type] - SORT_PRIORITY[b.type] ||
+                COMMON_COLLATOR.compare(a.name, b.name)
+              );
+            })
+            .forEach((row) => {
+              flat.push({type: row.type, repoAddress, row});
             });
         }
       });
@@ -162,7 +161,7 @@ export const RunTimeline = (props: Props) => {
   const duplicateRepoNames = findDuplicateRepoNames(
     repoOrder.map((repoKey) => repoAddressFromPath(repoKey)?.name || ''),
   );
-  const anyJobs = repoOrder.length > 0;
+  const anyObjects = repoOrder.length > 0;
 
   return (
     <>
@@ -173,10 +172,10 @@ export const RunTimeline = (props: Props) => {
         style={{fontSize: '16px', flex: `0 0 ${DATE_TIME_HEIGHT}px`}}
         border="top-and-bottom"
       >
-        Jobs
+        Runs
       </Box>
       <div style={{position: 'relative'}}>
-        <TimeDividers interval={ONE_HOUR_MSEC} rangeMs={rangeMs} height={anyJobs ? height : 0} />
+        <TimeDividers interval={ONE_HOUR_MSEC} rangeMs={rangeMs} height={anyObjects ? height : 0} />
       </div>
       {repoOrder.length ? (
         <div style={{overflow: 'hidden', position: 'relative'}}>
@@ -196,7 +195,7 @@ export const RunTimeline = (props: Props) => {
                       top={start}
                       repoAddress={row.repoAddress}
                       isDuplicateRepoName={!!(repoName && duplicateRepoNames.has(repoName))}
-                      jobs={buckets[repoKey]!}
+                      rows={buckets[repoKey]!}
                       onToggle={onToggle}
                       onToggleAll={onToggleAll}
                     />
@@ -205,7 +204,7 @@ export const RunTimeline = (props: Props) => {
 
                 return (
                   <RunTimelineRow
-                    job={row.job}
+                    row={row.row}
                     key={key}
                     height={size}
                     top={start}
@@ -228,7 +227,7 @@ interface TimelineHeaderRowProps {
   expanded: boolean;
   repoAddress: RepoAddress;
   isDuplicateRepoName: boolean;
-  jobs: TimelineJob[];
+  rows: TimelineRow[];
   height: number;
   top: number;
   onToggle: (repoAddress: RepoAddress) => void;
@@ -236,7 +235,7 @@ interface TimelineHeaderRowProps {
 }
 
 const TimelineHeaderRow = (props: TimelineHeaderRowProps) => {
-  const {expanded, onToggle, onToggleAll, repoAddress, isDuplicateRepoName, jobs, height, top} =
+  const {expanded, onToggle, onToggleAll, repoAddress, isDuplicateRepoName, rows, height, top} =
     props;
 
   return (
@@ -248,17 +247,17 @@ const TimelineHeaderRow = (props: TimelineHeaderRowProps) => {
       showLocation={isDuplicateRepoName}
       onToggle={onToggle}
       onToggleAll={onToggleAll}
-      rightElement={<RunStatusTags jobs={jobs} />}
+      rightElement={<RunStatusTags rows={rows} />} // todo dish: Fix this
     />
   );
 };
 
-const RunStatusTags = React.memo(({jobs}: {jobs: TimelineJob[]}) => {
+const RunStatusTags = React.memo(({rows}: {rows: TimelineRow[]}) => {
   const counts = React.useMemo(() => {
     let inProgressCount = 0;
     let failedCount = 0;
     let succeededCount = 0;
-    jobs.forEach(({runs}) => {
+    rows.forEach(({runs}) => {
       runs.forEach(({status}) => {
         // Refine `SCHEDULED` out so that our Set checks below pass TypeScript.
         if (status === 'SCHEDULED') {
@@ -274,7 +273,7 @@ const RunStatusTags = React.memo(({jobs}: {jobs: TimelineJob[]}) => {
       });
     });
     return {inProgressCount, failedCount, succeededCount};
-  }, [jobs]);
+  }, [rows]);
 
   return <RunStatusTagsWithCounts {...counts} />;
 });
@@ -571,13 +570,13 @@ const MIN_CHUNK_WIDTH = 4;
 const MIN_WIDTH_FOR_MULTIPLE = 12;
 
 const RunTimelineRow = ({
-  job,
+  row,
   top,
   height,
   rangeMs,
   width: containerWidth,
 }: {
-  job: TimelineJob;
+  row: TimelineRow;
   top: number;
   height: number;
   rangeMs: [number, number];
@@ -585,7 +584,7 @@ const RunTimelineRow = ({
 }) => {
   const [start, end] = rangeMs;
   const width = containerWidth - LEFT_SIDE_SPACE_ALLOTTED;
-  const {runs} = job;
+  const {runs} = row;
 
   // Batch overlapping runs in this row.
   const batched = React.useMemo(() => {
@@ -601,26 +600,26 @@ const RunTimelineRow = ({
     return batches;
   }, [runs, start, end, width]);
 
-  if (!job.runs.length) {
+  if (!row.runs.length) {
     return null;
   }
 
   return (
     <TimelineRowContainer $height={height} $start={top}>
-      <JobName>
-        <Icon name={job.jobType === 'asset' ? 'asset' : 'job'} />
+      <RowName>
+        <RunTimelineRowIcon type={row.type} />
         <div style={{width: LABEL_WIDTH}}>
-          {job.jobType === 'asset' ? (
-            <span style={{color: Colors.textDefault()}}>
-              <MiddleTruncate text={job.jobName} />
-            </span>
-          ) : (
-            <Link to={job.path}>
-              <MiddleTruncate text={job.jobName} />
+          {row.path ? (
+            <Link to={row.path}>
+              <MiddleTruncate text={row.name} />
             </Link>
+          ) : (
+            <span style={{color: Colors.textDefault()}}>
+              <MiddleTruncate text={row.name} />
+            </span>
           )}
         </div>
-      </JobName>
+      </RowName>
       <RunChunks>
         {batched.map((batch) => {
           const {left, width, runs} = batch;
@@ -636,7 +635,7 @@ const RunTimelineRow = ({
               }}
             >
               <Popover
-                content={<RunHoverContent job={job} batch={batch} />}
+                content={<RunHoverContent row={row} batch={batch} />}
                 position="top"
                 interactionKind="hover"
                 className="chunk-popover-target"
@@ -727,7 +726,7 @@ export const TimelineRowContainer = styled.div.attrs<RowProps>(({$height, $start
   }
 `;
 
-const JobName = styled.div`
+const RowName = styled.div`
   align-items: center;
   display: flex;
   font-size: 13px;
@@ -786,19 +785,20 @@ const BatchCount = styled.div`
 `;
 
 interface RunHoverContentProps {
-  job: TimelineJob;
+  row: TimelineRow;
   batch: RunBatch<TimelineRun>;
 }
 
 const RunHoverContent = (props: RunHoverContentProps) => {
-  const {job, batch} = props;
+  const {row, batch} = props;
   const sliced = batch.runs.slice(0, 50);
   const remaining = batch.runs.length - sliced.length;
 
   return (
     <Box style={{width: '260px'}}>
-      <Box padding={12} border="bottom">
-        <HoverContentJobName>{job.jobName}</HoverContentJobName>
+      <Box padding={12} border="bottom" flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+        <RunTimelineRowIcon type={row.type} />
+        <HoverContentRowName>{row.name}</HoverContentRowName>
       </Box>
       <div style={{maxHeight: '240px', overflowY: 'auto'}}>
         {sliced.map((run, ii) => (
@@ -830,14 +830,14 @@ const RunHoverContent = (props: RunHoverContentProps) => {
       </div>
       {remaining > 0 ? (
         <Box padding={12} border="top">
-          <Link to={`${job.path}/runs`}>+ {remaining} more</Link>
+          <Link to={`${row.path}/runs`}>+ {remaining} more</Link>
         </Box>
       ) : null}
     </Box>
   );
 };
 
-const HoverContentJobName = styled.strong`
+const HoverContentRowName = styled.strong`
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimelineRowIcon.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimelineRowIcon.tsx
@@ -1,0 +1,23 @@
+import {Icon} from '@dagster-io/ui-components';
+
+import {RowObjectType} from './RunTimelineTypes';
+import {assertUnreachable} from '../app/Util';
+
+export const RunTimelineRowIcon = ({type}: {type: RowObjectType}) => {
+  switch (type) {
+    case 'asset':
+      return <Icon name="asset" />;
+    case 'job':
+      return <Icon name="job" />;
+    case 'manual':
+      return <Icon name="account_circle" />;
+    case 'schedule':
+      return <Icon name="schedule" />;
+    case 'sensor':
+      return <Icon name="sensors" />;
+    case 'legacy-amp':
+      return <Icon name="sensors" />;
+    default:
+      return assertUnreachable(type);
+  }
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimelineTypes.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTimelineTypes.tsx
@@ -1,0 +1,25 @@
+import {RunStatus} from '../graphql/types';
+import {RepoAddress} from '../workspace/types';
+
+export type RunAutomation =
+  | {type: 'legacy-amp'}
+  | {type: 'schedule' | 'sensor'; repoAddress: RepoAddress; name: string};
+
+export type TimelineRun = {
+  id: string;
+  status: RunStatus | 'SCHEDULED';
+  startTime: number;
+  endTime: number;
+  automation: null | RunAutomation;
+};
+
+export type RowObjectType = 'job' | 'asset' | 'schedule' | 'sensor' | 'legacy-amp' | 'manual';
+
+export type TimelineRow = {
+  key: string;
+  repoAddress: RepoAddress;
+  name: string;
+  type: RowObjectType;
+  path: string;
+  runs: TimelineRun[];
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__stories__/RunTimeline.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__stories__/RunTimeline.stories.tsx
@@ -3,9 +3,10 @@ import faker from 'faker';
 import {useMemo} from 'react';
 
 import {RunStatus} from '../../graphql/types';
-import {RunTimeline, TimelineJob} from '../../runs/RunTimeline';
+import {RunTimeline} from '../../runs/RunTimeline';
 import {generateRunMocks} from '../../testing/generateRunMocks';
 import {buildRepoAddress} from '../../workspace/buildRepoAddress';
+import {TimelineRow} from '../RunTimelineTypes';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -20,60 +21,60 @@ export const OneRow = () => {
   const sixHoursAgo = useMemo(() => Date.now() - 6 * 60 * 60 * 1000, []);
   const now = useMemo(() => Date.now(), []);
 
-  const jobs: TimelineJob[] = useMemo(() => {
-    const jobKey = faker.random.words(2).split(' ').join('-').toLowerCase();
+  const rows: TimelineRow[] = useMemo(() => {
+    const rowKey = faker.random.words(2).split(' ').join('-').toLowerCase();
     const repoAddress = makeRepoAddress();
     return [
       {
-        key: jobKey,
-        jobName: jobKey,
-        jobType: 'job',
-        path: `/${jobKey}`,
+        key: rowKey,
+        name: rowKey,
+        type: 'job',
+        path: `/${rowKey}`,
         repoAddress,
         runs: generateRunMocks(6, [sixHoursAgo, now]),
       },
     ];
   }, [sixHoursAgo, now]);
 
-  return <RunTimeline jobs={jobs} rangeMs={[sixHoursAgo, now]} />;
+  return <RunTimeline rows={rows} rangeMs={[sixHoursAgo, now]} />;
 };
 
 export const RowWithOverlappingRuns = () => {
   const sixHoursAgo = useMemo(() => Date.now() - 6 * 60 * 60 * 1000, []);
   const now = useMemo(() => Date.now(), []);
 
-  const jobs: TimelineJob[] = useMemo(() => {
-    const jobKey = faker.random.words(2).split(' ').join('-').toLowerCase();
+  const rows: TimelineRow[] = useMemo(() => {
+    const rowKey = faker.random.words(2).split(' ').join('-').toLowerCase();
     const repoAddress = makeRepoAddress();
     const [first, second, third] = generateRunMocks(3, [sixHoursAgo, now]);
     return [
       {
-        key: jobKey,
-        jobName: jobKey,
-        jobType: 'job',
-        path: `/${jobKey}`,
+        key: rowKey,
+        name: rowKey,
+        type: 'job',
+        path: `/${rowKey}`,
         repoAddress,
         runs: [{...first!}, {...first!}, {...second!}, {...second!}, {...second!}, third!],
       },
     ];
   }, [sixHoursAgo, now]);
 
-  return <RunTimeline jobs={jobs} rangeMs={[sixHoursAgo, now]} />;
+  return <RunTimeline rows={rows} rangeMs={[sixHoursAgo, now]} />;
 };
 
 export const OverlapWithRunning = () => {
   const twoHoursAgo = useMemo(() => Date.now() - 2 * 60 * 60 * 1000, []);
   const now = useMemo(() => Date.now(), []);
 
-  const jobs: TimelineJob[] = useMemo(() => {
-    const jobKey = faker.random.words(2).split(' ').join('-').toLowerCase();
+  const rows: TimelineRow[] = useMemo(() => {
+    const rowKey = faker.random.words(2).split(' ').join('-').toLowerCase();
     const repoAddress = makeRepoAddress();
     return [
       {
-        key: jobKey,
-        jobName: jobKey,
-        jobType: 'job',
-        path: `/${jobKey}`,
+        key: rowKey,
+        name: rowKey,
+        type: 'job',
+        path: `/${rowKey}`,
         repoAddress,
         runs: [
           {
@@ -81,41 +82,45 @@ export const OverlapWithRunning = () => {
             status: RunStatus.SUCCESS,
             startTime: twoHoursAgo + 20 * 60 * 1000,
             endTime: twoHoursAgo + 95 * 60 * 1000,
+            automation: null,
           },
           {
             id: faker.datatype.uuid(),
             status: RunStatus.SUCCESS,
             startTime: twoHoursAgo + 90 * 60 * 1000,
             endTime: twoHoursAgo + 110 * 60 * 1000,
+            automation: null,
           },
           {
             id: faker.datatype.uuid(),
             status: RunStatus.STARTED,
             startTime: twoHoursAgo + 60 * 60 * 1000,
             endTime: now,
+            automation: null,
           },
         ],
       },
     ];
   }, [twoHoursAgo, now]);
 
-  return <RunTimeline jobs={jobs} rangeMs={[twoHoursAgo, now + 60 * 6000]} />;
+  return <RunTimeline rows={rows} rangeMs={[twoHoursAgo, now + 60 * 6000]} />;
 };
 
 export const ManyRows = () => {
   const sixHoursAgo = useMemo(() => Date.now() - 6 * 60 * 60 * 1000, []);
   const now = useMemo(() => Date.now(), []);
 
-  const jobs: TimelineJob[] = useMemo(() => {
+  const rows: TimelineRow[] = useMemo(() => {
     const repoAddress = makeRepoAddress();
     return [...new Array(12)].reduce((accum) => {
-      const jobKey = faker.random.words(3).split(' ').join('-').toLowerCase();
+      const rowKey = faker.random.words(3).split(' ').join('-').toLowerCase();
       return [
         ...accum,
         {
-          key: jobKey,
-          jobName: jobKey,
-          path: `/${jobKey}`,
+          key: rowKey,
+          name: rowKey,
+          path: `/${rowKey}`,
+          type: 'job',
           repoAddress,
           runs: generateRunMocks(6, [sixHoursAgo, now]),
         },
@@ -123,7 +128,7 @@ export const ManyRows = () => {
     }, []);
   }, [sixHoursAgo, now]);
 
-  return <RunTimeline jobs={jobs} rangeMs={[sixHoursAgo, now]} />;
+  return <RunTimeline rows={rows} rangeMs={[sixHoursAgo, now]} />;
 };
 
 export const VeryLongRunning = () => {
@@ -132,16 +137,16 @@ export const VeryLongRunning = () => {
   const twoDaysAgo = useMemo(() => Date.now() - 48 * 60 * 60 * 1000, []);
   const future = useMemo(() => Date.now() + 1 * 60 * 60 * 1000, []);
 
-  const jobs: TimelineJob[] = useMemo(() => {
+  const rows: TimelineRow[] = useMemo(() => {
     const repoAddress = makeRepoAddress();
-    const jobKeyA = faker.random.words(2).split(' ').join('-').toLowerCase();
-    const jobKeyB = faker.random.words(2).split(' ').join('-').toLowerCase();
+    const rowKeyA = faker.random.words(2).split(' ').join('-').toLowerCase();
+    const rowKeyB = faker.random.words(2).split(' ').join('-').toLowerCase();
     return [
       {
-        key: jobKeyA,
-        jobName: jobKeyA,
-        jobType: 'job',
-        path: `/${jobKeyA}`,
+        key: rowKeyA,
+        name: rowKeyA,
+        type: 'job',
+        path: `/${rowKeyA}`,
         repoAddress,
         runs: [
           {
@@ -149,14 +154,15 @@ export const VeryLongRunning = () => {
             status: RunStatus.FAILURE,
             startTime: twoDaysAgo,
             endTime: sixHoursAgo,
+            automation: null,
           },
         ],
       },
       {
-        key: jobKeyB,
-        jobName: jobKeyB,
-        jobType: 'job',
-        path: `/${jobKeyB}`,
+        key: rowKeyB,
+        name: rowKeyB,
+        type: 'job',
+        path: `/${rowKeyB}`,
         repoAddress,
         runs: [
           {
@@ -164,28 +170,29 @@ export const VeryLongRunning = () => {
             status: RunStatus.STARTED,
             startTime: twoDaysAgo,
             endTime: Date.now(),
+            automation: null,
           },
         ],
       },
     ];
   }, [twoDaysAgo, sixHoursAgo]);
 
-  return <RunTimeline jobs={jobs} rangeMs={[fourHoursAgo, future]} />;
+  return <RunTimeline rows={rows} rangeMs={[fourHoursAgo, future]} />;
 };
 
 export const MultipleStatusesBatched = () => {
   const twoHoursAgo = useMemo(() => Date.now() - 2 * 60 * 60 * 1000, []);
   const now = useMemo(() => Date.now(), []);
 
-  const jobs: TimelineJob[] = useMemo(() => {
-    const jobKey = faker.random.words(2).split(' ').join('-').toLowerCase();
+  const rows: TimelineRow[] = useMemo(() => {
+    const rowKey = faker.random.words(2).split(' ').join('-').toLowerCase();
     const repoAddress = makeRepoAddress();
     return [
       {
-        key: jobKey,
-        jobName: jobKey,
-        jobType: 'job',
-        path: `/${jobKey}`,
+        key: rowKey,
+        name: rowKey,
+        type: 'job',
+        path: `/${rowKey}`,
         repoAddress,
         runs: [
           {
@@ -193,52 +200,57 @@ export const MultipleStatusesBatched = () => {
             status: RunStatus.SUCCESS,
             startTime: twoHoursAgo + 20 * 60 * 1000,
             endTime: twoHoursAgo + 95 * 60 * 1000,
+            automation: null,
           },
           {
             id: faker.datatype.uuid(),
             status: RunStatus.SUCCESS,
             startTime: twoHoursAgo + 90 * 60 * 1000,
             endTime: twoHoursAgo + 110 * 60 * 1000,
+            automation: null,
           },
           {
             id: faker.datatype.uuid(),
             status: RunStatus.FAILURE,
             startTime: twoHoursAgo + 60 * 60 * 1000,
             endTime: now,
+            automation: null,
           },
           {
             id: faker.datatype.uuid(),
             status: RunStatus.SUCCESS,
             startTime: twoHoursAgo + 60 * 60 * 1000,
             endTime: now,
+            automation: null,
           },
           {
             id: faker.datatype.uuid(),
             status: RunStatus.STARTED,
             startTime: twoHoursAgo + 60 * 60 * 1000,
             endTime: now,
+            automation: null,
           },
         ],
       },
     ];
   }, [twoHoursAgo, now]);
 
-  return <RunTimeline jobs={jobs} rangeMs={[twoHoursAgo, now]} />;
+  return <RunTimeline rows={rows} rangeMs={[twoHoursAgo, now]} />;
 };
 
 export const BatchThresholdTesting = () => {
   const threeHoursAgo = useMemo(() => Date.now() - 3 * 60 * 60 * 1000, []);
   const now = useMemo(() => Date.now(), []);
 
-  const jobs: TimelineJob[] = useMemo(() => {
-    const jobKey = faker.random.words(2).split(' ').join('-').toLowerCase();
+  const rows: TimelineRow[] = useMemo(() => {
+    const rowKey = faker.random.words(2).split(' ').join('-').toLowerCase();
     const repoAddress = makeRepoAddress();
     return [
       {
-        key: jobKey,
-        jobName: jobKey,
-        jobType: 'job',
-        path: `/${jobKey}`,
+        key: rowKey,
+        name: rowKey,
+        type: 'job',
+        path: `/${rowKey}`,
         repoAddress,
         runs: [
           {
@@ -246,47 +258,92 @@ export const BatchThresholdTesting = () => {
             status: 'SCHEDULED',
             startTime: now,
             endTime: now + 5 * 1000,
+            automation: null,
           },
           {
             id: faker.datatype.uuid(),
             status: 'SCHEDULED',
             startTime: now + 60 * 2 * 1000,
             endTime: now + 60 * 2 * 1000 + 5 * 1000,
+            automation: null,
           },
           {
             id: faker.datatype.uuid(),
             status: 'SCHEDULED',
             startTime: now + 60 * 4 * 1000,
             endTime: now + 60 * 4 * 1000 + 5 * 1000,
+            automation: null,
           },
           {
             id: faker.datatype.uuid(),
             status: 'SCHEDULED',
             startTime: now + 60 * 6 * 1000,
             endTime: now + 60 * 6 * 1000 + 5 * 1000,
+            automation: null,
           },
           {
             id: faker.datatype.uuid(),
             status: 'SCHEDULED',
             startTime: now + 60 * 8 * 1000,
             endTime: now + 60 * 8 * 1000 + 5 * 1000,
+            automation: null,
           },
           {
             id: faker.datatype.uuid(),
             status: RunStatus.SUCCESS,
             startTime: threeHoursAgo + 24 * 60 * 1000,
             endTime: threeHoursAgo + 26 * 60 * 1000,
+            automation: null,
           },
           {
             id: faker.datatype.uuid(),
             status: RunStatus.FAILURE,
             startTime: threeHoursAgo + 28 * 60 * 1000,
             endTime: threeHoursAgo + 30 * 60 * 1000,
+            automation: null,
           },
         ],
       },
     ];
   }, [threeHoursAgo, now]);
 
-  return <RunTimeline jobs={jobs} rangeMs={[threeHoursAgo, now + 60 * 60 * 1000]} />;
+  return <RunTimeline rows={rows} rangeMs={[threeHoursAgo, now + 60 * 60 * 1000]} />;
+};
+
+export const GroupByAutomations = () => {
+  const sixHoursAgo = useMemo(() => Date.now() - 6 * 60 * 60 * 1000, []);
+  const now = useMemo(() => Date.now(), []);
+
+  const rows: TimelineRow[] = useMemo(() => {
+    const repoAddress = makeRepoAddress();
+    const automations = [...new Array(12)].reduce((accum, _, ii) => {
+      const rowKey = faker.random.words(3).split(' ').join('-').toLowerCase();
+      const rowType = ii % 2 ? 'schedule' : 'sensor';
+      const pathPrefix = rowType === 'schedule' ? 'schedules' : 'sensors';
+      return [
+        ...accum,
+        {
+          key: rowKey,
+          name: rowKey,
+          path: `/${pathPrefix}/${rowKey}`,
+          type: rowType,
+          repoAddress,
+          runs: generateRunMocks(6, [sixHoursAgo, now]),
+        },
+      ];
+    }, []);
+    return [
+      ...automations,
+      {
+        key: 'manual',
+        name: 'Launched manually',
+        path: null,
+        type: 'manual',
+        repoAddress,
+        runs: generateRunMocks(6, [sixHoursAgo, now]),
+      },
+    ];
+  }, [sixHoursAgo, now]);
+
+  return <RunTimeline rows={rows} rangeMs={[sixHoursAgo, now]} />;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/mergeStatusToBackground.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/mergeStatusToBackground.test.tsx
@@ -1,29 +1,78 @@
 import {Colors} from '@dagster-io/ui-components';
 
 import {RunStatus} from '../../graphql/types';
-import {TimelineRun} from '../RunTimeline';
 import {mergeStatusToBackground} from '../mergeStatusToBackground';
 
 describe('mergeStatusToBackground', () => {
-  const failedA = {id: 'failed-a', status: RunStatus.FAILURE, startTime: 10, endTime: 50};
-  const failedB = {id: 'failed-b', status: RunStatus.FAILURE, startTime: 10, endTime: 50};
-  const succeededA = {id: 'succeeded-a', status: RunStatus.SUCCESS, startTime: 10, endTime: 50};
-  const succeededB = {id: 'succeeded-b', status: RunStatus.SUCCESS, startTime: 10, endTime: 50};
-  const inProgressA = {id: 'inProgress-a', status: RunStatus.STARTED, startTime: 10, endTime: 50};
-  const inProgressB = {id: 'inProgress-b', status: RunStatus.STARTED, startTime: 10, endTime: 50};
-  const queuedA = {id: 'queued-a', status: RunStatus.QUEUED, startTime: 10, endTime: 50};
-  const queuedB = {id: 'queued-b', status: RunStatus.QUEUED, startTime: 10, endTime: 50};
-  const scheduledA: TimelineRun = {
-    id: 'scheduled-a',
-    status: 'SCHEDULED',
+  const failedA = {
+    id: 'failed-a',
+    status: RunStatus.FAILURE,
     startTime: 10,
     endTime: 50,
+    automation: null,
   };
-  const scheduledB: TimelineRun = {
-    id: 'scheduled-b',
-    status: 'SCHEDULED',
+  const failedB = {
+    id: 'failed-b',
+    status: RunStatus.FAILURE,
     startTime: 10,
     endTime: 50,
+    automation: null,
+  };
+  const succeededA = {
+    id: 'succeeded-a',
+    status: RunStatus.SUCCESS,
+    startTime: 10,
+    endTime: 50,
+    automation: null,
+  };
+  const succeededB = {
+    id: 'succeeded-b',
+    status: RunStatus.SUCCESS,
+    startTime: 10,
+    endTime: 50,
+    automation: null,
+  };
+  const inProgressA = {
+    id: 'inProgress-a',
+    status: RunStatus.STARTED,
+    startTime: 10,
+    endTime: 50,
+    automation: null,
+  };
+  const inProgressB = {
+    id: 'inProgress-b',
+    status: RunStatus.STARTED,
+    startTime: 10,
+    endTime: 50,
+    automation: null,
+  };
+  const queuedA = {
+    id: 'queued-a',
+    status: RunStatus.QUEUED,
+    startTime: 10,
+    endTime: 50,
+    automation: null,
+  };
+  const queuedB = {
+    id: 'queued-b',
+    status: RunStatus.QUEUED,
+    startTime: 10,
+    endTime: 50,
+    automation: null,
+  };
+  const scheduledA = {
+    id: 'scheduled-a',
+    status: 'SCHEDULED' as const,
+    startTime: 10,
+    endTime: 50,
+    automation: null,
+  };
+  const scheduledB = {
+    id: 'scheduled-b',
+    status: 'SCHEDULED' as const,
+    startTime: 10,
+    endTime: 50,
+    automation: null,
   };
 
   it('uses a single color if all runs are the same status', () => {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useRunsForTimeline.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useRunsForTimeline.test.tsx
@@ -230,12 +230,12 @@ describe('useRunsForTimeline', () => {
       expect(result.current.jobs).toHaveLength(buckets.length + 1);
     });
 
-    const pipeline0 = result.current.jobs.find((job) => job.jobName === 'pipeline0');
+    const pipeline0 = result.current.jobs.find((job) => job.name === 'pipeline0');
 
     expect(pipeline0).toEqual({
       key: 'pipeline0-repo1@repo1',
-      jobName: 'pipeline0',
-      jobType: 'job',
+      name: 'pipeline0',
+      type: 'job',
       repoAddress: {name: 'repo1', location: 'repo1'},
       path: '/locations/repo1@repo1/jobs/pipeline0',
       runs: [
@@ -244,6 +244,7 @@ describe('useRunsForTimeline', () => {
           status: RunStatus.SUCCESS,
           startTime: buckets[0]![0] * 1000,
           endTime: buckets[0]![1] * 1000,
+          automation: null,
         },
       ],
     });
@@ -497,6 +498,7 @@ describe('useRunsForTimeline', () => {
       status: 'SUCCESS',
       startTime: buckets[0]![0] * 1000,
       endTime: buckets[0]![1] * 1000,
+      automation: null,
     });
 
     expect(result.current.jobs[0]!.runs[1]).toEqual({
@@ -504,6 +506,7 @@ describe('useRunsForTimeline', () => {
       status: 'SUCCESS',
       startTime: buckets[0]![0] * 1000,
       endTime: buckets[0]![1] * 1000,
+      automation: null,
     });
 
     mockCbs.forEach((mockFn) => {
@@ -613,10 +616,10 @@ describe('useRunsForTimeline', () => {
       expect(result.current.jobs).toHaveLength(1);
     });
 
-    expect(result.current.jobs.find((job) => job.jobName === 'pipeline0')).toEqual({
+    expect(result.current.jobs.find((job) => job.name === 'pipeline0')).toEqual({
       key: 'pipeline0-repo1@repo1',
-      jobName: 'pipeline0',
-      jobType: 'job',
+      name: 'pipeline0',
+      type: 'job',
       repoAddress: {name: 'repo1', location: 'repo1'},
       path: '/locations/repo1@repo1/jobs/pipeline0',
       runs: [
@@ -625,12 +628,14 @@ describe('useRunsForTimeline', () => {
           id: 'cached-run',
           startTime: initialRange[0] * 1000,
           status: RunStatus.SUCCESS,
+          automation: null,
         },
         {
           endTime: initialRange[1] * 1000,
           id: '1-0',
           startTime: initialRange[0] * 1000,
           status: RunStatus.SUCCESS,
+          automation: null,
         },
       ],
     });

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/getAutomationForRun.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/getAutomationForRun.tsx
@@ -1,0 +1,23 @@
+import {DagsterTag} from './RunTag';
+import {RunAutomation} from './RunTimelineTypes';
+import {RunTimelineFragment} from './types/useRunsForTimeline.types';
+import {RepoAddress} from '../workspace/types';
+
+export const getAutomationForRun = (
+  repoAddress: RepoAddress,
+  run: RunTimelineFragment,
+): RunAutomation | null => {
+  const {tags = []} = run;
+  for (const tag of tags) {
+    if (tag.key === DagsterTag.ScheduleName) {
+      return {type: 'schedule', repoAddress, name: tag.value};
+    }
+    if (tag.key === DagsterTag.SensorName) {
+      return {type: 'sensor', repoAddress, name: tag.value};
+    }
+    if (tag.key === DagsterTag.Automaterialize) {
+      return {type: 'legacy-amp'};
+    }
+  }
+  return null;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/mergeStatusToBackground.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/mergeStatusToBackground.tsx
@@ -1,7 +1,7 @@
 import {Colors} from '@dagster-io/ui-components';
 
 import {failedStatuses, inProgressStatuses, queuedStatuses, successStatuses} from './RunStatuses';
-import {TimelineRun} from './RunTimeline';
+import {TimelineRun} from './RunTimelineTypes';
 
 type BackgroundStatus = 'inProgress' | 'queued' | 'failed' | 'succeeded' | 'scheduled';
 
@@ -52,7 +52,6 @@ export const mergeStatusToBackground = (runs: TimelineRun[]) => {
     return statusToColor(element!);
   }
 
-  // const colorList = statusArr.map(statusToColor);
   const runCount = runs.length;
 
   const colors = [

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsForTimeline.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsForTimeline.types.ts
@@ -11,6 +11,7 @@ export type RunTimelineFragment = {
   startTime: number | null;
   endTime: number | null;
   updateTime: number | null;
+  tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
   repositoryOrigin: {
     __typename: 'RepositoryOrigin';
     id: string;
@@ -41,6 +42,7 @@ export type OngoingRunTimelineQuery = {
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;
+          tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
           repositoryOrigin: {
             __typename: 'RepositoryOrigin';
             id: string;
@@ -73,6 +75,7 @@ export type CompletedRunTimelineQuery = {
           startTime: number | null;
           endTime: number | null;
           updateTime: number | null;
+          tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
           repositoryOrigin: {
             __typename: 'RepositoryOrigin';
             id: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/testing/generateRunMocks.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/testing/generateRunMocks.ts
@@ -21,6 +21,7 @@ export const generateRunMocks = (runCount: number, range: [number, number]) => {
         startTime,
         status,
         endTime,
+        automation: null,
       };
     });
 };


### PR DESCRIPTION
## Summary & Motivation

When the viewer is in the IA feature flag, re-bucket the run timeline by automations, i.e.: schedule, sensor, auto-materialize, and manually launched. (And no more "Ad hoc materializations".)

This is accomplished by retrieving run tags, and tracking automation data on each run. If the flag is true, take the existing bucketed state and re-bucket it for display. Additionally, I have done a lot of renaming from "job" to "row", since our components and utilities currently always assume that bucketing takes place strictly by job.

<img width="1421" alt="Screenshot 2024-07-16 at 15 45 55" src="https://github.com/user-attachments/assets/98ab2474-c231-44ce-b73c-a7d04563b48c">


## How I Tested These Changes

With the flag enabled and disabled, view the run timeline. Verify that bucketing is correct in each state, and that links work correctly.