### PR TITLE
[single-implicit-asset-job] `create_external_run` accept asset graph, not partitions def

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -110,7 +110,9 @@ def create_valid_pipeline_run(
         status=DagsterRunStatus.NOT_STARTED,
         external_job_origin=external_pipeline.get_external_origin(),
         job_code_origin=external_pipeline.get_python_origin(),
-        asset_job_partitions_def=code_location.get_asset_job_partitions_def(external_pipeline),
+        asset_graph=code_location.get_repository(
+            external_pipeline.repository_handle.repository_name
+        ).asset_graph,
     )
 
     return dagster_run

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -497,7 +497,7 @@ def _create_external_run(
         job_code_origin=external_job.get_python_origin(),
         asset_selection=None,
         asset_check_selection=None,
-        asset_job_partitions_def=code_location.get_asset_job_partitions_def(external_job),
+        asset_graph=external_repo.asset_graph,
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -742,6 +742,12 @@ class JobDefinition(IHasInternalInit):
         )
         return partitions_def.get_tags_for_partition_key(partition_key)
 
+    def get_run_config_for_partition_key(self, partition_key: str) -> Mapping[str, Any]:
+        if self._partitioned_config:
+            return self._partitioned_config.get_run_config_for_partition_key(partition_key)
+        else:
+            return {}
+
     @property
     def op_selection_data(self) -> Optional[OpSelectionData]:
         return (

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -1,8 +1,11 @@
+from collections import defaultdict
 from datetime import datetime
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
+    AbstractSet,
     Any,
+    Dict,
     List,
     Mapping,
     NamedTuple,
@@ -10,7 +13,6 @@ from typing import (
     Sequence,
     Set,
     Union,
-    cast,
 )
 
 import dagster._check as check
@@ -32,13 +34,13 @@ from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_START_TAG,
     PARTITION_NAME_TAG,
 )
-from dagster._record import IHaveNew, LegacyNamedTupleMixin, record_custom
+from dagster._record import IHaveNew, LegacyNamedTupleMixin, record, record_custom
 from dagster._serdes.serdes import whitelist_for_serdes
+from dagster._utils.cached_method import cached_method
 from dagster._utils.error import SerializableErrorInfo
 
 if TYPE_CHECKING:
     from dagster._core.definitions.job_definition import JobDefinition
-    from dagster._core.definitions.partition import PartitionsDefinition
     from dagster._core.definitions.run_config import RunConfig
 
 
@@ -186,40 +188,24 @@ class RunRequest(IHaveNew, LegacyNamedTupleMixin):
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> "RunRequest":
-        from dagster._core.definitions.partition import PartitionsDefinition
-
         if self.partition_key is None:
             check.failed(
                 "Cannot resolve partition for run request without partition key",
             )
 
-        partitions_def = target_definition.partitions_def
-        if partitions_def is None:
-            check.failed(
-                "Cannot resolve partition for run request when target job"
-                f" '{target_definition.name}' is unpartitioned.",
+        dynamic_partitions_store_after_requests = (
+            DynamicPartitionsStoreAfterRequests.from_requests(
+                dynamic_partitions_store, dynamic_partitions_requests
             )
-        partitions_def = cast(PartitionsDefinition, partitions_def)
-
-        partitioned_config = target_definition.partitioned_config
-        if partitioned_config is None:
-            check.failed(
-                "Cannot resolve partition for run request on unpartitioned job",
-            )
-
-        _check_valid_partition_key_after_dynamic_partitions_requests(
-            self.partition_key,
-            partitions_def,
-            dynamic_partitions_requests,
-            current_time,
-            dynamic_partitions_store,
+            if dynamic_partitions_store
+            else None
         )
-
         tags = {
             **(self.tags or {}),
-            **partitioned_config.get_tags_for_partition_key(
+            **target_definition.get_tags_for_partition_key(
                 self.partition_key,
-                job_name=target_definition.name,
+                dynamic_partitions_store=dynamic_partitions_store_after_requests,
+                selected_asset_keys=self.asset_selection,
             ),
         }
 
@@ -227,7 +213,7 @@ class RunRequest(IHaveNew, LegacyNamedTupleMixin):
             run_config=(
                 self.run_config
                 if self.run_config
-                else partitioned_config.get_run_config_for_partition_key(self.partition_key)
+                else target_definition.get_run_config_for_partition_key(self.partition_key)
             ),
             tags=tags,
         )
@@ -257,68 +243,63 @@ class RunRequest(IHaveNew, LegacyNamedTupleMixin):
         return self.asset_graph_subset is not None
 
 
-def _check_valid_partition_key_after_dynamic_partitions_requests(
-    partition_key: str,
-    partitions_def: "PartitionsDefinition",
-    dynamic_partitions_requests: Sequence[
-        Union[AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest]
-    ],
-    current_time: Optional[datetime] = None,
-    dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
-):
-    from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
-    from dagster._core.definitions.partition import DynamicPartitionsDefinition
+@record
+class DynamicPartitionsStoreAfterRequests(DynamicPartitionsStore):
+    """Represents the dynamic partitions that will be in the contained DynamicPartitionsStore
+    after the contained requests are satisfied.
+    """
 
-    if isinstance(partitions_def, MultiPartitionsDefinition):
-        multipartition_key = partitions_def.get_partition_key_from_str(partition_key)
+    wrapped_dynamic_partitions_store: DynamicPartitionsStore
+    added_partition_keys_by_partitions_def_name: Mapping[str, AbstractSet[str]]
+    deleted_partition_keys_by_partitions_def_name: Mapping[str, AbstractSet[str]]
 
-        for dimension in partitions_def.partitions_defs:
-            _check_valid_partition_key_after_dynamic_partitions_requests(
-                multipartition_key.keys_by_dimension[dimension.name],
-                dimension.partitions_def,
-                dynamic_partitions_requests,
-                current_time,
-                dynamic_partitions_store,
-            )
+    @staticmethod
+    def from_requests(
+        wrapped_dynamic_partitions_store: DynamicPartitionsStore,
+        dynamic_partitions_requests: Sequence[
+            Union[AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest]
+        ],
+    ) -> "DynamicPartitionsStoreAfterRequests":
+        added_partition_keys_by_partitions_def_name: Dict[str, Set[str]] = defaultdict(set)
+        deleted_partition_keys_by_partitions_def_name: Dict[str, Set[str]] = defaultdict(set)
 
-    elif isinstance(partitions_def, DynamicPartitionsDefinition) and partitions_def.name:
-        if not dynamic_partitions_store:
-            check.failed(
-                "Cannot resolve partition for run request on dynamic partitions without"
-                " dynamic_partitions_store"
-            )
-
-        add_partition_keys: Set[str] = set()
-        delete_partition_keys: Set[str] = set()
         for req in dynamic_partitions_requests:
+            name = req.partitions_def_name
             if isinstance(req, AddDynamicPartitionsRequest):
-                if req.partitions_def_name == partitions_def.name:
-                    add_partition_keys.update(set(req.partition_keys))
+                added_partition_keys_by_partitions_def_name[name].update(set(req.partition_keys))
             elif isinstance(req, DeleteDynamicPartitionsRequest):
-                if req.partitions_def_name == partitions_def.name:
-                    delete_partition_keys.update(set(req.partition_keys))
+                deleted_partition_keys_by_partitions_def_name[name].update(set(req.partition_keys))
+            else:
+                check.failed(f"Unexpected request type: {req}")
 
-        partition_keys_after_requests_resolved = (
-            set(
-                dynamic_partitions_store.get_dynamic_partitions(
-                    partitions_def_name=partitions_def.name
-                )
+        return DynamicPartitionsStoreAfterRequests(
+            wrapped_dynamic_partitions_store=wrapped_dynamic_partitions_store,
+            added_partition_keys_by_partitions_def_name=added_partition_keys_by_partitions_def_name,
+            deleted_partition_keys_by_partitions_def_name=deleted_partition_keys_by_partitions_def_name,
+        )
+
+    @cached_method
+    def get_dynamic_partitions(self, partitions_def_name: str) -> Sequence[str]:
+        partition_keys = set(
+            self.wrapped_dynamic_partitions_store.get_dynamic_partitions(partitions_def_name)
+        )
+        added_partition_keys = self.added_partition_keys_by_partitions_def_name.get(
+            partitions_def_name, set()
+        )
+        deleted_partition_keys = self.deleted_partition_keys_by_partitions_def_name.get(
+            partitions_def_name, set()
+        )
+        return list((partition_keys | added_partition_keys) - deleted_partition_keys)
+
+    def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
+        return partition_key not in self.deleted_partition_keys_by_partitions_def_name.get(
+            partitions_def_name, set()
+        ) and (
+            partition_key
+            in self.added_partition_keys_by_partitions_def_name.get(partitions_def_name, set())
+            or self.wrapped_dynamic_partitions_store.has_dynamic_partition(
+                partitions_def_name, partition_key
             )
-            | add_partition_keys
-        ) - delete_partition_keys
-
-        if partition_key not in partition_keys_after_requests_resolved:
-            check.failed(
-                f"Dynamic partition key {partition_key} for partitions def"
-                f" '{partitions_def.name}' is invalid. After dynamic partitions requests are"
-                " applied, it does not exist in the set of valid partition keys."
-            )
-
-    else:
-        partitions_def.validate_partition_key(
-            partition_key,
-            dynamic_partitions_store=dynamic_partitions_store,
-            current_time=current_time,
         )
 
 

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -440,7 +440,9 @@ def create_backfill_run(
             frozenset(backfill_job.asset_selection) if backfill_job.asset_selection else None
         ),
         asset_check_selection=None,
-        asset_job_partitions_def=code_location.get_asset_job_partitions_def(external_pipeline),
+        asset_graph=code_location.get_repository(
+            external_pipeline.repository_handle.repository_name
+        ).asset_graph,
     )
 
 

--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -6,7 +6,6 @@ from typing import AbstractSet, Dict, NamedTuple, Optional, Sequence, cast
 import dagster._check as check
 from dagster._core.definitions.asset_job import is_base_asset_job_name
 from dagster._core.definitions.events import AssetKey
-from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.selector import JobSubsetSelector
@@ -24,7 +23,6 @@ EXECUTION_PLAN_CREATION_RETRIES = 1
 class RunRequestExecutionData(NamedTuple):
     external_job: ExternalJob
     external_execution_plan: ExternalExecutionPlan
-    partitions_def: Optional[PartitionsDefinition]
 
 
 def _get_implicit_job_name_for_assets(
@@ -96,12 +94,9 @@ def _get_job_execution_data_from_run_request(
             instance=instance,
         )
 
-        partitions_def = code_location.get_asset_job_partitions_def(external_job)
-
         run_request_execution_data_cache[selector_id] = RunRequestExecutionData(
             external_job,
             external_execution_plan,
-            partitions_def,
         )
 
     return run_request_execution_data_cache[selector_id]
@@ -180,7 +175,6 @@ def _create_asset_run(
         if not should_retry:
             external_job = check.not_none(execution_data).external_job
             external_execution_plan = check.not_none(execution_data).external_execution_plan
-            partitions_def = check.not_none(execution_data).partitions_def
 
             run = instance.create_run(
                 job_snapshot=external_job.job_snapshot,
@@ -200,7 +194,7 @@ def _create_asset_run(
                 job_code_origin=external_job.get_python_origin(),
                 asset_selection=frozenset(run_request.asset_selection),
                 asset_check_selection=None,
-                asset_job_partitions_def=partitions_def,
+                asset_graph=asset_graph,
             )
 
             return run

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -19,7 +19,6 @@ from dagster._api.snapshot_partition import (
 from dagster._api.snapshot_repository import sync_get_streaming_external_repositories_data_grpc
 from dagster._api.snapshot_schedule import sync_get_external_schedule_execution_data_grpc
 from dagster._core.code_pointer import CodePointer
-from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.reconstruct import ReconstructableJob
 from dagster._core.definitions.repository_definition import RepositoryDefinition
 from dagster._core.definitions.selector import JobSubsetSelector
@@ -45,7 +44,6 @@ from dagster._core.remote_representation.external_data import (
     ExternalPartitionNamesData,
     ExternalScheduleExecutionErrorData,
     ExternalSensorExecutionErrorData,
-    external_partition_set_name_for_job_name,
     external_repository_data_from_def,
 )
 from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
@@ -229,26 +227,6 @@ class CodeLocation(AbstractContextManager):
         last_sensor_start_time: Optional[float],
     ) -> "SensorExecutionData":
         pass
-
-    def get_asset_job_partitions_def(
-        self, external_job: ExternalJob
-    ) -> Optional[PartitionsDefinition]:
-        external_repository_data = self.get_repository(
-            external_job.repository_handle.repository_name
-        ).external_repository_data
-        external_partition_set_name = external_partition_set_name_for_job_name(external_job.name)
-
-        if external_repository_data.has_external_partition_set_data(external_partition_set_name):
-            external_partitions_def_data = external_repository_data.get_external_partition_set_data(
-                external_partition_set_name
-            ).external_partitions_data
-            return (
-                external_partitions_def_data.get_partitions_definition()
-                if external_partitions_def_data
-                else None
-            )
-
-        return None
 
     @abstractmethod
     def get_external_notebook_data(self, notebook_path: str) -> bytes:

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -156,7 +156,7 @@ def create_run_for_test(
     asset_selection=None,
     asset_check_selection=None,
     op_selection=None,
-    asset_job_partitions_def=None,
+    asset_graph=None,
 ):
     return instance.create_run(
         job_name=job_name,
@@ -176,7 +176,7 @@ def create_run_for_test(
         asset_selection=asset_selection,
         asset_check_selection=asset_check_selection,
         op_selection=op_selection,
-        asset_job_partitions_def=asset_job_partitions_def,
+        asset_graph=asset_graph,
     )
 
 

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -1068,5 +1068,7 @@ def _create_sensor_run(
         asset_check_selection=(
             frozenset(run_request.asset_check_keys) if run_request.asset_check_keys else None
         ),
-        asset_job_partitions_def=code_location.get_asset_job_partitions_def(external_job),
+        asset_graph=code_location.get_repository(
+            external_job.repository_handle.repository_name
+        ).asset_graph,
     )

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -985,7 +985,9 @@ def _create_scheduler_run(
             frozenset(run_request.asset_selection) if run_request.asset_selection else None
         ),
         asset_check_selection=None,
-        asset_job_partitions_def=code_location.get_asset_job_partitions_def(external_job),
+        asset_graph=code_location.get_repository(
+            external_job.repository_handle.repository_name
+        ).asset_graph,
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_run_request.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_run_request.py
@@ -1,0 +1,57 @@
+from typing import Sequence, Union, cast
+
+import pytest
+from dagster import (
+    AddDynamicPartitionsRequest,
+    DeleteDynamicPartitionsRequest,
+    DynamicPartitionsDefinition,
+    RunRequest,
+    job,
+)
+from dagster._core.errors import DagsterUnknownPartitionError
+from dagster._core.test_utils import instance_for_test
+
+
+@pytest.mark.parametrize(
+    "prior_partitions,dynamic_partitions_requests,expect_success",
+    [
+        (["a"], [], True),
+        ([], [], False),
+        ([], [AddDynamicPartitionsRequest("something", ["a"])], True),
+        ([], [AddDynamicPartitionsRequest("something_else", ["a"])], False),
+        (["a"], [DeleteDynamicPartitionsRequest("something", ["a"])], False),
+        (["a"], [DeleteDynamicPartitionsRequest("something_else", ["a"])], True),
+    ],
+)
+def test_validate_dynamic_partitions(
+    prior_partitions: Sequence[str],
+    dynamic_partitions_requests: Sequence[
+        Union[AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest]
+    ],
+    expect_success: bool,
+):
+    partitions_def = DynamicPartitionsDefinition(name="something")
+
+    @job(partitions_def=partitions_def)
+    def job1():
+        pass
+
+    run_request = RunRequest(partition_key="a")
+    with instance_for_test() as instance:
+        instance.add_dynamic_partitions(cast(str, partitions_def.name), prior_partitions)
+
+        if expect_success:
+            run_request.with_resolved_tags_and_config(
+                target_definition=job1,
+                dynamic_partitions_requests=dynamic_partitions_requests,
+                dynamic_partitions_store=instance,
+            )
+        else:
+            with pytest.raises(
+                DagsterUnknownPartitionError, match="Could not find a partition with key `a`."
+            ):
+                run_request.with_resolved_tags_and_config(
+                    target_definition=job1,
+                    dynamic_partitions_requests=dynamic_partitions_requests,
+                    dynamic_partitions_store=instance,
+                )

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -335,7 +335,7 @@ def test_create_run_with_asset_partitions():
                 execution_plan_snapshot=ep_snapshot,
                 job_snapshot=noop_asset_job.get_job_snapshot(),
                 tags={ASSET_PARTITION_RANGE_START_TAG: "partition_0"},
-                asset_job_partitions_def=noop_asset_job.partitions_def,
+                asset_graph=noop_asset_job.asset_layer.asset_graph,
             )
 
         with pytest.raises(
@@ -351,7 +351,7 @@ def test_create_run_with_asset_partitions():
                 execution_plan_snapshot=ep_snapshot,
                 job_snapshot=noop_asset_job.get_job_snapshot(),
                 tags={ASSET_PARTITION_RANGE_END_TAG: "partition_0"},
-                asset_job_partitions_def=noop_asset_job.partitions_def,
+                asset_graph=noop_asset_job.asset_layer.asset_graph,
             )
 
         create_run_for_test(
@@ -360,7 +360,7 @@ def test_create_run_with_asset_partitions():
             execution_plan_snapshot=ep_snapshot,
             job_snapshot=noop_asset_job.get_job_snapshot(),
             tags={ASSET_PARTITION_RANGE_START_TAG: "bar", ASSET_PARTITION_RANGE_END_TAG: "foo"},
-            asset_job_partitions_def=noop_asset_job.partitions_def,
+            asset_graph=noop_asset_job.asset_layer.asset_graph,
         )
 
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -3189,7 +3189,7 @@ def test_error_on_deleted_dynamic_partitions_run_request(
         expected_datetime=None,
         expected_status=TickStatus.FAILURE,
         expected_run_ids=None,
-        expected_error="Dynamic partition key 2 for partitions def 'quux' is invalid",
+        expected_error="Could not find a partition with key `2`",
     )
     assert set(instance.get_dynamic_partitions("quux")) == set(["2"])
 
@@ -3239,7 +3239,7 @@ def test_multipartitions_with_dynamic_dims_run_request_sensor(
             expected_datetime=None,
             expected_status=TickStatus.FAILURE,
             expected_run_ids=None,
-            expected_error="does not exist in the set of valid partition keys",
+            expected_error="Could not find a partition with key `2|1`",
         )
 
 

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
@@ -250,7 +250,9 @@ def test_successful_run_from_pending(
         asset_selection=None,
         op_selection=None,
         asset_check_selection=None,
-        asset_job_partitions_def=code_location.get_asset_job_partitions_def(external_job),
+        asset_graph=code_location.get_repository(
+            external_job.repository_handle.repository_name
+        ).asset_graph,
     )
 
     run_id = created_run.run_id

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
@@ -151,9 +151,9 @@ def test_run_from_pending_repository():
                     asset_selection=None,
                     op_selection=None,
                     asset_check_selection=None,
-                    asset_job_partitions_def=code_location.get_asset_job_partitions_def(
-                        external_job
-                    ),
+                    asset_graph=code_location.get_repository(
+                        external_job.repository_handle.repository_name
+                    ).asset_graph,
                 )
 
                 run_id = dagster_run.run_id


### PR DESCRIPTION
## Summary & Motivation

Small refactor that makes replaces the `asset_job_partitions_def: PartitionsDefinition` argument on `create_external_run` with an `asset_graph: AssetGraph` argument.

This reduces lines of code and also makes way for a world where a run can target assets with different `PartitionsDefinitions`, e.g. `DailyPartitionsDefinitions` with different start dates.

## How I Tested These Changes
