### PR TITLE
make job backfill status consistent with asset backfill status

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
@@ -15,17 +15,14 @@ import {
   SingleBackfillQueryVariables,
 } from './types/BackfillRow.types';
 import {BackfillTableFragment} from './types/BackfillTable.types';
-import {showCustomAlert} from '../../app/CustomAlertProvider';
-import {PythonErrorInfo} from '../../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../../app/QueryRefresh';
 import {isHiddenAssetGroupJob} from '../../asset-graph/Utils';
-import {BulkActionStatus, RunStatus} from '../../graphql/types';
+import {RunStatus} from '../../graphql/types';
 import {PartitionStatus, PartitionStatusHealthSourceOps} from '../../partitions/PartitionStatus';
 import {useBlockTraceOnQueryResult} from '../../performance/TraceContext';
 import {PipelineReference} from '../../pipelines/PipelineReference';
 import {AssetKeyTagCollection} from '../../runs/AssetTagCollections';
 import {CreatedByTagCell} from '../../runs/CreatedByTag';
-import {inProgressStatuses} from '../../runs/RunStatuses';
 import {RunStatusTagsWithCounts} from '../../runs/RunTimeline';
 import {runsPathWithFilters} from '../../runs/RunsFilterInput';
 import {TimestampDisplay} from '../../schedules/TimestampDisplay';
@@ -386,11 +383,7 @@ const RequestedPartitionStatusBar = ({all, requested}: {all: string[]; requested
   return <PartitionStatus small hideStatusTooltip partitionNames={all} health={health} />;
 };
 
-export const BackfillStatusTag = ({
-  backfill,
-}: {
-  backfill: BackfillTableFragment;
-}) => {
+export const BackfillStatusTag = ({backfill}: {backfill: BackfillTableFragment}) => {
   return <BackfillStatusTagForPage backfill={backfill} />;
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
@@ -140,7 +140,7 @@ export const BackfillRowContent = ({
     statusQueryResult?.loading ? (
       <div style={{color: Colors.textLight()}}>Loading</div>
     ) : (
-      <BackfillStatusTag backfill={backfill} counts={counts} />
+      <BackfillStatusTag backfill={backfill} />
     );
 
   const renderRunStatus = () => {
@@ -388,51 +388,10 @@ const RequestedPartitionStatusBar = ({all, requested}: {all: string[]; requested
 
 export const BackfillStatusTag = ({
   backfill,
-  counts,
 }: {
   backfill: BackfillTableFragment;
-  counts: {[status: string]: number} | null;
 }) => {
-  if (backfill.isAssetBackfill) {
-    return <BackfillStatusTagForPage backfill={backfill} />;
-  }
-
-  switch (backfill.status) {
-    case BulkActionStatus.REQUESTED:
-      return <Tag>In progress</Tag>;
-    case BulkActionStatus.FAILED:
-      return (
-        <Box margin={{bottom: 12}}>
-          <TagButton
-            onClick={() =>
-              backfill.error &&
-              showCustomAlert({title: 'Error', body: <PythonErrorInfo error={backfill.error} />})
-            }
-          >
-            <Tag intent="danger">Failed</Tag>
-          </TagButton>
-        </Box>
-      );
-    case BulkActionStatus.COMPLETED:
-      if (backfill.partitionNames === null) {
-        return <Tag intent="success">Completed</Tag>;
-      }
-      if (!counts) {
-        return <div style={{color: Colors.textLight()}}>None</div>;
-      }
-      if (counts[RunStatus.SUCCESS] === backfill.partitionNames.length) {
-        return <Tag intent="success">Completed</Tag>;
-      }
-      if (Array.from(inProgressStatuses).some((status) => counts[status])) {
-        return <Tag intent="primary">In progress</Tag>;
-      }
-      return <Tag intent="warning">Incomplete</Tag>;
-    case BulkActionStatus.CANCELING:
-      return <Tag>Canceling</Tag>;
-    case BulkActionStatus.CANCELED:
-      return <Tag>Canceled</Tag>;
-  }
-  return <span />;
+  return <BackfillStatusTagForPage backfill={backfill} />;
 };
 
 const TagButton = styled.button`

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -103,7 +103,7 @@ def execute_job_backfill_iteration(
             for run in backfill_runs:
                 if run.status not in FINISHED_STATUSES:
                     logger.info(
-                        f"Backfill {backfill.backfill_id} has in progress runs. Status will be updated when all runs are finished."
+                        f"Backfill {backfill.backfill_id} has in-progress runs. Status will be updated when all runs are finished."
                     )
                     return
             partition_names = cast(Sequence[str], backfill.partition_names)
@@ -189,7 +189,7 @@ def _get_partitions_chunk(
     partition_names = partition_names[initial_checkpoint:]
     if len(partition_names) == 0:
         # no more partitions to submit, return early
-        return [], initial_checkpoint, False
+        return [], checkpoint or "", False
 
     backfill_policy = partition_set.backfill_policy
     if backfill_policy and backfill_policy.max_partitions_per_run != 1:

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -100,6 +100,14 @@ FINISHED_STATUSES = [
     DagsterRunStatus.CANCELED,
 ]
 
+NOT_FINISHED_STATUSES = [
+    DagsterRunStatus.STARTING,
+    DagsterRunStatus.STARTED,
+    DagsterRunStatus.CANCELING,
+    DagsterRunStatus.QUEUED,
+    DagsterRunStatus.NOT_STARTED,
+]
+
 # Run statuses for runs that can be safely canceled.
 # Does not include the other unfinished statuses for the following reasons:
 # STARTING: Control has been ceded to the run worker, which will eventually move the run to a STARTED.


### PR DESCRIPTION
## Summary & Motivation
the status for a job backfill and a pure asset backfill means different things. 

For a job backfill, the backfill is considered complete once all of the runs have been **submitted**. For a pure asset backfill, the backfill is considered complete once all runs have **finished**.

We also display the status differently in the UI:
For pure asset backfills, we mirror the backfill's status exactly
For job backfills, if the backfill has completed status, the backfill can be displayed as "In Progress" if runs are still in progress, or "Incomplete" if some runs have failed or were canceled manually.

This adds extra work for the front end and communicates different information to the user depending on what type of backfill was launched. 

This PR consolidates how we show the status of a backfill to the user on the system used by pure asset backfills. It updates the job backfill code to only be marked complete once all runs have finished. This lets us display the backfill status directly without having to do additional queries of run status.

In the future, we may want to break the COMPLETED status down to show if all runs were successful, or if some failed. But that will be future work and will be easier and more consistent now that job and asset backfills display status in the same way.

## How I Tested These Changes
new unit test. manually ran a backfill and confirmed that the backfill of a long-running job did not get COMPLETED status until after all runs had finished