### PR TITLE
[docs] - Fix link in Limiting concurrency guide

### DIFF
--- a/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
+++ b/docs/content/guides/limiting-concurrency-in-data-pipelines.mdx
@@ -578,4 +578,4 @@ If runs aren’t being dequeued in Dagster Open Source, the root cause is likely
 
 [custom-run-queue]: /guides/customizing-run-queue-priority
 
-[cloud-deployment-settings]: /dagster-cloud/managing-deployments/managing-deployments#configuring-deployment-settings
+[cloud-deployment-settings]: /dagster-plus/managing-deployments/managing-deployments#configuring-deployment-settings


### PR DESCRIPTION
## Summary & Motivation

This PR updates a `dagster-cloud` straggler, which was caused a broken link in the **Limiting concurrency** guide.

## How I Tested These Changes

👀 