### PR TITLE
take experimental marker off of external assets in docs

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -114,7 +114,7 @@
             ]
           },
           {
-            "title": "External assets (Experimental)",
+            "title": "External assets",
             "path": "/concepts/assets/external-assets"
           }
         ]

--- a/docs/content/concepts.mdx
+++ b/docs/content/concepts.mdx
@@ -42,7 +42,7 @@ An asset is an object in persistent storage, such as a table, file, or persisted
     href="/concepts/assets/asset-checks"
   ></ArticleListItem>
   <ArticleListItem
-    title="External assets (Experimental)"
+    title="External assets"
     href="/concepts/assets/external-assets"
   ></ArticleListItem>
 </ArticleList>

--- a/docs/content/concepts/assets/external-assets.mdx
+++ b/docs/content/concepts/assets/external-assets.mdx
@@ -3,7 +3,7 @@ title: External Assets | Dagster
 description: External assets model assets in Dagster that are not scheduled or materialized in Dagster.
 ---
 
-# External Assets (Experimental)
+# External Assets
 
 An **external asset** is an asset that is visible in Dagster but executed by an external process. For example, you have a process that loads data from Kafka into Amazon S3 every day. You want the S3 asset to be visible alongside your other data assets, but not triggered by Dagster.
 


### PR DESCRIPTION
## Summary & Motivation

Takes the experimental marker off the concept page and associated links.

## How I Tested These Changes
