### PR TITLE
[single-implicit-asset-job] `get_tags_for_partition_key` on `JobDefinition`

### DIFF
--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -9,7 +9,7 @@ from dagster._cli.workspace.cli_target import (
 )
 from dagster._core.definitions.asset_selection import AssetSelection
 from dagster._core.definitions.events import AssetKey
-from dagster._core.errors import DagsterInvalidSubsetError
+from dagster._core.errors import DagsterInvalidSubsetError, DagsterUnknownPartitionError
 from dagster._core.execution.api import execute_job
 from dagster._core.instance import DagsterInstance
 from dagster._core.origin import JobPythonOrigin
@@ -61,14 +61,22 @@ def execute_materialize_command(instance: DagsterInstance, kwargs: Mapping[str, 
     )
     partition = kwargs.get("partition")
     if partition:
-        partitions_def = implicit_job_def.partitions_def
-        if partitions_def is None or all(
+        if all(
             implicit_job_def.asset_layer.get(asset_key).partitions_def is None
             for asset_key in asset_keys
         ):
             check.failed("Provided '--partition' option, but none of the assets are partitioned")
 
-        tags = partitions_def.get_tags_for_partition_key(partition)
+        try:
+            tags = implicit_job_def.get_tags_for_partition_key(
+                partition, selected_asset_keys=asset_keys, dynamic_partitions_store=instance
+            )
+        except DagsterUnknownPartitionError:
+            raise DagsterInvalidSubsetError(
+                "All selected assets must have a PartitionsDefinition containing the passed"
+                f" partition key `{partition}` or have no PartitionsDefinition."
+            )
+
     else:
         if any(
             implicit_job_def.asset_layer.get(asset_key).partitions_def is not None

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -674,22 +674,23 @@ class JobDefinition(IHasInternalInit):
 
         merged_tags = merge_dicts(self.tags, tags or {})
         if partition_key:
-            if not (self.partitions_def and self.partitioned_config):
-                check.failed("Attempted to execute a partitioned run for a non-partitioned job")
-            self.partitions_def.validate_partition_key(
-                partition_key, dynamic_partitions_store=instance
+            tags_for_partition_key = ephemeral_job.get_tags_for_partition_key(
+                partition_key,
+                selected_asset_keys=asset_selection,
+                dynamic_partitions_store=instance,
             )
 
-            run_config = (
-                run_config
-                if run_config
-                else self.partitioned_config.get_run_config_for_partition_key(partition_key)
-            )
-            merged_tags.update(
-                self.partitioned_config.get_tags_for_partition_key(
-                    partition_key, job_name=self.name
+            if not run_config and self.partitioned_config:
+                run_config = self.partitioned_config.get_run_config_for_partition_key(partition_key)
+
+            if self.partitioned_config:
+                merged_tags.update(
+                    self.partitioned_config.get_tags_for_partition_key(
+                        partition_key, job_name=self.name
+                    )
                 )
-            )
+            else:
+                merged_tags.update(tags_for_partition_key)
 
         return core_execute_in_process(
             ephemeral_job=ephemeral_job,
@@ -701,6 +702,45 @@ class JobDefinition(IHasInternalInit):
             run_id=run_id,
             asset_selection=frozenset(asset_selection),
         )
+
+    def get_tags_for_partition_key(
+        self,
+        partition_key: str,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"],
+        selected_asset_keys: Optional[Iterable[AssetKey]],
+    ) -> Mapping[str, str]:
+        """Gets tags for the given partition key and ensures that it's a member of the PartitionsDefinition
+        corresponding to every asset in the selection.
+        """
+        partitions_def = None
+        if self.partitions_def:
+            partitions_def = self.partitions_def
+        elif self.asset_layer:
+            if selected_asset_keys:
+                resolved_selected_asset_keys = selected_asset_keys
+            elif self.asset_selection:
+                resolved_selected_asset_keys = self.asset_selection
+            else:
+                resolved_selected_asset_keys = [
+                    key for key in self.asset_layer.asset_keys_by_node_output_handle.values()
+                ]
+
+            unique_partitions_defs = {
+                self.asset_layer.get(asset_key).partitions_def
+                for asset_key in resolved_selected_asset_keys
+            } - {None}
+            if len(unique_partitions_defs) == 1:
+                partitions_def = next(iter(unique_partitions_defs))
+            elif len(unique_partitions_defs) > 1:
+                check.failed("Attempted to execute a run for assets with different partitions")
+
+        if partitions_def is None:
+            check.failed("Attempted to execute a partitioned run for a non-partitioned job")
+
+        partitions_def.validate_partition_key(
+            partition_key, dynamic_partitions_store=dynamic_partitions_store
+        )
+        return partitions_def.get_tags_for_partition_key(partition_key)
 
     @property
     def op_selection_data(self) -> Optional[OpSelectionData]:


### PR DESCRIPTION
## Summary & Motivation

Adds a `get_tags_for_partition_key` method to `JobDefinition`. This means that code paths trying to get the partition key for a run don't need to look at the `partitions_def` on the job.

For asset jobs, implements this method by looking at the selected assets, rather than the `partitions_def` on the job.

This will allow downstream PRs to build and use jobs that target assets with multiple `PartitionsDefinitions`, and to hide per-run `PartitionsDefinition` resolution from callers.

Also see it used here: https://github.com/dagster-io/dagster/pull/23287.

## How I Tested These Changes
