### PR TITLE
refactor(sling): remove `Pattern` type hint

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
@@ -52,7 +52,7 @@ def _strip_quotes_target_table_name(target_table_name: str) -> str:
     return target_table_name.replace('"', "")
 
 
-INSERT_REGEX: re.Pattern[str] = re.compile(r".*inserted (\d+) rows into (.*) in.*")
+INSERT_REGEX = re.compile(r".*inserted (\d+) rows into (.*) in.*")
 
 
 def _get_target_table_name(stream_name: str, sling_cli: "SlingResource") -> Optional[str]:


### PR DESCRIPTION
## Summary & Motivation
This is not working in Python 3.8. Fix that by removing the type hint.

## How I Tested These Changes
bk