### PR TITLE
[RFC][1.8] `AssetExecutionContext.for_input`

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/asset_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/asset_execution_context.py
@@ -23,6 +23,7 @@ from dagster._core.log_manager import DagsterLogManager
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._utils.forked_pdb import ForkedPdb
 
+from .asset_input_execution_context import AssetInputExecutionContext
 from .op_execution_context import OpExecutionContext
 from .system import StepExecutionContext
 
@@ -159,6 +160,10 @@ class AssetExecutionContext(OpExecutionContext):
         Returns: JobDefinition.
         """
         return self.op_execution_context.job_def
+
+    @public
+    def for_input(self, input_name: str) -> AssetInputExecutionContext:
+        return self.op_execution_context.for_input(input_name)
 
     @property
     def repository_def(self) -> RepositoryDefinition:

--- a/python_modules/dagster/dagster/_core/execution/context/asset_input_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/asset_input_execution_context.py
@@ -1,0 +1,50 @@
+from typing import Sequence
+
+from dagster import _check as check
+from dagster._annotations import public
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.partition_key_range import PartitionKeyRange
+from dagster._core.definitions.time_window_partitions import TimeWindow
+
+from .system import StepExecutionContext
+
+
+class AssetInputExecutionContext:
+    """This class should not be instantiated directly by users."""
+
+    def __init__(self, step_context: StepExecutionContext, input_name: str):
+        self._step_context = step_context
+        self._input_name = input_name
+
+    @public
+    @property
+    def asset_key(self) -> AssetKey:
+        return check.not_none(
+            self._step_context.job_def.asset_layer.asset_key_for_input(
+                node_handle=self._step_context.node_handle, input_name=self._input_name
+            )
+        )
+
+    @public
+    @property
+    def partition_time_window(self) -> TimeWindow:
+        return self._step_context.asset_partitions_time_window_for_input(self._input_name)
+
+    @public
+    @property
+    def partition_key(self) -> str:
+        return self._step_context.asset_partition_key_for_input(self._input_name)
+
+    @public
+    @property
+    def partition_keys(self) -> Sequence[str]:
+        return list(
+            self._step_context.asset_partitions_subset_for_input(
+                self._input_name
+            ).get_partition_keys()
+        )
+
+    @public
+    @property
+    def partition_key_range(self) -> PartitionKeyRange:
+        return self._step_context.asset_partition_key_range_for_input(self._input_name)

--- a/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
@@ -35,6 +35,7 @@ from dagster._core.storage.dagster_run import DagsterRun
 from dagster._utils.forked_pdb import ForkedPdb
 from dagster._utils.warnings import deprecation_warning
 
+from .asset_input_execution_context import AssetInputExecutionContext
 from .system import StepExecutionContext
 
 
@@ -627,6 +628,9 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
         else:
             return node_output_handle.output_name
 
+    @deprecated(
+        breaking_version="2.0", additional_warn_text="Use `for_input(name).asset_key` instead."
+    )
     @public
     def asset_key_for_input(self, input_name: str) -> AssetKey:
         """Return the AssetKey for the corresponding input."""
@@ -834,6 +838,14 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
         return self._step_execution_context.asset_partition_key_range_for_output(output_name)
 
     @public
+    def for_input(self, input_name: str) -> AssetInputExecutionContext:
+        return AssetInputExecutionContext(self._step_execution_context, input_name)
+
+    @deprecated(
+        breaking_version="2.0",
+        additional_warn_text="Use `for_input(name).partition_key_range` instead.",
+    )
+    @public
     def asset_partition_key_range_for_input(self, input_name: str) -> PartitionKeyRange:
         """Return the PartitionKeyRange for the corresponding input. Errors if the asset depends on a
         non-contiguous chunk of the input.
@@ -896,6 +908,9 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
         """
         return self._step_execution_context.asset_partition_key_range_for_input(input_name)
 
+    @deprecated(
+        breaking_version="2.0", additional_warn_text="Use `for_input(name).partition_key` instead."
+    )
     @public
     def asset_partition_key_for_input(self, input_name: str) -> str:
         """Returns the partition key of the upstream asset corresponding to the given input.
@@ -1090,6 +1105,9 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
             dynamic_partitions_store=self.instance,
         )
 
+    @deprecated(
+        breaking_version="2.0", additional_warn_text="Use `for_input(name).partition_keys` instead."
+    )
     @public
     def asset_partition_keys_for_input(self, input_name: str) -> Sequence[str]:
         """Returns a list of the partition keys of the upstream asset corresponding to the
@@ -1155,6 +1173,10 @@ class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionC
             ).get_partition_keys()
         )
 
+    @deprecated(
+        breaking_version="2.0",
+        additional_warn_text="Use `for_input(name).partition_time_window` instead.",
+    )
     @public
     def asset_partitions_time_window_for_input(self, input_name: str = "result") -> TimeWindow:
         """The time window for the partitions of the input asset.

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -808,7 +808,7 @@ def test_multi_partition_mapping_with_asset_deps():
 
     @asset(partitions_def=partitions_def, deps=[AssetDep(upstream, partition_mapping=mapping)])
     def downstream(context: AssetExecutionContext):
-        upstream_mp_key = context.asset_partition_key_for_input("upstream")
+        upstream_mp_key = context.for_input("upstream").partition_key
         current_mp_key = context.partition_key
 
         if isinstance(upstream_mp_key, MultiPartitionKey) and isinstance(
@@ -894,8 +894,8 @@ def test_multi_partition_mapping_with_asset_deps():
 
     @multi_asset(specs=[asset_3, asset_4], partitions_def=partitions_def)
     def multi_asset_2(context: AssetExecutionContext):
-        asset_1_mp_key = context.asset_partition_key_for_input("asset_1")
-        asset_2_mp_key = context.asset_partition_key_for_input("asset_2")
+        asset_1_mp_key = context.for_input("asset_1").partition_key
+        asset_2_mp_key = context.for_input("asset_2").partition_key
         current_mp_key = context.partition_key
 
         if (

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
@@ -1887,7 +1887,7 @@ def test_resolve_dependency_in_group():
     @asset
     def asset2(context, asset1):
         del asset1
-        assert context.asset_key_for_input("asset1") == AssetKey(["abc", "asset1"])
+        assert context.for_input("asset1").asset_key == AssetKey(["abc", "asset1"])
 
     with disable_dagster_warnings():
         assert materialize_to_memory([asset1, asset2]).success

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -1246,7 +1246,7 @@ def test_graph_backed_asset_subset_two_routes():
 
     @op(ins={"in1": In(Nothing), "in2": In(Nothing)})
     def op2(context) -> None:
-        assert context.asset_key_for_input("in1") == AssetKey("asset1")
+        assert context.for_input("in1").asset_key == AssetKey("asset1")
 
     @graph_multi_asset(
         outs={
@@ -1275,7 +1275,7 @@ def test_graph_backed_asset_subset_two_routes_yield_only_selected():
 
     @op(ins={"in1": In(Nothing), "in2": In(Nothing)})
     def op2(context) -> None:
-        assert context.asset_key_for_input("in1") == AssetKey("asset1")
+        assert context.for_input("in1").asset_key == AssetKey("asset1")
 
     @graph_multi_asset(
         outs={

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -952,7 +952,7 @@ def test_graph_asset_partition_mapping():
     @op(ins={"in1": In(Nothing)})
     def my_op(context):
         assert context.partition_key == "a"
-        assert context.asset_partition_keys_for_input("in1") == ["a"]
+        assert context.for_input("in1").partition_keys == ["a"]
 
     @graph_asset(
         partitions_def=partitions_def,
@@ -1079,8 +1079,8 @@ def test_graph_multi_asset_decorator(automation_condition_arg):
 
     @op(out={"one": Out(), "two": Out()})
     def two_in_two_out(context, in1, in2):
-        assert context.asset_key_for_input("in1") == AssetKey("x")
-        assert context.asset_key_for_input("in2") == AssetKey("y")
+        assert context.for_input("in1").asset_key == AssetKey("x")
+        assert context.for_input("in2").asset_key == AssetKey("y")
         assert context.asset_key_for_output("one") == AssetKey("first_asset")
         assert context.asset_key_for_output("two") == AssetKey("second_asset")
         return 4, 5
@@ -1133,8 +1133,8 @@ def test_graph_multi_asset_decorator(automation_condition_arg):
 def test_graph_multi_asset_w_key_prefix():
     @op(out={"one": Out(), "two": Out()})
     def two_in_two_out(context, in1, in2):
-        assert context.asset_key_for_input("in1") == AssetKey("x")
-        assert context.asset_key_for_input("in2") == AssetKey("y")
+        assert context.for_input("in1").asset_key == AssetKey("x")
+        assert context.for_input("in2").asset_key == AssetKey("y")
         assert context.asset_key_for_output("one") == AssetKey("first_asset")
         assert context.asset_key_for_output("two") == AssetKey("second_asset")
         return 4, 5

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -331,7 +331,7 @@ def test_input_context_asset_partitions_time_window():
 
     @asset(partitions_def=partitions_def)
     def downstream_asset(context, upstream_asset):
-        assert context.asset_partitions_time_window_for_input("upstream_asset") == TimeWindow(
+        assert context.for_input("upstream_asset").partition_time_window == TimeWindow(
             parse_time_string("2021-06-06"), parse_time_string("2021-06-07")
         )
         assert upstream_asset is None
@@ -615,7 +615,7 @@ def test_partition_range_single_run():
 
     @asset(partitions_def=partitions_def, deps=["upstream_asset"])
     def downstream_asset(context: AssetExecutionContext) -> None:
-        assert context.asset_partition_key_range_for_input("upstream_asset") == PartitionKeyRange(
+        assert context.for_input("upstream_asset").partition_key_range == PartitionKeyRange(
             start="2020-01-01", end="2020-01-03"
         )
         assert context.partition_key_range == PartitionKeyRange(

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
@@ -115,7 +115,7 @@ def test_execute_asset_and_check() -> None:
 
     @asset_check(asset=asset1, description="desc")
     def check1(context: AssetCheckExecutionContext):
-        assert context.op_execution_context.asset_key_for_input("asset1") == asset1.key
+        assert context.op_execution_context.for_input("asset1").asset_key == asset1.key
         return AssetCheckResult(
             asset_key=asset1.key,
             check_name="check1",
@@ -190,7 +190,7 @@ def test_execute_check_and_asset_in_separate_run():
 
     @asset_check(asset=asset1, description="desc")
     def check1(context: AssetCheckExecutionContext):
-        assert context.op_execution_context.asset_key_for_input("asset1") == asset1.key
+        assert context.op_execution_context.for_input("asset1").asset_key == asset1.key
         return AssetCheckResult(
             asset_key=asset1.key,
             check_name="check1",

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_dynamic_partitions.py
@@ -154,13 +154,13 @@ def test_dynamic_partitions_mapping():
 
     @asset(partitions_def=partitions_def)
     def dynamic2(context: AssetExecutionContext, dynamic1):
-        assert context.asset_partition_keys_for_input("dynamic1") == ["apple"]
+        assert context.for_input("dynamic1").partition_keys == ["apple"]
         assert context.partition_key == "apple"
         return 1
 
     @asset
     def unpartitioned(context, dynamic1):
-        assert context.asset_partition_keys_for_input("dynamic1") == ["apple"]
+        assert context.for_input("dynamic1").partition_keys == ["apple"]
         return 1
 
     with instance_for_test() as instance:
@@ -184,7 +184,7 @@ def test_unpartitioned_downstream_of_dynamic_asset():
 
     @asset
     def unpartitioned(context, dynamic1):
-        assert set(context.asset_partition_keys_for_input("dynamic1")) == set(partitions)
+        assert set(context.for_input("dynamic1").partition_keys) == set(partitions)
         return 1
 
     with instance_for_test() as instance:

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_multi_partitions.py
@@ -594,7 +594,7 @@ def test_context_returns_multipartition_keys():
     def downstream(context: AssetExecutionContext, upstream):
         assert isinstance(context.partition_key, MultiPartitionKey)
 
-        input_range = context.asset_partition_key_range_for_input("upstream")
+        input_range = context.for_input("upstream").partition_key_range
         assert isinstance(input_range.start, MultiPartitionKey)
         assert isinstance(input_range.end, MultiPartitionKey)
 


### PR DESCRIPTION
## Summary & Motivation

`AssetExecutionContext` has a lot of methods like `asset_key_for_input` and `asset_partition_keys_for_input`. This proposes deprecating them in favor of a single `for_input` method, which returns an `AssetInputExecutionContext` that contains properties relevant to a particular input.

Instead of introducing `AssetInputExecutionContext`, I also considered reusing `InputContext`, which is the context object that we pass to `IOManager.load_input`. After trying that approach, I abandoned it after noticing it has fields like `config` and `resources` which are relevant specifically to the IO manager context.

## How I Tested These Changes
