### PR TITLE
[dagster-airlift] mwaa auth backend

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/mwaa/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/mwaa/__init__.py
@@ -1,0 +1,1 @@
+from .auth_backend import MwaaSessionAuthBackend as MwaaSessionAuthBackend

--- a/examples/experimental/dagster-airlift/dagster_airlift/mwaa/auth_backend.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/mwaa/auth_backend.py
@@ -1,0 +1,55 @@
+from typing import Optional, Tuple
+
+import boto3
+import requests
+
+from ..airflow_utils import AirflowAuthBackend
+
+
+def get_session_info(region: str, env_name: str) -> Tuple[str, str]:
+    # Initialize MWAA client and request a web login token
+    mwaa = boto3.client("mwaa", region_name=region)
+    response = mwaa.create_web_login_token(Name=env_name)
+
+    # Extract the web server hostname and login token
+    web_server_host_name = response["WebServerHostname"]
+    web_token = response["WebToken"]
+
+    # Construct the URL needed for authentication
+    login_url = f"https://{web_server_host_name}/aws_mwaa/login"
+    login_payload = {"token": web_token}
+
+    # Make a POST request to the MWAA login url using the login payload
+    response = requests.post(login_url, data=login_payload, timeout=10)
+
+    # Check if login was succesfull
+    if response.status_code == 200:
+        # Return the hostname and the session cookie
+        return (web_server_host_name, response.cookies["session"])
+    else:
+        raise Exception(f"Failed to get session info: {response.text}")
+
+
+class MwaaSessionAuthBackend(AirflowAuthBackend):
+    def __init__(self, region: str, env_name: str):
+        self.region = region
+        self.env_name = env_name
+        # Session info is generated when we either try to retrieve a session or retrieve the web server url
+        self._session_info: Optional[Tuple[str, str]] = None
+
+    def get_session(self) -> requests.Session:
+        # Get the session info
+        if not self._session_info:
+            self._session_info = get_session_info(self.region, self.env_name)
+        session_cookie = self._session_info[1]
+        # Create a new session
+        session = requests.Session()
+        session.cookies.set("session", session_cookie)
+
+        # Return the session
+        return session
+
+    def get_webserver_url(self) -> str:
+        if not self._session_info:
+            self._session_info = get_session_info(self.region, self.env_name)
+        return f"https://{self._session_info[0]}"

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/test_airflow_utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/test_airflow_utils.py
@@ -25,8 +25,9 @@ def test_dag_peering(
 ) -> None:
     """Test that dags can be correctly peered from airflow, and certain metadata properties are retained."""
     instance = AirflowInstance(
-        airflow_webserver_url="http://localhost:8080",
-        auth_backend=BasicAuthBackend(username="admin", password="admin"),
+        auth_backend=BasicAuthBackend(
+            webserver_url="http://localhost:8080", username="admin", password="admin"
+        ),
         name="airflow_instance",
     )
     assets_defs = assets_defs_from_airflow_instance(

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/test_mwaa_auth.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/test_mwaa_auth.py
@@ -1,0 +1,12 @@
+import mock
+from dagster_airlift.mwaa import MwaaSessionAuthBackend
+
+
+def test_mwaa_session_auth() -> None:
+    """Test output format of mwaa auth backend. Does not actually make any live requests to boto or exercise usage of aws apis in any way."""
+    with mock.patch("dagster_airlift.mwaa.auth_backend.get_session_info") as mock_get_session_info:
+        mock_get_session_info.return_value = ("my-webserver-hostname", "my-session-cookie")
+        auth_backend = MwaaSessionAuthBackend(region="us-west-2", env_name="my-env")
+        session = auth_backend.get_session()
+        assert session.cookies["session"] == "my-session-cookie"
+        assert auth_backend.get_webserver_url() == "https://my-webserver-hostname"

--- a/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/dagster_defs/definitions.py
+++ b/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/dagster_defs/definitions.py
@@ -20,8 +20,9 @@ PASSWORD = "admin"
 manifest_path = os.path.join(os.environ["DBT_PROJECT_DIR"], "target", "manifest.json")
 
 airflow_instance = AirflowInstance(
-    airflow_webserver_url=AIRFLOW_BASE_URL,
-    auth_backend=BasicAuthBackend(USERNAME, PASSWORD),
+    auth_backend=BasicAuthBackend(
+        webserver_url=AIRFLOW_BASE_URL, username=USERNAME, password=PASSWORD
+    ),
     name=AIRFLOW_INSTANCE_NAME,
 )
 

--- a/examples/experimental/dagster-airlift/setup.py
+++ b/examples/experimental/dagster-airlift/setup.py
@@ -47,6 +47,9 @@ setup(
         "dbt-duckdb",
         "pendulum>=2.0.0,<3.0.0",
     ],
+    extras_require={
+        "mwaa": ["boto3"],
+    },
     zip_safe=False,
     entry_points={
         "console_scripts": [

--- a/examples/experimental/dagster-airlift/tox.ini
+++ b/examples/experimental/dagster-airlift/tox.ini
@@ -10,7 +10,7 @@ deps =
   -e ../../../python_modules/dagster-test
   -e ../../../python_modules/dagster-pipes
   -e ../../../python_modules/libraries/dagster-dbt
-  -e .
+  -e .[mwaa]
 allowlist_externals =
   /bin/bash
   uv


### PR DESCRIPTION
Stacks on top of AirflowInstanceAPI to add a MwaaAuthBackend.

Requires vending webserver url from the backend instead of passing it directly, since this is procured from the session info in mwaa.

Tested this manually with our running mwaa instance, and verified that dag peering works. Example code:
```python
import os

from dagster import Definitions
from dagster_airlift import AirflowInstance, assets_defs_from_airflow_instance
from dagster_airlift.mwaa import MwaaSessionAuthBackend

os.environ["AWS_PROFILE"] = "the-profile-containing-mwaa"
mwaa_env = "mwaa-test-env"

defs = Definitions(
    assets=assets_defs_from_airflow_instance(
        airflow_instance=AirflowInstance(
            auth_backend=MwaaSessionAuthBackend(region="us-west-2", env_name=mwaa_env),
            name=mwaa_env,
        )
    )
)
```