### PR TITLE
[ui] Show metadataEntries when displaying EngineEvent logs with errors

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowStructuredContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsRowStructuredContent.tsx
@@ -205,7 +205,14 @@ export const LogsRowStructuredContent = ({node, metadata}: IStructuredContentPro
       return <FailureContent message={node.message} eventType={eventType} />;
     case 'EngineEvent':
       if (node.error) {
-        return <FailureContent message={node.message} error={node.error} eventType={eventType} />;
+        return (
+          <FailureContent
+            message={node.message}
+            error={node.error}
+            metadataEntries={node.metadataEntries}
+            eventType={eventType}
+          />
+        );
       }
       return (
         <DefaultContent


### PR DESCRIPTION
https://linear.app/dagster-labs/issue/FE-450/in-the-event-log-show-both-metadata-and-error-when-present-on-an

## Summary & Motivation

Turns out this is a very trivial fix, the component already supports the display of metadataEntries and we just need to pass them through.
