### PR TITLE
chore: upgrade to `ruff=0.5.5`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_stages: [pre-commit] # don't run on push by default
 repos:
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.5.1
+  rev: v0.5.5
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ extend-exclude = [
 line-length = 100
 
 # Fail if Ruff is not running this version.
-required-version = "0.5.1"
+required-version = "0.5.5"
 
 [tool.ruff.lint]
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_op.py
@@ -1026,7 +1026,7 @@ def test_args_kwargs_op():
             pass
 
     @op(ins={"the_in": In()})
-    def the_op(**kwargs):  # noqa: F811
+    def the_op(**kwargs):
         return kwargs["the_in"]
 
     @op

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -164,7 +164,7 @@ setup(
             "types-toml",  # version will be resolved against toml
         ],
         "ruff": [
-            "ruff==0.5.1",
+            "ruff==0.5.5",
         ],
     },
     entry_points={


### PR DESCRIPTION
## Summary & Motivation
I want to take advantage of Ruff's new native language server: https://x.com/charliermarsh/status/1815475688688005615. In 0.5.3, it was recently marked stable.

Even though it's available in our current 0.5.1 version, there are some hiccups (e.g. random process failures that kill the native server). Hoping upgrading to a stable version will alleviate these issues.

## How I Tested These Changes
bk