### PR TITLE
[ui] Use single hidden asset job for all single-run asset executions

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
@@ -31,8 +31,20 @@ export interface PipelineRunTag {
 }
 
 export type SessionBase =
-  | {presetName: string; tags: PipelineRunTag[] | null}
-  | {partitionsSetName: string; partitionName: string | null; tags: PipelineRunTag[] | null};
+  | {
+      presetName: string;
+      tags: PipelineRunTag[] | null;
+    }
+  | {
+      isAssetJob: true; // partition set name not required
+      partitionName: string | null;
+      tags: PipelineRunTag[] | null;
+    }
+  | {
+      partitionsSetName: string; // required for op jobs
+      partitionName: string | null;
+      tags: PipelineRunTag[] | null;
+    };
 
 export interface IExecutionSession {
   key: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
@@ -32,16 +32,18 @@ export interface PipelineRunTag {
 
 export type SessionBase =
   | {
+      type: 'preset';
       presetName: string;
       tags: PipelineRunTag[] | null;
     }
   | {
-      isAssetJob: true; // partition set name not required
+      type: 'asset-job-partition';
       partitionName: string | null;
       tags: PipelineRunTag[] | null;
     }
   | {
-      partitionsSetName: string; // required for op jobs
+      type: 'op-job-partition-set';
+      partitionsSetName: string;
       partitionName: string | null;
       tags: PipelineRunTag[] | null;
     };
@@ -242,7 +244,7 @@ export const useInitialDataForMode = (
   partitionSets: LaunchpadSessionPartitionSetsFragment,
   rootDefaultYaml: string | undefined,
   shouldPopulateWithDefaults: boolean,
-) => {
+): {base?: SessionBase; runConfigYaml?: string} => {
   const {isJob, isAssetJob, presets} = pipeline;
   const partitionSetsForMode = partitionSets.results;
 
@@ -254,14 +256,23 @@ export const useInitialDataForMode = (
     // `default` preset
     if (presetsForMode.length === 1 && (isAssetJob || partitionSetsForMode.length === 0)) {
       return {
-        base: {presetName: presetsForMode[0]!.name, tags: null},
+        base: {
+          type: 'preset',
+          presetName: presetsForMode[0]!.name,
+          tags: null,
+        },
         runConfigYaml: presetsForMode[0]!.runConfigYaml,
       };
     }
 
     if (!presetsForMode.length && partitionSetsForMode.length === 1) {
       return {
-        base: {partitionsSetName: partitionSetsForMode[0]!.name, partitionName: null, tags: null},
+        base: {
+          type: 'op-job-partition-set',
+          partitionsSetName: partitionSetsForMode[0]!.name,
+          partitionName: null,
+          tags: null,
+        },
         runConfigYaml: rootDefaultYaml,
       };
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -47,7 +47,6 @@ import {PartitionDimensionSelection, usePartitionHealthData} from './usePartitio
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {PipelineRunTag} from '../app/ExecutionSessionStorage';
 import {usePermissionsForLocation} from '../app/Permissions';
-import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {
   displayNameForAssetKey,
   isHiddenAssetGroupJob,
@@ -60,13 +59,9 @@ import {
   LaunchPartitionBackfillMutation,
   LaunchPartitionBackfillMutationVariables,
 } from '../instance/backfill/types/BackfillUtils.types';
-import {CONFIG_PARTITION_SELECTION_QUERY} from '../launchpad/ConfigEditorConfigPicker';
+import {fetchTagsAndConfigForAssetJob} from '../launchpad/ConfigFetch';
 import {useLaunchPadHooks} from '../launchpad/LaunchpadHooksContext';
 import {TagContainer, TagEditor} from '../launchpad/TagEditor';
-import {
-  ConfigPartitionSelectionQuery,
-  ConfigPartitionSelectionQueryVariables,
-} from '../launchpad/types/ConfigEditorConfigPicker.types';
 import {
   DAEMON_NOT_RUNNING_ALERT_INSTANCE_FRAGMENT,
   DaemonNotRunningAlert,
@@ -269,50 +264,19 @@ const LaunchAssetChoosePartitionsDialogBody = ({
       });
     }
 
-    const {data: tagAndConfigData} = await client.query<
-      ConfigPartitionSelectionQuery,
-      ConfigPartitionSelectionQueryVariables
-    >({
-      query: CONFIG_PARTITION_SELECTION_QUERY,
-      fetchPolicy: 'network-only',
-      variables: {
-        repositorySelector: {
-          repositoryLocationName: repoAddress.location,
-          repositoryName: repoAddress.name,
-        },
-        partitionSetName: target.partitionSetName,
-        partitionName: keysFiltered[0]!,
-      },
+    const config = await fetchTagsAndConfigForAssetJob(client, {
+      partitionName: keysFiltered[0]!,
+      repositoryLocationName: repoAddress.location,
+      repositoryName: repoAddress.name,
+      assetKeys: target.assetKeys,
+      jobName: target.jobName,
     });
-
-    if (
-      !tagAndConfigData ||
-      !tagAndConfigData.partitionSetOrError ||
-      tagAndConfigData.partitionSetOrError.__typename !== 'PartitionSet' ||
-      !tagAndConfigData.partitionSetOrError.partition
-    ) {
+    if (!config) {
       return;
     }
 
-    const {partition} = tagAndConfigData.partitionSetOrError;
-
-    if (partition.tagsOrError.__typename === 'PythonError') {
-      showCustomAlert({
-        title: 'Unable to load tags',
-        body: <PythonErrorInfo error={partition.tagsOrError} />,
-      });
-      return;
-    }
-    if (partition.runConfigOrError.__typename === 'PythonError') {
-      showCustomAlert({
-        title: 'Unable to load tags',
-        body: <PythonErrorInfo error={partition.runConfigOrError} />,
-      });
-      return;
-    }
-
-    const runConfigData = partition.runConfigOrError.yaml || '';
-    let allTags = [...partition.tagsOrError.results, ...tags];
+    const runConfigData = config.yaml || '';
+    let allTags = [...config.tags, ...tags];
 
     if (launchWithRangesAsTags) {
       allTags = allTags.filter((t) => !t.key.startsWith(DagsterTag.Partition));
@@ -331,7 +295,6 @@ const LaunchAssetChoosePartitionsDialogBody = ({
         executionParams: {
           ...executionParamsForAssetJob(repoAddress, target.jobName, assets, allTags),
           runConfigData,
-          mode: partition.mode,
         },
       },
       'toast',
@@ -351,7 +314,8 @@ const LaunchAssetChoosePartitionsDialogBody = ({
             partitionNames: keysFiltered,
             fromFailure: false,
             selector: {
-              partitionSetName: target.partitionSetName,
+              // Todo: Fix after PR #23720 merges
+              partitionSetName: `${target.jobName}_partition_set`,
               repositorySelector: {
                 repositoryLocationName: repoAddress.location,
                 repositoryName: repoAddress.name,
@@ -618,9 +582,8 @@ const LaunchAssetChoosePartitionsDialogBody = ({
       <DialogFooter
         topBorder={!previewNotice}
         left={
-          'partitionSetName' in target && (
-            <RunningBackfillsNotice partitionSetName={target.partitionSetName} />
-          )
+          'assetKeys' in target &&
+          target.assetKeys && <RunningBackfillsNotice assetSelection={target.assetKeys} />
         }
       >
         <Button intent="none" onClick={() => setOpen(false)}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -81,7 +81,7 @@ import {RepoAddress} from '../workspace/types';
 
 const MISSING_FAILED_STATUSES = [AssetPartitionStatus.MISSING, AssetPartitionStatus.FAILED];
 
-interface Props {
+export interface LaunchAssetChoosePartitionsDialogProps {
   open: boolean;
   setOpen: (open: boolean) => void;
   repoAddress: RepoAddress;
@@ -94,7 +94,9 @@ interface Props {
   refetch?: () => Promise<void>;
 }
 
-export const LaunchAssetChoosePartitionsDialog = (props: Props) => {
+export const LaunchAssetChoosePartitionsDialog = (
+  props: LaunchAssetChoosePartitionsDialogProps,
+) => {
   const displayName =
     props.assets.length > 1
       ? `${props.assets.length} assets`
@@ -130,7 +132,7 @@ const LaunchAssetChoosePartitionsDialogBody = ({
   target,
   upstreamAssetKeys,
   refetch: _refetch,
-}: Props) => {
+}: LaunchAssetChoosePartitionsDialogProps) => {
   const partitionedAssets = assets.filter((a) => !!a.partitionDefinition);
 
   const {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -559,7 +559,9 @@ async function stateForLaunchingAssets(
         ),
         includeSeparatelyExecutableChecks: true,
         solidSelectionQuery: assetOpNames.map((name) => `"${name}"`).join(', '),
-        base: partitionDefinition ? {isAssetJob: true, partitionName: null, tags: []} : undefined,
+        base: partitionDefinition
+          ? {type: 'asset-job-partition', partitionName: null, tags: []}
+          : undefined,
       },
     };
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetExecutionButton.tsx
@@ -407,7 +407,6 @@ export const useMaterializationAction = (preferredJobName?: string) => {
 
   const launchpad = () => {
     if (state.type === 'launchpad') {
-      console.log(state.sessionPresets);
       return (
         <AssetLaunchpad
           assetJobName={state.jobName}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/RunningBackfillsNotice.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/RunningBackfillsNotice.tsx
@@ -1,14 +1,17 @@
 import {gql, useQuery} from '@apollo/client';
 import {Box, Colors, Icon} from '@dagster-io/ui-components';
+import {useMemo} from 'react';
 import {Link} from 'react-router-dom';
 
 import {
   RunningBackfillsNoticeQuery,
   RunningBackfillsNoticeQueryVariables,
 } from './types/RunningBackfillsNotice.types';
+import {tokenForAssetKey} from '../asset-graph/Utils';
+import {AssetKeyInput} from '../graphql/types';
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
-export const RunningBackfillsNotice = ({partitionSetName}: {partitionSetName: string}) => {
+export const RunningBackfillsNotice = ({assetSelection}: {assetSelection: AssetKeyInput[]}) => {
   const queryResult = useQuery<RunningBackfillsNoticeQuery, RunningBackfillsNoticeQueryVariables>(
     RUNNING_BACKFILLS_NOTICE_QUERY,
   );
@@ -20,18 +23,24 @@ export const RunningBackfillsNotice = ({partitionSetName}: {partitionSetName: st
       ? data.partitionBackfillsOrError.results
       : [];
 
+  const assetSelectionTokens = useMemo(
+    () => new Set(assetSelection.map(tokenForAssetKey)),
+    [assetSelection],
+  );
+
   const runningBackfillCount = runningBackfills.filter(
-    (r) => r.partitionSetName === partitionSetName,
+    (r) => r.assetSelection?.some((a) => assetSelectionTokens.has(tokenForAssetKey(a))),
   ).length;
 
   if (runningBackfillCount === 0) {
     return <span />;
   }
+
   return (
     <div style={{color: Colors.textLight(), maxWidth: 350}}>
       {runningBackfillCount === 1
-        ? 'Note: A backfill has been requested for this job and may be refreshing displayed assets. '
-        : `Note: ${runningBackfillCount} backfills have been requested for this job and may be refreshing displayed assets. `}
+        ? `Note: A backfill has been requested and may be refreshing displayed assets. `
+        : `Note: ${runningBackfillCount} backfills have been requested and may be refreshing displayed assets. `}
       <Link to="/overview/backfills" target="_blank">
         <Box flex={{gap: 4, display: 'inline-flex', alignItems: 'center'}}>
           View <Icon name="open_in_new" color={Colors.linkDefault()} />
@@ -48,6 +57,9 @@ export const RUNNING_BACKFILLS_NOTICE_QUERY = gql`
         results {
           id
           partitionSetName
+          assetSelection {
+            path
+          }
         }
       }
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetChoosePartitionsDialog.fixtures.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetChoosePartitionsDialog.fixtures.tsx
@@ -1,6 +1,7 @@
 import {assetNodes} from './LaunchAssetLoaderQuery.fixtures';
+import {LaunchAssetChoosePartitionsDialogProps} from '../LaunchAssetChoosePartitionsDialog';
 
-export const ReleasesJobProps = {
+export const ReleasesJobProps: Omit<LaunchAssetChoosePartitionsDialogProps, 'open' | 'setOpen'> = {
   assets: assetNodes,
   upstreamAssetKeys: [],
   repoAddress: {
@@ -10,7 +11,6 @@ export const ReleasesJobProps = {
   target: {
     type: 'job' as const,
     jobName: '__ASSET_JOB_0',
-    partitionSetName: '__ASSET_JOB_0_partition_set',
+    assetKeys: [{path: ['asset_key_1']}],
   },
-  open: true,
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/LaunchAssetExecutionButton.fixtures.ts
@@ -21,8 +21,10 @@ import {
   buildMaterializationEvent,
   buildMode,
   buildPartitionDefinition,
-  buildPartitionSet,
-  buildPartitionSets,
+  buildPartitionRunConfig,
+  buildPartitionTags,
+  buildPartitionTagsAndConfig,
+  buildPipeline,
   buildRegularConfigType,
   buildRepository,
   buildRepositoryLocation,
@@ -32,8 +34,8 @@ import {
 } from '../../graphql/types';
 import {LAUNCH_PARTITION_BACKFILL_MUTATION} from '../../instance/backfill/BackfillUtils';
 import {LaunchPartitionBackfillMutation} from '../../instance/backfill/types/BackfillUtils.types';
-import {CONFIG_PARTITION_SELECTION_QUERY} from '../../launchpad/ConfigEditorConfigPicker';
-import {ConfigPartitionSelectionQuery} from '../../launchpad/types/ConfigEditorConfigPicker.types';
+import {CONFIG_PARTITION_FOR_ASSET_JOB_QUERY} from '../../launchpad/ConfigFetch';
+import {ConfigPartitionForAssetJobQuery} from '../../launchpad/types/ConfigFetch.types';
 import {LAUNCH_PIPELINE_EXECUTION_MUTATION} from '../../runs/RunUtils';
 import {
   LaunchPipelineExecutionMutation,
@@ -94,7 +96,7 @@ export const UNPARTITIONED_ASSET = buildAssetNode({
   dependencyKeys: [],
   dependedByKeys: [],
   graphName: null,
-  jobNames: ['__ASSET_JOB_7', 'my_asset_job'],
+  jobNames: ['__ASSET_JOB', 'my_asset_job'],
   opNames: ['unpartitioned_asset'],
   opVersion: null,
   description: null,
@@ -114,7 +116,7 @@ export const UNPARTITIONED_ASSET = buildAssetNode({
 export const CHECKED_ASSET = buildAssetNode({
   ...UNPARTITIONED_ASSET,
   id: 'test.py.repo.["checked_asset"]',
-  jobNames: ['__ASSET_JOB_7', 'checks_included_job', 'checks_excluded_job'],
+  jobNames: ['__ASSET_JOB', 'checks_included_job', 'checks_excluded_job'],
   assetKey: buildAssetKey({path: ['checked_asset']}),
   configField: BASE_CONFIG_TYPE_FIELD,
   assetChecksOrError: buildAssetChecks({
@@ -165,14 +167,14 @@ export const UNPARTITIONED_ASSET_WITH_REQUIRED_CONFIG = buildAssetNode({
 export const MULTI_ASSET_OUT_1 = buildAssetNode({
   ...UNPARTITIONED_ASSET,
   id: 'test.py.repo.["multi_asset_out_1"]',
-  jobNames: ['__ASSET_JOB_7'],
+  jobNames: ['__ASSET_JOB'],
   assetKey: buildAssetKey({path: ['multi_asset_out_1']}),
 });
 
 export const MULTI_ASSET_OUT_2 = buildAssetNode({
   ...UNPARTITIONED_ASSET,
   id: 'test.py.repo.["multi_asset_out_2"]',
-  jobNames: ['__ASSET_JOB_7'],
+  jobNames: ['__ASSET_JOB'],
   assetKey: buildAssetKey({path: ['multi_asset_out_2']}),
 });
 
@@ -189,7 +191,7 @@ export const ASSET_DAILY = buildAssetNode({
   dependencyKeys: [],
   dependedByKeys: [{__typename: 'AssetKey', path: ['asset_weekly']}],
   graphName: null,
-  jobNames: ['__ASSET_JOB_7', 'my_asset_job'],
+  jobNames: ['__ASSET_JOB', 'my_asset_job'],
   opNames: ['asset_daily'],
   opVersion: null,
   description: null,
@@ -442,7 +444,6 @@ export const buildLaunchAssetLoaderGenericJobMock = (jobName: string) => {
     result: {
       data: {
         __typename: 'Query',
-        partitionSetsOrError: buildPartitionSets({results: []}),
         pipelineOrError: {
           id: '8e2d3f9597c4a45bb52fe9ab5656419f4329d4fb',
           modes: [
@@ -463,7 +464,7 @@ export const LaunchAssetLoaderResourceJob7Mock: MockedResponse<LaunchAssetLoader
   request: {
     query: LAUNCH_ASSET_LOADER_RESOURCE_QUERY,
     variables: {
-      pipelineName: '__ASSET_JOB_7',
+      pipelineName: '__ASSET_JOB',
       repositoryLocationName: 'test.py',
       repositoryName: 'repo',
     },
@@ -471,15 +472,6 @@ export const LaunchAssetLoaderResourceJob7Mock: MockedResponse<LaunchAssetLoader
   result: {
     data: {
       __typename: 'Query',
-      partitionSetsOrError: {
-        results: [
-          buildPartitionSet({
-            id: '5b10aae97b738c48a4262b1eca530f89b13e9afc',
-            name: '__ASSET_JOB_7_partition_set',
-          }),
-        ],
-        __typename: 'PartitionSets',
-      },
       pipelineOrError: {
         id: '8e2d3f9597c4a45bb52fe9ab5656419f4329d4fb',
         modes: [
@@ -575,15 +567,6 @@ export const LaunchAssetLoaderResourceJob8Mock: MockedResponse<LaunchAssetLoader
   result: {
     data: {
       __typename: 'Query',
-      partitionSetsOrError: {
-        results: [
-          buildPartitionSet({
-            id: '129179973a9144278c2429d3ba680bf0f809a59b',
-            name: '__ASSET_JOB_8_partition_set',
-          }),
-        ],
-        __typename: 'PartitionSets',
-      },
       pipelineOrError: {
         id: '8689a9dcd052f769b73d73dfe57e89065dac369d',
         modes: [
@@ -680,15 +663,6 @@ export const LaunchAssetLoaderResourceMyAssetJobMock: MockedResponse<LaunchAsset
     result: {
       data: {
         __typename: 'Query',
-        partitionSetsOrError: {
-          results: [
-            buildPartitionSet({
-              id: '129179973a9144278c2429d3ba680bf0f809a59b',
-              name: 'my_asset_job_partition_set',
-            }),
-          ],
-          __typename: 'PartitionSets',
-        },
         pipelineOrError: {
           id: '8689a9dcd052f769b73d73dfe57e89065dac369d',
           modes: [
@@ -738,35 +712,30 @@ export const LaunchAssetCheckUpstreamWeeklyRootMock: MockedResponse<LaunchAssetC
 
 export function buildConfigPartitionSelectionLatestPartitionMock(
   partitionName: string,
-  partitionSetName: string,
-): MockedResponse<ConfigPartitionSelectionQuery> {
+  jobName: string,
+): MockedResponse<ConfigPartitionForAssetJobQuery> {
   return {
     request: {
-      query: CONFIG_PARTITION_SELECTION_QUERY,
+      query: CONFIG_PARTITION_FOR_ASSET_JOB_QUERY,
       variables: {
+        jobName,
         partitionName,
-        partitionSetName,
-        repositorySelector: {
-          repositoryLocationName: 'test.py',
-          repositoryName: 'repo',
-        },
+        repositoryLocationName: 'test.py',
+        repositoryName: 'repo',
+        assetKeys: [{path: ['asset_daily']}],
       },
     },
     result: {
       data: {
         __typename: 'Query',
-        partitionSetOrError: {
-          __typename: 'PartitionSet',
-          id: '5b10aae97b738c48a4262b1eca530f89b13e9afc',
-          partition: {
+        pipelineOrError: buildPipeline({
+          partition: buildPartitionTagsAndConfig({
             name: '2023-03-14',
-            solidSelection: null,
-            runConfigOrError: {
+            runConfigOrError: buildPartitionRunConfig({
               yaml: '{}\n',
               __typename: 'PartitionRunConfig',
-            },
-            mode: 'default',
-            tagsOrError: {
+            }),
+            tagsOrError: buildPartitionTags({
               results: [
                 {
                   key: 'dagster/partition',
@@ -775,15 +744,13 @@ export function buildConfigPartitionSelectionLatestPartitionMock(
                 },
                 {
                   key: 'dagster/partition_set',
-                  value: partitionSetName,
+                  value: `${jobName}_partition_set`,
                   __typename: 'PipelineTag',
                 },
               ],
-              __typename: 'PartitionTags',
-            },
-            __typename: 'Partition',
-          },
-        },
+            }),
+          }),
+        }),
       },
     },
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetChoosePartitionsDialog.test.tsx
@@ -102,8 +102,8 @@ describe('launchAssetChoosePartitionsDialog', () => {
               setOpen={(_open: boolean) => {}}
               repoAddress={buildRepoAddress('test', 'test')}
               target={{
-                jobName: '__ASSET_JOB_0',
-                partitionSetName: '__ASSET_JOB_0_partition_set',
+                jobName: '__ASSET_JOB',
+                assetKeys: [assetA.assetKey, assetB.assetKey],
                 type: 'job',
               }}
               assets={[assetA, assetB]}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/LaunchAssetExecutionButton.test.tsx
@@ -240,7 +240,7 @@ describe('LaunchAssetExecutionButton', () => {
         selector: {
           repositoryLocationName: 'test.py',
           repositoryName: 'repo',
-          pipelineName: '__ASSET_JOB_7',
+          pipelineName: '__ASSET_JOB',
           assetSelection: [{path: ['unpartitioned_asset']}],
           assetCheckSelection: [],
         },
@@ -375,7 +375,7 @@ describe('LaunchAssetExecutionButton', () => {
         executionMetadata: {
           tags: [
             {key: 'dagster/partition', value: '2023-02-22'},
-            {key: 'dagster/partition_set', value: '__ASSET_JOB_7_partition_set'},
+            {key: 'dagster/partition_set', value: '__ASSET_JOB_partition_set'},
           ],
         },
         mode: 'default',
@@ -383,7 +383,7 @@ describe('LaunchAssetExecutionButton', () => {
         selector: {
           assetSelection: [{path: ['asset_daily']}],
           assetCheckSelection: [],
-          pipelineName: '__ASSET_JOB_7',
+          pipelineName: '__ASSET_JOB',
           repositoryLocationName: 'test.py',
           repositoryName: 'repo',
         },
@@ -593,7 +593,7 @@ describe('LaunchAssetExecutionButton', () => {
         selector: {
           repositoryLocationName: 'test.py',
           repositoryName: 'repo',
-          pipelineName: '__ASSET_JOB_7',
+          pipelineName: '__ASSET_JOB',
           assetSelection: [
             asAssetKeyInput(MULTI_ASSET_OUT_1.assetKey),
             asAssetKeyInput(MULTI_ASSET_OUT_2.assetKey),
@@ -644,9 +644,9 @@ function renderButton({
     LaunchAssetCheckUpstreamWeeklyRootMock,
     ...PartitionHealthAssetMocks,
     buildLaunchAssetWarningsMock([]),
-    buildConfigPartitionSelectionLatestPartitionMock('2020-01-02', 'my_asset_job_partition_set'),
-    buildConfigPartitionSelectionLatestPartitionMock('2023-02-22', 'my_asset_job_partition_set'),
-    buildConfigPartitionSelectionLatestPartitionMock('2023-02-22', '__ASSET_JOB_7_partition_set'),
+    buildConfigPartitionSelectionLatestPartitionMock('2020-01-02', 'my_asset_job'),
+    buildConfigPartitionSelectionLatestPartitionMock('2023-02-22', 'my_asset_job'),
+    buildConfigPartitionSelectionLatestPartitionMock('2023-02-22', '__ASSET_JOB'),
     buildLaunchAssetLoaderMock([MULTI_ASSET_OUT_1.assetKey], {
       assetNodeAdditionalRequiredKeys: [MULTI_ASSET_OUT_2.assetKey],
     }),

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/LaunchAssetExecutionButton.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/LaunchAssetExecutionButton.types.ts
@@ -1871,13 +1871,6 @@ export type LaunchAssetLoaderResourceQueryVariables = Types.Exact<{
 
 export type LaunchAssetLoaderResourceQuery = {
   __typename: 'Query';
-  partitionSetsOrError:
-    | {
-        __typename: 'PartitionSets';
-        results: Array<{__typename: 'PartitionSet'; id: string; name: string}>;
-      }
-    | {__typename: 'PipelineNotFoundError'; message: string}
-    | {__typename: 'PythonError'; message: string};
   pipelineOrError:
     | {__typename: 'InvalidSubsetError'; message: string}
     | {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/RunningBackfillsNotice.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/RunningBackfillsNotice.types.ts
@@ -13,6 +13,7 @@ export type RunningBackfillsNoticeQuery = {
           __typename: 'PartitionBackfill';
           id: string;
           partitionSetName: string | null;
+          assetSelection: Array<{__typename: 'AssetKey'; path: Array<string>}> | null;
         }>;
       }
     | {__typename: 'PythonError'};

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -1076,6 +1076,24 @@ type Pipeline implements SolidContainer & IPipelineSnapshot {
   isJob: Boolean!
   isAssetJob: Boolean!
   repository: Repository!
+  partitionKeysOrError(
+    cursor: String
+    limit: Int
+    reverse: Boolean
+    selectedAssetKeys: [AssetKeyInput!]
+  ): PartitionKeys!
+  partition(partitionName: String!, selectedAssetKeys: [AssetKeyInput!]): PartitionTagsAndConfig
+}
+
+type PartitionKeys {
+  partitionKeys: [String!]!
+}
+
+type PartitionTagsAndConfig {
+  name: String!
+  jobName: String!
+  runConfigOrError: PartitionRunConfigOrError!
+  tagsOrError: PartitionTagsOrError!
 }
 
 interface PipelineConfigValidationError {
@@ -2125,6 +2143,13 @@ type Job implements SolidContainer & IPipelineSnapshot {
   isJob: Boolean!
   isAssetJob: Boolean!
   repository: Repository!
+  partitionKeysOrError(
+    cursor: String
+    limit: Int
+    reverse: Boolean
+    selectedAssetKeys: [AssetKeyInput!]
+  ): PartitionKeys!
+  partition(partitionName: String!, selectedAssetKeys: [AssetKeyInput!]): PartitionTagsAndConfig
 }
 
 enum SensorType {
@@ -3507,10 +3532,6 @@ type AutoMaterializeRuleEvaluation {
 }
 
 union PartitionKeysOrError = PartitionKeys | PartitionSubsetDeserializationError
-
-type PartitionKeys {
-  partitionKeys: [String!]!
-}
 
 type PartitionSubsetDeserializationError implements Error {
   message: String!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2074,6 +2074,8 @@ export type Job = IPipelineSnapshot &
     modes: Array<Mode>;
     name: Scalars['String']['output'];
     parentSnapshotId: Maybe<Scalars['String']['output']>;
+    partition: Maybe<PartitionTagsAndConfig>;
+    partitionKeysOrError: PartitionKeys;
     pipelineSnapshotId: Scalars['String']['output'];
     presets: Array<PipelinePreset>;
     repository: Repository;
@@ -2088,6 +2090,18 @@ export type Job = IPipelineSnapshot &
 
 export type JobDagsterTypeOrErrorArgs = {
   dagsterTypeName: Scalars['String']['input'];
+};
+
+export type JobPartitionArgs = {
+  partitionName: Scalars['String']['input'];
+  selectedAssetKeys?: InputMaybe<Array<AssetKeyInput>>;
+};
+
+export type JobPartitionKeysOrErrorArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  reverse?: InputMaybe<Scalars['Boolean']['input']>;
+  selectedAssetKeys?: InputMaybe<Array<AssetKeyInput>>;
 };
 
 export type JobRunsArgs = {
@@ -3262,6 +3276,14 @@ export type PartitionTags = {
   results: Array<PipelineTag>;
 };
 
+export type PartitionTagsAndConfig = {
+  __typename: 'PartitionTagsAndConfig';
+  jobName: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  runConfigOrError: PartitionRunConfigOrError;
+  tagsOrError: PartitionTagsOrError;
+};
+
 export type PartitionTagsOrError = PartitionTags | PythonError;
 
 export type PartitionedAssetConditionEvaluationNode = {
@@ -3348,6 +3370,8 @@ export type Pipeline = IPipelineSnapshot &
     modes: Array<Mode>;
     name: Scalars['String']['output'];
     parentSnapshotId: Maybe<Scalars['String']['output']>;
+    partition: Maybe<PartitionTagsAndConfig>;
+    partitionKeysOrError: PartitionKeys;
     pipelineSnapshotId: Scalars['String']['output'];
     presets: Array<PipelinePreset>;
     repository: Repository;
@@ -3362,6 +3386,18 @@ export type Pipeline = IPipelineSnapshot &
 
 export type PipelineDagsterTypeOrErrorArgs = {
   dagsterTypeName: Scalars['String']['input'];
+};
+
+export type PipelinePartitionArgs = {
+  partitionName: Scalars['String']['input'];
+  selectedAssetKeys?: InputMaybe<Array<AssetKeyInput>>;
+};
+
+export type PipelinePartitionKeysOrErrorArgs = {
+  cursor?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  reverse?: InputMaybe<Scalars['Boolean']['input']>;
+  selectedAssetKeys?: InputMaybe<Array<AssetKeyInput>>;
 };
 
 export type PipelineRunsArgs = {
@@ -9054,6 +9090,18 @@ export const buildJob = (
       overrides && overrides.hasOwnProperty('parentSnapshotId')
         ? overrides.parentSnapshotId!
         : 'tempore',
+    partition:
+      overrides && overrides.hasOwnProperty('partition')
+        ? overrides.partition!
+        : relationshipsToOmit.has('PartitionTagsAndConfig')
+        ? ({} as PartitionTagsAndConfig)
+        : buildPartitionTagsAndConfig({}, relationshipsToOmit),
+    partitionKeysOrError:
+      overrides && overrides.hasOwnProperty('partitionKeysOrError')
+        ? overrides.partitionKeysOrError!
+        : relationshipsToOmit.has('PartitionKeys')
+        ? ({} as PartitionKeys)
+        : buildPartitionKeys({}, relationshipsToOmit),
     pipelineSnapshotId:
       overrides && overrides.hasOwnProperty('pipelineSnapshotId')
         ? overrides.pipelineSnapshotId!
@@ -11040,6 +11088,31 @@ export const buildPartitionTags = (
   };
 };
 
+export const buildPartitionTagsAndConfig = (
+  overrides?: Partial<PartitionTagsAndConfig>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'PartitionTagsAndConfig'} & PartitionTagsAndConfig => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('PartitionTagsAndConfig');
+  return {
+    __typename: 'PartitionTagsAndConfig',
+    jobName: overrides && overrides.hasOwnProperty('jobName') ? overrides.jobName! : 'quia',
+    name: overrides && overrides.hasOwnProperty('name') ? overrides.name! : 'eaque',
+    runConfigOrError:
+      overrides && overrides.hasOwnProperty('runConfigOrError')
+        ? overrides.runConfigOrError!
+        : relationshipsToOmit.has('PartitionRunConfig')
+        ? ({} as PartitionRunConfig)
+        : buildPartitionRunConfig({}, relationshipsToOmit),
+    tagsOrError:
+      overrides && overrides.hasOwnProperty('tagsOrError')
+        ? overrides.tagsOrError!
+        : relationshipsToOmit.has('PartitionTags')
+        ? ({} as PartitionTags)
+        : buildPartitionTags({}, relationshipsToOmit),
+  };
+};
+
 export const buildPartitionedAssetConditionEvaluationNode = (
   overrides?: Partial<PartitionedAssetConditionEvaluationNode>,
   _relationshipsToOmit: Set<string> = new Set(),
@@ -11201,6 +11274,18 @@ export const buildPipeline = (
       overrides && overrides.hasOwnProperty('parentSnapshotId')
         ? overrides.parentSnapshotId!
         : 'et',
+    partition:
+      overrides && overrides.hasOwnProperty('partition')
+        ? overrides.partition!
+        : relationshipsToOmit.has('PartitionTagsAndConfig')
+        ? ({} as PartitionTagsAndConfig)
+        : buildPartitionTagsAndConfig({}, relationshipsToOmit),
+    partitionKeysOrError:
+      overrides && overrides.hasOwnProperty('partitionKeysOrError')
+        ? overrides.partitionKeysOrError!
+        : relationshipsToOmit.has('PartitionKeys')
+        ? ({} as PartitionKeys)
+        : buildPartitionKeys({}, relationshipsToOmit),
     pipelineSnapshotId:
       overrides && overrides.hasOwnProperty('pipelineSnapshotId')
         ? overrides.pipelineSnapshotId!

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -105,6 +105,7 @@ export const ConfigEditorConfigPicker = (props: ConfigEditorConfigPickerProps) =
       onSaveSession({
         mode: item.mode,
         base: {
+          type: 'op-job-partition-set',
           partitionsSetName: item.name,
           partitionName: null,
           tags: base ? base.tags : null,

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -20,7 +20,6 @@ import styled from 'styled-components';
 import {
   ConfigEditorGeneratorPipelineFragment,
   ConfigEditorPipelinePresetFragment,
-  ConfigPartitionResultFragment,
   ConfigPartitionsAssetsQuery,
   ConfigPartitionsAssetsQueryVariables,
   ConfigPartitionsQuery,
@@ -44,7 +43,6 @@ import {RepoAddress} from '../workspace/types';
 type Pipeline = ConfigEditorGeneratorPipelineFragment;
 type Preset = ConfigEditorPipelinePresetFragment;
 type PartitionSet = PartitionSetForConfigEditorFragment;
-type Partition = ConfigPartitionResultFragment;
 type ConfigGenerator = Preset | PartitionSet;
 
 interface ConfigEditorConfigPickerProps {

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigEditorConfigPicker.tsx
@@ -21,6 +21,8 @@ import {
   ConfigEditorGeneratorPipelineFragment,
   ConfigEditorPipelinePresetFragment,
   ConfigPartitionResultFragment,
+  ConfigPartitionsAssetsQuery,
+  ConfigPartitionsAssetsQueryVariables,
   ConfigPartitionsQuery,
   ConfigPartitionsQueryVariables,
   PartitionSetForConfigEditorFragment,
@@ -94,8 +96,10 @@ export const ConfigEditorConfigPicker = (props: ConfigEditorConfigPickerProps) =
     if ('presetName' in base) {
       return `Preset: ${base.presetName}`;
     }
-
-    return `Partition Set: ${base.partitionsSetName}`;
+    if ('partitionsSetName' in base) {
+      return `Partition Set: ${base.partitionsSetName}`;
+    }
+    return `Partitions`;
   };
 
   const onSelect = (item: ConfigGenerator) => {
@@ -122,10 +126,10 @@ export const ConfigEditorConfigPicker = (props: ConfigEditorConfigPickerProps) =
           onSelect={onSelect}
         />
       )}
-      {base && 'partitionsSetName' in base ? (
+      {base && 'partitionName' in base ? (
         <ConfigEditorPartitionPicker
           pipeline={pipeline}
-          partitionSetName={base.partitionsSetName}
+          partitionSetName={'partitionsSetName' in base ? base.partitionsSetName : ''}
           value={base.partitionName}
           onSelect={onSelectPartition}
           repoAddress={repoAddress}
@@ -157,19 +161,33 @@ const ConfigEditorPartitionPicker = React.memo((props: ConfigEditorPartitionPick
   const {basePath} = React.useContext(AppContext);
   const repositorySelector = repoAddressToSelector(repoAddress);
 
-  const queryResult = useQuery<ConfigPartitionsQuery, ConfigPartitionsQueryVariables>(
+  const queryResultNoAssets = useQuery<ConfigPartitionsQuery, ConfigPartitionsQueryVariables>(
     CONFIG_PARTITIONS_QUERY,
     {
-      variables: {
-        repositorySelector,
-        partitionSetName,
-        assetKeys: assetSelection
-          ? assetSelection.map((selection) => ({path: selection.assetKey.path}))
-          : [],
-      },
+      skip: !!assetSelection,
+      variables: {repositorySelector, partitionSetName},
       fetchPolicy: 'network-only',
     },
   );
+
+  const queryResultAssets = useQuery<
+    ConfigPartitionsAssetsQuery,
+    ConfigPartitionsAssetsQueryVariables
+  >(CONFIG_PARTITIONS_ASSETS_QUERY, {
+    skip: !assetSelection,
+    variables: {
+      params: {
+        ...repositorySelector,
+        pipelineName: props.pipeline.name,
+      },
+      assetKeys: assetSelection
+        ? assetSelection.map((selection) => ({path: selection.assetKey.path}))
+        : [],
+    },
+    fetchPolicy: 'network-only',
+  });
+
+  const queryResult = assetSelection ? queryResultAssets : queryResultNoAssets;
   const {data, refetch, loading} = queryResult;
   useBlockTraceOnQueryResult(queryResult, 'ConfigPartitionsQuery');
 
@@ -182,26 +200,18 @@ const ConfigEditorPartitionPicker = React.memo((props: ConfigEditorPartitionPick
   );
 
   const doesAnyAssetHavePartitions = React.useMemo(
-    () => data?.assetNodes?.some((node) => !!node.partitionDefinition),
+    () =>
+      data && 'assetNodes' in data && data.assetNodes?.some((node) => !!node.partitionDefinition),
     [data],
   );
 
-  const partitions: Partition[] = React.useMemo(() => {
-    const retrieved =
-      data?.partitionSetOrError.__typename === 'PartitionSet' &&
-      data?.partitionSetOrError.partitionsOrError.__typename === 'Partitions'
-        ? data.partitionSetOrError.partitionsOrError.results
-        : [];
+  const partitions: string[] = React.useMemo(() => {
+    const retrieved = partitionKeysFromData(data);
     return sortOrder === 'asc' ? retrieved : [...retrieved].reverse();
   }, [data, sortOrder]);
 
-  const error =
-    data?.partitionSetOrError.__typename === 'PartitionSet' &&
-    data?.partitionSetOrError.partitionsOrError.__typename !== 'Partitions'
-      ? data.partitionSetOrError.partitionsOrError
-      : null;
-
-  const selected = partitions.find((p) => p.name === value);
+  const error = errorFromData(data);
+  const selected = value && partitions.includes(value) ? value : undefined;
 
   const onClickSort = React.useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -225,7 +235,7 @@ const ConfigEditorPartitionPicker = React.memo((props: ConfigEditorPartitionPick
   };
 
   const {isDynamicPartition, dynamicPartitionsDefinitionName} = React.useMemo(() => {
-    const assetNodes = data?.assetNodes;
+    const assetNodes = data && 'assetNodes' in data ? data?.assetNodes : undefined;
     const definition = assetNodes?.find((a) => !!a.partitionDefinition)?.partitionDefinition;
     if (
       !definition ||
@@ -240,7 +250,7 @@ const ConfigEditorPartitionPicker = React.memo((props: ConfigEditorPartitionPick
       isDynamicPartition: definition.type === PartitionDefinitionType.DYNAMIC,
       dynamicPartitionsDefinitionName: definition.name,
     };
-  }, [data?.assetNodes]);
+  }, [data]);
 
   const [showCreatePartition, setShowCreatePartition] = React.useState(false);
 
@@ -289,24 +299,24 @@ const ConfigEditorPartitionPicker = React.memo((props: ConfigEditorPartitionPick
   // and ensure it is re-applied to the internal state when it changes (via `key` below).
   return (
     <>
-      <Suggest<Partition>
-        key={selected ? selected.name : 'none'}
+      <Suggest<string>
+        key={selected ? selected : 'none'}
         defaultSelectedItem={selected}
         items={partitions}
         inputProps={inputProps}
-        inputValueRenderer={(partition) => partition.name}
-        itemPredicate={(query, partition) => query.length === 0 || partition.name.includes(query)}
+        inputValueRenderer={(partition) => partition}
+        itemPredicate={(query, partition) => query.length === 0 || partition.includes(query)}
         itemRenderer={(partition, props) => (
           <MenuItem
             active={props.modifiers.active}
             onClick={props.handleClick}
-            key={partition.name}
-            text={partition.name}
+            key={partition}
+            text={partition}
           />
         )}
         noResults={<MenuItem disabled={true} text="No presets." />}
         onItemSelect={(item) => {
-          onSelect(repositorySelector, partitionSetName, item.name);
+          onSelect(repositorySelector, partitionSetName, item);
         }}
       />
       {isDynamicPartition ? (
@@ -457,7 +467,6 @@ const CONFIG_PARTITIONS_QUERY = gql`
   query ConfigPartitionsQuery(
     $repositorySelector: RepositorySelector!
     $partitionSetName: String!
-    $assetKeys: [AssetKeyInput!]
   ) {
     partitionSetOrError(
       repositorySelector: $repositorySelector
@@ -475,13 +484,6 @@ const CONFIG_PARTITIONS_QUERY = gql`
         }
       }
     }
-    assetNodes(assetKeys: $assetKeys) {
-      id
-      partitionDefinition {
-        name
-        type
-      }
-    }
   }
 
   fragment ConfigPartitionResult on Partition {
@@ -491,38 +493,30 @@ const CONFIG_PARTITIONS_QUERY = gql`
   ${PYTHON_ERROR_FRAGMENT}
 `;
 
-export const CONFIG_PARTITION_SELECTION_QUERY = gql`
-  query ConfigPartitionSelectionQuery(
-    $repositorySelector: RepositorySelector!
-    $partitionSetName: String!
-    $partitionName: String!
-  ) {
-    partitionSetOrError(
-      repositorySelector: $repositorySelector
-      partitionSetName: $partitionSetName
-    ) {
-      ... on PartitionSet {
+const CONFIG_PARTITIONS_ASSETS_QUERY = gql`
+  query ConfigPartitionsAssetsQuery($params: PipelineSelector!, $assetKeys: [AssetKeyInput!]) {
+    pipelineOrError(params: $params) {
+      ...PythonErrorFragment
+      ... on PipelineNotFoundError {
+        message
+      }
+      ... on InvalidSubsetError {
+        message
+      }
+      ... on Pipeline {
         id
-        partition(partitionName: $partitionName) {
-          name
-          solidSelection
-          runConfigOrError {
-            ... on PartitionRunConfig {
-              yaml
-            }
-            ...PythonErrorFragment
-          }
-          mode
-          tagsOrError {
-            ... on PartitionTags {
-              results {
-                key
-                value
-              }
-            }
-            ...PythonErrorFragment
+        partitionKeysOrError(selectedAssetKeys: $assetKeys) {
+          ... on PartitionKeys {
+            partitionKeys
           }
         }
+      }
+    }
+    assetNodes(assetKeys: $assetKeys) {
+      id
+      partitionDefinition {
+        name
+        type
       }
     }
   }
@@ -571,3 +565,44 @@ export const CONFIG_EDITOR_GENERATOR_PARTITION_SETS_FRAGMENT = gql`
     solidSelection
   }
 `;
+
+function partitionKeysFromData(
+  data: ConfigPartitionsAssetsQuery | ConfigPartitionsQuery | undefined,
+) {
+  if (!data) {
+    return [];
+  }
+
+  if (
+    'partitionSetOrError' in data &&
+    data.partitionSetOrError.__typename === 'PartitionSet' &&
+    data.partitionSetOrError.partitionsOrError.__typename === 'Partitions'
+  ) {
+    return data.partitionSetOrError.partitionsOrError.results.map((a) => a.name);
+  }
+  if ('pipelineOrError' in data && data.pipelineOrError.__typename === 'Pipeline') {
+    return data.pipelineOrError.partitionKeysOrError.partitionKeys;
+  }
+  return [];
+}
+
+function errorFromData(data: ConfigPartitionsAssetsQuery | ConfigPartitionsQuery | undefined) {
+  if (!data) {
+    return null;
+  }
+  if (
+    'partitionSetOrError' in data &&
+    data.partitionSetOrError.__typename === 'PartitionSet' &&
+    data.partitionSetOrError.partitionsOrError.__typename !== 'Partitions'
+  ) {
+    return data.partitionSetOrError.partitionsOrError;
+  }
+  if (
+    'pipelineOrError' in data &&
+    data.pipelineOrError &&
+    data.pipelineOrError.__typename !== 'Pipeline'
+  ) {
+    return data.pipelineOrError;
+  }
+  return null;
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigFetch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/ConfigFetch.tsx
@@ -1,0 +1,185 @@
+import {ApolloClient, gql} from '@apollo/client';
+
+import {
+  ConfigPartitionForAssetJobQuery,
+  ConfigPartitionForAssetJobQueryVariables,
+  ConfigPartitionSelectionQuery,
+  ConfigPartitionSelectionQueryVariables,
+} from './types/ConfigFetch.types';
+import {showCustomAlert} from '../app/CustomAlertProvider';
+import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
+import {PythonErrorInfo} from '../app/PythonErrorInfo';
+
+export async function fetchTagsAndConfigForJob(
+  client: ApolloClient<any>,
+  variables: ConfigPartitionSelectionQueryVariables,
+) {
+  const {data} = await client.query<
+    ConfigPartitionSelectionQuery,
+    ConfigPartitionSelectionQueryVariables
+  >({
+    query: CONFIG_PARTITION_SELECTION_QUERY,
+    variables,
+  });
+
+  if (
+    !data ||
+    !data.partitionSetOrError ||
+    data.partitionSetOrError.__typename !== 'PartitionSet' ||
+    !data.partitionSetOrError.partition
+  ) {
+    return;
+  }
+
+  const {partition} = data.partitionSetOrError;
+
+  if (partition.tagsOrError.__typename === 'PythonError') {
+    showCustomAlert({
+      title: 'Unable to load tags',
+      body: <PythonErrorInfo error={partition.tagsOrError} />,
+    });
+    return;
+  }
+  if (partition.runConfigOrError.__typename === 'PythonError') {
+    showCustomAlert({
+      title: 'Unable to load tags',
+      body: <PythonErrorInfo error={partition.runConfigOrError} />,
+    });
+    return;
+  }
+
+  return {
+    yaml: partition.runConfigOrError.yaml,
+    tags: partition.tagsOrError.results.map((t) => ({key: t.key, value: t.value})),
+    solidSelection: partition.solidSelection,
+    mode: partition.mode,
+  };
+}
+
+export async function fetchTagsAndConfigForAssetJob(
+  client: ApolloClient<any>,
+  variables: ConfigPartitionForAssetJobQueryVariables,
+) {
+  const {data: tagAndConfigData} = await client.query<
+    ConfigPartitionForAssetJobQuery,
+    ConfigPartitionForAssetJobQueryVariables
+  >({
+    query: CONFIG_PARTITION_FOR_ASSET_JOB_QUERY,
+    fetchPolicy: 'network-only',
+    variables,
+  });
+
+  if (
+    !tagAndConfigData ||
+    !tagAndConfigData.pipelineOrError ||
+    tagAndConfigData.pipelineOrError.__typename !== 'Pipeline' ||
+    !tagAndConfigData.pipelineOrError.partition
+  ) {
+    return;
+  }
+
+  const {partition} = tagAndConfigData.pipelineOrError;
+
+  if (partition.tagsOrError.__typename === 'PythonError') {
+    showCustomAlert({
+      title: 'Unable to load tags',
+      body: <PythonErrorInfo error={partition.tagsOrError} />,
+    });
+    return;
+  }
+  if (partition.runConfigOrError.__typename === 'PythonError') {
+    showCustomAlert({
+      title: 'Unable to load tags',
+      body: <PythonErrorInfo error={partition.runConfigOrError} />,
+    });
+    return;
+  }
+
+  return {
+    yaml: partition.runConfigOrError.yaml,
+    tags: partition.tagsOrError.results.map((t) => ({key: t.key, value: t.value})),
+    solidSelection: null,
+    mode: null,
+  };
+}
+
+export const CONFIG_PARTITION_FOR_ASSET_JOB_QUERY = gql`
+  query ConfigPartitionForAssetJobQuery(
+    $repositoryName: String!
+    $repositoryLocationName: String!
+    $jobName: String!
+    $partitionName: String!
+    $assetKeys: [AssetKeyInput!]!
+  ) {
+    pipelineOrError(
+      params: {
+        pipelineName: $jobName
+        repositoryName: $repositoryName
+        repositoryLocationName: $repositoryLocationName
+      }
+    ) {
+      ... on Pipeline {
+        id
+        partition(partitionName: $partitionName, selectedAssetKeys: $assetKeys) {
+          name
+          runConfigOrError {
+            ... on PartitionRunConfig {
+              yaml
+            }
+            ...PythonErrorFragment
+          }
+          tagsOrError {
+            ... on PartitionTags {
+              results {
+                key
+                value
+              }
+            }
+            ...PythonErrorFragment
+          }
+        }
+      }
+    }
+  }
+
+  ${PYTHON_ERROR_FRAGMENT}
+`;
+
+export const CONFIG_PARTITION_SELECTION_QUERY = gql`
+  query ConfigPartitionSelectionQuery(
+    $repositorySelector: RepositorySelector!
+    $partitionSetName: String!
+    $partitionName: String!
+  ) {
+    partitionSetOrError(
+      repositorySelector: $repositorySelector
+      partitionSetName: $partitionSetName
+    ) {
+      ... on PartitionSet {
+        id
+        partition(partitionName: $partitionName) {
+          name
+          solidSelection
+          runConfigOrError {
+            ... on PartitionRunConfig {
+              yaml
+            }
+            ...PythonErrorFragment
+          }
+          mode
+          tagsOrError {
+            ... on PartitionTags {
+              results {
+                key
+                value
+              }
+            }
+            ...PythonErrorFragment
+          }
+        }
+      }
+    }
+  }
+
+  ${PYTHON_ERROR_FRAGMENT}
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
@@ -447,7 +447,7 @@ const LaunchpadSession = (props: LaunchpadSessionProps) => {
     const newBaseTags = preset.tags.map(onlyKeyAndValue);
 
     onSaveSession({
-      base: {presetName: preset.name, tags: newBaseTags},
+      base: {type: 'preset', presetName: preset.name, tags: newBaseTags},
       name: preset.name,
       runConfigYaml: preset.runConfigYaml || '',
       solidSelection: preset.solidSelection,

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
@@ -559,9 +559,7 @@ const LaunchpadSession = (props: LaunchpadSessionProps) => {
     if (
       base &&
       needsRefresh &&
-      ('presetName' in base ||
-        ('partitionsSetName' in base && base.partitionsSetName && base.partitionName) ||
-        ('assetKeys' in base && base.assetKeys && base.partitionName))
+      ('presetName' in base || ('partitionName' in base && base.partitionName))
     ) {
       return base;
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
@@ -24,11 +24,9 @@ import * as React from 'react';
 import styled from 'styled-components';
 import * as yaml from 'yaml';
 
-import {
-  CONFIG_PARTITION_SELECTION_QUERY,
-  ConfigEditorConfigPicker,
-} from './ConfigEditorConfigPicker';
+import {ConfigEditorConfigPicker} from './ConfigEditorConfigPicker';
 import {ConfigEditorModePicker} from './ConfigEditorModePicker';
+import {fetchTagsAndConfigForAssetJob, fetchTagsAndConfigForJob} from './ConfigFetch';
 import {LaunchpadConfigExpansionButton} from './LaunchpadConfigExpansionButton';
 import {useLaunchPadHooks} from './LaunchpadHooksContext';
 import {LoadingOverlay} from './LoadingOverlay';
@@ -38,11 +36,7 @@ import {SessionSettingsBar} from './SessionSettingsBar';
 import {TagContainer, TagEditor} from './TagEditor';
 import {scaffoldPipelineConfig} from './scaffoldType';
 import {LaunchpadType} from './types';
-import {
-  ConfigEditorPipelinePresetFragment,
-  ConfigPartitionSelectionQuery,
-  ConfigPartitionSelectionQueryVariables,
-} from './types/ConfigEditorConfigPicker.types';
+import {ConfigEditorPipelinePresetFragment} from './types/ConfigEditorConfigPicker.types';
 import {
   LaunchpadSessionPartitionSetsFragment,
   LaunchpadSessionPipelineFragment,
@@ -62,7 +56,6 @@ import {
   SessionBase,
 } from '../app/ExecutionSessionStorage';
 import {usePermissionsForLocation} from '../app/Permissions';
-import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {ShortcutHandler} from '../app/ShortcutHandler';
 import {displayNameForAssetKey, tokenForAssetKey} from '../asset-graph/Utils';
 import {asAssetCheckHandleInput, asAssetKeyInput} from '../assets/asInput';
@@ -474,55 +467,35 @@ const LaunchpadSession = (props: LaunchpadSessionProps) => {
     onConfigLoading();
     try {
       const {base} = currentSession;
-      const {data} = await client.query<
-        ConfigPartitionSelectionQuery,
-        ConfigPartitionSelectionQueryVariables
-      >({
-        query: CONFIG_PARTITION_SELECTION_QUERY,
-        variables: {repositorySelector, partitionSetName, partitionName},
-      });
 
-      if (
-        !data ||
-        !data.partitionSetOrError ||
-        data.partitionSetOrError.__typename !== 'PartitionSet' ||
-        !data.partitionSetOrError.partition
-      ) {
+      const resp = props.session.assetSelection
+        ? await fetchTagsAndConfigForAssetJob(client, {
+            ...repositorySelector,
+            jobName: pipeline.name,
+            assetKeys: props.session.assetSelection.map(asAssetKeyInput),
+            partitionName,
+          })
+        : await fetchTagsAndConfigForJob(client, {
+            repositorySelector,
+            partitionSetName,
+            partitionName,
+          });
+
+      if (!resp) {
         onConfigLoaded();
         return;
       }
 
-      const {partition} = data.partitionSetOrError;
-
-      let newBaseTags: {key: string; value: string}[] = [];
-      if (partition.tagsOrError.__typename === 'PythonError') {
-        showCustomAlert({
-          body: <PythonErrorInfo error={partition.tagsOrError} />,
-        });
-      } else {
-        newBaseTags = partition.tagsOrError.results.map(onlyKeyAndValue);
-      }
-
-      let runConfigYaml;
-      if (partition.runConfigOrError.__typename === 'PythonError') {
-        runConfigYaml = '';
-        showCustomAlert({
-          body: <PythonErrorInfo error={partition.runConfigOrError} />,
-        });
-      } else {
-        runConfigYaml = mergeYaml(currentSession.runConfigYaml, partition.runConfigOrError.yaml);
-      }
-
-      const solidSelection = sessionSolidSelection || partition.solidSelection;
+      const solidSelection = sessionSolidSelection || resp.solidSelection;
 
       onSaveSession({
-        name: partition.name,
-        base: Object.assign({}, base, {partitionName: partition.name, tags: newBaseTags}),
-        runConfigYaml,
+        name: partitionName,
+        base: Object.assign({}, base, {partitionName, tags: resp.tags}),
+        runConfigYaml: mergeYaml(currentSession.runConfigYaml, resp.yaml),
         solidSelection,
         solidSelectionQuery: solidSelection === null ? '*' : solidSelection.join(','),
-        mode: partition.mode,
-        tags: tagsApplyingNewBaseTags(newBaseTags),
+        mode: resp.mode,
+        tags: tagsApplyingNewBaseTags(resp.tags),
         needsRefresh: false,
       });
     } catch {}
@@ -544,17 +517,16 @@ const LaunchpadSession = (props: LaunchpadSessionProps) => {
     }
 
     // Otherwise, handle partition-based configuration.
-    const {partitionName, partitionsSetName} = base;
     const repositorySelector = repoAddressToSelector(repoAddress);
 
     // It is expected that `partitionName` is set here, since we shouldn't be showing the
     // button at all otherwise.
-    if (partitionName) {
+    if (base.partitionName) {
       onConfigLoading();
       await onSelectPartition(
         repositorySelector,
-        partitionsSetName,
-        partitionName,
+        'partitionsSetName' in base ? base.partitionsSetName : '',
+        base.partitionName,
         currentSession.solidSelection,
       );
       onConfigLoaded();
@@ -587,7 +559,9 @@ const LaunchpadSession = (props: LaunchpadSessionProps) => {
     if (
       base &&
       needsRefresh &&
-      ('presetName' in base || (base.partitionsSetName && base.partitionName))
+      ('presetName' in base ||
+        ('partitionsSetName' in base && base.partitionsSetName && base.partitionName) ||
+        ('assetKeys' in base && base.assetKeys && base.partitionName))
     ) {
       return base;
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/ConfigEditorConfigPicker.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/ConfigEditorConfigPicker.types.ts
@@ -5,7 +5,6 @@ import * as Types from '../../graphql/types';
 export type ConfigPartitionsQueryVariables = Types.Exact<{
   repositorySelector: Types.RepositorySelector;
   partitionSetName: Types.Scalars['String']['input'];
-  assetKeys?: Types.InputMaybe<Array<Types.AssetKeyInput> | Types.AssetKeyInput>;
 }>;
 
 export type ConfigPartitionsQuery = {
@@ -29,6 +28,35 @@ export type ConfigPartitionsQuery = {
       }
     | {__typename: 'PartitionSetNotFoundError'}
     | {__typename: 'PythonError'};
+};
+
+export type ConfigPartitionResultFragment = {__typename: 'Partition'; name: string};
+
+export type ConfigPartitionsAssetsQueryVariables = Types.Exact<{
+  params: Types.PipelineSelector;
+  assetKeys?: Types.InputMaybe<Array<Types.AssetKeyInput> | Types.AssetKeyInput>;
+}>;
+
+export type ConfigPartitionsAssetsQuery = {
+  __typename: 'Query';
+  pipelineOrError:
+    | {__typename: 'InvalidSubsetError'; message: string}
+    | {
+        __typename: 'Pipeline';
+        id: string;
+        partitionKeysOrError: {__typename: 'PartitionKeys'; partitionKeys: Array<string>};
+      }
+    | {__typename: 'PipelineNotFoundError'; message: string}
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      };
   assetNodes: Array<{
     __typename: 'AssetNode';
     id: string;
@@ -38,58 +66,6 @@ export type ConfigPartitionsQuery = {
       type: Types.PartitionDefinitionType;
     } | null;
   }>;
-};
-
-export type ConfigPartitionResultFragment = {__typename: 'Partition'; name: string};
-
-export type ConfigPartitionSelectionQueryVariables = Types.Exact<{
-  repositorySelector: Types.RepositorySelector;
-  partitionSetName: Types.Scalars['String']['input'];
-  partitionName: Types.Scalars['String']['input'];
-}>;
-
-export type ConfigPartitionSelectionQuery = {
-  __typename: 'Query';
-  partitionSetOrError:
-    | {
-        __typename: 'PartitionSet';
-        id: string;
-        partition: {
-          __typename: 'Partition';
-          name: string;
-          solidSelection: Array<string> | null;
-          mode: string;
-          runConfigOrError:
-            | {__typename: 'PartitionRunConfig'; yaml: string}
-            | {
-                __typename: 'PythonError';
-                message: string;
-                stack: Array<string>;
-                errorChain: Array<{
-                  __typename: 'ErrorChainLink';
-                  isExplicitLink: boolean;
-                  error: {__typename: 'PythonError'; message: string; stack: Array<string>};
-                }>;
-              };
-          tagsOrError:
-            | {
-                __typename: 'PartitionTags';
-                results: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
-              }
-            | {
-                __typename: 'PythonError';
-                message: string;
-                stack: Array<string>;
-                errorChain: Array<{
-                  __typename: 'ErrorChainLink';
-                  isExplicitLink: boolean;
-                  error: {__typename: 'PythonError'; message: string; stack: Array<string>};
-                }>;
-              };
-        } | null;
-      }
-    | {__typename: 'PartitionSetNotFoundError'}
-    | {__typename: 'PythonError'};
 };
 
 export type ConfigEditorGeneratorPipelineFragment = {

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/ConfigFetch.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/ConfigFetch.types.ts
@@ -1,0 +1,104 @@
+// Generated GraphQL types, do not edit manually.
+
+import * as Types from '../../graphql/types';
+
+export type ConfigPartitionForAssetJobQueryVariables = Types.Exact<{
+  repositoryName: Types.Scalars['String']['input'];
+  repositoryLocationName: Types.Scalars['String']['input'];
+  jobName: Types.Scalars['String']['input'];
+  partitionName: Types.Scalars['String']['input'];
+  assetKeys: Array<Types.AssetKeyInput> | Types.AssetKeyInput;
+}>;
+
+export type ConfigPartitionForAssetJobQuery = {
+  __typename: 'Query';
+  pipelineOrError:
+    | {__typename: 'InvalidSubsetError'}
+    | {
+        __typename: 'Pipeline';
+        id: string;
+        partition: {
+          __typename: 'PartitionTagsAndConfig';
+          name: string;
+          runConfigOrError:
+            | {__typename: 'PartitionRunConfig'; yaml: string}
+            | {
+                __typename: 'PythonError';
+                message: string;
+                stack: Array<string>;
+                errorChain: Array<{
+                  __typename: 'ErrorChainLink';
+                  isExplicitLink: boolean;
+                  error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+                }>;
+              };
+          tagsOrError:
+            | {
+                __typename: 'PartitionTags';
+                results: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
+              }
+            | {
+                __typename: 'PythonError';
+                message: string;
+                stack: Array<string>;
+                errorChain: Array<{
+                  __typename: 'ErrorChainLink';
+                  isExplicitLink: boolean;
+                  error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+                }>;
+              };
+        } | null;
+      }
+    | {__typename: 'PipelineNotFoundError'}
+    | {__typename: 'PythonError'};
+};
+
+export type ConfigPartitionSelectionQueryVariables = Types.Exact<{
+  repositorySelector: Types.RepositorySelector;
+  partitionSetName: Types.Scalars['String']['input'];
+  partitionName: Types.Scalars['String']['input'];
+}>;
+
+export type ConfigPartitionSelectionQuery = {
+  __typename: 'Query';
+  partitionSetOrError:
+    | {
+        __typename: 'PartitionSet';
+        id: string;
+        partition: {
+          __typename: 'Partition';
+          name: string;
+          solidSelection: Array<string> | null;
+          mode: string;
+          runConfigOrError:
+            | {__typename: 'PartitionRunConfig'; yaml: string}
+            | {
+                __typename: 'PythonError';
+                message: string;
+                stack: Array<string>;
+                errorChain: Array<{
+                  __typename: 'ErrorChainLink';
+                  isExplicitLink: boolean;
+                  error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+                }>;
+              };
+          tagsOrError:
+            | {
+                __typename: 'PartitionTags';
+                results: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
+              }
+            | {
+                __typename: 'PythonError';
+                message: string;
+                stack: Array<string>;
+                errorChain: Array<{
+                  __typename: 'ErrorChainLink';
+                  isExplicitLink: boolean;
+                  error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+                }>;
+              };
+        } | null;
+      }
+    | {__typename: 'PartitionSetNotFoundError'}
+    | {__typename: 'PythonError'};
+};

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -290,5 +290,29 @@ class ExecutionMetadata(
         }
 
 
+def apply_cursor_limit_reverse(
+    items: Sequence[str], cursor: Optional[str], limit: Optional[int], reverse: Optional[bool]
+) -> Sequence[str]:
+    start = 0
+    end = len(items)
+    index = 0
+
+    if cursor:
+        index = next((idx for (idx, item) in enumerate(items) if item == cursor))
+
+        if reverse:
+            end = index
+        else:
+            start = index + 1
+
+    if limit:
+        if reverse:
+            start = end - limit
+        else:
+            end = start + limit
+
+    return items[max(start, 0) : end]
+
+
 BackfillParams: TypeAlias = Mapping[str, Any]
 AssetBackfillPreviewParams: TypeAlias = Mapping[str, Any]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -15,30 +15,10 @@ from dagster_graphql.schema.errors import GrapheneError
 
 from .asset_key import GrapheneAssetKey
 from .auto_materialize_policy import GrapheneAutoMaterializeRule
+from .partition_keys import GraphenePartitionKeys, GraphenePartitionKeysOrError
 from .util import non_null_list
 
 GrapheneAutoMaterializeDecisionType = graphene.Enum.from_enum(AutoMaterializeDecisionType)
-
-
-class GraphenePartitionKeys(graphene.ObjectType):
-    partitionKeys = non_null_list(graphene.String)
-
-    class Meta:
-        name = "PartitionKeys"
-
-
-class GraphenePartitionSubsetDeserializationError(graphene.ObjectType):
-    message = graphene.NonNull(graphene.String)
-
-    class Meta:
-        interfaces = (GrapheneError,)
-        name = "PartitionSubsetDeserializationError"
-
-
-class GraphenePartitionKeysOrError(graphene.Union):
-    class Meta:
-        types = (GraphenePartitionKeys, GraphenePartitionSubsetDeserializationError)
-        name = "PartitionKeysOrError"
 
 
 class GrapheneTextRuleEvaluationData(graphene.ObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -1,4 +1,5 @@
 import graphene
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.events import DagsterEventType
 from dagster._core.storage.dagster_run import DagsterRunStatus, RunsFilter
 from dagster._time import datetime_from_timestamp
@@ -14,6 +15,9 @@ class GrapheneAssetKeyInput(graphene.InputObjectType):
 
     class Meta:
         name = "AssetKeyInput"
+
+    def to_asset_key(self) -> AssetKey:
+        return AssetKey(self.path)
 
 
 class GrapheneAssetCheckHandleInput(graphene.InputObjectType):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_keys.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_keys.py
@@ -1,0 +1,26 @@
+import graphene
+
+from dagster_graphql.schema.errors import GrapheneError
+
+from .util import non_null_list
+
+
+class GraphenePartitionKeys(graphene.ObjectType):
+    partitionKeys = non_null_list(graphene.String)
+
+    class Meta:
+        name = "PartitionKeys"
+
+
+class GraphenePartitionSubsetDeserializationError(graphene.ObjectType):
+    message = graphene.NonNull(graphene.String)
+
+    class Meta:
+        interfaces = (GrapheneError,)
+        name = "PartitionSubsetDeserializationError"
+
+
+class GraphenePartitionKeysOrError(graphene.Union):
+    class Meta:
+        types = (GraphenePartitionKeys, GraphenePartitionSubsetDeserializationError)
+        name = "PartitionKeysOrError"

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -1,11 +1,17 @@
-from typing import List, Optional, Sequence
+from typing import TYPE_CHECKING, AbstractSet, List, Optional, Sequence
 
 import dagster._check as check
 import graphene
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.time_window_partitions import PartitionRangeStatus
+from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.events import DagsterEventType
 from dagster._core.remote_representation.external import ExternalExecutionPlan, ExternalJob
-from dagster._core.remote_representation.external_data import DEFAULT_MODE_NAME, ExternalPresetData
+from dagster._core.remote_representation.external_data import (
+    DEFAULT_MODE_NAME,
+    ExternalPartitionExecutionErrorData,
+    ExternalPresetData,
+)
 from dagster._core.remote_representation.represented import RepresentedJob
 from dagster._core.storage.dagster_run import (
     DagsterRunStatsSnapshot,
@@ -26,7 +32,11 @@ from ...implementation.fetch_pipelines import get_job_reference_or_raise
 from ...implementation.fetch_runs import get_runs, get_stats, get_step_stats
 from ...implementation.fetch_schedules import get_schedules_for_pipeline
 from ...implementation.fetch_sensors import get_sensors_for_pipeline
-from ...implementation.utils import UserFacingGraphQLError, capture_error
+from ...implementation.utils import (
+    UserFacingGraphQLError,
+    apply_cursor_limit_reverse,
+    capture_error,
+)
 from ..asset_checks import GrapheneAssetCheckHandle
 from ..asset_key import GrapheneAssetKey
 from ..dagster_types import (
@@ -37,6 +47,7 @@ from ..dagster_types import (
 )
 from ..errors import GrapheneDagsterTypeNotFoundError, GraphenePythonError, GrapheneRunNotFoundError
 from ..execution import GrapheneExecutionPlan
+from ..inputs import GrapheneAssetKeyInput
 from ..logs.compute_logs import GrapheneCapturedLogs, from_captured_log_data
 from ..logs.events import (
     GrapheneDagsterRunEvent,
@@ -44,6 +55,7 @@ from ..logs.events import (
     GrapheneObservationEvent,
     GrapheneRunStepStats,
 )
+from ..partition_keys import GraphenePartitionKeys
 from ..repository_origin import GrapheneRepositoryOrigin
 from ..runs import GrapheneRunConfigData
 from ..runs_feed import GrapheneRunsFeedEntry
@@ -62,6 +74,10 @@ from .mode import GrapheneMode
 from .pipeline_ref import GraphenePipelineReference
 from .pipeline_run_stats import GrapheneRunStatsSnapshotOrError
 from .status import GrapheneRunStatus
+
+if TYPE_CHECKING:
+    from ..partition_sets import GrapheneJobSelectionPartition
+
 
 STARTED_STATUSES = {
     DagsterRunStatus.STARTED,
@@ -871,6 +887,22 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
     isJob = graphene.NonNull(graphene.Boolean)
     isAssetJob = graphene.NonNull(graphene.Boolean)
     repository = graphene.NonNull("dagster_graphql.schema.external.GrapheneRepository")
+    partitionKeysOrError = graphene.Field(
+        graphene.NonNull(GraphenePartitionKeys),
+        cursor=graphene.String(),
+        limit=graphene.Int(),
+        reverse=graphene.Boolean(),
+        selected_asset_keys=graphene.Argument(
+            graphene.List(graphene.NonNull(GrapheneAssetKeyInput))
+        ),
+    )
+    partition = graphene.Field(
+        "dagster_graphql.schema.partition_sets.GrapheneJobSelectionPartition",
+        partition_name=graphene.NonNull(graphene.String),
+        selected_asset_keys=graphene.Argument(
+            graphene.List(graphene.NonNull(GrapheneAssetKeyInput))
+        ),
+    )
 
     class Meta:
         interfaces = (GrapheneSolidContainer, GrapheneIPipelineSnapshot)
@@ -910,6 +942,47 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
             graphene_info.context,
             location.get_repository(handle.repository_name),
             location,
+        )
+
+    @capture_error
+    def resolve_partitionKeysOrError(
+        self,
+        graphene_info: ResolveInfo,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+        reverse: Optional[bool] = None,
+        selected_asset_keys: Optional[List[GrapheneAssetKeyInput]] = None,
+    ) -> GraphenePartitionKeys:
+        result = graphene_info.context.get_external_partition_names(
+            repository_handle=self._external_job.repository_handle,
+            job_name=self._external_job.name,
+            selected_asset_keys=_asset_key_input_list_to_asset_key_set(selected_asset_keys),
+            instance=graphene_info.context.instance,
+        )
+
+        if isinstance(result, ExternalPartitionExecutionErrorData):
+            raise DagsterUserCodeProcessError.from_error_info(result.error)
+
+        all_partition_keys = result.partition_names
+
+        return GraphenePartitionKeys(
+            partitionKeys=apply_cursor_limit_reverse(
+                all_partition_keys, cursor=cursor, limit=limit, reverse=reverse or False
+            )
+        )
+
+    def resolve_partition(
+        self,
+        graphene_info: ResolveInfo,
+        partition_name: str,
+        selected_asset_keys: Optional[List[GrapheneAssetKeyInput]] = None,
+    ) -> "GrapheneJobSelectionPartition":
+        from ..partition_sets import GrapheneJobSelectionPartition
+
+        return GrapheneJobSelectionPartition(
+            external_job=self._external_job,
+            partition_name=partition_name,
+            selected_asset_keys=_asset_key_input_list_to_asset_key_set(selected_asset_keys),
         )
 
 
@@ -992,3 +1065,11 @@ class GrapheneRunOrError(graphene.Union):
     class Meta:
         types = (GrapheneRun, GrapheneRunNotFoundError, GraphenePythonError)
         name = "RunOrError"
+
+
+def _asset_key_input_list_to_asset_key_set(
+    asset_keys: Optional[List[GrapheneAssetKeyInput]],
+) -> Optional[AbstractSet[AssetKey]]:
+    return (
+        {key_input.to_asset_key() for key_input in asset_keys} if asset_keys is not None else None
+    )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_job_partitions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_job_partitions.py
@@ -1,0 +1,263 @@
+from dagster import (
+    AssetKey,
+    ConfigurableResource,
+    Definitions,
+    StaticPartitionsDefinition,
+    asset,
+    job,
+    op,
+    static_partitioned_config,
+)
+from dagster._core.definitions.repository_definition import SINGLETON_REPOSITORY_NAME
+from dagster._core.test_utils import ensure_dagster_tests_import, instance_for_test
+from dagster_graphql.test.utils import define_out_of_process_context, execute_dagster_graphql
+
+ensure_dagster_tests_import()
+
+
+GET_PARTITIONS_QUERY = """
+    query SingleJobQuery($selector: PipelineSelector!, $selectedAssetKeys: [AssetKeyInput!]) {
+        pipelineOrError(params: $selector) {
+            ... on Pipeline {
+                name
+                partitionKeysOrError(selectedAssetKeys: $selectedAssetKeys) {
+                    partitionKeys
+                }
+            }
+        }
+    }
+"""
+
+GET_PARTITION_TAGS_QUERY = """
+    query SingleJobQuery($selector: PipelineSelector!, $partitionName: String!, $selectedAssetKeys: [AssetKeyInput!]) {
+        pipelineOrError(params: $selector) {
+            ... on Pipeline {
+                name
+                partition(partitionName: $partitionName, selectedAssetKeys: $selectedAssetKeys) {
+                    name
+                    tagsOrError {
+                        ... on PartitionTags {
+                            results {
+                                key
+                                value
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+GET_PARTITION_RUN_CONFIG_QUERY = """
+    query SingleJobQuery($selector: PipelineSelector!, $partitionName: String!, $selectedAssetKeys: [AssetKeyInput!]) {
+        pipelineOrError(params: $selector) {
+            ... on Pipeline {
+                name
+                partition(partitionName: $partitionName, selectedAssetKeys: $selectedAssetKeys) {
+                    name
+                    runConfigOrError {
+                        ... on PartitionRunConfig {
+                            yaml
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+
+def get_repo_with_partitioned_op_job():
+    @op
+    def op1(): ...
+
+    @static_partitioned_config(["1", "2"])
+    def my_partitioned_config(partition):
+        return {"ops": {"op1": {"config": {"p": partition}}}}
+
+    @job(config=my_partitioned_config)
+    def job1():
+        op1()
+
+    return Definitions(jobs=[job1]).get_repository_def()
+
+
+def get_repo_with_differently_partitioned_assets():
+    @asset(partitions_def=StaticPartitionsDefinition(["1", "2"]))
+    def asset1(): ...
+
+    ab_partitions_def = StaticPartitionsDefinition(["a", "b"])
+
+    @asset(partitions_def=ab_partitions_def)
+    def asset2(): ...
+
+    class MyResource(ConfigurableResource):
+        foo: str
+
+    @asset(partitions_def=ab_partitions_def)
+    def asset3(resource1: MyResource): ...
+
+    return Definitions(
+        assets=[asset1, asset2, asset3], resources={"resource1": MyResource(foo="bar")}
+    ).get_repository_def()
+
+
+def test_get_partition_names():
+    with instance_for_test() as instance:
+        with define_out_of_process_context(
+            __file__, "get_repo_with_partitioned_op_job", instance
+        ) as context:
+            result = execute_dagster_graphql(
+                context,
+                GET_PARTITIONS_QUERY,
+                variables={
+                    "selector": {
+                        "repositoryLocationName": context.code_location_names[0],
+                        "repositoryName": SINGLETON_REPOSITORY_NAME,
+                        "pipelineName": "job1",
+                    }
+                },
+            )
+            assert result.data["pipelineOrError"]["name"] == "job1"
+            assert result.data["pipelineOrError"]["partitionKeysOrError"]["partitionKeys"] == [
+                "1",
+                "2",
+            ]
+
+
+def test_get_partition_names_asset_selection():
+    with instance_for_test() as instance:
+        with define_out_of_process_context(
+            __file__, "get_repo_with_differently_partitioned_assets", instance
+        ) as context:
+            result = execute_dagster_graphql(
+                context,
+                GET_PARTITIONS_QUERY,
+                variables={
+                    "selector": {
+                        "repositoryLocationName": context.code_location_names[0],
+                        "repositoryName": SINGLETON_REPOSITORY_NAME,
+                        "pipelineName": "__ASSET_JOB",
+                    },
+                    "selectedAssetKeys": [
+                        AssetKey("asset2").to_graphql_input(),
+                        AssetKey("asset3").to_graphql_input(),
+                    ],
+                },
+            )
+            assert result.data["pipelineOrError"]["name"] == "__ASSET_JOB"
+            assert result.data["pipelineOrError"]["partitionKeysOrError"]["partitionKeys"] == [
+                "a",
+                "b",
+            ]
+
+
+def test_get_partition_tags():
+    with instance_for_test() as instance:
+        with define_out_of_process_context(
+            __file__, "get_repo_with_partitioned_op_job", instance
+        ) as context:
+            result = execute_dagster_graphql(
+                context,
+                GET_PARTITION_TAGS_QUERY,
+                variables={
+                    "selector": {
+                        "repositoryLocationName": context.code_location_names[0],
+                        "repositoryName": SINGLETON_REPOSITORY_NAME,
+                        "pipelineName": "job1",
+                    },
+                    "partitionName": "1",
+                },
+            )
+            assert result.data["pipelineOrError"]["name"] == "job1"
+            result_partition = result.data["pipelineOrError"]["partition"]
+            assert result_partition["name"] == "1"
+            assert {
+                item["key"]: item["value"] for item in result_partition["tagsOrError"]["results"]
+            } == {
+                "dagster/partition": "1",
+                "dagster/partition_set": "job1_partition_set",
+            }
+
+
+def test_get_partition_tags_asset_selection():
+    with instance_for_test() as instance:
+        with define_out_of_process_context(
+            __file__, "get_repo_with_differently_partitioned_assets", instance
+        ) as context:
+            result = execute_dagster_graphql(
+                context,
+                GET_PARTITION_TAGS_QUERY,
+                variables={
+                    "selector": {
+                        "repositoryLocationName": context.code_location_names[0],
+                        "repositoryName": SINGLETON_REPOSITORY_NAME,
+                        "pipelineName": "__ASSET_JOB",
+                    },
+                    "selectedAssetKeys": [
+                        AssetKey("asset2").to_graphql_input(),
+                        AssetKey("asset3").to_graphql_input(),
+                    ],
+                    "partitionName": "b",
+                },
+            )
+            assert result.data["pipelineOrError"]["name"] == "__ASSET_JOB"
+            result_partition = result.data["pipelineOrError"]["partition"]
+            assert result_partition["name"] == "b"
+            assert {
+                item["key"]: item["value"] for item in result_partition["tagsOrError"]["results"]
+            } == {"dagster/partition": "b"}
+
+
+def test_get_partition_config():
+    with instance_for_test() as instance:
+        with define_out_of_process_context(
+            __file__, "get_repo_with_partitioned_op_job", instance
+        ) as context:
+            result = execute_dagster_graphql(
+                context,
+                GET_PARTITION_RUN_CONFIG_QUERY,
+                variables={
+                    "selector": {
+                        "repositoryLocationName": context.code_location_names[0],
+                        "repositoryName": SINGLETON_REPOSITORY_NAME,
+                        "pipelineName": "job1",
+                    },
+                    "partitionName": "1",
+                },
+            )
+            assert result.data["pipelineOrError"]["name"] == "job1"
+            result_partition = result.data["pipelineOrError"]["partition"]
+            assert result_partition["name"] == "1"
+            assert (
+                result_partition["runConfigOrError"]["yaml"]
+                == """ops:\n  op1:\n    config:\n      p: '1'\n"""
+            )
+
+
+def test_get_partition_config_asset_selection():
+    with instance_for_test() as instance:
+        with define_out_of_process_context(
+            __file__, "get_repo_with_differently_partitioned_assets", instance
+        ) as context:
+            result = execute_dagster_graphql(
+                context,
+                GET_PARTITION_RUN_CONFIG_QUERY,
+                variables={
+                    "selector": {
+                        "repositoryLocationName": context.code_location_names[0],
+                        "repositoryName": SINGLETON_REPOSITORY_NAME,
+                        "pipelineName": "__ASSET_JOB",
+                    },
+                    "selectedAssetKeys": [
+                        AssetKey("asset2").to_graphql_input(),
+                        AssetKey("asset3").to_graphql_input(),
+                    ],
+                    "partitionName": "b",
+                },
+            )
+            assert result.data["pipelineOrError"]["name"] == "__ASSET_JOB"
+            result_partition = result.data["pipelineOrError"]["partition"]
+            assert result_partition["name"] == "b"
+            assert result_partition["runConfigOrError"]["yaml"] == "{}\n"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_job_partitions.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_job_partitions.py
@@ -1,13 +1,4 @@
-from dagster import (
-    AssetKey,
-    ConfigurableResource,
-    Definitions,
-    StaticPartitionsDefinition,
-    asset,
-    job,
-    op,
-    static_partitioned_config,
-)
+from dagster import Definitions, job, op, static_partitioned_config
 from dagster._core.definitions.repository_definition import SINGLETON_REPOSITORY_NAME
 from dagster._core.test_utils import ensure_dagster_tests_import, instance_for_test
 from dagster_graphql.test.utils import define_out_of_process_context, execute_dagster_graphql
@@ -83,26 +74,6 @@ def get_repo_with_partitioned_op_job():
     return Definitions(jobs=[job1]).get_repository_def()
 
 
-def get_repo_with_differently_partitioned_assets():
-    @asset(partitions_def=StaticPartitionsDefinition(["1", "2"]))
-    def asset1(): ...
-
-    ab_partitions_def = StaticPartitionsDefinition(["a", "b"])
-
-    @asset(partitions_def=ab_partitions_def)
-    def asset2(): ...
-
-    class MyResource(ConfigurableResource):
-        foo: str
-
-    @asset(partitions_def=ab_partitions_def)
-    def asset3(resource1: MyResource): ...
-
-    return Definitions(
-        assets=[asset1, asset2, asset3], resources={"resource1": MyResource(foo="bar")}
-    ).get_repository_def()
-
-
 def test_get_partition_names():
     with instance_for_test() as instance:
         with define_out_of_process_context(
@@ -123,33 +94,6 @@ def test_get_partition_names():
             assert result.data["pipelineOrError"]["partitionKeysOrError"]["partitionKeys"] == [
                 "1",
                 "2",
-            ]
-
-
-def test_get_partition_names_asset_selection():
-    with instance_for_test() as instance:
-        with define_out_of_process_context(
-            __file__, "get_repo_with_differently_partitioned_assets", instance
-        ) as context:
-            result = execute_dagster_graphql(
-                context,
-                GET_PARTITIONS_QUERY,
-                variables={
-                    "selector": {
-                        "repositoryLocationName": context.code_location_names[0],
-                        "repositoryName": SINGLETON_REPOSITORY_NAME,
-                        "pipelineName": "__ASSET_JOB",
-                    },
-                    "selectedAssetKeys": [
-                        AssetKey("asset2").to_graphql_input(),
-                        AssetKey("asset3").to_graphql_input(),
-                    ],
-                },
-            )
-            assert result.data["pipelineOrError"]["name"] == "__ASSET_JOB"
-            assert result.data["pipelineOrError"]["partitionKeysOrError"]["partitionKeys"] == [
-                "a",
-                "b",
             ]
 
 
@@ -181,35 +125,6 @@ def test_get_partition_tags():
             }
 
 
-def test_get_partition_tags_asset_selection():
-    with instance_for_test() as instance:
-        with define_out_of_process_context(
-            __file__, "get_repo_with_differently_partitioned_assets", instance
-        ) as context:
-            result = execute_dagster_graphql(
-                context,
-                GET_PARTITION_TAGS_QUERY,
-                variables={
-                    "selector": {
-                        "repositoryLocationName": context.code_location_names[0],
-                        "repositoryName": SINGLETON_REPOSITORY_NAME,
-                        "pipelineName": "__ASSET_JOB",
-                    },
-                    "selectedAssetKeys": [
-                        AssetKey("asset2").to_graphql_input(),
-                        AssetKey("asset3").to_graphql_input(),
-                    ],
-                    "partitionName": "b",
-                },
-            )
-            assert result.data["pipelineOrError"]["name"] == "__ASSET_JOB"
-            result_partition = result.data["pipelineOrError"]["partition"]
-            assert result_partition["name"] == "b"
-            assert {
-                item["key"]: item["value"] for item in result_partition["tagsOrError"]["results"]
-            } == {"dagster/partition": "b"}
-
-
 def test_get_partition_config():
     with instance_for_test() as instance:
         with define_out_of_process_context(
@@ -234,30 +149,3 @@ def test_get_partition_config():
                 result_partition["runConfigOrError"]["yaml"]
                 == """ops:\n  op1:\n    config:\n      p: '1'\n"""
             )
-
-
-def test_get_partition_config_asset_selection():
-    with instance_for_test() as instance:
-        with define_out_of_process_context(
-            __file__, "get_repo_with_differently_partitioned_assets", instance
-        ) as context:
-            result = execute_dagster_graphql(
-                context,
-                GET_PARTITION_RUN_CONFIG_QUERY,
-                variables={
-                    "selector": {
-                        "repositoryLocationName": context.code_location_names[0],
-                        "repositoryName": SINGLETON_REPOSITORY_NAME,
-                        "pipelineName": "__ASSET_JOB",
-                    },
-                    "selectedAssetKeys": [
-                        AssetKey("asset2").to_graphql_input(),
-                        AssetKey("asset3").to_graphql_input(),
-                    ],
-                    "partitionName": "b",
-                },
-            )
-            assert result.data["pipelineOrError"]["name"] == "__ASSET_JOB"
-            result_partition = result.data["pipelineOrError"]["partition"]
-            assert result_partition["name"] == "b"
-            assert result_partition["runConfigOrError"]["yaml"] == "{}\n"


### PR DESCRIPTION
## Summary & Motivation

Related: https://linear.app/dagster-labs/issue/FE-509/update-the-materialize-button-to-pull-jobpartitiondefinition-using-the

This PR stacks on top of #23494:

- On the backend, there is now just a single hidden asset job which contains all assets.

- This asset job has no partition_set, but given a set of asset keys, you can still retrieve the list of available partitions and config + tags for a specific partition using new resolvers on the job. (Added in @sryza's PR)

This requires some changes to expectations made on the front-end:

- We no longer check both the partition definitions AND the presence of a partition set on the job the assets have in common. If you select partitioned assets you will get the partitions dialog.

- When we launch a job targeting a single partition, OR open the launchpad and allow you to choose a partition, we now use a new resolver that is asset-specific to retrieve the config YAML + tags. (The "partition => config YAML" resolver previously required the partition set definition)

The last point means that there is a different config-loader query for the hidden asset job and standard user-defined asset/  op jobs (which still use partition set definitions).  I co-located both approaches in the same file to try to make things a bit easier to follow, but there's a bit of code duplication.

Sidenote:

This code is super old and still supports pipelines with multiple modes.  If modes are fully gone I would love to rip that stuff out...

## How I Tested These Changes

I updated the tests and also ran through a bunch of manual tests listed that I listed out in https://www.notion.so/dagster/Hidden-asset-job-change-test-cases-7a96046234da46f3a0e6b2a44e349474?pvs=4.