### PR TITLE
Bump langchain version to 0.2.9 in with_openai

### DIFF
--- a/examples/with_openai/setup.py
+++ b/examples/with_openai/setup.py
@@ -9,7 +9,7 @@ setup(
         "dagster-openai",
         "faiss-cpu==1.8.0",
         "filelock",
-        "langchain==0.2.7",
+        "langchain==0.2.9",
         "langchain-community==0.2.9",
         "langchain-openai==0.1.14",
     ],


### PR DESCRIPTION
## Summary & Motivation

Required for PR #23207.

Pip's message "langchain-community 0.2.9 requires langchain<0.3.0,>=0.2.9, but you have langchain 0.2.7 which is incompatible."

## How I Tested These Changes

Tested locally with dagster dev
