### PR TITLE
[dagster-airlift] AirflowInstance, sensor refactor

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import timedelta
-from typing import Dict, Sequence, Set
+from typing import Dict, List, Set, Tuple
 
 from dagster import (
     AssetKey,
@@ -18,11 +18,10 @@ from dagster import (
 from dagster._core.definitions.repository_definition.repository_definition import (
     RepositoryDefinition,
 )
-from dagster._core.utils import toposort_flatten
 from dagster._time import datetime_from_timestamp, get_current_datetime, get_current_timestamp
 
-from .airflow_instance import AirflowInstance
-from .utils import get_dag_id_from_asset
+from .airflow_instance import AirflowInstance, TaskInstance
+from .utils import get_dag_id_from_asset, get_task_id_from_asset
 
 
 def build_airflow_polling_sensor(
@@ -36,100 +35,95 @@ def build_airflow_polling_sensor(
     def airflow_dag_sensor(context: SensorEvaluationContext) -> SensorResult:
         """Sensor to report materialization events for each asset as new runs come in."""
         repository_def = check.not_none(context.repository_def)
-        toposorted_keys_per_dag = retrieve_toposorted_dag_keys(repository_def)
-
         last_effective_date = (
             datetime_from_timestamp(float(context.cursor))
             if context.cursor
             else get_current_datetime() - timedelta(days=1)
         )
         current_date = get_current_datetime()
-        materializations_to_report = []
-        for dag_id, topo_order_keys in toposorted_keys_per_dag.items():
+        materializations_to_report: List[Tuple[float, AssetMaterialization]] = []
+        for dag_id, (dag_key, task_keys) in retrieve_dag_keys(repository_def).items():
             # For now, we materialize assets representing tasks only when the whole dag completes.
             # With a more robust cursor that can let us know when we've seen a particular task run already, then we can relax this constraint.
             for dag_run in airflow_instance.get_dag_runs(dag_id, last_effective_date, current_date):
-                # If the dag run succeeded, add materializations for all assets referring to dags.
-                if dag_run["state"] != "success":
+                if not dag_run.success:
                     raise Exception("Should only see successful dag runs at this point.")
-                for asset_key in topo_order_keys:
-                    asset_node = repository_def.asset_graph.get(asset_key)
-                    spec = asset_node.to_asset_spec()
-                    task_id = spec.tags.get("airlift/task_id")
-                    details_link = (
-                        airflow_instance.get_dag_run_url(dag_id, dag_run["dag_run_id"])
-                        if task_id is None
-                        else airflow_instance.get_task_instance_url(
-                            dag_id, task_id, dag_run["dag_run_id"]
-                        )
-                    )
-                    metadata = {
-                        "Airflow Run ID": dag_run["dag_run_id"],
-                        "Run Metadata (raw)": JsonMetadataValue(dag_run),
-                        "Start Date": TimestampMetadataValue(
-                            airflow_instance.timestamp_from_airflow_date(dag_run["start_date"])
-                        ),
-                        "End Date": TimestampMetadataValue(
-                            airflow_instance.timestamp_from_airflow_date(dag_run["end_date"])
-                        ),
-                        "Run Type": dag_run["run_type"],
-                        "Airflow Config": JsonMetadataValue(dag_run["conf"]),
-                        "Run Details": MarkdownMetadataValue(f"[View]({details_link})"),
-                        "Creation Timestamp": TimestampMetadataValue(get_current_timestamp()),
-                    }
-                    if task_id:
-                        metadata["Task Logs"] = MarkdownMetadataValue(
-                            f"[View Logs]({airflow_instance.get_task_instance_log_url(dag_id, task_id, dag_run['dag_run_id'])})"
-                        )
 
-                    materializations_to_report.append(
+                metadata = {
+                    "Airflow Run ID": dag_run.run_id,
+                    "Run Metadata (raw)": JsonMetadataValue(dag_run.metadata),
+                    "Run Type": dag_run.run_type,
+                    "Airflow Config": JsonMetadataValue(dag_run.config),
+                    "Creation Timestamp": TimestampMetadataValue(get_current_timestamp()),
+                }
+                # Add dag materialization
+                dag_metadata = {
+                    **metadata,
+                    "Run Details": MarkdownMetadataValue(f"[View Run]({dag_run.url})"),
+                    "Start Date": TimestampMetadataValue(dag_run.start_date),
+                    "End Date": TimestampMetadataValue(dag_run.end_date),
+                }
+                materializations_to_report.append(
+                    (
+                        dag_run.end_date,
                         AssetMaterialization(
-                            asset_key=asset_key,
-                            description=dag_run["note"],
-                            metadata=metadata,
+                            asset_key=dag_key,
+                            description=dag_run.note,
+                            metadata=dag_metadata,
+                        ),
+                    )
+                )
+                task_runs = {}
+                for task_id, asset_key in task_keys:
+                    task_run: TaskInstance = task_runs.get(
+                        task_id, airflow_instance.get_task_instance(dag_id, task_id, dag_run.run_id)
+                    )
+                    task_runs[task_id] = task_run
+                    task_metadata = {
+                        **metadata,
+                        "Run Details": MarkdownMetadataValue(f"[View Run]({task_run.details_url})"),
+                        "Task Logs": MarkdownMetadataValue(f"[View Logs]({task_run.log_url})"),
+                        "Start Date": TimestampMetadataValue(dag_run.start_date),
+                        "End Date": TimestampMetadataValue(dag_run.end_date),
+                    }
+                    materializations_to_report.append(
+                        (
+                            task_run.end_date,
+                            AssetMaterialization(
+                                asset_key=asset_key,
+                                description=task_run.note,
+                                metadata=task_metadata,
+                            ),
                         )
                     )
+        # Sort materialization
+        sorted_mats = sorted(materializations_to_report, key=lambda x: x[0])
         context.update_cursor(str(current_date.timestamp()))
         return SensorResult(
-            asset_events=materializations_to_report,
+            asset_events=[sorted_mat[1] for sorted_mat in sorted_mats],
         )
 
     return airflow_dag_sensor
 
 
-def retrieve_toposorted_dag_keys(
+def retrieve_dag_keys(
     repository_def: RepositoryDefinition,
-) -> Dict[str, Sequence[AssetKey]]:
-    """For each dag, retrieve the topologically sorted list of asset keys."""
+) -> Dict[str, Tuple[AssetKey, Set[Tuple[str, AssetKey]]]]:
+    """For each dag, retrieve the list of asset keys."""
     # First, we need to retrieve the upstreams for each asset key
-    upstreams_asset_dependency_graph: Dict[AssetKey, Set[AssetKey]] = defaultdict(set)
-    asset_keys_per_dag: Dict[str, Set[AssetKey]] = defaultdict(set)
+    key_per_dag = {}
+    task_keys_per_dag = defaultdict(set)
     for assets_def in repository_def.assets_defs_by_key.values():
         # We could be more specific about the checks here to ensure that there's only one asset key
         # specifying the dag, and that all others have a task id.
         dag_id = get_dag_id_from_asset(assets_def)
+        task_id = get_task_id_from_asset(assets_def)
         if dag_id is None:
             continue
-        for spec in assets_def.specs:
-            for dep in spec.deps:
-                upstreams_asset_dependency_graph[spec.key].add(dep.asset_key)
-            asset_keys_per_dag[dag_id].add(spec.key)
-
-    # Now, we can retrieve the topologically sorted list of asset keys for each dag
-    dag_keys_to_toposorted_asset_keys: Dict[str, Sequence[AssetKey]] = {}
-    for dag_id, asset_keys in asset_keys_per_dag.items():
-        dag_keys_to_toposorted_asset_keys[dag_id] = toposort_keys(
-            asset_keys, upstreams_asset_dependency_graph
-        )
-
-    return dag_keys_to_toposorted_asset_keys
-
-
-def toposort_keys(
-    keys_in_subgraph: Set[AssetKey], upstreams_asset_dependency_graph: Dict[AssetKey, Set[AssetKey]]
-) -> Sequence[AssetKey]:
-    narrowed_asset_dependency_graph = {
-        key: {dep for dep in upstreams_asset_dependency_graph[key] if dep in keys_in_subgraph}
-        for key in keys_in_subgraph
-    }
-    return toposort_flatten(narrowed_asset_dependency_graph)
+        if task_id is None:
+            key_per_dag[dag_id] = (
+                assets_def.key
+            )  # There should only be one key in the case of a "dag" asset
+        else:
+            task_keys_per_dag[dag_id].update((task_id, spec.key) for spec in assets_def.specs)
+    return {dag_id: (key, task_keys_per_dag[dag_id]) for dag_id, key in key_per_dag.items()}

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/conftest.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/conftest.py
@@ -2,10 +2,16 @@ import os
 import subprocess
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Generator
+from typing import Any, Generator
 
 import pytest
+import requests
 from dagster._core.test_utils import environ
+
+
+def assert_link_exists(link_name: str, link_url: Any):
+    assert isinstance(link_url, str)
+    assert requests.get(link_url).status_code == 200, f"{link_name} is broken"
 
 
 @pytest.fixture(name="dags_dir")

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_airflow_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_airflow_instance.py
@@ -2,8 +2,10 @@ import pytest
 from dagster._core.errors import DagsterError
 from dagster_airlift.core import AirflowInstance, BasicAuthBackend
 
+from .conftest import assert_link_exists
 
-def test_airflow_instance(airflow_instance: None):
+
+def test_airflow_instance(airflow_instance: None) -> None:
     """Test AirflowInstance APIs against live-running airflow.
 
     Airflow is loaded with one dag (print_dag) which contains two tasks (print_task, downstream_print_task).
@@ -28,10 +30,12 @@ def test_airflow_instance(airflow_instance: None):
     task_info = instance.get_task_info(dag_id="print_dag", task_id="print_task")
     assert task_info.dag_id == "print_dag"
     assert task_info.task_id == "print_task"
+    assert_link_exists("Dag url from task info object", task_info.dag_url)
 
     task_info = instance.get_task_info(dag_id="print_dag", task_id="downstream_print_task")
     assert task_info.dag_id == "print_dag"
     assert task_info.task_id == "downstream_print_task"
+    assert_link_exists("Dag url from task info object", task_info.dag_url)
 
     # Attempt a nonexistent task
     with pytest.raises(
@@ -39,14 +43,24 @@ def test_airflow_instance(airflow_instance: None):
     ):
         instance.get_task_info(dag_id="print_dag", task_id="nonexistent_task")
 
-    assert instance.get_dag_url(dag_id="print_dag") == "http://localhost:8080/dags/print_dag"
-    assert (
-        instance.get_dag_run_url(dag_id="print_dag", run_id="run_id")
-        == "http://localhost:8080/dags/print_dag/grid?dag_run_id=run_id&tab=details"
+    # Kick off a run of the dag.
+    run_id = instance.trigger_dag(dag_id="print_dag")
+    instance.wait_for_run_completion(dag_id="print_dag", run_id=run_id)
+    run = instance.get_dag_run(dag_id="print_dag", run_id=run_id)
+
+    assert run.run_id == run_id
+    assert_link_exists("Dag run", run.url)
+
+    assert run.finished
+    assert run.success
+
+    # Fetch task instance
+    task_instance = instance.get_task_instance(
+        dag_id="print_dag", task_id="print_task", run_id=run_id
     )
-    assert (
-        instance.get_task_instance_log_url(
-            dag_id="print_dag", task_id="print_task", run_id="run_id"
-        )
-        == "http://localhost:8080/dags/print_dag/grid?dag_run_id=run_id&task_id=print_task&tab=logs"
-    )
+    assert_link_exists("Task instance", task_instance.details_url)
+    assert_link_exists("Task logs", task_instance.log_url)
+
+    assert isinstance(task_instance.start_date, float)
+    assert isinstance(task_instance.end_date, float)
+    assert isinstance(task_instance.note, str)

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_peering.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_peering.py
@@ -1,9 +1,7 @@
 import re
-import time
 from typing import Any, cast
 
 import pytest
-import requests
 from dagster import (
     AssetDep,
     AssetsDefinition,
@@ -23,6 +21,8 @@ from dagster_airlift.core.migration_state import (
     DagMigrationState,
     TaskMigrationState,
 )
+
+from .conftest import assert_link_exists
 
 
 @pytest.mark.flaky(reruns=2)
@@ -91,7 +91,7 @@ def test_dag_peering(
         "[View DAG](http://localhost:8080/dags/print_dag)"
     )
     link = extract_link(spec_metadata["Link to DAG"].value)
-    _assert_link_exists("Link to DAG", link)
+    assert_link_exists("Link to DAG", link)
     assert "Source Code" in spec_metadata
 
     task_def: AssetsDefinition = [  # noqa
@@ -105,7 +105,7 @@ def test_dag_peering(
         "[View DAG](http://localhost:8080/dags/print_dag)"
     )
     link = extract_link(task_spec.metadata["Link to DAG"].value)
-    _assert_link_exists("Link to DAG", link)
+    assert_link_exists("Link to DAG", link)
 
     other_task_def: AssetsDefinition = [  # noqa
         assets_def for assets_def in assets_defs if assets_def.key == AssetKey(["other", "key"])
@@ -120,23 +120,8 @@ def test_dag_peering(
     sensor_def = next(iter(defs.sensors))
 
     # Kick off a run of the dag
-    response = requests.post(
-        "http://localhost:8080/api/v1/dags/print_dag/dagRuns", auth=("admin", "admin"), json={}
-    )
-    assert response.status_code == 200, response.json()
-    # Wait until the run enters a terminal state
-    terminal_status = None
-    while True:
-        response = requests.get(
-            "http://localhost:8080/api/v1/dags/print_dag/dagRuns", auth=("admin", "admin")
-        )
-        assert response.status_code == 200, response.json()
-        dag_runs = response.json()["dag_runs"]
-        if dag_runs[0]["state"] in ["success", "failed"]:
-            terminal_status = dag_runs[0]["state"]
-            break
-        time.sleep(1)
-    assert terminal_status == "success"
+    run_id = instance.trigger_dag("print_dag")
+    instance.wait_for_run_completion("print_dag", run_id, timeout=60)
 
     # invoke the sensor and check the sensor result. It should contain a new asset materialization for the dag.
     with instance_for_test() as instance:
@@ -154,10 +139,10 @@ def test_dag_peering(
         assert "manual" in cast(str, dag_mat.metadata["Airflow Run ID"].value)
         run_id = dag_mat.metadata["Airflow Run ID"].value
         assert dag_mat.metadata["Run Details"] == MarkdownMetadataValue(
-            f"[View](http://localhost:8080/dags/print_dag/grid?dag_run_id={run_id}&tab=details)"
+            f"[View Run](http://localhost:8080/dags/print_dag/grid?dag_run_id={run_id}&tab=details)"
         )
         pure_link = extract_link(dag_mat.metadata["Run Details"].value)
-        _assert_link_exists("Run Details", pure_link)
+        assert_link_exists("Run Details", pure_link)
         assert dag_mat.metadata["Airflow Config"] == JsonMetadataValue({})
 
         task_mat = [  # noqa
@@ -171,17 +156,17 @@ def test_dag_peering(
         assert "manual" in cast(str, task_mat.metadata["Airflow Run ID"].value)
         run_id = task_mat.metadata["Airflow Run ID"].value
         assert task_mat.metadata["Run Details"] == MarkdownMetadataValue(
-            f"[View](http://localhost:8080/dags/print_dag/grid?dag_run_id={run_id}&task_id=print_task)"
+            f"[View Run](http://localhost:8080/dags/print_dag/grid?dag_run_id={run_id}&task_id=print_task)"
         )
         link = extract_link(task_mat.metadata["Run Details"].value)
-        _assert_link_exists("Run Details", link)
+        assert_link_exists("Run Details", link)
 
         assert "Task Logs" in task_mat.metadata
         assert task_mat.metadata["Task Logs"] == MarkdownMetadataValue(
             f"[View Logs](http://localhost:8080/dags/print_dag/grid?dag_run_id={run_id}&task_id=print_task&tab=logs)"
         )
         link = extract_link(task_mat.metadata["Task Logs"].value)
-        _assert_link_exists("Task Logs", link)
+        assert_link_exists("Task Logs", link)
 
         other_mat = [  # noqa
             asset_mat
@@ -195,11 +180,6 @@ def test_dag_peering(
             other_mat.metadata["Creation Timestamp"].value
             >= task_mat.metadata["Creation Timestamp"].value
         )
-
-
-def _assert_link_exists(link_name: str, link_url: Any):
-    assert isinstance(link_url, str)
-    assert requests.get(link_url).status_code == 200, f"{link_name} is broken"
 
 
 def extract_link(mrkdwn: Any) -> str:

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_transitive_asset_deps.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_transitive_asset_deps.py
@@ -3,7 +3,6 @@ from typing import List
 
 import pytest
 from dagster import Definitions, multi_asset
-from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster_airlift.core.airflow_cacheable_assets_def import AirflowCacheableAssetsDefinition
@@ -63,14 +62,10 @@ def test_transitive_deps(airflow_instance: None) -> None:
     assert AssetKey(["airflow_instance", "dag", "first"]) in assets_defs
     dag_def = assets_defs[AssetKey(["airflow_instance", "dag", "first"])]
     spec = next(iter(dag_def.specs))
-    assert spec.deps == [
-        AssetDep(asset=AssetKey(["first_two"])),
-        AssetDep(asset=AssetKey(["first_three"])),
-    ]
+    deps_keys = {dep.asset_key for dep in spec.deps}
+    assert deps_keys == {AssetKey(["first_two"]), AssetKey(["first_three"])}
     assert AssetKey(["airflow_instance", "dag", "second"]) in assets_defs
     dag_def = assets_defs[AssetKey(["airflow_instance", "dag", "second"])]
     spec = next(iter(dag_def.specs))
-    assert spec.deps == [
-        AssetDep(asset=AssetKey(["second_one"])),
-        AssetDep(asset=AssetKey(["second_two"])),
-    ]
+    deps_keys = {dep.asset_key for dep in spec.deps}
+    assert deps_keys == {AssetKey(["second_one"]), AssetKey(["second_two"])}


### PR DESCRIPTION
Made the AirflowInstance vended classes more composable so we're not throwing around raw dicts everywhere. Added some utilities to trigger and wait for the completion of airflow runs, which are used in tests (for now...)

Made some refactors to the sensor after realizing we don't actually want to report in topological order... we want to report in task order. So instead, retrieve per-task info about each execution. Better testing of this new method is forthcoming, but existing tests already exercise the codepath.