### PR TITLE
[dagster-databricks] Update to support databricks-sdk<=0.17.0

### DIFF
--- a/docs/content/concepts/dagster-pipes/databricks.mdx
+++ b/docs/content/concepts/dagster-pipes/databricks.mdx
@@ -139,8 +139,8 @@ Add the following to the bottom of `dagster_databricks_pipes.py` to define the r
 ```python file=/guides/dagster/dagster_pipes/databricks/databricks_asset_client.py startafter=start_definitions endbefore=end_definitions
 pipes_databricks_resource = PipesDatabricksClient(
     client=WorkspaceClient(
-        host=os.getenv("DATABRICKS_HOST"),
-        token=os.getenv("DATABRICKS_TOKEN"),
+        host=os.environ["DATABRICKS_HOST"],
+        token=os.environ["DATABRICKS_TOKEN"],
     )
 )
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/databricks/databricks_asset_client.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/databricks/databricks_asset_client.py
@@ -59,8 +59,8 @@ def databricks_asset(
 
 pipes_databricks_resource = PipesDatabricksClient(
     client=WorkspaceClient(
-        host=os.getenv("DATABRICKS_HOST"),
-        token=os.getenv("DATABRICKS_TOKEN"),
+        host=os.environ["DATABRICKS_HOST"],
+        token=os.environ["DATABRICKS_TOKEN"],
     )
 )
 

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -168,7 +168,7 @@ dask-kubernetes==2022.9.0
 dask-yarn==0.9
 databricks-api==0.9.0
 databricks-cli==0.18.0
-databricks-sdk==0.8.0
+databricks-sdk==0.17.0
 dataclasses-json==0.6.6
 datadog==0.49.1
 dataproperty==1.0.1

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks.py
@@ -4,7 +4,7 @@ import os
 import time
 from enum import Enum
 from importlib.metadata import version
-from typing import IO, Any, List, Mapping, Optional, Tuple, Union, cast
+from typing import IO, Any, Mapping, Optional, Tuple, Union
 
 import dagster
 import dagster._check as check
@@ -21,7 +21,7 @@ from databricks.sdk.core import (
     oauth_service_principal,
     pat_auth,
 )
-from databricks.sdk.service import compute, jobs
+from databricks.sdk.service import jobs
 from typing_extensions import Final
 
 import dagster_databricks
@@ -119,11 +119,11 @@ class WorkspaceClientFactory:
             if host is not None:
                 # This allows for explicit override of the host, while letting other credentials be read from the
                 # environment or ~/.databrickscfg file
-                c = Config(host=host, credentials_provider=DefaultCredentials(), **product_info)
+                c = Config(host=host, credentials_provider=DefaultCredentials(), **product_info)  # type: ignore  # (bad stubs)
             else:
                 # The initialization machinery in the Config object will look for the host and other auth info in the
                 # environment, as long as no values are provided for those attributes (including None)
-                c = Config(credentials_provider=DefaultCredentials(), **product_info)
+                c = Config(credentials_provider=DefaultCredentials(), **product_info)  # type: ignore  # (bad stubs)
         else:
             raise ValueError(f"Unexpected auth type {auth_type}")
         self.config = c
@@ -264,7 +264,7 @@ class DatabricksClient:
 
     def __setup_user_agent(
         self,
-        client: Union[WorkspaceClient, databricks_api.DatabricksAPI, databricks_cli.sdk.ApiClient],
+        client: Union[databricks_api.DatabricksAPI, databricks_cli.sdk.ApiClient],
     ) -> None:
         """Overrides the user agent for the Databricks API client."""
         client.default_headers["user-agent"] = f"dagster-databricks/{__version__}"
@@ -391,11 +391,13 @@ class DatabricksClient:
         dbfs_service = self.workspace_client.dbfs
 
         jdoc = dbfs_service.read(path=dbfs_path, length=block_size)
-        data += base64.b64decode(jdoc.data)
+        jdoc_data = check.not_none(jdoc.data, f"read file {dbfs_path} with no data")
+        data += base64.b64decode(jdoc_data)
         while jdoc.bytes_read == block_size:
-            bytes_read += jdoc.bytes_read
+            bytes_read += check.not_none(jdoc.bytes_read)
             jdoc = dbfs_service.read(path=dbfs_path, offset=bytes_read, length=block_size)
-            data += base64.b64decode(jdoc.data)
+            jdoc_data = check.not_none(jdoc.data, f"read file {dbfs_path} with no data")
+            data += base64.b64decode(jdoc_data)
 
         return data
 
@@ -412,7 +414,9 @@ class DatabricksClient:
         dbfs_service = self.workspace_client.dbfs
 
         create_response = dbfs_service.create(path=dbfs_path, overwrite=overwrite)
-        handle = create_response.handle
+        handle = check.not_none(
+            create_response.handle, "create file response did not return handle"
+        )
 
         block = file_obj.read(block_size)
         while block:
@@ -429,6 +433,8 @@ class DatabricksClient:
         attribute may be `None` if the run hasn't yet terminated.
         """
         run = self.workspace_client.jobs.get_run(databricks_run_id)
+        if run.state is None:
+            check.failed("Databricks job run state is None")
         return DatabricksRunState.from_databricks(run.state)
 
     def poll_run_state(
@@ -628,9 +634,6 @@ class DatabricksJobRunner:
             "Multiple tasks specified in Databricks run",
         )
 
-        notification_settings = self._get_notification_settings(run_config)
-        job_health_settings = self._get_job_health_settings(run_config)
-
         return self.client.workspace_client.jobs.submit(
             run_name=run_config.get("run_name"),
             tasks=[
@@ -646,54 +649,37 @@ class DatabricksJobRunner:
             ],
             idempotency_token=run_config.get("idempotency_token"),
             timeout_seconds=run_config.get("timeout_seconds"),
-            health=job_health_settings,
-            **notification_settings,
-        ).bind()["run_id"]
-
-    def _get_job_health_settings(
-        self, run_config: Mapping[str, Any]
-    ) -> Optional[List[jobs.JobsHealthRule]]:
-        if "job_health_settings" in run_config:
-            job_health_settings = [
-                jobs.JobsHealthRule.from_dict(h) for h in run_config["job_health_settings"]
-            ]
-        else:
-            job_health_settings = None
-        return job_health_settings
-
-    def _get_notification_settings(
-        self, run_config: Mapping[str, Any]
-    ) -> Mapping[
-        str,
-        Union[jobs.JobEmailNotifications, jobs.JobNotificationSettings, jobs.WebhookNotifications],
-    ]:
-        notification_configs = {}
-        if "email_notifications" in run_config:
-            email_notifications = jobs.JobEmailNotifications.from_dict(
+            health=jobs.JobsHealthRules.from_dict({"rules": run_config["job_health_settings"]})
+            if "job_health_settings" in run_config
+            else None,
+            email_notifications=jobs.JobEmailNotifications.from_dict(
                 run_config["email_notifications"]
             )
-            notification_configs.update({"email_notifications": email_notifications})
-        if "notification_settings" in run_config:
-            notification_settings = jobs.JobNotificationSettings.from_dict(
+            if "email_notifications" in run_config
+            else None,
+            notification_settings=jobs.JobNotificationSettings.from_dict(
                 run_config["notification_settings"]
             )
-            notification_configs.update({"notification_settings": notification_settings})
-        if "webhook_notifications" in run_config:
-            webhook_notifications = jobs.WebhookNotifications.from_dict(
+            if "notification_settings" in run_config
+            else None,
+            webhook_notifications=jobs.WebhookNotifications.from_dict(
                 run_config["webhook_notifications"]
             )
-            notification_configs.update({"webhook_notifications": webhook_notifications})
-        return notification_configs
+            if "webhook_notifications" in run_config
+            else None,
+        ).bind()["run_id"]
 
     def retrieve_logs_for_run_id(
         self, log: logging.Logger, databricks_run_id: int
     ) -> Optional[Tuple[Optional[str], Optional[str]]]:
         """Retrieve the stdout and stderr logs for a run."""
         run = self.client.workspace_client.jobs.get_run(databricks_run_id)
-
         # Run.cluster_instance can be None. In that case, fall back to cluster instance on first
         # task. Currently pyspark step launcher runs jobs with singleton tasks.
-        cluster_instance = run.cluster_instance or run.tasks[0].cluster_instance
+        cluster_instance = check.not_none(
+            run.cluster_instance or check.not_none(run.tasks)[0].cluster_instance,
+            "Run has no attached cluster instance.",
+        )
         cluster_id = check.inst(
             cluster_instance.cluster_id,
             str,
@@ -707,12 +693,16 @@ class DatabricksJobRunner:
                 f"Logs not configured for cluster {cluster_id} used for run {databricks_run_id}"
             )
             return None
-        if cast(Optional[compute.S3StorageInfo], log_config.s3) is not None:
-            logs_prefix = log_config.s3.destination
+        if log_config.s3 is not None:
+            logs_prefix = check.not_none(
+                log_config.s3.destination, "S3 logs destination not set for cluster"
+            )
             log.warn("Retrieving S3 logs not yet implemented")
             return None
-        elif cast(Optional[compute.DbfsStorageInfo], log_config.dbfs) is not None:
-            logs_prefix = log_config.dbfs.destination
+        elif log_config.dbfs is not None:
+            logs_prefix = check.not_none(
+                log_config.dbfs.destination, "DBFS logs destination not set for cluster"
+            )
             stdout = self.wait_for_dbfs_logs(log, logs_prefix, cluster_id, "stdout")
             stderr = self.wait_for_dbfs_logs(log, logs_prefix, cluster_id, "stderr")
             return stdout, stderr

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 import time
 import zlib
-from typing import Any, Dict, Iterator, Mapping, Optional, Sequence, cast
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Sequence, cast
 
 from dagster import (
     Bool,
@@ -35,7 +35,7 @@ from dagster._serdes import deserialize_value
 from dagster._utils.backoff import backoff
 from dagster_pyspark.utils import build_pyspark_zip
 from databricks.sdk.core import DatabricksError
-from databricks.sdk.service import jobs
+from databricks.sdk.service import iam, jobs
 
 from dagster_databricks import databricks_step_main
 from dagster_databricks.databricks import DEFAULT_RUN_MAX_WAIT_TIME_SEC, DatabricksJobRunner
@@ -426,6 +426,8 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         cluster_id = None
         for i in range(1, request_retries + 1):
             run_info = client.jobs.get_run(databricks_run_id)
+            if run_info.cluster_instance is None:
+                check.failed("Databricks run {databricks_run_id} has null cluster_instance")
             # if a new job cluster is created, the cluster_instance key may not be immediately present in the run response
             try:
                 cluster_id = run_info.cluster_instance.cluster_id
@@ -446,9 +448,11 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         # Update job permissions
         if "job_permissions" in self.permissions:
             job_permissions = self._format_permissions(self.permissions["job_permissions"])
-            job_id = run_info.job_id
+            job_id = check.not_none(
+                run_info.job_id, f"Databricks run {databricks_run_id} has null job_id"
+            )
             log.debug(f"Updating job permissions with following json: {job_permissions}")
-            client.permissions.update("jobs", job_id, access_control_list=job_permissions)
+            client.permissions.update("jobs", str(job_id), access_control_list=job_permissions)
             log.info("Successfully updated cluster permissions")
 
         # Update cluster permissions
@@ -467,7 +471,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
 
     def _format_permissions(
         self, input_permissions: Mapping[str, Sequence[Mapping[str, str]]]
-    ) -> Sequence[Mapping[str, str]]:
+    ) -> List[iam.AccessControlRequest]:
         access_control_list = []
         for permission, accessors in input_permissions.items():
             access_control_list.extend(

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/types.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/types.py
@@ -46,7 +46,7 @@ class DatabricksRunState(NamedTuple):
 
     life_cycle_state: Optional["DatabricksRunLifeCycleState"]
     result_state: Optional["DatabricksRunResultState"]
-    state_message: str
+    state_message: Optional[str]
 
     def has_terminated(self) -> bool:
         """Has the job terminated?"""

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_databricks.py
@@ -49,9 +49,9 @@ def test_databricks_submit_job_existing_cluster(mock_submit_run, databricks_run_
             pypi=compute.PythonPyPiLibrary(package=f"databricks-sdk=={version('databricks-sdk')}")
         ),
     ]
-    expected_health = [
-        jobs.JobsHealthRule.from_dict(h) for h in databricks_run_config["job_health_settings"]
-    ]
+    expected_health = jobs.JobsHealthRules.from_dict(
+        {"rules": databricks_run_config["job_health_settings"]}
+    )
 
     runner.submit_run(databricks_run_config, task)
     mock_submit_run.assert_called_with(
@@ -60,6 +60,9 @@ def test_databricks_submit_job_existing_cluster(mock_submit_run, databricks_run_
         health=expected_health,
         idempotency_token=databricks_run_config["idempotency_token"],
         timeout_seconds=databricks_run_config["timeout_seconds"],
+        email_notifications=None,
+        notification_settings=None,
+        webhook_notifications=None,
     )
 
     databricks_run_config["install_default_libraries"] = False
@@ -72,6 +75,9 @@ def test_databricks_submit_job_existing_cluster(mock_submit_run, databricks_run_
         health=expected_health,
         idempotency_token=databricks_run_config["idempotency_token"],
         timeout_seconds=databricks_run_config["timeout_seconds"],
+        email_notifications=None,
+        notification_settings=None,
+        webhook_notifications=None,
     )
 
 
@@ -156,9 +162,9 @@ def test_databricks_submit_job_new_cluster(mock_submit_run, databricks_run_confi
     expected_webhook_notifications = jobs.WebhookNotifications.from_dict(
         databricks_run_config["webhook_notifications"]
     )
-    expected_job_health_settings = [
-        jobs.JobsHealthRule.from_dict(j) for j in databricks_run_config["job_health_settings"]
-    ]
+    expected_job_health_settings = jobs.JobsHealthRules.from_dict(
+        {"rules": databricks_run_config["job_health_settings"]}
+    )
     runner.submit_run(databricks_run_config, task)
     mock_submit_run.assert_called_once_with(
         run_name=databricks_run_config["run_name"],


### PR DESCRIPTION
## Summary & Motivation

Update dagster-databricks to support `databricks-sdk` 0.17.0.

#21232 bumped databricks-sdk to 0.17.0 but did not bump pyright pins. Though this PR passed our tests (which are pretty spotty for this package), it introduced many type errors against the newer `databricks-sdk` that manifested when bumping pyright pins.

The present PR fixes the type errors, allowing us to bump pyright pins and hopefully avoiding crashes against the newer databricks-sdk we now support.

## How I Tested These Changes

Existing test suite, pyright.
