### PR TITLE
pin deltalake

### DIFF
--- a/python_modules/libraries/dagster-polars/setup.py
+++ b/python_modules/libraries/dagster-polars/setup.py
@@ -44,7 +44,7 @@ setup(
         "universal_pathlib>=0.1.4",
     ],
     extras_require={
-        "deltalake": ["deltalake>=0.15.0"],
+        "deltalake": ["deltalake>=0.15.0,<0.19"],
         "gcp": ["dagster-gcp>=0.19.5"],
         "test": [
             "pytest>=8",


### PR DESCRIPTION
Deltalake 0.19.0 is causing test failures: https://buildkite.com/dagster/dagster-dagster/builds/90827#0191576f-e904-4619-9cfd-5afeba81a258