### PR TITLE
[ui] Fix tag misalignment on TickTagForRun

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/TickTagForRun.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/TickTagForRun.tsx
@@ -1,4 +1,4 @@
-import {ButtonLink, MiddleTruncate, Tag} from '@dagster-io/ui-components';
+import {Box, ButtonLink, MiddleTruncate, Tag} from '@dagster-io/ui-components';
 import {useState} from 'react';
 
 import {DagsterTag} from './RunTag';
@@ -19,14 +19,14 @@ export const TickTagForRun = ({instigationSelector, instigationType, tickId}: Pr
   return (
     <>
       <Tag icon={icon}>
-        <span>
-          Launched by{' '}
+        <Box flex={{direction: 'row'}}>
+          <span>Launched by&nbsp;</span>
           <ButtonLink onClick={() => setIsOpen(true)}>
             <div style={{maxWidth: '140px'}}>
               <MiddleTruncate text={name} />
             </div>
           </ButtonLink>
-        </span>
+        </Box>
       </Tag>
       <TickDetailsDialog
         isOpen={isOpen}


### PR DESCRIPTION
## Summary & Motivation

Repair misalignment of text and button-link in `TickTagForRun`.

<img width="269" alt="Screenshot 2024-07-22 at 16 13 13" src="https://github.com/user-attachments/assets/9cfe45ec-cf4e-455d-8e2b-b71732ac5dc7">


## How I Tested These Changes

View a run launched by a schedule, verify correct alignment of elements.

Tested in Chrome, FF, Safari.