### PR TITLE
Run Vale on API docs and fix errors.

### DIFF
--- a/docs/sphinx/sections/api/apidocs/asset-checks.rst
+++ b/docs/sphinx/sections/api/apidocs/asset-checks.rst
@@ -3,7 +3,7 @@
 Asset Checks
 ===========================
 
-Dagster allows you to define and execute checks on your software-defined assets. Each asset check verifies some property of a data asset, e.g. that is has no null values in a particular column.
+With Dagster, you can define and execute checks on your software-defined assets. Each asset check verifies some property of a data asset, for example that it has no null values in a particular column.
 
 .. autodecorator:: asset_check
 

--- a/docs/sphinx/sections/api/apidocs/config.rst
+++ b/docs/sphinx/sections/api/apidocs/config.rst
@@ -6,7 +6,7 @@ Config
 Pythonic config system
 ----------------------
 
-The following classes are used as part of the new `Pythonic config system </concepts/configuration/config-schema>`_. They are used in conjunction with builtin types.
+The following classes work with the new `Pythonic config system </concepts/configuration/config-schema>`_ alongside builtin types.
 
 .. autoclass:: Config
 
@@ -17,7 +17,7 @@ The following classes are used as part of the new `Pythonic config system </conc
 Legacy Dagster config types
 ---------------------------
 
-The following types are used as part of the legacy `Dagster config system </concepts/configuration/config-schema-legacy>`_. They are used in conjunction with builtin types.
+The following types work with the legacy `Dagster config system </concepts/configuration/config-schema-legacy>`_ in conjunction with builtin types.
 
 .. autoclass:: ConfigSchema
 

--- a/docs/sphinx/sections/api/apidocs/dynamic.rst
+++ b/docs/sphinx/sections/api/apidocs/dynamic.rst
@@ -1,7 +1,7 @@
 Dynamic Mapping & Collect
 =========================
 
-These APIs provide the means for a simple kind of *dynamic orchestration* — where the work to be orchestrated is determined not at job definition time but at runtime, dependent on data that's observed as part of job execution.
+These APIs enable dynamic orchestration. They determine work at runtime, based on data observed during job execution, rather than at job definition time.
 
 .. currentmodule:: dagster
 

--- a/docs/sphinx/sections/api/apidocs/execution.rst
+++ b/docs/sphinx/sections/api/apidocs/execution.rst
@@ -4,15 +4,15 @@ Execution
 =========
 
 
-Materializing Assets
+Asset Materialization
 --------------------
 
 .. autofunction:: materialize
 
 .. autofunction:: materialize_to_memory
 
-Executing Jobs
---------------
+Job Execution
+-------------
 
 .. autoclass:: JobDefinition
   :noindex:
@@ -25,7 +25,7 @@ Executing Jobs
 
 .. autofunction:: instance_for_test
 
-Executing Graphs
+Graph Execution
 ----------------
 
 .. autoclass:: GraphDefinition

--- a/docs/sphinx/sections/api/apidocs/external-assets.rst
+++ b/docs/sphinx/sections/api/apidocs/external-assets.rst
@@ -1,16 +1,16 @@
 External assets (Experimental)
 ==============================
 
-As Dagster doesn't control scheduling or materializing `external assets </concepts/assets/external-assets>`_, it's up to you to keep their metadata updated. The APIs in this reference can be used to keep external assets updated in Dagster.
+As Dagster doesn't control scheduling or materializing `external assets </concepts/assets/external-assets>`_, you need to keep their metadata updated. Use the APIs in this reference to keep external assets updated in Dagster.
 
 ----
 
 Instance API
 ------------
 
-External asset events can be recorded using :py:func:`DagsterInstance.report_runless_asset_event` on :py:class:`DagsterInstance`.
+You can record external asset events using :py:func:`DagsterInstance.report_runless_asset_event` on :py:class:`DagsterInstance`.
 
-**Example:** Reporting an asset materialization:
+**Example:** reporting an asset materialization:
 
 .. code-block:: python
 
@@ -19,7 +19,7 @@ External asset events can be recorded using :py:func:`DagsterInstance.report_run
     instance = DagsterInstance.get()
     instance.report_runless_asset_event(AssetMaterialization(AssetKey("example_asset")))
 
-**Example:** Reporting an asset check evaluation:
+**Example:** reporting an asset check evaluation:
 
 .. code-block:: python
 

--- a/docs/sphinx/sections/api/apidocs/internals.rst
+++ b/docs/sphinx/sections/api/apidocs/internals.rst
@@ -3,7 +3,7 @@ Internals
 
 .. currentmodule:: dagster
 
-Note that APIs imported from Dagster submodules are not considered stable, and are potentially subject to change in the future.
+Note that APIs imported from Dagster submodules aren't considered stable, and are subject to change in the future.
 
 If you find yourself consulting these docs because you are writing custom components and plug-ins,
 please get in touch with the core team `on our Slack <https://join.slack.com/t/dagster/shared_invite/enQtNjEyNjkzNTA2OTkzLTI0MzdlNjU0ODVhZjQyOTMyMGM1ZDUwZDQ1YjJmYjI3YzExZGViMDI1ZDlkNTY5OThmYWVlOWM1MWVjN2I3NjU>`_.

--- a/docs/sphinx/sections/api/apidocs/io-managers.rst
+++ b/docs/sphinx/sections/api/apidocs/io-managers.rst
@@ -44,7 +44,7 @@ Built-in IO Managers
   :annotation: IOManagerDefinition
 
 
-The ``UPathIOManager`` can be used to easily define filesystem-based IO Managers.
+The ``UPathIOManager`` defines filesystem-based IO Managers.
 
 .. autoclass:: UPathIOManager
 

--- a/docs/sphinx/sections/api/apidocs/jobs.rst
+++ b/docs/sphinx/sections/api/apidocs/jobs.rst
@@ -3,9 +3,9 @@ Jobs
 
 A ``Job`` binds a ``Graph`` and the resources it needs to be executable.
 
-Jobs are created by calling :py:meth:`GraphDefinition.to_job` on a graph instance, or using the :py:class:`job` decorator.
-
 .. currentmodule:: dagster
+
+You can create Jobs by calling :py:meth:`GraphDefinition.to_job` on a graph instance or using the :py:class:`job` decorator.
 
 .. autodecorator:: job
 

--- a/docs/sphinx/sections/api/apidocs/loggers.rst
+++ b/docs/sphinx/sections/api/apidocs/loggers.rst
@@ -15,7 +15,7 @@ Logging from an @op
 
 .. autoclass:: DagsterLogManager
 
-Defining custom loggers
+Custom loggers
 -----------------------
 .. currentmodule:: dagster
 

--- a/docs/sphinx/sections/api/apidocs/memoization.rst
+++ b/docs/sphinx/sections/api/apidocs/memoization.rst
@@ -1,7 +1,7 @@
 Job-Level Versioning and Memoization (Deprecated)
 =================================================
 
-Dagster has deprecated functionality that allows for job-level code versioning and memoization of previous op outputs based upon that versioning.
+Dagster has deprecated functionality for job-level code versioning and memoization of previous op outputs based upon that versioning.
 
 This is currently deprecated in favor of `asset versioning </concepts/assets/software-defined-assets#asset-code-versions>`_.
 

--- a/docs/sphinx/sections/api/apidocs/ops.rst
+++ b/docs/sphinx/sections/api/apidocs/ops.rst
@@ -7,7 +7,7 @@ The foundational unit of computation in Dagster.
 
 -----
 
-Defining ops
+Op Definition
 ------------
 .. autodecorator:: op
 
@@ -42,10 +42,9 @@ Execution
 Events
 ------
 
-The objects that can be yielded by the body of ops' compute functions to communicate with the
-Dagster framework.
+Objects that ops' compute functions can yield to communicate with the Dagster framework.
 
-(Note that :py:class:`Failure` and :py:class:`RetryRequested` are intended to be raised from ops rather than yielded.)
+(Note: raise :py:class:`Failure` and :py:class:`RetryRequested` from ops rather than yielding them.)
 
 Event types
 ^^^^^^^^^^^

--- a/docs/sphinx/sections/api/apidocs/pipes.rst
+++ b/docs/sphinx/sections/api/apidocs/pipes.rst
@@ -7,7 +7,7 @@ Dagster Pipes
 
 For a detailed look at the Pipes process, including how to customize it, refer to the `Dagster Pipes details and customization guide </concepts/dagster-pipes/dagster-pipes-details-and-customization#overview-and-terms>`__.
 
-**Looking to write code in an external process?** Refer to the API reference for the separately-installed `dagster-pipes </_apidocs/libraries/dagster-pipes>`_ library. 
+**Looking to write code in an external process?** Refer to the API reference for the standalone `dagster-pipes </_apidocs/libraries/dagster-pipes>`_ library. 
 
 ----
 
@@ -36,14 +36,14 @@ Clients
 Advanced
 --------
 
-Most Pipes users won't need to use the APIs in the following sections unless they are customizing the Pipes protocol.
+Most Pipes users won't need to use the APIs in the following sections unless they're customizing the Pipes protocol.
 
 Refer to the `Dagster Pipes details and customization guide </concepts/dagster-pipes/dagster-pipes-details-and-customization#overview-and-terms>`__ for more information.
 
 Context injectors
 ^^^^^^^^^^^^^^^^^
 
-Context injectors write context payloads to an externally accessible location and yield a set of parameters encoding the location for inclusion in the bootstrap payload.
+Context injectors write context payloads to an external location and yield a set of parameters encoding the location for inclusion in the bootstrap payload.
 
 .. autoclass:: PipesContextInjector
 
@@ -58,7 +58,7 @@ Context injectors write context payloads to an externally accessible location an
 Message readers
 ^^^^^^^^^^^^^^^
 
-Message readers read messages (and optionally log files) from an externally accessible location and yield a set of parameters encoding the location in the bootstrap payload. 
+Message readers read messages and, optionally, log files from an external location and yield a set of parameters encoding the location in the bootstrap payload. 
 
 .. autoclass:: PipesMessageReader
 

--- a/docs/sphinx/sections/api/apidocs/schedules-sensors.rst
+++ b/docs/sphinx/sections/api/apidocs/schedules-sensors.rst
@@ -3,7 +3,7 @@
 Schedules and sensors
 =====================
 
-Dagster offers several ways to run data pipelines without manual intervation, including traditional scheduling and event-based triggers. `Automating your Dagster pipelines </concepts/automation>`_ can boost efficiency and ensure that data is produced consistently and reliably.
+Dagster offers several ways to run data pipelines without manual intervention, including traditional scheduling and event-based triggers. `Automating your Dagster pipelines </concepts/automation>`_ can boost efficiency and help maintain consistent and reliable data production.
 
 ----
 
@@ -17,7 +17,7 @@ Run requests
 Schedules
 ---------
 
-`Schedules </concepts/automationschedules>`__ are Dagster's way to support traditional ways of automation, such as specifying a job should run at Mondays at 9:00AM. Jobs triggered by schedules can contain a subset of `assets </concepts/assets/software-defined-assets>`__ or `ops </concepts/ops-jobs-graphs/ops>`__.
+`Schedules </concepts/automationschedules>`__ are Dagster's way to support traditional ways of automation, such as specifying a job should run at Mondays at 9:00 AM. Jobs triggered by schedules can contain a subset of `assets </concepts/assets/software-defined-assets>`__ or `ops </concepts/ops-jobs-graphs/ops>`__.
 
 .. autodecorator:: schedule
 

--- a/docs/sphinx/sections/api/apidocs/types.rst
+++ b/docs/sphinx/sections/api/apidocs/types.rst
@@ -3,7 +3,7 @@ Types
 
 .. currentmodule:: dagster
 
-Dagster includes facilities for typing the input and output values of ops ("runtime" types).
+Dagster includes facilities for typing the input and output values of ops, also known as "runtime" types.
 
 .. _builtin:
 
@@ -49,8 +49,8 @@ Built-in types
             done(wait_int())
 
 
-Making New Types
-----------------
+New Type Definition
+---------------------
 
 .. autoclass:: DagsterType
 
@@ -66,7 +66,7 @@ Making New Types
 
 .. autofunction:: make_python_type_usable_as_dagster_type
 
-Testing Types
-^^^^^^^^^^^^^
+Type Testing
+------------
 
 .. autofunction:: check_dagster_type


### PR DESCRIPTION
This was a one-time run using some standard out-of-the-box linting from the Google and Microsoft style
guides. Further docs work will incorporate an automatic CI-based linter
as well as instructions for adding linting to code editors.

## Summary & Motivation

## How I Tested These Changes
