### PR TITLE
[docs] also use 'allowlist' when referencing 'whitelist'

### DIFF
--- a/docs/content/dagster-plus/deployment/serverless.mdx
+++ b/docs/content/dagster-plus/deployment/serverless.mdx
@@ -333,9 +333,9 @@ To avoid this behavior, you can:
 
 ---
 
-## Whitelisting Dagster's IP addresses
+## Whitelisting / Allowlisting Dagster's IP addresses
 
-Serverless code will make requests from one of the following IP addresses. You may need to whitelist them for services your code interacts with.
+Serverless code will make requests from one of the following IP addresses. You may need to whitelist / allowlist them for services your code interacts with.
 
 ```plain
 34.216.9.66


### PR DESCRIPTION
## Summary & Motivation
The terms "allowlist" and "allowlisting" are synonymous with "whitelist" and "whitelisting". Users may be searching for one term rather than the other.

## How I Tested These Changes
👀

## Changelog

NOCHANGELOG