### PR TITLE
[dagster-embedded-elt] load docstrings as default dlt resource descriptions

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/translator.py
@@ -70,6 +70,11 @@ class DagsterDltTranslator:
         Returns:
             Optional[str]: The Dagster description for the dlt resource.
         """
+        pipe = resource._pipe  # noqa: SLF001
+        # If the function underlying the resource is a single callable,
+        # return the docstring of the callable.
+        if len(pipe.steps) == 1 and callable(pipe.steps[0]):
+            return pipe.steps[0].__doc__
         return None
 
     @public

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/dlt_test_sources/duckdb_with_transformer.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/dlt_test_sources/duckdb_with_transformer.py
@@ -37,6 +37,7 @@ def pipeline(month: Optional[str] = None):
         primary_key=["repo_id", "issue_id"], write_disposition="merge", data_from=repos
     )
     def repo_issues(repo):
+        """Extracted list of issues from repositories."""
         if repo["last_modified_dt"][:-3] == month or not month:
             yield MOCK_ISSUES[repo["id"]]
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_asset_decorator.py
@@ -50,6 +50,19 @@ def test_example_pipeline_deps(dlt_pipeline: Pipeline) -> None:
     } == example_pipeline_assets.asset_deps
 
 
+def test_example_pipeline_descs(dlt_pipeline: Pipeline) -> None:
+    @dlt_assets(dlt_source=pipeline(), dlt_pipeline=dlt_pipeline)
+    def example_pipeline_assets(
+        context: AssetExecutionContext, dlt_pipeline_resource: DagsterDltResource
+    ):
+        yield from dlt_pipeline_resource.run(context=context)
+
+    assert (
+        example_pipeline_assets.descriptions_by_key[AssetKey("dlt_pipeline_repo_issues")]
+        == "Extracted list of issues from repositories."
+    )
+
+
 def test_example_pipeline(dlt_pipeline: Pipeline) -> None:
     @dlt_assets(dlt_source=pipeline(), dlt_pipeline=dlt_pipeline)
     def example_pipeline_assets(


### PR DESCRIPTION
## Summary

Little QoL feature for dlt assets - if a docstring is defined on the dlt resource, we'll pull it as the default asset description.

The mapping here is a little imprecise, since technically the docstring is describing the generic resource on the source class and not the specific instantiation (e.g. for GitHub, what repos we're looking at), but users can always customize that with a translator.

## Test Plan

New unit test.
