### PR TITLE
fix termination dialogue appearing when canceling asset backfills

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillTerminationDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillTerminationDialog.tsx
@@ -99,7 +99,7 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
           )}
         </DialogFooter>
       </Dialog>
-      {(!backfill.isAssetBackfill && unfinishedMap) && (
+      {!backfill.isAssetBackfill && unfinishedMap && (
         <TerminationDialog
           isOpen={
             !!backfill &&

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillTerminationDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillTerminationDialog.tsx
@@ -99,7 +99,7 @@ export const BackfillTerminationDialog = ({backfill, onClose, onComplete}: Props
           )}
         </DialogFooter>
       </Dialog>
-      {unfinishedMap && (
+      {(!backfill.isAssetBackfill && unfinishedMap) && (
         <TerminationDialog
           isOpen={
             !!backfill &&


### PR DESCRIPTION
## Summary & Motivation
https://github.com/dagster-io/dagster/pull/23147 tried to remove getting information about individual partition statuses from backfill cancellation logic. However it introduced a bug when determining if we show the run termination dialogue. The resolver to get partition statuses always returned an empty list for asset backfills, which made it skip showing the termination dialogue. that behavior wasn't replicated when we switched to checking for cancelable runs to decide if we should show the dialogue.

## How I Tested These Changes
terminated a backfill from the backfill table and from the backfill details page and observed that the run termination dialogue did not appear, the backfill was immediately moved to CANCELING and the backfill daemon took care of canceling in progress runs