### PR TITLE
[2/p][dagster-embedded-etl] add ability to fetch columnar metadata for Sling assets

### DIFF
--- a/examples/experimental/sling_decorator/sling_decorator/definitions.py
+++ b/examples/experimental/sling_decorator/sling_decorator/definitions.py
@@ -22,7 +22,7 @@ sling_resource = SlingResource(
 
 @sling_assets(replication_config=replication_config)
 def my_assets(context, sling: SlingResource):
-    yield from sling.replicate(context=context)
+    yield from sling.replicate(context=context).fetch_column_metadata()
     for row in sling.stream_raw_logs():
         context.log.info(row)
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -427,10 +427,7 @@ class SlingResource(ConfigurableResource):
         column_keys: List[str] = table_output["fields"]
         column_values: List[List[str]] = table_output["rows"]
 
-        return [
-            {column_keys[i]: column_values[i] for i in range(len(column_keys))}
-            for column_values in column_values
-        ]
+        return [dict(zip(column_keys, column_values)) for column_values in column_values]
 
     def get_column_info_for_table(self, target_name: str, table_name: str) -> List[Dict[str, str]]:
         """Fetches column metadata for a given table in a Sling target and parses it into a list of
@@ -459,7 +456,7 @@ class SlingResource(ConfigurableResource):
             str: The output from the Sling CLI.
         """
         with environ({"SLING_OUTPUT": "json"}) if force_json else contextlib.nullcontext():
-            return subprocess.check_output(args=[sling.SLING_BIN, *args]).decode("utf-8")
+            return subprocess.check_output(args=[sling.SLING_BIN, *args], text=True)
 
     def replicate(
         self,

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
@@ -125,9 +125,8 @@ def fetch_column_metadata(
                     column_lineage=column_lineage,
                 )
             )
-        except Exception as e:
-            raise e
-            context.log.warning("Failed to fetch column metadata for stream %s: %s", stream_name, e)
+        except Exception:
+            context.log.warning("Failed to fetch column metadata for stream %s: %s", stream_name, exc_info=True)
 
     return {}
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
@@ -1,7 +1,21 @@
+import re
 from collections import abc
-from typing import TYPE_CHECKING, Any, Dict, Generic, Iterator
+from typing import TYPE_CHECKING, Any, Dict, Generic, Iterator, Sequence, Union, cast
 
-from dagster import AssetMaterialization
+from dagster import (
+    AssetMaterialization,
+    _check as check,
+)
+from dagster._annotations import experimental, public
+from dagster._core.definitions.metadata.metadata_set import TableMetadataSet
+from dagster._core.definitions.metadata.table import (
+    TableColumn,
+    TableColumnDep,
+    TableColumnLineage,
+    TableSchema,
+)
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from dagster._core.execution.context.op_execution_context import OpExecutionContext
 from typing_extensions import TypeVar
 
 if TYPE_CHECKING:
@@ -16,20 +30,139 @@ SlingEventType = AssetMaterialization
 T = TypeVar("T", bound=SlingEventType)
 
 
+def _get_logs_for_stream(
+    stream_name: str,
+    sling_cli: "SlingResource",
+) -> Sequence[str]:
+    corresponding_logs = []
+    recording_logs = False
+    for log in sling_cli.stream_raw_logs():
+        if (f"running stream {stream_name}") in log:
+            corresponding_logs.append(log)
+            recording_logs = True
+        elif recording_logs:
+            if len(log.strip()) == 0:
+                break
+            corresponding_logs.append(log)
+    return corresponding_logs
+
+
+def _strip_quotes_target_table_name(target_table_name: str) -> str:
+    return target_table_name.replace('"', "")
+
+
+INSERT_REGEX: re.Pattern[str] = re.compile(r".*inserted (\d+) rows into (.*) in.*")
+SLING_COLUMN_PREFIX = "_sling_"
+
+
+def fetch_column_metadata(
+    materialization: AssetMaterialization,
+    sling_cli: "SlingResource",
+    replication_config: Dict[str, Any],
+    context: Union[OpExecutionContext, AssetExecutionContext],
+) -> Dict[str, Any]:
+    target_name = replication_config["target"]
+    stream_name = cast(str, materialization.metadata["stream_name"].value)
+
+    upstream_assets = set()
+    if isinstance(context, AssetExecutionContext):
+        upstream_assets = context.assets_def.asset_deps[materialization.asset_key]
+
+    corresponding_logs = _get_logs_for_stream(stream_name, sling_cli)
+    insert_log = next((log for log in corresponding_logs if re.match(INSERT_REGEX, log)), None)
+
+    if insert_log:
+        try:
+            target_table_name = check.not_none(re.match(INSERT_REGEX, insert_log)).group(2)
+            target_table_name = _strip_quotes_target_table_name(target_table_name)
+
+            output = sling_cli.run_sling_cli(
+                ["conns", "discover", target_name, "--pattern", target_table_name, "--columns"]
+            )
+            table_rows = [row.strip()[1:-1] for row in output.split("\n") if row.startswith("|")]
+            tabular_data = [[x.strip() for x in row.split("|")] for row in table_rows]
+
+            col_name_idx = tabular_data[0].index("COLUMN")
+            general_type_idx = tabular_data[0].index("GENERAL TYPE")
+
+            column_type_map = {row[col_name_idx]: row[general_type_idx] for row in tabular_data[1:]}
+
+            column_lineage = None
+            # If there is only one upstream asset (typical case), we can infer column lineage
+            # from the single upstream asset which is being replicated exactly.
+            if len(upstream_assets) == 1:
+                upstream_asset_key = next(iter(upstream_assets))
+                column_lineage = TableColumnLineage(
+                    deps_by_column={
+                        column_name: [
+                            TableColumnDep(
+                                asset_key=upstream_asset_key,
+                                column_name=column_name,
+                            )
+                        ]
+                        for column_name in column_type_map.keys()
+                        if not column_name.startswith(SLING_COLUMN_PREFIX)
+                    }
+                )
+
+            return dict(
+                TableMetadataSet(
+                    column_schema=TableSchema(
+                        columns=[
+                            TableColumn(name=column_name, type=column_type)
+                            for column_name, column_type in column_type_map.items()
+                        ]
+                    ),
+                    column_lineage=column_lineage,
+                )
+            )
+        except Exception as e:
+            context.log.warning("Failed to fetch column metadata for stream %s: %s", stream_name, e)
+
+    return {}
+
+
 class SlingEventIterator(Generic[T], abc.Iterator):
     """A wrapper around an iterator of Sling events which contains additional methods for
     post-processing the events, such as fetching column metadata.
     """
 
     def __init__(
-        self, events: Iterator[T], sling_cli: "SlingResource", replication_config: Dict[str, Any]
+        self,
+        events: Iterator[T],
+        sling_cli: "SlingResource",
+        replication_config: Dict[str, Any],
+        context: Union[OpExecutionContext, AssetExecutionContext],
     ) -> None:
         self._inner_iterator = events
         self._sling_cli = sling_cli
         self._replication_config = replication_config
+        self._context = context
 
     def __next__(self) -> T:
         return next(self._inner_iterator)
 
     def __iter__(self) -> "SlingEventIterator[T]":
         return self
+
+    @experimental
+    @public
+    def fetch_column_metadata(self) -> "SlingEventIterator":
+        """Fetches column metadata for each table synced by the Sling CLI.
+
+        Retrieves the column schema and lineage for each target table.
+
+        Returns:
+            SlingEventIterator: An iterator of Dagster events with column metadata attached.
+        """
+
+        def _fetch_column_metadata() -> Iterator[T]:
+            for event in self:
+                col_metadata = fetch_column_metadata(
+                    event, self._sling_cli, self._replication_config, self._context
+                )
+                yield event.with_metadata({**col_metadata, **event.metadata})
+
+        return SlingEventIterator[T](
+            _fetch_column_metadata(), self._sling_cli, self._replication_config, self._context
+        )

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
@@ -126,7 +126,9 @@ def fetch_column_metadata(
                 )
             )
         except Exception:
-            context.log.warning("Failed to fetch column metadata for stream %s: %s", stream_name, exc_info=True)
+            context.log.warning(
+                "Failed to fetch column metadata for stream %s", stream_name, exc_info=True
+            )
 
     return {}
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
@@ -66,8 +66,8 @@ def _get_target_table_name(stream_name: str, sling_cli: "SlingResource") -> Opti
     return _strip_quotes_target_table_name(target_table_name)
 
 
-COLUMN_NAME_COL = "COLUMN"
-COLUMN_TYPE_COL = "GENERAL TYPE"
+COLUMN_NAME_COL = "Column"
+COLUMN_TYPE_COL = "General Type"
 
 SLING_COLUMN_PREFIX = "_sling_"
 
@@ -126,6 +126,7 @@ def fetch_column_metadata(
                 )
             )
         except Exception as e:
+            raise e
             context.log.warning("Failed to fetch column metadata for stream %s: %s", stream_name, e)
 
     return {}

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_asset_decorator.py
@@ -13,6 +13,16 @@ from dagster import (
     file_relative_path,
 )
 from dagster._core.definitions.materialize import materialize
+from dagster._core.definitions.metadata.metadata_value import (
+    TableColumnLineageMetadataValue,
+    TableSchemaMetadataValue,
+)
+from dagster._core.definitions.metadata.table import (
+    TableColumn,
+    TableColumnDep,
+    TableColumnLineage,
+    TableSchema,
+)
 from dagster_embedded_elt.sling import SlingReplicationParam, sling_assets
 from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
 from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingResource
@@ -334,6 +344,67 @@ def test_base_with_custom_asset_key_prefix():
         AssetKey(["custom", "departments"]),
         AssetKey(["custom", "public", "transactions"]),
     }
+
+
+def test_fetch_column_metadata(
+    csv_to_sqlite_dataworks_replication: SlingReplicationParam,
+    path_to_temp_sqlite_db: str,
+):
+    @sling_assets(replication_config=csv_to_sqlite_dataworks_replication)
+    def my_sling_assets(context: AssetExecutionContext, sling: SlingResource):
+        yield from sling.replicate(context=context).fetch_column_metadata()
+
+    sling_resource = SlingResource(
+        connections=[
+            SlingConnectionResource(type="file", name="SLING_FILE"),
+            SlingConnectionResource(
+                type="sqlite",
+                name="SLING_SQLITE",
+                connection_string=f"sqlite://{path_to_temp_sqlite_db}",
+            ),
+        ]
+    )
+    res = materialize(
+        [my_sling_assets],
+        resources={"sling": sling_resource},
+    )
+
+    assert res.success
+    asset_materializations = res.get_asset_materialization_events()
+    assert len(asset_materializations) == 3
+
+    metadatas = [
+        asset_materialization.step_materialization_data.materialization.metadata
+        for asset_materialization in asset_materializations
+    ]
+    assert all(["dagster/column_schema" in metadata for metadata in metadatas]), str(metadatas)
+    assert all(["dagster/column_lineage" in metadata for metadata in metadatas]), str(metadatas)
+
+    assert metadatas[0]["dagster/column_schema"] == TableSchemaMetadataValue(
+        schema=TableSchema(
+            columns=[
+                TableColumn(name="product_id", type="bigint"),
+                TableColumn(name="name", type="text"),
+                TableColumn(name="category", type="text"),
+                TableColumn(name="price", type="decimal"),
+                TableColumn(name="_sling_loaded_at", type="bigint"),
+            ]
+        )
+    )
+
+    # upstream key is gross filepath thing, we just extract it
+    upstream_key = next(iter(next(iter(my_sling_assets.asset_deps.values()))))
+    assert metadatas[0]["dagster/column_lineage"] == TableColumnLineageMetadataValue(
+        column_lineage=TableColumnLineage(
+            deps_by_column={
+                "product_id": [TableColumnDep(asset_key=upstream_key, column_name="product_id")],
+                "name": [TableColumnDep(asset_key=upstream_key, column_name="name")],
+                "category": [TableColumnDep(asset_key=upstream_key, column_name="category")],
+                "price": [TableColumnDep(asset_key=upstream_key, column_name="price")],
+                # absent is _sling_loaded_at, since sling introduces this column
+            }
+        )
+    )
 
 
 def test_subset_with_asset_selection(

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_asset_decorator.py
@@ -380,7 +380,13 @@ def test_fetch_column_metadata(
     assert all(["dagster/column_schema" in metadata for metadata in metadatas]), str(metadatas)
     assert all(["dagster/column_lineage" in metadata for metadata in metadatas]), str(metadatas)
 
-    assert metadatas[0]["dagster/column_schema"] == TableSchemaMetadataValue(
+    products_metadata = next(
+        mat
+        for mat in asset_materializations
+        if mat.asset_key and mat.asset_key.path[-1] == "products"
+    ).step_materialization_data.materialization.metadata
+
+    assert products_metadata["dagster/column_schema"] == TableSchemaMetadataValue(
         schema=TableSchema(
             columns=[
                 TableColumn(name="product_id", type="bigint"),
@@ -394,7 +400,7 @@ def test_fetch_column_metadata(
 
     # upstream key is gross filepath thing, we just extract it
     upstream_key = next(iter(next(iter(my_sling_assets.asset_deps.values()))))
-    assert metadatas[0]["dagster/column_lineage"] == TableColumnLineageMetadataValue(
+    assert products_metadata["dagster/column_lineage"] == TableColumnLineageMetadataValue(
         column_lineage=TableColumnLineage(
             deps_by_column={
                 "product_id": [TableColumnDep(asset_key=upstream_key, column_name="product_id")],

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_asset_decorator.py
@@ -380,10 +380,9 @@ def test_fetch_column_metadata(
     assert all(["dagster/column_schema" in metadata for metadata in metadatas]), str(metadatas)
     assert all(["dagster/column_lineage" in metadata for metadata in metadatas]), str(metadatas)
 
+    products_key = AssetKey(["target", "main", "products"])
     products_metadata = next(
-        mat
-        for mat in asset_materializations
-        if mat.asset_key and mat.asset_key.path[-1] == "products"
+        mat for mat in asset_materializations if mat.asset_key and mat.asset_key == products_key
     ).step_materialization_data.materialization.metadata
 
     assert products_metadata["dagster/column_schema"] == TableSchemaMetadataValue(
@@ -399,7 +398,7 @@ def test_fetch_column_metadata(
     )
 
     # upstream key is gross filepath thing, we just extract it
-    upstream_key = next(iter(next(iter(my_sling_assets.asset_deps.values()))))
+    upstream_key = next(iter(my_sling_assets.asset_deps[products_key]))
     assert products_metadata["dagster/column_lineage"] == TableColumnLineageMetadataValue(
         column_lineage=TableColumnLineage(
             deps_by_column={

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_asset_decorator.py
@@ -13,16 +13,6 @@ from dagster import (
     file_relative_path,
 )
 from dagster._core.definitions.materialize import materialize
-from dagster._core.definitions.metadata.metadata_value import (
-    TableColumnLineageMetadataValue,
-    TableSchemaMetadataValue,
-)
-from dagster._core.definitions.metadata.table import (
-    TableColumn,
-    TableColumnDep,
-    TableColumnLineage,
-    TableSchema,
-)
 from dagster_embedded_elt.sling import SlingReplicationParam, sling_assets
 from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
 from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingResource
@@ -344,72 +334,6 @@ def test_base_with_custom_asset_key_prefix():
         AssetKey(["custom", "departments"]),
         AssetKey(["custom", "public", "transactions"]),
     }
-
-
-def test_fetch_column_metadata(
-    csv_to_sqlite_dataworks_replication: SlingReplicationParam,
-    path_to_temp_sqlite_db: str,
-):
-    @sling_assets(replication_config=csv_to_sqlite_dataworks_replication)
-    def my_sling_assets(context: AssetExecutionContext, sling: SlingResource):
-        yield from sling.replicate(context=context).fetch_column_metadata()
-
-    sling_resource = SlingResource(
-        connections=[
-            SlingConnectionResource(type="file", name="SLING_FILE"),
-            SlingConnectionResource(
-                type="sqlite",
-                name="SLING_SQLITE",
-                connection_string=f"sqlite://{path_to_temp_sqlite_db}",
-            ),
-        ]
-    )
-    res = materialize(
-        [my_sling_assets],
-        resources={"sling": sling_resource},
-    )
-
-    assert res.success
-    asset_materializations = res.get_asset_materialization_events()
-    assert len(asset_materializations) == 3
-
-    metadatas = [
-        asset_materialization.step_materialization_data.materialization.metadata
-        for asset_materialization in asset_materializations
-    ]
-    assert all(["dagster/column_schema" in metadata for metadata in metadatas]), str(metadatas)
-    assert all(["dagster/column_lineage" in metadata for metadata in metadatas]), str(metadatas)
-
-    products_key = AssetKey(["target", "main", "products"])
-    products_metadata = next(
-        mat for mat in asset_materializations if mat.asset_key and mat.asset_key == products_key
-    ).step_materialization_data.materialization.metadata
-
-    assert products_metadata["dagster/column_schema"] == TableSchemaMetadataValue(
-        schema=TableSchema(
-            columns=[
-                TableColumn(name="product_id", type="bigint"),
-                TableColumn(name="name", type="text"),
-                TableColumn(name="category", type="text"),
-                TableColumn(name="price", type="decimal"),
-                TableColumn(name="_sling_loaded_at", type="bigint"),
-            ]
-        )
-    )
-
-    # upstream key is gross filepath thing, we just extract it
-    upstream_key = next(iter(my_sling_assets.asset_deps[products_key]))
-    assert products_metadata["dagster/column_lineage"] == TableColumnLineageMetadataValue(
-        column_lineage=TableColumnLineage(
-            deps_by_column={
-                "product_id": [TableColumnDep(asset_key=upstream_key, column_name="product_id")],
-                "name": [TableColumnDep(asset_key=upstream_key, column_name="name")],
-                "category": [TableColumnDep(asset_key=upstream_key, column_name="category")],
-                "price": [TableColumnDep(asset_key=upstream_key, column_name="price")],
-                # absent is _sling_loaded_at, since sling introduces this column
-            }
-        )
-    )
 
 
 def test_subset_with_asset_selection(

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_fetch_metadata.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_fetch_metadata.py
@@ -1,0 +1,126 @@
+import mock
+from dagster import AssetExecutionContext, AssetKey
+from dagster._core.definitions.materialize import materialize
+from dagster._core.definitions.metadata.metadata_value import (
+    TableColumnLineageMetadataValue,
+    TableSchemaMetadataValue,
+)
+from dagster._core.definitions.metadata.table import (
+    TableColumn,
+    TableColumnDep,
+    TableColumnLineage,
+    TableSchema,
+)
+from dagster_embedded_elt.sling import SlingReplicationParam, sling_assets
+
+
+def test_fetch_column_metadata(
+    csv_to_sqlite_dataworks_replication: SlingReplicationParam,
+    path_to_temp_sqlite_db: str,
+):
+    from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingResource
+
+    @sling_assets(replication_config=csv_to_sqlite_dataworks_replication)
+    def my_sling_assets(context: AssetExecutionContext, sling: SlingResource):
+        yield from sling.replicate(context=context).fetch_column_metadata()
+
+    sling_resource = SlingResource(
+        connections=[
+            SlingConnectionResource(type="file", name="SLING_FILE"),
+            SlingConnectionResource(
+                type="sqlite",
+                name="SLING_SQLITE",
+                connection_string=f"sqlite://{path_to_temp_sqlite_db}",
+            ),
+        ]
+    )
+    res = materialize(
+        [my_sling_assets],
+        resources={"sling": sling_resource},
+    )
+
+    assert res.success
+    asset_materializations = res.get_asset_materialization_events()
+    assert len(asset_materializations) == 3
+
+    metadatas = [
+        asset_materialization.step_materialization_data.materialization.metadata
+        for asset_materialization in asset_materializations
+    ]
+    assert all(["dagster/column_schema" in metadata for metadata in metadatas]), str(metadatas)
+    assert all(["dagster/column_lineage" in metadata for metadata in metadatas]), str(metadatas)
+
+    products_key = AssetKey(["target", "main", "products"])
+    products_metadata = next(
+        mat for mat in asset_materializations if mat.asset_key and mat.asset_key == products_key
+    ).step_materialization_data.materialization.metadata
+
+    assert products_metadata["dagster/column_schema"] == TableSchemaMetadataValue(
+        schema=TableSchema(
+            columns=[
+                TableColumn(name="product_id", type="bigint"),
+                TableColumn(name="name", type="text"),
+                TableColumn(name="category", type="text"),
+                TableColumn(name="price", type="decimal"),
+                TableColumn(name="_sling_loaded_at", type="bigint"),
+            ]
+        )
+    )
+
+    # upstream key is gross filepath thing, we just extract it
+    upstream_key = next(iter(my_sling_assets.asset_deps[products_key]))
+    assert products_metadata["dagster/column_lineage"] == TableColumnLineageMetadataValue(
+        column_lineage=TableColumnLineage(
+            deps_by_column={
+                "product_id": [TableColumnDep(asset_key=upstream_key, column_name="product_id")],
+                "name": [TableColumnDep(asset_key=upstream_key, column_name="name")],
+                "category": [TableColumnDep(asset_key=upstream_key, column_name="category")],
+                "price": [TableColumnDep(asset_key=upstream_key, column_name="price")],
+                # absent is _sling_loaded_at, since sling introduces this column
+            }
+        )
+    )
+
+
+def test_fetch_column_metadata_failure(
+    csv_to_sqlite_dataworks_replication: SlingReplicationParam,
+    path_to_temp_sqlite_db: str,
+):
+    with mock.patch(
+        "dagster_embedded_elt.sling.resources.SlingResource.get_column_info_for_table",
+        side_effect=Exception("test error"),
+    ):
+        from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingResource
+
+        sling_resource = SlingResource(
+            connections=[
+                SlingConnectionResource(type="file", name="SLING_FILE"),
+                SlingConnectionResource(
+                    type="sqlite",
+                    name="SLING_SQLITE",
+                    connection_string=f"sqlite://{path_to_temp_sqlite_db}",
+                ),
+            ]
+        )
+
+        @sling_assets(replication_config=csv_to_sqlite_dataworks_replication)
+        def my_sling_assets(context: AssetExecutionContext, sling: SlingResource):
+            yield from sling.replicate(context=context).fetch_column_metadata()
+
+        res = materialize(
+            [my_sling_assets],
+            resources={"sling": sling_resource},
+        )
+
+        # Assert run succeeds but no column metadata is materialized
+        assert res.success
+        asset_materializations = res.get_asset_materialization_events()
+        assert len(asset_materializations) == 3
+
+        metadatas = [
+            asset_materialization.step_materialization_data.materialization.metadata
+            for asset_materialization in asset_materializations
+        ]
+        assert not any(["dagster/column_schema" in metadata for metadata in metadatas]), str(
+            metadatas
+        )


### PR DESCRIPTION
## Summary

After SQL modeling/transform integrations like dbt, ELT seems like an obvious place to drop in table metadata and extend Dagster's awareness of column lineage. This PR explores that direction with Sling, which helps expand column lineage in our own DOP data platform.

Adds a chain-able metadata fetch method for Sling syncs which attaches column schema and column lineage to assets output from a Sling sync.

```python
@sling_assets(replication_config=replication_config)
def my_assets(context, sling: SlingResource):
    yield from sling.replicate(context=context).fetch_column_metadata()
```

Under the hood, invokes `sling conns discover [target conn] --pattern [target stream] --columns`, which uses Sling's underlying db adapters to fetch this metadata.

Lineage is inferred as 1:1 for all columns other than Sling data columns (like `_sling_loaded_at`).

Right now this fetch is synchronous and only happens after the sync completes, since this is when materializations are yielded. A future improvement could yield materializations as they happen and fetch the metadata right away.

Curious how others feel about using the iterator-plus-chaining-operations approach here? Does that disincentivize adoption, e.g. should we just be doing this automatically and incurring whatever (probably small) perf cost that entails, or is opt-in good?

## Test Plan

Unit test; TODO - add more.

