### PR TITLE
[ui] Hide jobs with dunder anonymous prefix

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -31,9 +31,10 @@ type AssetLiveNode = AssetNodeLiveFragment;
 type AssetLatestInfo = AssetLatestInfoFragment;
 
 export const __ASSET_JOB_PREFIX = '__ASSET_JOB';
+export const __ANONYMOUS_ASSET_JOB_PREFIX = '__anonymous_asset_job';
 
 export function isHiddenAssetGroupJob(jobName: string) {
-  return jobName.startsWith(__ASSET_JOB_PREFIX);
+  return jobName.startsWith(__ASSET_JOB_PREFIX) || jobName.startsWith(__ANONYMOUS_ASSET_JOB_PREFIX);
 }
 
 // IMPORTANT: We use this, rather than AssetNode.id throughout this file because

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleRow.tsx
@@ -24,6 +24,7 @@ import {
 } from './types/VirtualizedScheduleRow.types';
 import {workspacePathFromAddress} from './workspacePath';
 import {FIFTEEN_SECONDS, useQueryRefreshAtInterval} from '../app/QueryRefresh';
+import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {InstigationStatus} from '../graphql/types';
 import {LastRunSummary} from '../instance/LastRunSummary';
 import {TICK_TAG_FRAGMENT} from '../instigation/InstigationTick';
@@ -144,7 +145,7 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
                 <MiddleTruncate text={name} />
               </Link>
             </span>
-            {scheduleData ? (
+            {scheduleData && !isHiddenAssetGroupJob(scheduleData.pipelineName) ? (
               <Caption>
                 <PipelineReference
                   showIcon


### PR DESCRIPTION
## Summary & Motivation

@smackesey is introducing a new anonymous job prefix. We should handle this the same as the existing `__ASSET_JOB` prefix, which is to hide it aggressively throughout the app.

The simplest thing to do here seems to be to just add it as another check alongside the existing prefix check.

## How I Tested These Changes

Run dagster dev with a target code location that includes sensors and schedules with anonymous jobs using the new prefix.

View Jobs list, verify that these jobs don't appear. View Schedules and Sensors lists, verify same.