### PR TITLE
Make @sensor pass eval_fn name as SensorDefinition.name

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -90,7 +90,7 @@ def sensor(
         check.callable_param(fn, "fn")
 
         sensor_def = SensorDefinition.dagster_internal_init(
-            name=name,
+            name=name or fn.__name__,
             job_name=job_name,
             evaluation_fn=fn,
             minimum_interval_seconds=minimum_interval_seconds,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_sensor_decorator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_sensor_decorator.py
@@ -22,3 +22,14 @@ def test_coerce_to_asset_selection():
     def sensor2(): ...
 
     assert sensor2.asset_selection.resolve(assets) == {AssetKey("asset1"), AssetKey("asset2")}
+
+
+def test_jobless_sensor_uses_eval_fn_name():
+    @asset
+    def asset1(): ...
+
+    @sensor(target=asset1)
+    def my_sensor():
+        pass
+
+    assert my_sensor.name == "my_sensor"


### PR DESCRIPTION
## Summary & Motivation

This makes `@sensor` pass `name or eval_fn.__name__` to `SensorDefinition` (which is what schedules already do), preventing an invariant error when doing this, since jobless sensors/schedules require a set `name`:

```
@sensor(target=[...])
def my_sensor():
    ...
```

## How I Tested These Changes

New unit test.