### PR TITLE
[1.8][external assets] deprecate external_assets_from_specs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -25,6 +25,7 @@ from dagster._core.definitions.resolved_asset_deps import ResolvedAssetDependenc
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster._core.selector.subset_selector import generate_asset_dep_graph
+from dagster._utils.warnings import disable_dagster_warnings
 
 
 class AssetNode(BaseAssetNode):
@@ -169,10 +170,7 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
         - Creating unexecutable external asset definitions for any keys referenced by asset checks
           or as dependencies, but for which no definition was provided.
         """
-        from dagster._core.definitions.external_asset import (
-            create_external_asset_from_source_asset,
-            external_asset_from_spec,
-        )
+        from dagster._core.definitions.external_asset import create_external_asset_from_source_asset
 
         # Convert any source assets to external assets
         assets_defs = [
@@ -208,12 +206,18 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
         all_referenced_asset_keys = {
             key for assets_def in assets_defs for key in assets_def.dependency_keys
         }
-        for key in all_referenced_asset_keys.difference(all_keys):
-            assets_defs.append(
-                external_asset_from_spec(
-                    AssetSpec(key=key, metadata={SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET: True})
+        with disable_dagster_warnings():
+            for key in all_referenced_asset_keys.difference(all_keys):
+                assets_defs.append(
+                    AssetsDefinition(
+                        specs=[
+                            AssetSpec(
+                                key=key,
+                                metadata={SYSTEM_METADATA_KEY_AUTO_CREATED_STUB_ASSET: True},
+                            )
+                        ]
+                    )
                 )
-            )
         return assets_defs
 
     @classmethod

--- a/python_modules/dagster/dagster/_core/definitions/external_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/external_asset.py
@@ -1,6 +1,7 @@
 from typing import List, Sequence
 
 from dagster import _check as check
+from dagster._annotations import deprecated, experimental
 from dagster._core.definitions.asset_spec import (
     SYSTEM_METADATA_KEY_AUTO_OBSERVE_INTERVAL_MINUTES,
     SYSTEM_METADATA_KEY_IO_MANAGER_KEY,
@@ -21,6 +22,8 @@ def external_asset_from_spec(spec: AssetSpec) -> AssetsDefinition:
     return external_assets_from_specs([spec])[0]
 
 
+@deprecated(breaking_version="1.9.0", additional_warn_text="Directly use the AssetSpecs instead.")
+@experimental
 def external_assets_from_specs(specs: Sequence[AssetSpec]) -> List[AssetsDefinition]:
     """Create an external assets definition from a sequence of asset specs.
 


### PR DESCRIPTION
## Summary & Motivation

Also retroactively marks it as experimental, which was the original intention.

## How I Tested These Changes
