### PR TITLE
Don't propagate click events from popover + remove unnecessary overflow hidden

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/ProductTour.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/ProductTour.tsx
@@ -84,7 +84,11 @@ export const ProductTour = ({
       }}
       minimal={false}
       content={
-        <>
+        <div
+          onClick={(ev) => {
+            ev.stopPropagation();
+          }}
+        >
           <div />
           <ProductTourContainer flex={{direction: 'column', gap: 4}} padding={16} style={{width}}>
             <Box flex={{direction: 'column', gap: 8}}>
@@ -95,7 +99,7 @@ export const ProductTour = ({
             {actionsJsx}
           </ProductTourContainer>
           <div />
-        </>
+        </div>
       }
     >
       {children}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
@@ -72,10 +72,7 @@ export const AssetPageHeader = ({
   return (
     <PageHeader
       title={
-        <Box
-          flex={{alignItems: 'center', gap: 4}}
-          style={{maxWidth: '600px', overflow: 'hidden', marginBottom: 4}}
-        >
+        <Box flex={{alignItems: 'center', gap: 4}} style={{maxWidth: '600px', marginBottom: 4}}>
           <Title>
             <BreadcrumbsWithSlashes
               items={breadcrumbs}


### PR DESCRIPTION
## Summary & Motivation

1. Don't propagate click events from the popover of ProductTour since by default blueprint's `Popover` seems to bubble them up to the element its wrapping (super weird!).
2. Remove overflow: hidden from the AssetPageHeader because this wraps a button that uses outerglow on hover and the overflow hidden ends up hiding the outerglow making it look weird.

