### PR TITLE
Guide users toward paginated runs queries

### DIFF
--- a/docs/content/concepts/webserver/graphql.mdx
+++ b/docs/content/concepts/webserver/graphql.mdx
@@ -71,31 +71,6 @@ Dagster also provides a Python client to interface with Dagster's GraphQL API fr
 ### Get a list of Dagster runs
 
 <TabGroup>
-<TabItem name="Retrieve all runs">
-
-To retrieve a list of all runs, use the `runsOrError` query.
-
-```shell
-query RunsQuery {
-  runsOrError {
-    __typename
-    ... on Runs {
-      results {
-        runId
-        jobName
-        status
-        runConfigYaml
-        startTime
-        endTime
-      }
-    }
-  }
-}
-```
-
----
-
-</TabItem>
 <TabItem name="Paginate through runs">
 
 You may eventually accumulate too many runs to return in one query. The `runsOrError` query takes in optional `cursor` and `limit` arguments for pagination:
@@ -137,7 +112,11 @@ For example, the following query will return all failed runs:
 
 ```shell
 query FilteredRunsQuery {
-  runsOrError(filter: { statuses: [FAILURE] }) {
+  runsOrError(
+    filter: { statuses: [FAILURE] }
+    cursor: "7fd2e5ef-5591-43db-be15-1ebbbbed8bb5"
+    limit: 10
+  ) {
     __typename
     ... on Runs {
       results {

--- a/docs/content/concepts/webserver/graphql.mdx
+++ b/docs/content/concepts/webserver/graphql.mdx
@@ -76,9 +76,9 @@ Dagster also provides a Python client to interface with Dagster's GraphQL API fr
 You may eventually accumulate too many runs to return in one query. The `runsOrError` query takes in optional `cursor` and `limit` arguments for pagination:
 
 ```shell
-query PaginatedRunsQuery {
+query PaginatedRunsQuery($cursor: String) {
   runsOrError(
-    cursor: "7fd2e5ef-5591-43db-be15-1ebbbbed8bb5"
+    cursor: $cursor
     limit: 10
   ) {
     __typename
@@ -111,10 +111,10 @@ The `runsOrError` query also takes in an optional filter argument, of type `Runs
 For example, the following query will return all failed runs:
 
 ```shell
-query FilteredRunsQuery {
+query FilteredRunsQuery($cursor: String) {
   runsOrError(
     filter: { statuses: [FAILURE] }
-    cursor: "7fd2e5ef-5591-43db-be15-1ebbbbed8bb5"
+    cursor: $cursor
     limit: 10
   ) {
     __typename


### PR DESCRIPTION
For larger deployments, getting all runs isn't very useful nor is it very performant. While we work on shifting the API to require pagination, let's make sure our examples represent best practice.