### PR TITLE
[ui] Filter out runs that are too old for timeline window

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -328,6 +328,13 @@ export const useRunsForTimeline = ({
       if (run.startTime === null) {
         return;
       }
+
+      // If the run has ended prior to the start of the range, discard it. This can occur
+      // because we are using "updated" time for filtering our runs, which is a value
+      // independent of start/end timestamps.
+      if (run.endTime && run.endTime * 1000 < start) {
+        return;
+      }
       if (!run.repositoryOrigin) {
         return;
       }
@@ -366,7 +373,7 @@ export const useRunsForTimeline = ({
     const current = {jobInfo, runsByJobKey: map};
     previousRunsByJobKey.current = current;
     return current;
-  }, [loading, ongoingRunsData, completedRuns]);
+  }, [loading, ongoingRunsData, completedRuns, start]);
 
   const jobsWithCompletedRunsAndOngoingRuns = useMemo(() => {
     const jobs: Record<string, TimelineRow> = {};


### PR DESCRIPTION
## Summary & Motivation

We are currently retrieving too many runs for the run timeline due to our usage of `updated` time for windowing. (We should use start/end times instead, and an upcoming fix will handle this.)

These excess completed runs show up as a big chunk at the left side of the timeline.

To resolve this (for now), filter out runs (post-query) that don't belong in the visible window.

## How I Tested These Changes

View timeline with lots of runs. Verify that the incorrect chunk of runs is no longer present on the timeline.