### PR TITLE
fix docs publish gh action

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -7,13 +7,13 @@ on:
       - docs-prod # prod
     paths:
       - docs/**
-      - examples/doc_snippets/**
+      - examples/docs_snippets/**
       - CHANGES.md
       - .github/workflows/build-docs.yml
   pull_request:
     paths:
       - docs/**
-      - examples/doc_snippets/**
+      - examples/docs_snippets/**
       - CHANGES.md
       - .github/workflows/build-docs.yml
 concurrency:


### PR DESCRIPTION
## Summary & Motivation
fix a typo in the docs build step added in https://github.com/dagster-io/dagster/pull/23117

docs builds in the docs-prod branch are faling because of this:
- https://github.com/dagster-io/dagster/actions/runs/10311108286/job/28544589300
- https://github.com/dagster-io/dagster/actions/runs/10307006075/job/28531327009

we didn't encounter this until now because there was no docs pushes since the PR was landed 

## How I Tested These Changes
build should succeed on docs-prod branch
