### PR TITLE
Attempt to fix issue where asset nodes were getting incorrectly mapped to solids

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -440,7 +440,7 @@ class ISolidDefinitionMixin:
             nodes = [
                 node
                 for node in ext_repo.get_external_asset_nodes()
-                if node.op_name == self.solid_def_name
+                if node.node_definition_name == self.solid_def_name
             ]
             asset_checks_loader = AssetChecksLoader(
                 context=graphene_info.context, asset_keys=[node.asset_key for node in nodes]


### PR DESCRIPTION
Summary:
This locally fixes an issue introduced in https://github.com/dagster-io/dagster/pull/22747 that we were seeing where two separate dbt_assets with different subsets of the same manifest resulted in jobs without any assets attached to them. Still need to create a test that reproduces the problem.

## Summary & Motivation

## How I Tested These Changes
