### PR TITLE
[ui] Allow control of run timeline grouping

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/overview/GroupTimelineRunsBySelect.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/GroupTimelineRunsBySelect.tsx
@@ -1,0 +1,53 @@
+import {Button, Icon, IconName, MenuItem, Select} from '@dagster-io/ui-components';
+
+import {GroupRunsBy} from './useGroupTimelineRunsBy';
+import {assertUnreachable} from '../app/Util';
+
+interface Props {
+  value: GroupRunsBy;
+  onSelect: (value: GroupRunsBy) => void;
+}
+
+export const GroupTimelineRunsBySelect = ({value, onSelect}: Props) => {
+  return (
+    <Select<GroupRunsBy>
+      items={['automation', 'job']}
+      itemRenderer={(item, props) => (
+        <MenuItem
+          key={item}
+          icon={valueToIcon(item)}
+          text={valueToLabel(item)}
+          onClick={props.handleClick}
+        />
+      )}
+      onItemSelect={onSelect}
+      filterable={false}
+    >
+      <Button icon={<Icon name={valueToIcon(value)} />} rightIcon={<Icon name="arrow_drop_down" />}>
+        {valueToLabel(value)}
+      </Button>
+    </Select>
+  );
+};
+
+const valueToLabel = (value: GroupRunsBy) => {
+  switch (value) {
+    case 'automation':
+      return 'Automation';
+    case 'job':
+      return 'Job';
+    default:
+      return assertUnreachable(value);
+  }
+};
+
+const valueToIcon = (value: GroupRunsBy): IconName => {
+  switch (value) {
+    case 'automation':
+      return 'sensors';
+    case 'job':
+      return 'job';
+    default:
+      return assertUnreachable(value);
+  }
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/useGroupTimelineRunsBy.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/useGroupTimelineRunsBy.tsx
@@ -1,0 +1,35 @@
+import {useCallback, useMemo} from 'react';
+
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
+
+const GROUP_BY_KEY = 'dagster.run-timeline-group-by';
+
+export type GroupRunsBy = 'job' | 'automation';
+
+export const useGroupTimelineRunsBy = (
+  defaultValue: GroupRunsBy = 'job',
+  storageKey = GROUP_BY_KEY,
+): [GroupRunsBy, (value: GroupRunsBy) => void] => {
+  const validate = useCallback(
+    (value: string) => {
+      switch (value) {
+        case 'job':
+        case 'automation':
+          return value;
+        default:
+          return defaultValue;
+      }
+    },
+    [defaultValue],
+  );
+
+  const [groupRunsBy, setGroupRunsBy] = useStateWithStorage(storageKey, validate);
+  const setGroupByWithDefault = useCallback(
+    (value: GroupRunsBy) => {
+      setGroupRunsBy(value || defaultValue);
+    },
+    [defaultValue, setGroupRunsBy],
+  );
+
+  return useMemo(() => [groupRunsBy, setGroupByWithDefault], [groupRunsBy, setGroupByWithDefault]);
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -395,12 +395,14 @@ export const useRunsForTimeline = ({
         name: isAdHoc ? 'Ad hoc materializations' : pipelineName,
         type: isAdHoc ? 'asset' : 'job',
         repoAddress,
-        path: workspacePipelinePath({
-          repoName: repoAddress.name,
-          repoLocation: repoAddress.location,
-          pipelineName,
-          isJob: true,
-        }),
+        path: isAdHoc
+          ? null
+          : workspacePipelinePath({
+              repoName: repoAddress.name,
+              repoLocation: repoAddress.location,
+              pipelineName,
+              isJob: true,
+            }),
         runs,
       } as TimelineRow;
     });


### PR DESCRIPTION
## Summary & Motivation

Make it possible to toggle between grouping "by job" and "by automation" in the Run timeline.

If grouping by automation, the  fallback "ad hoc materializations" bucket is eliminated, and "Manually launched" is used to group runs that have no associated automation (sensor, schedule, AMP).

<img width="1060" alt="Screenshot 2024-08-02 at 09 37 39" src="https://github.com/user-attachments/assets/ef21e5b0-6026-4113-892a-523d93dc1dc9">
<img width="1060" alt="Screenshot 2024-08-02 at 09 37 32" src="https://github.com/user-attachments/assets/248093a5-8628-4b5b-90bd-1b85e8c9cf65">

## How I Tested These Changes

View run timeline, verify that toggling between group-by options works correctly.