### PR TITLE
Add graphql_request_context context manager to allow hooks around graphql request handling

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/graphql.py
+++ b/python_modules/dagster-webserver/dagster_webserver/graphql.py
@@ -242,7 +242,7 @@ class GraphQLServer(ABC):
         request_context = self.make_request_context(request)
 
         def _graphql_request():
-            with self.wrap_graphql_execution(request):
+            with self.graphql_request_context(request):
                 return run(
                     self._graphql_schema.execute_async(
                         query,
@@ -256,7 +256,7 @@ class GraphQLServer(ABC):
         return await run_in_threadpool(_graphql_request)
 
     @contextmanager
-    def wrap_graphql_execution(self, request: Request):
+    def graphql_request_context(self, request: Request):
         """This context manager executes within the threadpool and can be used to wrap logic around a single graphql request."""
         yield
 


### PR DESCRIPTION
## Summary & Motivation

This allows subclasses to override the `graphql_request_context()` method and inject code around the graphql handler. Specifically this code runs in the same thread as the graphph resolver. 

## How I Tested These Changes
Existing tests should be sufficient, since we're not changing any behavior.