### PR TITLE
[ui] Allow filtering run logs for metadata entry keys and values

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventMetadataEntriesTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventMetadataEntriesTable.tsx
@@ -26,6 +26,7 @@ import {Timestamp} from '../app/time/Timestamp';
 import {
   HIDDEN_METADATA_ENTRY_LABELS,
   MetadataEntry,
+  MetadataEntryLabelOnly,
   isCanonicalRowCountMetadataEntry,
 } from '../metadata/MetadataEntry';
 import {
@@ -135,14 +136,7 @@ export const AssetEventMetadataEntriesTable = ({
     () =>
       allRows
         .filter((row) => !filter || row.entry.label.toLowerCase().includes(filter.toLowerCase()))
-        .filter(
-          (row) =>
-            !HIDDEN_METADATA_ENTRY_LABELS.has(row.entry.label) &&
-            !(isCanonicalColumnSchemaEntry(row.entry) && hideTableSchema) &&
-            !isCanonicalColumnLineageEntry(row.entry) &&
-            !isCanonicalRowCountMetadataEntry(row.entry) &&
-            !isCanonicalCodeSourceEntry(row.entry),
-        ),
+        .filter((row) => !isEntryHidden(row.entry, {hideTableSchema})),
     [allRows, filter, hideTableSchema],
   );
 
@@ -331,3 +325,16 @@ export const StyledTableWithHeader = styled.table`
     }
   }
 `;
+
+function isEntryHidden(
+  entry: MetadataEntryLabelOnly,
+  {hideTableSchema}: {hideTableSchema: boolean | undefined},
+) {
+  return (
+    HIDDEN_METADATA_ENTRY_LABELS.has(entry.label) ||
+    (isCanonicalColumnSchemaEntry(entry) && hideTableSchema) ||
+    isCanonicalColumnLineageEntry(entry) ||
+    isCanonicalRowCountMetadataEntry(entry) ||
+    isCanonicalCodeSourceEntry(entry)
+  );
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/filterLogs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/filterLogs.tsx
@@ -1,6 +1,7 @@
 import {LogFilter, LogsProviderLogs} from './LogsProvider';
 import {eventTypeToDisplayType} from './getRunFilterProviders';
 import {logNodeLevel} from './logNodeLevel';
+import {LogNode} from './types';
 
 export function filterLogs(logs: LogsProviderLogs, filter: LogFilter, filterStepKeys: string[]) {
   const filteredNodes = logs.allNodes.filter((node) => {
@@ -26,6 +27,7 @@ export function filterLogs(logs: LogsProviderLogs, filter: LogFilter, filterStep
 
   const textMatchNodes = hasTextFilter
     ? filteredNodes.filter((node) => {
+        const nodeTexts = [node.message.toLowerCase(), ...metadataEntryKeyValueStrings(node)];
         return (
           filter.logQuery.length > 0 &&
           filter.logQuery.every((f) => {
@@ -38,7 +40,7 @@ export function filterLogs(logs: LogsProviderLogs, filter: LogFilter, filterStep
             if (f.token === 'type') {
               return node.eventType && f.value === eventTypeToDisplayType(node.eventType);
             }
-            return node.message.toLowerCase().includes(f.value.toLowerCase());
+            return nodeTexts.some((text) => text.toLowerCase().includes(f.value.toLowerCase()));
           })
         );
       })
@@ -48,4 +50,24 @@ export function filterLogs(logs: LogsProviderLogs, filter: LogFilter, filterStep
     filteredNodes: hasTextFilter && filter.hideNonMatches ? textMatchNodes : filteredNodes,
     textMatchNodes,
   };
+}
+
+// Given an array of metadata entries, returns searchable text in the format:
+// [`label1:value1`, ...], where "value1" is the top-level value(s) present in the
+// metadata entry object converted to JSON. All of our metadata entry types contain
+// different top-level keys, such as "intValue", "mdStr" and "tableSchema", and
+// the searchable text is the value of these keys.
+//
+function metadataEntryKeyValueStrings(node: LogNode) {
+  if (!('metadataEntries' in node)) {
+    return [];
+  }
+  const s = node.metadataEntries.map(
+    // eslint-disable-next-line unused-imports/no-unused-vars
+    ({__typename, label, description, ...rest}) =>
+      `${label}:${Object.values(rest)
+        .map((v) => (typeof v === 'string' ? v : JSON.stringify(v)))
+        .join(' ')}`,
+  );
+  return s;
 }


### PR DESCRIPTION
## Summary & Motivation

Related:  https://linear.app/dagster-labs/issue/FE-484/run-logs-search-doesnt-search-through-dictionary-logs

I implemented this in a pretty generic way so that we won't have to revisit this each time we add new events, BUT I think it'd also be fairly straightforward to write a big-ol switch statement that stringifies each unique type, down to switch to that if my "stringify all the metadata entry values" thing is too whacky :-) 

## How I Tested These Changes

I tested this using a bunch of real-world run logs:

Examples:

![image](https://github.com/user-attachments/assets/72192c78-b42b-45fa-a85d-24b4a4b5a653)

A value or the key or both
![image](https://github.com/user-attachments/assets/c63123e1-0106-4bbe-b105-7ff43352abd2)
![image](https://github.com/user-attachments/assets/b9e33758-c420-48e1-a031-cdb457609394)

A value inside "Show JSON"
![image](https://github.com/user-attachments/assets/5e2fd156-b4f8-44ee-8be3-1d6c64942bca)

