### PR TITLE
[dagster-airbyte] Support `client_id` and `client_secret` in AirbyteCloudResource

### DIFF
--- a/docs/content/integrations/airbyte-cloud.mdx
+++ b/docs/content/integrations/airbyte-cloud.mdx
@@ -45,7 +45,7 @@ To get started, you will need to install the `dagster` and `dagster-airbyte` Pyt
 pip install dagster dagster-airbyte
 ```
 
-You'll also need to have an Airbyte Cloud account, and have created an Airbyte API Key. For more information, see the [Airbyte API docs](https://reference.airbyte.com/reference/start).
+You'll also need to have an Airbyte Cloud account, and have created an Airbyte client ID and client secret. For more information, see the [Airbyte API docs](https://reference.airbyte.com/reference/getting-started) and [Airbyte authentication guide](https://reference.airbyte.com/reference/authentication).
 
 ---
 
@@ -58,11 +58,12 @@ from dagster import EnvVar
 from dagster_airbyte import AirbyteCloudResource
 
 airbyte_instance = AirbyteCloudResource(
-    api_key=EnvVar("AIRBYTE_API_KEY"),
+    client_id=EnvVar("AIRBYTE_CLIENT_ID"),
+    client_secret=EnvVar("AIRBYTE_CLIENT_SECRET"),
 )
 ```
 
-Here, the API key is provided using an <PyObject object="EnvVar" />. For more information on setting environment variables in a production setting, see [Using environment variables and secrets](/guides/dagster/using-environment-variables-and-secrets).
+Here, the client ID and client secret are provided using an <PyObject object="EnvVar" />. For more information on setting environment variables in a production setting, see [Using environment variables and secrets](/guides/dagster/using-environment-variables-and-secrets).
 
 ---
 
@@ -104,7 +105,8 @@ from dagster_airbyte import build_airbyte_assets, AirbyteCloudResource
 from dagster import Definitions, EnvVar
 
 airbyte_instance = AirbyteCloudResource(
-    api_key=EnvVar("AIRBYTE_API_KEY"),
+    client_id=EnvVar("AIRBYTE_CLIENT_ID"),
+    client_secret=EnvVar("AIRBYTE_CLIENT_SECRET"),
 )
 airbyte_assets = build_airbyte_assets(
     connection_id="43908042-8399-4a58-82f1-71a45099fff7",
@@ -153,7 +155,8 @@ from dagster_snowflake_pandas import SnowflakePandasIOManager
 import pandas as pd
 
 airbyte_instance = AirbyteCloudResource(
-    api_key=EnvVar("AIRBYTE_API_KEY"),
+    client_id=EnvVar("AIRBYTE_CLIENT_ID"),
+    client_secret=EnvVar("AIRBYTE_CLIENT_SECRET"),
 )
 airbyte_assets = build_airbyte_assets(
     connection_id="43908042-8399-4a58-82f1-71a45099fff7",
@@ -207,7 +210,8 @@ from dagster_airbyte import (
 from dagster_snowflake import SnowflakeResource
 
 airbyte_instance = AirbyteCloudResource(
-    api_key=EnvVar("AIRBYTE_API_KEY"),
+    client_id=EnvVar("AIRBYTE_CLIENT_ID"),
+    client_secret=EnvVar("AIRBYTE_CLIENT_SECRET"),
 )
 airbyte_assets = build_airbyte_assets(
     connection_id="43908042-8399-4a58-82f1-71a45099fff7",
@@ -261,7 +265,8 @@ from dagster import (
 )
 
 airbyte_instance = AirbyteCloudResource(
-    api_key=EnvVar("AIRBYTE_API_KEY"),
+    client_id=EnvVar("AIRBYTE_CLIENT_ID"),
+    client_secret=EnvVar("AIRBYTE_CLIENT_SECRET"),
 )
 airbyte_assets = build_airbyte_assets(
     connection_id="43908042-8399-4a58-82f1-71a45099fff7",

--- a/examples/docs_snippets/docs_snippets/integrations/airbyte/airbyte.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airbyte/airbyte.py
@@ -22,7 +22,8 @@ def scope_define_cloud_instance() -> None:
     from dagster_airbyte import AirbyteCloudResource
 
     airbyte_instance = AirbyteCloudResource(
-        api_key=EnvVar("AIRBYTE_API_KEY"),
+        client_id=EnvVar("AIRBYTE_CLIENT_ID"),
+        client_secret=EnvVar("AIRBYTE_CLIENT_SECRET"),
     )
     # end_define_cloud_instance
 
@@ -126,7 +127,8 @@ def scope_airbyte_cloud_manual_config():
     from dagster import Definitions, EnvVar
 
     airbyte_instance = AirbyteCloudResource(
-        api_key=EnvVar("AIRBYTE_API_KEY"),
+        client_id=EnvVar("AIRBYTE_CLIENT_ID"),
+        client_secret=EnvVar("AIRBYTE_CLIENT_SECRET"),
     )
     airbyte_assets = build_airbyte_assets(
         connection_id="43908042-8399-4a58-82f1-71a45099fff7",
@@ -257,7 +259,8 @@ def scope_add_downstream_assets_cloud():
         import pandas as pd
 
         airbyte_instance = AirbyteCloudResource(
-            api_key=EnvVar("AIRBYTE_API_KEY"),
+            client_id=EnvVar("AIRBYTE_CLIENT_ID"),
+            client_secret=EnvVar("AIRBYTE_CLIENT_SECRET"),
         )
         airbyte_assets = build_airbyte_assets(
             connection_id="43908042-8399-4a58-82f1-71a45099fff7",
@@ -310,7 +313,8 @@ def scope_add_downstream_assets_cloud_with_deps():
         from dagster_snowflake import SnowflakeResource
 
         airbyte_instance = AirbyteCloudResource(
-            api_key=EnvVar("AIRBYTE_API_KEY"),
+            client_id=EnvVar("AIRBYTE_CLIENT_ID"),
+            client_secret=EnvVar("AIRBYTE_CLIENT_SECRET"),
         )
         airbyte_assets = build_airbyte_assets(
             connection_id="43908042-8399-4a58-82f1-71a45099fff7",
@@ -400,7 +404,8 @@ def scope_schedule_assets_cloud():
     )
 
     airbyte_instance = AirbyteCloudResource(
-        api_key=EnvVar("AIRBYTE_API_KEY"),
+        client_id=EnvVar("AIRBYTE_CLIENT_ID"),
+        client_secret=EnvVar("AIRBYTE_CLIENT_SECRET"),
     )
     airbyte_assets = build_airbyte_assets(
         connection_id="43908042-8399-4a58-82f1-71a45099fff7",

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -7,7 +7,6 @@ from abc import abstractmethod
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Mapping, Optional, cast
-from pydantic import PrivateAttr
 
 import requests
 from dagster import (
@@ -22,7 +21,7 @@ from dagster._config.pythonic_config import infer_schema_from_config_class
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._utils.cached_method import cached_method
 from dagster._utils.merger import deep_merge_dicts
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 from requests.exceptions import RequestException
 
 from dagster_airbyte.types import AirbyteOutput
@@ -293,7 +292,10 @@ class AirbyteCloudResource(BaseAirbyteResource):
         if self._needs_refreshed_access_token():
             self._refresh_access_token()
         return {
-            "headers": {"Authorization": f"Bearer {self._access_token_value}", "User-Agent": "dagster"}
+            "headers": {
+                "Authorization": f"Bearer {self._access_token_value}",
+                "User-Agent": "dagster",
+            }
         }
 
     def start_sync(self, connection_id: str) -> Mapping[str, object]:
@@ -340,7 +342,7 @@ class AirbyteCloudResource(BaseAirbyteResource):
         # The access token expire every 3 minutes in Airbyte Cloud.
         # Refresh is needed after 2.5 minutes to avoid the "token expired" error message.
         return not self._access_token_value or self._access_token_timestamp <= datetime.timestamp(
-                datetime.now() - timedelta(seconds=150)
+            datetime.now() - timedelta(seconds=150)
         )
 
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/resources.py
@@ -348,8 +348,11 @@ class AirbyteCloudResource(BaseAirbyteResource):
     def _needs_refreshed_access_token(self) -> bool:
         # The access token expire every 3 minutes in Airbyte Cloud.
         # Refresh is needed after 2.5 minutes to avoid the "token expired" error message.
-        return not self._access_token_value or self._access_token_timestamp <= datetime.timestamp(
-            datetime.now() - timedelta(seconds=150)
+        return (
+            not self._access_token_value
+            or not self._access_token_timestamp
+            or self._access_token_timestamp
+            <= datetime.timestamp(datetime.now() - timedelta(seconds=150))
         )
 
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -224,6 +224,11 @@ def test_assets_cloud() -> None:
     with responses.RequestsMock() as rsps:
         rsps.add(
             rsps.POST,
+            f"{ab_url}/applications/token",
+            json={"access_token": "some_access_token"},
+        )
+        rsps.add(
+            rsps.POST,
             f"{ab_url}/jobs",
             json={"jobId": 1, "status": "pending", "jobType": "sync"},
         )
@@ -237,11 +242,6 @@ def test_assets_cloud() -> None:
             rsps.GET,
             f"{ab_url}/jobs/1",
             json={"jobId": 1, "status": "succeeded", "jobType": "sync"},
-        )
-        rsps.add(
-            rsps.POST,
-            f"{ab_url}/applications/token",
-            json={"access_token": "some_access_token"},
         )
 
         res = materialize_to_memory(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -208,7 +208,9 @@ def test_assets_with_normalization(
 
 
 def test_assets_cloud() -> None:
-    ab_resource = AirbyteCloudResource(api_key="some_key", poll_interval=0)
+    ab_resource = AirbyteCloudResource(
+        client_id="some_client_id", client_secret="some_client_secret", poll_interval=0
+    )
     ab_url = ab_resource.api_base_url
 
     ab_assets = build_airbyte_assets(
@@ -235,6 +237,11 @@ def test_assets_cloud() -> None:
             rsps.GET,
             f"{ab_url}/jobs/1",
             json={"jobId": 1, "status": "succeeded", "jobType": "sync"},
+        )
+        rsps.add(
+            rsps.POST,
+            f"{ab_url}/applications/token",
+            json={"access_token": "some_access_token"},
         )
 
         res = materialize_to_memory(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_cloud_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_cloud_resources.py
@@ -8,7 +8,12 @@ from dagster_airbyte import AirbyteCloudResource, AirbyteOutput, AirbyteState
 
 @responses.activate
 def test_trigger_connection() -> None:
-    ab_resource = AirbyteCloudResource(api_key="some_key", poll_interval=0)
+    ab_resource = AirbyteCloudResource(client_id="some_client_id", client_secret="some_client_secret", poll_interval=0)
+    responses.add(
+        responses.POST,
+        f"{ab_resource.api_base_url}/applications/token",
+        json={"access_token": "some_access_token"},
+    )
     responses.add(
         method=responses.POST,
         url=ab_resource.api_base_url + "/jobs",
@@ -19,8 +24,17 @@ def test_trigger_connection() -> None:
     assert resp == {"job": {"id": 1, "status": "pending"}}
 
 
+@responses.activate
 def test_trigger_connection_fail() -> None:
-    ab_resource = AirbyteCloudResource(api_key="some_key")
+    ab_resource = AirbyteCloudResource(
+        client_id="some_client_id", client_secret="some_client_secret"
+    )
+    responses.add(
+        responses.POST,
+        f"{ab_resource.api_base_url}/applications/token",
+        json={"access_token": "some_access_token"},
+    )
+
     with pytest.raises(
         Failure,
         match=re.escape("Max retries (3) exceeded with url: https://api.airbyte.com/v1/jobs."),
@@ -34,7 +48,13 @@ def test_trigger_connection_fail() -> None:
     [AirbyteState.SUCCEEDED, AirbyteState.CANCELLED, AirbyteState.ERROR, "unrecognized"],
 )
 def test_sync_and_poll(state) -> None:
-    ab_resource = AirbyteCloudResource(api_key="some_key", poll_interval=0)
+    ab_resource = AirbyteCloudResource(client_id="some_client_id", client_secret="some_client_secret", poll_interval=0)
+
+    responses.add(
+        responses.POST,
+        f"{ab_resource.api_base_url}/applications/token",
+        json={"access_token": "some_access_token"},
+    )
     responses.add(
         method=responses.POST,
         url=ab_resource.api_base_url + "/jobs",
@@ -78,8 +98,13 @@ def test_sync_and_poll(state) -> None:
 
 @responses.activate
 def test_start_sync_bad_out_fail() -> None:
-    ab_resource = AirbyteCloudResource(api_key="some_key", poll_interval=0)
+    ab_resource = AirbyteCloudResource(client_id="some_client_id", client_secret="some_client_secret", poll_interval=0)
 
+    responses.add(
+        responses.POST,
+        f"{ab_resource.api_base_url}/applications/token",
+        json={"access_token": "some_access_token"},
+    )
     responses.add(
         method=responses.POST,
         url=ab_resource.api_base_url + "/jobs",

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_cloud_resources.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_cloud_resources.py
@@ -1,4 +1,7 @@
+import datetime
+import json
 import re
+from unittest import mock
 
 import pytest
 import responses
@@ -8,7 +11,9 @@ from dagster_airbyte import AirbyteCloudResource, AirbyteOutput, AirbyteState
 
 @responses.activate
 def test_trigger_connection() -> None:
-    ab_resource = AirbyteCloudResource(client_id="some_client_id", client_secret="some_client_secret", poll_interval=0)
+    ab_resource = AirbyteCloudResource(
+        client_id="some_client_id", client_secret="some_client_secret", poll_interval=0
+    )
     responses.add(
         responses.POST,
         f"{ab_resource.api_base_url}/applications/token",
@@ -48,7 +53,9 @@ def test_trigger_connection_fail() -> None:
     [AirbyteState.SUCCEEDED, AirbyteState.CANCELLED, AirbyteState.ERROR, "unrecognized"],
 )
 def test_sync_and_poll(state) -> None:
-    ab_resource = AirbyteCloudResource(client_id="some_client_id", client_secret="some_client_secret", poll_interval=0)
+    ab_resource = AirbyteCloudResource(
+        client_id="some_client_id", client_secret="some_client_secret", poll_interval=0
+    )
 
     responses.add(
         responses.POST,
@@ -98,7 +105,9 @@ def test_sync_and_poll(state) -> None:
 
 @responses.activate
 def test_start_sync_bad_out_fail() -> None:
-    ab_resource = AirbyteCloudResource(client_id="some_client_id", client_secret="some_client_secret", poll_interval=0)
+    ab_resource = AirbyteCloudResource(
+        client_id="some_client_id", client_secret="some_client_secret", poll_interval=0
+    )
 
     responses.add(
         responses.POST,
@@ -116,3 +125,67 @@ def test_start_sync_bad_out_fail() -> None:
         match=re.escape("Max retries (3) exceeded with url: https://api.airbyte.com/v1/jobs."),
     ):
         ab_resource.start_sync("some_connection")
+
+
+@responses.activate
+def test_refresh_access_token() -> None:
+    ab_resource = AirbyteCloudResource(
+        client_id="some_client_id", client_secret="some_client_secret", poll_interval=0
+    )
+    responses.add(
+        responses.POST,
+        f"{ab_resource.api_base_url}/applications/token",
+        json={"access_token": "some_access_token"},
+    )
+    responses.add(
+        method=responses.POST,
+        url=ab_resource.api_base_url + "/jobs",
+        json={"jobId": 1, "status": "pending", "jobType": "sync"},
+        status=200,
+    )
+
+    test_time_first_call = datetime.datetime(2024, 1, 1, 0, 0, 0)
+    test_time_before_expiration = datetime.datetime(2024, 1, 1, 0, 2, 0)
+    test_time_after_expiration = datetime.datetime(2024, 1, 1, 0, 3, 0)
+    with mock.patch("dagster_airbyte.resources.datetime", wraps=datetime.datetime) as dt:
+        # Test first call, must get the access token before calling the jobs api
+        dt.now.return_value = test_time_first_call
+        ab_resource.start_sync("some_connection")
+
+        assert len(responses.calls) == 2
+        access_token_call = responses.calls[0]
+        jobs_api_call = responses.calls[1]
+
+        assert "Authorization" not in access_token_call.request.headers
+        access_token_call_body = json.loads(access_token_call.request.body.decode("utf-8"))
+        assert access_token_call_body["client_id"] == "some_client_id"
+        assert access_token_call_body["client_secret"] == "some_client_secret"
+        assert jobs_api_call.request.headers["Authorization"] == "Bearer some_access_token"
+
+        responses.calls.reset()
+
+        # Test second call, occurs before the access token expiration, only the jobs api is called
+        dt.now.return_value = test_time_before_expiration
+        ab_resource.start_sync("some_connection")
+
+        assert len(responses.calls) == 1
+        jobs_api_call = responses.calls[0]
+
+        assert jobs_api_call.request.headers["Authorization"] == "Bearer some_access_token"
+
+        responses.calls.reset()
+
+        # Test third call, occurs after the token expiration,
+        # must refresh the access token before calling the jobs api
+        dt.now.return_value = test_time_after_expiration
+        ab_resource.start_sync("some_connection")
+
+        assert len(responses.calls) == 2
+        access_token_call = responses.calls[0]
+        jobs_api_call = responses.calls[1]
+
+        assert "Authorization" not in access_token_call.request.headers
+        access_token_call_body = json.loads(access_token_call.request.body.decode("utf-8"))
+        assert access_token_call_body["client_id"] == "some_client_id"
+        assert access_token_call_body["client_secret"] == "some_client_secret"
+        assert jobs_api_call.request.headers["Authorization"] == "Bearer some_access_token"

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -288,7 +288,9 @@ def test_load_from_instance(
 
 
 def test_load_from_instance_cloud() -> None:
-    airbyte_cloud_instance = AirbyteCloudResource(api_key="foo", poll_interval=0)
+    airbyte_cloud_instance = AirbyteCloudResource(
+        client_id="some_client_id", client_secret="some_client_secret", poll_interval=0
+    )
 
     with pytest.raises(
         DagsterInvalidInvocationError,


### PR DESCRIPTION
## Summary & Motivation

This PR updates the `AirbyteCloudResource` to support `client_id` and `client_secret` for authentication. The `api_key` can no longer be used for authentication because Airbyte is [deprecating portal.airbyte.com](https://reference.airbyte.com/reference/portalairbytecom-deprecation).

Tests and docs are updated to reflect the changes.

Two main questions for reviewers:
- this PR implements a pattern where the access token is refreshed before making a call to the API, if the token was fetched more than 2.5 minutes ago. Should we avoid this pattern and let users manage the resource lifecycle?
  - [According to Airbyte](https://reference.airbyte.com/reference/portalairbytecom-deprecation), the access token expires after 3 minutes.
  - The access token is initially fetched in `setup_for_execution`, then refreshed if needed. I'm concerned that for jobs including other assets, it might take more than 3 minutes before the Airbyte assets are materialized.
- [portal.airbyte.com will be deprecated next week](https://reference.airbyte.com/reference/portalairbytecom-deprecation), on August 15th, so I removed the previous `api_key` attribute without deprecation warning. Are we comfortable doing so? Considering that this approach will fail next week.

## How I Tested These Changes

BK with updated tests

Fully tested on a live cloud instance with this code: 

```python
from dagster import Definitions, EnvVar
from dagster_airbyte import AirbyteCloudResource, build_airbyte_assets

airbyte_instance = AirbyteCloudResource(
    client_id=EnvVar("AIRBYTE_CLIENT_ID"),
    client_secret=EnvVar("AIRBYTE_CLIENT_SECRET"),
)

airbyte_assets = build_airbyte_assets(
    # Test connection - Sample Data (Faker) to Google Sheets 
    connection_id="0bb7a00c-0b85-4fac-b8ff-67dc380f1c29",
    destination_tables=["products", "purchases", "users"],
)

defs = Definitions(assets=airbyte_assets, resources={"airbyte": airbyte_instance})
```

Job successful:
<img width="1037" alt="Screenshot 2024-08-13 at 4 30 12 PM" src="https://github.com/user-attachments/assets/46c91c95-b597-48de-bcbd-8bbb38f5f6d4">

Asset graph:
<img width="1037" alt="Screenshot 2024-08-13 at 4 30 38 PM" src="https://github.com/user-attachments/assets/eae8ab12-0da9-4956-8ae6-10932cd0c199">
