### PR TITLE
[dagster-airlift] more flexible DbtProjectDefs params

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/dbt/multi_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/dbt/multi_asset.py
@@ -1,37 +1,91 @@
-import json
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Optional
+from typing import Any, Mapping, Optional
 
-from dagster import AssetExecutionContext, Definitions
-from dagster_dbt import DbtCliResource, dbt_assets
+from dagster import AssetExecutionContext, Definitions, multi_asset
+from dagster_dbt import (
+    DagsterDbtTranslator,
+    DbtCliResource,
+    DbtProject,
+    build_dbt_asset_specs,
+    dbt_assets,
+)
+from dagster_dbt.dbt_manifest import DbtManifestParam, validate_manifest
 
 from dagster_airlift.core import DefsFactory
 
 
 @dataclass
 class DbtProjectDefs(DefsFactory):
-    dbt_project_path: Path
+    """A factory that builds a :py:class:`dagster.Definitions` object from a dbt project.
+    If the dbt project is not living within the dagster codebase and/or the dbt project is not
+    being orchestrated by dagster, just provide a reference to the manifest and external assets
+    will be constructed.
+
+    Args:
+        dbt_manifest (DbtManifestParam): The dbt manifest. This can be a path to a manifest file,
+            a string of the manifest JSON, or the parsed manifest JSON.
+        dbt_project_path (Path): The path to the dbt project.
+        name (str): The name to give the dbt project. In the case of airflow-orchestrated DBT assets,
+            this should be <dag_id>__<task_id>.
+        group (Optional[str], optional): The asset group name for the dbt assets. Default is "default".
+    """
+
+    dbt_manifest: Mapping[str, Any]
     name: str
-    group: Optional[str] = None
+    translator: Optional[DagsterDbtTranslator]
+    select: str
+    exclude: Optional[str]
+    project: Optional[DbtProject]
+
+    def __init__(
+        self,
+        dbt_manifest: DbtManifestParam,
+        name: str,
+        translator: Optional[DagsterDbtTranslator] = None,
+        select: str = "fqn:*",
+        exclude: Optional[str] = None,
+        project: Optional[DbtProject] = None,
+    ):
+        self.dbt_manifest = validate_manifest(dbt_manifest)
+        self.name = name
+        self.translator = translator
+        self.select = select
+        self.exclude = exclude
+        self.project = project
 
     def build_defs(self) -> Definitions:
-        dbt_manifest_path = self.dbt_project_path / "target" / "manifest.json"
+        if self.project is None:
 
-        @dbt_assets(manifest=json.loads(dbt_manifest_path.read_text()), name=self.name)
-        def _dbt_asset(context: AssetExecutionContext, dbt: DbtCliResource):
-            yield from dbt.cli(["build"], context=context).stream()
-
-        if self.group:
-            _dbt_asset = _dbt_asset.with_attributes(
-                group_names_by_key={key: self.group for key in _dbt_asset.keys}
+            @multi_asset(
+                name=self.name,
+                specs=build_dbt_asset_specs(
+                    manifest=self.dbt_manifest,
+                    dagster_dbt_translator=self.translator,
+                    select=self.select,
+                    exclude=self.exclude,
+                    project=self.project,
+                ),
             )
+            def _multi_asset():
+                raise Exception("This should never be called")
 
-        return Definitions(
-            assets=[_dbt_asset],
-            resources={
-                "dbt": DbtCliResource(
-                    project_dir=self.dbt_project_path, profiles_dir=self.dbt_project_path
-                )
-            },
-        )
+            return Definitions(
+                assets=[_multi_asset],
+            )
+        else:
+
+            @dbt_assets(
+                manifest=self.dbt_manifest,
+                name=self.name,
+                project=self.project,
+                dagster_dbt_translator=self.translator,
+                select=self.select,
+                exclude=self.exclude,
+            )
+            def _dbt_asset(context: AssetExecutionContext, dbt: DbtCliResource):
+                yield from dbt.cli(["build"], context=context).stream()
+
+            return Definitions(
+                assets=[_dbt_asset],
+                resources={"dbt": DbtCliResource(project_dir=self.project)},
+            )

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_dbt_multi_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_dbt_multi_asset.py
@@ -7,6 +7,7 @@ import pytest
 from dagster import AssetKey, AssetsDefinition
 from dagster._core.test_utils import environ
 from dagster_airlift.dbt import DbtProjectDefs
+from dagster_dbt import DbtProject
 
 
 @pytest.fixture(name="dbt_project_dir")
@@ -34,7 +35,8 @@ def test_load_dbt_project(dbt_project_dir: Path, dbt_project: None) -> None:
         dbt_project_dir
     ), "Expected dbt project dir to be set as env var"
     defs = DbtProjectDefs(
-        dbt_project_path=dbt_project_dir,
+        dbt_manifest=dbt_project_dir / "target" / "manifest.json",
+        project=DbtProject(project_dir=dbt_project_dir),
         name="my_dbt_multi_asset",
     ).build_defs()
     assert defs.assets

--- a/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/definitions.py
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/definitions.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from dagster_airlift.core import AirflowInstance, BasicAuthBackend, build_defs_from_airflow_instance
 from dagster_airlift.core.def_factory import defs_from_factories
 from dagster_airlift.dbt import DbtProjectDefs
+from dagster_dbt import DbtProject
 
 from dbt_example.dagster_defs.csv_to_duckdb_defs import CSVToDuckdbDefs
 
@@ -43,8 +44,8 @@ defs = build_defs_from_airflow_instance(
         ),
         DbtProjectDefs(
             name="dbt_dag__build_dbt_models",
-            dbt_project_path=dbt_project_path(),
-            group="dbt",
+            dbt_manifest=dbt_project_path() / "target" / "manifest.json",
+            project=DbtProject(project_dir=dbt_project_path()),
         ),
     ),
 )


### PR DESCRIPTION
Allows for more flexible DbtProjectDefs. The idea here is to allow for both external assets and dbt-computable assets.

Makes the implementation more complex. I'm starting to think we kind of need an intermediate pattern beyond just `build_defs`...