### PR TITLE
[1.8][external assets] deprecate SourceAsset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -189,22 +189,23 @@ class _ObservableSourceAsset:
         )
         resolved_resource_keys = decorator_resource_keys.union(arg_resource_keys)
 
-        return SourceAsset(
-            key=source_asset_key,
-            metadata=self.metadata,
-            io_manager_key=self.io_manager_key,
-            io_manager_def=self.io_manager_def,
-            description=self.description,
-            group_name=self.group_name,
-            _required_resource_keys=resolved_resource_keys,
-            resource_defs=self.resource_defs,
-            observe_fn=observe_fn,
-            op_tags=self.op_tags,
-            partitions_def=self.partitions_def,
-            auto_observe_interval_minutes=self.auto_observe_interval_minutes,
-            freshness_policy=self.freshness_policy,
-            tags=self.tags,
-        )
+        with disable_dagster_warnings():
+            return SourceAsset(
+                key=source_asset_key,
+                metadata=self.metadata,
+                io_manager_key=self.io_manager_key,
+                io_manager_def=self.io_manager_def,
+                description=self.description,
+                group_name=self.group_name,
+                _required_resource_keys=resolved_resource_keys,
+                resource_defs=self.resource_defs,
+                observe_fn=observe_fn,
+                op_tags=self.op_tags,
+                partitions_def=self.partitions_def,
+                auto_observe_interval_minutes=self.auto_observe_interval_minutes,
+                freshness_policy=self.freshness_policy,
+                tags=self.tags,
+            )
 
 
 @experimental

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -13,7 +13,7 @@ from typing import (
 from typing_extensions import TypeAlias
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, experimental_param, public
+from dagster._annotations import PublicAttr, deprecated, experimental_param, public
 from dagster._core.decorator_utils import get_function_params
 from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.data_version import (
@@ -167,6 +167,7 @@ def wrap_source_asset_observe_fn_in_op_compute_fn(
 @experimental_param(param="io_manager_def")
 @experimental_param(param="freshness_policy")
 @experimental_param(param="tags")
+@deprecated(breaking_version="2.0.0", additional_warn_text="Use AssetSpec instead.")
 class SourceAsset(ResourceAddable):
     """A SourceAsset represents an asset that will be loaded by (but not updated by) Dagster.
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_job.py
@@ -254,6 +254,7 @@ def test_asset_key_for_asset_with_key_prefix_str():
     assert _asset_keys_for_node(result, "hello__asset_foo") == {AssetKey(["hello", "asset_foo"])}
 
 
+@ignore_warning("Class `SourceAsset` is deprecated and will be removed in 2.0.0.")
 def test_source_asset():
     @asset
     def asset1(source1):
@@ -298,6 +299,7 @@ def test_source_asset():
     assert _asset_keys_for_node(result, "asset1") == {AssetKey("asset1")}
 
 
+@ignore_warning("Class `SourceAsset` is deprecated and will be removed in 2.0.0.")
 def test_missing_io_manager():
     @asset
     def asset1(source1):
@@ -1550,6 +1552,7 @@ def test_multi_all():
         assert materialization_events[2].asset_key == AssetKey("foo")
 
 
+@ignore_warning("Class `SourceAsset` is deprecated and will be removed in 2.0.0.")
 def test_subset_with_source_asset():
     class MyIOManager(IOManager):
         def handle_output(self, context, obj):
@@ -1674,6 +1677,7 @@ def test_graph_output_is_input_within_graph():
     assert result.output_for_node("complicated_graph", "asset_3") == 4
 
 
+@ignore_warning("Class `SourceAsset` is deprecated and will be removed in 2.0.0.")
 @ignore_warning("Parameter `io_manager_def` .* is experimental")
 def test_source_asset_io_manager_def():
     class MyIOManager(IOManager):
@@ -1700,6 +1704,7 @@ def test_source_asset_io_manager_def():
     assert result.output_for_node("my_derived_asset") == 9
 
 
+@ignore_warning("Class `SourceAsset` is deprecated and will be removed in 2.0.0.")
 def test_source_asset_io_manager_not_provided():
     class MyIOManager(IOManager):
         def handle_output(self, context, obj):
@@ -1728,6 +1733,7 @@ def test_source_asset_io_manager_not_provided():
     assert result.output_for_node("my_derived_asset") == 9
 
 
+@ignore_warning("Class `SourceAsset` is deprecated and will be removed in 2.0.0.")
 def test_source_asset_io_manager_key_provided():
     class MyIOManager(IOManager):
         def handle_output(self, context, obj):
@@ -1756,6 +1762,7 @@ def test_source_asset_io_manager_key_provided():
     assert result.output_for_node("my_derived_asset") == 9
 
 
+@ignore_warning("Class `SourceAsset` is deprecated and will be removed in 2.0.0.")
 @ignore_warning("Parameter `resource_defs` .* is experimental")
 @ignore_warning("Parameter `io_manager_def` .* is experimental")
 def test_source_asset_requires_resource_defs():
@@ -1845,6 +1852,7 @@ def test_transitive_resource_deps_provided():
     assert the_job.execute_in_process().success
 
 
+@ignore_warning("Class `SourceAsset` is deprecated and will be removed in 2.0.0.")
 @ignore_warning("Parameter `io_manager_def` .* is experimental")
 def test_transitive_io_manager_dep_not_provided():
     @io_manager(required_resource_keys={"foo"})
@@ -1988,6 +1996,7 @@ def test_async_multi_asset():
     assert result.success
 
 
+@ignore_warning("Class `SourceAsset` is deprecated and will be removed in 2.0.0.")
 def test_selection_multi_component():
     source_asset = SourceAsset(["apple", "banana"])
 
@@ -2593,6 +2602,7 @@ def test_subset_cycle_resolution_complex():
     assert result.output_for_node("foo_3", "f") == 9
 
 
+@ignore_warning("Class `SourceAsset` is deprecated and will be removed in 2.0.0.")
 def test_subset_cycle_resolution_basic():
     """Ops:
         foo produces: a, b
@@ -2660,6 +2670,7 @@ def test_subset_cycle_resolution_basic():
     }
 
 
+@ignore_warning("Class `SourceAsset` is deprecated and will be removed in 2.0.0.")
 def test_subset_cycle_resolution_with_asset_check():
     """Ops:
         foo produces: a, b

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize.py
@@ -129,6 +129,7 @@ def test_materialize_conflicting_resources():
 
 
 @ignore_warning("Parameter `io_manager_def` .* is experimental")
+@ignore_warning("Class `SourceAsset` is deprecated and will be removed in 2.0.0.")
 def test_materialize_source_assets():
     class MyIOManager(IOManager):
         def handle_output(self, context, obj):
@@ -192,6 +193,7 @@ def test_materialize_asset_specs_conflicting_key():
 
 @ignore_warning("Parameter `resource_defs` .* is experimental")
 @ignore_warning("Parameter `io_manager_def` .* is experimental")
+@ignore_warning("Class `SourceAsset` is deprecated and will be removed in 2.0.0.")
 def test_materialize_source_asset_conflicts():
     @io_manager(required_resource_keys={"foo"})
     def the_manager():

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -45,6 +45,7 @@ from dagster._core.storage.tags import (
 from dagster._core.test_utils import (
     assert_namedtuple_lists_equal,
     freeze_time,
+    ignore_warning,
     raise_exception_on_warnings,
 )
 from dagster._time import create_datetime, parse_time_string
@@ -376,6 +377,7 @@ def test_cross_job_different_partitions():
     ).success
 
 
+@ignore_warning("Class `SourceAsset` is deprecated and will be removed in 2.0.0.")
 def test_source_asset_partitions():
     hourly_asset = SourceAsset(
         AssetKey("hourly_asset"),


### PR DESCRIPTION
## Summary & Motivation

`AssetSpec` can now be used instead.

## How I Tested These Changes
