### PR TITLE
[dagster-airlift] dagster operator

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/__init__.py
@@ -1,0 +1,1 @@
+from .mark_as_migrating import mark_as_dagster_migrating as mark_as_dagster_migrating

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/dagster_operator.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/dagster_operator.py
@@ -1,0 +1,81 @@
+import os
+
+import requests
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+from .gql_queries import ASSET_NODES_QUERY, RUNS_QUERY, TRIGGER_ASSETS_MUTATION
+
+
+def compute_fn() -> None:
+    # https://github.com/apache/airflow/discussions/24463
+    os.environ["NO_PROXY"] = "*"
+    dag_id = os.environ["AIRFLOW_CTX_DAG_ID"]
+    task_id = os.environ["AIRFLOW_CTX_TASK_ID"]
+    expected_op_name = f"{dag_id}__{task_id}"
+    assets_to_trigger = {}  # key is (repo_location, repo_name, job_name), value is list of asset keys
+    # create graphql client
+    dagster_url = os.environ["DAGSTER_URL"]
+    response = requests.post(f"{dagster_url}/graphql", json={"query": ASSET_NODES_QUERY}, timeout=3)
+    for asset_node in response.json()["data"]["assetNodes"]:
+        if asset_node["opName"] == expected_op_name:
+            repo_location = asset_node["jobs"][0]["repository"]["location"]["name"]
+            repo_name = asset_node["jobs"][0]["repository"]["name"]
+            job_name = asset_node["jobs"][0]["name"]
+            if (repo_location, repo_name, job_name) not in assets_to_trigger:
+                assets_to_trigger[(repo_location, repo_name, job_name)] = []
+            assets_to_trigger[(repo_location, repo_name, job_name)].append(
+                asset_node["assetKey"]["path"]
+            )
+    print(f"Found assets to trigger: {assets_to_trigger}")  # noqa: T201
+    triggered_runs = []
+    for (repo_location, repo_name, job_name), asset_keys in assets_to_trigger.items():
+        execution_params = {
+            "mode": "default",
+            "executionMetadata": {"tags": []},
+            "runConfigData": "{}",
+            "selector": {
+                "repositoryLocationName": repo_location,
+                "repositoryName": repo_name,
+                "pipelineName": job_name,
+                "assetSelection": [{"path": asset_key} for asset_key in asset_keys],
+                "assetCheckSelection": [],
+            },
+        }
+        print(f"Triggering run for {repo_location}/{repo_name}/{job_name} with assets {asset_keys}")  # noqa: T201
+        response = requests.post(
+            f"{dagster_url}/graphql",
+            json={
+                "query": TRIGGER_ASSETS_MUTATION,
+                "variables": {"executionParams": execution_params},
+            },
+            timeout=3,
+        )
+        run_id = response.json()["data"]["launchPipelineExecution"]["run"]["id"]
+        print(f"Launched run {run_id}...")  # noqa: T201
+        triggered_runs.append(run_id)
+    completed_runs = {}  # key is run_id, value is status
+    while len(completed_runs) < len(triggered_runs):
+        for run_id in triggered_runs:
+            if run_id in completed_runs:
+                continue
+            response = requests.post(
+                f"{dagster_url}/graphql",
+                json={"query": RUNS_QUERY, "variables": {"runId": run_id}},
+                timeout=3,
+            )
+            run_status = response.json()["data"]["runOrError"]["status"]
+            if run_status in ["SUCCESS", "FAILURE", "CANCELED"]:
+                print(f"Run {run_id} completed with status {run_status}")  # noqa: T201
+                completed_runs[run_id] = run_status
+    non_successful_runs = [
+        run_id for run_id, status in completed_runs.items() if status != "SUCCESS"
+    ]
+    if non_successful_runs:
+        raise Exception(f"Runs {non_successful_runs} did not complete successfully.")
+    print("All runs completed successfully.")  # noqa: T201
+    return None
+
+
+def build_dagster_task(task_id: str, dag: DAG, **kwargs):
+    return PythonOperator(task_id=task_id, dag=dag, python_callable=compute_fn, **kwargs)

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/gql_queries.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/gql_queries.py
@@ -1,0 +1,104 @@
+ASSET_NODES_QUERY = """
+query AssetNodeQuery {
+    assetNodes {
+        id
+        assetKey {
+            path
+        }
+        opName
+        jobs {
+            id
+            name
+            repository {
+                id
+                name
+                location {
+                    id
+                    name
+                }
+            }
+        }
+    }
+}
+"""
+
+TRIGGER_ASSETS_MUTATION = """
+mutation LaunchAssetsExecution($executionParams: ExecutionParams!) {
+  launchPipelineExecution(executionParams: $executionParams) {
+    ... on LaunchRunSuccess {
+      run {
+        id
+        pipelineName
+        __typename
+      }
+      __typename
+    }
+    ... on PipelineNotFoundError {
+      message
+      __typename
+    }
+    ... on InvalidSubsetError {
+      message
+      __typename
+    }
+    ... on RunConfigValidationInvalid {
+      errors {
+        message
+        __typename
+      }
+      __typename
+    }
+    ...PythonErrorFragment
+    __typename
+  }
+}
+
+fragment PythonErrorFragment on PythonError {
+  message
+  stack
+  errorChain {
+    ...PythonErrorChain
+    __typename
+  }
+  __typename
+}
+
+fragment PythonErrorChain on ErrorChainLink {
+  isExplicitLink
+  error {
+    message
+    stack
+    __typename
+  }
+  __typename
+}
+"""
+
+RUNS_QUERY = """
+query RunQuery($runId: ID!) {
+	runOrError(runId: $runId) {
+		__typename
+		...PythonErrorFragment
+		...NotFoundFragment
+		... on Run {
+			id
+			status
+			__typename
+		}
+	}
+}
+fragment NotFoundFragment on RunNotFoundError {
+	__typename
+	message
+}
+fragment PythonErrorFragment on PythonError {
+	__typename
+	message
+	stack
+	causes {
+		message
+		stack
+		__typename
+	}
+}
+"""

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/mark_as_migrating.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/mark_as_migrating.py
@@ -1,0 +1,49 @@
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from airflow import DAG
+
+from ..migration_state import AirflowMigrationState
+
+
+def mark_as_dagster_migrating(
+    *,
+    global_vars: Dict[str, Any],
+    migration_state: AirflowMigrationState,
+    logger: Optional[logging.Logger] = None,
+) -> None:
+    """Alters all airflow dags in the current context to be marked as migrating to dagster.
+    Uses a migration dictionary to determine the status of the migration for each task within each dag.
+    Should only ever be the last line in a dag file.
+
+    Args:
+        global_vars (Dict[str, Any]): The global variables in the current context. In most cases, retrieved with `globals()` (no import required).
+            This is equivalent to what airflow already does to introspect the dags which exist in a given module context:
+            https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/dags.html#loading-dags
+        migration_state (AirflowMigrationState): The migration state for the dags.
+        logger (Optional[logging.Logger]): The logger to use. Defaults to logging.getLogger("dagster_airlift").
+    """
+    caller_module = global_vars.get("__module__")
+    suffix = f" in module `{caller_module}`" if caller_module else ""
+    if not logger:
+        logger = logging.getLogger("dagster_airlift")
+    logger.debug(f"Searching for dags migrating to dagster{suffix}...")
+    num_dags = 0
+    for obj in global_vars.values():
+        if not isinstance(obj, DAG):
+            continue
+        dag: DAG = obj
+        logger.debug(f"Checking dag with id `{dag.dag_id}` for migration state.")
+        migration_state_for_dag = migration_state.get_migration_dict_for_dag(dag.dag_id)
+        if migration_state_for_dag is None:
+            logger.debug(
+                f"Dag with id `{dag.dag_id} hasn't been marked with migration state. Skipping..."
+            )
+        else:
+            dag.tags.append(json.dumps({"DAGSTER_MIGRATION_STATUS": migration_state_for_dag}))
+            logger.debug(
+                f"Dag with id `{dag.dag_id}` has been marked with migration state. Adding state to tags for dag."
+            )
+            num_dags += 1
+    logger.info(f"Marked {num_dags} dags as migrating to dagster{suffix}.")

--- a/examples/experimental/dagster-airlift/dagster_airlift/migration_state.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/migration_state.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, NamedTuple
+from typing import Any, Dict, NamedTuple, Optional
 
 import yaml
 
@@ -18,9 +18,36 @@ class AirflowMigrationState(NamedTuple):
     def get_migration_state_for_task(self, dag_id: str, task_id: str) -> bool:
         return self.dags[dag_id].tasks[task_id].migrated
 
+    def get_migration_dict_for_dag(self, dag_id: str) -> Optional[Dict[str, Dict[str, Any]]]:
+        if dag_id not in self.dags:
+            return None
+        return {
+            "tasks": {
+                task_id: {"migrated": task_state.migrated}
+                for task_id, task_state in self.dags[dag_id].tasks.items()
+            }
+        }
+
 
 class MigrationStateParsingError(Exception):
     pass
+
+
+def load_dag_migration_state_from_dict(dag_dict: Dict[str, Dict[str, Any]]) -> DagMigrationState:
+    if "tasks" not in dag_dict:
+        raise Exception("Expected a 'tasks' key in the yaml")
+    task_migration_states = {}
+    for task_id, task_dict in dag_dict["tasks"].items():
+        if not isinstance(task_dict, dict):
+            raise Exception("Expected a dictionary for each task")
+        if "migrated" not in task_dict:
+            raise Exception("Expected a 'migrated' key in the task dictionary")
+        if set(task_dict.keys()) != {"migrated"}:
+            raise Exception("Expected only a 'migrated' key in the task dictionary")
+        if task_dict["migrated"] not in [True, False]:
+            raise Exception("Expected 'migrated' key to be a boolean")
+        task_migration_states[task_id] = TaskMigrationState(migrated=task_dict["migrated"])
+    return DagMigrationState(tasks=task_migration_states)
 
 
 def load_migration_state_from_yaml(migration_yaml_path: Path) -> AirflowMigrationState:
@@ -37,20 +64,7 @@ def load_migration_state_from_yaml(migration_yaml_path: Path) -> AirflowMigratio
             yaml_dict = yaml.safe_load(dag_file.read_text())
             if not isinstance(yaml_dict, dict):
                 raise Exception("Expected a dictionary")
-            if "tasks" not in yaml_dict:
-                raise Exception("Expected a 'tasks' key in the yaml")
-            task_migration_states = {}
-            for task_id, task_dict in yaml_dict["tasks"].items():
-                if not isinstance(task_dict, dict):
-                    raise Exception("Expected a dictionary for each task")
-                if "migrated" not in task_dict:
-                    raise Exception("Expected a 'migrated' key in the task dictionary")
-                if set(task_dict.keys()) != {"migrated"}:
-                    raise Exception("Expected only a 'migrated' key in the task dictionary")
-                if task_dict["migrated"] not in [True, False]:
-                    raise Exception("Expected 'migrated' key to be a boolean")
-                task_migration_states[task_id] = TaskMigrationState(migrated=task_dict["migrated"])
-            dag_migration_states[dag_id] = DagMigrationState(tasks=task_migration_states)
+            dag_migration_states[dag_id] = load_dag_migration_state_from_dict(yaml_dict)
     except Exception as e:
         raise MigrationStateParsingError("Error parsing migration yaml") from e
     return AirflowMigrationState(dags=dag_migration_states)

--- a/examples/experimental/dagster-airlift/dagster_airlift/test/shared_fixtures.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/test/shared_fixtures.py
@@ -31,7 +31,7 @@ def airflow_instance_fixture(setup: None) -> Generator[Any, None, None]:
     initial_time = get_current_timestamp()
 
     airflow_ready = False
-    while get_current_timestamp() - initial_time < 30:
+    while get_current_timestamp() - initial_time < 60:
         if airflow_is_ready():
             airflow_ready = True
             break

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/conftest.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/conftest.py
@@ -1,5 +1,7 @@
 import os
+import signal
 import subprocess
+import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Generator
@@ -7,6 +9,7 @@ from typing import Any, Generator
 import pytest
 import requests
 from dagster._core.test_utils import environ
+from dagster._time import get_current_timestamp
 
 
 def assert_link_exists(link_name: str, link_url: Any):
@@ -19,17 +22,26 @@ def default_dags_dir():
     return Path(__file__).parent / "dags"
 
 
-@pytest.fixture(name="setup")
-def setup_fixture(dags_dir: Path) -> Generator[str, None, None]:
+@pytest.fixture(name="airflow_home")
+def default_airflow_home() -> Generator[str, None, None]:
     with TemporaryDirectory() as tmpdir:
-        # run chmod +x create_airflow_cfg.sh and then run create_airflow_cfg.sh tmpdir
-        temp_env = {**os.environ.copy(), "AIRFLOW_HOME": tmpdir}
-        # go up one directory from current
-        path_to_script = Path(__file__).parent.parent.parent / "airflow_setup.sh"
-        subprocess.run(["chmod", "+x", path_to_script], check=True, env=temp_env)
-        subprocess.run([path_to_script, dags_dir], check=True, env=temp_env)
-        with environ({"AIRFLOW_HOME": tmpdir}):
-            yield tmpdir
+        yield tmpdir
+
+
+@pytest.fixture(name="setup")
+def setup_fixture(airflow_home: Path, dags_dir: Path) -> Generator[str, None, None]:
+    # run chmod +x create_airflow_cfg.sh and then run create_airflow_cfg.sh tmpdir
+    temp_env = {
+        **os.environ.copy(),
+        "AIRFLOW_HOME": str(airflow_home),
+        "DAGSTER_URL": "http://localhost:3333",
+    }
+    # go up one directory from current
+    path_to_script = Path(__file__).parent.parent.parent / "airflow_setup.sh"
+    subprocess.run(["chmod", "+x", path_to_script], check=True, env=temp_env)
+    subprocess.run([path_to_script, dags_dir], check=True, env=temp_env)
+    with environ({"AIRFLOW_HOME": str(airflow_home), "DAGSTER_URL": "http://localhost:3333"}):
+        yield str(airflow_home)
 
 
 @pytest.fixture(name="dbt_project_dir")
@@ -49,3 +61,46 @@ def dbt_project(dbt_project_dir: Path) -> None:
         check=True,
         env=os.environ.copy(),
     )
+
+
+def dagster_is_ready() -> bool:
+    try:
+        response = requests.get("http://localhost:3333")
+        return response.status_code == 200
+    except:
+        return False
+
+
+@pytest.fixture(name="dagster_home")
+def setup_dagster_home() -> Generator[str, None, None]:
+    """Instantiate a temporary directory to serve as the DAGSTER_HOME."""
+    with TemporaryDirectory() as tmpdir:
+        yield tmpdir
+
+
+@pytest.fixture(name="dagster_dev")
+def setup_dagster(dagster_home: str, dagster_defs_path: str) -> Generator[Any, None, None]:
+    """Stands up a dagster instance using the dagster dev CLI. dagster_defs_path must be provided
+    by a fixture included in the callsite.
+    """
+    temp_env = {**os.environ.copy(), "DAGSTER_HOME": dagster_home}
+    process = subprocess.Popen(
+        ["dagster", "dev", "-f", dagster_defs_path, "-p", "3333"],
+        env=temp_env,
+        shell=False,
+        preexec_fn=os.setsid,  # noqa
+    )
+    # Give dagster a second to stand up
+    time.sleep(5)
+
+    dagster_ready = False
+    initial_time = get_current_timestamp()
+    while get_current_timestamp() - initial_time < 60:
+        if dagster_is_ready():
+            dagster_ready = True
+            break
+        time.sleep(1)
+
+    assert dagster_ready, "Dagster did not start within 30 seconds..."
+    yield process
+    os.killpg(process.pid, signal.SIGKILL)

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/correctly_marked_dag/dags/marked.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/correctly_marked_dag/dags/marked.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from pathlib import Path
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from dagster_airlift.in_airflow import mark_as_dagster_migrating
+from dagster_airlift.migration_state import load_migration_state_from_yaml
+
+
+def print_hello():
+    print("Hello")  # noqa: T201
+
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2023, 1, 1),
+    "retries": 1,
+}
+
+marked_dag = DAG(
+    "marked_dag", default_args=default_args, schedule_interval=None, is_paused_upon_creation=False
+)
+print_op = PythonOperator(task_id="print_task", python_callable=print_hello, dag=marked_dag)
+downstream_print_op = PythonOperator(
+    task_id="downstream_print_task", python_callable=print_hello, dag=marked_dag
+)
+
+
+path_to_migration_state = Path(__file__).parent.parent / "migration_state"
+mark_as_dagster_migrating(
+    migration_state=load_migration_state_from_yaml(path_to_migration_state), global_vars=globals()
+)

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/correctly_marked_dag/migration_state/marked_dag.yaml
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/correctly_marked_dag/migration_state/marked_dag.yaml
@@ -1,0 +1,3 @@
+tasks:
+  print_task:
+    migrated: False 

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/incorrectly_marked_dag/dags/marked.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/incorrectly_marked_dag/dags/marked.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from pathlib import Path
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from dagster_airlift.in_airflow import mark_as_dagster_migrating
+from dagster_airlift.migration_state import load_migration_state_from_yaml
+
+
+def print_hello():
+    print("Hello")  # noqa: T201
+
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2023, 1, 1),
+    "retries": 1,
+}
+
+marked_dag = DAG(
+    "marked_dag", default_args=default_args, schedule_interval=None, is_paused_upon_creation=False
+)
+print_op = PythonOperator(task_id="print_task", python_callable=print_hello, dag=marked_dag)
+downstream_print_op = PythonOperator(
+    task_id="downstream_print_task", python_callable=print_hello, dag=marked_dag
+)
+
+# There is no entry for marked_dag in the migration state directory. There shouldn't be an exception, the dag just shouldn't be marked.
+path_to_migration_state = Path(__file__).parent.parent / "migration_state"
+mark_as_dagster_migrating(
+    migration_state=load_migration_state_from_yaml(path_to_migration_state), global_vars=globals()
+)

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/incorrectly_marked_dag/migration_state/some_other_dag.yaml
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/incorrectly_marked_dag/migration_state/some_other_dag.yaml
@@ -1,0 +1,3 @@
+tasks:
+  print_task:
+    migrated: False 

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/operator_test_project/dags/migrated_dag.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/operator_test_project/dags/migrated_dag.py
@@ -1,0 +1,29 @@
+import logging
+from datetime import datetime
+
+from airflow import DAG
+from dagster_airlift.in_airflow.dagster_operator import build_dagster_task
+
+logging.basicConfig()
+logging.getLogger().setLevel(logging.INFO)
+requests_log = logging.getLogger("requests.packages.urllib3")
+requests_log.setLevel(logging.INFO)
+requests_log.propagate = True
+
+
+def print_hello():
+    print("Hello")  # noqa: T201
+
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2023, 1, 1),
+    "retries": 1,
+}
+
+dag = DAG(
+    "the_dag", default_args=default_args, schedule_interval=None, is_paused_upon_creation=False
+)
+migrated_op = build_dagster_task(task_id="some_task", dag=dag)
+other_migrated_op = build_dagster_task(task_id="other_task", dag=dag)

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/operator_test_project/dagster_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/operator_test_project/dagster_defs.py
@@ -1,0 +1,19 @@
+from dagster import Definitions, asset
+
+
+@asset
+def the_dag__some_task():
+    return "asset_value"
+
+
+@asset
+def unrelated():
+    return "unrelated_value"
+
+
+@asset
+def the_dag__other_task():
+    return "other_task_value"
+
+
+defs = Definitions(assets=[the_dag__other_task, the_dag__some_task, unrelated])

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_dagster_operator.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_dagster_operator.py
@@ -1,0 +1,61 @@
+import time
+from pathlib import Path
+
+import pytest
+import requests
+from dagster import AssetKey, DagsterInstance, DagsterRunStatus
+from dagster._core.test_utils import environ
+from dagster._time import get_current_timestamp
+
+
+@pytest.fixture(name="dags_dir")
+def dags_dir() -> Path:
+    return Path(__file__).parent / "operator_test_project" / "dags"
+
+
+@pytest.fixture(name="dagster_defs_path")
+def dagster_defs_path() -> Path:
+    return Path(__file__).parent / "operator_test_project" / "dagster_defs.py"
+
+
+def test_dagster_operator(airflow_instance: None, dagster_dev: None, dagster_home: str) -> None:
+    """Tests that dagster operator can correctly map airflow tasks to dagster tasks, and kick off executions."""
+    response = requests.post(
+        "http://localhost:8080/api/v1/dags/the_dag/dagRuns", auth=("admin", "admin"), json={}
+    )
+    assert response.status_code == 200, response.json()
+    # Wait until the run enters a terminal state
+    terminal_status = None
+    start_time = get_current_timestamp()
+    while get_current_timestamp() - start_time < 30:
+        response = requests.get(
+            "http://localhost:8080/api/v1/dags/the_dag/dagRuns", auth=("admin", "admin")
+        )
+        assert response.status_code == 200, response.json()
+        dag_runs = response.json()["dag_runs"]
+        if dag_runs[0]["state"] in ["success", "failed"]:
+            terminal_status = dag_runs[0]["state"]
+            break
+        time.sleep(1)
+    assert terminal_status == "success", (
+        "Never reached terminal status"
+        if terminal_status is None
+        else f"terminal status was {terminal_status}"
+    )
+    with environ({"DAGSTER_HOME": dagster_home}):
+        instance = DagsterInstance.get()
+        runs = instance.get_runs()
+        # The graphql endpoint kicks off a run for each of the tasks in the dag
+        assert len(runs) == 2
+        some_task_run = [  # noqa
+            run
+            for run in runs
+            if set(list(run.asset_selection)) == {AssetKey(["the_dag__other_task"])}  # type: ignore
+        ][0]
+        other_task_run = [  # noqa
+            run
+            for run in runs
+            if set(list(run.asset_selection)) == {AssetKey(["the_dag__some_task"])}  # type: ignore
+        ][0]
+        assert some_task_run.status == DagsterRunStatus.SUCCESS
+        assert other_task_run.status == DagsterRunStatus.SUCCESS

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_migrating_dag_correctly_marked.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_migrating_dag_correctly_marked.py
@@ -1,0 +1,41 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Generator
+
+import pytest
+import requests
+from dagster._core.test_utils import environ
+
+
+@pytest.fixture(name="setup")
+def setup_fixture() -> Generator[str, None, None]:
+    with TemporaryDirectory() as tmpdir:
+        # run chmod +x create_airflow_cfg.sh and then run create_airflow_cfg.sh tmpdir
+        temp_env = {**os.environ.copy(), "AIRFLOW_HOME": tmpdir}
+        # go up one directory from current
+        path_to_script = Path(__file__).parent.parent.parent / "airflow_setup.sh"
+        path_to_dags = Path(__file__).parent / "correctly_marked_dag" / "dags"
+        subprocess.run(["chmod", "+x", path_to_script], check=True, env=temp_env)
+        subprocess.run([path_to_script, path_to_dags], check=True, env=temp_env)
+        with environ({"AIRFLOW_HOME": tmpdir}):
+            yield tmpdir
+
+
+def test_migrating_dag(airflow_instance: None) -> None:
+    """Tests that a correctly marked dag is marked as migrating via a tag on the dag object."""
+    response = requests.get("http://localhost:8080/api/v1/dags/marked_dag", auth=("admin", "admin"))
+    assert response.status_code == 200
+    tags = response.json()["tags"]
+    assert len(tags) == 1
+    assert json.loads(tags[0]["name"]) == {
+        "DAGSTER_MIGRATION_STATUS": {
+            "tasks": {
+                "print_task": {
+                    "migrated": False,
+                }
+            }
+        }
+    }

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_migrating_dag_incorrectly_marked.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_migrating_dag_incorrectly_marked.py
@@ -1,0 +1,31 @@
+import os
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Generator
+
+import pytest
+import requests
+from dagster._core.test_utils import environ
+
+
+@pytest.fixture(name="setup")
+def setup_fixture() -> Generator[str, None, None]:
+    with TemporaryDirectory() as tmpdir:
+        # run chmod +x create_airflow_cfg.sh and then run create_airflow_cfg.sh tmpdir
+        temp_env = {**os.environ.copy(), "AIRFLOW_HOME": tmpdir}
+        # go up one directory from current
+        path_to_script = Path(__file__).parent.parent.parent / "airflow_setup.sh"
+        path_to_dags = Path(__file__).parent / "incorrectly_marked_dag" / "dags"
+        subprocess.run(["chmod", "+x", path_to_script], check=True, env=temp_env)
+        subprocess.run([path_to_script, path_to_dags], check=True, env=temp_env)
+        with environ({"AIRFLOW_HOME": tmpdir}):
+            yield tmpdir
+
+
+def test_migrating_dag(airflow_instance: None) -> None:
+    """Tests that an incorrectly marked dag throws an exception, and is not loaded."""
+    response = requests.get("http://localhost:8080/api/v1/dags/marked_dag", auth=("admin", "admin"))
+    assert response.status_code == 200
+    tags = response.json()["tags"]
+    assert len(tags) == 0

--- a/examples/experimental/dagster-airlift/setup.py
+++ b/examples/experimental/dagster-airlift/setup.py
@@ -37,7 +37,7 @@ setup(
         "in-airflow": airflow_dep_list,
         "mwaa": ["boto3"],
         "dbt": ["dagster-dbt"],
-        "test": ["pytest", "dagster-dbt", "dbt-duckdb", "boto3"],
+        "test": ["pytest", "dagster-dbt", "dbt-duckdb", "boto3", "dagster-webserver"],
     },
     zip_safe=False,
 )

--- a/examples/experimental/dagster-airlift/tox.ini
+++ b/examples/experimental/dagster-airlift/tox.ini
@@ -12,6 +12,8 @@ deps =
   -e ../../../python_modules/dagster[test]
   -e ../../../python_modules/dagster-test
   -e ../../../python_modules/dagster-pipes
+  -e ../../../python_modules/dagster-webserver
+  -e ../../../python_modules/dagster-graphql
   -e ../../../python_modules/libraries/dagster-dbt
   -e .[core,mwaa,dbt,test,in-airflow]
   dbt-duckdb
@@ -19,5 +21,6 @@ allowlist_externals =
   /bin/bash
   uv
 commands =
+  make -C ../../.. rebuild_ui
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml ./dagster_airlift_tests --snapshot-warn-unused -vv {posargs}


### PR DESCRIPTION
Dagster operator which is able to remotely invoke dagster via airflow.
It searches for a "node def" with the name that matches the task (and matches our opinionated file format for blueprints). 

Includes unit test which runs against live airflow and dagster, checks that runs of the respective assets are invoked for each task.

Tests are probably not entirely sufficient. I'd ideally like to run against a few other cases:
- workspace with multiple defined code locations
- multi asset with multiple keys. Ensure they all get picked up within same run.

The api surface area here won't actually be exposed to the user. What I'm imagining is something like this:
```python
... # dag code
create_migrating_dag(
    migrating_dict={...},
    dagster_instance=DagsterInstance(url=...) # or, in cloud case DagsterCloudInstance(url=..., auth_token=...)
)
```
then, under the hood, we swap out operators via the stack, same as we do with the dag construction.

any real use case will need new graphql endpoints so that we can easily retrieve asset info per node. The number of steps here feels gratuitous (although only because the way we're retrieving information is a bit hacky)