### PR TITLE
[dagster-aws] Adding EcsRunLauncher config option for propagating tags from Dagster run to ECS task

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -599,7 +599,12 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
     def _get_run_task_kwargs_from_run(self, run: DagsterRun) -> Mapping[str, Any]:
         run_task_kwargs = run.tags.get("ecs/run_task_kwargs")
         if run_task_kwargs:
-            return json.loads(run_task_kwargs)
+            result = json.loads(run_task_kwargs)
+            check.invariant(
+                not isinstance(result, list),
+                f"Unexpected type for `ecs/run_task_kwargs` tag: {type(result)}",
+            )
+            return result
         return {}
 
     def terminate(self, run_id: str):

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -408,13 +408,12 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         tags_to_propagate = []
         if allow_list := (self.propagate_tags or {}).get("allow_list", []):
             # Add contextual Dagster run tags to ECS tags
-            if allow_list:
-                tags_to_propagate = [
-                    {"key": k, "value": v}
-                    for k, v in run.tags.items()
-                    if k in self.propagate_tags["allow_list"]
-                    and k not in TAGS_TO_EXCLUDE_FROM_PROPAGATION
-                ]
+            tags_to_propagate = [
+                {"key": k, "value": v}
+                for k, v in run.tags.items()
+                if k in allow_list
+                and k not in TAGS_TO_EXCLUDE_FROM_PROPAGATION
+            ]
         return tags_to_propagate
 
     def _get_run_tags(self, run_id: str) -> Tags:

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -498,6 +498,8 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         )
         command = self._get_command_args(args, context)
         image = self._get_image_for_run(context)
+        if image is None:
+            raise ValueError("Could not determine image for run")
 
         run_task_kwargs = self._run_task_kwargs(run, image, container_context)
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -4,7 +4,7 @@ import os
 import uuid
 import warnings
 from collections import namedtuple
-from typing import Any, Dict, List, Mapping, Optional, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 import boto3
 from botocore.exceptions import ClientError
@@ -185,7 +185,7 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
             propagate_tags,
             "propagate_tags",
             key_type=str,
-            value_type=bool | list,
+            value_type=Union[bool, List],
         )
         if self.propagate_tags:
             check.invariant(

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -355,7 +355,7 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
     def from_config_value(
         cls, inst_data: ConfigurableClassData, config_value: Mapping[str, Any]
     ) -> Self:
-        return EcsRunLauncher(inst_data=inst_data, **config_value)
+        return cls(inst_data=inst_data, **config_value)
 
     def _set_run_tags(self, run_id: str, cluster: str, task_arn: str):
         tags = {
@@ -371,6 +371,10 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
 
         to_add = []
         if self.add_dagster_metadata_tags:
+
+            if "dagster/job_name" in run.tags:
+                raise ValueError(f"Cannot override dagster/job_name when `add_dagster_metadata_tags` is set to True on the EcsRunLauncher. Either remove the dagster/job_name tag from the job definition / run, or set `add_dagster_metadata_tags=False`")
+
             to_add.append({"key": "dagster/job_name", "value": run.job_name})
             if run.tags.get("user"):
                 to_add.append({"key": "user", "value": run.tags["user"]})

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -188,7 +188,10 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
             value_type=bool | list,
         )
         if self.propagate_tags:
-            check.invariant(len([k for k, v in self.propagate_tags.items() if v]) <= 1, "Only one of include_only, include_all, or exclude can be set for the propagate_tags config property")
+            check.invariant(
+                len([k for k, v in self.propagate_tags.items() if v and k != "add_job_name"]) <= 1,
+                "Only one of include_only, include_all, or exclude can be set for the propagate_tags config property",
+            )
 
         self._current_task_metadata = None
         self._current_task = None
@@ -363,6 +366,11 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
                             default_value=[],
                             description="List of specific tag keys which should not be propagated to the ECS task. All other tags will be propagated to the ECS task.",
                         ),
+                        "add_job_name": Field(
+                            bool,
+                            default_value=True,
+                            description="Whether to propagate the job name from the Dagster run to the ECS task.",
+                        ),
                     }
                 ),
                 is_required=False,
@@ -393,14 +401,18 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
             # Add contextual Dagster run tags to ECS tags
             tags = run.tags
             if self.propagate_tags.get("include_all"):
-                tags = {k: v for k, v in run.tags.items() if not k.startswith("ecs/")}  # ecs tags are redundant to information already defined on the task
+                tags = {
+                    k: v for k, v in run.tags.items() if not k.startswith("ecs/")
+                }  # ecs tags are redundant to information already defined on the task
             elif self.propagate_tags.get("include_only"):
                 tags = {
                     k: v for k, v in run.tags.items() if k in self.propagate_tags["include_only"]
                 }
             elif self.propagate_tags.get("exclude"):
                 tags = {
-                    k: v for k, v in run.tags.items() if k not in self.propagate_tags["exclude"] and not k.startswith("ecs/")
+                    k: v
+                    for k, v in run.tags.items()
+                    if k not in self.propagate_tags["exclude"] and not k.startswith("ecs/")
                 }
             if self.propagate_tags.get("add_job_name"):
                 tags["dagster/job_name"] = run.job_name

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -193,8 +193,8 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
                 "Only allow_list can be set for the propagate_tags config property",
             )
         if self.propagate_tags.get("allow_list"):
-            invalid_tags = {"dagster/op_selection", "dagster/solid_selection"}
             # These tags are potentially very large and can cause ECS to fail to start a task. They also don't seem particularly useful in a task-tagging context
+            invalid_tags = {"dagster/op_selection", "dagster/solid_selection"}
             check.invariant(
                 invalid_tags - set(self.propagate_tags.get("allow_list", [])) == invalid_tags,
                 f"Cannot include {invalid_tags} in allow_list",

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -411,8 +411,7 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
             tags_to_propagate = [
                 {"key": k, "value": v}
                 for k, v in run.tags.items()
-                if k in allow_list
-                and k not in TAGS_TO_EXCLUDE_FROM_PROPAGATION
+                if k in allow_list and k not in TAGS_TO_EXCLUDE_FROM_PROPAGATION
             ]
         return tags_to_propagate
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -197,7 +197,8 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         if self.propagate_tags.get("allow_list"):
             # These tags are potentially very large and can cause ECS to fail to start a task. They also don't seem particularly useful in a task-tagging context
             check.invariant(
-                TAGS_TO_EXCLUDE_FROM_PROPAGATION - set(self.propagate_tags.get("allow_list", [])) == TAGS_TO_EXCLUDE_FROM_PROPAGATION,
+                TAGS_TO_EXCLUDE_FROM_PROPAGATION - set(self.propagate_tags.get("allow_list", []))
+                == TAGS_TO_EXCLUDE_FROM_PROPAGATION,
                 f"Cannot include {TAGS_TO_EXCLUDE_FROM_PROPAGATION} in allow_list",
             )
 
@@ -411,7 +412,8 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
                 tags_to_propagate = [
                     {"key": k, "value": v}
                     for k, v in run.tags.items()
-                    if k in self.propagate_tags["allow_list"] and k not in TAGS_TO_EXCLUDE_FROM_PROPAGATION
+                    if k in self.propagate_tags["allow_list"]
+                    and k not in TAGS_TO_EXCLUDE_FROM_PROPAGATION
                 ]
         return tags_to_propagate
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -594,7 +594,7 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
 
         return overrides
 
-    def _get_run_task_kwargs_from_run(self, run: DagsterRun) -> Dict[str, Any]:
+    def _get_run_task_kwargs_from_run(self, run: DagsterRun) -> Mapping[str, Any]:
         run_task_kwargs = run.tags.get("ecs/run_task_kwargs")
         if run_task_kwargs:
             return json.loads(run_task_kwargs)

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -357,15 +357,6 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
                     " always be set by the run launcher."
                 ),
             ),
-            "add_dagster_metadata_tags": Field(
-                bool,
-                is_required=False,
-                default_value=False,
-                description=(
-                    "Whether to apply tags to the launched task describing metadata about the run,"
-                    " such as job name, submitting user, and partition"
-                ),
-            ),
             "propagate_tags": Field(
                 Shape(
                     {

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -4,7 +4,7 @@ import os
 import uuid
 import warnings
 from collections import namedtuple
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 import boto3
 from botocore.exceptions import ClientError
@@ -195,7 +195,10 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         if self.propagate_tags.get("allow_list"):
             invalid_tags = {"dagster/op_selection", "dagster/solid_selection"}
             # These tags are potentially very large and can cause ECS to fail to start a task. They also don't seem particularly useful in a task-tagging context
-            check.invariant(invalid_tags - set(self.propagate_tags.get("allow_list")) == invalid_tags, f"Cannot include {invalid_tags} in allow_list")
+            check.invariant(
+                invalid_tags - set(self.propagate_tags.get("allow_list")) == invalid_tags,
+                f"Cannot include {invalid_tags} in allow_list",
+            )
 
         self._current_task_metadata = None
         self._current_task = None
@@ -388,14 +391,19 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
 
         # these tags often contain * or + characters which are not allowed in ECS tags. They don't seem super useful
         # from an observability perspective, so we exclude them from the ECS tags
-        tags_to_exclude = ("dagster/op_selection", "dagster/solid_selection",)
+        tags_to_exclude = (
+            "dagster/op_selection",
+            "dagster/solid_selection",
+        )
 
         tags_to_propagate = []
         if self.propagate_tags:
             # Add contextual Dagster run tags to ECS tags
             if self.propagate_tags.get("allow_list"):
                 tags_to_propagate = [
-                    {"key": k, "value": v} for k, v in run.tags.items() if k in self.propagate_tags["allow_list"] and k not in tags_to_exclude
+                    {"key": k, "value": v}
+                    for k, v in run.tags.items()
+                    if k in self.propagate_tags["allow_list"] and k not in tags_to_exclude
                 ]
 
         return [

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -2,6 +2,7 @@ import copy
 import json
 import time
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 
 import pytest
 from botocore.exceptions import ClientError
@@ -975,9 +976,7 @@ def test_launch_cannot_use_system_tags(instance_cm, workspace, job, remote_job):
     [
         "run_tags",
         "expected_ecs_tag_keys",
-        "include_all",
-        "include_only",
-        "exclude",
+        "allow_list",
     ],
     [
         (
@@ -985,9 +984,7 @@ def test_launch_cannot_use_system_tags(instance_cm, workspace, job, remote_job):
                 "dagster/partition_key": "abc",
                 "dagster/git_commit_hash": "b54e4ddfbf2f4f661cdb312b6f3dd49de6139c94",
             },
-            {"dagster/partition_key", "dagster/git_commit_hash", "dagster/job_name"},
-            True,
-            [],
+            {"dagster/run_id", "dagster/job_name"},
             [],
         ),
         (
@@ -995,43 +992,15 @@ def test_launch_cannot_use_system_tags(instance_cm, workspace, job, remote_job):
                 "dagster/partition_key": "abc",
                 "dagster/git_commit_hash": "b54e4ddfbf2f4f661cdb312b6f3dd49de6139c94",
             },
-            {"dagster/partition_key", "dagster/job_name"},
-            False,
+            {"dagster/partition_key", "dagster/job_name", "dagster/run_id"},
             ["dagster/partition_key"],
-            [],
-        ),
-        (
-            {
-                "dagster/partition_key": "abc",
-                "dagster/git_commit_hash": "b54e4ddfbf2f4f661cdb312b6f3dd49de6139c94",
-            },
-            {"dagster/git_commit_hash", "dagster/job_name"},
-            False,
-            [],
-            [
-                "dagster/partition_key",
-            ],
-        ),
-        (
-            {
-                "dagster/partition_key": "abc",
-                "dagster/git_commit_hash": "b54e4ddfbf2f4f661cdb312b6f3dd49de6139c94",
-            },
-            {"dagster/git_commit_hash", "dagster/job_name"},
-            False,
-            [],
-            [
-                "dagster/partition_key",
-            ],
         ),
     ],
 )
 def test_propagate_tags_include_all(
     run_tags: dict[str, str],
     expected_ecs_tag_keys: set[str],
-    include_all: bool,
-    include_only: list[str],
-    exclude: list[str],
+    allow_list: list[str],
     instance_cm,
     workspace,
     job,
@@ -1041,9 +1010,7 @@ def test_propagate_tags_include_all(
     with instance_cm(
         {
             "propagate_tags": {
-                "include_all": include_all,
-                "include_only": include_only,
-                "exclude": exclude,
+                "allow_list": allow_list,
             },
         }
     ) as instance:
@@ -1065,16 +1032,24 @@ def test_propagate_tags_include_all(
         assert set([tag["key"] for tag in tags]) == expected_ecs_tag_keys
 
 
+@pytest.mark.parametrize(
+    ["propagate_tags"],
+    [
+        [{"allow_list": ["dagster/op_selection"]}],
+        [{"allow_list": ["dagster/solid_selection", "dagster/git_commit_hash"]}],
+    ]
+)
 def test_propagate_tags_args_validated(
     instance_cm,
     workspace,
     job,
     external_job,
+    propagate_tags: dict[str, Any],
 ):
     with pytest.raises(CheckError):
         with instance_cm(
             {
-                "propagate_tags": {"include_only": ["a"], "exclude": ["b"]},
+                "propagate_tags": propagate_tags
             }
         ) as instance:
             run = instance.create_run_for_job(

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -1004,7 +1004,7 @@ def test_propagate_tags_include_all(
     instance_cm,
     workspace,
     job,
-    external_job,
+    remote_job,
     ecs,
 ):
     with instance_cm(
@@ -1016,8 +1016,8 @@ def test_propagate_tags_include_all(
     ) as instance:
         run = instance.create_run_for_job(
             job,
-            external_job_origin=external_job.get_external_origin(),
-            job_code_origin=external_job.get_python_origin(),
+            remote_job_origin=remote_job.get_remote_origin(),
+            job_code_origin=remote_job.get_python_origin(),
         )
         test_tags = {**run_tags, "ecs/memory": "30720", "ecs/cpu": "4096"}
 
@@ -1043,15 +1043,15 @@ def test_propagate_tags_args_validated(
     instance_cm,
     workspace,
     job,
-    external_job,
+    remote_job,
     propagate_tags: Dict[str, Any],
 ):
     with pytest.raises(CheckError):
         with instance_cm({"propagate_tags": propagate_tags}) as instance:
             run = instance.create_run_for_job(
                 job,
-                external_job_origin=external_job.get_external_origin(),
-                job_code_origin=external_job.get_python_origin(),
+                remote_job_origin=remote_job.get_remote_origin(),
+                job_code_origin=remote_job.get_python_origin(),
             )
             instance.launch_run(run.run_id, workspace)
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -972,7 +972,13 @@ def test_launch_cannot_use_system_tags(instance_cm, workspace, job, remote_job):
 
 
 @pytest.mark.parametrize(
-    ["run_tags", "expected_ecs_tag_keys", "include_all", "include_only", "exclude",],
+    [
+        "run_tags",
+        "expected_ecs_tag_keys",
+        "include_all",
+        "include_only",
+        "exclude",
+    ],
     [
         (
             {

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -2,7 +2,7 @@ import copy
 import json
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any
+from typing import Any, Dict, List, Set
 
 import pytest
 from botocore.exceptions import ClientError
@@ -998,9 +998,9 @@ def test_launch_cannot_use_system_tags(instance_cm, workspace, job, remote_job):
     ],
 )
 def test_propagate_tags_include_all(
-    run_tags: dict[str, str],
-    expected_ecs_tag_keys: set[str],
-    allow_list: list[str],
+    run_tags: Dict[str, str],
+    expected_ecs_tag_keys: Set[str],
+    allow_list: List[str],
     instance_cm,
     workspace,
     job,
@@ -1044,7 +1044,7 @@ def test_propagate_tags_args_validated(
     workspace,
     job,
     external_job,
-    propagate_tags: dict[str, Any],
+    propagate_tags: Dict[str, Any],
 ):
     with pytest.raises(CheckError):
         with instance_cm(

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -1002,7 +1002,7 @@ def test_launch_cannot_use_system_tags(instance_cm, workspace, job, remote_job):
                 "dagster/git_commit_hash": "b54e4ddfbf2f4f661cdb312b6f3dd49de6139c94",
             },
             {"dagster/git_commit_hash"},
-            True,
+            False,
             [],
             ["dagster/partition_key",],
             False

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -1037,7 +1037,7 @@ def test_propagate_tags_include_all(
     [
         [{"allow_list": ["dagster/op_selection"]}],
         [{"allow_list": ["dagster/solid_selection", "dagster/git_commit_hash"]}],
-    ]
+    ],
 )
 def test_propagate_tags_args_validated(
     instance_cm,
@@ -1047,11 +1047,7 @@ def test_propagate_tags_args_validated(
     propagate_tags: Dict[str, Any],
 ):
     with pytest.raises(CheckError):
-        with instance_cm(
-            {
-                "propagate_tags": propagate_tags
-            }
-        ) as instance:
+        with instance_cm({"propagate_tags": propagate_tags}) as instance:
             run = instance.create_run_for_job(
                 job,
                 external_job_origin=external_job.get_external_origin(),

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -972,42 +972,27 @@ def test_launch_cannot_use_system_tags(instance_cm, workspace, job, remote_job):
 
 
 @pytest.mark.parametrize(
-    ["run_tags", "expected_ecs_tag_keys", "include_all", "include_only", "exclude", "add_job_name"],
+    ["run_tags", "expected_ecs_tag_keys", "include_all", "include_only", "exclude",],
     [
         (
             {
                 "dagster/partition_key": "abc",
                 "dagster/git_commit_hash": "b54e4ddfbf2f4f661cdb312b6f3dd49de6139c94",
             },
-            {"dagster/partition_key", "dagster/git_commit_hash"},
+            {"dagster/partition_key", "dagster/git_commit_hash", "dagster/job_name"},
             True,
             [],
             [],
-            False,
         ),
         (
             {
                 "dagster/partition_key": "abc",
                 "dagster/git_commit_hash": "b54e4ddfbf2f4f661cdb312b6f3dd49de6139c94",
             },
-            {"dagster/partition_key"},
+            {"dagster/partition_key", "dagster/job_name"},
             False,
             ["dagster/partition_key"],
             [],
-            False,
-        ),
-        (
-            {
-                "dagster/partition_key": "abc",
-                "dagster/git_commit_hash": "b54e4ddfbf2f4f661cdb312b6f3dd49de6139c94",
-            },
-            {"dagster/git_commit_hash"},
-            False,
-            [],
-            [
-                "dagster/partition_key",
-            ],
-            False,
         ),
         (
             {
@@ -1020,7 +1005,18 @@ def test_launch_cannot_use_system_tags(instance_cm, workspace, job, remote_job):
             [
                 "dagster/partition_key",
             ],
-            True,
+        ),
+        (
+            {
+                "dagster/partition_key": "abc",
+                "dagster/git_commit_hash": "b54e4ddfbf2f4f661cdb312b6f3dd49de6139c94",
+            },
+            {"dagster/git_commit_hash", "dagster/job_name"},
+            False,
+            [],
+            [
+                "dagster/partition_key",
+            ],
         ),
     ],
 )
@@ -1030,7 +1026,6 @@ def test_propagate_tags_include_all(
     include_all: bool,
     include_only: list[str],
     exclude: list[str],
-    add_job_name: bool,
     instance_cm,
     workspace,
     job,
@@ -1043,7 +1038,6 @@ def test_propagate_tags_include_all(
                 "include_all": include_all,
                 "include_only": include_only,
                 "exclude": exclude,
-                "add_job_name": add_job_name,
             },
         }
     ) as instance:

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -983,7 +983,7 @@ def test_launch_cannot_use_system_tags(instance_cm, workspace, job, remote_job):
             True,
             [],
             [],
-            False
+            False,
         ),
         (
             {
@@ -994,7 +994,7 @@ def test_launch_cannot_use_system_tags(instance_cm, workspace, job, remote_job):
             False,
             ["dagster/partition_key"],
             [],
-            False
+            False,
         ),
         (
             {
@@ -1004,8 +1004,10 @@ def test_launch_cannot_use_system_tags(instance_cm, workspace, job, remote_job):
             {"dagster/git_commit_hash"},
             False,
             [],
-            ["dagster/partition_key",],
-            False
+            [
+                "dagster/partition_key",
+            ],
+            False,
         ),
         (
             {
@@ -1015,30 +1017,34 @@ def test_launch_cannot_use_system_tags(instance_cm, workspace, job, remote_job):
             {"dagster/git_commit_hash", "dagster/job_name"},
             False,
             [],
-            ["dagster/partition_key",],
-            True
-        )
-
+            [
+                "dagster/partition_key",
+            ],
+            True,
+        ),
     ],
 )
 def test_propagate_tags_include_all(
     run_tags: dict[str, str],
     expected_ecs_tag_keys: set[str],
     include_all: bool,
-    include_only: list[str], exclude: list[str],
+    include_only: list[str],
+    exclude: list[str],
     add_job_name: bool,
     instance_cm,
     workspace,
     job,
     external_job,
-    ecs
+    ecs,
 ):
     with instance_cm(
         {
-            "propagate_tags": {"include_all": include_all,
-                               "include_only": include_only,
-                               "exclude": exclude,
-                               "add_job_name": add_job_name},
+            "propagate_tags": {
+                "include_all": include_all,
+                "include_only": include_only,
+                "exclude": exclude,
+                "add_job_name": add_job_name,
+            },
         }
     ) as instance:
         run = instance.create_run_for_job(

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -971,10 +971,74 @@ def test_launch_cannot_use_system_tags(instance_cm, workspace, job, remote_job):
             instance.launch_run(run.run_id, workspace)
 
 
-def test_propagate_tags_include_all(instance_cm, workspace, job, external_job, ecs):
+@pytest.mark.parametrize(
+    ["run_tags", "expected_ecs_tag_keys", "include_all", "include_only", "exclude", "add_job_name"],
+    [
+        (
+            {
+                "dagster/partition_key": "abc",
+                "dagster/git_commit_hash": "b54e4ddfbf2f4f661cdb312b6f3dd49de6139c94",
+            },
+            {"dagster/partition_key", "dagster/git_commit_hash"},
+            True,
+            [],
+            [],
+            False
+        ),
+        (
+            {
+                "dagster/partition_key": "abc",
+                "dagster/git_commit_hash": "b54e4ddfbf2f4f661cdb312b6f3dd49de6139c94",
+            },
+            {"dagster/partition_key"},
+            False,
+            ["dagster/partition_key"],
+            [],
+            False
+        ),
+        (
+            {
+                "dagster/partition_key": "abc",
+                "dagster/git_commit_hash": "b54e4ddfbf2f4f661cdb312b6f3dd49de6139c94",
+            },
+            {"dagster/git_commit_hash"},
+            True,
+            [],
+            ["dagster/partition_key",],
+            False
+        ),
+        (
+            {
+                "dagster/partition_key": "abc",
+                "dagster/git_commit_hash": "b54e4ddfbf2f4f661cdb312b6f3dd49de6139c94",
+            },
+            {"dagster/git_commit_hash", "dagster/job_name"},
+            False,
+            [],
+            ["dagster/partition_key",],
+            True
+        )
+
+    ],
+)
+def test_propagate_tags_include_all(
+    run_tags: dict[str, str],
+    expected_ecs_tag_keys: set[str],
+    include_all: bool,
+    include_only: list[str], exclude: list[str],
+    add_job_name: bool,
+    instance_cm,
+    workspace,
+    job,
+    external_job,
+    ecs
+):
     with instance_cm(
         {
-            "propagate_tags": {"include_all": True},
+            "propagate_tags": {"include_all": include_all,
+                               "include_only": include_only,
+                               "exclude": exclude,
+                               "add_job_name": add_job_name},
         }
     ) as instance:
         run = instance.create_run_for_job(
@@ -982,24 +1046,37 @@ def test_propagate_tags_include_all(instance_cm, workspace, job, external_job, e
             external_job_origin=external_job.get_external_origin(),
             job_code_origin=external_job.get_python_origin(),
         )
-        expected_tags = {
-            "dagster/partition_key": "abc",
-            "dagster/git_commit_hash": "b54e4ddfbf2f4f661cdb312b6f3dd49de6139c94",
-        }
-        test_tags = {
-            **expected_tags,
-           "ecs/memory": "30720",
-           "ecs/cpu": "4096"
-        }
+        test_tags = {**run_tags, "ecs/memory": "30720", "ecs/cpu": "4096"}
 
         instance.add_run_tags(run.run_id, test_tags)
         instance.launch_run(run.run_id, workspace)
 
-        expected_tags.update({"dagster/run_id": run.run_id})
+        run_tags.update({"dagster/run_id": run.run_id})
         initial_tasks = ecs.list_tasks()
         tasks = ecs.describe_tasks(tasks=initial_tasks["taskArns"])
         tags = tasks["tasks"][1]["tags"]
-        assert set([tag["key"] for tag in tags]) == set(expected_tags.keys())
+        expected_ecs_tag_keys.add("dagster/run_id")
+        assert set([tag["key"] for tag in tags]) == expected_ecs_tag_keys
+
+
+def test_propagate_tags_args_validated(
+    instance_cm,
+    workspace,
+    job,
+    external_job,
+):
+    with pytest.raises(CheckError):
+        with instance_cm(
+            {
+                "propagate_tags": {"include_only": ["a"], "exclude": ["b"]},
+            }
+        ) as instance:
+            run = instance.create_run_for_job(
+                job,
+                external_job_origin=external_job.get_external_origin(),
+                job_code_origin=external_job.get_python_origin(),
+            )
+            instance.launch_run(run.run_id, workspace)
 
 
 def test_launch_run_with_container_context(

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -971,6 +971,37 @@ def test_launch_cannot_use_system_tags(instance_cm, workspace, job, remote_job):
             instance.launch_run(run.run_id, workspace)
 
 
+def test_propagate_tags_include_all(instance_cm, workspace, job, external_job, ecs):
+    with instance_cm(
+        {
+            "propagate_tags": {"include_all": True},
+        }
+    ) as instance:
+        run = instance.create_run_for_job(
+            job,
+            external_job_origin=external_job.get_external_origin(),
+            job_code_origin=external_job.get_python_origin(),
+        )
+        expected_tags = {
+            "dagster/partition_key": "abc",
+            "dagster/git_commit_hash": "b54e4ddfbf2f4f661cdb312b6f3dd49de6139c94",
+        }
+        test_tags = {
+            **expected_tags,
+           "ecs/memory": "30720",
+           "ecs/cpu": "4096"
+        }
+
+        instance.add_run_tags(run.run_id, test_tags)
+        instance.launch_run(run.run_id, workspace)
+
+        expected_tags.update({"dagster/run_id": run.run_id})
+        initial_tasks = ecs.list_tasks()
+        tasks = ecs.describe_tasks(tasks=initial_tasks["taskArns"])
+        tags = tasks["tasks"][1]["tags"]
+        assert set([tag["key"] for tag in tags]) == set(expected_tags.keys())
+
+
 def test_launch_run_with_container_context(
     ecs,
     instance,


### PR DESCRIPTION
## Summary & Motivation

It is currently very difficult to get cost and performance tracking information for specific jobs and runs without doing a bunch of kung-fu with `run_task_kwargs` and job definitions. This PR allows tags set on a Dagster run to be selectively propagated to the ECS task used to carry out the run, to simplify cost tracking and enable tracking based on tags that are only available at runtime such as partition key and job name.

## How I Tested These Changes

Added a set of unit tests for the propagate_tags functionality. Booted up a Dagster environment and launched runs using different `propagate_tags` configurations and checked that the ECS tasks created had the correct tags applied.
