### PR TITLE
[sensor-upgrades][4/n] Move UserCodeAutomationConditionSensorDefinition to Sensor Daemon

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -90,8 +90,8 @@ class SensorType(Enum):
 
     @property
     def is_handled_by_asset_daemon(self) -> bool:
-        # these "sensors" are currently evaluated by the asset daemon and not the sensor daemon
-        return self in (SensorType.AUTOMATION, SensorType.AUTO_MATERIALIZE)
+        # only the `AUTO_MATERIALIZE` sensor type is handled by the daemon
+        return self == SensorType.AUTO_MATERIALIZE
 
 
 DEFAULT_SENSOR_DAEMON_INTERVAL = 30

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -27,6 +27,8 @@ from dagster._core.utils import make_new_run_id
 from dagster._serdes.serdes import NamedTupleSerializer, whitelist_for_serdes
 
 from .tags import (
+    ASSET_EVALUATION_ID_TAG,
+    AUTOMATION_CONDITION_TAG,
     BACKFILL_ID_TAG,
     REPOSITORY_LABEL_TAG,
     RESUME_RETRY_TAG,
@@ -498,8 +500,12 @@ class DagsterRun(
         return {BACKFILL_ID_TAG: backfill_id}
 
     @staticmethod
-    def tags_for_tick_id(tick_id: str) -> Mapping[str, str]:
-        return {TICK_ID_TAG: tick_id}
+    def tags_for_tick_id(tick_id: str, has_evaluations: bool = False) -> Mapping[str, str]:
+        if has_evaluations:
+            automation_tags = {AUTOMATION_CONDITION_TAG: "true", ASSET_EVALUATION_ID_TAG: tick_id}
+        else:
+            automation_tags = {}
+        return {TICK_ID_TAG: tick_id, **automation_tags}
 
 
 class RunsFilter(

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -991,6 +991,7 @@ def _resolve_run_requests(
     context: SensorLaunchContext,
     external_sensor: ExternalSensor,
     run_ids_with_requests: Sequence[Tuple[str, RunRequest]],
+    has_evaluations: bool,
 ) -> Sequence[Tuple[str, RunRequest]]:
     resolved_run_ids_with_requests = []
 
@@ -998,7 +999,7 @@ def _resolve_run_requests(
         run_request = raw_run_request.with_replaced_attrs(
             tags=merge_dicts(
                 raw_run_request.tags,
-                DagsterRun.tags_for_tick_id(context.tick_id),
+                DagsterRun.tags_for_tick_id(context.tick_id, has_evaluations),
             )
         )
 
@@ -1085,7 +1086,11 @@ def _submit_run_requests(
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags] = None,
 ):
     resolved_run_ids_with_requests = _resolve_run_requests(
-        workspace_process_context, context, external_sensor, raw_run_ids_with_requests
+        workspace_process_context,
+        context,
+        external_sensor,
+        raw_run_ids_with_requests,
+        has_evaluations=len(automation_condition_evaluations) > 0,
     )
     existing_runs_by_key = _fetch_existing_runs(
         instance, external_sensor, [request for _, request in resolved_run_ids_with_requests]


### PR DESCRIPTION
## Summary & Motivation

As title -- this builds on the previous PRs which allow regular sensors to emit AutomationConditions and take advantage of checkpointing logic. Now, we flip a switch to have these user code sensors evaluated in the Sensor Daemon insteaad of the Asset Daemon.

We can consider moving the non-user code verison of these sensors to the Sensor Daemon at a later point.

## How I Tested These Changes
