### PR TITLE
Update dagster uni dbt course to be runnable + add missing code in sample python file

### DIFF
--- a/docs/dagster-university/pages/dagster-dbt/lesson-6/3-creating-a-partitioned-dbt-asset.md
+++ b/docs/dagster-university/pages/dagster-dbt/lesson-6/3-creating-a-partitioned-dbt-asset.md
@@ -175,8 +175,7 @@ def incremental_dbt_models(context: AssetExecutionContext, dbt: DbtCliResource):
     }
 
     yield from dbt.cli(
-        ["build", "--vars", json.dumps(dbt_vars)],
-        context=context,
+        ["build", "--vars", json.dumps(dbt_vars)], context=context
     ).stream()
 
 ```
@@ -197,7 +196,7 @@ Here, we’ve changed the logic to say that we only want to select rows between 
 
 ---
 
-## Updating the existing `trip_update_job` definition
+## Updating the `trip_update_job` definition
 
 Before we can run the pipeline, we need to do a small bit of housekeeping. The job is partitioned monthly, and our `daily_metrics` asset is given a daily parition. It does not make sense for these to run together. So we must exclude the `daily_metrics` asset from our `trip_update_job`.  We can update this in `dagster_university/jobs/__init__.py` it to the following:
 

--- a/docs/dagster-university/pages/dagster-dbt/lesson-6/3-creating-a-partitioned-dbt-asset.md
+++ b/docs/dagster-university/pages/dagster-dbt/lesson-6/3-creating-a-partitioned-dbt-asset.md
@@ -197,6 +197,22 @@ Here, we’ve changed the logic to say that we only want to select rows between 
 
 ---
 
+## Updating the existing `trip_update_job` definition
+
+Before we can run the pipeline, we need to do a small bit of housekeeping. The job is partitioned monthly, and our `daily_metrics` asset is given a daily parition. It does not make sense for these to run together. So we must exclude the `daily_metrics` asset from our `trip_update_job`.  We can update this in `dagster_university/jobs/__init__.py` it to the following:
+
+```python
+daily_metrics = AssetSelection.assets("daily_metrics")
+
+trip_update_job = define_asset_job(
+    name="trip_update_job",
+    partitions_def=monthly_partition,
+    selection=AssetSelection.all() - trips_by_week - adhoc_request - dbt_trips_selection - daily_metrics,
+)
+```
+
+---
+
 ## Running the pipeline
 
 That’s it! Now you can check out the new `daily_metrics` asset in Dagster.


### PR DESCRIPTION
## Summary & Motivation

Reference: https://dagster.slack.com/archives/C01U5LFUZJS/p1723380580256499

### Resolves: Workspace can not be successfully loaded due to missing steps not documented

The current guide on Dagster Uni titled `Dagster & dbt` [Lesson 6](https://courses.dagster.io/courses/take/dagster-dbt/multimedia/52912190-creating-a-partitioned-dbt-asset) is broken.

After partitioning the incremental model, it is not possible to successfully reload the Dagster workspace due to the following error:

```
dagster._core.errors.DagsterInvalidDefinitionError: Selected assets must have the same partitions definitions, but the selected assets have different partitions definitions: 
Monthly, starting 2023-01-01 UTC.: {AssetKey(['taxi_trips']), AssetKey(['taxi_trips_file'])}
Daily, starting 2023-01-01 UTC.: {AssetKey(['daily_metrics'])}
``` 

This is a bad experience as we have followed the steps as mentioned and are unable to progress due to some additional changes required in the project. These have been addressed in the 1st commit.


### Resolves: incorrect/outdated `dagster_university/assets/dbt.py` file

The current guide on Dagster Uni titled `Dagster & dbt` [Lesson 6](https://courses.dagster.io/courses/take/dagster-dbt/multimedia/52912190-creating-a-partitioned-dbt-asset) references an older version of a python file in the docs.

Specifically the code block under `"At this point, the dagster_university/assets/dbt.py file should look like this:"` would be better to include the state of that file including the changes that the course already introduced:
* use of DAGSTER_DBT_PARSE_PROJECT_ON_LOAD
* addition of the get_group_name() function within CustomizedDagsterDbtTranslator
* `@dbt_assets` using the previously evaluated `manifest=dbt_manifest_path`

This has been addressed in the 2nd commit


## How I Tested These Changes

Markdown renders correctly in local viewer
