### PR TITLE
[ui] Automation table tests, update userLabel usage

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/EvaluationConditionalLabel.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/EvaluationConditionalLabel.tsx
@@ -13,15 +13,7 @@ export const EvaluationConditionalLabel = ({segments}: Props) => {
         if (segment.startsWith('(') && segment.endsWith(')')) {
           const inner = segment.slice(1, -1);
           return (
-            <Tooltip
-              key={key}
-              content={
-                <div style={{maxWidth: '500px', whiteSpace: 'normal'}}>
-                  <CaptionMono>{inner}</CaptionMono>
-                </div>
-              }
-              placement="top"
-            >
+            <Tooltip key={key} content={<TooltipContent text={inner} />} placement="top">
               <Operand>{inner}</Operand>
             </Tooltip>
           );
@@ -32,14 +24,39 @@ export const EvaluationConditionalLabel = ({segments}: Props) => {
   );
 };
 
+interface EvaluationUserLabelProps {
+  userLabel: string;
+  expandedLabel: string[];
+}
+
+export const EvaluationUserLabel = ({userLabel, expandedLabel}: EvaluationUserLabelProps) => {
+  return (
+    <Box flex={{direction: 'row', gap: 8, wrap: 'wrap', alignItems: 'center'}}>
+      <Tooltip content={<TooltipContent text={expandedLabel.join(' ')} />} placement="top">
+        <Operand>{userLabel}</Operand>
+      </Tooltip>
+    </Box>
+  );
+};
+
+const TooltipContent = ({text}: {text: string}) => {
+  return (
+    <div style={{maxWidth: '500px', whiteSpace: 'normal'}}>
+      <CaptionMono>{text}</CaptionMono>
+    </div>
+  );
+};
+
 const Operand = styled(Code)`
   background-color: ${Colors.backgroundGray()};
   border-radius: 8px;
   color: ${Colors.textLight()};
   display: block;
   font-size: 12px;
+  font-weight: 400;
   padding: 4px 8px;
   max-width: 300px;
+  outline: none;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PolicyEvaluationTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PolicyEvaluationTable.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {useCallback, useMemo, useState} from 'react';
 import styled, {css} from 'styled-components';
 
-import {EvaluationConditionalLabel} from './EvaluationConditionalLabel';
+import {EvaluationConditionalLabel, EvaluationUserLabel} from './EvaluationConditionalLabel';
 import {PartitionSegmentWithPopover} from './PartitionSegmentWithPopover';
 import {PolicyEvaluationCondition} from './PolicyEvaluationCondition';
 import {PolicyEvaluationStatusTag} from './PolicyEvaluationStatusTag';
@@ -149,7 +149,13 @@ const NewPolicyEvaluationTable = ({
                       <Icon name="cancel" color={Colors.accentGray()} />
                     )
                   }
-                  label={<EvaluationConditionalLabel segments={expandedLabel} />}
+                  label={
+                    userLabel ? (
+                      <EvaluationUserLabel userLabel={userLabel} expandedLabel={expandedLabel} />
+                    ) : (
+                      <EvaluationConditionalLabel segments={expandedLabel} />
+                    )
+                  }
                   skipped={status === AssetConditionEvaluationStatus.SKIPPED}
                   depth={depth}
                   type={type}
@@ -447,4 +453,9 @@ const EvaluationRow = styled.tr<{$highlight: RowHighlightType}>`
     }
     return '';
   }}
+`;
+
+const UserLabel = styled.div`
+  font-size: 12px;
+  color: ${Colors.textDefault()};
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/PolicyEvaluationTable.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/PolicyEvaluationTable.stories.tsx
@@ -1,4 +1,11 @@
-import {buildAssetConditionEvaluationRecord} from '../../../graphql/types';
+import {
+  buildAssetSubset,
+  buildAssetSubsetValue,
+  buildAutomationConditionEvaluationNode,
+  buildPartitionedAssetConditionEvaluationNode,
+  buildSpecificPartitionAssetConditionEvaluationNode,
+  buildUnpartitionedAssetConditionEvaluationNode,
+} from '../../../graphql/types';
 import {PolicyEvaluationTable} from '../PolicyEvaluationTable';
 
 // eslint-disable-next-line import/no-default-export
@@ -8,31 +15,105 @@ export default {
 };
 
 export const NonPartitioned = () => {
-  const evaluation = buildAssetConditionEvaluationRecord({
-    startTimestamp: 1,
-    endTimestamp: 200,
-  });
+  const nodes = [
+    buildUnpartitionedAssetConditionEvaluationNode({
+      startTimestamp: 0,
+      endTimestamp: 10,
+      uniqueId: 'a',
+      description: 'parent condition',
+      childUniqueIds: ['b'],
+    }),
+    buildUnpartitionedAssetConditionEvaluationNode({
+      startTimestamp: 0,
+      endTimestamp: 10,
+      uniqueId: 'b',
+      description: 'child condition',
+    }),
+  ];
 
   return (
     <PolicyEvaluationTable
-      evaluationNodes={evaluation.evaluationNodes}
-      rootUniqueId={evaluation.rootUniqueId}
+      evaluationNodes={nodes}
+      rootUniqueId="a"
       isLegacyEvaluation
       selectPartition={() => {}}
     />
   );
 };
 
-export const Partitioned = () => {
-  const evaluation = buildAssetConditionEvaluationRecord({
-    startTimestamp: 1,
-    endTimestamp: 200,
-  });
+export const NewTableStyle = () => {
+  const nodes = [
+    buildAutomationConditionEvaluationNode({
+      startTimestamp: 0,
+      endTimestamp: 10,
+      uniqueId: 'a',
+      userLabel: 'parent condition',
+      expandedLabel: ['(must be)', 'something'],
+      isPartitioned: false,
+      numTrue: 0,
+      childUniqueIds: ['b', 'c'],
+    }),
+    buildAutomationConditionEvaluationNode({
+      startTimestamp: 0,
+      endTimestamp: 10,
+      uniqueId: 'b',
+      userLabel: 'child condition',
+      expandedLabel: ['(a OR b)', 'NOT', '(c OR d)'],
+      numTrue: 0,
+      isPartitioned: false,
+    }),
+    buildAutomationConditionEvaluationNode({
+      startTimestamp: 0,
+      endTimestamp: 10,
+      uniqueId: 'c',
+      userLabel: null,
+      expandedLabel: ['(e OR f)', 'NOT', '(g OR h)'],
+      numTrue: 1,
+      isPartitioned: false,
+    }),
+  ];
 
   return (
     <PolicyEvaluationTable
-      evaluationNodes={evaluation.evaluationNodes}
-      rootUniqueId={evaluation.rootUniqueId}
+      evaluationNodes={nodes}
+      rootUniqueId="a"
+      isLegacyEvaluation={false}
+      selectPartition={() => {}}
+    />
+  );
+};
+
+export const Partitioned = () => {
+  const nodes = [
+    buildPartitionedAssetConditionEvaluationNode({
+      startTimestamp: 0,
+      endTimestamp: 10,
+      uniqueId: 'a',
+      description: 'hi i am partitioned',
+      candidateSubset: buildAssetSubset({
+        subsetValue: buildAssetSubsetValue({
+          partitionKeys: ['100', '101', '102'],
+        }),
+      }),
+      childUniqueIds: ['b'],
+    }),
+    buildPartitionedAssetConditionEvaluationNode({
+      startTimestamp: 0,
+      endTimestamp: 10,
+      uniqueId: 'b',
+      description: 'child condition',
+      candidateSubset: buildAssetSubset({
+        subsetValue: buildAssetSubsetValue({
+          partitionKeys: ['100', '101', '102'],
+        }),
+      }),
+    }),
+  ];
+
+  return (
+    <PolicyEvaluationTable
+      evaluationNodes={nodes}
+      rootUniqueId="a"
       isLegacyEvaluation
       selectPartition={() => {}}
     />
@@ -40,15 +121,22 @@ export const Partitioned = () => {
 };
 
 export const SpecificPartition = () => {
-  const evaluation = buildAssetConditionEvaluationRecord({
-    startTimestamp: 1,
-    endTimestamp: 200,
-  });
+  const nodes = [
+    buildSpecificPartitionAssetConditionEvaluationNode({
+      uniqueId: 'a',
+      description: 'parent condition',
+      childUniqueIds: ['b'],
+    }),
+    buildSpecificPartitionAssetConditionEvaluationNode({
+      uniqueId: 'b',
+      description: 'child condition',
+    }),
+  ];
 
   return (
     <PolicyEvaluationTable
-      evaluationNodes={evaluation.evaluationNodes}
-      rootUniqueId={evaluation.rootUniqueId}
+      evaluationNodes={nodes}
+      rootUniqueId="a"
       isLegacyEvaluation
       selectPartition={() => {}}
     />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__tests__/PolicyEvaluationTable.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__tests__/PolicyEvaluationTable.test.tsx
@@ -1,0 +1,188 @@
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {
+  buildAssetSubset,
+  buildAssetSubsetValue,
+  buildAutomationConditionEvaluationNode,
+  buildPartitionedAssetConditionEvaluationNode,
+  buildUnpartitionedAssetConditionEvaluationNode,
+} from '../../../graphql/types';
+import {PolicyEvaluationTable} from '../PolicyEvaluationTable';
+
+describe('PolicyEvaluationTable', () => {
+  it('renders legacy non-partitioned table for non-partitioned `isLegacy` evaluation', () => {
+    const nodes = [
+      buildUnpartitionedAssetConditionEvaluationNode({
+        startTimestamp: 0,
+        endTimestamp: 10,
+        uniqueId: 'a',
+        description: 'some condition',
+      }),
+    ];
+
+    render(
+      <PolicyEvaluationTable
+        evaluationNodes={nodes}
+        rootUniqueId="a"
+        isLegacyEvaluation
+        selectPartition={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('columnheader', {name: /condition/i})).toBeVisible();
+    expect(screen.getByRole('columnheader', {name: /result/i})).toBeVisible();
+    expect(screen.getByRole('columnheader', {name: /duration/i})).toBeVisible();
+    expect(screen.getByRole('columnheader', {name: /details/i})).toBeVisible();
+
+    expect(screen.getByRole('cell', {name: /some condition/i})).toBeVisible();
+  });
+
+  it('renders legacy partitioned table for partitioned `isLegacy` evaluation', () => {
+    const nodes = [
+      buildPartitionedAssetConditionEvaluationNode({
+        startTimestamp: 0,
+        endTimestamp: 10,
+        uniqueId: 'a',
+        description: 'hi i am partitioned',
+        candidateSubset: buildAssetSubset({
+          subsetValue: buildAssetSubsetValue({
+            partitionKeys: ['100', '101', '102'],
+          }),
+        }),
+      }),
+    ];
+
+    render(
+      <PolicyEvaluationTable
+        evaluationNodes={nodes}
+        rootUniqueId="a"
+        isLegacyEvaluation
+        selectPartition={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('columnheader', {name: /condition/i})).toBeVisible();
+    expect(screen.getByRole('columnheader', {name: /partitions evaluated/i})).toBeVisible();
+    expect(screen.getByRole('columnheader', {name: /result/i})).toBeVisible();
+    expect(screen.getByRole('columnheader', {name: /duration/i})).toBeVisible();
+
+    expect(screen.getByRole('cell', {name: /hi i am partitioned/i})).toBeVisible();
+  });
+
+  it('renders new table for non-legacy evaluation', async () => {
+    const nodes = [
+      buildAutomationConditionEvaluationNode({
+        startTimestamp: 0,
+        endTimestamp: 10,
+        uniqueId: 'a',
+        userLabel: 'my user label',
+        isPartitioned: false,
+      }),
+    ];
+
+    render(
+      <PolicyEvaluationTable
+        evaluationNodes={nodes}
+        rootUniqueId="a"
+        isLegacyEvaluation={false}
+        selectPartition={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('columnheader', {name: /condition/i})).toBeVisible();
+
+    // `isPartitioned` is false, so no column for that.
+    expect(screen.queryByRole('columnheader', {name: /partitions evaluated/i})).toBeNull();
+
+    expect(screen.getByRole('columnheader', {name: /result/i})).toBeVisible();
+    expect(screen.getByRole('columnheader', {name: /duration/i})).toBeVisible();
+
+    expect(screen.getByRole('cell', {name: /my user label/i})).toBeVisible();
+  });
+
+  describe('Row expansion', () => {
+    it('toggles rows in legacy table', async () => {
+      const user = userEvent.setup();
+      const nodes = [
+        buildUnpartitionedAssetConditionEvaluationNode({
+          startTimestamp: 0,
+          endTimestamp: 10,
+          uniqueId: 'a',
+          description: 'parent condition',
+          childUniqueIds: ['b'],
+        }),
+        buildUnpartitionedAssetConditionEvaluationNode({
+          startTimestamp: 2,
+          endTimestamp: 8,
+          uniqueId: 'b',
+          description: 'child condition',
+        }),
+      ];
+
+      render(
+        <PolicyEvaluationTable
+          evaluationNodes={nodes}
+          rootUniqueId="a"
+          isLegacyEvaluation
+          selectPartition={() => {}}
+        />,
+      );
+
+      const parentRow = screen.getByRole('cell', {name: /parent condition/i});
+
+      // In legacy table, rows are expanded by default.
+      expect(screen.getByRole('cell', {name: /child condition/i})).toBeVisible();
+
+      await user.click(parentRow);
+
+      expect(screen.queryByRole('cell', {name: /child condition/i})).toBeNull();
+
+      // Parent condition remains visible.
+      expect(screen.getByRole('cell', {name: /parent condition/i})).toBeVisible();
+    });
+
+    it('toggles rows in new table', async () => {
+      const user = userEvent.setup();
+      const nodes = [
+        buildAutomationConditionEvaluationNode({
+          startTimestamp: 0,
+          endTimestamp: 10,
+          uniqueId: 'a',
+          userLabel: 'parent condition',
+          isPartitioned: false,
+          numTrue: 0,
+          childUniqueIds: ['b'],
+        }),
+        buildAutomationConditionEvaluationNode({
+          startTimestamp: 0,
+          endTimestamp: 10,
+          uniqueId: 'b',
+          userLabel: 'child condition',
+          numTrue: 0,
+          isPartitioned: false,
+        }),
+      ];
+
+      render(
+        <PolicyEvaluationTable
+          evaluationNodes={nodes}
+          rootUniqueId="a"
+          isLegacyEvaluation={false}
+          selectPartition={() => {}}
+        />,
+      );
+
+      const parentRow = screen.getByRole('cell', {name: /parent condition/i});
+
+      // In new table, rows are collapsed by default.
+      expect(screen.queryByRole('cell', {name: /child condition/i})).toBeNull();
+
+      await user.click(parentRow);
+
+      // Both conditions visible.
+      expect(screen.getByRole('cell', {name: /child condition/i})).toBeVisible();
+      expect(screen.getByRole('cell', {name: /parent condition/i})).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
## Summary & Motivation

Add a test for `PolicyEvaluationTable` to sanity check which table is rendered for each type of evaluation, and that row collapse/expand behaves as expected.

Also:

- Update Storybook examples.
- Add `userLabel` behavior, which renders the user label as an operand with a tooltip that displays the full `expandedLabel` string.

<img width="1161" alt="Screenshot 2024-07-18 at 11 43 55" src="https://github.com/user-attachments/assets/cc95e0ef-d227-49e8-8762-7949820e82fa">

User label:

<img width="287" alt="Screenshot 2024-07-18 at 11 38 38" src="https://github.com/user-attachments/assets/c381da84-7f65-4a09-a44b-a0a6d97bc255">

Hover on user label:

<img width="241" alt="Screenshot 2024-07-18 at 11 38 45" src="https://github.com/user-attachments/assets/a32f5937-34c1-4876-85ba-1f0412a961b6">


## How I Tested These Changes

Storybook, jest. Load evaluation tables, verify that they render and behave correctly.