### PR TITLE
Move Definitions to definitions.py in scaffold

### DIFF
--- a/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/CODE_LOCATION_NAME_PLACEHOLDER/__init__.py
+++ b/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/CODE_LOCATION_NAME_PLACEHOLDER/__init__.py
@@ -1,9 +1,0 @@
-from dagster import Definitions, load_assets_from_modules
-
-from . import assets
-
-all_assets = load_assets_from_modules([assets])
-
-defs = Definitions(
-    assets=all_assets,
-)

--- a/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/CODE_LOCATION_NAME_PLACEHOLDER/definitions.py
+++ b/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/CODE_LOCATION_NAME_PLACEHOLDER/definitions.py
@@ -1,0 +1,9 @@
+from dagster import Definitions, load_assets_from_modules
+
+from . import assets
+
+all_assets = load_assets_from_modules([assets])
+
+defs = Definitions(
+    assets=all_assets,
+)

--- a/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/pyproject.toml.tmpl
+++ b/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/pyproject.toml.tmpl
@@ -3,4 +3,5 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.dagster]
-module_name = "{{ code_location_name }}"
+module_name = "{{ code_location_name }}.definitions"
+code_location_name = "{{ code_location_name }}"

--- a/python_modules/dagster/dagster_tests/cli_tests/test_project_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_project_commands.py
@@ -48,7 +48,7 @@ def test_project_scaffold_command_succeeds():
         # test target loadable
         origins = get_origins_from_toml("my_dagster_project/pyproject.toml")
         assert len(origins) == 1
-        assert origins[0].loadable_target_origin.module_name == "my_dagster_project"
+        assert origins[0].loadable_target_origin.module_name == "my_dagster_project.definitions"
 
 
 def test_scaffold_code_location_scaffold_command_fails_when_dir_path_exists():
@@ -73,7 +73,7 @@ def test_scaffold_code_location_command_succeeds():
         # test target loadable
         origins = get_origins_from_toml("my_dagster_code/pyproject.toml")
         assert len(origins) == 1
-        assert origins[0].loadable_target_origin.module_name == "my_dagster_code"
+        assert origins[0].loadable_target_origin.module_name == "my_dagster_code.definitions"
 
 
 def test_from_example_command_fails_when_example_not_available():


### PR DESCRIPTION
## Summary & Motivation

This PR updates the scaffold - it removes Definitions from `__init__.py` and add them to `definitions.py`.

## How I Tested These Changes

`dagster project scaffold --name my-dagster-project`
BK with alread existing tests
