### PR TITLE
[exploration] update docs to reflect function not being part of asset definition

### DIFF
--- a/docs/content/concepts/assets/software-defined-assets.mdx
+++ b/docs/content/concepts/assets/software-defined-assets.mdx
@@ -17,7 +17,7 @@ description: An asset definition is a description of how to compute the contents
   videos to get a quick look at asset definitions.
 </Note>
 
-An **asset** is an object in persistent storage, such as a table, file, or persisted machine learning model. An **asset definition** is a description, in code, of an asset that should exist and how to produce and update that asset.
+An **asset** is an object in persistent storage, such as a table, file, or persisted machine learning model. An **asset definition** is a description, in code, of an asset that should exist, typically accompanied by a description of how to produce and update that asset.
 
 Asset definitions enable a declarative approach to data management, in which code is the source of truth on what data assets should exist and how those assets are computed.
 
@@ -25,7 +25,9 @@ An asset definition includes the following:
 
 - An <PyObject object="AssetKey" />, which is a handle for referring to the asset.
 - A set of upstream asset keys, which refer to assets that the contents of the asset definition are derived from.
-- A Python function, which is responsible for computing the contents of the asset from its upstream dependencies and storing the results.
+- Metadata, which describes the asset.
+
+Assets are usually defined along with a Python function, which is responsible for computing the contents of the asset from its upstream dependencies and storing the results.
 
   **Note**: Behind-the-scenes, the Python function is an [op](/concepts/ops-jobs-graphs/ops). Ops are an advanced topic that isn't required to get started with Dagster. A crucial distinction between asset definitions and ops is that asset definitions know about their dependencies, while ops do not. Ops aren't connected to dependencies until they're placed inside a [graph](/concepts/ops-jobs-graphs/graphs).
 
@@ -50,9 +52,9 @@ An asset definition includes the following:
 - [Accessing asset context](#asset-context)
 - [Configuring assets](#asset-configuration)
 
-### Basic asset definitions
+### Basic asset definitions, with materialization functions
 
-The easiest way to create an asset definition is with the <PyObject object="asset" decorator /> decorator.
+The easiest way to create an asset definition and accompanying materializaing function is with the <PyObject object="asset" decorator /> decorator.
 
 ```python file=/concepts/assets/basic_asset_definition.py
 import json
@@ -173,7 +175,7 @@ Refer to the [Config schema documentation](/concepts/configuration/config-schema
 
 ### Asset context
 
-When writing an asset, users can optionally provide a first parameter, `context`. When this parameter is supplied, Dagster will supply an <PyObject object="AssetExecutionContext"/> object to the body of the asset which provides access to system information like loggers and the current run ID.
+When writing an asset materialization function, users can optionally provide a first parameter, `context`. When this parameter is supplied, Dagster will supply an <PyObject object="AssetExecutionContext"/> object to the body of the asset which provides access to system information like loggers and the current run ID.
 
 For example, to access the logger and log an info message:
 

--- a/docs/content/tutorial/building-an-asset-graph.mdx
+++ b/docs/content/tutorial/building-an-asset-graph.mdx
@@ -5,7 +5,7 @@ description: Learn how to build graphs of assets in Dagster
 
 # Tutorial, part four: Building an asset graph
 
-In the previous portion of the tutorial, you wrote your first asset definition, looked at Dagster's UI, and manually materialized your asset.
+In the previous portion of the tutorial, you wrote your first asset definition and associated materialization function, looked at Dagster's UI, and manually materialized your asset.
 
 Continuing from there, you will:
 
@@ -100,7 +100,7 @@ For more information about loggers, such as the different types of logging, refe
 
 ---
 
-## Step 2: Creating an unstructured data asset
+## Step 2: An unstructured data asset
 
 Along with structured data like tables, Dagster's assets can also be unstructured data, such as JSON files or images. Your next and final asset will take the DataFrame of stories and create a dictionary of the most frequent words in the titles.
 

--- a/docs/content/tutorial/introduction.mdx
+++ b/docs/content/tutorial/introduction.mdx
@@ -25,7 +25,7 @@ If you have an existing data pipeline, you likely already have assets.
 
 _Asset definitions_ are a Dagster concept that allows you to write data pipelines in terms of the assets that they produce. How they work: you write code that describes an asset that you want to exist, along with any other assets that the asset is derived from, and a function that can be run to compute the contents of the asset.
 
-Here's an example. The asset is a dataset called `topstories`, and it depends on another asset called `topstory_ids`. `topstories` gets the IDs computed in `topstory_ids`, then fetches data for each of those IDs.
+Here's an example asset definition and associated function. The asset is a dataset called `topstories`, and it depends on another asset called `topstory_ids`. `topstories` gets the IDs computed in `topstory_ids`, then fetches data for each of those IDs.
 
 ```python
 @asset(deps=[topstory_ids])

--- a/docs/content/tutorial/writing-your-first-asset.mdx
+++ b/docs/content/tutorial/writing-your-first-asset.mdx
@@ -20,7 +20,7 @@ By the end of this section, you will:
 
 ## Step 1: Write your first asset
 
-In Dagster, the main way to create data pipelines is by writing assets. By the end of this tutorial section, you'll have written your first asset.
+In Dagster, the main way to create data pipelines is by writing assets, linked to the functions that materialize them. By the end of this tutorial section, you'll have written your first asset and function.
 
 The scaffolded Dagster project has a directory called `tutorial`. If you named your project differently when running the Dagster CLI, the directory will be named after that.
 
@@ -46,7 +46,7 @@ with open("data/topstory_ids.json", "w") as f:
 
 This code creates a list of integers representing the IDs for the current top stories on Hacker News and stores them in a file called `data/topstory_ids.json`.
 
-Next, you will work towards making this code into an asset definition. The first step is turning it into a function:
+Next, you will work towards making this code into an asset definition and associated materialization function. The first step is turning it into a function:
 
 ```python
 import json


### PR DESCRIPTION
## Summary & Motivation

This is an exploration of what our docs would look like if we changed the meaning of "asset definition" to not include the associated compute function.

## How I Tested These Changes
