### PR TITLE
[Filters] Memoize filter objects + renderFilterButton

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useDebugChanged.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useDebugChanged.tsx
@@ -1,0 +1,57 @@
+import isEqual from 'lodash/isEqual';
+import {useEffect, useRef} from 'react';
+
+type Difference<T> = {
+  previous: T;
+  current: T;
+};
+
+type Changes<T> = {
+  index: number;
+  previous: T;
+  current: T;
+  differences: Partial<Record<keyof T, Difference<any>>>;
+};
+
+const getDifferences = <T extends Record<any, any>>(
+  obj1: T,
+  obj2: T,
+): Partial<Record<keyof T, Difference<any>>> => {
+  const diffs: Partial<Record<keyof T, Difference<any>>> = {};
+  Object.keys({...obj1, ...obj2}).forEach((key) => {
+    if (!isEqual(obj1[key], obj2[key])) {
+      diffs[key as keyof T] = {previous: obj1[key], current: obj2[key]};
+    }
+  });
+  return diffs;
+};
+
+/**
+ * Hook for debugging what is changing across renders to debug unnecessary renders and figure out
+ *  what needs memoization
+ */
+export const useDebugChanged = <T,>(objects: T[]): void => {
+  const previousObjectsRef = useRef<T[]>(objects);
+
+  useEffect(() => {
+    const previousObjects = previousObjectsRef.current;
+    const changes: Changes<T>[] = [];
+
+    objects.forEach((obj, index) => {
+      if (!isEqual(obj, previousObjects[index])) {
+        changes.push({
+          index,
+          previous: previousObjects[index]!,
+          current: obj,
+          differences: getDifferences(previousObjects[index]!, obj!),
+        });
+      }
+    });
+
+    if (changes.length > 0) {
+      console.log('Changed objects:', changes);
+    }
+
+    previousObjectsRef.current = objects;
+  }, [objects]);
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/FilterDropdown.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/FilterDropdown.tsx
@@ -283,8 +283,9 @@ export const FilterDropdown = ({filters, setIsOpen, setPortaledElements}: Filter
 
 type FilterDropdownButtonProps = {
   filters: FilterObject[];
+  label?: string;
 };
-export const FilterDropdownButton = React.memo(({filters}: FilterDropdownButtonProps) => {
+export const FilterDropdownButton = React.memo(({filters, label}: FilterDropdownButtonProps) => {
   const keyRef = React.useRef(0);
 
   const [isOpen, _setIsOpen] = useState(false);
@@ -367,7 +368,7 @@ export const FilterDropdownButton = React.memo(({filters}: FilterDropdownButtonP
                 setIsOpen((isOpen) => !isOpen);
               }}
             >
-              Filter
+              {label ?? 'Filter'}
             </Button>
           </Popover>
         </div>

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useFilters.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment, useCallback, useMemo} from 'react';
 
 import {FilterDropdownButton} from './FilterDropdown';
 import {FilterObject} from './useFilter';
@@ -16,6 +16,12 @@ export const useFilters = ({filters}: UseFiltersProps) => {
 
   return {
     button: useMemo(() => <FilterDropdownButton filters={filters} />, [filters]),
+    renderButton: useCallback(
+      (label: string) => {
+        <FilterDropdownButton filters={filters} label={label} />;
+      },
+      [filters],
+    ),
     activeFiltersJsx: activeFilterJsx,
   };
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useFilters.tsx
@@ -17,9 +17,9 @@ export const useFilters = ({filters}: UseFiltersProps) => {
   return {
     button: useMemo(() => <FilterDropdownButton filters={filters} />, [filters]),
     renderButton: useCallback(
-      (props: Parameters<RenderButtonType>[0]) => {
-        <FilterDropdownButton filters={filters} {...props} />;
-      },
+      (props: Parameters<RenderButtonType>[0]) => (
+        <FilterDropdownButton filters={filters} {...props} />
+      ),
       [filters],
     ),
     activeFiltersJsx: activeFilterJsx,

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useFilters.tsx
@@ -17,11 +17,15 @@ export const useFilters = ({filters}: UseFiltersProps) => {
   return {
     button: useMemo(() => <FilterDropdownButton filters={filters} />, [filters]),
     renderButton: useCallback(
-      (label: string) => {
-        <FilterDropdownButton filters={filters} label={label} />;
+      (props: Parameters<RenderButtonType>[0]) => {
+        <FilterDropdownButton filters={filters} {...props} />;
       },
       [filters],
     ),
     activeFiltersJsx: activeFilterJsx,
   };
 };
+
+export type RenderButtonType = (
+  props: Partial<React.ComponentProps<typeof FilterDropdownButton>>,
+) => React.ReactNode;

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useFilters.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useFilters.tsx
@@ -17,7 +17,7 @@ export const useFilters = ({filters}: UseFiltersProps) => {
   return {
     button: useMemo(() => <FilterDropdownButton filters={filters} />, [filters]),
     renderButton: useCallback(
-      (props: Parameters<RenderButtonType>[0]) => (
+      (props: Parameters<RenderButtonType>[0]): ReturnType<RenderButtonType> => (
         <FilterDropdownButton filters={filters} {...props} />
       ),
       [filters],

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useAssetGroupFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useAssetGroupFilter.tsx
@@ -37,7 +37,7 @@ export const useAssetGroupFilter = ({
     menuWidth: '300px',
     state: useMemo(() => new Set(assetGroups ?? []), [assetGroups]),
     onStateChanged: useCallback(
-      (values) => {
+      (values: Set<AssetGroupSelector>) => {
         if (setGroups) {
           setGroups(Array.from(values));
         }

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useAssetGroupFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useAssetGroupFilter.tsx
@@ -1,5 +1,5 @@
 import {Box, Icon} from '@dagster-io/ui-components';
-import {useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import {buildAssetGroupSelector} from '../../assets/AssetGroupSuggest';
 import {AssetGroupSelector, AssetNode} from '../../graphql/types';
@@ -16,26 +16,34 @@ export const useAssetGroupFilter = ({
   assetGroups?: AssetGroupSelector[] | null;
   setGroups?: null | ((groups: AssetGroupSelector[]) => void);
 }) => {
+  const allValues = useMemo(
+    () =>
+      (allAssetGroups || []).map((group) => ({
+        key: group.groupName,
+        value:
+          assetGroups?.find(
+            (visibleGroup) =>
+              visibleGroup.groupName === group.groupName &&
+              visibleGroup.repositoryName === group.repositoryName &&
+              visibleGroup.repositoryLocationName === group.repositoryLocationName,
+          ) ?? group,
+        match: [group.groupName],
+      })),
+    [allAssetGroups, assetGroups],
+  );
   return useStaticSetFilter<AssetGroupSelector>({
     ...BaseConfig,
-    allValues: (allAssetGroups || []).map((group) => ({
-      key: group.groupName,
-      value:
-        assetGroups?.find(
-          (visibleGroup) =>
-            visibleGroup.groupName === group.groupName &&
-            visibleGroup.repositoryName === group.repositoryName &&
-            visibleGroup.repositoryLocationName === group.repositoryLocationName,
-        ) ?? group,
-      match: [group.groupName],
-    })),
+    allValues,
     menuWidth: '300px',
     state: useMemo(() => new Set(assetGroups ?? []), [assetGroups]),
-    onStateChanged: (values) => {
-      if (setGroups) {
-        setGroups(Array.from(values));
-      }
-    },
+    onStateChanged: useCallback(
+      (values) => {
+        if (setGroups) {
+          setGroups(Array.from(values));
+        }
+      },
+      [setGroups],
+    ),
   });
 };
 


### PR DESCRIPTION
## Summary & Motivation

Two things:


1. We're passing the filterButton upwards to the CatalogViewProvider so that it can use it without having to recreate it from scratch. While doing that I encountered an infinite loop due to the provider updating the context which causes `useAssetCatalogFiltering.cloud` to re-render which causes `useAssetCatalogFiltering.oss` to re-render and it ends up creating new filter objects due to some aspects of it being unmemoized. To fix this I memoized things that were causing unnecessary re-renders. 

2. Added a `renderButton` return to `useFilters` which can be used to change the label on the button. I opted to just return a new prop instead of modifying the existing one to this in order to reduce the number of changes in this PR. In a future pr we can consolidate or figure out a more elegant approach.

## How I Tested These Changes

host cloud.
