### PR TITLE
[dagster-fivetran] Add storage kind to fivetran assets

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/test_load_from_instance.py
@@ -155,7 +155,12 @@ def test_load_from_instance(
             tables = {
                 connector_to_asset_key_fn(
                     FivetranConnectionMetadata(
-                        "some_service.some_name", "", "=", {}, database="example_database"
+                        "some_service.some_name",
+                        "",
+                        "=",
+                        {},
+                        database="example_database",
+                        service="snowflake",
                     ),
                     ".".join(t.path),
                 )
@@ -166,7 +171,12 @@ def test_load_from_instance(
         xyz_asset_key = (
             connector_to_asset_key_fn(
                 FivetranConnectionMetadata(
-                    "some_service.some_name", "", "=", {}, database="example_database"
+                    "some_service.some_name",
+                    "",
+                    "=",
+                    {},
+                    database="example_database",
+                    service="snowflake",
                 ),
                 "abc.xyz",
             )
@@ -187,6 +197,7 @@ def test_load_from_instance(
             )
 
         # Check schema metadata is added correctly to asset def
+        assets_def = ft_assets[0]
         assert any(
             metadata.get("dagster/column_schema")
             == (
@@ -198,12 +209,13 @@ def test_load_from_instance(
                     ]
                 )
             )
-            for key, metadata in ft_assets[0].metadata_by_key.items()
+            for key, metadata in assets_def.metadata_by_key.items()
         )
-        for key, metadata in ft_assets[0].metadata_by_key.items():
+        for key, metadata in assets_def.metadata_by_key.items():
             assert metadata.get("dagster/relation_identifier") == (
                 "example_database." + ".".join(key.path[-2:])
             )
+            assert assets_def.tags_by_key[key]["dagster/storage_kind"] == "snowflake"
 
         assert ft_assets[0].keys == tables
         assert all(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/utils.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/utils.py
@@ -243,4 +243,9 @@ def get_sample_connectors_response_multiple():
 
 
 def get_sample_destination_details_response():
-    return {"data": {"config": {"database": "example_database"}}}
+    return {
+        "data": {
+            "service": "snowflake",
+            "config": {"database": "example_database"},
+        }
+    }


### PR DESCRIPTION
## Summary

Pull and thread through storage kind from the destination's `service` field in the API:

https://fivetran.com/docs/rest-api/destinations#retrievedestinationdetails


<img width="333" alt="Screenshot 2024-08-15 at 3 20 49 PM" src="https://github.com/user-attachments/assets/714259db-72a7-4f6f-83a6-35f79120e5e6">

## Test Plan

Unit test; tested locally w/ prod Fivetran.
