### PR TITLE
Fix issue with EcsRunLauncher with include_sidecars set to True

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -70,6 +70,7 @@ def task_definition(ecs, image, environment):
                         "condition": "SUCCESS",
                     },
                 ],
+                "healthCheck": {"command": ["HELLO"]},
             },
             {
                 "name": "other",


### PR DESCRIPTION
Summary:
https://github.com/dagster-io/dagster/pull/20663 modified the current container definition to exclude the "healthCheck" key, which means that the deep-equality check here is no longer valid - prompting the issue described in https://github.com/dagster-io/dagster/discussions/23162. This fixes that issue by excluding the container by name instead of by deep equality.

## Summary & Motivation

## How I Tested These Changes
BK (test change reproduced the problem in master)