### PR TITLE
[docs] Fix broken link for project file reference

### DIFF
--- a/docs/content/guides/dagster/recommended-project-structure.mdx
+++ b/docs/content/guides/dagster/recommended-project-structure.mdx
@@ -220,7 +220,7 @@ project_fully_featured
 <ArticleList>
   <ArticleListItem
     title="Dagster project files"
-    href="/getting-started/project-file-reference"
+    href="/guides/understanding-dagster-project-files"
   ></ArticleListItem>
   <ArticleListItem
     title="Dagster instance (dagster.yaml)"

--- a/docs/dagster-university/pages/dagster-essentials/lesson-2/project-files.md
+++ b/docs/dagster-university/pages/dagster-essentials/lesson-2/project-files.md
@@ -118,4 +118,4 @@ The columns in the following table are as follows:
 
 {% /table %}
 
-For more info about the other files in your Dagster project, check out the [Project file reference in the Dagster Docs](https://docs.dagster.io/getting-started/project-file-reference).
+For more info about the other files in your Dagster project, check out the [Project file reference in the Dagster Docs](https://docs.dagster.io/guides/understanding-dagster-project-files).


### PR DESCRIPTION
## Summary & Motivation

This PR updates the url for the project file reference in the recommended structure guide and Dagster University.

URL redirection is set for this reference and works correctly when navigating from the search bar, but fails when navigating from other pages in the docs. 

## How I Tested These Changes

Link in other docs: Docs preview
Dagster University: tested locally