### PR TITLE
[ui] Asset detail: fix missing materializations error

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetBaseDataProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/AssetBaseDataProvider.tsx
@@ -5,7 +5,12 @@ import {
   AssetGraphLiveQuery,
   AssetGraphLiveQueryVariables,
 } from './types/AssetBaseDataProvider.types';
-import {buildLiveDataForNode, tokenForAssetKey, tokenToAssetKey} from '../asset-graph/Utils';
+import {
+  LiveDataForNode,
+  buildLiveDataForNode,
+  tokenForAssetKey,
+  tokenToAssetKey,
+} from '../asset-graph/Utils';
 import {AssetKeyInput} from '../graphql/types';
 import {liveDataFactory} from '../live-data-provider/Factory';
 import {LiveDataThreadID} from '../live-data-provider/LiveDataThread';
@@ -24,17 +29,20 @@ function init() {
           assetKeys: keys.map(tokenToAssetKey),
         },
       });
+
       const nodesByKey = Object.fromEntries(
         data.assetNodes.map((node) => [tokenForAssetKey(node.assetKey), node]),
       );
 
-      const liveDataByKey = Object.fromEntries(
-        data.assetsLatestInfo.map((assetLatestInfo) => {
-          const id = tokenForAssetKey(assetLatestInfo.assetKey);
-          return [id, buildLiveDataForNode(nodesByKey[id]!, assetLatestInfo)];
-        }),
+      return Object.fromEntries(
+        data.assetsLatestInfo
+          .map((assetLatestInfo) => {
+            const id = tokenForAssetKey(assetLatestInfo.assetKey);
+            const node = nodesByKey[id];
+            return node ? [id, buildLiveDataForNode(node, assetLatestInfo)] : null;
+          })
+          .filter((entry): entry is [string, LiveDataForNode] => !!entry),
       );
-      return liveDataByKey;
     },
   );
 }


### PR DESCRIPTION
## Summary & Motivation

In the asset detail view, we're encountering an error when reading `assetMaterializations` for assets that don't exist in the workspace. Make the code a little more defensive.

## How I Tested These Changes

View an asset that exists in the workspace, verify that the page loads with no errors. View an asset that no longer exists, verify same.