### PR TITLE
[docs] - Fix dagster.yaml > dagster_cloud.yaml in Hybrid agent env var guide

### DIFF
--- a/docs/content/dagster-plus/managing-deployments/setting-environment-variables-agents.mdx
+++ b/docs/content/dagster-plus/managing-deployments/setting-environment-variables-agents.mdx
@@ -11,7 +11,7 @@ In this guide, we'll walk you through setting environment variables for a Dagste
 
 There are two ways to set environment variables:
 
-- **On a per-code location basis**, which involves modifying the `dagster.yaml` file. **Note**: This approach is functionally the same as [setting environment variables using the Dagster+ UI](/dagster-plus/managing-deployments/environment-variables-and-secrets). Values will pass through Dagster+.
+- **On a per-code location basis**, which involves modifying the `dagster_cloud.yaml` file. **Note**: This approach is functionally the same as [setting environment variables using the Dagster+ UI](/dagster-plus/managing-deployments/environment-variables-and-secrets). Values will pass through Dagster+.
 - **For a full deployment and all the code locations it contains**. This approach makes variables available for all code locations in a full Dagster+ deployment. As values are pulled from the user cluster, values will bypass Dagster+ entirely.
 
 ---


### PR DESCRIPTION
## Summary & Motivation

This PR corrects a file name in the Hybrid agent env vars guide for Dagster+. The intro says the change for code locations will be made in `dagster.yaml`, but it's actually `dagster_cloud.yaml` as [per part 1 of this guide](https://docs.dagster.io/dagster-plus/managing-deployments/setting-environment-variables-agents#amazon-ecs-agents).

## How I Tested These Changes
