### PR TITLE
[DA][11/n][user-code] Don't require `requires_cursor` to be set

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -89,7 +89,7 @@ class AutomationCondition(ABC):
 
     @property
     def requires_cursor(self) -> bool:
-        return False
+        return True
 
     @property
     def children(self) -> Sequence["AutomationCondition"]:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
@@ -128,6 +128,12 @@ class AutomationContext:
         """Returns the evaluation node for this node from the previous evaluation, if this node
         was evaluated on the previous tick.
         """
+        check.invariant(
+            self.condition.requires_cursor,
+            f"Attempted to access cursor for a node of type {self.condition.__class__.__name__} "
+            "which does not store a cursor. Set the `requires_cursor` property to `True` to enable access.",
+        )
+
         return (
             self._cursor.node_cursors_by_unique_id.get(self.condition_unique_id)
             if self._cursor

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/rule_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/rule_condition.py
@@ -21,10 +21,6 @@ class RuleCondition(AutomationCondition):
     rule: AutoMaterializeRule
     label: Optional[str] = None
 
-    @property
-    def requires_cursor(self) -> bool:
-        return True
-
     def get_unique_id(self, *, parent_unique_id: Optional[str], index: Optional[str]) -> str:
         # preserves old (bad) behavior of not including the parent_unique_id to avoid inavlidating
         # old serialized information

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
@@ -20,10 +20,6 @@ class CodeVersionChangedCondition(AutomationCondition):
     def name(self) -> str:
         return "code_version_changed"
 
-    @property
-    def requires_cursor(self) -> bool:
-        return True
-
     def evaluate(self, context: AutomationContext) -> AutomationResult:
         previous_code_version = context.cursor
         current_code_version = context.asset_graph.get(context.asset_key).code_version

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
@@ -15,6 +15,10 @@ from ..automation_context import AutomationContext
 class SliceAutomationCondition(AutomationCondition):
     """Base class for simple conditions which compute a simple slice of the asset graph."""
 
+    @property
+    def requires_cursor(self) -> bool:
+        return False
+
     @abstractmethod
     def compute_slice(self, context: AutomationContext) -> AssetSlice: ...
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
@@ -27,6 +27,10 @@ class DownstreamConditionWrapperCondition(AutomationCondition):
     def children(self) -> Sequence[AutomationCondition]:
         return [self.operand]
 
+    @property
+    def requires_cursor(self) -> bool:
+        return False
+
     def evaluate(self, context: AutomationContext) -> AutomationResult:
         child_result = self.operand.evaluate(
             context.for_child_condition(
@@ -50,6 +54,10 @@ class AnyDownstreamConditionsCondition(AutomationCondition):
     @property
     def name(self) -> str:
         return "ANY_DOWNSTREAM_CONDITIONS"
+
+    @property
+    def requires_cursor(self) -> bool:
+        return False
 
     def _get_ignored_conditions(
         self, context: AutomationContext

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -16,16 +16,20 @@ class AndAutomationCondition(AutomationCondition):
     label: Optional[str] = None
 
     @property
-    def children(self) -> Sequence[AutomationCondition]:
-        return self.operands
-
-    @property
     def description(self) -> str:
         return "All of"
 
     @property
     def name(self) -> str:
         return "AND"
+
+    @property
+    def children(self) -> Sequence[AutomationCondition]:
+        return self.operands
+
+    @property
+    def requires_cursor(self) -> bool:
+        return False
 
     def evaluate(self, context: AutomationContext) -> AutomationResult:
         child_results: List[AutomationResult] = []
@@ -49,16 +53,20 @@ class OrAutomationCondition(AutomationCondition):
     label: Optional[str] = None
 
     @property
-    def children(self) -> Sequence[AutomationCondition]:
-        return self.operands
-
-    @property
     def description(self) -> str:
         return "Any of"
 
     @property
     def name(self) -> str:
         return "OR"
+
+    @property
+    def children(self) -> Sequence[AutomationCondition]:
+        return self.operands
+
+    @property
+    def requires_cursor(self) -> bool:
+        return False
 
     def evaluate(self, context: AutomationContext) -> AutomationResult:
         child_results: List[AutomationResult] = []

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -69,6 +69,10 @@ class DepCondition(AutomationCondition):
             description += f" except for {self.ignore_selection}"
         return description
 
+    @property
+    def requires_cursor(self) -> bool:
+        return False
+
     def allow(self, selection: "AssetSelection") -> "DepCondition":
         """Returns a copy of this condition that will only consider dependencies within the provided
         AssetSelection.

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
@@ -16,10 +16,6 @@ class NewlyTrueCondition(AutomationCondition):
     label: Optional[str] = None
 
     @property
-    def requires_cursor(self) -> bool:
-        return True
-
-    @property
     def description(self) -> str:
         return "Condition newly became true."
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
@@ -15,10 +15,6 @@ class SinceCondition(AutomationCondition):
     label: Optional[str] = None
 
     @property
-    def requires_cursor(self) -> bool:
-        return True
-
-    @property
     def description(self) -> str:
         return (
             "Trigger condition has become true since the last time the reset condition became true."

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/user_defined/test_user_defined_automation_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/user_defined/test_user_defined_automation_condition.py
@@ -1,0 +1,32 @@
+from dagster import AutomationCondition, DagsterInstance, asset, evaluate_automation_conditions
+from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
+from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
+
+
+def test_cursoring() -> None:
+    class MyAutomationCondition(AutomationCondition):
+        def evaluate(self, context: AutomationContext) -> AutomationResult:
+            if context.cursor == "hi":
+                cursor = None
+                true_slice = context.candidate_slice
+            else:
+                cursor = "hi"
+                true_slice = context.get_empty_slice()
+
+            return AutomationResult(context, true_slice=true_slice, cursor=cursor)
+
+    @asset(automation_condition=MyAutomationCondition())
+    def my_asset() -> None: ...
+
+    instance = DagsterInstance.ephemeral()
+    cursor = None
+
+    for i in range(5):
+        result = evaluate_automation_conditions(defs=[my_asset], instance=instance, cursor=cursor)
+        cursor = result.cursor
+
+        # should toggle between returning 0 and 1 every evaluation
+        if i % 2 == 0:
+            assert result.get_num_requested(my_asset.key) == 0
+        else:
+            assert result.get_num_requested(my_asset.key) == 1


### PR DESCRIPTION
## Summary & Motivation

Previously, it was required to opt into storing a cursor, as most builtin conditions do not require a cursor and it would be wasteful to store one. However, this is unintuitive for user-defined AutomationConditions, and so for non-builtins, we will automatically opt into using cursors.

## How I Tested These Changes
