### PR TITLE
Don't use `isEqual` to compare groups in `useAssetDefinitionFilterState`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.oss.tsx
@@ -162,7 +162,15 @@ export function filterAssetDefinition(
       return false;
     }
     const nodeGroup = buildAssetGroupSelector({definition: {groupName, repository}});
-    if (!filters.groups.some((g) => isEqual(g, nodeGroup))) {
+    if (
+      !filters.groups.some((g) => {
+        return (
+          g.groupName === nodeGroup?.groupName &&
+          g.repositoryLocationName === nodeGroup.repositoryLocationName &&
+          g.repositoryName === nodeGroup.repositoryName
+        );
+      })
+    ) {
       return false;
     }
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useChangedFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useChangedFilter.tsx
@@ -50,5 +50,4 @@ export const BaseConfig: StaticBaseConfig<ChangeReason> = {
     </Box>
   ),
   getStringValue: (value: ChangeReason) => value[0] + value.slice(1).toLowerCase(),
-  matchType: 'all-of',
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useComputeKindTagFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useComputeKindTagFilter.tsx
@@ -57,5 +57,4 @@ export const BaseConfig: StaticBaseConfig<string> = {
     </Box>
   ),
   getStringValue: (value: string) => value,
-  matchType: 'all-of',
 };


### PR DESCRIPTION
## Summary & Motivation

Don't use `isEqual` to compare groups in `useAssetDefinitionFilterState` because we're reusing the logic in catalog views and in that context the filters have a different ` __typename`. I could remove the typename before passing it to this abstraction but its more performant to just skip the intermediate objects and just directly compare the attributes we care about.

## How I Tested These Changes

used this in catalog views 
buildkite.