### PR TITLE
[ui] CronTag

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/automation/VirtualizedAutomationScheduleRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/VirtualizedAutomationScheduleRow.tsx
@@ -1,5 +1,5 @@
 import {useLazyQuery} from '@apollo/client';
-import {Box, Caption, Checkbox, Colors, MiddleTruncate, Tooltip} from '@dagster-io/ui-components';
+import {Box, Caption, Checkbox, MiddleTruncate, Tooltip} from '@dagster-io/ui-components';
 import {forwardRef, useMemo} from 'react';
 import {Link} from 'react-router-dom';
 
@@ -9,13 +9,13 @@ import {InstigationStatus} from '../graphql/types';
 import {LastRunSummary} from '../instance/LastRunSummary';
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {PipelineReference} from '../pipelines/PipelineReference';
+import {CronTag} from '../schedules/CronTag';
 import {ScheduleSwitch} from '../schedules/ScheduleSwitch';
 import {errorDisplay} from '../schedules/SchedulesTable';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
-import {humanCronString} from '../schedules/humanCronString';
 import {TickStatusTag} from '../ticks/TickStatusTag';
 import {RowCell} from '../ui/VirtualizedTable';
-import {SINGLE_SCHEDULE_QUERY, ScheduleStringContainer} from '../workspace/VirtualizedScheduleRow';
+import {SINGLE_SCHEDULE_QUERY} from '../workspace/VirtualizedScheduleRow';
 import {LoadingOrNone, useDelayedRowQuery} from '../workspace/VirtualizedWorkspaceTable';
 import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext';
 import {RepoAddress} from '../workspace/types';
@@ -68,10 +68,6 @@ export const VirtualizedAutomationScheduleRow = forwardRef(
     }, [data]);
 
     const isJob = !!(scheduleData && isThisThingAJob(repo, scheduleData.pipelineName));
-
-    const cronString = scheduleData
-      ? humanCronString(scheduleData.cronSchedule, scheduleData.executionTimezone || 'UTC')
-      : '';
 
     const onChange = (e: React.FormEvent<HTMLInputElement>) => {
       if (onToggleChecked && e.target instanceof HTMLInputElement) {
@@ -135,22 +131,10 @@ export const VirtualizedAutomationScheduleRow = forwardRef(
           <RowCell>
             {scheduleData ? (
               <Box flex={{direction: 'column', gap: 4}}>
-                <ScheduleStringContainer style={{maxWidth: '100%'}}>
-                  <Tooltip position="top-left" content={scheduleData.cronSchedule} display="block">
-                    <div
-                      style={{
-                        color: Colors.textDefault(),
-                        overflow: 'hidden',
-                        whiteSpace: 'nowrap',
-                        maxWidth: '100%',
-                        textOverflow: 'ellipsis',
-                      }}
-                      title={cronString}
-                    >
-                      {cronString}
-                    </div>
-                  </Tooltip>
-                </ScheduleStringContainer>
+                <CronTag
+                  cronSchedule={scheduleData.cronSchedule}
+                  executionTimezone={scheduleData.executionTimezone}
+                />
                 {scheduleData.scheduleState.nextTick &&
                 scheduleData.scheduleState.status === InstigationStatus.RUNNING ? (
                   <Caption>

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/CronTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/CronTag.tsx
@@ -1,0 +1,32 @@
+import {Tag, Tooltip} from '@dagster-io/ui-components';
+import styled from 'styled-components';
+
+import {humanCronString} from './humanCronString';
+
+interface Props {
+  cronSchedule: string;
+  executionTimezone: string | null;
+}
+
+export const CronTag = (props: Props) => {
+  const {cronSchedule, executionTimezone} = props;
+  const humanString = humanCronString(cronSchedule, executionTimezone || 'UTC');
+
+  return (
+    <Container>
+      <Tooltip content={cronSchedule} placement="top">
+        <Tag icon="schedule">{humanString}</Tag>
+      </Tooltip>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  .bp4-popover2-target {
+    max-width: 100%;
+
+    :focus {
+      outline: none;
+    }
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedScheduleRow.tsx
@@ -32,10 +32,10 @@ import {BasicInstigationStateFragment} from '../overview/types/BasicInstigationS
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 import {PipelineReference} from '../pipelines/PipelineReference';
 import {RUN_TIME_FRAGMENT} from '../runs/RunUtils';
+import {CronTag} from '../schedules/CronTag';
 import {SCHEDULE_SWITCH_FRAGMENT, ScheduleSwitch} from '../schedules/ScheduleSwitch';
 import {errorDisplay} from '../schedules/SchedulesTable';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
-import {humanCronString} from '../schedules/humanCronString';
 import {TickStatusTag} from '../ticks/TickStatusTag';
 import {MenuLink} from '../ui/MenuLink';
 import {HeaderCell, HeaderRow, Row, RowCell} from '../ui/VirtualizedTable';
@@ -98,10 +98,6 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
 
   const isJob = !!(scheduleData && isThisThingAJob(repo, scheduleData.pipelineName));
 
-  const cronString = scheduleData
-    ? humanCronString(scheduleData.cronSchedule, scheduleData.executionTimezone || 'UTC')
-    : '';
-
   const onChange = (e: React.FormEvent<HTMLInputElement>) => {
     if (onToggleChecked && e.target instanceof HTMLInputElement) {
       const {checked} = e.target;
@@ -161,22 +157,10 @@ export const VirtualizedScheduleRow = (props: ScheduleRowProps) => {
         <RowCell>
           {scheduleData ? (
             <Box flex={{direction: 'column', gap: 4}}>
-              <ScheduleStringContainer style={{maxWidth: '100%'}}>
-                <Tooltip position="top-left" content={scheduleData.cronSchedule} display="block">
-                  <div
-                    style={{
-                      color: Colors.textDefault(),
-                      overflow: 'hidden',
-                      whiteSpace: 'nowrap',
-                      maxWidth: '100%',
-                      textOverflow: 'ellipsis',
-                    }}
-                    title={cronString}
-                  >
-                    {cronString}
-                  </div>
-                </Tooltip>
-              </ScheduleStringContainer>
+              <CronTag
+                cronSchedule={scheduleData.cronSchedule}
+                executionTimezone={scheduleData.executionTimezone}
+              />
               {scheduleData.scheduleState.nextTick &&
               scheduleData.scheduleState.status === InstigationStatus.RUNNING ? (
                 <Caption>
@@ -301,18 +285,6 @@ const RowGrid = styled(Box)<{$showCheckboxColumn: boolean}>`
   grid-template-columns: ${({$showCheckboxColumn}) =>
     $showCheckboxColumn ? TEMPLATE_COLUMNS_WITH_CHECKBOX : TEMPLATE_COLUMNS};
   height: 100%;
-`;
-
-export const ScheduleStringContainer = styled.div`
-  max-width: 100%;
-
-  .bp4-popover2-target {
-    max-width: 100%;
-
-    :focus {
-      outline: none;
-    }
-  }
 `;
 
 export const SINGLE_SCHEDULE_QUERY = gql`


### PR DESCRIPTION
## Summary & Motivation

For schedule table rows, render human-readable cron strings in tags.

<img width="1284" alt="Screenshot 2024-07-26 at 09 54 01" src="https://github.com/user-attachments/assets/9116de3a-75e5-40e1-8882-beeaf3b4a215">

## How I Tested These Changes

View Schedules list and merged automations list, verify rendering and behavior of cron tags, including hover states for tooltips and expanded human-readable string.