### PR TITLE
[daggy-u] [dbt] - Correct S3 env var key

### DIFF
--- a/docs/dagster-university/pages/dagster-dbt/lesson-7/5-preparing-for-a-successful-run.md
+++ b/docs/dagster-university/pages/dagster-dbt/lesson-7/5-preparing-for-a-successful-run.md
@@ -153,7 +153,7 @@ The following table contains the environment variables we need to create in Dags
 
 ---
 
-- `S3_BUCKET_NAME`
+- `S3_BUCKET_PREFIX`
 - The name of the S3 bucket, by default `"s3://dagster-university/"`, for the S3 bucket where your taxi data will be stored.
 
 {% /table %}


### PR DESCRIPTION
## Summary & Motivation

This PR corrects the name of the S3 bucket environment variable in Lesson 7 to `S3_BUCKET_PREFIX`.

## How I Tested These Changes

Matches the [`constants.py` of the accompanying project](https://github.com/dagster-io/project-dagster-university/blob/module/dagster-and-dbt/dagster_university/assets/constants.py)