### PR TITLE
[DA][2/n][user-code] Allow custom AutomationConditions to cross a serdes boundary

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -1130,6 +1130,15 @@ class ExternalAssetNode(IHaveNew):
             # job, and no source assets could be part of any job
             is_source = len(job_names or []) == 0
 
+        # do not include automation conditions containing user-defined info on the ExternalAssetNode
+        # TODO: include a snapshot of the condition on this class instead
+        if (
+            auto_materialize_policy
+            and auto_materialize_policy.asset_condition
+            and not auto_materialize_policy.asset_condition.is_serializable
+        ):
+            auto_materialize_policy = None
+
         return super().__new__(
             cls,
             asset_key=asset_key,

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_auto_materialize_policy_conversion.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_auto_materialize_policy_conversion.py
@@ -10,6 +10,7 @@ from dagster import (
 
 
 def test_round_trip_conversion() -> None:
+    assert AutomationCondition.eager().is_serializable
     policy = AutomationCondition.eager().as_auto_materialize_policy()
     serialized_policy = serialize_value(policy)
     deserialized_policy = deserialize_value(serialized_policy, AutoMaterializePolicy)


### PR DESCRIPTION
## Summary & Motivation

If users create a custom AutomationCondition, it will of course not be serializable. This updates the serialization logic to detect this case and convert the entire AutomationCondition into a format that retains the essential information but does not contain an evaluation function. This allows us to render it in the UI (if we so desire -- currently we only render historical values, not the current condition on the definition object).

Note that this serialization logic is happening in a somewhat-surprising spot, which is the AutoMaterializePolicy object. This is because we store AutomationConditions wrapped inside an AutoMaterializePolicy on the ExternalAssetNode. I'll move this logic over to ExternalAssetNode further up the stack.

## How I Tested These Changes
