### PR TITLE
[dagster-airlift] core submodule

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/__init__.py
@@ -1,7 +1,0 @@
-from .core.basic_auth import BasicAuthBackend as BasicAuthBackend
-from .core.defs_from_airflow import (
-    AirflowInstance as AirflowInstance,
-    build_defs_from_airflow_instance as build_defs_from_airflow_instance,
-)
-from .core.migration_state import load_migration_state_from_yaml as load_migration_state_from_yaml
-from .core.multi_asset import PythonDefs as PythonDefs

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/__init__.py
@@ -1,0 +1,7 @@
+from .basic_auth import BasicAuthBackend as BasicAuthBackend
+from .defs_from_airflow import (
+    AirflowInstance as AirflowInstance,
+    build_defs_from_airflow_instance as build_defs_from_airflow_instance,
+)
+from .migration_state import load_migration_state_from_yaml as load_migration_state_from_yaml
+from .multi_asset import PythonDefs as PythonDefs

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_peering.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_peering.py
@@ -16,7 +16,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.test_utils import instance_for_test
-from dagster_airlift import AirflowInstance, BasicAuthBackend, build_defs_from_airflow_instance
+from dagster_airlift.core import AirflowInstance, BasicAuthBackend, build_defs_from_airflow_instance
 from dagster_airlift.core.migration_state import (
     AirflowMigrationState,
     DagMigrationState,

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_migration_state.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_migration_state.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 from dagster._core.errors import DagsterInvalidDefinitionError
-from dagster_airlift import load_migration_state_from_yaml
+from dagster_airlift.core import load_migration_state_from_yaml
 from dagster_airlift.core.migration_state import (
     AirflowMigrationState,
     DagMigrationState,

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_python_multi_assets.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_python_multi_assets.py
@@ -1,5 +1,5 @@
 from dagster import AssetDep, AssetKey, AssetsDefinition, AssetSpec
-from dagster_airlift import PythonDefs
+from dagster_airlift.core import PythonDefs
 
 from dagster_airlift_tests.unit_tests.multi_asset_python import compute_fn
 

--- a/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/dagster_defs/definitions.py
+++ b/examples/experimental/dagster-airlift/examples/peering-with-dbt/peering_with_dbt/dagster_defs/definitions.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
-from dagster_airlift import (
+from dagster_airlift.core import (
     AirflowInstance,
     BasicAuthBackend,
     PythonDefs,

--- a/examples/experimental/dagster-airlift/examples/peering-with-dbt/tox.ini
+++ b/examples/experimental/dagster-airlift/examples/peering-with-dbt/tox.ini
@@ -15,7 +15,7 @@ deps =
   -e ../../../../../python_modules/dagster-pipes
   -e ../../../../../python_modules/dagster-graphql
   -e ../../../../../python_modules/libraries/dagster-dbt
-  -e ../../../dagster-airlift[dbt,test]
+  -e ../../../dagster-airlift[core,dbt,test]
   -e .
   pandas
 allowlist_externals =

--- a/examples/experimental/dagster-airlift/setup.py
+++ b/examples/experimental/dagster-airlift/setup.py
@@ -36,16 +36,16 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_airlift_tests*", "examples*"]),
-    install_requires=[
-        f"dagster{pin}",
-        "apache-airflow>=2.0.0,<2.8",
-        # Flask-session 0.6 is incompatible with certain airflow-provided test
-        # utilities.
-        "flask-session<0.6.0",
-        "connexion<3.0.0",  # https://github.com/apache/airflow/issues/35234
-        "pendulum>=2.0.0,<3.0.0",
-    ],
     extras_require={
+        "core": [
+            f"dagster{pin}",
+            "apache-airflow>=2.0.0,<2.8",
+            # Flask-session 0.6 is incompatible with certain airflow-provided test
+            # utilities.
+            "flask-session<0.6.0",
+            "connexion<3.0.0",  # https://github.com/apache/airflow/issues/35234
+            "pendulum>=2.0.0,<3.0.0",
+        ],
         "mwaa": ["boto3"],
         "dbt": [f"dagster-dbt{pin}"],
         "test": ["pytest", f"dagster-dbt{pin}", "dbt-duckdb", "boto3"],

--- a/examples/experimental/dagster-airlift/tox.ini
+++ b/examples/experimental/dagster-airlift/tox.ini
@@ -13,7 +13,7 @@ deps =
   -e ../../../python_modules/dagster-test
   -e ../../../python_modules/dagster-pipes
   -e ../../../python_modules/libraries/dagster-dbt
-  -e .[mwaa,dbt,test]
+  -e .[core,mwaa,dbt,test]
   dbt-duckdb
 allowlist_externals =
   /bin/bash


### PR DESCRIPTION
Moves airlift core into it's own submodule. The in-dagster side should exist as its own component (which is core), and then the in-airflow side should exist as its own component.