### PR TITLE
remove experimental tag for core pipes apis and PipesSubprocessClient 1/3

### DIFF
--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -11,7 +11,7 @@ from dagster_pipes import (
 )
 
 import dagster._check as check
-from dagster._annotations import experimental, public
+from dagster._annotations import public
 from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.result import MaterializeResult
 from dagster._core.execution.context.compute import OpExecutionContext
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from .context import PipesMessageHandler
 
 
-@experimental
 class PipesClient(ABC):
     """Pipes client base class.
 
@@ -52,7 +51,6 @@ class PipesClient(ABC):
         """
 
 
-@experimental
 class PipesClientCompletedInvocation:
     def __init__(
         self,
@@ -119,7 +117,6 @@ class PipesClientCompletedInvocation:
         return self._session.get_custom_messages()
 
 
-@experimental
 class PipesContextInjector(ABC):
     @abstractmethod
     @contextmanager
@@ -147,7 +144,6 @@ class PipesContextInjector(ABC):
         """
 
 
-@experimental
 class PipesMessageReader(ABC):
     @abstractmethod
     @contextmanager

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -25,7 +25,7 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster import DagsterEvent
-from dagster._annotations import experimental, public
+from dagster._annotations import public
 from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
 from dagster._core.definitions.data_version import DataProvenance, DataVersion
@@ -54,7 +54,6 @@ if TYPE_CHECKING:
 PipesExecutionResult: TypeAlias = Union[MaterializeResult, AssetCheckResult]
 
 
-@experimental
 class PipesMessageHandler:
     """Class to process :py:obj:`PipesMessage` objects received from a pipes process.
 
@@ -239,7 +238,6 @@ class PipesMessageHandler:
         )
 
 
-@experimental
 @dataclass
 class PipesSession:
     """Object representing a pipes session.

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -6,7 +6,7 @@ from typing import Mapping, Optional, Sequence, Union
 from dagster_pipes import PipesExtras
 
 from dagster import _check as check
-from dagster._annotations import experimental, public
+from dagster._annotations import public
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.errors import DagsterExecutionInterruptedError, DagsterPipesExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
@@ -23,7 +23,6 @@ from dagster._core.pipes.utils import (
 )
 
 
-@experimental
 class PipesSubprocessClient(PipesClient, TreatAsResourceParam):
     """A pipes client that runs a subprocess with the given command and environment.
 

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -24,7 +24,6 @@ from dagster import (
     OpExecutionContext,
     _check as check,
 )
-from dagster._annotations import experimental
 from dagster._core.errors import DagsterInvariantViolationError, DagsterPipesExecutionError
 from dagster._core.pipes.client import PipesContextInjector, PipesMessageReader
 from dagster._core.pipes.context import (
@@ -38,7 +37,6 @@ _CONTEXT_INJECTOR_FILENAME = "context"
 _MESSAGE_READER_FILENAME = "messages"
 
 
-@experimental
 class PipesFileContextInjector(PipesContextInjector):
     """Context injector that injects context data into the external process by writing it to a
     specified file.
@@ -75,7 +73,6 @@ class PipesFileContextInjector(PipesContextInjector):
         return f"Attempted to inject context via file {self._path}"
 
 
-@experimental
 class PipesTempFileContextInjector(PipesContextInjector):
     """Context injector that injects context data into the external process by writing it to an
     automatically-generated temporary file.
@@ -127,7 +124,6 @@ class PipesEnvContextInjector(PipesContextInjector):
         return "Attempted to inject context directly, typically as an environment variable."
 
 
-@experimental
 class PipesFileMessageReader(PipesMessageReader):
     """Message reader that reads messages by tailing a specified file.
 
@@ -159,7 +155,9 @@ class PipesFileMessageReader(PipesMessageReader):
         try:
             open(self._path, "w").close()  # create file
             thread = Thread(
-                target=self._reader_thread, args=(handler, is_session_closed), daemon=True
+                target=self._reader_thread,
+                args=(handler, is_session_closed),
+                daemon=True,
             )
             thread.start()
             yield {PipesDefaultMessageWriter.FILE_PATH_KEY: self._path}
@@ -186,7 +184,6 @@ class PipesFileMessageReader(PipesMessageReader):
         return f"Attempted to read messages from file {self._path}."
 
 
-@experimental
 class PipesTempFileMessageReader(PipesMessageReader):
     """Message reader that reads messages by tailing an automatically-generated temporary file."""
 
@@ -239,7 +236,6 @@ WAIT_FOR_LOGS_AFTER_EXECUTION_INTERVAL = 10
 WAIT_FOR_LOGS_TIMEOUT = 60
 
 
-@experimental
 class PipesBlobStoreMessageReader(PipesMessageReader):
     """Message reader that reads a sequence of message chunks written by an external process into a
     blob store such as S3, Azure blob storage, or GCS.
@@ -451,7 +447,6 @@ class PipesLogReader(ABC):
         return self.__class__.__name__
 
 
-@experimental
 class PipesChunkedLogReader(PipesLogReader):
     """Reader for reading stdout/stderr logs from a blob store such as S3, Azure blob storage, or GCS.
 
@@ -540,7 +535,6 @@ _FAIL_TO_YIELD_ERROR_MESSAGE = (
 )
 
 
-@experimental
 @contextmanager
 def open_pipes_session(
     context: OpExecutionContext,

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -51,6 +51,7 @@ from dagster._core.pipes.utils import (
 from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecordStatus
 from dagster._utils import process_is_alive
 from dagster._utils.env import environ
+from dagster._utils.warnings import ExperimentalWarning
 from dagster_pipes import DagsterPipesError
 
 _PYTHON_EXECUTABLE = shutil.which("python")
@@ -452,7 +453,11 @@ def test_pipes_manual_close():
             return pipes_client.run(command=cmd, context=context).get_results()
 
     with instance_for_test() as instance:
-        materialize([foo], instance=instance, resources={"pipes_client": PipesSubprocessClient()})
+        materialize(
+            [foo],
+            instance=instance,
+            resources={"pipes_client": PipesSubprocessClient()},
+        )
         mat = instance.get_latest_materialization_event(foo.key)
         assert mat and mat.asset_materialization
 
@@ -472,7 +477,9 @@ def test_pipes_no_close():
 
     with instance_for_test() as instance:
         result = materialize(
-            [foo], instance=instance, resources={"pipes_client": PipesSubprocessClient()}
+            [foo],
+            instance=instance,
+            resources={"pipes_client": PipesSubprocessClient()},
         )
         assert result.success  # doesn't fail out, just warns
         conn = instance.get_records_for_run(result.run_id)
@@ -794,3 +801,27 @@ def test_pipes_cli_args_params_loader():
         resources={"pipes_client": PipesSubprocessClient()},
     )
     assert result.success
+
+
+def test_pipes_subprocess_client_no_experimental_warning():
+    def script_fn():
+        pass
+
+    @asset
+    def foo(context: OpExecutionContext, pipes_client: PipesSubprocessClient):
+        # print("blah")
+        with temp_script(script_fn) as external_script:
+            cmd = [_PYTHON_EXECUTABLE, external_script]
+            return pipes_client.run(command=cmd, context=context).get_materialize_result()
+
+    with pytest.warns() as record:
+        materialize(
+            [foo],
+            resources={"pipes_client": PipesSubprocessClient()},
+        )
+
+    experimental_warnings = [w for w in record if issubclass(w.category, ExperimentalWarning)]
+
+    if experimental_warnings:
+        for warning in experimental_warnings:
+            assert "Pipes" not in str(warning.message)


### PR DESCRIPTION
## Summary & Motivation
this PR unexperimentalizes the core abstraction of Pipes, and its builtin client implementation PipesSubprocessClient.

subsequent docs update: https://github.com/dagster-io/dagster/pull/23250

## How I Tested These Changes
added a unit test to ensure no pipes related experimental warnings are fired when invoking Pipes subprocess.