### PR TITLE
[dagster-dbt] Log a deprecation warning for users using log_column_level_metadata

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -619,6 +619,8 @@ class DbtCliInvocation:
         Returns:
             Iterator[DbtCliEventMessage]: An iterator of events from the dbt CLI process.
         """
+        has_emitted_metadata_warning = False
+
         event_history_metadata_by_unique_id: Dict[str, Dict[str, Any]] = {}
 
         for raw_event in self._stdout or self._stream_stdout():
@@ -640,6 +642,13 @@ class DbtCliInvocation:
             event = DbtCliEventMessage(
                 raw_event=raw_event, event_history_metadata=event_history_metadata
             )
+            if event.has_column_lineage_metadata and not has_emitted_metadata_warning:
+                logger.warning(
+                    "Fetching column metadata using `log_column_level_metadata` macro is deprecated and will be"
+                    " removed in Dagster 1.9. Use the `fetch_column_metadata` method in your asset definition"
+                    " to fetch column metadata instead."
+                )
+                has_emitted_metadata_warning = True
 
             # Attempt to parse the column level metadata from the event message.
             # If it exists, save it as historical metadata to attach to the NodeFinished event.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -1847,7 +1847,7 @@ class DbtCliResource(ConfigurableResource):
         ):
             context.log.warn(
                 "Fetching column metadata using `log_column_level_metadata` macro is deprecated and will be"
-                " removed in Dagster 1.9. Use the `fetch_column_metadata` method in your asset definition"
+                " removed in dagster-dbt 0.24.0. Use the `fetch_column_metadata` method in your asset definition"
                 " to fetch column metadata instead."
             )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -559,9 +559,8 @@ def test_column_lineage(
     )
 
     # Check that the warning is printed only when using log_column_level_metadata
-    assert ("`log_column_level_metadata` macro is deprecated" in capsys.readouterr().err) == (
-        not use_async_fetch_column_schema
-    )
+    if not use_async_fetch_column_schema:
+        assert "`log_column_level_metadata` macro is deprecated" in capsys.readouterr().err
 
     column_lineage_by_asset_key = {
         event.materialization.asset_key: TableMetadataSet.extract(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/packages.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/packages.yml
@@ -1,4 +1,6 @@
 # We keep use `packages.yml` for compatability with `dbt-core==1.5.*`.
 # Once we remove support for that version, we should rename this file to `dependencies.yml`
 packages:
-  - local: "../../../dbt_packages/dagster"
+  - git: "https://github.com/dagster-io/dagster.git"
+    subdirectory: "python_modules/libraries/dagster-dbt/dbt_packages/dagster"
+    revision: 1.7.13

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/packages.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/packages.yml
@@ -3,4 +3,4 @@
 packages:
   - git: "https://github.com/dagster-io/dagster.git"
     subdirectory: "python_modules/libraries/dagster-dbt/dbt_packages/dagster"
-    revision: 1.7.13
+    revision: master


### PR DESCRIPTION
## Summary

Logs a new warning message telling users who are using the log_column_level_metadata macro that it will be deprecated in 1.9, and pointing them to fetch_column_metadata instead.

## Test Plan

Unit test.
