### PR TITLE
[ui] Hide Jobs item from nav if there are no jobs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavLinks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavLinks.tsx
@@ -1,5 +1,5 @@
 import {Box} from '@dagster-io/ui-components';
-import {ReactNode} from 'react';
+import {ReactElement} from 'react';
 import {useHistory} from 'react-router-dom';
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
@@ -11,6 +11,7 @@ import {
   jobsPathMatcher,
   locationPathMatcher,
 } from './activePathMatchers';
+import {JobStateForNav} from './useJobStateForNav';
 import {DeploymentStatusIcon} from '../../nav/DeploymentStatusIcon';
 import {featureEnabled} from '../Flags';
 import {ShortcutHandler} from '../ShortcutHandler';
@@ -18,7 +19,7 @@ import {ShortcutHandler} from '../ShortcutHandler';
 export type AppNavLinkType = {
   key: string;
   path: string;
-  element: ReactNode;
+  element: ReactElement;
 };
 
 export const AppTopNavLinks = ({links}: {links: AppNavLinkType[]}) => {
@@ -42,7 +43,13 @@ export const AppTopNavLinks = ({links}: {links: AppNavLinkType[]}) => {
   );
 };
 
-export const navLinks = () => {
+type Config = {
+  jobState?: JobStateForNav;
+};
+
+export const navLinks = (config: Config): AppNavLinkType[] => {
+  const {jobState = 'unknown'} = config;
+
   const overview = {
     key: 'overview',
     path: '/overview',
@@ -59,16 +66,6 @@ export const navLinks = () => {
     element: (
       <TopNavLink to="/runs" data-cy="AppTopNav_RunsLink">
         Runs
-      </TopNavLink>
-    ),
-  };
-
-  const jobs = {
-    key: 'jobs',
-    path: '/jobs',
-    element: (
-      <TopNavLink to="/jobs" data-cy="AppTopNav_JobsLink" isActive={jobsPathMatcher}>
-        Jobs
       </TopNavLink>
     ),
   };
@@ -98,6 +95,19 @@ export const navLinks = () => {
   };
 
   if (featureEnabled(FeatureFlag.flagSettingsPage)) {
+    const jobs =
+      jobState === 'has-jobs'
+        ? {
+            key: 'jobs',
+            path: '/jobs',
+            element: (
+              <TopNavLink to="/jobs" data-cy="AppTopNav_JobsLink" isActive={jobsPathMatcher}>
+                Jobs
+              </TopNavLink>
+            ),
+          }
+        : null;
+
     const deployment = {
       key: 'deployment',
       path: '/deployment',
@@ -114,7 +124,10 @@ export const navLinks = () => {
         </TopNavLink>
       ),
     };
-    return [overview, runs, assets, jobs, automation, deployment];
+
+    return [overview, runs, assets, jobs, automation, deployment].filter(
+      (link): link is AppNavLinkType => !!link,
+    );
   }
 
   const deployment = {

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavRightOfLogo.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavRightOfLogo.oss.tsx
@@ -1,7 +1,9 @@
 import {memo} from 'react';
 
 import {AppTopNavLinks, navLinks} from './AppTopNavLinks';
+import {useJobStateForNav} from './useJobStateForNav';
 
 export const AppTopNavRightOfLogo = memo(() => {
-  return <AppTopNavLinks links={navLinks()} />;
+  const jobState = useJobStateForNav();
+  return <AppTopNavLinks links={navLinks({jobState})} />;
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/useJobStateForNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/useJobStateForNav.tsx
@@ -1,0 +1,26 @@
+import {useMemo} from 'react';
+
+import {isHiddenAssetGroupJob} from '../../asset-graph/Utils';
+import {useRepositoryOptions} from '../../workspace/WorkspaceContext';
+
+export type JobStateForNav = 'unknown' | 'has-jobs' | 'no-jobs';
+
+/**
+ * Determine whether the viewer has any jobs in any of their code locations. We use
+ * this information to determine whether to show the "Jobs" item in the top navigation
+ * at all. If there are no jobs, we won't show it.
+ */
+export const useJobStateForNav = () => {
+  const {options, loading} = useRepositoryOptions();
+  return useMemo(() => {
+    if (loading) {
+      return 'unknown';
+    }
+
+    const hasJobs = options.some((option) =>
+      option.repository.pipelines.some((job) => !isHiddenAssetGroupJob(job.name)),
+    );
+
+    return hasJobs ? 'has-jobs' : 'no-jobs';
+  }, [options, loading]);
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__fixtures__/useJobStateForNav.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__fixtures__/useJobStateForNav.fixtures.tsx
@@ -1,0 +1,58 @@
+import {__ANONYMOUS_ASSET_JOB_PREFIX} from '../../asset-graph/Utils';
+import {
+  buildPipeline,
+  buildRepository,
+  buildRepositoryLocation,
+  buildWorkspaceLocationEntry,
+} from '../../graphql/types';
+import {buildWorkspaceMocks} from '../../workspace/__fixtures__/Workspace.fixtures';
+
+export const workspaceWithJob = buildWorkspaceMocks([
+  buildWorkspaceLocationEntry({
+    name: 'some_workspace',
+    locationOrLoadError: buildRepositoryLocation({
+      name: 'location_with_job',
+      repositories: [
+        buildRepository({
+          name: 'repo_with_job',
+          pipelines: [
+            buildPipeline({
+              name: 'some_job',
+              isJob: true,
+            }),
+          ],
+        }),
+      ],
+    }),
+  }),
+]);
+
+export const workspaceWithNoJobs = buildWorkspaceMocks([
+  buildWorkspaceLocationEntry({
+    name: 'some_workspace',
+    locationOrLoadError: buildRepositoryLocation({
+      name: 'location_without_job',
+      repositories: [
+        buildRepository({
+          name: 'repo_without_job',
+          pipelines: [],
+        }),
+      ],
+    }),
+  }),
+]);
+
+export const workspaceWithDunderJob = buildWorkspaceMocks([
+  buildWorkspaceLocationEntry({
+    name: 'some_workspace',
+    locationOrLoadError: buildRepositoryLocation({
+      name: 'location_without_job',
+      repositories: [
+        buildRepository({
+          name: `${__ANONYMOUS_ASSET_JOB_PREFIX}_pseudo_job`,
+          pipelines: [],
+        }),
+      ],
+    }),
+  }),
+]);

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/AppTopNav.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/AppTopNav.test.tsx
@@ -2,7 +2,9 @@ import {MockedProvider} from '@apollo/client/testing';
 import {render, screen} from '@testing-library/react';
 import {MemoryRouter} from 'react-router-dom';
 
+import {WorkspaceProvider} from '../../workspace/WorkspaceContext';
 import {AppTopNav} from '../AppTopNav/AppTopNav';
+import {workspaceWithNoJobs} from '../__fixtures__/useJobStateForNav.fixtures';
 
 // We don't need to render the search input here.
 jest.mock('../../search/SearchDialog', () => ({
@@ -12,9 +14,11 @@ jest.mock('../../search/SearchDialog', () => ({
 describe('AppTopNav', () => {
   it('renders links and controls', async () => {
     render(
-      <MockedProvider>
+      <MockedProvider mocks={[...workspaceWithNoJobs]}>
         <MemoryRouter>
-          <AppTopNav />
+          <WorkspaceProvider>
+            <AppTopNav />
+          </WorkspaceProvider>
         </MemoryRouter>
       </MockedProvider>,
     );

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/useJobStateForNav.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/useJobStateForNav.test.tsx
@@ -1,0 +1,62 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {render, screen} from '@testing-library/react';
+
+import {WorkspaceProvider} from '../../workspace/WorkspaceContext';
+import {useJobStateForNav} from '../AppTopNav/useJobStateForNav';
+import {
+  workspaceWithDunderJob,
+  workspaceWithJob,
+  workspaceWithNoJobs,
+} from '../__fixtures__/useJobStateForNav.fixtures';
+
+describe('useJobStateForNav', () => {
+  const Test = () => {
+    const value = useJobStateForNav();
+    return <div>{value}</div>;
+  };
+
+  it('returns `unknown` if still loading, then finds jobs and returns `has-jobs`', async () => {
+    render(
+      <MockedProvider mocks={workspaceWithJob}>
+        <WorkspaceProvider>
+          <Test />
+        </WorkspaceProvider>
+      </MockedProvider>,
+    );
+
+    expect(screen.getByText(/unknown/i)).toBeVisible();
+
+    const found = await screen.findByText(/has-jobs/i);
+    expect(found).toBeVisible();
+  });
+
+  it('returns `no-jobs` if no jobs found after loading', async () => {
+    render(
+      <MockedProvider mocks={workspaceWithNoJobs}>
+        <WorkspaceProvider>
+          <Test />
+        </WorkspaceProvider>
+      </MockedProvider>,
+    );
+
+    expect(screen.getByText(/unknown/i)).toBeVisible();
+
+    const found = await screen.findByText(/no-jobs/i);
+    expect(found).toBeVisible();
+  });
+
+  it('returns `no-jobs` if only dunder job found', async () => {
+    render(
+      <MockedProvider mocks={workspaceWithDunderJob}>
+        <WorkspaceProvider>
+          <Test />
+        </WorkspaceProvider>
+      </MockedProvider>,
+    );
+
+    expect(screen.getByText(/unknown/i)).toBeVisible();
+
+    const found = await screen.findByText(/no-jobs/i);
+    expect(found).toBeVisible();
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
@@ -432,6 +432,7 @@ const useVisibleRepos = (
 
 const getRepositoryOptionHash = (a: DagsterRepoOption) =>
   `${a.repository.name}:${a.repositoryLocation.name}`;
+
 export const useRepositoryOptions = () => {
   const {allRepos: options, loading} = React.useContext(WorkspaceContext);
   return {options, loading};


### PR DESCRIPTION
## Summary & Motivation

In the experimental navigation, don't show a "Jobs" top nav item if there are no jobs in the workspace.

## How I Tested These Changes

TS, lint, jest.

Load app with default toys repo, verify that the Jobs item appears. Load app with a repo that only contains an asset, verify that it does not appear.