### PR TITLE
[check] fix tuple name resolution

### DIFF
--- a/python_modules/dagster/dagster/_check/builder.py
+++ b/python_modules/dagster/dagster/_check/builder.py
@@ -219,8 +219,11 @@ def _name(target: Optional[TypeOrTupleOfTypes]) -> str:
     if target is None:
         return "None"
 
+    if target is NoneType:
+        return "check.NoneType"
+
     if isinstance(target, tuple):
-        return f"({', '.join(tup_type.__name__ if tup_type is not NoneType else 'check.NoneType' for tup_type in target)})"
+        return f"({', '.join(_name(tup_type) for tup_type in target)})"
 
     if hasattr(target, "__name__"):
         return target.__name__


### PR DESCRIPTION
call `_name` on each entry in a tuple to ensure older python logic (`_name`) gets applied

also moves around some code to avoid a `ForwardRef` for a `Union` which is hard to solve in `3.8`

## How I Tested These Changes

test on 3.8