### PR TITLE
[dagster-dbt] Do not add database when database is null

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -458,11 +458,13 @@ def default_metadata_from_dbt_resource_props(
         and "alias" in dbt_resource_props
     ):
         relation_name = ".".join(
-            [
-                dbt_resource_props["database"],
-                dbt_resource_props["schema"],
-                dbt_resource_props["alias"],
-            ]
+            filter(None,
+                   [
+                       dbt_resource_props["database"],
+                       dbt_resource_props["schema"],
+                       dbt_resource_props["alias"],
+                   ]
+                   )
         )
 
     return {


### PR DESCRIPTION
## Summary & Motivation

When dbt type is `SPARK` or `MYSQL`, the `database` property is null, it will throw an exception ,like this:

```
The above exception was caused by the following exception:
TypeError: sequence item 0: expected str instance, NoneType found
```

we should not add the `database` for this case.


## How I Tested These Changes
