### PR TITLE
[jobless-automation] Expose target as assetSelection in GQL

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -1611,11 +1611,19 @@ type Schedule {
   futureTicks(cursor: Float, limit: Int, until: Float): DryRunInstigationTicks!
   futureTick(tickTimestamp: Int!): DryRunInstigationTick!
   potentialTickTimestamps(startTimestamp: Float, upperLimit: Int, lowerLimit: Int): [Float!]!
+  assetSelection: AssetSelection
 }
 
 enum InstigationStatus {
   RUNNING
   STOPPED
+}
+
+type AssetSelection {
+  assetSelectionString: String
+  assetKeys: [AssetKey!]!
+  assets: [Asset!]!
+  assetsOrError: AssetsOrError!
 }
 
 union ScheduleMutationResult = PythonError | UnauthorizedError | ScheduleStateResult
@@ -2977,13 +2985,6 @@ type Target {
 
 type SensorMetadata {
   assetKeys: [AssetKey!]
-}
-
-type AssetSelection {
-  assetSelectionString: String
-  assetKeys: [AssetKey!]!
-  assets: [Asset!]!
-  assetsOrError: AssetsOrError!
 }
 
 union SensorOrError = Sensor | SensorNotFoundError | UnauthorizedError | PythonError

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -4766,6 +4766,7 @@ export type ScalarUnionConfigType = ConfigType & {
 
 export type Schedule = {
   __typename: 'Schedule';
+  assetSelection: Maybe<AssetSelection>;
   canReset: Scalars['Boolean']['output'];
   cronSchedule: Scalars['String']['output'];
   defaultStatus: InstigationStatus;
@@ -13534,6 +13535,12 @@ export const buildSchedule = (
   relationshipsToOmit.add('Schedule');
   return {
     __typename: 'Schedule',
+    assetSelection:
+      overrides && overrides.hasOwnProperty('assetSelection')
+        ? overrides.assetSelection!
+        : relationshipsToOmit.has('AssetSelection')
+        ? ({} as AssetSelection)
+        : buildAssetSelection({}, relationshipsToOmit),
     canReset: overrides && overrides.hasOwnProperty('canReset') ? overrides.canReset! : false,
     cronSchedule:
       overrides && overrides.hasOwnProperty('cronSchedule') ? overrides.cronSchedule! : 'possimus',

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -142,7 +142,9 @@ def get_schedules_or_error(
         filtered = external_schedules
 
     results = [
-        GrapheneSchedule(schedule, schedule_states_by_name.get(schedule.name), batch_loader)
+        GrapheneSchedule(
+            schedule, repository, schedule_states_by_name.get(schedule.name), batch_loader
+        )
         for schedule in filtered
     ]
 
@@ -169,7 +171,7 @@ def get_schedules_for_pipeline(
             external_schedule.get_external_origin_id(),
             external_schedule.selector_id,
         )
-        results.append(GrapheneSchedule(external_schedule, schedule_state))
+        results.append(GrapheneSchedule(external_schedule, repository, schedule_state))
 
     return results
 
@@ -194,7 +196,7 @@ def get_schedule_or_error(
     schedule_state = graphene_info.context.instance.get_instigator_state(
         external_schedule.get_external_origin_id(), external_schedule.selector_id
     )
-    return GrapheneSchedule(external_schedule, schedule_state)
+    return GrapheneSchedule(external_schedule, repository, schedule_state)
 
 
 def get_schedule_next_tick(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -970,7 +970,9 @@ class GrapheneAssetNode(graphene.ObjectType):
                     external_schedule.get_external_origin_id(),
                     external_schedule.selector_id,
                 )
-                results.append(GrapheneSchedule(external_schedule, schedule_state))
+                results.append(
+                    GrapheneSchedule(external_schedule, self._external_repository, schedule_state)
+                )
 
         return results
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -301,6 +301,7 @@ class GrapheneRepository(graphene.ObjectType):
             [
                 GrapheneSchedule(
                     schedule,
+                    self._repository,
                     self._batch_loader.get_schedule_state(schedule.name),
                     self._batch_loader,
                 )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -1510,6 +1510,31 @@ def test_asset_selection(graphql_context):
     ]
 
 
+def test_jobless_asset_selection(graphql_context):
+    sensor_name = "jobless_sensor"
+    sensor_selector = infer_sensor_selector(graphql_context, sensor_name)
+
+    result = execute_dagster_graphql(
+        graphql_context, GET_SENSOR_QUERY, variables={"sensorSelector": sensor_selector}
+    )
+
+    assert result.data
+    assert result.data["sensorOrError"]["__typename"] == "Sensor"
+    assert result.data["sensorOrError"]["assetSelection"]["assetSelectionString"] == "asset_one"
+    assert result.data["sensorOrError"]["assetSelection"]["assetKeys"] == [{"path": ["asset_one"]}]
+    assert result.data["sensorOrError"]["assetSelection"]["assets"] == [
+        {
+            "key": {"path": ["asset_one"]},
+            "definition": {"assetKey": {"path": ["asset_one"]}},
+        }
+    ]
+    assert result.data["sensorOrError"]["assetSelection"]["assetsOrError"]["nodes"] == [
+        {
+            "key": {"path": ["asset_one"]},
+        }
+    ]
+
+
 def test_invalid_sensor_asset_selection(graphql_context):
     sensor_name = "invalid_asset_selection_error"
     sensor_selector = infer_sensor_selector(graphql_context, sensor_name)

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -783,7 +783,7 @@ class SensorDefinition(IHasInternalInit):
 
     @public
     @property
-    def job(self) -> ExecutableDefinition:
+    def job(self) -> Union[JobDefinition, "UnresolvedAssetJobDefinition"]:
         """Union[GraphDefinition, JobDefinition, UnresolvedAssetJobDefinition]: The job that is
         targeted by this schedule.
         """

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -776,6 +776,10 @@ class ExternalSchedule:
         return self._external_schedule_data.job_name
 
     @property
+    def asset_selection(self) -> Optional[AssetSelection]:
+        return self._external_schedule_data.asset_selection
+
+    @property
     def mode(self) -> Optional[str]:
         return self._external_schedule_data.mode
 

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -87,6 +87,7 @@ from dagster._core.definitions.sensor_definition import (
     SensorType,
 )
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
+from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.snap import JobSnapshot
@@ -430,6 +431,7 @@ class ScheduleSnap(
             ("execution_timezone", Optional[str]),
             ("description", Optional[str]),
             ("default_status", Optional[DefaultScheduleStatus]),
+            ("asset_selection", Optional[AssetSelection]),
         ],
     )
 ):
@@ -445,10 +447,18 @@ class ScheduleSnap(
         execution_timezone: Optional[str],
         description: Optional[str] = None,
         default_status: Optional[DefaultScheduleStatus] = None,
+        asset_selection: Optional[AssetSelection] = None,
     ):
         cron_schedule = check.inst_param(cron_schedule, "cron_schedule", (str, Sequence))
         if not isinstance(cron_schedule, str):
             cron_schedule = check.sequence_param(cron_schedule, "cron_schedule", of_type=str)
+
+        if asset_selection is not None:
+            check.opt_inst_param(asset_selection, "asset_selection", AssetSelection)
+            check.invariant(
+                is_whitelisted_for_serdes_object(asset_selection),
+                "asset_selection must be serializable",
+            )
 
         return super(ScheduleSnap, cls).__new__(
             cls,
@@ -467,10 +477,27 @@ class ScheduleSnap(
                 if default_status == DefaultScheduleStatus.RUNNING
                 else None
             ),
+            asset_selection=check.opt_inst_param(
+                asset_selection, "asset_selection", AssetSelection
+            ),
         )
 
     @classmethod
-    def from_def(cls, schedule_def: ScheduleDefinition) -> Self:
+    def from_def(
+        cls, schedule_def: ScheduleDefinition, repository_def: RepositoryDefinition
+    ) -> Self:
+        if schedule_def.has_anonymous_job:
+            job_def = check.inst(
+                schedule_def.job,
+                UnresolvedAssetJobDefinition,
+                "Anonymous job should be UnresolvedAssetJobDefinition",
+            )
+            serializable_asset_selection = job_def.selection.to_serializable_asset_selection(
+                repository_def.asset_graph
+            )
+        else:
+            serializable_asset_selection = None
+
         return cls(
             name=schedule_def.name,
             cron_schedule=schedule_def.cron_schedule,
@@ -482,6 +509,7 @@ class ScheduleSnap(
             execution_timezone=schedule_def.execution_timezone,
             description=schedule_def.description,
             default_status=schedule_def.default_status,
+            asset_selection=serializable_asset_selection,
         )
 
 
@@ -644,7 +672,17 @@ class SensorSnap(
                 for target in sensor_def.targets
             }
 
-            serializable_asset_selection = None
+            if sensor_def.has_anonymous_job:
+                job_def = check.inst(
+                    sensor_def.job,
+                    UnresolvedAssetJobDefinition,
+                    "Anonymous job should be UnresolvedAssetJobDefinition",
+                )
+                serializable_asset_selection = job_def.selection.to_serializable_asset_selection(
+                    repository_def.asset_graph
+                )
+            else:
+                serializable_asset_selection = None
 
         return cls(
             name=sensor_def.name,
@@ -1591,7 +1629,10 @@ def external_repository_data_from_def(
     return ExternalRepositoryData(
         name=repository_def.name,
         external_schedule_datas=sorted(
-            [ScheduleSnap.from_def(schedule_def) for schedule_def in repository_def.schedule_defs],
+            [
+                ScheduleSnap.from_def(schedule_def, repository_def)
+                for schedule_def in repository_def.schedule_defs
+            ],
             key=lambda sd: sd.name,
         ),
         # `PartitionSetDefinition` has been deleted, so we now construct `PartitionSetSnap`
@@ -1961,22 +2002,6 @@ def external_resource_data_from_def(
         sensors_using=resource_sensor_usage_map.get(name, []),
         resource_type=resource_type,
         dagster_maintained=dagster_maintained,
-    )
-
-
-def external_schedule_data_from_def(schedule_def: ScheduleDefinition) -> ScheduleSnap:
-    check.inst_param(schedule_def, "schedule_def", ScheduleDefinition)
-    return ScheduleSnap(
-        name=schedule_def.name,
-        cron_schedule=schedule_def.cron_schedule,
-        job_name=schedule_def.job_name,
-        op_selection=schedule_def.target.op_selection,
-        mode=DEFAULT_MODE_NAME,
-        environment_vars=schedule_def.environment_vars,
-        partition_set_name=None,
-        execution_timezone=schedule_def.execution_timezone,
-        description=schedule_def.description,
-        default_status=schedule_def.default_status,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
@@ -2280,6 +2280,7 @@
     "external_schedule_datas": [
       {
         "__class__": "ExternalScheduleData",
+        "asset_selection": null,
         "cron_schedule": "@daily",
         "description": null,
         "environment_vars": {},


### PR DESCRIPTION
## Summary & Motivation

- Add an `asset_selection` param to `ScheduleSnap` and `Schedule` in GQL API
- Populate `asset_selection` on both `ScheduleSnap` and `SensorSnap` (which leads to population of corresponding fields in GQL) using the `target` passed to `ScheduleDefinition`/`SensorDefinition` for jobless automation.

Background: "jobless" (i.e. assets passed as `target`) schedules/sensors create an anonymous asset job under the hood. We do not want the UI to expose this asset job-- instead, we want it to just show the targeted assets. There is prior art here. Before the new `target` parameter, it was already possible to pass an `asset_selection` rather than `job` to `SensorDefinition`, and the UI would render the target accordingly.

This PR leverages/copies this existing "jobless sensor" infrastructure for the snap/GQL layer:

- `SensorSnap`/`GrapheneSensor` already had an `asset_selection` parameter, so we just needed to correctly populate it with the targeted assets when a sensor has an anonymous asset job. This allows the UI to inspect the `assetSelection` field on a fetched sensor and render the selected assets and hide the job for all jobless sensors.
- `ScheduleSnap`/`GrapheneSensor` did not have an `asset_selection` parameter, but it was simple to just copy the approach already used for sensors.

## How I Tested These Changes

New unit tests. @hellendag has also stacked UI on this that is working in his tests:

- #23208
- #23233 

