### PR TITLE
[serdes] typehints to handle @record_custom

### DIFF
--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -49,7 +49,13 @@ from typing_extensions import Final, Self, TypeAlias, TypeVar
 import dagster._check as check
 import dagster._seven as seven
 from dagster._model.pydantic_compat_layer import ModelFieldCompat, model_fields
-from dagster._record import as_dict_for_new, get_record_annotations, has_generated_new, is_record
+from dagster._record import (
+    IHaveNew,
+    as_dict_for_new,
+    get_record_annotations,
+    has_generated_new,
+    is_record,
+)
 from dagster._utils import is_named_tuple_instance, is_named_tuple_subclass
 from dagster._utils.warnings import disable_dagster_warnings
 
@@ -89,6 +95,7 @@ PackableValue: TypeAlias = Union[
     Set["PackableValue"],
     FrozenSet["PackableValue"],
     Enum,
+    IHaveNew,  # indirect way of indicating @record_custom classes are packable
 ]
 
 UnpackedValue: TypeAlias = Union[
@@ -106,6 +113,7 @@ UnpackedValue: TypeAlias = Union[
     FrozenSet["PackableValue"],
     Enum,
     "UnknownSerdesValue",
+    IHaveNew,
 ]
 
 SerializableObject: TypeAlias = Union[

--- a/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_serdes.py
@@ -948,7 +948,7 @@ def test_record() -> None:
 
     m = LegacyModel(nums=[1, 2, 3])
 
-    m_str = serialize_value(m, whitelist_map=test_env)  # type: ignore # with_new not seen as packable
+    m_str = serialize_value(m, whitelist_map=test_env)
     m2_str = m_str.replace("nums", "old_nums")
     assert m == deserialize_value(m2_str, whitelist_map=test_env)
 
@@ -1056,7 +1056,7 @@ def test_record_kwargs():
     )
 
 
-def test_record_remap():
+def test_record_remap() -> None:
     test_env = WhitelistMap.create()
 
     # time 1: record object created with non-serializable field


### PR DESCRIPTION
`@record` classes are considered `PackableValue` thanks to `DataclassInstance`, but this doesn't cover `@record_custom` which currently causes type errors. To solve this we add the marker class `IHaveNew` that all `@record_custom` classes are expected to subclass to the `PackableValue` and `UnpackedValue` `Union`s.

## How I Tested These Changes

added `-> None` to a test that previously caused type errors