### PR TITLE
[1.8][external assets] enable passing `AssetSpec`s as graph inputs

### DIFF
--- a/docs/content/concepts/ops-jobs-graphs/graphs.mdx
+++ b/docs/content/concepts/ops-jobs-graphs/graphs.mdx
@@ -281,10 +281,10 @@ def send_emails(emails) -> None: ...
 
 @job
 def send_emails_job():
-    send_emails(emails_to_send.to_source_asset())
+    send_emails(emails_to_send.get_asset_spec())
 ```
 
-We must use the <PyObject object="AssetsDefinition" method="to_source_asset" />, because <PyObject object="SourceAsset" pluralize /> are used to represent assets that other assets or jobs depend on, in settings where they won't be materialized themselves.
+We must use the <PyObject object="AssetsDefinition" method="get_asset_spec" />, because <PyObject object="AssetSpec" pluralize /> are used to represent assets that other assets or jobs depend on, in settings where they won't be materialized themselves.
 
 If the asset is partitioned, then:
 

--- a/docs/content/guides/dagster/how-assets-relate-to-ops-and-graphs.mdx
+++ b/docs/content/guides/dagster/how-assets-relate-to-ops-and-graphs.mdx
@@ -147,7 +147,7 @@ def send_emails(emails) -> None: ...
 
 @job
 def send_emails_job():
-    send_emails(emails_to_send.to_source_asset())
+    send_emails(emails_to_send.get_asset_spec())
 ```
 
 In this case, the asset - specifically, the table the job reads from - is only used as a data source for the job. It’s not materialized when the graph is run.

--- a/examples/docs_snippets/docs_snippets/guides/dagster/assets_ops_graphs/op_graph_asset_input.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/assets_ops_graphs/op_graph_asset_input.py
@@ -11,4 +11,4 @@ def send_emails(emails) -> None: ...
 
 @job
 def send_emails_job():
-    send_emails(emails_to_send.to_source_asset())
+    send_emails(emails_to_send.get_asset_spec())

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1401,6 +1401,10 @@ class AssetsDefinition(ResourceAddable, RequiresResources, IHasInternalInit):
                 tags=spec.tags,
             )
 
+    @public
+    def get_asset_spec(self, key: Optional[AssetKey] = None) -> AssetSpec:
+        return self._specs_by_key[key or self.key]
+
     def get_io_manager_key_for_asset_key(self, key: AssetKey) -> str:
         if self._computation is None:
             return self._specs_by_key[key].metadata.get(

--- a/python_modules/dagster/dagster/_core/definitions/composition.py
+++ b/python_modules/dagster/dagster/_core/definitions/composition.py
@@ -32,6 +32,7 @@ from dagster._core.errors import (
     DagsterInvariantViolationError,
 )
 from dagster._utils import is_named_tuple_instance
+from dagster._utils.warnings import disable_dagster_warnings
 
 from .config import ConfigMapping
 from .dependency import (
@@ -504,6 +505,7 @@ class PendingNodeInvocation(Generic[T_NodeDefinition]):
     def _process_argument_node(
         self, node_name: str, output_node, input_name: str, input_bindings, arg_desc: str
     ) -> None:
+        from .asset_spec import AssetSpec
         from .assets import AssetsDefinition
         from .external_asset import create_external_asset_from_source_asset
         from .source_asset import SourceAsset
@@ -517,6 +519,9 @@ class PendingNodeInvocation(Generic[T_NodeDefinition]):
 
         if isinstance(output_node, SourceAsset):
             input_bindings[input_name] = create_external_asset_from_source_asset(output_node)
+        elif isinstance(output_node, AssetSpec):
+            with disable_dagster_warnings():
+                input_bindings[input_name] = AssetsDefinition(specs=[output_node])
         elif isinstance(
             output_node, (AssetsDefinition, InvokedNodeOutputHandle, InputMappingNode, DynamicFanIn)
         ):

--- a/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph_source_asset_input.py
+++ b/python_modules/dagster/dagster_tests/core_tests/graph_tests/test_graph_source_asset_input.py
@@ -3,7 +3,7 @@ from typing import Union
 import pytest
 from dagster import (
     AssetKey,
-    AssetsDefinition,
+    AssetSpec,
     DagsterInvalidDefinitionError,
     IOManager,
     IOManagerDefinition,
@@ -13,12 +13,9 @@ from dagster import (
     job,
     op,
 )
-from dagster._core.definitions.external_asset import create_external_asset_from_source_asset
 
 
-def make_io_manager(
-    asset: Union[AssetsDefinition, SourceAsset], input_value=5, expected_metadata={}
-):
+def make_io_manager(asset: Union[SourceAsset, AssetSpec], input_value=5, expected_metadata={}):
     class MyIOManager(IOManager):
         def handle_output(self, context, obj): ...
 
@@ -49,7 +46,7 @@ def test_source_asset_input_value():
 
 
 def test_external_asset_input_value():
-    asset1 = create_external_asset_from_source_asset(SourceAsset("asset1", metadata={"foo": "bar"}))
+    asset1 = AssetSpec("asset1", metadata={"foo": "bar"})
 
     @op
     def op1(input1):


### PR DESCRIPTION
## Summary & Motivation

It's currently possible to pass a `SourceAsset` as an input in an op graph: https://docs.dagster.io/concepts/ops-jobs-graphs/graphs#loading-an-asset-as-an-input.

Like this:

```python
from dagster import asset, job, op


@asset
def emails_to_send(): ...


@op
def send_emails(emails) -> None: ...


@job
def send_emails_job():
    send_emails(emails_to_send.to_source_asset())
```

`SourceAsset`s are being replaced by `AssetSpec`s, so this PR enables the same with `AssetSpec`s.

## How I Tested These Changes
