### PR TITLE
rework partial resource resolution

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/tutorial_tests/connecting/test_resources.py
+++ b/examples/docs_snippets/docs_snippets_tests/tutorial_tests/connecting/test_resources.py
@@ -8,9 +8,9 @@ from docs_snippets.tutorial.connecting import (
 from docs_snippets.tutorial.connecting.resources import DataGeneratorResource
 
 
-def test_definitions_with_resources():
+def test_definitions_with_resources() -> None:
     repository = connecting.defs.get_repository_def()
-    resource_keys = repository.get_resource_key_mapping().values()
+    resource_keys = repository.get_top_level_resources()
     assert len(resource_keys) == 1
     assert "hackernews_api" in resource_keys
 

--- a/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/__init__.py
@@ -21,8 +21,6 @@ from .resource import (
     ConfigurableResourceFactoryResourceDefinition as ConfigurableResourceFactoryResourceDefinition,
     PartialResource as PartialResource,
     ResourceDependency as ResourceDependency,
-    ResourceWithKeyMapping as ResourceWithKeyMapping,
-    attach_resource_id_to_key_mapping as attach_resource_id_to_key_mapping,
     is_coercible_to_resource as is_coercible_to_resource,
     validate_resource_annotated_function as validate_resource_annotated_function,
 )

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -45,6 +45,7 @@ from dagster._core.definitions.partition_mapping import MultiPartitionMapping
 from dagster._core.definitions.resource_requirement import (
     ExternalAssetIOManagerRequirement,
     ResourceAddable,
+    ResourceKeyRequirement,
     ResourceRequirement,
     merge_resource_defs,
 )
@@ -1447,7 +1448,12 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
     @property
     def required_resource_keys(self) -> Set[str]:
         """Set[str]: The set of keys for resources that must be provided to this AssetsDefinition."""
-        return {requirement.key for requirement in self.get_resource_requirements()}
+        return {
+            requirement.key
+            for requirement in self.get_resource_requirements()
+            if requirement
+            if isinstance(requirement, ResourceKeyRequirement)
+        }
 
     def __str__(self):
         if len(self.keys) == 1:

--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -158,7 +158,6 @@ class _Repository:
                     default_executor_def=self.default_executor_def,
                     default_logger_defs=self.default_logger_defs,
                     top_level_resources=self.top_level_resources,
-                    resource_key_mapping=self.resource_key_mapping,
                 )
             )
 
@@ -232,7 +231,6 @@ def repository(
     default_executor_def: Optional[ExecutorDefinition] = ...,
     default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = ...,
     _top_level_resources: Optional[Mapping[str, ResourceDefinition]] = ...,
-    _resource_key_mapping: Optional[Mapping[int, str]] = ...,
 ) -> _Repository: ...
 
 
@@ -250,7 +248,6 @@ def repository(
     default_executor_def: Optional[ExecutorDefinition] = None,
     default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
     _top_level_resources: Optional[Mapping[str, ResourceDefinition]] = None,
-    _resource_key_mapping: Optional[Mapping[int, str]] = None,
 ) -> Union[RepositoryDefinition, PendingRepositoryDefinition, _Repository]:
     """Create a repository from the decorated function.
 
@@ -406,5 +403,4 @@ def repository(
         default_executor_def=default_executor_def,
         default_logger_defs=default_logger_defs,
         top_level_resources=_top_level_resources,
-        resource_key_mapping=_resource_key_mapping,
     )

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -15,7 +15,6 @@ from typing import (
 
 import dagster._check as check
 from dagster._annotations import deprecated, experimental, public
-from dagster._config.pythonic_config import attach_resource_id_to_key_mapping
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_spec import AssetSpec
@@ -270,21 +269,7 @@ def _create_repository_using_definitions_args(
         else ExecutorDefinition.hardcoded_executor(executor)
     )
 
-    # Generate a mapping from each top-level resource instance ID to its resource key
-    resource_key_mapping = {id(v): k for k, v in resources.items()} if resources else {}
-
-    # Provide this mapping to each resource instance so that it can be used to resolve
-    # nested resources
-    resources_with_key_mapping = (
-        {
-            k: attach_resource_id_to_key_mapping(v, resource_key_mapping)
-            for k, v in resources.items()
-        }
-        if resources
-        else {}
-    )
-
-    resource_defs = wrap_resources_for_execution(resources_with_key_mapping)
+    resource_defs = wrap_resources_for_execution(resources)
 
     # Binds top-level resources to jobs and any jobs attached to schedules or sensors
     (
@@ -298,7 +283,6 @@ def _create_repository_using_definitions_args(
         default_executor_def=executor_def,
         default_logger_defs=loggers,
         _top_level_resources=resource_defs,
-        _resource_key_mapping=resource_key_mapping,
     )
     def created_repo():
         return [

--- a/python_modules/dagster/dagster/_core/definitions/materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/materialize.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Set, Union
 
 import dagster._check as check
+from dagster._core.definitions.resource_requirement import ResourceKeyRequirement
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._utils.merger import merge_dicts
 
@@ -213,6 +214,8 @@ def _get_required_io_manager_keys(
     for asset in assets:
         if isinstance(asset, (AssetsDefinition, SourceAsset)):
             for requirement in asset.get_resource_requirements():
-                if requirement.expected_type == IOManagerDefinition:
+                if requirement.expected_type == IOManagerDefinition and isinstance(
+                    requirement, ResourceKeyRequirement
+                ):
                     io_manager_keys.add(requirement.key)
     return io_manager_keys

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data.py
@@ -49,10 +49,6 @@ class RepositoryData(ABC):
     """
 
     @abstractmethod
-    def get_resource_key_mapping(self) -> Mapping[int, str]:
-        pass
-
-    @abstractmethod
     def get_top_level_resources(self) -> Mapping[str, ResourceDefinition]:
         """Return all top-level resources in the repository as a list,
         such as those provided to the Definitions constructor.
@@ -225,7 +221,6 @@ class CachingRepositoryData(RepositoryData):
         asset_checks_defs_by_key: Mapping[AssetCheckKey, "AssetChecksDefinition"],
         top_level_resources: Mapping[str, ResourceDefinition],
         utilized_env_vars: Mapping[str, AbstractSet[str]],
-        resource_key_mapping: Mapping[int, str],
         unresolved_partitioned_asset_schedules: Mapping[
             str, "UnresolvedPartitionedAssetScheduleDefinition"
         ],
@@ -285,9 +280,6 @@ class CachingRepositoryData(RepositoryData):
             "utilized_resources",
             key_type=str,
         )
-        check.mapping_param(
-            resource_key_mapping, "resource_key_mapping", key_type=int, value_type=str
-        )
 
         self._jobs = CacheingDefinitionIndex(
             JobDefinition,
@@ -322,7 +314,6 @@ class CachingRepositoryData(RepositoryData):
         self._assets_checks_defs_by_key = asset_checks_defs_by_key
         self._top_level_resources = top_level_resources
         self._utilized_env_vars = utilized_env_vars
-        self._resource_key_mapping = resource_key_mapping
 
         self._sensors = CacheingDefinitionIndex(
             SensorDefinition,
@@ -372,7 +363,6 @@ class CachingRepositoryData(RepositoryData):
         default_executor_def: Optional[ExecutorDefinition] = None,
         default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
         top_level_resources: Optional[Mapping[str, ResourceDefinition]] = None,
-        resource_key_mapping: Optional[Mapping[int, str]] = None,
     ) -> "CachingRepositoryData":
         """Static constructor.
 
@@ -389,14 +379,10 @@ class CachingRepositoryData(RepositoryData):
             default_executor_def=default_executor_def,
             default_logger_defs=default_logger_defs,
             top_level_resources=top_level_resources,
-            resource_key_mapping=resource_key_mapping,
         )
 
     def get_env_vars_by_top_level_resource(self) -> Mapping[str, AbstractSet[str]]:
         return self._utilized_env_vars
-
-    def get_resource_key_mapping(self) -> Mapping[int, str]:
-        return self._resource_key_mapping
 
     def get_job_names(self) -> Sequence[str]:
         """Get the names of all jobs in the repository.

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -20,7 +20,6 @@ import dagster._check as check
 from dagster._config.pythonic_config import (
     ConfigurableIOManagerFactoryResourceDefinition,
     ConfigurableResourceFactoryResourceDefinition,
-    ResourceWithKeyMapping,
 )
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_graph import AssetGraph
@@ -106,14 +105,14 @@ def _env_vars_from_resource_defaults(resource_def: ResourceDefinition) -> Set[st
 
     env_vars = _find_env_vars(config_schema_default)
 
-    if isinstance(resource_def, ResourceWithKeyMapping) and isinstance(
-        resource_def.inner_resource,
+    if isinstance(
+        resource_def,
         (
             ConfigurableIOManagerFactoryResourceDefinition,
             ConfigurableResourceFactoryResourceDefinition,
         ),
     ):
-        nested_resources = resource_def.inner_resource.nested_resources
+        nested_resources = resource_def.nested_resources
         for nested_resource in nested_resources.values():
             env_vars = env_vars.union(
                 _env_vars_from_resource_defaults(wrap_resource_for_execution(nested_resource))
@@ -369,7 +368,6 @@ def build_caching_repository_data_from_list(
         asset_checks_defs_by_key=asset_checks_defs_by_key,
         top_level_resources=top_level_resources or {},
         utilized_env_vars=utilized_env_vars,
-        resource_key_mapping=resource_key_mapping or {},
         unresolved_partitioned_asset_schedules=unresolved_partitioned_asset_schedules,
     )
 
@@ -432,7 +430,6 @@ def build_caching_repository_data_from_dict(
         asset_checks_defs_by_key={},
         top_level_resources={},
         utilized_env_vars={},
-        resource_key_mapping={},
         unresolved_partitioned_asset_schedules={},
     )
 

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -145,9 +145,6 @@ class RepositoryDefinition:
     def get_env_vars_by_top_level_resource(self) -> Mapping[str, AbstractSet[str]]:
         return self._repository_data.get_env_vars_by_top_level_resource()
 
-    def get_resource_key_mapping(self) -> Mapping[int, str]:
-        return self._repository_data.get_resource_key_mapping()
-
     @public
     def has_job(self, name: str) -> bool:
         """Check if a job with a given name is present in the repository.
@@ -382,7 +379,6 @@ class PendingRepositoryDefinition:
         default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
         default_executor_def: Optional[ExecutorDefinition] = None,
         _top_level_resources: Optional[Mapping[str, ResourceDefinition]] = None,
-        _resource_key_mapping: Optional[Mapping[int, str]] = None,
     ):
         self._repository_definitions = check.list_param(
             repository_definitions,
@@ -397,7 +393,6 @@ class PendingRepositoryDefinition:
         self._default_logger_defs = default_logger_defs
         self._default_executor_def = default_executor_def
         self._top_level_resources = _top_level_resources
-        self._resource_key_mapping = _resource_key_mapping
 
     @property
     def name(self) -> str:
@@ -442,7 +437,6 @@ class PendingRepositoryDefinition:
             default_executor_def=self._default_executor_def,
             default_logger_defs=self._default_logger_defs,
             top_level_resources=self._top_level_resources,
-            resource_key_mapping=self._resource_key_mapping,
         )
 
         return RepositoryDefinition(

--- a/python_modules/dagster/dagster/_core/definitions/resource_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_definition.py
@@ -151,6 +151,11 @@ class ResourceDefinition(AnonymousConfigurableDefinition, IHasInternalInit):
         """
         return self._required_resource_keys
 
+    def get_required_resource_keys(
+        self, resource_defs: Mapping[str, "ResourceDefinition"]
+    ) -> AbstractSet[str]:
+        return self.required_resource_keys
+
     def _is_dagster_maintained(self) -> bool:
         return self._dagster_maintained
 

--- a/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_invocation.py
@@ -88,6 +88,7 @@ def _check_invocation_requirements(
         resource_config=resource_config,
         resources=_init_context.resources,
         resource_def=resource_def,
+        all_resource_defs={},
         instance=_init_context.instance,
         log_manager=_init_context.log,
     )

--- a/python_modules/dagster/dagster/_core/definitions/resource_requirement.py
+++ b/python_modules/dagster/dagster/_core/definitions/resource_requirement.py
@@ -1,28 +1,22 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, AbstractSet, Mapping, Optional, Sequence, Type
 
-from dagster._record import record
+from typing_extensions import Annotated
+
+from dagster._record import ImportFrom, record
 from dagster._utils.merger import merge_dicts
 
 from ..errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
 from .utils import DEFAULT_IO_MANAGER_KEY
 
 if TYPE_CHECKING:
+    from dagster._config.pythonic_config.resource import CoercibleToResource
     from dagster._core.definitions.assets import AssetsDefinition
 
     from .resource_definition import ResourceDefinition
 
 
 class ResourceRequirement(ABC):
-    @property
-    @abstractmethod
-    def key(self) -> str:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def describe_requirement(self) -> str:
-        raise NotImplementedError()
-
     @property
     def expected_type(self) -> Type:
         from .resource_definition import ResourceDefinition
@@ -51,15 +45,41 @@ class ResourceRequirement(ABC):
             if isinstance(resource_def, self.expected_type)
         ]
 
-    def resource_is_expected_type(self, resource_defs: Mapping[str, "ResourceDefinition"]) -> bool:
-        # Expects resource key to be in resource_defs
-        return isinstance(resource_defs[self.key], self.expected_type)
+    @abstractmethod
+    def is_satisfied(self, resource_defs: Mapping[str, "ResourceDefinition"]) -> bool: ...
 
-    def resources_contain_key(
-        self,
-        resource_defs: Mapping[str, "ResourceDefinition"],
-    ) -> bool:
-        return self.key in resource_defs
+    @abstractmethod
+    def ensure_satisfied(self, resource_defs: Mapping[str, "ResourceDefinition"]): ...
+
+
+class ResourceKeyRequirement(ResourceRequirement, ABC):
+    @property
+    @abstractmethod
+    def key(self) -> str:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def describe_requirement(self) -> str:
+        raise NotImplementedError()
+
+    def is_satisfied(self, resource_defs: Mapping[str, "ResourceDefinition"]) -> bool:
+        return self.key in resource_defs and isinstance(resource_defs[self.key], self.expected_type)
+
+    def ensure_satisfied(self, resource_defs: Mapping[str, "ResourceDefinition"]):
+        requirement_expected_type_name = self.expected_type.__name__
+        if self.key not in resource_defs:
+            raise DagsterInvalidDefinitionError(
+                f"{self.describe_requirement()} was not provided. Please"
+                f" provide a {requirement_expected_type_name} to key '{self.key}', or change"
+                " the required key to one of the following keys which points to an"
+                f" {requirement_expected_type_name}:"
+                f" {self.keys_of_expected_type(resource_defs)}"
+            )
+        resource_def = resource_defs[self.key]
+        if not isinstance(resource_def, self.expected_type):
+            raise DagsterInvalidDefinitionError(
+                f"{self.describe_requirement()}, but received" f" {type(resource_def)}."
+            )
 
 
 class ResourceAddable(ABC):
@@ -71,7 +91,7 @@ class ResourceAddable(ABC):
 
 
 @record
-class OpDefinitionResourceRequirement(ResourceRequirement):
+class OpDefinitionResourceRequirement(ResourceKeyRequirement):
     key: str
     node_description: str
 
@@ -80,7 +100,7 @@ class OpDefinitionResourceRequirement(ResourceRequirement):
 
 
 @record
-class InputManagerRequirement(ResourceRequirement):
+class InputManagerRequirement(ResourceKeyRequirement):
     key: str
     node_description: str
     input_name: str
@@ -102,7 +122,7 @@ class InputManagerRequirement(ResourceRequirement):
 # The ResourceRequirement for unexecutable external assets. Is an analogue to
 # `SourceAssetIOManagerRequirement`.
 @record
-class ExternalAssetIOManagerRequirement(ResourceRequirement):
+class ExternalAssetIOManagerRequirement(ResourceKeyRequirement):
     key: str
     asset_key: Optional[str]
 
@@ -120,7 +140,7 @@ class ExternalAssetIOManagerRequirement(ResourceRequirement):
 
 
 @record
-class SourceAssetIOManagerRequirement(ResourceRequirement):
+class SourceAssetIOManagerRequirement(ResourceKeyRequirement):
     key: str
     asset_key: Optional[str]
 
@@ -138,7 +158,7 @@ class SourceAssetIOManagerRequirement(ResourceRequirement):
 
 
 @record
-class OutputManagerRequirement(ResourceRequirement):
+class OutputManagerRequirement(ResourceKeyRequirement):
     key: str
     node_description: str
     output_name: str
@@ -157,7 +177,7 @@ class OutputManagerRequirement(ResourceRequirement):
 
 
 @record
-class HookResourceRequirement(ResourceRequirement):
+class HookResourceRequirement(ResourceKeyRequirement):
     key: str
     attached_to: Optional[str]
     hook_name: str
@@ -170,7 +190,7 @@ class HookResourceRequirement(ResourceRequirement):
 
 
 @record
-class TypeResourceRequirement(ResourceRequirement):
+class TypeResourceRequirement(ResourceKeyRequirement):
     key: str
     type_display_name: str
 
@@ -179,7 +199,7 @@ class TypeResourceRequirement(ResourceRequirement):
 
 
 @record
-class TypeLoaderResourceRequirement(ResourceRequirement):
+class TypeLoaderResourceRequirement(ResourceKeyRequirement):
     key: str
     type_display_name: str
 
@@ -191,7 +211,7 @@ class TypeLoaderResourceRequirement(ResourceRequirement):
 
 
 @record
-class ResourceDependencyRequirement(ResourceRequirement):
+class ResourceDependencyRequirement(ResourceKeyRequirement):
     key: str
     source_key: Optional[str]
 
@@ -200,17 +220,24 @@ class ResourceDependencyRequirement(ResourceRequirement):
         return f"resource with key '{self.key}' required{source_descriptor}"
 
 
-def ensure_resources_of_expected_type(
-    resource_defs: Mapping[str, "ResourceDefinition"],
-    requirements: Sequence[ResourceRequirement],
-) -> None:
-    for requirement in requirements:
-        if requirement.resources_contain_key(
-            resource_defs
-        ) and not requirement.resource_is_expected_type(resource_defs):
+@record
+class PartialResourceDependencyRequirement(ResourceRequirement):
+    class_name: str
+    attr_name: str
+    partial_resource: Annotated[
+        "CoercibleToResource", ImportFrom("dagster._config.pythonic_config.resource")
+    ]
+
+    def is_satisfied(self, resource_defs: Mapping[str, "ResourceDefinition"]):
+        from dagster._config.pythonic_config.resource import coerce_to_resource
+
+        return coerce_to_resource(self.partial_resource) in resource_defs.values()
+
+    def ensure_satisfied(self, resource_defs: Mapping[str, "ResourceDefinition"]):
+        if not self.is_satisfied(resource_defs):
             raise DagsterInvalidDefinitionError(
-                f"{requirement.describe_requirement()}, but received"
-                f" {type(resource_defs[requirement.key])}."
+                f"Failed to resolve resource nested at {self.class_name}.{self.attr_name}. "
+                "Any partially configured, nested resources must be provided as a top level resource."
             )
 
 
@@ -218,19 +245,8 @@ def ensure_requirements_satisfied(
     resource_defs: Mapping[str, "ResourceDefinition"],
     requirements: Sequence[ResourceRequirement],
 ) -> None:
-    ensure_resources_of_expected_type(resource_defs, requirements)
-
-    # Error if resource defs don't provide the correct resource key
     for requirement in requirements:
-        if not requirement.resources_contain_key(resource_defs):
-            requirement_expected_type_name = requirement.expected_type.__name__
-            raise DagsterInvalidDefinitionError(
-                f"{requirement.describe_requirement()} was not provided. Please"
-                f" provide a {requirement_expected_type_name} to key '{requirement.key}', or change"
-                " the required key to one of the following keys which points to an"
-                f" {requirement_expected_type_name}:"
-                f" {requirement.keys_of_expected_type(resource_defs)}"
-            )
+        requirement.ensure_satisfied(resource_defs)
 
 
 def get_resource_key_conflicts(
@@ -264,9 +280,15 @@ def merge_resource_defs(
 
     # Ensure top-level resource requirements are met - except for
     # io_manager, since that is a default it can be resolved later.
-    ensure_requirements_satisfied(
-        merged_resource_defs, list(requires_resources.get_resource_requirements())
-    )
+    requirements = [
+        *requires_resources.get_resource_requirements(),
+        *[
+            req
+            for key, resource in merged_resource_defs.items()
+            for req in resource.get_resource_requirements(source_key=key)
+        ],
+    ]
+    ensure_requirements_satisfied(merged_resource_defs, requirements)
 
     # Get all transitive resource dependencies from other resources.
     relevant_keys = get_transitive_required_resource_keys(

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -34,6 +34,7 @@ from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.resource_requirement import (
     ResourceAddable,
+    ResourceKeyRequirement,
     ResourceRequirement,
     SourceAssetIOManagerRequirement,
     ensure_requirements_satisfied,
@@ -327,7 +328,11 @@ class SourceAsset(ResourceAddable):
 
     @property
     def required_resource_keys(self) -> AbstractSet[str]:
-        return {requirement.key for requirement in self.get_resource_requirements()}
+        return {
+            requirement.key
+            for requirement in self.get_resource_requirements()
+            if isinstance(requirement, ResourceKeyRequirement)
+        }
 
     @property
     def node_def(self) -> Optional[OpDefinition]:

--- a/python_modules/dagster/dagster/_core/execution/resources_init.py
+++ b/python_modules/dagster/dagster/_core/execution/resources_init.py
@@ -76,7 +76,8 @@ def resolve_resource_dependencies(
 ) -> Mapping[str, AbstractSet[str]]:
     """Generates a dictionary that maps resource key to resource keys it requires for initialization."""
     resource_dependencies = {
-        key: resource_def.required_resource_keys for key, resource_def in resource_defs.items()
+        key: resource_def.get_required_resource_keys(resource_defs)
+        for key, resource_def in resource_defs.items()
     }
     return resource_dependencies
 
@@ -163,7 +164,7 @@ def _core_resource_initialization_event_generator(
 
                 resource_fn = cast(Callable[[InitResourceContext], Any], resource_def.resource_fn)
                 resources = ScopedResourcesBuilder(resource_instances).build(
-                    resource_def.required_resource_keys
+                    resource_def.get_required_resource_keys(resource_defs)
                 )
                 resource_context = InitResourceContext(
                     resource_def=resource_def,
@@ -176,6 +177,7 @@ def _core_resource_initialization_event_generator(
                     ),
                     resources=resources,
                     instance=instance,
+                    all_resource_defs=resource_defs,
                 )
                 manager = single_resource_generation_manager(
                     resource_context, resource_name, resource_def

--- a/python_modules/dagster/dagster/_core/types/config_schema.py
+++ b/python_modules/dagster/dagster/_core/types/config_schema.py
@@ -36,10 +36,7 @@ class DagsterTypeLoader(ABC):
     def required_resource_keys(self) -> AbstractSet[str]:
         return frozenset()
 
-    def get_resource_requirements(
-        self,
-        type_display_name: str,
-    ) -> Iterator[ResourceRequirement]:
+    def get_resource_requirements(self, type_display_name: str) -> Iterator[ResourceRequirement]:
         for resource_key in sorted(list(self.required_resource_keys())):
             yield TypeLoaderResourceRequirement(
                 key=resource_key, type_display_name=type_display_name

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
@@ -51,9 +51,6 @@ class TestDynamicRepositoryData(RepositoryData):
     def get_env_vars_by_top_level_resource(self):
         return {}
 
-    def get_resource_key_mapping(self):
-        return {}
-
 
 @repository
 def bar_repo():

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/test_with_resources.py
@@ -289,9 +289,9 @@ def test_asset_io_manager_transitive_dependencies():
         assert context.resources.foo == "bar"
 
     with pytest.raises(
-        DagsterInvariantViolationError,
+        DagsterInvalidDefinitionError,
         match=(
-            "Resource with key 'foo' required by resource with key 'the_resource', but not"
+            "resource with key 'foo' required by resource with key 'the_resource' was not"
             " provided."
         ),
     ):

--- a/python_modules/dagster/dagster_tests/core_tests/test_job_init.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_job_init.py
@@ -78,6 +78,7 @@ def test_clean_event_generator_exit():
     resource_context = InitResourceContext(
         resource_def=resource_def,
         resources=ScopedResourcesBuilder().build(None),
+        all_resource_defs=job_def.resource_defs,
         resource_config=None,
         dagster_run=run,
         instance=instance,


### PR DESCRIPTION
This changes the scheme for how we resolve shared references to nested partially configured resource objects/dependencies.

Previously we would  create (in `Definitions` only) a map from object `id(...)` to resource key which would get bound using a collection of  `*WithKeyMapping` classes.

The new approach adds a `PartialResourceDependencyRequirement` to model the partial resource dependency and then makes the full set of resources available on to `InitResourceContext` and via a new `get_required_resource_keys(resource_defs)` to be able to resolve this dependency type. This scheme depends on  the memoization of `get_resource_definition` making it possible to do `is` comparisons for object equality. 

`ResourceRequirements` gains a new parent class with `ResourceKeyRequirement` to split the static key behavior of all previous requirements from the new dynamic key calculation needed for partial nested resources.


## How I Tested These Changes

added test for direct job execution with nested partial resources