### PR TITLE
Mark airlift as unsupported in 3.8 and 3.12

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -355,6 +355,10 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     ),
     PackageSpec(
         "examples/experimental/dagster-airlift",
+        unsupported_python_versions=[
+            AvailablePythonVersion.V3_8,
+            AvailablePythonVersion.V3_12,
+        ],
     ),
 ]
 


### PR DESCRIPTION
The build is breaking on these two versions. I'll add a task for us to get this working before this is taken out of experimentation.
