### PR TITLE
Refactor event log storage tests to use instance as a fixture

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -1999,7 +1999,7 @@ class TestEventLogStorage:
             )
             assert _get_storage_ids(result) == [storage_id_3, storage_id_1]
 
-    def test_get_event_records_sqlite(self, storage):
+    def test_get_event_records_sqlite(self, storage, instance):
         if not self.is_sqlite(storage):
             pytest.skip()
 
@@ -2032,119 +2032,109 @@ class TestEventLogStorage:
         def a_job():
             materialize_one()
 
-        with instance_for_test() as instance:
-            if not storage.has_instance:
-                storage.register_instance(instance)
+        instance.wipe()
 
-            # first run
-            execute_run(
-                InMemoryJob(a_job),
-                instance.create_run_for_job(
-                    a_job,
-                    run_id=run_id_1,
-                    run_config={"loggers": {"callback": {}, "console": {}}},
-                ),
-                instance,
-            )
+        # first run
+        execute_run(
+            InMemoryJob(a_job),
+            instance.create_run_for_job(
+                a_job,
+                run_id=run_id_1,
+                run_config={"loggers": {"callback": {}, "console": {}}},
+            ),
+            instance,
+        )
 
-            for event in events:
-                storage.store_event(event)
+        run_records = instance.get_run_records()
+        assert len(run_records) == 1
 
-            run_records = instance.get_run_records()
-            assert len(run_records) == 1
+        # second run
+        events = []
+        execute_run(
+            InMemoryJob(a_job),
+            instance.create_run_for_job(
+                a_job,
+                run_id=run_id_2,
+                run_config={"loggers": {"callback": {}, "console": {}}},
+            ),
+            instance,
+        )
+        run_records = instance.get_run_records()
+        assert len(run_records) == 2
 
-            # second run
-            events = []
-            execute_run(
-                InMemoryJob(a_job),
-                instance.create_run_for_job(
-                    a_job,
-                    run_id=run_id_2,
-                    run_config={"loggers": {"callback": {}, "console": {}}},
-                ),
-                instance,
-            )
-            run_records = instance.get_run_records()
-            assert len(run_records) == 2
-            for event in events:
-                storage.store_event(event)
+        # third run
+        events = []
+        execute_run(
+            InMemoryJob(a_job),
+            instance.create_run_for_job(
+                a_job,
+                run_id=run_id_3,
+                run_config={"loggers": {"callback": {}, "console": {}}},
+            ),
+            instance,
+        )
+        run_records = instance.get_run_records()
+        assert len(run_records) == 3
 
-            # third run
-            events = []
-            execute_run(
-                InMemoryJob(a_job),
-                instance.create_run_for_job(
-                    a_job,
-                    run_id=run_id_3,
-                    run_config={"loggers": {"callback": {}, "console": {}}},
-                ),
-                instance,
-            )
-            run_records = instance.get_run_records()
-            assert len(run_records) == 3
-            for event in events:
-                storage.store_event(event)
+        update_timestamp = run_records[-1].update_timestamp
 
-            update_timestamp = run_records[-1].update_timestamp
+        # use tz-aware cursor
+        filtered_records = storage.get_event_records(
+            EventRecordsFilter(
+                event_type=DagsterEventType.RUN_SUCCESS,
+                after_cursor=RunShardedEventsCursor(
+                    id=0, run_updated_after=update_timestamp
+                ),  # events after first run
+            ),
+            ascending=True,
+        )
 
-            # use tz-aware cursor
-            filtered_records = storage.get_event_records(
+        assert len(filtered_records) == 2
+        assert _event_types([r.event_log_entry for r in filtered_records]) == [
+            DagsterEventType.RUN_SUCCESS,
+            DagsterEventType.RUN_SUCCESS,
+        ]
+        assert [r.event_log_entry.run_id for r in filtered_records] == [run_id_2, run_id_3]
+
+        # use tz-naive cursor
+        filtered_records = storage.get_event_records(
+            EventRecordsFilter(
+                event_type=DagsterEventType.RUN_SUCCESS,
+                after_cursor=RunShardedEventsCursor(
+                    id=0, run_updated_after=update_timestamp.replace(tzinfo=None)
+                ),  # events after first run
+            ),
+            ascending=True,
+        )
+        assert len(filtered_records) == 2
+        assert _event_types([r.event_log_entry for r in filtered_records]) == [
+            DagsterEventType.RUN_SUCCESS,
+            DagsterEventType.RUN_SUCCESS,
+        ]
+        assert [r.event_log_entry.run_id for r in filtered_records] == [run_id_2, run_id_3]
+
+        # use invalid cursor
+        with pytest.raises(Exception, match="Add a RunShardedEventsCursor to your query filter"):
+            storage.get_event_records(
                 EventRecordsFilter(
                     event_type=DagsterEventType.RUN_SUCCESS,
-                    after_cursor=RunShardedEventsCursor(
-                        id=0, run_updated_after=update_timestamp
-                    ),  # events after first run
+                    after_cursor=0,
                 ),
-                ascending=True,
             )
-            assert len(filtered_records) == 2
-            assert _event_types([r.event_log_entry for r in filtered_records]) == [
-                DagsterEventType.RUN_SUCCESS,
-                DagsterEventType.RUN_SUCCESS,
-            ]
-            assert [r.event_log_entry.run_id for r in filtered_records] == [run_id_2, run_id_3]
 
-            # use tz-naive cursor
-            filtered_records = storage.get_event_records(
-                EventRecordsFilter(
-                    event_type=DagsterEventType.RUN_SUCCESS,
-                    after_cursor=RunShardedEventsCursor(
-                        id=0, run_updated_after=update_timestamp.replace(tzinfo=None)
-                    ),  # events after first run
-                ),
-                ascending=True,
-            )
-            assert len(filtered_records) == 2
-            assert _event_types([r.event_log_entry for r in filtered_records]) == [
-                DagsterEventType.RUN_SUCCESS,
-                DagsterEventType.RUN_SUCCESS,
-            ]
-            assert [r.event_log_entry.run_id for r in filtered_records] == [run_id_2, run_id_3]
-
-            # use invalid cursor
-            with pytest.raises(
-                Exception, match="Add a RunShardedEventsCursor to your query filter"
-            ):
-                storage.get_event_records(
-                    EventRecordsFilter(
-                        event_type=DagsterEventType.RUN_SUCCESS,
-                        after_cursor=0,
-                    ),
-                )
-
-            # check that events were double-written to the index shard
-            with storage.index_connection() as conn:
-                run_status_change_events = conn.execute(
-                    db_select([SqlEventLogStorageTable.c.id]).where(
-                        SqlEventLogStorageTable.c.dagster_event_type.in_(
-                            [
-                                event_type.value
-                                for event_type in EVENT_TYPE_TO_PIPELINE_RUN_STATUS.keys()
-                            ]
-                        )
+        # check that events were double-written to the index shard
+        with storage.index_connection() as conn:
+            run_status_change_events = conn.execute(
+                db_select([SqlEventLogStorageTable.c.id]).where(
+                    SqlEventLogStorageTable.c.dagster_event_type.in_(
+                        [
+                            event_type.value
+                            for event_type in EVENT_TYPE_TO_PIPELINE_RUN_STATUS.keys()
+                        ]
                     )
-                ).fetchall()
-                assert len(run_status_change_events) == 6
+                )
+            ).fetchall()
+            assert len(run_status_change_events) == 6
 
     # .watch() is async, there's a small chance they don't run before the asserts
     @pytest.mark.flaky(reruns=1)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_event_log.py
@@ -30,10 +30,20 @@ def _clean_storage(conn_string):
 class TestPostgresEventLogStorage(TestEventLogStorage):
     __test__ = True
 
+    @pytest.fixture(name="instance", scope="function")
+    def instance(self, conn_string):
+        PostgresEventLogStorage.create_clean_storage(conn_string)
+
+        with instance_for_test(
+            overrides={"storage": {"postgres": {"postgres_url": conn_string}}}
+        ) as instance:
+            yield instance
+
     @pytest.fixture(scope="function", name="storage")
-    def event_log_storage(self, conn_string):
-        with _clean_storage(conn_string) as storage:
-            yield storage
+    def event_log_storage(self, instance):
+        event_log_storage = instance.event_log_storage
+        assert isinstance(event_log_storage, PostgresEventLogStorage)
+        yield event_log_storage
 
     def test_event_log_storage_two_watchers(self, conn_string):
         with _clean_storage(conn_string) as storage:


### PR DESCRIPTION
Summary:
Allows us to add test cases to TestEventLogStorage that use the instance directly.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes
