### PR TITLE
Update examples to remove Dagster code from __init__.py (part 1)

### DIFF
--- a/examples/development_to_production/development_to_production/__init__.py
+++ b/examples/development_to_production/development_to_production/__init__.py
@@ -1,1 +1,0 @@
-from .definitions import defs as defs

--- a/examples/development_to_production/development_to_production/assets/__init__.py
+++ b/examples/development_to_production/development_to_production/assets/__init__.py
@@ -1,5 +1,0 @@
-from .hacker_news_assets import (
-    comments as comments,
-    items as items,
-    stories as stories,
-)

--- a/examples/development_to_production/development_to_production/definitions.py
+++ b/examples/development_to_production/development_to_production/definitions.py
@@ -3,7 +3,7 @@ import os
 from dagster import Definitions, EnvVar
 from dagster_snowflake_pandas import SnowflakePandasIOManager
 
-from development_to_production.assets import comments, items, stories
+from development_to_production.assets.hacker_news_assets import comments, items, stories
 from development_to_production.resources import HNAPIClient
 
 resource_defs = {

--- a/examples/development_to_production/development_to_production_tests/test_assets.py
+++ b/examples/development_to_production/development_to_production_tests/test_assets.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from dagster import build_asset_context
 
-from development_to_production.assets import comments, items, stories
+from development_to_production.assets.hacker_news_assets import comments, items, stories
 from development_to_production.resources import StubHNClient
 
 

--- a/examples/development_to_production/pyproject.toml
+++ b/examples/development_to_production/pyproject.toml
@@ -3,4 +3,5 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.dagster]
-module_name = "development_to_production"
+module_name = "development_to_production.definitions"
+code_location_name = "development_to_production"

--- a/examples/feature_graph_backed_assets/feature_graph_backed_assets/__init__.py
+++ b/examples/feature_graph_backed_assets/feature_graph_backed_assets/__init__.py
@@ -1,1 +1,1 @@
-from .definitions import defs as defs
+

--- a/examples/feature_graph_backed_assets/feature_graph_backed_assets/assets/__init__.py
+++ b/examples/feature_graph_backed_assets/feature_graph_backed_assets/assets/__init__.py
@@ -1,1 +1,0 @@
-from .airlines import passenger_flights as passenger_flights

--- a/examples/feature_graph_backed_assets/feature_graph_backed_assets_tests/test_assets.py
+++ b/examples/feature_graph_backed_assets/feature_graph_backed_assets_tests/test_assets.py
@@ -1,6 +1,6 @@
 from dagster._core.test_utils import instance_for_test
 
-from feature_graph_backed_assets import defs
+from feature_graph_backed_assets.definitions import defs
 
 
 def test_feature_graph_backed_assets():

--- a/examples/feature_graph_backed_assets/pyproject.toml
+++ b/examples/feature_graph_backed_assets/pyproject.toml
@@ -3,4 +3,5 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.dagster]
-module_name = "feature_graph_backed_assets"
+module_name = "feature_graph_backed_assets.definitions"
+code_location_name = "feature_graph_backed_assets"

--- a/examples/quickstart_aws/pyproject.toml
+++ b/examples/quickstart_aws/pyproject.toml
@@ -3,4 +3,5 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.dagster]
-module_name = "quickstart_aws"
+module_name = "quickstart_aws.definitions"
+code_location_name = "quickstart_aws"

--- a/examples/quickstart_aws/quickstart_aws/__init__.py
+++ b/examples/quickstart_aws/quickstart_aws/__init__.py
@@ -1,1 +1,1 @@
-from .definitions import defs as defs
+

--- a/examples/quickstart_aws/quickstart_aws_tests/test_defs.py
+++ b/examples/quickstart_aws/quickstart_aws_tests/test_defs.py
@@ -1,4 +1,4 @@
-from quickstart_aws import defs
+from quickstart_aws.definitions import defs
 
 
 def test_def_can_load():

--- a/examples/quickstart_etl/pyproject.toml
+++ b/examples/quickstart_etl/pyproject.toml
@@ -3,4 +3,5 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.dagster]
-module_name = "quickstart_etl"
+module_name = "quickstart_etl.definitions"
+code_location_name = "quickstart_etl"

--- a/examples/quickstart_etl/quickstart_etl/__init__.py
+++ b/examples/quickstart_etl/quickstart_etl/__init__.py
@@ -1,1 +1,0 @@
-from .definitions import defs as defs

--- a/examples/quickstart_etl/quickstart_etl_tests/test_defs.py
+++ b/examples/quickstart_etl/quickstart_etl_tests/test_defs.py
@@ -1,4 +1,4 @@
-from quickstart_etl import defs
+from quickstart_etl.definitions import defs
 
 
 def test_def_can_load():

--- a/examples/quickstart_gcp/pyproject.toml
+++ b/examples/quickstart_gcp/pyproject.toml
@@ -3,4 +3,5 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.dagster]
-module_name = "quickstart_gcp"
+module_name = "quickstart_gcp.definitions"
+code_location_name = "quickstart_gcp"

--- a/examples/quickstart_gcp/quickstart_gcp/__init__.py
+++ b/examples/quickstart_gcp/quickstart_gcp/__init__.py
@@ -1,1 +1,1 @@
-from .definitions import defs as defs
+

--- a/examples/quickstart_gcp/quickstart_gcp_tests/test_defs.py
+++ b/examples/quickstart_gcp/quickstart_gcp_tests/test_defs.py
@@ -1,4 +1,4 @@
-from quickstart_gcp import defs
+from quickstart_gcp.definitions import defs
 
 
 def test_def_can_load():

--- a/examples/quickstart_snowflake/pyproject.toml
+++ b/examples/quickstart_snowflake/pyproject.toml
@@ -3,4 +3,5 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.dagster]
-module_name = "quickstart_snowflake"
+module_name = "quickstart_snowflake.definitions"
+code_location_name = "quickstart_snowflake"

--- a/examples/quickstart_snowflake/quickstart_snowflake/__init__.py
+++ b/examples/quickstart_snowflake/quickstart_snowflake/__init__.py
@@ -1,1 +1,0 @@
-from .definitions import defs as defs

--- a/examples/quickstart_snowflake/quickstart_snowflake_tests/test_defs.py
+++ b/examples/quickstart_snowflake/quickstart_snowflake_tests/test_defs.py
@@ -1,4 +1,4 @@
-from quickstart_snowflake import defs
+from quickstart_snowflake.definitions import defs
 
 
 def test_def_can_load():

--- a/examples/with_great_expectations/pyproject.toml
+++ b/examples/with_great_expectations/pyproject.toml
@@ -3,4 +3,5 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.dagster]
-module_name = "with_great_expectations"
+module_name = "with_great_expectations.definitions"
+code_location_name = "with_great_expectations"

--- a/examples/with_great_expectations/with_great_expectations/__init__.py
+++ b/examples/with_great_expectations/with_great_expectations/__init__.py
@@ -1,1 +1,0 @@
-from .definitions import defs as defs

--- a/examples/with_great_expectations/with_great_expectations_tests/test_ge_example.py
+++ b/examples/with_great_expectations/with_great_expectations_tests/test_ge_example.py
@@ -3,7 +3,7 @@ from dagster import RunConfig
 from dagster._utils import file_relative_path
 from dagster_ge.factory import GEContextResource
 
-from with_great_expectations import defs
+from with_great_expectations.definitions import defs
 from with_great_expectations.ge_demo import GEOpConfig, payroll_data
 
 

--- a/examples/with_openai/pyproject.toml
+++ b/examples/with_openai/pyproject.toml
@@ -3,4 +3,5 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.dagster]
-module_name = "with_openai"
+module_name = "with_openai.definitions"
+code_location_name = "with_openai"

--- a/examples/with_openai/with_openai/__init__.py
+++ b/examples/with_openai/with_openai/__init__.py
@@ -1,1 +1,1 @@
-from .definitions import defs as defs
+

--- a/examples/with_openai/with_openai_tests/test_defs.py
+++ b/examples/with_openai/with_openai_tests/test_defs.py
@@ -1,4 +1,4 @@
-from with_openai import defs
+from with_openai.definitions import defs
 
 
 def test_defs():

--- a/examples/with_wandb/pyproject.toml
+++ b/examples/with_wandb/pyproject.toml
@@ -3,4 +3,5 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.dagster]
-module_name = "with_wandb"
+module_name = "with_wandb.definitions"
+code_location_name = "with_wandb"

--- a/examples/with_wandb/with_wandb/__init__.py
+++ b/examples/with_wandb/with_wandb/__init__.py
@@ -1,1 +1,0 @@
-from .definitions import defs as defs

--- a/examples/with_wandb/with_wandb_tests/test_basic_wandb_example.py
+++ b/examples/with_wandb/with_wandb_tests/test_basic_wandb_example.py
@@ -1,4 +1,4 @@
-from with_wandb import defs
+from with_wandb.definitions import defs
 
 
 def test_defs_can_load():

--- a/examples/with_wandb/workspace.yaml
+++ b/examples/with_wandb/workspace.yaml
@@ -1,2 +1,2 @@
 load_from:
-  - python_module: with_wandb
+  - python_module: with_wandb.definitions


### PR DESCRIPTION
## Summary & Motivation

Follow-up to PR #20771

This PR removes any Dagster code from `__init__.py` files in our examples.

Examples that are missing from this PR and should be updated in another one:
- assets_*
- experimental
- project_*
- tutorial_*

Examples that we should be updated when we update the docs:
- doc_snippets


## How I Tested These Changes

Manually tested with pytest
