### PR TITLE
Fix `useStateWithStorage`'s return type 

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
@@ -323,8 +323,7 @@ export const MAX_SESSION_WRITE_ATTEMPTS = 10;
  * write is successful or we run out of retries.
  */
 export const writeLaunchpadSessionToStorage =
-  (setState: React.Dispatch<React.SetStateAction<IStorageData | undefined>>) =>
-  (data: IStorageData) => {
+  (setState: React.Dispatch<React.SetStateAction<IStorageData>>) => (data: IStorageData) => {
     const tryWrite = (data: IStorageData) => {
       try {
         setState(data);

--- a/js_modules/dagster-ui/packages/ui-core/src/app/time/TimeContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/time/TimeContext.tsx
@@ -7,13 +7,13 @@ export const TimezoneStorageKey = 'TimezonePreference';
 export const HourCycleKey = 'HourCyclePreference';
 
 type TimeContextValue = {
-  timezone: [string, React.Dispatch<React.SetStateAction<string | undefined>>];
-  hourCycle: [HourCycle, React.Dispatch<React.SetStateAction<HourCycle | undefined>>];
+  timezone: ReturnType<typeof useStateWithStorage<string>>;
+  hourCycle: ReturnType<typeof useStateWithStorage<HourCycle>>;
 };
 
 export const TimeContext = React.createContext<TimeContextValue>({
-  timezone: ['UTC', () => 'UTC'],
-  hourCycle: ['Automatic', () => 'Automatic'],
+  timezone: ['UTC', () => 'UTC', () => {}],
+  hourCycle: ['Automatic', () => 'Automatic', () => {}],
 });
 
 const validateTimezone = (saved: string | undefined) =>

--- a/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLinkProtocol.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-links/CodeLinkProtocol.tsx
@@ -27,8 +27,8 @@ export type ProtocolData = {
 };
 
 export const CodeLinkProtocolContext = React.createContext<
-  [ProtocolData, React.Dispatch<React.SetStateAction<ProtocolData | undefined>>]
->([DEFAULT_PROTOCOL, () => '']);
+  ReturnType<typeof useStateWithStorage<ProtocolData>>
+>([DEFAULT_PROTOCOL, () => '', () => {}]);
 
 export const CodeLinkProtocolProvider = ({children}: {children: React.ReactNode}) => {
   const state = useStateWithStorage<ProtocolData>(

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useSetStateUpdateCallback.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useSetStateUpdateCallback.tsx
@@ -15,7 +15,7 @@ import * as React from 'react';
 export function useSetStateUpdateCallback<T>(
   currentState: T,
   updateCallback: (next: T) => void,
-): (next: React.SetStateAction<T>) => void {
+): React.Dispatch<React.SetStateAction<T>> {
   const stateRef = React.useRef<T>(currentState);
   stateRef.current = currentState;
 

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useStateWithStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useStateWithStorage.tsx
@@ -69,7 +69,9 @@ export function useStateWithStorage<T>(key: string, validate: (json: any) => T) 
 
   const setState = React.useCallback(
     (input: React.SetStateAction<T>) => {
-      setStateInner(getStateOrSetterValue(key, input, validateRef.current));
+      const next =
+        input instanceof Function ? input(validateRef.current(getJSONForKey(key))) : input;
+      setStateInner(next);
     },
     [key, setStateInner],
   );
@@ -79,12 +81,4 @@ export function useStateWithStorage<T>(key: string, validate: (json: any) => T) 
   }, [setStateInner]);
 
   return [state, setState, clearState] as const;
-}
-
-function getStateOrSetterValue<T = any>(
-  key: string,
-  input: React.SetStateAction<T>,
-  validate: (value: T | undefined) => T,
-) {
-  return input instanceof Function ? input(validate(getJSONForKey(key))) : input;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useStateWithStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useStateWithStorage.tsx
@@ -69,6 +69,5 @@ export function useStateWithStorage<T>(key: string, validate: (json: any) => T) 
     [key, listener],
   );
 
-  const value = React.useMemo(() => [state, setState], [state, setState]);
-  return value as [T, React.Dispatch<React.SetStateAction<T>>];
+  return [state, setState] as const;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useStateWithStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useStateWithStorage.tsx
@@ -70,5 +70,5 @@ export function useStateWithStorage<T>(key: string, validate: (json: any) => T) 
   );
 
   const value = React.useMemo(() => [state, setState], [state, setState]);
-  return value as [T, React.Dispatch<React.SetStateAction<T | undefined>>];
+  return value as [T, React.Dispatch<React.SetStateAction<T>>];
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/LeftNavRepositorySection.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/__tests__/LeftNavRepositorySection.test.tsx
@@ -86,7 +86,7 @@ describe('Repository options', () => {
     });
 
     it(`initializes with one repo if it's the only one, even though it's hidden`, async () => {
-      window.localStorage.setItem(HIDDEN_REPO_KEYS, `["${repoOne}:${locationOne}"]`);
+      window.localStorage.setItem(`:${HIDDEN_REPO_KEYS}`, `["${repoOne}:${locationOne}"]`);
       await act(() =>
         render(
           <MemoryRouter initialEntries={['/runs']}>
@@ -136,7 +136,7 @@ describe('Repository options', () => {
 
     it('initializes with correct repo option, if `HIDDEN_REPO_KEYS` localStorage', async () => {
       window.localStorage.setItem(
-        HIDDEN_REPO_KEYS,
+        `:${HIDDEN_REPO_KEYS}`,
         `["lorem:ipsum","${DUNDER_REPO_NAME}:abc_location"]`,
       );
 
@@ -162,7 +162,7 @@ describe('Repository options', () => {
     });
 
     it('initializes with all repo options, no matching `HIDDEN_REPO_KEYS` localStorage', async () => {
-      window.localStorage.setItem(HIDDEN_REPO_KEYS, '["hello:world"]');
+      window.localStorage.setItem(`:${HIDDEN_REPO_KEYS}`, '["hello:world"]');
 
       await act(() =>
         render(
@@ -198,7 +198,7 @@ describe('Repository options', () => {
 
     it('initializes empty, if all items in `HIDDEN_REPO_KEYS` localStorage', async () => {
       window.localStorage.setItem(
-        HIDDEN_REPO_KEYS,
+        `:${HIDDEN_REPO_KEYS}`,
         `["lorem:ipsum", "foo:bar", "${DUNDER_REPO_NAME}:abc_location"]`,
       );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
@@ -363,24 +363,12 @@ const useVisibleRepos = (
 } => {
   const {basePath} = React.useContext(AppContext);
 
-  const [oldHiddenKeys, setOldHiddenKeys] = useStateWithStorage<string[]>(
-    HIDDEN_REPO_KEYS,
-    validateHiddenKeys,
-  );
   const [hiddenKeys, setHiddenKeys] = useStateWithStorage<string[]>(
     basePath + ':' + HIDDEN_REPO_KEYS,
     validateHiddenKeys,
   );
 
   const hiddenKeysJSON = JSON.stringify([...hiddenKeys.sort()]);
-
-  // TODO: Remove this logic eventually...
-  const migratedOldHiddenKeys = React.useRef(false);
-  if (oldHiddenKeys.length && !migratedOldHiddenKeys.current) {
-    setHiddenKeys(oldHiddenKeys);
-    setOldHiddenKeys(undefined);
-    migratedOldHiddenKeys.current = true;
-  }
 
   const toggleVisible = React.useCallback(
     (repoAddresses: RepoAddress[]) => {


### PR DESCRIPTION
## Summary & Motivation

The return type lies to you. it tells you that you might get undefined as an argument to your setter but this is untrue. The argument you receive is always guaranteed to be type T, and if undefined is not included in it then you'll never get it.

this addresses pr feedback from https://github.com/dagster-io/internal/pull/10591/files#r1681728346

## How I Tested These Changes
buildkite