### PR TITLE
[chore] unify local and pre-commit ruff configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,34 @@
 default_stages: [pre-commit] # don't run on push by default
 repos:
-- repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.5.5
-  hooks:
-    - id: ruff
-      args: [--fix, --exit-non-zero-on-fix]
-      types_or: [python, pyi, jupyter]
-    - id: ruff-format
 - repo: local
   hooks:
-    - id: docs-mdx-format
-      name: Format Docs
-      language: system
-      entry: bash -c "cd docs && make mdx-format"
-      pass_filenames: false
-      files: ^docs/content
+  - id: ruff-format
+    name: Ruff Format
+    entry: ruff
+    args: [format]
+    language: system
+    pass_filenames: false
+  - id: ruff-lint
+    name: Ruff Lint
+    entry: ruff
+    args: [check, --fix, --exit-non-zero-on-fix]
+    language: system
+    pass_filenames: false
+  - id: docs-mdx-format
+    name: Format Docs
+    language: system
+    entry: bash -c "cd docs && make mdx-format"
+    pass_filenames: false
+    files: ^docs/content
 
-    # We do not use pyright's provided pre-commit hook because we need the environment management
-    # supplied by `scripts/run-pyright.py`.
-    - id: pyright
-      name: pyright
-      entry: make quick_pyright
-      stages: [pre-push]
-      # This means pre-commit will not try to install a new environment for this hook. It relies on
-      # having a pre-existing `make` installed (and scripts/run-pyright.py).
-      language: system
-      pass_filenames: false
-      types: [python]
+  # We do not use pyright's provided pre-commit hook because we need the environment management
+  # supplied by `scripts/run-pyright.py`.
+  - id: pyright
+    name: pyright
+    entry: make quick_pyright
+    stages: [pre-push]
+    # This means pre-commit will not try to install a new environment for this hook. It relies on
+    # having a pre-existing `make` installed (and scripts/run-pyright.py).
+    language: system
+    pass_filenames: false
+    types: [python]

--- a/examples/with_great_expectations/with_great_expectations/great_expectations/notebooks/pandas/validation_playground.ipynb
+++ b/examples/with_great_expectations/with_great_expectations/great_expectations/notebooks/pandas/validation_playground.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expectation_suite_name =  # TODO: set to a name from the list above"
+    "expectation_suite_name = None  # TODO: set to a name from the list above"
    ]
   },
   {
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datasource_name = # TODO: set to a datasource name from above"
+    "datasource_name = None  # TODO: set to a datasource name from above"
    ]
   },
   {
@@ -231,10 +231,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },

--- a/examples/with_great_expectations/with_great_expectations/great_expectations/notebooks/spark/validation_playground.ipynb
+++ b/examples/with_great_expectations/with_great_expectations/great_expectations/notebooks/spark/validation_playground.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expectation_suite_name =  # TODO: set to a name from the list above"
+    "expectation_suite_name = None  # TODO: set to a name from the list above"
    ]
   },
   {
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datasource_name = # TODO: set to a datasource name from above"
+    "datasource_name = None  # TODO: set to a datasource name from above"
    ]
   },
   {
@@ -232,10 +232,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },

--- a/examples/with_great_expectations/with_great_expectations/great_expectations/notebooks/sql/validation_playground.ipynb
+++ b/examples/with_great_expectations/with_great_expectations/great_expectations/notebooks/sql/validation_playground.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expectation_suite_name =  # TODO: set to a name from the list above"
+    "expectation_suite_name = None  # TODO: set to a name from the list above"
    ]
   },
   {
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datasource_name = # TODO: set to a datasource name from above"
+    "datasource_name = None  # TODO: set to a datasource name from above"
    ]
   },
   {
@@ -234,10 +234,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,11 +100,15 @@ filterwarnings = [
 
 target-version = "py38"
 
+# *.py, *.ipy are included by default
+extend-include = ["*.ipynb"]
+
 extend-exclude = [
   "*/__generated__/*",
   "*/dagster_airflow/vendor/*",
   "*/_vendored/*",
   "*/snapshots/*",
+  "python_modules/libraries/dagstermill/dagstermill_tests/notebooks/cli_test_scaffold.ipynb",
 ]
 
 # Codebase-wide default line length. Override in package-specific pyproject.toml where a different
@@ -115,6 +119,9 @@ line-length = 100
 required-version = "0.5.5"
 
 [tool.ruff.lint]
+
+# we only want to format notebooks, not lint them
+exclude = ["*.ipynb"]
 
 ignore = [
 

--- a/python_modules/libraries/dagster-ge/dagster_ge/examples/great_expectations/notebooks/pandas/validation_playground.ipynb
+++ b/python_modules/libraries/dagster-ge/dagster_ge/examples/great_expectations/notebooks/pandas/validation_playground.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expectation_suite_name =  # TODO: set to a name from the list above"
+    "expectation_suite_name = None  # TODO: set to a name from the list above"
    ]
   },
   {
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datasource_name = # TODO: set to a datasource name from above"
+    "datasource_name = None  # TODO: set to a datasource name from above"
    ]
   },
   {
@@ -231,10 +231,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },

--- a/python_modules/libraries/dagster-ge/dagster_ge/examples/great_expectations/notebooks/spark/validation_playground.ipynb
+++ b/python_modules/libraries/dagster-ge/dagster_ge/examples/great_expectations/notebooks/spark/validation_playground.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expectation_suite_name =  # TODO: set to a name from the list above"
+    "expectation_suite_name = None  # TODO: set to a name from the list above"
    ]
   },
   {
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datasource_name = # TODO: set to a datasource name from above"
+    "datasource_name = None  # TODO: set to a datasource name from above"
    ]
   },
   {
@@ -232,10 +232,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },

--- a/python_modules/libraries/dagster-ge/dagster_ge/examples/great_expectations/notebooks/sql/validation_playground.ipynb
+++ b/python_modules/libraries/dagster-ge/dagster_ge/examples/great_expectations/notebooks/sql/validation_playground.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expectation_suite_name =  # TODO: set to a name from the list above"
+    "expectation_suite_name = None  # TODO: set to a name from the list above"
    ]
   },
   {
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datasource_name = # TODO: set to a datasource name from above"
+    "datasource_name = None  # TODO: set to a datasource name from above"
    ]
   },
   {
@@ -234,10 +234,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },

--- a/python_modules/libraries/dagster-ge/dagster_ge_tests/great_expectations/notebooks/pandas/validation_playground.ipynb
+++ b/python_modules/libraries/dagster-ge/dagster_ge_tests/great_expectations/notebooks/pandas/validation_playground.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expectation_suite_name =  # TODO: set to a name from the list above"
+    "expectation_suite_name = None  # TODO: set to a name from the list above"
    ]
   },
   {
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datasource_name = # TODO: set to a datasource name from above"
+    "datasource_name = None  # TODO: set to a datasource name from above"
    ]
   },
   {
@@ -231,10 +231,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },

--- a/python_modules/libraries/dagster-ge/dagster_ge_tests/great_expectations/notebooks/spark/validation_playground.ipynb
+++ b/python_modules/libraries/dagster-ge/dagster_ge_tests/great_expectations/notebooks/spark/validation_playground.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expectation_suite_name =  # TODO: set to a name from the list above"
+    "expectation_suite_name = None  # TODO: set to a name from the list above"
    ]
   },
   {
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datasource_name = # TODO: set to a datasource name from above"
+    "datasource_name = None  # TODO: set to a datasource name from above"
    ]
   },
   {
@@ -232,10 +232,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },

--- a/python_modules/libraries/dagster-ge/dagster_ge_tests/great_expectations/notebooks/sql/validation_playground.ipynb
+++ b/python_modules/libraries/dagster-ge/dagster_ge_tests/great_expectations/notebooks/sql/validation_playground.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expectation_suite_name =  # TODO: set to a name from the list above"
+    "expectation_suite_name = None  # TODO: set to a name from the list above"
    ]
   },
   {
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datasource_name = # TODO: set to a datasource name from above"
+    "datasource_name = None  # TODO: set to a datasource name from above"
    ]
   },
   {
@@ -234,10 +234,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },

--- a/scripts/templates_create_dagster_package/__init__.py.tmpl
+++ b/scripts/templates_create_dagster_package/__init__.py.tmpl
@@ -1,4 +1,5 @@
 from dagster._core.libraries import DagsterLibraryRegistry
+
 from .version import __version__ as __version__
 
 DagsterLibraryRegistry.register("{{ hyphen_name }}", __version__)


### PR DESCRIPTION
## Summary & Motivation

This PR makes `pre-commit` use the same `ruff` settings & executable as the local environment (e.g. when run via `make ruff`). 

Should we add a `buildkite` job for `pre-commit`? Currently it's not being tested in CI.

Context: https://dagsterlabs.slack.com/archives/C03A0D72A6T/p1723065934987029

## How I Tested These Changes
`pre-commit` can be enabled and doesn't produce any changes when run

---

P.S. I had to add a few ` = None` placeholders in some of the notebooks since previously these expressions lacked any assignment and were invalid (`ruff` was failing completely on these files) 