### PR TITLE
[asset-effect-type] `effect_type` argument on `@asset` decorator

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -140,7 +140,10 @@ from dagster._core.definitions.asset_selection import AssetSelection as AssetSel
 from dagster._core.definitions.asset_sensor_definition import (
     AssetSensorDefinition as AssetSensorDefinition,
 )
-from dagster._core.definitions.asset_spec import AssetSpec as AssetSpec
+from dagster._core.definitions.asset_spec import (
+    AssetEffectType as AssetEffectType,
+    AssetSpec as AssetSpec,
+)
 from dagster._core.definitions.assets import AssetsDefinition as AssetsDefinition
 from dagster._core.definitions.auto_materialize_policy import (
     AutoMaterializePolicy as AutoMaterializePolicy,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -1,7 +1,7 @@
 from typing import AbstractSet, Any, Callable, Mapping, Optional, Sequence, Set, Union, overload
 
 import dagster._check as check
-from dagster._annotations import experimental
+from dagster._annotations import deprecated, experimental
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
 from dagster._core.definitions.asset_spec import AssetEffectType, AssetSpec
 from dagster._core.definitions.assets import AssetsDefinition
@@ -50,6 +50,10 @@ def observable_source_asset(
 
 
 @experimental
+@deprecated(
+    breaking_version="1.9",
+    additional_warn_text="Use @asset(effect_type=AssetEffectType.OBSERVE) instead.",
+)
 def observable_source_asset(
     observe_fn: Optional[SourceAssetObserveFunction] = None,
     *,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_observe.py
@@ -2,10 +2,12 @@ from typing import Optional
 
 import pytest
 from dagster import (
+    AssetEffectType,
     ConfigurableResource,
     DataVersionsByPartition,
     IOManager,
     StaticPartitionsDefinition,
+    asset,
 )
 from dagster._core.definitions.data_version import DataVersion, extract_data_version_from_entry
 from dagster._core.definitions.decorators.source_asset_decorator import observable_source_asset
@@ -43,7 +45,10 @@ def test_basic_observe():
 
 
 def test_observe_partitions():
-    @observable_source_asset(partitions_def=StaticPartitionsDefinition(["apple", "orange", "kiwi"]))
+    @asset(
+        partitions_def=StaticPartitionsDefinition(["apple", "orange", "kiwi"]),
+        effect_type=AssetEffectType.OBSERVE,
+    )
     def foo():
         return DataVersionsByPartition({"apple": "one", "orange": DataVersion("two")})
 
@@ -63,7 +68,7 @@ def test_observe_partitions():
 
 
 def test_observe_partitions_non_partitioned_asset():
-    @observable_source_asset
+    @asset(effect_type=AssetEffectType.OBSERVE)
     def foo():
         return DataVersionsByPartition({"apple": "one", "orange": DataVersion("two")})
 
@@ -81,7 +86,7 @@ def test_observe_data_version_partitioned_asset():
 
 
 def test_observe_tags():
-    @observable_source_asset
+    @asset(effect_type=AssetEffectType.OBSERVE)
     def foo(_context) -> DataVersion:
         return DataVersion("alpha")
 


### PR DESCRIPTION
## Summary & Motivation

This PR explores replacing `@observable_source_asset` with `@asset(effect_type=AssetEffectType.OBSERVE)`. The impetus is the deprecation of the term "source asset".

This is an alternative to [this other PR](https://github.com/dagster-io/dagster/pull/23277) that explores replacing it with `@observable_asset`. I've come around to prefering this approach, because it will allow us to avoid `@observable_` decorators corresponding to `@multi_asset`, `@graph_asset`, and `@graph_multi_asset`.

It sits atop these two PRs that make it less of a mouthful (`execution_type=AssetExecutionType.OBSERVATION` -> `effect_type=AssetEffectType.OBSERVE`):
* https://github.com/dagster-io/dagster/pull/23331
* https://github.com/dagster-io/dagster/pull/23330

Users can use the existing `AutomationCondition` argument on `@asset` to automate their observe computations, now that https://github.com/dagster-io/dagster/pull/23317 is merged.


## How I Tested These Changes
