### PR TITLE
[single-implicit-asset-job] add `partitionKeysOrError` and `partition` to `GrapheneJob`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -1076,6 +1076,24 @@ type Pipeline implements SolidContainer & IPipelineSnapshot {
   isJob: Boolean!
   isAssetJob: Boolean!
   repository: Repository!
+  partitionKeysOrError(
+    cursor: String
+    limit: Int
+    reverse: Boolean
+    selectedAssetKeys: [AssetKeyInput!]
+  ): PartitionKeys!
+  partition(partitionName: String!, selectedAssetKeys: [AssetKeyInput!]): PartitionTagsAndConfig
+}
+
+type PartitionKeys {
+  partitionKeys: [String!]!
+}
+
+type PartitionTagsAndConfig {
+  name: String!
+  jobName: String!
+  runConfigOrError: PartitionRunConfigOrError!
+  tagsOrError: PartitionTagsOrError!
 }
 
 interface PipelineConfigValidationError {
@@ -2125,6 +2143,13 @@ type Job implements SolidContainer & IPipelineSnapshot {
   isJob: Boolean!
   isAssetJob: Boolean!
   repository: Repository!
+  partitionKeysOrError(
+    cursor: String
+    limit: Int
+    reverse: Boolean
+    selectedAssetKeys: [AssetKeyInput!]
+  ): PartitionKeys!
+  partition(partitionName: String!, selectedAssetKeys: [AssetKeyInput!]): PartitionTagsAndConfig
 }
 
 enum SensorType {
@@ -3507,10 +3532,6 @@ type AutoMaterializeRuleEvaluation {
 }
 
 union PartitionKeysOrError = PartitionKeys | PartitionSubsetDeserializationError
-
-type PartitionKeys {
-  partitionKeys: [String!]!
-}
 
 type PartitionSubsetDeserializationError implements Error {
   message: String!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2074,6 +2074,8 @@ export type Job = IPipelineSnapshot &
     modes: Array<Mode>;
     name: Scalars['String']['output'];
     parentSnapshotId: Maybe<Scalars['String']['output']>;
+    partition: Maybe<PartitionTagsAndConfig>;
+    partitionKeysOrError: PartitionKeys;
     pipelineSnapshotId: Scalars['String']['output'];
     presets: Array<PipelinePreset>;
     repository: Repository;
@@ -2088,6 +2090,18 @@ export type Job = IPipelineSnapshot &
 
 export type JobDagsterTypeOrErrorArgs = {
   dagsterTypeName: Scalars['String']['input'];
+};
+
+export type JobPartitionArgs = {
+  partitionName: Scalars['String']['input'];
+  selectedAssetKeys?: InputMaybe<Array<AssetKeyInput>>;
+};
+
+export type JobPartitionKeysOrErrorArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  reverse?: InputMaybe<Scalars['Boolean']['input']>;
+  selectedAssetKeys?: InputMaybe<Array<AssetKeyInput>>;
 };
 
 export type JobRunsArgs = {
@@ -3262,6 +3276,14 @@ export type PartitionTags = {
   results: Array<PipelineTag>;
 };
 
+export type PartitionTagsAndConfig = {
+  __typename: 'PartitionTagsAndConfig';
+  jobName: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  runConfigOrError: PartitionRunConfigOrError;
+  tagsOrError: PartitionTagsOrError;
+};
+
 export type PartitionTagsOrError = PartitionTags | PythonError;
 
 export type PartitionedAssetConditionEvaluationNode = {
@@ -3348,6 +3370,8 @@ export type Pipeline = IPipelineSnapshot &
     modes: Array<Mode>;
     name: Scalars['String']['output'];
     parentSnapshotId: Maybe<Scalars['String']['output']>;
+    partition: Maybe<PartitionTagsAndConfig>;
+    partitionKeysOrError: PartitionKeys;
     pipelineSnapshotId: Scalars['String']['output'];
     presets: Array<PipelinePreset>;
     repository: Repository;
@@ -3362,6 +3386,18 @@ export type Pipeline = IPipelineSnapshot &
 
 export type PipelineDagsterTypeOrErrorArgs = {
   dagsterTypeName: Scalars['String']['input'];
+};
+
+export type PipelinePartitionArgs = {
+  partitionName: Scalars['String']['input'];
+  selectedAssetKeys?: InputMaybe<Array<AssetKeyInput>>;
+};
+
+export type PipelinePartitionKeysOrErrorArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  reverse?: InputMaybe<Scalars['Boolean']['input']>;
+  selectedAssetKeys?: InputMaybe<Array<AssetKeyInput>>;
 };
 
 export type PipelineRunsArgs = {
@@ -9054,6 +9090,18 @@ export const buildJob = (
       overrides && overrides.hasOwnProperty('parentSnapshotId')
         ? overrides.parentSnapshotId!
         : 'tempore',
+    partition:
+      overrides && overrides.hasOwnProperty('partition')
+        ? overrides.partition!
+        : relationshipsToOmit.has('PartitionTagsAndConfig')
+        ? ({} as PartitionTagsAndConfig)
+        : buildPartitionTagsAndConfig({}, relationshipsToOmit),
+    partitionKeysOrError:
+      overrides && overrides.hasOwnProperty('partitionKeysOrError')
+        ? overrides.partitionKeysOrError!
+        : relationshipsToOmit.has('PartitionKeys')
+        ? ({} as PartitionKeys)
+        : buildPartitionKeys({}, relationshipsToOmit),
     pipelineSnapshotId:
       overrides && overrides.hasOwnProperty('pipelineSnapshotId')
         ? overrides.pipelineSnapshotId!
@@ -11040,6 +11088,31 @@ export const buildPartitionTags = (
   };
 };
 
+export const buildPartitionTagsAndConfig = (
+  overrides?: Partial<PartitionTagsAndConfig>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'PartitionTagsAndConfig'} & PartitionTagsAndConfig => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('PartitionTagsAndConfig');
+  return {
+    __typename: 'PartitionTagsAndConfig',
+    jobName: overrides && overrides.hasOwnProperty('jobName') ? overrides.jobName! : 'quia',
+    name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : 'eaque',
+    runConfigOrError:
+      overrides && overrides.hasOwnProperty('runConfigOrError')
+        ? overrides.runConfigOrError!
+        : relationshipsToOmit.has('PartitionRunConfig')
+        ? ({} as PartitionRunConfig)
+        : buildPartitionRunConfig({}, relationshipsToOmit),
+    tagsOrError:
+      overrides && overrides.hasOwnProperty('tagsOrError')
+        ? overrides.tagsOrError!
+        : relationshipsToOmit.has('PartitionTags')
+        ? ({} as PartitionTags)
+        : buildPartitionTags({}, relationshipsToOmit),
+  };
+};
+
 export const buildPartitionedAssetConditionEvaluationNode = (
   overrides?: Partial<PartitionedAssetConditionEvaluationNode>,
   _relationshipsToOmit: Set<string> = new Set(),
@@ -11201,6 +11274,18 @@ export const buildPipeline = (
       overrides && overrides.hasOwnProperty('parentSnapshotId')
         ? overrides.parentSnapshotId!
         : 'et',
+    partition:
+      overrides && overrides.hasOwnProperty('partition')
+        ? overrides.partition!
+        : relationshipsToOmit.has('PartitionTagsAndConfig')
+        ? ({} as PartitionTagsAndConfig)
+        : buildPartitionTagsAndConfig({}, relationshipsToOmit),
+    partitionKeysOrError:
+      overrides && overrides.hasOwnProperty('partitionKeysOrError')
+        ? overrides.partitionKeysOrError!
+        : relationshipsToOmit.has('PartitionKeys')
+        ? ({} as PartitionKeys)
+        : buildPartitionKeys({}, relationshipsToOmit),
     pipelineSnapshotId:
       overrides && overrides.hasOwnProperty('pipelineSnapshotId')
         ? overrides.pipelineSnapshotId!

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -290,5 +290,29 @@ class ExecutionMetadata(
         }
 
 
+def apply_cursor_limit_reverse(
+    items: Sequence[str], cursor: Optional[str], limit: Optional[int], reverse: Optional[bool]
+) -> Sequence[str]:
+    start = 0
+    end = len(items)
+    index = 0
+
+    if cursor:
+        index = next((idx for (idx, item) in enumerate(items) if item == cursor))
+
+        if reverse:
+            end = index
+        else:
+            start = index + 1
+
+    if limit:
+        if reverse:
+            start = end - limit
+        else:
+            end = start + limit
+
+    return items[max(start, 0) : end]
+
+
 BackfillParams: TypeAlias = Mapping[str, Any]
 AssetBackfillPreviewParams: TypeAlias = Mapping[str, Any]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -15,30 +15,10 @@ from dagster_graphql.schema.errors import GrapheneError
 
 from .asset_key import GrapheneAssetKey
 from .auto_materialize_policy import GrapheneAutoMaterializeRule
+from .partition_keys import GraphenePartitionKeys, GraphenePartitionKeysOrError
 from .util import non_null_list
 
 GrapheneAutoMaterializeDecisionType = graphene.Enum.from_enum(AutoMaterializeDecisionType)
-
-
-class GraphenePartitionKeys(graphene.ObjectType):
-    partitionKeys = non_null_list(graphene.String)
-
-    class Meta:
-        name = "PartitionKeys"
-
-
-class GraphenePartitionSubsetDeserializationError(graphene.ObjectType):
-    message = graphene.NonNull(graphene.String)
-
-    class Meta:
-        interfaces = (GrapheneError,)
-        name = "PartitionSubsetDeserializationError"
-
-
-class GraphenePartitionKeysOrError(graphene.Union):
-    class Meta:
-        types = (GraphenePartitionKeys, GraphenePartitionSubsetDeserializationError)
-        name = "PartitionKeysOrError"
 
 
 class GrapheneTextRuleEvaluationData(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -1,4 +1,5 @@
 import graphene
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.events import DagsterEventType
 from dagster._core.storage.dagster_run import DagsterRunStatus, RunsFilter
 from dagster._time import datetime_from_timestamp
@@ -14,6 +15,9 @@ class GrapheneAssetKeyInput(graphene.InputObjectType):
 
     class Meta:
         name = "AssetKeyInput"
+
+    def to_asset_key(self) -> AssetKey:
+        return AssetKey(self.path)
 
 
 class GrapheneAssetCheckHandleInput(graphene.InputObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_keys.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_keys.py
@@ -1,0 +1,26 @@
+import graphene
+
+from dagster_graphql.schema.errors import GrapheneError
+
+from .util import non_null_list
+
+
+class GraphenePartitionKeys(graphene.ObjectType):
+    partitionKeys = non_null_list(graphene.String)
+
+    class Meta:
+        name = "PartitionKeys"
+
+
+class GraphenePartitionSubsetDeserializationError(graphene.ObjectType):
+    message = graphene.NonNull(graphene.String)
+
+    class Meta:
+        interfaces = (GrapheneError,)
+        name = "PartitionSubsetDeserializationError"
+
+
+class GraphenePartitionKeysOrError(graphene.Union):
+    class Meta:
+        types = (GraphenePartitionKeys, GraphenePartitionSubsetDeserializationError)
+        name = "PartitionKeysOrError"

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -1,11 +1,17 @@
-from typing import List, Optional, Sequence
+from typing import TYPE_CHECKING, AbstractSet, List, Optional, Sequence
 
 import dagster._check as check
 import graphene
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.time_window_partitions import PartitionRangeStatus
+from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.events import DagsterEventType
 from dagster._core.remote_representation.external import ExternalExecutionPlan, ExternalJob
-from dagster._core.remote_representation.external_data import DEFAULT_MODE_NAME, ExternalPresetData
+from dagster._core.remote_representation.external_data import (
+    DEFAULT_MODE_NAME,
+    ExternalPartitionExecutionErrorData,
+    ExternalPresetData,
+)
 from dagster._core.remote_representation.represented import RepresentedJob
 from dagster._core.storage.dagster_run import (
     DagsterRunStatsSnapshot,
@@ -26,7 +32,11 @@ from ...implementation.fetch_pipelines import get_job_reference_or_raise
 from ...implementation.fetch_runs import get_runs, get_stats, get_step_stats
 from ...implementation.fetch_schedules import get_schedules_for_pipeline
 from ...implementation.fetch_sensors import get_sensors_for_pipeline
-from ...implementation.utils import UserFacingGraphQLError, capture_error
+from ...implementation.utils import (
+    UserFacingGraphQLError,
+    apply_cursor_limit_reverse,
+    capture_error,
+)
 from ..asset_checks import GrapheneAssetCheckHandle
 from ..asset_key import GrapheneAssetKey
 from ..dagster_types import (
@@ -37,6 +47,7 @@ from ..dagster_types import (
 )
 from ..errors import GrapheneDagsterTypeNotFoundError, GraphenePythonError, GrapheneRunNotFoundError
 from ..execution import GrapheneExecutionPlan
+from ..inputs import GrapheneAssetKeyInput
 from ..logs.compute_logs import GrapheneCapturedLogs, from_captured_log_data
 from ..logs.events import (
     GrapheneDagsterRunEvent,
@@ -44,6 +55,7 @@ from ..logs.events import (
     GrapheneObservationEvent,
     GrapheneRunStepStats,
 )
+from ..partition_keys import GraphenePartitionKeys
 from ..repository_origin import GrapheneRepositoryOrigin
 from ..runs import GrapheneRunConfigData
 from ..runs_feed import GrapheneRunsFeedEntry
@@ -62,6 +74,10 @@ from .mode import GrapheneMode
 from .pipeline_ref import GraphenePipelineReference
 from .pipeline_run_stats import GrapheneRunStatsSnapshotOrError
 from .status import GrapheneRunStatus
+
+if TYPE_CHECKING:
+    from ..partition_sets import GrapheneJobSelectionPartition
+
 
 STARTED_STATUSES = {
     DagsterRunStatus.STARTED,
@@ -871,6 +887,22 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
     isJob = graphene.NonNull(graphene.Boolean)
     isAssetJob = graphene.NonNull(graphene.Boolean)
     repository = graphene.NonNull("dagster_graphql.schema.external.GrapheneRepository")
+    partitionKeysOrError = graphene.Field(
+        graphene.NonNull(GraphenePartitionKeys),
+        cursor=graphene.String(),
+        limit=graphene.Int(),
+        reverse=graphene.Boolean(),
+        selected_asset_keys=graphene.Argument(
+            graphene.List(graphene.NonNull(GrapheneAssetKeyInput))
+        ),
+    )
+    partition = graphene.Field(
+        "dagster_graphql.schema.partition_sets.GrapheneJobSelectionPartition",
+        partition_name=graphene.NonNull(graphene.String),
+        selected_asset_keys=graphene.Argument(
+            graphene.List(graphene.NonNull(GrapheneAssetKeyInput))
+        ),
+    )
 
     class Meta:
         interfaces = (GrapheneSolidContainer, GrapheneIPipelineSnapshot)
@@ -910,6 +942,47 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
             graphene_info.context,
             location.get_repository(handle.repository_name),
             location,
+        )
+
+    @capture_error
+    def resolve_partitionKeysOrError(
+        self,
+        graphene_info: ResolveInfo,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+        reverse: Optional[bool] = None,
+        selected_asset_keys: Optional[List[GrapheneAssetKeyInput]] = None,
+    ) -> GraphenePartitionKeys:
+        result = graphene_info.context.get_external_partition_names(
+            repository_handle=self._external_job.repository_handle,
+            job_name=self._external_job.name,
+            selected_asset_keys=_asset_key_input_list_to_asset_key_set(selected_asset_keys),
+            instance=graphene_info.context.instance,
+        )
+
+        if isinstance(result, ExternalPartitionExecutionErrorData):
+            raise DagsterUserCodeProcessError.from_error_info(result.error)
+
+        all_partition_keys = result.partition_names
+
+        return GraphenePartitionKeys(
+            partitionKeys=apply_cursor_limit_reverse(
+                all_partition_keys, cursor=cursor, limit=limit, reverse=reverse or False
+            )
+        )
+
+    def resolve_partition(
+        self,
+        graphene_info: ResolveInfo,
+        partition_name: str,
+        selected_asset_keys: Optional[List[GrapheneAssetKeyInput]] = None,
+    ) -> "GrapheneJobSelectionPartition":
+        from ..partition_sets import GrapheneJobSelectionPartition
+
+        return GrapheneJobSelectionPartition(
+            external_job=self._external_job,
+            partition_name=partition_name,
+            selected_asset_keys=_asset_key_input_list_to_asset_key_set(selected_asset_keys),
         )
 
 
@@ -992,3 +1065,11 @@ class GrapheneRunOrError(graphene.Union):
     class Meta:
         types = (GrapheneRun, GrapheneRunNotFoundError, GraphenePythonError)
         name = "RunOrError"
+
+
+def _asset_key_input_list_to_asset_key_set(
+    asset_keys: Optional[List[GrapheneAssetKeyInput]],
+) -> Optional[AbstractSet[AssetKey]]:
+    return (
+        {key_input.to_asset_key() for key_input in asset_keys} if asset_keys is not None else None
+    )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_job_partitions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_job_partitions.py
@@ -1,0 +1,263 @@
+from dagster import (
+    AssetKey,
+    ConfigurableResource,
+    Definitions,
+    StaticPartitionsDefinition,
+    asset,
+    job,
+    op,
+    static_partitioned_config,
+)
+from dagster._core.definitions.repository_definition import SINGLETON_REPOSITORY_NAME
+from dagster._core.test_utils import ensure_dagster_tests_import, instance_for_test
+from dagster_graphql.test.utils import define_out_of_process_context, execute_dagster_graphql
+
+ensure_dagster_tests_import()
+
+
+GET_PARTITIONS_QUERY = """
+    query SingleJobQuery($selector: PipelineSelector!, $selectedAssetKeys: [AssetKeyInput!]) {
+        pipelineOrError(params: $selector) {
+            ... on Pipeline {
+                name
+                partitionKeysOrError(selectedAssetKeys: $selectedAssetKeys) {
+                    partitionKeys
+                }
+            }
+        }
+    }
+"""
+
+GET_PARTITION_TAGS_QUERY = """
+    query SingleJobQuery($selector: PipelineSelector!, $partitionName: String!, $selectedAssetKeys: [AssetKeyInput!]) {
+        pipelineOrError(params: $selector) {
+            ... on Pipeline {
+                name
+                partition(partitionName: $partitionName, selectedAssetKeys: $selectedAssetKeys) {
+                    name
+                    tagsOrError {
+                        ... on PartitionTags {
+                            results {
+                                key
+                                value
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+GET_PARTITION_RUN_CONFIG_QUERY = """
+    query SingleJobQuery($selector: PipelineSelector!, $partitionName: String!, $selectedAssetKeys: [AssetKeyInput!]) {
+        pipelineOrError(params: $selector) {
+            ... on Pipeline {
+                name
+                partition(partitionName: $partitionName, selectedAssetKeys: $selectedAssetKeys) {
+                    name
+                    runConfigOrError {
+                        ... on PartitionRunConfig {
+                            yaml
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+
+def get_repo_with_partitioned_op_job():
+    @op
+    def op1(): ...
+
+    @static_partitioned_config(["1", "2"])
+    def my_partitioned_config(partition):
+        return {"ops": {"op1": {"config": {"p": partition}}}}
+
+    @job(config=my_partitioned_config)
+    def job1():
+        op1()
+
+    return Definitions(jobs=[job1]).get_repository_def()
+
+
+def get_repo_with_differently_partitioned_assets():
+    @asset(partitions_def=StaticPartitionsDefinition(["1", "2"]))
+    def asset1(): ...
+
+    ab_partitions_def = StaticPartitionsDefinition(["a", "b"])
+
+    @asset(partitions_def=ab_partitions_def)
+    def asset2(): ...
+
+    class MyResource(ConfigurableResource):
+        foo: str
+
+    @asset(partitions_def=ab_partitions_def)
+    def asset3(resource1: MyResource): ...
+
+    return Definitions(
+        assets=[asset1, asset2, asset3], resources={"resource1": MyResource(foo="bar")}
+    ).get_repository_def()
+
+
+def test_get_partition_names():
+    with instance_for_test() as instance:
+        with define_out_of_process_context(
+            __file__, "get_repo_with_partitioned_op_job", instance
+        ) as context:
+            result = execute_dagster_graphql(
+                context,
+                GET_PARTITIONS_QUERY,
+                variables={
+                    "selector": {
+                        "repositoryLocationName": context.code_location_names[0],
+                        "repositoryName": SINGLETON_REPOSITORY_NAME,
+                        "pipelineName": "job1",
+                    }
+                },
+            )
+            assert result.data["pipelineOrError"]["name"] == "job1"
+            assert result.data["pipelineOrError"]["partitionKeysOrError"]["partitionKeys"] == [
+                "1",
+                "2",
+            ]
+
+
+def test_get_partition_names_asset_selection():
+    with instance_for_test() as instance:
+        with define_out_of_process_context(
+            __file__, "get_repo_with_differently_partitioned_assets", instance
+        ) as context:
+            result = execute_dagster_graphql(
+                context,
+                GET_PARTITIONS_QUERY,
+                variables={
+                    "selector": {
+                        "repositoryLocationName": context.code_location_names[0],
+                        "repositoryName": SINGLETON_REPOSITORY_NAME,
+                        "pipelineName": "__ASSET_JOB",
+                    },
+                    "selectedAssetKeys": [
+                        AssetKey("asset2").to_graphql_input(),
+                        AssetKey("asset3").to_graphql_input(),
+                    ],
+                },
+            )
+            assert result.data["pipelineOrError"]["name"] == "__ASSET_JOB"
+            assert result.data["pipelineOrError"]["partitionKeysOrError"]["partitionKeys"] == [
+                "a",
+                "b",
+            ]
+
+
+def test_get_partition_tags():
+    with instance_for_test() as instance:
+        with define_out_of_process_context(
+            __file__, "get_repo_with_partitioned_op_job", instance
+        ) as context:
+            result = execute_dagster_graphql(
+                context,
+                GET_PARTITION_TAGS_QUERY,
+                variables={
+                    "selector": {
+                        "repositoryLocationName": context.code_location_names[0],
+                        "repositoryName": SINGLETON_REPOSITORY_NAME,
+                        "pipelineName": "job1",
+                    },
+                    "partitionName": "1",
+                },
+            )
+            assert result.data["pipelineOrError"]["name"] == "job1"
+            result_partition = result.data["pipelineOrError"]["partition"]
+            assert result_partition["name"] == "1"
+            assert {
+                item["key"]: item["value"] for item in result_partition["tagsOrError"]["results"]
+            } == {
+                "dagster/partition": "1",
+                "dagster/partition_set": "job1_partition_set",
+            }
+
+
+def test_get_partition_tags_asset_selection():
+    with instance_for_test() as instance:
+        with define_out_of_process_context(
+            __file__, "get_repo_with_differently_partitioned_assets", instance
+        ) as context:
+            result = execute_dagster_graphql(
+                context,
+                GET_PARTITION_TAGS_QUERY,
+                variables={
+                    "selector": {
+                        "repositoryLocationName": context.code_location_names[0],
+                        "repositoryName": SINGLETON_REPOSITORY_NAME,
+                        "pipelineName": "__ASSET_JOB",
+                    },
+                    "selectedAssetKeys": [
+                        AssetKey("asset2").to_graphql_input(),
+                        AssetKey("asset3").to_graphql_input(),
+                    ],
+                    "partitionName": "b",
+                },
+            )
+            assert result.data["pipelineOrError"]["name"] == "__ASSET_JOB"
+            result_partition = result.data["pipelineOrError"]["partition"]
+            assert result_partition["name"] == "b"
+            assert {
+                item["key"]: item["value"] for item in result_partition["tagsOrError"]["results"]
+            } == {"dagster/partition": "b"}
+
+
+def test_get_partition_config():
+    with instance_for_test() as instance:
+        with define_out_of_process_context(
+            __file__, "get_repo_with_partitioned_op_job", instance
+        ) as context:
+            result = execute_dagster_graphql(
+                context,
+                GET_PARTITION_RUN_CONFIG_QUERY,
+                variables={
+                    "selector": {
+                        "repositoryLocationName": context.code_location_names[0],
+                        "repositoryName": SINGLETON_REPOSITORY_NAME,
+                        "pipelineName": "job1",
+                    },
+                    "partitionName": "1",
+                },
+            )
+            assert result.data["pipelineOrError"]["name"] == "job1"
+            result_partition = result.data["pipelineOrError"]["partition"]
+            assert result_partition["name"] == "1"
+            assert (
+                result_partition["runConfigOrError"]["yaml"]
+                == """ops:\n  op1:\n    config:\n      p: '1'\n"""
+            )
+
+
+def test_get_partition_config_asset_selection():
+    with instance_for_test() as instance:
+        with define_out_of_process_context(
+            __file__, "get_repo_with_differently_partitioned_assets", instance
+        ) as context:
+            result = execute_dagster_graphql(
+                context,
+                GET_PARTITION_RUN_CONFIG_QUERY,
+                variables={
+                    "selector": {
+                        "repositoryLocationName": context.code_location_names[0],
+                        "repositoryName": SINGLETON_REPOSITORY_NAME,
+                        "pipelineName": "__ASSET_JOB",
+                    },
+                    "selectedAssetKeys": [
+                        AssetKey("asset2").to_graphql_input(),
+                        AssetKey("asset3").to_graphql_input(),
+                    ],
+                    "partitionName": "b",
+                },
+            )
+            assert result.data["pipelineOrError"]["name"] == "__ASSET_JOB"
+            result_partition = result.data["pipelineOrError"]["partition"]
+            assert result_partition["name"] == "b"
+            assert result_partition["runConfigOrError"]["yaml"] == "{}\n"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_job_partitions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_job_partitions.py
@@ -1,13 +1,4 @@
-from dagster import (
-    AssetKey,
-    ConfigurableResource,
-    Definitions,
-    StaticPartitionsDefinition,
-    asset,
-    job,
-    op,
-    static_partitioned_config,
-)
+from dagster import Definitions, job, op, static_partitioned_config
 from dagster._core.definitions.repository_definition import SINGLETON_REPOSITORY_NAME
 from dagster._core.test_utils import ensure_dagster_tests_import, instance_for_test
 from dagster_graphql.test.utils import define_out_of_process_context, execute_dagster_graphql
@@ -83,26 +74,6 @@ def get_repo_with_partitioned_op_job():
     return Definitions(jobs=[job1]).get_repository_def()
 
 
-def get_repo_with_differently_partitioned_assets():
-    @asset(partitions_def=StaticPartitionsDefinition(["1", "2"]))
-    def asset1(): ...
-
-    ab_partitions_def = StaticPartitionsDefinition(["a", "b"])
-
-    @asset(partitions_def=ab_partitions_def)
-    def asset2(): ...
-
-    class MyResource(ConfigurableResource):
-        foo: str
-
-    @asset(partitions_def=ab_partitions_def)
-    def asset3(resource1: MyResource): ...
-
-    return Definitions(
-        assets=[asset1, asset2, asset3], resources={"resource1": MyResource(foo="bar")}
-    ).get_repository_def()
-
-
 def test_get_partition_names():
     with instance_for_test() as instance:
         with define_out_of_process_context(
@@ -123,33 +94,6 @@ def test_get_partition_names():
             assert result.data["pipelineOrError"]["partitionKeysOrError"]["partitionKeys"] == [
                 "1",
                 "2",
-            ]
-
-
-def test_get_partition_names_asset_selection():
-    with instance_for_test() as instance:
-        with define_out_of_process_context(
-            __file__, "get_repo_with_differently_partitioned_assets", instance
-        ) as context:
-            result = execute_dagster_graphql(
-                context,
-                GET_PARTITIONS_QUERY,
-                variables={
-                    "selector": {
-                        "repositoryLocationName": context.code_location_names[0],
-                        "repositoryName": SINGLETON_REPOSITORY_NAME,
-                        "pipelineName": "__ASSET_JOB",
-                    },
-                    "selectedAssetKeys": [
-                        AssetKey("asset2").to_graphql_input(),
-                        AssetKey("asset3").to_graphql_input(),
-                    ],
-                },
-            )
-            assert result.data["pipelineOrError"]["name"] == "__ASSET_JOB"
-            assert result.data["pipelineOrError"]["partitionKeysOrError"]["partitionKeys"] == [
-                "a",
-                "b",
             ]
 
 
@@ -181,35 +125,6 @@ def test_get_partition_tags():
             }
 
 
-def test_get_partition_tags_asset_selection():
-    with instance_for_test() as instance:
-        with define_out_of_process_context(
-            __file__, "get_repo_with_differently_partitioned_assets", instance
-        ) as context:
-            result = execute_dagster_graphql(
-                context,
-                GET_PARTITION_TAGS_QUERY,
-                variables={
-                    "selector": {
-                        "repositoryLocationName": context.code_location_names[0],
-                        "repositoryName": SINGLETON_REPOSITORY_NAME,
-                        "pipelineName": "__ASSET_JOB",
-                    },
-                    "selectedAssetKeys": [
-                        AssetKey("asset2").to_graphql_input(),
-                        AssetKey("asset3").to_graphql_input(),
-                    ],
-                    "partitionName": "b",
-                },
-            )
-            assert result.data["pipelineOrError"]["name"] == "__ASSET_JOB"
-            result_partition = result.data["pipelineOrError"]["partition"]
-            assert result_partition["name"] == "b"
-            assert {
-                item["key"]: item["value"] for item in result_partition["tagsOrError"]["results"]
-            } == {"dagster/partition": "b"}
-
-
 def test_get_partition_config():
     with instance_for_test() as instance:
         with define_out_of_process_context(
@@ -234,30 +149,3 @@ def test_get_partition_config():
                 result_partition["runConfigOrError"]["yaml"]
                 == """ops:\n  op1:\n    config:\n      p: '1'\n"""
             )
-
-
-def test_get_partition_config_asset_selection():
-    with instance_for_test() as instance:
-        with define_out_of_process_context(
-            __file__, "get_repo_with_differently_partitioned_assets", instance
-        ) as context:
-            result = execute_dagster_graphql(
-                context,
-                GET_PARTITION_RUN_CONFIG_QUERY,
-                variables={
-                    "selector": {
-                        "repositoryLocationName": context.code_location_names[0],
-                        "repositoryName": SINGLETON_REPOSITORY_NAME,
-                        "pipelineName": "__ASSET_JOB",
-                    },
-                    "selectedAssetKeys": [
-                        AssetKey("asset2").to_graphql_input(),
-                        AssetKey("asset3").to_graphql_input(),
-                    ],
-                    "partitionName": "b",
-                },
-            )
-            assert result.data["pipelineOrError"]["name"] == "__ASSET_JOB"
-            result_partition = result.data["pipelineOrError"]["partition"]
-            assert result_partition["name"] == "b"
-            assert result_partition["runConfigOrError"]["yaml"] == "{}\n"


### PR DESCRIPTION
## Summary & Motivation

This enables the frontend to query for partition information with respect to an asset selection within a job. This enables a world where jobs can contain assets with different `PartitionsDefinition`s.

It's used by @bengotow 's `partition-set-to-job/graphql-ui` branch.

Sits atop https://github.com/dagster-io/dagster/pull/23491.

## How I Tested These Changes
