### PR TITLE
update core callsites for compute log manager

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_app.py
+++ b/python_modules/dagster-webserver/dagster_webserver_tests/webserver/test_app.py
@@ -272,11 +272,11 @@ def test_download_compute(instance, test_client: TestClient):
     logs = instance.all_logs(run_id, of_type=DagsterEventType.LOGS_CAPTURED)
     entry = logs[0]
     file_key = entry.dagster_event.logs_captured_data.file_key
-    response = test_client.get(f"/download/{run_id}/{file_key}/stdout")
+    response = test_client.get(f"/logs/{run_id}/compute_logs/{file_key}/out")
     assert response.status_code == 200
     assert "STDOUT RULEZ" in str(response.content)
 
-    response = test_client.get(f"/download/{run_id}/jonx/stdout")
+    response = test_client.get(f"/logs/{run_id}/compute_logs/jonx/stdout")
     assert response.status_code == 404
 
 

--- a/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
+++ b/python_modules/dagster/dagster/_core/definitions/instigation_logger.py
@@ -8,8 +8,7 @@ from typing import IO, Any, List, Mapping, Optional, Sequence
 from dagster import _seven
 from dagster._core.instance import DagsterInstance
 from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR
-from dagster._core.storage.captured_log_manager import CapturedLogManager
-from dagster._core.storage.compute_log_manager import ComputeIOType
+from dagster._core.storage.captured_log_manager import CapturedLogManager, ComputeIOType
 from dagster._core.utils import coerce_valid_log_level
 from dagster._utils.log import create_console_logger
 

--- a/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/captured_log_manager.py
@@ -1,15 +1,20 @@
 import os
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
+from enum import Enum
 from typing import IO, Callable, Generator, Iterator, NamedTuple, Optional, Sequence, Tuple
 
 from typing_extensions import Final, Self
 
 import dagster._check as check
 from dagster._core.captured_log_api import LogLineCursor
-from dagster._core.storage.compute_log_manager import ComputeIOType
 
 MAX_BYTES_CHUNK_READ: Final = 4194304  # 4 MB
+
+
+class ComputeIOType(Enum):
+    STDOUT = "stdout"
+    STDERR = "stderr"
 
 
 class CapturedLogContext(

--- a/python_modules/dagster/dagster/_core/storage/compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/compute_log_manager.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from enum import Enum
 from typing import Callable, Iterator, NamedTuple, Optional
 
 from typing_extensions import Self
@@ -9,13 +8,10 @@ import dagster._check as check
 from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun
 
+from .captured_log_manager import ComputeIOType
+
 MAX_BYTES_FILE_READ = 33554432  # 32 MB
 MAX_BYTES_CHUNK_READ = 4194304  # 4 MB
-
-
-class ComputeIOType(Enum):
-    STDOUT = "stdout"
-    STDERR = "stderr"
 
 
 class ComputeLogFileData(


### PR DESCRIPTION
## Summary & Motivation
This PR strips out the legacy compute log manager interface from the critical engine paths.

This includes:
1. the execution engine
2. the instigation logger path
3. the webserver / subscriptions

## How I Tested These Changes
BK