### PR TITLE
[ui] Always launch using pure asset backfills except on asset job pages

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -48,11 +48,7 @@ import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PipelineRunTag} from '../app/ExecutionSessionStorage';
 import {usePermissionsForLocation} from '../app/Permissions';
 import {PythonErrorInfo} from '../app/PythonErrorInfo';
-import {
-  displayNameForAssetKey,
-  isHiddenAssetGroupJob,
-  itemWithAssetKey,
-} from '../asset-graph/Utils';
+import {displayNameForAssetKey, itemWithAssetKey} from '../asset-graph/Utils';
 import {AssetKey} from '../assets/types';
 import {LaunchBackfillParams, PartitionDefinitionType} from '../graphql/types';
 import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../instance/backfill/BackfillUtils';
@@ -344,7 +340,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
 
   const onLaunchAsBackfill = async () => {
     const backfillParams: LaunchBackfillParams =
-      target.type === 'job' && !isHiddenAssetGroupJob(target.jobName)
+      target.type === 'job'
         ? {
             tags,
             assetSelection: assets.map(asAssetKeyInput),


### PR DESCRIPTION
Related: https://linear.app/dagster-labs/issue/FE-499/launch-all-non-asset-job-runs-using-pure-asset-backfill-path

## Summary & Motivation

We are switching from many hidden asset jobs to just one which does not have a predefined partition set (this has already merged). We are currently launching assets incorrectly because the new singleton-hidden-asset-job does not have a pipeline partition set definition, which prevents the UI from launching single runs of partitioned assets. 

This PR explores launching ALL non-asset-job runs for assets as pure-asset backfills endpoint (the launchBackfill mutation with an `assetSelection`.

This is much simpler, and it does work (though you always get a backfill currently), BUT:

- There is no way to provide config (previously shift-clicking would give you the launchpad)
- There is no way to indicate whether to include checks (previously a checkbox inside the launchpad)
- There is no way to launch a backfill using a single run and a partition range specified in tags
- There is always a backfill created (though this seems fixable)

Curious to get thoughts on this direction @sryza

It seems like we could use the new singleton-hidden-asset-job for unpartitioned assets with config, but I can't think of a way to allow execution of a single partition of a partitioned asset with config.