### PR TITLE
[single-implicit-asset-job] methods on `CodeLocation` to get job partitions, partition tags, and partition config, with asset selection

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -140,7 +140,10 @@ def create_and_launch_partition_backfill(
 
         if backfill_params.get("allPartitions"):
             result = graphene_info.context.get_external_partition_names(
-                external_partition_set, instance=graphene_info.context.instance
+                repository_handle=repository.handle,
+                job_name=external_partition_set.job_name,
+                instance=graphene_info.context.instance,
+                selected_asset_keys=None,
             )
             if isinstance(result, ExternalPartitionExecutionErrorData):
                 raise DagsterUserCodeProcessError.from_error_info(result.error)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
-from typing import TYPE_CHECKING, Optional, Sequence, Union
+from typing import TYPE_CHECKING, AbstractSet, Optional, Sequence, Union
 
 import dagster._check as check
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.selector import RepositorySelector
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.remote_representation import ExternalPartitionSet, RepositoryHandle
@@ -107,20 +108,18 @@ def get_partition_by_name(
 def get_partition_config(
     graphene_info: ResolveInfo,
     repository_handle: RepositoryHandle,
-    partition_set_name: str,
+    job_name: str,
     partition_name: str,
+    selected_asset_keys: Optional[AbstractSet[AssetKey]],
 ) -> "GraphenePartitionRunConfig":
     from ..schema.partition_sets import GraphenePartitionRunConfig
 
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
-    check.str_param(partition_set_name, "partition_set_name")
+    check.str_param(job_name, "job_name")
     check.str_param(partition_name, "partition_name")
 
     result = graphene_info.context.get_external_partition_config(
-        repository_handle,
-        partition_set_name,
-        partition_name,
-        graphene_info.context.instance,
+        repository_handle, job_name, partition_name, graphene_info.context.instance
     )
 
     if isinstance(result, ExternalPartitionExecutionErrorData):
@@ -132,18 +131,23 @@ def get_partition_config(
 def get_partition_tags(
     graphene_info: ResolveInfo,
     repository_handle: RepositoryHandle,
-    partition_set_name: str,
+    job_name: str,
     partition_name: str,
+    selected_asset_keys: Optional[AbstractSet[AssetKey]],
 ) -> "GraphenePartitionTags":
     from ..schema.partition_sets import GraphenePartitionTags
     from ..schema.tags import GraphenePipelineTag
 
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
-    check.str_param(partition_set_name, "partition_set_name")
+    check.str_param(job_name, "job_name")
     check.str_param(partition_name, "partition_name")
 
     result = graphene_info.context.get_external_partition_tags(
-        repository_handle, partition_set_name, partition_name, graphene_info.context.instance
+        repository_handle,
+        job_name,
+        partition_name,
+        graphene_info.context.instance,
+        selected_asset_keys=selected_asset_keys,
     )
 
     if isinstance(result, ExternalPartitionExecutionErrorData):

--- a/python_modules/dagster/dagster/_cli/asset.py
+++ b/python_modules/dagster/dagster/_cli/asset.py
@@ -68,8 +68,11 @@ def execute_materialize_command(instance: DagsterInstance, kwargs: Mapping[str, 
             check.failed("Provided '--partition' option, but none of the assets are partitioned")
 
         try:
-            tags = implicit_job_def.get_tags_for_partition_key(
+            implicit_job_def.validate_partition_key(
                 partition, selected_asset_keys=asset_keys, dynamic_partitions_store=instance
+            )
+            tags = implicit_job_def.get_tags_for_partition_key(
+                partition, selected_asset_keys=asset_keys
             )
         except DagsterUnknownPartitionError:
             raise DagsterInvalidSubsetError(

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -650,7 +650,10 @@ def _execute_backfill_command_at_location(
 
     try:
         partition_names_or_error = code_location.get_external_partition_names(
-            job_partition_set, instance=instance
+            repository_handle=repo_handle,
+            job_name=external_job.name,
+            instance=instance,
+            selected_asset_keys=None,
         )
     except Exception as e:
         error_info = serializable_error_info_from_exc_info(sys.exc_info())

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -685,10 +685,14 @@ class JobDefinition(IHasInternalInit):
 
         merged_tags = merge_dicts(self.tags, tags or {})
         if partition_key:
-            tags_for_partition_key = ephemeral_job.get_tags_for_partition_key(
+            ephemeral_job.validate_partition_key(
                 partition_key,
                 selected_asset_keys=asset_selection,
                 dynamic_partitions_store=instance,
+            )
+            tags_for_partition_key = ephemeral_job.get_tags_for_partition_key(
+                partition_key,
+                selected_asset_keys=asset_selection,
             )
 
             if not run_config and self.partitioned_config:
@@ -714,18 +718,11 @@ class JobDefinition(IHasInternalInit):
             asset_selection=frozenset(asset_selection),
         )
 
-    def get_tags_for_partition_key(
-        self,
-        partition_key: str,
-        dynamic_partitions_store: Optional["DynamicPartitionsStore"],
-        selected_asset_keys: Optional[Iterable[AssetKey]],
-    ) -> Mapping[str, str]:
-        """Gets tags for the given partition key and ensures that it's a member of the PartitionsDefinition
-        corresponding to every asset in the selection.
-        """
-        partitions_def = None
+    def _get_partitions_def(
+        self, selected_asset_keys: Optional[Iterable[AssetKey]]
+    ) -> PartitionsDefinition:
         if self.partitions_def:
-            partitions_def = self.partitions_def
+            return self.partitions_def
         elif self.asset_layer:
             if selected_asset_keys:
                 resolved_selected_asset_keys = selected_asset_keys
@@ -736,21 +733,48 @@ class JobDefinition(IHasInternalInit):
                     key for key in self.asset_layer.asset_keys_by_node_output_handle.values()
                 ]
 
-            unique_partitions_defs = {
-                self.asset_layer.get(asset_key).partitions_def
-                for asset_key in resolved_selected_asset_keys
-            } - {None}
+            unique_partitions_defs: Set[PartitionsDefinition] = set()
+            for asset_key in resolved_selected_asset_keys:
+                partitions_def = self.asset_layer.get(asset_key).partitions_def
+                if partitions_def is not None:
+                    unique_partitions_defs.add(partitions_def)
+
             if len(unique_partitions_defs) == 1:
-                partitions_def = next(iter(unique_partitions_defs))
-            elif len(unique_partitions_defs) > 1:
-                check.failed("Attempted to execute a run for assets with different partitions")
+                return check.not_none(next(iter(unique_partitions_defs)))
 
-        if partitions_def is None:
-            check.failed("Attempted to execute a partitioned run for a non-partitioned job")
+        if selected_asset_keys is not None:
+            check.failed("There is no PartitionsDefinition shared by all the provided assets")
+        else:
+            check.failed("Job has no PartitionsDefinition")
 
+    def get_partition_keys(
+        self, selected_asset_keys: Optional[Iterable[AssetKey]]
+    ) -> Sequence[str]:
+        partitions_def = self._get_partitions_def(selected_asset_keys)
+        return partitions_def.get_partition_keys()
+
+    def validate_partition_key(
+        self,
+        partition_key: str,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"],
+        selected_asset_keys: Optional[Iterable[AssetKey]],
+    ) -> None:
+        """Ensures that the given partition_key is a member of the PartitionsDefinition
+        corresponding to every asset in the selection.
+        """
+        partitions_def = self._get_partitions_def(selected_asset_keys)
         partitions_def.validate_partition_key(
             partition_key, dynamic_partitions_store=dynamic_partitions_store
         )
+
+    def get_tags_for_partition_key(
+        self, partition_key: str, selected_asset_keys: Optional[Iterable[AssetKey]]
+    ) -> Mapping[str, str]:
+        """Gets tags for the given partition key."""
+        if self._partitioned_config is not None:
+            return self._partitioned_config.get_tags_for_partition_key(partition_key, self.name)
+
+        partitions_def = self._get_partitions_def(selected_asset_keys)
         return partitions_def.get_tags_for_partition_key(partition_key)
 
     def get_run_config_for_partition_key(self, partition_key: str) -> Mapping[str, Any]:

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -203,12 +203,16 @@ class RunRequest(IHaveNew, LegacyNamedTupleMixin):
             if dynamic_partitions_store
             else None
         )
+        target_definition.validate_partition_key(
+            self.partition_key,
+            dynamic_partitions_store=dynamic_partitions_store_after_requests,
+            selected_asset_keys=self.asset_selection,
+        )
+
         tags = {
             **(self.tags or {}),
             **target_definition.get_tags_for_partition_key(
-                self.partition_key,
-                dynamic_partitions_store=dynamic_partitions_store_after_requests,
-                selected_asset_keys=self.asset_selection,
+                self.partition_key, selected_asset_keys=self.asset_selection
             ),
         }
 

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -2,7 +2,18 @@ import sys
 import threading
 from abc import abstractmethod
 from contextlib import AbstractContextManager
-from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Sequence, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Any,
+    Dict,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
 
 import dagster._check as check
 from dagster._api.get_server_id import sync_get_server_id
@@ -19,6 +30,7 @@ from dagster._api.snapshot_partition import (
 from dagster._api.snapshot_repository import sync_get_streaming_external_repositories_data_grpc
 from dagster._api.snapshot_schedule import sync_get_external_schedule_execution_data_grpc
 from dagster._core.code_pointer import CodePointer
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.reconstruct import ReconstructableJob
 from dagster._core.definitions.repository_definition import RepositoryDefinition
 from dagster._core.definitions.selector import JobSubsetSelector
@@ -37,13 +49,13 @@ from dagster._core.remote_representation import ExternalJobSubsetResult
 from dagster._core.remote_representation.external import (
     ExternalExecutionPlan,
     ExternalJob,
-    ExternalPartitionSet,
     ExternalRepository,
 )
 from dagster._core.remote_representation.external_data import (
     ExternalPartitionNamesData,
     ExternalScheduleExecutionErrorData,
     ExternalSensorExecutionErrorData,
+    external_partition_set_name_for_job_name,
     external_repository_data_from_def,
 )
 from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
@@ -172,7 +184,7 @@ class CodeLocation(AbstractContextManager):
     def get_external_partition_config(
         self,
         repository_handle: RepositoryHandle,
-        partition_set_name: str,
+        job_name: str,
         partition_name: str,
         instance: DagsterInstance,
     ) -> Union["ExternalPartitionConfigData", "ExternalPartitionExecutionErrorData"]:
@@ -182,15 +194,20 @@ class CodeLocation(AbstractContextManager):
     def get_external_partition_tags(
         self,
         repository_handle: RepositoryHandle,
-        partition_set_name: str,
+        job_name: str,
         partition_name: str,
         instance: DagsterInstance,
+        selected_asset_keys: Optional[AbstractSet[AssetKey]],
     ) -> Union["ExternalPartitionTagsData", "ExternalPartitionExecutionErrorData"]:
         pass
 
     @abstractmethod
     def get_external_partition_names(
-        self, external_partition_set: ExternalPartitionSet, instance: DagsterInstance
+        self,
+        repository_handle: RepositoryHandle,
+        job_name: str,
+        instance: DagsterInstance,
+        selected_asset_keys: Optional[AbstractSet[AssetKey]],
     ) -> Union["ExternalPartitionNamesData", "ExternalPartitionExecutionErrorData"]:
         pass
 
@@ -428,17 +445,17 @@ class InProcessCodeLocation(CodeLocation):
     def get_external_partition_config(
         self,
         repository_handle: RepositoryHandle,
-        partition_set_name: str,
+        job_name: str,
         partition_name: str,
         instance: DagsterInstance,
     ) -> Union["ExternalPartitionConfigData", "ExternalPartitionExecutionErrorData"]:
         check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
-        check.str_param(partition_set_name, "partition_set_name")
+        check.str_param(job_name, "job_name")
         check.str_param(partition_name, "partition_name")
 
         return get_partition_config(
             self._get_repo_def(repository_handle.repository_name),
-            partition_set_name=partition_set_name,
+            job_name=job_name,
             partition_key=partition_name,
             instance_ref=instance.get_ref(),
         )
@@ -446,37 +463,35 @@ class InProcessCodeLocation(CodeLocation):
     def get_external_partition_tags(
         self,
         repository_handle: RepositoryHandle,
-        partition_set_name: str,
+        job_name: str,
         partition_name: str,
         instance: DagsterInstance,
+        selected_asset_keys: Optional[AbstractSet[AssetKey]],
     ) -> Union["ExternalPartitionTagsData", "ExternalPartitionExecutionErrorData"]:
         check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
-        check.str_param(partition_set_name, "partition_set_name")
+        check.str_param(job_name, "job_name")
         check.str_param(partition_name, "partition_name")
         check.inst_param(instance, "instance", DagsterInstance)
 
         return get_partition_tags(
             self._get_repo_def(repository_handle.repository_name),
-            partition_set_name=partition_set_name,
+            job_name=job_name,
             partition_name=partition_name,
             instance_ref=instance.get_ref(),
+            selected_asset_keys=selected_asset_keys,
         )
 
     def get_external_partition_names(
-        self, external_partition_set: ExternalPartitionSet, instance: DagsterInstance
+        self,
+        repository_handle: RepositoryHandle,
+        job_name: str,
+        instance: DagsterInstance,
+        selected_asset_keys: Optional[AbstractSet[AssetKey]],
     ) -> Union["ExternalPartitionNamesData", "ExternalPartitionExecutionErrorData"]:
-        check.inst_param(external_partition_set, "external_partition_set", ExternalPartitionSet)
-
-        # Prefer to return the names without calling out to user code if the
-        # partition set allows it
-        if external_partition_set.has_partition_name_data():
-            return ExternalPartitionNamesData(
-                partition_names=external_partition_set.get_partition_names(instance)
-            )
-
         return get_partition_names(
-            self._get_repo_def(external_partition_set.repository_handle.repository_name),
-            partition_set_name=external_partition_set.name,
+            self._get_repo_def(repository_handle.repository_name),
+            job_name=job_name,
+            selected_asset_keys=selected_asset_keys,
         )
 
     def get_external_schedule_execution_data(
@@ -826,47 +841,56 @@ class GrpcServerCodeLocation(CodeLocation):
     def get_external_partition_config(
         self,
         repository_handle: RepositoryHandle,
-        partition_set_name: str,
+        job_name: str,
         partition_name: str,
         instance: DagsterInstance,
     ) -> "ExternalPartitionConfigData":
         check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
-        check.str_param(partition_set_name, "partition_set_name")
+        check.str_param(job_name, "job_name")
         check.str_param(partition_name, "partition_name")
 
         return sync_get_external_partition_config_grpc(
-            self.client, repository_handle, partition_set_name, partition_name, instance
+            self.client, repository_handle, job_name, partition_name, instance
         )
 
     def get_external_partition_tags(
         self,
         repository_handle: RepositoryHandle,
-        partition_set_name: str,
+        job_name: str,
         partition_name: str,
         instance: DagsterInstance,
+        selected_asset_keys: Optional[AbstractSet[AssetKey]],
     ) -> "ExternalPartitionTagsData":
         check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
-        check.str_param(partition_set_name, "partition_set_name")
+        check.str_param(job_name, "job_name")
         check.str_param(partition_name, "partition_name")
 
         return sync_get_external_partition_tags_grpc(
-            self.client, repository_handle, partition_set_name, partition_name, instance
+            self.client, repository_handle, job_name, partition_name, instance, selected_asset_keys
         )
 
     def get_external_partition_names(
-        self, external_partition_set: ExternalPartitionSet, instance: DagsterInstance
+        self,
+        repository_handle: RepositoryHandle,
+        job_name: str,
+        instance: DagsterInstance,
+        selected_asset_keys: Optional[AbstractSet[AssetKey]],
     ) -> "ExternalPartitionNamesData":
-        check.inst_param(external_partition_set, "external_partition_set", ExternalPartitionSet)
+        external_repo = self.get_repository(repository_handle.repository_name)
+        partition_set_name = external_partition_set_name_for_job_name(job_name)
 
-        # Prefer to return the names without calling out to user code if the
-        # partition set allows it
-        if external_partition_set.has_partition_name_data():
-            return ExternalPartitionNamesData(
-                partition_names=external_partition_set.get_partition_names(instance=instance)
-            )
+        # Prefer to return the names without calling out to user code if there's a corresponding
+        # partition set that allows it
+        if external_repo.has_external_partition_set(partition_set_name):
+            external_partition_set = external_repo.get_external_partition_set(partition_set_name)
+
+            if external_partition_set.has_partition_name_data():
+                return ExternalPartitionNamesData(
+                    partition_names=external_partition_set.get_partition_names(instance=instance)
+                )
 
         return sync_get_external_partition_names_grpc(
-            self.client, external_partition_set.repository_handle, external_partition_set.name
+            self.client, repository_handle, job_name, selected_asset_keys
         )
 
     def get_external_schedule_execution_data(

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -875,20 +875,38 @@ class GrpcServerCodeLocation(CodeLocation):
         job_name: str,
         instance: DagsterInstance,
         selected_asset_keys: Optional[AbstractSet[AssetKey]],
-    ) -> "ExternalPartitionNamesData":
+    ) -> Union[ExternalPartitionNamesData, "ExternalPartitionExecutionErrorData"]:
         external_repo = self.get_repository(repository_handle.repository_name)
         partition_set_name = external_partition_set_name_for_job_name(job_name)
 
-        # Prefer to return the names without calling out to user code if there's a corresponding
-        # partition set that allows it
         if external_repo.has_external_partition_set(partition_set_name):
             external_partition_set = external_repo.get_external_partition_set(partition_set_name)
 
+            # Prefer to return the names without calling out to user code if there's a corresponding
+            # partition set that allows it
             if external_partition_set.has_partition_name_data():
                 return ExternalPartitionNamesData(
                     partition_names=external_partition_set.get_partition_names(instance=instance)
                 )
+            else:
+                return self._get_external_partition_names_from_code_server(
+                    repository_handle, job_name, selected_asset_keys
+                )
+        else:
+            # Asset jobs might have no corresponding partition set but still have partitioned
+            # assets, so we get the partition names using the assets.
+            return ExternalPartitionNamesData(
+                partition_names=external_repo.get_partition_names_for_asset_job(
+                    job_name=job_name, selected_asset_keys=selected_asset_keys, instance=instance
+                )
+            )
 
+    def _get_external_partition_names_from_code_server(
+        self,
+        repository_handle: RepositoryHandle,
+        job_name: str,
+        selected_asset_keys: Optional[AbstractSet[AssetKey]],
+    ) -> Union[ExternalPartitionNamesData, "ExternalPartitionExecutionErrorData"]:
         return sync_get_external_partition_names_grpc(
             self.client, repository_handle, job_name, selected_asset_keys
         )

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -12,6 +12,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    Set,
     Union,
 )
 
@@ -424,6 +425,33 @@ class ExternalRepository:
             ],
             external_asset_checks=self.get_external_asset_checks(),
         )
+
+    def get_partition_names_for_asset_job(
+        self,
+        job_name: str,
+        selected_asset_keys: Optional[AbstractSet[AssetKey]],
+        instance: DagsterInstance,
+    ) -> Sequence[str]:
+        asset_nodes = self.get_external_asset_nodes(job_name)
+        unique_partitions_defs: Set[PartitionsDefinition] = set()
+        for asset_node in asset_nodes:
+            if selected_asset_keys is not None and asset_node.asset_key not in selected_asset_keys:
+                continue
+
+            if asset_node.partitions_def_data is not None:
+                unique_partitions_defs.add(
+                    asset_node.partitions_def_data.get_partitions_definition()
+                )
+
+        if len(unique_partitions_defs) == 1:
+            return next(iter(unique_partitions_defs)).get_partition_keys(
+                dynamic_partitions_store=instance
+            )
+        else:
+            check.failed(
+                "There is no PartitionsDefinition shared by all the provided assets."
+                f" {len(unique_partitions_defs)} unique PartitionsDefinitions."
+            )
 
 
 class ExternalJob(RepresentedJob):

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -613,13 +613,14 @@ class DagsterApiServer(DagsterApiServicer):
     ) -> api_pb2.ExternalPartitionNamesReply:
         try:
             partition_names_args = deserialize_value(
-                request.serialized_partition_names_args,
-                PartitionNamesArgs,
+                request.serialized_partition_names_args, PartitionNamesArgs
             )
+
             serialized_response = serialize_value(
                 get_partition_names(
                     self._get_repo_for_origin(partition_names_args.repository_origin),
-                    partition_names_args.partition_set_name,
+                    job_name=partition_names_args.job_name,
+                    selected_asset_keys=partition_names_args.selected_asset_keys,
                 )
             )
         except Exception:
@@ -681,8 +682,8 @@ class DagsterApiServer(DagsterApiServicer):
             serialized_data = serialize_value(
                 get_partition_config(
                     self._get_repo_for_origin(args.repository_origin),
-                    args.partition_set_name,
-                    args.partition_name,
+                    job_name=args.job_name,
+                    partition_key=args.partition_name,
                     instance_ref=instance_ref,
                 )
             )
@@ -710,8 +711,9 @@ class DagsterApiServer(DagsterApiServicer):
             serialized_data = serialize_value(
                 get_partition_tags(
                     self._get_repo_for_origin(partition_args.repository_origin),
-                    partition_args.partition_set_name,
-                    partition_args.partition_name,
+                    job_name=partition_args.job_name,
+                    partition_name=partition_args.partition_name,
+                    selected_asset_keys=partition_args.selected_asset_keys,
                     instance_ref=instance_ref,
                 )
             )

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
@@ -1,14 +1,12 @@
 import string
 
 import pytest
-from dagster import AssetKey, ConfigurableResource, Definitions, StaticPartitionsDefinition, asset
 from dagster._api.snapshot_partition import (
     sync_get_external_partition_config_grpc,
     sync_get_external_partition_names_grpc,
     sync_get_external_partition_set_execution_param_data_grpc,
     sync_get_external_partition_tags_grpc,
 )
-from dagster._core.definitions.repository_definition import SINGLETON_REPOSITORY_NAME
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation import (
@@ -24,27 +22,7 @@ from dagster._serdes import deserialize_value
 
 ensure_dagster_tests_import()
 
-from dagster_tests.api_tests.utils import get_bar_repo_code_location, get_code_location  # noqa: I001
-
-
-def get_repo_with_differently_partitioned_assets():
-    @asset(partitions_def=StaticPartitionsDefinition(["1", "2"]))
-    def asset1(): ...
-
-    ab_partitions_def = StaticPartitionsDefinition(["a", "b"])
-
-    @asset(partitions_def=ab_partitions_def)
-    def asset2(): ...
-
-    class MyResource(ConfigurableResource):
-        foo: str
-
-    @asset(partitions_def=ab_partitions_def)
-    def asset3(resource1: MyResource): ...
-
-    return Definitions(
-        assets=[asset1, asset2, asset3], resources={"resource1": MyResource(foo="bar")}
-    ).get_repository_def()
+from dagster_tests.api_tests.utils import get_bar_repo_code_location
 
 
 def test_external_partition_names_grpc(instance: DagsterInstance):
@@ -67,23 +45,6 @@ def test_external_partition_names(instance: DagsterInstance):
         )
         assert isinstance(data, ExternalPartitionNamesData)
         assert data.partition_names == list(string.ascii_lowercase)
-
-
-def test_external_partition_names_asset_selection(instance: DagsterInstance):
-    with get_code_location(
-        python_file=__file__,
-        attribute="get_repo_with_differently_partitioned_assets",
-        location_name="something",
-        instance=instance,
-    ) as code_location:
-        data = code_location.get_external_partition_names(
-            repository_handle=code_location.get_repository(SINGLETON_REPOSITORY_NAME).handle,
-            job_name="__ASSET_JOB",
-            instance=instance,
-            selected_asset_keys={AssetKey("asset2"), AssetKey("asset3")},
-        )
-        assert isinstance(data, ExternalPartitionNamesData)
-        assert data.partition_names == ["a", "b"]
 
 
 def test_external_partition_names_deserialize_error_grpc(instance: DagsterInstance):

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
@@ -1,12 +1,15 @@
 import string
 
 import pytest
+from dagster import AssetKey, ConfigurableResource, Definitions, StaticPartitionsDefinition, asset
 from dagster._api.snapshot_partition import (
     sync_get_external_partition_config_grpc,
     sync_get_external_partition_names_grpc,
     sync_get_external_partition_set_execution_param_data_grpc,
     sync_get_external_partition_tags_grpc,
 )
+from dagster._core.definitions.asset_job import IMPLICIT_ASSET_JOB_NAME
+from dagster._core.definitions.repository_definition import SINGLETON_REPOSITORY_NAME
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation import (
@@ -16,20 +19,72 @@ from dagster._core.remote_representation import (
     ExternalPartitionSetExecutionParamData,
     ExternalPartitionTagsData,
 )
+from dagster._core.test_utils import ensure_dagster_tests_import
 from dagster._grpc.types import PartitionArgs, PartitionNamesArgs, PartitionSetExecutionParamArgs
 from dagster._serdes import deserialize_value
 
-from .utils import get_bar_repo_code_location
+ensure_dagster_tests_import()
+
+from dagster_tests.api_tests.utils import get_bar_repo_code_location, get_code_location  # noqa: I001
+
+
+def get_repo_with_differently_partitioned_assets():
+    @asset(partitions_def=StaticPartitionsDefinition(["1", "2"]))
+    def asset1(): ...
+
+    ab_partitions_def = StaticPartitionsDefinition(["a", "b"])
+
+    @asset(partitions_def=ab_partitions_def)
+    def asset2(): ...
+
+    class MyResource(ConfigurableResource):
+        foo: str
+
+    @asset(partitions_def=ab_partitions_def)
+    def asset3(resource1: MyResource): ...
+
+    return Definitions(
+        assets=[asset1, asset2, asset3], resources={"resource1": MyResource(foo="bar")}
+    ).get_repository_def()
 
 
 def test_external_partition_names_grpc(instance: DagsterInstance):
     with get_bar_repo_code_location(instance) as code_location:
         repository_handle = code_location.get_repository("bar_repo").handle
         data = sync_get_external_partition_names_grpc(
-            code_location.client, repository_handle, "baz_partition_set"
+            code_location.client, repository_handle, "baz", None
         )
         assert isinstance(data, ExternalPartitionNamesData)
         assert data.partition_names == list(string.ascii_lowercase)
+
+
+def test_external_partition_names(instance: DagsterInstance):
+    with get_bar_repo_code_location(instance) as code_location:
+        data = code_location.get_external_partition_names(
+            repository_handle=code_location.get_repository("bar_repo").handle,
+            job_name="baz",
+            instance=instance,
+            selected_asset_keys=None,
+        )
+        assert isinstance(data, ExternalPartitionNamesData)
+        assert data.partition_names == list(string.ascii_lowercase)
+
+
+def test_external_partition_names_asset_selection(instance: DagsterInstance):
+    with get_code_location(
+        python_file=__file__,
+        attribute="get_repo_with_differently_partitioned_assets",
+        location_name="something",
+        instance=instance,
+    ) as code_location:
+        data = code_location.get_external_partition_names(
+            repository_handle=code_location.get_repository(SINGLETON_REPOSITORY_NAME).handle,
+            job_name=IMPLICIT_ASSET_JOB_NAME,
+            instance=instance,
+            selected_asset_keys={AssetKey("asset2"), AssetKey("asset3")},
+        )
+        assert isinstance(data, ExternalPartitionNamesData)
+        assert data.partition_names == ["a", "b"]
 
 
 def test_external_partition_names_deserialize_error_grpc(instance: DagsterInstance):
@@ -57,11 +112,42 @@ def test_external_partitions_config_grpc(instance: DagsterInstance):
         repository_handle = code_location.get_repository("bar_repo").handle
 
         data = sync_get_external_partition_config_grpc(
-            code_location.client, repository_handle, "baz_partition_set", "c", instance
+            code_location.client, repository_handle, "baz", "c", instance
         )
         assert isinstance(data, ExternalPartitionConfigData)
         assert data.run_config
         assert data.run_config["ops"]["do_input"]["inputs"]["x"]["value"] == "c"  # type: ignore
+
+
+def test_external_partition_config(instance: DagsterInstance):
+    with get_bar_repo_code_location(instance) as code_location:
+        data = code_location.get_external_partition_config(
+            job_name="baz",
+            repository_handle=code_location.get_repository("bar_repo").handle,
+            partition_name="c",
+            instance=instance,
+        )
+
+        assert isinstance(data, ExternalPartitionConfigData)
+        assert data.run_config
+        assert data.run_config["ops"]["do_input"]["inputs"]["x"]["value"] == "c"  # type: ignore
+
+
+def test_external_partition_config_different_partitions_defs(instance: DagsterInstance):
+    with get_code_location(
+        python_file=__file__,
+        attribute="get_repo_with_differently_partitioned_assets",
+        location_name="something",
+        instance=instance,
+    ) as code_location:
+        data = code_location.get_external_partition_config(
+            job_name=IMPLICIT_ASSET_JOB_NAME,
+            repository_handle=code_location.get_repository(SINGLETON_REPOSITORY_NAME).handle,
+            partition_name="b",
+            instance=instance,
+        )
+        assert isinstance(data, ExternalPartitionConfigData)
+        assert data.run_config == {}
 
 
 def test_external_partitions_config_error_grpc(instance: DagsterInstance):
@@ -70,11 +156,7 @@ def test_external_partitions_config_error_grpc(instance: DagsterInstance):
 
         with pytest.raises(DagsterUserCodeProcessError):
             sync_get_external_partition_config_grpc(
-                code_location.client,
-                repository_handle,
-                "error_partition_config",
-                "c",
-                instance,
+                code_location.client, repository_handle, "error_partition_config", "c", instance
             )
 
 
@@ -105,11 +187,50 @@ def test_external_partitions_tags_grpc(instance: DagsterInstance):
         repository_handle = code_location.get_repository("bar_repo").handle
 
         data = sync_get_external_partition_tags_grpc(
-            code_location.client, repository_handle, "baz_partition_set", "c", instance=instance
+            code_location.client,
+            repository_handle,
+            "baz",
+            "c",
+            instance=instance,
+            selected_asset_keys=None,
         )
         assert isinstance(data, ExternalPartitionTagsData)
         assert data.tags
         assert data.tags["foo"] == "bar"
+
+
+def test_external_partition_tags(instance: DagsterInstance):
+    with get_bar_repo_code_location(instance) as code_location:
+        data = code_location.get_external_partition_tags(
+            repository_handle=code_location.get_repository("bar_repo").handle,
+            job_name="baz",
+            partition_name="c",
+            instance=instance,
+            selected_asset_keys=None,
+        )
+
+        assert isinstance(data, ExternalPartitionTagsData)
+        assert data.tags
+        assert data.tags["foo"] == "bar"
+
+
+def test_external_partition_tags_different_partitions_defs(instance: DagsterInstance):
+    with get_code_location(
+        python_file=__file__,
+        attribute="get_repo_with_differently_partitioned_assets",
+        location_name="something",
+        instance=instance,
+    ) as code_location:
+        data = code_location.get_external_partition_tags(
+            repository_handle=code_location.get_repository(SINGLETON_REPOSITORY_NAME).handle,
+            job_name=IMPLICIT_ASSET_JOB_NAME,
+            selected_asset_keys={AssetKey("asset2"), AssetKey("asset3")},
+            partition_name="b",
+            instance=instance,
+        )
+        assert isinstance(data, ExternalPartitionTagsData)
+        assert data.tags
+        assert data.tags["dagster/partition"] == "b"
 
 
 def test_external_partitions_tags_deserialize_error_grpc(instance: DagsterInstance):
@@ -140,7 +261,7 @@ def test_external_partitions_tags_error_grpc(instance: DagsterInstance):
 
         with pytest.raises(DagsterUserCodeProcessError):
             sync_get_external_partition_tags_grpc(
-                code_location.client, repository_handle, "error_partition_tags", "c", instance
+                code_location.client, repository_handle, "error_partition_tags", "c", instance, None
             )
 
 
@@ -197,22 +318,14 @@ def test_dynamic_partition_set_grpc(instance: DagsterInstance):
         assert len(data.partition_data) == 3
 
         data = sync_get_external_partition_config_grpc(
-            code_location.client,
-            repository_handle,
-            "dynamic_job_partition_set",
-            "a",
-            instance,
+            code_location.client, repository_handle, "dynamic_job", "a", instance
         )
         assert isinstance(data, ExternalPartitionConfigData)
         assert data.name == "a"
         assert data.run_config == {}
 
         data = sync_get_external_partition_tags_grpc(
-            code_location.client,
-            repository_handle,
-            "dynamic_job_partition_set",
-            "a",
-            instance,
+            code_location.client, repository_handle, "dynamic_job", "a", instance, None
         )
         assert isinstance(data, ExternalPartitionTagsData)
         assert data.tags
@@ -227,21 +340,3 @@ def test_dynamic_partition_set_grpc(instance: DagsterInstance):
         )
         assert isinstance(data, ExternalPartitionSetExecutionParamData)
         assert data.partition_data == []
-
-        with pytest.raises(DagsterUserCodeProcessError, match="Could not find a partition"):
-            sync_get_external_partition_config_grpc(
-                code_location.client,
-                repository_handle,
-                "dynamic_job_partition_set",
-                "nonexistent_partition",
-                instance,
-            )
-
-        with pytest.raises(DagsterUserCodeProcessError, match="Could not find a partition"):
-            sync_get_external_partition_tags_grpc(
-                code_location.client,
-                repository_handle,
-                "dynamic_job_partition_set",
-                "nonexistent_partition",
-                instance,
-            )

--- a/python_modules/dagster/dagster_tests/api_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/api_tests/utils.py
@@ -49,6 +49,28 @@ def get_bar_repo_code_location(
 
 
 @contextmanager
+def get_code_location(
+    python_file: str,
+    attribute: str,
+    location_name: str,
+    instance: Optional[DagsterInstance] = None,
+) -> Iterator[GrpcServerCodeLocation]:
+    with ExitStack() as stack:
+        if not instance:
+            instance = stack.enter_context(instance_for_test())
+
+        loadable_target_origin = LoadableTargetOrigin(
+            executable_path=sys.executable,
+            python_file=python_file,
+            attribute=attribute,
+        )
+        origin = ManagedGrpcPythonEnvCodeLocationOrigin(loadable_target_origin, location_name)
+
+        with origin.create_single_location(instance) as location:
+            yield location
+
+
+@contextmanager
 def get_bar_repo_handle(instance: Optional[DagsterInstance] = None) -> Iterator[RepositoryHandle]:
     with ExitStack() as stack:
         if not instance:

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_materialize_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_materialize_command.py
@@ -118,8 +118,8 @@ def test_conflicting_partitions():
     with instance_for_test():
         result = invoke_materialize("partitioned_asset,differently_partitioned_asset")
         assert (
-            "All selected assets must share the same PartitionsDefinition or have no"
-            " PartitionsDefinition" in str(result.exception)
+            "All selected assets must share the same PartitionsDefinition or have no PartitionsDefinition"
+            in str(result.exception)
         )
 
 


### PR DESCRIPTION
## Summary & Motivation

This builds on top of https://github.com/dagster-io/dagster/pull/23527 to do two related things:
- On the host process side, refactors `CodeLocation` methods and call sites to use job names and selected asset keys instead of partition set names.
- On the user code process side, updates the implementations of grpc APIs that fetch partition information to pass selected asset keys to the `JobDefinition`.

## How I Tested These Changes
