### PR TITLE
[dagster-airlift] add pyright checking, fix type errors

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/airflow_project/dags/simple_dag.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/airflow_project/dags/simple_dag.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from airflow import DAG
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 
 
 def print_hello():

--- a/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/airflow_dags/dbt_dag.py
+++ b/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/airflow_dags/dbt_dag.py
@@ -3,7 +3,7 @@ import os
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from airflow.operators.bash_operator import BashOperator
+from airflow.operators.bash import BashOperator
 
 default_args = {
     "owner": "airflow",

--- a/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/airflow_dags/lakehouse.py
+++ b/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/airflow_dags/lakehouse.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import duckdb
 import pandas as pd
 from airflow import DAG
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 
 
 def load_csv_to_duckdb():

--- a/pyright/master/exclude.txt
+++ b/pyright/master/exclude.txt
@@ -12,5 +12,4 @@ examples/project_analytics
 examples/project_dagster_university_start
 examples/project_du_dbt_starter
 examples/tutorial
-examples/experimental/dagster-airlift
 helm

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -100,6 +100,7 @@ daff==1.3.46
 -e python_modules/dagster
 -e python_modules/libraries/dagster-airbyte
 -e python_modules/libraries/dagster-airflow
+-e examples/experimental/dagster-airlift
 -e python_modules/libraries/dagster-aws
 -e python_modules/libraries/dagster-azure
 -e python_modules/libraries/dagster-celery
@@ -403,6 +404,7 @@ path==16.16.0
 pathable==0.4.3
 pathspec==0.12.1
 pathvalidate==3.2.0
+-e examples/experimental/dagster-airlift/examples/peering-with-dbt
 pendulum==2.1.2
 pexpect==4.9.0
 pillow==10.4.0

--- a/pyright/master/requirements.txt
+++ b/pyright/master/requirements.txt
@@ -128,3 +128,4 @@ pendulum<3
 -e examples/with_pyspark
 -e examples/with_wandb
 -e examples/experimental/dagster-airlift # (includes airflow dependencies)
+-e examples/experimental/dagster-airlift/examples/peering-with-dbt


### PR DESCRIPTION
## Summary & Motivation

`dagster-airflift` was excluded from pyright checking when it was merged due to issues with updating pyright pins unrelated to the `dagster-airlift` PR (see #23254). Those issues are fixed downstack. This PR adds `dagster-airlift` to pyright and fixes some type errors.

## How I Tested These Changes

Existing test suite.