### PR TITLE
Compat mode for editable installs

### DIFF
--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -146,7 +146,12 @@ def main(
     # NOTE: These need to be installed as one long pip install command, otherwise pip will install
     # conflicting dependencies, which will break pip freeze snapshot creation during the integration
     # image build!
-    cmd = ["uv", "pip", "install"] + (["--system"] if system else []) + install_targets
+    cmd = (
+        ["uv", "pip", "install"]
+        + (["--system"] if system else [])
+        + install_targets
+        + ["--config-settings", "editable_mode=compat"]
+    )
 
     if quiet is not None:
         cmd.append(f'-{"q" * quiet}')


### PR DESCRIPTION
Pylance requires editable_mode=strict to be set in order for imports to be properly resolved. https://github.com/microsoft/pylance-release/issues/3473
