### PR TITLE
Rename DefsFactory classes and document them

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/__init__.py
@@ -4,4 +4,4 @@ from .core.defs_from_airflow import (
     create_defs_from_airflow_instance as create_defs_from_airflow_instance,
 )
 from .core.migration_state import load_migration_state_from_yaml as load_migration_state_from_yaml
-from .core.multi_asset import PythonDefs as PythonDefs
+from .core.multi_asset import PythonFnDefs as PythonFnDefs

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/multi_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/multi_asset.py
@@ -7,7 +7,11 @@ from .def_factory import DefsFactory
 
 
 @dataclass
-class PythonDefs(DefsFactory):
+class PythonFnDefs(DefsFactory):
+    """Create definitions that are backed by a Python function. Meant to
+    replace `PythonOperator` in your Airflow installation.
+    """
+
     specs: List[AssetSpec]
     name: str
     python_fn: Optional[Callable] = None

--- a/examples/experimental/dagster-airlift/dagster_airlift/dbt/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/dbt/__init__.py
@@ -1,1 +1,1 @@
-from .multi_asset import DbtProjectDefs as DbtProjectDefs
+from .multi_asset import DbtBuildProjectDefs as DbtBuildProjectDefs

--- a/examples/experimental/dagster-airlift/dagster_airlift/dbt/multi_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/dbt/multi_asset.py
@@ -10,7 +10,16 @@ from dagster_airlift.core.def_factory import DefsFactory
 
 
 @dataclass
-class DbtProjectDefs(DefsFactory):
+class DbtBuildProjectDefs(DefsFactory):
+    """Produce definitions that build a DBT project. Meant to replace, for example,
+    a `BashOperator` that invokes `dbt build` in your Airflow installation.
+
+    If you have further customization needs, we recommend that you subclass
+    `DefsFactory` directly and write `build_defs` such that it returns
+    a `Definitions` object with the desired assets and resources, constructed
+    using `dbt_assets`.
+    """
+
     dbt_project_path: Path
     name: str
     group: Optional[str] = None

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_dbt_multi_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_dbt_multi_asset.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from dagster import AssetKey, AssetsDefinition
-from dagster_airlift.dbt import DbtProjectDefs
+from dagster_airlift.dbt import DbtBuildProjectDefs
 
 
 def test_load_dbt_project(dbt_project_dir: Path, dbt_project: None) -> None:
@@ -11,7 +11,7 @@ def test_load_dbt_project(dbt_project_dir: Path, dbt_project: None) -> None:
     assert os.environ["DBT_PROJECT_DIR"] == str(
         dbt_project_dir
     ), "Expected dbt project dir to be set as env var"
-    defs = DbtProjectDefs(
+    defs = DbtBuildProjectDefs(
         dbt_project_path=dbt_project_dir,
         name="my_dbt_multi_asset",
     ).build_defs()

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_python_multi_assets.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_python_multi_assets.py
@@ -1,5 +1,5 @@
 from dagster import AssetDep, AssetKey, AssetsDefinition, AssetSpec
-from dagster_airlift import PythonDefs
+from dagster_airlift import PythonFnDefs
 
 from dagster_airlift_tests.unit_tests.multi_asset_python import compute_fn
 
@@ -16,7 +16,7 @@ def test_python_multi_asset_factory() -> None:
         key=ak("my/asset"),
         deps=[AssetDep(ak("upstream/asset"))],
     )
-    defs = PythonDefs(
+    defs = PythonFnDefs(
         specs=[asset_spec],
         python_fn=compute_fn,
         name="test_dag__test_task",

--- a/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/dagster_defs/definitions.py
+++ b/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/dagster_defs/definitions.py
@@ -6,12 +6,12 @@ from dagster._core.definitions.asset_spec import AssetSpec
 from dagster_airlift import (
     AirflowInstance,
     BasicAuthBackend,
-    PythonDefs,
+    PythonFnDefs,
     create_defs_from_airflow_instance,
     load_migration_state_from_yaml,
 )
 from dagster_airlift.core.def_factory import defs_from_factories
-from dagster_airlift.dbt import DbtProjectDefs
+from dagster_airlift.dbt import DbtBuildProjectDefs
 
 from ..business_logic import load_csv_to_duckdb
 from .constants import (
@@ -39,12 +39,12 @@ def dbt_project_path() -> Path:
 defs = create_defs_from_airflow_instance(
     airflow_instance=airflow_instance,
     orchestrated_defs=defs_from_factories(
-        PythonDefs(
+        PythonFnDefs(
             name="load_lakehouse__load_iris",
             specs=[AssetSpec(key=AssetKey.from_user_string("iris_dataset/iris_lakehouse_table"))],
             python_fn=load_csv_to_duckdb,
         ),
-        DbtProjectDefs(
+        DbtBuildProjectDefs(
             name="dbt_dag__build_dbt_models",
             dbt_project_path=dbt_project_path(),
             group="dbt",


### PR DESCRIPTION
## Summary & Motivation

This does some light renaming to be more accurate (`PythonDefs` to `PythonFnDefs` and `DbtProjectDefs` to `DbtBuildProjectDefs`) and provides some airflow-friendly docstrings

## How I Tested These Changes

BK
