### PR TITLE
Add Configuration to `OpenAIResource`

### DIFF
--- a/python_modules/libraries/dagster-openai/dagster_openai/resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai/resources.py
@@ -180,9 +180,9 @@ class OpenAIResource(ConfigurableResource):
     """
 
     api_key: str = Field(description=("OpenAI API key. See https://platform.openai.com/api-keys"))
-    organization: Optional[str] = None
-    project: Optional[str] = None
-    base_url: Optional[str] = None
+    organization: Optional[str] = Field(default=None)
+    project: Optional[str] = Field(default=None)
+    base_url: Optional[str] = Field(default=None)
 
     _client: Client = PrivateAttr()
 
@@ -215,14 +215,12 @@ class OpenAIResource(ConfigurableResource):
 
     def setup_for_execution(self, context: InitResourceContext) -> None:
         # Set up an OpenAI client based on the API key.
-        kwargs = {}
-        if self.organization:
-            kwargs["organization"] = self.organization
-        if self.project:
-            kwargs["project"] = self.project
-        if self.base_url:
-            kwargs["base_url"] = self.base_url
-        self._client = Client(api_key=self.api_key, **kwargs)
+        self._client = Client(
+            api_key=self.api_key,
+            organization=self.organization,
+            project=self.project,
+            base_url=self.base_url,
+        )
 
     @public
     @contextmanager

--- a/python_modules/libraries/dagster-openai/dagster_openai/resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai/resources.py
@@ -180,6 +180,9 @@ class OpenAIResource(ConfigurableResource):
     """
 
     api_key: str = Field(description=("OpenAI API key. See https://platform.openai.com/api-keys"))
+    organization: Optional[str] = None
+    project: Optional[str] = None
+    base_url: Optional[str] = None
 
     _client: Client = PrivateAttr()
 
@@ -212,7 +215,17 @@ class OpenAIResource(ConfigurableResource):
 
     def setup_for_execution(self, context: InitResourceContext) -> None:
         # Set up an OpenAI client based on the API key.
-        self._client = Client(api_key=self.api_key)
+        kwargs = {}
+        if self.organization:
+            kwargs["organization"] = self.organization
+        if self.project:
+            kwargs["project"] = self.project
+        if self.base_url:
+            kwargs["base_url"] = self.base_url
+        self._client = Client(
+            api_key=self.api_key,
+            **kwargs
+        )
 
     @public
     @contextmanager

--- a/python_modules/libraries/dagster-openai/dagster_openai/resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai/resources.py
@@ -222,10 +222,7 @@ class OpenAIResource(ConfigurableResource):
             kwargs["project"] = self.project
         if self.base_url:
             kwargs["base_url"] = self.base_url
-        self._client = Client(
-            api_key=self.api_key,
-            **kwargs
-        )
+        self._client = Client(api_key=self.api_key, **kwargs)
 
     @public
     @contextmanager

--- a/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
@@ -28,7 +28,12 @@ def test_openai_client(mock_client) -> None:
 
     mock_context = MagicMock()
     with openai_resource.get_client(mock_context):
-        mock_client.assert_called_once_with(api_key="xoxp-1234123412341234-12341234-1234")
+        mock_client.assert_called_once_with(
+            api_key="xoxp-1234123412341234-12341234-1234",
+            organization=None,
+            project=None,
+            base_url=None,
+        )
 
 
 @patch("dagster_openai.resources.Client")

--- a/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
@@ -1,3 +1,4 @@
+from mock.mock import Base
 import pytest
 from dagster import (
     AssetExecutionContext,
@@ -19,6 +20,7 @@ from dagster._core.execution.context.init import build_init_resource_context
 from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_openai import OpenAIResource, with_usage_metadata
 from mock import ANY, MagicMock, patch
+from openai import OpenAI
 
 
 @patch("dagster_openai.resources.Client")
@@ -29,6 +31,26 @@ def test_openai_client(mock_client) -> None:
     mock_context = MagicMock()
     with openai_resource.get_client(mock_context):
         mock_client.assert_called_once_with(api_key="xoxp-1234123412341234-12341234-1234")
+
+
+@patch("dagster_openai.resources.Client")
+def test_openai_client_with_config(mock_client) -> None:
+    openai_resource = OpenAIResource(
+        api_key="xoxp-1234123412341234-12341234-1234",
+        organization="foo",
+        project="bar",
+        base_url="http://foo.bar"
+    )
+    openai_resource.setup_for_execution(build_init_resource_context())
+
+    mock_context = MagicMock()
+    with openai_resource.get_client(mock_context):
+        mock_client.assert_called_once_with(
+            api_key="xoxp-1234123412341234-12341234-1234",
+            organization="foo",
+            project="bar",
+            base_url="http://foo.bar"
+        )
 
 
 @patch("dagster_openai.resources.OpenAIResource._wrap_with_usage_metadata")

--- a/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
@@ -1,4 +1,3 @@
-from mock.mock import Base
 import pytest
 from dagster import (
     AssetExecutionContext,
@@ -20,7 +19,6 @@ from dagster._core.execution.context.init import build_init_resource_context
 from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_openai import OpenAIResource, with_usage_metadata
 from mock import ANY, MagicMock, patch
-from openai import OpenAI
 
 
 @patch("dagster_openai.resources.Client")
@@ -39,7 +37,7 @@ def test_openai_client_with_config(mock_client) -> None:
         api_key="xoxp-1234123412341234-12341234-1234",
         organization="foo",
         project="bar",
-        base_url="http://foo.bar"
+        base_url="http://foo.bar",
     )
     openai_resource.setup_for_execution(build_init_resource_context())
 
@@ -49,7 +47,7 @@ def test_openai_client_with_config(mock_client) -> None:
             api_key="xoxp-1234123412341234-12341234-1234",
             organization="foo",
             project="bar",
-            base_url="http://foo.bar"
+            base_url="http://foo.bar",
         )
 
 


### PR DESCRIPTION
## Summary & Motivation

When creating an `OpenAIResource`, we might want to pass these additional arguments to the OpenAI `Client`.

## How I Tested These Changes

I added a test case that validates that these new arguments are passed from the `OpenAIResource` to the `Client`.