### PR TITLE
[DA] Update AssetDaemon and co. to handle observable assets with AutomationConditions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -16,6 +16,9 @@ from dagster._core.definitions.base_asset_graph import (
     BaseAssetGraph,
     BaseAssetNode,
 )
+from dagster._core.definitions.declarative_automation.automation_condition import (
+    AutomationCondition,
+)
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
@@ -99,6 +102,10 @@ class AssetNode(BaseAssetNode):
     @property
     def auto_materialize_policy(self) -> Optional[AutoMaterializePolicy]:
         return self._spec.auto_materialize_policy
+
+    @property
+    def automation_condition(self) -> Optional[AutomationCondition]:
+        return self._spec.automation_condition
 
     @property
     def auto_observe_interval_minutes(self) -> Optional[float]:

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -132,6 +132,10 @@ class BaseAssetNode(ABC):
 
     @property
     @abstractmethod
+    def automation_condition(self) -> Optional["AutomationCondition"]: ...
+
+    @property
+    @abstractmethod
     def auto_observe_interval_minutes(self) -> Optional[float]: ...
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
@@ -110,8 +110,7 @@ class AutomationContext(NamedTuple):
         legacy_context: "LegacyRuleEvaluationContext",
     ) -> "AutomationContext":
         asset_graph = asset_graph_view.asset_graph
-        auto_materialize_policy = check.not_none(asset_graph.get(asset_key).auto_materialize_policy)
-        automation_condition = auto_materialize_policy.to_automation_condition()
+        automation_condition = check.not_none(asset_graph.get(asset_key).automation_condition)
 
         return AutomationContext(
             candidate_slice=asset_graph_view.get_asset_slice(asset_key=asset_key),

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -21,6 +21,9 @@ from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_job import ASSET_BASE_JOB_PREFIX
 from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
+from dagster._core.definitions.declarative_automation.automation_condition import (
+    AutomationCondition,
+)
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
 from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster._core.remote_representation.external import ExternalRepository
@@ -126,6 +129,15 @@ class RemoteAssetNode(BaseAssetNode):
     @property
     def auto_materialize_policy(self) -> Optional[AutoMaterializePolicy]:
         return self._materializable_node.auto_materialize_policy if self.is_materializable else None
+
+    @property
+    def automation_condition(self) -> Optional[AutomationCondition]:
+        if self.is_materializable:
+            return self._materializable_node.automation_condition
+        elif self.is_observable:
+            return self._observable_node.automation_condition
+        else:
+            return None
 
     @property
     def auto_observe_interval_minutes(self) -> Optional[float]:

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -251,7 +251,10 @@ class ExternalRepository:
                     default_sensor_asset_keys.add(asset_key)
 
             for asset_key in asset_graph.observable_asset_keys:
-                if asset_graph.get(asset_key).auto_observe_interval_minutes is None:
+                if (
+                    asset_graph.get(asset_key).auto_observe_interval_minutes is None
+                    and asset_graph.get(asset_key).automation_condition is None
+                ):
                     continue
 
                 has_any_auto_observe_source_assets = True

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -54,6 +54,9 @@ from dagster._core.definitions.auto_materialize_sensor_definition import (
     AutomationConditionSensorDefinition,
 )
 from dagster._core.definitions.backfill_policy import BackfillPolicy
+from dagster._core.definitions.declarative_automation.automation_condition import (
+    AutomationCondition,
+)
 from dagster._core.definitions.definition_config_schema import ConfiguredDefinitionConfigSchema
 from dagster._core.definitions.dependency import (
     GraphNode,
@@ -1522,6 +1525,13 @@ class ExternalAssetNode(
     @property
     def is_executable(self) -> bool:
         return self.execution_type != AssetExecutionType.UNEXECUTABLE
+
+    @property
+    def automation_condition(self) -> Optional[AutomationCondition]:
+        if self.auto_materialize_policy is not None:
+            return self.auto_materialize_policy.to_automation_condition()
+        else:
+            return None
 
 
 ResourceJobUsageMap = Dict[str, List[ResourceJobUsageEntry]]

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -737,15 +737,12 @@ class AssetDaemon(DagsterDaemon):
                     check.not_none(repository).asset_graph
                 )
             else:
-                eligible_keys = {
-                    *asset_graph.materializable_asset_keys,
-                    *asset_graph.external_asset_keys,
-                }
+                eligible_keys = asset_graph.all_asset_keys
 
             auto_materialize_asset_keys = {
                 target_key
                 for target_key in eligible_keys
-                if asset_graph.get(target_key).auto_materialize_policy is not None
+                if asset_graph.get(target_key).automation_condition is not None
             }
             num_target_assets = len(auto_materialize_asset_keys)
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_automation_condition_tester.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/test_automation_condition_tester.py
@@ -1,12 +1,19 @@
+import datetime
+
 from dagster import (
+    AssetsDefinition,
     AssetSelection,
+    AssetSpec,
     AutomationCondition,
     Definitions,
     HourlyPartitionsDefinition,
     StaticPartitionsDefinition,
     asset,
     evaluate_automation_conditions,
+    op,
 )
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.instance import DagsterInstance
 
 
@@ -31,6 +38,43 @@ def unpartitioned() -> None: ...
 
 
 defs = Definitions(assets=[hourly, static, unpartitioned])
+
+
+@op
+def noop(): ...
+
+
+observable_a = AssetsDefinition(
+    specs=[AssetSpec("a", automation_condition=AutomationCondition.cron_tick_passed("@daily"))],
+    execution_type=AssetExecutionType.OBSERVATION,
+    node_def=noop,
+    keys_by_output_name={"result": AssetKey("a")},
+)
+observable_b = AssetsDefinition(
+    specs=[
+        AssetSpec(
+            "b",
+            deps=["a"],
+            automation_condition=AutomationCondition.cron_tick_passed("@daily"),
+        )
+    ],
+    execution_type=AssetExecutionType.OBSERVATION,
+    node_def=noop,
+    keys_by_output_name={"result": AssetKey("b")},
+)
+materializable_c = AssetsDefinition(
+    specs=[
+        AssetSpec(
+            "c",
+            deps="b",
+            automation_condition=AutomationCondition.cron_tick_passed("@daily"),
+        )
+    ],
+    execution_type=AssetExecutionType.MATERIALIZATION,
+    node_def=noop,
+    keys_by_output_name={"result": AssetKey("c")},
+)
+defs_with_observables = Definitions(assets=[observable_a, observable_b, materializable_c])
 
 
 def test_basic_regular_defs() -> None:
@@ -62,3 +106,23 @@ def test_basic_assets_defs() -> None:
         defs=[unpartitioned], instance=instance, cursor=result.cursor
     )
     assert result.total_requested == 0
+
+
+def test_observable_asset_defs() -> None:
+    instance = DagsterInstance.ephemeral()
+
+    evaluation_time = datetime.datetime(2024, 5, 5, 10, 1)
+    result = evaluate_automation_conditions(
+        defs=defs_with_observables, instance=instance, evaluation_time=evaluation_time
+    )
+    # no cron tick passed
+    assert result.total_requested == 0
+
+    evaluation_time = evaluation_time + datetime.timedelta(days=1)
+    result = evaluate_automation_conditions(
+        defs=defs_with_observables,
+        instance=instance,
+        cursor=result.cursor,
+        evaluation_time=evaluation_time,
+    )
+    assert result.total_requested == 3


### PR DESCRIPTION
## Summary & Motivation

You can (with some effort) construct an observable asset that has an AutomationCondition. This was not previously possible, meaning there are some code paths which explicitly filter out observable assets. This PR removes those filters, and adds some tests ensuring that these assets get properly evaluated.

## How I Tested These Changes
