### PR TITLE
[ui] Show target in Schedules lists

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/automation/VirtualizedAutomationSensorRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/VirtualizedAutomationSensorRow.tsx
@@ -162,16 +162,18 @@ export const VirtualizedAutomationSensorRow = forwardRef(
             </div>
           </RowCell>
           <RowCell>
-            <Box flex={{direction: 'column', gap: 4}} style={{fontSize: '12px'}}>
-              {sensorData ? (
+            {sensorData ? (
+              <div>
                 <AutomationTargetList
-                  targets={sensorData.targets}
+                  targets={sensorData.targets || null}
                   repoAddress={repoAddress}
                   assetSelection={selectedAssets}
                   automationType={sensorData.sensorType}
                 />
-              ) : null}
-            </Box>
+              </div>
+            ) : (
+              <LoadingOrNone queryResult={sensorAssetSelectionQueryResult} />
+            )}
           </RowCell>
           <RowCell>
             {tick ? (


### PR DESCRIPTION
## Summary & Motivation

Use `AutomationTargetList` in the Schedules and merged Automations lists.

- Add a column in the Schedules-only lists.
- Replace the existing pipeline reference in the merged automations list.

Schedule that targets assets:

<img width="1275" alt="Screenshot 2024-07-26 at 13 55 42" src="https://github.com/user-attachments/assets/baeecfb0-85ea-4e9e-a615-7aa5cbcb5039">


List of schedules with job targets:

<img width="1559" alt="Screenshot 2024-07-26 at 13 50 12" src="https://github.com/user-attachments/assets/307749f1-66c3-4b3f-be9f-31a48a4942c4">


Merged automation table:

<img width="1274" alt="Screenshot 2024-07-26 at 14 01 12" src="https://github.com/user-attachments/assets/653d0445-4bbe-43ae-a1d0-409b408d7fb9">

## How I Tested These Changes

View all schedules lists (overview and per-code location) and merged automation list. Verify correct rendering and behavior of target tag.

Repeat with the anonymous job schedules, verify that they show the asset selection target.