### PR TITLE
[dagster-airlift] Add better pypi tooling

### DIFF
--- a/examples/experimental/dagster-airlift/Makefile
+++ b/examples/experimental/dagster-airlift/Makefile
@@ -1,0 +1,5 @@
+# Makefile
+
+adhoc_pypi:
+	@chmod +x increment_pypi_version.sh
+	@./increment_pypi_version.sh

--- a/examples/experimental/dagster-airlift/build_and_publish.sh
+++ b/examples/experimental/dagster-airlift/build_and_publish.sh
@@ -4,14 +4,43 @@
 # 3. run this script from this directory
 # 4. once propted, use '__token__' for the username and the API key for the password
 
+# Define the path to the .pypirc file
+PYPIRC_FILE="$HOME/.pypirc"
+
+# Check if the .pypirc file exists
+if [ ! -f "$PYPIRC_FILE" ]; then
+    echo ".pypirc file not found in $HOME."
+
+    # Prompt the user for the API token
+    read -p "Enter your API token (must start with 'pypi-'): " API_TOKEN
+
+    # Check if the API token starts with 'pypi-'
+    if [[ $API_TOKEN != pypi-* ]]; then
+        echo "Invalid API token. It must start with 'pypi-'."
+        exit 1
+    fi
+
+    # Create the .pypirc file and write the configuration
+    cat <<EOF > "$PYPIRC_FILE"
+[pypi]
+username = __token__
+password = $API_TOKEN
+EOF
+
+    echo ".pypirc file created successfully."
+else
+    echo ".pypirc file already exists in $HOME. Using that as pypi credentials."
+fi
+
 rm -rf dist/*
 rm -rf dagster_airlift_prerelease/dagster_airlift_patched
 cp -R dagster_airlift dagster_airlift_prerelease/dagster_airlift_patched
-echo "Patching dagster_airlift"
+echo "Building package..."
 python3 -m build
-echo "Building dagster_airlift"
+echo "Uploading to pypi..."
 python3 -m twine upload --repository pypi dist/* --verbose
 
 # cleanup
+echo "Cleaning up..."
 rm -rf dist/*
 rm -rf dagster_airlift_prerelease/dagster_airlift_patched

--- a/examples/experimental/dagster-airlift/increment_pypi_version.sh
+++ b/examples/experimental/dagster-airlift/increment_pypi_version.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Define the path to the setup.py file
+SETUP_PY_FILE="setup.py"
+
+# Check if setup.py exists
+if [ ! -f "$SETUP_PY_FILE" ]; then
+    echo "Error: $SETUP_PY_FILE not found!"
+    exit 1
+fi
+
+# Extract the current version from 'version="x.y.z",'
+CURRENT_VERSION=$(sed -n 's/.*version="\([0-9]*\.[0-9]*\.[0-9]*\)",.*/\1/p' "$SETUP_PY_FILE")
+if [ -z "$CURRENT_VERSION" ]; then
+    echo "Error: Version string not found in $SETUP_PY_FILE!"
+    exit 1
+fi
+
+echo "Current version: $CURRENT_VERSION"
+
+# Extract x, y, z components of the version
+IFS='.' read -r X Y Z <<< "$CURRENT_VERSION"
+
+# Increment z
+NEW_Z=$((Z + 1))
+NEW_VERSION="$X.$Y.$NEW_Z"
+echo "New version: $NEW_VERSION"
+
+# Create a backup of the original file
+cp "$SETUP_PY_FILE" "${SETUP_PY_FILE}.bak"
+
+# Replace the old version with the new version in setup.py
+echo "Updating version in $SETUP_PY_FILE..."
+sed -i "" "s|version=\"$CURRENT_VERSION\"|version=\"$NEW_VERSION\"|" "$SETUP_PY_FILE"
+
+# Run the specified commands
+echo "Running commands..."
+if ! ./build_and_publish.sh; then
+    echo "Commands failed. Reverting to original version..."
+    mv "${SETUP_PY_FILE}.bak" "$SETUP_PY_FILE"
+    exit 1
+fi
+
+# Clean up the backup if successful
+rm "${SETUP_PY_FILE}.bak"
+echo "Commands completed successfully. Version updated to $NEW_VERSION."

--- a/examples/experimental/dagster-airlift/setup.py
+++ b/examples/experimental/dagster-airlift/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="dagster-airlift",
-    version="0.0.1",
+    version="0.0.3",
     author="Dagster Labs",
     author_email="hello@dagsterlabs.com",
     license="Apache-2.0",


### PR DESCRIPTION
Adds a bunch of tooling so that all you have to run is `make pypi_adhoc`, and all the cruft will be handled.
Updates the version number in setup.py, then writes out pypirc (prompting for creds), then uploads to pypi. Finally, if things fail, reverts setup.py changes.

Tested live, including pypirc setup. Correctly incremented everything.