### PR TITLE
Fix docs snippets after removing code from __init__.py in examples

### DIFF
--- a/docs/content/guides/dagster/transitioning-data-pipelines-from-development-to-production.mdx
+++ b/docs/content/guides/dagster/transitioning-data-pipelines-from-development-to-production.mdx
@@ -106,7 +106,7 @@ Now we can add these assets to our <PyObject object="Definitions" /> object and 
 from dagster_snowflake_pandas import SnowflakePandasIOManager
 
 from dagster import Definitions
-from development_to_production.assets import comments, items, stories
+from development_to_production.assets.hacker_news_assets import comments, items, stories
 
 # Note that storing passwords in configuration is bad practice. It will be resolved later in the guide.
 resources = {

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/repository/repository_v1.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/repository/repository_v1.py
@@ -3,7 +3,7 @@
 from dagster_snowflake_pandas import SnowflakePandasIOManager
 
 from dagster import Definitions
-from development_to_production.assets import comments, items, stories
+from development_to_production.assets.hacker_news_assets import comments, items, stories
 
 # Note that storing passwords in configuration is bad practice. It will be resolved later in the guide.
 resources = {

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/repository/repository_v2.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/repository/repository_v2.py
@@ -3,7 +3,7 @@ import os
 from dagster_snowflake_pandas import SnowflakePandasIOManager
 
 from dagster import Definitions
-from development_to_production.assets import comments, items, stories
+from development_to_production.assets.hacker_news_assets import comments, items, stories
 
 # start
 # __init__.py

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/repository/repository_v3.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/repository/repository_v3.py
@@ -3,7 +3,7 @@ import os
 from dagster_snowflake_pandas import SnowflakePandasIOManager
 
 from dagster import Definitions, EnvVar
-from development_to_production.assets import comments, items, stories
+from development_to_production.assets.hacker_news_assets import comments, items, stories
 
 # start
 # __init__.py

--- a/examples/docs_snippets/docs_snippets/guides/dagster/using_environment_variables_and_secrets/repository_v2.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/using_environment_variables_and_secrets/repository_v2.py
@@ -4,7 +4,7 @@ from dagster_snowflake_pandas import (
     SnowflakePandasIOManager,
     snowflake_pandas_io_manager,
 )
-from development_to_production.assets import comments, items, stories
+from development_to_production.assets.hacker_news_assets import comments, items, stories
 
 from dagster import Definitions, EnvVar
 


### PR DESCRIPTION
## Summary & Motivation

Updating the examples in PR #23155 broke the docs snippets. This PR fixes them.

## How I Tested These Changes

BK
