### PR TITLE
feat: asset scan & asset report

### DIFF
--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -1,6 +1,8 @@
 from typing import Mapping
 
 import click
+from rich import print
+from rich.progress import Progress
 
 import dagster._check as check
 from dagster._cli.workspace.cli_target import (
@@ -8,11 +10,13 @@ from dagster._cli.workspace.cli_target import (
     python_origin_target_argument,
 )
 from dagster._core.definitions.asset_selection import AssetSelection
-from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.events import AssetKey, AssetMaterialization
 from dagster._core.errors import DagsterInvalidSubsetError
 from dagster._core.execution.api import execute_job
+from dagster._core.execution.context.input import build_input_context
 from dagster._core.instance import DagsterInstance
 from dagster._core.origin import JobPythonOrigin
+from dagster._core.storage.upath_io_manager import UPathIOManager
 from dagster._core.telemetry import telemetry_wrapper
 from dagster._utils.hosted_user_process import recon_job_from_origin, recon_repository_from_origin
 from dagster._utils.interrupts import capture_interrupts
@@ -102,6 +106,117 @@ def asset_list_command(**kwargs):
 
     for asset_key in sorted(asset_keys):
         print(asset_key.to_user_string())  # noqa: T201
+@asset_cli.command(name="report", help="Report asset materialization")
+@python_origin_target_argument
+@click.option("--select", help="Asset selection to target", required=True)
+@click.option("--partition", help="Asset partition to target", required=False)
+@click.option("--all", is_flag=True, help="Report all partitions", default=False)
+def asset_materialization_report_command(**kwargs):
+    repository_origin = get_repository_python_origin_from_kwargs(kwargs)
+    recon_repo = recon_repository_from_origin(repository_origin)
+    repo_def = recon_repo.get_definition()
+
+    select = kwargs.get("select")
+    asset = repo_def.assets_defs_by_key.get(AssetKey(select), None)
+
+    partition = kwargs.get("partition", None)
+    report_all = kwargs.get("all", False)
+    if asset.partitions_def is not None and partition is None and not report_all:
+        raise click.UsageError(
+            f"Error, you must specify a partition for the asset '{asset.key.to_user_string()}'. Or use `--all` to select all partitions."
+        )
+
+    with get_instance_for_cli() as instance:
+        partitions = [partition] if not report_all else asset.partitions_def.get_partition_keys()
+        for partition in partitions:
+            instance.report_runless_asset_event(
+                AssetMaterialization(
+                    asset_key=asset.key,
+                    partition=partition,
+                    description="Runless materialization via REPORT",
+                )
+            )
+
+
+@asset_cli.command(name="scan", help="Scan asset materialization")
+@python_origin_target_argument
+@click.option("--select", help="Asset selection to target", required=True)
+@click.option("--verbose", help="Print all partitions' status", default=False)
+def asset_materialization_scan_command(**kwargs):
+    repository_origin = get_repository_python_origin_from_kwargs(kwargs)
+    recon_repo = recon_repository_from_origin(repository_origin)
+    repo_def = recon_repo.get_definition()
+
+    select = kwargs.get("select")
+    asset = repo_def.assets_defs_by_key.get(AssetKey(select), None)
+    with get_instance_for_cli() as instance:
+        with Progress() as progress_bar:
+            asset_name = asset.key.to_user_string()
+
+            # check if it's a partitioned or non partitioned asset
+            if asset.partitions_def is None:
+                partitions = [None]
+            else:
+                # get the list of partitions
+                all_partitions = set(asset.partitions_def.get_partition_keys())
+                materialized_partitions = set(
+                    instance.get_materialized_partitions(asset_key=asset.key)
+                )
+                # only scan not materialized partitions
+                partitions = list(all_partitions - materialized_partitions)
+
+            task_scanning_asset = progress_bar.add_task(
+                description=asset_name, total=len(partitions)
+            )
+            for partition in partitions:
+                # pretty the progress bar for partitions
+                if partition is not None:
+                    progress_bar.update(
+                        task_scanning_asset, description=f"{asset_name}:{partition}"
+                    )
+
+                with build_input_context(
+                    asset_key=asset.key,
+                    resources=asset.resource_defs,
+                    instance=instance,
+                    partition_key=partition,
+                    op_def=asset.op,
+                    asset_partitions_def=asset.partitions_def,
+                ) as asset_context:
+                    is_materialized = []
+                    for out in asset.op.output_defs:
+                        io_manager = asset_context.resources.__getattribute__(out.io_manager_key)
+
+                        if isinstance(io_manager, UPathIOManager):
+                            if partition is None:
+                                has_output = io_manager.has_output(asset_context)
+                            else:
+                                path = io_manager._with_extension(
+                                    io_manager.get_path_for_partition(
+                                        asset_context,
+                                        io_manager._get_path_without_extension(asset_context),
+                                        asset_context.partition_key,
+                                    )
+                                )
+                                has_output = io_manager.path_exists(path)
+                        else:
+                            obj = io_manager.load_input(asset_context)
+                            has_output = obj is not None
+                        if kwargs.get("verbose", False):
+                            click.echo(
+                                f'{asset_name}#{partition}:{out.name} has {"NOT" if not has_output else ""} been materialized'
+                            )
+                        is_materialized.append(has_output)
+                if all(is_materialized):
+                    instance.report_runless_asset_event(
+                        AssetMaterialization(
+                            asset_key=asset.key,
+                            partition=partition,
+                            description="Runless materialization via SCAN",
+                        )
+                    )
+
+                progress_bar.update(task_scanning_asset, advance=1)
 
 
 @asset_cli.command(name="wipe")


### PR DESCRIPTION
## Summary & Motivation

Sometimes, for reasons I don't intend to question, data associated to an asset has been written without a proper dagster materialization.
 
The purpose of this PR is to provide CLI tools to allow users to:
- mark some asset/partition as materialized
- scan for non-materialized asset/partition and mark it as materialized if data is present

This motivation is baked by this issue #17202 and is linked to [this discussion](https://github.com/dagster-io/dagster/discussions/17847#discussioncomment-7523902)

## Help Wanted

This PR shouldn't be accepted as it is. I am willing to continue working on it until it reaches the quality expected by the dagster team. But I'd like some guidance concerning (at least) the following topics:

- I used `rich.progress` because I find it pretty, is there any preferred progress bar library that should be used?
- I am using some of the private methods of the io manager. It is because I'd like the  `UPathIOManager.has_output` to manage both partitioned and non-partitioned assets as I've written here: https://github.com/dagster-io/dagster/compare/master...Tazoeur:dagster:upath_io_get_path
- Testing these features is valuable, but I am a bit lost concerning the path I should take to do that. Are there examples of tests that (a) manipulate storage data, (b) write files without using io manager, and then use the io manager to check that the file is present
- Am I using the correct dagster instance and context ?
- Should I split the PR in two, one for each new command?
- Are the CLI names ok?
- [new feature] the `dagster asset scan` could wipe a partition if the data associated with the materialized partition is missing. Should it be included in this PR?
- [new feature] Should the scan also perform dagster checks to (in)validate the asset/partition?