### PR TITLE
Bust RunTimeline cache

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/HourlyDataCache.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/HourlyDataCache.tsx
@@ -30,12 +30,12 @@ export class HourlyDataCache<T> {
     id,
     keyPrefix = '',
     keyMaxCount = 1,
-    version = '-1',
+    version,
   }: {
     id?: string | false;
     keyPrefix?: string;
     keyMaxCount?: number;
-    version?: string | number;
+    version: string | number;
   }) {
     this.version = version;
     this.indexedDBKey = keyPrefix ? `${keyPrefix}-hourlyData` : 'hourlyData';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useRunsForTimeline.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useRunsForTimeline.test.tsx
@@ -28,6 +28,7 @@ import {
   COMPLETED_RUN_TIMELINE_QUERY,
   FUTURE_TICKS_QUERY,
   ONGOING_RUN_TIMELINE_QUERY,
+  QUERY_VERSION,
   useRunsForTimeline,
 } from '../useRunsForTimeline';
 
@@ -573,32 +574,35 @@ describe('useRunsForTimeline', () => {
 
     const startHour = Math.floor(start / ONE_HOUR_S);
     mockedCache.get.mockResolvedValue({
-      value: new Map([
-        [
-          startHour,
+      value: {
+        version: QUERY_VERSION,
+        cache: new Map([
           [
-            {
-              start: cachedRange[0],
-              end: cachedRange[1],
-              data: [
-                buildRun({
-                  id: 'cached-run',
-                  pipelineName: 'pipeline0',
-                  repositoryOrigin: buildRepositoryOrigin({
-                    id: '1-1',
-                    repositoryName: 'repo1',
-                    repositoryLocationName: 'repo1',
+            startHour,
+            [
+              {
+                start: cachedRange[0],
+                end: cachedRange[1],
+                data: [
+                  buildRun({
+                    id: 'cached-run',
+                    pipelineName: 'pipeline0',
+                    repositoryOrigin: buildRepositoryOrigin({
+                      id: '1-1',
+                      repositoryName: 'repo1',
+                      repositoryLocationName: 'repo1',
+                    }),
+                    startTime: initialRange[0],
+                    endTime: initialRange[1],
+                    updateTime: initialRange[1],
+                    status: RunStatus.SUCCESS,
                   }),
-                  startTime: initialRange[0],
-                  endTime: initialRange[1],
-                  updateTime: initialRange[1],
-                  status: RunStatus.SUCCESS,
-                }),
-              ],
-            },
+                ],
+              },
+            ],
           ],
-        ],
-      ]),
+        ]),
+      },
     });
 
     const {result} = renderHook(

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -61,15 +61,17 @@ export const useRunsForTimeline = ({
   const {localCacheIdPrefix} = useContext(AppContext);
   const completedRunsCache = useMemo(() => {
     if (filter) {
-      return new HourlyDataCache<RunTimelineFragment>(
-        localCacheIdPrefix ? `${localCacheIdPrefix}-useRunsForTimeline-filtered` : false,
-        JSON.stringify(filter),
-        3,
-      );
+      return new HourlyDataCache<RunTimelineFragment>({
+        id: localCacheIdPrefix ? `${localCacheIdPrefix}-useRunsForTimeline-filtered` : false,
+        keyPrefix: JSON.stringify(filter),
+        keyMaxCount: 3,
+        version: 1,
+      });
     }
-    return new HourlyDataCache<RunTimelineFragment>(
-      localCacheIdPrefix ? `${localCacheIdPrefix}-useRunsForTimeline` : false,
-    );
+    return new HourlyDataCache<RunTimelineFragment>({
+      id: localCacheIdPrefix ? `${localCacheIdPrefix}-useRunsForTimeline` : false,
+      version: 1,
+    });
   }, [filter, localCacheIdPrefix]);
   const [completedRuns, setCompletedRuns] = useState<RunTimelineFragment[]>([]);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -30,6 +30,8 @@ import {workspacePipelinePath} from '../workspace/workspacePath';
 
 const BATCH_LIMIT = 500;
 
+const QUERY_VERSION = 1;
+
 export const useRunsForTimeline = ({
   rangeMs,
   filter,
@@ -65,12 +67,12 @@ export const useRunsForTimeline = ({
         id: localCacheIdPrefix ? `${localCacheIdPrefix}-useRunsForTimeline-filtered` : false,
         keyPrefix: JSON.stringify(filter),
         keyMaxCount: 3,
-        version: 1,
+        version: QUERY_VERSION,
       });
     }
     return new HourlyDataCache<RunTimelineFragment>({
       id: localCacheIdPrefix ? `${localCacheIdPrefix}-useRunsForTimeline` : false,
-      version: 1,
+      version: QUERY_VERSION,
     });
   }, [filter, localCacheIdPrefix]);
   const [completedRuns, setCompletedRuns] = useState<RunTimelineFragment[]>([]);

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -30,7 +30,7 @@ import {workspacePipelinePath} from '../workspace/workspacePath';
 
 const BATCH_LIMIT = 500;
 
-const QUERY_VERSION = 1;
+export const QUERY_VERSION = 1;
 
 export const useRunsForTimeline = ({
   rangeMs,


### PR DESCRIPTION
## Summary & Motivation

1. Add a version parameter to `HourlyDataCache`
2. If the version in the indexeddb cache  doesn't match the version in code then don't use the indexeddb cache data at all
3. Add version parameter to useRunTImeline

## How I Tested These Changes

Loaded the run timeline using app-proxy and saw that the cache was cleared. Subsequent loads used the cache