### PR TITLE
[DA][14/n][cleanup] Remove old backcompat logic

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_condition_evaluations.py
@@ -79,14 +79,8 @@ def fetch_asset_condition_evaluation_record_for_partition(
             )
         )
     )
-    asset_node = get_asset_nodes_by_asset_key(graphene_info).get(asset_key)
-    partitions_def = (
-        asset_node.external_asset_node.partitions_def_data.get_partitions_definition()
-        if asset_node and asset_node.external_asset_node.partitions_def_data
-        else None
-    )
     return GrapheneAssetConditionEvaluation(
-        record.get_evaluation_with_run_ids(partitions_def).evaluation, partition_key
+        record.get_evaluation_with_run_ids().evaluation, partition_key
     )
 
 
@@ -114,7 +108,7 @@ def fetch_true_partitions_for_evaluation_node(
     )
 
     # it's no longer necessary to pass in the partitions def in to get_evaluation_with_run_ids
-    root_evaluation = record.get_evaluation_with_run_ids(None).evaluation
+    root_evaluation = record.get_evaluation_with_run_ids().evaluation
     for evaluation in root_evaluation.iter_nodes():
         if evaluation.condition_snapshot.unique_id == node_unique_id:
             return list(evaluation.true_subset.subset_value.get_partition_keys())

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_auto_materialize_asset_evaluations.py
@@ -4,7 +4,6 @@ import dagster._check as check
 from dagster import AssetKey
 from dagster._core.scheduler.instigation import AutoMaterializeAssetEvaluationRecord
 
-from dagster_graphql.implementation.fetch_assets import get_asset_nodes_by_asset_key
 from dagster_graphql.schema.auto_materialize_asset_evaluations import (
     GrapheneAutoMaterializeAssetEvaluationNeedsMigrationError,
     GrapheneAutoMaterializeAssetEvaluationRecord,
@@ -34,27 +33,11 @@ def _get_migration_error(
 
 
 def _get_graphene_records_from_evaluations(
-    graphene_info: "ResolveInfo",
-    evaluation_records: Sequence[AutoMaterializeAssetEvaluationRecord],
+    graphene_info: "ResolveInfo", evaluation_records: Sequence[AutoMaterializeAssetEvaluationRecord]
 ) -> GrapheneAutoMaterializeAssetEvaluationRecords:
-    asset_keys = {record.asset_key for record in evaluation_records}
-
-    partitions_defs = {}
-
-    nodes = get_asset_nodes_by_asset_key(graphene_info)
-    for asset_key in asset_keys:
-        asset_node = nodes.get(asset_key)
-        partitions_defs[asset_key] = (
-            asset_node.external_asset_node.partitions_def_data.get_partitions_definition()
-            if asset_node and asset_node.external_asset_node.partitions_def_data
-            else None
-        )
-
     return GrapheneAutoMaterializeAssetEvaluationRecords(
         records=[
-            GrapheneAutoMaterializeAssetEvaluationRecord(
-                evaluation, partitions_defs[evaluation.asset_key]
-            )
+            GrapheneAutoMaterializeAssetEvaluationRecord(evaluation)
             for evaluation in evaluation_records
         ]
     )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
@@ -274,7 +274,7 @@ class GrapheneAssetConditionEvaluationRecord(graphene.ObjectType):
         record: AutoMaterializeAssetEvaluationRecord,
         partitions_def: Optional[PartitionsDefinition],
     ):
-        evaluation_with_run_ids = record.get_evaluation_with_run_ids(partitions_def)
+        evaluation_with_run_ids = record.get_evaluation_with_run_ids()
         root_evaluation = evaluation_with_run_ids.evaluation
 
         flattened_evaluations = _flatten_evaluation(evaluation_with_run_ids.evaluation)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -1,7 +1,6 @@
 from typing import Optional, Sequence, Tuple
 
 import graphene
-from dagster import PartitionsDefinition
 from dagster._core.definitions.auto_materialize_rule_evaluation import AutoMaterializeDecisionType
 from dagster._core.definitions.declarative_automation.legacy.rule_condition import RuleCondition
 from dagster._core.definitions.declarative_automation.serialized_objects import (
@@ -222,12 +221,8 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
     class Meta:
         name = "AutoMaterializeAssetEvaluationRecord"
 
-    def __init__(
-        self,
-        record: AutoMaterializeAssetEvaluationRecord,
-        partitions_def: Optional[PartitionsDefinition],
-    ):
-        evaluation_with_run_ids = record.get_evaluation_with_run_ids(partitions_def=partitions_def)
+    def __init__(self, record: AutoMaterializeAssetEvaluationRecord):
+        evaluation_with_run_ids = record.get_evaluation_with_run_ids()
         evaluation = evaluation_with_run_ids.evaluation
         (
             rules,

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
@@ -1,31 +1,26 @@
 from abc import ABC, abstractproperty
-from collections import defaultdict
 from enum import Enum
-from typing import AbstractSet, Dict, FrozenSet, NamedTuple, Optional, Sequence, Tuple, Union, cast
+from typing import Dict, FrozenSet, NamedTuple, Optional, Sequence, Tuple
 
-import dagster._check as check
 from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataMapping, MetadataValue
 from dagster._serdes.serdes import (
-    _WHITELIST_MAP,
     NamedTupleSerializer,
     PackableValue,
     UnpackContext,
     UnpackedValue,
     WhitelistMap,
-    deserialize_value,
     whitelist_for_serdes,
 )
-from dagster._utils.security import non_secure_md5_hash_str
 
 from .declarative_automation.serialized_objects import (
     AssetSubsetWithMetadata,
     AutomationConditionEvaluation,
     AutomationConditionEvaluationWithRunIds,
     AutomationConditionNodeSnapshot,
+    HistoricalAllPartitionsSubsetSentinel,
 )
-from .partition import PartitionsDefinition, SerializedPartitionsSubset
 
 
 @whitelist_for_serdes
@@ -42,15 +37,6 @@ class AutoMaterializeDecisionType(Enum):
     MATERIALIZE = "MATERIALIZE"
     SKIP = "SKIP"
     DISCARD = "DISCARD"
-
-
-@whitelist_for_serdes
-class AutoMaterializeRuleSnapshot(NamedTuple):
-    """A serializable snapshot of an AutoMaterializeRule for historical evaluations."""
-
-    class_name: str
-    description: str
-    decision_type: AutoMaterializeDecisionType
 
 
 class AutoMaterializeRuleEvaluationData(ABC):
@@ -119,233 +105,25 @@ class WaitingOnAssetsRuleEvaluationData(
 RuleEvaluations = Tuple[AssetSubset, Sequence["AssetSubsetWithMetadata"], PackableValue]
 
 
-@whitelist_for_serdes
-class AutoMaterializeRuleEvaluation(NamedTuple):
-    rule_snapshot: AutoMaterializeRuleSnapshot
-    evaluation_data: Optional[AutoMaterializeRuleEvaluationData]
-
-
 # BACKCOMPAT GRAVEYARD
 
 
-def deserialize_auto_materialize_asset_evaluation_to_asset_condition_evaluation_with_run_ids(
-    serialized_evaluation: str, partitions_def: Optional[PartitionsDefinition]
-) -> "AutomationConditionEvaluationWithRunIds":
-    """Provides a backcompat layer to allow deserializing old AutoMaterializeAssetEvaluation
-    objects into the new AutomationConditionEvaluationWithRunIds objects.
-    """
-    from .declarative_automation.serialized_objects import AutomationConditionEvaluationWithRunIds
+class BackcompatNullSerializer(NamedTupleSerializer):
+    """Unpacks an arbitrary object into None."""
 
-    class BackcompatDeserializer(BackcompatAutoMaterializeAssetEvaluationSerializer):
-        @property
-        def partitions_def(self) -> Optional[PartitionsDefinition]:
-            return partitions_def
-
-    # create a new WhitelistMap that can deserialize SerializedPartitionSubset objects stored
-    # on the old cursor format
-    whitelist_map = WhitelistMap(
-        object_serializers=_WHITELIST_MAP.object_serializers,
-        object_deserializers={
-            **_WHITELIST_MAP.object_deserializers,
-            "AutoMaterializeAssetEvaluation": BackcompatDeserializer(
-                klass=AutomationConditionEvaluationWithRunIds
-            ),
-        },
-        enum_serializers=_WHITELIST_MAP.enum_serializers,
-        object_type_map=_WHITELIST_MAP.object_type_map,
-    )
-
-    return deserialize_value(
-        serialized_evaluation, AutomationConditionEvaluationWithRunIds, whitelist_map=whitelist_map
-    )
-
-
-def deserialize_serialized_partitions_subset_to_asset_subset(
-    serialized: SerializedPartitionsSubset,
-    asset_key: AssetKey,
-    partitions_def: Optional[PartitionsDefinition],
-) -> AssetSubset:
-    if partitions_def is None or not serialized.can_deserialize(partitions_def):
-        # partitions def has changed since storage time
-        return AssetSubset.empty(asset_key, partitions_def)
-
-    return AssetSubset(asset_key=asset_key, value=serialized.deserialize(partitions_def))
+    def unpack(
+        self,
+        unpacked_dict: Dict[str, UnpackedValue],
+        whitelist_map: WhitelistMap,
+        context: UnpackContext,
+    ) -> None:
+        return None
 
 
 class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
-    """This handles backcompat for the old AutoMaterializeAssetEvaluation objects, turning them into
-    AutomationConditionEvaluationWithRunIds objects.
+    """Unpacks the legacy AutoMaterializeAssetEvaluation class into a completely empty
+    AutomationConditionEvaluationWithRunIds.
     """
-
-    @property
-    def partitions_def(self) -> Optional[PartitionsDefinition]:
-        """This property gets overridden by subclasses at runtime, once the partitions_def for the
-        specific record we're deserializing is known.
-        """
-        raise NotImplementedError()
-
-    def deserialize_serialized_partitions_subset_or_none(
-        self,
-        asset_key: AssetKey,
-        serialized: Union[None, SerializedPartitionsSubset],
-    ) -> AssetSubset:
-        if serialized is None:
-            # Confusingly, we used `None` to indicate "all of an unpartitioned asset" in the old
-            # serialization scheme
-            return AssetSubset(asset_key=asset_key, value=True)
-        return deserialize_serialized_partitions_subset_to_asset_subset(
-            serialized, asset_key, self.partitions_def
-        )
-
-    def _asset_condition_snapshot_from_rule_snapshot(
-        self, rule_snapshot: AutoMaterializeRuleSnapshot
-    ) -> "AutomationConditionNodeSnapshot":
-        from .declarative_automation.legacy.rule_condition import RuleCondition
-        from .declarative_automation.serialized_objects import AutomationConditionNodeSnapshot
-
-        unique_id_parts = [rule_snapshot.class_name, rule_snapshot.description]
-        unique_id = non_secure_md5_hash_str("".join(unique_id_parts).encode())
-
-        return AutomationConditionNodeSnapshot(
-            class_name=RuleCondition.__name__,
-            description=rule_snapshot.description,
-            unique_id=unique_id,
-        )
-
-    def _get_child_rule_evaluation(
-        self,
-        asset_key: AssetKey,
-        partition_subsets_by_condition: Sequence[
-            Tuple["AutoMaterializeRuleEvaluation", Optional[SerializedPartitionsSubset]]
-        ],
-        is_partitioned: bool,
-        rule_snapshot: AutoMaterializeRuleSnapshot,
-    ) -> "AutomationConditionEvaluation":
-        from .declarative_automation.serialized_objects import HistoricalAllPartitionsSubsetSentinel
-
-        condition_snapshot = self._asset_condition_snapshot_from_rule_snapshot(rule_snapshot)
-
-        subsets_with_metadata = [
-            AssetSubsetWithMetadata(
-                subset=self.deserialize_serialized_partitions_subset_or_none(asset_key, serialized),
-                metadata=rule_evaluation.evaluation_data.metadata,
-            )
-            for rule_evaluation, serialized in partition_subsets_by_condition
-            if rule_evaluation.evaluation_data
-        ]
-
-        true_subset = AssetSubset.empty(asset_key, self.partitions_def)
-        for _, serialized in partition_subsets_by_condition:
-            true_subset |= self.deserialize_serialized_partitions_subset_or_none(
-                asset_key, serialized
-            )
-
-        return AutomationConditionEvaluation(
-            condition_snapshot=condition_snapshot,
-            true_subset=true_subset,
-            candidate_subset=HistoricalAllPartitionsSubsetSentinel()
-            if is_partitioned
-            else AssetSubset.all(asset_key, None),
-            start_timestamp=None,
-            end_timestamp=None,
-            subsets_with_metadata=subsets_with_metadata,
-            child_evaluations=[],
-        )
-
-    def _get_child_decision_type_evaluation(
-        self,
-        asset_key: AssetKey,
-        partition_subsets_by_condition: Sequence[
-            Tuple["AutoMaterializeRuleEvaluation", Optional[SerializedPartitionsSubset]]
-        ],
-        rule_snapshots: Sequence[AutoMaterializeRuleSnapshot],
-        is_partitioned: bool,
-        decision_type: AutoMaterializeDecisionType,
-    ) -> Optional["AutomationConditionEvaluation"]:
-        from .declarative_automation.operators.boolean_operators import (
-            NotAutomationCondition,
-            OrAutomationCondition,
-        )
-        from .declarative_automation.serialized_objects import HistoricalAllPartitionsSubsetSentinel
-
-        partition_subsets_by_condition_by_rule_snapshot = defaultdict(list)
-        for elt in partition_subsets_by_condition:
-            partition_subsets_by_condition_by_rule_snapshot[elt[0].rule_snapshot].append(elt)
-
-        child_evaluations = [
-            self._get_child_rule_evaluation(
-                asset_key,
-                partition_subsets_by_condition_by_rule_snapshot[rule_snapshot],
-                is_partitioned,
-                rule_snapshot,
-            )
-            for rule_snapshot in (
-                set(rule_snapshots) | set(partition_subsets_by_condition_by_rule_snapshot.keys())
-            )
-            if rule_snapshot.decision_type == decision_type
-        ]
-
-        if decision_type == AutoMaterializeDecisionType.DISCARD:
-            # for the discard type, we don't have an OrAutomationCondition
-            if len(child_evaluations) != 1:
-                return None
-            evaluation = child_evaluations[0]
-        else:
-            unique_id_parts = [
-                OrAutomationCondition.__name__,
-                *[e.condition_snapshot.unique_id for e in child_evaluations],
-            ]
-            unique_id = non_secure_md5_hash_str("".join(unique_id_parts).encode())
-            decision_type_snapshot = AutomationConditionNodeSnapshot(
-                class_name=OrAutomationCondition.__name__, description="Any of", unique_id=unique_id
-            )
-            true_subset = AssetSubset.empty(asset_key, self.partitions_def)
-            for e in child_evaluations:
-                true_subset |= e.true_subset
-            evaluation = AutomationConditionEvaluation(
-                condition_snapshot=decision_type_snapshot,
-                true_subset=true_subset,
-                candidate_subset=HistoricalAllPartitionsSubsetSentinel()
-                if is_partitioned
-                else AssetSubset.all(asset_key, None),
-                subsets_with_metadata=[],
-                child_evaluations=child_evaluations,
-                start_timestamp=None,
-                end_timestamp=None,
-            )
-
-        if decision_type == AutoMaterializeDecisionType.MATERIALIZE:
-            return evaluation
-
-        # non-materialize conditions are inverted
-        unique_id_parts = [
-            NotAutomationCondition.__name__,
-            evaluation.condition_snapshot.unique_id,
-        ]
-        unique_id = non_secure_md5_hash_str("".join(unique_id_parts).encode())
-
-        if is_partitioned:
-            # In reality, we'd like to invert the inner true_subset here, but this is an
-            # expensive operation, and error-prone as the set of all partitions may have changed
-            # since the evaluation was stored. Instead, we just use an empty subset.
-            true_subset = AssetSubset.empty(asset_key, self.partitions_def)
-        else:
-            true_subset = evaluation.true_subset._replace(
-                value=not evaluation.true_subset.bool_value
-            )
-        return AutomationConditionEvaluation(
-            condition_snapshot=AutomationConditionNodeSnapshot(
-                class_name=NotAutomationCondition.__name__, description="Not", unique_id=unique_id
-            ),
-            true_subset=true_subset,
-            candidate_subset=HistoricalAllPartitionsSubsetSentinel()
-            if is_partitioned
-            else AssetSubset.all(asset_key, None),
-            subsets_with_metadata=[],
-            child_evaluations=[evaluation],
-            start_timestamp=None,
-            end_timestamp=None,
-        )
 
     def unpack(
         self,
@@ -353,179 +131,32 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
         whitelist_map: WhitelistMap,
         context: UnpackContext,
     ) -> "AutomationConditionEvaluationWithRunIds":
-        from .declarative_automation.operators.boolean_operators import AndAutomationCondition
-        from .declarative_automation.serialized_objects import HistoricalAllPartitionsSubsetSentinel
-
-        asset_key = cast(AssetKey, unpacked_dict.get("asset_key"))
-        partition_subsets_by_condition = cast(
-            Sequence[Tuple[AutoMaterializeRuleEvaluation, Optional[SerializedPartitionsSubset]]],
-            unpacked_dict.get("partition_subsets_by_condition"),
-        )
-        rule_snapshots = (
-            cast(Sequence[AutoMaterializeRuleSnapshot], unpacked_dict.get("rule_snapshots", []))
-            or []
-        )
-        is_partitioned = (
-            any(tup[1] is not None for tup in partition_subsets_by_condition)
-            if partition_subsets_by_condition
-            # if we don't have any partition_subsets_by_condition to look at, we can't tell if this
-            # asset was partitioned at the time that the evaluation was stored, so instead we assume
-            # that its current partition status is the same as its partition status at storage time.
-            else self.partitions_def is not None
+        return AutomationConditionEvaluationWithRunIds(
+            evaluation=AutomationConditionEvaluation(
+                condition_snapshot=AutomationConditionNodeSnapshot("", "", "", None, None),
+                start_timestamp=None,
+                end_timestamp=None,
+                true_subset=AssetSubset(asset_key=AssetKey("unknown"), value=False),
+                candidate_subset=HistoricalAllPartitionsSubsetSentinel(),
+                subsets_with_metadata=[],
+                child_evaluations=[],
+            ),
+            run_ids=frozenset(),
         )
 
-        # get the sub-evaluations for each decision type
-        materialize_evaluation = check.not_none(
-            self._get_child_decision_type_evaluation(
-                asset_key,
-                partition_subsets_by_condition,
-                rule_snapshots,
-                is_partitioned,
-                AutoMaterializeDecisionType.MATERIALIZE,
-            )
-        )
-        not_skip_evaluation = self._get_child_decision_type_evaluation(
-            asset_key,
-            partition_subsets_by_condition,
-            rule_snapshots,
-            is_partitioned,
-            AutoMaterializeDecisionType.SKIP,
-        )
-        not_discard_evaluation = self._get_child_decision_type_evaluation(
-            asset_key,
-            partition_subsets_by_condition,
-            rule_snapshots,
-            is_partitioned,
-            AutoMaterializeDecisionType.DISCARD,
-        )
 
-        # filter out any None evaluations (should realistically only happen for discard)
-        child_evaluations = list(
-            filter(None, [materialize_evaluation, not_skip_evaluation, not_discard_evaluation])
-        )
-
-        # the top level condition is the AND of all the sub-conditions
-        unique_id_parts = [
-            AndAutomationCondition.__name__,
-            *[e.condition_snapshot.unique_id for e in child_evaluations],
-        ]
-        unique_id = non_secure_md5_hash_str("".join(unique_id_parts).encode())
-        condition_snapshot = AutomationConditionNodeSnapshot(
-            class_name=AndAutomationCondition.__name__, description="All of", unique_id=unique_id
-        )
-
-        # all AssetSubsets generated here are created using the current partitions_def, so they
-        # will be valid
-        true_subset = materialize_evaluation.true_subset.as_valid(self.partitions_def)
-        if not_skip_evaluation:
-            true_subset -= not_skip_evaluation.child_evaluations[0].true_subset
-        if not_discard_evaluation:
-            true_subset -= not_discard_evaluation.child_evaluations[0].true_subset
-
-        return AutomationConditionEvaluation(
-            condition_snapshot=condition_snapshot,
-            true_subset=true_subset,
-            candidate_subset=HistoricalAllPartitionsSubsetSentinel()
-            if is_partitioned
-            else AssetSubset.all(asset_key, None),
-            subsets_with_metadata=[],
-            child_evaluations=child_evaluations,
-            start_timestamp=None,
-            end_timestamp=None,
-        ).with_run_ids(cast(AbstractSet[str], unpacked_dict.get("run_ids", set())))
+@whitelist_for_serdes(serializer=BackcompatAutoMaterializeAssetEvaluationSerializer)
+class AutoMaterializeAssetEvaluation(NamedTuple): ...
 
 
-class BackcompatAutoMaterializeConditionSerializer(NamedTupleSerializer):
-    """This handles backcompat for the old AutoMaterializeCondition objects, turning them into the
-    proper AutoMaterializeRuleEvaluation objects. This is necessary because old
-    AutoMaterializeAssetEvaluation objects will have serialized AutoMaterializeCondition objects,
-    and we need to be able to deserialize them.
-
-    In theory, as these serialized objects happen to be purged periodically, we can remove this
-    backcompat logic at some point in the future.
-    """
-
-    def unpack(
-        self,
-        unpacked_dict: Dict[str, UnpackedValue],
-        whitelist_map: WhitelistMap,
-        context: UnpackContext,
-    ) -> AutoMaterializeRuleEvaluation:
-        from .auto_materialize_rule import AutoMaterializeRule
-        from .auto_materialize_rule_impls import DiscardOnMaxMaterializationsExceededRule
-
-        if self.klass in (
-            FreshnessAutoMaterializeCondition,
-            DownstreamFreshnessAutoMaterializeCondition,
-        ):
-            return AutoMaterializeRuleEvaluation(
-                rule_snapshot=AutoMaterializeRule.materialize_on_required_for_freshness().to_snapshot(),
-                evaluation_data=None,
-            )
-        elif self.klass == MissingAutoMaterializeCondition:
-            return AutoMaterializeRuleEvaluation(
-                rule_snapshot=AutoMaterializeRule.materialize_on_missing().to_snapshot(),
-                evaluation_data=None,
-            )
-        elif self.klass == ParentMaterializedAutoMaterializeCondition:
-            updated_asset_keys = unpacked_dict.get("updated_asset_keys")
-            if isinstance(updated_asset_keys, set):
-                updated_asset_keys = cast(FrozenSet[AssetKey], frozenset(updated_asset_keys))
-            else:
-                updated_asset_keys = frozenset()
-            will_update_asset_keys = unpacked_dict.get("will_update_asset_keys")
-            if isinstance(will_update_asset_keys, set):
-                will_update_asset_keys = cast(
-                    FrozenSet[AssetKey], frozenset(will_update_asset_keys)
-                )
-            else:
-                will_update_asset_keys = frozenset()
-            return AutoMaterializeRuleEvaluation(
-                rule_snapshot=AutoMaterializeRule.materialize_on_parent_updated().to_snapshot(),
-                evaluation_data=ParentUpdatedRuleEvaluationData(
-                    updated_asset_keys=updated_asset_keys,
-                    will_update_asset_keys=will_update_asset_keys,
-                ),
-            )
-        elif self.klass == ParentOutdatedAutoMaterializeCondition:
-            waiting_on_asset_keys = unpacked_dict.get("waiting_on_asset_keys")
-            if isinstance(waiting_on_asset_keys, set):
-                waiting_on_asset_keys = cast(FrozenSet[AssetKey], frozenset(waiting_on_asset_keys))
-            else:
-                waiting_on_asset_keys = frozenset()
-            return AutoMaterializeRuleEvaluation(
-                rule_snapshot=AutoMaterializeRule.skip_on_parent_outdated().to_snapshot(),
-                evaluation_data=WaitingOnAssetsRuleEvaluationData(
-                    waiting_on_asset_keys=waiting_on_asset_keys
-                ),
-            )
-        elif self.klass == MaxMaterializationsExceededAutoMaterializeCondition:
-            return AutoMaterializeRuleEvaluation(
-                rule_snapshot=DiscardOnMaxMaterializationsExceededRule(limit=1).to_snapshot(),
-                evaluation_data=None,
-            )
-        check.failed(f"Unexpected class {self.klass}")
+@whitelist_for_serdes(serializer=BackcompatNullSerializer)
+class AutoMaterializeRuleSnapshot(NamedTuple):
+    class_name: str
+    description: str
+    decision_type: AutoMaterializeDecisionType
 
 
-@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
-class FreshnessAutoMaterializeCondition(NamedTuple): ...
-
-
-@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
-class DownstreamFreshnessAutoMaterializeCondition(NamedTuple): ...
-
-
-@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
-class ParentMaterializedAutoMaterializeCondition(NamedTuple): ...
-
-
-@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
-class MissingAutoMaterializeCondition(NamedTuple): ...
-
-
-@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
-class ParentOutdatedAutoMaterializeCondition(NamedTuple): ...
-
-
-@whitelist_for_serdes(serializer=BackcompatAutoMaterializeConditionSerializer)
-class MaxMaterializationsExceededAutoMaterializeCondition(NamedTuple): ...
+@whitelist_for_serdes(serializer=BackcompatNullSerializer)
+class AutoMaterializeRuleEvaluation(NamedTuple):
+    rule_snapshot: AutoMaterializeRuleSnapshot
+    evaluation_data: Optional[AutoMaterializeRuleEvaluationData]

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -923,9 +923,7 @@ class AssetDaemon(DagsterDaemon):
                     )
                 )
                 evaluations_by_asset_key = {
-                    evaluation_record.asset_key: evaluation_record.get_evaluation_with_run_ids(
-                        partitions_def=asset_graph.get(evaluation_record.asset_key).partitions_def
-                    )
+                    evaluation_record.asset_key: evaluation_record.get_evaluation_with_run_ids()
                     for evaluation_record in evaluation_records
                 }
             else:

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -752,7 +752,7 @@ def _resume_tick(
         and instance.schedule_storage.supports_auto_materialize_asset_evaluations
     ):
         evaluations = [
-            record.get_evaluation_with_run_ids(None)
+            record.get_evaluation_with_run_ids()
             for record in instance.schedule_storage.get_auto_materialize_evaluations_for_evaluation_id(
                 evaluation_id=tick.tick_id
             )

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -773,36 +773,36 @@ class TestScheduleStorage:
                 asset_key=AssetKey("asset_one"), limit=100
             )
             assert len(res) == 1
-            assert res[0].get_evaluation_with_run_ids(None).evaluation.asset_key == AssetKey(
+            assert res[0].get_evaluation_with_run_ids().evaluation.asset_key == AssetKey(
                 "asset_one"
             )
             assert res[0].evaluation_id == 10
-            assert res[0].get_evaluation_with_run_ids(None).evaluation.true_subset.size == 0
+            assert res[0].get_evaluation_with_run_ids().evaluation.true_subset.size == 0
 
             res = storage.get_auto_materialize_asset_evaluations(
                 asset_key=AssetKey("asset_two"), limit=100
             )
             assert len(res) == 1
-            assert res[0].get_evaluation_with_run_ids(None).evaluation.asset_key == AssetKey(
+            assert res[0].get_evaluation_with_run_ids().evaluation.asset_key == AssetKey(
                 "asset_two"
             )
             assert res[0].evaluation_id == 10
-            assert res[0].get_evaluation_with_run_ids(None).evaluation.true_subset.size == 1
+            assert res[0].get_evaluation_with_run_ids().evaluation.true_subset.size == 1
 
             res = storage.get_auto_materialize_evaluations_for_evaluation_id(evaluation_id=10)
 
             assert len(res) == 2
-            assert res[0].get_evaluation_with_run_ids(None).evaluation.asset_key == AssetKey(
+            assert res[0].get_evaluation_with_run_ids().evaluation.asset_key == AssetKey(
                 "asset_one"
             )
             assert res[0].evaluation_id == 10
-            assert res[0].get_evaluation_with_run_ids(None).evaluation.true_subset.size == 0
+            assert res[0].get_evaluation_with_run_ids().evaluation.true_subset.size == 0
 
-            assert res[1].get_evaluation_with_run_ids(None).evaluation.asset_key == AssetKey(
+            assert res[1].get_evaluation_with_run_ids().evaluation.asset_key == AssetKey(
                 "asset_two"
             )
             assert res[1].evaluation_id == 10
-            assert res[1].get_evaluation_with_run_ids(None).evaluation.true_subset.size == 1
+            assert res[1].get_evaluation_with_run_ids().evaluation.true_subset.size == 1
 
         storage.add_auto_materialize_asset_evaluations(
             evaluation_id=11,
@@ -877,7 +877,7 @@ class TestScheduleStorage:
         )
         assert len(res) == 2
         assert res[0].evaluation_id == 11
-        assert res[0].get_evaluation_with_run_ids(None).evaluation == eval_one.evaluation
+        assert res[0].get_evaluation_with_run_ids().evaluation == eval_one.evaluation
 
         res = storage.get_auto_materialize_asset_evaluations(
             asset_key=AssetKey("asset_three"), limit=100
@@ -885,7 +885,7 @@ class TestScheduleStorage:
 
         assert len(res) == 1
         assert res[0].evaluation_id == 11
-        assert res[0].get_evaluation_with_run_ids(None).evaluation == eval_asset_three.evaluation
+        assert res[0].get_evaluation_with_run_ids().evaluation == eval_asset_three.evaluation
 
     def test_auto_materialize_asset_evaluations_with_partitions(self, storage) -> None:
         if not self.can_store_auto_materialize_asset_evaluations():
@@ -923,14 +923,12 @@ class TestScheduleStorage:
             asset_key=AssetKey("asset_two"), limit=100
         )
         assert len(res) == 1
-        assert res[0].get_evaluation_with_run_ids(None).evaluation.asset_key == AssetKey(
-            "asset_two"
-        )
+        assert res[0].get_evaluation_with_run_ids().evaluation.asset_key == AssetKey("asset_two")
         assert res[0].evaluation_id == 10
-        assert res[0].get_evaluation_with_run_ids(None).evaluation.true_subset.size == 1
+        assert res[0].get_evaluation_with_run_ids().evaluation.true_subset.size == 1
 
         assert (
-            res[0].get_evaluation_with_run_ids(None).evaluation.subsets_with_metadata[0]
+            res[0].get_evaluation_with_run_ids().evaluation.subsets_with_metadata[0]
             == asset_subset_with_metadata
         )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_asset_daemon_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_asset_daemon_failure_recovery.py
@@ -495,10 +495,8 @@ def test_asset_daemon_crash_recovery(daemon_not_paused_instance, crash_location)
         asset_key=AssetKey("hourly"), limit=100
     )
     assert len(evaluations) == 1
-    assert evaluations[0].get_evaluation_with_run_ids(None).evaluation.asset_key == AssetKey(
-        "hourly"
-    )
-    assert evaluations[0].get_evaluation_with_run_ids(None).run_ids == {
+    assert evaluations[0].get_evaluation_with_run_ids().evaluation.asset_key == AssetKey("hourly")
+    assert evaluations[0].get_evaluation_with_run_ids().run_ids == {
         run.run_id for run in sorted_runs
     }
 
@@ -606,10 +604,8 @@ def test_asset_daemon_exception_recovery(daemon_not_paused_instance, crash_locat
         asset_key=AssetKey("hourly"), limit=100
     )
     assert len(evaluations) == 1
-    assert evaluations[0].get_evaluation_with_run_ids(None).evaluation.asset_key == AssetKey(
-        "hourly"
-    )
-    assert evaluations[0].get_evaluation_with_run_ids(None).run_ids == {
+    assert evaluations[0].get_evaluation_with_run_ids().evaluation.asset_key == AssetKey("hourly")
+    assert evaluations[0].get_evaluation_with_run_ids().run_ids == {
         run.run_id for run in sorted_runs
     }
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
@@ -250,9 +250,7 @@ class AssetDaemonScenarioState(ScenarioState):
 
             new_run_requests.extend(backfill_requests)
             new_evaluations = [
-                e.get_evaluation_with_run_ids(
-                    self.asset_graph.get(e.asset_key).partitions_def
-                ).evaluation
+                e.get_evaluation_with_run_ids().evaluation
                 for e in check.not_none(
                     self.instance.schedule_storage
                 ).get_auto_materialize_evaluations_for_evaluation_id(new_cursor.evaluation_id)
@@ -399,12 +397,7 @@ class AssetDaemonScenarioState(ScenarioState):
                 ]
             )
         )
-        assert (
-            new_run_ids_for_asset
-            == evaluation_record.get_evaluation_with_run_ids(
-                self.asset_graph.get(key).partitions_def
-            ).run_ids
-        )
+        assert new_run_ids_for_asset == evaluation_record.get_evaluation_with_run_ids().run_ids
 
     def assert_evaluation(
         self,


### PR DESCRIPTION
## Summary & Motivation

Ran into this big chunk of code while working on some other changes. It is no longer necessary and can be removed.

Put simply, we had a very old format for serializing information about AMP evaluations. When we switched formats, I created some fairly extensive / hacky backcompat logic to convert from the old format to the new format automatically in the serdes layer. Over time, this has broken down to a certain extent. For example, a change several months ago made it so that this logic would no longer work properly with partitioned assets.

This is ok, as we delete old evalaution data after 30 days, and most people have updated past this version long ago (the original backcompat changes were ~9 months ago). The net impact will be that now if someone is in this (exceedingly rare) situation, their old evaluations will not have useful data on them.

Note that I am un-whitelisting a lot of classes here, which seems scary, but they were only ever serialized in the context of this class which I am now completely ignoring in the unpack step. Some existing tests actually have serialized versions of these un-whitelisted classes in them, and the whole object deserializes without error because we don't even attempt to deserialialize the innards of AutoMaterializeAssetEvaluation.

## How I Tested These Changes
