### PR TITLE
[DA][7/n][user-code] Simplify AutomationResult

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -69,7 +69,7 @@ class MaterializeOnRequiredForFreshnessRule(
             context.legacy_context.root_context
         )
         true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
-        return AutomationResult.create(context, true_slice, subsets_with_metadata)
+        return AutomationResult(context, true_slice, subsets_with_metadata=subsets_with_metadata)
 
 
 @whitelist_for_serdes
@@ -208,7 +208,7 @@ class MaterializeOnCronRule(
         true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(
             asset_subset_to_request
         )
-        return AutomationResult.create(context, true_slice=true_slice)
+        return AutomationResult(context, true_slice=true_slice)
 
 
 @whitelist_for_serdes
@@ -431,7 +431,7 @@ class MaterializeOnParentUpdatedRule(
             )
         )
         true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
-        return AutomationResult.create(context, true_slice, subsets_with_metadata)
+        return AutomationResult(context, true_slice, subsets_with_metadata=subsets_with_metadata)
 
 
 @whitelist_for_serdes
@@ -532,7 +532,7 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
                 | context.legacy_context.previous_true_subset
             ) - context.legacy_context.previous_tick_requested_subset
 
-        return AutomationResult.create(
+        return AutomationResult(
             context,
             true_slice=context.asset_graph_view.get_asset_slice_from_valid_subset(
                 unhandled_candidates
@@ -591,7 +591,7 @@ class SkipOnParentOutdatedRule(AutoMaterializeRule, NamedTuple("_SkipOnParentOut
             )
         )
         true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
-        return AutomationResult.create(context, true_slice, subsets_with_metadata)
+        return AutomationResult(context, true_slice, subsets_with_metadata=subsets_with_metadata)
 
 
 @whitelist_for_serdes
@@ -648,7 +648,7 @@ class SkipOnParentMissingRule(AutoMaterializeRule, NamedTuple("_SkipOnParentMiss
             )
         )
         true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
-        return AutomationResult.create(context, true_slice, subsets_with_metadata)
+        return AutomationResult(context, true_slice, subsets_with_metadata=subsets_with_metadata)
 
 
 @whitelist_for_serdes
@@ -742,7 +742,7 @@ class SkipOnNotAllParentsUpdatedRule(
             )
         )
         true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
-        return AutomationResult.create(context, true_slice, subsets_with_metadata)
+        return AutomationResult(context, true_slice, subsets_with_metadata=subsets_with_metadata)
 
 
 @whitelist_for_serdes
@@ -966,7 +966,7 @@ class SkipOnNotAllParentsUpdatedSinceCronRule(
                 - context.legacy_context.previous_true_subset
             ) | all_parents_updated_subset
 
-        return AutomationResult.create(
+        return AutomationResult(
             context,
             true_slice=context.asset_graph_view.get_asset_slice_from_valid_subset(
                 context.legacy_context.candidate_subset - all_parents_updated_subset
@@ -1020,7 +1020,7 @@ class SkipOnRequiredButNonexistentParentsRule(
             )
         )
         true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
-        return AutomationResult.create(context, true_slice, subsets_with_metadata)
+        return AutomationResult(context, true_slice, subsets_with_metadata=subsets_with_metadata)
 
 
 @whitelist_for_serdes
@@ -1060,7 +1060,7 @@ class SkipOnBackfillInProgressRule(
             true_subset = context.legacy_context.candidate_subset & backfilling_subset
 
         true_slice = context.asset_graph_view.get_asset_slice_from_valid_subset(true_subset)
-        return AutomationResult.create(context, true_slice)
+        return AutomationResult(context, true_slice)
 
 
 @whitelist_for_serdes
@@ -1086,7 +1086,7 @@ class DiscardOnMaxMaterializationsExceededRule(
             )[self.limit :]
         )
 
-        return AutomationResult.create(
+        return AutomationResult(
             context,
             context.asset_graph_view.get_asset_slice_from_valid_subset(
                 AssetSubset.from_asset_partitions_set(
@@ -1124,13 +1124,13 @@ class SkipOnRunInProgressRule(AutoMaterializeRule, NamedTuple("_SkipOnRunInProgr
         if planned_materialization_info:
             dagster_run = instance.get_run_by_id(planned_materialization_info.run_id)
             if dagster_run and dagster_run.status in IN_PROGRESS_RUN_STATUSES:
-                return AutomationResult.create(
+                return AutomationResult(
                     context,
                     context.asset_graph_view.get_asset_slice_from_valid_subset(
                         context.legacy_context.candidate_subset
                     ),
                 )
-        return AutomationResult.create(
+        return AutomationResult(
             context,
             context.asset_graph_view.get_asset_slice_from_valid_subset(
                 context.legacy_context.empty_subset()

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -154,16 +154,15 @@ class AutomationConditionEvaluator:
                     # all these neighbors must be executed as a unit, we need to union together
                     # the subset of all required neighbors
                     if neighbor_key in self.current_results_by_key:
-                        neighbor_result = self.current_results_by_key[neighbor_key]
                         neighbor_true_subset = result.serializable_evaluation.true_subset._replace(
                             asset_key=neighbor_key
                         )
                         neighbor_evaluation = result.serializable_evaluation._replace(
                             true_subset=neighbor_true_subset
                         )
-                        self.current_results_by_key[neighbor_key] = neighbor_result._replace(
-                            serializable_evaluation=neighbor_evaluation
-                        )
+                        self.current_results_by_key[
+                            neighbor_key
+                        ].set_internal_serializable_evaluation_override(neighbor_evaluation)
                     self.to_request |= {
                         ap._replace(asset_key=neighbor_key)
                         for ap in result.true_subset.asset_partitions

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
@@ -37,7 +37,7 @@ def _has_legacy_condition(condition: AutomationCondition):
         return any(_has_legacy_condition(child) for child in condition.children)
 
 
-@dataclass
+@dataclass(frozen=True)
 class AutomationContext:
     condition: AutomationCondition
     condition_unique_id: str

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
@@ -37,4 +37,4 @@ class CodeVersionChangedCondition(AutomationCondition):
         else:
             true_slice = context.candidate_slice
 
-        return AutomationResult.create(context, true_slice, extra_state=current_code_version)
+        return AutomationResult(context, true_slice, extra_state=current_code_version)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
@@ -25,7 +25,7 @@ class SliceAutomationCondition(AutomationCondition):
         else:
             true_slice = self.compute_slice(context)
 
-        return AutomationResult.create(context, true_slice)
+        return AutomationResult(context, true_slice)
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
@@ -33,7 +33,7 @@ class DownstreamConditionWrapperCondition(AutomationCondition):
                 child_condition=self.operand, child_index=0, candidate_slice=context.candidate_slice
             )
         )
-        return AutomationResult.create_from_children(
+        return AutomationResult(
             context=context, true_slice=child_result.true_slice, child_results=[child_result]
         )
 
@@ -89,6 +89,4 @@ class AnyDownstreamConditionsCondition(AutomationCondition):
             child_results.append(child_result)
             true_slice = true_slice.compute_union(child_result.true_slice)
 
-        return AutomationResult.create_from_children(
-            context=context, true_slice=true_slice, child_results=child_results
-        )
+        return AutomationResult(context=context, true_slice=true_slice, child_results=child_results)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -37,7 +37,7 @@ class AndAutomationCondition(AutomationCondition):
             child_result = child.evaluate(child_context)
             child_results.append(child_result)
             true_slice = true_slice.compute_intersection(child_result.true_slice)
-        return AutomationResult.create_from_children(context, true_slice, child_results)
+        return AutomationResult(context, true_slice, child_results)
 
 
 @whitelist_for_serdes(storage_name="OrAssetCondition")
@@ -71,7 +71,7 @@ class OrAutomationCondition(AutomationCondition):
             child_results.append(child_result)
             true_slice = true_slice.compute_union(child_result.true_slice)
 
-        return AutomationResult.create_from_children(context, true_slice, child_results)
+        return AutomationResult(context, true_slice, child_results)
 
 
 @whitelist_for_serdes(storage_name="NotAssetCondition")
@@ -101,4 +101,4 @@ class NotAutomationCondition(AutomationCondition):
         child_result = self.operand.evaluate(child_context)
         true_slice = context.candidate_slice.compute_difference(child_result.true_slice)
 
-        return AutomationResult.create_from_children(context, true_slice, [child_result])
+        return AutomationResult(context, true_slice, [child_result])

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -42,9 +42,7 @@ class DepConditionWrapperCondition(AutomationCondition):
 
         # find all children of the true dep slice
         true_slice = dep_result.true_slice.compute_child_slice(context.asset_key)
-        return AutomationResult.create_from_children(
-            context=context, true_slice=true_slice, child_results=[dep_result]
-        )
+        return AutomationResult(context=context, true_slice=true_slice, child_results=[dep_result])
 
 
 @record
@@ -129,9 +127,7 @@ class AnyDepsCondition(DepCondition):
             true_slice = true_slice.compute_union(dep_result.true_slice)
 
         true_slice = context.candidate_slice.compute_intersection(true_slice)
-        return AutomationResult.create_from_children(
-            context, true_slice=true_slice, child_results=dep_results
-        )
+        return AutomationResult(context, true_slice=true_slice, child_results=dep_results)
 
 
 @whitelist_for_serdes
@@ -162,6 +158,4 @@ class AllDepsCondition(DepCondition):
             dep_results.append(dep_result)
             true_slice = true_slice.compute_intersection(dep_result.true_slice)
 
-        return AutomationResult.create_from_children(
-            context, true_slice=true_slice, child_results=dep_results
-        )
+        return AutomationResult(context, true_slice=true_slice, child_results=dep_results)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
@@ -57,7 +57,7 @@ class NewlyTrueCondition(AutomationCondition):
             self._get_previous_child_true_slice(context) or context.get_empty_slice()
         )
 
-        return AutomationResult.create_from_children(
+        return AutomationResult(
             context=context,
             true_slice=context.candidate_slice.compute_intersection(newly_true_child_slice),
             child_results=[child_result],

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
@@ -58,6 +58,6 @@ class SinceCondition(AutomationCondition):
         # remove any newly true reset asset partitions
         true_slice = true_slice.compute_difference(reset_result.true_slice)
 
-        return AutomationResult.create_from_children(
+        return AutomationResult(
             context=context, true_slice=true_slice, child_results=[trigger_result, reset_result]
         )

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/automation_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/automation_condition_scenario.py
@@ -43,7 +43,7 @@ class FalseAutomationCondition(AutomationCondition):
         return ""
 
     def evaluate(self, context: AutomationContext) -> AutomationResult:
-        return AutomationResult.create(context, true_slice=context.get_empty_slice())
+        return AutomationResult(context, true_slice=context.get_empty_slice())
 
 
 @dataclass(frozen=True)

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_automation_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_automation_condition.py
@@ -95,7 +95,7 @@ def test_serialize_definitions_with_asset_condition() -> None:
 def test_serialize_definitions_with_user_code_asset_condition() -> None:
     class MyAutomationCondition(AutomationCondition):
         def evaluate(self, context: AutomationContext) -> AutomationResult:
-            return AutomationResult.create(
+            return AutomationResult(
                 context, context.asset_graph_view.get_asset_slice(asset_key=context.asset_key)
             )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/auto_materialize_tests/asset_condition_tests/test_dep_condition.py
@@ -39,7 +39,7 @@ def get_hardcoded_condition():
             partitions_def = context.asset_graph_view.asset_graph.get(
                 context.asset_key
             ).partitions_def
-            return AutomationResult.create(
+            return AutomationResult(
                 context,
                 true_slice=check.not_none(
                     context.asset_graph_view.get_asset_slice_from_subset(


### PR DESCRIPTION
## Summary & Motivation

This reduces the number of fields on the AutomationCondition class by taking advantage of cached properties. I also removed the somewhat confusing `create()` methods in favor of just a bog-standard `__init__` method, which routes all construction through the same entrypoint. I think this will feel more intuitive in most cases.

I plan on using a hidden-param-style pattern to futher hide "extra_state" and "asset_subsets_with_metadata", which are not needed for user-defined automation conditions.

## How I Tested These Changes
