### PR TITLE
feat: add snowflake partner connection id to snowflake lib

### DIFF
--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/constants.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/constants.py
@@ -1,0 +1,5 @@
+# Description: This file contains the Snowflake connection identifiers for the Snowflake partner account.
+# The connection identifiers are used to identify the partner account when connecting to Snowflake.
+# We use different connection identifiers for different connection code paths to ensure that each is
+# working as expected.
+SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER_PYSPARK = "DagsterLabs_Dagster_Pyspark"

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark/snowflake_pyspark_type_handler.py
@@ -9,6 +9,8 @@ from dagster_snowflake.snowflake_io_manager import SnowflakeDbClient
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.types import StructType
 
+from .constants import SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER_PYSPARK
+
 SNOWFLAKE_CONNECTOR = "net.snowflake.spark.snowflake"
 
 
@@ -25,6 +27,7 @@ def _get_snowflake_options(config, table_slice: TableSlice) -> Mapping[str, str]
         "sfDatabase": config["database"],
         "sfSchema": table_slice.schema,
         "sfWarehouse": config["warehouse"],
+        "APPLICATION": SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER_PYSPARK,
     }
 
     return conf

--- a/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_get_snowflake_options.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/dagster_snowflake_pyspark_tests/test_get_snowflake_options.py
@@ -1,0 +1,43 @@
+from typing import Dict
+
+import pytest
+from dagster._check import CheckError
+from dagster._core.storage.db_io_manager import TableSlice
+from dagster_snowflake_pyspark.constants import SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER_PYSPARK
+from dagster_snowflake_pyspark.snowflake_pyspark_type_handler import _get_snowflake_options
+
+
+@pytest.fixture
+def snowflake_config() -> Dict[str, str]:
+    return {
+        "account": "account",
+        "user": "user",
+        "password": "password",
+        "database": "database",
+        "warehouse": "warehouse",
+    }
+
+
+@pytest.fixture
+def table_slice() -> TableSlice:
+    return TableSlice("table_name", "schema_name", "database_name")
+
+
+def test_get_snowflake_options(snowflake_config, table_slice):
+    options = _get_snowflake_options(snowflake_config, table_slice)
+    assert options == {
+        "sfURL": "account.snowflakecomputing.com",
+        "sfUser": "user",
+        "sfPassword": "password",
+        "sfDatabase": "database",
+        "sfWarehouse": "warehouse",
+        "sfSchema": "schema_name",
+        "APPLICATION": SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER_PYSPARK,
+    }
+
+
+def test_missing_warehouse(snowflake_config, table_slice):
+    del snowflake_config["warehouse"]
+
+    with pytest.raises(CheckError):
+        _get_snowflake_options(snowflake_config, table_slice)

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/constants.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/constants.py
@@ -1,0 +1,7 @@
+# Description: This file contains the Snowflake connection identifiers for the Snowflake partner account.
+# The connection identifiers are used to identify the partner account when connecting to Snowflake.
+
+# We use different connection identifiers for different connection code paths to ensure that each is
+# working as expected.
+SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER = "DagsterLabs_Dagster"
+SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER_SQLALCHEMY = "DagsterLabs_Dagster_SqlAlchemy"

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -21,6 +21,11 @@ from dagster._model.pydantic_compat_layer import compat_model_validator
 from dagster._utils.cached_method import cached_method
 from pydantic import Field, validator
 
+from .constants import (
+    SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER,
+    SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER_SQLALCHEMY,
+)
+
 try:
     import snowflake.connector
 except ImportError:
@@ -333,6 +338,7 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
         ):
             conn_args["private_key"] = self._snowflake_private_key(self._resolved_config_dict)
 
+        conn_args["application"] = SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER
         return conn_args
 
     @property
@@ -353,6 +359,7 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
             )
             if self._resolved_config_dict.get(k) is not None
         }
+        conn_args["application"] = SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER_SQLALCHEMY
 
         return conn_args
 

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_ops.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_ops.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_snowflake import snowflake_resource
+from dagster_snowflake.constants import SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER
 from dagster_snowflake.ops import snowflake_solid_for_query
 
 from .utils import create_mock_connector
@@ -37,4 +38,5 @@ def test_snowflake_op(snowflake_connect):
         database="TESTDB",
         schema="TESTSCHEMA",
         warehouse="TINY_WAREHOUSE",
+        application=SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER,
     )

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
@@ -5,6 +5,7 @@ from typing import Iterator
 from unittest import mock
 
 import pytest
+import sqlalchemy  # noqa: F401
 from dagster import (
     DagsterInstance,
     DagsterResourceFunctionError,
@@ -22,6 +23,7 @@ from dagster._core.definitions.observe import observe
 from dagster._core.test_utils import environ
 from dagster._time import get_current_timestamp
 from dagster_snowflake import SnowflakeResource, fetch_last_updated_timestamps, snowflake_resource
+from dagster_snowflake.constants import SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER
 
 from .utils import create_mock_connector
 
@@ -85,6 +87,7 @@ def test_snowflake_resource(snowflake_connect):
         database="TESTDB",
         schema="TESTSCHEMA",
         warehouse="TINY_WAREHOUSE",
+        application=SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER,
     )
 
 
@@ -118,6 +121,7 @@ def test_pydantic_snowflake_resource(snowflake_connect):
         database="TESTDB",
         schema="TESTSCHEMA",
         warehouse="TINY_WAREHOUSE",
+        application=SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER,
     )
 
 
@@ -162,6 +166,7 @@ def test_snowflake_resource_from_envvars(snowflake_connect):
             database="TESTDB",
             schema="TESTSCHEMA",
             warehouse="TINY_WAREHOUSE",
+            application=SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER,
         )
 
 
@@ -204,6 +209,7 @@ def test_pydantic_snowflake_resource_from_envvars(snowflake_connect):
             database="TESTDB",
             schema="TESTSCHEMA",
             warehouse="TINY_WAREHOUSE",
+            application=SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER,
         )
 
 
@@ -339,3 +345,41 @@ def test_fetch_last_updated_timestamps(db_str: str):
         assert isinstance(freshness_val, FloatMetadataValue)
         assert freshness_val.value
         assert freshness_val.value > start_time
+
+
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
+@pytest.mark.importorskip(
+    "snowflake.sqlalchemy", reason="sqlalchemy is not available in the test environment"
+)
+@pytest.mark.integration
+def test_resources_snowflake_sqlalchemy_connection():
+    with SnowflakeResource(
+        connector="sqlalchemy",
+        account=os.getenv("SNOWFLAKE_ACCOUNT"),
+        user=os.environ["SNOWFLAKE_USER"],
+        password=os.getenv("SNOWFLAKE_PASSWORD"),
+        database="TESTDB",
+        schema="TESTSCHEMA",
+    ).get_connection() as conn:
+        # Snowflake table names are expected to be capitalized.
+        table_name = f"test_table_{str(uuid.uuid4()).replace('-', '_')}".lower()
+        try:
+            start_time = get_current_timestamp()
+            conn.cursor().execute(f"create table {table_name} (foo string)")
+            # Insert one row
+            conn.cursor().execute(f"insert into {table_name} values ('bar')")
+
+            freshness_for_table = fetch_last_updated_timestamps(
+                snowflake_connection=conn,
+                database="TESTDB",
+                tables=[
+                    table_name
+                ],  # Snowflake table names are expected uppercase. Test that lowercase also works.
+                schema="TESTSCHEMA",
+            )[table_name].timestamp()
+
+            end_time = get_current_timestamp()
+
+            assert end_time > freshness_for_table > start_time
+        finally:
+            conn.cursor().execute(f"drop table if exists {table_name}")

--- a/python_modules/libraries/dagster-snowflake/tox.ini
+++ b/python_modules/libraries/dagster-snowflake/tox.ini
@@ -6,6 +6,7 @@ download = True
 passenv = CI_* COVERALLS_REPO_TOKEN AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID BUILDKITE* SNOWFLAKE_ACCOUNT SNOWFLAKE_USER SNOWFLAKE_PASSWORD
 install_command = uv pip install {opts} {packages}
 deps =
+  -e .[snowflake.sqlalchemy]
   -e ../../dagster[test]
   -e ../../dagster-pipes
   -e ../dagster-pandas


### PR DESCRIPTION
## Summary & Motivation

As part of a partnership initiative with Snowflake, we'd like to track usage that originates from Dagster Snowflake integrations. 

## How I Tested These Changes

- BK
- Validation from Snowflake specialists that connections are observed.
  - [x] Pending confirmation for SQLAlchemy
