### PR TITLE
[ui] Allow deleting dynamic partitions from asset pages

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitions.tsx
@@ -203,6 +203,7 @@ export const AssetPartitions = ({
       {timeDimensionIdx !== -1 && (
         <Box padding={{vertical: 16, horizontal: 24}} border="bottom">
           <DimensionRangeWizard
+            dimensionType={selections[timeDimensionIdx]!.dimension.type}
             partitionKeys={selections[timeDimensionIdx]!.dimension.partitionKeys}
             health={{ranges: rangesForEachDimension[timeDimensionIdx]!}}
             selected={selections[timeDimensionIdx]!.selectedKeys}
@@ -211,7 +212,6 @@ export const AssetPartitions = ({
                 selections.map((r, idx) => (idx === timeDimensionIdx ? {...r, selectedKeys} : r)),
               )
             }
-            dimensionType={selections[timeDimensionIdx]!.dimension.type}
           />
         </Box>
       )}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
@@ -22,7 +22,7 @@ import {AssetViewType} from './useAssetView';
 import {CloudOSSContext} from '../app/CloudOSSContext';
 import {useUnscopedPermissions} from '../app/Permissions';
 import {QueryRefreshCountdown, RefreshState} from '../app/QueryRefresh';
-import {AssetKeyInput, DefinitionTag} from '../graphql/types';
+import {DefinitionTag} from '../graphql/types';
 import {useSelectionReducer} from '../hooks/useSelectionReducer';
 import {testId} from '../testing/testId';
 import {StaticSetFilter} from '../ui/BaseFilters/useStaticSetFilter';
@@ -57,8 +57,6 @@ export const AssetTable = ({
   computeKindFilter,
   storageKindFilter,
 }: Props) => {
-  const [toWipe, setToWipe] = React.useState<AssetKeyInput[] | undefined>();
-
   const groupedByDisplayKey = useMemo(
     () => groupBy(assets, (a) => JSON.stringify(displayPathForAsset(a))),
     [assets, displayPathForAsset],
@@ -139,9 +137,9 @@ export const AssetTable = ({
         groups={groupedByDisplayKey}
         checkedDisplayKeys={checkedDisplayKeys}
         onToggleFactory={onToggleFactory}
+        onRefresh={() => refreshState.refetch()}
         showRepoColumn
         view={view}
-        onWipe={(assetKeys: AssetKeyInput[]) => setToWipe(assetKeys)}
         computeKindFilter={computeKindFilter}
         storageKindFilter={storageKindFilter}
       />
@@ -188,12 +186,6 @@ export const AssetTable = ({
         {belowActionBarComponents}
         {content()}
       </Box>
-      <AssetWipeDialog
-        assetKeys={toWipe || []}
-        isOpen={!!toWipe}
-        onClose={() => setToWipe(undefined)}
-        onComplete={() => refreshState.refetch()}
-      />
     </>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTableFragment.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTableFragment.tsx
@@ -13,6 +13,10 @@ export const ASSET_TABLE_DEFINITION_FRAGMENT = gql`
     hasMaterializePermission
     partitionDefinition {
       description
+      dimensionTypes {
+        type
+        dynamicPartitionsDefinitionName
+      }
     }
     description
     owners {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -29,6 +29,7 @@ import {
   AssetViewDefinitionQuery,
   AssetViewDefinitionQueryVariables,
 } from './types/AssetView.types';
+import {useDeleteDynamicPartitionsDialog} from './useDeleteDynamicPartitionsDialog';
 import {healthRefreshHintFromLiveData} from './usePartitionHealthData';
 import {useReportEventsModal} from './useReportEventsModal';
 import {useWipeModal} from './useWipeModal';
@@ -46,8 +47,7 @@ import {useAssetGraphData} from '../asset-graph/useAssetGraphData';
 import {StaleReasonsTag} from '../assets/Stale';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
-import {useDeleteDynamicPartitionsDialog} from './useDeleteDynamicPartitionsDialog';
-import {PartitionDefinitionType} from '../graphql/types';
+import {buildRepoAddress} from '../workspace/buildRepoAddress';
 
 interface Props {
   assetKey: AssetKey;
@@ -259,6 +259,14 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
     }
   };
 
+  const repoAddress = useMemo(
+    () =>
+      definition
+        ? buildRepoAddress(definition.repository.name, definition.repository.location.name)
+        : null,
+    [definition],
+  );
+
   const setCurrentPage = useSetRecoilState(currentPageAtom);
   const {path} = useRouteMatch();
   useEffect(() => {
@@ -266,35 +274,21 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
   }, [path, selectedTab, setCurrentPage]);
 
   const wipe = useWipeModal(
-    definition
-      ? {
-          assetKey: definition.assetKey,
-          repository: definition.repository,
-        }
-      : null,
+    definition ? {assetKey: definition.assetKey, repository: definition.repository} : null,
     refresh,
   );
 
-  const dynamicDimension = definition?.partitionDefinition?.dimensionTypes.some(
-    (d) => d.type === PartitionDefinitionType.DYNAMIC,
-  );
   const dynamicPartitionsDelete = useDeleteDynamicPartitionsDialog(
-    dynamicDimension
-      ? {
-          partitionsDefName: dynamicDimension.dynamicPartitionsDefinitionName,
-          repository: definition.repository,
-        }
-      : null,
-    refresh,
+    definition && repoAddress ? {assetKey: definition.assetKey, definition, repoAddress} : null,
+    () => {
+      definitionQueryResult.refetch();
+      refresh();
+    },
   );
 
   const reportEvents = useReportEventsModal(
-    definition
-      ? {
-          assetKey: definition.assetKey,
-          isPartitioned: definition.isPartitioned,
-          repository: definition.repository,
-        }
+    definition && repoAddress
+      ? {assetKey: definition.assetKey, isPartitioned: definition.isPartitioned, repoAddress}
       : null,
     refresh,
   );
@@ -342,6 +336,7 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
                 additionalDropdownOptions={[
                   ...reportEvents.dropdownOptions,
                   ...wipe.dropdownOptions,
+                  ...dynamicPartitionsDelete.dropdownOptions,
                 ]}
               />
             ) : undefined}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -46,6 +46,8 @@ import {useAssetGraphData} from '../asset-graph/useAssetGraphData';
 import {StaleReasonsTag} from '../assets/Stale';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
+import {useDeleteDynamicPartitionsDialog} from './useDeleteDynamicPartitionsDialog';
+import {PartitionDefinitionType} from '../graphql/types';
 
 interface Props {
   assetKey: AssetKey;
@@ -272,6 +274,20 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
       : null,
     refresh,
   );
+
+  const dynamicDimension = definition?.partitionDefinition?.dimensionTypes.some(
+    (d) => d.type === PartitionDefinitionType.DYNAMIC,
+  );
+  const dynamicPartitionsDelete = useDeleteDynamicPartitionsDialog(
+    dynamicDimension
+      ? {
+          partitionsDefName: dynamicDimension.dynamicPartitionsDefinitionName,
+          repository: definition.repository,
+        }
+      : null,
+    refresh,
+  );
+
   const reportEvents = useReportEventsModal(
     definition
       ? {
@@ -331,6 +347,7 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
             ) : undefined}
             {reportEvents.element}
             {wipe.element}
+            {dynamicPartitionsDelete.element}
           </Box>
         }
       />
@@ -470,6 +487,10 @@ export const ASSET_VIEW_DEFINITION_QUERY = gql`
     groupName
     partitionDefinition {
       description
+      dimensionTypes {
+        type
+        dynamicPartitionsDefinitionName
+      }
     }
     partitionKeysByDimension {
       name

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/DeleteDynamicPartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/DeleteDynamicPartitionsDialog.tsx
@@ -163,7 +163,7 @@ export const DeleteDynamicPartitionsModalInner = memo(
   },
 );
 
-const DELETE_DYNAMIC_PARTITIONS_MUTATION = gql`
+export const DELETE_DYNAMIC_PARTITIONS_MUTATION = gql`
   mutation DeleteDynamicPartitionsMutation(
     $partitionKeys: [String!]!
     $partitionsDefName: String!

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/DeleteDynamicPartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/DeleteDynamicPartitionsDialog.tsx
@@ -1,0 +1,112 @@
+import {RefetchQueriesFunction} from '@apollo/client';
+// eslint-disable-next-line no-restricted-imports
+import {ProgressBar} from '@blueprintjs/core';
+import {Body1, Box, Button, Dialog, DialogBody, DialogFooter} from '@dagster-io/ui-components';
+import {memo, useMemo} from 'react';
+
+import {asAssetPartitionRangeInput} from './asInput';
+import {useWipeAssets} from './useWipeAssets';
+import {AssetKeyInput} from '../graphql/types';
+import {NavigationBlock} from '../runs/NavigationBlock';
+import {numberFormatter} from '../ui/formatters';
+import {RepoAddress} from '../workspace/types';
+
+export interface DeleteDynamicPartitionsDialogProps {
+  repo: RepoAddress;
+  partitionsDefName: string;
+  assetKey: AssetKeyInput;
+}
+
+export const DeleteDynamicPartitionsDialog = memo(
+  (props: {
+    isOpen: boolean;
+    onClose: () => void;
+    onComplete?: () => void;
+    requery?: RefetchQueriesFunction;
+  }) => {
+    return (
+      <Dialog
+        isOpen={props.isOpen}
+        title={`Delete ${props.partitionsDefName} partitions`}
+        onClose={props.onClose}
+        style={{width: '80vw', maxWidth: '1200px', minWidth: '600px'}}
+      >
+        <DeleteDynamicPartitionsModalInner {...props} />
+      </Dialog>
+    );
+  },
+);
+
+export const DeleteDynamicPartitionsModalInner = memo(
+  ({
+    repo,
+    partitionsDefName,
+    onClose,
+    onComplete,
+    requery,
+  }: {
+    repo: {name: string; location: {name: string}};
+    partitionsDefName: string;
+    onClose: () => void;
+    onComplete?: () => void;
+    requery?: RefetchQueriesFunction;
+  }) => {
+    const {wipeAssets, isWiping, isDone, wipedCount, failedCount} = useWipeAssets({
+      refetchQueries: requery,
+      onClose,
+      onComplete,
+    });
+
+    const health = use;
+    const content = useMemo(() => {
+      if (isDone) {
+        return (
+          <Box flex={{direction: 'column'}}>
+            {wipedCount ? <Body1>{numberFormatter.format(wipedCount)} Wiped</Body1> : null}
+            {failedCount ? <Body1>{numberFormatter.format(failedCount)} Failed</Body1> : null}
+          </Box>
+        );
+      } else if (!isWiping) {
+        return (
+          <Box>
+            <div>
+              Choose partitions to delete below. Materialization events for these partitions will
+              also be wiped.
+            </div>
+            <OrdinalPartitionSelector />
+            <strong>This action cannot be undone.</strong>
+          </Box>
+        );
+      }
+      const value = assetKeys.length > 0 ? (wipedCount + failedCount) / assetKeys.length : 1;
+      return (
+        <Box flex={{gap: 8, direction: 'column'}}>
+          <div>Wiping...</div>
+          <ProgressBar intent="primary" value={Math.max(0.1, value)} animate={value < 1} />
+          <NavigationBlock message="Wiping in progress, please do not navigate away yet." />
+        </Box>
+      );
+    }, [isDone, isWiping, assetKeys, wipedCount, failedCount]);
+
+    return (
+      <>
+        <DialogBody>{content}</DialogBody>
+        <DialogFooter topBorder>
+          <Button intent={isDone ? 'primary' : 'none'} onClick={onClose}>
+            {isDone ? 'Done' : 'Cancel'}
+          </Button>
+          {isDone ? null : (
+            <Button
+              intent="danger"
+              onClick={() => wipeAssets(assetKeys.map((key) => asAssetPartitionRangeInput(key)))}
+              disabled={isWiping}
+              loading={isWiping}
+            >
+              Wipe
+            </Button>
+          )}
+        </DialogFooter>
+      </>
+    );
+  },
+);

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/PartitionHealth.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/PartitionHealth.fixtures.ts
@@ -304,3 +304,25 @@ export const TWO_DIMENSIONAL_ASSET_EMPTY: PartitionHealthQuery = {
     },
   },
 };
+
+export const ONE_DIMENSIONAL_DYNAMIC_ASSET: PartitionHealthQuery = {
+  __typename: 'Query',
+  assetNodeOrError: {
+    __typename: 'AssetNode',
+    id: '1234',
+    partitionKeysByDimension: [
+      {
+        __typename: 'DimensionPartitionKeys',
+        name: 'default',
+        partitionKeys: ['apple', 'pear', 'fig'],
+        type: PartitionDefinitionType.DYNAMIC,
+      },
+    ],
+    assetPartitionStatuses: {
+      __typename: 'DefaultPartitionStatuses',
+      materializedPartitions: ['apple', 'pear', 'fig'],
+      materializingPartitions: [],
+      failedPartitions: [],
+    },
+  },
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/DeleteDynamicPartitionsDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/DeleteDynamicPartitionsDialog.test.tsx
@@ -1,0 +1,78 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {waitFor} from '@testing-library/dom';
+import {render} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {
+  buildQueryMock,
+  mockViewportClientRect,
+  restoreViewportClientRect,
+} from '../../testing/mocking';
+import {
+  DELETE_DYNAMIC_PARTITIONS_MUTATION,
+  DeleteDynamicPartitionsDialog,
+} from '../DeleteDynamicPartitionsDialog';
+import {ONE_DIMENSIONAL_DYNAMIC_ASSET} from '../__fixtures__/PartitionHealth.fixtures';
+import {PARTITION_HEALTH_QUERY} from '../usePartitionHealthData';
+
+describe('DeleteDynamicPartitionsDialog', () => {
+  beforeAll(() => {
+    mockViewportClientRect();
+  });
+  afterAll(() => {
+    restoreViewportClientRect();
+  });
+
+  it('should show a partition selector and delete selected partitions', async () => {
+    const deletePartitionsMock = {
+      request: {
+        query: DELETE_DYNAMIC_PARTITIONS_MUTATION,
+        variables: {
+          repositorySelector: {repositoryLocationName: 'location', repositoryName: 'repo.py'},
+          partitionsDefName: 'fruits',
+          partitionKeys: ['apple', 'fig'],
+        },
+      },
+      result: jest.fn(() => ({
+        data: {
+          __typename: 'Mutation',
+          deleteDynamicPartitions: {},
+        },
+      })),
+    };
+
+    const {getByText, getByTestId} = render(
+      <MockedProvider
+        mocks={[
+          buildQueryMock({
+            query: PARTITION_HEALTH_QUERY,
+            variables: {assetKey: {path: ['asset']}},
+            data: ONE_DIMENSIONAL_DYNAMIC_ASSET,
+          }),
+          deletePartitionsMock,
+        ]}
+      >
+        <DeleteDynamicPartitionsDialog
+          assetKey={{path: ['asset']}}
+          repoAddress={{location: 'location', name: 'repo.py'}}
+          partitionsDefName="fruits"
+          isOpen
+          onClose={() => {}}
+        />
+      </MockedProvider>,
+    );
+    await waitFor(() => {
+      expect(getByText('Delete fruits partitions')).toBeVisible();
+    });
+    const user = userEvent.setup();
+    await waitFor(async () => {
+      await user.click(getByText('Select a partition'));
+    });
+    await user.click(getByTestId(`menu-item-apple`));
+    await user.click(getByTestId(`menu-item-fig`));
+
+    await user.click(getByText('Delete 2 partitions'));
+
+    expect(deletePartitionsMock.result).toHaveBeenCalled();
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx
@@ -9,6 +9,7 @@ import {
   buildAddDynamicPartitionSuccess,
   buildAssetKey,
   buildAssetNode,
+  buildDimensionDefinitionType,
   buildDimensionPartitionKeys,
   buildMultiPartitionStatuses,
   buildPartitionDefinition,
@@ -127,6 +128,7 @@ describe('launchAssetChoosePartitionsDialog', () => {
     const savePartitionButton = screen.getByTestId('save-partition-button');
     userEvent.click(savePartitionButton);
 
+    // Verify that it refreshes asset health after partition is added
     await waitFor(() => {
       expect(assetASecondQueryMockResult).toHaveBeenCalled();
     });
@@ -150,7 +152,18 @@ function buildAsset(name: string, dynamicPartitionKeys: string[]) {
       }),
     ],
     partitionDefinition: buildPartitionDefinition({
-      name: 'foo',
+      name: 'not-foo',
+      dimensionTypes: [
+        buildDimensionDefinitionType({
+          name: 'a',
+          type: PartitionDefinitionType.DYNAMIC,
+          dynamicPartitionsDefinitionName: 'foo',
+        }),
+        buildDimensionDefinitionType({
+          name: 'b',
+          type: PartitionDefinitionType.TIME_WINDOW,
+        }),
+      ],
     }),
     assetPartitionStatuses: buildMultiPartitionStatuses({
       primaryDimensionName: 'b',

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetTableFragment.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetTableFragment.types.ts
@@ -14,7 +14,15 @@ export type AssetTableDefinitionFragment = {
   computeKind: string | null;
   hasMaterializePermission: boolean;
   description: string | null;
-  partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
+  partitionDefinition: {
+    __typename: 'PartitionDefinition';
+    description: string;
+    dimensionTypes: Array<{
+      __typename: 'DimensionDefinitionType';
+      type: Types.PartitionDefinitionType;
+      dynamicPartitionsDefinitionName: string | null;
+    }>;
+  } | null;
   owners: Array<
     {__typename: 'TeamAssetOwner'; team: string} | {__typename: 'UserAssetOwner'; email: string}
   >;
@@ -43,7 +51,15 @@ export type AssetTableFragment = {
     computeKind: string | null;
     hasMaterializePermission: boolean;
     description: string | null;
-    partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
+    partitionDefinition: {
+      __typename: 'PartitionDefinition';
+      description: string;
+      dimensionTypes: Array<{
+        __typename: 'DimensionDefinitionType';
+        type: Types.PartitionDefinitionType;
+        dynamicPartitionsDefinitionName: string | null;
+      }>;
+    } | null;
     owners: Array<
       {__typename: 'TeamAssetOwner'; team: string} | {__typename: 'UserAssetOwner'; email: string}
     >;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
@@ -34,7 +34,15 @@ export type AssetViewDefinitionQuery = {
           computeKind: string | null;
           isPartitioned: boolean;
           isObservable: boolean;
-          partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
+          partitionDefinition: {
+            __typename: 'PartitionDefinition';
+            description: string;
+            dimensionTypes: Array<{
+              __typename: 'DimensionDefinitionType';
+              type: Types.PartitionDefinitionType;
+              dynamicPartitionsDefinitionName: string | null;
+            }>;
+          } | null;
           partitionKeysByDimension: Array<{__typename: 'DimensionPartitionKeys'; name: string}>;
           repository: {
             __typename: 'Repository';
@@ -16305,7 +16313,15 @@ export type AssetViewDefinitionNodeFragment = {
   computeKind: string | null;
   isPartitioned: boolean;
   isObservable: boolean;
-  partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
+  partitionDefinition: {
+    __typename: 'PartitionDefinition';
+    description: string;
+    dimensionTypes: Array<{
+      __typename: 'DimensionDefinitionType';
+      type: Types.PartitionDefinitionType;
+      dynamicPartitionsDefinitionName: string | null;
+    }>;
+  } | null;
   partitionKeysByDimension: Array<{__typename: 'DimensionPartitionKeys'; name: string}>;
   repository: {
     __typename: 'Repository';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetsCatalogTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetsCatalogTable.types.ts
@@ -29,7 +29,15 @@ export type AssetCatalogTableQuery = {
             computeKind: string | null;
             hasMaterializePermission: boolean;
             description: string | null;
-            partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
+            partitionDefinition: {
+              __typename: 'PartitionDefinition';
+              description: string;
+              dimensionTypes: Array<{
+                __typename: 'DimensionDefinitionType';
+                type: Types.PartitionDefinitionType;
+                dynamicPartitionsDefinitionName: string | null;
+              }>;
+            } | null;
             owners: Array<
               | {__typename: 'TeamAssetOwner'; team: string}
               | {__typename: 'UserAssetOwner'; email: string}
@@ -75,7 +83,15 @@ export type AssetCatalogGroupTableQuery = {
     hasMaterializePermission: boolean;
     description: string | null;
     assetKey: {__typename: 'AssetKey'; path: Array<string>};
-    partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
+    partitionDefinition: {
+      __typename: 'PartitionDefinition';
+      description: string;
+      dimensionTypes: Array<{
+        __typename: 'DimensionDefinitionType';
+        type: Types.PartitionDefinitionType;
+        dynamicPartitionsDefinitionName: string | null;
+      }>;
+    } | null;
     owners: Array<
       {__typename: 'TeamAssetOwner'; team: string} | {__typename: 'UserAssetOwner'; email: string}
     >;
@@ -102,7 +118,15 @@ export type AssetCatalogGroupTableNodeFragment = {
   hasMaterializePermission: boolean;
   description: string | null;
   assetKey: {__typename: 'AssetKey'; path: Array<string>};
-  partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
+  partitionDefinition: {
+    __typename: 'PartitionDefinition';
+    description: string;
+    dimensionTypes: Array<{
+      __typename: 'DimensionDefinitionType';
+      type: Types.PartitionDefinitionType;
+      dynamicPartitionsDefinitionName: string | null;
+    }>;
+  } | null;
   owners: Array<
     {__typename: 'TeamAssetOwner'; team: string} | {__typename: 'UserAssetOwner'; email: string}
   >;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/DeleteDynamicPartitionsDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/DeleteDynamicPartitionsDialog.types.ts
@@ -1,0 +1,26 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type DeleteDynamicPartitionsMutationVariables = Types.Exact<{
+  partitionKeys: Array<Types.Scalars['String']['input']> | Types.Scalars['String']['input'];
+  partitionsDefName: Types.Scalars['String']['input'];
+  repositorySelector: Types.RepositorySelector;
+}>;
+
+export type DeleteDynamicPartitionsMutation = {
+  __typename: 'Mutation';
+  deleteDynamicPartitions:
+    | {__typename: 'DeleteDynamicPartitionsSuccess'}
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      }
+    | {__typename: 'UnauthorizedError'; message: string};
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useReportEventsModal.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useReportEventsModal.types.ts
@@ -2,6 +2,31 @@
 
 import * as Types from '../../graphql/types';
 
+export type ReportEventPartitionDefinitionQueryVariables = Types.Exact<{
+  assetKey: Types.AssetKeyInput;
+}>;
+
+export type ReportEventPartitionDefinitionQuery = {
+  __typename: 'Query';
+  assetNodeOrError:
+    | {
+        __typename: 'AssetNode';
+        id: string;
+        partitionDefinition: {
+          __typename: 'PartitionDefinition';
+          type: Types.PartitionDefinitionType;
+          name: string | null;
+          dimensionTypes: Array<{
+            __typename: 'DimensionDefinitionType';
+            type: Types.PartitionDefinitionType;
+            name: string;
+            dynamicPartitionsDefinitionName: string | null;
+          }>;
+        } | null;
+      }
+    | {__typename: 'AssetNotFoundError'};
+};
+
 export type ReportEventMutationVariables = Types.Exact<{
   eventParams: Types.ReportRunlessAssetEventsParams;
 }>;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useDeleteDynamicPartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useDeleteDynamicPartitionsDialog.tsx
@@ -1,0 +1,46 @@
+import {Colors, Icon, MenuItem} from '@dagster-io/ui-components';
+import {useContext, useState} from 'react';
+
+import {DeleteDynamicPartitionsDialog} from './DeleteDynamicPartitionsDialog';
+import {CloudOSSContext} from '../app/CloudOSSContext';
+import {usePermissionsForLocation} from '../app/Permissions';
+
+export function useDeleteDynamicPartitionsDialog(
+  opts: {partitionsDefName: string; repository: {name: string; location: {name: string}}} | null,
+  refresh: () => void,
+) {
+  const [showing, setShowing] = useState(false);
+  const {
+    permissions: {canWipeAssets},
+  } = usePermissionsForLocation(opts ? opts.repository.location.name : null);
+
+  const {
+    featureContext: {canSeeWipeMaterializationAction},
+  } = useContext(CloudOSSContext);
+
+  return {
+    element: opts ? (
+      <DeleteDynamicPartitionsDialog
+        partitionsDefName={opts.partitionsDefName}
+        repository={opts.repository}
+        isOpen={showing}
+        onClose={() => setShowing(false)}
+        onComplete={refresh}
+      />
+    ) : (
+      <span />
+    ),
+    dropdownOptions: canSeeWipeMaterializationAction
+      ? [
+          <MenuItem
+            key="delete"
+            text="Delete dynamic partitions"
+            icon={<Icon name="delete" color={Colors.accentRed()} />}
+            disabled={!canWipeAssets}
+            intent="danger"
+            onClick={() => setShowing(true)}
+          />,
+        ]
+      : ([] as JSX.Element[]),
+  };
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useWipeModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useWipeModal.tsx
@@ -8,7 +8,7 @@ import {AssetKeyInput} from '../graphql/types';
 
 export function useWipeModal(
   opts: {assetKey: AssetKeyInput; repository: {location: {name: string}}} | null,
-  refresh: () => void,
+  refresh?: () => void,
 ) {
   const [showing, setShowing] = useState(false);
   const {

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -224,7 +224,7 @@ const ConfigEditorPartitionPicker = React.memo((props: ConfigEditorPartitionPick
     rightElement,
   };
 
-  const {isDynamicPartition, partitionDefinitionName} = React.useMemo(() => {
+  const {isDynamicPartition, dynamicPartitionsDefinitionName} = React.useMemo(() => {
     const assetNodes = data?.assetNodes;
     const definition = assetNodes?.find((a) => !!a.partitionDefinition)?.partitionDefinition;
     if (
@@ -234,11 +234,11 @@ const ConfigEditorPartitionPicker = React.memo((props: ConfigEditorPartitionPick
           node?.partitionDefinition?.name && node?.partitionDefinition?.name !== definition?.name,
       )
     ) {
-      return {isDynamicPartition: false, partitionDefinitionName: undefined};
+      return {isDynamicPartition: false, dynamicPartitionsDefinitionName: undefined};
     }
     return {
       isDynamicPartition: definition.type === PartitionDefinitionType.DYNAMIC,
-      partitionDefinitionName: definition.name,
+      dynamicPartitionsDefinitionName: definition.name,
     };
   }, [data?.assetNodes]);
 
@@ -323,7 +323,7 @@ const ConfigEditorPartitionPicker = React.memo((props: ConfigEditorPartitionPick
         <CreatePartitionDialog
           key={showCreatePartition ? '1' : '0'}
           isOpen={showCreatePartition}
-          partitionDefinitionName={partitionDefinitionName}
+          dynamicPartitionsDefinitionName={dynamicPartitionsDefinitionName}
           repoAddress={repoAddress}
           close={() => {
             setShowCreatePartition(false);

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/CreatePartitionDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/CreatePartitionDialog.tsx
@@ -64,14 +64,14 @@ const INVALID_PARTITION_SUBSTRINGS_READABLE = [
 
 export const CreatePartitionDialog = ({
   isOpen,
-  partitionDefinitionName,
+  dynamicPartitionsDefinitionName,
   close,
   repoAddress,
   refetch,
   onCreated,
 }: {
   isOpen: boolean;
-  partitionDefinitionName?: string | null;
+  dynamicPartitionsDefinitionName?: string | null;
   close: () => void;
   repoAddress: RepoAddress;
   refetch?: () => Promise<void>;
@@ -117,7 +117,7 @@ export const CreatePartitionDialog = ({
     const result = await createPartition({
       variables: {
         repositorySelector: repoAddressToSelector(repoAddress),
-        partitionsDefName: partitionDefinitionName || '',
+        partitionsDefName: dynamicPartitionsDefinitionName || '',
         partitionKey: partitionName,
       },
 
@@ -175,10 +175,10 @@ export const CreatePartitionDialog = ({
           <Icon name="add_circle" size={24} />
           <div>
             Add a partition
-            {partitionDefinitionName ? (
+            {dynamicPartitionsDefinitionName ? (
               <>
                 {' '}
-                for <Mono>{partitionDefinitionName}</Mono>
+                for <Mono>{dynamicPartitionsDefinitionName}</Mono>
               </>
             ) : (
               ''

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeWizard.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeWizard.tsx
@@ -16,7 +16,7 @@ export const DimensionRangeWizard = ({
   partitionKeys,
   health,
   dimensionType,
-  partitionDefinitionName,
+  dynamicPartitionsDefinitionName,
   repoAddress,
   refetch,
 }: {
@@ -25,7 +25,7 @@ export const DimensionRangeWizard = ({
   partitionKeys: string[];
   health: PartitionStatusHealthSource;
   dimensionType: PartitionDefinitionType;
-  partitionDefinitionName?: string | null;
+  dynamicPartitionsDefinitionName?: string | null;
   repoAddress?: RepoAddress;
   refetch?: () => Promise<void>;
 }) => {
@@ -96,7 +96,7 @@ export const DimensionRangeWizard = ({
         <CreatePartitionDialog
           key={showCreatePartition ? '1' : '0'}
           isOpen={showCreatePartition}
-          partitionDefinitionName={partitionDefinitionName}
+          dynamicPartitionsDefinitionName={dynamicPartitionsDefinitionName}
           repoAddress={repoAddress}
           close={() => {
             setShowCreatePartition(false);

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeWizards.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeWizards.tsx
@@ -65,8 +65,7 @@ export const DimensionRangeWizards = ({
                 selections.map((r) => (r.dimension === range.dimension ? {...r, selectedKeys} : r)),
               )
             }
-            partitionDefinitionName={
-              displayedPartitionDefinition?.name ||
+            dynamicPartitionsDefinitionName={
               displayedPartitionDefinition?.dimensionTypes.find(
                 (d) => d.name === range.dimension.name,
               )?.dynamicPartitionsDefinitionName

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/__tests__/CreatePartitionDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/__tests__/CreatePartitionDialog.test.tsx
@@ -30,7 +30,7 @@ function Test({mocks}: {mocks?: MockedResponse[]}) {
           name: 'testing',
           location: 'testing',
         }}
-        partitionDefinitionName="testPartitionDef"
+        dynamicPartitionsDefinitionName="testPartitionDef"
         onCreated={onCreatedMock}
       />
     </MockedProvider>

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -50,7 +50,7 @@ interface AssetRowProps {
   repoAddress: RepoAddress | null;
   height: number;
   start: number;
-  onWipe: (assets: AssetKeyInput[]) => void;
+  onRefresh: () => void;
   computeKindFilter?: StaticSetFilter<string>;
   storageKindFilter?: StaticSetFilter<DefinitionTag>;
 }
@@ -65,7 +65,7 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
     height,
     checked,
     onToggleChecked,
-    onWipe,
+    onRefresh,
     showCheckboxColumn = false,
     showRepoColumn,
     view = 'flat',
@@ -220,7 +220,7 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
               path={path}
               definition={definition}
               repoAddress={repoAddress}
-              onWipe={onWipe}
+              onRefresh={onRefresh}
             />
           ) : null}
         </RowCell>

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetTable.tsx
@@ -5,7 +5,7 @@ import {VirtualizedAssetCatalogHeader, VirtualizedAssetRow} from './VirtualizedA
 import {buildRepoAddress} from './buildRepoAddress';
 import {AssetTableFragment} from '../assets/types/AssetTableFragment.types';
 import {AssetViewType} from '../assets/useAssetView';
-import {AssetKeyInput, DefinitionTag} from '../graphql/types';
+import {DefinitionTag} from '../graphql/types';
 import {StaticSetFilter} from '../ui/BaseFilters/useStaticSetFilter';
 import {Container, Inner} from '../ui/VirtualizedTable';
 
@@ -83,8 +83,6 @@ export const VirtualizedAssetTable = (props: Props) => {
               const repository = row.asset.definition.repository;
               return buildRepoAddress(repository.name, repository.location.name);
             };
-
-            const wipeableAssets = row.type === 'folder' ? row.assets : [row.asset];
 
             return (
               <VirtualizedAssetRow

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetTable.tsx
@@ -19,7 +19,7 @@ interface Props {
   groups: {[displayKey: string]: AssetTableFragment[]};
   checkedDisplayKeys: Set<string>;
   onToggleFactory: (path: string) => (values: {checked: boolean; shiftKey: boolean}) => void;
-  onWipe: (assets: AssetKeyInput[]) => void;
+  onRefresh: () => void;
   showRepoColumn: boolean;
   view?: AssetViewType;
   computeKindFilter?: StaticSetFilter<string>;
@@ -33,7 +33,7 @@ export const VirtualizedAssetTable = (props: Props) => {
     groups,
     checkedDisplayKeys,
     onToggleFactory,
-    onWipe,
+    onRefresh,
     showRepoColumn,
     view = 'flat',
     computeKindFilter,
@@ -100,7 +100,7 @@ export const VirtualizedAssetTable = (props: Props) => {
                 start={start}
                 checked={checkedDisplayKeys.has(row.displayKey)}
                 onToggleChecked={onToggleFactory(row.displayKey)}
-                onWipe={() => onWipe(wipeableAssets.map((a) => a.key))}
+                onRefresh={onRefresh}
                 computeKindFilter={computeKindFilter}
                 storageKindFilter={storageKindFilter}
               />

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedRepoAssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedRepoAssetTable.tsx
@@ -103,7 +103,7 @@ export const VirtualizedRepoAssetTable = ({repoAddress, assets}: Props) => {
                 start={start}
                 checked={false}
                 onToggleChecked={() => {}}
-                onWipe={() => {}}
+                onRefresh={() => {}}
               />
             );
           })}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedRepoAssetTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedRepoAssetTable.types.ts
@@ -15,7 +15,15 @@ export type RepoAssetTableFragment = {
   hasMaterializePermission: boolean;
   description: string | null;
   assetKey: {__typename: 'AssetKey'; path: Array<string>};
-  partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
+  partitionDefinition: {
+    __typename: 'PartitionDefinition';
+    description: string;
+    dimensionTypes: Array<{
+      __typename: 'DimensionDefinitionType';
+      type: Types.PartitionDefinitionType;
+      dynamicPartitionsDefinitionName: string | null;
+    }>;
+  } | null;
   owners: Array<
     {__typename: 'TeamAssetOwner'; team: string} | {__typename: 'UserAssetOwner'; email: string}
   >;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceAssetsRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceAssetsRoot.types.ts
@@ -36,7 +36,15 @@ export type WorkspaceAssetsQuery = {
           hasMaterializePermission: boolean;
           description: string | null;
           assetKey: {__typename: 'AssetKey'; path: Array<string>};
-          partitionDefinition: {__typename: 'PartitionDefinition'; description: string} | null;
+          partitionDefinition: {
+            __typename: 'PartitionDefinition';
+            description: string;
+            dimensionTypes: Array<{
+              __typename: 'DimensionDefinitionType';
+              type: Types.PartitionDefinitionType;
+              dynamicPartitionsDefinitionName: string | null;
+            }>;
+          } | null;
           owners: Array<
             | {__typename: 'TeamAssetOwner'; team: string}
             | {__typename: 'UserAssetOwner'; email: string}


### PR DESCRIPTION
## Summary & Motivation

Fixes https://github.com/dagster-io/dagster/issues/14026

This PR adds a new "delete partitions" modal in both OSS and Plus that allows you to remove dynamic partitions from the UI.  The UI immediately updates to reflect the change.

During testing I also found that our current UI for adding dynamic partitions didn't work quite right in cases where the dynamic partition was one of the dimensions of a multi-dimensional partition def, because the `dimension.name` and the `dimension.dynamicPartitionsDefinitionName` are not the same, and the Add Partition mutation requires the latter.

The new dropdown option in these screenshots only appears if the asset has a dynamic partition dimension, so non-dynamic assets are unimpacted.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/91812d57-a972-40f5-b11d-13eba0603ee3">

<img width="498" alt="image" src="https://github.com/user-attachments/assets/eb2a9aff-846f-456b-9fbb-72f9648dedd4">

<img width="877" alt="image" src="https://github.com/user-attachments/assets/d3ca68eb-b9a6-4f61-a917-7f3afae37832">

## How I Tested These Changes

There's a new test file covering this modal!

I also tested this manually using both assets that have dynamic partitions and assets that have multi-dimensional partition defs where one axis is dynamic. Also verified the changes in the report materialization events modal and the wipe assets implementation on the asset table didn't have any impact.

