### PR TITLE
feat(dbt): remove support for `dbt-core==1.6.*`

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -482,7 +482,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         "python_modules/libraries/dagster-dbt",
         pytest_tox_factors=[
             f"{deps_factor}-{command_factor}"
-            for deps_factor in ["dbt16", "dbt17", "dbt18", "pydantic1"]
+            for deps_factor in ["dbt17", "dbt18", "pydantic1"]
             for command_factor in ["cloud", "core-main", "core-derived-metadata"]
         ],
         unsupported_python_versions=[

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -315,9 +315,9 @@ class DbtCliResource(ConfigurableResource):
     @compat_model_validator(mode="before")
     def validate_dbt_version(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Validate that the dbt version is supported."""
-        if version.parse(dbt_version) < version.parse("1.6.0"):
+        if version.parse(dbt_version) < version.parse("1.7.0"):
             raise ValueError(
-                "To use `dagster_dbt.DbtCliResource`, you must use `dbt-core>=1.6.0`. Currently,"
+                "To use `dagster_dbt.DbtCliResource`, you must use `dbt-core>=1.7.0`. Currently,"
                 f" you are using `dbt-core=={dbt_version}`. Please install a compatible dbt-core"
                 " version."
             )

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -42,7 +42,7 @@ setup(
     install_requires=[
         f"dagster{pin}",
         # Follow the version support constraints for dbt Core: https://docs.getdbt.com/docs/dbt-versions/core
-        f"dbt-core>=1.6,<{DBT_CORE_VERSION_UPPER_BOUND}",
+        f"dbt-core>=1.7,<{DBT_CORE_VERSION_UPPER_BOUND}",
         "Jinja2",
         "networkx",
         "orjson",

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -10,10 +10,6 @@ deps =
   -e ../../dagster-pipes
   -e ../dagster-duckdb
   -e ../dagster-duckdb-pandas
-  dbt16: dbt-core==1.6.*
-  dbt16: dbt-duckdb==1.6.*
-  dbt16: dbt-snowflake==1.6.*
-  dbt16: dbt-bigquery==1.6.*
   dbt17: dbt-core==1.7.*
   dbt17: dbt-duckdb==1.7.*
   dbt17: dbt-snowflake==1.7.*


### PR DESCRIPTION
## Summary & Motivation
`dbt-core==1.6.*` has been EOL since July 30, 2024: https://docs.getdbt.com/docs/dbt-versions/core.

Also, enforce that dbt-core>=1.7 on installation.

Same rodeo as #21518.

## How I Tested These Changes
bk