### PR TITLE
Add an env var that, when enabled, logs exceptions raised during code server calls to stderr

### DIFF
--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -56,10 +56,7 @@ from dagster._core.remote_representation.external_data import (
     job_name_for_external_partition_set_name,
 )
 from dagster._core.remote_representation.origin import CodeLocationOrigin
-from dagster._core.snap.execution_plan_snapshot import (
-    ExecutionPlanSnapshotErrorData,
-    snapshot_from_execution_plan,
-)
+from dagster._core.snap.execution_plan_snapshot import snapshot_from_execution_plan
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._grpc.types import ExecutionPlanSnapshotArgs
 from dagster._serdes import deserialize_value
@@ -528,29 +525,24 @@ def get_external_execution_plan_snapshot(
     job_name: str,
     args: ExecutionPlanSnapshotArgs,
 ):
-    try:
-        job_def = repo_def.get_maybe_subset_job_def(
-            job_name,
-            op_selection=args.op_selection,
-            asset_selection=args.asset_selection,
-            asset_check_selection=args.asset_check_selection,
-        )
+    job_def = repo_def.get_maybe_subset_job_def(
+        job_name,
+        op_selection=args.op_selection,
+        asset_selection=args.asset_selection,
+        asset_check_selection=args.asset_check_selection,
+    )
 
-        return snapshot_from_execution_plan(
-            create_execution_plan(
-                job_def,
-                run_config=args.run_config,
-                step_keys_to_execute=args.step_keys_to_execute,
-                known_state=args.known_state,
-                instance_ref=args.instance_ref,
-                repository_load_data=repo_def.repository_load_data,
-            ),
-            args.job_snapshot_id,
-        )
-    except:
-        return ExecutionPlanSnapshotErrorData(
-            error=serializable_error_info_from_exc_info(sys.exc_info())
-        )
+    return snapshot_from_execution_plan(
+        create_execution_plan(
+            job_def,
+            run_config=args.run_config,
+            step_keys_to_execute=args.step_keys_to_execute,
+            known_state=args.known_state,
+            instance_ref=args.instance_ref,
+            repository_load_data=repo_def.repository_load_data,
+        ),
+        args.job_snapshot_id,
+    )
 
 
 def get_partition_set_execution_param_data(

--- a/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
+++ b/python_modules/dagster/dagster_tests/general_tests/grpc_tests/test_persistent.py
@@ -25,7 +25,12 @@ from dagster._core.test_utils import (
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._grpc.client import DagsterGrpcClient
 from dagster._grpc.server import ExecuteExternalJobArgs, open_server_process, wait_for_grpc_server
-from dagster._grpc.types import ListRepositoriesResponse, SensorExecutionArgs, StartRunResult
+from dagster._grpc.types import (
+    JobSubsetSnapshotArgs,
+    ListRepositoriesResponse,
+    SensorExecutionArgs,
+    StartRunResult,
+)
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
 from dagster._utils import file_relative_path, find_free_port, safe_tempfile_path_unmanaged
@@ -898,3 +903,58 @@ def test_load_with_container_context(entrypoint):
     finally:
         process.terminate()
         process.wait()
+
+
+def test_load_with_error_logging(capfd):
+    port = find_free_port()
+    python_file = file_relative_path(__file__, "grpc_repo.py")
+
+    subprocess_args = ["dagster", "api", "grpc"] + [
+        "--port",
+        str(port),
+        "--python-file",
+        python_file,
+    ]
+
+    process = subprocess.Popen(
+        subprocess_args,
+        env={**os.environ, "DAGSTER_CODE_SERVER_LOG_EXCEPTIONS": "1"},
+        text=True,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    )
+
+    try:
+        client = DagsterGrpcClient(port=port, host="localhost")
+
+        wait_for_grpc_server(process, client, subprocess_args)
+
+        missing_job_origin = RemoteJobOrigin(
+            job_name="missing_job_name",
+            repository_origin=RemoteRepositoryOrigin(
+                repository_name="missing_repo_name",
+                code_location_origin=RegisteredCodeLocationOrigin(
+                    location_name="missing_location_name"
+                ),
+            ),
+        )
+
+        result = deserialize_value(
+            client.external_pipeline_subset(
+                pipeline_subset_snapshot_args=JobSubsetSnapshotArgs(
+                    job_origin=missing_job_origin,
+                    op_selection=None,
+                ),
+            )
+        )
+
+        assert result.error
+        assert 'Could not find a repository called "missing_repo_name"' in str(result.error)
+
+    finally:
+        process.terminate()
+        process.wait()
+
+    out, _err = capfd.readouterr()
+
+    assert 'Could not find a repository called "missing_repo_name"' in out


### PR DESCRIPTION
## Summary & Motivation
Allows you to run code servers in a mode where exceptions are logged to the console, in addition to being logged to the caller.

## How I Tested These Changes
New test case - run code server locally and add an exception to schedules/sensors, view code server output
