### PR TITLE
Pin setuptools < 71.0.0 in dagster-airflow

### DIFF
--- a/python_modules/libraries/dagster-airflow/setup.py
+++ b/python_modules/libraries/dagster-airflow/setup.py
@@ -36,6 +36,7 @@ setup(
         "docker>=5.0.3,<6.0.0",
         "urllib3<2",  # docker version pinned above requires this but has no pin
         "lazy_object_proxy",
+        "setuptools<71.0.0",
     ],
     project_urls={
         # airflow will embed a link this in the providers page UI


### PR DESCRIPTION
Incompatible with dagster-airflow on python3.8

https://buildkite.com/dagster/dagster-dagster/builds/88420#0190c75d-1346-485c-bad5-5f87916e69e3