### PR TITLE
[2/n][dagster-powerbi] scaffold DagsterPowerBITranslator class

### DIFF
--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -147,6 +147,7 @@ daff==1.3.46
 -e python_modules/dagster-pipes
 -e python_modules/libraries/dagster-polars
 -e python_modules/libraries/dagster-postgres
+-e python_modules/libraries/dagster-powerbi
 -e python_modules/libraries/dagster-prometheus
 -e python_modules/libraries/dagster-pyspark
 -e python_modules/libraries/dagster-sdf

--- a/pyright/master/requirements.txt
+++ b/pyright/master/requirements.txt
@@ -76,6 +76,7 @@
 -e python_modules/libraries/dagster-papertrail/
 -e python_modules/libraries/dagster-polars[deltalake,gcp,test]
 -e python_modules/libraries/dagster-postgres/
+-e python_modules/libraries/dagster-powerbi
 -e python_modules/libraries/dagster-prometheus/
 -e python_modules/libraries/dagster-pyspark/
 -e python_modules/libraries/dagster-sdf/

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/__init__.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/__init__.py
@@ -1,5 +1,7 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
+from .translator import DagsterPowerBITranslator as DagsterPowerBITranslator
+
 # Move back to version.py and edit setup.py once we are ready to publish.
 __version__ = "1!0+dev"
 

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/__init__.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/__init__.py
@@ -1,6 +1,6 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
-from .translator import DagsterPowerBITranslator as DagsterPowerBITranslator
+from dagster_powerbi.translator import DagsterPowerBITranslator as DagsterPowerBITranslator
 
 # Move back to version.py and edit setup.py once we are ready to publish.
 __version__ = "1!0+dev"

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -48,7 +48,7 @@ class PowerBIWorkspaceData:
 
     dashboards_by_id: Dict[str, PowerBIContentData]
     reports_by_id: Dict[str, PowerBIContentData]
-    datasets_by_id: Dict[str, PowerBIContentData]
+    semantic_models_by_id: Dict[str, PowerBIContentData]
     data_sources_by_id: Dict[str, PowerBIContentData]
 
 

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -1,0 +1,70 @@
+from enum import Enum
+from typing import Any, Dict, Generic
+
+from dagster import _check as check
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._record import record
+from typing_extensions import TypeVar
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+class DagsterTranslator(Generic[T, U]):
+    def __init__(self, context: U):
+        self._context = context
+
+    def get_asset_spec(self, data: T) -> AssetSpec:
+        raise NotImplementedError
+
+
+class PowerBIContentType(Enum):
+    DASHBOARD = "dashboard"
+    REPORT = "report"
+    SEMANTIC_MODEL = "semantic_model"
+    DATA_SOURCE = "data_source"
+
+
+@record
+class PowerBIContentData:
+    content_type: PowerBIContentType
+    data: Dict[str, Any]
+
+
+@record
+class PowerBIWorkspaceData:
+    dashboards_by_id: Dict[str, PowerBIContentData]
+    reports_by_id: Dict[str, PowerBIContentData]
+    datasets_by_id: Dict[str, PowerBIContentData]
+    data_sources_by_id: Dict[str, PowerBIContentData]
+
+
+class DagsterPowerBITranslator(DagsterTranslator[PowerBIContentData, PowerBIWorkspaceData]):
+    @property
+    def workspace_data(self) -> PowerBIWorkspaceData:
+        return self._context
+
+    def get_asset_spec(self, data: PowerBIContentData) -> AssetSpec:
+        if data.content_type == PowerBIContentType.DASHBOARD:
+            return self.get_dashboard_spec(data)
+        elif data.content_type == PowerBIContentType.REPORT:
+            return self.get_report_spec(data)
+        elif data.content_type == PowerBIContentType.SEMANTIC_MODEL:
+            return self.get_semantic_model_spec(data)
+        elif data.content_type == PowerBIContentType.DATA_SOURCE:
+            return self.get_data_source_spec(data)
+        else:
+            check.assert_never(data.content_type)
+
+    def get_dashboard_asset_key(self, data: PowerBIContentData) -> AssetKey: ...
+    def get_dashboard_spec(self, data: PowerBIContentData) -> AssetSpec: ...
+
+    def get_report_asset_key(self, data: PowerBIContentData) -> AssetKey: ...
+    def get_report_spec(self, data: PowerBIContentData) -> AssetSpec: ...
+
+    def get_semantic_model_asset_key(self, data: PowerBIContentData) -> AssetKey: ...
+    def get_semantic_model_spec(self, data: PowerBIContentData) -> AssetSpec: ...
+
+    def get_data_source_asset_key(self, data: PowerBIContentData) -> AssetKey: ...
+    def get_data_source_spec(self, data: PowerBIContentData) -> AssetSpec: ...

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -11,6 +11,7 @@ T = TypeVar("T")
 U = TypeVar("U")
 
 
+# scaffold out what a generic translator class might look like
 class DagsterTranslator(Generic[T, U]):
     def __init__(self, context: U):
         self._context = context
@@ -20,6 +21,8 @@ class DagsterTranslator(Generic[T, U]):
 
 
 class PowerBIContentType(Enum):
+    """Enum representing each object in PowerBI's ontology, generically referred to as "content" by the API."""
+
     DASHBOARD = "dashboard"
     REPORT = "report"
     SEMANTIC_MODEL = "semantic_model"
@@ -28,12 +31,21 @@ class PowerBIContentType(Enum):
 
 @record
 class PowerBIContentData:
+    """A record representing a piece of content in PowerBI.
+    Includes the content's type and data as returned from the API.
+    """
+
     content_type: PowerBIContentType
     data: Dict[str, Any]
 
 
 @record
 class PowerBIWorkspaceData:
+    """A record representing all content in a PowerBI workspace.
+
+    Provided as context for the translator so that it can resolve dependencies between content.
+    """
+
     dashboards_by_id: Dict[str, PowerBIContentData]
     reports_by_id: Dict[str, PowerBIContentData]
     datasets_by_id: Dict[str, PowerBIContentData]
@@ -41,6 +53,10 @@ class PowerBIWorkspaceData:
 
 
 class DagsterPowerBITranslator(DagsterTranslator[PowerBIContentData, PowerBIWorkspaceData]):
+    """Translator class which converts raw response data from the PowerBI API into AssetSpecs.
+    Subclass this class to implement custom logic for each type of PowerBI content.
+    """
+
     @property
     def workspace_data(self) -> PowerBIWorkspaceData:
         return self._context

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -36,7 +36,7 @@ class PowerBIContentData:
     """
 
     content_type: PowerBIContentType
-    data: Dict[str, Any]
+    properties: Dict[str, Any]
 
 
 @record

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -1,23 +1,10 @@
 from enum import Enum
-from typing import Any, Dict, Generic
+from typing import Any, Dict
 
 from dagster import _check as check
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._record import record
-from typing_extensions import TypeVar
-
-T = TypeVar("T")
-U = TypeVar("U")
-
-
-# scaffold out what a generic translator class might look like
-class DagsterTranslator(Generic[T, U]):
-    def __init__(self, context: U):
-        self._context = context
-
-    def get_asset_spec(self, data: T) -> AssetSpec:
-        raise NotImplementedError
 
 
 class PowerBIContentType(Enum):
@@ -52,10 +39,13 @@ class PowerBIWorkspaceData:
     data_sources_by_id: Dict[str, PowerBIContentData]
 
 
-class DagsterPowerBITranslator(DagsterTranslator[PowerBIContentData, PowerBIWorkspaceData]):
+class DagsterPowerBITranslator:
     """Translator class which converts raw response data from the PowerBI API into AssetSpecs.
     Subclass this class to implement custom logic for each type of PowerBI content.
     """
+
+    def __init__(self, context: PowerBIWorkspaceData):
+        self._context = context
 
     @property
     def workspace_data(self) -> PowerBIWorkspaceData:


### PR DESCRIPTION
## Summary

Builds out a very barebones translator class to build specs for PowerBI assets.

The structure of this translator is slightly different than our existing ones, curious for feedback. Instead of implementing many functions to define each property of an asset, it has a single function that returns an asset spec (which calls out to other functions for each object type).

The user also supplies a translator class rather than a translator instance. The ontology in this model is:
- A translator class defines the logic for how to translate API data into asset specs.
- A user can subclass a translator class to override or customize this logic.
- An instance of a translator class represents a translation "session," provided with any global context information (`PowerBIWorkspaceData`, in this case).
- An invocation of `get_asset_spec` represents translating an individual object, and is provided with local context (the object we're translating, `PowerBIContentData`, in this case).

One hesitation is that `Type[DagsterPowerBITranslator]` is an awkward and potentially confusing type annotation vs passing an instance.

For PowerBI (and I'd imagine many integrations), we need global context to resolve local translation because each local object has relationships with the global context - in this case we need to figure out the asset key of an upstream asset from its internal PowerBI ID.

## Test Plan

n/a, subsequent PRs will test impl - this PR is mostly around settling on the translator API