### PR TITLE
refactor(dbt): allow `Path` for `DbtCliResource` arguments

### DIFF
--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -136,13 +136,12 @@ Creating the manifest at runtime in production is known to cause issues and is n
 
 ```python startafter=start_troubleshooting_dbt_manifest endbefore=end_troubleshooting_dbt_manifest file=/integrations/dbt/dbt.py dedent=4
 """❌ This is not recommended."""
-import os
 from pathlib import Path
 
 from dagster_dbt import DbtCliResource
 
 dbt_project_dir = Path(__file__).joinpath("..", "..", "..").resolve()
-dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
+dbt = DbtCliResource(project_dir=dbt_project_dir)
 
 # A manifest will always be created at runtime.
 dbt_manifest_path = (
@@ -167,7 +166,7 @@ from pathlib import Path
 from dagster_dbt import DbtCliResource
 
 dbt_project_dir = Path(__file__).joinpath("..", "..", "..").resolve()
-dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
+dbt = DbtCliResource(project_dir=dbt_project_dir)
 
 # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at runtime.
 # Otherwise, we expect a manifest to be present in the project's target directory.

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -12,7 +12,7 @@ def scope_compile_dbt_manifest(manifest):
     from dagster_dbt import DbtCliResource
 
     dbt_project_dir = Path(__file__).joinpath("..", "..", "..").resolve()
-    dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
+    dbt = DbtCliResource(project_dir=dbt_project_dir)
 
     # If DAGSTER_DBT_PARSE_PROJECT_ON_LOAD is set, a manifest will be created at runtime.
     # Otherwise, we expect a manifest to be present in the project's target directory.
@@ -33,13 +33,12 @@ def scope_compile_dbt_manifest(manifest):
 def scope_troubleshooting_dbt_manifest(manifest):
     # start_troubleshooting_dbt_manifest
     """❌ This is not recommended."""
-    import os
     from pathlib import Path
 
     from dagster_dbt import DbtCliResource
 
     dbt_project_dir = Path(__file__).joinpath("..", "..", "..").resolve()
-    dbt = DbtCliResource(project_dir=os.fspath(dbt_project_dir))
+    dbt = DbtCliResource(project_dir=dbt_project_dir)
 
     # A manifest will always be created at runtime.
     dbt_manifest_path = (

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -1356,23 +1356,26 @@ class DbtCliResource(ConfigurableResource):
 
     def __init__(
         self,
-        project_dir: Union[str, DbtProject],
+        project_dir: Union[str, Path, DbtProject],
         global_config_flags: Optional[List[str]] = None,
-        profiles_dir: Optional[str] = None,
+        profiles_dir: Optional[Union[str, Path]] = None,
         profile: Optional[str] = None,
         target: Optional[str] = None,
-        dbt_executable: str = DBT_EXECUTABLE,
-        state_path: Optional[str] = None,
+        dbt_executable: Union[str, Path] = DBT_EXECUTABLE,
+        state_path: Optional[Union[str, Path]] = None,
         **kwargs,  # allow custom subclasses to add fields
     ):
         if isinstance(project_dir, DbtProject):
             if not state_path and project_dir.state_path:
-                state_path = os.fspath(project_dir.state_path)
+                state_path = project_dir.state_path
 
             if not target and project_dir.target:
                 target = project_dir.target
 
-            project_dir = os.fspath(project_dir.project_dir)
+            project_dir = project_dir.project_dir
+
+        project_dir = os.fspath(project_dir)
+        state_path = state_path and os.fspath(state_path)
 
         # static typing doesn't understand whats going on here, thinks these fields dont exist
         super().__init__(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/definitions.py.jinja
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/include/scaffold/definitions.py.jinja
@@ -2,8 +2,6 @@
 from dagster import Definitions
 from dagster_dbt import DbtCliResource
 {% else -%}
-import os
-
 from dagster import Definitions
 from dagster_dbt import DbtCliResource
 {% endif %}
@@ -22,7 +20,7 @@ defs = Definitions(
         {% if use_dbt_project -%}
         "dbt": DbtCliResource(project_dir={{ dbt_project_name }}),
         {%- else -%}
-        "dbt": DbtCliResource(project_dir=os.fspath(dbt_project_dir)),
+        "dbt": DbtCliResource(project_dir=dbt_project_dir),
         {%- endif %}
     },
 )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resources_v2.py
@@ -63,7 +63,7 @@ def test_dbt_cli_executable() -> None:
     assert (
         DbtCliResource(
             project_dir=os.fspath(test_jaffle_shop_path),
-            dbt_executable=Path(dbt_executable),  # type: ignore
+            dbt_executable=Path(dbt_executable),
         )
         .cli(["parse"])
         .is_successful()
@@ -75,7 +75,7 @@ def test_dbt_cli_executable() -> None:
 
 
 def test_dbt_cli_project_dir_path() -> None:
-    dbt = DbtCliResource(project_dir=test_jaffle_shop_path)  # type: ignore
+    dbt = DbtCliResource(project_dir=test_jaffle_shop_path)
 
     assert Path(dbt.project_dir).is_absolute()
     assert dbt.cli(["parse"]).is_successful()
@@ -234,7 +234,7 @@ def test_dbt_profiles_dir_configuration(profiles_dir: Union[str, Path]) -> None:
     assert (
         DbtCliResource(
             project_dir=os.fspath(test_jaffle_shop_path),
-            profiles_dir=profiles_dir,  # type: ignore
+            profiles_dir=profiles_dir,
         )
         .cli(["parse"])
         .is_successful()


### PR DESCRIPTION
## Summary & Motivation
This was always allowed, but this failed type-hinting. Now it shouldn't fail type-hinting.

## How I Tested These Changes
pytest, pyright