### PR TITLE
add "dagster-dbt/materialization_type" to default metadata produced for dbt assets

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -53,6 +53,7 @@ from dagster._core.definitions.metadata.source_code import (
 from dagster._core.definitions.tags import build_kind_tag
 from dagster._utils.merger import merge_dicts
 
+from dagster_dbt.metadata_set import DbtMetadataSet
 from dagster_dbt.utils import (
     ASSET_RESOURCE_TYPES,
     dagster_name_fn,
@@ -462,7 +463,9 @@ def default_metadata_from_dbt_resource_props(
     ]
     relation_name = ".".join(relation_parts) if relation_parts else None
 
+    materialization_type = dbt_resource_props.get("config", {}).get("materialized")
     return {
+        **DbtMetadataSet(materialization_type=materialization_type),
         **TableMetadataSet(
             column_schema=column_schema,
             relation_identifier=relation_name,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/metadata_set.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/metadata_set.py
@@ -1,0 +1,18 @@
+from typing import Optional
+
+from dagster._core.definitions.metadata.metadata_set import NamespacedMetadataSet
+
+
+class DbtMetadataSet(NamespacedMetadataSet):
+    """Metadata entries that apply to dbt objects.
+
+    Args:
+        materialization_type (Optional[str]): The materialization type, like "table" or "view". See
+            https://docs.getdbt.com/docs/build/materializations.
+    """
+
+    materialization_type: Optional[str]
+
+    @classmethod
+    def namespace(cls) -> str:
+        return "dagster-dbt"


### PR DESCRIPTION
## Summary & Motivation

Without this, it's difficult to determine whether a dbt model is a view or not.

https://docs.getdbt.com/docs/build/materializations

One question that came up is whether this should instead be "dagster-dbt/**materialized**_type", given that it's configured in dbt using e.g. `+materialized: table`. However, in their docs they call it "materialization", and the past tense seems a little awkward for this use case.

## How I Tested These Changes
