### PR TITLE
Allow attaching IO managers to specs

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1423,6 +1423,8 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
                 SYSTEM_METADATA_KEY_IO_MANAGER_KEY, DEFAULT_IO_MANAGER_KEY
             )
         else:
+            if SYSTEM_METADATA_KEY_IO_MANAGER_KEY in self._specs_by_key[key].metadata:
+                return self._specs_by_key[key].metadata[SYSTEM_METADATA_KEY_IO_MANAGER_KEY]
             check.invariant(
                 SYSTEM_METADATA_KEY_IO_MANAGER_KEY not in self._specs_by_key[key].metadata
             )

--- a/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/decorator_assets_definition_builder.py
@@ -24,7 +24,11 @@ from dagster._core.definitions.asset_dep import AssetDep
 from dagster._core.definitions.asset_in import AssetIn
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_out import AssetOut
-from dagster._core.definitions.asset_spec import AssetExecutionType, AssetSpec
+from dagster._core.definitions.asset_spec import (
+    SYSTEM_METADATA_KEY_IO_MANAGER_KEY,
+    AssetExecutionType,
+    AssetSpec,
+)
 from dagster._core.definitions.assets import (
     ASSET_SUBSET_INPUT_PREFIX,
     AssetsDefinition,
@@ -41,7 +45,11 @@ from dagster._core.definitions.resource_annotation import get_resource_args
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.storage.tags import COMPUTE_KIND_TAG
-from dagster._core.types.dagster_type import DagsterType, Nothing
+from dagster._core.types.dagster_type import (
+    Any as DagsterAny,
+    DagsterType,
+    Nothing,
+)
 
 from ..asset_check_spec import AssetCheckSpec
 from ..utils import NoValueSentinel
@@ -328,11 +336,14 @@ class DecoratorAssetsDefinitionBuilder:
             named_outs_by_asset_key[asset_spec.key] = NamedOut(
                 output_name,
                 Out(
-                    Nothing,
+                    DagsterAny
+                    if asset_spec.metadata.get(SYSTEM_METADATA_KEY_IO_MANAGER_KEY)
+                    else Nothing,
                     is_required=not (can_subset or asset_spec.skippable),
                     description=asset_spec.description,
                     code_version=asset_spec.code_version,
                     metadata=asset_spec.metadata,
+                    io_manager_key=asset_spec.metadata.get(SYSTEM_METADATA_KEY_IO_MANAGER_KEY),
                 ),
             )
 


### PR DESCRIPTION
## Summary

For purposes of migrating older `@multi_assets` without dropping custom IO manager capability, it's useful to be able to specify an IO manager to use for each asset output. Currently, an invariant will error if the special `SYSTEM_METADATA_KEY_IO_MANAGER_KEY` key is set on a materializable multi-asset.

This PR drops that requirement and threads through this IO manager expectation into the `Out`, also allowing any data type to be returned if an IO manager override is specified.


Before:
```python
@multi_asset(
  outs={
    "foo": AssetOut(key=AssetKey("foo_asset"), io_manager_key="foo_io_manager", dagster_type=int)
    "bar": AssetOut(key=AssetKey("bar_asset"), io_manager_key="bar_io_manager", dagster_type=int)
  }
)
def my_multi_asset():
  ...
  yield Output(output_name="foo", value=5)
  yield Output(output_name="bar", value=10)

```

After:
```python
@multi_asset(
  specs=[
    AssetSpec(key=AssetKey("foo_asset"), metadata={SYSTEM_METADATA_KEY_IO_MANAGER_KEY: "foo_io_manager"}),
    AssetSpec(key=AssetKey("bar_asset"), metadata={SYSTEM_METADATA_KEY_IO_MANAGER_KEY: "bar_io_manager"}),
  ]
)
def my_multi_asset():
  ...
  yield Output(output_name=AssetKey("foo_asset").to_python_identifier(), value=5)
  yield Output(output_name=AssetKey("bar_asset").to_python_identifier(), value=10)
```

This is not particularly elegant, but lets us update existing multi-assets with IO-manager-processed outputs in-place to use specs, without breaking downstream assets which might depend on them. For a concrete example, see #23676. We wouldn't expect users to replicate this pattern, & shouldn't do so on any greenfield code.

## Test Plan

New unit tests.
