### PR TITLE
[DA][8/n][user-code] Add simplified string-only `cursor` property

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -449,7 +449,7 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
         Accounts for cases in which the partitions definition may have changed between ticks.
         """
         previous_handled_subset = (
-            context.legacy_context.node_cursor.get_extra_state(AssetSubset)
+            context.legacy_context.node_cursor.get_structured_cursor(AssetSubset)
             if context.legacy_context.node_cursor
             else None
         )
@@ -539,7 +539,7 @@ class MaterializeOnMissingRule(AutoMaterializeRule, NamedTuple("_MaterializeOnMi
             ),
             # we keep track of the handled subset instead of the unhandled subset because new
             # partitions may spontaneously jump into existence at any time
-            extra_state=handled_subset,
+            structured_cursor=handled_subset,
         )
 
 
@@ -809,7 +809,9 @@ class SkipOnNotAllParentsUpdatedSinceCronRule(
             )
         else:
             # previous state still valid
-            previous_parent_subsets = context.legacy_context.node_cursor.get_extra_state(list) or []
+            previous_parent_subsets = (
+                context.legacy_context.node_cursor.get_structured_cursor(list) or []
+            )
             previous_parent_subset = next(
                 (s for s in previous_parent_subsets if s.asset_key == parent_asset_key),
                 ValidAssetSubset.empty(
@@ -971,7 +973,7 @@ class SkipOnNotAllParentsUpdatedSinceCronRule(
             true_slice=context.asset_graph_view.get_asset_slice_from_valid_subset(
                 context.legacy_context.candidate_subset - all_parents_updated_subset
             ),
-            extra_state=list(updated_subsets_by_key.values()),
+            structured_cursor=list(updated_subsets_by_key.values()),
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
@@ -24,17 +24,12 @@ class CodeVersionChangedCondition(AutomationCondition):
     def requires_cursor(self) -> bool:
         return True
 
-    def _get_previous_code_version(self, context: AutomationContext) -> Optional[str]:
-        if context.node_cursor is None:
-            return None
-        return context.node_cursor.get_extra_state(as_type=str)
-
     def evaluate(self, context: AutomationContext) -> AutomationResult:
-        previous_code_version = self._get_previous_code_version(context)
+        previous_code_version = context.cursor
         current_code_version = context.asset_graph.get(context.asset_key).code_version
         if previous_code_version is None or previous_code_version == current_code_version:
             true_slice = context.get_empty_slice()
         else:
             true_slice = context.candidate_slice
 
-        return AutomationResult(context, true_slice, extra_state=current_code_version)
+        return AutomationResult(context, true_slice, cursor=current_code_version)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -37,7 +37,7 @@ class AndAutomationCondition(AutomationCondition):
             child_result = child.evaluate(child_context)
             child_results.append(child_result)
             true_slice = true_slice.compute_intersection(child_result.true_slice)
-        return AutomationResult(context, true_slice, child_results)
+        return AutomationResult(context, true_slice, child_results=child_results)
 
 
 @whitelist_for_serdes(storage_name="OrAssetCondition")
@@ -71,7 +71,7 @@ class OrAutomationCondition(AutomationCondition):
             child_results.append(child_result)
             true_slice = true_slice.compute_union(child_result.true_slice)
 
-        return AutomationResult(context, true_slice, child_results)
+        return AutomationResult(context, true_slice, child_results=child_results)
 
 
 @whitelist_for_serdes(storage_name="NotAssetCondition")
@@ -101,4 +101,4 @@ class NotAutomationCondition(AutomationCondition):
         child_result = self.operand.evaluate(child_context)
         true_slice = context.candidate_slice.compute_difference(child_result.true_slice)
 
-        return AutomationResult(context, true_slice, [child_result])
+        return AutomationResult(context, true_slice, child_results=[child_result])

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
@@ -35,9 +35,7 @@ class NewlyTrueCondition(AutomationCondition):
         """Returns the true slice of the child from the previous tick, which is stored in the
         extra state field of the cursor.
         """
-        if not context.node_cursor:
-            return None
-        true_subset = context.node_cursor.get_extra_state(as_type=AssetSubset)
+        true_subset = context.get_structured_cursor(as_type=AssetSubset)
         if not true_subset:
             return None
         return context.asset_graph_view.get_asset_slice_from_subset(true_subset)
@@ -61,5 +59,5 @@ class NewlyTrueCondition(AutomationCondition):
             context=context,
             true_slice=context.candidate_slice.compute_intersection(newly_true_child_slice),
             child_results=[child_result],
-            extra_state=child_result.true_subset,
+            structured_cursor=child_result.true_subset,
         )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
@@ -31,7 +31,8 @@ if TYPE_CHECKING:
         AutomationContext,
     )
 
-T = TypeVar("T")
+StructuredCursor = Union[str, AssetSubset, Sequence[AssetSubset]]
+T_StructuredCursor = TypeVar("T_StructuredCursor", bound=StructuredCursor)
 
 
 @whitelist_for_serdes
@@ -175,7 +176,7 @@ class AutomationConditionEvaluationState:
     previous_tick_evaluation_timestamp: Optional[float]
 
     max_storage_id: Optional[int]
-    extra_state_by_unique_id: Mapping[str, Optional[Union[AssetSubset, Sequence[AssetSubset]]]]
+    extra_state_by_unique_id: Mapping[str, Optional[StructuredCursor]]
 
     @property
     def asset_key(self) -> AssetKey:
@@ -191,9 +192,11 @@ class AutomationConditionNodeCursor(NamedTuple):
     true_subset: AssetSubset
     candidate_subset: Union[AssetSubset, HistoricalAllPartitionsSubsetSentinel]
     subsets_with_metadata: Sequence[AssetSubsetWithMetadata]
-    extra_state: Optional[Union[AssetSubset, Sequence[AssetSubset]]]
+    extra_state: Optional[StructuredCursor]
 
-    def get_extra_state(self, as_type: Type[T]) -> Optional[T]:
+    def get_structured_cursor(
+        self, as_type: Type[T_StructuredCursor]
+    ) -> Optional[T_StructuredCursor]:
         """Returns the extra_state value if it is of the expected type. Otherwise, returns None."""
         if isinstance(self.extra_state, as_type):
             return self.extra_state


### PR DESCRIPTION
## Summary & Motivation

Technically, the Declarative Automation cursoring system can accept and store any serializable value in its "extra_state". This is useful as a performance optimization (it is common for us to want to keep track of serialized AssetSubsets between ticks, so not needing to do a double serialization / deserialization process is pretty valuable), but this overly-broad construct is likely more confusing than anything if we expose it as a public API.

Instead, expose a simplified, string-only cursor interface on the context. This mirrors the existing sensor APIs more closely.

## How I Tested These Changes
