### PR TITLE
[dagster-airlift] build_defs rename and docstring

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/__init__.py
@@ -1,7 +1,7 @@
 from .core.basic_auth import BasicAuthBackend as BasicAuthBackend
 from .core.defs_from_airflow import (
     AirflowInstance as AirflowInstance,
-    create_defs_from_airflow_instance as create_defs_from_airflow_instance,
+    build_defs_from_airflow_instance as build_defs_from_airflow_instance,
 )
 from .core.migration_state import load_migration_state_from_yaml as load_migration_state_from_yaml
 from .core.multi_asset import PythonDefs as PythonDefs

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/defs_from_airflow.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/defs_from_airflow.py
@@ -9,7 +9,7 @@ from .airflow_instance import AirflowInstance
 from .migration_state import AirflowMigrationState
 
 
-def create_defs_from_airflow_instance(
+def build_defs_from_airflow_instance(
     airflow_instance: AirflowInstance,
     cache_polling_interval: int = DEFAULT_POLL_INTERVAL,
     orchestrated_defs: Optional[Definitions] = None,
@@ -17,6 +17,27 @@ def create_defs_from_airflow_instance(
     # Alternatively, we can keep it around to let people override the migration state if they want.
     migration_state_override: Optional[AirflowMigrationState] = None,
 ) -> Definitions:
+    """From a provided airflow instance and a set of airflow-orchestrated dagster definitions, build a set of dagster definitions to peer and observe the airflow instance.
+
+    Each airflow dag will be represented as a dagster asset, and each dag run will be represented as an asset materialization. A :py:class:`dagster.SensorDefinition` provided in the returned Definitions will be used to poll for dag runs.
+
+    The provided orchestrated defs are expected to contain fully qualified :py:class:`dagster.AssetsDefinition` objects, each of which should be mapped to a task and dag in the provided airflow instance. Using the airflow instance,
+    dagster will provide dependency information between the assets representing tasks, and the dags that they contain. The included :py:class:`dagster.SensorDefinition` will poll for dag runs and materialize runs including each task as an asset for that task.
+
+    There are two ways that the mapping can be done on a provided definition:
+    1. By using the `airlift/dag_id` and `airlift/task_id` op tags on the underlying :py:class:`dagster.NodeDefinition` for the asset.
+    2. By using an opinionated naming format on the :py:class:`dagster.NodeDefinition` for the asset. The naming format is `dag_id__task_id`.
+
+    Args:
+        airflow_instance (AirflowInstance): The airflow instance to peer with.
+        cache_polling_interval (int, optional): The interval at which to poll for updated assets from airflow. Defaults to 60 seconds.
+        orchestrated_defs (Optional[Definitions], optional): The orchestrated definitions to peer. If None are provided, only dags will be represented.
+        migration_state_override (Optional[AirflowMigrationState], optional): The migration state to use for the provided orchestrated defs. Defaults to None.
+
+    Returns:
+        Definitions: The definitions to use for the provided airflow instance. Contains an asset per dag, an asset per task in the provided orchestrated defs, all resources provided in the orchestrated defs, and a sensor to poll for airflow dag runs.
+
+    """
     assets_defs = AirflowCacheableAssetsDefinition(
         airflow_instance=airflow_instance,
         orchestrated_defs=orchestrated_defs,

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_peering.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_peering.py
@@ -16,7 +16,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.test_utils import instance_for_test
-from dagster_airlift import AirflowInstance, BasicAuthBackend, create_defs_from_airflow_instance
+from dagster_airlift import AirflowInstance, BasicAuthBackend, build_defs_from_airflow_instance
 from dagster_airlift.core.migration_state import (
     AirflowMigrationState,
     DagMigrationState,
@@ -53,7 +53,7 @@ def test_dag_peering(
     def print_dag__downstream_print_task():
         pass
 
-    defs = create_defs_from_airflow_instance(
+    defs = build_defs_from_airflow_instance(
         airflow_instance=instance,
         orchestrated_defs=Definitions(
             assets=[

--- a/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/dagster_defs/definitions.py
+++ b/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/dagster_defs/definitions.py
@@ -7,7 +7,7 @@ from dagster_airlift import (
     AirflowInstance,
     BasicAuthBackend,
     PythonDefs,
-    create_defs_from_airflow_instance,
+    build_defs_from_airflow_instance,
     load_migration_state_from_yaml,
 )
 from dagster_airlift.core.def_factory import defs_from_factories
@@ -35,7 +35,7 @@ def dbt_project_path() -> Path:
     return Path(env_val)
 
 
-defs = create_defs_from_airflow_instance(
+defs = build_defs_from_airflow_instance(
     airflow_instance=airflow_instance,
     orchestrated_defs=defs_from_factories(
         PythonDefs(


### PR DESCRIPTION
Rename the function `create_defs_from_airflow_instance` to `build_defs_from_airflow_instance`, and add a docstring.
For the sake of consistency with other defs builders, a la build_freshness_checks and kin.