### PR TITLE
[dagster-openai] Add dagster-openai to `make dev_install` script

### DIFF
--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -77,6 +77,7 @@ def main(
         "-e python_modules/libraries/dagster-mlflow",
         "-e python_modules/libraries/dagster-mysql",
         "-e python_modules/libraries/dagster-looker",
+        "-e python_modules/libraries/dagster-openai",
         "-e python_modules/libraries/dagster-pagerduty",
         "-e python_modules/libraries/dagster-pandas",
         "-e python_modules/libraries/dagster-papertrail",


### PR DESCRIPTION
## Summary & Motivation

Update the script called by `make dev_install` to include `dagster-openai`.

## How I Tested These Changes

Tested locally with `make dev_install`