### PR TITLE
Expose storage kind property on ExternalAssetNode

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -96,7 +96,7 @@ from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.snap import JobSnapshot
 from dagster._core.snap.mode import ResourceDefSnap, build_resource_def_snap
 from dagster._core.storage.io_manager import IOManagerDefinition
-from dagster._core.storage.tags import COMPUTE_KIND_TAG
+from dagster._core.storage.tags import COMPUTE_KIND_TAG, STORAGE_KIND_TAG
 from dagster._core.utils import is_valid_email
 from dagster._record import IHaveNew, LegacyNamedTupleMixin, record, record_custom
 from dagster._serdes import whitelist_for_serdes
@@ -1183,6 +1183,10 @@ class ExternalAssetNode(IHaveNew):
             return self.auto_materialize_policy.to_automation_condition()
         else:
             return None
+
+    @property
+    def storage_kind(self) -> Optional[str]:
+        return (self.tags or {}).get(STORAGE_KIND_TAG)
 
 
 ResourceJobUsageMap = Dict[str, List[ResourceJobUsageEntry]]

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -78,6 +78,7 @@ RUN_FAILURE_REASON_TAG = f"{SYSTEM_TAG_PREFIX}failure_reason"
 # Support for the legacy compute kind tag will be removed in 1.9.0
 LEGACY_COMPUTE_KIND_TAG = "kind"
 COMPUTE_KIND_TAG = f"{SYSTEM_TAG_PREFIX}compute_kind"
+STORAGE_KIND_TAG = f"{SYSTEM_TAG_PREFIX}storage_kind"
 
 USER_EDITABLE_SYSTEM_TAGS = [
     PRIORITY_TAG,

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/asset_decorator.py
@@ -8,6 +8,7 @@ from dagster import (
     multi_asset,
 )
 from dagster._annotations import deprecated_param
+from dagster._core.storage.tags import STORAGE_KIND_TAG
 from dlt.extract.source import DltSource
 from dlt.pipeline.pipeline import Pipeline
 
@@ -51,7 +52,7 @@ def build_dlt_asset_specs(
             },
             owners=dagster_dlt_translator.get_owners(dlt_source_resource),
             tags={
-                "dagster/storage_kind": destination_type,
+                STORAGE_KIND_TAG: destination_type,
                 **dagster_dlt_translator.get_tags(dlt_source_resource),
             },
         )


### PR DESCRIPTION
Improves ergonomics and exposes the storage kind tag as a constant.

Used in https://github.com/dagster-io/internal/pull/11016