### PR TITLE
[dagster-embedded-elt] for dlt transformers, use base resource as parent

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/translator.py
@@ -51,6 +51,11 @@ class DagsterDltTranslator:
             Iterable[AssetKey]: The Dagster asset keys upstream of `dlt_resource_key`.
 
         """
+        if resource.is_transformer:
+            pipe = resource._pipe  # noqa: SLF001
+            while pipe.has_parent:
+                pipe = pipe.parent
+            return [AssetKey(f"{resource.source_name}_{pipe.name}")]
         return [AssetKey(f"{resource.source_name}_{resource.name}")]
 
     @public

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_asset_decorator.py
@@ -35,6 +35,21 @@ def test_example_pipeline_asset_keys(dlt_pipeline: Pipeline) -> None:
     } == example_pipeline_assets.keys
 
 
+def test_example_pipeline_deps(dlt_pipeline: Pipeline) -> None:
+    @dlt_assets(dlt_source=pipeline(), dlt_pipeline=dlt_pipeline)
+    def example_pipeline_assets(
+        context: AssetExecutionContext, dlt_pipeline_resource: DagsterDltResource
+    ):
+        yield from dlt_pipeline_resource.run(context=context)
+
+    # Since repo_issues is a transform of the repo data, its upstream
+    # asset key should be the repo data asset key as well.
+    assert {
+        AssetKey("dlt_pipeline_repos"): {AssetKey("pipeline_repos")},
+        AssetKey("dlt_pipeline_repo_issues"): {AssetKey("pipeline_repos")},
+    } == example_pipeline_assets.asset_deps
+
+
 def test_example_pipeline(dlt_pipeline: Pipeline) -> None:
     @dlt_assets(dlt_source=pipeline(), dlt_pipeline=dlt_pipeline)
     def example_pipeline_assets(


### PR DESCRIPTION
## Summary

For dlt `@dlt.transformer` resources, we currently generate upstream asset keys matching the transformer name. This usually doesn't map to the actual upstream source since the data is a transformation of other resources. For example, the course reviews here in reality comes from the same data source as courses:

<img width="529" alt="Screenshot 2024-08-06 at 2 57 06 PM" src="https://github.com/user-attachments/assets/54214b74-bebd-4300-a7b8-dbc2bbe03664">



This PR updates that mapping by walking up the list of parent resources and using the outermost, raw resource for the key name.

## Test Plan

New unit test.
