### PR TITLE
Update source_code.py to allow self-hosted GitLab for code references

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -313,7 +313,7 @@ def link_code_references_to_git(
                     )
                 )
     """
-    if "gitlab.com" in git_url:
+    if "gitlab" in git_url:
         git_url = _build_gitlab_url(git_url, git_branch)
     elif "github.com" in git_url:
         git_url = _build_github_url(git_url, git_branch)


### PR DESCRIPTION
## Summary & Motivation

Currently the git [code reference](https://docs.dagster.io/guides/dagster/code-references#in-any-dagster-environment) feature only works for URLs containing "gitlab.com" and "github.com". This doesn't work with self-hosted GitLab because the string "gitlab.com" is not in "gitlab.self-hosted.xyz".

https://github.com/dagster-io/dagster/issues/23135

## How I Tested These Changes

Confirmed locally against self-hosted GitLab instance.
