### PR TITLE
feat(instigator-tick-logs): add cursor to tick details dialog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
@@ -7,6 +7,7 @@ import {
   Dialog,
   DialogFooter,
   DialogHeader,
+  FontFamily,
   MiddleTruncate,
   Spinner,
   Subtitle2,
@@ -66,7 +67,7 @@ interface InnerProps {
 }
 
 const TickDetailsDialogImpl = ({tickId, instigationSelector}: InnerProps) => {
-  const [activeTab, setActiveTab] = useState<'result' | 'logs'>('result');
+  const [activeTab, setActiveTab] = useState<'result' | 'cursor' | 'logs'>('result');
 
   const {data} = useQuery<SelectedTickQuery, SelectedTickQueryVariables>(JOB_SELECTED_TICK_QUERY, {
     variables: {instigationSelector, tickId: tickId || 0},
@@ -77,6 +78,7 @@ const TickDetailsDialogImpl = ({tickId, instigationSelector}: InnerProps) => {
     data?.instigationStateOrError.__typename === 'InstigationState'
       ? data?.instigationStateOrError.tick
       : undefined;
+  const cursor = tick?.cursor;
 
   const [addedPartitionRequests, deletedPartitionRequests] = useMemo(() => {
     const added = tick?.dynamicPartitionsRequestResults.filter(
@@ -116,6 +118,7 @@ const TickDetailsDialogImpl = ({tickId, instigationSelector}: InnerProps) => {
       <Box padding={{horizontal: 24}} border="bottom">
         <Tabs selectedTabId={activeTab} onChange={setActiveTab}>
           <Tab id="result" title="Result" />
+          <Tab id="cursor" title="Cursor" />
           <Tab id="logs" title="Logs" />
         </Tabs>
       </Box>
@@ -158,6 +161,15 @@ const TickDetailsDialogImpl = ({tickId, instigationSelector}: InnerProps) => {
             </Box>
           ) : null}
         </div>
+      ) : null}
+      {activeTab === 'cursor' ? (
+        <Box style={{height: 500}} flex={{direction: 'column'}}>
+          <Box padding={24}>
+            <span style={{fontFamily: FontFamily.monospace, fontSize: '14px'}}>
+              {cursor ? cursor : 'None'}
+            </span>
+          </Box>
+        </Box>
       ) : null}
       {activeTab === 'logs' ? (
         <QueryfulTickLogsTable instigationSelector={instigationSelector} tick={tick} />


### PR DESCRIPTION
## Summary & Motivation
Currently, you can only see the cursor in the tick history table.

When looking at the details of a tick, you should be able to see the same cursor, rather than having to flip back and forth between the two experiences.

## How I Tested These Changes
local

![Screenshot 2024-08-15 at 11.36.10 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/3paPzMeByK6VgE9uQe4F/5c81c397-4083-4e5b-bbc1-8e6f73e00710.png)

![Screenshot 2024-08-15 at 11.45.59 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/3paPzMeByK6VgE9uQe4F/f06b9a45-d9f5-4bb5-9187-3455dfac7880.png)

