### PR TITLE
PLA 509 dump docker compose logs on failure

### DIFF
--- a/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
+++ b/python_modules/dagster-test/dagster_test/fixtures/docker_compose.py
@@ -55,7 +55,7 @@ def dump_docker_compose_logs(context, docker_compose_yml):
         "logs",
     ]
 
-    subprocess.run(compose_command, capture_output=True, check=False)
+    subprocess.run(compose_command, check=False)
 
 
 @pytest.fixture(scope="module", name="docker_compose_cm")


### PR DESCRIPTION
## Summary & Motivation

when docker-compose up throws an exception, just dump docker logs to stdout. sometimes there isn't anything more revealing here than what we get in the initial exception, but sometimes it points to an issue with the underlying service that wasn't in the original exception

## How I Tested These Changes

forced docker-compose to fail with a bad health check definition, and ensured that the dump_logs function was invoked and did print to stdout