### PR TITLE
make asset execution context a standalone class

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_pipes.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_pipes.py
@@ -194,7 +194,7 @@ def test_use_execute_k8s_job(namespace, cluster_provider):
 
             # stand-in for any means of creating kubernetes work
             execute_k8s_job(
-                context=context,
+                context=context.op_execution_context,
                 image=docker_image,
                 command=[
                     "python",

--- a/python_modules/dagster/dagster/_core/execution/context/asset_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/asset_execution_context.py
@@ -83,7 +83,7 @@ def _get_deprecation_kwargs(attr: str) -> Mapping[str, Any]:
     return deprecation_kwargs
 
 
-class AssetExecutionContext(OpExecutionContext):
+class AssetExecutionContext:
     def __init__(self, op_execution_context: OpExecutionContext) -> None:
         self._op_execution_context = check.inst_param(
             op_execution_context, "op_execution_context", OpExecutionContext
@@ -381,6 +381,12 @@ class AssetExecutionContext(OpExecutionContext):
     @_copy_docs_from_op_execution_context
     def partition_keys(self) -> Sequence[str]:
         return self.op_execution_context.partition_keys
+
+    @public
+    @property
+    @_copy_docs_from_op_execution_context
+    def has_partition_key_range(self) -> bool:
+        return self.op_execution_context.has_partition_key_range
 
     @deprecated(breaking_version="2.0", additional_warn_text="Use `partition_key_range` instead.")
     @public

--- a/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
@@ -1,4 +1,4 @@
-from abc import ABC, ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from typing import AbstractSet, Any, Dict, Iterator, List, Mapping, Optional, Sequence, cast
 
 import dagster._check as check
@@ -33,17 +33,11 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.log_manager import DagsterLogManager
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._utils.forked_pdb import ForkedPdb
-from dagster._utils.warnings import deprecation_warning
 
 from .system import StepExecutionContext
 
 
-# This metaclass has to exist for OpExecutionContext to have a metaclass
-class AbstractComputeMetaclass(ABCMeta):
-    pass
-
-
-class AbstractComputeExecutionContext(ABC, metaclass=AbstractComputeMetaclass):
+class AbstractComputeExecutionContext(ABC):
     """Base class for op context implemented by OpExecutionContext and DagstermillExecutionContext."""
 
     @abstractmethod
@@ -95,27 +89,7 @@ class AbstractComputeExecutionContext(ABC, metaclass=AbstractComputeMetaclass):
         """The parsed config specific to this op."""
 
 
-class OpExecutionContextMetaClass(AbstractComputeMetaclass):
-    def __instancecheck__(cls, instance) -> bool:
-        from .asset_execution_context import AssetExecutionContext
-
-        # This makes isinstance(context, OpExecutionContext) throw a deprecation warning when
-        # context is an AssetExecutionContext. This metaclass can be deleted once AssetExecutionContext
-        # has been split into it's own class in 1.7.0
-        if type(instance) is AssetExecutionContext and cls is not AssetExecutionContext:
-            deprecation_warning(
-                subject="AssetExecutionContext",
-                additional_warn_text=(
-                    "Starting in version 1.8.0 AssetExecutionContext will no longer be a subclass"
-                    " of OpExecutionContext."
-                ),
-                breaking_version="1.8.0",
-                stacklevel=1,
-            )
-        return super().__instancecheck__(instance)
-
-
-class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionContextMetaClass):
+class OpExecutionContext(AbstractComputeExecutionContext):
     """The ``context`` object that can be made available as the first argument to the function
     used for computing an op or asset.
 

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Sequence, Union
 
 from dagster_pipes import (
     DagsterPipesError,
@@ -14,7 +14,8 @@ import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.result import MaterializeResult
-from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from dagster._core.execution.context.op_execution_context import OpExecutionContext
 
 from .context import PipesExecutionResult, PipesSession
 
@@ -33,7 +34,7 @@ class PipesClient(ABC):
     def run(
         self,
         *,
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
         extras: Optional[PipesExtras] = None,
         **kwargs,
     ) -> "PipesClientCompletedInvocation":
@@ -42,7 +43,7 @@ class PipesClient(ABC):
          arguments that are appropriate for their own implementation.
 
         Args:
-            context (OpExecutionContext): The context from the executing op/asset.
+            context (Union[OpExecutionContext, AssetExecutionContext]): The context from the executing op/asset.
             extras (Optional[PipesExtras]): Arbitrary data to pass to the external environment.
 
         Returns:

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -39,8 +39,9 @@ from dagster._core.definitions.time_window_partitions import (
 )
 from dagster._core.errors import DagsterPipesExecutionError
 from dagster._core.events import EngineEventData
-from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.execution.context.invocation import BaseDirectExecutionContext
+from dagster._core.execution.context.op_execution_context import OpExecutionContext
 from dagster._utils.error import (
     ExceptionInfo,
     SerializableErrorInfo,
@@ -58,7 +59,7 @@ class PipesMessageHandler:
     """Class to process :py:obj:`PipesMessage` objects received from a pipes process.
 
     Args:
-        context (OpExecutionContext): The context for the executing op/asset.
+        context (Union[OpExecutionContext, AssetExecutionContext]): The context for the executing op/asset.
         message_reader (PipesMessageReader): The message reader used to read messages from the
             external process.
     """
@@ -66,7 +67,11 @@ class PipesMessageHandler:
     # In the future it may make sense to merge PipesMessageReader and PipesMessageHandler, or
     # otherwise adjust their relationship. The current interaction between the two is a bit awkward,
     # but it would also be awkward to have a monolith that users extend.
-    def __init__(self, context: OpExecutionContext, message_reader: "PipesMessageReader") -> None:
+    def __init__(
+        self,
+        context: Union[OpExecutionContext, AssetExecutionContext],
+        message_reader: "PipesMessageReader",
+    ) -> None:
         self._context = context
         self._message_reader = message_reader
         # Queue is thread-safe
@@ -273,7 +278,7 @@ class PipesSession:
     message_handler: PipesMessageHandler
     context_injector_params: PipesParams
     message_reader_params: PipesParams
-    context: OpExecutionContext
+    context: Union[OpExecutionContext, AssetExecutionContext]
 
     @public
     def get_bootstrap_env_vars(self) -> Mapping[str, str]:
@@ -375,7 +380,7 @@ class PipesSession:
 
 
 def build_external_execution_context_data(
-    context: OpExecutionContext,
+    context: Union[OpExecutionContext, AssetExecutionContext],
     extras: Optional[PipesExtras],
 ) -> "PipesContextData":
     asset_keys = (

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -9,7 +9,8 @@ from dagster import _check as check
 from dagster._annotations import public
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.errors import DagsterExecutionInterruptedError, DagsterPipesExecutionError
-from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from dagster._core.execution.context.op_execution_context import OpExecutionContext
 from dagster._core.pipes.client import (
     PipesClient,
     PipesClientCompletedInvocation,
@@ -83,7 +84,7 @@ class PipesSubprocessClient(PipesClient, TreatAsResourceParam):
     def run(
         self,
         *,
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
         extras: Optional[PipesExtras] = None,
         command: Union[str, Sequence[str]],
         env: Optional[Mapping[str, str]] = None,

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -8,7 +8,7 @@ import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from threading import Event, Thread
-from typing import Iterator, Optional, Sequence, TextIO
+from typing import Iterator, Optional, Sequence, TextIO, Union
 
 from dagster_pipes import (
     PIPES_PROTOCOL_VERSION_FIELD,
@@ -25,6 +25,7 @@ from dagster import (
     _check as check,
 )
 from dagster._core.errors import DagsterInvariantViolationError, DagsterPipesExecutionError
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.client import PipesContextInjector, PipesMessageReader
 from dagster._core.pipes.context import (
     PipesMessageHandler,
@@ -537,7 +538,7 @@ _FAIL_TO_YIELD_ERROR_MESSAGE = (
 
 @contextmanager
 def open_pipes_session(
-    context: OpExecutionContext,
+    context: Union[OpExecutionContext, AssetExecutionContext],
     context_injector: PipesContextInjector,
     message_reader: PipesMessageReader,
     extras: Optional[PipesExtras] = None,
@@ -557,7 +558,7 @@ def open_pipes_session(
 
 
     Args:
-        context (OpExecutionContext): The context for the current op/asset execution.
+        context (Union[OpExecutionContext, AssetExecutionContext]): The context for the current op/asset execution.
         context_injector (PipesContextInjector): The context injector to use to inject context into the external process.
         message_reader (PipesMessageReader): The message reader to use to read messages from the external process.
         extras (Optional[PipesExtras]): Optional extras to pass to the external process via the injected context.
@@ -573,7 +574,7 @@ def open_pipes_session(
         extras = {"foo": "bar"}
 
         @asset
-        def ext_asset(context: OpExecutionContext):
+        def ext_asset(context: AssetExecutionContext):
             with open_pipes_session(
                 context=context,
                 extras={"foo": "bar"},

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 from dagster import (
     AllPartitionMapping,
+    AssetExecutionContext,
     AssetKey,
     AssetOut,
     DagsterInvalidDefinitionError,
@@ -15,7 +16,6 @@ from dagster import (
     MultiPartitionMapping,
     MultiPartitionsDefinition,
     Nothing,
-    OpExecutionContext,
     Out,
     Output,
     StaticPartitionsDefinition,
@@ -551,7 +551,7 @@ def test_invoking_asset_with_deps():
 def test_invoking_asset_with_context():
     @asset
     def asset_with_context(context, arg1):
-        assert isinstance(context, OpExecutionContext)
+        assert isinstance(context, AssetExecutionContext)
         return arg1
 
     ctx = build_asset_context()

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_execution_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_execution_context.py
@@ -1,10 +1,10 @@
-import pytest
-from dagster import AssetExecutionContext, OpExecutionContext, asset, materialize
-from dagster._core.execution.context.asset_execution_context import _get_deprecation_kwargs
-from dagster._core.test_utils import raise_exception_on_warnings
+from dagster import AssetExecutionContext, OpExecutionContext
 
 
 def test_doc_strings():
+    """Tests that methods on AssetExecutionContext correctly get their doc strings from the corresponding
+    method on OpExecutionContext.
+    """
     ignores = [
         "_abc_impl",
         "_events",
@@ -26,129 +26,3 @@ def test_doc_strings():
             asset_attr = getattr(AssetExecutionContext, attr_name)
 
             assert op_attr.__doc__ == asset_attr.__doc__
-
-
-def test_deprecation_warnings():
-    # Test that every method on OpExecutionContext is either reimplemented by AssetExecutionContext
-    # or throws a deprecation warning on AssetExecutionContext. This will allow us to eventually make
-    # AssetExecutionContext not a subclass of OpExecutionContext without doing a breaking change.
-
-    # If this test fails, it is likely because you added a method to OpExecutionContext without
-    # also adding that method to AssetExecutionContext. Please add the same method to AssetExecutionContext
-    # with an appropriate deprecation warning (see existing deprecated methods for examples).
-    # If the method should not be deprecated for AssetExecutionContext, please still add the same method
-    # to AssetExecutionContext and add the method name to asset_context_not_deprecated
-
-    # This list maintains all methods on OpExecutionContext that are not deprecated on AssetExecutionContext
-    asset_context_not_deprecated = [
-        # will not be deprecated
-        "job_def",
-        "log",
-        "pdb",
-        "run",
-        "get",
-        # methods/properties that may be deprecated in future PRs
-        "add_output_metadata",
-        "asset_check_spec",
-        "asset_checks_def",
-        "asset_key",
-        "asset_key_for_input",
-        "asset_key_for_output",
-        "asset_partition_key_for_input",
-        "asset_partition_key_range",
-        "asset_partition_key_range_for_input",
-        "asset_partition_keys_for_input",
-        "asset_partitions_def_for_input",
-        "asset_partitions_time_window_for_input",
-        "assets_def",
-        "get_output_metadata",
-        "has_asset_checks_def",
-        "has_partition_key",
-        "has_partition_key_range",
-        "instance",
-        "job_name",
-        "output_for_asset_key",
-        "partition_key",
-        "partition_key_range",
-        "partition_time_window",
-        "requires_typed_event_stream",
-        "resources",
-        "selected_asset_check_keys",
-        "selected_asset_keys",
-        "set_data_version",
-        "set_requires_typed_event_stream",
-        "typed_event_stream_error_message",
-        "describe_op",
-        "op_def",
-        "has_assets_def",
-        "get_step_execution_context",
-        "step_launcher",
-        "has_events",
-        "consume_events",
-        "log_event",
-        "get_asset_provenance",
-        "is_subset",
-        "partition_keys",
-        "retry_number",
-        "op_execution_context",
-        "repository_def",
-    ]
-
-    other_ignores = [
-        "_abc_impl",
-        "_events",
-        "_output_metadata",
-        "_pdb",
-        "_step_execution_context",
-    ]
-
-    def assert_deprecation_messages_as_expected(received_info, expected_info):
-        assert received_info.breaking_version == expected_info["breaking_version"]
-        assert received_info.additional_warn_text == expected_info["additional_warn_text"]
-        assert received_info.subject == expected_info["subject"]
-
-    for attr in dir(OpExecutionContext):
-        if attr.startswith("__") or attr in other_ignores:
-            continue
-        if not hasattr(AssetExecutionContext, attr):
-            raise Exception(
-                f"Property {attr} on OpExecutionContext does not have an implementation on"
-                " AssetExecutionContext. All properties on OpExecutionContext must be"
-                " re-implemented on AssetExecutionContext with appropriate deprecation"
-                " warnings. See the class implementation of AssetExecutionContext for more details."
-            )
-
-        asset_context_attr = getattr(AssetExecutionContext, attr)
-
-        if attr not in asset_context_not_deprecated:
-            if isinstance(asset_context_attr, property):
-                asset_context_fn = asset_context_attr.fget
-            else:
-                asset_context_fn = asset_context_attr
-            if not hasattr(asset_context_fn, "_deprecated"):
-                raise Exception(
-                    f"Property {attr} on OpExecutionContext is implemented but not deprecated on"
-                    " AssetExecutionContext. If this in intended, update asset_context_not_deprecated."
-                    f" Otherwise, add a deprecation warning to {attr}."
-                )
-
-            deprecation_info = asset_context_fn._deprecated  # noqa: SLF001
-            expected_deprecation_args = _get_deprecation_kwargs(attr)
-            assert_deprecation_messages_as_expected(deprecation_info, expected_deprecation_args)
-
-
-def test_instance_check():
-    raise_exception_on_warnings()
-
-    @asset
-    def test_op_context_instance_check(context: AssetExecutionContext):
-        assert isinstance(context, OpExecutionContext)
-
-    with pytest.raises(DeprecationWarning):
-        materialize([test_op_context_instance_check])
-
-    @asset
-    def test_asset_context_instance_check(context: AssetExecutionContext):
-        assert isinstance(context, AssetExecutionContext)
-
-    assert materialize([test_asset_context_instance_check]).success

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
@@ -33,7 +33,7 @@ from dagster._core.definitions.repository_definition.repository_definition impor
 )
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._core.storage.dagster_run import DagsterRun
-from dagster._core.test_utils import instance_for_test, raise_exception_on_warnings
+from dagster._core.test_utils import instance_for_test
 
 
 def test_op_execution_context():
@@ -97,46 +97,6 @@ def test_asset_execution_repo_context():
     with instance_for_test() as instance:
         result = execute_job(recon_job, instance)
         assert result.success
-
-
-def test_instance_check():
-    raise_exception_on_warnings()
-
-    class AssetExecutionContextSubclass(AssetExecutionContext):
-        # allows us to confirm isinstance(context, AssetExecutionContext)
-        # does not throw deprecation warnings
-        def __init__(self):
-            pass
-
-    @op
-    def test_op_context_instance_check(context: OpExecutionContext):
-        step_context = context._step_execution_context  # noqa: SLF001
-        op_context = OpExecutionContext(step_execution_context=step_context)
-        asset_context = AssetExecutionContext(op_execution_context=op_context)
-        with pytest.raises(DeprecationWarning):
-            isinstance(asset_context, OpExecutionContext)
-        assert not isinstance(op_context, AssetExecutionContext)
-
-        # the instance checks below will not hit the metaclass __instancecheck__ method because
-        # python returns early if the type is the same
-        # https://github.com/python/cpython/blob/b57b4ac042b977e0b42a2f5ddb30ca7edffacfa9/Objects/abstract.c#L2404
-        # but still test for completeness
-        assert isinstance(asset_context, AssetExecutionContext)
-        assert isinstance(op_context, OpExecutionContext)
-
-        # since python short circuits when context is AssetExecutionContext and you call
-        # isinstance(context, AssetExecutionContext), make a subclass of AssetExecutionContext
-        # so that we can ensure isinstance(context, AssetExecutionContext) doesn't throw a
-        # deprecation warning
-
-        asset_subclass_context = AssetExecutionContextSubclass()
-        assert isinstance(asset_subclass_context, AssetExecutionContext)
-
-    @job
-    def test_isinstance():
-        test_op_context_instance_check()
-
-    test_isinstance.execute_in_process()
 
 
 def test_context_provided_to_asset():

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/in_process_client.py
@@ -1,9 +1,10 @@
 from contextlib import contextmanager
-from typing import Callable, Iterator, List, Optional
+from typing import Callable, Iterator, List, Optional, Union
 
 from dagster._annotations import public
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
-from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from dagster._core.execution.context.op_execution_context import OpExecutionContext
 from dagster._core.pipes.client import (
     PipesClient,
     PipesClientCompletedInvocation,
@@ -101,7 +102,7 @@ class InProcessPipesClient(PipesClient, TreatAsResourceParam):
     def run(
         self,
         *,
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
         fn: Callable[[PipesContext], None],
         extras: Optional[PipesExtras] = None,
     ) -> PipesClientCompletedInvocation:

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
@@ -5,7 +5,7 @@ import random
 import string
 import time
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Dict, Iterator, Literal, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Literal, Mapping, Optional, Sequence, Union
 
 import boto3
 import dagster._check as check
@@ -13,7 +13,8 @@ from botocore.exceptions import ClientError
 from dagster import PipesClient
 from dagster._annotations import experimental
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
-from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from dagster._core.execution.context.op_execution_context import OpExecutionContext
 from dagster._core.pipes.client import (
     PipesClientCompletedInvocation,
     PipesContextInjector,
@@ -220,7 +221,7 @@ class PipesLambdaClient(PipesClient, TreatAsResourceParam):
         *,
         function_name: str,
         event: Mapping[str, Any],
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
     ) -> PipesClientCompletedInvocation:
         """Synchronously invoke a lambda function, enriched with the pipes protocol.
 
@@ -310,7 +311,7 @@ class PipesGlueClient(PipesClient, TreatAsResourceParam):
         self,
         *,
         job_name: str,
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
         extras: Optional[Dict[str, Any]] = None,
         arguments: Optional[Mapping[str, Any]] = None,
         job_run_id: Optional[str] = None,

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -6,11 +6,7 @@ import string
 import sys
 import time
 from contextlib import ExitStack, contextmanager
-<<<<<<< HEAD
-from typing import Any, Iterator, Literal, Mapping, Optional, Sequence, TextIO
-=======
-from typing import Iterator, Literal, Mapping, Optional, Sequence, TextIO, Union
->>>>>>> aceb299e5e (update pipes to accept asset execution context)
+from typing import Any, Iterator, Literal, Mapping, Optional, Sequence, TextIO, Union
 
 import dagster._check as check
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -6,12 +6,17 @@ import string
 import sys
 import time
 from contextlib import ExitStack, contextmanager
+<<<<<<< HEAD
 from typing import Any, Iterator, Literal, Mapping, Optional, Sequence, TextIO
+=======
+from typing import Iterator, Literal, Mapping, Optional, Sequence, TextIO, Union
+>>>>>>> aceb299e5e (update pipes to accept asset execution context)
 
 import dagster._check as check
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.errors import DagsterExecutionInterruptedError, DagsterPipesExecutionError
-from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from dagster._core.execution.context.op_execution_context import OpExecutionContext
 from dagster._core.pipes.client import (
     PipesClient,
     PipesClientCompletedInvocation,
@@ -107,7 +112,7 @@ class PipesDatabricksClient(PipesClient, TreatAsResourceParam):
     def run(
         self,
         *,
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
         extras: Optional[PipesExtras] = None,
         task: jobs.SubmitTask,
         submit_args: Optional[Mapping[str, Any]] = None,
@@ -120,7 +125,7 @@ class PipesDatabricksClient(PipesClient, TreatAsResourceParam):
                 `spark_env_vars` key of the `new_cluster` field (if there is an existing dictionary
                 here, the Pipes environment variables will be merged in). Everything else will be
                 passed unaltered under the `tasks` arg to `WorkspaceClient.jobs.submit`.
-            context (OpExecutionContext): The context from the executing op or asset.
+            context (Union[OpExecutionContext, AssetExecutionContext]): The context from the executing op or asset.
             extras (Optional[PipesExtras]): An optional dict of extra parameters to pass to the
                 subprocess.
             submit_args (Optional[Mapping[str, Any]]): Additional keyword arguments that will be
@@ -160,7 +165,9 @@ class PipesDatabricksClient(PipesClient, TreatAsResourceParam):
 
         return PipesClientCompletedInvocation(pipes_session)
 
-    def _poll_til_success(self, context: OpExecutionContext, run_id: int) -> None:
+    def _poll_til_success(
+        self, context: Union[OpExecutionContext, AssetExecutionContext], run_id: int
+    ) -> None:
         # poll the Databricks run until it reaches RunResultState.SUCCESS, raising otherwise
 
         last_observed_state = None

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -9,6 +9,7 @@ from dagster import (
 )
 from dagster._annotations import experimental
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.client import (
     PipesClient,
     PipesClientCompletedInvocation,
@@ -103,7 +104,7 @@ class PipesDockerClient(PipesClient, TreatAsResourceParam):
     def run(
         self,
         *,
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
         image: str,
         extras: Optional[PipesExtras] = None,
         command: Optional[Union[str, Sequence[str]]] = None,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -12,6 +12,7 @@ from dagster import (
 )
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.errors import DagsterInvariantViolationError
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.client import (
     PipesClient,
     PipesClientCompletedInvocation,
@@ -186,7 +187,7 @@ class PipesK8sClient(PipesClient, TreatAsResourceParam):
     def run(
         self,
         *,
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
         extras: Optional[PipesExtras] = None,
         image: Optional[str] = None,
         command: Optional[Union[str, Sequence[str]]] = None,


### PR DESCRIPTION
## Summary & Motivation
Removes the `OpExecutionContext` parent class from `AssetExecutionContext`

## How I Tested These Changes
