### PR TITLE
[RFC] lazy Definitions loading via `@defs_loader` decorator

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -182,6 +182,7 @@ from dagster._core.definitions.decorators.asset_decorator import (
 from dagster._core.definitions.decorators.config_mapping_decorator import (
     config_mapping as config_mapping,
 )
+from dagster._core.definitions.decorators.defs_loader_decorator import defs_loader as defs_loader
 from dagster._core.definitions.decorators.graph_decorator import graph as graph
 from dagster._core.definitions.decorators.hook_decorator import (
     failure_hook as failure_hook,
@@ -205,6 +206,7 @@ from dagster._core.definitions.definitions_class import (
     Definitions as Definitions,
     create_repository_using_definitions_args as create_repository_using_definitions_args,
 )
+from dagster._core.definitions.definitions_loader import DefinitionsLoader as DefinitionsLoader
 from dagster._core.definitions.dependency import (
     DependencyDefinition as DependencyDefinition,
     MultiDependencyDefinition as MultiDependencyDefinition,

--- a/python_modules/dagster/dagster/_check/builder.py
+++ b/python_modules/dagster/dagster/_check/builder.py
@@ -285,6 +285,8 @@ def build_check_call_str(
             return name  # no-op
     elif origin is Literal:
         return f'check.literal_param({name}, "{name}", {args})'
+    elif origin is Callable or origin is collections.abc.Callable:
+        return f'check.callable_param({name}, "{name}")'
     else:
         if _is_annotated(origin, args):
             _process_annotated(ttype, args, eval_ctx)

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -15,6 +15,7 @@ from dagster._cli.workspace.cli_target import (
     get_working_directory_from_kwargs,
     python_origin_target_argument,
 )
+from dagster._core.definitions.definitions_load_context import DefinitionsLoadContext
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.errors import DagsterExecutionInterruptedError
 from dagster._core.events import DagsterEvent, DagsterEventType, EngineEventData
@@ -152,7 +153,10 @@ def _execute_run_command_body(
     else:
         metrics_thread, metrics_thread_shutdown_event = None, None
 
-    recon_job = recon_job_from_origin(cast(JobPythonOrigin, dagster_run.job_code_origin))
+    recon_job = recon_job_from_origin(
+        cast(JobPythonOrigin, dagster_run.job_code_origin),
+        DefinitionsLoadContext(load_type="run_worker", repository_load_data=None),
+    )
 
     pid = os.getpid()
     instance.report_engine_event(
@@ -267,7 +271,10 @@ def _resume_run_command_body(
     else:
         metrics_thread, metrics_thread_shutdown_event = None, None
 
-    recon_job = recon_job_from_origin(cast(JobPythonOrigin, dagster_run.job_code_origin))
+    recon_job = recon_job_from_origin(
+        cast(JobPythonOrigin, dagster_run.job_code_origin),
+        DefinitionsLoadContext(load_type="run_worker", repository_load_data=None),
+    )
 
     pid = os.getpid()
     instance.report_engine_event(
@@ -470,14 +477,15 @@ def _execute_step_command_body(
         else:
             repository_load_data = None
 
-        recon_job = (
-            recon_job_from_origin(cast(JobPythonOrigin, dagster_run.job_code_origin))
-            .with_repository_load_data(repository_load_data)
-            .get_subset(
-                op_selection=dagster_run.resolved_op_selection,
-                asset_selection=dagster_run.asset_selection,
-                asset_check_selection=dagster_run.asset_check_selection,
-            )
+        recon_job = recon_job_from_origin(
+            cast(JobPythonOrigin, dagster_run.job_code_origin),
+            context=DefinitionsLoadContext(
+                load_type="step_worker", repository_load_data=repository_load_data
+            ),
+        ).get_subset(
+            op_selection=dagster_run.resolved_op_selection,
+            asset_selection=dagster_run.asset_selection,
+            asset_check_selection=dagster_run.asset_check_selection,
         )
 
         execution_plan = create_execution_plan(

--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -24,6 +24,7 @@ from typing_extensions import Never, TypeAlias
 
 import dagster._check as check
 from dagster._core.code_pointer import CodePointer
+from dagster._core.definitions.definitions_load_context import DefinitionsLoadContext
 from dagster._core.definitions.reconstruct import repository_def_from_target_def
 from dagster._core.definitions.repository_definition import RepositoryDefinition
 from dagster._core.instance import DagsterInstance
@@ -564,12 +565,16 @@ def _get_code_pointer_dict_from_kwargs(kwargs: ClickArgMapping) -> Mapping[str, 
     package_name = check.opt_str_elem(kwargs, "package_name")
     working_directory = get_working_directory_from_kwargs(kwargs)
     attribute = check.opt_str_elem(kwargs, "attribute")
+
+    load_context = DefinitionsLoadContext(load_type="cli", repository_load_data=None)
     if python_file:
         _check_cli_arguments_none(kwargs, "module_name", "package_name")
         return {
             cast(
                 RepositoryDefinition,
-                repository_def_from_target_def(loadable_target.target_definition),
+                repository_def_from_target_def(
+                    loadable_target.target_definition, context=load_context
+                ),
             ).name: CodePointer.from_python_file(
                 python_file, loadable_target.attribute, working_directory
             )
@@ -582,7 +587,9 @@ def _get_code_pointer_dict_from_kwargs(kwargs: ClickArgMapping) -> Mapping[str, 
         return {
             cast(
                 RepositoryDefinition,
-                repository_def_from_target_def(loadable_target.target_definition),
+                repository_def_from_target_def(
+                    loadable_target.target_definition, context=load_context
+                ),
             ).name: CodePointer.from_module(
                 module_name, loadable_target.attribute, working_directory
             )
@@ -595,7 +602,9 @@ def _get_code_pointer_dict_from_kwargs(kwargs: ClickArgMapping) -> Mapping[str, 
         return {
             cast(
                 RepositoryDefinition,
-                repository_def_from_target_def(loadable_target.target_definition),
+                repository_def_from_target_def(
+                    loadable_target.target_definition, context=load_context
+                ),
             ).name: CodePointer.from_python_package(
                 package_name, loadable_target.attribute, working_directory
             )

--- a/python_modules/dagster/dagster/_core/definitions/decorators/defs_loader_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/defs_loader_decorator.py
@@ -1,0 +1,23 @@
+from typing import Callable
+
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.definitions_loader import DefinitionsLoader
+
+
+def defs_loader(fn: Callable[[], Definitions]) -> DefinitionsLoader:
+    """Produces a DefinitionsLoader by decorating a function that returns a Definitions object.
+
+    Returns:
+        DefinitionsLoader
+
+    Examples:
+        .. code-block:: python
+            from dagster import defs_loader, Definitions
+
+            @defs_loader
+            def defs() -> Definitions:
+                my_assets = build_assets_in_computationally_expensive_way()
+
+                return Definitions(assets=assets)
+    """
+    return DefinitionsLoader(load_fn=fn)

--- a/python_modules/dagster/dagster/_core/definitions/decorators/defs_loader_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/defs_loader_decorator.py
@@ -1,10 +1,11 @@
 from typing import Callable
 
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.definitions_load_context import DefinitionsLoadContext
 from dagster._core.definitions.definitions_loader import DefinitionsLoader
 
 
-def defs_loader(fn: Callable[[], Definitions]) -> DefinitionsLoader:
+def defs_loader(fn: Callable[[DefinitionsLoadContext], Definitions]) -> DefinitionsLoader:
     """Produces a DefinitionsLoader by decorating a function that returns a Definitions object.
 
     Returns:
@@ -12,10 +13,10 @@ def defs_loader(fn: Callable[[], Definitions]) -> DefinitionsLoader:
 
     Examples:
         .. code-block:: python
-            from dagster import defs_loader, Definitions
+            from dagster import Definitions, DefinitionsLoadContext, defs_loader
 
             @defs_loader
-            def defs() -> Definitions:
+            def defs(context: DefinitionsLoadContext) -> Definitions:
                 my_assets = build_assets_in_computationally_expensive_way()
 
                 return Definitions(assets=assets)

--- a/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
@@ -1,0 +1,26 @@
+from typing import TYPE_CHECKING, Literal, Optional
+
+from dagster._record import record
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.repository_definition import RepositoryLoadData
+
+DefinitionsLoadType = Literal[
+    "code_server", "step_worker", "run_worker", "step_launcher_external_step", "cli"
+]
+
+
+@record(checked=False)
+class DefinitionsLoadContext:
+    """Holds data that's made available to Definitions-loading code when a DefinitionsLoader is
+    invoked.
+
+    User construction of this object is not supported.
+    """
+
+    load_type: Optional[DefinitionsLoadType]
+    repository_load_data: Optional["RepositoryLoadData"]
+
+    @staticmethod
+    def empty() -> "DefinitionsLoadContext":
+        return DefinitionsLoadContext(load_type=None, repository_load_data=None)

--- a/python_modules/dagster/dagster/_core/definitions/definitions_loader.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_loader.py
@@ -1,6 +1,7 @@
 from typing import Callable
 
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.definitions_load_context import DefinitionsLoadContext
 from dagster._record import record
 
 
@@ -8,4 +9,4 @@ from dagster._record import record
 class DefinitionsLoader:
     """An object that can be invoked to load a set of definitions."""
 
-    load_fn: Callable[[], Definitions]
+    load_fn: Callable[[DefinitionsLoadContext], Definitions]

--- a/python_modules/dagster/dagster/_core/definitions/definitions_loader.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_loader.py
@@ -1,0 +1,11 @@
+from typing import Callable
+
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._record import record
+
+
+@record
+class DefinitionsLoader:
+    """An object that can be invoked to load a set of definitions."""
+
+    load_fn: Callable[[], Definitions]

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -589,6 +589,7 @@ def _is_list_of_assets(
 
 def _check_is_loadable(definition: T_LoadableDefinition) -> T_LoadableDefinition:
     from .definitions_class import Definitions
+    from .definitions_loader import DefinitionsLoader
     from .graph_definition import GraphDefinition
     from .job_definition import JobDefinition
     from .repository_definition import PendingRepositoryDefinition, RepositoryDefinition
@@ -602,13 +603,14 @@ def _check_is_loadable(definition: T_LoadableDefinition) -> T_LoadableDefinition
                 PendingRepositoryDefinition,
                 GraphDefinition,
                 Definitions,
+                DefinitionsLoader,
             ),
         )
         or _is_list_of_assets(definition)
     ):
         raise DagsterInvariantViolationError(
-            "Loadable attributes must be either a JobDefinition, GraphDefinition, "
-            f"or RepositoryDefinition. Got {definition!r}."
+            "Loadable attributes must be either a JobDefinition, GraphDefinition, Definitions, "
+            "DefinitionsLoader or RepositoryDefinition. Got {definition!r}."
         )
     return definition
 
@@ -697,6 +699,7 @@ def repository_def_from_target_def(
 ) -> Optional["RepositoryDefinition"]:
     from .assets import AssetsDefinition
     from .definitions_class import Definitions
+    from .definitions_loader import DefinitionsLoader
     from .graph_definition import GraphDefinition
     from .job_definition import JobDefinition
     from .repository_definition import (
@@ -706,6 +709,11 @@ def repository_def_from_target_def(
         RepositoryDefinition,
     )
     from .source_asset import SourceAsset
+
+    if isinstance(target, DefinitionsLoader):
+        # TODO: validate that it takes no arguments
+        target = target.load_fn()
+        # TODO: validate that it's a Definitions object
 
     if isinstance(target, Definitions):
         # reassign to handle both repository and pending repo case

--- a/python_modules/dagster/dagster/_core/execution/plan/external_step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/external_step.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Callable, Iterator, Optional, Sequence, cast
 import dagster._check as check
 from dagster._config import Field, StringSource
 from dagster._core.code_pointer import FileCodePointer, ModuleCodePointer
+from dagster._core.definitions.definitions_load_context import DefinitionsLoadContext
 from dagster._core.definitions.partition import DynamicPartitionsDefinition
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
 from dagster._core.definitions.resource_definition import dagster_maintained_resource, resource
@@ -140,7 +141,10 @@ def step_context_to_step_run_ref(
                     executable_path=recon_job.repository.executable_path,
                     entry_point=recon_job.repository.entry_point,
                     container_context=recon_job.repository.container_context,
-                    repository_load_data=step_context.plan_data.execution_plan.repository_load_data,
+                    load_context=DefinitionsLoadContext(
+                        load_type="step_launcher_external_step",
+                        repository_load_data=step_context.plan_data.execution_plan.repository_load_data,
+                    ),
                 ),
                 job_name=recon_job.job_name,
                 op_selection=recon_job.op_selection,
@@ -199,7 +203,7 @@ def step_run_ref_to_step_context(
         known_state=step_run_ref.known_state,
         # we packaged repository_load_data onto the reconstructable job when creating the
         # StepRunRef, rather than putting it in a separate field
-        repository_load_data=job.repository.repository_load_data,
+        repository_load_data=job.repository.load_context.repository_load_data,
     )
 
     initialization_manager = PlanExecutionContextManager(

--- a/python_modules/dagster/dagster/_utils/hosted_user_process.py
+++ b/python_modules/dagster/dagster/_utils/hosted_user_process.py
@@ -9,19 +9,24 @@ to be the case.
 """
 
 import dagster._check as check
+from dagster._core.definitions.definitions_load_context import DefinitionsLoadContext
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
 from dagster._core.origin import JobPythonOrigin, RepositoryPythonOrigin
 from dagster._core.remote_representation import ExternalJob
 from dagster._core.remote_representation.external_data import external_job_data_from_def
 
 
-def recon_job_from_origin(origin: JobPythonOrigin) -> ReconstructableJob:
+def recon_job_from_origin(
+    origin: JobPythonOrigin, context: DefinitionsLoadContext
+) -> ReconstructableJob:
     check.inst_param(origin, "origin", JobPythonOrigin)
-    recon_repo = recon_repository_from_origin(origin.repository_origin)
+    recon_repo = recon_repository_from_origin(origin.repository_origin, context=context)
     return recon_repo.get_reconstructable_job(origin.job_name)
 
 
-def recon_repository_from_origin(origin: RepositoryPythonOrigin) -> "ReconstructableRepository":
+def recon_repository_from_origin(
+    origin: RepositoryPythonOrigin, context: DefinitionsLoadContext
+) -> "ReconstructableRepository":
     check.inst_param(origin, "origin", RepositoryPythonOrigin)
     return ReconstructableRepository(
         origin.code_pointer,
@@ -29,6 +34,7 @@ def recon_repository_from_origin(origin: RepositoryPythonOrigin) -> "Reconstruct
         origin.executable_path,
         origin.entry_point,
         origin.container_context,
+        context,
     )
 
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/build_defs.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/build_defs.py
@@ -1,8 +1,8 @@
-from dagster import Definitions, asset, defs_loader
+from dagster import Definitions, DefinitionsLoadContext, asset, defs_loader
 
 
 @defs_loader
-def defs():
+def defs(context: DefinitionsLoadContext) -> Definitions:
     @asset
     def asset1(): ...
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/build_defs.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/build_defs.py
@@ -1,0 +1,9 @@
+from dagster import Definitions, asset, defs_loader
+
+
+@defs_loader
+def defs():
+    @asset
+    def asset1(): ...
+
+    return Definitions(assets=[asset1])

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
@@ -258,3 +258,17 @@ def test_local_directory_file():
 
     with alter_sys_path(to_add=[os.path.dirname(path)], to_remove=[]):
         loadable_targets_from_python_file(path, working_directory=os.path.dirname(path))
+
+
+def test_defs_loader():
+    module_path = file_relative_path(__file__, "build_defs.py")
+    loadable_targets = loadable_targets_from_python_file(module_path)
+
+    assert len(loadable_targets) == 1
+    symbol = loadable_targets[0].attribute
+    assert symbol == "defs"
+
+    repo_def = repository_def_from_pointer(CodePointer.from_python_file(module_path, symbol, None))
+
+    assert isinstance(repo_def, RepositoryDefinition)
+    assert len(repo_def.assets_defs_by_key) == 1

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
@@ -4,6 +4,7 @@ import sys
 import pytest
 from dagster import DagsterInvariantViolationError, RepositoryDefinition
 from dagster._core.code_pointer import CodePointer
+from dagster._core.definitions.definitions_load_context import DefinitionsLoadContext
 from dagster._core.definitions.reconstruct import repository_def_from_pointer
 from dagster._core.definitions.repository_definition import PendingRepositoryDefinition
 from dagster._core.errors import DagsterImportError
@@ -268,7 +269,9 @@ def test_defs_loader():
     symbol = loadable_targets[0].attribute
     assert symbol == "defs"
 
-    repo_def = repository_def_from_pointer(CodePointer.from_python_file(module_path, symbol, None))
+    repo_def = repository_def_from_pointer(
+        CodePointer.from_python_file(module_path, symbol, None), DefinitionsLoadContext.empty()
+    )
 
     assert isinstance(repo_def, RepositoryDefinition)
     assert len(repo_def.assets_defs_by_key) == 1

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -7,6 +7,7 @@ from typing import (
     TYPE_CHECKING,
     AbstractSet,
     Any,
+    Callable,
     Dict,
     Iterable,
     List,
@@ -1650,6 +1651,8 @@ BUILD_CASES = [
     (TypeVar("T"), [Foo(), None], []),
     (Literal["apple"], ["apple"], ["banana"]),
     (Literal["apple", "manzana"], ["apple", "manzana"], ["banana"]),
+    (Callable, [lambda x: x, int], [4]),
+    (Callable[[], int], [lambda x: x, int], [4]),
     # fwd refs
     ("Foo", [Foo()], [Bar()]),
     (Optional["Foo"], [Foo()], [Bar()]),


### PR DESCRIPTION
## Summary & Motivation

This PR proposes an API for loading definitions outside of import time. It supersedes https://github.com/dagster-io/dagster/pull/23253.

```python
from dagster import Definitions, DefinitionsLoadContext, defs_loader


@defs_loader
def defs(context: DefinitionsLoadContext) -> Definitions:
    my_assets = invoke_expensive_factory_to_build_asset_defs()

    return Definitions(assets=my_assets)
```

This API is useful when the code that generates the set of `Definitions` is heavyweight: e.g. involves parsing lots of YAML files or makes calls to an external service. This heavyweight code won't be invoked every time the user imports their Python modules (e.g. to run a unit test). It will only be invoked when the Dagster framework invokes it, e.g. to execute a step or populate the definitions for a code server.

### `DefinitionsLoadContext`

The user-defined loading function has access to a `DefinitionsLoadContext`, which contains metadata about the definitions are being loaded within.

I haven't though too deeply about the attributes that will live on this class, but it would likely have:
- Some sort of enum that represents the different places where definitions can be loaded. This PR has `load_type: Literal["code_server", "step_worker", "run_worker", ...].`
- (For step and run workers) a way to access cached metadata that was produced by the load process on the code server. This makes it so that step and run workers don't need to redo heavyweight work to assemble definition metadata that already occurred when loading definitions into the deployment . This would be a replacement for `CacheableAssetsDefinition`.
- Some sort of identifier for the definitions that are needed for the current process. This would enable optimizations in the future that allow step workers to avoid loading definitions that aren't needed for the execution they're carrying out.

### When should this be used?

One big question is whether this should supplant `defs = Definitions(...)` as the default way we recommend that users expose their definitions.  E.g. should it go into our tutorial? I lean slightly against but am not sure yet.

Arguments in favor of making it the new default:
- New users just need to learn one way of doing things. No discontinuity when they adopt one of the BI integrations.

Arguments against making it the new default:
- It's more verbose
- It can confuse users about what's happening when. Right now, everything happens at import time. As soon as there's a lazily invoked function, there's another time that things might be happening, and some users are sure to think things are happening at import time that are happening at load time and vice versa.
- Change. Would mean updating a lot of examples and content. And the old version will live on forever via ChatGPT.

### Decorator vs. inheritance

One of the ideas raised on https://github.com/dagster-io/dagster/pull/23253 was an inheritance-based API where the user overrides a function instead of using a decorator.

The main reason I opted for a decorator is consistency with our existing decorator-based convention. The second reason is that it's a little less verbose and doesn't require the user to name a class.

### `CodeLocation` vs. `DefinitionsLoader`

Is the object introduced here a "code location"? The stance that this PR takes is that this object is humbly responsible for producing a set of definition objects. A "code location" is an address where you can find code to run to produce a set of definition objects. I.e. "code location" is a concept that's only relevant from the perspective of a host process that needs to know where to go to load definitions.

Another angle is that "code location" doesn't feel right for an object whose primary function will sometimes be fetching definitions from Airbyte (which is not backed by code).

A third angle is that "code locations" can encompass multiple repositories, but this only supplies the definitions for a single repository. But repository is sort of a legacy concept so maybe this isn't important.

### What about other lifecycle methods?

@schrockn raised the question of supporting other lifecycle methods [here](https://github.com/dagster-io/dagster/pull/23253#pullrequestreview-2202069260). I think some of these, e.g. "Definitions are reloaded without restarting the process" and perhaps "The code server process is started" and "A worker process is started" could be addressed by branching on attributes exposed on the load context.

I think it's worth discussing these in more detail before committing to this direction. @schrockn – I'm interested in the use cases you have in mind.

## How I Tested These Changes
