### PR TITLE
[ui] Code locations: new definitions page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefinitionsMain.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefinitionsMain.tsx
@@ -1,0 +1,135 @@
+import {Box} from '@dagster-io/ui-components';
+import {useMemo} from 'react';
+import {Switch} from 'react-router-dom';
+
+import {CodeLocationSearchableList, SearchableListRow} from './CodeLocationSearchableList';
+import {Route} from '../app/Route';
+import {COMMON_COLLATOR} from '../app/Util';
+import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
+import {RepoAddress} from '../workspace/types';
+import {WorkspaceRepositoryFragment} from '../workspace/types/WorkspaceQueries.types';
+import {workspacePathFromAddress} from '../workspace/workspacePath';
+
+interface Props {
+  repoAddress: RepoAddress;
+  repository: WorkspaceRepositoryFragment;
+}
+
+export const CodeLocationDefinitionsMain = ({repoAddress, repository}: Props) => {
+  return (
+    <Box flex={{direction: 'column', alignItems: 'stretch'}} style={{flex: 1, overflow: 'hidden'}}>
+      <Switch>
+        <Route path="/locations/:repoPath/jobs">
+          <CodeLocationJobsList repoAddress={repoAddress} repository={repository} />
+        </Route>
+        <Route path="/locations/:repoPath/sensors">
+          <CodeLocationSensorsList repoAddress={repoAddress} repository={repository} />
+        </Route>
+        <Route path="/locations/:repoPath/schedules">
+          <CodeLocationSchedulesList repoAddress={repoAddress} repository={repository} />
+        </Route>
+        <Route path="/locations/:repoPath/resources">
+          <CodeLocationResourcesList repoAddress={repoAddress} repository={repository} />
+        </Route>
+      </Switch>
+    </Box>
+  );
+};
+
+const CodeLocationJobsList = (props: Props) => {
+  const {repoAddress, repository} = props;
+  const jobs = useMemo(
+    () =>
+      repository.pipelines
+        .filter(({name}) => !isHiddenAssetGroupJob(name))
+        .sort((a, b) => COMMON_COLLATOR.compare(a.name, b.name)),
+    [repository],
+  );
+
+  return (
+    <CodeLocationSearchableList
+      items={jobs}
+      placeholder="Search jobs by name…"
+      nameFilter={(job, value) => job.name.toLowerCase().includes(value)}
+      renderRow={(job) => (
+        <SearchableListRow
+          iconName="job"
+          label={job.name}
+          path={workspacePathFromAddress(repoAddress, `/jobs/${job.name}`)}
+        />
+      )}
+    />
+  );
+};
+
+const CodeLocationSensorsList = (props: Props) => {
+  const {repoAddress, repository} = props;
+  const sensors = useMemo(
+    () => [...repository.sensors].sort((a, b) => COMMON_COLLATOR.compare(a.name, b.name)),
+    [repository],
+  );
+
+  return (
+    <CodeLocationSearchableList
+      items={sensors}
+      placeholder="Search sensors by name…"
+      nameFilter={(sensor, value) => sensor.name.toLowerCase().includes(value)}
+      renderRow={(sensor) => (
+        <SearchableListRow
+          iconName="sensors"
+          label={sensor.name}
+          path={workspacePathFromAddress(repoAddress, `/sensors/${sensor.name}`)}
+        />
+      )}
+    />
+  );
+};
+
+const CodeLocationSchedulesList = (props: Props) => {
+  const {repoAddress, repository} = props;
+  const schedules = useMemo(
+    () => [...repository.schedules].sort((a, b) => COMMON_COLLATOR.compare(a.name, b.name)),
+    [repository],
+  );
+
+  return (
+    <CodeLocationSearchableList
+      items={schedules}
+      placeholder="Search schedules by name…"
+      nameFilter={(schedule, value) => schedule.name.toLowerCase().includes(value)}
+      renderRow={(schedule) => (
+        <SearchableListRow
+          iconName="schedule"
+          label={schedule.name}
+          path={workspacePathFromAddress(repoAddress, `/schedules/${schedule.name}`)}
+        />
+      )}
+    />
+  );
+};
+
+const CodeLocationResourcesList = (props: Props) => {
+  const {repoAddress, repository} = props;
+  const resources = useMemo(
+    () =>
+      [...repository.allTopLevelResourceDetails].sort((a, b) =>
+        COMMON_COLLATOR.compare(a.name, b.name),
+      ),
+    [repository],
+  );
+
+  return (
+    <CodeLocationSearchableList
+      items={resources}
+      placeholder="Search resoruces by name…"
+      nameFilter={(resource, value) => resource.name.toLowerCase().includes(value)}
+      renderRow={(resource) => (
+        <SearchableListRow
+          iconName="resource"
+          label={resource.name}
+          path={workspacePathFromAddress(repoAddress, `/resources/${resource.name}`)}
+        />
+      )}
+    />
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefinitionsNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefinitionsNav.tsx
@@ -1,0 +1,87 @@
+import {Box, Icon, Tag} from '@dagster-io/ui-components';
+
+import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
+import {SideNavItem, SideNavItemConfig} from '../ui/SideNavItem';
+import {numberFormatter} from '../ui/formatters';
+import {RepoAddress} from '../workspace/types';
+import {WorkspaceRepositoryFragment} from '../workspace/types/WorkspaceQueries.types';
+import {workspacePathFromAddress} from '../workspace/workspacePath';
+
+interface Props {
+  repoAddress: RepoAddress;
+  repository: WorkspaceRepositoryFragment;
+}
+
+export const CodeLocationDefinitionsNav = (props: Props) => {
+  const {repoAddress, repository} = props;
+  const jobCount = repository.pipelines.filter(({name}) => !isHiddenAssetGroupJob(name)).length;
+  const scheduleCount = repository.schedules.length;
+  const sensorCount = repository.sensors.length;
+  const resourceCount = repository.allTopLevelResourceDetails.length;
+
+  const items: SideNavItemConfig[] = [
+    {
+      key: 'assets',
+      type: 'link',
+      icon: <Icon name="asset" />,
+      label: 'Assets',
+      path: workspacePathFromAddress(repoAddress, '/assets'),
+    },
+    {
+      key: 'jobs',
+      type: 'link',
+      icon: <Icon name="job" />,
+      label: 'Jobs',
+      path: workspacePathFromAddress(repoAddress, '/jobs'),
+      rightElement: jobCount ? <Tag>{numberFormatter.format(jobCount)}</Tag> : null,
+    },
+    {
+      key: 'sensors',
+      type: 'link',
+      icon: <Icon name="sensors" />,
+      label: 'Sensors',
+      path: workspacePathFromAddress(repoAddress, '/sensors'),
+      rightElement: sensorCount ? <Tag>{numberFormatter.format(sensorCount)}</Tag> : null,
+    },
+    {
+      key: 'schedules',
+      type: 'link',
+      icon: <Icon name="schedule" />,
+      label: 'Schedules',
+      path: workspacePathFromAddress(repoAddress, '/schedules'),
+      rightElement: scheduleCount ? <Tag>{numberFormatter.format(scheduleCount)}</Tag> : null,
+    },
+    {
+      key: 'resources',
+      type: 'link',
+      icon: <Icon name="resource" />,
+      label: 'Resources',
+      path: workspacePathFromAddress(repoAddress, '/resources'),
+      rightElement: resourceCount ? <Tag>{numberFormatter.format(resourceCount)}</Tag> : null,
+    },
+    {
+      key: 'graphs',
+      type: 'link',
+      icon: <Icon name="graph" />,
+      label: 'Graphs',
+      path: workspacePathFromAddress(repoAddress, '/graphs'),
+    },
+    {
+      key: 'ops',
+      type: 'link',
+      icon: <Icon name="op" />,
+      label: 'Ops',
+      path: workspacePathFromAddress(repoAddress, '/ops'),
+    },
+  ];
+
+  return (
+    <>
+      <Box padding={{bottom: 12}}>
+        {items.map((item) => {
+          return <SideNavItem key={item.key} item={item} active={false} />;
+        })}
+      </Box>
+    </>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefinitionsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefinitionsRoot.tsx
@@ -1,0 +1,40 @@
+import {Box} from '@dagster-io/ui-components';
+
+import {CodeLocationDefinitionsMain} from './CodeLocationDefinitionsMain';
+import {CodeLocationDefinitionsNav} from './CodeLocationDefinitionsNav';
+import {CodeLocationPageHeader} from './CodeLocationPageHeader';
+import {CodeLocationTabs} from './CodeLocationTabs';
+import {RepoAddress} from '../workspace/types';
+import {WorkspaceRepositoryFragment} from '../workspace/types/WorkspaceQueries.types';
+
+interface Props {
+  repoAddress: RepoAddress;
+  repository: WorkspaceRepositoryFragment;
+}
+
+export const CodeLocationDefinitionsRoot = (props: Props) => {
+  const {repoAddress, repository} = props;
+  return (
+    <Box style={{height: '100%', overflow: 'hidden'}} flex={{direction: 'column'}}>
+      <CodeLocationPageHeader repoAddress={repoAddress} />
+      <Box padding={{horizontal: 24}} border="bottom">
+        <CodeLocationTabs selectedTab="definitions" repoAddress={repoAddress} />
+      </Box>
+      <Box style={{overflow: 'hidden'}} flex={{direction: 'row', grow: 1}}>
+        <Box
+          style={{flex: '0 0 292px', overflowY: 'auto'}}
+          padding={{vertical: 16, horizontal: 12}}
+          border="right"
+        >
+          <CodeLocationDefinitionsNav repoAddress={repoAddress} repository={repository} />
+        </Box>
+        <Box
+          flex={{direction: 'column', alignItems: 'stretch'}}
+          style={{flex: 1, overflow: 'hidden'}}
+        >
+          <CodeLocationDefinitionsMain repoAddress={repoAddress} repository={repository} />
+        </Box>
+      </Box>
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationOverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationOverviewRoot.tsx
@@ -2,24 +2,21 @@ import {
   Box,
   Colors,
   FontFamily,
-  Heading,
   MiddleTruncate,
   Mono,
-  PageHeader,
   StyledRawCodeMirror,
   Subheading,
   Table,
 } from '@dagster-io/ui-components';
 import {ComponentProps, ReactNode, useMemo} from 'react';
-import {Link} from 'react-router-dom';
 import {createGlobalStyle} from 'styled-components';
 import * as yaml from 'yaml';
 
+import {CodeLocationPageHeader} from './CodeLocationPageHeader';
 import {CodeLocationTabs} from './CodeLocationTabs';
 import {TimeFromNow} from '../ui/TimeFromNow';
 import {LocationStatus} from '../workspace/CodeLocationRowSet';
 import {WorkspaceRepositoryLocationNode} from '../workspace/WorkspaceContext';
-import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {LocationStatusEntryFragment} from '../workspace/types/WorkspaceQueries.types';
 
@@ -56,19 +53,7 @@ export const CodeLocationOverviewRoot = (props: Props) => {
 
   return (
     <>
-      <PageHeader
-        title={
-          <Heading>
-            <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
-              <div>
-                <Link to="/locations">Code locations</Link>
-              </div>
-              <div>/</div>
-              <div>{repoAddressAsHumanString(repoAddress)}</div>
-            </Box>
-          </Heading>
-        }
-      />
+      <CodeLocationPageHeader repoAddress={repoAddress} />
       <Box padding={{horizontal: 24}} border="bottom">
         <CodeLocationTabs selectedTab="overview" repoAddress={repoAddress} />
       </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationPageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationPageHeader.tsx
@@ -1,0 +1,23 @@
+import {Box, Heading, PageHeader} from '@dagster-io/ui-components';
+import {Link} from 'react-router-dom';
+
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
+import {RepoAddress} from '../workspace/types';
+
+export const CodeLocationPageHeader = ({repoAddress}: {repoAddress: RepoAddress}) => {
+  return (
+    <PageHeader
+      title={
+        <Heading>
+          <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+            <div>
+              <Link to="/locations">Code locations</Link>
+            </div>
+            <div>/</div>
+            <div>{repoAddressAsHumanString(repoAddress)}</div>
+          </Box>
+        </Heading>
+      }
+    />
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationSearchableList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationSearchableList.tsx
@@ -1,0 +1,103 @@
+import {Box, Colors, Icon, IconName, MiddleTruncate, TextInput} from '@dagster-io/ui-components';
+import {useVirtualizer} from '@tanstack/react-virtual';
+import {ChangeEvent, ReactNode, useCallback, useRef, useState} from 'react';
+import {Link} from 'react-router-dom';
+import styled from 'styled-components';
+
+import {Container, HeaderCell, HeaderRow, Inner, Row} from '../ui/VirtualizedTable';
+
+const ROW_HEIGHT = 44;
+
+interface Props<T> {
+  items: T[];
+  placeholder: string;
+  nameFilter: (item: T, searchValue: string) => boolean;
+  renderRow: (item: T) => ReactNode;
+}
+
+export const CodeLocationSearchableList = <T,>(props: Props<T>) => {
+  const {items, placeholder, nameFilter, renderRow} = props;
+
+  const [searchValue, setSearchValue] = useState('');
+  const onChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    setSearchValue(e.target.value);
+  }, []);
+
+  const trimmedValue = searchValue.trim().toLowerCase();
+  const filteredItems = items.filter((item) => nameFilter(item, trimmedValue));
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: filteredItems.length,
+    getScrollElement: () => containerRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 10,
+  });
+
+  const totalHeight = rowVirtualizer.getTotalSize();
+  const virtualItems = rowVirtualizer.getVirtualItems();
+
+  return (
+    <Box flex={{direction: 'column'}} style={{overflow: 'hidden'}}>
+      <Box padding={{vertical: 8, horizontal: 24}}>
+        <TextInput
+          value={searchValue}
+          onChange={onChange}
+          placeholder={placeholder}
+          style={{width: '300px'}}
+          icon="search"
+        />
+      </Box>
+      <div style={{flex: 1, overflow: 'hidden'}}>
+        <Container ref={containerRef}>
+          <HeaderRow templateColumns="1fr" sticky>
+            <HeaderCell>Name</HeaderCell>
+          </HeaderRow>
+          <Inner $totalHeight={totalHeight}>
+            {virtualItems.map(({index, key, size, start}) => {
+              const item = filteredItems[index]!;
+              return (
+                <Row key={key} $height={size} $start={start}>
+                  {renderRow(item)}
+                </Row>
+              );
+            })}
+          </Inner>
+        </Container>
+      </div>
+    </Box>
+  );
+};
+
+interface SearchableListRowProps {
+  iconName: IconName;
+  label: string;
+  path: string;
+}
+
+export const SearchableListRow = ({iconName, label, path}: SearchableListRowProps) => {
+  return (
+    <Box
+      padding={{horizontal: 24}}
+      border="bottom"
+      flex={{direction: 'column', justifyContent: 'center', alignItems: 'flex-start'}}
+      style={{height: ROW_HEIGHT, overflow: 'hidden'}}
+    >
+      <ListLink to={path} style={{width: '100%', overflow: 'hidden'}}>
+        <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
+          <Icon name={iconName} color={Colors.linkDefault()} />
+          <div style={{flex: 1, overflow: 'hidden'}}>
+            <MiddleTruncate text={label} />
+          </div>
+        </Box>
+      </ListLink>
+    </Box>
+  );
+};
+
+const ListLink = styled(Link)`
+  :active,
+  :focus {
+    outline: none;
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/__fixtures__/CodeLocationPages.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/__fixtures__/CodeLocationPages.fixtures.ts
@@ -1,0 +1,82 @@
+import faker from 'faker';
+
+import {
+  buildDagsterLibraryVersion,
+  buildPipeline,
+  buildRepository,
+  buildRepositoryLocation,
+  buildRepositoryMetadata,
+  buildResourceDetails,
+  buildSchedule,
+  buildSensor,
+  buildWorkspaceLocationEntry,
+} from '../../graphql/types';
+
+export const buildEmptyWorkspaceLocationEntry = (config: {time: number; locationName: string}) => {
+  const {time, locationName} = config;
+  return buildWorkspaceLocationEntry({
+    updatedTimestamp: time,
+    name: locationName,
+    displayMetadata: [
+      buildRepositoryMetadata({
+        key: 'image',
+        value:
+          'whereami.kz.almaty-2.amazonaws.com/whoami:whoami-b0d8eb5c3518ddd5640657075-cb6978e44008',
+      }),
+      buildRepositoryMetadata({key: 'module_name', value: 'my.cool.module'}),
+      buildRepositoryMetadata({key: 'working_directory', value: '/foo/bar/baz'}),
+      buildRepositoryMetadata({
+        key: 'commit_hash',
+        value: '3c88b0248f9b66f2a49e154e4731fe70',
+      }),
+      buildRepositoryMetadata({
+        key: 'url',
+        value: 'https://github.com/supercool-org/foobar/tree/3c88b0248f9b66f2a49e154e4731fe70',
+      }),
+    ],
+    locationOrLoadError: buildRepositoryLocation({
+      name: locationName,
+      dagsterLibraryVersions: [
+        buildDagsterLibraryVersion({
+          name: 'dagster',
+          version: '1.8',
+        }),
+      ],
+    }),
+  });
+};
+
+export const buildSampleRepository = (config: {
+  name: string;
+  jobCount: number;
+  scheduleCount: number;
+  sensorCount: number;
+  resourceCount: number;
+}) => {
+  const {name, jobCount, scheduleCount, sensorCount, resourceCount} = config;
+  return buildRepository({
+    id: name,
+    name,
+    pipelines: new Array(jobCount).fill(null).map(() => {
+      return buildPipeline({
+        name: faker.random.words(2).split(' ').join('-').toLowerCase(),
+        isJob: true,
+      });
+    }),
+    schedules: new Array(scheduleCount).fill(null).map(() => {
+      return buildSchedule({
+        name: faker.random.words(2).split(' ').join('-').toLowerCase(),
+      });
+    }),
+    sensors: new Array(sensorCount).fill(null).map(() => {
+      return buildSensor({
+        name: faker.random.words(10).split(' ').join('-').toLowerCase(),
+      });
+    }),
+    allTopLevelResourceDetails: new Array(resourceCount).fill(null).map(() => {
+      return buildResourceDetails({
+        name: faker.random.words(2).split(' ').join('-').toLowerCase(),
+      });
+    }),
+  });
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/__stories__/CodeLocationDefinitionsRoot.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/__stories__/CodeLocationDefinitionsRoot.stories.tsx
@@ -1,0 +1,45 @@
+import {MockedProvider} from '@apollo/client/testing';
+import {Meta} from '@storybook/react';
+import {MemoryRouter} from 'react-router';
+import {RecoilRoot} from 'recoil';
+
+import {buildRepoAddress} from '../../workspace/buildRepoAddress';
+import {workspacePathFromAddress} from '../../workspace/workspacePath';
+import {CodeLocationDefinitionsRoot} from '../CodeLocationDefinitionsRoot';
+import {buildSampleRepository} from '../__fixtures__/CodeLocationPages.fixtures';
+
+// eslint-disable-next-line import/no-default-export
+export default {
+  title: 'Code Location/CodeLocationDefinitionsRoot',
+  component: CodeLocationDefinitionsRoot,
+} as Meta;
+
+export const Default = () => {
+  const repoName = 'foo';
+  const locationName = 'bar';
+  const repoAddress = buildRepoAddress(repoName, locationName);
+
+  // const now = useMemo(() => Date.now() / 1000, []);
+  const repository = buildSampleRepository({
+    name: repoName,
+    jobCount: 500,
+    scheduleCount: 200,
+    sensorCount: 200,
+    resourceCount: 100,
+  });
+
+  return (
+    <RecoilRoot>
+      <MemoryRouter initialEntries={[workspacePathFromAddress(repoAddress, '/jobs')]}>
+        <MockedProvider>
+          <div style={{height: '500px', overflow: 'hidden'}}>
+            <CodeLocationDefinitionsRoot
+              repoAddress={buildRepoAddress(repoName, locationName)}
+              repository={repository}
+            />
+          </div>
+        </MockedProvider>
+      </MemoryRouter>
+    </RecoilRoot>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/__stories__/CodeLocationOverviewRoot.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/__stories__/CodeLocationOverviewRoot.stories.tsx
@@ -2,16 +2,10 @@ import {MockedProvider} from '@apollo/client/testing';
 import {Meta} from '@storybook/react';
 import {useMemo} from 'react';
 
-import {
-  RepositoryLocationLoadStatus,
-  buildDagsterLibraryVersion,
-  buildRepositoryLocation,
-  buildRepositoryMetadata,
-  buildWorkspaceLocationEntry,
-  buildWorkspaceLocationStatusEntry,
-} from '../../graphql/types';
+import {RepositoryLocationLoadStatus, buildWorkspaceLocationStatusEntry} from '../../graphql/types';
 import {buildRepoAddress} from '../../workspace/buildRepoAddress';
 import {CodeLocationOverviewRoot} from '../CodeLocationOverviewRoot';
+import {buildEmptyWorkspaceLocationEntry} from '../__fixtures__/CodeLocationPages.fixtures';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -24,36 +18,7 @@ export const Default = () => {
   const locationName = 'bar';
 
   const now = useMemo(() => Date.now() / 1000, []);
-  const locationEntry = buildWorkspaceLocationEntry({
-    updatedTimestamp: now,
-    name: locationName,
-    displayMetadata: [
-      buildRepositoryMetadata({
-        key: 'image',
-        value:
-          'whereami.kz.almaty-2.amazonaws.com/whoami:whoami-b0d8eb5c3518ddd5640657075-cb6978e44008',
-      }),
-      buildRepositoryMetadata({key: 'module_name', value: 'my.cool.module'}),
-      buildRepositoryMetadata({key: 'working_directory', value: '/foo/bar/baz'}),
-      buildRepositoryMetadata({
-        key: 'commit_hash',
-        value: '3c88b0248f9b66f2a49e154e4731fe70',
-      }),
-      buildRepositoryMetadata({
-        key: 'url',
-        value: 'https://github.com/supercool-org/foobar/tree/3c88b0248f9b66f2a49e154e4731fe70',
-      }),
-    ],
-    locationOrLoadError: buildRepositoryLocation({
-      name: locationName,
-      dagsterLibraryVersions: [
-        buildDagsterLibraryVersion({
-          name: 'dagster',
-          version: '1.8',
-        }),
-      ],
-    }),
-  });
+  const locationEntry = buildEmptyWorkspaceLocationEntry({time: now, locationName});
 
   const locationStatus = buildWorkspaceLocationStatusEntry({
     loadStatus: RepositoryLocationLoadStatus.LOADED,

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceQueries.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceQueries.tsx
@@ -60,10 +60,7 @@ export const LOCATION_WORKSPACE_QUERY = gql`
     name
     pipelines {
       id
-      name
-      isJob
-      isAssetJob
-      pipelineSnapshotId
+      ...WorkspacePipeline
     }
     schedules {
       id
@@ -87,6 +84,14 @@ export const LOCATION_WORKSPACE_QUERY = gql`
       ...ResourceEntryFragment
     }
     ...RepositoryInfoFragment
+  }
+
+  fragment WorkspacePipeline on Pipeline {
+    id
+    name
+    isJob
+    isAssetJob
+    pipelineSnapshotId
   }
 
   fragment WorkspaceSchedule on Schedule {

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceQueries.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceQueries.types.ts
@@ -393,6 +393,15 @@ export type WorkspaceRepositoryFragment = {
   displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
 };
 
+export type WorkspacePipelineFragment = {
+  __typename: 'Pipeline';
+  id: string;
+  name: string;
+  isJob: boolean;
+  isAssetJob: boolean;
+  pipelineSnapshotId: string;
+};
+
 export type WorkspaceScheduleFragment = {
   __typename: 'Schedule';
   id: string;


### PR DESCRIPTION
## Summary & Motivation

Components for the newly designed code location definitions page, which is a stripped down browse view intended to reduce some of the list view duplication we have throughout the app.

This is just in storybook for now, and implements only the jobs, schedules, sensors, and resources sections. Graphs are slightly trickier, and for ops I'm just going to transplant the existing ops viewer. Assets are also slightly different since we'll need to incorporate asset groups.

## How I Tested These Changes

Yarn storybook, click on each nav item. Verify searchability, scrollability.