### PR TITLE
[record] IHaveNew.__new__ Self return typehint

### DIFF
--- a/python_modules/dagster/dagster/_record/__init__.py
+++ b/python_modules/dagster/dagster/_record/__init__.py
@@ -15,7 +15,7 @@ from typing import (
     overload,
 )
 
-from typing_extensions import dataclass_transform
+from typing_extensions import Self, dataclass_transform
 
 import dagster._check as check
 from dagster._check import EvalContext, build_check_call_str
@@ -245,7 +245,7 @@ class IHaveNew:
 
     if TYPE_CHECKING:
 
-        def __new__(cls, **kwargs): ...
+        def __new__(cls, **kwargs) -> Self: ...
 
 
 def is_record(obj) -> bool:


### PR DESCRIPTION
it appears that when installed, `@record_custom` + `IHaveNew` is assuming `__new__` returns `None` instead of `Unknown` causing it to believe `x` is `None` for `x = RunRecord()` 

explicitly tag `__new__`'s return to `Self` to resolve

resolves https://github.com/dagster-io/dagster/issues/23214

## How I Tested These Changes

manually made the change in `site-packages` of installed copy of `1.7.13`
