### PR TITLE
[dagster-airlift] fix& test links

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_cacheable_assets_def.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_cacheable_assets_def.py
@@ -277,8 +277,8 @@ def construct_cacheable_assets_and_infer_dependencies(
             "Task Info (raw)": JsonMetadataValue(task_info.metadata),
             # In this case,
             "Dag ID": task_info.dag_id,
-            "Link to Task": MarkdownMetadataValue(
-                f"[View Task]({airflow_instance.get_task_url(task_info.dag_id, task_info.task_id)})"
+            "Link to DAG": MarkdownMetadataValue(
+                f"[View DAG]({airflow_instance.get_dag_url(task_info.dag_id)})"
             ),
         }
         migration_state_for_task = _get_migration_state_for_task(

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_instance.py
@@ -59,14 +59,19 @@ class AirflowInstance:
                 f"Failed to fetch task info for {dag_id}/{task_id}. Status code: {response.status_code}, Message: {response.text}"
             )
 
-    def get_task_url(self, dag_id: str, task_id: str) -> str:
-        return f"{self.auth_backend.get_webserver_url()}/dags/{dag_id}/{task_id}"
-
     def get_dag_url(self, dag_id: str) -> str:
         return f"{self.auth_backend.get_webserver_url()}/dags/{dag_id}"
 
     def get_dag_run_url(self, dag_id: str, run_id: str) -> str:
         return f"{self.auth_backend.get_webserver_url()}/dags/{dag_id}/grid?dag_run_id={run_id}&tab=details"
+
+    def get_task_instance_url(self, dag_id: str, task_id: str, run_id: str) -> str:
+        # http://localhost:8080/dags/print_dag/grid?dag_run_id=manual__2024-08-08T17%3A21%3A22.427241%2B00%3A00&task_id=print_task
+        return f"{self.auth_backend.get_webserver_url()}/dags/{dag_id}/grid?dag_run_id={run_id}&task_id={task_id}"
+
+    def get_task_instance_log_url(self, dag_id: str, task_id: str, run_id: str) -> str:
+        # http://localhost:8080/dags/print_dag/grid?dag_run_id=manual__2024-08-08T17%3A21%3A22.427241%2B00%3A00&task_id=print_task&tab=logs
+        return f"{self.get_task_instance_url(dag_id, task_id, run_id)}&tab=logs"
 
     def get_dag_run_asset_key(self, dag_id: str) -> AssetKey:
         return AssetKey([self.normalized_name, "dag", dag_id])

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_airflow_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_airflow_instance.py
@@ -39,12 +39,14 @@ def test_airflow_instance(airflow_instance: None):
     ):
         instance.get_task_info(dag_id="print_dag", task_id="nonexistent_task")
 
-    assert (
-        instance.get_task_url(dag_id="print_dag", task_id="print_task")
-        == "http://localhost:8080/dags/print_dag/print_task"
-    )
     assert instance.get_dag_url(dag_id="print_dag") == "http://localhost:8080/dags/print_dag"
     assert (
         instance.get_dag_run_url(dag_id="print_dag", run_id="run_id")
         == "http://localhost:8080/dags/print_dag/grid?dag_run_id=run_id&tab=details"
+    )
+    assert (
+        instance.get_task_instance_log_url(
+            dag_id="print_dag", task_id="print_task", run_id="run_id"
+        )
+        == "http://localhost:8080/dags/print_dag/grid?dag_run_id=run_id&task_id=print_task&tab=logs"
     )

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_cacheable_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_cacheable_asset.py
@@ -92,7 +92,7 @@ def test_cacheable_asset(airflow_instance: None) -> None:
         assert next(iter(some_key_def.specs)).metadata.keys() == {
             "Task Info (raw)",
             "Dag ID",
-            "Link to Task",
+            "Link to DAG",
             "Computed in Task ID",
         }
         assert next(iter(some_key_def.specs)).tags["airlift/task_id"] == "print_task"
@@ -103,7 +103,7 @@ def test_cacheable_asset(airflow_instance: None) -> None:
         assert next(iter(other_key_def.specs)).metadata.keys() == {
             "Task Info (raw)",
             "Dag ID",
-            "Link to Task",
+            "Link to DAG",
             "Computed in Task ID",
         }
         assert next(iter(other_key_def.specs)).tags["airlift/task_id"] == "downstream_print_task"


### PR DESCRIPTION
A few of the links were broken for airlift.
- There's not actually a tasks page, just a task instances page. So from the task definition, link to the dag page.
- Link directly to the logs for each task from the asset materialization.
- Test links against running airflow for correctness