### PR TITLE
[docs] Update recommended structure to remove Dagster code from `__init__.py`

### DIFF
--- a/docs/content/concepts/code-locations.mdx
+++ b/docs/content/concepts/code-locations.mdx
@@ -53,7 +53,7 @@ Code locations are loaded in a different process and communicate with Dagster sy
 To define a code location, create a top-level variable that contains a <PyObject object="Definitions"/> object in a Python module. For example:
 
 ```python
-# my_file.py
+# definitions.py
 
 defs = Definitions(
     assets=[dbt_customers_asset, dbt_orders_asset],
@@ -63,7 +63,7 @@ defs = Definitions(
 )
 ```
 
-Definitions can be included in a Python file like `my_file.py` or a Python module. If using the latter, the <PyObject object="Definitions"/> object should be defined in the module's top-level `__init__.py` file.
+It is recommenced to include Definitions in a Python file named `definitions.py`.
 
 ---
 
@@ -110,7 +110,7 @@ To load a code location from a Python module, use the `module_name` property in 
 locations:
   - location_name: my-code-location
     code_source:
-      module_name: my_module_name
+      module_name: my_module_name.definitions
 ```
 
 </TabItem>

--- a/docs/content/concepts/code-locations.mdx
+++ b/docs/content/concepts/code-locations.mdx
@@ -63,7 +63,7 @@ defs = Definitions(
 )
 ```
 
-It is recommenced to include Definitions in a Python file named `definitions.py`.
+It is recommenced to include definitions in a Python file named `definitions.py`.
 
 ---
 

--- a/docs/content/concepts/code-locations/workspace-files.mdx
+++ b/docs/content/concepts/code-locations/workspace-files.mdx
@@ -81,7 +81,7 @@ To load a code location from a local or installed Python module, use the `python
 # workspace.yaml
 
 load_from:
-  - python_module: hello_world_module
+  - python_module: hello_world_module.definitions
 ```
 
 </TabItem>
@@ -153,7 +153,7 @@ dagster api grpc --python-file /path/to/file.py --host 0.0.0.0 --socket /path/to
 Using a Python module:
 
 ```shell
-dagster api grpc --module-name my_module_name --host 0.0.0.0 --port 4266
+dagster api grpc --module-name my_module_name.definitions --host 0.0.0.0 --port 4266
 ```
 
 ---

--- a/docs/content/concepts/configuration/configured.mdx
+++ b/docs/content/concepts/configuration/configured.mdx
@@ -155,7 +155,7 @@ def another_configured_example(config):
 A common pattern in the development cycle is to use different configuration for each environment. For example, you might connect to a local database during local development and to a production database in your cloud environment. You can use the `configured` API to select between different configurations at runtime:
 
 ```python file=/guides/dagster/using_environment_variables_and_secrets/repository_v2.py startafter=start_old endbefore=end_old
-# __init__.py
+# definitions.py
 
 resources = {
     "local": {

--- a/docs/content/guides/dagster/branch_deployments.mdx
+++ b/docs/content/guides/dagster/branch_deployments.mdx
@@ -130,7 +130,7 @@ Dagster automatically sets certain [environment variables](/dagster-plus/managin
 Because we want to configure our assets to write to Snowflake using a different set of credentials and database in each environment, we’ll configure a separate I/O manager for each environment:
 
 ```python file=/guides/dagster/development_to_production/branch_deployments/repository_v1.py startafter=start_repository endbefore=end_repository
-# __init__.py
+# definitions.py
 from dagster import Definitions
 
 from ..assets import comments, items, stories

--- a/docs/content/guides/dagster/recommended-project-structure.mdx
+++ b/docs/content/guides/dagster/recommended-project-structure.mdx
@@ -132,7 +132,7 @@ In this example, we grouped resources (e.g., database connections, Spark session
 
 In complex projects, we find it helpful to make resources reusable and configured with pre-defined values via <PyObject object="configured" />. This approach allows your teammates to use a pre-defined resource set or make changes to shared resources, thus enabling more efficient project development.
 
-This pattern also helps you easily execute jobs in different environments without code changes. In this example, we dynamically defined a code location based on the deployment in [`definitions.py`](https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/project_fully_featured/defininitions.py) and can keep all code the same across testing, local development, staging, and production. Read more about our recommendations in the [Transitioning data pipelines from Development to Production](/guides/dagster/transitioning-data-pipelines-from-development-to-production) guide.
+This pattern also helps you easily execute jobs in different environments without code changes. In this example, we dynamically defined a code location based on the deployment in [`definitions.py`](https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/project_fully_featured/__init__.py) and can keep all code the same across testing, local development, staging, and production. Read more about our recommendations in the [Transitioning data pipelines from Development to Production](/guides/dagster/transitioning-data-pipelines-from-development-to-production) guide.
 
 ---
 

--- a/docs/content/guides/dagster/recommended-project-structure.mdx
+++ b/docs/content/guides/dagster/recommended-project-structure.mdx
@@ -132,7 +132,7 @@ In this example, we grouped resources (e.g., database connections, Spark session
 
 In complex projects, we find it helpful to make resources reusable and configured with pre-defined values via <PyObject object="configured" />. This approach allows your teammates to use a pre-defined resource set or make changes to shared resources, thus enabling more efficient project development.
 
-This pattern also helps you easily execute jobs in different environments without code changes. In this example, we dynamically defined a code location based on the deployment in [`definitions.py`](https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/project_fully_featured/__init__.py) and can keep all code the same across testing, local development, staging, and production. Read more about our recommendations in the [Transitioning data pipelines from Development to Production](/guides/dagster/transitioning-data-pipelines-from-development-to-production) guide.
+This pattern also helps you easily execute jobs in different environments without code changes. In this example, we dynamically defined a code location based on the deployment in [`definitions.py`](https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/project_fully_featured/\__init\_\_.py) and can keep all code the same across testing, local development, staging, and production. Read more about our recommendations in the [Transitioning data pipelines from Development to Production](/guides/dagster/transitioning-data-pipelines-from-development-to-production) guide.
 
 ---
 

--- a/docs/content/guides/dagster/recommended-project-structure.mdx
+++ b/docs/content/guides/dagster/recommended-project-structure.mdx
@@ -54,6 +54,7 @@ project_fully_featured
 │   │       ├── recommender_model.py
 │   │       ├── user_story_matrix.py
 │   │       └── user_top_recommended_stories.py
+│   ├── definitions.py
 │   ├── jobs.py
 │   ├── partitions.py
 │   ├── resources
@@ -131,7 +132,7 @@ In this example, we grouped resources (e.g., database connections, Spark session
 
 In complex projects, we find it helpful to make resources reusable and configured with pre-defined values via <PyObject object="configured" />. This approach allows your teammates to use a pre-defined resource set or make changes to shared resources, thus enabling more efficient project development.
 
-This pattern also helps you easily execute jobs in different environments without code changes. In this example, we dynamically defined a code location based on the deployment in [`__init__.py`](https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/project_fully_featured/\__init\_\_.py) and can keep all code the same across testing, local development, staging, and production. Read more about our recommendations in the [Transitioning data pipelines from Development to Production](/guides/dagster/transitioning-data-pipelines-from-development-to-production) guide.
+This pattern also helps you easily execute jobs in different environments without code changes. In this example, we dynamically defined a code location based on the deployment in [`definitions.py`](https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/project_fully_featured/defininitions.py) and can keep all code the same across testing, local development, staging, and production. Read more about our recommendations in the [Transitioning data pipelines from Development to Production](/guides/dagster/transitioning-data-pipelines-from-development-to-production) guide.
 
 ---
 

--- a/docs/content/guides/dagster/software-defined-assets.mdx
+++ b/docs/content/guides/dagster/software-defined-assets.mdx
@@ -71,7 +71,7 @@ To load definitions such as assets and resources, we use <PyObject object="Defin
 - We supply resources mapped to the assets using the `resources` argument to the <PyObject object="Definitions" /> object.
 
 ```python file=../../assets_pandas_pyspark/assets_pandas_pyspark/definitions.py startafter=gather_assets_start endbefore=gather_assets_end
-# __init__.py
+# definitions.py
     from dagster import Definitions, load_assets_from_modules
 
     from .assets import table_assets
@@ -146,7 +146,7 @@ def daily_temperature_high_diffs(daily_temperature_highs: SparkDF) -> SparkDF:
 Here's an extended version of `weather_assets` that contains the new asset:
 
 ```python file=../../assets_pandas_pyspark/assets_pandas_pyspark/definitions.py  startafter=gather_spark_assets_start endbefore=gather_spark_assets_end
-# __init__.py
+# definitions.py
 
     from dagster import Definitions, load_assets_from_modules
 

--- a/docs/content/guides/dagster/transitioning-data-pipelines-from-development-to-production.mdx
+++ b/docs/content/guides/dagster/transitioning-data-pipelines-from-development-to-production.mdx
@@ -102,7 +102,7 @@ def stories(items: pd.DataFrame) -> pd.DataFrame:
 Now we can add these assets to our <PyObject object="Definitions" /> object and materialize them via the UI as part of our local development workflow. We can pass in credentials to our `SnowflakePandasIOManager`.
 
 ```python file=/guides/dagster/development_to_production/repository/repository_v1.py startafter=start endbefore=end
-# __init__.py
+# definitions.py
 from dagster_snowflake_pandas import SnowflakePandasIOManager
 
 from dagster import Definitions
@@ -163,7 +163,7 @@ We want to store the assets in a production Snowflake database, so we need to up
 Instead, we can determine the configuration for resources based on the environment:
 
 ```python file=/guides/dagster/development_to_production/repository/repository_v2.py startafter=start endbefore=end
-# __init__.py
+# definitions.py
 
 # Note that storing passwords in configuration is bad practice. It will be resolved soon.
 resources = {
@@ -207,7 +207,7 @@ We still have some problems with this setup:
 We can easily solve these problems using <PyObject object="EnvVar"/>, which lets us source configuration for resources from environment variables. This allows us to store Snowflake configuration values as environment variables and point the I/O manager to those environment variables:
 
 ```python file=/guides/dagster/development_to_production/repository/repository_v3.py startafter=start endbefore=end
-# __init__.py
+# definitions.py
 
 
 resources = {

--- a/docs/content/guides/dagster/using-environment-variables-and-secrets.mdx
+++ b/docs/content/guides/dagster/using-environment-variables-and-secrets.mdx
@@ -196,7 +196,7 @@ Let's review what's happening here:
 As storing secrets in configuration is bad practice, we'll opt for using an environment variable. In this code, we're configuring the resource supplying it to our assets:
 
 ```python file=/guides/dagster/using_environment_variables_and_secrets/repository.py startafter=start endbefore=end
-# __init__.py
+# definitions.py
 
 from my_dagster_project import assets
 from my_dagster_project.resources import GithubClientResource
@@ -232,7 +232,7 @@ In this example, we'll demonstrate how to use different I/O manager configuratio
 This example is adapted from the [Transitioning data pipelines from development to production guide](/guides/dagster/transitioning-data-pipelines-from-development-to-production):
 
 ```python file=/guides/dagster/using_environment_variables_and_secrets/repository_v2.py startafter=start_new endbefore=end_new
-# __init__.py
+# definitions.py
 
 resources = {
     "local": {

--- a/docs/content/guides/understanding-dagster-project-files.mdx
+++ b/docs/content/guides/understanding-dagster-project-files.mdx
@@ -23,7 +23,8 @@ The following demonstrates a Dagster project using the default project skeleton,
 ├── README.md
 ├── my_dagster_project
 │   ├── __init__.py
-│   └──  assets.py
+│   ├──  assets.py
+│   └──  definitions.py
 ├── my_dagster_project_tests
 ├── pyproject.toml
 ├── setup.cfg
@@ -83,10 +84,7 @@ Let's take a look at what each of these files and directories does:
     <tr>
       <td>__init__.py</td>
       <td>
-        The <code>__init__.py</code> file includes a{" "}
-        <PyObject object="Definitions" /> object that contains all the definitions defined within your project. A definition can be an asset, a job, a schedule, a sensor, or a resource. This allows Dagster to load the definitions in a module.
-        <br /><br />
-        Refer to the <a href="/concepts/code-locations#load-definitions-in-an-installed-package">Code locations documentation</a> to learn other ways to deploy and load your Dagster code.
+        A file required in a Python package. Refer to the <a href="https://docs.python.org/3/reference/import.html#regular-packages">Python documentation</a> for more information.
       </td>
     </tr>
     <tr>
@@ -105,6 +103,15 @@ Let's take a look at what each of these files and directories does:
         <br />
         Similarly, you can also use <PyObject object="load_assets_from_modules" /> to
         load assets from single Python files. Refer to the <a href="/guides/dagster/example_project">Fully featured project guide</a> for more info and best practices.
+      </td>
+    </tr>
+    <tr>
+      <td>definitions.py</td>
+      <td>
+        The <code>definitions.py</code> file includes a{" "}
+        <PyObject object="Definitions" /> object that contains all the definitions defined within your project. A definition can be an asset, a job, a schedule, a sensor, or a resource. This allows Dagster to load the definitions in a module.
+        <br /><br />
+        Refer to the <a href="/concepts/code-locations#load-definitions-in-an-installed-package">Code locations documentation</a> to learn other ways to deploy and load your Dagster code.
       </td>
     </tr>
 
@@ -291,7 +298,8 @@ For local development, a project with a single code location might look like thi
 ├── README.md
 ├── my_dagster_project
 │   ├── __init__.py
-│   └──  assets.py
+│   ├──  assets.py
+│   └──  definitions.py
 ├── my_dagster_project_tests
 ├── dagster.yaml      ## optional, used for instance settings
 ├── pyproject.toml    ## optional, used to define the project as a module
@@ -312,7 +320,8 @@ For local development, a project with multiple code locations might look like th
 ├── README.md
 ├── my_dagster_project
 │   ├── __init__.py
-│   └──  assets.py
+│   ├──  assets.py
+│   └──  definitions.py
 ├── my_dagster_project_tests
 ├── dagster.yaml      ## optional, used for instance settings
 ├── pyproject.toml
@@ -338,7 +347,8 @@ A Dagster project deployed to your infrastructure might look like this:
 ├── README.md
 ├── my_dagster_project
 │   ├── __init__.py
-│   └──  assets.py
+│   ├──  assets.py
+│   └──  definitions.py
 ├── my_dagster_project_tests
 ├── dagster.yaml      ## optional, used for instance settings
 ├── pyproject.toml
@@ -364,7 +374,8 @@ For a Dagster+ Serverless deployment, a project might look like this:
 ├── README.md
 ├── my_dagster_project
 │   ├── __init__.py
-│   └──  assets.py
+│   ├──  assets.py
+│   └──  definitions.py
 ├── my_dagster_project_tests
 ├── dagster_cloud.yaml         ## defines code locations
 ├── deployment_settings.yaml   ## optional, defines settings for full deployments
@@ -386,7 +397,8 @@ For a Dagster+ Hybrid deployment, a project might look like this:
 ├── README.md
 ├── my_dagster_project
 │   ├── __init__.py
-│   └──  assets.py
+│   ├──  assets.py
+│   └──  definitions.py
 ├── my_dagster_project_tests
 ├── dagster.yaml                ## optional, hybrid agent custom configuration
 ├── dagster_cloud.yaml          ## defines code locations

--- a/docs/content/tutorial/connecting-to-external-services.mdx
+++ b/docs/content/tutorial/connecting-to-external-services.mdx
@@ -171,7 +171,7 @@ from dagster import (
     EnvVar,
 )
 
-# ... the existing portion of your `__init__.py` goes here.
+# ... the existing portion of your `definitions.py` goes here.
 
 # Configure the resource with an environment variable here
 datagen = DataGeneratorResource(

--- a/docs/next/components/mdx/includes/dagster/DagsterDevTabs.mdx
+++ b/docs/next/components/mdx/includes/dagster/DagsterDevTabs.mdx
@@ -20,20 +20,20 @@ dagster dev -f my_file.py -f my_second_file.py
 </TabItem>
 <TabItem name="From a module">
 
-Dagster can also load Python modules as [code locations](/concepts/code-locations). When this approach is used, Dagster loads the definitions defined at the top-level of the module, in a variable containing the <PyObject object="Definitions" /> object of its root `__init__.py` file. As this style of development eliminates an entire class of Python import errors, we strongly recommend it for Dagster projects deployed to production.
+Dagster can also load Python modules as [code locations](/concepts/code-locations). When this approach is used, Dagster loads the definitions defined in the module passed to the command line. It is recommended to define a variable containing the <PyObject object="Definitions" /> object in a submodule named `definitions` inside the Python module. In practice, the submodule can be created by adding a file named `definitions.py` at the root level of the Python module. As this style of development eliminates an entire class of Python import errors, we strongly recommend it for Dagster projects deployed to production.
 
-In the following example, we used the `-m` argument to supply the name of the module:
+In the following example, we used the `-m` argument to supply the name of the module and where to find the definitions:
 
 ```shell
-dagster dev -m your_module_name
+dagster dev -m your_module_name.definitions
 ```
 
-This command loads the definitions in the variable containing the <PyObject object="Definitions" /> object in the named module - defined as the root `__init__.py` file - in the current Python environment.
+This command loads the definitions in the variable containing the <PyObject object="Definitions" /> object in the `definitions` submodule in the current Python environment.
 
 You can also include multiple modules at a time, where each module will be loaded as a code location:
 
 ```shell
-dagster dev -m your_module_name -m your_second_module
+dagster dev -m your_module_name.definitions -m your_second_module.definitions
 ```
 
 ---
@@ -45,7 +45,7 @@ To load definitions without supplying command line arguments, you can use the `p
 
 ```toml
 [tool.dagster]
-module_name = "your_module_name"  ## name of project's Python module
+module_name = "your_module_name.definitions"  ## name of project's Python module and where to find the definitions
 code_location_name = "your_code_location_name"  ## optional, name of code location to display in the Dagster UI
 ```
 
@@ -58,7 +58,7 @@ dagster dev
 Instead of this:
 
 ```shell
-dagster dev -m your_module_name
+dagster dev -m your_module_name.definitions
 ```
 
 ---

--- a/docs/next/components/mdx/includes/dagster/DagsterDevTabs.mdx
+++ b/docs/next/components/mdx/includes/dagster/DagsterDevTabs.mdx
@@ -20,7 +20,11 @@ dagster dev -f my_file.py -f my_second_file.py
 </TabItem>
 <TabItem name="From a module">
 
-Dagster can also load Python modules as [code locations](/concepts/code-locations). When this approach is used, Dagster loads the definitions defined in the module passed to the command line. It is recommended to define a variable containing the <PyObject object="Definitions" /> object in a submodule named `definitions` inside the Python module. In practice, the submodule can be created by adding a file named `definitions.py` at the root level of the Python module. As this style of development eliminates an entire class of Python import errors, we strongly recommend it for Dagster projects deployed to production.
+Dagster can also load Python modules as [code locations](/concepts/code-locations). When this approach is used, Dagster loads the definitions defined in the module passed to the command line.
+
+We recommend defining a variable containing the <PyObject object="Definitions" /> object in a submodule named `definitions` inside the Python module. In practice, the submodule can be created by adding a file named `definitions.py` at the root level of the Python module.
+
+As this style of development eliminates an entire class of Python import errors, we strongly recommend it for Dagster projects deployed to production.
 
 In the following example, we used the `-m` argument to supply the name of the module and where to find the definitions:
 

--- a/examples/assets_pandas_pyspark/assets_pandas_pyspark/definitions.py
+++ b/examples/assets_pandas_pyspark/assets_pandas_pyspark/definitions.py
@@ -1,7 +1,7 @@
 def get_weather_defs():
     # gather_assets_start
 
-    # __init__.py
+    # definitions.py
     from dagster import Definitions, load_assets_from_modules
 
     from .assets import table_assets
@@ -23,7 +23,7 @@ def get_weather_defs():
 def get_spark_weather_defs():
     # gather_spark_assets_start
 
-    # __init__.py
+    # definitions.py
 
     from dagster import Definitions, load_assets_from_modules
 

--- a/examples/docs_snippets/docs_snippets/concepts/repositories_workspaces/workspace_python_module.yaml
+++ b/examples/docs_snippets/docs_snippets/concepts/repositories_workspaces/workspace_python_module.yaml
@@ -1,4 +1,4 @@
 # workspace.yaml
 
 load_from:
-  - python_module: hello_world_module
+  - python_module: hello_world_module.definitions

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/branch_deployments/repository_v1.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/branch_deployments/repository_v1.py
@@ -3,7 +3,7 @@ import os
 from dagster_snowflake_pandas import SnowflakePandasIOManager
 
 # start_repository
-# __init__.py
+# definitions.py
 from dagster import Definitions
 
 from ..assets import comments, items, stories

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/repository/repository_v1.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/repository/repository_v1.py
@@ -1,5 +1,5 @@
 # start
-# __init__.py
+# definitions.py
 from dagster_snowflake_pandas import SnowflakePandasIOManager
 
 from dagster import Definitions

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/repository/repository_v2.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/repository/repository_v2.py
@@ -6,7 +6,7 @@ from dagster import Definitions
 from development_to_production.assets.hacker_news_assets import comments, items, stories
 
 # start
-# __init__.py
+# definitions.py
 
 # Note that storing passwords in configuration is bad practice. It will be resolved soon.
 resources = {

--- a/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/repository/repository_v3.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/development_to_production/repository/repository_v3.py
@@ -6,7 +6,7 @@ from dagster import Definitions, EnvVar
 from development_to_production.assets.hacker_news_assets import comments, items, stories
 
 # start
-# __init__.py
+# definitions.py
 
 
 resources = {

--- a/examples/docs_snippets/docs_snippets/guides/dagster/using_environment_variables_and_secrets/repository.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/using_environment_variables_and_secrets/repository.py
@@ -1,7 +1,7 @@
 # pyright: reportMissingImports=none
 
 # start
-# __init__.py
+# definitions.py
 
 from my_dagster_project import assets
 from my_dagster_project.resources import GithubClientResource

--- a/examples/docs_snippets/docs_snippets/guides/dagster/using_environment_variables_and_secrets/repository_v2.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/using_environment_variables_and_secrets/repository_v2.py
@@ -9,7 +9,7 @@ from development_to_production.assets.hacker_news_assets import comments, items,
 from dagster import Definitions, EnvVar
 
 # start_new
-# __init__.py
+# definitions.py
 
 resources = {
     "local": {
@@ -42,7 +42,7 @@ defs = Definitions(
 
 
 # start_old
-# __init__.py
+# definitions.py
 
 resources = {
     "local": {

--- a/examples/docs_snippets/docs_snippets/tutorial/connecting/connecting_with_envvar.py
+++ b/examples/docs_snippets/docs_snippets/tutorial/connecting/connecting_with_envvar.py
@@ -9,7 +9,7 @@ from dagster import (
     EnvVar,
 )
 
-# ... the existing portion of your `__init__.py` goes here.
+# ... the existing portion of your `definitions.py` goes here.
 
 # Configure the resource with an environment variable here
 datagen = DataGeneratorResource(


### PR DESCRIPTION
## Summary & Motivation

This PR updates the recommended folder structure to include the Definitions object in `definitions.py` instead of `__init__.py`. It also updates related guides and references.

Tutorials in the docs are not yet updated. Will open more PRs:
- Update the project in examples/
- Update the tutorials in examples/
- Update tutorials in docs
- Update Dag Uni content
- Update Dag Uni starter projects once we have a PR for Dag Uni content

## How I Tested These Changes

make mdx-full-format
