### PR TITLE
[dagster-dbt] Ensure exceptions properly propagate through deferred metadata fetches

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resources_v2.py
@@ -89,7 +89,7 @@ from ..dbt_manifest import DbtManifestParam, validate_manifest
 from ..dbt_project import DbtProject
 from ..errors import DagsterDbtCliRuntimeError
 from ..utils import ASSET_RESOURCE_TYPES, get_dbt_resource_props_by_dbt_unique_id_from_manifest
-from .utils import imap
+from .utils import exhaust_iterator_and_yield_results_with_exception, imap
 
 IS_DBT_CORE_VERSION_LESS_THAN_1_8_0 = version.parse(dbt_version) < version.parse("1.8.0")
 
@@ -1187,7 +1187,8 @@ class DbtEventIterator(Generic[T], abc.Iterator):
             from dbt.adapters.duckdb import DuckDBAdapter
 
             if isinstance(self._dbt_cli_invocation.adapter, DuckDBAdapter):
-                event_stream = iter(list(self))
+                event_stream = exhaust_iterator_and_yield_results_with_exception(self)
+
         except ImportError:
             pass
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_postprocessing.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_postprocessing.py
@@ -204,6 +204,17 @@ def test_row_count_does_not_obscure_errors(
     assert not result.success
     assert len(result.get_asset_materialization_events()) == 7
 
+    metadata_by_asset_key = {
+        check.not_none(event.asset_key): event.materialization.metadata
+        for event in result.get_asset_materialization_events()
+    }
+    assert all(
+        "dagster/row_count" in metadata
+        for asset_key, metadata in metadata_by_asset_key.items()
+        # staging tables are views, so we don't attempt to get row counts for them
+        if "stg" not in asset_key.path[-1]
+    ), str(metadata_by_asset_key)
+
 
 def test_row_count_err(
     test_jaffle_shop_manifest_standalone_duckdb_dbfile: Dict[str, Any],

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_postprocessing.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_postprocessing.py
@@ -162,8 +162,9 @@ def test_row_count_does_not_obscure_errors(
     request: pytest.FixtureRequest, target: str, manifest_fixture_name: str
 ) -> None:
     manifest = cast(Dict[str, Any], request.getfixturevalue(manifest_fixture_name))
-    # Test that row count fetching does not obscure other errors in the dbt run
 
+    # Test that row count fetching does not obscure other errors in the dbt run
+    # First, run dbt without any row count fetching, and ensure that it fails
     @dbt_assets(manifest=manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
         yield from (
@@ -183,6 +184,8 @@ def test_row_count_does_not_obscure_errors(
     assert not result.success
     assert len(result.get_asset_materialization_events()) == 7
 
+    # Next, run the exact same dbt run, but with row count fetching enabled
+    # And ensure it fails in the same way
     @dbt_assets(manifest=manifest)
     def my_dbt_assets_row_count(context: AssetExecutionContext, dbt: DbtCliResource):
         yield from (

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_postprocessing.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_postprocessing.py
@@ -198,13 +198,11 @@ def test_row_count_does_not_obscure_errors(
         resources={
             "dbt": DbtCliResource(project_dir=os.fspath(test_jaffle_shop_path), target=target)
         },
-        raise_on_error=True,
+        raise_on_error=False,
     )
 
     assert not result.success
-    # Right now, duckdb fully processes all models before starting to fetch row counts -
-    # so no materializations will be emitted before the error fires. We should probably adjust this.
-    assert len(result.get_asset_materialization_events()) == 0 if target == "duckdb" else 7
+    assert len(result.get_asset_materialization_events()) == 7
 
 
 def test_row_count_err(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/models/customers.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/jaffle_shop/models/customers.sql
@@ -67,3 +67,9 @@ final as (
 )
 
 select * from final
+
+{% if var('break_customer_build', 'false') == 'true' %}
+
+does not work
+
+{% endif %}


### PR DESCRIPTION
## Summary

Addresses https://github.com/dagster-io/dagster/issues/23109.

Ensures that any exception which is fired during the dbt execution (or any subsequent metadata fetch) is properly propagated through later metadata fetches. For example, if materializing a model fails, ensure that the exception fails the run.

Also ensure that any successful materializations have their metadata fetched before the run is failed (e.g. we get row count for all assets that do materialize).

## Test Plan

Adds a test which ensures that failure behavior works as expected when fetching row counts.

Snowflake/bq test: https://buildkite.com/dagster/full-moon-with-face-dagster-nightly/builds/99
