### PR TITLE
Add "isEnabled" prop to `useAssetcatalogFiltering` to allow calling hook hook while disabling all of its side effects.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetCatalogFiltering.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetCatalogFiltering.oss.tsx
@@ -37,10 +37,12 @@ export function useAssetCatalogFiltering<
   assets = EMPTY_ARRAY,
   includeRepos = true,
   loading = false,
+  isEnabled = true,
 }: {
   assets: T[] | undefined;
   includeRepos?: boolean;
   loading?: boolean;
+  isEnabled?: boolean;
 }) {
   const {
     filters,
@@ -53,7 +55,7 @@ export function useAssetCatalogFiltering<
     setCodeLocations,
     setStorageKindTags,
     setSelectAllFilters,
-  } = useAssetDefinitionFilterState();
+  } = useAssetDefinitionFilterState({isEnabled});
 
   const allAssetGroupOptions = useAssetGroupSelectorsForAssets(assets);
   const allComputeKindTags = useAssetKindTagsForAssets(assets);
@@ -161,7 +163,7 @@ export function useAssetCatalogFiltering<
      * This effect handles syncing the `selectAllFilters` query param state with the actual filtering state.
      * eg: If all of the items are selected then we include that key, otherwise we remove it.
      */
-    if (loading) {
+    if (loading || !isEnabled) {
       return;
     }
     if (!didWaitAfterLoading) {
@@ -211,6 +213,7 @@ export function useAssetCatalogFiltering<
     nonStorageKindTags,
     setSelectAllFilters,
     storageKindTags,
+    isEnabled,
   ]);
 
   const filtered = React.useMemo(

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.oss.tsx
@@ -43,9 +43,9 @@ export type AssetFilterType = AssetFilterBaseType & {
   selectAllFilters: Array<keyof AssetFilterBaseType>;
 };
 
-export const useAssetDefinitionFilterState = () => {
+export const useAssetDefinitionFilterState = ({isEnabled = true}: {isEnabled?: boolean}) => {
   const [filters, setFilters] = useQueryPersistedState<AssetFilterType>({
-    encode: ({
+    encode: isEnabled ? ({
       groups,
       computeKindTags,
       storageKindTags,
@@ -63,15 +63,15 @@ export const useAssetDefinitionFilterState = () => {
       tags: tags?.length ? JSON.stringify(tags) : undefined,
       codeLocations: codeLocations?.length ? JSON.stringify(codeLocations) : undefined,
       selectAllFilters: selectAllFilters?.length ? JSON.stringify(selectAllFilters) : undefined,
-    }),
+    }) : () => ({}),
     decode: (qs) => ({
-      groups: qs.groups ? JSON.parse(qs.groups) : [],
-      computeKindTags: qs.computeKindTags ? JSON.parse(qs.computeKindTags) : [],
-      storageKindTags: qs.storageKindTags ? JSON.parse(qs.storageKindTags) : [],
-      changedInBranch: qs.changedInBranch ? JSON.parse(qs.changedInBranch) : [],
-      owners: qs.owners ? JSON.parse(qs.owners) : [],
-      tags: qs.tags ? JSON.parse(qs.tags) : [],
-      codeLocations: qs.codeLocations
+      groups: qs.groups && isEnabled  ? JSON.parse(qs.groups) : [],
+      computeKindTags: qs.computeKindTags && isEnabled? JSON.parse(qs.computeKindTags) : [],
+      storageKindTags: qs.storageKindTags && isEnabled? JSON.parse(qs.storageKindTags) : [],
+      changedInBranch: qs.changedInBranch && isEnabled? JSON.parse(qs.changedInBranch) : [],
+      owners: qs.owners && isEnabled? JSON.parse(qs.owners) : [],
+      tags: qs.tags && isEnabled? JSON.parse(qs.tags) : [],
+      codeLocations: qs.codeLocations && isEnabled
         ? JSON.parse(qs.codeLocations).map((repo: RepoAddress) =>
             buildRepoAddress(repo.name, repo.location),
           )

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.oss.tsx
@@ -45,37 +45,40 @@ export type AssetFilterType = AssetFilterBaseType & {
 
 export const useAssetDefinitionFilterState = ({isEnabled = true}: {isEnabled?: boolean}) => {
   const [filters, setFilters] = useQueryPersistedState<AssetFilterType>({
-    encode: isEnabled ? ({
-      groups,
-      computeKindTags,
-      storageKindTags,
-      changedInBranch,
-      owners,
-      tags,
-      codeLocations,
-      selectAllFilters,
-    }) => ({
-      groups: groups?.length ? JSON.stringify(groups) : undefined,
-      computeKindTags: computeKindTags?.length ? JSON.stringify(computeKindTags) : undefined,
-      storageKindTags: storageKindTags?.length ? JSON.stringify(storageKindTags) : undefined,
-      changedInBranch: changedInBranch?.length ? JSON.stringify(changedInBranch) : undefined,
-      owners: owners?.length ? JSON.stringify(owners) : undefined,
-      tags: tags?.length ? JSON.stringify(tags) : undefined,
-      codeLocations: codeLocations?.length ? JSON.stringify(codeLocations) : undefined,
-      selectAllFilters: selectAllFilters?.length ? JSON.stringify(selectAllFilters) : undefined,
-    }) : () => ({}),
+    encode: isEnabled
+      ? ({
+          groups,
+          computeKindTags,
+          storageKindTags,
+          changedInBranch,
+          owners,
+          tags,
+          codeLocations,
+          selectAllFilters,
+        }) => ({
+          groups: groups?.length ? JSON.stringify(groups) : undefined,
+          computeKindTags: computeKindTags?.length ? JSON.stringify(computeKindTags) : undefined,
+          storageKindTags: storageKindTags?.length ? JSON.stringify(storageKindTags) : undefined,
+          changedInBranch: changedInBranch?.length ? JSON.stringify(changedInBranch) : undefined,
+          owners: owners?.length ? JSON.stringify(owners) : undefined,
+          tags: tags?.length ? JSON.stringify(tags) : undefined,
+          codeLocations: codeLocations?.length ? JSON.stringify(codeLocations) : undefined,
+          selectAllFilters: selectAllFilters?.length ? JSON.stringify(selectAllFilters) : undefined,
+        })
+      : () => ({}),
     decode: (qs) => ({
-      groups: qs.groups && isEnabled  ? JSON.parse(qs.groups) : [],
-      computeKindTags: qs.computeKindTags && isEnabled? JSON.parse(qs.computeKindTags) : [],
-      storageKindTags: qs.storageKindTags && isEnabled? JSON.parse(qs.storageKindTags) : [],
-      changedInBranch: qs.changedInBranch && isEnabled? JSON.parse(qs.changedInBranch) : [],
-      owners: qs.owners && isEnabled? JSON.parse(qs.owners) : [],
-      tags: qs.tags && isEnabled? JSON.parse(qs.tags) : [],
-      codeLocations: qs.codeLocations && isEnabled
-        ? JSON.parse(qs.codeLocations).map((repo: RepoAddress) =>
-            buildRepoAddress(repo.name, repo.location),
-          )
-        : [],
+      groups: qs.groups && isEnabled ? JSON.parse(qs.groups) : [],
+      computeKindTags: qs.computeKindTags && isEnabled ? JSON.parse(qs.computeKindTags) : [],
+      storageKindTags: qs.storageKindTags && isEnabled ? JSON.parse(qs.storageKindTags) : [],
+      changedInBranch: qs.changedInBranch && isEnabled ? JSON.parse(qs.changedInBranch) : [],
+      owners: qs.owners && isEnabled ? JSON.parse(qs.owners) : [],
+      tags: qs.tags && isEnabled ? JSON.parse(qs.tags) : [],
+      codeLocations:
+        qs.codeLocations && isEnabled
+          ? JSON.parse(qs.codeLocations).map((repo: RepoAddress) =>
+              buildRepoAddress(repo.name, repo.location),
+            )
+          : [],
       selectAllFilters: qs.selectAllFilters ? JSON.parse(qs.selectAllFilters) : [],
     }),
   });


### PR DESCRIPTION
## Summary & Motivation

In cloud we want to conditionally call this hook, or an elastic search backed version of the hook, but we can't do that because it would break the rules of hooks. Unfortunately the place where we want to call it conditionally is inside of another hook used by multiple different components and even other hooks, so going to the parent component and making them conditionally pass 1 version of the hook or another would not be very elegant since there would be a lot of threading of hooks around from places which really shouldn't know anything about this hook or its implementation. So... instead of that what we're doing is calling both hooks, but only returning the results of the hook we're using. The problem is that this hook has global side effects (by way of CatalogViewProvider integration and useQueryPersistedState) so I'm adding an `isEnabled` prop so that we disable all of these side effects and avoid bugs.

## How I Tested These Changes

Tested with https://github.com/dagster-io/internal/pull/11040/files