### PR TITLE
[dagster-fivetran][refactor] Use specs instead of outs when building Fivetran multi assets

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_load_from_instance.py
@@ -64,7 +64,6 @@ def test_load_from_instance(
         def test_io_manager(_context) -> IOManager:
             class TestIOManager(IOManager):
                 def handle_output(self, context: OutputContext, obj) -> None:
-                    assert context.dagster_type.is_nothing
                     return
 
                 def load_input(self, context: InputContext) -> Any:


### PR DESCRIPTION
## Summary

Internal refactor to use specs instead of outs to build the Fivetran multi-asset. This should hopefully make further reworks of the integration a little bit easier, and in the meantime enables us to do things like set asset tags.

## Test Plan

Existing unit tests.
