### PR TITLE
deprecate `partitions_def` param on `define_asset_job`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -4,7 +4,7 @@ from itertools import groupby
 from typing import TYPE_CHECKING, AbstractSet, Any, Mapping, NamedTuple, Optional, Sequence, Union
 
 import dagster._check as check
-from dagster._annotations import deprecated
+from dagster._annotations import deprecated, deprecated_param
 from dagster._core.definitions import AssetKey
 from dagster._core.definitions.asset_job import build_asset_job, get_asset_graph_for_job
 from dagster._core.definitions.asset_selection import AssetSelection
@@ -229,6 +229,11 @@ class UnresolvedAssetJobDefinition(
         )
 
 
+@deprecated_param(
+    param="partitions_def",
+    breaking_version="2.0.0",
+    additional_warn_text="Partitioning is inferred from the selected assets, so setting this is redundant.",
+)
 def define_asset_job(
     name: str,
     selection: Optional["CoercibleToAssetSelection"] = None,
@@ -291,16 +296,15 @@ def define_asset_job(
             returned by a MetadataValue static method.
         description (Optional[str]):
             A description for the Job.
-        partitions_def (Optional[PartitionsDefinition]):
-            Defines the set of partitions for this job. All AssetDefinitions selected for this job
-            must have a matching PartitionsDefinition. If no PartitionsDefinition is provided, the
-            PartitionsDefinition will be inferred from the selected AssetDefinitions.
         executor_def (Optional[ExecutorDefinition]):
             How this Job will be executed. Defaults to :py:class:`multi_or_in_process_executor`,
             which can be switched between multi-process and in-process modes of execution. The
             default mode of execution is multi-process.
         op_retry_policy (Optional[RetryPolicy]): The default retry policy for all ops that compute assets in this job.
             Only used if retry policy is not defined on the asset definition.
+        partitions_def (Optional[PartitionsDefinition]): (Deprecated)
+            Defines the set of partitions for this job. Deprecated because partitioning is inferred
+            from the selected assets, so setting this is redundant.
 
 
     Returns:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -542,11 +542,9 @@ def test_job_config_with_asset_partitions():
         assert context.op_execution_context.op_config["a"] == 5
         assert context.partition_key == "2020-01-01"
 
-    the_job = define_asset_job(
-        "job",
-        partitions_def=daily_partitions_def,
-        config={"ops": {"asset1": {"config": {"a": 5}}}},
-    ).resolve(asset_graph=AssetGraph.from_assets([asset1]))
+    the_job = define_asset_job("job", config={"ops": {"asset1": {"config": {"a": 5}}}}).resolve(
+        asset_graph=AssetGraph.from_assets([asset1])
+    )
 
     assert the_job.execute_in_process(partition_key="2020-01-01").success
     assert (


### PR DESCRIPTION
## Summary & Motivation

Partitioning is inferred from the selected assets, so setting this is redundant.

## How I Tested These Changes
