### PR TITLE
remove `partitions_def` from `define_asset_job` in graphql test repo

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1788,9 +1788,7 @@ def multipartitions_fail(context):
 
 
 multi_partitions_job = define_asset_job(
-    "multipartitions_job",
-    AssetSelection.assets(multipartitions_1, multipartitions_2),
-    partitions_def=multipartitions_def,
+    "multipartitions_job", AssetSelection.assets(multipartitions_1, multipartitions_2)
 )
 
 
@@ -1815,15 +1813,11 @@ dynamic_in_multipartitions_def = MultiPartitionsDefinition(
 )
 
 no_multi_partitions_job = define_asset_job(
-    "no_multipartitions_job",
-    AssetSelection.assets(no_multipartitions_1),
-    partitions_def=no_partitions_multipartitions_def,
+    "no_multipartitions_job", AssetSelection.assets(no_multipartitions_1)
 )
 
 multi_partitions_fail_job = define_asset_job(
-    "multipartitions_fail_job",
-    AssetSelection.assets(multipartitions_fail),
-    partitions_def=multipartitions_def,
+    "multipartitions_fail_job", AssetSelection.assets(multipartitions_fail)
 )
 
 
@@ -1840,7 +1834,6 @@ def dynamic_in_multipartitions_fail(context, dynamic_in_multipartitions_success)
 dynamic_in_multipartitions_success_job = define_asset_job(
     "dynamic_in_multipartitions_success_job",
     AssetSelection.assets(dynamic_in_multipartitions_success, dynamic_in_multipartitions_fail),
-    partitions_def=dynamic_in_multipartitions_def,
 )
 
 


### PR DESCRIPTION
## Summary & Motivation

This parameter is now deprecated and redundant with partition defs provided on the assets. This avoids deprecation warnings when running tests.

## How I Tested These Changes
