### PR TITLE
[quick pr] Add definition object to `SearchResult`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/CloudOSSContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/CloudOSSContext.tsx
@@ -14,7 +14,10 @@ type FeatureContext = {
 export const CloudOSSContext = React.createContext<{
   isBranchDeployment: boolean;
   featureContext: FeatureContext;
-  useAugmentSearchResults: () => (results: SearchResult[], isCatalog: boolean) => SearchResult[];
+  useAugmentSearchResults: () => (
+    results: SearchResult[],
+    searchContext: 'catalog' | 'global',
+  ) => SearchResult[];
 }>({
   isBranchDeployment: false,
   featureContext: {

--- a/js_modules/dagster-ui/packages/ui-core/src/app/CloudOSSContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/CloudOSSContext.tsx
@@ -14,7 +14,7 @@ type FeatureContext = {
 export const CloudOSSContext = React.createContext<{
   isBranchDeployment: boolean;
   featureContext: FeatureContext;
-  useAugmentSearchResults: () => (results: SearchResult[]) => SearchResult[];
+  useAugmentSearchResults: () => (results: SearchResult[], isCatalog: boolean) => SearchResult[];
 }>({
   isBranchDeployment: false,
   featureContext: {

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -76,7 +76,7 @@ const DEBOUNCE_MSEC = 100;
 export const SearchDialog = () => {
   const history = useHistory();
   const {initialize, loading, searchPrimary, searchSecondary} = useGlobalSearch({
-    isCatalog: false,
+    searchContext: 'global',
   });
   const trackEvent = useTrackEvent();
 

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -76,7 +76,7 @@ const DEBOUNCE_MSEC = 100;
 export const SearchDialog = () => {
   const history = useHistory();
   const {initialize, loading, searchPrimary, searchSecondary} = useGlobalSearch({
-    includeAssetFilters: false,
+    isCatalog: false,
   });
   const trackEvent = useTrackEvent();
 

--- a/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
@@ -1,7 +1,7 @@
 import Fuse from 'fuse.js';
 
 import {
-  SearchAssetDefinitionFragment,
+  SearchAssetFragment,
   SearchGroupFragment,
   SearchPartitionSetFragment,
   SearchPipelineFragment,
@@ -57,9 +57,9 @@ export type SearchResult = {
   tags?: DefinitionTag[];
   numResults?: number;
   repoPath?: string;
-  definition?:
+  node?:
     | null
-    | SearchAssetDefinitionFragment
+    | SearchAssetFragment
     | SearchGroupFragment
     | SearchPipelineFragment
     | SearchScheduleFragment

--- a/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
@@ -1,5 +1,14 @@
 import Fuse from 'fuse.js';
 
+import {
+  SearchAssetDefinitionFragment,
+  SearchGroupFragment,
+  SearchPartitionSetFragment,
+  SearchPipelineFragment,
+  SearchResourceDetailFragment,
+  SearchScheduleFragment,
+  SearchSensorFragment,
+} from './types/useGlobalSearch.types';
 import {DefinitionTag} from '../graphql/types';
 
 export enum SearchResultType {
@@ -48,6 +57,15 @@ export type SearchResult = {
   tags?: DefinitionTag[];
   numResults?: number;
   repoPath?: string;
+  definition?:
+    | null
+    | SearchAssetDefinitionFragment
+    | SearchGroupFragment
+    | SearchPipelineFragment
+    | SearchScheduleFragment
+    | SearchSensorFragment
+    | SearchPartitionSetFragment
+    | SearchResourceDetailFragment;
 };
 
 export type ReadyResponse = {type: 'ready'};

--- a/js_modules/dagster-ui/packages/ui-core/src/search/types/useGlobalSearch.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/types/useGlobalSearch.types.ts
@@ -60,6 +60,32 @@ export type SearchPrimaryQuery = {
       };
 };
 
+export type SearchGroupFragment = {__typename: 'AssetGroup'; id: string; groupName: string};
+
+export type SearchPipelineFragment = {
+  __typename: 'Pipeline';
+  id: string;
+  isJob: boolean;
+  name: string;
+};
+
+export type SearchScheduleFragment = {__typename: 'Schedule'; id: string; name: string};
+
+export type SearchSensorFragment = {__typename: 'Sensor'; id: string; name: string};
+
+export type SearchPartitionSetFragment = {
+  __typename: 'PartitionSet';
+  id: string;
+  name: string;
+  pipelineName: string;
+};
+
+export type SearchResourceDetailFragment = {
+  __typename: 'ResourceDetails';
+  id: string;
+  name: string;
+};
+
 export type SearchSecondaryQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type SearchSecondaryQuery = {
@@ -91,4 +117,21 @@ export type SearchSecondaryQuery = {
         }>;
       }
     | {__typename: 'PythonError'};
+};
+
+export type SearchAssetDefinitionFragment = {
+  __typename: 'AssetNode';
+  id: string;
+  computeKind: string | null;
+  groupName: string;
+  owners: Array<
+    {__typename: 'TeamAssetOwner'; team: string} | {__typename: 'UserAssetOwner'; email: string}
+  >;
+  tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
+  repository: {
+    __typename: 'Repository';
+    id: string;
+    name: string;
+    location: {__typename: 'RepositoryLocation'; id: string; name: string};
+  };
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/search/types/useGlobalSearch.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/types/useGlobalSearch.types.ts
@@ -119,19 +119,24 @@ export type SearchSecondaryQuery = {
     | {__typename: 'PythonError'};
 };
 
-export type SearchAssetDefinitionFragment = {
-  __typename: 'AssetNode';
+export type SearchAssetFragment = {
+  __typename: 'Asset';
   id: string;
-  computeKind: string | null;
-  groupName: string;
-  owners: Array<
-    {__typename: 'TeamAssetOwner'; team: string} | {__typename: 'UserAssetOwner'; email: string}
-  >;
-  tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
-  repository: {
-    __typename: 'Repository';
+  key: {__typename: 'AssetKey'; path: Array<string>};
+  definition: {
+    __typename: 'AssetNode';
     id: string;
-    name: string;
-    location: {__typename: 'RepositoryLocation'; id: string; name: string};
-  };
+    computeKind: string | null;
+    groupName: string;
+    owners: Array<
+      {__typename: 'TeamAssetOwner'; team: string} | {__typename: 'UserAssetOwner'; email: string}
+    >;
+    tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
+    repository: {
+      __typename: 'Repository';
+      id: string;
+      name: string;
+      location: {__typename: 'RepositoryLocation'; id: string; name: string};
+    };
+  } | null;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -186,10 +186,7 @@ const primaryDataToSearchResults = (input: {data?: SearchPrimaryQuery}) => {
   return allEntries;
 };
 
-const secondaryDataToSearchResults = (
-  input: {data?: SearchSecondaryQuery},
-  includeAssetFilters: boolean,
-) => {
+const secondaryDataToSearchResults = (input: {data?: SearchSecondaryQuery}, isCatalog: boolean) => {
   const {data} = input;
   if (!data?.assetsOrError || data.assetsOrError.__typename === 'PythonError') {
     return [];
@@ -217,7 +214,7 @@ const secondaryDataToSearchResults = (
         ),
     }));
 
-  if (!includeAssetFilters) {
+  if (!isCatalog) {
     return [...assets];
   } else {
     const countsBySection = buildAssetCountBySection(nodes);
@@ -332,7 +329,7 @@ export const SEARCH_SECONDARY_DATA_VERSION = 2;
  *
  * A `terminate` function is provided, but it's probably not necessary to use it.
  */
-export const useGlobalSearch = ({includeAssetFilters}: {includeAssetFilters: boolean}) => {
+export const useGlobalSearch = ({isCatalog}: {isCatalog: boolean}) => {
   const primarySearch = useRef<WorkerSearchResult | null>(null);
   const secondarySearch = useRef<WorkerSearchResult | null>(null);
 
@@ -384,26 +381,26 @@ export const useGlobalSearch = ({includeAssetFilters}: {includeAssetFilters: boo
       return;
     }
     const results = primaryDataToSearchResults({data: primaryData});
-    const augmentedResults = augmentSearchResults(results);
+    const augmentedResults = augmentSearchResults(results, isCatalog);
     if (!primarySearch.current) {
       primarySearch.current = createSearchWorker('primary', fuseOptions);
     }
     primarySearch.current.update(augmentedResults);
     consumeBufferEffect(primarySearchBuffer, primarySearch.current);
-  }, [consumeBufferEffect, primaryData, augmentSearchResults]);
+  }, [consumeBufferEffect, primaryData, isCatalog, augmentSearchResults]);
 
   useEffect(() => {
     if (!secondaryData) {
       return;
     }
-    const results = secondaryDataToSearchResults({data: secondaryData}, includeAssetFilters);
-    const augmentedResults = augmentSearchResults(results);
+    const results = secondaryDataToSearchResults({data: secondaryData}, isCatalog);
+    const augmentedResults = augmentSearchResults(results, isCatalog);
     if (!secondarySearch.current) {
       secondarySearch.current = createSearchWorker('secondary', fuseOptions);
     }
     secondarySearch.current.update(augmentedResults);
     consumeBufferEffect(secondarySearchBuffer, secondarySearch.current);
-  }, [consumeBufferEffect, secondaryData, includeAssetFilters, augmentSearchResults]);
+  }, [consumeBufferEffect, secondaryData, isCatalog, augmentSearchResults]);
 
   const primarySearchBuffer = useRef<IndexBuffer | null>(null);
   const secondarySearchBuffer = useRef<IndexBuffer | null>(null);


### PR DESCRIPTION
## Summary & Motivation

For catalog views we need access to the definition object in order to filter the results further based on the active catalog view.

## How I Tested These Changes
buildkite