### PR TITLE
[DA][9/n][user-code] Rename temporal-context-related fields

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -561,8 +561,8 @@ class AutomationResult:
     def get_new_cursor(self) -> AutomationConditionCursor:
         return AutomationConditionCursor(
             previous_requested_subset=self.serializable_evaluation.true_subset,
-            effective_timestamp=self._context.effective_dt.timestamp(),
-            last_event_id=self._context.new_max_storage_id,
+            effective_timestamp=self._context.evaluation_time.timestamp(),
+            last_event_id=self._context.max_storage_id,
             node_cursors_by_unique_id=self.get_child_node_cursors(),
             result_value_hash=self.value_hash,
         )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
@@ -149,11 +149,11 @@ class NewlyUpdatedCondition(SliceAutomationCondition):
 
     def compute_slice(self, context: AutomationContext) -> AssetSlice:
         # if it's the first time evaluating, just return the empty slice
-        if context.previous_evaluation_effective_dt is None:
+        if context.previous_evaluation_time is None:
             return context.get_empty_slice()
         else:
             return context.asset_graph_view.compute_updated_since_cursor_slice(
-                asset_key=context.asset_key, cursor=context.previous_evaluation_max_storage_id
+                asset_key=context.asset_key, cursor=context.previous_max_storage_id
             )
 
 
@@ -181,12 +181,12 @@ class CronTickPassedCondition(SliceAutomationCondition):
         return next(previous_ticks)
 
     def compute_slice(self, context: AutomationContext) -> AssetSlice:
-        previous_cron_tick = self._get_previous_cron_tick(context.effective_dt)
+        previous_cron_tick = self._get_previous_cron_tick(context.evaluation_time)
         if (
             # no previous evaluation
-            context.previous_evaluation_effective_dt is None
+            context.previous_evaluation_time is None
             # cron tick was not newly passed
-            or previous_cron_tick < context.previous_evaluation_effective_dt
+            or previous_cron_tick < context.previous_evaluation_time
         ):
             return context.get_empty_slice()
         else:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
@@ -269,8 +269,8 @@ class AutomationConditionCursor(NamedTuple):
 
         return AutomationConditionCursor(
             previous_requested_subset=result.true_subset,
-            effective_timestamp=context.effective_dt.timestamp(),
-            last_event_id=context.new_max_storage_id,
+            effective_timestamp=context.evaluation_time.timestamp(),
+            last_event_id=context.max_storage_id,
             node_cursors_by_unique_id=_gather_node_cursors(result),
             result_value_hash=result_hash,
         )


### PR DESCRIPTION
## Summary & Motivation

I don't want to expose "TemporalContext" as part of the public API, so I remove references to it. Also renamed the existing fields (subjective, but I think they look a little better this way).

## How I Tested These Changes
