### PR TITLE
[RFC] offer way to avoid loading Definitions on import

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -3,6 +3,7 @@ import json
 import os
 import sys
 from functools import lru_cache
+from inspect import isfunction
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
@@ -706,6 +707,11 @@ def repository_def_from_target_def(
         RepositoryDefinition,
     )
     from .source_asset import SourceAsset
+
+    if isfunction(target):
+        # TODO: validate that it takes no arguments
+        target = target()
+        # TODO: validate that it's a Definitions object
 
     if isinstance(target, Definitions):
         # reassign to handle both repository and pending repo case

--- a/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
+++ b/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
@@ -1,4 +1,5 @@
 import inspect
+from inspect import isfunction
 from types import ModuleType
 from typing import Callable, NamedTuple, Optional, Sequence, Tuple, Type, Union
 
@@ -9,6 +10,7 @@ from dagster._core.definitions.load_assets_from_modules import assets_from_modul
 from dagster._core.definitions.repository_definition import PendingRepositoryDefinition
 
 LOAD_ALL_ASSETS = "<<LOAD_ALL_ASSETS>>"
+BUILD_DEFS_FN_NAME = "build_defs"
 
 
 class LoadableTarget(NamedTuple):
@@ -49,6 +51,10 @@ def loadable_targets_from_python_package(
 
 def loadable_targets_from_loaded_module(module: ModuleType) -> Sequence[LoadableTarget]:
     from dagster._core.definitions import JobDefinition
+
+    for name, value in inspect.getmembers(module):
+        if name == BUILD_DEFS_FN_NAME and isfunction(value):
+            return [LoadableTarget(name, value)]
 
     loadable_defs = _loadable_targets_of_type(module, Definitions)
 
@@ -103,7 +109,7 @@ def loadable_targets_from_loaded_module(module: ModuleType) -> Sequence[Loadable
         return [LoadableTarget(LOAD_ALL_ASSETS, [*module_assets, *module_source_assets])]
 
     raise DagsterInvariantViolationError(
-        "No repositories, jobs, pipelines, graphs, or asset definitions found in "
+        "No repositories, jobs, pipelines, graphs, asset definitions, or build_defs functions found in "
         f'"{module.__name__}".'
     )
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/build_defs.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/build_defs.py
@@ -1,0 +1,8 @@
+from dagster import Definitions, asset
+
+
+def build_defs():
+    @asset
+    def asset1(): ...
+
+    return Definitions(assets=[asset1])

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
@@ -258,3 +258,17 @@ def test_local_directory_file():
 
     with alter_sys_path(to_add=[os.path.dirname(path)], to_remove=[]):
         loadable_targets_from_python_file(path, working_directory=os.path.dirname(path))
+
+
+def test_build_defs_function():
+    module_path = file_relative_path(__file__, "build_defs.py")
+    loadable_targets = loadable_targets_from_python_file(module_path)
+
+    assert len(loadable_targets) == 1
+    symbol = loadable_targets[0].attribute
+    assert symbol == "build_defs"
+
+    repo_def = repository_def_from_pointer(CodePointer.from_python_file(module_path, symbol, None))
+
+    assert isinstance(repo_def, RepositoryDefinition)
+    assert len(repo_def.assets_defs_by_key) == 1


### PR DESCRIPTION
## Summary & Motivation

Instead of directly defining a variable that points to a `Definitions` object, users can define a `build_defs` function that returns a `Definitions` object. If there's code that they want to execute when loading `Definitions`, but not on import, they can put it inside this function.  This function will be executed anywhere that the `Definitions` object would be accessed – in the code server, in step processes, and in most `dagster` CLI commands.

```python
from dagster import asset, Definitions

def build_defs():
    @asset
    def my_asset(): ...
    
    return Definitions(assets=[my_asset])
```

Questions to think about:
- Best practices. This is the biggest open question for me. E.g. do we update our tutorial to use this? Is our advice "when constructing `Definitions` starts to get expensive, we recommend switching to `build_defs`"?
- Backcompat - in theory, if someone already has a function named `build_defs`, we could break them.
- Naming

## How I Tested These Changes
