### PR TITLE
chore: register `dbt-core` version in `DagsterLibraryRegistry`

### DIFF
--- a/python_modules/dagster/dagster/_core/libraries.py
+++ b/python_modules/dagster/dagster/_core/libraries.py
@@ -8,8 +8,10 @@ class DagsterLibraryRegistry:
     _libraries: Dict[str, str] = {"dagster": __version__}
 
     @classmethod
-    def register(cls, name: str, version: str):
-        check_dagster_package_version(name, version)
+    def register(cls, name: str, version: str, *, is_dagster_package: bool = True):
+        if is_dagster_package:
+            check_dagster_package_version(name, version)
+
         cls._libraries[name] = version
 
     @classmethod

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/__init__.py
@@ -54,9 +54,11 @@ from typing import Any, Mapping, Sequence, Tuple
 from dagster._annotations import deprecated
 from dagster._core.libraries import DagsterLibraryRegistry
 from dagster._utils.warnings import deprecation_warning
+from dbt.version import __version__ as __dbt_version__
 from typing_extensions import Final
 
 DagsterLibraryRegistry.register("dagster-dbt", __version__)
+DagsterLibraryRegistry.register("dbt-core", __dbt_version__)
 
 
 _DEPRECATED: Final[Mapping[str, Tuple[str, str, str]]] = {


### PR DESCRIPTION
## Summary & Motivation
As the title. Since `dbt-core` isn't a Dagster library, we'll skip the version check and write it directly into the library mapping.

## How I Tested These Changes
N/A