### PR TITLE
[6/n][dagster-powerbi] use asset caching logic for powerbi assets

### DIFF
--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
@@ -3,10 +3,12 @@ from typing import Any, Dict, Sequence, Type
 import requests
 from dagster import ConfigurableResource
 from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.cacheable_assets import extract_from_current_repository_load_data
 from dagster._utils.cached_method import cached_method
 from pydantic import Field
 
 from dagster_powerbi.translator import (
+    POWERBI_PREFIX,
     DagsterPowerBITranslator,
     PowerBIContentData,
     PowerBIContentType,
@@ -112,13 +114,9 @@ class PowerBIWorkspace(ConfigurableResource):
             PowerBIContentData(content_type=PowerBIContentType.SEMANTIC_MODEL, properties=dataset)
             for dataset in semantic_models_data
         ]
-        return PowerBIWorkspaceData(
-            dashboards_by_id={dashboard.properties["id"]: dashboard for dashboard in dashboards},
-            reports_by_id={report.properties["id"]: report for report in reports},
-            semantic_models_by_id={
-                dataset.properties["id"]: dataset for dataset in semantic_models
-            },
-            data_sources_by_id=data_sources_by_id,
+        return PowerBIWorkspaceData.from_content_data(
+            self.workspace_id,
+            dashboards + reports + semantic_models + list(data_sources_by_id.values()),
         )
 
     def build_asset_specs(
@@ -136,7 +134,17 @@ class PowerBIWorkspace(ConfigurableResource):
         Returns:
             Sequence[AssetSpec]: A list of AssetSpecs representing the Power BI content.
         """
-        workspace_data = self.fetch_powerbi_workspace_data()
+        cached_workspace_data = extract_from_current_repository_load_data(
+            f"{POWERBI_PREFIX}{self.workspace_id}"
+        )
+        if cached_workspace_data:
+            workspace_data = PowerBIWorkspaceData.from_content_data(
+                self.workspace_id,
+                [PowerBIContentData.from_cached_data(data) for data in cached_workspace_data],
+            )
+        else:
+            workspace_data = self.fetch_powerbi_workspace_data()
+
         translator = dagster_powerbi_translator(context=workspace_data)
 
         all_content = [

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
@@ -4,6 +4,7 @@ import requests
 from dagster import (
     AssetsDefinition,
     ConfigurableResource,
+    Definitions,
     _check as check,
     external_assets_from_specs,
 )
@@ -127,7 +128,7 @@ class PowerBIWorkspace(ConfigurableResource):
 
     def build_assets(
         self,
-        dagster_powerbi_translator: Type[DagsterPowerBITranslator] = DagsterPowerBITranslator,
+        dagster_powerbi_translator: Type[DagsterPowerBITranslator],
     ) -> Sequence[CacheableAssetsDefinition]:
         """Returns a set of CacheableAssetsDefinition which will load Power BI content from
         the workspace and translates it into AssetSpecs, using the provided translator.
@@ -141,6 +142,23 @@ class PowerBIWorkspace(ConfigurableResource):
                 will load the Power BI content.
         """
         return [PowerBICacheableAssetsDefinition(self, dagster_powerbi_translator)]
+
+    def build_defs(
+        self, dagster_powerbi_translator: Type[DagsterPowerBITranslator] = DagsterPowerBITranslator
+    ) -> Definitions:
+        """Returns a Definitions object which will load Power BI content from
+        the workspace and translate it into assets, using the provided translator.
+
+        Args:
+            dagster_powerbi_translator (Type[DagsterPowerBITranslator]): The translator to use
+                to convert Power BI content into AssetSpecs. Defaults to DagsterPowerBITranslator.
+
+        Returns:
+            Definitions: A Definitions object which will build and return the Power BI content.
+        """
+        return Definitions(
+            assets=self.build_assets(dagster_powerbi_translator=dagster_powerbi_translator)
+        )
 
 
 class PowerBICacheableAssetsDefinition(CacheableAssetsDefinition):

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -6,10 +6,6 @@ from typing import Any, Dict, Mapping, Sequence
 from dagster import _check as check
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster._core.definitions.cacheable_assets import (
-    CACHED_ASSET_ID_KEY,
-    CACHED_ASSET_METADATA_KEY,
-)
 from dagster._record import record
 
 POWERBI_PREFIX = "powerbi/"
@@ -143,10 +139,6 @@ class DagsterPowerBITranslator:
             key=self.get_dashboard_asset_key(data),
             tags={"dagster/storage_kind": "powerbi"},
             deps=report_keys,
-            metadata={
-                CACHED_ASSET_ID_KEY: f"{POWERBI_PREFIX}{self.workspace_data.workspace_id}",
-                CACHED_ASSET_METADATA_KEY: data.to_cached_data(),
-            },
         )
 
     def get_report_asset_key(self, data: PowerBIContentData) -> AssetKey:
@@ -161,10 +153,6 @@ class DagsterPowerBITranslator:
             key=self.get_report_asset_key(data),
             deps=[dataset_key] if dataset_key else None,
             tags={"dagster/storage_kind": "powerbi"},
-            metadata={
-                CACHED_ASSET_ID_KEY: f"{POWERBI_PREFIX}{self.workspace_data.workspace_id}",
-                CACHED_ASSET_METADATA_KEY: data.to_cached_data(),
-            },
         )
 
     def get_semantic_model_asset_key(self, data: PowerBIContentData) -> AssetKey:
@@ -181,10 +169,6 @@ class DagsterPowerBITranslator:
             key=self.get_semantic_model_asset_key(data),
             tags={"dagster/storage_kind": "powerbi"},
             deps=source_keys,
-            metadata={
-                CACHED_ASSET_ID_KEY: f"{POWERBI_PREFIX}{self.workspace_data.workspace_id}",
-                CACHED_ASSET_METADATA_KEY: data.to_cached_data(),
-            },
         )
 
     def get_data_source_asset_key(self, data: PowerBIContentData) -> AssetKey:
@@ -203,8 +187,4 @@ class DagsterPowerBITranslator:
         return AssetSpec(
             key=self.get_data_source_asset_key(data),
             tags={"dagster/storage_kind": "powerbi"},
-            metadata={
-                CACHED_ASSET_ID_KEY: f"{POWERBI_PREFIX}{self.workspace_data.workspace_id}",
-                CACHED_ASSET_METADATA_KEY: data.to_cached_data(),
-            },
         )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -1,12 +1,18 @@
 import re
 import urllib.parse
 from enum import Enum
-from typing import Any, Dict
+from typing import Any, Dict, Mapping, Sequence
 
 from dagster import _check as check
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.cacheable_assets import (
+    CACHED_ASSET_ID_KEY,
+    CACHED_ASSET_METADATA_KEY,
+)
 from dagster._record import record
+
+POWERBI_PREFIX = "powerbi/"
 
 
 def _get_last_filepath_component(path: str) -> str:
@@ -42,6 +48,16 @@ class PowerBIContentData:
     content_type: PowerBIContentType
     properties: Dict[str, Any]
 
+    def to_cached_data(self) -> Dict[str, Any]:
+        return {"content_type": self.content_type.value, "properties": self.properties}
+
+    @classmethod
+    def from_cached_data(cls, data: Mapping[Any, Any]) -> "PowerBIContentData":
+        return cls(
+            content_type=PowerBIContentType(data["content_type"]),
+            properties=data["properties"],
+        )
+
 
 @record
 class PowerBIWorkspaceData:
@@ -50,10 +66,39 @@ class PowerBIWorkspaceData:
     Provided as context for the translator so that it can resolve dependencies between content.
     """
 
+    workspace_id: str
     dashboards_by_id: Dict[str, PowerBIContentData]
     reports_by_id: Dict[str, PowerBIContentData]
     semantic_models_by_id: Dict[str, PowerBIContentData]
     data_sources_by_id: Dict[str, PowerBIContentData]
+
+    @classmethod
+    def from_content_data(
+        cls, workspace_id: str, content_data: Sequence[PowerBIContentData]
+    ) -> "PowerBIWorkspaceData":
+        return cls(
+            workspace_id=workspace_id,
+            dashboards_by_id={
+                dashboard.properties["id"]: dashboard
+                for dashboard in content_data
+                if dashboard.content_type == PowerBIContentType.DASHBOARD
+            },
+            reports_by_id={
+                report.properties["id"]: report
+                for report in content_data
+                if report.content_type == PowerBIContentType.REPORT
+            },
+            semantic_models_by_id={
+                dataset.properties["id"]: dataset
+                for dataset in content_data
+                if dataset.content_type == PowerBIContentType.SEMANTIC_MODEL
+            },
+            data_sources_by_id={
+                data_source.properties["datasourceId"]: data_source
+                for data_source in content_data
+                if data_source.content_type == PowerBIContentType.DATA_SOURCE
+            },
+        )
 
 
 class DagsterPowerBITranslator:
@@ -98,6 +143,10 @@ class DagsterPowerBITranslator:
             key=self.get_dashboard_asset_key(data),
             tags={"dagster/storage_kind": "powerbi"},
             deps=report_keys,
+            metadata={
+                CACHED_ASSET_ID_KEY: f"{POWERBI_PREFIX}{self.workspace_data.workspace_id}",
+                CACHED_ASSET_METADATA_KEY: data.to_cached_data(),
+            },
         )
 
     def get_report_asset_key(self, data: PowerBIContentData) -> AssetKey:
@@ -112,6 +161,10 @@ class DagsterPowerBITranslator:
             key=self.get_report_asset_key(data),
             deps=[dataset_key] if dataset_key else None,
             tags={"dagster/storage_kind": "powerbi"},
+            metadata={
+                CACHED_ASSET_ID_KEY: f"{POWERBI_PREFIX}{self.workspace_data.workspace_id}",
+                CACHED_ASSET_METADATA_KEY: data.to_cached_data(),
+            },
         )
 
     def get_semantic_model_asset_key(self, data: PowerBIContentData) -> AssetKey:
@@ -128,6 +181,10 @@ class DagsterPowerBITranslator:
             key=self.get_semantic_model_asset_key(data),
             tags={"dagster/storage_kind": "powerbi"},
             deps=source_keys,
+            metadata={
+                CACHED_ASSET_ID_KEY: f"{POWERBI_PREFIX}{self.workspace_data.workspace_id}",
+                CACHED_ASSET_METADATA_KEY: data.to_cached_data(),
+            },
         )
 
     def get_data_source_asset_key(self, data: PowerBIContentData) -> AssetKey:
@@ -146,4 +203,8 @@ class DagsterPowerBITranslator:
         return AssetSpec(
             key=self.get_data_source_asset_key(data),
             tags={"dagster/storage_kind": "powerbi"},
+            metadata={
+                CACHED_ASSET_ID_KEY: f"{POWERBI_PREFIX}{self.workspace_data.workspace_id}",
+                CACHED_ASSET_METADATA_KEY: data.to_cached_data(),
+            },
         )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/conftest.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/conftest.py
@@ -76,10 +76,15 @@ SAMPLE_DATA_SOURCES = [
 ]
 
 
+@pytest.fixture(name="workspace_id")
+def workspace_id_fixture() -> str:
+    return "a2122b8f-d7e1-42e8-be2b-a5e636ca3221"
+
+
 @pytest.fixture(
     name="workspace_data",
 )
-def workspace_data_fixture() -> PowerBIWorkspaceData:
+def workspace_data_fixture(workspace_id: str) -> PowerBIWorkspaceData:
     sample_dash = SAMPLE_DASH.copy()
     # Response from tiles API, which we add to the dashboard data
     sample_dash["tiles"] = SAMPLE_DASH_TILES
@@ -90,6 +95,7 @@ def workspace_data_fixture() -> PowerBIWorkspaceData:
     sample_semantic_model["sources"] = [ds["datasourceId"] for ds in sample_data_sources]
 
     return PowerBIWorkspaceData(
+        workspace_id=workspace_id,
         dashboards_by_id={
             sample_dash["id"]: PowerBIContentData(
                 content_type=PowerBIContentType.DASHBOARD, properties=sample_dash
@@ -114,15 +120,10 @@ def workspace_data_fixture() -> PowerBIWorkspaceData:
     )
 
 
-@pytest.fixture(name="workspace_id")
-def workspace_id_fixture() -> str:
-    return "a2122b8f-d7e1-42e8-be2b-a5e636ca3221"
-
-
 @pytest.fixture(
     name="workspace_data_api_mocks",
 )
-def workspace_data_api_mocks_fixture(workspace_id: str) -> Iterator[None]:
+def workspace_data_api_mocks_fixture(workspace_id: str) -> Iterator[responses.RequestsMock]:
     with responses.RequestsMock() as response:
         response.add(
             method=responses.GET,
@@ -159,4 +160,4 @@ def workspace_data_api_mocks_fixture(workspace_id: str) -> Iterator[None]:
             status=200,
         )
 
-        yield
+        yield response

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo.py
@@ -1,0 +1,31 @@
+import uuid
+from typing import cast
+
+from dagster import asset, define_asset_job, external_assets_from_specs
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.repository_definition.repository_definition import (
+    PendingRepositoryDefinition,
+)
+from dagster_powerbi import PowerBIWorkspace
+
+fake_token = uuid.uuid4().hex
+resource = PowerBIWorkspace(
+    api_token=fake_token,
+    workspace_id="a2122b8f-d7e1-42e8-be2b-a5e636ca3221",
+)
+all_asset_specs = resource.build_asset_specs()
+
+assets = external_assets_from_specs(all_asset_specs)
+
+
+@asset
+def my_materializable_asset():
+    pass
+
+
+pending_repo_from_cached_asset_metadata = cast(
+    PendingRepositoryDefinition,
+    Definitions(
+        assets=[*assets, my_materializable_asset], jobs=[define_asset_job("all_asset_job")]
+    ).get_inner_repository(),
+)

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import cast
 
-from dagster import asset, define_asset_job, external_assets_from_specs
+from dagster import asset, define_asset_job
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.repository_definition.repository_definition import (
     PendingRepositoryDefinition,
@@ -13,9 +13,7 @@ resource = PowerBIWorkspace(
     api_token=fake_token,
     workspace_id="a2122b8f-d7e1-42e8-be2b-a5e636ca3221",
 )
-all_asset_specs = resource.build_asset_specs()
-
-assets = external_assets_from_specs(all_asset_specs)
+pbi_assets = resource.build_assets()
 
 
 @asset
@@ -26,6 +24,6 @@ def my_materializable_asset():
 pending_repo_from_cached_asset_metadata = cast(
     PendingRepositoryDefinition,
     Definitions(
-        assets=[*assets, my_materializable_asset], jobs=[define_asset_job("all_asset_job")]
+        assets=[*pbi_assets, my_materializable_asset], jobs=[define_asset_job("all_asset_job")]
     ).get_inner_repository(),
 )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo.py
@@ -13,7 +13,7 @@ resource = PowerBIWorkspace(
     api_token=fake_token,
     workspace_id="a2122b8f-d7e1-42e8-be2b-a5e636ca3221",
 )
-pbi_assets = resource.build_assets()
+pbi_defs = resource.build_defs()
 
 
 @asset
@@ -23,7 +23,8 @@ def my_materializable_asset():
 
 pending_repo_from_cached_asset_metadata = cast(
     PendingRepositoryDefinition,
-    Definitions(
-        assets=[*pbi_assets, my_materializable_asset], jobs=[define_asset_job("all_asset_job")]
+    Definitions.merge(
+        Definitions(assets=[my_materializable_asset], jobs=[define_asset_job("all_asset_job")]),
+        pbi_defs,
     ).get_inner_repository(),
 )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -30,9 +30,7 @@ def test_translator_dashboard_spec(workspace_data_api_mocks: None, workspace_id:
         api_token=fake_token,
         workspace_id=workspace_id,
     )
-    cacheable_asset = resource.build_assets()[0]
-    data = cacheable_asset.compute_cacheable_data()
-    all_assets = cacheable_asset.build_definitions(data)
+    all_assets = resource.build_defs().get_asset_graph().assets_defs
 
     # 1 dashboard, 1 report, 1 semantic model, 2 data sources
     assert len(all_assets) == 5
@@ -67,7 +65,7 @@ def test_using_cached_asset_data(workspace_data_api_mocks: responses.RequestsMoc
     with instance_for_test() as instance:
         assert len(workspace_data_api_mocks.calls) == 0
 
-        from dags.pending_repo import pending_repo_from_cached_asset_metadata
+        from dagster_powerbi_tests.pending_repo import pending_repo_from_cached_asset_metadata
 
         # first, we resolve the repository to generate our cached metadata
         repository_def = pending_repo_from_cached_asset_metadata.compute_repository_definition()

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -1,6 +1,12 @@
 import uuid
 
+import responses
 from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
+from dagster._core.events import DagsterEventType
+from dagster._core.execution.api import create_execution_plan, execute_plan
+from dagster._core.instance_for_test import instance_for_test
+from dagster._utils import file_relative_path
 from dagster_powerbi import PowerBIWorkspace
 
 
@@ -53,3 +59,45 @@ def test_translator_dashboard_spec(workspace_data_api_mocks: None, workspace_id:
         AssetKey(["data_27_09_2019.xlsx"]),
         AssetKey(["sales_marketing_datas.xlsx"]),
     }
+
+
+def test_using_cached_asset_data(workspace_data_api_mocks: responses.RequestsMock) -> None:
+    with instance_for_test() as instance:
+        assert len(workspace_data_api_mocks.calls) == 0
+
+        from dags.pending_repo import pending_repo_from_cached_asset_metadata
+
+        assert len(workspace_data_api_mocks.calls) == 5
+
+        # first, we resolve the repository to generate our cached metadata
+        repository_def = pending_repo_from_cached_asset_metadata.compute_repository_definition()
+
+        # 5 PowerBI external assets, one materializable asset
+        assert len(repository_def.assets_defs_by_key) == 5 + 1
+
+        job_def = repository_def.get_job("all_asset_job")
+        repository_load_data = repository_def.repository_load_data
+
+        recon_repo = ReconstructableRepository.for_file(
+            file_relative_path(__file__, "pending_repo.py"),
+            fn_name="pending_repo_from_cached_asset_metadata",
+        )
+        recon_job = ReconstructableJob(repository=recon_repo, job_name="all_asset_job")
+
+        execution_plan = create_execution_plan(recon_job, repository_load_data=repository_load_data)
+
+        run = instance.create_run_for_job(job_def=job_def, execution_plan=execution_plan)
+
+        events = execute_plan(
+            execution_plan=execution_plan,
+            job=recon_job,
+            dagster_run=run,
+            instance=instance,
+        )
+
+        assert (
+            len([event for event in events if event.event_type == DagsterEventType.STEP_SUCCESS])
+            == 1
+        ), "Expected two successful steps"
+
+        assert len(workspace_data_api_mocks.calls) == 5


### PR DESCRIPTION
## Summary

In response to feedback on asset caching apis in #23341, uses cacheable assets definitions to ensure that PowerBI data is only fetched from the API once. Once we settle on more agreeable asset caching apis, we can improve the ergonomics here.

## Test Plan

New unit test to load a repo and launch runs without re-fetching data from PowerBI APIs.