### PR TITLE
[DA] Use storage_name instead of old_storage_names

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     )
 
 
-@whitelist_for_serdes(old_storage_names={"AssetConditionCursorExtras"})
+@whitelist_for_serdes(storage_name="AssetConditionCursorExtras")
 class AutomationConditionCursorExtras(NamedTuple):
     """Represents additional state that may be optionally saved by an AutomationCondition between
     evaluations.

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -7,7 +7,7 @@ from ..automation_condition import AutomationCondition, AutomationResult
 from ..automation_context import AutomationContext
 
 
-@whitelist_for_serdes(old_storage_names={"AndAssetCondition"})
+@whitelist_for_serdes(storage_name="AndAssetCondition")
 @record
 class AndAutomationCondition(AutomationCondition):
     """This class represents the condition that all of its children evaluate to true."""
@@ -40,7 +40,7 @@ class AndAutomationCondition(AutomationCondition):
         return AutomationResult.create_from_children(context, true_slice, child_results)
 
 
-@whitelist_for_serdes(old_storage_names={"OrAssetCondition"})
+@whitelist_for_serdes(storage_name="OrAssetCondition")
 @record
 class OrAutomationCondition(AutomationCondition):
     """This class represents the condition that any of its children evaluate to true."""
@@ -74,7 +74,7 @@ class OrAutomationCondition(AutomationCondition):
         return AutomationResult.create_from_children(context, true_slice, child_results)
 
 
-@whitelist_for_serdes(old_storage_names={"NotAssetCondition"})
+@whitelist_for_serdes(storage_name="NotAssetCondition")
 @record
 class NotAutomationCondition(AutomationCondition):
     """This class represents the condition that none of its children evaluate to true."""

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
@@ -52,7 +52,7 @@ def get_serializable_candidate_subset(
     return candidate_subset
 
 
-@whitelist_for_serdes(old_storage_names={"AssetConditionSnapshot"})
+@whitelist_for_serdes(storage_name="AssetConditionSnapshot")
 class AutomationConditionSnapshot(NamedTuple):
     """A serializable snapshot of a node in the AutomationCondition tree."""
 
@@ -75,7 +75,7 @@ class AssetSubsetWithMetadata(NamedTuple):
         return frozenset(self.metadata.items())
 
 
-@whitelist_for_serdes(old_storage_names={"AssetConditionEvaluation"})
+@whitelist_for_serdes(storage_name="AssetConditionEvaluation")
 class AutomationConditionEvaluation(NamedTuple):
     """Serializable representation of the results of evaluating a node in the evaluation tree."""
 
@@ -132,7 +132,7 @@ class AutomationConditionEvaluation(NamedTuple):
         return discarded_subset.size
 
 
-@whitelist_for_serdes(old_storage_names={"AssetConditionEvaluationWithRunIds"})
+@whitelist_for_serdes(storage_name="AssetConditionEvaluationWithRunIds")
 class AutomationConditionEvaluationWithRunIds(NamedTuple):
     """A union of an AutomatConditionEvaluation and the set of run IDs that have been launched in
     response to it.
@@ -150,7 +150,7 @@ class AutomationConditionEvaluationWithRunIds(NamedTuple):
         return self.evaluation.true_subset.size
 
 
-@whitelist_for_serdes(old_storage_names={"AssetConditionEvaluationState"})
+@whitelist_for_serdes(storage_name="AssetConditionEvaluationState")
 @dataclass(frozen=True)
 class AutomationConditionEvaluationState:
     """Incremental state calculated during the evaluation of an AutomationCondition. This may be used


### PR DESCRIPTION
## Summary & Motivation

Discussed in standup, this is ultimately a better / safer way of handling name changes.

## How I Tested These Changes
