### PR TITLE
Rename ChangeReason to AssetDefinitionChangeType

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -6,7 +6,7 @@ from dagster import (
     DagsterError,
     _check as check,
 )
-from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer, ChangeReason
+from dagster._core.definitions.asset_graph_differ import AssetDefinitionChangeType, AssetGraphDiffer
 from dagster._core.definitions.asset_job import ASSET_BASE_JOB_PREFIX
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.data_version import (
@@ -103,7 +103,7 @@ GrapheneAssetStaleCauseCategory = graphene.Enum.from_enum(
     StaleCauseCategory, name="StaleCauseCategory"
 )
 
-GrapheneAssetChangedReason = graphene.Enum.from_enum(ChangeReason, name="ChangeReason")
+GrapheneAssetChangedReason = graphene.Enum.from_enum(AssetDefinitionChangeType, name="ChangeReason")
 
 
 class GrapheneUserAssetOwner(graphene.ObjectType):


### PR DESCRIPTION
## Summary

Based on suggestion from @sryza, updates the name of `ChangeReason` to `AssetDefinitionChangeType` now that the situations in which we're using it have expanded.
