### PR TITLE
[record] config/snap.py

### DIFF
--- a/python_modules/dagster/dagster/_config/config_type.py
+++ b/python_modules/dagster/dagster/_config/config_type.py
@@ -111,7 +111,9 @@ class ConfigType:
     def get_schema_snapshot(self) -> "ConfigSchemaSnapshot":
         from .snap import ConfigSchemaSnapshot
 
-        return ConfigSchemaSnapshot({ct.key: ct.get_snapshot() for ct in self.type_iterator()})
+        return ConfigSchemaSnapshot(
+            all_config_snaps_by_key={ct.key: ct.get_snapshot() for ct in self.type_iterator()}
+        )
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/snap/config_types.py
+++ b/python_modules/dagster/dagster/_core/snap/config_types.py
@@ -5,7 +5,8 @@ from dagster._core.definitions.job_definition import JobDefinition
 
 def build_config_schema_snapshot(job_def: JobDefinition) -> ConfigSchemaSnapshot:
     check.inst_param(job_def, "job_def", JobDefinition)
-    config_snaps_by_key = {
-        ct.key: snap_from_config_type(ct) for ct in job_def.run_config_schema.all_config_types()
-    }
-    return ConfigSchemaSnapshot(config_snaps_by_key)
+    return ConfigSchemaSnapshot(
+        all_config_snaps_by_key={
+            ct.key: snap_from_config_type(ct) for ct in job_def.run_config_schema.all_config_types()
+        }
+    )

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_config_schema_snapshot.py
@@ -30,7 +30,7 @@ def test_enum_snap():
     assert enum_snap.key == "CowboyType"
     assert enum_snap.kind == ConfigTypeKind.ENUM
     assert enum_snap.enum_values == [
-        ConfigEnumValueSnap(value, description=None) for value in ["good", "bad", "ugly"]
+        ConfigEnumValueSnap(value=value, description=None) for value in ["good", "bad", "ugly"]
     ]
     assert enum_snap.fields is None
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
@@ -24,19 +24,25 @@ def instance():
 
 def test_basic_default():
     snap = snap_from_config_type(resolve_to_config_type({"a": Field(str, "foo")}))
-    yaml_str = default_values_yaml_from_type_snap(ConfigSchemaSnapshot({}), snap)
+    yaml_str = default_values_yaml_from_type_snap(
+        ConfigSchemaSnapshot(all_config_snaps_by_key={}), snap
+    )
     assert yaml_str == "a: foo\n"
 
 
 def test_basic_no_nested_fields():
     snap = snap_from_config_type(resolve_to_config_type(str))
-    yaml_str = default_values_yaml_from_type_snap(ConfigSchemaSnapshot({}), snap)
+    yaml_str = default_values_yaml_from_type_snap(
+        ConfigSchemaSnapshot(all_config_snaps_by_key={}), snap
+    )
     assert yaml_str == "{}\n"
 
 
 def test_with_spaces():
     snap = snap_from_config_type(resolve_to_config_type({"a": Field(str, "with spaces")}))
-    yaml_str = default_values_yaml_from_type_snap(ConfigSchemaSnapshot({}), snap)
+    yaml_str = default_values_yaml_from_type_snap(
+        ConfigSchemaSnapshot(all_config_snaps_by_key={}), snap
+    )
     assert yaml_str == "a: with spaces\n"
 
 


### PR DESCRIPTION
noticed some `check.opt_str_param` checks from these objects show up in the profiler - moving to record will inline that checks and make it faster

## How I Tested These Changes

bk
