### PR TITLE
remove experimental tag for pipes k8s, lamdba, databricks 3/3

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes.py
@@ -120,7 +120,6 @@ class PipesS3MessageReader(PipesBlobStoreMessageReader):
         )
 
 
-@experimental
 class PipesLambdaLogsMessageReader(PipesMessageReader):
     """Message reader that consumes buffered pipes messages that were flushed on exit from the
     final 4k of logs that are returned from issuing a sync lambda invocation. This means messages
@@ -183,13 +182,11 @@ class PipesCloudWatchMessageReader(PipesMessageReader):
         return "Attempted to read messages by extracting them from the tail of CloudWatch logs directly."
 
 
-@experimental
 class PipesLambdaEventContextInjector(PipesEnvContextInjector):
     def no_messages_debug_text(self) -> str:
         return "Attempted to inject context via the lambda event input."
 
 
-@experimental
 class PipesLambdaClient(PipesClient, TreatAsResourceParam):
     """A pipes client for invoking AWS lambda.
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -9,7 +9,6 @@ from contextlib import ExitStack, contextmanager
 from typing import Any, Iterator, Literal, Mapping, Optional, Sequence, TextIO
 
 import dagster._check as check
-from dagster._annotations import experimental
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.errors import DagsterExecutionInterruptedError, DagsterPipesExecutionError
 from dagster._core.execution.context.compute import OpExecutionContext
@@ -31,7 +30,6 @@ from databricks.sdk.service import files, jobs
 from pydantic import Field
 
 
-@experimental
 class PipesDatabricksClient(PipesClient, TreatAsResourceParam):
     """Pipes client for databricks.
 
@@ -89,10 +87,14 @@ class PipesDatabricksClient(PipesClient, TreatAsResourceParam):
         if task.as_dict().get("new_cluster", {}).get("cluster_log_conf", {}).get("dbfs", None):
             log_readers = [
                 PipesDbfsLogReader(
-                    client=self.client, remote_log_name="stdout", target_stream=sys.stdout
+                    client=self.client,
+                    remote_log_name="stdout",
+                    target_stream=sys.stdout,
                 ),
                 PipesDbfsLogReader(
-                    client=self.client, remote_log_name="stderr", target_stream=sys.stderr
+                    client=self.client,
+                    remote_log_name="stderr",
+                    target_stream=sys.stderr,
                 ),
             ]
         else:
@@ -223,7 +225,6 @@ def dbfs_tempdir(dbfs_client: files.DbfsAPI) -> Iterator[str]:
         dbfs_client.delete(tempdir, recursive=True)
 
 
-@experimental
 class PipesDbfsContextInjector(PipesContextInjector):
     """A context injector that injects context into a Databricks job by writing a JSON file to DBFS.
 
@@ -261,7 +262,6 @@ class PipesDbfsContextInjector(PipesContextInjector):
         )
 
 
-@experimental
 class PipesDbfsMessageReader(PipesBlobStoreMessageReader):
     """Message reader that reads messages by periodically reading message chunks from an
     automatically-generated temporary directory on DBFS.
@@ -319,7 +319,6 @@ class PipesDbfsMessageReader(PipesBlobStoreMessageReader):
         )
 
 
-@experimental
 class PipesDbfsLogReader(PipesChunkedLogReader):
     """Reader that reads a log file from DBFS.
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -10,7 +10,6 @@ from dagster import (
     OpExecutionContext,
     _check as check,
 )
-from dagster._annotations import experimental
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.pipes.client import (
@@ -52,7 +51,6 @@ _NAMESPACE_SECRET_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/nam
 _DEV_NULL_MESSAGE_WRITER = encode_env_var({"path": "/dev/null"})
 
 
-@experimental
 class PipesK8sPodLogsMessageReader(PipesMessageReader):
     """Message reader that reads messages from kubernetes pod logs."""
 
@@ -90,7 +88,6 @@ class PipesK8sPodLogsMessageReader(PipesMessageReader):
         return "Attempted to read messages by extracting them from kubernetes pod logs directly."
 
 
-@experimental
 class PipesK8sClient(PipesClient, TreatAsResourceParam):
     """A pipes client for launching kubernetes pods.
 


### PR DESCRIPTION
## Summary & Motivation
This PR unexperimentalizes:
- Lambda Pipes
  * PipesLambdaClient
  * PipesLambdaLogsMessageReader
  * PipesLambdaEventContextInjector
  * note: PipesS3MessageReader isn't experimental in status quo which might have been an oversight
- K8s Pipes
  * PipesK8sClient
  * PipesK8sPodLogsMessageReader
- Databricks Pipes
  * PipesDatabricksClient
  * PipesDbfsContextInjector
  * PipesDbfsMessageReader
  * PipesDbfsLogReader

## How I Tested These Changes
