### PR TITLE
[ui] Bulk actions for merged automations table

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationBulkActionMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationBulkActionMenu.tsx
@@ -1,0 +1,64 @@
+import {Button, Icon, Menu, MenuItem, Popover} from '@dagster-io/ui-components';
+import {useMemo, useState} from 'react';
+
+import {AutomationInfo, AutomationStateChangeDialog} from './AutomationStateChangeDialog';
+import {instigationStateSummary} from '../instigation/instigationStateSummary';
+import {OpenWithIntent} from '../instigation/useInstigationStateReducer';
+
+interface Props {
+  automations: AutomationInfo[];
+  onDone: () => void;
+}
+
+export const AutomationBulkActionMenu = (props: Props) => {
+  const {automations, onDone} = props;
+  const count = automations.length;
+
+  const [openWithIntent, setOpenWithIntent] = useState<OpenWithIntent>('not-open');
+
+  const {anyOff, anyOn} = useMemo(() => {
+    return instigationStateSummary(automations.map(({instigationState}) => instigationState));
+  }, [automations]);
+
+  return (
+    <>
+      <Popover
+        content={
+          <Menu>
+            <MenuItem
+              text={`Start ${count === 1 ? '1 automation' : `${count} automations`}`}
+              disabled={!anyOff}
+              aria-disabled={!anyOff}
+              icon="toggle_on"
+              onClick={() => {
+                setOpenWithIntent('start');
+              }}
+            />
+            <MenuItem
+              text={`Stop ${count === 1 ? '1 automation' : `${count} automations`}`}
+              disabled={!anyOn}
+              aria-disabled={!anyOn}
+              icon="toggle_off"
+              onClick={() => {
+                setOpenWithIntent('stop');
+              }}
+            />
+          </Menu>
+        }
+        placement="bottom-end"
+      >
+        <Button disabled={!count} intent="primary" rightIcon={<Icon name="expand_more" />}>
+          Actions
+        </Button>
+      </Popover>
+      <AutomationStateChangeDialog
+        openWithIntent={openWithIntent}
+        automations={automations}
+        onClose={() => setOpenWithIntent('not-open')}
+        onComplete={() => {
+          onDone();
+        }}
+      />
+    </>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationStateChangeDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationStateChangeDialog.tsx
@@ -1,0 +1,361 @@
+import {useMutation} from '@apollo/client';
+// eslint-disable-next-line no-restricted-imports
+import {ProgressBar} from '@blueprintjs/core';
+import {
+  Button,
+  Colors,
+  Dialog,
+  DialogBody,
+  DialogFooter,
+  Group,
+  Icon,
+} from '@dagster-io/ui-components';
+import {useEffect} from 'react';
+
+import {assertUnreachable} from '../app/Util';
+import {
+  OpenWithIntent,
+  useInstigationStateReducer,
+} from '../instigation/useInstigationStateReducer';
+import {BasicInstigationStateFragment} from '../overview/types/BasicInstigationStateFragment.types';
+import {NavigationBlock} from '../runs/NavigationBlock';
+import {START_SCHEDULE_MUTATION, STOP_SCHEDULE_MUTATION} from '../schedules/ScheduleMutations';
+import {
+  StartThisScheduleMutation,
+  StartThisScheduleMutationVariables,
+  StopScheduleMutation,
+  StopScheduleMutationVariables,
+} from '../schedules/types/ScheduleMutations.types';
+import {START_SENSOR_MUTATION, STOP_SENSOR_MUTATION} from '../sensors/SensorMutations';
+import {
+  StartSensorMutation,
+  StartSensorMutationVariables,
+  StopRunningSensorMutation,
+  StopRunningSensorMutationVariables,
+} from '../sensors/types/SensorMutations.types';
+import {RepoAddress} from '../workspace/types';
+
+export interface AutomationInfo {
+  repoAddress: RepoAddress;
+  name: string;
+  type: 'sensor' | 'schedule';
+  instigationState: BasicInstigationStateFragment;
+}
+
+export interface Props {
+  openWithIntent: OpenWithIntent;
+  onClose: () => void;
+  onComplete: () => void;
+  automations: AutomationInfo[];
+}
+
+export const AutomationStateChangeDialog = (props: Props) => {
+  const {openWithIntent, onClose, onComplete, automations} = props;
+  const count = automations.length;
+
+  const [state, dispatch] = useInstigationStateReducer();
+
+  // If the dialog is newly closed, reset state.
+  useEffect(() => {
+    if (openWithIntent === 'not-open') {
+      dispatch({type: 'reset'});
+    }
+  }, [openWithIntent, dispatch]);
+
+  const [startSensor] = useMutation<StartSensorMutation, StartSensorMutationVariables>(
+    START_SENSOR_MUTATION,
+  );
+
+  const [stopSensor] = useMutation<StopRunningSensorMutation, StopRunningSensorMutationVariables>(
+    STOP_SENSOR_MUTATION,
+  );
+
+  const [startSchedule] = useMutation<
+    StartThisScheduleMutation,
+    StartThisScheduleMutationVariables
+  >(START_SCHEDULE_MUTATION);
+
+  const [stopSchedule] = useMutation<StopScheduleMutation, StopScheduleMutationVariables>(
+    STOP_SCHEDULE_MUTATION,
+  );
+
+  const start = async (automation: AutomationInfo) => {
+    const {repoAddress, name, type} = automation;
+    const repoValues = {
+      repositoryLocationName: repoAddress.location,
+      repositoryName: repoAddress.name,
+    };
+
+    switch (type) {
+      case 'sensor': {
+        const {data} = await startSensor({
+          variables: {sensorSelector: {...repoValues, sensorName: name}},
+        });
+
+        switch (data?.startSensor.__typename) {
+          case 'Sensor':
+            dispatch({type: 'update-success'});
+            return;
+          case 'SensorNotFoundError':
+          case 'UnauthorizedError':
+          case 'PythonError':
+            dispatch({
+              type: 'update-error',
+              name,
+              error: data.startSensor.message,
+            });
+        }
+
+        break;
+      }
+
+      case 'schedule': {
+        const {data} = await startSchedule({
+          variables: {scheduleSelector: {...repoValues, scheduleName: name}},
+        });
+
+        switch (data?.startSchedule.__typename) {
+          case 'ScheduleStateResult':
+            dispatch({type: 'update-success'});
+            return;
+          case 'UnauthorizedError':
+          case 'PythonError':
+            dispatch({
+              type: 'update-error',
+              name,
+              error: data.startSchedule.message,
+            });
+        }
+
+        break;
+      }
+
+      default:
+        assertUnreachable(type);
+    }
+  };
+
+  const stop = async (automation: AutomationInfo) => {
+    const {name, type, instigationState} = automation;
+    const variables = {id: instigationState.id};
+
+    switch (type) {
+      case 'sensor': {
+        const {data} = await stopSensor({variables});
+        switch (data?.stopSensor.__typename) {
+          case 'StopSensorMutationResult':
+            dispatch({type: 'update-success'});
+            return;
+          case 'UnauthorizedError':
+          case 'PythonError':
+            dispatch({
+              type: 'update-error',
+              name,
+              error: data.stopSensor.message,
+            });
+        }
+        break;
+      }
+
+      case 'schedule': {
+        const {data} = await stopSchedule({variables});
+        switch (data?.stopRunningSchedule.__typename) {
+          case 'ScheduleStateResult':
+            dispatch({type: 'update-success'});
+            return;
+          case 'UnauthorizedError':
+          case 'PythonError':
+            dispatch({
+              type: 'update-error',
+              name,
+              error: data.stopRunningSchedule.message,
+            });
+        }
+        break;
+      }
+
+      default:
+        assertUnreachable(type);
+    }
+  };
+
+  const mutate = async () => {
+    if (openWithIntent === 'not-open') {
+      return;
+    }
+
+    dispatch({type: 'start'});
+    for (const automation of automations) {
+      if (openWithIntent === 'start') {
+        await start(automation);
+      } else {
+        await stop(automation);
+      }
+    }
+
+    dispatch({type: 'complete'});
+    onComplete();
+  };
+
+  const progressContent = () => {
+    if (openWithIntent === 'not-open') {
+      return null;
+    }
+
+    switch (state.step) {
+      case 'initial':
+        if (openWithIntent === 'stop') {
+          return (
+            <div>
+              {`${
+                count === 1 ? '1 automation' : `${count} automations`
+              } will be stopped. Do you want to continue?`}
+            </div>
+          );
+        }
+        return (
+          <div>
+            {`${
+              count === 1 ? '1 automation' : `${count} automations`
+            } will be started. Do you want to continue?`}
+          </div>
+        );
+      case 'updating':
+      case 'completed':
+        const value = count > 0 ? state.completion.completed / count : 1;
+        return (
+          <Group direction="column" spacing={8}>
+            <ProgressBar intent="primary" value={Math.max(0.1, value)} animate={value < 1} />
+            {state.step === 'updating' ? (
+              <NavigationBlock message="Automations are being updated, please do not navigate away yet." />
+            ) : null}
+          </Group>
+        );
+      default:
+        return null;
+    }
+  };
+
+  const buttons = () => {
+    if (openWithIntent === 'not-open') {
+      return null;
+    }
+
+    switch (state.step) {
+      case 'initial': {
+        const label =
+          openWithIntent === 'start'
+            ? `Start ${count === 1 ? '1 automation' : `${count} automations`}`
+            : `Stop ${count === 1 ? '1 automation' : `${count} automations`}`;
+        return (
+          <>
+            <Button onClick={onClose}>Cancel</Button>
+            <Button intent="primary" onClick={mutate}>
+              {label}
+            </Button>
+          </>
+        );
+      }
+      case 'updating': {
+        const label =
+          openWithIntent === 'start'
+            ? `Starting ${count === 1 ? '1 automation' : `${count} automations`}`
+            : `Stopping ${count === 1 ? '1 automation' : `${count} automations`}`;
+        return (
+          <Button intent="primary" disabled>
+            {label}
+          </Button>
+        );
+      }
+      case 'completed':
+        return (
+          <Button intent="primary" onClick={onClose}>
+            Done
+          </Button>
+        );
+    }
+  };
+
+  const completionContent = () => {
+    if (openWithIntent === 'not-open' || state.step === 'initial') {
+      return null;
+    }
+
+    if (state.step === 'updating') {
+      return (
+        <div>
+          Please do not close the window or navigate away while automations are being updated.
+        </div>
+      );
+    }
+
+    const errors = state.completion.errors;
+    const errorCount = Object.keys(errors).length;
+    const successCount = state.completion.completed - errorCount;
+
+    return (
+      <Group direction="column" spacing={8}>
+        {successCount ? (
+          <Group direction="row" spacing={8} alignItems="flex-start">
+            <Icon name="check_circle" color={Colors.accentGreen()} />
+            <div>
+              {openWithIntent === 'start'
+                ? `Successfully started ${
+                    successCount === 1 ? '1 automation' : `${successCount} automations`
+                  }.`
+                : `Successfully stopped ${
+                    successCount === 1 ? '1 automation' : `${successCount} automations`
+                  }.`}
+            </div>
+          </Group>
+        ) : null}
+        {errorCount ? (
+          <Group direction="column" spacing={8}>
+            <Group direction="row" spacing={8} alignItems="flex-start">
+              <Icon name="warning" color={Colors.accentYellow()} />
+              <div>
+                {openWithIntent === 'start'
+                  ? `Could not start ${
+                      errorCount === 1 ? '1 automation' : `${errorCount} automations`
+                    }:`
+                  : `Could not stop ${
+                      errorCount === 1 ? '1 automation' : `${errorCount} automations`
+                    }:`}
+              </div>
+            </Group>
+            <ul style={{margin: '8px 0'}}>
+              {Object.keys(errors).map((automationName) => (
+                <li key={automationName}>
+                  <Group direction="row" spacing={8}>
+                    <strong>{automationName}:</strong>
+                    {errors[automationName] ? <div>{errors[automationName]}</div> : null}
+                  </Group>
+                </li>
+              ))}
+            </ul>
+          </Group>
+        ) : null}
+      </Group>
+    );
+  };
+
+  const canQuicklyClose = state.step !== 'updating';
+
+  return (
+    <Dialog
+      isOpen={openWithIntent !== 'not-open'}
+      title={openWithIntent === 'start' ? 'Start automations' : 'Stop automations'}
+      canEscapeKeyClose={canQuicklyClose}
+      canOutsideClickClose={canQuicklyClose}
+      onClose={onClose}
+    >
+      <DialogBody>
+        <Group direction="column" spacing={24}>
+          {progressContent()}
+          {completionContent()}
+        </Group>
+      </DialogBody>
+      <DialogFooter>{buttons()}</DialogFooter>
+    </Dialog>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/__fixtures__/AutomationState.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/__fixtures__/AutomationState.fixtures.tsx
@@ -1,0 +1,383 @@
+import {MockedResponse} from '@apollo/client/testing';
+
+import {
+  InstigationStatus,
+  buildInstigationState,
+  buildScheduleStateResult,
+  buildSensor,
+  buildStopSensorMutationResult,
+  buildUnauthorizedError,
+} from '../../graphql/types';
+import {START_SCHEDULE_MUTATION, STOP_SCHEDULE_MUTATION} from '../../schedules/ScheduleMutations';
+import {
+  StartThisScheduleMutation,
+  StopScheduleMutation,
+} from '../../schedules/types/ScheduleMutations.types';
+import {START_SENSOR_MUTATION, STOP_SENSOR_MUTATION} from '../../sensors/SensorMutations';
+import {
+  StartSensorMutation,
+  StopRunningSensorMutation,
+} from '../../sensors/types/SensorMutations.types';
+import {buildRepoAddress} from '../../workspace/buildRepoAddress';
+
+const repoAddress = buildRepoAddress('foo', 'bar');
+
+export const scheduleAlaskaCurrentlyStopped = {
+  repoAddress,
+  name: 'alaska',
+  type: 'schedule' as const,
+  instigationState: buildInstigationState({
+    status: InstigationStatus.STOPPED,
+    hasStartPermission: true,
+    hasStopPermission: true,
+  }),
+};
+
+export const scheduleColoradoCurrentlyStopped = {
+  repoAddress,
+  name: 'colorado',
+  type: 'schedule' as const,
+  instigationState: buildInstigationState({
+    status: InstigationStatus.STOPPED,
+  }),
+};
+
+export const scheduleDelawareCurrentlyRunning = {
+  repoAddress,
+  name: 'delaware',
+  type: 'schedule' as const,
+  instigationState: buildInstigationState({
+    id: 'delaware-id',
+    status: InstigationStatus.RUNNING,
+  }),
+};
+
+export const scheduleHawaiiCurrentlyRunning = {
+  repoAddress,
+  name: 'hawaii',
+  type: 'schedule' as const,
+  instigationState: buildInstigationState({
+    id: 'hawaii-id',
+    status: InstigationStatus.RUNNING,
+  }),
+};
+
+export const buildStartAlaskaSuccess = (delay = 0): MockedResponse<StartThisScheduleMutation> => {
+  return {
+    request: {
+      query: START_SCHEDULE_MUTATION,
+      variables: {
+        scheduleSelector: {
+          repositoryLocationName: repoAddress.location,
+          repositoryName: repoAddress.name,
+          scheduleName: 'alaska',
+        },
+      },
+    },
+    result: {
+      data: {
+        __typename: 'Mutation',
+        startSchedule: buildScheduleStateResult({
+          scheduleState: buildInstigationState({
+            status: InstigationStatus.RUNNING,
+          }),
+        }),
+      },
+    },
+    delay,
+  };
+};
+
+export const buildStartColoradoSuccess = (delay = 0): MockedResponse<StartThisScheduleMutation> => {
+  return {
+    request: {
+      query: START_SCHEDULE_MUTATION,
+      variables: {
+        scheduleSelector: {
+          repositoryLocationName: repoAddress.location,
+          repositoryName: repoAddress.name,
+          scheduleName: 'colorado',
+        },
+      },
+    },
+    result: {
+      data: {
+        __typename: 'Mutation',
+        startSchedule: buildScheduleStateResult({
+          scheduleState: buildInstigationState({
+            status: InstigationStatus.RUNNING,
+          }),
+        }),
+      },
+    },
+    delay,
+  };
+};
+
+export const buildStartColoradoError = (delay = 0): MockedResponse<StartThisScheduleMutation> => {
+  return {
+    request: {
+      query: START_SCHEDULE_MUTATION,
+      variables: {
+        scheduleSelector: {
+          repositoryLocationName: repoAddress.location,
+          repositoryName: repoAddress.name,
+          scheduleName: 'colorado',
+        },
+      },
+    },
+    result: {
+      data: {
+        __typename: 'Mutation',
+        startSchedule: buildUnauthorizedError({
+          message: 'lol u cannot',
+        }),
+      },
+    },
+    delay,
+  };
+};
+
+export const buildStopDelawareSuccess = (delay = 0): MockedResponse<StopScheduleMutation> => {
+  return {
+    request: {
+      query: STOP_SCHEDULE_MUTATION,
+      variables: {
+        id: 'delaware-id',
+      },
+    },
+    result: {
+      data: {
+        __typename: 'Mutation',
+        stopRunningSchedule: buildScheduleStateResult({
+          scheduleState: buildInstigationState({
+            status: InstigationStatus.STOPPED,
+          }),
+        }),
+      },
+    },
+    delay,
+  };
+};
+
+export const buildStopHawaiiSuccess = (delay = 0): MockedResponse<StopScheduleMutation> => {
+  return {
+    request: {
+      query: STOP_SCHEDULE_MUTATION,
+      variables: {
+        id: 'hawaii-id',
+      },
+    },
+    result: {
+      data: {
+        __typename: 'Mutation',
+        stopRunningSchedule: buildScheduleStateResult({
+          scheduleState: buildInstigationState({
+            status: InstigationStatus.STOPPED,
+          }),
+        }),
+      },
+    },
+    delay,
+  };
+};
+
+export const buildStopHawaiiError = (delay = 0): MockedResponse<StopScheduleMutation> => {
+  return {
+    request: {
+      query: STOP_SCHEDULE_MUTATION,
+      variables: {
+        id: 'hawaii-id',
+      },
+    },
+    result: {
+      data: {
+        __typename: 'Mutation',
+        stopRunningSchedule: buildUnauthorizedError({
+          message: 'lol u cannot',
+        }),
+      },
+    },
+    delay,
+  };
+};
+
+export const sensorKansasCurrentlyStopped = {
+  repoAddress,
+  name: 'kansas',
+  type: 'sensor' as const,
+  instigationState: buildInstigationState({
+    status: InstigationStatus.STOPPED,
+    hasStartPermission: true,
+    hasStopPermission: true,
+  }),
+};
+
+export const sensorLouisianaCurrentlyStopped = {
+  repoAddress,
+  name: 'louisiana',
+  type: 'sensor' as const,
+  instigationState: buildInstigationState({
+    status: InstigationStatus.STOPPED,
+  }),
+};
+
+export const sensorMinnesotaCurrentlyRunning = {
+  repoAddress,
+  name: 'minnesota',
+  type: 'sensor' as const,
+  instigationState: buildInstigationState({
+    id: 'minnesota-id',
+    status: InstigationStatus.RUNNING,
+  }),
+};
+
+export const sensorOregonCurrentlyRunning = {
+  repoAddress,
+  name: 'oregon',
+  type: 'sensor' as const,
+  instigationState: buildInstigationState({
+    id: 'oregon-id',
+    status: InstigationStatus.RUNNING,
+  }),
+};
+
+export const buildStartKansasSuccess = (delay = 0): MockedResponse<StartSensorMutation> => {
+  return {
+    request: {
+      query: START_SENSOR_MUTATION,
+      variables: {
+        sensorSelector: {
+          repositoryLocationName: repoAddress.location,
+          repositoryName: repoAddress.name,
+          sensorName: 'kansas',
+        },
+      },
+    },
+    result: {
+      data: {
+        __typename: 'Mutation',
+        startSensor: buildSensor({
+          sensorState: buildInstigationState({
+            status: InstigationStatus.RUNNING,
+          }),
+        }),
+      },
+    },
+    delay,
+  };
+};
+
+export const buildStartLouisianaSuccess = (delay = 0): MockedResponse<StartSensorMutation> => {
+  return {
+    request: {
+      query: START_SENSOR_MUTATION,
+      variables: {
+        sensorSelector: {
+          repositoryLocationName: repoAddress.location,
+          repositoryName: repoAddress.name,
+          sensorName: 'louisiana',
+        },
+      },
+    },
+    result: {
+      data: {
+        __typename: 'Mutation',
+        startSensor: buildSensor({
+          sensorState: buildInstigationState({
+            status: InstigationStatus.RUNNING,
+          }),
+        }),
+      },
+    },
+    delay,
+  };
+};
+
+export const buildStartLouisianaError = (delay = 0): MockedResponse<StartSensorMutation> => {
+  return {
+    request: {
+      query: START_SENSOR_MUTATION,
+      variables: {
+        sensorSelector: {
+          repositoryLocationName: repoAddress.location,
+          repositoryName: repoAddress.name,
+          sensorName: 'louisiana',
+        },
+      },
+    },
+    result: {
+      data: {
+        __typename: 'Mutation',
+        startSensor: buildUnauthorizedError({
+          message: 'lol u cannot',
+        }),
+      },
+    },
+    delay,
+  };
+};
+
+export const buildStopMinnesotaSuccess = (delay = 0): MockedResponse<StopRunningSensorMutation> => {
+  return {
+    request: {
+      query: STOP_SENSOR_MUTATION,
+      variables: {
+        id: 'minnesota-id',
+      },
+    },
+    result: {
+      data: {
+        __typename: 'Mutation',
+        stopSensor: buildStopSensorMutationResult({
+          instigationState: buildInstigationState({
+            status: InstigationStatus.STOPPED,
+          }),
+        }),
+      },
+    },
+    delay,
+  };
+};
+
+export const buildStopOregonSuccess = (delay = 0): MockedResponse<StopRunningSensorMutation> => {
+  return {
+    request: {
+      query: STOP_SENSOR_MUTATION,
+      variables: {
+        id: 'oregon-id',
+      },
+    },
+    result: {
+      data: {
+        __typename: 'Mutation',
+        stopSensor: buildStopSensorMutationResult({
+          instigationState: buildInstigationState({
+            status: InstigationStatus.STOPPED,
+          }),
+        }),
+      },
+    },
+    delay,
+  };
+};
+
+export const buildStopOregonError = (delay = 0): MockedResponse<StopRunningSensorMutation> => {
+  return {
+    request: {
+      query: STOP_SENSOR_MUTATION,
+      variables: {
+        id: 'oregon-id',
+      },
+    },
+    result: {
+      data: {
+        __typename: 'Mutation',
+        stopSensor: buildUnauthorizedError({
+          message: 'lol u cannot',
+        }),
+      },
+    },
+    delay,
+  };
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/__tests__/AutomationStateChangeDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/__tests__/AutomationStateChangeDialog.test.tsx
@@ -1,0 +1,630 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {AutomationStateChangeDialog} from '../AutomationStateChangeDialog';
+import {
+  buildStartAlaskaSuccess,
+  buildStartColoradoError,
+  buildStartColoradoSuccess,
+  buildStartKansasSuccess,
+  buildStartLouisianaError,
+  buildStartLouisianaSuccess,
+  buildStopDelawareSuccess,
+  buildStopHawaiiError,
+  buildStopHawaiiSuccess,
+  buildStopMinnesotaSuccess,
+  buildStopOregonError,
+  buildStopOregonSuccess,
+  scheduleAlaskaCurrentlyStopped,
+  scheduleColoradoCurrentlyStopped,
+  scheduleDelawareCurrentlyRunning,
+  scheduleHawaiiCurrentlyRunning,
+  sensorKansasCurrentlyStopped,
+  sensorLouisianaCurrentlyStopped,
+  sensorMinnesotaCurrentlyRunning,
+  sensorOregonCurrentlyRunning,
+} from '../__fixtures__/AutomationState.fixtures';
+
+jest.mock('../../runs/NavigationBlock', () => ({
+  NavigationBlock: () => <div />,
+}));
+
+describe('AutomationStateChangeDialog', () => {
+  describe('Initial rendering', () => {
+    it('shows content when starting single sensor', () => {
+      render(
+        <MockedProvider>
+          <AutomationStateChangeDialog
+            openWithIntent="start"
+            automations={[sensorKansasCurrentlyStopped]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      expect(
+        screen.getByText(/1 automation will be started\. do you want to continue\?/i),
+      ).toBeVisible();
+
+      expect(screen.getByRole('button', {name: /start 1 automation/i})).toBeVisible();
+    });
+
+    it('shows content when starting single schedule', () => {
+      render(
+        <MockedProvider>
+          <AutomationStateChangeDialog
+            openWithIntent="start"
+            automations={[scheduleAlaskaCurrentlyStopped]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      expect(
+        screen.getByText(/1 automation will be started\. do you want to continue\?/i),
+      ).toBeVisible();
+
+      expect(screen.getByRole('button', {name: /start 1 automation/i})).toBeVisible();
+    });
+
+    it('shows content when starting multiple sensors', () => {
+      render(
+        <MockedProvider>
+          <AutomationStateChangeDialog
+            openWithIntent="start"
+            automations={[sensorKansasCurrentlyStopped, sensorLouisianaCurrentlyStopped]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      expect(
+        screen.getByText(/2 automations will be started\. do you want to continue\?/i),
+      ).toBeVisible();
+
+      expect(screen.getByRole('button', {name: /start 2 automations/i})).toBeVisible();
+    });
+
+    it('shows content when starting multiple schedules', () => {
+      render(
+        <MockedProvider>
+          <AutomationStateChangeDialog
+            openWithIntent="start"
+            automations={[scheduleAlaskaCurrentlyStopped, scheduleColoradoCurrentlyStopped]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      expect(
+        screen.getByText(/2 automations will be started\. do you want to continue\?/i),
+      ).toBeVisible();
+
+      expect(screen.getByRole('button', {name: /start 2 automations/i})).toBeVisible();
+    });
+
+    it('shows content when starting combination of automations', () => {
+      render(
+        <MockedProvider>
+          <AutomationStateChangeDialog
+            openWithIntent="start"
+            automations={[
+              sensorKansasCurrentlyStopped,
+              sensorLouisianaCurrentlyStopped,
+              scheduleAlaskaCurrentlyStopped,
+              scheduleColoradoCurrentlyStopped,
+            ]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      expect(
+        screen.getByText(/4 automations will be started\. do you want to continue\?/i),
+      ).toBeVisible();
+
+      expect(screen.getByRole('button', {name: /start 4 automations/i})).toBeVisible();
+    });
+
+    it('shows content when stopping single sensor', () => {
+      render(
+        <MockedProvider>
+          <AutomationStateChangeDialog
+            openWithIntent="stop"
+            automations={[sensorMinnesotaCurrentlyRunning]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      expect(
+        screen.getByText(/1 automation will be stopped\. do you want to continue\?/i),
+      ).toBeVisible();
+
+      expect(screen.getByRole('button', {name: /stop 1 automation/i})).toBeVisible();
+    });
+
+    it('shows content when stopping multiple sensors', () => {
+      render(
+        <MockedProvider>
+          <AutomationStateChangeDialog
+            openWithIntent="stop"
+            automations={[sensorMinnesotaCurrentlyRunning, sensorOregonCurrentlyRunning]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      expect(
+        screen.getByText(/2 automations will be stopped\. do you want to continue\?/i),
+      ).toBeVisible();
+
+      expect(screen.getByRole('button', {name: /stop 2 automations/i})).toBeVisible();
+    });
+
+    it('shows content when stopping single schedule', () => {
+      render(
+        <MockedProvider>
+          <AutomationStateChangeDialog
+            openWithIntent="stop"
+            automations={[scheduleHawaiiCurrentlyRunning]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      expect(
+        screen.getByText(/1 automation will be stopped\. do you want to continue\?/i),
+      ).toBeVisible();
+
+      expect(screen.getByRole('button', {name: /stop 1 automation/i})).toBeVisible();
+    });
+
+    it('shows content when stopping multiple schedules', () => {
+      render(
+        <MockedProvider>
+          <AutomationStateChangeDialog
+            openWithIntent="stop"
+            automations={[scheduleHawaiiCurrentlyRunning, scheduleDelawareCurrentlyRunning]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      expect(
+        screen.getByText(/2 automations will be stopped\. do you want to continue\?/i),
+      ).toBeVisible();
+
+      expect(screen.getByRole('button', {name: /stop 2 automations/i})).toBeVisible();
+    });
+  });
+
+  describe('Mutation: start', () => {
+    it('starts sensors', async () => {
+      const mocks = [buildStartKansasSuccess(100), buildStartLouisianaSuccess(100)];
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <AutomationStateChangeDialog
+            openWithIntent="start"
+            automations={[sensorKansasCurrentlyStopped, sensorLouisianaCurrentlyStopped]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      const confirmButton = screen.getByRole('button', {name: /start/i});
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        const button = screen.getByRole('button', {name: /starting/i});
+        expect(button).toBeVisible();
+        expect(button).toBeDisabled();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/successfully started 2 automations/i)).toBeVisible();
+      });
+    });
+
+    it('shows error when starting a sensor fails', async () => {
+      const mocks = [buildStartKansasSuccess(100), buildStartLouisianaError(100)];
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <AutomationStateChangeDialog
+            openWithIntent="start"
+            automations={[sensorKansasCurrentlyStopped, sensorLouisianaCurrentlyStopped]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      const confirmButton = screen.getByRole('button', {name: /start/i});
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        const button = screen.getByRole('button', {name: /starting/i});
+        expect(button).toBeVisible();
+        expect(button).toBeDisabled();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/successfully started 1 automation/i)).toBeVisible();
+      });
+
+      expect(screen.getByText(/could not start 1 automation/i)).toBeVisible();
+      const errorItem = screen.getByRole('listitem');
+
+      expect(errorItem.textContent).toMatch(/louisiana/i);
+      expect(errorItem.textContent).toMatch(/lol u cannot/i);
+    });
+
+    it('starts schedules', async () => {
+      const mocks = [buildStartColoradoSuccess(100), buildStartAlaskaSuccess(100)];
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <AutomationStateChangeDialog
+            openWithIntent="start"
+            automations={[scheduleAlaskaCurrentlyStopped, scheduleColoradoCurrentlyStopped]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      const confirmButton = screen.getByRole('button', {name: /start/i});
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        const button = screen.getByRole('button', {name: /starting/i});
+        expect(button).toBeVisible();
+        expect(button).toBeDisabled();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/successfully started 2 automations/i)).toBeVisible();
+      });
+    });
+
+    it('shows error when starting a schedule fails', async () => {
+      const mocks = [buildStartAlaskaSuccess(100), buildStartColoradoError(100)];
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <AutomationStateChangeDialog
+            openWithIntent="start"
+            automations={[scheduleAlaskaCurrentlyStopped, scheduleColoradoCurrentlyStopped]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      const confirmButton = screen.getByRole('button', {name: /start/i});
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        const button = screen.getByRole('button', {name: /starting/i});
+        expect(button).toBeVisible();
+        expect(button).toBeDisabled();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/successfully started 1 automation/i)).toBeVisible();
+      });
+
+      expect(screen.getByText(/could not start 1 automation/i)).toBeVisible();
+      const errorItem = screen.getByRole('listitem');
+
+      expect(errorItem.textContent).toMatch(/colorado/i);
+      expect(errorItem.textContent).toMatch(/lol u cannot/i);
+    });
+
+    it('starts a combination of schedules and sensors', async () => {
+      const mocks = [
+        buildStartKansasSuccess(100),
+        buildStartLouisianaSuccess(100),
+        buildStartColoradoSuccess(100),
+        buildStartAlaskaSuccess(100),
+      ];
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <AutomationStateChangeDialog
+            openWithIntent="start"
+            automations={[
+              sensorKansasCurrentlyStopped,
+              sensorLouisianaCurrentlyStopped,
+              scheduleAlaskaCurrentlyStopped,
+              scheduleColoradoCurrentlyStopped,
+            ]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      const confirmButton = screen.getByRole('button', {name: /start/i});
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        const button = screen.getByRole('button', {name: /starting/i});
+        expect(button).toBeVisible();
+        expect(button).toBeDisabled();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/successfully started 4 automations/i)).toBeVisible();
+      });
+    });
+
+    it('shows errors when starting a combination of schedules and sensors', async () => {
+      const mocks = [
+        buildStartKansasSuccess(100),
+        buildStartLouisianaError(100),
+        buildStartColoradoError(100),
+        buildStartAlaskaSuccess(100),
+      ];
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <AutomationStateChangeDialog
+            openWithIntent="start"
+            automations={[
+              sensorKansasCurrentlyStopped,
+              sensorLouisianaCurrentlyStopped,
+              scheduleAlaskaCurrentlyStopped,
+              scheduleColoradoCurrentlyStopped,
+            ]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      const confirmButton = screen.getByRole('button', {name: /start/i});
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        const button = screen.getByRole('button', {name: /starting/i});
+        expect(button).toBeVisible();
+        expect(button).toBeDisabled();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(/successfully started 2 automations/i)).toBeVisible();
+      });
+
+      expect(screen.getByText(/could not start 2 automations/i)).toBeVisible();
+      const errorItems = screen.getAllByRole('listitem');
+
+      expect(errorItems[0]!.textContent).toMatch(/louisiana/i);
+      expect(errorItems[0]!.textContent).toMatch(/lol u cannot/i);
+      expect(errorItems[1]!.textContent).toMatch(/colorado/i);
+      expect(errorItems[1]!.textContent).toMatch(/lol u cannot/i);
+    });
+  });
+
+  describe('Mutation: stop', () => {
+    it('stops sensors', async () => {
+      const mocks = [buildStopMinnesotaSuccess(100), buildStopOregonSuccess(100)];
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <AutomationStateChangeDialog
+            openWithIntent="stop"
+            automations={[sensorMinnesotaCurrentlyRunning, sensorOregonCurrentlyRunning]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      const confirmButton = screen.getByRole('button', {name: /stop/i});
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        const button = screen.getByRole('button', {name: /stopping/i});
+        expect(button).toBeVisible();
+        expect(button).toBeDisabled();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/successfully stopped 2 automations/i)).toBeVisible();
+      });
+    });
+
+    it('shows error when stopping a sensor fails', async () => {
+      const mocks = [buildStopMinnesotaSuccess(100), buildStopOregonError(100)];
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <AutomationStateChangeDialog
+            openWithIntent="stop"
+            automations={[sensorMinnesotaCurrentlyRunning, sensorOregonCurrentlyRunning]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      const confirmButton = screen.getByRole('button', {name: /stop/i});
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        const button = screen.getByRole('button', {name: /stopping/i});
+        expect(button).toBeVisible();
+        expect(button).toBeDisabled();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/successfully stopped 1 automation/i)).toBeVisible();
+      });
+
+      expect(screen.getByText(/could not stop 1 automation/i)).toBeVisible();
+      const errorItem = screen.getByRole('listitem');
+
+      expect(errorItem.textContent).toMatch(/oregon/i);
+      expect(errorItem.textContent).toMatch(/lol u cannot/i);
+    });
+
+    it('stops schedules', async () => {
+      const mocks = [buildStopDelawareSuccess(100), buildStopHawaiiSuccess(100)];
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <AutomationStateChangeDialog
+            openWithIntent="stop"
+            automations={[scheduleDelawareCurrentlyRunning, scheduleHawaiiCurrentlyRunning]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      const confirmButton = screen.getByRole('button', {name: /stop/i});
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        const button = screen.getByRole('button', {name: /stopping/i});
+        expect(button).toBeVisible();
+        expect(button).toBeDisabled();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/successfully stopped 2 automations/i)).toBeVisible();
+      });
+    });
+
+    it('shows error when stopping a schedule fails', async () => {
+      const mocks = [buildStopDelawareSuccess(100), buildStopHawaiiError(100)];
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <AutomationStateChangeDialog
+            openWithIntent="stop"
+            automations={[scheduleDelawareCurrentlyRunning, scheduleHawaiiCurrentlyRunning]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      const confirmButton = screen.getByRole('button', {name: /stop/i});
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        const button = screen.getByRole('button', {name: /stopping/i});
+        expect(button).toBeVisible();
+        expect(button).toBeDisabled();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/successfully stopped 1 automation/i)).toBeVisible();
+      });
+
+      expect(screen.getByText(/could not stop 1 automation/i)).toBeVisible();
+      const errorItem = screen.getByRole('listitem');
+
+      expect(errorItem.textContent).toMatch(/hawaii/i);
+      expect(errorItem.textContent).toMatch(/lol u cannot/i);
+    });
+
+    it('stops a combination of sensors and schedules', async () => {
+      const mocks = [
+        buildStopMinnesotaSuccess(100),
+        buildStopOregonSuccess(100),
+        buildStopDelawareSuccess(100),
+        buildStopHawaiiSuccess(100),
+      ];
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <AutomationStateChangeDialog
+            openWithIntent="stop"
+            automations={[
+              sensorMinnesotaCurrentlyRunning,
+              sensorOregonCurrentlyRunning,
+              scheduleDelawareCurrentlyRunning,
+              scheduleHawaiiCurrentlyRunning,
+            ]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      const confirmButton = screen.getByRole('button', {name: /stop/i});
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        const button = screen.getByRole('button', {name: /stopping/i});
+        expect(button).toBeVisible();
+        expect(button).toBeDisabled();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/successfully stopped 4 automations/i)).toBeVisible();
+      });
+    });
+
+    it('shows errors when stopping a combination of schedules and sensors', async () => {
+      const mocks = [
+        buildStopMinnesotaSuccess(100),
+        buildStopOregonError(100),
+        buildStopDelawareSuccess(100),
+        buildStopHawaiiError(100),
+      ];
+
+      render(
+        <MockedProvider mocks={mocks}>
+          <AutomationStateChangeDialog
+            openWithIntent="stop"
+            automations={[
+              sensorMinnesotaCurrentlyRunning,
+              sensorOregonCurrentlyRunning,
+              scheduleDelawareCurrentlyRunning,
+              scheduleHawaiiCurrentlyRunning,
+            ]}
+            onClose={jest.fn()}
+            onComplete={jest.fn()}
+          />
+        </MockedProvider>,
+      );
+
+      const confirmButton = screen.getByRole('button', {name: /stop/i});
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        const button = screen.getByRole('button', {name: /stopping/i});
+        expect(button).toBeVisible();
+        expect(button).toBeDisabled();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/successfully stopped 2 automations/i)).toBeVisible();
+      });
+
+      expect(screen.getByText(/could not stop 2 automations/i)).toBeVisible();
+      const errorItems = screen.getAllByRole('listitem');
+
+      expect(errorItems[0]!.textContent).toMatch(/oregon/i);
+      expect(errorItems[0]!.textContent).toMatch(/lol u cannot/i);
+      expect(errorItems[1]!.textContent).toMatch(/hawaii/i);
+      expect(errorItems[1]!.textContent).toMatch(/lol u cannot/i);
+    });
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/__tests__/SensorStateChangeDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/__tests__/SensorStateChangeDialog.test.tsx
@@ -16,7 +16,7 @@ import {
   sensorOregonCurrentlyRunning,
 } from '../__fixtures__/SensorState.fixtures';
 
-jest.mock('../..//runs/NavigationBlock', () => ({
+jest.mock('../../runs/NavigationBlock', () => ({
   NavigationBlock: () => <div />,
 }));
 


### PR DESCRIPTION
## Summary & Motivation

Add bulk start/stop to the merged automations table. This heavily reuses existing bulk actions for schedules/sensors, merging them into a single dialog with four possible mutations (start/stop for schedule/sensor).

I expect that the existing schedule/sensor tables will go away entirely at some point soon. Leaving them in place for now.

<img width="242" alt="Screenshot 2024-07-25 at 15 24 32" src="https://github.com/user-attachments/assets/1066d7e6-938b-4e2e-9c8e-29e2f8396a8a">

<img width="551" alt="Screenshot 2024-07-25 at 15 24 41" src="https://github.com/user-attachments/assets/812fb717-40f2-4bcc-bc79-a01e0bb19691">

<img width="550" alt="Screenshot 2024-07-25 at 15 24 46" src="https://github.com/user-attachments/assets/0e980e34-8464-4f52-acc9-602b6e9c6849">


## How I Tested These Changes

View merged automation table, select single and multiple schedules and sensors. Verify correct behavior of bulk action menu and dialog.