### PR TITLE
[dagster-dbt] Support @dbt_assets with select in a dbt-core>=1.8 project with unit tests

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -2,6 +2,7 @@ from argparse import Namespace
 from typing import AbstractSet, Any, Dict, Mapping
 
 from dagster import AssetKey
+from packaging import version
 
 # dbt resource types that may be considered assets
 ASSET_RESOURCE_TYPES = ["model", "seed", "snapshot"]
@@ -41,10 +42,11 @@ def select_unique_ids_from_manifest(
             # allow recursive access e.g. foo.bar.baz
             return _DictShim(ret) if isinstance(ret, dict) else ret
 
-    if dbt_version >= "1.8.0":
+    unit_tests = {}
+    if version.parse(dbt_version) >= version.parse("1.8.0"):
         from dbt.contracts.graph.nodes import UnitTestDefinition
 
-        unit_test = (
+        unit_tests = (
             {
                 "unit_tests": {
                     # unit test nodes must be of type UnitTestDefinition
@@ -55,8 +57,6 @@ def select_unique_ids_from_manifest(
             if manifest_json.get("unit_tests")
             else {}
         )
-    else:
-        unit_test = {}
 
     manifest = Manifest(
         nodes={unique_id: _DictShim(info) for unique_id, info in manifest_json["nodes"].items()},
@@ -92,7 +92,7 @@ def select_unique_ids_from_manifest(
             if manifest_json.get("saved_queries")
             else {}
         ),
-        **unit_test,
+        **unit_tests,
     )
     child_map = manifest_json["child_map"]
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -25,9 +25,9 @@ def select_unique_ids_from_manifest(
     """Method to apply a selection string to an existing manifest.json file."""
     import dbt.graph.cli as graph_cli
     import dbt.graph.selector as graph_selector
-    from dbt.version import __version__ as dbt_version
     from dbt.contracts.graph.manifest import Manifest
     from dbt.graph.selector_spec import IndirectSelection, SelectionSpec
+    from dbt.version import __version__ as dbt_version
     from networkx import DiGraph
 
     # NOTE: this was faster than calling `Manifest.from_dict`, so we are keeping this.

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -1,9 +1,7 @@
 from argparse import Namespace
 from typing import AbstractSet, Any, Dict, Mapping
 
-from dagster import AssetKey, get_dagster_logger
-
-logger = get_dagster_logger()
+from dagster import AssetKey
 
 # dbt resource types that may be considered assets
 ASSET_RESOURCE_TYPES = ["model", "seed", "snapshot"]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py
@@ -24,6 +24,7 @@ def select_unique_ids_from_manifest(
     import dbt.graph.cli as graph_cli
     import dbt.graph.selector as graph_selector
     from dbt.contracts.graph.manifest import Manifest
+    from dbt.contracts.graph.nodes import UnitTestDefinition
     from dbt.graph.selector_spec import IndirectSelection, SelectionSpec
     from networkx import DiGraph
 
@@ -77,7 +78,8 @@ def select_unique_ids_from_manifest(
         **(
             {
                 "unit_tests": {
-                    unique_id: _DictShim(info)
+                    # unit test nodes must be of type UnitTestDefinition
+                    unique_id: UnitTestDefinition(**info)
                     for unique_id, info in manifest_json["unit_tests"].items()
                 },
             }

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -1063,8 +1063,10 @@ def test_dbt_with_unit_tests(test_dbt_unit_tests_manifest: Dict[str, Any]) -> No
 @pytest.mark.skipif(
     version.parse(dbt_version) < version.parse("1.8.0"),
     reason="dbt unit test support is only available in `dbt-core>=1.8.0`",
-    )
-def test_dbt_with_unit_tests_with_tags_selector(test_dbt_unit_tests_manifest: Dict[str, Any]) -> None:
+)
+def test_dbt_with_unit_tests_with_tags_selector(
+    test_dbt_unit_tests_manifest: Dict[str, Any],
+) -> None:
     @dbt_assets(
         manifest=test_dbt_unit_tests_manifest,
         select="tag:test",

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -1048,28 +1048,11 @@ def test_dbt_with_semantic_models(test_dbt_semantic_models_manifest: Dict[str, A
     version.parse(dbt_version) < version.parse("1.8.0"),
     reason="dbt unit test support is only available in `dbt-core>=1.8.0`",
 )
-def test_dbt_with_unit_tests(test_dbt_unit_tests_manifest: Dict[str, Any]) -> None:
-    @dbt_assets(manifest=test_dbt_unit_tests_manifest)
-    def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        yield from dbt.cli(["build"], context=context).stream()
-
-    result = materialize(
-        [my_dbt_assets],
-        resources={"dbt": DbtCliResource(project_dir=os.fspath(test_dbt_unit_tests_path))},
-    )
-    assert result.success
-
-
-@pytest.mark.skipif(
-    version.parse(dbt_version) < version.parse("1.8.0"),
-    reason="dbt unit test support is only available in `dbt-core>=1.8.0`",
-)
-def test_dbt_with_unit_tests_with_tags_selector(
-    test_dbt_unit_tests_manifest: Dict[str, Any],
-) -> None:
+@pytest.mark.parametrize("select", ["fqn:*", "tag:test"])
+def test_dbt_with_unit_tests(test_dbt_unit_tests_manifest: Dict[str, Any], select: str) -> None:
     @dbt_assets(
         manifest=test_dbt_unit_tests_manifest,
-        select="tag:test",
+        select=select,
     )
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
         yield from dbt.cli(["build"], context=context).stream()

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_unit_tests/dbt_project.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_unit_tests/dbt_project.yml
@@ -24,3 +24,8 @@ models:
     materialized: table
     staging:
       materialized: view
+
+seeds:
+  jaffle_shop:
+    raw_payments:
+      +tags: test

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_unit_tests/dbt_project.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_unit_tests/dbt_project.yml
@@ -21,11 +21,11 @@ require-dbt-version: [">=1.0.0", "<2.0.0"]
 
 models:
   jaffle_shop:
+    +tags: test
     materialized: table
     staging:
       materialized: view
 
 seeds:
   jaffle_shop:
-    raw_payments:
-      +tags: test
+    +tags: test

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_unit_tests/models/staging/stg_payments.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_unit_tests/models/staging/stg_payments.sql
@@ -1,9 +1,3 @@
-{{
-    config(
-        tags=["test"],
-    )
-}}
-
 with source as (
     
     {#-

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_unit_tests/models/staging/stg_payments.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_unit_tests/models/staging/stg_payments.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        tags=["test"],
+    )
+}}
+
 with source as (
     
     {#-


### PR DESCRIPTION
## Summary & Motivation

This PR fixes issue #22854.

### Problem

An exception is raised when initializing `@dbt_assets` with a selector method "tag" passed to either `select` or `exclude`, only when the dbt project includes a `unit_test.yml` file.

The exception is caused because `node.tags == None` when running [this line of code](https://github.com/dbt-labs/dbt-core/blob/v1.8.4/core/dbt/graph/selector_methods.py#L266-L271) in `dbt.graph.selector_methods`.

Adding a tag in `unit_test.yml` does not fixed the problem. Eg.

```
unit_tests:
  - name: test_unit_test
    config:
      tags:
        - test
    model: my model
```

Taking a closer look, `node.__class__  == 'dagster_dbt.utils.select_unique_ids_from_manifest.<locals>._DictShim'>` when running the selector method code [here](https://github.com/dbt-labs/dbt-core/blob/v1.8.4/core/dbt/graph/selector_methods.py#L266-L271). The `_DictShim` class is defined in `dagster-dbt` [here](https://github.com/dagster-io/dagster/blob/1.7.14/python_modules/libraries/dagster-dbt/dagster_dbt/utils.py#L233).

The class is expected to be one of the SelectorTarget classes, see [here](https://github.com/dbt-labs/dbt-core/blob/v1.8.4/core/dbt/graph/selector_methods.py#L105-L107).

For unit test, the class is expected to be UnitTestDefinition, see [here](https://github.com/dbt-labs/dbt-core/blob/1a2d367e7f09cdc8e8af77f0646ebbd07742a451/core/dbt/contracts/graph/manifest.py#L827). The root problem is that `UnitTestDefinition` has a property names `tags`, see [here](https://github.com/dbt-labs/dbt-core/blob/1a2d367e7f09cdc8e8af77f0646ebbd07742a451/core/dbt/contracts/graph/nodes.py#L966-L969), but `_DictShim` will return `None` because of how its `__get_attr__()` is implemented.

For the other manifest nodes, it is not a problem because the `tags` property is not implemented in the other `SelectorTarget` classes.

### Fix

In our code, creating nodes of type `UnitTestDefinitions` for unit tests, instead of `_DictShim`, fixes the problem.

## How I Tested These Changes

Tested locally + additional test in BK
