### PR TITLE
[1/k] Store special cached data from AssetsDefinitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
@@ -18,6 +18,14 @@ from dagster._core.definitions.resource_requirement import ResourceAddable
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils import hash_collection
 
+# Cached data can be stored directly on AssetsDefinitions passed to a repository/Definitions
+# object. Any asset which has CACHED_ASSET_ID_KEY specified will have its metadata stored
+# in the cache under the key CACHED_ASSET_PREFIX + id. This allows for the metadata
+# to be retrieved in subsequent loads.
+CACHED_ASSET_ID_KEY = "dagster/cached_asset_id"
+CACHED_ASSET_METADATA_KEY = "dagster/cached_asset_metadata"
+CACHED_ASSET_PREFIX = "cached_asset/"
+
 
 @whitelist_for_serdes
 class AssetsDefinitionCacheableData(

--- a/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/cacheable_assets.py
@@ -20,10 +20,10 @@ from dagster._utils import hash_collection
 
 # Cached data can be stored directly on AssetsDefinitions passed to a repository/Definitions
 # object. Any asset which has CACHED_ASSET_ID_KEY specified will have its metadata stored
-# in the cache under the key CACHED_ASSET_PREFIX + id. This allows for the metadata
-# to be retrieved in subsequent loads.
-CACHED_ASSET_ID_KEY = "dagster/cached_asset_id"
-CACHED_ASSET_METADATA_KEY = "dagster/cached_asset_metadata"
+# in RepositoryLoadData's cached data under the key CACHED_ASSET_PREFIX + id.
+# This allows for the metadata to be retrieved in subsequent loads.
+CACHED_ASSET_ID_KEY = "dagster/repo_load_data_cached_asset_id"
+CACHED_ASSET_METADATA_KEY = "dagster/repo_load_data_cached_asset_metadata"
 CACHED_ASSET_PREFIX = "cached_asset/"
 
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -104,7 +104,10 @@ class _Repository:
         ],
     ) -> Union[RepositoryDefinition, PendingRepositoryDefinition]:
         from dagster._core.definitions import AssetsDefinition, SourceAsset
-        from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
+        from dagster._core.definitions.cacheable_assets import (
+            CACHED_ASSET_ID_KEY,
+            CacheableAssetsDefinition,
+        )
 
         check.callable_param(fn, "fn")
 
@@ -136,6 +139,12 @@ class _Repository:
                 ):
                     bad_defns.append((i, type(definition)))
                 else:
+                    if isinstance(definition, AssetsDefinition):
+                        if any(
+                            CACHED_ASSET_ID_KEY in meta
+                            for meta in definition.metadata_by_key.values()
+                        ):
+                            defer_repository_data = True
                     repository_defns.append(definition)
 
             if bad_defns:


### PR DESCRIPTION
## Summary

Beginning of a stack of PRs to enable the behavior described in https://github.com/dagster-io/internal/discussions/10666.

This allows `AssetsDefinitions` to specify a set of data which should be cached and made available to subsequent code location loads.

This PR adds the behavior that any `AssetsDefinition` with the metadata key `dagster/cached_asset_id` will have the data encoded in `dagster/cached_asset_metadata` stored in `AssetsDefinitionCacheableData`, embedded in the `RepositoryLoadData` that is sent with the execution plan snapshot. Right now this is a bit of a minimal, hacky piggyback on the existing cacheable assets implementation to avoid core framework changes, but future PRs could reverse this relationship and remove the `PendingRepositoryDefinition` entirely.

Subsequent PRs will make this data available contextually (e.g. in global state) in the run/step setting so that it does not need to be re-fetched from an external service.


## Test Plan

Tests which ensure that cached data is properly stored in the `RepositoryLoadData`.

