### PR TITLE
Enable auto materialize sensors with Helm

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -80,6 +80,10 @@ class Schedules(BaseModel):
     numSubmitWorkers: Optional[int]
 
 
+class AutoMaterialize(BaseModel):
+    useSensors: bool
+
+
 class Daemon(BaseModel):
     enabled: bool
     image: kubernetes.Image
@@ -104,6 +108,7 @@ class Daemon(BaseModel):
     runRetries: Dict[str, Any]
     sensors: Sensors
     schedules: Schedules
+    autoMaterialize: AutoMaterialize
     schedulerName: Optional[str]
     volumeMounts: Optional[List[kubernetes.VolumeMount]]
     volumes: Optional[List[kubernetes.Volume]]

--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -353,6 +353,36 @@ def test_sensor_threading_disabled(
     assert "sensors" not in instance
 
 
+def test_automaterialize_use_sensor_default(
+    instance_template: HelmTemplate,
+):
+    helm_values = DagsterHelmValues.construct(dagsterDaemon=Daemon.construct())
+
+    configmaps = instance_template.render(helm_values)
+
+    assert len(configmaps) == 1
+
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    assert "autoMaterialize" not in instance
+
+
+def test_automaterialize_use_sensor_enabled(
+    instance_template: HelmTemplate,
+):
+    helm_values = DagsterHelmValues.construct(
+        dagsterDaemon=Daemon.construct(autoMaterialize={"useSensors": True})
+    )
+
+    configmaps = instance_template.render(helm_values)
+
+    assert len(configmaps) == 1
+
+    instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
+
+    assert instance["auto_materialize"]["use_sensors"] is True
+
+
 def test_run_retries_default(
     instance_template: HelmTemplate,
 ):

--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -364,7 +364,7 @@ def test_automaterialize_use_sensor_default(
 
     instance = yaml.full_load(configmaps[0].data["dagster.yaml"])
 
-    assert "autoMaterialize" not in instance
+    assert "auto_materialize" not in instance
 
 
 def test_automaterialize_use_sensor_enabled(

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -133,6 +133,12 @@ data:
       {{- end }}
     {{- end }}
 
+    {{- $autoMaterialize := .Values.dagsterDaemon.autoMaterialize }}
+    {{- if and (.Values.dagsterDaemon.enabled) ($autoMaterialize.useSensors) }}
+    auto_materialize:
+      use_sensors: {{ $autoMaterialize.useSensors }}
+    {{- end }}
+
     telemetry:
       enabled: {{ .Values.telemetry.enabled }}
 

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -2790,6 +2790,19 @@
                 "useThreads"
             ]
         },
+        "AutoMaterialize": {
+            "title": "AutoMaterialize",
+            "type": "object",
+            "properties": {
+                "useSensors": {
+                    "title": "Usesensors",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "useSensors"
+            ]
+        },
         "Daemon": {
             "title": "Daemon",
             "type": "object",
@@ -2896,6 +2909,9 @@
                 },
                 "schedules": {
                     "$ref": "#/definitions/Schedules"
+                },
+                "autoMaterialize": {
+                    "$ref": "#/definitions/AutoMaterialize"
                 },
                 "schedulerName": {
                     "title": "Schedulername",

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -2987,7 +2987,8 @@
                 "runMonitoring",
                 "runRetries",
                 "sensors",
-                "schedules"
+                "schedules",
+                "autoMaterialize"
             ],
             "additionalProperties": false
         },

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -1141,6 +1141,11 @@ dagsterDaemon:
     # used to decrease latency when a schedule emits multiple run requests within a single tick.
     # numSubmitWorkers: 4
 
+  autoMaterialize:
+    # Whether or not to use auto-materialize sensors. See:
+    # https://docs.dagster.io/concepts/assets/asset-auto-execution#auto-materialize-sensors
+    useSensors: false
+
   # Additional environment variables to set.
   # These will be directly applied to the daemon container. See
   # https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/


### PR DESCRIPTION
## Summary & Motivation
In order to enable auto materialize sensors, it's needed to set this configuration on `dagster.yaml`:
```
auto_materialize:
  use_sensors: true
```
See: https://docs.dagster.io/concepts/assets/asset-auto-execution#auto-materialize-sensors

This PR implements that configuration on the Helm chart to be enabled if wanted. Auto materialize sensors will be disabled by default.

## How I Tested These Changes
* Added two unit-tests, one for each possible case (enabled or disabled)
* Verified by changing `values.yaml` and running: `helm template --show-only templates/configmap-instance.yaml .`
