### PR TITLE
[dagster-airlift] handle transitive dependencies between cacheable assets

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/conftest.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/conftest.py
@@ -8,16 +8,20 @@ import pytest
 from dagster._core.test_utils import environ
 
 
+@pytest.fixture(name="dags_dir")
+def default_dags_dir():
+    return Path(__file__).parent / "dags"
+
+
 @pytest.fixture(name="setup")
-def setup_fixture() -> Generator[str, None, None]:
+def setup_fixture(dags_dir: Path) -> Generator[str, None, None]:
     with TemporaryDirectory() as tmpdir:
         # run chmod +x create_airflow_cfg.sh and then run create_airflow_cfg.sh tmpdir
         temp_env = {**os.environ.copy(), "AIRFLOW_HOME": tmpdir}
         # go up one directory from current
         path_to_script = Path(__file__).parent.parent.parent / "airflow_setup.sh"
-        path_to_dags = Path(__file__).parent / "dags"
         subprocess.run(["chmod", "+x", path_to_script], check=True, env=temp_env)
-        subprocess.run([path_to_script, path_to_dags], check=True, env=temp_env)
+        subprocess.run([path_to_script, dags_dir], check=True, env=temp_env)
         with environ({"AIRFLOW_HOME": tmpdir}):
             yield tmpdir
 

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_transitive_asset_deps.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_transitive_asset_deps.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+from typing import List
+
+import pytest
+from dagster import Definitions, multi_asset
+from dagster._core.definitions.asset_dep import AssetDep
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster_airlift.core.airflow_cacheable_assets_def import AirflowCacheableAssetsDefinition
+from dagster_airlift.core.airflow_instance import AirflowInstance
+from dagster_airlift.core.basic_auth import BasicAuthBackend
+
+
+# Dag dir override
+@pytest.fixture(name="dags_dir")
+def dag_dir_fixture() -> Path:
+    return Path(__file__).parent / "transitive_asset_deps_dags"
+
+
+def create_asset_for_task(task_id: str, dag_id: str, key: str, dep_keys: List[str] = []):
+    @multi_asset(
+        specs=[
+            AssetSpec(
+                key=AssetKey([key]),
+                deps=[AssetSpec(key=AssetKey([dep_key])) for dep_key in dep_keys],
+            )
+        ],
+        op_tags={"airlift/task_id": task_id, "airlift/dag_id": dag_id},
+    )
+    def the_asset():
+        return 1
+
+    return the_asset
+
+
+def test_transitive_deps(airflow_instance: None) -> None:
+    """Test that even with cross-dag transitive asset deps, the correct dependencies are generated for the asset graph."""
+    instance = AirflowInstance(
+        auth_backend=BasicAuthBackend(
+            webserver_url="http://localhost:8080", username="admin", password="admin"
+        ),
+        name="airflow_instance",
+    )
+    cacheable_assets = AirflowCacheableAssetsDefinition(
+        airflow_instance=instance,
+        orchestrated_defs=Definitions(
+            assets=[
+                create_asset_for_task("one", "first", "first_one"),
+                create_asset_for_task("two", "first", "first_two", dep_keys=["second_one"]),
+                create_asset_for_task("three", "first", "first_three", dep_keys=["second_two"]),
+                create_asset_for_task("one", "second", "second_one", dep_keys=["first_one"]),
+                create_asset_for_task("two", "second", "second_two"),
+            ]
+        ),
+        migration_state_override=None,
+        poll_interval=1,
+    )
+
+    defs = Definitions(assets=[cacheable_assets])
+    repository_def = defs.get_repository_def()
+    assets_defs = repository_def.assets_defs_by_key
+    assert len(assets_defs) == 7  # 5 tasks + 2 dags
+    assert AssetKey(["airflow_instance", "dag", "first"]) in assets_defs
+    dag_def = assets_defs[AssetKey(["airflow_instance", "dag", "first"])]
+    spec = next(iter(dag_def.specs))
+    assert spec.deps == [
+        AssetDep(asset=AssetKey(["first_two"])),
+        AssetDep(asset=AssetKey(["first_three"])),
+    ]
+    assert AssetKey(["airflow_instance", "dag", "second"]) in assets_defs
+    dag_def = assets_defs[AssetKey(["airflow_instance", "dag", "second"])]
+    spec = next(iter(dag_def.specs))
+    assert spec.deps == [
+        AssetDep(asset=AssetKey(["second_one"])),
+        AssetDep(asset=AssetKey(["second_two"])),
+    ]

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/transitive_asset_deps_dags/first.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/transitive_asset_deps_dags/first.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2023, 1, 1),
+    "retries": 1,
+}
+
+dag = DAG("first", default_args=default_args, schedule_interval=None, is_paused_upon_creation=False)
+# This task will have a downstream to second.upstream_on_first
+one = PythonOperator(task_id="one", python_callable=lambda: None, dag=dag)
+# This task will have an upstream on second.only. Meaning first.one should not be considered a "leaf".
+two = PythonOperator(task_id="two", python_callable=lambda: None, dag=dag)
+# This task will have an upstream on second.only. Meaning first.one should not be considered a "leaf".
+three = PythonOperator(task_id="three", python_callable=lambda: None, dag=dag)

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/transitive_asset_deps_dags/second.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/transitive_asset_deps_dags/second.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2023, 1, 1),
+    "retries": 1,
+}
+
+dag = DAG(
+    "second", default_args=default_args, schedule_interval=None, is_paused_upon_creation=False
+)
+# Neither of these tasks have downstreams within the dag, so they should be considered "leaf" tasks.
+# This task will have a downstream to first.two
+one = PythonOperator(task_id="one", python_callable=lambda: None, dag=dag)
+# This task will have a downstream to first.three
+two = PythonOperator(task_id="two", python_callable=lambda: None, dag=dag)


### PR DESCRIPTION
Was previously not properly handling transitive cross dag dependencies between assets when linking the "dag" asset to its constituent task assets. 
Tested by creating a transitive dependency between two dags, and ensuring that the correct task assets are considered "leaves"