### PR TITLE
support Callable annotations on record fields

### DIFF
--- a/python_modules/dagster/dagster/_check/builder.py
+++ b/python_modules/dagster/dagster/_check/builder.py
@@ -285,6 +285,8 @@ def build_check_call_str(
             return name  # no-op
     elif origin is Literal:
         return f'check.literal_param({name}, "{name}", {args})'
+    elif origin is Callable or origin is collections.abc.Callable:
+        return f'check.callable_param({name}, "{name}")'
     else:
         if _is_annotated(origin, args):
             _process_annotated(ttype, args, eval_ctx)

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -7,6 +7,7 @@ from typing import (
     TYPE_CHECKING,
     AbstractSet,
     Any,
+    Callable,
     Dict,
     Iterable,
     List,
@@ -1650,6 +1651,8 @@ BUILD_CASES = [
     (TypeVar("T"), [Foo(), None], []),
     (Literal["apple"], ["apple"], ["banana"]),
     (Literal["apple", "manzana"], ["apple", "manzana"], ["banana"]),
+    (Callable, [lambda x: x, int], [4]),
+    (Callable[[], int], [lambda x: x, int], [4]),
     # fwd refs
     ("Foo", [Foo()], [Bar()]),
     (Optional["Foo"], [Foo()], [Bar()]),


### PR DESCRIPTION
## Summary & Motivation

A further step would be to check the args passed to `Callable`, but I think this is a useful start on its own.

## How I Tested These Changes
