### PR TITLE
[1/p][dagster-embedded-etl] add SlingEventIterator

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -339,7 +339,6 @@ class SlingResource(ConfigurableResource):
             )
 
         prepared_environment = self.prepare_environment()
-        print(prepared_environment)
         with environ(prepared_environment):
             yield
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
@@ -1,0 +1,35 @@
+from collections import abc
+from typing import TYPE_CHECKING, Any, Dict, Generic, Iterator
+
+from dagster import AssetMaterialization
+from typing_extensions import TypeVar
+
+if TYPE_CHECKING:
+    from .resources import SlingResource
+
+
+SlingEventType = AssetMaterialization
+
+# We define DbtEventIterator as a generic type for the sake of type hinting.
+# This is so that users who inspect the type of the return value of `DbtCliInvocation.stream()`
+# will be able to see the inner type of the iterator, rather than just `DbtEventIterator`.
+T = TypeVar("T", bound=SlingEventType)
+
+
+class SlingEventIterator(Generic[T], abc.Iterator):
+    """A wrapper around an iterator of ling events which contains additional methods for
+    post-processing the events, such as fetching column metadata.
+    """
+
+    def __init__(
+        self, events: Iterator[T], sling_cli: "SlingResource", replication_config: Dict[str, Any]
+    ) -> None:
+        self._inner_iterator = events
+        self._sling_cli = sling_cli
+        self._replication_config = replication_config
+
+    def __next__(self) -> T:
+        return next(self._inner_iterator)
+
+    def __iter__(self) -> "SlingEventIterator[T]":
+        return self

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
@@ -10,14 +10,14 @@ if TYPE_CHECKING:
 
 SlingEventType = AssetMaterialization
 
-# We define DbtEventIterator as a generic type for the sake of type hinting.
-# This is so that users who inspect the type of the return value of `DbtCliInvocation.stream()`
-# will be able to see the inner type of the iterator, rather than just `DbtEventIterator`.
+# We define SlingEventIterator as a generic type for the sake of type hinting.
+# This is so that users who inspect the type of the return value of `SlingResource.replicate()`
+# will be able to see the inner type of the iterator, rather than just `SlingEventIterator`.
 T = TypeVar("T", bound=SlingEventType)
 
 
 class SlingEventIterator(Generic[T], abc.Iterator):
-    """A wrapper around an iterator of ling events which contains additional methods for
+    """A wrapper around an iterator of Sling events which contains additional methods for
     post-processing the events, such as fetching column metadata.
     """
 


### PR DESCRIPTION
## Summary

Adds `SlingEventIterator` class which we can use to chain subsequent computation on Sling syncs. Motivated by stacked PR #23388.

## Test Plan

Existing unit tests, inspect in editor to make sure type hints are happy.
