### PR TITLE
[asset differ] Optionally return diff information when generating asset diff

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -235,24 +235,32 @@ class AssetGraphDiffer:
                 data = TagsChangeData(base_tags=base_asset.tags, branch_tags=branch_asset.tags)
             changes.append((AssetDefinitionChangeType.TAGS, data))
 
-        branch_keys = set(branch_asset.metadata.keys())
-        base_keys = set(base_asset.metadata.keys())
+        if not record_changes:
+            if base_asset.metadata != branch_asset.metadata:
+                changes.append((AssetDefinitionChangeType.METADATA, None))
+        else:
+            # if we are recording changes, we need to compare the metadata keys and values
+            # fully to determine what has changed
+            branch_keys = set(branch_asset.metadata.keys())
+            base_keys = set(base_asset.metadata.keys())
 
-        new_keys = branch_keys - base_keys
-        removed_keys = base_keys - branch_keys
-        key_overlap = branch_keys.intersection(base_keys)
-        keys_changed = {
-            k for k in key_overlap if branch_asset.metadata[k] != base_asset.metadata[k]
-        }
-        if new_keys or removed_keys or keys_changed:
-            data = None
-            if record_changes:
-                data = MetadataChangeData(
-                    added_keys=new_keys,
-                    modified_keys=keys_changed,
-                    removed_keys=removed_keys,
+            new_keys = branch_keys - base_keys
+            removed_keys = base_keys - branch_keys
+            key_overlap = branch_keys.intersection(base_keys)
+            keys_changed = {
+                k for k in key_overlap if branch_asset.metadata[k] != base_asset.metadata[k]
+            }
+            if new_keys or removed_keys or keys_changed:
+                changes.append(
+                    (
+                        AssetDefinitionChangeType.METADATA,
+                        MetadataChangeData(
+                            added_keys=new_keys,
+                            modified_keys=keys_changed,
+                            removed_keys=removed_keys,
+                        ),
+                    )
                 )
-            changes.append((AssetDefinitionChangeType.METADATA, data))
 
         return changes
 


### PR DESCRIPTION
## Summary

One immediate desire now that we are generating and storing asset diffs in Plus is more detailed information about what specifically changed in each push.

This PR introduces a new method which optionally builds serializable change data that we can persist. This data should be relatively compact (e.g. we only store metadata keys rather than the full diff) so it should be suitable to record with the existing asset diff rows.

## Test Plan

Unit tests.

