### PR TITLE
[dagster-k8s] fix: azureBlobComputeLogManagerConfig.secret_key is optional

### DIFF
--- a/helm/dagster/templates/helpers/instance/_compute-log-manager.tpl
+++ b/helm/dagster/templates/helpers/instance/_compute-log-manager.tpl
@@ -20,7 +20,10 @@ class: AzureBlobComputeLogManager
 config:
   storage_account: {{ include "stringSource" $azureBlobComputeLogManagerConfig.storageAccount }}
   container: {{ include "stringSource" $azureBlobComputeLogManagerConfig.container }}
+
+  {{- if $azureBlobComputeLogManagerConfig.secretKey }}
   secret_key: {{ include "stringSource" $azureBlobComputeLogManagerConfig.secretKey }}
+  {{- end }}
 
   {{- if $azureBlobComputeLogManagerConfig.localDir }}
   local_dir: {{ include "stringSource" $azureBlobComputeLogManagerConfig.localDir }}


### PR DESCRIPTION
## Summary & Motivation
This field is no longer mandatory and it breaks AzureBlobComputeLogManager in dagster-k8s.

## How I Tested These Changes
Ran job in kubernetes with edited helm chart.
