### PR TITLE
Transition runs to CANCELED rather than FAILURE if they fail after a user-initiated run cancellation

### DIFF
--- a/python_modules/dagster/dagster/_core/events/__init__.py
+++ b/python_modules/dagster/dagster/_core/events/__init__.py
@@ -1121,12 +1121,14 @@ class DagsterEvent(
 
     @staticmethod
     def job_canceled(
-        job_context: IPlanContext, error_info: Optional[SerializableErrorInfo] = None
+        job_context: IPlanContext,
+        error_info: Optional[SerializableErrorInfo] = None,
+        message: Optional[str] = None,
     ) -> "DagsterEvent":
         return DagsterEvent.from_job(
             DagsterEventType.RUN_CANCELED,
             job_context,
-            message=f'Execution of run for "{job_context.job_name}" canceled.',
+            message=message or f'Execution of run for "{job_context.job_name}" canceled.',
             event_specific_data=JobCanceledData(
                 check.opt_inst_param(error_info, "error_info", SerializableErrorInfo)
             ),

--- a/python_modules/dagster/dagster/_core/executor/child_process_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/child_process_executor.py
@@ -60,7 +60,8 @@ class ChildProcessCommand(ABC):
 class ChildProcessCrashException(Exception):
     """Thrown when the child process crashes."""
 
-    def __init__(self, exit_code=None):
+    def __init__(self, pid, exit_code=None):
+        self.pid = pid
         self.exit_code = exit_code
         super().__init__()
 
@@ -169,7 +170,7 @@ def execute_child_process_command(
 
         if not completed_properly:
             # TODO Figure out what to do about stderr/stdout
-            raise ChildProcessCrashException(exit_code=process.exitcode)
+            raise ChildProcessCrashException(pid=process.pid, exit_code=process.exitcode)
 
         process.join()
     finally:

--- a/python_modules/dagster/dagster/_core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/_core/executor/multiprocess.py
@@ -288,6 +288,7 @@ class MultiprocessExecutor(Executor):
                             active_execution.handle_event(step_failure_event)
                             yield step_failure_event
                             empty_iters.append(key)
+                            errors[crash.pid] = serializable_error
                         except StopIteration:
                             empty_iters.append(key)
 


### PR DESCRIPTION
Summary:
The terminal event after
Once a user indicates that they want a run to terminate from the UI or via the API, if there's an exception that would normally fail the run, the run should still enter CANCELED rather than FAILURE. This ensures that retries will never fire after a run is put into a CANCELING state.

## Summary & Motivation

## How I Tested These Changes
