### PR TITLE
[dagster-dbt] publicize experimental dbt attach_metadata utility

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -19,6 +19,7 @@ from .cloud import (
     load_assets_from_dbt_cloud_job as load_assets_from_dbt_cloud_job,
 )
 from .core.resource import (
+    DbtAttachMetadataContext as DbtAttachMetadataContext,
     DbtCliEventMessage as DbtCliEventMessage,
     DbtCliInvocation as DbtCliInvocation,
     DbtCliResource as DbtCliResource,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -656,7 +656,7 @@ def _fetch_column_metadata(
         }
 
 
-def _fetch_row_count_metadata(ctx: DbtAttachMetadataContext) -> Optional[Dict[str, Any]]:
+def _fetch_row_count_metadata(ctx: DbtAttachMetadataContext) -> Optional[Mapping[str, Any]]:
     """Threaded task which fetches row counts for materialized dbt models in a dbt run
     once they are built, and attaches the row count as metadata to the event.
     """
@@ -766,7 +766,7 @@ class DbtEventIterator(Generic[T], abc.Iterator):
     @experimental
     def attach_metadata(
         self,
-        fn: Callable[[DbtAttachMetadataContext], Optional[Dict[str, Any]]],
+        fn: Callable[[DbtAttachMetadataContext], Optional[Mapping[str, Any]]],
     ) -> "DbtEventIterator[DbtDagsterEventType]":
         """Runs a threaded task to attach metadata to each event in the iterator.
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -543,7 +543,7 @@ class DbtAttachMetadataContext(NamedTuple):
 
     event: Union[Output, AssetMaterialization, AssetCheckResult, AssetObservation]
     invocation: DbtCliInvocation
-    dbt_resource_props: Dict[str, Any]
+    dbt_resource_props: Mapping[str, Any]
 
     @property
     def adapter(self) -> BaseAdapter:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -538,8 +538,30 @@ def _get_relation_from_adapter(adapter: BaseAdapter, relation_key: RelationKey) 
     )
 
 
+class DbtAttachMetadataContext(NamedTuple):
+    """Context used for attaching metadata to dbt events."""
+
+    event: Union[Output, AssetMaterialization, AssetCheckResult, AssetObservation]
+    invocation: DbtCliInvocation
+    dbt_resource_props: Dict[str, Any]
+
+    @property
+    def adapter(self) -> BaseAdapter:
+        """Dbt adapter which can be used to interact with
+        the underlying database.
+        """
+        return check.not_none(self.invocation.adapter)
+
+    @property
+    def relation_name(self) -> str:
+        """The name of the relation in the database, which can be used to
+        query the created table or view.
+        """
+        return self.dbt_resource_props["relation_name"]
+
+
 def _fetch_column_metadata(
-    invocation: DbtCliInvocation, event: DbtDagsterEventType, with_column_lineage: bool
+    ctx: DbtAttachMetadataContext, with_column_lineage: bool
 ) -> Optional[Dict[str, Any]]:
     """Threaded task which fetches column schema and lineage metadata for dbt models in a dbt
     run once they are built, returning the metadata to be attached.
@@ -553,9 +575,10 @@ def _fetch_column_metadata(
         event (DbtDagsterEventType): The dbt event to append column metadata to.
         with_column_lineage (bool): Whether to include column lineage metadata in the event.
     """
-    adapter = check.not_none(invocation.adapter)
+    invocation = ctx.invocation
+    adapter = ctx.adapter
 
-    dbt_resource_props = _get_dbt_resource_props_from_event(invocation, event)
+    dbt_resource_props = ctx.dbt_resource_props
 
     with adapter.connection_named(f"column_metadata_{dbt_resource_props['unique_id']}"):
         try:
@@ -633,19 +656,15 @@ def _fetch_column_metadata(
         }
 
 
-def _fetch_row_count_metadata(
-    invocation: DbtCliInvocation,
-    event: DbtDagsterEventType,
-) -> Optional[Dict[str, Any]]:
+def _fetch_row_count_metadata(ctx: DbtAttachMetadataContext) -> Optional[Dict[str, Any]]:
     """Threaded task which fetches row counts for materialized dbt models in a dbt run
     once they are built, and attaches the row count as metadata to the event.
     """
-    if not isinstance(event, (AssetMaterialization, Output)):
+    if not isinstance(ctx.event, (AssetMaterialization, Output)):
         return None
+    adapter = ctx.adapter
 
-    adapter = check.not_none(invocation.adapter)
-
-    dbt_resource_props = _get_dbt_resource_props_from_event(invocation, event)
+    dbt_resource_props = ctx.dbt_resource_props
     is_view = dbt_resource_props["config"]["materialized"] == "view"
 
     # Avoid counting rows for views, since they may include complex SQL queries
@@ -656,7 +675,6 @@ def _fetch_row_count_metadata(
 
     unique_id = dbt_resource_props["unique_id"]
     logger.debug("Fetching row count for %s", unique_id)
-    relation_name = dbt_resource_props["relation_name"]
 
     try:
         with adapter.connection_named(f"row_count_{unique_id}"):
@@ -665,7 +683,7 @@ def _fetch_row_count_metadata(
                     SELECT
                     count(*) as row_count
                     FROM
-                    {relation_name}
+                    {ctx.relation_name}
                 """,
                 fetch=True,
             )
@@ -719,7 +737,7 @@ class DbtEventIterator(Generic[T], abc.Iterator):
                 A set of corresponding Dagster events for dbt models, with row counts attached,
                 yielded in the order they are emitted by dbt.
         """
-        return self._attach_metadata(_fetch_row_count_metadata)
+        return self.attach_metadata(_fetch_row_count_metadata)
 
     @public
     @experimental
@@ -741,21 +759,22 @@ class DbtEventIterator(Generic[T], abc.Iterator):
                 A set of corresponding Dagster events for dbt models, with column metadata attached,
                 yielded in the order they are emitted by dbt.
         """
-        fetch_metadata = lambda invocation, event: _fetch_column_metadata(
-            invocation, event, with_column_lineage
-        )
-        return self._attach_metadata(fetch_metadata)
+        fetch_metadata = lambda ctx: _fetch_column_metadata(ctx, with_column_lineage)
+        return self.attach_metadata(fetch_metadata)
 
-    def _attach_metadata(
+    @public
+    @experimental
+    def attach_metadata(
         self,
-        fn: Callable[[DbtCliInvocation, DbtDagsterEventType], Optional[Dict[str, Any]]],
+        fn: Callable[[DbtAttachMetadataContext], Optional[Dict[str, Any]]],
     ) -> "DbtEventIterator[DbtDagsterEventType]":
         """Runs a threaded task to attach metadata to each event in the iterator.
 
         Args:
-            fn (Callable[[DbtCliInvocation, DbtDagsterEventType], Optional[Dict[str, Any]]]):
-                A function which takes a DbtCliInvocation and a DbtDagsterEventType and returns
-                a dictionary of metadata to attach to the event.
+            fn (Callable[[DbtAttachMetadataContext], Optional[Dict[str, Any]]):
+                A function which takes various contextual information about an event
+                and returns a dictionary of metadata to attach. If the function
+                returns None, then no metadata will be attached.
 
         Returns:
              Iterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]:
@@ -764,7 +783,14 @@ class DbtEventIterator(Generic[T], abc.Iterator):
         """
 
         def _map_fn(event: DbtDagsterEventType) -> DbtDagsterEventType:
-            result = fn(self._dbt_cli_invocation, event)
+            ctx = DbtAttachMetadataContext(
+                event=event,
+                invocation=self._dbt_cli_invocation,
+                dbt_resource_props=_get_dbt_resource_props_from_event(
+                    self._dbt_cli_invocation, event
+                ),
+            )
+            result = fn(ctx)
             if result is None:
                 return event
 


### PR DESCRIPTION
## Summary

Tweaks the `attach_metadata` method used under the hood by our row-count-fetching and column-lineage-fetching logic and exposes it to users for custom post-dbt-build operations:

```python
def _summarize(event: DbtDagsterEventType, ctx: DbtAttachMetadataContext):
    if not isinstance(event, (AssetMaterialization, Output)):
        return None

    dbt_resource_props = _get_dbt_resource_props_from_event(ctx.invocation, event)

    with ctx.adapter.connection_named(f"row_count_{dbt_resource_props['unique_id']}"):
        query_result = ctx.adapter.execute(
            f"SUMMARIZE {ctx.relation_name}",
            fetch=True,
        )

    table_metadata = MetadataValue.table(
        records=[
            TableRecord({k: float(v) if isinstance(v, Decimal) else v for k, v in row.items()})
            for row in query_result[1].rows
        ]
    )
    return {"summary": table_metadata}

@dbt_assets(manifest=test_jaffle_shop_manifest_standalone_duckdb_dbfile)
def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
    yield from dbt.cli(["build"], context=context).stream().attach_metadata(_summarize)
```

Could see the API going a few different directions, so curious what folks think.

Adjusts signature a bit to provide the event and a context object with various small utilities.

## Test Plan

Update unit test.
