### PR TITLE
feat(catalog): add `AssetSelection` stub to select by code location

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -901,6 +901,24 @@ class OwnerAssetSelection(AssetSelection):
 
 
 @whitelist_for_serdes
+class CodeLocationAssetSelection(AssetSelection):
+    """Used to represent a UI asset selection by code location. This should not be resolved against
+    an in-process asset graph.
+    """
+
+    selected_code_location: str
+
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
+        """This should not be invoked in user code."""
+        raise NotImplementedError
+
+    def __str__(self) -> str:
+        return f"code_location:{self.selected_code_location}"
+
+
+@whitelist_for_serdes
 class KeysAssetSelection(AssetSelection):
     selected_keys: Sequence[AssetKey]
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -28,6 +28,7 @@ from dagster._core.definitions.asset_selection import (
     AndAssetSelection,
     AssetCheckKeysSelection,
     AssetChecksForAssetKeysSelection,
+    CodeLocationAssetSelection,
     DownstreamAssetSelection,
     GroupsAssetSelection,
     KeyPrefixesAssetSelection,
@@ -797,3 +798,15 @@ def test_owner() -> None:
         AssetKey("asset1"),
         AssetKey("asset3"),
     }
+
+
+def test_code_location() -> None:
+    @asset
+    def my_asset(): ...
+
+    # Selection can be instantiated.
+    selection = CodeLocationAssetSelection(selected_code_location="code_location1")
+
+    # But not resolved.
+    with pytest.raises(NotImplementedError):
+        selection.resolve([my_asset])


### PR DESCRIPTION
## Summary & Motivation
Add an `AssetSelection` subclass that represents a selection by code location.

Its selection method isn't implemented yet since we don't expect users to use this in code. Code location information for a given node in the asset graph is only available in a remote context, not an in-process context.

## How I Tested These Changes
pytest