### PR TITLE
[ui] Hide “materialization planned” events from the log filter bar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/getRunFilterProviders.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/getRunFilterProviders.ts
@@ -4,7 +4,17 @@ import uniq from 'lodash/uniq';
 import {DagsterEventType} from '../graphql/types';
 
 const typeValues = memoize(() =>
-  uniq(Object.values(DagsterEventType).map(eventTypeToDisplayType)).sort(),
+  uniq(
+    Object.values(DagsterEventType)
+      .filter(
+        (t) =>
+          ![
+            DagsterEventType.ASSET_CHECK_EVALUATION_PLANNED,
+            DagsterEventType.ASSET_MATERIALIZATION_PLANNED,
+          ].includes(t),
+      )
+      .map(eventTypeToDisplayType),
+  ).sort(),
 );
 
 export const eventTypeToDisplayType = (eventType: string) => {


### PR DESCRIPTION
## Summary & Motivation

Related: https://linear.app/dagster-labs/issue/FE-374/hide-planned-events-from-filter-typeahead-in-log-viewer

I verified that these logs are already filtered out of the log view itself, but they were not filtered from the typeahead text input above the log view. This list is mostly synthesized from the enum itself, so I added a filter to remove them.

![image](https://github.com/user-attachments/assets/64584a61-3a8d-46a6-b5b2-530a241f7b14)

## How I Tested These Changes

Confirmed that they are no longer listed in the typeahead