### PR TITLE
Add breadcrumb to update the buildkite-test account when you update the buildkite base image

### DIFF
--- a/python_modules/automation/automation/docker/images/README.md
+++ b/python_modules/automation/automation/docker/images/README.md
@@ -42,6 +42,9 @@ Once you are authenticated, you can publish the newly built images with:
 
     dagster-image push-all --name <IMAGE NAME>
 
+Note that for the buildkite-test image you must also push the images to the dagster-buildkite
+AWS account as well (559363006250).
+
 To see your published images on AWS, go to https://elementl.awsapps.com/start#/
 and enter the "Management Console" for the "elementl" account (#968703565975).
 Click through to "ECR" and you should see a list of "Private repositories".


### PR DESCRIPTION
Forgot to do this when updating the base image.

Test Plan: View page
