### PR TITLE
[tsconfig] Remove base url from  tsconfig + src -> shared

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/tsconfig.json
+++ b/js_modules/dagster-ui/packages/app-oss/tsconfig.json
@@ -3,7 +3,7 @@
     "paths": {
       "@dagster-io/ui-core/*": ["../ui-core/src/*"],
       "@dagster-io/ui-components": ["../ui-components/src"],
-      "src/*": ["../ui-core/src/*"]
+      "shared/*": ["../ui-core/src/*"]
     },
     "module": "esnext",
     "target": "es2022",

--- a/js_modules/dagster-ui/packages/eslint-config/rules/no-oss-imports.js
+++ b/js_modules/dagster-ui/packages/eslint-config/rules/no-oss-imports.js
@@ -22,10 +22,12 @@ module.exports = {
             node,
             message: 'Relative importing files that end with ".oss" is not allowed.',
             fix: (fixer) => {
-              const absolutePath = path.relative(
-                context.getCwd(),
-                path.resolve(path.dirname(context.getFilename()), node.source.value),
-              );
+              const absolutePath = path
+                .relative(
+                  context.getCwd(),
+                  path.resolve(path.dirname(context.getFilename()), node.source.value),
+                )
+                .replace(/^src/, 'shared');
               return fixer.replaceText(node.source, `'${absolutePath}'`);
             },
           });
@@ -37,10 +39,12 @@ module.exports = {
             node,
             message: 'Relative dynamic importing files that end with ".oss.tsx" is not allowed.',
             fix: (fixer) => {
-              const absolutePath = path.relative(
-                context.getCwd(),
-                path.resolve(path.dirname(context.getFilename()), node.source.value),
-              );
+              const absolutePath = path
+                .relative(
+                  context.getCwd(),
+                  path.resolve(path.dirname(context.getFilename()), node.source.value),
+                )
+                .replace(/^src/, 'shared');
               return fixer.replaceText(node.source, `'${absolutePath}'`);
             },
           });

--- a/js_modules/dagster-ui/packages/ui-core/jest.config.js
+++ b/js_modules/dagster-ui/packages/ui-core/jest.config.js
@@ -78,7 +78,7 @@ module.exports = {
     '\\.(css|less)$': 'identity-obj-proxy',
     '^worker-loader(.*)/workers/(.*)$': '<rootDir>/jest/mocks/$2',
     '^@dagster-io/ui-components$': '<rootDir>/../ui-components/src/index',
-    '^src/(.*)$': '<rootDir>/src/$1',
+    '^shared/(.*)$': '<rootDir>/src/$1',
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNav.tsx
@@ -1,7 +1,7 @@
 import {Box, Colors, Icon, IconWrapper, Tooltip} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link, NavLink} from 'react-router-dom';
-import {AppTopNavRightOfLogo} from 'src/app/AppTopNav/AppTopNavRightOfLogo.oss';
+import {AppTopNavRightOfLogo} from 'shared/app/AppTopNav/AppTopNavRightOfLogo.oss';
 import styled from 'styled-components';
 
 import {VersionNumber} from '../../nav/VersionNumber';

--- a/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
@@ -1,7 +1,7 @@
 import {ErrorBoundary, MainContent} from '@dagster-io/ui-components';
 import {memo, useEffect, useRef} from 'react';
 import {Switch, useLocation} from 'react-router-dom';
-import {AssetsOverviewRoot} from 'src/assets/AssetsOverviewRoot.oss';
+import {AssetsOverviewRoot} from 'shared/assets/AssetsOverviewRoot.oss';
 
 import {Route} from './Route';
 import {AssetFeatureProvider} from '../assets/AssetFeatureContext';
@@ -11,7 +11,7 @@ const WorkspaceRoot = lazy(() => import('../workspace/WorkspaceRoot'));
 const OverviewRoot = lazy(() => import('../overview/OverviewRoot'));
 const AutomationRoot = lazy(() => import('../automation/AutomationRoot'));
 const FallthroughRoot = lazy(() =>
-  import('src/app/FallthroughRoot.oss').then((mod) => ({default: mod.FallthroughRoot})),
+  import('shared/app/FallthroughRoot.oss').then((mod) => ({default: mod.FallthroughRoot})),
 );
 const AssetsGroupsGlobalGraphRoot = lazy(() => import('../assets/AssetsGroupsGlobalGraphRoot'));
 const CodeLocationsPage = lazy(() => import('../instance/CodeLocationsPage'));

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/UserSettingsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/UserSettingsDialog.tsx
@@ -11,7 +11,7 @@ import {
   Tooltip,
 } from '@dagster-io/ui-components';
 import * as React from 'react';
-import {UserPreferences} from 'src/app/UserSettingsDialog/UserPreferences.oss';
+import {UserPreferences} from 'shared/app/UserSettingsDialog/UserPreferences.oss';
 
 import {CodeLinkProtocolSelect} from '../../code-links/CodeLinkProtocol';
 import {FeatureFlagType, getFeatureFlags, setFeatureFlags} from '../Flags';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -15,8 +15,8 @@ import uniq from 'lodash/uniq';
 import without from 'lodash/without';
 import * as React from 'react';
 import {useMemo} from 'react';
-import {useAssetGraphExplorerFilters} from 'src/asset-graph/useAssetGraphExplorerFilters.oss';
-import {AssetFilterState} from 'src/assets/useAssetDefinitionFilterState.oss';
+import {useAssetGraphExplorerFilters} from 'shared/asset-graph/useAssetGraphExplorerFilters.oss';
+import {AssetFilterState} from 'shared/assets/useAssetDefinitionFilterState.oss';
 import styled from 'styled-components';
 
 import {AssetEdges} from './AssetEdges';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphExplorerFilters.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphExplorerFilters.oss.tsx
@@ -1,5 +1,5 @@
 import React, {useContext, useEffect, useState} from 'react';
-import {AssetFilterState} from 'src/assets/useAssetDefinitionFilterState.oss';
+import {AssetFilterState} from 'shared/assets/useAssetDefinitionFilterState.oss';
 
 import {AssetGraphFilterBar} from './AssetGraphFilterBar';
 import {GraphNode} from './Utils';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetGroupRoot.tsx
@@ -2,8 +2,8 @@ import {gql, useQuery} from '@apollo/client';
 import {Box, Heading, Page, PageHeader, Tabs, Tag} from '@dagster-io/ui-components';
 import React, {useCallback, useMemo} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
-import {AssetGlobalLineageLink} from 'src/assets/AssetPageHeader.oss';
-import {useAssetDefinitionFilterState} from 'src/assets/useAssetDefinitionFilterState.oss';
+import {AssetGlobalLineageLink} from 'shared/assets/AssetPageHeader.oss';
+import {useAssetDefinitionFilterState} from 'shared/assets/useAssetDefinitionFilterState.oss';
 
 import {AssetsCatalogTable} from './AssetsCatalogTable';
 import {useAutoMaterializeSensorFlag} from './AutoMaterializeSensorFlag';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
@@ -14,7 +14,7 @@ import {
 import groupBy from 'lodash/groupBy';
 import * as React from 'react';
 import {useContext, useMemo} from 'react';
-import {AssetWipeDialog} from 'src/assets/AssetWipeDialog.oss';
+import {AssetWipeDialog} from 'shared/assets/AssetWipeDialog.oss';
 
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
 import {AssetTableFragment} from './types/AssetTableFragment.types';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -5,7 +5,7 @@ import {Alert, Box, ErrorBoundary, NonIdealState, Spinner, Tag} from '@dagster-i
 import {useContext, useEffect, useMemo} from 'react';
 import {Link, Redirect, useLocation, useRouteMatch} from 'react-router-dom';
 import {useSetRecoilState} from 'recoil';
-import {AssetPageHeader} from 'src/assets/AssetPageHeader.oss';
+import {AssetPageHeader} from 'shared/assets/AssetPageHeader.oss';
 
 import {AssetEvents} from './AssetEvents';
 import {AssetFeatureContext} from './AssetFeatureContext';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -4,8 +4,8 @@ import * as React from 'react';
 import {useCallback, useContext, useEffect, useLayoutEffect, useMemo, useState} from 'react';
 import {useRouteMatch} from 'react-router-dom';
 import {useSetRecoilState} from 'recoil';
-import {AssetCatalogTableBottomActionBar} from 'src/assets/AssetCatalogTableBottomActionBar.oss';
-import {useAssetCatalogFiltering} from 'src/assets/useAssetCatalogFiltering.oss';
+import {AssetCatalogTableBottomActionBar} from 'shared/assets/AssetCatalogTableBottomActionBar.oss';
+import {useAssetCatalogFiltering} from 'shared/assets/useAssetCatalogFiltering.oss';
 
 import {AssetTable} from './AssetTable';
 import {ASSET_TABLE_DEFINITION_FRAGMENT, ASSET_TABLE_FRAGMENT} from './AssetTableFragment';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -222,8 +222,6 @@ export const AssetsCatalogTable = ({
     leading: true,
   });
 
-  const loaded = !!assets;
-
   React.useEffect(() => {
     if (view !== 'directory' && prefixPath.length) {
       setView('directory');

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsGroupsGlobalGraphRoot.tsx
@@ -1,8 +1,8 @@
 import {Page} from '@dagster-io/ui-components';
 import {useCallback, useMemo} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
-import {AssetsGraphHeader} from 'src/assets/AssetsGraphHeader.oss';
-import {useAssetDefinitionFilterState} from 'src/assets/useAssetDefinitionFilterState.oss';
+import {AssetsGraphHeader} from 'shared/assets/AssetsGraphHeader.oss';
+import {useAssetDefinitionFilterState} from 'shared/assets/useAssetDefinitionFilterState.oss';
 
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverviewRoot.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsOverviewRoot.oss.tsx
@@ -4,7 +4,7 @@ import {BreadcrumbProps} from '@blueprintjs/core';
 import {Box} from '@dagster-io/ui-components';
 import React, {useMemo} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
-import {AssetGlobalLineageLink, AssetPageHeader} from 'src/assets/AssetPageHeader.oss';
+import {AssetGlobalLineageLink, AssetPageHeader} from 'shared/assets/AssetPageHeader.oss';
 
 import {AssetView} from './AssetView';
 import {AssetsCatalogTable} from './AssetsCatalogTable';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/filterAssetDefinition.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/filterAssetDefinition.test.tsx
@@ -2,7 +2,7 @@ import {
   AssetFilterBaseType,
   AssetFilterType,
   filterAssetDefinition,
-} from 'src/assets/useAssetDefinitionFilterState.oss';
+} from 'shared/assets/useAssetDefinitionFilterState.oss';
 
 import {
   ChangeReason,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetCatalogFiltering.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetCatalogFiltering.oss.tsx
@@ -1,7 +1,7 @@
 import {TextInput} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {useMemo} from 'react';
-import {useAssetDefinitionFilterState} from 'src/assets/useAssetDefinitionFilterState.oss';
+import {useAssetDefinitionFilterState} from 'shared/assets/useAssetDefinitionFilterState.oss';
 
 import {useAssetGroupSelectorsForAssets} from './AssetGroupSuggest';
 import {AssetTableFragment} from './types/AssetTableFragment.types';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useWipeModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useWipeModal.tsx
@@ -1,6 +1,6 @@
 import {Colors, Icon, MenuDivider, MenuItem} from '@dagster-io/ui-components';
 import {useContext, useState} from 'react';
-import {AssetWipeDialog} from 'src/assets/AssetWipeDialog.oss';
+import {AssetWipeDialog} from 'shared/assets/AssetWipeDialog.oss';
 
 import {CloudOSSContext} from '../app/CloudOSSContext';
 import {usePermissionsForLocation} from '../app/Permissions';

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewAssetsRoot.tsx
@@ -78,7 +78,7 @@ export const OverviewAssetsRoot = ({Header, TabButton}: Props) => {
     () => groupedAssets.flatMap((group) => group.assets.map((asset) => asset.key)) ?? [],
     [groupedAssets],
   );
-  const {liveDataByNode} = useAssetsBaseData(orderedAssets, 'OverviewAssetsRoot');
+  useAssetsBaseData(orderedAssets, 'OverviewAssetsRoot');
 
   const parentRef = React.useRef<HTMLDivElement | null>(null);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewPageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewPageHeader.tsx
@@ -1,6 +1,6 @@
 import {Box, Heading, PageHeader} from '@dagster-io/ui-components';
 import React from 'react';
-import {OverviewPageAlerts} from 'src/overview/OverviewPageAlerts.oss';
+import {OverviewPageAlerts} from 'shared/overview/OverviewPageAlerts.oss';
 
 import {OverviewTabs} from './OverviewTabs';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunActionsMenu.tsx
@@ -17,7 +17,7 @@ import {
 } from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
-import {RunMetricsDialog} from 'src/runs/RunMetricsDialog.oss';
+import {RunMetricsDialog} from 'shared/runs/RunMetricsDialog.oss';
 import styled from 'styled-components';
 
 import {DeletionDialog} from './DeletionDialog';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunHeaderActions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunHeaderActions.tsx
@@ -2,7 +2,7 @@ import {useMutation} from '@apollo/client';
 import {Button, Group, Icon, Menu, MenuItem, Popover, Tooltip} from '@dagster-io/ui-components';
 import {useContext, useState} from 'react';
 import {useHistory} from 'react-router-dom';
-import {RunMetricsDialog} from 'src/runs/RunMetricsDialog.oss';
+import {RunMetricsDialog} from 'shared/runs/RunMetricsDialog.oss';
 
 import {DeletionDialog} from './DeletionDialog';
 import {QueuedRunCriteriaDialog} from './QueuedRunCriteriaDialog';

--- a/js_modules/dagster-ui/packages/ui-core/tsconfig.json
+++ b/js_modules/dagster-ui/packages/ui-core/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "paths": {
-      "src/*": ["./src/*"],
-      "@dagster-io/ui-components": ["../ui-components/src"]
+      "@dagster-io/ui-components": ["../ui-components/src"],
+      "shared/*": ["./src/*"]
     },
     "module": "es2022",
     "target": "es2022",

--- a/js_modules/dagster-ui/packages/ui-core/tsconfig.json
+++ b/js_modules/dagster-ui/packages/ui-core/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
+      "src/*": ["./src/*"],
       "@dagster-io/ui-components": ["../ui-components/src"]
     },
     "module": "es2022",


### PR DESCRIPTION
I added `baseUrl` to make `src/...` imports work in OSS, instead of using baseUrl lets use paths with a regex.

This makes it so that we stop automatically recommending imports that start with "src/..."

#### Test Plan
yarn ts