### PR TITLE
Revert "Return storage ID when adding to the event log"

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2374,8 +2374,8 @@ class DagsterInstance(DynamicPartitionsStore):
         handlers.extend(self._get_yaml_python_handlers())
         return handlers
 
-    def store_event(self, event: "EventLogEntry") -> Optional[int]:
-        return self._event_storage.store_event(event)
+    def store_event(self, event: "EventLogEntry") -> None:
+        self._event_storage.store_event(event)
 
     def handle_new_event(
         self,

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -228,15 +228,16 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         return build_run_step_stats_from_events(run_id, logs)
 
     @abstractmethod
-    def store_event(self, event: "EventLogEntry") -> Optional[int]:
+    def store_event(self, event: "EventLogEntry") -> None:
         """Store an event corresponding to a pipeline run.
 
         Args:
             event (EventLogEntry): The event to store.
         """
 
-    def store_event_batch(self, events: Sequence["EventLogEntry"]) -> Sequence[Optional[int]]:
-        return [self.store_event(event) for event in events]
+    def store_event_batch(self, events: Sequence["EventLogEntry"]) -> None:
+        for event in events:
+            self.store_event(event)
 
     @abstractmethod
     def delete_events(self, run_id: str) -> None:

--- a/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/in_memory.py
@@ -80,8 +80,8 @@ class InMemoryEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def upgrade(self):
         pass
 
-    def store_event(self, event) -> Optional[int]:
-        event_id = super(InMemoryEventLogStorage, self).store_event(event)
+    def store_event(self, event):
+        super(InMemoryEventLogStorage, self).store_event(event)
         self._storage_id += 1
 
         handlers = list(self._handlers[event.run_id])
@@ -90,8 +90,6 @@ class InMemoryEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 handler(event, str(EventLogCursor.from_storage_id(self._storage_id)))
             except Exception:
                 logging.exception("Exception in callback for event watch on run %s.", event.run_id)
-
-        return event_id
 
     def watch(self, run_id: str, cursor: str, callback: Callable[..., Any]):
         self._handlers[run_id].add(callback)

--- a/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sql_event_log.py
@@ -429,7 +429,7 @@ class SqlEventLogStorage(EventLogStorage):
         keys_to_index = self.get_asset_tags_to_index(set(tags.keys()))
         return {k: v for k, v in tags.items() if k in keys_to_index}
 
-    def store_event(self, event: EventLogEntry) -> Optional[int]:
+    def store_event(self, event: EventLogEntry) -> None:
         """Store an event corresponding to a pipeline run.
 
         Args:
@@ -461,8 +461,6 @@ class SqlEventLogStorage(EventLogStorage):
 
         if event.is_dagster_event and event.dagster_event_type in ASSET_CHECK_EVENTS:
             self.store_asset_check_event(event, event_id)
-
-        return event_id
 
     def get_records_for_run(
         self,

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -225,7 +225,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
     def index_connection(self) -> ContextManager[Connection]:
         return self._connect(INDEX_SHARD_NAME)
 
-    def store_event(self, event: EventLogEntry) -> Optional[int]:
+    def store_event(self, event: EventLogEntry) -> None:
         """Overridden method to replicate asset events in a central assets.db sqlite shard, enabling
         cross-run asset queries.
 
@@ -236,7 +236,6 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         insert_event_statement = self.prepare_insert_event(event)
         run_id = event.run_id
 
-        event_id = None
         with self.run_connection(run_id) as conn:
             conn.execute(insert_event_statement)
 
@@ -246,6 +245,8 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
                 "Can only store asset materializations, materialization_planned, and"
                 " observations in index database",
             )
+
+            event_id = None
 
             # mirror the event in the cross-run index database
             with self.index_connection() as conn:
@@ -268,8 +269,6 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             # should mirror run status change events in the index shard
             with self.index_connection() as conn:
                 conn.execute(insert_event_statement)
-
-        return event_id
 
     def get_event_records(
         self,

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -399,7 +399,7 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
     ) -> Sequence["RunStepKeyStatsSnapshot"]:
         return self._storage.event_log_storage.get_step_stats_for_run(run_id, step_keys)
 
-    def store_event(self, event: "EventLogEntry") -> Optional[int]:
+    def store_event(self, event: "EventLogEntry") -> None:
         return self._storage.event_log_storage.store_event(event)
 
     def delete_events(self, run_id: str) -> None:

--- a/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py
@@ -10,9 +10,6 @@ import pytest
 import sqlalchemy
 import sqlalchemy as db
 from dagster._core.errors import DagsterEventLogInvalidForRun
-from dagster._core.events import DagsterEvent, DagsterEventType
-from dagster._core.events.log import EventLogEntry
-from dagster._core.execution.plan.objects import StepSuccessData
 from dagster._core.storage.event_log import (
     ConsolidatedSqliteEventLogStorage,
     InMemoryEventLogStorage,
@@ -20,7 +17,6 @@ from dagster._core.storage.event_log import (
     SqlEventLogStorageTable,
     SqliteEventLogStorage,
 )
-from dagster._core.storage.event_log.base import EventLogStorage
 from dagster._core.storage.event_log.schema import ConcurrencyLimitsTable, ConcurrencySlotsTable
 from dagster._core.storage.legacy_storage import LegacyEventLogStorage
 from dagster._core.storage.sql import create_engine
@@ -66,26 +62,6 @@ class TestSqliteEventLogStorage(TestEventLogStorage):
                 yield storage
             finally:
                 storage.dispose()
-
-    def test_no_storage_id_non_asset_events(
-        self, test_run_id, storage: EventLogStorage, instance
-    ) -> None:
-        assert len(storage.get_logs_for_run(test_run_id)) == 0
-        storage_id = storage.store_event(
-            EventLogEntry(
-                error_info=None,
-                level="debug",
-                user_message="",
-                run_id=test_run_id,
-                timestamp=time.time(),
-                dagster_event=DagsterEvent(
-                    DagsterEventType.STEP_SUCCESS.value,
-                    "nonce",
-                    event_specific_data=StepSuccessData(duration_ms=100.0),
-                ),
-            )
-        )
-        assert storage_id is None
 
     def test_filesystem_event_log_storage_run_corrupted(self, storage):
         # URL begins sqlite:///

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -503,9 +503,7 @@ class TestEventLogStorage:
         with mock.patch.object(storage, "get_asset_tags_to_index", passthrough_all_tags):
             yield
 
-    def test_event_log_storage_store_events_and_wipe(
-        self, test_run_id, storage: EventLogStorage, instance
-    ):
+    def test_event_log_storage_store_events_and_wipe(self, test_run_id, storage: EventLogStorage):
         assert len(storage.get_logs_for_run(test_run_id)) == 0
         storage.store_event(
             EventLogEntry(
@@ -521,47 +519,12 @@ class TestEventLogStorage:
                 ),
             )
         )
-
         assert len(storage.get_logs_for_run(test_run_id)) == 1
         assert storage.get_stats_for_run(test_run_id)
 
         if self.can_wipe():
             storage.wipe()
             assert len(storage.get_logs_for_run(test_run_id)) == 0
-
-    def test_event_log_storage_lookup_by_id(self, test_run_id, storage: EventLogStorage, instance):
-        assert len(storage.get_logs_for_run(test_run_id)) == 0
-        storage_id = storage.store_event(
-            EventLogEntry(
-                error_info=None,
-                level="debug",
-                user_message="",
-                run_id=test_run_id,
-                timestamp=time.time(),
-                dagster_event=DagsterEvent(
-                    DagsterEventType.ASSET_MATERIALIZATION.value,
-                    "nonce",
-                    event_specific_data=StepMaterializationData(
-                        AssetMaterialization(asset_key=AssetKey("foo"), partition="foo")
-                    ),
-                ),
-            )
-        )
-        assert storage_id
-        # Ensure we can query the event log by storage ID
-        assert (
-            len(
-                storage.get_event_records(
-                    event_records_filter=EventRecordsFilter(
-                        event_type=DagsterEventType.ASSET_MATERIALIZATION, storage_ids=[storage_id]
-                    )
-                )
-            )
-            == 1
-        )
-
-        if self.can_wipe():
-            storage.wipe()
 
     def test_event_log_storage_store_with_multiple_runs(
         self,

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/event_log/event_log.py
@@ -165,7 +165,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
 
         return PostgresEventLogStorage(conn_string, should_autocreate_tables)
 
-    def store_event(self, event: EventLogEntry) -> Optional[int]:
+    def store_event(self, event: EventLogEntry) -> None:
         """Store an event corresponding to a run.
 
         Args:
@@ -207,9 +207,7 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         if event.is_dagster_event and event.dagster_event_type in ASSET_CHECK_EVENTS:
             self.store_asset_check_event(event, event_id)
 
-        return event_id
-
-    def store_event_batch(self, events: Sequence[EventLogEntry]) -> Sequence[Optional[int]]:
+    def store_event_batch(self, events: Sequence[EventLogEntry]) -> None:
         check.sequence_param(events, "event", of_type=EventLogEntry)
 
         check.invariant(
@@ -229,8 +227,6 @@ class PostgresEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             raise DagsterInvariantViolationError("Cannot store asset event tags for null event id.")
 
         self.store_asset_event_tags(events, event_ids)
-
-        return event_ids
 
     def store_asset_event(self, event: EventLogEntry, event_id: int) -> None:
         check.inst_param(event, "event", EventLogEntry)


### PR DESCRIPTION
Reverts dagster-io/dagster#23206

I believe we decided on a different approach here - reverting so I can back it out of 1.8.0