### PR TITLE
[ui] Evaluations table: Don't load all partition keys up front

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/GetEvaluationsQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/GetEvaluationsQuery.tsx
@@ -2,19 +2,6 @@ import {gql} from '@apollo/client';
 
 import {METADATA_ENTRY_FRAGMENT} from '../../metadata/MetadataEntryFragment';
 
-const AssetSubsetFragment = gql`
-  fragment AssetSubsetFragment on AssetSubset {
-    subsetValue {
-      isPartitioned
-      partitionKeys
-      partitionKeyRanges {
-        start
-        end
-      }
-    }
-  }
-`;
-
 const SpecificPartitionAssetConditionEvaluationNodeFragment = gql`
   fragment SpecificPartitionAssetConditionEvaluationNodeFragment on SpecificPartitionAssetConditionEvaluationNode {
     description
@@ -48,18 +35,11 @@ const PartitionedAssetConditionEvaluationNodeFragment = gql`
     startTimestamp
     endTimestamp
     numTrue
-    numFalse
-    numSkipped
-    trueSubset {
-      ...AssetSubsetFragment
-    }
-    candidateSubset {
-      ...AssetSubsetFragment
-    }
     uniqueId
     childUniqueIds
+    numTrue
+    numCandidates
   }
-  ${AssetSubsetFragment}
 `;
 
 const NEW_EVALUATION_NODE_FRAGMENT = gql`
@@ -69,18 +49,11 @@ const NEW_EVALUATION_NODE_FRAGMENT = gql`
     userLabel
     startTimestamp
     endTimestamp
+    numCandidates
     numTrue
     isPartitioned
     childUniqueIds
-    trueSubset {
-      ...AssetSubsetFragment
-    }
-    candidateSubset {
-      ...AssetSubsetFragment
-    }
   }
-
-  ${AssetSubsetFragment}
 `;
 
 const AssetConditionEvaluationRecordFragment = gql`

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PartitionSegmentWithPopover.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PartitionSegmentWithPopover.tsx
@@ -1,61 +1,33 @@
-import {
-  Box,
-  Colors,
-  Menu,
-  MenuItem,
-  MiddleTruncate,
-  Popover,
-  Tag,
-  TextInput,
-  TextInputContainer,
-} from '@dagster-io/ui-components';
-import {useVirtualizer} from '@tanstack/react-virtual';
-import {useMemo, useRef, useState} from 'react';
-import styled from 'styled-components';
+import {Popover, Tag} from '@dagster-io/ui-components';
 
-import {PolicyEvaluationStatusTag} from './PolicyEvaluationStatusTag';
-import {assertUnreachable} from '../../app/Util';
-import {AssetConditionEvaluationStatus, AssetSubsetValue} from '../../graphql/types';
-import {Container, Inner, Row} from '../../ui/VirtualizedTable';
+import {PartitionSubsetList} from './PartitionSubsetList';
+import {AssetConditionEvaluationStatus} from '../../graphql/types';
 import {numberFormatter} from '../../ui/formatters';
-
-const statusToColors = (status: AssetConditionEvaluationStatus) => {
-  switch (status) {
-    case AssetConditionEvaluationStatus.TRUE:
-      return {color: Colors.accentGreen(), hoverColor: Colors.accentGreenHover()};
-    case AssetConditionEvaluationStatus.FALSE:
-      return {color: Colors.accentYellow(), hoverColor: Colors.accentYellowHover()};
-    case AssetConditionEvaluationStatus.SKIPPED:
-      return {color: Colors.accentGray(), hoverColor: Colors.accentGrayHover()};
-    default:
-      return assertUnreachable(status);
-  }
-};
-
-type AssetSusbsetWithoutTypenames = {
-  subsetValue: Omit<AssetSubsetValue, '__typename' | 'boolValue'>;
-};
 
 interface Props {
   description: string;
-  subset: AssetSusbsetWithoutTypenames | null;
+  numTrue: number;
+  assetKeyPath: string[];
+  evaluationId: number;
+  nodeUniqueId: string;
   selectPartition?: (partitionKey: string | null) => void;
 }
 
-export const PartitionSegmentWithPopover = ({description, selectPartition, subset}: Props) => {
-  if (!subset) {
-    return null;
-  }
-
-  const count = subset.subsetValue.partitionKeys?.length || 0;
-
+export const PartitionSegmentWithPopover = ({
+  description,
+  selectPartition,
+  assetKeyPath,
+  evaluationId,
+  nodeUniqueId,
+  numTrue,
+}: Props) => {
   const tag = (
-    <Tag intent={count > 0 ? 'success' : 'none'} icon={count > 0 ? 'check_circle' : undefined}>
-      {numberFormatter.format(count)} True
+    <Tag intent={numTrue > 0 ? 'success' : 'none'} icon={numTrue > 0 ? 'check_circle' : undefined}>
+      {numberFormatter.format(numTrue)} True
     </Tag>
   );
 
-  if (count === 0) {
+  if (numTrue === 0) {
     return tag;
   }
 
@@ -69,7 +41,9 @@ export const PartitionSegmentWithPopover = ({description, selectPartition, subse
         <PartitionSubsetList
           description={description}
           status={AssetConditionEvaluationStatus.TRUE}
-          subset={subset}
+          assetKeyPath={assetKeyPath}
+          evaluationId={evaluationId}
+          nodeUniqueId={nodeUniqueId}
           selectPartition={selectPartition}
         />
       }
@@ -78,120 +52,3 @@ export const PartitionSegmentWithPopover = ({description, selectPartition, subse
     </Popover>
   );
 };
-
-interface ListProps {
-  description: string;
-  status?: AssetConditionEvaluationStatus;
-  subset: AssetSusbsetWithoutTypenames;
-  selectPartition?: (partitionKey: string | null) => void;
-}
-
-const ITEM_HEIGHT = 32;
-const MAX_ITEMS_BEFORE_TRUNCATION = 4;
-
-export const PartitionSubsetList = ({description, status, subset, selectPartition}: ListProps) => {
-  const container = useRef<HTMLDivElement | null>(null);
-  const [searchValue, setSearchValue] = useState('');
-
-  const {color, hoverColor} = useMemo(
-    () => statusToColors(status ?? AssetConditionEvaluationStatus.TRUE),
-    [status],
-  );
-
-  const partitionKeys = useMemo(() => subset.subsetValue.partitionKeys || [], [subset]);
-
-  const filteredKeys = useMemo(() => {
-    const searchLower = searchValue.toLocaleLowerCase();
-    return partitionKeys.filter((key) => key.toLocaleLowerCase().includes(searchLower));
-  }, [partitionKeys, searchValue]);
-
-  const count = filteredKeys.length;
-
-  const rowVirtualizer = useVirtualizer({
-    count: filteredKeys.length,
-    getScrollElement: () => container.current,
-    estimateSize: () => ITEM_HEIGHT,
-    overscan: 10,
-  });
-
-  const totalHeight = rowVirtualizer.getTotalSize();
-  const virtualItems = rowVirtualizer.getVirtualItems();
-
-  return (
-    <div style={{width: '292px'}}>
-      <Box
-        padding={{vertical: 8, left: 12, right: 8}}
-        border="bottom"
-        flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
-        style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) auto', gap: 8}}
-      >
-        <strong>
-          <MiddleTruncate text={description} />
-        </strong>
-        {status ? <PolicyEvaluationStatusTag status={status} /> : null}
-      </Box>
-      {partitionKeys.length > MAX_ITEMS_BEFORE_TRUNCATION ? (
-        <SearchContainer padding={{vertical: 4, horizontal: 8}}>
-          <TextInput
-            icon="search"
-            placeholder="Filter partitions…"
-            value={searchValue}
-            onChange={(e) => setSearchValue(e.target.value)}
-          />
-        </SearchContainer>
-      ) : null}
-      <div
-        style={{
-          height: count > MAX_ITEMS_BEFORE_TRUNCATION ? '150px' : count * ITEM_HEIGHT + 16,
-          overflow: 'hidden',
-        }}
-      >
-        <Container ref={container}>
-          <Menu>
-            <Inner $totalHeight={totalHeight}>
-              {virtualItems.map(({index, key, size, start}) => {
-                const partitionKey = filteredKeys[index]!;
-                return (
-                  <Row $height={size} $start={start} key={key}>
-                    <MenuItem
-                      onClick={() => {
-                        selectPartition && selectPartition(partitionKey);
-                      }}
-                      text={
-                        <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
-                          <PartitionStatusDot $color={color} $hoverColor={hoverColor} />
-                          <div>
-                            <MiddleTruncate text={partitionKey} />
-                          </div>
-                        </Box>
-                      }
-                    />
-                  </Row>
-                );
-              })}
-            </Inner>
-          </Menu>
-        </Container>
-      </div>
-    </div>
-  );
-};
-
-const SearchContainer = styled(Box)`
-  display: flex;
-  ${TextInputContainer} {
-    flex: 1;
-  }
-`;
-
-const PartitionStatusDot = styled.div<{$color: string; $hoverColor: string}>`
-  background-color: ${({$color}) => $color};
-  height: 8px;
-  width: 8px;
-  border-radius: 50%;
-  transition: background-color 100ms linear;
-
-  :hover {
-    background-color: ${({$hoverColor}) => $hoverColor};
-  }
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PartitionSubsetList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PartitionSubsetList.tsx
@@ -1,0 +1,199 @@
+import {useQuery} from '@apollo/client';
+import {
+  Box,
+  Colors,
+  Menu,
+  MenuItem,
+  MiddleTruncate,
+  SpinnerWithText,
+  TextInput,
+  TextInputContainer,
+} from '@dagster-io/ui-components';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import {useMemo, useRef, useState} from 'react';
+import styled from 'styled-components';
+
+import {PARTITION_SUBSET_LIST_QUERY} from './PartitionSubsetListQuery';
+import {PolicyEvaluationStatusTag} from './PolicyEvaluationStatusTag';
+import {AssetConditionEvaluationStatus} from './types';
+import {
+  PartitionSubsetListQuery,
+  PartitionSubsetListQueryVariables,
+} from './types/PartitionSubsetListQuery.types';
+import {Container, Inner, Row} from '../../ui/VirtualizedTable';
+
+interface Props {
+  description: string;
+  status?: AssetConditionEvaluationStatus;
+  assetKeyPath: string[];
+  evaluationId: number;
+  nodeUniqueId: string;
+  selectPartition?: (partitionKey: string | null) => void;
+}
+
+const ITEM_HEIGHT = 32;
+const MAX_ITEMS_BEFORE_TRUNCATION = 4;
+
+export const PartitionSubsetList = ({
+  description,
+  status,
+  assetKeyPath,
+  evaluationId,
+  nodeUniqueId,
+  selectPartition,
+}: Props) => {
+  const container = useRef<HTMLDivElement | null>(null);
+  const [searchValue, setSearchValue] = useState('');
+
+  const {color, hoverColor} = useMemo(
+    () => statusToColors[status ?? AssetConditionEvaluationStatus.TRUE],
+    [status],
+  );
+
+  const {data, loading} = useQuery<PartitionSubsetListQuery, PartitionSubsetListQueryVariables>(
+    PARTITION_SUBSET_LIST_QUERY,
+    {
+      variables: {
+        assetKey: {path: assetKeyPath},
+        evaluationId,
+        nodeUniqueId,
+      },
+      fetchPolicy: 'cache-first',
+    },
+  );
+
+  const partitionKeys = useMemo(() => {
+    return data?.truePartitionsForAutomationConditionEvaluationNode || [];
+  }, [data]);
+
+  const filteredKeys = useMemo(() => {
+    const searchLower = searchValue.toLocaleLowerCase();
+    return partitionKeys.filter((key) => key.toLocaleLowerCase().includes(searchLower));
+  }, [partitionKeys, searchValue]);
+
+  const count = filteredKeys.length;
+
+  const rowVirtualizer = useVirtualizer({
+    count: filteredKeys.length,
+    getScrollElement: () => container.current,
+    estimateSize: () => ITEM_HEIGHT,
+    overscan: 10,
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const virtualItems = rowVirtualizer.getVirtualItems();
+
+  const content = () => {
+    if (loading && !data) {
+      return (
+        <Box padding={24} flex={{direction: 'row', justifyContent: 'center'}}>
+          <SpinnerWithText label="Loading partition keys…" />
+        </Box>
+      );
+    }
+
+    return (
+      <>
+        {partitionKeys.length > MAX_ITEMS_BEFORE_TRUNCATION ? (
+          <SearchContainer padding={{vertical: 4, horizontal: 8}}>
+            <TextInput
+              icon="search"
+              placeholder="Filter partitions…"
+              value={searchValue}
+              onChange={(e) => setSearchValue(e.target.value)}
+            />
+          </SearchContainer>
+        ) : null}
+        <div
+          style={{
+            height: count > MAX_ITEMS_BEFORE_TRUNCATION ? '150px' : count * ITEM_HEIGHT + 16,
+            overflow: 'hidden',
+          }}
+        >
+          <Container ref={container}>
+            <Menu>
+              <Inner $totalHeight={totalHeight}>
+                {virtualItems.map(({index, key, size, start}) => {
+                  const partitionKey = filteredKeys[index]!;
+                  return (
+                    <Row $height={size} $start={start} key={key}>
+                      <MenuItem
+                        onClick={() => {
+                          selectPartition && selectPartition(partitionKey);
+                        }}
+                        text={
+                          <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+                            <PartitionStatusDot $color={color} $hoverColor={hoverColor} />
+                            <div>
+                              <MiddleTruncate text={partitionKey} />
+                            </div>
+                          </Box>
+                        }
+                      />
+                    </Row>
+                  );
+                })}
+              </Inner>
+            </Menu>
+          </Container>
+        </div>
+      </>
+    );
+  };
+
+  return (
+    <div style={{width: '292px'}}>
+      <Box
+        padding={{vertical: 8, left: 12, right: 8}}
+        border="bottom"
+        flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}
+        style={{display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) auto', gap: 8}}
+      >
+        <strong>
+          <MiddleTruncate text={description} />
+        </strong>
+        {status ? <PolicyEvaluationStatusTag status={status} /> : null}
+      </Box>
+      {content()}
+    </div>
+  );
+};
+
+type ColorConfig = {
+  color: string;
+  hoverColor: string;
+};
+
+const statusToColors: Record<AssetConditionEvaluationStatus, ColorConfig> = {
+  [AssetConditionEvaluationStatus.TRUE]: {
+    color: Colors.accentGreen(),
+    hoverColor: Colors.accentGreenHover(),
+  },
+  [AssetConditionEvaluationStatus.FALSE]: {
+    color: Colors.accentYellow(),
+    hoverColor: Colors.accentYellowHover(),
+  },
+  [AssetConditionEvaluationStatus.SKIPPED]: {
+    color: Colors.accentGray(),
+    hoverColor: Colors.accentGrayHover(),
+  },
+};
+
+const SearchContainer = styled(Box)`
+  display: flex;
+  ${TextInputContainer} {
+    flex: 1;
+  }
+`;
+
+const PartitionStatusDot = styled.div<{$color: string; $hoverColor: string}>`
+  background-color: ${({$color}) => $color};
+  height: 8px;
+  width: 8px;
+  border-radius: 50%;
+  transition: background-color 100ms linear;
+
+  :hover {
+    background-color: ${({$hoverColor}) => $hoverColor};
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PartitionSubsetListQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PartitionSubsetListQuery.tsx
@@ -1,0 +1,15 @@
+import {gql} from '@apollo/client';
+
+export const PARTITION_SUBSET_LIST_QUERY = gql`
+  query PartitionSubsetListQuery(
+    $assetKey: AssetKeyInput!
+    $evaluationId: Int!
+    $nodeUniqueId: String!
+  ) {
+    truePartitionsForAutomationConditionEvaluationNode(
+      assetKey: $assetKey
+      evaluationId: $evaluationId
+      nodeUniqueId: $nodeUniqueId
+    )
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__fixtures__/PartitionSegmentWithPopover.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__fixtures__/PartitionSegmentWithPopover.fixtures.ts
@@ -1,0 +1,50 @@
+import {buildQueryMock} from '../../../testing/mocking';
+import {PARTITION_SUBSET_LIST_QUERY} from '../PartitionSubsetListQuery';
+import {
+  PartitionSubsetListQuery,
+  PartitionSubsetListQueryVariables,
+} from '../types/PartitionSubsetListQuery.types';
+
+export const SAMPLE_ASSET_KEY_PATH = ['foo', 'bar'];
+export const SAMPLE_EVALUATION_ID = 1;
+export const SAMPLE_NODE_UNIQUE_ID = 'a1b2c3';
+export const SAMPLE_PARTITION_KEYS = ['partition-a', 'partition-b'];
+export const SAMPLE_MANY_PARTITIONS_COUNT = 100000;
+
+export const buildHasFewPartitions = (delayMsec: number = 0) => {
+  return buildQueryMock<PartitionSubsetListQuery, PartitionSubsetListQueryVariables>({
+    query: PARTITION_SUBSET_LIST_QUERY,
+    variables: {
+      assetKey: {path: SAMPLE_ASSET_KEY_PATH},
+      evaluationId: SAMPLE_EVALUATION_ID,
+      nodeUniqueId: SAMPLE_NODE_UNIQUE_ID,
+    },
+    data: {
+      truePartitionsForAutomationConditionEvaluationNode: SAMPLE_PARTITION_KEYS,
+    },
+    delay: delayMsec,
+  });
+};
+
+export const buildHasManyPartitions = ({
+  delayMsec = 0,
+  partitionCount,
+}: {
+  delayMsec?: number;
+  partitionCount: number;
+}) => {
+  return buildQueryMock<PartitionSubsetListQuery, PartitionSubsetListQueryVariables>({
+    query: PARTITION_SUBSET_LIST_QUERY,
+    variables: {
+      assetKey: {path: SAMPLE_ASSET_KEY_PATH},
+      evaluationId: SAMPLE_EVALUATION_ID,
+      nodeUniqueId: SAMPLE_NODE_UNIQUE_ID,
+    },
+    data: {
+      truePartitionsForAutomationConditionEvaluationNode: new Array(partitionCount)
+        .fill(null)
+        .map((_, ii) => `${ii}`),
+    },
+    delay: delayMsec,
+  });
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/PartitionSegmentWithPopover.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/PartitionSegmentWithPopover.stories.tsx
@@ -1,8 +1,16 @@
+import {MockedProvider} from '@apollo/client/testing';
 import {Box} from '@dagster-io/ui-components';
-import faker from 'faker';
-import {useMemo} from 'react';
 
 import {PartitionSegmentWithPopover} from '../PartitionSegmentWithPopover';
+import {
+  SAMPLE_ASSET_KEY_PATH,
+  SAMPLE_EVALUATION_ID,
+  SAMPLE_MANY_PARTITIONS_COUNT,
+  SAMPLE_NODE_UNIQUE_ID,
+  SAMPLE_PARTITION_KEYS,
+  buildHasFewPartitions,
+  buildHasManyPartitions,
+} from '../__fixtures__/PartitionSegmentWithPopover.fixtures';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -10,58 +18,40 @@ export default {
   component: PartitionSegmentWithPopover,
 };
 
-const PARTITION_COUNT = 300;
-
-export const TruePartitions = () => {
-  const subset = useMemo(() => {
-    const partitionKeys = new Array(PARTITION_COUNT)
-      .fill(null)
-      .map(() => faker.random.words(2).toLowerCase().replace(/ /g, '-'));
-    return {
-      assetKey: {path: ['foo', 'bar']},
-      subsetValue: {
-        boolValue: true,
-        partitionKeys,
-        partitionKeyRanges: null,
-        isPartitioned: true,
-      },
-    };
-  }, []);
-
+export const FewPartitions = () => {
   return (
-    <Box flex={{direction: 'row'}}>
-      <PartitionSegmentWithPopover
-        description="is_missing"
-        subset={subset}
-        selectPartition={() => {}}
-      />
-    </Box>
+    <MockedProvider mocks={[buildHasFewPartitions(2000)]}>
+      <Box flex={{direction: 'row', justifyContent: 'center'}} style={{width: '100%'}}>
+        <PartitionSegmentWithPopover
+          description="is_missing"
+          assetKeyPath={SAMPLE_ASSET_KEY_PATH}
+          evaluationId={SAMPLE_EVALUATION_ID}
+          nodeUniqueId={SAMPLE_NODE_UNIQUE_ID}
+          numTrue={SAMPLE_PARTITION_KEYS.length}
+          selectPartition={() => {}}
+        />
+      </Box>
+    </MockedProvider>
   );
 };
 
-export const FewPartitions = () => {
-  const subset = useMemo(() => {
-    const partitionKeys = new Array(2)
-      .fill(null)
-      .map(() => faker.random.words(2).toLowerCase().replace(/ /g, '-'));
-    return {
-      assetKey: {path: ['foo', 'bar']},
-      subsetValue: {
-        boolValue: true,
-        partitionKeys,
-        partitionKeyRanges: null,
-        isPartitioned: true,
-      },
-    };
-  }, []);
-
+export const ManyPartitions = () => {
+  const mocks = buildHasManyPartitions({
+    delayMsec: 2000,
+    partitionCount: SAMPLE_MANY_PARTITIONS_COUNT,
+  });
   return (
-    <Box flex={{direction: 'row'}}>
-      <PartitionSegmentWithPopover
-        description="is_missing"
-        subset={subset}
-        selectPartition={() => {}}
-      />
-    </Box>
+    <MockedProvider mocks={[mocks]}>
+      <Box flex={{direction: 'row', justifyContent: 'center'}} style={{width: '100%'}}>
+        <PartitionSegmentWithPopover
+          description="is_missing"
+          assetKeyPath={SAMPLE_ASSET_KEY_PATH}
+          evaluationId={SAMPLE_EVALUATION_ID}
+          nodeUniqueId={SAMPLE_NODE_UNIQUE_ID}
+          numTrue={SAMPLE_MANY_PARTITIONS_COUNT}
+          selectPartition={() => {}}
+        />
+      </Box>
+    </MockedProvider>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/PolicyEvaluationTable.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__stories__/PolicyEvaluationTable.stories.tsx
@@ -1,6 +1,4 @@
 import {
-  buildAssetSubset,
-  buildAssetSubsetValue,
   buildAutomationConditionEvaluationNode,
   buildPartitionedAssetConditionEvaluationNode,
   buildSpecificPartitionAssetConditionEvaluationNode,
@@ -34,6 +32,8 @@ export const NonPartitioned = () => {
   return (
     <PolicyEvaluationTable
       evaluationNodes={nodes}
+      assetKeyPath={['foo', 'bar']}
+      evaluationId={1}
       rootUniqueId="a"
       isLegacyEvaluation
       selectPartition={() => {}}
@@ -76,6 +76,8 @@ export const NewTableStyle = () => {
   return (
     <PolicyEvaluationTable
       evaluationNodes={nodes}
+      assetKeyPath={['foo', 'bar']}
+      evaluationId={1}
       rootUniqueId="a"
       isLegacyEvaluation={false}
       selectPartition={() => {}}
@@ -90,11 +92,7 @@ export const Partitioned = () => {
       endTimestamp: 10,
       uniqueId: 'a',
       description: 'hi i am partitioned',
-      candidateSubset: buildAssetSubset({
-        subsetValue: buildAssetSubsetValue({
-          partitionKeys: ['100', '101', '102'],
-        }),
-      }),
+      numCandidates: 3,
       childUniqueIds: ['b'],
     }),
     buildPartitionedAssetConditionEvaluationNode({
@@ -102,17 +100,15 @@ export const Partitioned = () => {
       endTimestamp: 10,
       uniqueId: 'b',
       description: 'child condition',
-      candidateSubset: buildAssetSubset({
-        subsetValue: buildAssetSubsetValue({
-          partitionKeys: ['100', '101', '102'],
-        }),
-      }),
+      numCandidates: 3,
     }),
   ];
 
   return (
     <PolicyEvaluationTable
       evaluationNodes={nodes}
+      assetKeyPath={['foo', 'bar']}
+      evaluationId={1}
       rootUniqueId="a"
       isLegacyEvaluation
       selectPartition={() => {}}
@@ -136,6 +132,8 @@ export const SpecificPartition = () => {
   return (
     <PolicyEvaluationTable
       evaluationNodes={nodes}
+      assetKeyPath={['foo', 'bar']}
+      evaluationId={1}
       rootUniqueId="a"
       isLegacyEvaluation
       selectPartition={() => {}}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__tests__/PolicyEvaluationTable.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/__tests__/PolicyEvaluationTable.test.tsx
@@ -2,8 +2,6 @@ import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
-  buildAssetSubset,
-  buildAssetSubsetValue,
   buildAutomationConditionEvaluationNode,
   buildPartitionedAssetConditionEvaluationNode,
   buildUnpartitionedAssetConditionEvaluationNode,
@@ -24,6 +22,8 @@ describe('PolicyEvaluationTable', () => {
     render(
       <PolicyEvaluationTable
         evaluationNodes={nodes}
+        assetKeyPath={['foo', 'bar']}
+        evaluationId={1}
         rootUniqueId="a"
         isLegacyEvaluation
         selectPartition={() => {}}
@@ -45,17 +45,15 @@ describe('PolicyEvaluationTable', () => {
         endTimestamp: 10,
         uniqueId: 'a',
         description: 'hi i am partitioned',
-        candidateSubset: buildAssetSubset({
-          subsetValue: buildAssetSubsetValue({
-            partitionKeys: ['100', '101', '102'],
-          }),
-        }),
+        numCandidates: 3,
       }),
     ];
 
     render(
       <PolicyEvaluationTable
         evaluationNodes={nodes}
+        assetKeyPath={['foo', 'bar']}
+        evaluationId={1}
         rootUniqueId="a"
         isLegacyEvaluation
         selectPartition={() => {}}
@@ -84,6 +82,8 @@ describe('PolicyEvaluationTable', () => {
     render(
       <PolicyEvaluationTable
         evaluationNodes={nodes}
+        assetKeyPath={['foo', 'bar']}
+        evaluationId={1}
         rootUniqueId="a"
         isLegacyEvaluation={false}
         selectPartition={() => {}}
@@ -123,6 +123,8 @@ describe('PolicyEvaluationTable', () => {
       render(
         <PolicyEvaluationTable
           evaluationNodes={nodes}
+          assetKeyPath={['foo', 'bar']}
+          evaluationId={1}
           rootUniqueId="a"
           isLegacyEvaluation
           selectPartition={() => {}}
@@ -167,6 +169,8 @@ describe('PolicyEvaluationTable', () => {
       render(
         <PolicyEvaluationTable
           evaluationNodes={nodes}
+          assetKeyPath={['foo', 'bar']}
+          evaluationId={1}
           rootUniqueId="a"
           isLegacyEvaluation={false}
           selectPartition={() => {}}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
@@ -2,16 +2,6 @@
 
 import * as Types from '../../../graphql/types';
 
-export type AssetSubsetFragment = {
-  __typename: 'AssetSubset';
-  subsetValue: {
-    __typename: 'AssetSubsetValue';
-    isPartitioned: boolean;
-    partitionKeys: Array<string> | null;
-    partitionKeyRanges: Array<{__typename: 'PartitionKeyRange'; start: string; end: string}> | null;
-  };
-};
-
 export type SpecificPartitionAssetConditionEvaluationNodeFragment = {
   __typename: 'SpecificPartitionAssetConditionEvaluationNode';
   description: string;
@@ -326,36 +316,9 @@ export type PartitionedAssetConditionEvaluationNodeFragment = {
   startTimestamp: number | null;
   endTimestamp: number | null;
   numTrue: number;
-  numFalse: number | null;
-  numSkipped: number | null;
   uniqueId: string;
   childUniqueIds: Array<string>;
-  trueSubset: {
-    __typename: 'AssetSubset';
-    subsetValue: {
-      __typename: 'AssetSubsetValue';
-      isPartitioned: boolean;
-      partitionKeys: Array<string> | null;
-      partitionKeyRanges: Array<{
-        __typename: 'PartitionKeyRange';
-        start: string;
-        end: string;
-      }> | null;
-    };
-  };
-  candidateSubset: {
-    __typename: 'AssetSubset';
-    subsetValue: {
-      __typename: 'AssetSubsetValue';
-      isPartitioned: boolean;
-      partitionKeys: Array<string> | null;
-      partitionKeyRanges: Array<{
-        __typename: 'PartitionKeyRange';
-        start: string;
-        end: string;
-      }> | null;
-    };
-  } | null;
+  numCandidates: number | null;
 };
 
 export type NewEvaluationNodeFragment = {
@@ -365,35 +328,10 @@ export type NewEvaluationNodeFragment = {
   userLabel: string | null;
   startTimestamp: number | null;
   endTimestamp: number | null;
+  numCandidates: number | null;
   numTrue: number;
   isPartitioned: boolean;
   childUniqueIds: Array<string>;
-  trueSubset: {
-    __typename: 'AssetSubset';
-    subsetValue: {
-      __typename: 'AssetSubsetValue';
-      isPartitioned: boolean;
-      partitionKeys: Array<string> | null;
-      partitionKeyRanges: Array<{
-        __typename: 'PartitionKeyRange';
-        start: string;
-        end: string;
-      }> | null;
-    };
-  };
-  candidateSubset: {
-    __typename: 'AssetSubset';
-    subsetValue: {
-      __typename: 'AssetSubsetValue';
-      isPartitioned: boolean;
-      partitionKeys: Array<string> | null;
-      partitionKeyRanges: Array<{
-        __typename: 'PartitionKeyRange';
-        start: string;
-        end: string;
-      }> | null;
-    };
-  } | null;
 };
 
 export type AssetConditionEvaluationRecordFragment = {
@@ -417,36 +355,9 @@ export type AssetConditionEvaluationRecordFragment = {
           startTimestamp: number | null;
           endTimestamp: number | null;
           numTrue: number;
-          numFalse: number | null;
-          numSkipped: number | null;
           uniqueId: string;
           childUniqueIds: Array<string>;
-          trueSubset: {
-            __typename: 'AssetSubset';
-            subsetValue: {
-              __typename: 'AssetSubsetValue';
-              isPartitioned: boolean;
-              partitionKeys: Array<string> | null;
-              partitionKeyRanges: Array<{
-                __typename: 'PartitionKeyRange';
-                start: string;
-                end: string;
-              }> | null;
-            };
-          };
-          candidateSubset: {
-            __typename: 'AssetSubset';
-            subsetValue: {
-              __typename: 'AssetSubsetValue';
-              isPartitioned: boolean;
-              partitionKeys: Array<string> | null;
-              partitionKeyRanges: Array<{
-                __typename: 'PartitionKeyRange';
-                start: string;
-                end: string;
-              }> | null;
-            };
-          } | null;
+          numCandidates: number | null;
         }
       | {
           __typename: 'SpecificPartitionAssetConditionEvaluationNode';
@@ -803,35 +714,10 @@ export type AssetConditionEvaluationRecordFragment = {
     userLabel: string | null;
     startTimestamp: number | null;
     endTimestamp: number | null;
+    numCandidates: number | null;
     numTrue: number;
     isPartitioned: boolean;
     childUniqueIds: Array<string>;
-    trueSubset: {
-      __typename: 'AssetSubset';
-      subsetValue: {
-        __typename: 'AssetSubsetValue';
-        isPartitioned: boolean;
-        partitionKeys: Array<string> | null;
-        partitionKeyRanges: Array<{
-          __typename: 'PartitionKeyRange';
-          start: string;
-          end: string;
-        }> | null;
-      };
-    };
-    candidateSubset: {
-      __typename: 'AssetSubset';
-      subsetValue: {
-        __typename: 'AssetSubsetValue';
-        isPartitioned: boolean;
-        partitionKeys: Array<string> | null;
-        partitionKeyRanges: Array<{
-          __typename: 'PartitionKeyRange';
-          start: string;
-          end: string;
-        }> | null;
-      };
-    } | null;
   }>;
 };
 
@@ -883,36 +769,9 @@ export type GetEvaluationsQuery = {
                   startTimestamp: number | null;
                   endTimestamp: number | null;
                   numTrue: number;
-                  numFalse: number | null;
-                  numSkipped: number | null;
                   uniqueId: string;
                   childUniqueIds: Array<string>;
-                  trueSubset: {
-                    __typename: 'AssetSubset';
-                    subsetValue: {
-                      __typename: 'AssetSubsetValue';
-                      isPartitioned: boolean;
-                      partitionKeys: Array<string> | null;
-                      partitionKeyRanges: Array<{
-                        __typename: 'PartitionKeyRange';
-                        start: string;
-                        end: string;
-                      }> | null;
-                    };
-                  };
-                  candidateSubset: {
-                    __typename: 'AssetSubset';
-                    subsetValue: {
-                      __typename: 'AssetSubsetValue';
-                      isPartitioned: boolean;
-                      partitionKeys: Array<string> | null;
-                      partitionKeyRanges: Array<{
-                        __typename: 'PartitionKeyRange';
-                        start: string;
-                        end: string;
-                      }> | null;
-                    };
-                  } | null;
+                  numCandidates: number | null;
                 }
               | {
                   __typename: 'SpecificPartitionAssetConditionEvaluationNode';
@@ -1281,35 +1140,10 @@ export type GetEvaluationsQuery = {
             userLabel: string | null;
             startTimestamp: number | null;
             endTimestamp: number | null;
+            numCandidates: number | null;
             numTrue: number;
             isPartitioned: boolean;
             childUniqueIds: Array<string>;
-            trueSubset: {
-              __typename: 'AssetSubset';
-              subsetValue: {
-                __typename: 'AssetSubsetValue';
-                isPartitioned: boolean;
-                partitionKeys: Array<string> | null;
-                partitionKeyRanges: Array<{
-                  __typename: 'PartitionKeyRange';
-                  start: string;
-                  end: string;
-                }> | null;
-              };
-            };
-            candidateSubset: {
-              __typename: 'AssetSubset';
-              subsetValue: {
-                __typename: 'AssetSubsetValue';
-                isPartitioned: boolean;
-                partitionKeys: Array<string> | null;
-                partitionKeyRanges: Array<{
-                  __typename: 'PartitionKeyRange';
-                  start: string;
-                  end: string;
-                }> | null;
-              };
-            } | null;
           }>;
         }>;
       }
@@ -1335,36 +1169,9 @@ export type GetEvaluationsSpecificPartitionQuery = {
           startTimestamp: number | null;
           endTimestamp: number | null;
           numTrue: number;
-          numFalse: number | null;
-          numSkipped: number | null;
           uniqueId: string;
           childUniqueIds: Array<string>;
-          trueSubset: {
-            __typename: 'AssetSubset';
-            subsetValue: {
-              __typename: 'AssetSubsetValue';
-              isPartitioned: boolean;
-              partitionKeys: Array<string> | null;
-              partitionKeyRanges: Array<{
-                __typename: 'PartitionKeyRange';
-                start: string;
-                end: string;
-              }> | null;
-            };
-          };
-          candidateSubset: {
-            __typename: 'AssetSubset';
-            subsetValue: {
-              __typename: 'AssetSubsetValue';
-              isPartitioned: boolean;
-              partitionKeys: Array<string> | null;
-              partitionKeyRanges: Array<{
-                __typename: 'PartitionKeyRange';
-                start: string;
-                end: string;
-              }> | null;
-            };
-          } | null;
+          numCandidates: number | null;
         }
       | {
           __typename: 'SpecificPartitionAssetConditionEvaluationNode';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/PartitionSubsetListQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/PartitionSubsetListQuery.types.ts
@@ -1,0 +1,14 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../../graphql/types';
+
+export type PartitionSubsetListQueryVariables = Types.Exact<{
+  assetKey: Types.AssetKeyInput;
+  evaluationId: Types.Scalars['Int']['input'];
+  nodeUniqueId: Types.Scalars['String']['input'];
+}>;
+
+export type PartitionSubsetListQuery = {
+  __typename: 'Query';
+  truePartitionsForAutomationConditionEvaluationNode: Array<string>;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3263,6 +3263,11 @@ type Query {
     limit: Int!
     cursor: String
   ): AutoMaterializeAssetEvaluationRecordsOrError
+  truePartitionsForAutomationConditionEvaluationNode(
+    assetKey: AssetKeyInput!
+    evaluationId: Int!
+    nodeUniqueId: String
+  ): [String!]!
   autoMaterializeEvaluationsForEvaluationId(
     evaluationId: Int!
   ): AutoMaterializeAssetEvaluationRecordsOrError
@@ -3536,24 +3541,9 @@ type PartitionedAssetConditionEvaluationNode {
   description: String!
   startTimestamp: Float
   endTimestamp: Float
-  trueSubset: AssetSubset!
-  candidateSubset: AssetSubset
   numTrue: Int!
-  numFalse: Int
-  numSkipped: Int
+  numCandidates: Int
   childUniqueIds: [String!]!
-}
-
-type AssetSubset {
-  assetKey: AssetKey!
-  subsetValue: AssetSubsetValue!
-}
-
-type AssetSubsetValue {
-  boolValue: Boolean
-  partitionKeys: [String!]
-  partitionKeyRanges: [PartitionKeyRange!]
-  isPartitioned: Boolean!
 }
 
 type SpecificPartitionAssetConditionEvaluationNode {
@@ -3594,9 +3584,8 @@ type AutomationConditionEvaluationNode {
   startTimestamp: Float
   endTimestamp: Float
   numTrue: Int!
+  numCandidates: Int
   isPartitioned: Boolean!
-  trueSubset: AssetSubset!
-  candidateSubset: AssetSubset
   childUniqueIds: [String!]!
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -600,20 +600,6 @@ export type AssetSelection = {
   assetsOrError: AssetsOrError;
 };
 
-export type AssetSubset = {
-  __typename: 'AssetSubset';
-  assetKey: AssetKey;
-  subsetValue: AssetSubsetValue;
-};
-
-export type AssetSubsetValue = {
-  __typename: 'AssetSubsetValue';
-  boolValue: Maybe<Scalars['Boolean']['output']>;
-  isPartitioned: Scalars['Boolean']['output'];
-  partitionKeyRanges: Maybe<Array<PartitionKeyRange>>;
-  partitionKeys: Maybe<Array<Scalars['String']['output']>>;
-};
-
 export type AssetWipeMutationResult =
   | AssetNotFoundError
   | AssetWipeSuccess
@@ -700,14 +686,13 @@ export type AutoMaterializeRuleWithRuleEvaluations = {
 
 export type AutomationConditionEvaluationNode = {
   __typename: 'AutomationConditionEvaluationNode';
-  candidateSubset: Maybe<AssetSubset>;
   childUniqueIds: Array<Scalars['String']['output']>;
   endTimestamp: Maybe<Scalars['Float']['output']>;
   expandedLabel: Array<Scalars['String']['output']>;
   isPartitioned: Scalars['Boolean']['output'];
+  numCandidates: Maybe<Scalars['Int']['output']>;
   numTrue: Scalars['Int']['output'];
   startTimestamp: Maybe<Scalars['Float']['output']>;
-  trueSubset: AssetSubset;
   uniqueId: Scalars['String']['output'];
   userLabel: Maybe<Scalars['String']['output']>;
 };
@@ -3275,15 +3260,12 @@ export type PartitionTagsOrError = PartitionTags | PythonError;
 
 export type PartitionedAssetConditionEvaluationNode = {
   __typename: 'PartitionedAssetConditionEvaluationNode';
-  candidateSubset: Maybe<AssetSubset>;
   childUniqueIds: Array<Scalars['String']['output']>;
   description: Scalars['String']['output'];
   endTimestamp: Maybe<Scalars['Float']['output']>;
-  numFalse: Maybe<Scalars['Int']['output']>;
-  numSkipped: Maybe<Scalars['Int']['output']>;
+  numCandidates: Maybe<Scalars['Int']['output']>;
   numTrue: Scalars['Int']['output'];
   startTimestamp: Maybe<Scalars['Float']['output']>;
-  trueSubset: AssetSubset;
   uniqueId: Scalars['String']['output'];
 };
 
@@ -3714,6 +3696,7 @@ export type Query = {
   shouldShowNux: Scalars['Boolean']['output'];
   test: Maybe<TestFields>;
   topLevelResourceDetailsOrError: ResourceDetailsOrError;
+  truePartitionsForAutomationConditionEvaluationNode: Array<Scalars['String']['output']>;
   utilizedEnvVarsOrError: EnvVarWithConsumersOrError;
   version: Scalars['String']['output'];
   workspaceLocationEntryOrError: Maybe<WorkspaceLocationEntryOrError>;
@@ -3943,6 +3926,12 @@ export type QuerySensorsOrErrorArgs = {
 
 export type QueryTopLevelResourceDetailsOrErrorArgs = {
   resourceSelector: ResourceSelector;
+};
+
+export type QueryTruePartitionsForAutomationConditionEvaluationNodeArgs = {
+  assetKey: AssetKeyInput;
+  evaluationId: Scalars['Int']['input'];
+  nodeUniqueId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type QueryUtilizedEnvVarsOrErrorArgs = {
@@ -6668,49 +6657,6 @@ export const buildAssetSelection = (
   };
 };
 
-export const buildAssetSubset = (
-  overrides?: Partial<AssetSubset>,
-  _relationshipsToOmit: Set<string> = new Set(),
-): {__typename: 'AssetSubset'} & AssetSubset => {
-  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
-  relationshipsToOmit.add('AssetSubset');
-  return {
-    __typename: 'AssetSubset',
-    assetKey:
-      overrides && overrides.hasOwnProperty('assetKey')
-        ? overrides.assetKey!
-        : relationshipsToOmit.has('AssetKey')
-        ? ({} as AssetKey)
-        : buildAssetKey({}, relationshipsToOmit),
-    subsetValue:
-      overrides && overrides.hasOwnProperty('subsetValue')
-        ? overrides.subsetValue!
-        : relationshipsToOmit.has('AssetSubsetValue')
-        ? ({} as AssetSubsetValue)
-        : buildAssetSubsetValue({}, relationshipsToOmit),
-  };
-};
-
-export const buildAssetSubsetValue = (
-  overrides?: Partial<AssetSubsetValue>,
-  _relationshipsToOmit: Set<string> = new Set(),
-): {__typename: 'AssetSubsetValue'} & AssetSubsetValue => {
-  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
-  relationshipsToOmit.add('AssetSubsetValue');
-  return {
-    __typename: 'AssetSubsetValue',
-    boolValue: overrides && overrides.hasOwnProperty('boolValue') ? overrides.boolValue! : false,
-    isPartitioned:
-      overrides && overrides.hasOwnProperty('isPartitioned') ? overrides.isPartitioned! : false,
-    partitionKeyRanges:
-      overrides && overrides.hasOwnProperty('partitionKeyRanges')
-        ? overrides.partitionKeyRanges!
-        : [],
-    partitionKeys:
-      overrides && overrides.hasOwnProperty('partitionKeys') ? overrides.partitionKeys! : [],
-  };
-};
-
 export const buildAssetWipeSuccess = (
   overrides?: Partial<AssetWipeSuccess>,
   _relationshipsToOmit: Set<string> = new Set(),
@@ -6880,12 +6826,6 @@ export const buildAutomationConditionEvaluationNode = (
   relationshipsToOmit.add('AutomationConditionEvaluationNode');
   return {
     __typename: 'AutomationConditionEvaluationNode',
-    candidateSubset:
-      overrides && overrides.hasOwnProperty('candidateSubset')
-        ? overrides.candidateSubset!
-        : relationshipsToOmit.has('AssetSubset')
-        ? ({} as AssetSubset)
-        : buildAssetSubset({}, relationshipsToOmit),
     childUniqueIds:
       overrides && overrides.hasOwnProperty('childUniqueIds') ? overrides.childUniqueIds! : [],
     endTimestamp:
@@ -6894,15 +6834,11 @@ export const buildAutomationConditionEvaluationNode = (
       overrides && overrides.hasOwnProperty('expandedLabel') ? overrides.expandedLabel! : [],
     isPartitioned:
       overrides && overrides.hasOwnProperty('isPartitioned') ? overrides.isPartitioned! : true,
+    numCandidates:
+      overrides && overrides.hasOwnProperty('numCandidates') ? overrides.numCandidates! : 6123,
     numTrue: overrides && overrides.hasOwnProperty('numTrue') ? overrides.numTrue! : 5212,
     startTimestamp:
       overrides && overrides.hasOwnProperty('startTimestamp') ? overrides.startTimestamp! : 5.42,
-    trueSubset:
-      overrides && overrides.hasOwnProperty('trueSubset')
-        ? overrides.trueSubset!
-        : relationshipsToOmit.has('AssetSubset')
-        ? ({} as AssetSubset)
-        : buildAssetSubset({}, relationshipsToOmit),
     uniqueId: overrides && overrides.hasOwnProperty('uniqueId') ? overrides.uniqueId! : 'sit',
     userLabel:
       overrides && overrides.hasOwnProperty('userLabel') ? overrides.userLabel! : 'dolorem',
@@ -11063,29 +10999,17 @@ export const buildPartitionedAssetConditionEvaluationNode = (
   relationshipsToOmit.add('PartitionedAssetConditionEvaluationNode');
   return {
     __typename: 'PartitionedAssetConditionEvaluationNode',
-    candidateSubset:
-      overrides && overrides.hasOwnProperty('candidateSubset')
-        ? overrides.candidateSubset!
-        : relationshipsToOmit.has('AssetSubset')
-        ? ({} as AssetSubset)
-        : buildAssetSubset({}, relationshipsToOmit),
     childUniqueIds:
       overrides && overrides.hasOwnProperty('childUniqueIds') ? overrides.childUniqueIds! : [],
     description:
       overrides && overrides.hasOwnProperty('description') ? overrides.description! : 'quam',
     endTimestamp:
       overrides && overrides.hasOwnProperty('endTimestamp') ? overrides.endTimestamp! : 9.74,
-    numFalse: overrides && overrides.hasOwnProperty('numFalse') ? overrides.numFalse! : 4729,
-    numSkipped: overrides && overrides.hasOwnProperty('numSkipped') ? overrides.numSkipped! : 5678,
+    numCandidates:
+      overrides && overrides.hasOwnProperty('numCandidates') ? overrides.numCandidates! : 9986,
     numTrue: overrides && overrides.hasOwnProperty('numTrue') ? overrides.numTrue! : 3015,
     startTimestamp:
       overrides && overrides.hasOwnProperty('startTimestamp') ? overrides.startTimestamp! : 5.96,
-    trueSubset:
-      overrides && overrides.hasOwnProperty('trueSubset')
-        ? overrides.trueSubset!
-        : relationshipsToOmit.has('AssetSubset')
-        ? ({} as AssetSubset)
-        : buildAssetSubset({}, relationshipsToOmit),
     uniqueId: overrides && overrides.hasOwnProperty('uniqueId') ? overrides.uniqueId! : 'sed',
   };
 };
@@ -12050,6 +11974,10 @@ export const buildQuery = (
         : relationshipsToOmit.has('PythonError')
         ? ({} as PythonError)
         : buildPythonError({}, relationshipsToOmit),
+    truePartitionsForAutomationConditionEvaluationNode:
+      overrides && overrides.hasOwnProperty('truePartitionsForAutomationConditionEvaluationNode')
+        ? overrides.truePartitionsForAutomationConditionEvaluationNode!
+        : [],
     utilizedEnvVarsOrError:
       overrides && overrides.hasOwnProperty('utilizedEnvVarsOrError')
         ? overrides.utilizedEnvVarsOrError!


### PR DESCRIPTION
## Summary & Motivation

Defer fetching partition keys affected by an automation policy evaluation.

For assets with tons of partitions, this page is slowed significantly by retrieving the parititon subsets up front. Instead, retrieve them when actually hovering over the evaluation data for the relevant row.

## How I Tested These Changes

Load a repo with an asset with 200k partitions, then perform some automation evaluations. View an evaluation result, and hover over the "200,000 True" tag. Verify loading state for the partition key query, and correct rendering of partition list.