### PR TITLE
[dagster-fivetran] Pull column schema at runtime after syncing table

### DIFF
--- a/python_modules/dagster/dagster/_core/utils.py
+++ b/python_modules/dagster/dagster/_core/utils.py
@@ -4,13 +4,15 @@ import re
 import string
 import uuid
 import warnings
-from collections import OrderedDict
-from concurrent.futures import Future, ThreadPoolExecutor
+from collections import OrderedDict, deque
+from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
 from contextvars import copy_context
 from typing import (
     AbstractSet,
     Any,
+    Callable,
     Iterable,
+    Iterator,
     Mapping,
     Optional,
     Sequence,
@@ -196,3 +198,74 @@ class InheritContextThreadPoolExecutor(FuturesAwareThreadPoolExecutor):
 def is_valid_email(email: str) -> bool:
     regex = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,7}\b"
     return bool(re.fullmatch(regex, email))
+
+
+T = TypeVar("T")
+P = TypeVar("P")
+
+
+def imap(
+    executor: ThreadPoolExecutor,
+    iterable: Iterator[T],
+    func: Callable[[T], P],
+) -> Iterator[P]:
+    """A version of `concurrent.futures.ThreadpoolExecutor.map` which tails the input iterator in
+    a separate thread. This means that the map function can begin processing and yielding results from
+    the first elements of the iterator before the iterator is fully consumed.
+
+    Args:
+        executor: The ThreadPoolExecutor to use for parallel execution.
+        iterable: The iterator to apply the function to.
+        func: The function to apply to each element of the iterator.
+    """
+    work_queue: deque[Future] = deque([])
+
+    # create a small task which waits on the iterator
+    # and enqueues work items as they become available
+    def _apply_func_to_iterator_results(iterable: Iterator) -> None:
+        for arg in iterable:
+            work_queue.append(executor.submit(func, arg))
+
+    enqueuing_task = executor.submit(
+        _apply_func_to_iterator_results,
+        iterable,
+    )
+
+    while True:
+        if (not enqueuing_task or enqueuing_task.done()) and len(work_queue) == 0:
+            break
+
+        if len(work_queue) > 0:
+            current_work_item = work_queue[0]
+
+            try:
+                yield current_work_item.result(timeout=0.1)
+                work_queue.popleft()
+            except TimeoutError:
+                pass
+
+    # Ensure any exceptions from the enqueuing task processing the iterator are raised,
+    # after all work items have been processed.
+    exc = enqueuing_task.exception()
+    if exc:
+        raise exc
+
+
+def exhaust_iterator_and_yield_results_with_exception(iterable: Iterator[T]) -> Iterator[T]:
+    """Fully exhausts an iterator and then yield its results. If the iterator raises an exception,
+    raise that exception at the position in the iterator where it was originally raised.
+
+    This is useful if we want to exhaust an iterator, but don't want to discard the elements
+    that were yielded before the exception was raised.
+    """
+    results = []
+    caught_exception = None
+    try:
+        for result in iterable:
+            results.append(result)
+    except Exception as e:
+        caught_exception = e
+
+    yield from results
+    if caught_exception:
+        raise caught_exception

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
@@ -13,11 +13,11 @@ from dagster import (
 from dagster._annotations import experimental, public
 from dagster._core.definitions.metadata import TableMetadataSet, TextMetadataValue
 from dagster._core.errors import DagsterInvalidPropertyError
+from dagster._core.utils import exhaust_iterator_and_yield_results_with_exception, imap
 from typing_extensions import TypeVar
 
 from dagster_dbt.asset_utils import default_metadata_from_dbt_resource_props
 from dagster_dbt.core.dbt_cli_event import EventHistoryMetadata, _build_column_lineage_metadata
-from dagster_dbt.core.utils import exhaust_iterator_and_yield_results_with_exception, imap
 
 if TYPE_CHECKING:
     from dagster_dbt.core.dbt_cli_invocation import DbtCliInvocation

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/utils.py
@@ -1,6 +1,5 @@
-from collections import deque
-from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError
-from typing import Any, Callable, Iterator, List, TypeVar, Union
+from concurrent.futures import Future
+from typing import Any, List, Union
 
 
 def get_future_completion_state_or_err(futures: List[Union[Future, Any]]) -> bool:
@@ -18,74 +17,3 @@ def get_future_completion_state_or_err(futures: List[Union[Future, Any]]) -> boo
         if exception:
             raise exception
     return True
-
-
-T = TypeVar("T")
-P = TypeVar("P")
-
-
-def imap(
-    executor: ThreadPoolExecutor,
-    iterable: Iterator[T],
-    func: Callable[[T], P],
-) -> Iterator[P]:
-    """A version of `concurrent.futures.ThreadpoolExecutor.map` which tails the input iterator in
-    a separate thread. This means that the map function can begin processing and yielding results from
-    the first elements of the iterator before the iterator is fully consumed.
-
-    Args:
-        executor: The ThreadPoolExecutor to use for parallel execution.
-        iterable: The iterator to apply the function to.
-        func: The function to apply to each element of the iterator.
-    """
-    work_queue: deque[Future] = deque([])
-
-    # create a small task which waits on the iterator
-    # and enqueues work items as they become available
-    def _apply_func_to_iterator_results(iterable: Iterator[T]) -> None:
-        for arg in iterable:
-            work_queue.append(executor.submit(func, arg))
-
-    enqueuing_task = executor.submit(
-        _apply_func_to_iterator_results,
-        iterable,
-    )
-
-    while True:
-        if (not enqueuing_task or enqueuing_task.done()) and len(work_queue) == 0:
-            break
-
-        if len(work_queue) > 0:
-            current_work_item = work_queue[0]
-
-            try:
-                yield current_work_item.result(timeout=0.1)
-                work_queue.popleft()
-            except TimeoutError:
-                pass
-
-    # Ensure any exceptions from the enqueuing task processing the iterator are raised,
-    # after all work items have been processed.
-    exc = enqueuing_task.exception()
-    if exc:
-        raise exc
-
-
-def exhaust_iterator_and_yield_results_with_exception(iterable: Iterator[T]) -> Iterator[T]:
-    """Fully exhausts an iterator and then yield its results. If the iterator raises an exception,
-    raise that exception at the position in the iterator where it was originally raised.
-
-    This is useful if we want to exhaust an iterator, but don't want to discard the elements
-    that were yielded before the exception was raised.
-    """
-    results = []
-    caught_exception = None
-    try:
-        for result in iterable:
-            results.append(result)
-    except Exception as e:
-        caught_exception = e
-
-    yield from results
-    if caught_exception:
-        raise caught_exception

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_asset_defs.py
@@ -12,6 +12,7 @@ from dagster_fivetran.resources import (
 
 from dagster_fivetran_tests.utils import (
     DEFAULT_CONNECTOR_ID,
+    get_sample_columns_response,
     get_sample_connector_response,
     get_sample_connector_schema_config,
     get_sample_sync_response,
@@ -106,6 +107,17 @@ def test_fivetran_asset_run(tables, infer_missing_tables, should_error, schema_p
             final_json["data"]["config"]["schema_prefix"] = schema_prefix
         # final state will be updated
         rsps.add(rsps.GET, api_prefix, json=final_json)
+
+        for schema, table in [
+            ("schema1", "tracked"),
+            ("schema1", "untracked"),
+            ("schema2", "tracked"),
+        ]:
+            rsps.add(
+                rsps.GET,
+                f"{api_prefix}/schemas/{schema}/tables/{table}/columns",
+                json=get_sample_columns_response(),
+            )
 
         if should_error:
             with pytest.raises(DagsterStepOutputNotFoundError):

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_load_from_instance.py
@@ -9,6 +9,7 @@ from dagster import (
     EnvVar,
     InputContext,
     IOManager,
+    MetadataValue,
     OutputContext,
     asset,
     io_manager,
@@ -29,6 +30,7 @@ from dagster_fivetran_tests.utils import (
     DEFAULT_CONNECTOR_ID,
     DEFAULT_CONNECTOR_ID_2,
     get_complex_sample_connector_schema_config,
+    get_sample_columns_response,
     get_sample_connector_response,
     get_sample_connectors_response,
     get_sample_connectors_response_multiple,
@@ -204,9 +206,9 @@ def test_load_from_instance(
             == (
                 TableSchema(
                     columns=[
-                        TableColumn(name="column_1", type="any"),
-                        TableColumn(name="column_2", type="any"),
-                        TableColumn(name="column_3", type="any"),
+                        TableColumn(name="column_1", type=""),
+                        TableColumn(name="column_2", type=""),
+                        TableColumn(name="column_3", type=""),
                     ]
                 )
             )
@@ -261,6 +263,17 @@ def test_load_from_instance(
                 # final state will be updated
                 rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response(data=final_data))
 
+                for schema, table in [
+                    ("schema_1", "table_1"),
+                    ("schema_1", "table_2"),
+                    ("schema_2", "table_1"),
+                ]:
+                    rsps.add(
+                        rsps.GET,
+                        f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID}/schemas/{schema}/tables/{table}/columns",
+                        json=get_sample_columns_response(),
+                    )
+
             result = materialize(all_assets)
             asset_materializations = [
                 event
@@ -268,6 +281,21 @@ def test_load_from_instance(
                 if event.event_type_value == "ASSET_MATERIALIZATION"
             ]
             assert len(asset_materializations) == 3
+
+            # Check that we correctly pull runtime schema metadata from the API
+            for mat in asset_materializations:
+                schema = mat.materialization.metadata.get("dagster/column_schema")
+                assert schema == MetadataValue.table_schema(
+                    TableSchema(
+                        columns=[
+                            TableColumn(name="column_1", type=""),
+                            TableColumn(name="column_2_renamed", type=""),
+                            TableColumn(name="column_3", type=""),
+                        ]
+                    )
+                ), f"{mat.asset_key} {schema}"
+
+
             asset_keys = set(
                 mat.event_specific_data.materialization.asset_key  # type: ignore
                 for mat in asset_materializations

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_load_from_instance.py
@@ -9,12 +9,12 @@ from dagster import (
     EnvVar,
     InputContext,
     IOManager,
-    MetadataValue,
     OutputContext,
     asset,
     io_manager,
 )
 from dagster._core.definitions.materialize import materialize
+from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._core.definitions.metadata.table import TableColumn, TableSchema
 from dagster._core.definitions.tags import has_kind
 from dagster._core.execution.with_resources import with_resources
@@ -42,7 +42,9 @@ from dagster_fivetran_tests.utils import (
 
 
 @responses.activate
-@pytest.mark.parametrize("connector_to_group_fn", [None, lambda x: f"{x[0]}_group"])
+@pytest.mark.parametrize(
+    "connector_to_group_fn", [None, lambda x: f"{x[0]}_group"], ids=("default", "custom")
+)
 @pytest.mark.parametrize("filter_connector", [True, False])
 @pytest.mark.parametrize(
     "connector_to_asset_key_fn",
@@ -50,6 +52,7 @@ from dagster_fivetran_tests.utils import (
         None,
         lambda conn, name: AssetKey([*conn.name.split("."), *name.split(".")]),
     ],
+    ids=("default", "custom"),
 )
 @pytest.mark.parametrize("multiple_connectors", [True, False])
 @pytest.mark.parametrize("destination_ids", [None, [], ["some_group"]])
@@ -82,68 +85,67 @@ def test_load_from_instance(
         b64_encoded_auth_str = base64.b64encode(b"some_key:some_secret").decode("utf-8")
         expected_auth_header = {"Authorization": f"Basic {b64_encoded_auth_str}"}
 
-        with responses.RequestsMock() as rsps:
-            rsps.add(
-                method=rsps.GET,
-                url=ft_resource.api_base_url + "groups",
-                json=get_sample_groups_response(),
-                status=200,
-                match=[matchers.header_matcher(expected_auth_header)],
-            )
-            rsps.add(
-                method=rsps.GET,
-                url=ft_resource.api_base_url + "destinations/some_group",
-                json=(get_sample_destination_details_response()),
-                status=200,
-                match=[matchers.header_matcher(expected_auth_header)],
-            )
-            rsps.add(
-                method=rsps.GET,
-                url=ft_resource.api_base_url + "groups/some_group/connectors",
-                json=(
-                    get_sample_connectors_response_multiple()
-                    if multiple_connectors
-                    else get_sample_connectors_response()
-                ),
-                status=200,
-                match=[matchers.header_matcher(expected_auth_header)],
-            )
-            rsps.add(
-                rsps.GET,
-                f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID}/schemas",
-                json=get_complex_sample_connector_schema_config(),
-            )
-            if multiple_connectors:
-                rsps.add(
-                    rsps.GET,
-                    f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID_2}/schemas",
-                    json=get_complex_sample_connector_schema_config("_xyz1", "_abc"),
-                    match=[matchers.header_matcher(expected_auth_header)],
-                )
+        responses.add(
+            method=responses.GET,
+            url=ft_resource.api_base_url + "groups",
+            json=get_sample_groups_response(),
+            status=200,
+            match=[matchers.header_matcher(expected_auth_header)],
+        )
+        responses.add(
+            method=responses.GET,
+            url=ft_resource.api_base_url + "destinations/some_group",
+            json=(get_sample_destination_details_response()),
+            status=200,
+            match=[matchers.header_matcher(expected_auth_header)],
+        )
+        responses.add(
+            method=responses.GET,
+            url=ft_resource.api_base_url + "groups/some_group/connectors",
+            json=(
+                get_sample_connectors_response_multiple()
+                if multiple_connectors
+                else get_sample_connectors_response()
+            ),
+            status=200,
+            match=[matchers.header_matcher(expected_auth_header)],
+        )
 
-            if connector_to_group_fn:
-                ft_cacheable_assets = load_assets_from_fivetran_instance(
-                    ft_resource,
-                    connector_to_group_fn=connector_to_group_fn,
-                    connector_filter=(lambda _: False) if filter_connector else None,
-                    connector_to_asset_key_fn=connector_to_asset_key_fn,
-                    connector_to_io_manager_key_fn=(lambda _: "test_io_manager"),
-                    poll_interval=10,
-                    poll_timeout=600,
-                )
-            else:
-                ft_cacheable_assets = load_assets_from_fivetran_instance(
-                    ft_resource,
-                    connector_filter=(lambda _: False) if filter_connector else None,
-                    connector_to_asset_key_fn=connector_to_asset_key_fn,
-                    io_manager_key="test_io_manager",
-                    poll_interval=10,
-                    poll_timeout=600,
-                )
-            ft_assets = ft_cacheable_assets.build_definitions(
-                ft_cacheable_assets.compute_cacheable_data()
+        responses.add(
+            responses.GET,
+            f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID}/schemas",
+            json=get_complex_sample_connector_schema_config(),
+        )
+        if multiple_connectors:
+            responses.add(
+                responses.GET,
+                f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID_2}/schemas",
+                json=get_complex_sample_connector_schema_config("_xyz1", "_abc"),
             )
-            ft_assets = with_resources(ft_assets, {"test_io_manager": test_io_manager})
+
+        if connector_to_group_fn:
+            ft_cacheable_assets = load_assets_from_fivetran_instance(
+                ft_resource,
+                connector_to_group_fn=connector_to_group_fn,
+                connector_filter=(lambda _: False) if filter_connector else None,
+                connector_to_asset_key_fn=connector_to_asset_key_fn,
+                connector_to_io_manager_key_fn=(lambda _: "test_io_manager"),
+                poll_interval=10,
+                poll_timeout=600,
+            )
+        else:
+            ft_cacheable_assets = load_assets_from_fivetran_instance(
+                ft_resource,
+                connector_filter=(lambda _: False) if filter_connector else None,
+                connector_to_asset_key_fn=connector_to_asset_key_fn,
+                io_manager_key="test_io_manager",
+                poll_interval=10,
+                poll_timeout=600,
+            )
+        ft_assets = ft_cacheable_assets.build_definitions(
+            ft_cacheable_assets.compute_cacheable_data()
+        )
+        ft_assets = with_resources(ft_assets, {"test_io_manager": test_io_manager})
         if filter_connector:
             assert len(ft_assets) == 0
             return
@@ -193,14 +195,9 @@ def test_load_from_instance(
 
         all_assets = [downstream_asset] + ft_assets  # type: ignore
 
-        if destination_ids:
-            # if destination_ids is truthy then we should skip the API call to get groups
-            assert not any(
-                map(lambda call: call.url == ft_resource.api_base_url + "groups", rsps.calls)
-            )
-
         # Check schema metadata is added correctly to asset def
         assets_def = ft_assets[0]
+
         assert any(
             metadata.get("dagster/column_schema")
             == (
@@ -213,7 +210,8 @@ def test_load_from_instance(
                 )
             )
             for key, metadata in assets_def.metadata_by_key.items()
-        )
+        ), str(assets_def.metadata_by_key)
+
         for key, metadata in assets_def.metadata_by_key.items():
             assert metadata.get("dagster/relation_identifier") == (
                 "example_database." + ".".join(key.path[-2:])
@@ -237,70 +235,75 @@ def test_load_from_instance(
         # Kick off a run to materialize all assets
         final_data = {"succeeded_at": "2021-01-01T02:00:00.0Z"}
 
-        with responses.RequestsMock() as rsps:
-            api_prefixes = [(f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID}", tuple())]
-            if multiple_connectors:
-                api_prefixes.append(
-                    (f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID_2}", ("_xyz1", "_abc"))
-                )
-            # for api_prefix in api_prefixes:
-            for api_prefix, schema_args in api_prefixes:
-                rsps.add(rsps.PATCH, api_prefix, json=get_sample_update_response())
-                rsps.add(rsps.POST, f"{api_prefix}/force", json=get_sample_sync_response())
+        api_prefixes = [(f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID}", tuple())]
+        if multiple_connectors:
+            api_prefixes.append(
+                (f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID_2}", ("_xyz1", "_abc"))
+            )
 
-                # connector schema
-                rsps.add(
-                    rsps.GET,
-                    f"{api_prefix}/schemas",
-                    # json=get_complex_sample_connector_schema_config(),
-                    json=get_complex_sample_connector_schema_config(*schema_args),
-                )
-                # initial state
-                rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response())
-                # n polls before updating
-                for _ in range(2):
-                    rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response())
-                # final state will be updated
-                rsps.add(rsps.GET, api_prefix, json=get_sample_connector_response(data=final_data))
+        for api_prefix, schema_args in api_prefixes:
+            responses.add(responses.PATCH, api_prefix, json=get_sample_update_response())
+            responses.add(responses.POST, f"{api_prefix}/force", json=get_sample_sync_response())
 
-                for schema, table in [
-                    ("schema_1", "table_1"),
-                    ("schema_1", "table_2"),
-                    ("schema_2", "table_1"),
-                ]:
-                    rsps.add(
-                        rsps.GET,
-                        f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID}/schemas/{schema}/tables/{table}/columns",
+            # connector schema
+            responses.add(
+                responses.GET,
+                f"{api_prefix}/schemas",
+                # json=get_complex_sample_connector_schema_config(),
+                json=get_complex_sample_connector_schema_config(*schema_args),
+            )
+            # initial state
+            responses.add(responses.GET, api_prefix, json=get_sample_connector_response())
+            # n polls before updating
+            for _ in range(2):
+                responses.add(responses.GET, api_prefix, json=get_sample_connector_response())
+            # final state will be updated
+            responses.add(
+                responses.GET, api_prefix, json=get_sample_connector_response(data=final_data)
+            )
+
+            for schema, table in [
+                ("schema_1", "table_1"),
+                ("schema_1", "table_2"),
+                ("schema_2", "table_1"),
+            ]:
+                responses.add(
+                    responses.GET,
+                    f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID}/schemas/{schema}/tables/{table}/columns",
+                    json=get_sample_columns_response(),
+                )
+                if multiple_connectors:
+                    responses.add(
+                        responses.GET,
+                        f"{ft_resource.api_connector_url}{DEFAULT_CONNECTOR_ID_2}/schemas/{schema}/tables/{table}/columns",
                         json=get_sample_columns_response(),
                     )
+        result = materialize(all_assets)
+        asset_materializations = [
+            event
+            for event in result.events_for_node("fivetran_sync_some_connector")
+            if event.event_type_value == "ASSET_MATERIALIZATION"
+        ]
+        assert len(asset_materializations) == 3
 
-            result = materialize(all_assets)
-            asset_materializations = [
-                event
-                for event in result.events_for_node("fivetran_sync_some_connector")
-                if event.event_type_value == "ASSET_MATERIALIZATION"
-            ]
-            assert len(asset_materializations) == 3
+        # Check that we correctly pull runtime schema metadata from the API
+        for mat in asset_materializations:
+            schema = mat.materialization.metadata.get("dagster/column_schema")
+            assert schema == MetadataValue.table_schema(
+                TableSchema(
+                    columns=[
+                        TableColumn(name="column_1", type=""),
+                        TableColumn(name="column_2_renamed", type=""),
+                        TableColumn(name="column_3", type=""),
+                    ]
+                )
+            ), f"{mat.asset_key} {schema}"
 
-            # Check that we correctly pull runtime schema metadata from the API
-            for mat in asset_materializations:
-                schema = mat.materialization.metadata.get("dagster/column_schema")
-                assert schema == MetadataValue.table_schema(
-                    TableSchema(
-                        columns=[
-                            TableColumn(name="column_1", type=""),
-                            TableColumn(name="column_2_renamed", type=""),
-                            TableColumn(name="column_3", type=""),
-                        ]
-                    )
-                ), f"{mat.asset_key} {schema}"
+        asset_keys = set(
+            mat.event_specific_data.materialization.asset_key  # type: ignore
+            for mat in asset_materializations
+        )
+        assert asset_keys == tables
 
-
-            asset_keys = set(
-                mat.event_specific_data.materialization.asset_key  # type: ignore
-                for mat in asset_materializations
-            )
-            assert asset_keys == tables
-
-            # Validate IO manager is called to retrieve the xyz asset which our downstream asset depends on
-            assert load_calls == [xyz_asset_key]
+        # Validate IO manager is called to retrieve the xyz asset which our downstream asset depends on
+        assert load_calls == [xyz_asset_key]

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/utils.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/utils.py
@@ -249,3 +249,32 @@ def get_sample_destination_details_response():
             "config": {"database": "example_database"},
         }
     }
+
+
+def get_sample_columns_response():
+    return {
+        "columns": {
+            "column_1": {
+                "name_in_destination": "column_1",
+                "enabled": True,
+                "hashed": False,
+                "enabled_patch_settings": {
+                    "allowed": False,
+                    "reason_code": "SYSTEM_COLUMN",
+                    "reason": ("The column does not support exclusion as it is a" " Primary Key"),
+                },
+            },
+            "column_2": {
+                "name_in_destination": "column_2_renamed",
+                "enabled": True,
+                "hashed": False,
+                "enabled_patch_settings": {"allowed": True},
+            },
+            "column_3": {
+                "name_in_destination": "column_3",
+                "enabled": True,
+                "hashed": True,
+                "enabled_patch_settings": {"allowed": True},
+            },
+        },
+    }


### PR DESCRIPTION
## Summary


Currently, we attach column schema information to Fivetran asset definitions [if provided by the API, but](https://fivetran.com/docs/rest-api/connectors#retrieveconnectordetails)

> The schema config includes schemas, tables, and columns. If you have not specified any schema configurations that differ from the default, the response will consist of only the top schema level. 

In other words, if a user is syncing an entire table, we don't get this information at Asset definition creation time. This is why our Fivetran assets on Hooli don't have schema info.

We can separately request this information from the API, but it requires one request per table, which adds up quickly. This PR
adds a default-on option to fetch column schema information after syncing a set of Fivetran tables, so we only fetch the info when a table is newly materialized.

In the future, when we rework this API's structure, we should consider moving this to a deferred metadata fetch method like we do on dbt.

## Test Plan

New unit tests. Tested against live Fivetran.