### PR TITLE
Have `AssetsDefinition`s hold less info on unselected assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_computation.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_computation.py
@@ -86,8 +86,9 @@ class AssetGraphComputation(IHaveNew):
         for output_name, key in itertools.chain(
             self.keys_by_output_name.items(), self.check_keys_by_output_name.items()
         ):
-            output_def, node_handle = self.full_node_def.resolve_output_to_origin(output_name, None)
-            result[NodeOutputHandle(node_handle=node_handle, output_name=output_def.name)] = key
+            if key in self.selected_asset_keys or key in self.selected_asset_check_keys:
+                output_def, node_handle = self.node_def.resolve_output_to_origin(output_name, None)
+                result[NodeOutputHandle(node_handle=node_handle, output_name=output_def.name)] = key
 
         return result
 
@@ -215,13 +216,13 @@ class AssetGraphComputation(IHaveNew):
         path directly correspond to other assets.
         """
         asset_or_check_keys_by_op_output_handle = self.asset_or_check_keys_by_op_output_handle
-        if not isinstance(self.full_node_def, GraphDefinition):
+        if not isinstance(self.node_def, GraphDefinition):
             return {
                 key: {op_output_handle}
                 for key, op_output_handle in asset_or_check_keys_by_op_output_handle.items()
             }
 
-        op_output_graph = OpOutputHandleGraph.from_graph(self.full_node_def)
+        op_output_graph = OpOutputHandleGraph.from_graph(self.node_def)
         reverse_toposorted_op_outputs_handles = [
             *reversed(toposort_flatten(op_output_graph.upstream)),
             *(op_output_graph.op_output_handles - op_output_graph.upstream.keys()),

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -66,7 +66,7 @@ class AssetLayer(NamedTuple):
         for node_handle, assets_def in assets_defs_by_outer_node_handle.items():
             computation = check.not_none(assets_def.computation)
             node_def = computation.node_def
-            for input_name, input_asset_key in assets_def.keys_by_input_name.items():
+            for input_name, input_asset_key in assets_def.node_keys_by_input_name.items():
                 input_handle = NodeInputHandle(node_handle=node_handle, input_name=input_name)
                 asset_key_by_input[input_handle] = input_asset_key
                 # resolve graph input to list of op inputs that consume it

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -65,18 +65,18 @@ class AssetLayer(NamedTuple):
 
         for node_handle, assets_def in assets_defs_by_outer_node_handle.items():
             computation = check.not_none(assets_def.computation)
-            full_node_def = computation.full_node_def
-            for input_name, input_asset_key in assets_def.node_keys_by_input_name.items():
+            node_def = computation.node_def
+            for input_name, input_asset_key in assets_def.keys_by_input_name.items():
                 input_handle = NodeInputHandle(node_handle=node_handle, input_name=input_name)
                 asset_key_by_input[input_handle] = input_asset_key
                 # resolve graph input to list of op inputs that consume it
-                node_input_handles = full_node_def.resolve_input_to_destinations(input_handle)
+                node_input_handles = node_def.resolve_input_to_destinations(input_handle)
                 for node_input_handle in node_input_handles:
                     asset_key_by_input[node_input_handle] = input_asset_key
 
-            for output_name, asset_key in assets_def.node_keys_by_output_name.items():
+            for output_name, asset_key in assets_def.keys_by_output_name.items():
                 # resolve graph output to the op output it comes from
-                inner_output_def, inner_node_handle = full_node_def.resolve_output_to_origin(
+                inner_output_def, inner_node_handle = node_def.resolve_output_to_origin(
                     output_name, handle=node_handle
                 )
                 node_output_handle = NodeOutputHandle(
@@ -85,13 +85,11 @@ class AssetLayer(NamedTuple):
 
                 asset_keys_by_node_output_handle[node_output_handle] = asset_key
 
-                destinations = full_node_def.resolve_output_to_destinations(
-                    output_name, node_handle
-                )
+                destinations = node_def.resolve_output_to_destinations(output_name, node_handle)
                 for destination in destinations:
                     asset_key_by_input[destination] = asset_key
-                    if isinstance(full_node_def, GraphDefinition):
-                        for op_input_handle in full_node_def.get_node(
+                    if isinstance(node_def, GraphDefinition):
+                        for op_input_handle in node_def.get_node(
                             destination.node_handle.pop()
                         ).definition.resolve_input_to_destinations(destination):
                             asset_key_by_input[op_input_handle] = asset_key
@@ -245,14 +243,12 @@ class AssetLayer(NamedTuple):
         Calling downstream_dep_assets with node handle add_one will return:
         - {AssetKey("asset_two")} if output_name="result"
         """
-        assets_def = self.assets_defs_by_node_handle[node_handle]
+        computation = check.not_none(self.assets_defs_by_node_handle[node_handle].computation)
         return {
             key
-            for key in check.not_none(
-                assets_def.computation
-            ).asset_or_check_keys_by_dep_op_output_handle[
-                NodeOutputHandle(node_handle=node_handle.pop(), output_name=output_name)
-            ]
+            for key in computation.asset_or_check_keys_by_dep_op_output_handle.get(
+                NodeOutputHandle(node_handle=node_handle.pop(), output_name=output_name), []
+            )
         }
 
     def upstream_dep_op_handles(self, asset_key: AssetKey) -> AbstractSet[NodeHandle]:

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1324,6 +1324,10 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
                 "node_def": subsetted_computation.node_def,
                 "selected_asset_keys": subsetted_computation.selected_asset_keys,
                 "selected_asset_check_keys": subsetted_computation.selected_asset_check_keys,
+                "keys_by_input_name": {
+                    **self.node_keys_by_input_name,
+                    **subsetted_computation.keys_by_input_name,
+                },
                 "is_subset": True,
             }
         )

--- a/python_modules/dagster/dagster/_core/definitions/dependency.py
+++ b/python_modules/dagster/dagster/_core/definitions/dependency.py
@@ -65,7 +65,7 @@ class NodeInvocation(
     """Identifies an instance of a node in a graph dependency structure.
 
     Args:
-        name (str): Name of the node of which this is an instance.
+        name (str): Name of the node definition of which this is an instance.
         alias (Optional[str]): Name specific to this instance of the node. Necessary when there are
             multiple instances of the same node.
         tags (Optional[Dict[str, Any]]): Optional tags values to extend or override those
@@ -111,6 +111,10 @@ class NodeInvocation(
         if not hasattr(self, "_hash"):
             self._hash = hash_collection(self)
         return self._hash
+
+    @property
+    def resolved_name(self) -> str:
+        return self.alias or self.name
 
 
 class Node(ABC):
@@ -566,6 +570,11 @@ class NodeInput(NamedTuple("_NodeInput", [("node", Node), ("input_def", InputDef
     @property
     def input_name(self) -> str:
         return self.input_def.name
+
+    def to_handle(self, parent: Optional[NodeHandle]) -> NodeInputHandle:
+        return NodeInputHandle(
+            node_handle=NodeHandle(name=self.node_name, parent=parent), input_name=self.input_name
+        )
 
 
 class NodeOutput(NamedTuple("_NodeOutput", [("node", Node), ("output_def", OutputDefinition)])):

--- a/python_modules/dagster/dagster/_core/definitions/op_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_selection.py
@@ -220,9 +220,14 @@ def _get_graph_subset(
     ]
 
     return SubselectedGraphDefinition(
+        name=graph.name,
+        description=graph.description,
         parent_graph_def=graph,
+        config=graph.config_mapping,
+        tags=graph.tags,
         dependencies=subgraph_deps,
         node_defs=list(subgraph_nodes.values()),
         input_mappings=subgraph_input_mappings,
         output_mappings=subgraph_output_mappings,
+        input_assets=graph.input_assets,
     )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1530,7 +1530,7 @@ def test_graph_backed_asset_reused():
                 get_num_events(instance, result.run_id, DagsterEventType.ASSET_MATERIALIZATION) == 2
             )
             step_keys = get_step_keys_from_run(instance, result.run_id)
-            assert set(step_keys) == set(["graph_asset_2.foo", "duplicate_one_downstream"])
+            assert set(step_keys) == set(["graph_asset.foo", "duplicate_one_downstream"])
 
 
 def test_self_dependency():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1530,7 +1530,7 @@ def test_graph_backed_asset_reused():
                 get_num_events(instance, result.run_id, DagsterEventType.ASSET_MATERIALIZATION) == 2
             )
             step_keys = get_step_keys_from_run(instance, result.run_id)
-            assert set(step_keys) == set(["graph_asset.foo", "duplicate_one_downstream"])
+            assert set(step_keys) == set(["graph_asset_2.foo", "duplicate_one_downstream"])
 
 
 def test_self_dependency():


### PR DESCRIPTION
## Summary & Motivation

`AssetsDefinition` has a (non-public) `subset_for` method, which takes a set of asset and check keys and produces a "subselected" `AssetsDefinition` object that just targets those assets and checks.  The subselected object still holds full metadata about unselected assets, and in many cases when we're operating on `AssetsDefinition`s internally, we operate on keys not in the subset.

This leads to a confusing state where, any time you're operating on an `AssetsDefinition` internally, you need to always be thinking about whether you're operating on subsetted keys or all keys.

Having merged https://github.com/dagster-io/dagster/pull/23004, we mostly don't need to care about unselected keys anymore.

This PR excludes unselected keys from many of the internal data structures we use to track metadata about assets being executed.

The hairiest part of this PR.

## How I Tested These Changes
