### PR TITLE
[RFC][1.8] hide deprecated methods from `dir`

### DIFF
--- a/python_modules/dagster/dagster/_annotations.py
+++ b/python_modules/dagster/dagster/_annotations.py
@@ -1,6 +1,6 @@
 import inspect
 from dataclasses import dataclass
-from typing import Any, Callable, Mapping, Optional, TypeVar, Union, overload
+from typing import Any, Callable, Mapping, Optional, Sequence, TypeVar, Union, overload
 
 from typing_extensions import Annotated, Final, TypeAlias
 
@@ -575,3 +575,15 @@ def _get_warning_stacklevel(obj: Annotatable):
 def _annotatable_has_param(obj: Annotatable, param: str) -> bool:
     target_fn = get_decorator_target(obj)
     return param in inspect.signature(target_fn).parameters
+
+
+class HideDeprecatedMethods:
+    def __dir__(self) -> Sequence[str]:
+        result = []
+        for attr_name in super().__dir__():
+            attr = getattr(self.__class__, attr_name, None)
+            obj = attr.fget if isinstance(attr, property) else attr
+            if obj is None or not hasattr(obj, _DEPRECATED_ATTR_NAME):
+                result.append(attr_name)
+
+        return result

--- a/python_modules/dagster/dagster/_core/execution/context/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/context/compute.py
@@ -17,7 +17,7 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster._annotations import deprecated, experimental, public
+from dagster._annotations import HideDeprecatedMethods, deprecated, experimental, public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSpec
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.data_version import (
@@ -133,7 +133,9 @@ class OpExecutionContextMetaClass(AbstractComputeMetaclass):
         return super().__instancecheck__(instance)
 
 
-class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionContextMetaClass):
+class OpExecutionContext(
+    AbstractComputeExecutionContext, HideDeprecatedMethods, metaclass=OpExecutionContextMetaClass
+):
     """The ``context`` object that can be made available as the first argument to the function
     used for computing an op or asset.
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
@@ -45,6 +45,9 @@ def test_op_execution_context():
         check.inst(context.job_def, JobDefinition)
         assert context.op_config is None
         check.inst(context.op_def, OpDefinition)
+        dir_context = dir(context)
+        assert "asset_partition_key_range" not in dir_context
+        assert "partition_key_range" in dir_context
 
     @job
     def foo():


### PR DESCRIPTION
## Summary & Motivation

Inspired by [this](https://github.com/dagster-io/dagster/discussions/23031#discussioncomment-10065065). Auto-complete gets polluted with lots of deprecated properties. It would be nice to hide them.

If we want to do this, I think we should try to get it in for 1.8, because it could be a disruptive change in ways that we can't anticipate.

## How I Tested These Changes

STILL NEED TO TEST THAT THIS ACTUALLY HELPS WITH AUTOCOMPLETE IN VSCODE.