### PR TITLE
Update dagster_cloud.yaml to use definitions.py in examples

### DIFF
--- a/examples/assets_dbt_python/dagster_cloud.yaml
+++ b/examples/assets_dbt_python/dagster_cloud.yaml
@@ -1,4 +1,4 @@
 locations:
   - location_name: assets_dbt_python
     code_source:
-      package_name: assets_dbt_python
+      module_name: assets_dbt_python.definitions

--- a/examples/assets_modern_data_stack/dagster_cloud.yaml
+++ b/examples/assets_modern_data_stack/dagster_cloud.yaml
@@ -1,4 +1,4 @@
 locations:
   - location_name: assets_modern_data_stack
     code_source:
-      package_name: assets_modern_data_stack
+      module_name: assets_modern_data_stack.definitions

--- a/examples/experimental/external_assets/dagster_cloud.yaml
+++ b/examples/experimental/external_assets/dagster_cloud.yaml
@@ -1,4 +1,4 @@
 locations:
   - location_name: pipes_external_airflow_demo
     code_source:
-      package_name: pipes_external_airflow_demo
+      module_name: pipes_external_airflow_demo.definitions


### PR DESCRIPTION
## Summary & Motivation

Following the fix in #23325

Some examples that were updated in #23155 and #20809 have a `dagster_cloud.yaml` file. This PR makes sure that dagster_cloud.yaml is updated for examples that are now using `definitions.py` instead of `__init__.py`. Quickstart examples were fixed in #23325.
