### PR TITLE
[single-implicit-asset-job] add `selected_asset_keys` and `job_name` to grpc partition api params

### DIFF
--- a/python_modules/dagster/dagster/_api/snapshot_partition.py
+++ b/python_modules/dagster/dagster/_api/snapshot_partition.py
@@ -9,6 +9,7 @@ from dagster._core.remote_representation.external_data import (
     ExternalPartitionNamesData,
     ExternalPartitionSetExecutionParamData,
     ExternalPartitionTagsData,
+    job_name_for_external_partition_set_name,
 )
 from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._grpc.types import PartitionArgs, PartitionNamesArgs, PartitionSetExecutionParamArgs
@@ -31,7 +32,9 @@ def sync_get_external_partition_names_grpc(
         api_client.external_partition_names(
             partition_names_args=PartitionNamesArgs(
                 repository_origin=repository_origin,
+                job_name=job_name_for_external_partition_set_name(partition_set_name),
                 partition_set_name=partition_set_name,
+                selected_asset_keys=None,
             ),
         ),
         (ExternalPartitionNamesData, ExternalPartitionExecutionErrorData),
@@ -60,9 +63,11 @@ def sync_get_external_partition_config_grpc(
         api_client.external_partition_config(
             partition_args=PartitionArgs(
                 repository_origin=repository_origin,
+                job_name=job_name_for_external_partition_set_name(partition_set_name),
                 partition_set_name=partition_set_name,
                 partition_name=partition_name,
                 instance_ref=instance.get_ref(),
+                selected_asset_keys=None,
             ),
         ),
         (ExternalPartitionConfigData, ExternalPartitionExecutionErrorData),
@@ -92,9 +97,11 @@ def sync_get_external_partition_tags_grpc(
         api_client.external_partition_tags(
             partition_args=PartitionArgs(
                 repository_origin=repository_origin,
+                job_name=job_name_for_external_partition_set_name(partition_set_name),
                 partition_set_name=partition_set_name,
                 partition_name=partition_name,
                 instance_ref=instance.get_ref(),
+                selected_asset_keys=None,
             ),
         ),
         (ExternalPartitionTagsData, ExternalPartitionExecutionErrorData),

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -405,18 +405,27 @@ class PartitionArgs(
         "_PartitionArgs",
         [
             ("repository_origin", RemoteRepositoryOrigin),
+            ("job_name", str),
+            # This is here for backcompat. it's expected to always be f"{job_name}_partition_set".
             ("partition_set_name", str),
             ("partition_name", str),
             ("instance_ref", Optional[InstanceRef]),
+            # This is introduced in the same release that we're making it possible for an asset job
+            # to target assets with different PartitionsDefinitions. Prior user code versions can
+            # (and do) safely ignore this parameter, because, in those versions, the job name on its
+            # own is enough to specify which PartitionsDefinition to use.
+            ("selected_asset_keys", Optional[AbstractSet[AssetKey]]),
         ],
     )
 ):
     def __new__(
         cls,
         repository_origin: RemoteRepositoryOrigin,
+        job_name: str,
         partition_set_name: str,
         partition_name: str,
         instance_ref: Optional[InstanceRef] = None,
+        selected_asset_keys: Optional[AbstractSet[AssetKey]] = None,
     ):
         return super(PartitionArgs, cls).__new__(
             cls,
@@ -426,8 +435,12 @@ class PartitionArgs(
                 RemoteRepositoryOrigin,
             ),
             partition_set_name=check.str_param(partition_set_name, "partition_set_name"),
+            job_name=check.str_param(job_name, "job_name"),
             partition_name=check.str_param(partition_name, "partition_name"),
             instance_ref=check.opt_inst_param(instance_ref, "instance_ref", InstanceRef),
+            selected_asset_keys=check.opt_nullable_set_param(
+                selected_asset_keys, "selected_asset_keys", of_type=AssetKey
+            ),
         )
 
 
@@ -435,16 +448,36 @@ class PartitionArgs(
 class PartitionNamesArgs(
     NamedTuple(
         "_PartitionNamesArgs",
-        [("repository_origin", RemoteRepositoryOrigin), ("partition_set_name", str)],
+        [
+            ("repository_origin", RemoteRepositoryOrigin),
+            ("job_name", str),
+            # This is here for backcompat. it's expected to always be f"{job_name}_partition_set".
+            ("partition_set_name", str),
+            # This is introduced in the same release that we're making it possible for an asset job
+            # to target assets with different PartitionsDefinitions. Prior user code versions can
+            # (and do) safely ignore this parameter, because, in those versions, the job name on its
+            # own is enough to specify which PartitionsDefinition to use.
+            ("selected_asset_keys", Optional[AbstractSet[AssetKey]]),
+        ],
     )
 ):
-    def __new__(cls, repository_origin: RemoteRepositoryOrigin, partition_set_name: str):
+    def __new__(
+        cls,
+        repository_origin: RemoteRepositoryOrigin,
+        job_name: str,
+        partition_set_name: str,
+        selected_asset_keys: Optional[AbstractSet[AssetKey]] = None,
+    ):
         return super(PartitionNamesArgs, cls).__new__(
             cls,
             repository_origin=check.inst_param(
                 repository_origin, "repository_origin", RemoteRepositoryOrigin
             ),
+            job_name=check.str_param(job_name, "job_name"),
             partition_set_name=check.str_param(partition_set_name, "partition_set_name"),
+            selected_asset_keys=check.opt_nullable_set_param(
+                selected_asset_keys, "selected_asset_keys", of_type=AssetKey
+            ),
         )
 
 

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
@@ -43,7 +43,9 @@ def test_external_partition_names_deserialize_error_grpc(instance: DagsterInstan
             api_client.external_partition_names(
                 partition_names_args=PartitionNamesArgs(
                     repository_origin=repository_origin,
-                    partition_set_name="foo",
+                    job_name="foo",
+                    partition_set_name="foo_partition_set",
+                    selected_asset_keys=None,
                 )._replace(repository_origin="INVALID"),
             )
         )
@@ -86,9 +88,11 @@ def test_external_partition_config_deserialize_error_grpc(instance: DagsterInsta
             api_client.external_partition_config(
                 partition_args=PartitionArgs(
                     repository_origin=repository_handle.get_external_origin(),
-                    partition_set_name="foo",
+                    job_name="foo",
+                    partition_set_name="foo_partition_set",
                     partition_name="bar",
                     instance_ref=instance.get_ref(),
+                    selected_asset_keys=None,
                 )._replace(repository_origin="INVALID"),
             )
         )
@@ -119,9 +123,11 @@ def test_external_partitions_tags_deserialize_error_grpc(instance: DagsterInstan
             api_client.external_partition_tags(
                 partition_args=PartitionArgs(
                     repository_origin=repository_origin,
-                    partition_set_name="fooba",
+                    job_name="fooba",
+                    partition_set_name="fooba_partition_set",
                     partition_name="c",
                     instance_ref=instance.get_ref(),
+                    selected_asset_keys=None,
                 )._replace(repository_origin="INVALID"),
             )
         )


### PR DESCRIPTION
## Summary & Motivation

"Partition set"s are an eliminated concept that lives on like a ghost inside our host processes and gRPC APIs. This PR is the bottom of a stack that makes a dent at removing it.

When a job has a `PartitionsDefinition`, we also automatically generate a `PartitionSetSnap` whose name is f"{job_name}_partition_set". This is a relic from a past era when jobs could have multiple partition sets. This partition set name is then referenced from host processes when they need to get partition-related information for the job:
- The set of partitions
- The tags corresponding to a particular partition
- The config corresponding to a particular partition

This is problematic for two reasons:

- The redundant and vestigial "partition set" concept is threaded through a bunch of our host process code
- When an asset job targets assets with different PartitionsDefinitions, there is no partition set for it. However, we still need to be able to get the partitions, tags, and config for subsets of assets, e.g. to populate the Launchpad. This functionality in the Launchpad has been broken since the single-implicit-asset-job PR was merged.

### Backwards compatibility

After this change (and some of the changes stacked on top), there will be two kinds of code locations:
1.  Code locations that don't know about these new params and never have jobs that include assets with different `PartitionsDefinition`s.
    -   These code locations will continue to use the `partition_set_name` param, which continues to be supplied by host processes, to find the associated job and fetch the associated data.
2. Code locations that do know about these new params and may have jobs that include assets with different `PartitionsDefinition`s.
   -  These code locations will make use of the new params.


## How I Tested These Changes

Up-stack: https://github.com/dagster-io/dagster/pull/23491
