### PR TITLE
[dagster-fivetran] add relation identifier metadata to fivetran assets

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -398,6 +398,10 @@ class FivetranResource(ConfigurableResource):
         )
         return FivetranOutput(connector_details=final_details, schema_config=schema_config)
 
+    def get_destination_details(self, destination_id: str) -> Mapping[str, Any]:
+        """Fetches details about a given destination from the Fivetran API."""
+        return self.make_request("GET", f"destinations/{destination_id}")
+
 
 @dagster_maintained_resource
 @resource(config_schema=FivetranResource.to_config_schema())

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/utils.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/utils.py
@@ -19,7 +19,12 @@ def get_fivetran_logs_url(connector_details: Mapping[str, Any]) -> str:
 
 
 def metadata_for_table(
-    table_data: Mapping[str, Any], connector_url: str, include_column_info: bool = False
+    table_data: Mapping[str, Any],
+    connector_url: str,
+    database: Optional[str],
+    schema: Optional[str],
+    table: Optional[str],
+    include_column_info: bool = False,
 ) -> RawMetadataMapping:
     metadata: Dict[str, MetadataValue] = {"connector_url": MetadataValue.url(connector_url)}
     if table_data.get("columns"):
@@ -35,6 +40,10 @@ def metadata_for_table(
         metadata["table_schema"] = MetadataValue.table_schema(TableSchema(table_columns))
         if include_column_info:
             metadata["column_info"] = MetadataValue.json(columns)
+    if database and schema and table:
+        metadata["dagster/relation_identifier"] = MetadataValue.text(
+            ".".join([database, schema, table])
+        )
 
     return metadata
 
@@ -57,6 +66,9 @@ def _table_data_to_materialization(
             table_data,
             get_fivetran_connector_url(fivetran_output.connector_details),
             include_column_info=True,
+            database=None,
+            schema=schema_name,
+            table=table_name,
         ),
     )
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/utils.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/utils.py
@@ -240,3 +240,7 @@ def get_sample_connectors_response_multiple():
             },
         ]
     }
+
+
+def get_sample_destination_details_response():
+    return {"data": {"config": {"database": "example_database"}}}


### PR DESCRIPTION
## Summary

Pull `database` config from Fivetran destinations when loading assets from a live Fivetran instance. Join this with known schema and table info to produce a full `dagster/relation_identifier`.

<img width="425" alt="Screenshot 2024-08-15 at 1 14 14 PM" src="https://github.com/user-attachments/assets/c8c44e50-4ab7-4cad-8c23-4ffdfa4f4fcb">

## Test Plan

Unit test, tested with live Fivetran instance.
