### PR TITLE
feat: automatically enable container metric collection in a containerized environment

### DIFF
--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -84,10 +84,6 @@ def execute_run_command(input_json):
                 sys.exit(return_code)
 
 
-def _should_start_metrics_thread(dagster_run: DagsterRun) -> bool:
-    return get_boolean_tag_value(dagster_run.tags.get("dagster/run_metrics"))
-
-
 def _enable_python_runtime_metrics(dagster_run: DagsterRun) -> bool:
     return get_boolean_tag_value(dagster_run.tags.get("dagster/python_runtime_metrics"))
 
@@ -136,20 +132,15 @@ def _execute_run_command_body(
         f"Run with id '{run_id}' does not include an origin.",
     )
 
-    start_metric_thread = _should_start_metrics_thread(dagster_run)
-    if start_metric_thread:
-        logger = logging.getLogger("run_metrics")
-        polling_interval = _metrics_polling_interval(dagster_run, logger=logger)
-        metrics_thread, metrics_thread_shutdown_event = start_run_metrics_thread(
-            instance,
-            dagster_run,
-            container_metrics_enabled=True,
-            python_metrics_enabled=_enable_python_runtime_metrics(dagster_run),
-            polling_interval=polling_interval,
-            logger=logger,
-        )
-    else:
-        metrics_thread, metrics_thread_shutdown_event = None, None
+    logger = logging.getLogger("run_metrics")
+    polling_interval = _metrics_polling_interval(dagster_run, logger=logger)
+    metrics_thread, metrics_thread_shutdown_event = start_run_metrics_thread(
+        instance,
+        dagster_run,
+        python_metrics_enabled=_enable_python_runtime_metrics(dagster_run),
+        polling_interval=polling_interval,
+        logger=logger,
+    )
 
     recon_job = recon_job_from_origin(cast(JobPythonOrigin, dagster_run.job_code_origin))
 
@@ -176,29 +167,48 @@ def _execute_run_command_body(
         # relies on core_execute_run writing failures to the event log before raising
         run_worker_failed = True
     finally:
-        if metrics_thread and metrics_thread_shutdown_event:
-            stopped = stop_run_metrics_thread(metrics_thread, metrics_thread_shutdown_event)
-            if not stopped:
-                instance.report_engine_event("Metrics thread did not shutdown properly")
-
-        if instance.should_start_background_run_thread:
-            cancellation_thread_shutdown_event = check.not_none(cancellation_thread_shutdown_event)
-            cancellation_thread = check.not_none(cancellation_thread)
-            cancellation_thread_shutdown_event.set()
-            if cancellation_thread.is_alive():
-                cancellation_thread.join(timeout=15)
-                if cancellation_thread.is_alive():
-                    instance.report_engine_event(
-                        "Cancellation thread did not shutdown gracefully",
-                        dagster_run,
-                    )
-
-        instance.report_engine_event(
-            f"Process for run exited (pid: {pid}).",
+        _shutdown_threads(
+            instance,
             dagster_run,
+            metrics_thread,
+            metrics_thread_shutdown_event,
+            cancellation_thread,
+            cancellation_thread_shutdown_event,
         )
 
     return 1 if (run_worker_failed and set_exit_code_on_failure) else 0
+
+
+def _shutdown_threads(
+    instance: DagsterInstance,
+    dagster_run: DagsterRun,
+    metrics_thread: Optional[threading.Thread],
+    metrics_thread_shutdown_event: Optional[threading.Event],
+    cancellation_thread: Optional[threading.Thread],
+    cancellation_thread_shutdown_event: Optional[threading.Event],
+):
+    pid = os.getpid()
+    if metrics_thread and metrics_thread_shutdown_event:
+        stopped = stop_run_metrics_thread(metrics_thread, metrics_thread_shutdown_event)
+        if not stopped:
+            instance.report_engine_event("Metrics thread did not shutdown properly")
+
+    if instance.should_start_background_run_thread:
+        cancellation_thread_shutdown_event = check.not_none(cancellation_thread_shutdown_event)
+        cancellation_thread = check.not_none(cancellation_thread)
+        cancellation_thread_shutdown_event.set()
+        if cancellation_thread.is_alive():
+            cancellation_thread.join(timeout=15)
+            if cancellation_thread.is_alive():
+                instance.report_engine_event(
+                    "Cancellation thread did not shutdown gracefully",
+                    dagster_run,
+                )
+
+    instance.report_engine_event(
+        f"Process for run exited (pid: {pid}).",
+        dagster_run,
+    )
 
 
 @api_cli.command(
@@ -251,20 +261,15 @@ def _resume_run_command_body(
         f"Run with id '{run_id}' does not include an origin.",
     )
 
-    start_metric_thread = _should_start_metrics_thread(dagster_run)
-    if start_metric_thread:
-        logger = logging.getLogger("run_metrics")
-        polling_interval = _metrics_polling_interval(dagster_run, logger=logger)
-        metrics_thread, metrics_thread_shutdown_event = start_run_metrics_thread(
-            instance,
-            dagster_run,
-            container_metrics_enabled=True,
-            python_metrics_enabled=_enable_python_runtime_metrics(dagster_run),
-            polling_interval=polling_interval,
-            logger=logger,
-        )
-    else:
-        metrics_thread, metrics_thread_shutdown_event = None, None
+    logger = logging.getLogger("run_metrics")
+    polling_interval = _metrics_polling_interval(dagster_run, logger=logger)
+    metrics_thread, metrics_thread_shutdown_event = start_run_metrics_thread(
+        instance,
+        dagster_run,
+        python_metrics_enabled=_enable_python_runtime_metrics(dagster_run),
+        polling_interval=polling_interval,
+        logger=logger,
+    )
 
     recon_job = recon_job_from_origin(cast(JobPythonOrigin, dagster_run.job_code_origin))
 
@@ -293,25 +298,13 @@ def _resume_run_command_body(
         # relies on core_execute_run writing failures to the event log before raising
         run_worker_failed = True
     finally:
-        if metrics_thread and metrics_thread_shutdown_event:
-            stopped = stop_run_metrics_thread(metrics_thread, metrics_thread_shutdown_event)
-            if not stopped:
-                instance.report_engine_event("Metrics thread did not shutdown properly")
-
-        if instance.should_start_background_run_thread:
-            cancellation_thread_shutdown_event = check.not_none(cancellation_thread_shutdown_event)
-            cancellation_thread = check.not_none(cancellation_thread)
-            cancellation_thread_shutdown_event.set()
-            if cancellation_thread.is_alive():
-                cancellation_thread.join(timeout=15)
-                if cancellation_thread.is_alive():
-                    instance.report_engine_event(
-                        "Cancellation thread did not shutdown gracefully",
-                        dagster_run,
-                    )
-        instance.report_engine_event(
-            f"Process for job exited (pid: {pid}).",
+        _shutdown_threads(
+            instance,
             dagster_run,
+            metrics_thread,
+            metrics_thread_shutdown_event,
+            cancellation_thread,
+            cancellation_thread_shutdown_event,
         )
 
     return 1 if (run_worker_failed and set_exit_code_on_failure) else 0

--- a/python_modules/dagster/dagster/_core/execution/run_metrics_thread.py
+++ b/python_modules/dagster/dagster/_core/execution/run_metrics_thread.py
@@ -223,6 +223,11 @@ def start_run_metrics_thread(
     check.opt_bool_param(python_metrics_enabled, "python_metrics_enabled")
     check.float_param(polling_interval, "polling_interval")
 
+    if not instance.run_storage.supports_run_telemetry():
+        if logger:
+            logger.debug("Run telemetry is not supported, skipping run metrics thread")
+        return None, None
+
     container_metrics_enabled = _process_is_containerized()
     if not container_metrics_enabled and not python_metrics_enabled:
         if logger:

--- a/python_modules/dagster/dagster/_core/execution/run_metrics_thread.py
+++ b/python_modules/dagster/dagster/_core/execution/run_metrics_thread.py
@@ -137,6 +137,8 @@ def _report_run_metrics(
 
     telemetry_data = RunTelemetryData(run_id=dagster_run.run_id, datapoints=datapoints)
 
+    # TODO - this should throw an exception or return a control value if the telemetry is not enabled server side
+    #   so that we can catch and stop the thread.
     instance._run_storage.add_run_telemetry(  # noqa: SLF001
         telemetry_data, tags=run_tags
     )

--- a/python_modules/dagster/dagster/_core/execution/run_metrics_thread.py
+++ b/python_modules/dagster/dagster/_core/execution/run_metrics_thread.py
@@ -12,8 +12,8 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._utils.container import retrieve_containerized_utilization_metrics
 
-DEFAULT_RUN_METRICS_POLL_INTERVAL_SECONDS = 15.0
-DEFAULT_RUN_METRICS_SHUTDOWN_SECONDS = 30
+DEFAULT_RUN_METRICS_POLL_INTERVAL_SECONDS = 30.0
+DEFAULT_RUN_METRICS_SHUTDOWN_SECONDS = 15.0
 
 
 def _get_platform_name() -> str:

--- a/python_modules/dagster/dagster/_core/execution/run_metrics_thread.py
+++ b/python_modules/dagster/dagster/_core/execution/run_metrics_thread.py
@@ -13,7 +13,7 @@ from dagster._core.storage.dagster_run import DagsterRun
 from dagster._utils.container import retrieve_containerized_utilization_metrics
 
 DEFAULT_RUN_METRICS_POLL_INTERVAL_SECONDS = 30.0
-DEFAULT_RUN_METRICS_SHUTDOWN_SECONDS = 15.0
+DEFAULT_RUN_METRICS_SHUTDOWN_SECONDS = 15
 
 
 def _get_platform_name() -> str:

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -353,6 +353,10 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
     def get_daemon_heartbeats(self) -> Mapping[str, DaemonHeartbeat]:
         """Latest heartbeats of all daemon types."""
 
+    def supports_run_telemetry(self) -> bool:
+        """Whether the storage supports run telemetry."""
+        return False
+
     def add_run_telemetry(
         self,
         run_telemetry: RunTelemetryData,

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_run_metrics_thread.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_run_metrics_thread.py
@@ -147,7 +147,6 @@ def test_start_run_metrics_thread(dagster_instance, dagster_run, mock_container_
                 dagster_instance,
                 dagster_run,
                 logger=logger,
-                container_metrics_enabled=True,
                 polling_interval=2.0,
             )
 


### PR DESCRIPTION
## Summary & Motivation

To make run metrics generally available without requiring an explicit tag set on every run.

## TODOs

- [x] Only start thread if add_run_telemetry is implemented


## How I Tested These Changes

- [x] Make sure that the thread stops when the graphql returns an exception
- [x] Buildkite
- [x] Manual re-test w/ supporting internal changes
