### PR TITLE
Run prettier in the root folder instead of via yarn

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -79,9 +79,7 @@ def build_repo_wide_prettier_steps() -> List[CommandStep]:
     return [
         CommandStepBuilder(":prettier: prettier")
         .run(
-            "pushd js_modules/dagster-ui/packages/eslint-config",
-            "yarn install",
-            "popd",
+            "make install_prettier",
             "make check_prettier",
         )
         .on_test_image(AvailablePythonVersion.get_default())

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -204,6 +204,9 @@ def get_commit(rev):
 
 
 def skip_if_no_python_changes(overrides: Optional[Sequence[str]] = None):
+    if message_contains("NO_SKIP"):
+        return None
+
     if not is_feature_branch():
         return None
 
@@ -219,6 +222,9 @@ def skip_if_no_python_changes(overrides: Optional[Sequence[str]] = None):
 
 
 def skip_if_no_pyright_requirements_txt_changes():
+    if message_contains("NO_SKIP"):
+        return None
+
     if not is_feature_branch():
         return None
 
@@ -229,6 +235,9 @@ def skip_if_no_pyright_requirements_txt_changes():
 
 
 def skip_if_no_yaml_changes():
+    if message_contains("NO_SKIP"):
+        return None
+
     if not is_feature_branch():
         return None
 
@@ -239,6 +248,9 @@ def skip_if_no_yaml_changes():
 
 
 def skip_if_no_non_docs_markdown_changes():
+    if message_contains("NO_SKIP"):
+        return None
+
     if not is_feature_branch():
         return None
 
@@ -263,6 +275,9 @@ def has_storage_test_fixture_changes():
 
 
 def skip_if_no_helm_changes():
+    if message_contains("NO_SKIP"):
+        return None
+
     if not is_feature_branch():
         return None
 
@@ -281,6 +296,9 @@ def message_contains(substring: str) -> bool:
 
 
 def skip_if_no_docs_changes():
+    if message_contains("NO_SKIP"):
+        return None
+
     if not is_feature_branch(os.getenv("BUILDKITE_BRANCH")):
         return None
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@
 pyright:
 	python scripts/run-pyright.py --all
 
+install_prettier:
+	npm install -g prettier
+
 install_pyright:
 	pip install -e 'python_modules/dagster[pyright]' -e 'python_modules/dagster-pipes'
 
@@ -36,13 +39,13 @@ check_ruff:
 
 check_prettier:
 #NOTE:  excludes README.md because it's a symlink
-	yarn exec --cwd js_modules/dagster-ui/packages/eslint-config -- prettier `git ls-files \
+	prettier `git ls-files \
 	'python_modules/*.yml' 'python_modules/*.yaml' 'helm/*.yml' 'helm/*.yaml' \
 	':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml' '*.md' ':!:docs/*.md' \
 	':!:README.md'` --check
 
 prettier:
-	yarn exec --cwd js_modules/dagster-ui/packages/eslint-config -- prettier `git ls-files \
+	prettier `git ls-files \
 	'python_modules/*.yml' 'python_modules/*.yaml' 'helm/*.yml' 'helm/*.yaml' \
 	':!:helm/**/templates/*.yml' ':!:helm/**/templates/*.yaml' '*.md' ':!:docs/*.md' \
 	':!:README.md'` --write


### PR DESCRIPTION
We can install prettier globally for this, no need to use yarn or hijack js_modules.
