### PR TITLE
support unserializable metadata on `AssetCheckSpec`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping, NamedTuple, Optional, 
 import dagster._check as check
 from dagster._annotations import PublicAttr
 from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey, CoercibleToAssetKey
-from dagster._core.definitions.metadata import RawMetadataMapping
 from dagster._serdes.serdes import whitelist_for_serdes
 
 if TYPE_CHECKING:
@@ -70,7 +69,7 @@ class AssetCheckSpec(
         description: Optional[str] = None,
         additional_deps: Optional[Iterable["CoercibleToAssetDep"]] = None,
         blocking: bool = False,
-        metadata: Optional[RawMetadataMapping] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
     ):
         from dagster._core.definitions.asset_dep import coerce_to_deps_and_check_duplicates
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_spec.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_spec.py
@@ -29,3 +29,11 @@ def test_additional_deps():
         ),
     ):
         AssetCheckSpec(asset="foo", name="check1", additional_deps=["foo"])
+
+
+def test_unserializable_metadata():
+    class SomeObject: ...
+
+    obj = SomeObject()
+
+    assert AssetCheckSpec(asset="foo", name="check1", metadata={"foo": obj}).metadata["foo"] == obj


### PR DESCRIPTION
## Summary & Motivation

In line with @schrockn's proposal here: https://github.com/dagster-io/dagster/pull/22314. This makes it function the same as `AssetSpec`.

The direct motivation for this is https://github.com/dagster-io/dagster/pull/23191.

## How I Tested These Changes

I would have also added a test to make sure it doesn't cause any errors on serialization, but discovered that `ExternalAssetCheck` doesn't actually have a metadata field yet, so this metadata is not currently serialized. I'll try to add that field as a followup if I can squeeze it in.