### PR TITLE
RFC: Minimum viable way to keep the partition status cache fast when it is up to date, even during in progress runs

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -65,6 +65,8 @@ class AssetEntry(
             ("last_observation_record", Optional[EventLogRecord]),
             ("last_planned_materialization_storage_id", Optional[int]),
             ("last_planned_materialization_run_id", Optional[str]),
+            ("last_materialization_failure_storage_id", Optional[int]),
+            ("last_materialization_failure_run_id", Optional[str]),
         ],
     )
 ):
@@ -78,6 +80,8 @@ class AssetEntry(
         last_observation_record: Optional[EventLogRecord] = None,
         last_planned_materialization_storage_id: Optional[int] = None,
         last_planned_materialization_run_id: Optional[str] = None,
+        last_materialization_failure_storage_id: Optional[int] = None,
+        last_materialization_failure_run_id: Optional[str] = None,
     ):
         from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
@@ -102,6 +106,12 @@ class AssetEntry(
             last_planned_materialization_run_id=check.opt_str_param(
                 last_planned_materialization_run_id,
                 "last_planned_materialization_run_id",
+            ),
+            last_materialization_failure_storage_id=check.opt_int_param(
+                last_materialization_failure_storage_id, "last_materialization_failure_storage_id"
+            ),
+            last_materialization_failure_run_id=check.opt_str_param(
+                last_materialization_failure_run_id, "last_materialization_failure_run_id"
             ),
         )
 
@@ -332,6 +342,10 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
 
     @property
     def asset_records_have_last_planned_materialization_storage_id(self) -> bool:
+        return False
+
+    @property
+    def asset_records_have_last_materialization_failure_storage_id(self) -> bool:
         return False
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -260,9 +260,19 @@ def _build_status_cache(
         instance, asset_key, asset_record
     )
 
+    last_materialization_failure_storage_id = (
+        asset_record.asset_entry.last_materialization_failure_storage_id
+        if (
+            asset_record
+            and instance.event_log_storage.asset_records_have_last_materialization_failure_storage_id
+        )
+        else 0
+    )
+
     latest_storage_id = max(
         last_materialization_storage_id or 0,
         last_planned_materialization_storage_id or 0,
+        last_materialization_failure_storage_id or 0,
     )
     if not latest_storage_id:
         return None
@@ -285,6 +295,8 @@ def _build_status_cache(
         if stored_cache_value
         else None
     )
+
+    cached_latest_storage_id = stored_cache_value.latest_storage_id if stored_cache_value else None
 
     if stored_cache_value:
         # fetch the incremental new materialized partitions, and update the cached materialized
@@ -327,19 +339,36 @@ def _build_status_cache(
             )
         )
 
-    (
-        failed_subset,
-        in_progress_subset,
-        earliest_in_progress_materialization_event_id,
-    ) = build_failed_and_in_progress_partition_subset(
-        instance,
-        asset_key,
-        partitions_def,
-        dynamic_partitions_store,
-        last_planned_materialization_storage_id=last_planned_materialization_storage_id,
-        failed_subset=failed_subset,
-        after_storage_id=cached_in_progress_cursor,
-    )
+    # If we are tracking ASSET_MATERIALIZATION_FAILURE events on the AssetRecord, the storage ID
+    # will increase whenever some event has come in that might affect the failed and in progress
+    # subset (because only ASSET_MATERIALIZATION_PLANNED, ASSET_MATERIALIZATION,
+    # or ASSET_MATERIALIZATION_FAILURE events will affect the storage ID, and only those events
+    # can affect the in progress subset
+    if (
+        not instance.event_log_storage.asset_records_have_last_materialization_failure_storage_id
+        or (cached_latest_storage_id and latest_storage_id > cached_latest_storage_id)
+    ):
+        (
+            failed_subset,
+            in_progress_subset,
+            earliest_in_progress_materialization_event_id,
+        ) = build_failed_and_in_progress_partition_subset(
+            instance,
+            asset_key,
+            partitions_def,
+            dynamic_partitions_store,
+            last_planned_materialization_storage_id=last_planned_materialization_storage_id,
+            failed_subset=failed_subset,
+            after_storage_id=cached_in_progress_cursor,
+        )
+    else:
+        failed_subset = failed_subset or partitions_def.empty_subset()
+        in_progress_subset = (
+            partitions_def.deserialize_subset(stored_cache_value.serialized_failed_partition_subset)
+            if stored_cache_value and stored_cache_value.serialized_failed_partition_subset
+            else partitions_def.empty_subset()
+        )
+        earliest_in_progress_materialization_event_id = cached_in_progress_cursor
 
     return AssetStatusCacheValue(
         latest_storage_id=latest_storage_id,


### PR DESCRIPTION
Summary:
This is a proof of concept for the simplest possible way to keep the asset status partition cache from needing to do any additional work when it is up to date, once we have an ASSET_MATERIALIZATION_FAILURE to work with. It is much less significant of a change than I had been originally imagining I would make - all it does is use the presence of a new FAILURE event to indicate that it should update the in progress and failed statuses. If there has been no new event since the last time it updated, it just uses the existing values. This should make the cache fast to compute when it is up to date, even when there are in progress runs.

What this does not help with at all yet is making the process of rebuilding it fast when an event does come and and it needs to update the cache - it still needs to start with the earliest in progress run, recompute the in progress subset from scratch, etc.

## Summary & Motivation

## How I Tested These Changes
