### PR TITLE
Store reported asset events with sensor ticks

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2485,7 +2485,7 @@ class DagsterInstance(DynamicPartitionsStore):
         dagster_event: "DagsterEvent",
         run_id: str,
         log_level: Union[str, int] = logging.INFO,
-    ) -> "EventLogEntry":
+    ) -> None:
         """Takes a DagsterEvent and stores it in persistent storage for the corresponding DagsterRun."""
         from dagster._core.events.log import EventLogEntry
 
@@ -2500,7 +2500,6 @@ class DagsterInstance(DynamicPartitionsStore):
             dagster_event=dagster_event,
         )
         self.handle_new_event(event_record)
-        return event_record
 
     def report_run_canceling(self, run: DagsterRun, message: Optional[str] = None):
         from dagster._core.events import DagsterEvent, DagsterEventType

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2485,7 +2485,7 @@ class DagsterInstance(DynamicPartitionsStore):
         dagster_event: "DagsterEvent",
         run_id: str,
         log_level: Union[str, int] = logging.INFO,
-    ) -> None:
+    ) -> "EventLogEntry":
         """Takes a DagsterEvent and stores it in persistent storage for the corresponding DagsterRun."""
         from dagster._core.events.log import EventLogEntry
 
@@ -2500,6 +2500,7 @@ class DagsterInstance(DynamicPartitionsStore):
             dagster_event=dagster_event,
         )
         self.handle_new_event(event_record)
+        return event_record
 
     def report_run_canceling(self, run: DagsterRun, message: Optional[str] = None):
         from dagster._core.events import DagsterEvent, DagsterEventType

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -3455,12 +3455,11 @@ def test_asset_event_reporting_sensor(
 
         assert tick.tick_data.asset_events and len(tick.tick_data.asset_events) == 1
         asset_event = tick.tick_data.asset_events[0]
-        assert asset_event.dagster_event
-        assert asset_event.dagster_event.asset_key == AssetKey(["asset_one"])
+        assert asset_event.asset_key == AssetKey(["asset_one"])
 
         last_materialization = instance.get_latest_materialization_event(AssetKey(["asset_one"]))
         assert last_materialization
-        assert last_materialization.timestamp == asset_event.timestamp
+        assert last_materialization.asset_materialization == asset_event
 
 
 def _get_last_tick(instance, sensor):


### PR DESCRIPTION
## Summary

Persists asset materialization/observation/check events emitted from `SensorResult` with the associated instigator tick, giving us the option of displaying and/or linking to the events in the UI - right now they're not persisted at all and not visualized in the UI.


## Test Plan

Unit test ensuring data is saved properly to tick storage.
