### PR TITLE
[DA] Lazily compute partitionKeys for Automation tab on Asset Details page

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -27,6 +27,7 @@ from dagster_graphql.implementation.fetch_asset_condition_evaluations import (
     fetch_asset_condition_evaluation_record_for_partition,
     fetch_asset_condition_evaluation_records_for_asset_key,
     fetch_asset_condition_evaluation_records_for_evaluation_id,
+    fetch_true_partitions_for_evaluation_node,
 )
 from dagster_graphql.implementation.fetch_auto_materialize_asset_evaluations import (
     fetch_auto_materialize_asset_evaluations,
@@ -522,6 +523,14 @@ class GrapheneQuery(graphene.ObjectType):
         limit=graphene.Argument(graphene.NonNull(graphene.Int)),
         cursor=graphene.Argument(graphene.String),
         description="Retrieve the auto materialization evaluation records for an asset.",
+    )
+
+    truePartitionsForAutomationConditionEvaluationNode = graphene.Field(
+        non_null_list(graphene.String),
+        assetKey=graphene.Argument(graphene.NonNull(GrapheneAssetKeyInput)),
+        evaluationId=graphene.Argument(graphene.NonNull(graphene.Int)),
+        nodeUniqueId=graphene.Argument(graphene.String),
+        description="Retrieve the partition keys which were true for a specific automation condition evaluation node.",
     )
 
     autoMaterializeEvaluationsForEvaluationId = graphene.Field(
@@ -1197,6 +1206,20 @@ class GrapheneQuery(graphene.ObjectType):
     ):
         return fetch_asset_condition_evaluation_records_for_asset_key(
             graphene_info=graphene_info, graphene_asset_key=assetKey, cursor=cursor, limit=limit
+        )
+
+    def resolve_truePartitionsForAutomationConditionEvaluationNode(
+        self,
+        graphene_info: ResolveInfo,
+        assetKey: GrapheneAssetKeyInput,
+        evaluationId: int,
+        nodeUniqueId: str,
+    ):
+        return fetch_true_partitions_for_evaluation_node(
+            graphene_info=graphene_info,
+            graphene_asset_key=assetKey,
+            evaluation_id=evaluationId,
+            node_unique_id=nodeUniqueId,
         )
 
     def resolve_assetConditionEvaluationsForEvaluationId(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
@@ -3,6 +3,7 @@ from typing import (
     TYPE_CHECKING,
     AbstractSet,
     FrozenSet,
+    Iterator,
     Mapping,
     NamedTuple,
     Optional,
@@ -130,6 +131,12 @@ class AutomationConditionEvaluation(NamedTuple):
         if discarded_subset is None:
             return 0
         return discarded_subset.size
+
+    def iter_nodes(self) -> Iterator["AutomationConditionEvaluation"]:
+        """Convenience utility for iterating through all nodes in an evaluation tree."""
+        yield self
+        for evaluation in self.child_evaluations:
+            yield from evaluation.iter_nodes()
 
 
 @whitelist_for_serdes(storage_name="AssetConditionEvaluationWithRunIds")

--- a/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/sql_schedule_storage.py
@@ -537,7 +537,7 @@ class SqlScheduleStorage(ScheduleStorage):
                 .order_by(AssetDaemonAssetEvaluationsTable.c.evaluation_id.desc())
             ).limit(limit)
 
-            if cursor:
+            if cursor is not None:
                 query = query.where(AssetDaemonAssetEvaluationsTable.c.evaluation_id < cursor)
 
             rows = db_fetch_mappings(conn, query)


### PR DESCRIPTION
## Summary & Motivation

For time-partitioned assets with many historical partition keys, it is very computationally expensive to compute the string values of each of those keys. Instead, we should rely solely on partition key ranges to power the frontend.

This PR removes fields on the evaluation record which eagerly compute the number of partition keys (making it impossible to accidentally use them), and adds a separate query on the frontend to fetch the specific set of partition keys where necessary. This change resulted in a fair amount of unused code being removed.

Specific differences for the frontend:

- Now use `numCandidates` instead of `candidateSubset` (as before, if this is `None`, that represents "all partitions at the time")
- Now use the new query (`truePartitionsForAutomationConditionEvaluationNode`) to fetch the relevant partition keys instead of `trueSubset` -- sample usage can be found in the provided test

This PR breaks the frontend and requires those changes to be built on top (will coordinate with @hellendag)


## How I Tested These Changes
