### PR TITLE
Eliminate blueprints dep

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/__init__.py
@@ -4,7 +4,4 @@ from .core.defs_from_airflow import (
     create_defs_from_airflow_instance as create_defs_from_airflow_instance,
 )
 from .core.migration_state import load_migration_state_from_yaml as load_migration_state_from_yaml
-from .core.multi_asset import (
-    PythonDefs as PythonDefs,
-    load_defs_from_yaml as load_defs_from_yaml,
-)
+from .core.multi_asset import PythonDefs as PythonDefs

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/def_factory.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/def_factory.py
@@ -1,0 +1,8 @@
+from abc import ABC, abstractmethod
+
+from dagster._core.definitions.definitions_class import Definitions
+
+
+class DefsFactory(ABC):
+    @abstractmethod
+    def build_defs(self) -> Definitions: ...

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/multi_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/multi_asset.py
@@ -1,58 +1,24 @@
-from importlib import import_module
-from pathlib import Path
-from typing import List, Literal, Optional, Sequence, Type, Union
+from dataclasses import dataclass
+from typing import Callable, List, Optional
 
-from dagster import AssetDep, AssetKey, AssetSpec, Definitions, multi_asset
-from dagster_blueprints import YamlBlueprintsLoader
-from dagster_blueprints.blueprint import Blueprint
-from pydantic import BaseModel
+from dagster import AssetSpec, Definitions, multi_asset
+
+from .def_factory import DefsFactory
 
 
-class AssetSpecModel(BaseModel):
-    key: str
-    deps: List[str] = []
-
-
-class PythonFn(BaseModel):
-    module_name: str
-    fn_name: str
-
-
-class PythonDefs(Blueprint):
-    type: Literal["multi_asset"] = "multi_asset"
-    specs: List[AssetSpecModel]
-    python_fn_pointer: Optional[PythonFn] = None
-    name: Optional[str] = None
+@dataclass
+class PythonDefs(DefsFactory):
+    specs: List[AssetSpec]
+    name: str
+    python_fn: Optional[Callable] = None
 
     def build_defs(self) -> Definitions:
-        asset_specs = [
-            AssetSpec(
-                key=AssetKey.from_user_string(spec.key),
-                deps=[AssetDep(AssetKey.from_user_string(dep)) for dep in spec.deps],
-            )
-            for spec in self.specs
-        ]
-        abridged_file_name = self.source_file_name.split(".")[0]
-
         @multi_asset(
-            specs=asset_specs,
-            name=self.name or abridged_file_name,
+            specs=self.specs,
+            name=self.name,
         )
         def _multi_asset() -> None:
-            if self.python_fn_pointer:
-                module = import_module(self.python_fn_pointer.module_name)
-                compute_fn = getattr(module, self.python_fn_pointer.fn_name)
-                compute_fn()
+            if self.python_fn:
+                self.python_fn()
 
         return Definitions(assets=[_multi_asset])
-
-
-# Eventually, we should be able to provide many different types of blueprints all from the same fxn call and same path.
-# But we can't currently handle multiple blueprint types in the same directory.
-def load_defs_from_yaml(
-    yaml_path: Path, defs_cls: Union[Type[Blueprint], Type[Sequence[Blueprint]]]
-) -> Definitions:
-    return YamlBlueprintsLoader(
-        path=yaml_path,
-        per_file_blueprint_type=defs_cls,
-    ).load_defs()

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_dbt_multi_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_dbt_multi_asset.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Dict, List
 
 from dagster import AssetKey, AssetsDefinition
-from dagster_airlift import load_defs_from_yaml
 from dagster_airlift.dbt import DbtProjectDefs
 
 
@@ -12,8 +11,10 @@ def test_load_dbt_project(dbt_project_dir: Path, dbt_project: None) -> None:
     assert os.environ["DBT_PROJECT_DIR"] == str(
         dbt_project_dir
     ), "Expected dbt project dir to be set as env var"
-    multi_asset_dir = Path(__file__).parent / "dbt_defs_from_yaml"
-    defs = load_defs_from_yaml(yaml_path=multi_asset_dir, defs_cls=DbtProjectDefs)
+    defs = DbtProjectDefs(
+        dbt_project_path=dbt_project_dir,
+        name="my_dbt_multi_asset",
+    ).build_defs()
     assert defs.assets
     all_assets = list(defs.assets)
     assert len(all_assets) == 1

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/python_multi_assets_yaml/asset_specs/test_dag/test_dag__test_task.yaml
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/python_multi_assets_yaml/asset_specs/test_dag/test_dag__test_task.yaml
@@ -1,8 +1,0 @@
-type: multi_asset
-specs:
-  - key: my/asset
-    deps:
-      - upstream/asset
-python_fn_pointer:
-  module_name: dagster_airlift_tests.unit_tests.multi_asset_python
-  fn_name: compute_fn

--- a/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/dagster_defs/definitions.py
+++ b/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/dagster_defs/definitions.py
@@ -1,12 +1,14 @@
-from typing import Union
+import os
+from pathlib import Path
 
 from dagster import Definitions
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster_airlift import (
     AirflowInstance,
     BasicAuthBackend,
     PythonDefs,
     create_defs_from_airflow_instance,
-    load_defs_from_yaml,
     load_migration_state_from_yaml,
 )
 from dagster_airlift.dbt import DbtProjectDefs
@@ -14,7 +16,6 @@ from dagster_airlift.dbt import DbtProjectDefs
 from .constants import (
     AIRFLOW_BASE_URL,
     AIRFLOW_INSTANCE_NAME,
-    ASSETS_PATH,
     MIGRATION_STATE_PATH,
     PASSWORD,
     USERNAME,
@@ -27,13 +28,26 @@ airflow_instance = AirflowInstance(
     name=AIRFLOW_INSTANCE_NAME,
 )
 
+
+def dbt_project_path() -> Path:
+    env_val = os.getenv("DBT_PROJECT_DIR")
+    assert env_val
+    return Path(env_val)
+
+
 defs = create_defs_from_airflow_instance(
     airflow_instance=airflow_instance,
     orchestrated_defs=Definitions.merge(
-        load_defs_from_yaml(
-            yaml_path=ASSETS_PATH,
-            defs_cls=Union[PythonDefs, DbtProjectDefs],
-        ),
+        PythonDefs(
+            name="load_lakehouse__load_iris",
+            specs=[AssetSpec(key=AssetKey.from_user_string("iris_dataset/iris_lakehouse_table"))],
+            python_fn=lambda: None,
+        ).build_defs(),
+        DbtProjectDefs(
+            name="dbt_dag__build_dbt_models",
+            dbt_project_path=dbt_project_path(),
+            group="dbt",
+        ).build_defs(),
     ),
     migration_state_override=load_migration_state_from_yaml(
         migration_yaml_path=MIGRATION_STATE_PATH

--- a/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/dagster_defs/defs/dbt_dag__build_dbt_models.yaml
+++ b/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/dagster_defs/defs/dbt_dag__build_dbt_models.yaml
@@ -1,4 +1,0 @@
-type: dbt_project
-dbt_project_path:
-  env_var: DBT_PROJECT_DIR
-group: dbt

--- a/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/dagster_defs/defs/load_lakehouse__load_iris.yaml
+++ b/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/dagster_defs/defs/load_lakehouse__load_iris.yaml
@@ -1,3 +1,0 @@
-type: multi_asset
-specs:
-  - key: iris_dataset/iris_lakehouse_table

--- a/examples/experimental/dagster-airlift/examples/peering-with-dbt/tox.ini
+++ b/examples/experimental/dagster-airlift/examples/peering-with-dbt/tox.ini
@@ -12,12 +12,7 @@ deps =
   -e ../../../../../python_modules/dagster-pipes
   -e ../../../../../python_modules/dagster-graphql
   -e ../../../../../python_modules/libraries/dagster-dbt
-  -e ../../../../../python_modules/libraries/dagster-databricks
-  -e ../../../../../python_modules/libraries/dagster-pandas
-  -e ../../../../../python_modules/libraries/dagster-pyspark
-  -e ../../../../../python_modules/libraries/dagster-spark
   -e ../../../dagster-airlift[dbt,test]
-  -e ../../../dagster-blueprints
   -e .
   pandas
 allowlist_externals =

--- a/examples/experimental/dagster-airlift/setup.py
+++ b/examples/experimental/dagster-airlift/setup.py
@@ -38,7 +38,6 @@ setup(
     packages=find_packages(exclude=["dagster_airlift_tests*", "examples*"]),
     install_requires=[
         f"dagster{pin}",
-        f"dagster-blueprints{pin}",
         "apache-airflow>=2.0.0,<2.8",
         # Flask-session 0.6 is incompatible with certain airflow-provided test
         # utilities.

--- a/examples/experimental/dagster-airlift/tox.ini
+++ b/examples/experimental/dagster-airlift/tox.ini
@@ -10,11 +10,6 @@ deps =
   -e ../../../python_modules/dagster-test
   -e ../../../python_modules/dagster-pipes
   -e ../../../python_modules/libraries/dagster-dbt
-  -e ../../../python_modules/libraries/dagster-databricks
-  -e ../../../python_modules/libraries/dagster-pandas
-  -e ../../../python_modules/libraries/dagster-pyspark
-  -e ../../../python_modules/libraries/dagster-spark
-  -e ../dagster-blueprints
   -e .[mwaa,dbt,test]
   dbt-duckdb
 allowlist_externals =


### PR DESCRIPTION
## Summary & Motivation

Eliminate blueprints dependency in airlift. Made the decision to make to `dataclass` from pydantic so we could use bare classes instead of having a wrapper set of classes to avoid pydantic forward ref issues.

## How I Tested These Changes

BK
