### PR TITLE
[single-implicit-asset-job] no `partitions_def` in `with_resolved_tags_and_config`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -742,6 +742,12 @@ class JobDefinition(IHasInternalInit):
         )
         return partitions_def.get_tags_for_partition_key(partition_key)
 
+    def get_run_config_for_partition_key(self, partition_key: str) -> Mapping[str, Any]:
+        if self._partitioned_config:
+            return self._partitioned_config.get_run_config_for_partition_key(partition_key)
+        else:
+            return {}
+
     @property
     def op_selection_data(self) -> Optional[OpSelectionData]:
         return (

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -1,8 +1,11 @@
+from collections import defaultdict
 from datetime import datetime
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
+    AbstractSet,
     Any,
+    Dict,
     List,
     Mapping,
     NamedTuple,
@@ -10,7 +13,6 @@ from typing import (
     Sequence,
     Set,
     Union,
-    cast,
 )
 
 import dagster._check as check
@@ -32,13 +34,13 @@ from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_START_TAG,
     PARTITION_NAME_TAG,
 )
-from dagster._record import IHaveNew, LegacyNamedTupleMixin, record_custom
+from dagster._record import IHaveNew, LegacyNamedTupleMixin, record, record_custom
 from dagster._serdes.serdes import whitelist_for_serdes
+from dagster._utils.cached_method import cached_method
 from dagster._utils.error import SerializableErrorInfo
 
 if TYPE_CHECKING:
     from dagster._core.definitions.job_definition import JobDefinition
-    from dagster._core.definitions.partition import PartitionsDefinition
     from dagster._core.definitions.run_config import RunConfig
 
 
@@ -186,40 +188,24 @@ class RunRequest(IHaveNew, LegacyNamedTupleMixin):
         current_time: Optional[datetime] = None,
         dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
     ) -> "RunRequest":
-        from dagster._core.definitions.partition import PartitionsDefinition
-
         if self.partition_key is None:
             check.failed(
                 "Cannot resolve partition for run request without partition key",
             )
 
-        partitions_def = target_definition.partitions_def
-        if partitions_def is None:
-            check.failed(
-                "Cannot resolve partition for run request when target job"
-                f" '{target_definition.name}' is unpartitioned.",
+        dynamic_partitions_store_after_requests = (
+            DynamicPartitionsStoreAfterRequests.from_requests(
+                dynamic_partitions_store, dynamic_partitions_requests
             )
-        partitions_def = cast(PartitionsDefinition, partitions_def)
-
-        partitioned_config = target_definition.partitioned_config
-        if partitioned_config is None:
-            check.failed(
-                "Cannot resolve partition for run request on unpartitioned job",
-            )
-
-        _check_valid_partition_key_after_dynamic_partitions_requests(
-            self.partition_key,
-            partitions_def,
-            dynamic_partitions_requests,
-            current_time,
-            dynamic_partitions_store,
+            if dynamic_partitions_store
+            else None
         )
-
         tags = {
             **(self.tags or {}),
-            **partitioned_config.get_tags_for_partition_key(
+            **target_definition.get_tags_for_partition_key(
                 self.partition_key,
-                job_name=target_definition.name,
+                dynamic_partitions_store=dynamic_partitions_store_after_requests,
+                selected_asset_keys=self.asset_selection,
             ),
         }
 
@@ -227,7 +213,7 @@ class RunRequest(IHaveNew, LegacyNamedTupleMixin):
             run_config=(
                 self.run_config
                 if self.run_config
-                else partitioned_config.get_run_config_for_partition_key(self.partition_key)
+                else target_definition.get_run_config_for_partition_key(self.partition_key)
             ),
             tags=tags,
         )
@@ -257,68 +243,63 @@ class RunRequest(IHaveNew, LegacyNamedTupleMixin):
         return self.asset_graph_subset is not None
 
 
-def _check_valid_partition_key_after_dynamic_partitions_requests(
-    partition_key: str,
-    partitions_def: "PartitionsDefinition",
-    dynamic_partitions_requests: Sequence[
-        Union[AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest]
-    ],
-    current_time: Optional[datetime] = None,
-    dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
-):
-    from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
-    from dagster._core.definitions.partition import DynamicPartitionsDefinition
+@record
+class DynamicPartitionsStoreAfterRequests(DynamicPartitionsStore):
+    """Represents the dynamic partitions that will be in the contained DynamicPartitionsStore
+    after the contained requests are satisfied.
+    """
 
-    if isinstance(partitions_def, MultiPartitionsDefinition):
-        multipartition_key = partitions_def.get_partition_key_from_str(partition_key)
+    wrapped_dynamic_partitions_store: DynamicPartitionsStore
+    added_partition_keys_by_partitions_def_name: Mapping[str, AbstractSet[str]]
+    deleted_partition_keys_by_partitions_def_name: Mapping[str, AbstractSet[str]]
 
-        for dimension in partitions_def.partitions_defs:
-            _check_valid_partition_key_after_dynamic_partitions_requests(
-                multipartition_key.keys_by_dimension[dimension.name],
-                dimension.partitions_def,
-                dynamic_partitions_requests,
-                current_time,
-                dynamic_partitions_store,
-            )
+    @staticmethod
+    def from_requests(
+        wrapped_dynamic_partitions_store: DynamicPartitionsStore,
+        dynamic_partitions_requests: Sequence[
+            Union[AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest]
+        ],
+    ) -> "DynamicPartitionsStoreAfterRequests":
+        added_partition_keys_by_partitions_def_name: Dict[str, Set[str]] = defaultdict(set)
+        deleted_partition_keys_by_partitions_def_name: Dict[str, Set[str]] = defaultdict(set)
 
-    elif isinstance(partitions_def, DynamicPartitionsDefinition) and partitions_def.name:
-        if not dynamic_partitions_store:
-            check.failed(
-                "Cannot resolve partition for run request on dynamic partitions without"
-                " dynamic_partitions_store"
-            )
-
-        add_partition_keys: Set[str] = set()
-        delete_partition_keys: Set[str] = set()
         for req in dynamic_partitions_requests:
+            name = req.partitions_def_name
             if isinstance(req, AddDynamicPartitionsRequest):
-                if req.partitions_def_name == partitions_def.name:
-                    add_partition_keys.update(set(req.partition_keys))
+                added_partition_keys_by_partitions_def_name[name].update(set(req.partition_keys))
             elif isinstance(req, DeleteDynamicPartitionsRequest):
-                if req.partitions_def_name == partitions_def.name:
-                    delete_partition_keys.update(set(req.partition_keys))
+                deleted_partition_keys_by_partitions_def_name[name].update(set(req.partition_keys))
+            else:
+                check.failed(f"Unexpected request type: {req}")
 
-        partition_keys_after_requests_resolved = (
-            set(
-                dynamic_partitions_store.get_dynamic_partitions(
-                    partitions_def_name=partitions_def.name
-                )
+        return DynamicPartitionsStoreAfterRequests(
+            wrapped_dynamic_partitions_store=wrapped_dynamic_partitions_store,
+            added_partition_keys_by_partitions_def_name=added_partition_keys_by_partitions_def_name,
+            deleted_partition_keys_by_partitions_def_name=deleted_partition_keys_by_partitions_def_name,
+        )
+
+    @cached_method
+    def get_dynamic_partitions(self, partitions_def_name: str) -> Sequence[str]:
+        partition_keys = set(
+            self.wrapped_dynamic_partitions_store.get_dynamic_partitions(partitions_def_name)
+        )
+        added_partition_keys = self.added_partition_keys_by_partitions_def_name.get(
+            partitions_def_name, set()
+        )
+        deleted_partition_keys = self.deleted_partition_keys_by_partitions_def_name.get(
+            partitions_def_name, set()
+        )
+        return list((partition_keys | added_partition_keys) - deleted_partition_keys)
+
+    def has_dynamic_partition(self, partitions_def_name: str, partition_key: str) -> bool:
+        return partition_key not in self.deleted_partition_keys_by_partitions_def_name.get(
+            partitions_def_name, set()
+        ) and (
+            partition_key
+            in self.added_partition_keys_by_partitions_def_name.get(partitions_def_name, set())
+            or self.wrapped_dynamic_partitions_store.has_dynamic_partition(
+                partitions_def_name, partition_key
             )
-            | add_partition_keys
-        ) - delete_partition_keys
-
-        if partition_key not in partition_keys_after_requests_resolved:
-            check.failed(
-                f"Dynamic partition key {partition_key} for partitions def"
-                f" '{partitions_def.name}' is invalid. After dynamic partitions requests are"
-                " applied, it does not exist in the set of valid partition keys."
-            )
-
-    else:
-        partitions_def.validate_partition_key(
-            partition_key,
-            dynamic_partitions_store=dynamic_partitions_store,
-            current_time=current_time,
         )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_run_request.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/test_run_request.py
@@ -1,0 +1,57 @@
+from typing import Sequence, Union, cast
+
+import pytest
+from dagster import (
+    AddDynamicPartitionsRequest,
+    DeleteDynamicPartitionsRequest,
+    DynamicPartitionsDefinition,
+    RunRequest,
+    job,
+)
+from dagster._core.errors import DagsterUnknownPartitionError
+from dagster._core.test_utils import instance_for_test
+
+
+@pytest.mark.parametrize(
+    "prior_partitions,dynamic_partitions_requests,expect_success",
+    [
+        (["a"], [], True),
+        ([], [], False),
+        ([], [AddDynamicPartitionsRequest("something", ["a"])], True),
+        ([], [AddDynamicPartitionsRequest("something_else", ["a"])], False),
+        (["a"], [DeleteDynamicPartitionsRequest("something", ["a"])], False),
+        (["a"], [DeleteDynamicPartitionsRequest("something_else", ["a"])], True),
+    ],
+)
+def test_validate_dynamic_partitions(
+    prior_partitions: Sequence[str],
+    dynamic_partitions_requests: Sequence[
+        Union[AddDynamicPartitionsRequest, DeleteDynamicPartitionsRequest]
+    ],
+    expect_success: bool,
+):
+    partitions_def = DynamicPartitionsDefinition(name="something")
+
+    @job(partitions_def=partitions_def)
+    def job1():
+        pass
+
+    run_request = RunRequest(partition_key="a")
+    with instance_for_test() as instance:
+        instance.add_dynamic_partitions(cast(str, partitions_def.name), prior_partitions)
+
+        if expect_success:
+            run_request.with_resolved_tags_and_config(
+                target_definition=job1,
+                dynamic_partitions_requests=dynamic_partitions_requests,
+                dynamic_partitions_store=instance,
+            )
+        else:
+            with pytest.raises(
+                DagsterUnknownPartitionError, match="Could not find a partition with key `a`."
+            ):
+                run_request.with_resolved_tags_and_config(
+                    target_definition=job1,
+                    dynamic_partitions_requests=dynamic_partitions_requests,
+                    dynamic_partitions_store=instance,
+                )

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -3189,7 +3189,7 @@ def test_error_on_deleted_dynamic_partitions_run_request(
         expected_datetime=None,
         expected_status=TickStatus.FAILURE,
         expected_run_ids=None,
-        expected_error="Dynamic partition key 2 for partitions def 'quux' is invalid",
+        expected_error="Could not find a partition with key `2`",
     )
     assert set(instance.get_dynamic_partitions("quux")) == set(["2"])
 
@@ -3239,7 +3239,7 @@ def test_multipartitions_with_dynamic_dims_run_request_sensor(
             expected_datetime=None,
             expected_status=TickStatus.FAILURE,
             expected_run_ids=None,
-            expected_error="does not exist in the set of valid partition keys",
+            expected_error="Could not find a partition with key `2|1`",
         )
 
 


### PR DESCRIPTION
## Summary & Motivation

This updates the implementation of `RunRequest.with_resolved_tags_and_config` to use the `get_tags_for_partition_key` method introduced in https://github.com/dagster-io/dagster/pull/23285.

The PR net deletes non-test LOC, but introduces a set of tests for `RunRequest.with_resolved_tags_and_config`.


## How I Tested These Changes
