### PR TITLE
[DA][4/n][user-code] Convert AutomationContext to dataclass, make methods private

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
@@ -151,7 +151,7 @@ class NewlyUpdatedCondition(SliceAutomationCondition):
 
     def compute_slice(self, context: AutomationContext) -> AssetSlice:
         # if it's the first time evaluating, just return the empty slice
-        if context.cursor is None:
+        if context.previous_evaluation_effective_dt is None:
             return context.asset_graph_view.create_empty_slice(asset_key=context.asset_key)
         else:
             return context.asset_graph_view.compute_updated_since_cursor_slice(


### PR DESCRIPTION
## Summary & Motivation

As title, this converts AutomationContext to a dataclass, which allows fields to start with underscores. This allows us to mark certain fields as private to help slim down the number of available properties.

## How I Tested These Changes
