### PR TITLE
[DA][6/n][user-code] Add `get_empty_slice` to AutomationContext

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -381,7 +381,7 @@ class AssetGraphView:
         )
 
     @cached_method
-    def create_empty_slice(self, *, asset_key: AssetKey) -> AssetSlice:
+    def get_empty_slice(self, *, asset_key: AssetKey) -> AssetSlice:
         return _slice_from_valid_subset(
             self,
             AssetSubset.empty(asset_key, self._get_partitions_def(asset_key)),
@@ -454,7 +454,7 @@ class AssetGraphView:
 
         latest_time_window = time_partitions_def.get_last_partition_window(self.effective_dt)
         if latest_time_window is None:
-            return self.create_empty_slice(asset_key=asset_key)
+            return self.get_empty_slice(asset_key=asset_key)
 
         # the time window in which to look for partitions
         time_window = (
@@ -531,7 +531,7 @@ class AssetGraphView:
     def compute_parent_updated_since_cursor_slice(
         self, *, asset_key: AssetKey, cursor: Optional[int]
     ) -> AssetSlice:
-        result_slice = self.create_empty_slice(asset_key=asset_key)
+        result_slice = self.get_empty_slice(asset_key=asset_key)
         for parent_key in self.asset_graph.get(asset_key).parent_keys:
             result_slice = result_slice.compute_union(
                 self.compute_updated_since_cursor_slice(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
@@ -209,3 +209,7 @@ class AutomationContext:
         return TemporalContext(
             effective_dt=self.effective_dt, last_event_id=self.new_max_storage_id
         )
+
+    def get_empty_slice(self) -> AssetSlice:
+        """Returns an empty AssetSlice of the currently-evaluated asset."""
+        return self.asset_graph_view.get_empty_slice(asset_key=self.asset_key)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
@@ -33,7 +33,7 @@ class CodeVersionChangedCondition(AutomationCondition):
         previous_code_version = self._get_previous_code_version(context)
         current_code_version = context.asset_graph.get(context.asset_key).code_version
         if previous_code_version is None or previous_code_version == current_code_version:
-            true_slice = context.asset_graph_view.create_empty_slice(asset_key=context.asset_key)
+            true_slice = context.get_empty_slice()
         else:
             true_slice = context.candidate_slice
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
@@ -21,7 +21,7 @@ class SliceAutomationCondition(AutomationCondition):
     def evaluate(self, context: AutomationContext) -> AutomationResult:
         # don't compute anything if there are no candidates
         if context.candidate_slice.is_empty:
-            true_slice = context.asset_graph_view.create_empty_slice(asset_key=context.asset_key)
+            true_slice = context.get_empty_slice()
         else:
             true_slice = self.compute_slice(context)
 
@@ -114,7 +114,7 @@ class WillBeRequestedCondition(SliceAutomationCondition):
         ):
             return current_result.true_slice
         else:
-            return context.asset_graph_view.create_empty_slice(asset_key=context.asset_key)
+            return context.get_empty_slice()
 
 
 @whitelist_for_serdes
@@ -131,9 +131,7 @@ class NewlyRequestedCondition(SliceAutomationCondition):
         return "newly_requested"
 
     def compute_slice(self, context: AutomationContext) -> AssetSlice:
-        return context.previous_requested_slice or context.asset_graph_view.create_empty_slice(
-            asset_key=context.asset_key
-        )
+        return context.previous_requested_slice or context.get_empty_slice()
 
 
 @whitelist_for_serdes
@@ -152,7 +150,7 @@ class NewlyUpdatedCondition(SliceAutomationCondition):
     def compute_slice(self, context: AutomationContext) -> AssetSlice:
         # if it's the first time evaluating, just return the empty slice
         if context.previous_evaluation_effective_dt is None:
-            return context.asset_graph_view.create_empty_slice(asset_key=context.asset_key)
+            return context.get_empty_slice()
         else:
             return context.asset_graph_view.compute_updated_since_cursor_slice(
                 asset_key=context.asset_key, cursor=context.previous_evaluation_max_storage_id
@@ -190,7 +188,7 @@ class CronTickPassedCondition(SliceAutomationCondition):
             # cron tick was not newly passed
             or previous_cron_tick < context.previous_evaluation_effective_dt
         ):
-            return context.asset_graph_view.create_empty_slice(asset_key=context.asset_key)
+            return context.get_empty_slice()
         else:
             return context.candidate_slice
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
@@ -69,7 +69,7 @@ class AnyDownstreamConditionsCondition(AutomationCondition):
             asset_key=context.asset_key
         )
 
-        true_slice = context.asset_graph_view.create_empty_slice(asset_key=context.asset_key)
+        true_slice = context.get_empty_slice()
         child_results = []
         for i, (downstream_condition, asset_keys) in enumerate(
             sorted(downstream_conditions.items(), key=lambda x: sorted(x[1]))

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -62,7 +62,7 @@ class OrAutomationCondition(AutomationCondition):
 
     def evaluate(self, context: AutomationContext) -> AutomationResult:
         child_results: List[AutomationResult] = []
-        true_slice = context.asset_graph_view.create_empty_slice(asset_key=context.asset_key)
+        true_slice = context.get_empty_slice()
         for i, child in enumerate(self.children):
             child_context = context.for_child_condition(
                 child_condition=child, child_index=i, candidate_slice=context.candidate_slice

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -112,7 +112,7 @@ class AnyDepsCondition(DepCondition):
 
     def evaluate(self, context: AutomationContext) -> AutomationResult:
         dep_results = []
-        true_slice = context.asset_graph_view.create_empty_slice(asset_key=context.asset_key)
+        true_slice = context.get_empty_slice()
 
         for i, dep_key in enumerate(
             sorted(self._get_dep_keys(context.asset_key, context.asset_graph))

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
@@ -54,8 +54,7 @@ class NewlyTrueCondition(AutomationCondition):
 
         # get the set of asset partitions of the child which newly became true
         newly_true_child_slice = child_result.true_slice.compute_difference(
-            self._get_previous_child_true_slice(context)
-            or context.asset_graph_view.create_empty_slice(asset_key=context.asset_key)
+            self._get_previous_child_true_slice(context) or context.get_empty_slice()
         )
 
         return AutomationResult.create_from_children(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
@@ -51,9 +51,8 @@ class SinceCondition(AutomationCondition):
         reset_result = self.reset_condition.evaluate(reset_context)
 
         # take the previous slice that this was true for
-        true_slice = context.previous_true_slice or context.asset_graph_view.create_empty_slice(
-            asset_key=context.asset_key
-        )
+        true_slice = context.previous_true_slice or context.get_empty_slice()
+
         # add in any newly true trigger asset partitions
         true_slice = true_slice.compute_union(trigger_result.true_slice)
         # remove any newly true reset asset partitions

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/automation_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/automation_condition_scenario.py
@@ -43,10 +43,7 @@ class FalseAutomationCondition(AutomationCondition):
         return ""
 
     def evaluate(self, context: AutomationContext) -> AutomationResult:
-        return AutomationResult.create(
-            context,
-            true_slice=context.asset_graph_view.create_empty_slice(asset_key=context.asset_key),
-        )
+        return AutomationResult.create(context, true_slice=context.get_empty_slice())
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary & Motivation

This is commonly used throughout our built-in AutomationConditions, and likely will be commonly-used in user-defined AutomationConditions. This is significantly more ergonomic than the previous setup. Note that there is not a corresponding utility provided for getting the "full" asset slice. This is because in almost all cases where you would want to do that, you should instead just use `context.candidate_slice` to avoid returning a superset of your candidates.

Also renamed `create_empty_slice` on `AssetGraphView`, as it's inconsistent naming-wise from the other methods (in which `get_*` indicates a cheap operation).

## How I Tested These Changes
