### PR TITLE
Fetch planned asset materializations from the execution plan snapshot, rather than doing an event log scan

### DIFF
--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -484,6 +484,11 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
             return set()
         elif run.asset_selection:
             return run.asset_selection
+        if run.execution_plan_snapshot_id:
+            execution_plan_snapshot = check.not_none(
+                self._instance.get_execution_plan_snapshot(run.execution_plan_snapshot_id)
+            )
+            return execution_plan_snapshot.asset_selection
         else:
             # must resort to querying the event log
             return self._get_planned_materializations_for_run_from_events(run_id=run_id)


### PR DESCRIPTION
Summary:
This gives us the ability to efficiently load asset selections for all runs without doing an event log scan for ASSET_MATERIALIZATION_PLANNED events. The asset selection is derived from the same place that we use to determine what ASSET_MATERIALIZATION_PLANNED events to emit (the execution plan snapshot)

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
