### PR TITLE
[RFC][DA] Update UserCodeAutomationConditionSensor

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_sensor_definition.py
@@ -84,10 +84,21 @@ def evaluate_automation_conditions(context: SensorEvaluationContext):
         # tick_id and sensor tags should get set in daemon
         run_tags=context.instance.auto_materialize_run_tags,
     )
+    # only record evaluation results where something changed
+    updated_evaluations = []
+    for result in results:
+        previous_cursor = cursor.get_previous_condition_cursor(result.asset_key)
+        if (
+            previous_cursor is None
+            or previous_cursor.result_value_hash != result.value_hash
+            or not result.true_slice.is_empty
+        ):
+            updated_evaluations.append(result.serializable_evaluation)
 
     return SensorResult(
         run_requests=run_requests,
         cursor=asset_daemon_cursor_to_instigator_serialized_cursor(new_cursor),
+        automation_condition_evaluations=updated_evaluations,
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -18,6 +18,9 @@ from dagster._annotations import PublicAttr, experimental_param
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.declarative_automation.serialized_objects import (
+    AutomationConditionEvaluation,
+)
 from dagster._core.definitions.dynamic_partitions_request import (
     AddDynamicPartitionsRequest,
     DeleteDynamicPartitionsRequest,
@@ -389,6 +392,7 @@ class SensorResult(
                 "asset_events",
                 List[Union[AssetObservation, AssetMaterialization, AssetCheckEvaluation]],
             ),
+            ("automation_condition_evaluations", Sequence[AutomationConditionEvaluation]),
         ],
     )
 ):
@@ -426,6 +430,7 @@ class SensorResult(
         asset_events: Optional[
             Sequence[Union[AssetObservation, AssetMaterialization, AssetCheckEvaluation]]
         ] = None,
+        **kwargs,
     ):
         if skip_reason and len(run_requests if run_requests else []) > 0:
             check.failed(
@@ -453,5 +458,10 @@ class SensorResult(
                     "asset_check_evaluations",
                     (AssetObservation, AssetMaterialization, AssetCheckEvaluation),
                 )
+            ),
+            automation_condition_evaluations=check.opt_sequence_param(
+                kwargs.get("automation_condition_evaluations"),
+                "automation_condition_evaluations",
+                AutomationConditionEvaluation,
             ),
         )

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -28,6 +28,9 @@ from typing_extensions import TypeAlias
 import dagster._check as check
 from dagster._annotations import deprecated, deprecated_param, experimental_param, public
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
+from dagster._core.definitions.declarative_automation.serialized_objects import (
+    AutomationConditionEvaluation,
+)
 from dagster._core.definitions.events import AssetMaterialization, AssetObservation
 from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.definitions.job_definition import JobDefinition
@@ -87,8 +90,8 @@ class SensorType(Enum):
 
     @property
     def is_handled_by_asset_daemon(self) -> bool:
-        # these "sensors" are currently evaluated by the asset daemon and not the sensor daemon
-        return self in (SensorType.AUTOMATION, SensorType.AUTO_MATERIALIZE)
+        # only the `AUTO_MATERIALIZE` sensor type is handled by the daemon
+        return self == SensorType.AUTO_MATERIALIZE
 
 
 DEFAULT_SENSOR_DAEMON_INTERVAL = 30
@@ -842,6 +845,7 @@ class SensorDefinition(IHasInternalInit):
         ] = []
         updated_cursor = context.cursor
         asset_events = []
+        automation_condition_evaluations: Sequence[AutomationConditionEvaluation] = []
 
         if not result or result == [None]:
             skip_message = "Sensor function returned an empty result"
@@ -869,6 +873,7 @@ class SensorDefinition(IHasInternalInit):
                     updated_cursor = item.cursor  # overwrite value set from context above
 
                 asset_events = item.asset_events
+                automation_condition_evaluations = item.automation_condition_evaluations
 
             elif isinstance(item, RunRequest):
                 run_requests = [item]
@@ -939,6 +944,7 @@ class SensorDefinition(IHasInternalInit):
             log_key=context.log_key if context.has_captured_logs() else None,
             dynamic_partitions_requests=dynamic_partitions_requests,
             asset_events=asset_events,
+            automation_condition_evaluations=automation_condition_evaluations,
         )
 
     def resolve_run_requests(
@@ -1098,6 +1104,7 @@ class SensorExecutionData(
                 "asset_events",
                 Sequence[Union[AssetMaterialization, AssetObservation, AssetCheckEvaluation]],
             ),
+            ("automation_condition_evaluations", Sequence[AutomationConditionEvaluation]),
         ],
     )
 ):
@@ -1116,6 +1123,7 @@ class SensorExecutionData(
         asset_events: Optional[
             Sequence[Union[AssetMaterialization, AssetObservation, AssetCheckEvaluation]]
         ] = None,
+        automation_condition_evaluations: Optional[Sequence[AutomationConditionEvaluation]] = None,
     ):
         check.opt_sequence_param(run_requests, "run_requests", RunRequest)
         check.opt_str_param(skip_message, "skip_message")
@@ -1132,6 +1140,11 @@ class SensorExecutionData(
             "asset_events",
             (AssetMaterialization, AssetObservation, AssetCheckEvaluation),
         )
+        check.opt_sequence_param(
+            automation_condition_evaluations,
+            "automation_condition_evaluations",
+            AutomationConditionEvaluation,
+        )
         check.invariant(
             not (run_requests and skip_message), "Found both skip data and run request data"
         )
@@ -1144,6 +1157,7 @@ class SensorExecutionData(
             log_key=log_key,
             dynamic_partitions_requests=dynamic_partitions_requests,
             asset_events=asset_events or [],
+            automation_condition_evaluations=automation_condition_evaluations or [],
         )
 
 

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -27,6 +27,8 @@ from dagster._core.utils import make_new_run_id
 from dagster._serdes.serdes import NamedTupleSerializer, whitelist_for_serdes
 
 from .tags import (
+    ASSET_EVALUATION_ID_TAG,
+    AUTO_MATERIALIZE_TAG,
     BACKFILL_ID_TAG,
     REPOSITORY_LABEL_TAG,
     RESUME_RETRY_TAG,
@@ -484,8 +486,12 @@ class DagsterRun(
         return {BACKFILL_ID_TAG: backfill_id}
 
     @staticmethod
-    def tags_for_tick_id(tick_id: str) -> Mapping[str, str]:
-        return {TICK_ID_TAG: tick_id}
+    def tags_for_tick_id(tick_id: str, is_automation: bool = False) -> Mapping[str, str]:
+        if is_automation:
+            automation_tags = {AUTO_MATERIALIZE_TAG: "true", ASSET_EVALUATION_ID_TAG: tick_id}
+        else:
+            automation_tags = {}
+        return {TICK_ID_TAG: tick_id, **automation_tags}
 
 
 class RunsFilter(

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -19,16 +19,13 @@ from dagster._core.definitions.asset_daemon_cursor import (
     backcompat_deserialize_asset_daemon_cursor_str,
 )
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
-from dagster._core.definitions.declarative_automation.serialized_objects import (
-    AutomationConditionEvaluation,
-)
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.repository_definition.valid_definitions import (
     SINGLETON_REPOSITORY_NAME,
 )
 from dagster._core.definitions.run_request import InstigatorType, RunRequest
-from dagster._core.definitions.sensor_definition import DefaultSensorStatus, SensorType
+from dagster._core.definitions.sensor_definition import DefaultSensorStatus
 from dagster._core.errors import DagsterCodeLocationLoadError, DagsterUserCodeUnreachableError
 from dagster._core.execution.backfill import PartitionBackfill
 from dagster._core.execution.submit_asset_runs import submit_asset_run
@@ -939,39 +936,25 @@ class AssetDaemon(DagsterDaemon):
         else:
             sensor_tags = {SENSOR_NAME_TAG: sensor.name, **sensor.run_tags} if sensor else {}
 
-            # experimental code path for evaluating scheduling in user space
-            if sensor and sensor.sensor_type == SensorType.AUTOMATION:
-                run_requests, new_cursor, evaluations = invoke_sensor_for_evaluation(
-                    sensor=sensor,
-                    workspace_process_context=workspace_process_context,
-                    instigator_data=check.inst(
-                        check.not_none(instigator_state).instigator_data, SensorInstigatorData
+            run_requests, new_cursor, evaluations = AssetDaemonContext(
+                evaluation_id=evaluation_id,
+                asset_graph=asset_graph,
+                auto_materialize_asset_keys=auto_materialize_asset_keys,
+                instance=instance,
+                cursor=stored_cursor,
+                materialize_run_tags={
+                    **instance.auto_materialize_run_tags,
+                    **DagsterRun.tags_for_tick_id(
+                        str(tick.tick_id),
                     ),
-                    evaluation_id=evaluation_id,
-                    stored_cursor=stored_cursor,
-                    tick=tick,
-                    asset_graph=asset_graph,
-                )
-            else:
-                run_requests, new_cursor, evaluations = AssetDaemonContext(
-                    evaluation_id=evaluation_id,
-                    asset_graph=asset_graph,
-                    auto_materialize_asset_keys=auto_materialize_asset_keys,
-                    instance=instance,
-                    cursor=stored_cursor,
-                    materialize_run_tags={
-                        **instance.auto_materialize_run_tags,
-                        **DagsterRun.tags_for_tick_id(
-                            str(tick.tick_id),
-                        ),
-                        **sensor_tags,
-                    },
-                    observe_run_tags={AUTO_OBSERVE_TAG: "true", **sensor_tags},
-                    auto_observe_asset_keys=auto_observe_asset_keys,
-                    respect_materialization_data_versions=instance.auto_materialize_respect_materialization_data_versions,
-                    logger=self._logger,
-                    request_backfills=request_backfills,
-                ).evaluate()
+                    **sensor_tags,
+                },
+                observe_run_tags={AUTO_OBSERVE_TAG: "true", **sensor_tags},
+                auto_observe_asset_keys=auto_observe_asset_keys,
+                respect_materialization_data_versions=instance.auto_materialize_respect_materialization_data_versions,
+                logger=self._logger,
+                request_backfills=request_backfills,
+            ).evaluate()
 
             check.invariant(new_cursor.evaluation_id == evaluation_id)
 
@@ -1121,46 +1104,3 @@ class AssetDaemon(DagsterDaemon):
             )
 
         self._logger.info(f"Finished auto-materialization tick{print_group_name}")
-
-
-def invoke_sensor_for_evaluation(
-    sensor: ExternalSensor,
-    workspace_process_context: IWorkspaceProcessContext,
-    instigator_data: SensorInstigatorData,
-    evaluation_id: int,
-    stored_cursor: AssetDaemonCursor,
-    tick: InstigatorTick,
-    asset_graph: RemoteAssetGraph,
-) -> Tuple[Sequence[RunRequest], AssetDaemonCursor, Sequence[AutomationConditionEvaluation]]:
-    sensor_origin = sensor.get_external_origin()
-    request_ctx = workspace_process_context.create_request_context()
-    code_loc = request_ctx.get_code_location(sensor_origin.location_name)
-
-    sensor_cursor = AssetDaemonCursor(
-        evaluation_id=evaluation_id,  # bump this before sending it over
-        previous_evaluation_state=stored_cursor.previous_evaluation_state,
-        last_observe_request_timestamp_by_asset_key=stored_cursor.last_observe_request_timestamp_by_asset_key,
-    )
-    sensor_cursor_str = asset_daemon_cursor_to_instigator_serialized_cursor(sensor_cursor)
-    result = code_loc.get_external_sensor_execution_data(
-        instance=workspace_process_context.instance,
-        repository_handle=sensor.handle.repository_handle,
-        name=sensor.name,
-        last_tick_completion_time=instigator_data.last_tick_timestamp,
-        last_run_key=instigator_data.last_run_key,
-        cursor=sensor_cursor_str,
-        log_key=[
-            sensor.handle.repository_handle.repository_name,
-            sensor.name,
-            str(tick.tick_id),
-        ],
-        last_sensor_start_time=instigator_data.last_sensor_start_timestamp,
-    )
-    run_requests = result.run_requests or []
-    new_cursor = asset_daemon_cursor_from_instigator_serialized_cursor(
-        result.cursor,
-        asset_graph,
-    )
-    # TODO: evaluations no longer exist on the cursor object
-    evaluations = []
-    return (run_requests, new_cursor, evaluations)


### PR DESCRIPTION
## Summary & Motivation

In the current-day world, UserCodeAutomationConditionSensor is still handled by the AssetDaemon. This PR imagines a world in which it is handled directly by the SensorDaemon.

This is an MVP, and as such I chose not to include the (rather important) error handling logic which exists inside of the AssetDaemon. That adds a fair amount of complexity which I haven't quite figured out.

The nice thing about this PR is that it doesn't really make any big changes to the SensorDaemon logic, it just adds a bit of extra code for handling sensor results which contain AutomationConditionEvaluations. This leaves the door open for a future in which "regular" sensors could also emit AutomationConditionEvaluations (i.e. imagine a sensor that sends an email if a particular AutomationCondition becomes true -- this wouldn't make sense to model as an asset, you'd want to attach an AutomationCondition directly to a chunk of user code).

However, if I want to replicate all of the error handling / retry stuff, I think I'll probably need to fork this a bit more, and ideally I'd do that in a nice way that is not 100% tied to this specific sensor type. A bit of an open question on how to do that, but wanted to get some ideas on this basic structure before charging ahead on that effort.

## How I Tested These Changes
