### PR TITLE
Bump dbt core-derived-metadata parallelism

### DIFF
--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -27,6 +27,6 @@ commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   cloud: pytest --numprocesses 6 --durations 10 --reruns 2 -c ../../../pyproject.toml -m "cloud" -vv {posargs}
   core-main: pytest --numprocesses 6 --durations 10 --reruns 2 -c ../../../pyproject.toml -m "core and not snowflake and not bigquery and not derived_metadata" -vv {posargs}
-  core-derived-metadata: pytest --numprocesses 6 --durations 10 --reruns 2 -c ../../../pyproject.toml -m "derived_metadata and not snowflake and not bigquery" -vv {posargs}
+  core-derived-metadata: pytest --numprocesses 8 --durations 10 --reruns 2 -c ../../../pyproject.toml -m "derived_metadata and not snowflake and not bigquery" -vv {posargs}
   snowflake: pytest -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'snowflake'
   bigquery: pytest -c ../../../pyproject.toml -vv --durations 10 {posargs} -m 'bigquery'


### PR DESCRIPTION
These have started timing out on 3.9. I don't see any obvious changes but I'm curious if we can just bump the parallelism.