### PR TITLE
create time filtering for bulk actions table

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -488,7 +488,9 @@ def get_runs_feed_entries(
     backfills = [
         GraphenePartitionBackfill(backfill)
         for backfill in instance.get_backfills(
-            cursor=cursor, limit=limit, created_before=created_before_cursor
+            cursor=runs_feed_cursor.backfill_cursor,
+            limit=limit,
+            created_before=created_before_cursor,
         )
     ]
     runs = [

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -19,6 +19,7 @@ from dagster import (
 )
 from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.errors import DagsterInvariantViolationError, DagsterRunNotFoundError
+from dagster._core.execution.backfill import BulkActionsFilter
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRunStatus, RunRecord, RunsFilter
 from dagster._core.storage.event_log.base import AssetRecord
@@ -490,7 +491,7 @@ def get_runs_feed_entries(
         for backfill in instance.get_backfills(
             cursor=runs_feed_cursor.backfill_cursor,
             limit=limit,
-            created_before=created_before_cursor,
+            filters=BulkActionsFilter(created_before=created_before_cursor),
         )
     ]
     runs = [

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
@@ -108,14 +108,10 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
             },
         )
         prev_run_time = None
-        id_to_timestamp_mapping = {}
         for res in result.data["runsFeedOrError"]["results"]:
-            id_to_timestamp_mapping[res["id"]] = res["creationTime"]
             if prev_run_time:
                 assert res["creationTime"] <= prev_run_time
             prev_run_time = res["creationTime"]
-
-        print(id_to_timestamp_mapping)
 
         result = execute_dagster_graphql(
             gql_context_with_runs_and_backfills.create_request_context(),
@@ -131,14 +127,10 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
 
         assert len(result.data["runsFeedOrError"]["results"]) == 10
         prev_run_time = None
-        id_to_timestamp_mapping = {}
         for res in result.data["runsFeedOrError"]["results"]:
-            id_to_timestamp_mapping[res["id"]] = res["creationTime"]
             if prev_run_time:
                 assert res["creationTime"] <= prev_run_time
             prev_run_time = res["creationTime"]
-
-        print(id_to_timestamp_mapping)
 
         assert result.data["runsFeedOrError"]["hasMore"]
         old_cursor = result.data["runsFeedOrError"]["cursor"]
@@ -153,20 +145,11 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
             },
         )
 
-        id_to_timestamp_mapping = {}
-        for res in result.data["runsFeedOrError"]["results"]:
-            id_to_timestamp_mapping[res["id"]] = res["creationTime"]
-
+        assert len(result.data["runsFeedOrError"]["results"]) == 10
         for res in result.data["runsFeedOrError"]["results"]:
             if prev_run_time:
                 assert res["creationTime"] <= prev_run_time
             prev_run_time = res["creationTime"]
-
-        print(id_to_timestamp_mapping)
-
-        assert len(result.data["runsFeedOrError"]["results"]) == 10
-
-        # assert False
 
         assert not result.data["runsFeedOrError"]["hasMore"]
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
@@ -51,7 +51,7 @@ query RunsFeedEntryQuery($cursor: String, $limit: Int!) {
 # CURRENT_TIMESTAMP only has second precision for sqlite, so if we create runs and backfills without any delay
 # the resulting list is a chunk of runs and then a chunk of backfills when ordered by time. Adding a small
 # delay between creating a run and a backfill makes the resulting list more interwoven
-CREATE_DELAY = 0.5
+CREATE_DELAY = 1
 
 
 def _create_run(graphql_context) -> DagsterRun:
@@ -103,6 +103,24 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
             gql_context_with_runs_and_backfills.create_request_context(),
             GET_RUNS_FEED_QUERY,
             variables={
+                "limit": 25,
+                "cursor": None,
+            },
+        )
+        prev_run_time = None
+        id_to_timestamp_mapping = {}
+        for res in result.data["runsFeedOrError"]["results"]:
+            id_to_timestamp_mapping[res["runId"]] = res["creationTime"]
+            if prev_run_time:
+                assert res["creationTime"] <= prev_run_time
+            prev_run_time = res["creationTime"]
+
+        print(id_to_timestamp_mapping)
+
+        result = execute_dagster_graphql(
+            gql_context_with_runs_and_backfills.create_request_context(),
+            GET_RUNS_FEED_QUERY,
+            variables={
                 "limit": 10,
                 "cursor": None,
             },
@@ -113,10 +131,14 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
 
         assert len(result.data["runsFeedOrError"]["results"]) == 10
         prev_run_time = None
+        id_to_timestamp_mapping = {}
         for res in result.data["runsFeedOrError"]["results"]:
+            id_to_timestamp_mapping[res["runId"]] = res["creationTime"]
             if prev_run_time:
                 assert res["creationTime"] <= prev_run_time
             prev_run_time = res["creationTime"]
+
+        print(id_to_timestamp_mapping)
 
         assert result.data["runsFeedOrError"]["hasMore"]
         old_cursor = result.data["runsFeedOrError"]["cursor"]
@@ -131,11 +153,18 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
             },
         )
 
+        id_to_timestamp_mapping = {}
+        for res in result.data["runsFeedOrError"]["results"]:
+            id_to_timestamp_mapping[res["runId"]] = res["creationTime"]
+
         assert len(result.data["runsFeedOrError"]["results"]) == 10
         for res in result.data["runsFeedOrError"]["results"]:
             if prev_run_time:
                 assert res["creationTime"] <= prev_run_time
             prev_run_time = res["creationTime"]
+
+        print(id_to_timestamp_mapping)
+        # assert False
 
         assert not result.data["runsFeedOrError"]["hasMore"]
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
@@ -110,7 +110,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
         prev_run_time = None
         id_to_timestamp_mapping = {}
         for res in result.data["runsFeedOrError"]["results"]:
-            id_to_timestamp_mapping[res["runId"]] = res["creationTime"]
+            id_to_timestamp_mapping[res["id"]] = res["creationTime"]
             if prev_run_time:
                 assert res["creationTime"] <= prev_run_time
             prev_run_time = res["creationTime"]
@@ -133,7 +133,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
         prev_run_time = None
         id_to_timestamp_mapping = {}
         for res in result.data["runsFeedOrError"]["results"]:
-            id_to_timestamp_mapping[res["runId"]] = res["creationTime"]
+            id_to_timestamp_mapping[res["id"]] = res["creationTime"]
             if prev_run_time:
                 assert res["creationTime"] <= prev_run_time
             prev_run_time = res["creationTime"]
@@ -155,15 +155,17 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
 
         id_to_timestamp_mapping = {}
         for res in result.data["runsFeedOrError"]["results"]:
-            id_to_timestamp_mapping[res["runId"]] = res["creationTime"]
+            id_to_timestamp_mapping[res["id"]] = res["creationTime"]
 
-        assert len(result.data["runsFeedOrError"]["results"]) == 10
         for res in result.data["runsFeedOrError"]["results"]:
             if prev_run_time:
                 assert res["creationTime"] <= prev_run_time
             prev_run_time = res["creationTime"]
 
         print(id_to_timestamp_mapping)
+
+        assert len(result.data["runsFeedOrError"]["results"]) == 10
+
         # assert False
 
         assert not result.data["runsFeedOrError"]["hasMore"]

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import Enum
 from typing import Mapping, NamedTuple, Optional, Sequence, Union
 
@@ -14,6 +15,7 @@ from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.remote_representation.origin import RemotePartitionSetOrigin
 from dagster._core.storage.tags import USER_TAG
 from dagster._core.workspace.workspace import IWorkspace
+from dagster._record import record
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils.error import SerializableErrorInfo
 
@@ -36,6 +38,13 @@ class BulkActionStatus(Enum):
     @staticmethod
     def from_graphql_input(graphql_str):
         return BulkActionStatus(graphql_str)
+
+
+@record
+class BulkActionsFilter:
+    status: Optional[BulkActionStatus] = None
+    created_before: Optional[datetime] = None
+    created_after: Optional[datetime] = None
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -42,6 +42,21 @@ class BulkActionStatus(Enum):
 
 @record
 class BulkActionsFilter:
+    """Filters to use when querying for bulk actions (i.e. backfills) from the BulkActionsTable.
+
+    Each field of the BulkActionsFilter represents a logical AND with each other. For
+    example, if you specify status and created_before, then you will receive only bulk actions
+    with the specified states AND the created before created_before. If left blank, then
+    all values will be permitted for that field.
+
+    Args:
+        status (Optional[BulkActionStatus]): A status to filter by.
+        created_before (Optional[DateTime]): Filter by bulk actions that were created before this datetime. Note that the
+            create_time for each bulk action is stored in UTC.
+        created_after (Optional[DateTime]): Filter by bulk actions that were created after this datetime. Note that the
+            create_time for each bulk action is stored in UTC.
+    """
+
     status: Optional[BulkActionStatus] = None
     created_before: Optional[datetime] = None
     created_after: Optional[datetime] = None

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -6,6 +6,7 @@ import warnings
 import weakref
 from abc import abstractmethod
 from collections import defaultdict
+from datetime import datetime
 from enum import Enum
 from tempfile import TemporaryDirectory
 from types import TracebackType
@@ -3076,8 +3077,16 @@ class DagsterInstance(DynamicPartitionsStore):
         status: Optional["BulkActionStatus"] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
+        created_before: Optional[datetime] = None,
+        created_after: Optional[datetime] = None,
     ) -> Sequence["PartitionBackfill"]:
-        return self._run_storage.get_backfills(status=status, cursor=cursor, limit=limit)
+        return self._run_storage.get_backfills(
+            status=status,
+            cursor=cursor,
+            limit=limit,
+            created_before=created_before,
+            created_after=created_after,
+        )
 
     def get_backfill(self, backfill_id: str) -> Optional["PartitionBackfill"]:
         return self._run_storage.get_backfill(backfill_id)

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -6,7 +6,6 @@ import warnings
 import weakref
 from abc import abstractmethod
 from collections import defaultdict
-from datetime import datetime
 from enum import Enum
 from tempfile import TemporaryDirectory
 from types import TracebackType
@@ -124,7 +123,11 @@ if TYPE_CHECKING:
         JobFailureData,
     )
     from dagster._core.events.log import EventLogEntry
-    from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
+    from dagster._core.execution.backfill import (
+        BulkActionsFilter,
+        BulkActionStatus,
+        PartitionBackfill,
+    )
     from dagster._core.execution.plan.plan import ExecutionPlan
     from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
     from dagster._core.execution.stats import RunStepKeyStatsSnapshot
@@ -3077,15 +3080,10 @@ class DagsterInstance(DynamicPartitionsStore):
         status: Optional["BulkActionStatus"] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
-        created_before: Optional[datetime] = None,
-        created_after: Optional[datetime] = None,
+        filters: Optional["BulkActionsFilter"] = None,
     ) -> Sequence["PartitionBackfill"]:
         return self._run_storage.get_backfills(
-            status=status,
-            cursor=cursor,
-            limit=limit,
-            created_before=created_before,
-            created_after=created_after,
+            status=status, cursor=cursor, limit=limit, filters=filters
         )
 
     def get_backfill(self, backfill_id: str) -> Optional["PartitionBackfill"]:

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Set, Tuple, Union
 
 from dagster import _check as check
@@ -34,7 +33,11 @@ if TYPE_CHECKING:
     from dagster._core.event_api import AssetRecordsFilter, RunStatusChangeRecordsFilter
     from dagster._core.events import DagsterEvent, DagsterEventType
     from dagster._core.events.log import EventLogEntry
-    from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
+    from dagster._core.execution.backfill import (
+        BulkActionsFilter,
+        BulkActionStatus,
+        PartitionBackfill,
+    )
     from dagster._core.execution.stats import RunStepKeyStatsSnapshot
     from dagster._core.instance import DagsterInstance
     from dagster._core.remote_representation.origin import RemoteJobOrigin
@@ -313,12 +316,9 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
         status: Optional["BulkActionStatus"] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
-        created_before: Optional[datetime] = None,
-        created_after: Optional[datetime] = None,
+        filters: Optional["BulkActionsFilter"] = None,
     ) -> Sequence["PartitionBackfill"]:
-        return self._storage.run_storage.get_backfills(
-            status, cursor, limit, created_before=created_before, created_after=created_after
-        )
+        return self._storage.run_storage.get_backfills(status, cursor, limit, filters=filters)
 
     def get_backfill(self, backfill_id: str) -> Optional["PartitionBackfill"]:
         return self._storage.run_storage.get_backfill(backfill_id)

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Set, Tuple, Union
 
 from dagster import _check as check
@@ -312,8 +313,12 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
         status: Optional["BulkActionStatus"] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
+        created_before: Optional[datetime] = None,
+        created_after: Optional[datetime] = None,
     ) -> Sequence["PartitionBackfill"]:
-        return self._storage.run_storage.get_backfills(status, cursor, limit)
+        return self._storage.run_storage.get_backfills(
+            status, cursor, limit, created_before=created_before, created_after=created_after
+        )
 
     def get_backfill(self, backfill_id: str) -> Optional["PartitionBackfill"]:
         return self._storage.run_storage.get_backfill(backfill_id)

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -1,11 +1,10 @@
 from abc import ABC, abstractmethod
-from datetime import datetime
 from typing import TYPE_CHECKING, Dict, Mapping, Optional, Sequence, Set, Tuple, Union
 
 from typing_extensions import TypedDict
 
 from dagster._core.events import DagsterEvent
-from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
+from dagster._core.execution.backfill import BulkActionsFilter, BulkActionStatus, PartitionBackfill
 from dagster._core.execution.telemetry import RunTelemetryData
 from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
 from dagster._core.snap import ExecutionPlanSnapshot, JobSnapshot
@@ -374,8 +373,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         status: Optional[BulkActionStatus] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
-        created_before: Optional[datetime] = None,
-        created_after: Optional[datetime] = None,
+        filters: Optional[BulkActionsFilter] = None,
     ) -> Sequence[PartitionBackfill]:
         """Get a list of partition backfills."""
 

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import TYPE_CHECKING, Dict, Mapping, Optional, Sequence, Set, Tuple, Union
 
 from typing_extensions import TypedDict
@@ -373,6 +374,8 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         status: Optional[BulkActionStatus] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
+        created_before: Optional[datetime] = None,
+        created_after: Optional[datetime] = None,
     ) -> Sequence[PartitionBackfill]:
         """Get a list of partition backfills."""
 

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -847,8 +847,8 @@ class SqlRunStorage(RunStorage):
                     "Conflicting status filters provided to get_backfills. Choose one of status or BulkActionsFilter.status."
                 )
             status = status or (filters.status if filters else None)
-            if status:  # should also be non-None at this point, but pyright must be appeased
-                query = query.where(BulkActionsTable.c.status == status.value)
+            assert status
+            query = query.where(BulkActionsTable.c.status == status.value)
         if cursor:
             cursor_query = db_select([BulkActionsTable.c.id]).where(
                 BulkActionsTable.c.key == cursor

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -837,6 +837,8 @@ class SqlRunStorage(RunStorage):
         status: Optional[BulkActionStatus] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
+        created_before: Optional[datetime] = None,
+        created_after: Optional[datetime] = None,
     ) -> Sequence[PartitionBackfill]:
         check.opt_inst_param(status, "status", BulkActionStatus)
         query = db_select([BulkActionsTable.c.body])
@@ -847,6 +849,14 @@ class SqlRunStorage(RunStorage):
                 BulkActionsTable.c.key == cursor
             )
             query = query.where(BulkActionsTable.c.id < cursor_query)
+        if created_after:
+            query = query.where(
+                BulkActionsTable.c.timestamp > created_after.replace(tzinfo=None).timestamp()
+            )
+        if created_before:
+            query = query.where(
+                BulkActionsTable.c.timestamp < created_before.replace(tzinfo=None).timestamp()
+            )
         if limit:
             query = query.limit(limit)
         query = query.order_by(BulkActionsTable.c.id.desc())

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -850,13 +850,9 @@ class SqlRunStorage(RunStorage):
             )
             query = query.where(BulkActionsTable.c.id < cursor_query)
         if created_after:
-            query = query.where(
-                BulkActionsTable.c.timestamp > created_after.replace(tzinfo=None).timestamp()
-            )
+            query = query.where(BulkActionsTable.c.timestamp > created_after)
         if created_before:
-            query = query.where(
-                BulkActionsTable.c.timestamp < created_before.replace(tzinfo=None).timestamp()
-            )
+            query = query.where(BulkActionsTable.c.timestamp < created_before)
         if limit:
             query = query.limit(limit)
         query = query.order_by(BulkActionsTable.c.id.desc())

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -841,7 +841,7 @@ class SqlRunStorage(RunStorage):
         created_after: Optional[datetime] = None,
     ) -> Sequence[PartitionBackfill]:
         check.opt_inst_param(status, "status", BulkActionStatus)
-        query = db_select([BulkActionsTable.c.body])
+        query = db_select([BulkActionsTable.c.body, BulkActionsTable.c.timestamp])
         if status:
             query = query.where(BulkActionsTable.c.status == status.value)
         if cursor:
@@ -852,7 +852,7 @@ class SqlRunStorage(RunStorage):
         if created_after:
             query = query.where(BulkActionsTable.c.timestamp > created_after)
         if created_before:
-            query = query.where(BulkActionsTable.c.timestamp < created_before)
+            query = query.where(BulkActionsTable.c.timestamp < created_before.replace(tzinfo=None))
         if limit:
             query = query.limit(limit)
         query = query.order_by(BulkActionsTable.c.id.desc())

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -855,13 +855,9 @@ class SqlRunStorage(RunStorage):
             )
             query = query.where(BulkActionsTable.c.id < cursor_query)
         if filters and filters.created_after:
-            query = query.where(
-                BulkActionsTable.c.timestamp > filters.created_after.replace(tzinfo=None)
-            )
+            query = query.where(BulkActionsTable.c.timestamp > filters.created_after)
         if filters and filters.created_before:
-            query = query.where(
-                BulkActionsTable.c.timestamp < filters.created_before.replace(tzinfo=None)
-            )
+            query = query.where(BulkActionsTable.c.timestamp < filters.created_before)
         if limit:
             query = query.limit(limit)
         query = query.order_by(BulkActionsTable.c.id.desc())

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -44,7 +44,7 @@ from dagster._core.utils import make_new_run_id
 from dagster._daemon.daemon import SensorDaemon
 from dagster._daemon.types import DaemonHeartbeat
 from dagster._serdes import serialize_pp
-from dagster._time import create_datetime
+from dagster._time import create_datetime, datetime_from_timestamp
 
 win_py36 = _seven.IS_WINDOWS and sys.version_info[0] == 3 and sys.version_info[1] == 6
 
@@ -1395,14 +1395,18 @@ class TestRunStorage:
             all_backfills.append(backfill)
 
         created_before = storage.get_backfills(
-            filters=BulkActionsFilter(created_before=all_backfills[3].backfill_timestamp)
+            filters=BulkActionsFilter(
+                created_before=datetime_from_timestamp(all_backfills[3].backfill_timestamp)
+            )
         )
         assert len(created_before) == 2
         for backfill in created_before:
             assert backfill.backfill_timestamp < all_backfills[3].backfill_timestamp
 
         created_after = storage.get_backfills(
-            filters=BulkActionsFilter(created_after=all_backfills[3].backfill_timestamp)
+            filters=BulkActionsFilter(
+                created_after=datetime_from_timestamp(all_backfills[3].backfill_timestamp)
+            )
         )
         assert len(created_after) == 2
         for backfill in created_after:

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -1360,10 +1360,10 @@ class TestRunStorage:
             len(storage.get_backfills(filters=BulkActionsFilter(status=BulkActionStatus.COMPLETED)))
             == 0
         )
-        backfill = storage.get_backfills(
+        backfills = storage.get_backfills(
             filters=BulkActionsFilter(status=BulkActionStatus.REQUESTED)
         )
-        assert backfill == one
+        assert backfills[0] == one
 
         storage.update_backfill(one.with_status(status=BulkActionStatus.COMPLETED))
         assert (
@@ -1396,21 +1396,21 @@ class TestRunStorage:
 
         created_before = storage.get_backfills(
             filters=BulkActionsFilter(
-                created_before=datetime_from_timestamp(all_backfills[3].backfill_timestamp)
+                created_before=datetime_from_timestamp(all_backfills[2].backfill_timestamp)
             )
         )
         assert len(created_before) == 2
         for backfill in created_before:
-            assert backfill.backfill_timestamp < all_backfills[3].backfill_timestamp
+            assert backfill.backfill_timestamp < all_backfills[2].backfill_timestamp
 
         created_after = storage.get_backfills(
             filters=BulkActionsFilter(
-                created_after=datetime_from_timestamp(all_backfills[3].backfill_timestamp)
+                created_after=datetime_from_timestamp(all_backfills[2].backfill_timestamp)
             )
         )
         assert len(created_after) == 2
         for backfill in created_after:
-            assert backfill.backfill_timestamp > all_backfills[3].backfill_timestamp
+            assert backfill.backfill_timestamp > all_backfills[2].backfill_timestamp
 
     def test_secondary_index(self, storage):
         self._skip_in_memory(storage)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_run_storage.py
@@ -8,7 +8,6 @@ from dagster_tests.storage_tests.utils.run_storage import TestRunStorage
 
 
 class TestPostgresRunStorage(TestRunStorage):
-    # TestPostgresRunStorage::test_backfill_created_time_filtering
     __test__ = True
 
     @pytest.fixture(scope="function", name="storage")

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_run_storage.py
@@ -8,6 +8,7 @@ from dagster_tests.storage_tests.utils.run_storage import TestRunStorage
 
 
 class TestPostgresRunStorage(TestRunStorage):
+    # TestPostgresRunStorage::test_backfill_created_time_filtering
     __test__ = True
 
     @pytest.fixture(scope="function", name="storage")


### PR DESCRIPTION
## Summary & Motivation
Adds ability to filter on create time to the BulkActions table so that we dont need to filter out results manually when serving the RunsFeed.  Does this by adding a `BulkActionsFilter` like `RunsFilter` so that if we want to add more filtering capabilities we can add them to this object rather than as new parameters on the `get_backfills` method

companion internal pr https://github.com/dagster-io/internal/pull/11031

## How I Tested These Changes
