### PR TITLE
[1.8] support AssetSpecs with different partitionings in same Definitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -314,11 +315,15 @@ def _create_repository_using_definitions_args(
 def _canonicalize_specs_to_assets_defs(
     assets: Iterable[Union[AssetsDefinition, AssetSpec, SourceAsset, CacheableAssetsDefinition]],
 ) -> Iterable[Union[AssetsDefinition, SourceAsset, CacheableAssetsDefinition]]:
-    asset_specs = [obj for obj in assets if isinstance(obj, AssetSpec)]
+    asset_specs_by_partitions_def = defaultdict(list)
+    for obj in assets:
+        if isinstance(obj, AssetSpec):
+            asset_specs_by_partitions_def[obj.partitions_def].append(obj)
     result = [obj for obj in assets if not isinstance(obj, AssetSpec)]
-    if asset_specs:
+
+    for specs in asset_specs_by_partitions_def.values():
         with disable_dagster_warnings():
-            result.append(AssetsDefinition(specs=asset_specs))
+            result.append(AssetsDefinition(specs=specs))
 
     return result
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -45,7 +45,7 @@ from dagster._core.definitions.executor_definition import executor
 from dagster._core.definitions.external_asset import create_external_asset_from_source_asset
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.logger_definition import logger
-from dagster._core.definitions.partition import PartitionsDefinition
+from dagster._core.definitions.partition import PartitionsDefinition, StaticPartitionsDefinition
 from dagster._core.definitions.repository_definition import (
     PendingRepositoryDefinition,
     RepositoryDefinition,
@@ -942,6 +942,12 @@ def test_get_all_asset_specs():
     )
     assert asset_specs_by_key[AssetKey("asset6")] == AssetSpec("asset6", group_name="blag")
     assert asset_specs_by_key[AssetKey("asset7")] == asset7._replace(group_name="default")
+
+
+def test_asset_specs_different_partitions():
+    asset1 = AssetSpec("asset1", partitions_def=StaticPartitionsDefinition(["a", "b"]))
+    asset2 = AssetSpec("asset2", partitions_def=StaticPartitionsDefinition(["1", "2"]))
+    Definitions.validate_loadable(Definitions(assets=[asset1, asset2]))
 
 
 def test_asset_spec_dependencies_in_graph() -> None:


### PR DESCRIPTION
## Summary & Motivation

Issue caught in dogfooding: prior to this PR, you'd hit an error if you tried to pass two `AssetSpec`s with different `partitions_def`s to the same `Definitions` object.

I hope that soon we'll be able to remove the single-`PartitionsDefinition` per `AssetsDefinition` constraint.

## How I Tested These Changes
