### PR TITLE
[ui] remove partition statuses from backfill termination logic

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2788,6 +2788,7 @@ type PartitionBackfill {
   partitionSet: PartitionSet
   runs(limit: Int): [Run!]!
   unfinishedRuns(limit: Int): [Run!]!
+  cancelableRuns(limit: Int): [Run!]!
   error: PythonError
   partitionStatuses: PartitionStatuses
   partitionStatusCounts: [PartitionStatusCounts!]!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -3083,6 +3083,7 @@ export type PartitionBackfill = {
   __typename: 'PartitionBackfill';
   assetBackfillData: Maybe<AssetBackfillData>;
   assetSelection: Maybe<Array<AssetKey>>;
+  cancelableRuns: Array<Run>;
   description: Maybe<Scalars['String']['output']>;
   endTimestamp: Maybe<Scalars['Float']['output']>;
   error: Maybe<PythonError>;
@@ -3109,6 +3110,10 @@ export type PartitionBackfill = {
   title: Maybe<Scalars['String']['output']>;
   unfinishedRuns: Array<Run>;
   user: Maybe<Scalars['String']['output']>;
+};
+
+export type PartitionBackfillCancelableRunsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type PartitionBackfillLogEventsArgs = {
@@ -10731,6 +10736,8 @@ export const buildPartitionBackfill = (
         : buildAssetBackfillData({}, relationshipsToOmit),
     assetSelection:
       overrides && overrides.hasOwnProperty('assetSelection') ? overrides.assetSelection! : [],
+    cancelableRuns:
+      overrides && overrides.hasOwnProperty('cancelableRuns') ? overrides.cancelableRuns! : [],
     description:
       overrides && overrides.hasOwnProperty('description')
         ? overrides.description!

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillActionsMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillActionsMenu.tsx
@@ -18,7 +18,7 @@ import {ResumeBackfillMutation, ResumeBackfillMutationVariables} from './types/B
 import {showCustomAlert} from '../../app/CustomAlertProvider';
 import {showSharedToaster} from '../../app/DomUtils';
 import {PythonErrorInfo} from '../../app/PythonErrorInfo';
-import {BulkActionStatus, RunStatus} from '../../graphql/types';
+import {BulkActionStatus} from '../../graphql/types';
 import {runsPathWithFilters} from '../../runs/RunsFilterInput';
 
 export function backfillCanCancelSubmission(backfill: {
@@ -48,14 +48,12 @@ export function backfillCanResume(backfill: {
 
 export function backfillCanCancelRuns(
   backfill: {hasCancelPermission: boolean},
-  counts: {[runStatus: string]: number} | null,
+  hasCancelableRuns: boolean,
 ) {
-  if (!backfill.hasCancelPermission || !counts) {
+  if (!backfill.hasCancelPermission || !hasCancelableRuns) {
     return false;
   }
-  const queuedCount = counts[RunStatus.QUEUED] || 0;
-  const startedCount = counts[RunStatus.STARTED] || 0;
-  return queuedCount > 0 || startedCount > 0;
+  return hasCancelableRuns;
 }
 
 export const BackfillActionsMenu = ({

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
@@ -6,6 +6,10 @@ import styled from 'styled-components';
 
 import {BackfillActionsMenu, backfillCanCancelRuns} from './BackfillActionsMenu';
 import {BackfillStatusTagForPage} from './BackfillStatusTagForPage';
+import {
+  SingleBackfillQuery,
+  SingleBackfillQueryVariables,
+} from './types/BackfillRow.types';
 import {BackfillTableFragment} from './types/BackfillTable.types';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../../app/QueryRefresh';
 import {isHiddenAssetGroupJob} from '../../asset-graph/Utils';
@@ -63,9 +67,7 @@ export const BackfillRowLoader = (props: {
   const cancelableRuns = useLazyQuery<SingleBackfillQuery, SingleBackfillQueryVariables>(
     SINGLE_BACKFILL_CANCELABLE_RUNS_QUERY,
     {
-      variables: {
-        backfillId: {backfillId},
-      },
+      variables: {backfillId},
       notifyOnNetworkStatusChange: true,
     },
   );
@@ -81,9 +83,12 @@ export const BackfillRowLoader = (props: {
     if (data?.partitionBackfillOrError.__typename !== 'PartitionBackfill') {
       return {cancelable_counts: null};
     }
-    const cancelable_counts = Object.fromEntries(Array.from(cancelableStatuses).map((status) => [status.toString(), data.partitionBackfillOrError.cancelableRuns.filter((run) => run.status === status).length])
-    );
-    return {cancelable_counts};
+    if ('cancelableRuns' in data.partitionBackfillOrError) {
+      const cancelable_counts = Object.fromEntries(Array.from(cancelableStatuses).map((status) => [status.toString(), data.partitionBackfillOrError.cancelableRuns.filter((run) => run.status === status).length])
+      );
+      return {cancelable_counts};
+    };
+    return {cancelable_counts: null};
 
   }, [data]);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
@@ -6,10 +6,6 @@ import styled from 'styled-components';
 
 import {BackfillActionsMenu, backfillCanCancelRuns} from './BackfillActionsMenu';
 import {BackfillStatusTagForPage} from './BackfillStatusTagForPage';
-import {
-  SingleBackfillCountsQuery,
-  SingleBackfillCountsQueryVariables,
-} from './types/BackfillRow.types';
 import {BackfillTableFragment} from './types/BackfillTable.types';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../../app/QueryRefresh';
 import {isHiddenAssetGroupJob} from '../../asset-graph/Utils';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillTerminationDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillTerminationDialog.tsx
@@ -11,7 +11,6 @@ import {
 } from './types/BackfillTerminationDialog.types';
 import {PYTHON_ERROR_FRAGMENT} from '../../app/PythonErrorFragment';
 import {BulkActionStatus} from '../../graphql/types';
-import {cancelableStatuses} from '../../runs/RunStatuses';
 import {TerminationDialog} from '../../runs/TerminationDialog';
 
 interface Props {

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillTerminationDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillTerminationDialog.tsx
@@ -2,7 +2,7 @@ import {gql, useMutation, useQuery} from '@apollo/client';
 import {Button, Dialog, DialogBody, DialogFooter} from '@dagster-io/ui-components';
 import {useMemo, useState} from 'react';
 
-import {SINGLE_BACKFILL_STATUS_DETAILS_QUERY} from './BackfillRow';
+import {SINGLE_BACKFILL_CANCELABLE_RUNS_QUERY} from './BackfillRow';
 import {SingleBackfillQuery, SingleBackfillQueryVariables} from './types/BackfillRow.types';
 import {
   BackfillTerminationDialogBackfillFragment,
@@ -25,7 +25,7 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
     CANCEL_BACKFILL_MUTATION,
   );
   const {data} = useQuery<SingleBackfillQuery, SingleBackfillQueryVariables>(
-    SINGLE_BACKFILL_STATUS_DETAILS_QUERY,
+    SINGLE_BACKFILL_CANCELABLE_RUNS_QUERY,
     {
       variables: {
         backfillId: backfill?.id || '',
@@ -39,15 +39,11 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
     if (!backfill || !data || data.partitionBackfillOrError.__typename !== 'PartitionBackfill') {
       return {};
     }
-    const unfinishedPartitions = data.partitionBackfillOrError.partitionStatuses?.results.filter(
-      (partition) =>
-        partition.runStatus && partition.runId && cancelableStatuses.has(partition.runStatus),
-    );
     return (
-      unfinishedPartitions?.reduce(
-        (accum, partition) => {
-          if (partition && partition.runId) {
-            accum[partition.runId] = true;
+      data.partitionBackfillOrError.cancelableRuns?.reduce(
+        (accum, run) => {
+          if (run && run.runId) {
+            accum[run.runId] = true;
           }
           return accum;
         },

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__fixtures__/BackfillTable.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__fixtures__/BackfillTable.fixtures.ts
@@ -12,13 +12,13 @@ import {
   buildPartitionStatuses,
   buildPythonError,
   buildRepositoryOrigin,
+  buildRun,
 } from '../../../graphql/types';
 import {DagsterTag} from '../../../runs/RunTag';
 import {
-  SINGLE_BACKFILL_STATUS_COUNTS_QUERY,
-  SINGLE_BACKFILL_STATUS_DETAILS_QUERY,
+  SINGLE_BACKFILL_CANCELABLE_RUNS_QUERY,
 } from '../BackfillRow';
-import {SingleBackfillCountsQuery, SingleBackfillQuery} from '../types/BackfillRow.types';
+import {SingleBackfillQuery} from '../types/BackfillRow.types';
 import {BackfillTableFragment} from '../types/BackfillTable.types';
 
 function buildTimePartitionNames(start: Date, count: number) {
@@ -50,39 +50,6 @@ export const BackfillTableFragmentRequested2000AssetsPure: BackfillTableFragment
       }),
     ],
   });
-
-export const BackfillTableFragmentRequested2000AssetsPureStatus: MockedResponse<SingleBackfillCountsQuery> =
-  {
-    request: {
-      query: SINGLE_BACKFILL_STATUS_COUNTS_QUERY,
-      variables: {
-        backfillId: 'qtpussca',
-      },
-    },
-    result: {
-      data: {
-        __typename: 'Query',
-        partitionBackfillOrError: buildPartitionBackfill({
-          id: 'qtpussca',
-          isAssetBackfill: true,
-          partitionStatusCounts: [
-            buildPartitionStatusCounts({
-              runStatus: RunStatus.NOT_STARTED,
-              count: 108088,
-            }),
-            buildPartitionStatusCounts({
-              runStatus: RunStatus.SUCCESS,
-              count: 71,
-            }),
-            buildPartitionStatusCounts({
-              runStatus: RunStatus.FAILURE,
-              count: 10,
-            }),
-          ],
-        }),
-      },
-    },
-  };
 
 export const BackfillTableFragmentCancelledAssetsPartitionSet: BackfillTableFragment =
   buildPartitionBackfill({
@@ -125,27 +92,6 @@ export const BackfillTableFragmentCancelledAssetsPartitionSet: BackfillTableFrag
     ],
   });
 
-export const BackfillTableFragmentCancelledAssetsPartitionSetStatus: MockedResponse<SingleBackfillCountsQuery> =
-  {
-    request: {
-      query: SINGLE_BACKFILL_STATUS_COUNTS_QUERY,
-      variables: {
-        backfillId: 'tclwoggv',
-      },
-    },
-    result: {
-      data: {
-        __typename: 'Query',
-        partitionBackfillOrError: buildPartitionBackfill({
-          id: 'tclwoggv',
-          partitionStatusCounts: [
-            {runStatus: RunStatus.NOT_STARTED, count: 6524, __typename: 'PartitionStatusCounts'},
-          ],
-        }),
-      },
-    },
-  };
-
 export const BackfillTableFragmentFailedError: BackfillTableFragment = buildPartitionBackfill({
   id: 'sjqzcfhe',
   status: BulkActionStatus.FAILED,
@@ -173,7 +119,7 @@ export const BackfillTableFragmentFailedError: BackfillTableFragment = buildPart
 
 export const BackfillTableFragmentFailedErrorStatus: MockedResponse<SingleBackfillQuery> = {
   request: {
-    query: SINGLE_BACKFILL_STATUS_DETAILS_QUERY,
+    query: SINGLE_BACKFILL_CANCELABLE_RUNS_QUERY,
     variables: {
       backfillId: 'sjqzcfhe',
     },
@@ -183,16 +129,7 @@ export const BackfillTableFragmentFailedErrorStatus: MockedResponse<SingleBackfi
       __typename: 'Query',
       partitionBackfillOrError: buildPartitionBackfill({
         id: 'sjqzcfhe',
-        partitionStatuses: buildPartitionStatuses({
-          results: BackfillTableFragmentFailedError.partitionNames!.map((n) =>
-            buildPartitionStatus({
-              id: `__NO_PARTITION_SET__:${n}:ccpbwdbq`,
-              partitionName: n,
-              runId: null,
-              runStatus: null,
-            }),
-          ),
-        }),
+        cancelableRuns: [],
       }),
     },
   },
@@ -252,7 +189,7 @@ export const BackfillTableFragmentCompletedAssetJob: BackfillTableFragment = bui
 
 export const BackfillTableFragmentCompletedAssetJobStatus: MockedResponse<SingleBackfillQuery> = {
   request: {
-    query: SINGLE_BACKFILL_STATUS_DETAILS_QUERY,
+    query: SINGLE_BACKFILL_CANCELABLE_RUNS_QUERY,
     variables: {
       backfillId: 'pwgcpiwc',
     },
@@ -262,88 +199,7 @@ export const BackfillTableFragmentCompletedAssetJobStatus: MockedResponse<Single
       __typename: 'Query',
       partitionBackfillOrError: {
         id: 'pwgcpiwc',
-        partitionStatuses: {
-          results: [
-            {
-              id: 'asset_job_partition_set:TN|2023-01-24:pwgcpiwc',
-              partitionName: 'TN|2023-01-24',
-              runId: 'f9060b59-44aa-4cc1-aac2-f1365ed3c4da',
-              runStatus: RunStatus.SUCCESS,
-              __typename: 'PartitionStatus',
-            },
-            {
-              id: 'asset_job_partition_set:VA|2023-01-24:pwgcpiwc',
-              partitionName: 'VA|2023-01-24',
-              runId: '719b32bc-d345-40f2-acf1-99d99bbd8b7f',
-              runStatus: RunStatus.SUCCESS,
-              __typename: 'PartitionStatus',
-            },
-            {
-              id: 'asset_job_partition_set:GA|2023-01-24:pwgcpiwc',
-              partitionName: 'GA|2023-01-24',
-              runId: 'c85345e4-ad71-47b7-9add-f73b02f57c65',
-              runStatus: RunStatus.SUCCESS,
-              __typename: 'PartitionStatus',
-            },
-            {
-              id: 'asset_job_partition_set:KY|2023-01-24:pwgcpiwc',
-              partitionName: 'KY|2023-01-24',
-              runId: 'f0b90d88-5b33-4287-92af-8b6b9e934ff4',
-              runStatus: RunStatus.SUCCESS,
-              __typename: 'PartitionStatus',
-            },
-            {
-              id: 'asset_job_partition_set:PA|2023-01-24:pwgcpiwc',
-              partitionName: 'PA|2023-01-24',
-              runId: 'cfa8f88a-5b65-486b-ab2c-841dd8c711fa',
-              runStatus: RunStatus.SUCCESS,
-              __typename: 'PartitionStatus',
-            },
-            {
-              id: 'asset_job_partition_set:NC|2023-01-24:pwgcpiwc',
-              partitionName: 'NC|2023-01-24',
-              runId: '1b59a3a2-98c7-495c-8758-6c689ac14f05',
-              runStatus: RunStatus.SUCCESS,
-              __typename: 'PartitionStatus',
-            },
-            {
-              id: 'asset_job_partition_set:SC|2023-01-24:pwgcpiwc',
-              partitionName: 'SC|2023-01-24',
-              runId: '0ac8630e-5467-48db-8fd1-c9d45bad382d',
-              runStatus: RunStatus.SUCCESS,
-              __typename: 'PartitionStatus',
-            },
-            {
-              id: 'asset_job_partition_set:FL|2023-01-24:pwgcpiwc',
-              partitionName: 'FL|2023-01-24',
-              runId: 'efb4a01d-4187-40b8-b9be-8b683173698e',
-              runStatus: RunStatus.SUCCESS,
-              __typename: 'PartitionStatus',
-            },
-            {
-              id: 'asset_job_partition_set:OH|2023-01-24:pwgcpiwc',
-              partitionName: 'OH|2023-01-24',
-              runId: '98778750-c49a-4896-9d39-6b36554f41ab',
-              runStatus: RunStatus.SUCCESS,
-              __typename: 'PartitionStatus',
-            },
-            {
-              id: 'asset_job_partition_set:IL|2023-01-24:pwgcpiwc',
-              partitionName: 'IL|2023-01-24',
-              runId: '8bab80df-571a-4dbc-9a08-9c3c33c962a6',
-              runStatus: RunStatus.SUCCESS,
-              __typename: 'PartitionStatus',
-            },
-            {
-              id: 'asset_job_partition_set:WV|2023-01-24:pwgcpiwc',
-              partitionName: 'WV|2023-01-24',
-              runId: 'fc54444c-4c28-485b-b581-53ea5ce287f2',
-              runStatus: RunStatus.SUCCESS,
-              __typename: 'PartitionStatus',
-            },
-          ],
-          __typename: 'PartitionStatuses',
-        },
+        cancelableRuns: [],
         __typename: 'PartitionBackfill',
       },
     },
@@ -378,7 +234,7 @@ export const BackfillTableFragmentCompletedOpJob: BackfillTableFragment = buildP
 
 export const BackfillTableFragmentCompletedOpJobStatus: MockedResponse<SingleBackfillQuery> = {
   request: {
-    query: SINGLE_BACKFILL_STATUS_DETAILS_QUERY,
+    query: SINGLE_BACKFILL_CANCELABLE_RUNS_QUERY,
     variables: {
       backfillId: 'pqdiepuf',
     },
@@ -389,34 +245,7 @@ export const BackfillTableFragmentCompletedOpJobStatus: MockedResponse<SingleBac
       partitionBackfillOrError: buildPartitionBackfill({
         id: 'pqdiepuf',
         isAssetBackfill: true,
-        partitionStatuses: buildPartitionStatuses({
-          results: [
-            buildPartitionStatus({
-              id: 'op_job_partition_set:2022-07-01:pqdiepuf',
-              partitionName: '2022-07-01',
-              runId: '5cb9f428-1721-45d5-979e-64e0376aad1a',
-              runStatus: RunStatus.FAILURE,
-            }),
-            buildPartitionStatus({
-              id: 'op_job_partition_set:2022-08-01:pqdiepuf',
-              partitionName: '2022-08-01',
-              runId: '7d76bc38-db6c-4d77-b3c2-38b1a3b69ed9',
-              runStatus: RunStatus.FAILURE,
-            }),
-            buildPartitionStatus({
-              id: 'op_job_partition_set:2022-09-01:pqdiepuf',
-              partitionName: '2022-09-01',
-              runId: 'ca54267a-225c-491a-ad71-f6f3e0e868eb',
-              runStatus: RunStatus.SUCCESS,
-            }),
-            buildPartitionStatus({
-              id: 'op_job_partition_set:2022-10-01:pqdiepuf',
-              partitionName: '2022-10-01',
-              runId: '1baeadb4-7e7d-47e5-aeac-8a5f921cf27c',
-              runStatus: RunStatus.QUEUED,
-            }),
-          ],
-        }),
+        cancelableRuns: [buildRun({runId: '1baeadb4-7e7d-47e5-aeac-8a5f921cf27c', status: RunStatus.QUEUED})],
       }),
     },
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__fixtures__/BackfillTable.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__fixtures__/BackfillTable.fixtures.ts
@@ -7,17 +7,12 @@ import {
   buildErrorChainLink,
   buildPartitionBackfill,
   buildPartitionSet,
-  buildPartitionStatus,
-  buildPartitionStatusCounts,
-  buildPartitionStatuses,
   buildPythonError,
   buildRepositoryOrigin,
   buildRun,
 } from '../../../graphql/types';
 import {DagsterTag} from '../../../runs/RunTag';
-import {
-  SINGLE_BACKFILL_CANCELABLE_RUNS_QUERY,
-} from '../BackfillRow';
+import {SINGLE_BACKFILL_CANCELABLE_RUNS_QUERY} from '../BackfillRow';
 import {SingleBackfillQuery} from '../types/BackfillRow.types';
 import {BackfillTableFragment} from '../types/BackfillTable.types';
 
@@ -245,7 +240,9 @@ export const BackfillTableFragmentCompletedOpJobStatus: MockedResponse<SingleBac
       partitionBackfillOrError: buildPartitionBackfill({
         id: 'pqdiepuf',
         isAssetBackfill: true,
-        cancelableRuns: [buildRun({runId: '1baeadb4-7e7d-47e5-aeac-8a5f921cf27c', status: RunStatus.QUEUED})],
+        cancelableRuns: [
+          buildRun({runId: '1baeadb4-7e7d-47e5-aeac-8a5f921cf27c', status: RunStatus.QUEUED}),
+        ],
       }),
     },
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__stories__/BackfillTable.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/__stories__/BackfillTable.stories.tsx
@@ -3,11 +3,9 @@ import {MockedProvider} from '@apollo/client/testing';
 import {StorybookProvider} from '../../../testing/StorybookProvider';
 import {BackfillTable} from '../BackfillTable';
 import {
-  BackfillTableFragmentCancelledAssetsPartitionSetStatus,
   BackfillTableFragmentCompletedAssetJobStatus,
   BackfillTableFragmentCompletedOpJobStatus,
   BackfillTableFragmentFailedErrorStatus,
-  BackfillTableFragmentRequested2000AssetsPureStatus,
   BackfillTableFragments,
 } from '../__fixtures__/BackfillTable.fixtures';
 
@@ -22,8 +20,6 @@ export const GeneralStates = () => {
     <StorybookProvider>
       <MockedProvider
         mocks={[
-          BackfillTableFragmentRequested2000AssetsPureStatus,
-          BackfillTableFragmentCancelledAssetsPartitionSetStatus,
           BackfillTableFragmentCompletedOpJobStatus,
           BackfillTableFragmentCompletedAssetJobStatus,
           BackfillTableFragmentFailedErrorStatus,

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillRow.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillRow.types.ts
@@ -2,26 +2,6 @@
 
 import * as Types from '../../../graphql/types';
 
-export type SingleBackfillCountsQueryVariables = Types.Exact<{
-  backfillId: Types.Scalars['String']['input'];
-}>;
-
-export type SingleBackfillCountsQuery = {
-  __typename: 'Query';
-  partitionBackfillOrError:
-    | {__typename: 'BackfillNotFoundError'}
-    | {
-        __typename: 'PartitionBackfill';
-        id: string;
-        partitionStatusCounts: Array<{
-          __typename: 'PartitionStatusCounts';
-          runStatus: Types.RunStatus;
-          count: number;
-        }>;
-      }
-    | {__typename: 'PythonError'};
-};
-
 export type SingleBackfillQueryVariables = Types.Exact<{
   backfillId: Types.Scalars['String']['input'];
 }>;
@@ -33,27 +13,12 @@ export type SingleBackfillQuery = {
     | {
         __typename: 'PartitionBackfill';
         id: string;
-        partitionStatuses: {
-          __typename: 'PartitionStatuses';
-          results: Array<{
-            __typename: 'PartitionStatus';
-            id: string;
-            partitionName: string;
-            runId: string | null;
-            runStatus: Types.RunStatus | null;
-          }>;
-        } | null;
+        cancelableRuns: Array<{
+          __typename: 'Run';
+          id: string;
+          runId: string;
+          status: Types.RunStatus;
+        }>;
       }
     | {__typename: 'PythonError'};
-};
-
-export type PartitionStatusesForBackfillFragment = {
-  __typename: 'PartitionStatuses';
-  results: Array<{
-    __typename: 'PartitionStatus';
-    id: string;
-    partitionName: string;
-    runId: string | null;
-    runStatus: Types.RunStatus | null;
-  }>;
 };

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -299,6 +299,9 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         non_null_list("dagster_graphql.schema.pipelines.pipeline.GrapheneRun"),
         limit=graphene.Int(),
     )
+    cancelableRuns = graphene.Field(
+        non_null_list("dagster_graphql.schema.pipelines.pipeline.GrapheneRun"), limit=graphene.Int()
+    )
     error = graphene.Field(GraphenePythonError)
     partitionStatuses = graphene.Field(
         "dagster_graphql.schema.partition_sets.GraphenePartitionStatuses"
@@ -428,6 +431,12 @@ class GraphenePartitionBackfill(graphene.ObjectType):
 
         records = self._get_records(graphene_info)
         return [GrapheneRun(record) for record in records if not record.dagster_run.is_finished]
+
+    def resolve_cancelableRuns(self, graphene_info: ResolveInfo) -> Sequence["GrapheneRun"]:
+        from .pipelines.pipeline import GrapheneRun
+
+        records = self._get_records(graphene_info)
+        return [GrapheneRun(record) for record in records if not record.dagster_run.is_cancelable]
 
     def resolve_runs(self, graphene_info: ResolveInfo) -> "Sequence[GrapheneRun]":
         from .pipelines.pipeline import GrapheneRun

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -448,6 +448,12 @@ class DagsterRun(
 
     @public
     @property
+    def is_cancelable(self) -> bool:
+        """bool: If this run an be canceled."""
+        return self.status in CANCELABLE_RUN_STATUSES
+
+    @public
+    @property
     def is_success(self) -> bool:
         """bool: If this run has successfully finished executing."""
         return self.status == DagsterRunStatus.SUCCESS


### PR DESCRIPTION
## Summary & Motivation
As discussed in https://github.com/dagster-io/dagster/pull/23143, there are issues loading per-partition status for asset-job backfills. The `PartitionStatusCounts` field on `PartitionBackfill` also uses this partition status information and the backfill cancelation action uses the status counts to determine if it can cancel the backfill. We need to get the same information another way, so this PR introduces a new field on `PartitionBackfill` - `cancelableRuns` which returns any runs that are part of the backfill and are in a cancelable state. This lets us remove the problematic queries from the backfill pages entirely

## How I Tested These Changes
