### PR TITLE
[docs] Update URL to Definitions for project-fully-featured

### DIFF
--- a/docs/content/guides/dagster/recommended-project-structure.mdx
+++ b/docs/content/guides/dagster/recommended-project-structure.mdx
@@ -132,7 +132,7 @@ In this example, we grouped resources (e.g., database connections, Spark session
 
 In complex projects, we find it helpful to make resources reusable and configured with pre-defined values via <PyObject object="configured" />. This approach allows your teammates to use a pre-defined resource set or make changes to shared resources, thus enabling more efficient project development.
 
-This pattern also helps you easily execute jobs in different environments without code changes. In this example, we dynamically defined a code location based on the deployment in [`definitions.py`](https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/project_fully_featured/\__init\_\_.py) and can keep all code the same across testing, local development, staging, and production. Read more about our recommendations in the [Transitioning data pipelines from Development to Production](/guides/dagster/transitioning-data-pipelines-from-development-to-production) guide.
+This pattern also helps you easily execute jobs in different environments without code changes. In this example, we dynamically defined a code location based on the deployment in [`definitions.py`](https://github.com/dagster-io/dagster/blob/master/examples/project_fully_featured/project_fully_featured/definitions.py) and can keep all code the same across testing, local development, staging, and production. Read more about our recommendations in the [Transitioning data pipelines from Development to Production](/guides/dagster/transitioning-data-pipelines-from-development-to-production) guide.
 
 ---
 


### PR DESCRIPTION
## Summary & Motivation

This PR updates the URL to the file containing Definitions in project-fully-featured. That was moved from #23316 to this PR to avoid failure when running the doc tests - the file must exist before being referenced, and it is updated in #23345.

## How I Tested These Changes

BK
