### PR TITLE
chore(dbt): support python 3.12

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -362,6 +362,9 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     ),
     PackageSpec(
         "examples/experimental/dagster-airlift/examples/peering-with-dbt",
+        unsupported_python_versions=[
+            AvailablePythonVersion.V3_12,
+        ],
     ),
 ]
 
@@ -484,10 +487,6 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             f"{deps_factor}-{command_factor}"
             for deps_factor in ["dbt17", "dbt18", "pydantic1"]
             for command_factor in ["cloud", "core-main", "core-derived-metadata"]
-        ],
-        unsupported_python_versions=[
-            # duckdb
-            AvailablePythonVersion.V3_12,
         ],
     ),
     PackageSpec(

--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -33,6 +33,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
## Summary & Motivation
Start testing `dagster-dbt` against python 3.12.

## How I Tested These Changes
bk