### PR TITLE
Accept KeyboardInterruptError in multiprocess executor termination logic

### DIFF
--- a/python_modules/dagster/dagster/_core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/_core/executor/multiprocess.py
@@ -329,7 +329,8 @@ class MultiprocessExecutor(Executor):
                 and (not active_iters)
                 and all(
                     [
-                        err_info.cls_name == "DagsterExecutionInterruptedError"
+                        err_info.cls_name
+                        in {"DagsterExecutionInterruptedError", "KeyboardInterrupt"}
                         for err_info in errs.values()
                     ]
                 )


### PR DESCRIPTION
Summary:
The dagster signal handler raises interrupts as DagsterExecutionInterruptedError, but sometimes ops can run code that installs its own signal handler, causing the interrupt to be raised as a KeyboardInterrupt (for example, the snowflake python connector does this: https://github.com/snowflakedb/snowflake-connector-python/blob/main/src/snowflake/connector/cursor.py#L663-L684). Handle both in the logic that decides if a run terminated cleanly or not.

Resolves https://github.com/dagster-io/dagster/issues/23406.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
