### PR TITLE
:sparkles: support Literal types in Pythonic Configuration

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/conversion_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/conversion_utils.py
@@ -1,10 +1,14 @@
 import inspect
 from enum import Enum
-from typing import Any, Dict, List, Mapping, Optional, Type, TypeVar, Union
+from typing import Any, Dict, List, Literal, Mapping, Optional, Type, TypeVar, Union
+from uuid import uuid4
 
 from typing_extensions import Annotated, get_args, get_origin
 
-from dagster import Enum as DagsterEnum
+from dagster import (
+    Enum as DagsterEnum,
+    EnumValue as DagsterEnumValue,
+)
 from dagster._config.config_type import Array, ConfigType, Noneable
 from dagster._config.post_process import resolve_defaults
 from dagster._config.source import BoolSource, IntSource, StringSource
@@ -104,6 +108,9 @@ def _convert_pydantic_field(
 
     if pydantic_field.discriminator:
         return _convert_pydantic_discriminated_union_field(pydantic_field)
+
+    if get_origin(pydantic_field.annotation) == Literal:
+        return _convert_typing_literal_field(pydantic_field)
 
     field_type = pydantic_field.annotation
     if safe_is_subclass(field_type, Config):
@@ -271,6 +278,47 @@ def _convert_pydantic_discriminated_union_field(pydantic_field: ModelFieldCompat
     # We then nest the union fields under a Selector. The keys for the selector
     # are the various discriminator values
     return Field(config=Selector(fields=dagster_config_field_mapping))
+
+
+def _convert_typing_literal_field(pydantic_field: ModelFieldCompat) -> Field:
+    """Builds a Enum config field from a Pydantic field which is a Literal type.
+
+    For example:
+
+    class ConfigWithLiteral(Config):
+        pet: Literal["cat", "dog"]
+
+    Becomes:
+
+    Shape({
+      "pet": Enum("cat", "dog")
+      })
+    })
+    """
+    field_type = pydantic_field.annotation
+
+    if not get_origin(field_type) == Literal:
+        raise DagsterInvalidDefinitionError("Must be a Literal type.")
+
+    sub_fields = get_args(field_type)
+
+    default_to_pass = (
+        pydantic_field.default
+        if pydantic_field.default is not PydanticUndefined
+        else FIELD_NO_DEFAULT_PROVIDED
+    )
+
+    return Field(
+        config=DagsterEnum(
+            str(
+                str(field_type).lstrip("typing.") + f"-{uuid4()}",
+            ),
+            list(map(DagsterEnumValue, sub_fields)),
+        ),
+        description=pydantic_field.description,
+        is_required=pydantic_field.is_required() and not is_closed_python_optional_type(field_type),
+        default_value=default_to_pass,
+    )
 
 
 def infer_schema_from_config_annotation(model_cls: Any, config_arg_default: Any) -> Field:

--- a/python_modules/dagster/dagster/_config/pythonic_config/conversion_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/conversion_utils.py
@@ -1,7 +1,6 @@
 import inspect
 from enum import Enum
 from typing import Any, Dict, List, Literal, Mapping, Optional, Type, TypeVar, Union
-from uuid import uuid4
 
 from typing_extensions import Annotated, get_args, get_origin
 
@@ -310,9 +309,7 @@ def _convert_typing_literal_field(pydantic_field: ModelFieldCompat) -> Field:
 
     return Field(
         config=DagsterEnum(
-            str(
-                str(field_type).lstrip("typing.") + f"-{uuid4()}",
-            ),
+            str(str(field_type).lstrip("typing.")),
             list(map(DagsterEnumValue, sub_fields)),
         ),
         description=pydantic_field.description,

--- a/python_modules/dagster/dagster/_config/pythonic_config/conversion_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/conversion_utils.py
@@ -290,7 +290,7 @@ def _convert_typing_literal_field(pydantic_field: ModelFieldCompat) -> Field:
     Becomes:
 
     Shape({
-      "pet": Enum("cat", "dog")
+      "pet": Enum(["cat", "dog"])
       })
     })
     """

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
@@ -816,7 +816,7 @@ def test_literal_in_resource_config() -> None:
 
     a_job.execute_in_process(resources={"my_resource": MyResource(a_literal="bar")})
 
-    with pytest.raises(pydantic.error_wrappers.ValidationError):
+    with pytest.raises(pydantic.ValidationError):
         a_job.execute_in_process(resources={"my_resource": MyResource(a_literal="baz")})  # type: ignore
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
@@ -817,7 +817,7 @@ def test_literal_in_resource_config() -> None:
     a_job.execute_in_process(resources={"my_resource": MyResource(a_literal="bar")})
 
     with pytest.raises(pydantic.error_wrappers.ValidationError):
-        a_job.execute_in_process(resources={"my_resource": MyResource(a_literal="baz")})
+        a_job.execute_in_process(resources={"my_resource": MyResource(a_literal="baz")})  # type: ignore
 
 
 def test_enum_complex() -> None:

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_pythonic_config_types.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Any, Dict, List, Mapping, Optional, Type, Union
+from typing import Any, Dict, List, Literal, Mapping, Optional, Type, Union
 
 import pytest
 from dagster import (
@@ -18,7 +18,7 @@ from dagster._config.type_printer import print_config_type_to_string
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._utils.cached_method import cached_method
 from pydantic import Field
-from typing_extensions import Literal
+from typing_extensions import TypeAlias
 
 
 def test_default_config_class_non_permissive() -> None:
@@ -899,9 +899,10 @@ def test_struct_config_non_optional_none_input_errors() -> None:
         )
 
 
-def test_conversion_to_fields() -> None:
-    FooBarLiteral = Literal["foo", "bar"]
+FooBarLiteral: TypeAlias = Literal["foo", "bar"]
 
+
+def test_conversion_to_fields() -> None:
     class ConfigClassToConvert(Config):
         a_string: str
         an_int: str


### PR DESCRIPTION
## Summary & Motivation

Resolve #8932

I believe this is a good start for supporting `Literal` type annotations in Dagster's configs. 

This implementation doesn't cover all cases, but the most common use case for `Literal[<some_strings>]` is already working. 

In the future we would probably want to cover: 

- mixed types: `Literal["a", 1]`
- Optionals: `Literal["a", "b"] | None`

## How I Tested These Changes
Added tests for Literal types