### PR TITLE
Proposed language for supporting multiple kinds in concept docs

### DIFF
--- a/docs/content/concepts/metadata-tags.mdx
+++ b/docs/content/concepts/metadata-tags.mdx
@@ -51,4 +51,4 @@ In its implementation, kinds are system-defined tags, prefixed with the "dagster
 
 ## How tags work
 
-In addition to definition metadata, you can also use tags to annotate and organize definitions in your Dagster project. Definitions like assets, jobs, and runs can have multiple tags, which are applied in code. Refer to the [Tags](/concepts/metadata-tags/tags) documentation to get started.
+Tags annotate and organize definitions in your Dagster project. Definitions like assets, jobs, and runs can have multiple tags, which are applied in code. Refer to the [Tags](/concepts/metadata-tags/tags) documentation to get started.

--- a/docs/content/concepts/metadata-tags.mdx
+++ b/docs/content/concepts/metadata-tags.mdx
@@ -3,11 +3,11 @@ title: "Metadata & tags | Dagster Docs"
 description: "Dagster offers several ways to provide useful information and documentation alongside your data pipelines, including metadata and tagging."
 ---
 
-# Metadata & tags
+# Metadata, kinds, and tags
 
 One of the core benefits of Dagster is fostering collaboration between the engineers who build data pipelines and the end users who consume the data pipelines produce.
 
-Dagster offers several ways to provide useful information and documentation alongside your data pipelines, including metadata and tagging.
+Dagster offers several ways to provide useful information and documentation alongside your data pipelines, including metadata, kinds, and tagging.
 
 ---
 
@@ -16,6 +16,7 @@ Dagster offers several ways to provide useful information and documentation alon
 Using metadata and tags helps you:
 
 - Create built-in documentation that makes your pipelines easy to understand
+- Visually categorize your assets
 - Provide useful context for other users of your project (and your future self!)
 - Improve the ease of debugging when issues arise
 - Organize definitions in your Dagster project and improve filtering in the Dagster UI
@@ -40,6 +41,14 @@ How metadata is defined depends on whether you're using assets or ops and jobs:
 
 ---
 
+## How kinds work
+
+Kinds are a way to label and categorize definitions in Dagster. Kinds correspond to prominently displayed icons in our visual tools (see XXX for supported visual kinds) and also can be the target of searches. A good proxy for whether something should be a kind is whether or not it is an adjective in your day-to-day language and meaningfully identifies that definition. E.g. "Is this a dbt asset or a databricks asset?" would indicate that "dbt" and "spark" are kinds for your project.
+
+In its implementation, kinds are system-defined tags, prefixed with the "dagster/" prefix. Our UIs reserve the right to treat these tags specially, hiding them or promoting them as appropriate.
+
+---
+
 ## How tags work
 
-In addition to definition metadata, you can also use tags to label and organize definitions in your Dagster project. Definitions like assets, jobs, and runs can have multiple tags, which are applied in code. Refer to the [Tags](/concepts/metadata-tags/tags) documentation to get started.
+In addition to definition metadata, you can also use tags to annotate and organize definitions in your Dagster project. Definitions like assets, jobs, and runs can have multiple tags, which are applied in code. Refer to the [Tags](/concepts/metadata-tags/tags) documentation to get started.

--- a/docs/content/concepts/metadata-tags.mdx
+++ b/docs/content/concepts/metadata-tags.mdx
@@ -13,10 +13,10 @@ Dagster offers several ways to provide useful information and documentation alon
 
 ## Benefits
 
-Using metadata and tags helps you:
+Using metadata, kinds, and tags helps you:
 
 - Create built-in documentation that makes your pipelines easy to understand
-- Visually categorize your assets
+- Visually categorize and enrich your definitions
 - Provide useful context for other users of your project (and your future self!)
 - Improve the ease of debugging when issues arise
 - Organize definitions in your Dagster project and improve filtering in the Dagster UI
@@ -43,9 +43,9 @@ How metadata is defined depends on whether you're using assets or ops and jobs:
 
 ## How kinds work
 
-Kinds are a way to label and categorize definitions in Dagster. Kinds correspond to prominently displayed icons in our visual tools (see XXX for supported visual kinds) and also can be the target of searches. A good proxy for whether something should be a kind is whether or not it is an adjective in your day-to-day language and meaningfully identifies that definition. E.g. "Is this a dbt asset or a databricks asset?" would indicate that "dbt" and "spark" are kinds for your project.
+Kinds label and categorize definitions in Dagster. Notably, kinds correspond to prominently displayed icons in our visual tools (see XXX for supported visual kinds). An effective proxy for whether something should be a kind is whether or not it is an adjective in your day-to-day language and meaningfully identifies that definition. E.g. If "Is this a dbt asset or a databricks asset?" is a question in your team that would indicate that "dbt" and "spark" are good kinds for your team.
 
-In its implementation, kinds are system-defined tags, prefixed with the "dagster/" prefix. Our UIs reserve the right to treat these tags specially, hiding them or promoting them as appropriate.
+In its implementation, kinds are system-defined tags, prefixed with the "dagster/kind/" prefix. As is true with all of our system tags, our UIs reserve the right to treat these tags specially, hiding them or promoting them as appropriate.
 
 ---
 


### PR DESCRIPTION
## Summary & Motivation

Per request as prerequiste to generalizing and pluralizing `kinds` in our APIs, I've written language to extend our "Metadata and tags" page to be "metadata, kinds, and tags".

The relevant explanation:

"Kinds label and categorize definitions in Dagster."

"Tags to annotate and organize definitions in your Dagster project."

General idea is that "label" and "categorize" are more specific and stronger forms of "annotate" and "organize".

It is also transparent that kinds are implemented as system tags.

## How I Tested These Changes

Read https://kinds-docs.dagster.dagster-docs.io/concepts/metadata-tags
