### PR TITLE
fix: use terminate to revoke celery task

### DIFF
--- a/python_modules/libraries/dagster-celery/dagster_celery/core_execution_loop.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/core_execution_loop.py
@@ -70,7 +70,7 @@ def core_celery_execution_loop(job_context, execution_plan, step_execution_fn):
                 stopping = True
                 active_execution.mark_interrupted()
                 for result in step_results.values():
-                    result.revoke(terminate=True, signal='SIGKILL')
+                    result.revoke(terminate=True)
             results_to_pop = []
             for step_key, result in sorted(
                 step_results.items(), key=lambda x: priority_for_key(x[0])

--- a/python_modules/libraries/dagster-celery/dagster_celery/core_execution_loop.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/core_execution_loop.py
@@ -70,7 +70,7 @@ def core_celery_execution_loop(job_context, execution_plan, step_execution_fn):
                 stopping = True
                 active_execution.mark_interrupted()
                 for result in step_results.values():
-                    result.revoke()
+                    result.revoke(terminate=True, signal='SIGKILL')
             results_to_pop = []
             for step_key, result in sorted(
                 step_results.items(), key=lambda x: priority_for_key(x[0])


### PR DESCRIPTION
## Summary & Motivation
this fixes the issue with celery-executor, where terminating a job keeps it running, due to the default nature of `revoke`, by default for result.revoke `Terminate=False`, replacing it with `True` fixes the issue https://github.com/dagster-io/dagster/issues/23222

## How I Tested These Changes
created a simple job and another one with executor as `celery-executor`, works as intended for both scenarios.

also the logs make it further clear that the tasks are terminated with signal `SIGTERM`