### PR TITLE
Remove next.js src alias

### DIFF
--- a/js_modules/dagster-ui/packages/app-oss/next.config.js
+++ b/js_modules/dagster-ui/packages/app-oss/next.config.js
@@ -21,8 +21,6 @@ const nextConfig = {
       bufferutil: 'commonjs bufferutil',
     });
 
-    config.resolve.alias['src'] = path.resolve(__dirname, '../ui-core/src');
-
     const prefix = config.assetPrefix ?? config.basePath ?? '';
     // Use file-loader to load mp4 files.
     config.module.rules.push({


### PR DESCRIPTION
## Summary & Motivation

Forgot to update this alias to use `shared/` instead but in doing so realized that next.js automatically picks up the aliases from `tsconfig.json` so we don't actually need this alias here.

## How I Tested These Changes
yarn build
