### PR TITLE
[du] remove fastparquet dependency [DEV-414]

### DIFF
--- a/docs/dagster-university/pages/dagster-dbt/lesson-2/2-set-up-the-dagster-project.md
+++ b/docs/dagster-university/pages/dagster-dbt/lesson-2/2-set-up-the-dagster-project.md
@@ -37,7 +37,6 @@ setup(
         "smart_open",
         "boto3",
         "pyarrow",
-        "fastparquet",
     ],
     extras_require={"dev": ["dagster-webserver", "pytest"]},
 )


### PR DESCRIPTION
## Summary & Motivation

fastparquet requires admin privileges on PCs, and it isn't required for this course.

## How I Tested These Changes
