### PR TITLE
[quick pr] Add a view prop AssetView

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
@@ -21,6 +21,7 @@ type Props = Partial<React.ComponentProps<typeof PageHeader>> & {
   assetKey: {path: string[]};
   headerBreadcrumbs: BreadcrumbProps[];
   Title?: ({children}: {children: React.ReactNode}) => React.ReactNode;
+  view: 'asset' | 'catalog';
 };
 
 const defaultTitleComponent = ({children}: {children: React.ReactNode}) => children;
@@ -29,6 +30,7 @@ export const AssetPageHeader = ({
   assetKey,
   headerBreadcrumbs,
   Title = defaultTitleComponent,
+  view,
   ...extra
 }: Props) => {
   const copy = useCopyToClipboard();

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -298,6 +298,7 @@ export const AssetView = ({
       style={{height: '100%', width: '100%', overflowY: 'auto'}}
     >
       <AssetPageHeader
+        view="asset"
         assetKey={assetKey}
         headerBreadcrumbs={headerBreadcrumbs}
         tags={

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverviewRoot.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverviewRoot.oss.tsx
@@ -58,6 +58,7 @@ export const AssetsOverviewRoot = ({
     return (
       <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
         <AssetPageHeader
+          view="catalog"
           assetKey={assetKey}
           headerBreadcrumbs={headerBreadcrumbs}
           right={


### PR DESCRIPTION
## Summary & Motivation

The view prop is needed for dagster+ to be able to conditionally show UI based on whether we're in an individual asset scoped view or whether we're looking at a catalog page.

## How I Tested These Changes

buildkite