### PR TITLE
Cache JobDefinition.get_job_index

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -56,6 +56,7 @@ from dagster._core.storage.io_manager import (
 from dagster._core.types.dagster_type import DagsterType
 from dagster._core.utils import str_format_set
 from dagster._utils import IHasInternalInit
+from dagster._utils.cached_method import cached_method
 from dagster._utils.merger import merge_dicts
 
 from .asset_layer import AssetLayer
@@ -955,6 +956,7 @@ class JobDefinition(IHasInternalInit):
     def get_job_snapshot(self) -> "JobSnapshot":
         return self.get_job_index().job_snapshot
 
+    @cached_method
     def get_job_index(self) -> "JobIndex":
         from dagster._core.remote_representation import JobIndex
         from dagster._core.snap import JobSnapshot


### PR DESCRIPTION
Summary:
This can take seconds on large jobs, and we call it at twice when loading a new code location when using defer_snapshots=True - once when generating the IDs for the JobRefs,and then again when loading the actual jobs.

Test Plan: BK, verify when running an agent locally that this is called only once per job when loading a new code locatoin

## Summary & Motivation

## How I Tested These Changes
