### PR TITLE
[DA][16/n][asset-graph-entity] Convert AssetSubset to dataclass

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime
 import logging
 import time
@@ -154,8 +155,8 @@ class AutomationConditionEvaluator:
                     # all these neighbors must be executed as a unit, we need to union together
                     # the subset of all required neighbors
                     if neighbor_key in self.current_results_by_key:
-                        neighbor_true_subset = result.serializable_evaluation.true_subset._replace(
-                            asset_key=neighbor_key
+                        neighbor_true_subset = dataclasses.replace(
+                            result.serializable_evaluation.true_subset, asset_key=neighbor_key
                         )
                         neighbor_evaluation = result.serializable_evaluation._replace(
                             true_subset=neighbor_true_subset

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
@@ -4,7 +4,7 @@ import functools
 import logging
 import os
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import (
     TYPE_CHECKING,
     AbstractSet,
@@ -226,7 +226,7 @@ class LegacyRuleEvaluationContext:
             if not parent_result:
                 continue
             parent_subset = parent_result.true_subset.as_valid(self.partitions_def)
-            subset |= parent_subset._replace(asset_key=self.asset_key)
+            subset |= replace(parent_subset, asset_key=self.asset_key)
         return subset
 
     @functools.cached_property


### PR DESCRIPTION
## Summary & Motivation

This converts AssetSubset to use dataclass instead of NamedTuple. This will make further changes which change its inheritence structure easier, as NamedTuples don't play nicely with multiple inheritence, and I found records to be a little tricky with Generics.

## How I Tested These Changes
