### PR TITLE
fix(duckdb) only specify custom_user_agent for duckdb > 1.0.0

### DIFF
--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/io_manager.py
@@ -15,6 +15,7 @@ from dagster._core.storage.db_io_manager import (
 )
 from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._utils.backoff import backoff
+from packaging.version import Version
 from pydantic import Field
 
 DUCKDB_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
@@ -283,7 +284,7 @@ class DuckDbClient(DbClient):
 
         # support for `custom_user_agent` was added in v1.0.0
         # https://github.com/duckdb/duckdb/commit/0c66b6007b736ed2197bca54d20c9ad9a5eeef46
-        if duckdb.__version__ > "1.0.0":
+        if Version(duckdb.__version__) >= Version("1.0.0"):
             config = {
                 "custom_user_agent": "dagster",
                 **config,

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 import duckdb
 from dagster import ConfigurableResource
 from dagster._utils.backoff import backoff
+from packaging.version import Version
 from pydantic import Field
 
 
@@ -52,7 +53,7 @@ class DuckDBResource(ConfigurableResource):
 
         # support for `custom_user_agent` was added in v1.0.0
         # https://github.com/duckdb/duckdb/commit/0c66b6007b736ed2197bca54d20c9ad9a5eeef46
-        if duckdb.__version__ > "1.0.0":
+        if Version(duckdb.__version__) >= Version("1.0.0"):
             config = {
                 "custom_user_agent": "dagster",
                 **config,

--- a/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
+++ b/python_modules/libraries/dagster-duckdb/dagster_duckdb/resource.py
@@ -48,16 +48,23 @@ class DuckDBResource(ConfigurableResource):
 
     @contextmanager
     def get_connection(self):
+        config = self.connection_config
+
+        # support for `custom_user_agent` was added in v1.0.0
+        # https://github.com/duckdb/duckdb/commit/0c66b6007b736ed2197bca54d20c9ad9a5eeef46
+        if duckdb.__version__ > "1.0.0":
+            config = {
+                "custom_user_agent": "dagster",
+                **config,
+            }
+
         conn = backoff(
             fn=duckdb.connect,
             retry_on=(RuntimeError, duckdb.IOException),
             kwargs={
                 "database": self.database,
                 "read_only": False,
-                "config": {
-                    "custom_user_agent": "dagster",
-                    **self.connection_config,
-                },
+                "config": config,
             },
             max_retries=10,
         )


### PR DESCRIPTION
## Summary & Motivation

- Resolves **https://github.com/dagster-io/dagster/issues/23761**

Only provide `custom_user_agent` when `duckdb.__version__` is greater than. `1.0.0`, as that is when this feature was included.

## How I Tested These Changes

- `tox`
