### PR TITLE
test(dbt): remove column lineage tests against redshift and clickhouse

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -519,10 +519,8 @@ def test_column_lineage_real_warehouse(
     "sql_dialect",
     [
         "bigquery",
-        "clickhouse",
         "databricks",
         "duckdb",
-        "redshift",
         "snowflake",
         "trino",
     ],


### PR DESCRIPTION
## Summary & Motivation
The column lineage tests take a long time to run in our test suite. For the sake of speed, pare down the existing test suite by removing dialect tests against redshift and clickhouse.

## How I Tested These Changes
pytest