### PR TITLE
chore: remove starlette lifespan warning

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/cli.py
+++ b/python_modules/dagster-webserver/dagster_webserver/cli.py
@@ -1,9 +1,10 @@
 import asyncio
+import contextlib
 import logging
 import os
 import sys
 import textwrap
-from typing import Optional
+from typing import AsyncIterator, Optional
 
 import click
 import dagster._check as check
@@ -232,7 +233,8 @@ def dagster_webserver(
             )
 
 
-async def _lifespan(app):
+@contextlib.asynccontextmanager
+async def _lifespan(app) -> AsyncIterator:
     # workaround from https://github.com/encode/uvicorn/issues/1160 for termination
     try:
         yield


### PR DESCRIPTION
## Summary & Motivation

Seeing the following error locally:

```diff
Downloads/projects/jaffle_dagster 🐍 (dagster)
❯ PYTHONWARNINGS=default dagster dev
2024-08-07 16:23:42 -0400 - dagster - INFO - Using temporary directory /Users/rexledesma/Downloads/projects/jaffle_dagster/tmpqbravcfj for storage. This will be removed when dagster dev exits.
2024-08-07 16:23:42 -0400 - dagster - INFO - To persist information across sessions, set the environment variable DAGSTER_HOME to a directory to use.
2024-08-07 16:23:42 -0400 - dagster - WARNING - /Users/rexledesma/dagster-labs/dagster/python_modules/dagster/dagster/_core/storage/sqlalchemy_compat.py:13: RemovedIn20Warning: Deprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0. To prevent incompatible upgrades prior to updating applications, ensure requirements files are pinned to "sqlalchemy<2.0". Set environment variable SQLALCHEMY_WARN_20=1 to show all deprecation warnings.  Set environment variable SQLALCHEMY_SILENCE_UBER_WARNING=1 to silence this message. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
  return db.select(items)

2024-08-07 16:23:42 -0400 - dagster - INFO - Launching Dagster services...
/Users/rexledesma/dagster-labs/dagster/python_modules/dagster/dagster/_core/storage/sqlalchemy_compat.py:13: RemovedIn20Warning: Deprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0. To prevent incompatible upgrades prior to updating applications, ensure requirements files are pinned to "sqlalchemy<2.0". Set environment variable SQLALCHEMY_WARN_20=1 to show all deprecation warnings.  Set environment variable SQLALCHEMY_SILENCE_UBER_WARNING=1 to silence this message. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
  return db.select(items)
2024-08-07 16:23:44 -0400 - dagster.daemon - INFO - Instance is configured with the following daemons: ['AssetDaemon', 'BackfillDaemon', 'SchedulerDaemon', 'SensorDaemon']
+ 2024-08-07 16:23:45 -0400 - dagster - WARNING - /Users/rexledesma/.pyenv/versions/3.10.13/envs/dagster/lib/python3.10/site-packages/starlette/routing.py:657: DeprecationWarning: async generator function lifespans are deprecated, use an @contextlib.asynccontextmanager function instead
  warnings.warn(

2024-08-07 16:23:45 -0400 - dagster-webserver - INFO - Serving dagster-webserver on http://127.0.0.1:3000 in process 36687
```

Fix the warning by using `@contextlib.asynccontextmanager`. See https://www.starlette.io/lifespan/.

## How I Tested These Changes
local, warning doesn't show anymore