### PR TITLE
Fix missing dynamic_partitions_store argument in _exceeds_self_partition_limit

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/data_version.py
+++ b/python_modules/dagster/dagster/_core/definitions/data_version.py
@@ -751,6 +751,8 @@ class CachingStaleStatusResolver:
 
     def _exceeds_self_partition_limit(self, asset_key: "AssetKey") -> bool:
         return (
-            check.not_none(self.asset_graph.get(asset_key).partitions_def).get_num_partitions()
+            check.not_none(self.asset_graph.get(asset_key).partitions_def).get_num_partitions(
+                dynamic_partitions_store=self._instance
+            )
             >= SKIP_PARTITION_DATA_VERSION_SELF_DEPENDENCY_THRESHOLD
         )


### PR DESCRIPTION
Summary:
I am not immediately sure how to create a test case that reproduces this problem, but this get_num_partitions call is missing a required argument when the asset has dynamic partitions.

Test Plan: Reproduce on a test query that was hitting a 500 with this error:

"Failure condition: The instance is not available to load partitions. You may be seeing this error when using dynamic partitions with a version of dagster-webserver or dagster-cloud that is older than 1.1.18. The other possibility is that an internal framework error where a dynamic partitions store was not properly threaded down a call stack."

## Summary & Motivation

## How I Tested These Changes
