### PR TITLE
[dagster-pandera] add support for polars

### DIFF
--- a/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Callable, Sequence, Type, Union
 import dagster._check as check
 import pandas as pd
 import pandera as pa
+import pandera.errors as pa_errors
 from dagster import (
     DagsterType,
     TableColumn,
@@ -16,6 +17,7 @@ from dagster import (
 )
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.libraries import DagsterLibraryRegistry
+from typing_extensions import TypeAlias
 
 from .version import __version__
 
@@ -32,19 +34,40 @@ from .version import __version__
 # alternatives in the future. These sections are marked with "TODO: pending
 # alternative dataframe support".
 
+try:
+    import pandera.polars as pa_polars
+    import polars as pl
+
+    VALID_DATAFRAME_CLASSES = (pd.DataFrame, pl.DataFrame)
+    VALID_SCHEMA_CLASSES = (pa.DataFrameSchema, pa_polars.DataFrameSchema)
+    VALID_SCHEMA_MODEL_CLASSES = (pa.DataFrameModel, pa_polars.DataFrameModel)
+    VALID_COLUMN_CLASSES = (pa.Column, pa_polars.Column)
+except ImportError:
+    pa_polars = None
+    pl = None
+    VALID_DATAFRAME_CLASSES = (pd.DataFrame,)
+    VALID_SCHEMA_CLASSES = (pa.DataFrameSchema,)
+    VALID_SCHEMA_MODEL_CLASSES = (pa.DataFrameModel,)
+    VALID_COLUMN_CLASSES = (pa.Column,)
+
 if TYPE_CHECKING:
-    ValidatableDataFrame = pd.DataFrame
+    # Unconditionally import pandera.polars for type-checking. Note that this is an unresolved
+    # import in a type checking process if polars isn't installed, but this won't interfere with the
+    # user type-checking experience-- the error will be suppressed because it is in a third-party
+    # library, and the type annotation will still render correctly as a string.
+    #
+    # NOTE: It is important NOT to import `pandera.polars` under the same pa_polars alias we use for
+    # the runtime import above-- that will confuse type checkers because that alias is a variable
+    # due to the runtime ImportError handling.
+    import pandera.polars  # noqa: TCH004
+
+DagsterPanderaSchema: TypeAlias = Union[pa.DataFrameSchema, "pandera.polars.DataFrameSchema"]
+DagsterPanderaSchemaModel: TypeAlias = Type[
+    Union[pa.DataFrameModel, "pandera.polars.DataFrameModel"]
+]
+DagsterPanderaColumn: TypeAlias = Union[pa.Column, "pandera.polars.Column"]
 
 DagsterLibraryRegistry.register("dagster-pandera", __version__)
-
-# ########################
-# ##### VALID DATAFRAME CLASSES
-# ########################
-
-# This layer of indirection is used because we may support alternative dataframe classes in the
-# future.
-VALID_DATAFRAME_CLASSES = (pd.DataFrame,)
-
 
 # ########################
 # ##### PANDERA SCHEMA TO DAGSTER TYPE
@@ -52,7 +75,7 @@ VALID_DATAFRAME_CLASSES = (pd.DataFrame,)
 
 
 def pandera_schema_to_dagster_type(
-    schema: Union[pa.DataFrameSchema, Type[pa.DataFrameModel]],
+    schema: Union[DagsterPanderaSchema, DagsterPanderaSchemaModel],
 ) -> DagsterType:
     """Convert a Pandera dataframe schema to a `DagsterType`.
 
@@ -85,8 +108,8 @@ def pandera_schema_to_dagster_type(
 
     """
     if not (
-        isinstance(schema, pa.DataFrameSchema)
-        or (isinstance(schema, type) and issubclass(schema, pa.DataFrameModel))
+        isinstance(schema, VALID_SCHEMA_CLASSES)
+        or (isinstance(schema, type) and issubclass(schema, VALID_SCHEMA_MODEL_CLASSES))
     ):
         raise TypeError(
             "schema must be a pandera `DataFrameSchema` or a subclass of a pandera `DataFrameModel`"
@@ -95,7 +118,7 @@ def pandera_schema_to_dagster_type(
     name = _extract_name_from_pandera_schema(schema)
     norm_schema = (
         schema.to_schema()
-        if isinstance(schema, type) and issubclass(schema, pa.DataFrameModel)
+        if isinstance(schema, type) and issubclass(schema, VALID_SCHEMA_MODEL_CLASSES)
         else schema
     )
     tschema = _pandera_schema_to_table_schema(norm_schema)
@@ -117,28 +140,38 @@ _anonymous_schema_name_generator = (f"DagsterPanderaDataframe{i}" for i in itert
 
 
 def _extract_name_from_pandera_schema(
-    schema: Union[pa.DataFrameSchema, Type[pa.DataFrameModel]],
+    schema: Union[DagsterPanderaSchema, DagsterPanderaSchemaModel],
 ) -> str:
-    if isinstance(schema, type) and issubclass(schema, pa.DataFrameModel):
+    if isinstance(schema, type) and issubclass(schema, VALID_SCHEMA_MODEL_CLASSES):
         return (
             getattr(schema.Config, "title", None)
             or getattr(schema.Config, "name", None)
             or schema.__name__
         )
-    elif isinstance(schema, pa.DataFrameSchema):
+    elif isinstance(schema, VALID_SCHEMA_CLASSES):
         return schema.title or schema.name or next(_anonymous_schema_name_generator)
 
 
 def _pandera_schema_to_type_check_fn(
-    schema: pa.DataFrameSchema,
+    schema: DagsterPanderaSchema,
     table_schema: TableSchema,
 ) -> Callable[[TypeCheckContext, object], TypeCheck]:
     def type_check_fn(_context, value: object) -> TypeCheck:
         if isinstance(value, VALID_DATAFRAME_CLASSES):
             try:
                 # `lazy` instructs pandera to capture every (not just the first) validation error
-                schema.validate(value, lazy=True)
-            except pa.errors.SchemaErrors as e:
+                if isinstance(schema, pa.DataFrameSchema):
+                    df = check.inst(value, pd.DataFrame, "Must be a pandas DataFrame.")
+                    schema.validate(df, lazy=True)
+                # need to check that polars and pandera.polars are available before isinstance
+                elif pl and pa_polars and isinstance(schema, pa_polars.DataFrameSchema):
+                    df = check.inst(value, pl.DataFrame, "Must be a polars DataFrame.")
+                    schema.validate(df, lazy=True)
+                else:
+                    check.failed(
+                        f"Unexpected schema/value type combination: {type(schema).__name__} / {type(value).__name__}"
+                    )
+            except pa_errors.SchemaErrors as e:
                 return _pandera_errors_to_type_check(e, table_schema)
             except Exception as e:
                 return TypeCheck(
@@ -171,11 +204,15 @@ PANDERA_FAILURE_CASES_SCHEMA = TableSchema(
             description="Column of value that failed the check, or `None` for wide checks.",
         ),
         TableColumn(
-            name="check", type="string", description="Description of the failed Pandera check."
+            name="check",
+            type="string",
+            description="Description of the failed Pandera check.",
         ),
         TableColumn(name="check_number", description="Index of the failed check."),
         TableColumn(
-            name="failure_case", type="number | string", description="Value that failed a check."
+            name="failure_case",
+            type="number | string",
+            description="Value that failed a check.",
         ),
         TableColumn(
             name="index",
@@ -187,7 +224,7 @@ PANDERA_FAILURE_CASES_SCHEMA = TableSchema(
 
 
 def _pandera_errors_to_type_check(
-    error: pa.errors.SchemaErrors, _table_schema: TableSchema
+    error: pa_errors.SchemaErrors, _table_schema: TableSchema
 ) -> TypeCheck:
     return TypeCheck(
         success=False,
@@ -195,7 +232,7 @@ def _pandera_errors_to_type_check(
     )
 
 
-def _pandera_schema_to_table_schema(schema: pa.DataFrameSchema) -> TableSchema:
+def _pandera_schema_to_table_schema(schema: DagsterPanderaSchema) -> TableSchema:
     df_constraints = _pandera_schema_wide_checks_to_table_constraints(schema.checks)
     columns = [_pandera_column_to_table_column(col) for k, col in schema.columns.items()]
     return TableSchema(columns=columns, constraints=df_constraints)
@@ -211,7 +248,7 @@ def _pandera_check_to_table_constraint(pa_check: Union[pa.Check, pa.Hypothesis])
     return _get_pandera_check_identifier(pa_check)
 
 
-def _pandera_column_to_table_column(pa_column: pa.Column) -> TableColumn:
+def _pandera_column_to_table_column(pa_column: DagsterPanderaColumn) -> TableColumn:
     constraints = TableColumnConstraints(
         nullable=pa_column.nullable,
         unique=pa_column.unique,

--- a/python_modules/libraries/dagster-pandera/dagster_pandera_tests/test_polars.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera_tests/test_polars.py
@@ -1,0 +1,193 @@
+import re
+
+import pandera.polars as pa
+import pandera.typing as pa_typing
+import polars as pl
+import pytest
+from dagster import DagsterType, TypeCheck, check_dagster_type
+from dagster._core.definitions.metadata import TableSchemaMetadataValue
+from dagster._core.definitions.metadata.table import (
+    TableColumn,
+    TableColumnConstraints,
+    TableConstraints,
+    TableSchema,
+)
+from dagster_pandera import pandera_schema_to_dagster_type
+from pandera.api.pandas.model_config import BaseConfig
+
+# ########################
+# ##### FIXTURES
+# ########################
+
+# ----- DATAFRAME
+
+DATA_OK = {
+    "a": [1, 4, 0, 10, 9],
+    "b": [-1.3, -1.4, -2.9, -10.1, -20.4],
+    "c": ["value_1", "value_2", "value_3", "value_2", "value_1"],
+}
+
+
+@pytest.fixture
+def dataframe():
+    return pl.DataFrame(DATA_OK)
+
+
+# ----- SCHEMA
+
+
+def sample_dataframe_schema(**kwargs):
+    return pa.DataFrameSchema(
+        {
+            "a": pa.Column(int, checks=pa.Check.le(10), description="a desc"),
+            "b": pa.Column(float, checks=pa.Check.lt(-1.2), description="b desc"),
+            "c": pa.Column(
+                str,
+                description="c desc",
+                checks=[
+                    pa.Check.str_startswith("value_"),
+                    pa.Check(
+                        lambda s: s.str.split("_", expand=True).shape[1] == 2,
+                        description="Two words separated by underscore.",
+                    ),
+                ],
+            ),
+        },
+        checks=[
+            pa.Check(lambda df: df["a"].sum() > df["b"].sum(), description="sum(a) > sum(b)."),
+        ],
+        **kwargs,
+    )
+
+
+def make_schema_model_config(**config_attrs):
+    class Config(BaseConfig):
+        pass
+
+    for k, v in config_attrs.items():
+        setattr(Config, k, v)
+    return Config
+
+
+def sample_schema_model(**config_attrs):
+    class SampleDataframeModel(pa.DataFrameModel):
+        a: pa_typing.Series[int] = pa.Field(le=10, description="a desc")
+        b: pa_typing.Series[float] = pa.Field(lt=-1.2, description="b desc")
+        c: pa_typing.Series[str] = pa.Field(str_startswith="value_", description="c desc")
+
+        @pa.check("c")
+        def c_check(cls, series: pa_typing.Series[str]) -> pa_typing.Series[bool]:
+            """Two words separated by underscore."""
+            split_df = series.lazyframe.select(pl.col(series.key).str.split("_", inclusive=True))
+            return split_df.select(pl.col(series.key).list.len() == 2)
+
+        @pa.dataframe_check
+        def a_gt_b(cls, df):
+            """sum(a) > sum(b)."""
+            sum_a = df.lazyframe.select(pl.col("a")).sum().collect().item()
+            sum_b = df.lazyframe.select(pl.col("b")).sum().collect().item()
+            return sum_a > sum_b
+
+        Config = make_schema_model_config(**config_attrs)
+
+    return SampleDataframeModel
+
+
+@pytest.fixture(
+    params=[sample_dataframe_schema, sample_schema_model], ids=["regular_schema", "schema_model"]
+)
+def schema(request):
+    return request.param()
+
+
+# ----- DAGSTER TYPE
+
+
+@pytest.fixture
+def dagster_type():
+    return pandera_schema_to_dagster_type(sample_schema_model())
+
+
+# ########################
+# ##### TESTS
+# ########################
+
+# ----- TYPE CONSTRUCTION
+
+
+def test_pandera_schema_to_dagster_type(schema):
+    dagster_type = pandera_schema_to_dagster_type(schema)
+    assert isinstance(dagster_type, DagsterType)
+    assert len(dagster_type.metadata) == 1
+    schema_metadata = dagster_type.metadata["schema"]
+    assert isinstance(schema_metadata, TableSchemaMetadataValue)
+    assert schema_metadata.schema == TableSchema(
+        constraints=TableConstraints(other=["sum(a) > sum(b)."]),
+        columns=[
+            TableColumn(
+                name="a",
+                type="Int64",
+                description="a desc",
+                constraints=TableColumnConstraints(nullable=False, other=["<= 10"]),
+            ),
+            TableColumn(
+                name="b",
+                type="Float64",
+                description="b desc",
+                constraints=TableColumnConstraints(nullable=False, other=["< -1.2"]),
+            ),
+            TableColumn(
+                name="c",
+                type="String",
+                description="c desc",
+                constraints=TableColumnConstraints(
+                    nullable=False,
+                    other=[
+                        "str_startswith('value_')",
+                        "Two words separated by underscore.",
+                    ],
+                ),
+            ),
+        ],
+    )
+
+
+def test_name_extraction():
+    schema = sample_schema_model()
+    assert pandera_schema_to_dagster_type(schema).key == schema.__name__
+
+    schema = sample_schema_model(name="foo")
+    assert pandera_schema_to_dagster_type(schema).key == "foo"
+
+    schema = sample_schema_model(title="foo", name="bar")
+    assert pandera_schema_to_dagster_type(schema).key == "foo"
+
+    schema = sample_dataframe_schema()
+    assert re.match(r"DagsterPanderaDataframe\d+", pandera_schema_to_dagster_type(schema).key)
+
+    schema = sample_dataframe_schema(title="foo", name="bar")
+    assert pandera_schema_to_dagster_type(schema).key == "foo"
+
+    schema = sample_dataframe_schema(name="foo")
+    assert pandera_schema_to_dagster_type(schema).key == "foo"
+
+
+# ----- VALIDATION
+
+
+def test_validate_ok(dagster_type, dataframe):
+    result = check_dagster_type(dagster_type, dataframe)
+    assert isinstance(result, TypeCheck)
+    assert result.success
+
+
+def test_validate_inv_bad_value(dagster_type, dataframe):
+    dataframe[0, "a"] = 11
+    result = check_dagster_type(dagster_type, dataframe)
+    assert not result.success
+
+
+def test_validate_inv_missing_column(dagster_type, dataframe):
+    dataframe = dataframe.drop(["a"])
+    result = check_dagster_type(dagster_type, dataframe)
+    assert not result.success

--- a/python_modules/libraries/dagster-pandera/setup.py
+++ b/python_modules/libraries/dagster-pandera/setup.py
@@ -43,9 +43,10 @@ setup(
         "numpy<2",
     ],
     extras_require={
+        "polars": ["polars>=1"],
         "test": [
+            "polars>=1",
             "pytest",
-            "pyarrow",  # optional dep of dagster-pandera
         ],
     },
 )

--- a/python_modules/libraries/dagster-pandera/tox.ini
+++ b/python_modules/libraries/dagster-pandera/tox.ini
@@ -15,5 +15,4 @@ allowlist_externals =
   uv
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-  ipython kernel install --name "dagster" --user
-  pytest -v{posargs}
+  pytest -v {posargs}


### PR DESCRIPTION
## Summary & Motivation

Resolves #20584.

Add support for `polars` to `dagster-pandera`. `polars` is added as an optional dependency under the new `polars` extra. The API of dagster-pandera remains the same except that `pandera_schema_to_dagster_type` now accepts `pandera.polars` schemas.

## How I Tested These Changes

New unit tests.