### PR TITLE
deprecate dagster-shell integration

### DIFF
--- a/python_modules/libraries/dagster-shell/dagster_shell/ops.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell/ops.py
@@ -92,7 +92,7 @@ def shell_op(context: OpExecutionContext, shell_command: str, config: ShellOpCon
     return output
 
 
-@deprecated(breaking_version="1.9", additional_warn_text="Use PipesSubprocessClient instead.")
+@deprecated(breaking_version="0.25", additional_warn_text="Use PipesSubprocessClient instead.")
 def create_shell_command_op(
     shell_command: str,
     name: str,
@@ -168,7 +168,7 @@ def create_shell_command_op(
     return _shell_fn
 
 
-@deprecated(breaking_version="1.9", additional_warn_text="Use PipesSubprocessClient instead.")
+@deprecated(breaking_version="0.25", additional_warn_text="Use PipesSubprocessClient instead.")
 def create_shell_script_op(
     shell_script_path,
     name="create_shell_script_op",

--- a/python_modules/libraries/dagster-shell/dagster_shell/ops.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell/ops.py
@@ -92,7 +92,7 @@ def shell_op(context: OpExecutionContext, shell_command: str, config: ShellOpCon
     return output
 
 
-@deprecated(breaking_version="1.9", additional_warn_text="Use Dagster Pipes subprocess instead.")
+@deprecated(breaking_version="1.9", additional_warn_text="Use PipesSubprocessClient instead.")
 def create_shell_command_op(
     shell_command: str,
     name: str,
@@ -100,7 +100,7 @@ def create_shell_command_op(
     required_resource_keys: Optional[AbstractSet[str]] = None,
     tags: Optional[Mapping[str, str]] = None,
 ) -> OpDefinition:
-    """DEPRECATED: Use Dagster Pipes subprocess instead.
+    """DEPRECATED: Use PipesSubprocessClient instead.
 
     This function is a factory that constructs ops to execute a shell command.
 
@@ -168,14 +168,14 @@ def create_shell_command_op(
     return _shell_fn
 
 
-@deprecated(breaking_version="1.9", additional_warn_text="Use Dagster Pipes subprocess instead.")
+@deprecated(breaking_version="1.9", additional_warn_text="Use PipesSubprocessClient instead.")
 def create_shell_script_op(
     shell_script_path,
     name="create_shell_script_op",
     ins: Optional[Mapping[str, In]] = None,
     **kwargs: Any,
 ) -> OpDefinition:
-    """DEPRECATED: Use Dagster Pipes subprocess instead.
+    """DEPRECATED: Use PipesSubprocessClient instead.
 
     This function is a factory which constructs an op that will execute a shell command read
     from a script file.

--- a/python_modules/libraries/dagster-shell/dagster_shell/ops.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell/ops.py
@@ -12,6 +12,7 @@ from dagster import (
     _check as check,
     op,
 )
+from dagster._annotations import deprecated
 from dagster._core.definitions.op_definition import OpDefinition
 from pydantic import Field
 
@@ -91,6 +92,7 @@ def shell_op(context: OpExecutionContext, shell_command: str, config: ShellOpCon
     return output
 
 
+@deprecated(breaking_version="1.9", additional_warn_text="Use Dagster Pipes subprocess instead.")
 def create_shell_command_op(
     shell_command: str,
     name: str,
@@ -98,7 +100,9 @@ def create_shell_command_op(
     required_resource_keys: Optional[AbstractSet[str]] = None,
     tags: Optional[Mapping[str, str]] = None,
 ) -> OpDefinition:
-    """This function is a factory that constructs ops to execute a shell command.
+    """DEPRECATED: Use Dagster Pipes subprocess instead.
+
+    This function is a factory that constructs ops to execute a shell command.
 
     Note that you can only use ``shell_command_op`` if you know the command you'd like to execute
     at job construction time. If you'd like to construct shell commands dynamically during
@@ -164,13 +168,16 @@ def create_shell_command_op(
     return _shell_fn
 
 
+@deprecated(breaking_version="1.9", additional_warn_text="Use Dagster Pipes subprocess instead.")
 def create_shell_script_op(
     shell_script_path,
     name="create_shell_script_op",
     ins: Optional[Mapping[str, In]] = None,
     **kwargs: Any,
 ) -> OpDefinition:
-    """This function is a factory which constructs an op that will execute a shell command read
+    """DEPRECATED: Use Dagster Pipes subprocess instead.
+
+    This function is a factory which constructs an op that will execute a shell command read
     from a script file.
 
     Any kwargs passed to this function will be passed along to the underlying :func:`@op
@@ -229,7 +236,9 @@ def create_shell_script_op(
     )
     def _shell_script_fn(context, config: ShellOpConfig):
         output, return_code = execute_script_file(
-            shell_script_path=shell_script_path, log=context.log, **config.to_execute_params()
+            shell_script_path=shell_script_path,
+            log=context.log,
+            **config.to_execute_params(),
         )
 
         if return_code:

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_ops.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_ops.py
@@ -178,3 +178,11 @@ def test_shell_script_op_run_time_config_composite(factory, monkeypatch):
 
     result = my_graph.execute_in_process()
     assert result.output_value() == "this is a test message: foobar\n"
+
+
+def test_shell_op_deprecation():
+    with pytest.warns(DeprecationWarning, match="Use Dagster Pipes subprocess instead."):
+        create_shell_command_op("echo 'hello world'", name="my_op")
+
+    with pytest.warns(DeprecationWarning, match="Use Dagster Pipes subprocess instead."):
+        create_shell_script_op("test.sh", name="my_op")

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_ops.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_ops.py
@@ -181,8 +181,8 @@ def test_shell_script_op_run_time_config_composite(factory, monkeypatch):
 
 
 def test_shell_op_deprecation():
-    with pytest.warns(DeprecationWarning, match="Use Dagster Pipes subprocess instead."):
+    with pytest.warns(DeprecationWarning, match="Use PipesSubprocessClient instead."):
         create_shell_command_op("echo 'hello world'", name="my_op")
 
-    with pytest.warns(DeprecationWarning, match="Use Dagster Pipes subprocess instead."):
+    with pytest.warns(DeprecationWarning, match="Use PipesSubprocessClient instead."):
         create_shell_script_op("test.sh", name="my_op")


### PR DESCRIPTION
## Summary & Motivation
deprecate dagster-shell integration in favor of Dagster Pipes subprocess.

specifically, this PR throws deprecation warnings in:
- `create_shell_command_op`
- `create_shell_script_op`

## How I Tested These Changes
- unit test
- <img width="1358" alt="image" src="https://github.com/user-attachments/assets/3446aed8-684c-44b8-8b2a-a33ef04cfe0a">