### PR TITLE
[sensor-upgrades][3/n] Add automation_condition_evaluations to SensorExecutionData & co.

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -20,6 +20,9 @@ from dagster._annotations import PublicAttr, experimental_param
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.declarative_automation.serialized_objects import (
+    AutomationConditionEvaluation,
+)
 from dagster._core.definitions.dynamic_partitions_request import (
     AddDynamicPartitionsRequest,
     DeleteDynamicPartitionsRequest,
@@ -362,6 +365,7 @@ class SensorResult(
                 "asset_events",
                 List[Union[AssetObservation, AssetMaterialization, AssetCheckEvaluation]],
             ),
+            ("automation_condition_evaluations", Optional[Sequence[AutomationConditionEvaluation]]),
         ],
     )
 ):
@@ -399,6 +403,7 @@ class SensorResult(
         asset_events: Optional[
             Sequence[Union[AssetObservation, AssetMaterialization, AssetCheckEvaluation]]
         ] = None,
+        **kwargs,
     ):
         if skip_reason and len(run_requests if run_requests else []) > 0:
             check.failed(
@@ -426,5 +431,10 @@ class SensorResult(
                     "asset_check_evaluations",
                     (AssetObservation, AssetMaterialization, AssetCheckEvaluation),
                 )
+            ),
+            automation_condition_evaluations=check.opt_sequence_param(
+                kwargs.get("automation_condition_evaluations"),
+                "automation_condition_evaluations",
+                AutomationConditionEvaluation,
             ),
         )


### PR DESCRIPTION
## Summary & Motivation

The UserCodeAutomationConditionSensorDefinition needs to be able to return the set of evaluations that were made during its tick (regardless of if it's managed by the sensor daemon or asset daemon -- currently it simply doesn't work). This adds a new field to the result object to allow us to return that information. It is implemented as a hidden parameter of the SensorResult object so that only framework code sets it. 

While this may at first glance seem overfit to one particular type of sensor, I'm imagining a future world in which you could have regular sensors also evaluate AutomationConditions, and which would also want to emit this type of information.

This uses the same failure-handling model as the Asset Daemon, in which we write the evaluations before submitting any runs, so that if we fail to submit some runs we can always pull those evaluations back in when we resume the tick.

## How I Tested These Changes
