### PR TITLE
Update event log storage to return an AssetPartitionRecord class rather than a tuple

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -1,15 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import (
-    TYPE_CHECKING,
-    Iterable,
-    Mapping,
-    NamedTuple,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Iterable, Mapping, NamedTuple, Optional, Sequence, Set, Union
 
 import dagster._check as check
 from dagster._core.assets import AssetDetails
@@ -122,6 +112,16 @@ class AssetEntry(
         if self.last_materialization_record is None:
             return None
         return self.last_materialization_record.storage_id
+
+
+class AssetPartitionSummaryRecord(NamedTuple):
+    partition: str
+    last_materialization_storage_id: Optional[int]
+    last_materialization_run_id: Optional[str]
+    last_planned_materialization_storage_id: Optional[int]
+    last_planned_materialization_run_id: Optional[str]
+    last_materialization_failure_storage_id: Optional[int]
+    last_materialization_failure_run_id: Optional[str]
 
 
 class AssetRecord(NamedTuple):
@@ -454,7 +454,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     @abstractmethod
     def get_latest_asset_partition_materialization_attempts_without_materializations(
         self, asset_key: AssetKey, after_storage_id: Optional[int] = None
-    ) -> Mapping[str, Tuple[str, int]]:
+    ) -> Mapping[str, AssetPartitionSummaryRecord]:
         pass
 
     @abstractmethod

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -16,6 +16,7 @@ from dagster._utils.concurrency import ConcurrencyClaimStatus, ConcurrencyKeyInf
 
 from .base_storage import DagsterStorage
 from .event_log.base import (
+    AssetPartitionSummaryRecord,
     AssetRecord,
     EventLogConnection,
     EventLogRecord,
@@ -566,7 +567,7 @@ class LegacyEventLogStorage(EventLogStorage, ConfigurableClass):
 
     def get_latest_asset_partition_materialization_attempts_without_materializations(
         self, asset_key: "AssetKey", after_storage_id: Optional[int] = None
-    ) -> Mapping[str, Tuple[str, int]]:
+    ) -> Mapping[str, AssetPartitionSummaryRecord]:
         return self._storage.event_log_storage.get_latest_asset_partition_materialization_attempts_without_materializations(
             asset_key, after_storage_id
         )


### PR DESCRIPTION
Summary:
This gives us tools to use additional columns in the asset partition cache if they are available.

## Summary & Motivation

## How I Tested These Changes
