### PR TITLE
Extract out business logic into neutral file in peering_with_dbt example

### DIFF
--- a/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/airflow_dags/lakehouse.py
+++ b/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/airflow_dags/lakehouse.py
@@ -1,36 +1,9 @@
-import os
 from datetime import datetime
 
-import duckdb
-import pandas as pd
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 
-
-def load_csv_to_duckdb():
-    # Absolute path to the iris dataset is path to current file's directory
-    csv_path = os.path.join(os.path.dirname(__file__), "iris.csv")
-    # Duckdb database stored in airflow home
-    duckdb_path = os.path.join(os.environ["AIRFLOW_HOME"], "jaffle_shop.duckdb")
-    iris_df = pd.read_csv(  # noqa: F841 # used by duckdb
-        csv_path,
-        names=[
-            "sepal_length_cm",
-            "sepal_width_cm",
-            "petal_length_cm",
-            "petal_width_cm",
-            "species",
-        ],
-    )
-
-    # Connect to DuckDB and create a new table
-    con = duckdb.connect(duckdb_path)
-    con.execute("CREATE SCHEMA IF NOT EXISTS iris_dataset").fetchall()
-    con.execute(
-        "CREATE TABLE IF NOT EXISTS jaffle_shop.iris_dataset.iris_lakehouse_table AS SELECT * FROM iris_df"
-    ).fetchall()
-    con.close()
-
+from ..business_logic import load_csv_to_duckdb
 
 default_args = {
     "owner": "airflow",

--- a/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/business_logic.py
+++ b/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/business_logic.py
@@ -1,0 +1,29 @@
+import os
+
+import duckdb
+import pandas as pd
+
+
+def load_csv_to_duckdb() -> None:
+    # Absolute path to the iris dataset is path to current file's directory
+    csv_path = os.path.join(os.path.dirname(__file__), "airflow_dags", "iris.csv")
+    # Duckdb database stored in airflow home
+    duckdb_path = os.path.join(os.environ["AIRFLOW_HOME"], "jaffle_shop.duckdb")
+    iris_df = pd.read_csv(  # noqa: F841 # used by duckdb
+        csv_path,
+        names=[
+            "sepal_length_cm",
+            "sepal_width_cm",
+            "petal_length_cm",
+            "petal_width_cm",
+            "species",
+        ],
+    )
+
+    # Connect to DuckDB and create a new table
+    con = duckdb.connect(duckdb_path)
+    con.execute("CREATE SCHEMA IF NOT EXISTS iris_dataset").fetchall()
+    con.execute(
+        "CREATE TABLE IF NOT EXISTS jaffle_shop.iris_dataset.iris_lakehouse_table AS SELECT * FROM iris_df"
+    ).fetchall()
+    con.close()

--- a/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/dagster_defs/definitions.py
+++ b/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/dagster_defs/definitions.py
@@ -13,6 +13,7 @@ from dagster_airlift import (
 from dagster_airlift.core.def_factory import defs_from_factories
 from dagster_airlift.dbt import DbtProjectDefs
 
+from ..business_logic import load_csv_to_duckdb
 from .constants import (
     AIRFLOW_BASE_URL,
     AIRFLOW_INSTANCE_NAME,
@@ -41,7 +42,7 @@ defs = create_defs_from_airflow_instance(
         PythonDefs(
             name="load_lakehouse__load_iris",
             specs=[AssetSpec(key=AssetKey.from_user_string("iris_dataset/iris_lakehouse_table"))],
-            python_fn=lambda: None,
+            python_fn=load_csv_to_duckdb,
         ),
         DbtProjectDefs(
             name="dbt_dag__build_dbt_models",


### PR DESCRIPTION
## Summary & Motivation

Move business logic (`load_csv_to_duckdb`) into neutral file so it can invoked by either airflow or dagster.

## How I Tested These Changes

BK
