### PR TITLE
Assign backfills a run status based on their sub-run statuses

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -9,7 +9,7 @@ from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPo
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.time_window_partitions import BaseTimeWindowPartitionsSubset
-from dagster._core.errors import DagsterError, DagsterInvariantViolationError
+from dagster._core.errors import DagsterError
 from dagster._core.execution.asset_backfill import (
     AssetBackfillStatus,
     PartitionedAssetBackfillStatus,
@@ -121,25 +121,6 @@ class GrapheneBulkActionStatus(graphene.Enum):
 
     class Meta:
         name = "BulkActionStatus"
-
-    def to_dagster_run_status(self) -> GrapheneRunStatus:
-        """Maps bulk action status to a run status for use with the RunsFeedEntry interface."""
-        # the pyright ignores are required because GrapheneBulkActionStatus.STATUS and GrapheneRunStatus.STATUS
-        # are interpreted as a Literal string during static analysis, but it is actually an Enum value
-        if self.args[0] == GrapheneBulkActionStatus.REQUESTED.value:  # pyright: ignore[reportAttributeAccessIssue]
-            return GrapheneRunStatus.STARTED  # pyright: ignore[reportReturnType]
-        if self.args[0] == GrapheneBulkActionStatus.COMPLETED.value:  # pyright: ignore[reportAttributeAccessIssue]
-            return GrapheneRunStatus.SUCCESS  # pyright: ignore[reportReturnType]
-        if self.args[0] == GrapheneBulkActionStatus.FAILED.value:  # pyright: ignore[reportAttributeAccessIssue]
-            return GrapheneRunStatus.FAILURE  # pyright: ignore[reportReturnType]
-        if self.args[0] == GrapheneBulkActionStatus.CANCELED.value:  # pyright: ignore[reportAttributeAccessIssue]
-            return GrapheneRunStatus.CANCELED  # pyright: ignore[reportReturnType]
-        if self.args[0] == GrapheneBulkActionStatus.CANCELING.value:  # pyright: ignore[reportAttributeAccessIssue]
-            return GrapheneRunStatus.CANCELING  # pyright: ignore[reportReturnType]
-
-        raise DagsterInvariantViolationError(
-            f"Unable to convert BulkActionStatus {self.args[0]} to a RunStatus. {self.args[0]} is an unknown status."
-        )
 
 
 class GrapheneAssetBackfillTargetPartitions(graphene.ObjectType):
@@ -512,6 +493,32 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         ]
 
     def resolve_runStatus(self, _graphene_info: ResolveInfo) -> GrapheneRunStatus:
+        if self.status == BulkActionStatus.FAILED:
+            return GrapheneRunStatus.FAILURE
+        if self.status == BulkActionStatus.CANCELED:
+            return GrapheneRunStatus.CANCELED
+        if self.status == BulkActionStatus.CANCELING:
+            return GrapheneRunStatus.CANCELING
+        if self.status == BulkActionStatus.REQUESTED:
+            # if no runs have been launched:
+            if len(self._get_records(_graphene_info)) == 0:
+                return GrapheneRunStatus.NOT_STARTED  # GrapheneRunStatus.QUEUED?
+            return GrapheneRunStatus.STARTED
+        # BulkActionStatus.COMPLETED
+        sub_runs = self._get_records(_graphene_info)
+        sub_run_statuses = [record.dagster_run.status for record in sub_runs]
+        if all(status == GrapheneRunStatus.SUCCESS for status in sub_run_statuses):
+            return GrapheneRunStatus.SUCCESS
+        if any(status == GrapheneRunStatus.FAILURE for status in sub_run_statuses):
+            return GrapheneRunStatus.FAILURE
+        if any(status == GrapheneRunStatus.CANCELED for status in sub_run_statuses):
+            return GrapheneRunStatus.FAILURE
+
+        return GrapheneRunStatus.FAILURE  # what should we default to? maybe raise an error
+        # raise DagsterInvariantViolationError(
+        #     f"Unable to convert BulkActionStatus {self.args[0]} to a RunStatus. {self.args[0]} is an unknown status."
+        # )
+
         return GrapheneBulkActionStatus(self.status).to_dagster_run_status()
 
     def resolve_endTimestamp(self, graphene_info: ResolveInfo) -> Optional[float]:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -503,7 +503,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         if converted_status is BulkActionStatus.REQUESTED:
             # if no runs have been launched:
             if len(self._get_records(_graphene_info)) == 0:
-                return GrapheneRunStatus.NOT_STARTED  # GrapheneRunStatus.QUEUED?
+                return GrapheneRunStatus.QUEUED
             return GrapheneRunStatus.STARTED
         # BulkActionStatus.COMPLETED
         sub_runs = self._get_records(_graphene_info)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -492,7 +492,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             if get_tag_type(key) != TagType.HIDDEN
         ]
 
-    def resolve_runStatus(self, _graphene_info: ResolveInfo) -> GrapheneRunStatus:
+    def resolve_runStatus(self, _graphene_info: ResolveInfo) -> str:
         converted_status = BulkActionStatus[self.status]
         if converted_status is BulkActionStatus.FAILED:
             return GrapheneRunStatus.FAILURE

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -38,6 +38,7 @@ GET_PARTITION_BACKFILLS_QUERY = """
         results {
           id
           status
+          runStatus
           numPartitions
           timestamp
           partitionNames
@@ -63,6 +64,7 @@ SINGLE_BACKFILL_QUERY = """
   query SingleBackfillQuery($backfillId: String!) {
     partitionBackfillOrError(backfillId: $backfillId) {
       ... on PartitionBackfill {
+        runStatus
         partitionStatuses {
           results {
             id
@@ -495,6 +497,7 @@ def test_launch_asset_backfill():
             assert backfill_results[0]["partitionSet"] is None
             assert backfill_results[0]["partitionSetName"] is None
             assert set(backfill_results[0]["partitionNames"]) == {"a", "b"}
+            assert backfill_results[0]["runStatus"] == "NOT_STARTED"
 
             # on PartitionBackfill
             single_backfill_result = execute_dagster_graphql(
@@ -504,6 +507,10 @@ def test_launch_asset_backfill():
             assert single_backfill_result.data
             assert (
                 single_backfill_result.data["partitionBackfillOrError"]["partitionStatuses"] is None
+            )
+            assert (
+                single_backfill_result.data["partitionBackfillOrError"]["runStatus"]
+                == "NOT_STARTED"
             )
 
 
@@ -620,6 +627,10 @@ def test_remove_partitions_defs_after_backfill():
             assert (
                 single_backfill_result.data["partitionBackfillOrError"]["partitionStatuses"] is None
             )
+            assert (
+                single_backfill_result.data["partitionBackfillOrError"]["runStatus"]
+                == "NOT_STARTED"
+            )
 
 
 def test_launch_asset_backfill_with_non_partitioned_asset():
@@ -712,6 +723,7 @@ def test_launch_asset_backfill_with_upstream_anchor_asset():
             assert backfill_results[0]["partitionSet"] is None
             assert backfill_results[0]["partitionSetName"] is None
             assert backfill_results[0]["partitionNames"] is None
+            assert backfill_results[0]["runStatus"] == "NOT_STARTED"
 
 
 def get_daily_two_hourly_repo() -> RepositoryDefinition:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -497,7 +497,7 @@ def test_launch_asset_backfill():
             assert backfill_results[0]["partitionSet"] is None
             assert backfill_results[0]["partitionSetName"] is None
             assert set(backfill_results[0]["partitionNames"]) == {"a", "b"}
-            assert backfill_results[0]["runStatus"] == "NOT_STARTED"
+            assert backfill_results[0]["runStatus"] == "QUEUED"
 
             # on PartitionBackfill
             single_backfill_result = execute_dagster_graphql(
@@ -508,10 +508,7 @@ def test_launch_asset_backfill():
             assert (
                 single_backfill_result.data["partitionBackfillOrError"]["partitionStatuses"] is None
             )
-            assert (
-                single_backfill_result.data["partitionBackfillOrError"]["runStatus"]
-                == "NOT_STARTED"
-            )
+            assert single_backfill_result.data["partitionBackfillOrError"]["runStatus"] == "QUEUED"
 
 
 def test_remove_partitions_defs_after_backfill_backcompat():
@@ -627,10 +624,7 @@ def test_remove_partitions_defs_after_backfill():
             assert (
                 single_backfill_result.data["partitionBackfillOrError"]["partitionStatuses"] is None
             )
-            assert (
-                single_backfill_result.data["partitionBackfillOrError"]["runStatus"]
-                == "NOT_STARTED"
-            )
+            assert single_backfill_result.data["partitionBackfillOrError"]["runStatus"] == "QUEUED"
 
 
 def test_launch_asset_backfill_with_non_partitioned_asset():
@@ -723,7 +717,7 @@ def test_launch_asset_backfill_with_upstream_anchor_asset():
             assert backfill_results[0]["partitionSet"] is None
             assert backfill_results[0]["partitionSetName"] is None
             assert backfill_results[0]["partitionNames"] is None
-            assert backfill_results[0]["runStatus"] == "NOT_STARTED"
+            assert backfill_results[0]["runStatus"] == "QUEUED"
 
 
 def get_daily_two_hourly_repo() -> RepositoryDefinition:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -427,7 +427,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data["partitionBackfillOrError"]["numCancelable"] == 2
         assert result.data["partitionBackfillOrError"]["hasCancelPermission"] is True
         assert result.data["partitionBackfillOrError"]["hasResumePermission"] is True
-        assert result.data["partitionBackfillOrError"]["runStatus"] == "NOT_STARTED"
+        assert result.data["partitionBackfillOrError"]["runStatus"] == "QUEUED"
 
         assert len(result.data["partitionBackfillOrError"]["partitionNames"]) == 2
 
@@ -502,7 +502,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data["partitionBackfillOrError"]["numCancelable"] == 2
         assert len(result.data["partitionBackfillOrError"]["partitionNames"]) == 2
         assert result.data["partitionBackfillOrError"]["reexecutionSteps"] == ["after_failure"]
-        assert result.data["partitionBackfillOrError"]["runStatus"] == "NOT_STARTED"
+        assert result.data["partitionBackfillOrError"]["runStatus"] == "QUEUED"
 
     def test_cancel_backfill(self, graphql_context):
         repository_selector = infer_repository_selector(graphql_context)
@@ -537,7 +537,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data["partitionBackfillOrError"]["status"] == "REQUESTED"
         assert result.data["partitionBackfillOrError"]["numCancelable"] == 2
         assert len(result.data["partitionBackfillOrError"]["partitionNames"]) == 2
-        assert result.data["partitionBackfillOrError"]["runStatus"] == "NOT_STARTED"
+        assert result.data["partitionBackfillOrError"]["runStatus"] == "QUEUED"
 
         result = execute_dagster_graphql(
             graphql_context,
@@ -700,7 +700,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data
         assert result.data["partitionBackfillOrError"]["__typename"] == "PartitionBackfill"
         assert result.data["partitionBackfillOrError"]["status"] == "REQUESTED"
-        assert result.data["partitionBackfillOrError"]["runStatus"] == "NOT_STARTED"
+        assert result.data["partitionBackfillOrError"]["runStatus"] == "QUEUED"
 
     def test_backfill_run_stats(self, graphql_context):
         repository_selector = infer_repository_selector(graphql_context)
@@ -1287,7 +1287,7 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
             )
             == 0
         )
-        assert result.data["partitionBackfillOrError"]["runStatus"] == "NOT_STARTED"
+        assert result.data["partitionBackfillOrError"]["runStatus"] == "QUEUED"
 
     def test_launch_backfill_with_all_partitions_flag(self, graphql_context):
         repository_selector = infer_repository_selector(graphql_context)
@@ -1331,4 +1331,4 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
             )
             == 0
         )
-        assert result.data["partitionBackfillOrError"]["runStatus"] == "NOT_STARTED"
+        assert result.data["partitionBackfillOrError"]["runStatus"] == "QUEUED"


### PR DESCRIPTION
## Summary & Motivation
Computes the `DagsterRunStatus` for a backfill based on the statuses of the sub-runs and the BulkAction status of the backfill, rather than just mapping `BulkActionStatus -> DagsterRunStatus` in a one-to-one fashion.

We might want to store the run status in the DB at some point to facilitate filtering, but as a first step I'm just adding it to the GQL layer where it will be faster to iterate on how sub-run statuses inform overall status and won't  potentially require migrating old data if we change how we determine status. 

## How I Tested These Changes
added assertions on run status in existing tests