### PR TITLE
Attach tick ID to Sensor-emitted asset events

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/events.py
+++ b/python_modules/dagster/dagster/_core/definitions/events.py
@@ -332,6 +332,15 @@ class AssetObservation(
             tags=self.tags,
         )
 
+    def with_tags(self, tags: Optional[Mapping[str, str]]) -> "AssetObservation":
+        return AssetObservation(
+            asset_key=self.asset_key,
+            description=self.description,
+            metadata=self.metadata,
+            partition=self.partition,
+            tags=tags,
+        )
+
 
 UNDEFINED_ASSET_KEY_PATH = ["__undefined__"]
 
@@ -471,6 +480,15 @@ class AssetMaterialization(
             metadata=metadata,
             partition=self.partition,
             tags=self.tags,
+        )
+
+    def with_tags(self, tags: Optional[Mapping[str, str]]) -> "AssetMaterialization":
+        return AssetMaterialization(
+            asset_key=self.asset_key,
+            description=self.description,
+            metadata=self.metadata,
+            partition=self.partition,
+            tags=tags,
         )
 
 

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -348,6 +348,11 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
     def with_log_key(self, log_key: Sequence[str]) -> "InstigatorTick":
         return self._replace(tick_data=self.tick_data.with_log_key(log_key))
 
+    def with_has_emitted_asset_events(self, has_emitted_asset_events: bool) -> "InstigatorTick":
+        return self._replace(
+            tick_data=self.tick_data._replace(has_emitted_asset_events=has_emitted_asset_events)
+        )
+
     def with_dynamic_partitions_request_result(
         self,
         dynamic_partitions_request_result: DynamicPartitionsRequestResult,
@@ -542,6 +547,7 @@ class TickData(
             ("run_requests", Optional[Sequence[RunRequest]]),  # run requests created by the tick
             ("auto_materialize_evaluation_id", Optional[int]),
             ("reserved_run_ids", Optional[Sequence[str]]),
+            ("has_emitted_asset_events", bool),
         ],
     )
 ):
@@ -575,6 +581,9 @@ class TickData(
         reserved_run_ids (Optional[Sequence[str]]): A list of run IDs to use for each of the
             run_requests. Used to ensure that if the tick fails partway through, we don't create
             any duplicate runs for the tick. Currently only used by AUTO_MATERIALIZE ticks.
+        has_emitted_asset_events (bool): Whether the tick has emitted asset events. This is used to
+            adjust tick rendering in the UI.
+
     """
 
     def __new__(
@@ -600,6 +609,7 @@ class TickData(
         run_requests: Optional[Sequence[RunRequest]] = None,
         auto_materialize_evaluation_id: Optional[int] = None,
         reserved_run_ids: Optional[Sequence[str]] = None,
+        has_emitted_asset_events: bool = False,
     ):
         _validate_tick_args(instigator_type, status, run_ids, error, skip_reason)
         check.opt_list_param(log_key, "log_key", of_type=str)
@@ -628,6 +638,9 @@ class TickData(
             run_requests=check.opt_sequence_param(run_requests, "run_requests"),
             auto_materialize_evaluation_id=auto_materialize_evaluation_id,
             reserved_run_ids=check.opt_sequence_param(reserved_run_ids, "reserved_run_ids"),
+            has_emitted_asset_events=check.bool_param(
+                has_emitted_asset_events, "has_emitted_asset_events"
+            ),
         )
 
     def with_status(

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -24,6 +24,7 @@ from typing_extensions import Self
 
 import dagster._check as check
 import dagster._seven as seven
+from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AutomationConditionEvaluation,
@@ -149,6 +150,7 @@ class SensorLaunchContext(AbstractContextManager):
         skip_reason = cast(Optional[str], kwargs.get("skip_reason"))
         cursor = cast(Optional[str], kwargs.get("cursor"))
         origin_run_id = cast(Optional[str], kwargs.get("origin_run_id"))
+        has_emitted_asset_events = cast(Optional[bool], kwargs.get("has_emitted_asset_events"))
         if "skip_reason" in kwargs:
             del kwargs["skip_reason"]
 
@@ -171,6 +173,9 @@ class SensorLaunchContext(AbstractContextManager):
 
         if origin_run_id:
             self._tick = self._tick.with_origin_run(origin_run_id)
+
+        if has_emitted_asset_events is not None:
+            self._tick.with_has_emitted_asset_events(has_emitted_asset_events)
 
     def add_run_info(self, run_id: Optional[str] = None, run_key: Optional[str] = None) -> None:
         self._tick = self._tick.with_run_info(run_id, run_key)
@@ -818,8 +823,17 @@ def _evaluate_sensor(
     if sensor_runtime_data.log_key:
         context.add_log_key(sensor_runtime_data.log_key)
 
+    if sensor_runtime_data.asset_events:
+        context.update_state(TickStatus.SKIPPED, has_emitted_asset_events=True)
     for asset_event in sensor_runtime_data.asset_events:
-        instance.report_runless_asset_event(asset_event)
+        # TODO: enable linking asset check evaluations, which do not have tags
+        if isinstance(asset_event, AssetCheckEvaluation):
+            instance.report_runless_asset_event(asset_event)
+        else:
+            event_with_tags = asset_event.with_tags(
+                merge_dicts(asset_event.tags or {}, {"dagster/tick_id": context.tick_id})
+            )
+            instance.report_runless_asset_event(event_with_tags)
 
     if sensor_runtime_data.dynamic_partitions_requests:
         _handle_dynamic_partitions_requests(

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -796,6 +796,15 @@ auto_materialize_sensor = AutomationConditionSensorDefinition(
 )
 
 
+@sensor(job_name="the_job")
+def asset_event_reporting_sensor(context) -> SensorResult:
+    return SensorResult(
+        asset_events=[
+            AssetMaterialization("asset_one"),
+        ]
+    )
+
+
 @repository
 def the_repo():
     return [
@@ -865,6 +874,7 @@ def the_repo():
         multipartitions_with_static_time_dimensions_run_requests_sensor,
         auto_materialize_sensor,
         run_request_check_only_sensor,
+        asset_event_reporting_sensor,
     ]
 
 
@@ -3456,6 +3466,37 @@ def test_start_tick_sensor(executor, instance, workspace_context, external_repo)
         last_tick = _get_last_tick(instance, start_skip_sensor)
         validate_tick(last_tick, start_skip_sensor, freeze_datetime, TickStatus.SUCCESS)
         assert last_sensor_start_time == last_tick.cursor
+
+
+def test_asset_event_reporting_sensor(
+    executor, instance: DagsterInstance, workspace_context, external_repo
+) -> None:
+    freeze_datetime = create_datetime(year=2019, month=2, day=27)
+    with freeze_time(freeze_datetime):
+        external_sensor = external_repo.get_external_sensor("asset_event_reporting_sensor")
+        external_origin_id = external_sensor.get_external_origin_id()
+        instance.start_sensor(external_sensor)
+
+        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        assert len(ticks) == 0
+
+        evaluate_sensors(workspace_context, executor)
+
+        ticks = instance.get_ticks(external_origin_id, external_sensor.selector_id)
+        assert len(ticks) == 1
+        tick = ticks[0]
+
+        assert tick.tick_data.has_emitted_asset_events
+
+        last_materialization = instance.get_latest_materialization_event(AssetKey(["asset_one"]))
+        assert last_materialization
+        assert (
+            last_materialization.asset_materialization
+            and last_materialization.asset_materialization.tags
+        )
+        assert last_materialization.asset_materialization.tags["dagster/tick_id"] == str(
+            tick.tick_id
+        )
 
 
 def _get_last_tick(instance, sensor):


### PR DESCRIPTION

## Summary

From discussion on https://github.com/dagster-io/internal/pull/10756#issuecomment-2263704394 - with the aim of being able to refer to emitted asset events from Sensors in the UI, attaches a tick ID to asset events which we can use to query for those events, and attaches a boolean to tick data to mark the tick as having emitted one or more events.

## Test Plan

Unit test

