### PR TITLE
[serdes] deserialize_values

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -69,6 +69,7 @@ from dagster._core.storage.sqlalchemy_compat import (
 )
 from dagster._serdes import deserialize_value, serialize_value
 from dagster._serdes.errors import DeserializationError
+from dagster._serdes.serdes import deserialize_values
 from dagster._time import datetime_from_timestamp, get_current_timestamp, utc_datetime_from_naive
 from dagster._utils import PrintFn
 from dagster._utils.concurrency import (
@@ -665,7 +666,7 @@ class SqlEventLogStorage(EventLogStorage):
             results = conn.execute(raw_event_query).fetchall()
 
         try:
-            records = [deserialize_value(json_str, EventLogEntry) for (json_str,) in results]
+            records = deserialize_values((json_str for (json_str,) in results), EventLogEntry)
             return build_run_step_stats_from_events(run_id, records)
         except (seven.JSONDecodeError, DeserializationError) as err:
             raise DagsterEventLogInvalidForRun(run_id=run_id) from err

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -62,6 +62,7 @@ from dagster._core.storage.tags import (
 )
 from dagster._daemon.types import DaemonHeartbeat
 from dagster._serdes import deserialize_value, serialize_value
+from dagster._serdes.serdes import deserialize_values
 from dagster._seven import JSONDecodeError
 from dagster._time import datetime_from_timestamp, get_current_datetime, utc_datetime_from_naive
 from dagster._utils import PrintFn
@@ -850,7 +851,7 @@ class SqlRunStorage(RunStorage):
             query = query.limit(limit)
         query = query.order_by(BulkActionsTable.c.id.desc())
         rows = self.fetchall(query)
-        return [deserialize_value(row["body"], PartitionBackfill) for row in rows]
+        return deserialize_values((row["body"] for row in rows), PartitionBackfill)
 
     def get_backfill(self, backfill_id: str) -> Optional[PartitionBackfill]:
         check.str_param(backfill_id, "backfill_id")

--- a/python_modules/dagster/dagster/_serdes/__init__.py
+++ b/python_modules/dagster/dagster/_serdes/__init__.py
@@ -9,6 +9,7 @@ from .serdes import (
     SerializableNonScalarKeyMapping as SerializableNonScalarKeyMapping,
     WhitelistMap as WhitelistMap,
     deserialize_value as deserialize_value,
+    deserialize_values as deserialize_values,
     pack_value as pack_value,
     serialize_value as serialize_value,
     unpack_value as unpack_value,


### PR DESCRIPTION
Adds a path for avoiding re-entering context managers for each value when deserializing a list of items

## How I Tested These Changes

updated some callsites, existing tests