### PR TITLE
chore: enable `include_package_data`

### DIFF
--- a/python_modules/dagster-pipes/setup.py
+++ b/python_modules/dagster-pipes/setup.py
@@ -35,6 +35,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_pipes_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     zip_safe=False,
 )

--- a/python_modules/dagster-test/setup.py
+++ b/python_modules/dagster-test/setup.py
@@ -16,6 +16,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_test_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         "dagster",

--- a/python_modules/libraries/dagster-airbyte/setup.py
+++ b/python_modules/libraries/dagster-airbyte/setup.py
@@ -35,6 +35,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_airbyte_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -30,6 +30,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_airflow_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-celery-docker/setup.py
+++ b/python_modules/libraries/dagster-celery-docker/setup.py
@@ -30,6 +30,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_celery_docker_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-celery-k8s/setup.py
+++ b/python_modules/libraries/dagster-celery-k8s/setup.py
@@ -30,6 +30,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_celery_k8s_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-census/setup.py
+++ b/python_modules/libraries/dagster-census/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_census_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}"],
     zip_safe=False,

--- a/python_modules/libraries/dagster-dask/setup.py
+++ b/python_modules/libraries/dagster-dask/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_dask_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         "bokeh",

--- a/python_modules/libraries/dagster-datadog/setup.py
+++ b/python_modules/libraries/dagster-datadog/setup.py
@@ -35,6 +35,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_datadog_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "datadog"],
     zip_safe=False,

--- a/python_modules/libraries/dagster-docker/setup.py
+++ b/python_modules/libraries/dagster-docker/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_docker_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "docker", "docker-image-py"],
     zip_safe=False,

--- a/python_modules/libraries/dagster-embedded-elt/setup.py
+++ b/python_modules/libraries/dagster-embedded-elt/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_embedded_elt_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "sling>=1.1.5", "dlt>=0.4"],
     zip_safe=False,

--- a/python_modules/libraries/dagster-fivetran/setup.py
+++ b/python_modules/libraries/dagster-fivetran/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_fivetran_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}"],
     zip_safe=False,

--- a/python_modules/libraries/dagster-gcp-pyspark/setup.py
+++ b/python_modules/libraries/dagster-gcp-pyspark/setup.py
@@ -34,6 +34,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_gcp_pyspark_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-gcp/setup.py
+++ b/python_modules/libraries/dagster-gcp/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_gcp_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-ge/setup.py
+++ b/python_modules/libraries/dagster-ge/setup.py
@@ -30,6 +30,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_ge_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-github/setup.py
+++ b/python_modules/libraries/dagster-github/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_github_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-k8s/setup.py
+++ b/python_modules/libraries/dagster-k8s/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_k8s_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-managed-elements/setup.py
+++ b/python_modules/libraries/dagster-managed-elements/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_managed_elements_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "requests", "click_spinner"],
     zip_safe=False,

--- a/python_modules/libraries/dagster-mlflow/setup.py
+++ b/python_modules/libraries/dagster-mlflow/setup.py
@@ -31,6 +31,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_mlflow_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "mlflow", "pandas"],
     zip_safe=False,

--- a/python_modules/libraries/dagster-msteams/setup.py
+++ b/python_modules/libraries/dagster-msteams/setup.py
@@ -34,6 +34,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_msteams_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-pagerduty/setup.py
+++ b/python_modules/libraries/dagster-pagerduty/setup.py
@@ -31,6 +31,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_pagerduty_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "pypd"],
     zip_safe=False,

--- a/python_modules/libraries/dagster-papertrail/setup.py
+++ b/python_modules/libraries/dagster-papertrail/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_papertrail_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}"],
     zip_safe=False,

--- a/python_modules/libraries/dagster-polars/setup.py
+++ b/python_modules/libraries/dagster-polars/setup.py
@@ -34,6 +34,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_polars_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-prometheus/setup.py
+++ b/python_modules/libraries/dagster-prometheus/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_prometheus_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "prometheus_client"],
     zip_safe=False,

--- a/python_modules/libraries/dagster-pyspark/setup.py
+++ b/python_modules/libraries/dagster-pyspark/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_pyspark_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-shell/setup.py
+++ b/python_modules/libraries/dagster-shell/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_shell_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}"],
     extras_require={"test": ["psutil"]},

--- a/python_modules/libraries/dagster-slack/setup.py
+++ b/python_modules/libraries/dagster-slack/setup.py
@@ -32,6 +32,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_slack_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-snowflake-pandas/setup.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/setup.py
@@ -34,6 +34,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_snowflake_pandas_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-snowflake-pyspark/setup.py
+++ b/python_modules/libraries/dagster-snowflake-pyspark/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_snowflake_pyspark_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-snowflake/setup.py
+++ b/python_modules/libraries/dagster-snowflake/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_snowflake_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/python_modules/libraries/dagster-spark/setup.py
+++ b/python_modules/libraries/dagster-spark/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_spark_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}"],
     zip_safe=False,

--- a/python_modules/libraries/dagster-ssh/setup.py
+++ b/python_modules/libraries/dagster-ssh/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_ssh_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "sshtunnel", "paramiko"],
     extras_require={"test": ["cryptography==2.6.1", "pytest-sftpserver==1.2.0"]},

--- a/python_modules/libraries/dagster-twilio/setup.py
+++ b/python_modules/libraries/dagster-twilio/setup.py
@@ -33,6 +33,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_twilio_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[f"dagster{pin}", "twilio"],
     zip_safe=False,

--- a/python_modules/libraries/dagster-wandb/setup.py
+++ b/python_modules/libraries/dagster-wandb/setup.py
@@ -32,6 +32,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_wandb_tests*"]),
+    include_package_data=True,
     python_requires=">=3.8,<3.13",
     install_requires=[
         f"dagster{pin}",

--- a/scripts/templates_create_dagster_package/setup.py.tmpl
+++ b/scripts/templates_create_dagster_package/setup.py.tmpl
@@ -37,6 +37,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["{{ underscore_name }}_tests*"]),
+    include_package_data=True,
     install_requires=[
         f"dagster{pin}",
         # TODO - fill in remaining dependencies


### PR DESCRIPTION
## Summary & Motivation
Resolves https://github.com/dagster-io/dagster/issues/23022.

Follow https://setuptools.pypa.io/en/latest/userguide/datafiles.html#summary to actually get our `MANIFEST.in` files to be used. 

Currently, these `setup.py` files do not have `include_package_data` enabled, while other packages do.

## How I Tested These Changes
N/A