### PR TITLE
[dagster-dbt] add `with_snowflake/bigquery_insights` chainable method

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -806,7 +806,7 @@ class DbtEventIterator(Generic[T], abc.Iterator):
     @experimental
     def with_snowflake_insights(
         self,
-        skip_config_check: bool=False,
+        skip_config_check: bool = False,
         record_observation_usage: bool = True,
     ) -> (
         "DbtEventIterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]"
@@ -855,7 +855,7 @@ class DbtEventIterator(Generic[T], abc.Iterator):
     @experimental
     def with_bigquery_insights(
         self,
-        skip_config_check: bool=False,
+        skip_config_check: bool = False,
         record_observation_usage: bool = True,
     ) -> (
         "DbtEventIterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -811,8 +811,10 @@ class DbtEventIterator(Generic[T], abc.Iterator):
     ) -> (
         "DbtEventIterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]"
     ):
-        """Wraps a dagster-dbt invocation to associate each Snowflake or Bigquery query with the produced
-        asset materializations. For more information, see the documentation for
+        """Associate each warehouse query with the produced asset materializations for use in Dagster
+        Plus Insights. Currently supports Snowflake and BigQuery.
+
+        For more information, see the documentation for
         `dagster_cloud.dagster_insights.dbt_with_snowflake_insights` and
         `dagster_cloud.dagster_insights.dbt_with_bigquery_insights`.
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -811,8 +811,29 @@ class DbtEventIterator(Generic[T], abc.Iterator):
     ) -> (
         "DbtEventIterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]"
     ):
+        """Wraps a dagster-dbt invocation to associate each Snowflake query with the produced
+        asset materializations. For more information, see the documentation for
+        `dagster_cloud.dagster_insights.dbt_with_snowflake_insights`.
+
+        Args:
+            skip_config_check (bool): If true, skips the check that the dbt project config is set up
+                correctly. Defaults to False.
+            record_observation_usage (bool): If True, associates the usage associated with
+                asset observations with that asset. Default is True.
+
+        **Example:**
+
+        .. code-block:: python
+
+            @dbt_assets(manifest=DBT_MANIFEST_PATH)
+            def jaffle_shop_dbt_assets(
+                context: AssetExecutionContext,
+                dbt: DbtCliResource,
+            ):
+                yield from dbt.cli(["build"], context=context).stream().with_snowflake_insights()
+        """
         try:
-            from dagster_cloud.dagster_insights.snowflake import dbt_with_snowflake_insights
+            from dagster_cloud.dagster_insights import dbt_with_snowflake_insights
         except ImportError as e:
             raise DagsterInvalidPropertyError(
                 "The `dagster_cloud` library is required to use the `with_snowflake_insights`"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -804,64 +804,16 @@ class DbtEventIterator(Generic[T], abc.Iterator):
 
     @public
     @experimental
-    def with_snowflake_insights(
+    def with_insights(
         self,
         skip_config_check: bool = False,
         record_observation_usage: bool = True,
     ) -> (
         "DbtEventIterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]"
     ):
-        """Wraps a dagster-dbt invocation to associate each Snowflake query with the produced
+        """Wraps a dagster-dbt invocation to associate each Snowflake or Bigquery query with the produced
         asset materializations. For more information, see the documentation for
-        `dagster_cloud.dagster_insights.dbt_with_snowflake_insights`.
-
-        Args:
-            skip_config_check (bool): If true, skips the check that the dbt project config is set up
-                correctly. Defaults to False.
-            record_observation_usage (bool): If True, associates the usage associated with
-                asset observations with that asset. Default is True.
-
-        **Example:**
-
-        .. code-block:: python
-
-            @dbt_assets(manifest=DBT_MANIFEST_PATH)
-            def jaffle_shop_dbt_assets(
-                context: AssetExecutionContext,
-                dbt: DbtCliResource,
-            ):
-                yield from dbt.cli(["build"], context=context).stream().with_snowflake_insights()
-        """
-        try:
-            from dagster_cloud.dagster_insights import dbt_with_snowflake_insights
-        except ImportError as e:
-            raise DagsterInvalidPropertyError(
-                "The `dagster_cloud` library is required to use the `with_snowflake_insights`"
-                " method. Install the library with `pip install dagster-cloud`."
-            ) from e
-
-        return DbtEventIterator(
-            events=dbt_with_snowflake_insights(
-                context=self._dbt_cli_invocation.context,
-                dbt_cli_invocation=self._dbt_cli_invocation,
-                dagster_events=self,
-                skip_config_check=skip_config_check,
-                record_observation_usage=record_observation_usage,
-            ),
-            dbt_cli_invocation=self._dbt_cli_invocation,
-        )
-
-    @public
-    @experimental
-    def with_bigquery_insights(
-        self,
-        skip_config_check: bool = False,
-        record_observation_usage: bool = True,
-    ) -> (
-        "DbtEventIterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]"
-    ):
-        """Wraps a dagster-dbt invocation to associate each Bigquery query with the produced
-        asset materializations. For more information, see the documentation for
+        `dagster_cloud.dagster_insights.dbt_with_snowflake_insights` and
         `dagster_cloud.dagster_insights.dbt_with_bigquery_insights`.
 
         Args:
@@ -879,26 +831,49 @@ class DbtEventIterator(Generic[T], abc.Iterator):
                 context: AssetExecutionContext,
                 dbt: DbtCliResource,
             ):
-                yield from dbt.cli(["build"], context=context).stream().with_bigquery_insights()
+                yield from dbt.cli(["build"], context=context).stream().with_insights()
         """
-        try:
-            from dagster_cloud.dagster_insights import dbt_with_bigquery_insights
-        except ImportError as e:
-            raise DagsterInvalidPropertyError(
-                "The `dagster_cloud` library is required to use the `with_bigquery_insights`"
-                " method. Install the library with `pip install dagster-cloud`."
-            ) from e
+        adapter_type = self._dbt_cli_invocation.manifest.get("metadata", {}).get("adapter_type")
+        if adapter_type == "snowflake":
+            try:
+                from dagster_cloud.dagster_insights import dbt_with_snowflake_insights
+            except ImportError as e:
+                raise DagsterInvalidPropertyError(
+                    "The `dagster_cloud` library is required to use the `with_snowflake_insights`"
+                    " method. Install the library with `pip install dagster-cloud`."
+                ) from e
 
-        return DbtEventIterator(
-            events=dbt_with_bigquery_insights(
-                context=self._dbt_cli_invocation.context,
+            return DbtEventIterator(
+                events=dbt_with_snowflake_insights(
+                    context=self._dbt_cli_invocation.context,
+                    dbt_cli_invocation=self._dbt_cli_invocation,
+                    dagster_events=self,
+                    skip_config_check=skip_config_check,
+                    record_observation_usage=record_observation_usage,
+                ),
                 dbt_cli_invocation=self._dbt_cli_invocation,
-                dagster_events=self,
-                skip_config_check=skip_config_check,
-                record_observation_usage=record_observation_usage,
-            ),
-            dbt_cli_invocation=self._dbt_cli_invocation,
-        )
+            )
+        elif adapter_type == "bigquery":
+            try:
+                from dagster_cloud.dagster_insights import dbt_with_bigquery_insights
+            except ImportError as e:
+                raise DagsterInvalidPropertyError(
+                    "The `dagster_cloud` library is required to use the `with_bigquery_insights`"
+                    " method. Install the library with `pip install dagster-cloud`."
+                ) from e
+
+            return DbtEventIterator(
+                events=dbt_with_bigquery_insights(
+                    context=self._dbt_cli_invocation.context,
+                    dbt_cli_invocation=self._dbt_cli_invocation,
+                    dagster_events=self,
+                    skip_config_check=skip_config_check,
+                    record_observation_usage=record_observation_usage,
+                ),
+                dbt_cli_invocation=self._dbt_cli_invocation,
+            )
+        else:
+            check.failed("The `with_insights` method is only supported for Snowflake and BigQuery.")
 
 
 def _dbt_packages_has_dagster_dbt(packages_file: Path) -> bool:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -802,6 +802,34 @@ class DbtEventIterator(Generic[T], abc.Iterator):
             dbt_cli_invocation=self._dbt_cli_invocation,
         )
 
+    @public
+    @experimental
+    def with_snowflake_insights(
+        self,
+        skip_config_check: bool=False,
+        record_observation_usage: bool = True,
+    ) -> (
+        "DbtEventIterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]"
+    ):
+        try:
+            from dagster_cloud.dagster_insights.snowflake import dbt_with_snowflake_insights
+        except ImportError as e:
+            raise DagsterInvalidPropertyError(
+                "The `dagster_cloud` library is required to use the `with_snowflake_insights`"
+                " method. Install the library with `pip install dagster-cloud`."
+            ) from e
+
+        return DbtEventIterator(
+            events=dbt_with_snowflake_insights(
+                context=self._dbt_cli_invocation.context,
+                dbt_cli_invocation=self._dbt_cli_invocation,
+                dagster_events=self,
+                skip_config_check=skip_config_check,
+                record_observation_usage=record_observation_usage,
+            ),
+            dbt_cli_invocation=self._dbt_cli_invocation,
+        )
+
 
 def _dbt_packages_has_dagster_dbt(packages_file: Path) -> bool:
     """Checks whether any package in the passed yaml file is the Dagster dbt package."""

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -873,7 +873,9 @@ class DbtEventIterator(Generic[T], abc.Iterator):
                 dbt_cli_invocation=self._dbt_cli_invocation,
             )
         else:
-            check.failed("The `with_insights` method is only supported for Snowflake and BigQuery.")
+            check.failed(
+                f"The `with_insights` method is only supported for Snowflake and BigQuery and is not supported for adapter type `{adapter_type}`"
+            )
 
 
 def _dbt_packages_has_dagster_dbt(packages_file: Path) -> bool:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -843,7 +843,7 @@ class DbtEventIterator(Generic[T], abc.Iterator):
                 )
             except ImportError as e:
                 raise DagsterInvalidPropertyError(
-                    "The `dagster_cloud` library is required to use the `with_snowflake_insights`"
+                    "The `dagster_cloud` library is required to use the `with_insights`"
                     " method. Install the library with `pip install dagster-cloud`."
                 ) from e
 
@@ -864,7 +864,7 @@ class DbtEventIterator(Generic[T], abc.Iterator):
                 )
             except ImportError as e:
                 raise DagsterInvalidPropertyError(
-                    "The `dagster_cloud` library is required to use the `with_bigquery_insights`"
+                    "The `dagster_cloud` library is required to use the `with_insights`"
                     " method. Install the library with `pip install dagster-cloud`."
                 ) from e
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -838,7 +838,9 @@ class DbtEventIterator(Generic[T], abc.Iterator):
         adapter_type = self._dbt_cli_invocation.manifest.get("metadata", {}).get("adapter_type")
         if adapter_type == "snowflake":
             try:
-                from dagster_cloud.dagster_insights import dbt_with_snowflake_insights
+                from dagster_cloud.dagster_insights import (  # type: ignore
+                    dbt_with_snowflake_insights,
+                )
             except ImportError as e:
                 raise DagsterInvalidPropertyError(
                     "The `dagster_cloud` library is required to use the `with_snowflake_insights`"
@@ -857,7 +859,9 @@ class DbtEventIterator(Generic[T], abc.Iterator):
             )
         elif adapter_type == "bigquery":
             try:
-                from dagster_cloud.dagster_insights import dbt_with_bigquery_insights
+                from dagster_cloud.dagster_insights import (  # type: ignore
+                    dbt_with_bigquery_insights,
+                )
             except ImportError as e:
                 raise DagsterInvalidPropertyError(
                     "The `dagster_cloud` library is required to use the `with_bigquery_insights`"

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -838,7 +838,7 @@ class DbtEventIterator(Generic[T], abc.Iterator):
         adapter_type = self._dbt_cli_invocation.manifest.get("metadata", {}).get("adapter_type")
         if adapter_type == "snowflake":
             try:
-                from dagster_cloud.dagster_insights import (  # type: ignore
+                from dagster_cloud.dagster_insights import (  # pyright: ignore[reportMissingImports]
                     dbt_with_snowflake_insights,
                 )
             except ImportError as e:
@@ -859,7 +859,7 @@ class DbtEventIterator(Generic[T], abc.Iterator):
             )
         elif adapter_type == "bigquery":
             try:
-                from dagster_cloud.dagster_insights import (  # type: ignore
+                from dagster_cloud.dagster_insights import (  # pyright: ignore[reportMissingImports]
                     dbt_with_bigquery_insights,
                 )
             except ImportError as e:


### PR DESCRIPTION
## Summary

Adds a `with_snowflake_insights` and `with_bigquery_insights` methods that can be chained to a `.stream()` call, simplifying using insights alongside other deferred fetches:

Before:

```python
@dbt_assets(manifest=snowflake_manifest_path)
def jaffle_shop_dbt_assets(
    context: AssetExecutionContext,
    dbt: DbtCliResource,
):
    dbt_cli_invocation = dbt.cli(["build", "--profile", "unittest"], context=context)
    yield from dbt_with_snowflake_insights(context, dbt_cli_invocation)

```


Now:

```python
@dbt_assets(manifest=snowflake_manifest_path)
def jaffle_shop_dbt_assets(
    context: AssetExecutionContext,
    dbt: DbtCliResource,
):
    yield from dbt.cli(
        ["build", "--profile", "unittest"], context=context
    ).stream().with_snowflake_insights()
```

## Test Plan

https://github.com/dagster-io/internal/pull/10731