### PR TITLE
[ui] Code location: Ops page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefinitionsMain.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefinitionsMain.tsx
@@ -2,6 +2,7 @@ import {Box} from '@dagster-io/ui-components';
 import {useMemo} from 'react';
 import {Switch} from 'react-router-dom';
 
+import {CodeLocationOpsView} from './CodeLocationOpsView';
 import {CodeLocationSearchableList, SearchableListRow} from './CodeLocationSearchableList';
 import {Route} from '../app/Route';
 import {COMMON_COLLATOR} from '../app/Util';
@@ -30,6 +31,9 @@ export const CodeLocationDefinitionsMain = ({repoAddress, repository}: Props) =>
         </Route>
         <Route path="/locations/:repoPath/resources">
           <CodeLocationResourcesList repoAddress={repoAddress} repository={repository} />
+        </Route>
+        <Route path="/locations/:repoPath/ops">
+          <CodeLocationOpsView repoAddress={repoAddress} />
         </Route>
       </Switch>
     </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationOpsView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationOpsView.tsx
@@ -1,0 +1,88 @@
+import {useQuery} from '@apollo/client';
+import {Box, NonIdealState, SpinnerWithText} from '@dagster-io/ui-components';
+import {useParams} from 'react-router-dom';
+
+import {PythonErrorInfo} from '../app/PythonErrorInfo';
+import {OPS_ROOT_QUERY, OpsRootWithData} from '../ops/OpsRoot';
+import {OpsRootQuery, OpsRootQueryVariables} from '../ops/types/OpsRoot.types';
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
+import {repoAddressToSelector} from '../workspace/repoAddressToSelector';
+import {RepoAddress} from '../workspace/types';
+
+interface Props {
+  repoAddress: RepoAddress;
+}
+
+export const CodeLocationOpsView = ({repoAddress}: Props) => {
+  const {name} = useParams<{name?: string}>();
+  const repositorySelector = repoAddressToSelector(repoAddress);
+
+  const queryResult = useQuery<OpsRootQuery, OpsRootQueryVariables>(OPS_ROOT_QUERY, {
+    variables: {repositorySelector},
+  });
+
+  useBlockTraceOnQueryResult(queryResult, 'OpsRootQuery');
+  const {data, loading} = queryResult;
+
+  const repoString = repoAddressAsHumanString(repoAddress);
+
+  if (loading) {
+    return (
+      <Box padding={64} flex={{direction: 'row', justifyContent: 'center'}}>
+        <SpinnerWithText label="Loading ops…" />
+      </Box>
+    );
+  }
+
+  if (!data || !data.repositoryOrError) {
+    return (
+      <Box padding={64}>
+        <NonIdealState
+          icon="op"
+          title="An unexpected error occurred"
+          description={`An error occurred while loading ops for ${repoString}`}
+        />
+      </Box>
+    );
+  }
+
+  if (data.repositoryOrError.__typename === 'PythonError') {
+    return (
+      <Box padding={64}>
+        <PythonErrorInfo error={data.repositoryOrError} />
+      </Box>
+    );
+  }
+
+  if (data.repositoryOrError.__typename === 'RepositoryNotFoundError') {
+    return (
+      <Box padding={64}>
+        <NonIdealState
+          icon="op"
+          title="Repository not found"
+          description={`The repository ${repoString} could not be found in this workspace.`}
+        />
+      </Box>
+    );
+  }
+
+  const {repositoryOrError} = data;
+  const {usedSolids} = repositoryOrError;
+
+  if (!usedSolids.length) {
+    return (
+      <Box padding={64}>
+        <NonIdealState
+          icon="op"
+          title="No ops found"
+          description={`The repository ${repoAddressAsHumanString(
+            repoAddress,
+          )} does not contain any ops.`}
+        />
+      </Box>
+    );
+  }
+
+  return <OpsRootWithData name={name} repoAddress={repoAddress} usedSolids={usedSolids} />;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/__fixtures__/CodeLocationPages.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/__fixtures__/CodeLocationPages.fixtures.ts
@@ -9,8 +9,15 @@ import {
   buildResourceDetails,
   buildSchedule,
   buildSensor,
+  buildSolidDefinition,
+  buildUsedSolid,
   buildWorkspaceLocationEntry,
 } from '../../graphql/types';
+import {OPS_ROOT_QUERY} from '../../ops/OpsRoot';
+import {OpsRootQuery, OpsRootQueryVariables} from '../../ops/types/OpsRoot.types';
+import {buildQueryMock} from '../../testing/mocking';
+import {repoAddressToSelector} from '../../workspace/repoAddressToSelector';
+import {RepoAddress} from '../../workspace/types';
 
 export const buildEmptyWorkspaceLocationEntry = (config: {time: number; locationName: string}) => {
   const {time, locationName} = config;
@@ -70,7 +77,7 @@ export const buildSampleRepository = (config: {
     }),
     sensors: new Array(sensorCount).fill(null).map(() => {
       return buildSensor({
-        name: faker.random.words(10).split(' ').join('-').toLowerCase(),
+        name: faker.random.words(2).split(' ').join('-').toLowerCase(),
       });
     }),
     allTopLevelResourceDetails: new Array(resourceCount).fill(null).map(() => {
@@ -78,5 +85,27 @@ export const buildSampleRepository = (config: {
         name: faker.random.words(2).split(' ').join('-').toLowerCase(),
       });
     }),
+  });
+};
+
+export const buildSampleOpsRootQuery = (config: {repoAddress: RepoAddress; opCount: number}) => {
+  const {repoAddress, opCount} = config;
+  return buildQueryMock<OpsRootQuery, OpsRootQueryVariables>({
+    query: OPS_ROOT_QUERY,
+    variables: {
+      repositorySelector: repoAddressToSelector(repoAddress),
+    },
+    data: {
+      repositoryOrError: buildRepository({
+        usedSolids: new Array(opCount).fill(null).map(() => {
+          return buildUsedSolid({
+            definition: buildSolidDefinition({
+              name: faker.random.words(2).split(' ').join('-').toLowerCase(),
+            }),
+          });
+        }),
+      }),
+    },
+    delay: 2000,
   });
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/__stories__/CodeLocationDefinitionsRoot.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/__stories__/CodeLocationDefinitionsRoot.stories.tsx
@@ -6,7 +6,10 @@ import {RecoilRoot} from 'recoil';
 import {buildRepoAddress} from '../../workspace/buildRepoAddress';
 import {workspacePathFromAddress} from '../../workspace/workspacePath';
 import {CodeLocationDefinitionsRoot} from '../CodeLocationDefinitionsRoot';
-import {buildSampleRepository} from '../__fixtures__/CodeLocationPages.fixtures';
+import {
+  buildSampleOpsRootQuery,
+  buildSampleRepository,
+} from '../__fixtures__/CodeLocationPages.fixtures';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -31,7 +34,7 @@ export const Default = () => {
   return (
     <RecoilRoot>
       <MemoryRouter initialEntries={[workspacePathFromAddress(repoAddress, '/jobs')]}>
-        <MockedProvider>
+        <MockedProvider mocks={[buildSampleOpsRootQuery({repoAddress, opCount: 500})]}>
           <div style={{height: '500px', overflow: 'hidden'}}>
             <CodeLocationDefinitionsRoot
               repoAddress={buildRepoAddress(repoName, locationName)}

--- a/js_modules/dagster-ui/packages/ui-core/src/ops/OpsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ops/OpsRoot.tsx
@@ -21,6 +21,7 @@ import styled from 'styled-components';
 import {OpDetailScrollContainer, UsedSolidDetails} from './OpDetailsRoot';
 import {OP_TYPE_SIGNATURE_FRAGMENT} from './OpTypeSignature';
 import {OpsRootQuery, OpsRootQueryVariables, OpsRootUsedSolidFragment} from './types/OpsRoot.types';
+import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {COMMON_COLLATOR} from '../app/Util';
 import {useTrackPageView} from '../app/analytics';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
@@ -156,7 +157,7 @@ interface OpsRootWithDataProps extends Props {
   usedSolids: Solid[];
 }
 
-const OpsRootWithData = (props: OpsRootWithDataProps) => {
+export const OpsRootWithData = (props: OpsRootWithDataProps) => {
   const {name, repoAddress, usedSolids} = props;
   const history = useHistory();
   const location = useLocation();
@@ -297,7 +298,7 @@ const OpList = (props: OpListProps) => {
   );
 };
 
-const OPS_ROOT_QUERY = gql`
+export const OPS_ROOT_QUERY = gql`
   query OpsRootQuery($repositorySelector: RepositorySelector!) {
     repositoryOrError(repositorySelector: $repositorySelector) {
       ... on Repository {
@@ -306,6 +307,7 @@ const OPS_ROOT_QUERY = gql`
           ...OpsRootUsedSolid
         }
       }
+      ...PythonErrorFragment
     }
   }
 
@@ -324,6 +326,7 @@ const OPS_ROOT_QUERY = gql`
   }
 
   ${OP_TYPE_SIGNATURE_FRAGMENT}
+  ${PYTHON_ERROR_FRAGMENT}
 `;
 
 const OpListItem = styled.div<{$selected: boolean}>`

--- a/js_modules/dagster-ui/packages/ui-core/src/ops/types/OpsRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ops/types/OpsRoot.types.ts
@@ -9,7 +9,16 @@ export type OpsRootQueryVariables = Types.Exact<{
 export type OpsRootQuery = {
   __typename: 'Query';
   repositoryOrError:
-    | {__typename: 'PythonError'}
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      }
     | {
         __typename: 'Repository';
         id: string;


### PR DESCRIPTION
## Summary & Motivation

Insert the ops explorer into the new code locations page.

<img width="1462" alt="Screenshot 2024-08-14 at 14 45 46" src="https://github.com/user-attachments/assets/ada4c182-d6d7-432b-8b91-ff7bc1af42a8">

## How I Tested These Changes

Storybook example.