### PR TITLE
[quick] remove debugging log message from job backfills

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -221,7 +221,6 @@ def _get_partitions_chunk(
         elif run.tags.get(PARTITION_NAME_TAG):
             completed_partitions.append(run.tags[PARTITION_NAME_TAG])
 
-    logger.info([run.tags for run in backfill_runs])
     initial_checkpoint = (
         partition_names.index(checkpoint) + 1 if checkpoint and checkpoint in partition_names else 0
     )


### PR DESCRIPTION
## Summary & Motivation
missed removing this message from https://github.com/dagster-io/dagster/pull/23613

## How I Tested These Changes
