### PR TITLE
[ui] Make automation target a tag

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/automation/__stories__/AutomationTargetList.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/__stories__/AutomationTargetList.stories.tsx
@@ -1,8 +1,16 @@
 import {MockedProvider} from '@apollo/client/testing';
 import {Meta} from '@storybook/react';
+import {RecoilRoot} from 'recoil';
 
 import {CustomAlertProvider} from '../../app/CustomAlertProvider';
-import {SensorType} from '../../graphql/types';
+import {
+  SensorType,
+  buildAsset,
+  buildAssetConnection,
+  buildAssetKey,
+  buildAssetSelection,
+  buildPythonError,
+} from '../../graphql/types';
 import {
   buildStartKansasSuccess,
   buildStartLouisianaError,
@@ -17,10 +25,9 @@ export default {
   component: AutomationTargetList,
 } as Meta;
 
-export const AutomationTargetListWithError = () => {
+export const SingleJob = () => {
   return (
-    <>
-      <CustomAlertProvider />
+    <RecoilRoot>
       <MockedProvider mocks={[buildStartKansasSuccess(1000), buildStartLouisianaError(1000)]}>
         <WorkspaceProvider>
           <AutomationTargetList
@@ -31,6 +38,101 @@ export const AutomationTargetListWithError = () => {
           />
         </WorkspaceProvider>
       </MockedProvider>
+    </RecoilRoot>
+  );
+};
+
+export const MultipleJobs = () => {
+  return (
+    <RecoilRoot>
+      <MockedProvider mocks={[buildStartKansasSuccess(1000), buildStartLouisianaError(1000)]}>
+        <WorkspaceProvider>
+          <AutomationTargetList
+            automationType={SensorType.ASSET}
+            targets={[{pipelineName: 'foo'}, {pipelineName: 'bar'}, {pipelineName: 'baz'}]}
+            repoAddress={buildRepoAddress('a', 'b')}
+            assetSelection={null}
+          />
+        </WorkspaceProvider>
+      </MockedProvider>
+    </RecoilRoot>
+  );
+};
+
+export const AssetSelection = () => {
+  const assetSelection = buildAssetSelection({
+    assetSelectionString: 'asset_one',
+    assetsOrError: buildAssetConnection({
+      nodes: [buildAsset({id: 'asset_one', key: buildAssetKey({path: ['a', 'b']})})],
+    }),
+  });
+
+  return (
+    <RecoilRoot>
+      <MockedProvider mocks={[buildStartKansasSuccess(1000), buildStartLouisianaError(1000)]}>
+        <WorkspaceProvider>
+          <AutomationTargetList
+            automationType={SensorType.ASSET}
+            targets={null}
+            repoAddress={buildRepoAddress('a', 'b')}
+            assetSelection={assetSelection}
+          />
+        </WorkspaceProvider>
+      </MockedProvider>
+    </RecoilRoot>
+  );
+};
+
+export const MultipleAssetSelection = () => {
+  const assetSelection = buildAssetSelection({
+    assetSelectionString: 'asset_one and asset_two',
+    assetsOrError: buildAssetConnection({
+      nodes: [
+        buildAsset({id: 'asset_one', key: buildAssetKey({path: ['a', 'b']})}),
+        buildAsset({id: 'asset_two', key: buildAssetKey({path: ['c', 'd']})}),
+      ],
+    }),
+  });
+
+  return (
+    <RecoilRoot>
+      <MockedProvider mocks={[buildStartKansasSuccess(1000), buildStartLouisianaError(1000)]}>
+        <WorkspaceProvider>
+          <AutomationTargetList
+            automationType={SensorType.ASSET}
+            targets={null}
+            repoAddress={buildRepoAddress('a', 'b')}
+            assetSelection={assetSelection}
+          />
+        </WorkspaceProvider>
+      </MockedProvider>
+    </RecoilRoot>
+  );
+};
+
+export const PythonError = () => {
+  const assetSelection = buildAssetSelection({
+    assetSelectionString: 'asset_one and asset_two',
+    assetsOrError: buildPythonError({
+      message: 'oh nooo',
+    }),
+  });
+
+  return (
+    <>
+      <CustomAlertProvider />
+      <RecoilRoot>
+        <MockedProvider mocks={[buildStartKansasSuccess(1000), buildStartLouisianaError(1000)]}>
+          <WorkspaceProvider>
+            <AutomationTargetList
+              automationType={SensorType.ASSET}
+              targets={null}
+              repoAddress={buildRepoAddress('a', 'b')}
+              assetSelection={assetSelection}
+            />
+          </WorkspaceProvider>
+        </MockedProvider>
+      </RecoilRoot>
     </>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedSensorRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedSensorRow.tsx
@@ -194,16 +194,16 @@ export const VirtualizedSensorRow = (props: SensorRowProps) => {
           </div>
         </RowCell>
         <RowCell>
-          <Box flex={{direction: 'column', gap: 4}} style={{fontSize: '12px'}}>
-            {sensorData ? (
+          {sensorData ? (
+            <div>
               <AutomationTargetList
                 targets={sensorData.targets}
                 repoAddress={repoAddress}
                 assetSelection={selectedAssets}
                 automationType={sensorData.sensorType}
               />
-            ) : null}
-          </Box>
+            </div>
+          ) : null}
         </RowCell>
         <RowCell>
           {sensorData ? (


### PR DESCRIPTION
## Summary & Motivation

For consistency, make the automation target list a tag (or list of tags, if multiple jobs) in all cases.

- If a job, link to the job.
- If multiple jobs, show multiple tags that each link to their jobs.
- If single asset, link to that asset.
- If multiple assets, open the dialog.

I also changed the dialog to prevent its height from jumping when opening/closing its sections, and fixed the virtualized table to window the list correctly.

<img width="1031" alt="Screenshot 2024-07-25 at 13 03 31" src="https://github.com/user-attachments/assets/e21c67c1-ac75-4d9d-acd1-74480a268e14">

<img width="465" alt="Screenshot 2024-07-25 at 13 03 40" src="https://github.com/user-attachments/assets/a42e88ce-68c9-4c59-8fa4-fad9082f6468">

<img width="871" alt="Screenshot 2024-07-25 at 13 15 07" src="https://github.com/user-attachments/assets/df660880-9d23-40f5-b23e-e30a518d23b1">

## How I Tested These Changes

View Sensors and Schedules list and individual pages. Verify correct rendering and link behavior of automation target tags, including asset dialog.