### PR TITLE
[dagster-datahub] (loosen pydantic requirement)

### DIFF
--- a/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
+++ b/python_modules/libraries/dagster-datahub/dagster_datahub/resources.py
@@ -77,7 +77,6 @@ class DatahubConnection(Config):
 
 class DatahubKafkaEmitterResource(ConfigurableResource):
     connection: DatahubConnection
-    topic: Optional[str] = None
     topic_routes: Dict[str, str] = Field(
         default={
             MCE_KEY: DEFAULT_MCE_KAFKA_TOPIC,

--- a/python_modules/libraries/dagster-datahub/setup.py
+++ b/python_modules/libraries/dagster-datahub/setup.py
@@ -42,7 +42,7 @@ setup(
         f"dagster{pin}",
         "packaging",
         "requests",
-        "pydantic>=1.10.0",
+        "pydantic>=1.10.0,<3.0.0",
     ],
     extras_require={},
     zip_safe=False,

--- a/python_modules/libraries/dagster-datahub/setup.py
+++ b/python_modules/libraries/dagster-datahub/setup.py
@@ -42,7 +42,7 @@ setup(
         f"dagster{pin}",
         "packaging",
         "requests",
-        "pydantic>=1.10.0,<2.0.0",
+        "pydantic>=1.10.0",
     ],
     extras_require={},
     zip_safe=False,


### PR DESCRIPTION
## Summary & Motivation
This pydantic requirement is needlessly strict give that the usage of Field is only in one file and uses only two parameters of it (both of which have not changed since the Pydantic 2.0 upgrade). This needlessly strict requirement is making it so that this won't resolve with other packages that require pydantic 2.0. Can we please loosen this restriction?

## How I Tested These Changes
Used the forked repo via pip