### PR TITLE
[asset diffs] special case ignore code reference diffs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Callable, Optional, Sequence, Union
 
 import dagster._check as check
+from dagster._core.definitions.metadata.source_code import CODE_REFERENCES_METADATA_KEY
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.remote_representation import ExternalRepository
@@ -157,7 +158,13 @@ class AssetGraphDiffer:
         if branch_asset.tags != base_asset.tags:
             changes.append(AssetDefinitionChangeType.TAGS)
 
-        if branch_asset.metadata != base_asset.metadata:
+        branch_meta_no_code_ref = {
+            k: v for k, v in branch_asset.metadata.items() if k != CODE_REFERENCES_METADATA_KEY
+        }
+        base_meta_no_code_ref = {
+            k: v for k, v in base_asset.metadata.items() if k != CODE_REFERENCES_METADATA_KEY
+        }
+        if branch_meta_no_code_ref != base_meta_no_code_ref:
             changes.append(AssetDefinitionChangeType.METADATA)
 
         return changes

--- a/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/source_code.py
@@ -86,6 +86,9 @@ class CodeReferencesMetadataSet(NamespacedMetadataSet):
         return "dagster"
 
 
+CODE_REFERENCES_METADATA_KEY = f"{CodeReferencesMetadataSet.namespace()}/code_references"
+
+
 def _with_code_source_single_definition(
     assets_def: Union["AssetsDefinition", "SourceAsset", "CacheableAssetsDefinition"],
 ) -> Union["AssetsDefinition", "SourceAsset", "CacheableAssetsDefinition"]:

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/metadata_asset_graph_code_refs/base_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/metadata_asset_graph_code_refs/base_asset_graph.py
@@ -1,0 +1,22 @@
+from dagster import Definitions, asset
+from dagster._core.definitions.metadata.source_code import (
+    CodeReferencesMetadataSet,
+    CodeReferencesMetadataValue,
+    LocalFileCodeReference,
+)
+
+
+@asset(
+    metadata={
+        **CodeReferencesMetadataSet(
+            code_references=CodeReferencesMetadataValue(
+                code_references=[LocalFileCodeReference(file_path="foo.py", line_number=1)]
+            )
+        )
+    }
+)
+def foo() -> int:
+    return 1
+
+
+defs = Definitions(assets=[foo])

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/metadata_asset_graph_code_refs/branch_deployment_change_metadata.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/asset_graph_scenarios/metadata_asset_graph_code_refs/branch_deployment_change_metadata.py
@@ -1,0 +1,22 @@
+from dagster import Definitions, asset
+from dagster._core.definitions.metadata.source_code import (
+    CodeReferencesMetadataSet,
+    CodeReferencesMetadataValue,
+    LocalFileCodeReference,
+)
+
+
+@asset(
+    metadata={
+        **CodeReferencesMetadataSet(
+            code_references=CodeReferencesMetadataValue(
+                code_references=[LocalFileCodeReference(file_path="foo.py", line_number=2)]
+            )
+        )
+    }
+)
+def foo() -> int:
+    return 1
+
+
+defs = Definitions(assets=[foo])

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -360,3 +360,15 @@ def test_change_metadata(instance):
     assert differ.get_changes_for_asset(AssetKey("fruits")) == [AssetDefinitionChangeType.METADATA]
     assert differ.get_changes_for_asset(AssetKey("letters")) == [AssetDefinitionChangeType.METADATA]
     assert len(differ.get_changes_for_asset(AssetKey("numbers"))) == 0
+
+
+def test_no_change_code_ref_metadata(instance) -> None:
+    differ = get_asset_graph_differ(
+        instance=instance,
+        code_location_to_diff="metadata_asset_graph_code_refs",
+        base_code_locations=["metadata_asset_graph_code_refs"],
+        branch_code_location_to_definitions={
+            "metadata_asset_graph_code_refs": "branch_deployment_change_metadata"
+        },
+    )
+    assert differ.get_changes_for_asset(AssetKey("foo")) == []

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/cacheable_assets.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/cacheable_assets.py
@@ -1,0 +1,5 @@
+from dagster import CacheableAssetsDefinition
+
+
+class MostlyCacheableAssets(CacheableAssetsDefinition):
+    pass

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/cacheable_assets.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/cacheable_assets.py
@@ -1,5 +1,0 @@
-from dagster import CacheableAssetsDefinition
-
-
-class MostlyCacheableAssets(CacheableAssetsDefinition):
-    pass


### PR DESCRIPTION
## Summary

Code reference metadata values often incorporate ever-changing data, such as the git sha of a deployed image. This changes with every deploy, which can add a ton of noise to the list of changed assets in branch deployments or in the asset history dialog. We explicitly block that key to alleviate this problem.

This is a very narrowly tailored solution, but it might speak to a broader need for evaluating changes in metadata beyond equality, e.g. maybe we still want to highlight adding, removing, or changing the number of code references but ignore any internal changes to the references themselves.

## Test Plan

Unit test.
