### PR TITLE
docs(looker): add `dagster-looker` API docs to integrations

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -1019,6 +1019,11 @@
         ]
       },
       {
+        "title": "Looker",
+        "path": "https://github.com/dagster-io/dagster/discussions/23479",
+        "isExternalLink": true
+      },
+      {
         "title": "OpenAI",
         "path": "/integrations/openai"
       },

--- a/docs/content/integrations.mdx
+++ b/docs/content/integrations.mdx
@@ -54,6 +54,10 @@ Using our integration guides and libraries, you can extend Dagster to interopera
     title="Google BigQuery"
     href="/integrations/bigquery"
   ></ArticleListItem>
+  <ArticleListItem
+    title="Looker"
+    href="https://github.com/dagster-io/dagster/discussions/23479"
+  ></ArticleListItem>
   <ArticleListItem title="OpenAI" href="/integrations/openai"></ArticleListItem>
   <ArticleListItem title="Pandas" href="/integrations/pandas"></ArticleListItem>
   <ArticleListItem
@@ -177,6 +181,10 @@ Explore libraries that are maintained by the Dagster core team.
   <ArticleListItem
     title="MySQL"
     href="/_apidocs/libraries/dagster-mysql"
+  ></ArticleListItem>
+  <ArticleListItem
+    title="Looker"
+    href="/_apidocs/libraries/dagster-looker"
   ></ArticleListItem>
   <ArticleListItem
     title="OpenAI"


### PR DESCRIPTION
## Summary & Motivation

- Links out to the GitHub discussion for Looker for folks to give feedback
- Links out to existing Looker API docs

## How I Tested These Changes
`yarn dev`