### PR TITLE
[ui] New automation evaluations table UI

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanel.tsx
@@ -46,6 +46,7 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
   });
 
   const skip = !!_selectedEvaluation || !!selectedPartition;
+  const isLegacy = !!_selectedEvaluation?.isLegacy;
 
   // We receive the selected evaluation ID and retrieve it here because the middle panel
   // may be displaying an evaluation that was not retrieved at the page level for the
@@ -61,8 +62,11 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
       skip,
     },
   );
+
   const {data, loading, error} = queryResult;
   useBlockTraceOnQueryResult(queryResult, 'GetEvaluationsQuery<Single>', {skip});
+
+  const skipSpecificPartitionQuery = !isLegacy || !selectedEvaluationId || !selectedPartition;
 
   const queryResult2 = useQuery<
     GetEvaluationsSpecificPartitionQuery,
@@ -73,11 +77,13 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
       evaluationId: selectedEvaluationId!,
       partition: selectedPartition!,
     },
-    skip: !selectedEvaluationId || !selectedPartition,
+    skip: skipSpecificPartitionQuery,
   });
+
   useBlockTraceOnQueryResult(queryResult2, 'GetEvaluationsSpecificPartitionQuery', {
-    skip: !selectedEvaluationId || !selectedPartition,
+    skip: skipSpecificPartitionQuery,
   });
+
   const {data: specificPartitionData, previousData: previousSpecificPartitionData} = queryResult2;
 
   const sensorName = React.useMemo(
@@ -153,7 +159,7 @@ export const AutomaterializeMiddlePanel = (props: Props) => {
               <Body2>
                 <Box flex={{direction: 'column', gap: 8}}>
                   <Body2>
-                    This asset’s automation policy has not been evaluated yet. Make sure your
+                    This asset&apos;s automation policy has not been evaluated yet. Make sure your
                     automation sensor is running.
                   </Body2>
                   <div>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/EvaluationConditionalLabel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/EvaluationConditionalLabel.tsx
@@ -1,4 +1,4 @@
-import {Box, Code, Colors, FontFamily} from '@dagster-io/ui-components';
+import {Box, CaptionMono, Code, Colors, FontFamily, Tooltip} from '@dagster-io/ui-components';
 import styled from 'styled-components';
 
 interface Props {
@@ -11,7 +11,20 @@ export const EvaluationConditionalLabel = ({segments}: Props) => {
       {segments.map((segment, ii) => {
         const key = `segment-${ii}`;
         if (segment.startsWith('(') && segment.endsWith(')')) {
-          return <Operand key={key}>{segment.slice(1, -1)}</Operand>;
+          const inner = segment.slice(1, -1);
+          return (
+            <Tooltip
+              key={key}
+              content={
+                <div style={{maxWidth: '500px', whiteSpace: 'normal'}}>
+                  <CaptionMono>{inner}</CaptionMono>
+                </div>
+              }
+              placement="top"
+            >
+              <Operand>{inner}</Operand>
+            </Tooltip>
+          );
         }
         return <Operator key={key}>{segment}</Operator>;
       })}
@@ -23,8 +36,13 @@ const Operand = styled(Code)`
   background-color: ${Colors.backgroundGray()};
   border-radius: 8px;
   color: ${Colors.textLight()};
+  display: block;
   font-size: 12px;
   padding: 4px 8px;
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const Operator = styled.div`

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/GetEvaluationsQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/GetEvaluationsQuery.tsx
@@ -62,6 +62,27 @@ const PartitionedAssetConditionEvaluationNodeFragment = gql`
   ${AssetSubsetFragment}
 `;
 
+const NEW_EVALUATION_NODE_FRAGMENT = gql`
+  fragment NewEvaluationNodeFragment on AutomationConditionEvaluationNode {
+    uniqueId
+    expandedLabel
+    userLabel
+    startTimestamp
+    endTimestamp
+    numTrue
+    isPartitioned
+    childUniqueIds
+    trueSubset {
+      ...AssetSubsetFragment
+    }
+    candidateSubset {
+      ...AssetSubsetFragment
+    }
+  }
+
+  ${AssetSubsetFragment}
+`;
+
 const AssetConditionEvaluationRecordFragment = gql`
   fragment AssetConditionEvaluationRecordFragment on AssetConditionEvaluationRecord {
     id
@@ -74,6 +95,7 @@ const AssetConditionEvaluationRecordFragment = gql`
     timestamp
     startTimestamp
     endTimestamp
+    isLegacy
     evaluation {
       rootUniqueId
       evaluationNodes {
@@ -82,10 +104,15 @@ const AssetConditionEvaluationRecordFragment = gql`
         ...SpecificPartitionAssetConditionEvaluationNodeFragment
       }
     }
+    evaluationNodes {
+      ...NewEvaluationNodeFragment
+    }
   }
+
   ${UnpartitionedAssetConditionEvaluationNodeFragment}
   ${PartitionedAssetConditionEvaluationNodeFragment}
   ${SpecificPartitionAssetConditionEvaluationNodeFragment}
+  ${NEW_EVALUATION_NODE_FRAGMENT}
 `;
 
 export const GET_EVALUATIONS_QUERY = gql`

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PartitionSegmentWithPopover.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PartitionSegmentWithPopover.tsx
@@ -38,22 +38,26 @@ type AssetSusbsetWithoutTypenames = {
 
 interface Props {
   description: string;
-  status: AssetConditionEvaluationStatus.TRUE;
   subset: AssetSusbsetWithoutTypenames | null;
-  selectPartition: (partitionKey: string | null) => void;
+  selectPartition?: (partitionKey: string | null) => void;
 }
 
-export const PartitionSegmentWithPopover = ({
-  description,
-  selectPartition,
-  status,
-  subset,
-}: Props) => {
+export const PartitionSegmentWithPopover = ({description, selectPartition, subset}: Props) => {
   if (!subset) {
     return null;
   }
 
   const count = subset.subsetValue.partitionKeys?.length || 0;
+
+  const tag = (
+    <Tag intent={count > 0 ? 'success' : 'none'} icon={count > 0 ? 'check_circle' : undefined}>
+      {numberFormatter.format(count)} True
+    </Tag>
+  );
+
+  if (count === 0) {
+    return tag;
+  }
 
   return (
     <Popover
@@ -64,15 +68,13 @@ export const PartitionSegmentWithPopover = ({
       content={
         <PartitionSubsetList
           description={description}
-          status={status}
+          status={AssetConditionEvaluationStatus.TRUE}
           subset={subset}
           selectPartition={selectPartition}
         />
       }
     >
-      <Tag intent={count > 0 ? 'success' : 'none'} icon={count > 0 ? 'check_circle' : undefined}>
-        {numberFormatter.format(count)} {status.charAt(0) + status.toLowerCase().slice(1)}
-      </Tag>
+      {tag}
     </Popover>
   );
 };
@@ -81,7 +83,7 @@ interface ListProps {
   description: string;
   status?: AssetConditionEvaluationStatus;
   subset: AssetSusbsetWithoutTypenames;
-  selectPartition: (partitionKey: string | null) => void;
+  selectPartition?: (partitionKey: string | null) => void;
 }
 
 const ITEM_HEIGHT = 32;
@@ -153,7 +155,7 @@ export const PartitionSubsetList = ({description, status, subset, selectPartitio
                   <Row $height={size} $start={start} key={key}>
                     <MenuItem
                       onClick={() => {
-                        selectPartition(partitionKey);
+                        selectPartition && selectPartition(partitionKey);
                       }}
                       text={
                         <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PolicyEvaluationCondition.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PolicyEvaluationCondition.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, Icon, IconName} from '@dagster-io/ui-components';
+import {Box, Colors, Icon} from '@dagster-io/ui-components';
 import * as React from 'react';
 import styled from 'styled-components';
 
@@ -6,16 +6,16 @@ export type ConditionType = 'group' | 'leaf';
 
 interface Props {
   depth: number;
-  icon: IconName;
+  icon: React.ReactNode;
   label: React.ReactNode;
   type: ConditionType;
   skipped?: boolean;
-  isCollapsed: boolean;
+  isExpanded: boolean;
   hasChildren: boolean;
 }
 
 export const PolicyEvaluationCondition = (props: Props) => {
-  const {depth, icon, label, type, skipped = false, isCollapsed, hasChildren} = props;
+  const {depth, icon, label, type, skipped = false, isExpanded, hasChildren} = props;
   const depthLines = React.useMemo(() => {
     return new Array(depth).fill(null).map((_, ii) => <DepthLine key={ii} />);
   }, [depth]);
@@ -24,17 +24,16 @@ export const PolicyEvaluationCondition = (props: Props) => {
     <Box
       padding={{vertical: 2, horizontal: 8}}
       flex={{direction: 'row', alignItems: 'center', gap: 8}}
-      style={{height: '48px'}}
     >
       {depthLines}
-
       {hasChildren ? (
         <Icon
           name="arrow_drop_down"
-          style={{transform: isCollapsed ? 'rotate(0deg)' : 'rotate(-90deg)'}}
+          size={20}
+          style={{transform: isExpanded ? 'rotate(0deg)' : 'rotate(-90deg)'}}
         />
       ) : null}
-      <Icon name={icon} color={Colors.accentPrimary()} />
+      {hasChildren ? icon : <div style={{marginLeft: 28}}>{icon}</div>}
       <ConditionLabel $type={type} $skipped={skipped}>
         {label}
       </ConditionLabel>
@@ -44,7 +43,7 @@ export const PolicyEvaluationCondition = (props: Props) => {
 
 const DepthLine = styled.div`
   background-color: ${Colors.keylineDefault()};
-  height: 100%;
+  align-self: stretch;
   margin: 0 4px 0 7px; /* 7px to align with center of icon in row above */
   width: 2px;
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PolicyEvaluationTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PolicyEvaluationTable.tsx
@@ -1,13 +1,15 @@
 import {Box, Button, Colors, Dialog, Icon, Table, Tooltip} from '@dagster-io/ui-components';
 import * as React from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import styled, {css} from 'styled-components';
 
+import {EvaluationConditionalLabel} from './EvaluationConditionalLabel';
 import {PartitionSegmentWithPopover} from './PartitionSegmentWithPopover';
 import {PolicyEvaluationCondition} from './PolicyEvaluationCondition';
 import {PolicyEvaluationStatusTag} from './PolicyEvaluationStatusTag';
-import {FlattenedConditionEvaluation, flattenEvaluations} from './flattenEvaluations';
+import {Evaluation, FlattenedConditionEvaluation, flattenEvaluations} from './flattenEvaluations';
 import {
-  AssetConditionEvaluationRecordFragment,
+  NewEvaluationNodeFragment,
   PartitionedAssetConditionEvaluationNodeFragment,
   SpecificPartitionAssetConditionEvaluationNodeFragment,
   UnpartitionedAssetConditionEvaluationNodeFragment,
@@ -16,24 +18,32 @@ import {AssetConditionEvaluationStatus} from '../../graphql/types';
 import {MetadataEntryFragment} from '../../metadata/types/MetadataEntryFragment.types';
 import {TimeElapsed} from '../../runs/TimeElapsed';
 import {AssetEventMetadataEntriesTable} from '../AssetEventMetadataEntriesTable';
-import {AssetViewDefinitionNodeFragment} from '../types/AssetView.types';
 
 interface Props {
-  evaluationRecord: Pick<AssetConditionEvaluationRecordFragment, 'evaluation'>;
-  definition?: AssetViewDefinitionNodeFragment | null;
+  evaluationNodes: Evaluation[];
+  rootUniqueId: string;
+  isLegacyEvaluation: boolean;
   selectPartition: (partitionKey: string | null) => void;
 }
 
-export const PolicyEvaluationTable = ({evaluationRecord, definition, selectPartition}: Props) => {
-  const [collapsedRecords, setcollapsedRecords] = React.useState<Set<string>>(new Set());
-  const flattened = React.useMemo(
-    () => flattenEvaluations(evaluationRecord, collapsedRecords),
-    [evaluationRecord, collapsedRecords],
-  );
+export const PolicyEvaluationTable = (props: Props) => {
+  const {evaluationNodes, rootUniqueId, isLegacyEvaluation, selectPartition} = props;
+  const [expandedRecords, setExpandedRecords] = useState<Set<string>>(() => {
+    const list = isLegacyEvaluation ? evaluationNodes.map((node) => node.uniqueId) : [];
+    return new Set(list);
+  });
 
-  const toggleCollapsed = React.useCallback((uniqueId: string) => {
-    setcollapsedRecords((collapsedRecords) => {
-      const copy = new Set(collapsedRecords);
+  const flattened = useMemo(() => {
+    return flattenEvaluations({
+      evaluationNodes,
+      rootUniqueId,
+      expandedRecords,
+    });
+  }, [evaluationNodes, rootUniqueId, expandedRecords]);
+
+  const toggleExpanded = useCallback((uniqueId: string) => {
+    setExpandedRecords((expandedRecords) => {
+      const copy = new Set(expandedRecords);
       if (copy.has(uniqueId)) {
         copy.delete(uniqueId);
       } else {
@@ -42,16 +52,27 @@ export const PolicyEvaluationTable = ({evaluationRecord, definition, selectParti
       return copy;
     });
   }, []);
+
+  if (!isLegacyEvaluation) {
+    return (
+      <NewPolicyEvaluationTable
+        flattenedRecords={flattened as FlattenedConditionEvaluation<NewEvaluationNodeFragment>[]}
+        toggleExpanded={toggleExpanded}
+        expandedRecords={expandedRecords}
+      />
+    );
+  }
+
   if (flattened[0]?.evaluation.__typename === 'PartitionedAssetConditionEvaluationNode') {
     return (
       <PartitionedPolicyEvaluationTable
         flattenedRecords={
           flattened as FlattenedConditionEvaluation<PartitionedAssetConditionEvaluationNodeFragment>[]
         }
-        definition={definition}
+        // definition={definition}
         selectPartition={selectPartition}
-        toggleCollapsed={toggleCollapsed}
-        collapsedRecords={collapsedRecords}
+        toggleExpanded={toggleExpanded}
+        expandedRecords={expandedRecords}
       />
     );
   }
@@ -63,24 +84,126 @@ export const PolicyEvaluationTable = ({evaluationRecord, definition, selectParti
           | FlattenedConditionEvaluation<UnpartitionedAssetConditionEvaluationNodeFragment>[]
           | FlattenedConditionEvaluation<SpecificPartitionAssetConditionEvaluationNodeFragment>[]
       }
-      toggleCollapsed={toggleCollapsed}
-      collapsedRecords={collapsedRecords}
+      toggleExpanded={toggleExpanded}
+      expandedRecords={expandedRecords}
     />
+  );
+};
+
+const NewPolicyEvaluationTable = ({
+  flattenedRecords,
+  expandedRecords,
+  toggleExpanded,
+}: {
+  expandedRecords: Set<string>;
+  toggleExpanded: (id: string) => void;
+  flattenedRecords: FlattenedConditionEvaluation<NewEvaluationNodeFragment>[];
+}) => {
+  const [hoveredKey, setHoveredKey] = useState<number | null>(null);
+  const isPartitioned = !!flattenedRecords[0]?.evaluation.isPartitioned;
+  return (
+    <VeryCompactTable>
+      <thead>
+        <tr>
+          <th>Condition</th>
+          <th>Result</th>
+          {isPartitioned ? <th>Partitions evaluated</th> : null}
+          <th>Duration</th>
+        </tr>
+      </thead>
+      <tbody>
+        {flattenedRecords.map(({evaluation, id, parentId, depth, type}) => {
+          const {userLabel, uniqueId, numTrue, candidateSubset, expandedLabel} = evaluation;
+          const anyCandidatePartitions = !!candidateSubset?.subsetValue.partitionKeys?.length;
+          const status =
+            numTrue === 0 && !anyCandidatePartitions
+              ? AssetConditionEvaluationStatus.SKIPPED
+              : numTrue > 0
+              ? AssetConditionEvaluationStatus.TRUE
+              : AssetConditionEvaluationStatus.FALSE;
+
+          let endTimestamp, startTimestamp;
+          if ('endTimestamp' in evaluation) {
+            endTimestamp = evaluation.endTimestamp;
+            startTimestamp = evaluation.startTimestamp;
+          }
+
+          return (
+            <EvaluationRow
+              key={id}
+              $highlight={
+                hoveredKey === id ? 'hovered' : parentId === hoveredKey ? 'highlighted' : 'none'
+              }
+              onMouseEnter={() => setHoveredKey(id)}
+              onMouseLeave={() => setHoveredKey(null)}
+              onClick={() => {
+                toggleExpanded(uniqueId);
+              }}
+            >
+              <td style={{width: '70%'}}>
+                <PolicyEvaluationCondition
+                  icon={
+                    status === AssetConditionEvaluationStatus.TRUE ? (
+                      <Icon name="check_circle" color={Colors.accentGreen()} />
+                    ) : (
+                      <Icon name="cancel" color={Colors.accentGray()} />
+                    )
+                  }
+                  label={<EvaluationConditionalLabel segments={expandedLabel} />}
+                  skipped={status === AssetConditionEvaluationStatus.SKIPPED}
+                  depth={depth}
+                  type={type}
+                  isExpanded={expandedRecords.has(uniqueId)}
+                  hasChildren={evaluation.childUniqueIds.length > 0}
+                />
+              </td>
+              {isPartitioned ? (
+                <td style={{width: 0}}>
+                  <Box
+                    flex={{direction: 'row', alignItems: 'center', gap: 2}}
+                    style={{width: FULL_SEGMENTS_WIDTH}}
+                  >
+                    <PartitionSegmentWithPopover
+                      description={userLabel || ''}
+                      subset={evaluation.trueSubset}
+                    />
+                  </Box>
+                </td>
+              ) : (
+                <td>
+                  <PolicyEvaluationStatusTag status={status} />
+                </td>
+              )}
+              {isPartitioned ? (
+                <td>{evaluation.candidateSubset?.subsetValue.partitionKeys?.length || '0'}</td>
+              ) : null}
+              <td>
+                {startTimestamp && endTimestamp ? (
+                  <TimeElapsed startUnix={startTimestamp} endUnix={endTimestamp} showMsec />
+                ) : (
+                  '\u2014'
+                )}
+              </td>
+            </EvaluationRow>
+          );
+        })}
+      </tbody>
+    </VeryCompactTable>
   );
 };
 
 const UnpartitionedPolicyEvaluationTable = ({
   flattenedRecords,
-  collapsedRecords,
-  toggleCollapsed,
+  expandedRecords,
+  toggleExpanded,
 }: {
-  collapsedRecords: Set<string>;
-  toggleCollapsed: (id: string) => void;
+  expandedRecords: Set<string>;
+  toggleExpanded: (id: string) => void;
   flattenedRecords:
     | FlattenedConditionEvaluation<UnpartitionedAssetConditionEvaluationNodeFragment>[]
     | FlattenedConditionEvaluation<SpecificPartitionAssetConditionEvaluationNodeFragment>[];
 }) => {
-  const [hoveredKey, setHoveredKey] = React.useState<number | null>(null);
+  const [hoveredKey, setHoveredKey] = useState<number | null>(null);
   const isSpecificPartitionAssetConditionEvaluations =
     flattenedRecords[0]?.evaluation.__typename === 'SpecificPartitionAssetConditionEvaluationNode';
 
@@ -111,17 +234,22 @@ const UnpartitionedPolicyEvaluationTable = ({
               onMouseEnter={() => setHoveredKey(id)}
               onMouseLeave={() => setHoveredKey(null)}
               onClick={() => {
-                toggleCollapsed(uniqueId);
+                toggleExpanded(uniqueId);
               }}
             >
               <td>
                 <PolicyEvaluationCondition
-                  icon={type === 'group' ? 'resource' : 'wysiwyg'}
+                  icon={
+                    <Icon
+                      name={type === 'group' ? 'resource' : 'wysiwyg'}
+                      color={Colors.accentPrimary()}
+                    />
+                  }
                   label={description}
                   skipped={status === AssetConditionEvaluationStatus.SKIPPED}
                   depth={depth}
                   type={type}
-                  isCollapsed={!collapsedRecords.has(uniqueId)}
+                  isExpanded={expandedRecords.has(uniqueId)}
                   hasChildren={evaluation.childUniqueIds.length > 0}
                 />
               </td>
@@ -151,7 +279,7 @@ const ViewDetailsButton = ({
 }: {
   evaluation: {metadataEntries: MetadataEntryFragment[]};
 }) => {
-  const [showDetails, setShowDetails] = React.useState(false);
+  const [showDetails, setShowDetails] = useState(false);
   return (
     <>
       <Dialog
@@ -176,20 +304,18 @@ const ViewDetailsButton = ({
 
 const FULL_SEGMENTS_WIDTH = 200;
 
-const PartitionedPolicyEvaluationTable = ({
+export const PartitionedPolicyEvaluationTable = ({
   flattenedRecords,
+  expandedRecords,
+  toggleExpanded,
   selectPartition,
-  collapsedRecords,
-  toggleCollapsed,
 }: {
   flattenedRecords: FlattenedConditionEvaluation<PartitionedAssetConditionEvaluationNodeFragment>[];
-  definition?: AssetViewDefinitionNodeFragment | null;
+  expandedRecords: Set<string>;
+  toggleExpanded: (id: string) => void;
   selectPartition: (partitionKey: string | null) => void;
-  collapsedRecords: Set<string>;
-  toggleCollapsed: (id: string) => void;
 }) => {
-  const [hoveredKey, setHoveredKey] = React.useState<number | null>(null);
-
+  const [hoveredKey, setHoveredKey] = useState<number | null>(null);
   return (
     <VeryCompactTable>
       <thead>
@@ -215,16 +341,21 @@ const PartitionedPolicyEvaluationTable = ({
               onMouseEnter={() => setHoveredKey(id)}
               onMouseLeave={() => setHoveredKey(null)}
               onClick={() => {
-                toggleCollapsed(uniqueId);
+                toggleExpanded(uniqueId);
               }}
             >
               <td>
                 <PolicyEvaluationCondition
-                  icon={type === 'group' ? 'resource' : 'wysiwyg'}
+                  icon={
+                    <Icon
+                      name={type === 'group' ? 'resource' : 'wysiwyg'}
+                      color={Colors.accentPrimary()}
+                    />
+                  }
                   label={description}
                   depth={depth}
                   type={type}
-                  isCollapsed={!collapsedRecords.has(evaluation.uniqueId)}
+                  isExpanded={expandedRecords.has(evaluation.uniqueId)}
                   hasChildren={evaluation.childUniqueIds.length > 0}
                 />
               </td>
@@ -247,7 +378,6 @@ const PartitionedPolicyEvaluationTable = ({
                 >
                   <PartitionSegmentWithPopover
                     description={description}
-                    status={AssetConditionEvaluationStatus.TRUE}
                     subset={trueSubset}
                     selectPartition={selectPartition}
                   />
@@ -267,10 +397,7 @@ const PartitionedPolicyEvaluationTable = ({
 const VeryCompactTable = styled(Table)`
   & tr td {
     vertical-align: middle;
-  }
-
-  & tr td:first-child {
-    padding: 2px 16px;
+    padding: 4px 16px;
   }
 
   & tr th:last-child,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/PartitionSegmentWithPopover.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/PartitionSegmentWithPopover.stories.tsx
@@ -2,7 +2,6 @@ import {Box} from '@dagster-io/ui-components';
 import faker from 'faker';
 import {useMemo} from 'react';
 
-import {AssetConditionEvaluationStatus} from '../../../graphql/types';
 import {PartitionSegmentWithPopover} from '../PartitionSegmentWithPopover';
 
 // eslint-disable-next-line import/no-default-export
@@ -33,7 +32,6 @@ export const TruePartitions = () => {
     <Box flex={{direction: 'row'}}>
       <PartitionSegmentWithPopover
         description="is_missing"
-        status={AssetConditionEvaluationStatus.TRUE}
         subset={subset}
         selectPartition={() => {}}
       />
@@ -61,7 +59,6 @@ export const FewPartitions = () => {
     <Box flex={{direction: 'row'}}>
       <PartitionSegmentWithPopover
         description="is_missing"
-        status={AssetConditionEvaluationStatus.TRUE}
         subset={subset}
         selectPartition={() => {}}
       />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/PolicyEvaluationCondition.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/PolicyEvaluationCondition.stories.tsx
@@ -19,7 +19,7 @@ export const Default = () => {
               icon="resource"
               label="All are true:"
               type="group"
-              isCollapsed={false}
+              isExpanded
               hasChildren
             />
           </td>
@@ -31,7 +31,7 @@ export const Default = () => {
               icon="resource"
               label="Any are true:"
               type="group"
-              isCollapsed={false}
+              isExpanded
               hasChildren
             />
           </td>
@@ -43,7 +43,7 @@ export const Default = () => {
               icon="wysiwyg"
               label="parent_updated"
               type="leaf"
-              isCollapsed={false}
+              isExpanded
               hasChildren={false}
             />
           </td>
@@ -56,7 +56,7 @@ export const Default = () => {
               label="is_missing"
               type="leaf"
               skipped
-              isCollapsed={false}
+              isExpanded
               hasChildren={false}
             />
           </td>
@@ -68,7 +68,7 @@ export const Default = () => {
               icon="resource"
               label="Not:"
               type="group"
-              isCollapsed={false}
+              isExpanded
               hasChildren={true}
             />
           </td>
@@ -80,7 +80,7 @@ export const Default = () => {
               icon="wysiwyg"
               label="parent_updated"
               type="leaf"
-              isCollapsed={false}
+              isExpanded
               hasChildren={false}
             />
           </td>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/PolicyEvaluationTable.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/PolicyEvaluationTable.stories.tsx
@@ -13,7 +13,14 @@ export const NonPartitioned = () => {
     endTimestamp: 200,
   });
 
-  return <PolicyEvaluationTable evaluationRecord={evaluation as any} selectPartition={() => {}} />;
+  return (
+    <PolicyEvaluationTable
+      evaluationNodes={evaluation.evaluationNodes}
+      rootUniqueId={evaluation.rootUniqueId}
+      isLegacyEvaluation
+      selectPartition={() => {}}
+    />
+  );
 };
 
 export const Partitioned = () => {
@@ -22,7 +29,14 @@ export const Partitioned = () => {
     endTimestamp: 200,
   });
 
-  return <PolicyEvaluationTable evaluationRecord={evaluation as any} selectPartition={() => {}} />;
+  return (
+    <PolicyEvaluationTable
+      evaluationNodes={evaluation.evaluationNodes}
+      rootUniqueId={evaluation.rootUniqueId}
+      isLegacyEvaluation
+      selectPartition={() => {}}
+    />
+  );
 };
 
 export const SpecificPartition = () => {
@@ -31,5 +45,12 @@ export const SpecificPartition = () => {
     endTimestamp: 200,
   });
 
-  return <PolicyEvaluationTable evaluationRecord={evaluation as any} selectPartition={() => {}} />;
+  return (
+    <PolicyEvaluationTable
+      evaluationNodes={evaluation.evaluationNodes}
+      rootUniqueId={evaluation.rootUniqueId}
+      isLegacyEvaluation
+      selectPartition={() => {}}
+    />
+  );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
@@ -358,6 +358,44 @@ export type PartitionedAssetConditionEvaluationNodeFragment = {
   } | null;
 };
 
+export type NewEvaluationNodeFragment = {
+  __typename: 'AutomationConditionEvaluationNode';
+  uniqueId: string;
+  expandedLabel: Array<string>;
+  userLabel: string | null;
+  startTimestamp: number | null;
+  endTimestamp: number | null;
+  numTrue: number;
+  isPartitioned: boolean;
+  childUniqueIds: Array<string>;
+  trueSubset: {
+    __typename: 'AssetSubset';
+    subsetValue: {
+      __typename: 'AssetSubsetValue';
+      isPartitioned: boolean;
+      partitionKeys: Array<string> | null;
+      partitionKeyRanges: Array<{
+        __typename: 'PartitionKeyRange';
+        start: string;
+        end: string;
+      }> | null;
+    };
+  };
+  candidateSubset: {
+    __typename: 'AssetSubset';
+    subsetValue: {
+      __typename: 'AssetSubsetValue';
+      isPartitioned: boolean;
+      partitionKeys: Array<string> | null;
+      partitionKeyRanges: Array<{
+        __typename: 'PartitionKeyRange';
+        start: string;
+        end: string;
+      }> | null;
+    };
+  } | null;
+};
+
 export type AssetConditionEvaluationRecordFragment = {
   __typename: 'AssetConditionEvaluationRecord';
   id: string;
@@ -367,6 +405,7 @@ export type AssetConditionEvaluationRecordFragment = {
   timestamp: number;
   startTimestamp: number | null;
   endTimestamp: number | null;
+  isLegacy: boolean;
   assetKey: {__typename: 'AssetKey'; path: Array<string>};
   evaluation: {
     __typename: 'AssetConditionEvaluation';
@@ -757,6 +796,43 @@ export type AssetConditionEvaluationRecordFragment = {
         }
     >;
   };
+  evaluationNodes: Array<{
+    __typename: 'AutomationConditionEvaluationNode';
+    uniqueId: string;
+    expandedLabel: Array<string>;
+    userLabel: string | null;
+    startTimestamp: number | null;
+    endTimestamp: number | null;
+    numTrue: number;
+    isPartitioned: boolean;
+    childUniqueIds: Array<string>;
+    trueSubset: {
+      __typename: 'AssetSubset';
+      subsetValue: {
+        __typename: 'AssetSubsetValue';
+        isPartitioned: boolean;
+        partitionKeys: Array<string> | null;
+        partitionKeyRanges: Array<{
+          __typename: 'PartitionKeyRange';
+          start: string;
+          end: string;
+        }> | null;
+      };
+    };
+    candidateSubset: {
+      __typename: 'AssetSubset';
+      subsetValue: {
+        __typename: 'AssetSubsetValue';
+        isPartitioned: boolean;
+        partitionKeys: Array<string> | null;
+        partitionKeyRanges: Array<{
+          __typename: 'PartitionKeyRange';
+          start: string;
+          end: string;
+        }> | null;
+      };
+    } | null;
+  }>;
 };
 
 export type GetEvaluationsQueryVariables = Types.Exact<{
@@ -795,6 +871,7 @@ export type GetEvaluationsQuery = {
           timestamp: number;
           startTimestamp: number | null;
           endTimestamp: number | null;
+          isLegacy: boolean;
           assetKey: {__typename: 'AssetKey'; path: Array<string>};
           evaluation: {
             __typename: 'AssetConditionEvaluation';
@@ -1197,6 +1274,43 @@ export type GetEvaluationsQuery = {
                 }
             >;
           };
+          evaluationNodes: Array<{
+            __typename: 'AutomationConditionEvaluationNode';
+            uniqueId: string;
+            expandedLabel: Array<string>;
+            userLabel: string | null;
+            startTimestamp: number | null;
+            endTimestamp: number | null;
+            numTrue: number;
+            isPartitioned: boolean;
+            childUniqueIds: Array<string>;
+            trueSubset: {
+              __typename: 'AssetSubset';
+              subsetValue: {
+                __typename: 'AssetSubsetValue';
+                isPartitioned: boolean;
+                partitionKeys: Array<string> | null;
+                partitionKeyRanges: Array<{
+                  __typename: 'PartitionKeyRange';
+                  start: string;
+                  end: string;
+                }> | null;
+              };
+            };
+            candidateSubset: {
+              __typename: 'AssetSubset';
+              subsetValue: {
+                __typename: 'AssetSubsetValue';
+                isPartitioned: boolean;
+                partitionKeys: Array<string> | null;
+                partitionKeyRanges: Array<{
+                  __typename: 'PartitionKeyRange';
+                  start: string;
+                  end: string;
+                }> | null;
+              };
+            } | null;
+          }>;
         }>;
       }
     | {__typename: 'AutoMaterializeAssetEvaluationNeedsMigrationError'; message: string}


### PR DESCRIPTION
## Summary & Motivation

Implement the updated automation policy evaluations table, showing operators and operands for individual evaluation nodes. This uses an `isLegacy` GraphQL field to determine how to render the evaluation. I also adjusted the density for the legacy table.

Legacy:

<img width="1548" alt="Screenshot 2024-07-17 at 12 54 02" src="https://github.com/user-attachments/assets/49cdbc3a-e853-4cc4-9031-3a507418082c">
<img width="1550" alt="Screenshot 2024-07-17 at 12 54 41" src="https://github.com/user-attachments/assets/e314a6a4-06d2-4990-9056-8b2f1132c353">

New:

<img width="1551" alt="Screenshot 2024-07-17 at 12 54 09" src="https://github.com/user-attachments/assets/6470eeed-3eef-4abf-8942-c7fea8a55cf5">
<img width="1550" alt="Screenshot 2024-07-17 at 12 54 24" src="https://github.com/user-attachments/assets/12499642-5f3d-4a38-a1a2-b102e7778cc5">
<img width="1552" alt="Screenshot 2024-07-17 at 12 55 03" src="https://github.com/user-attachments/assets/31126664-68d0-4742-9c0a-abe3ed924dc9">
<img width="592" alt="Screenshot 2024-07-17 at 12 55 43" src="https://github.com/user-attachments/assets/e4cc1b0a-9937-495a-91e9-2191be6a5781">


## How I Tested These Changes

Using some assets provided to me by @OwenKephart, let AMP run. Click to view assets and their evaluations, both legacy and non-legacy, and both partitioned and non-partitioned.

Verify that rendering is correct, including collapsed state, hover states, operators/operands, and partition popovers.