### PR TITLE
Revert "fix: use terminate to revoke celery task (#23513)"

### DIFF
--- a/python_modules/libraries/dagster-celery/dagster_celery/core_execution_loop.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery/core_execution_loop.py
@@ -70,7 +70,7 @@ def core_celery_execution_loop(job_context, execution_plan, step_execution_fn):
                 stopping = True
                 active_execution.mark_interrupted()
                 for result in step_results.values():
-                    result.revoke(terminate=True)
+                    result.revoke()
             results_to_pop = []
             for step_key, result in sorted(
                 step_results.items(), key=lambda x: priority_for_key(x[0])


### PR DESCRIPTION
This reverts commit 3a8a66f488340857f43c8df092d334d63bd2cd02 while we can figure out why it broke our celery-k8s integration tests.

## Summary & Motivation

## How I Tested These Changes
