### PR TITLE
followup to "replace GrapheneAssetNode isSource with isMaterializable"

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTabs.tsx
@@ -65,7 +65,7 @@ export const buildAssetTabMap = (input: AssetTabConfigInput) => {
       id: 'partitions',
       title: 'Partitions',
       to: buildAssetViewParams({...params, view: 'partitions'}),
-      hidden: !definition?.partitionDefinition || !definition?.isMaterializable,
+      hidden: !definition?.partitionDefinition || !definition?.isMaterializable === false,
     } as AssetTabConfig,
     checks: {
       id: 'checks',

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -163,7 +163,7 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
   };
 
   const renderPartitionsTab = () => {
-    if (!definition?.isMaterializable) {
+    if (definition?.isMaterializable === false) {
       return <Redirect to={assetDetailsPathForKey(assetKey, {view: 'events'})} />;
     }
 


### PR DESCRIPTION
## Summary & Motivation

I accidentally merged https://github.com/dagster-io/dagster/pull/23401 before fixing the bugs that @bengotow noticed. Here's a quick followup to fix.

## How I Tested These Changes
