### PR TITLE
[ui] Move Observe Sources into the Materialize button

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -51,7 +51,6 @@ import {
 import {AssetLocation, useFindAssetLocation} from './useFindAssetLocation';
 import {AssetLiveDataRefreshButton} from '../asset-data/AssetLiveDataProvider';
 import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
-import {LaunchAssetObservationButton} from '../assets/LaunchAssetObservationButton';
 import {AssetKey} from '../assets/types';
 import {DEFAULT_MAX_ZOOM, SVGViewport} from '../graph/SVGViewport';
 import {useAssetLayout} from '../graph/asyncGraphLayout';
@@ -734,14 +733,6 @@ const AssetGraphExplorerWithData = ({
                     />
                   </GraphQueryInputFlexWrap>
                   <AssetLiveDataRefreshButton />
-                  <LaunchAssetObservationButton
-                    preferredJobName={explorerPath.pipelineName}
-                    scope={
-                      selectedDefinitions.length
-                        ? {selected: selectedDefinitions.filter((a) => a.isObservable)}
-                        : {all: allDefinitionsForMaterialize.filter((a) => a.isObservable)}
-                    }
-                  />
                   <LaunchAssetExecutionButton
                     preferredJobName={explorerPath.pipelineName}
                     scope={

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNodeMenu.tsx
@@ -23,6 +23,7 @@ export type AssetNodeMenuNode = {
     isMaterializable: boolean;
     isObservable: boolean;
     isExecutable: boolean;
+    isPartitioned: boolean;
     hasMaterializePermission: boolean;
   };
 };
@@ -45,10 +46,11 @@ export const useAssetNodeMenu = ({
   const upstream = graphData ? Object.keys(graphData.upstream[node.id] ?? {}) : [];
   const downstream = graphData ? Object.keys(graphData.downstream[node.id] ?? {}) : [];
 
-  const {executeItem, launchpadElement} = useExecuteAssetMenuItem(
-    node.assetKey.path,
-    node.definition,
+  const asset = React.useMemo(
+    () => ({assetKey: node.assetKey, ...node.definition}),
+    [node.definition, node.assetKey],
   );
+  const {executeItem, launchpadElement} = useExecuteAssetMenuItem(asset);
 
   const [showParents, setShowParents] = React.useState(false);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetActionMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetActionMenu.tsx
@@ -1,18 +1,16 @@
 import {Button, Icon, Menu, MenuItem, Popover, Spinner, Tooltip} from '@dagster-io/ui-components';
-import {useContext} from 'react';
+import {useContext, useMemo} from 'react';
 
-import {
-  executionDisabledMessageForAssets,
-  useMaterializationAction,
-} from './LaunchAssetExecutionButton';
-import {useObserveAction} from './LaunchAssetObservationButton';
+import {optionsForExecuteButton, useMaterializationAction} from './LaunchAssetExecutionButton';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {AssetTableDefinitionFragment} from './types/AssetTableFragment.types';
 import {useDeleteDynamicPartitionsDialog} from './useDeleteDynamicPartitionsDialog';
+import {useObserveAction} from './useObserveAction';
 import {useReportEventsModal} from './useReportEventsModal';
 import {useWipeModal} from './useWipeModal';
 import {CloudOSSContext} from '../app/CloudOSSContext';
 import {showSharedToaster} from '../app/DomUtils';
+import {AssetKeyInput} from '../graphql/types';
 import {MenuLink} from '../ui/MenuLink';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
@@ -30,7 +28,17 @@ export const AssetActionMenu = (props: Props) => {
     featureContext: {canSeeMaterializeAction},
   } = useContext(CloudOSSContext);
 
-  const {executeItem, launchpadElement} = useExecuteAssetMenuItem(path, definition);
+  // Because the asset catalog loads a list of keys, and then definitions for SDAs,
+  // we don't re-fetch the key inside the definition of each asset. Re-attach the
+  // assetKey to the definition for the hook below.
+  const asset = useMemo(
+    () =>
+      definition
+        ? {...definition, isPartitioned: !!definition?.partitionDefinition, assetKey: {path}}
+        : null,
+    [path, definition],
+  );
+  const {executeItem, launchpadElement} = useExecuteAssetMenuItem(asset);
 
   const deletePartitions = useDeleteDynamicPartitionsDialog(
     repoAddress && definition ? {repoAddress, assetKey: {path}, definition} : null,
@@ -120,16 +128,18 @@ export const AssetActionMenu = (props: Props) => {
 };
 
 export const useExecuteAssetMenuItem = (
-  path: string[],
   definition: {
+    assetKey: AssetKeyInput;
     isObservable: boolean;
     isExecutable: boolean;
+    isPartitioned: boolean;
     hasMaterializePermission: boolean;
   } | null,
 ) => {
-  const disabledMessage = definition
-    ? executionDisabledMessageForAssets([definition])
-    : 'Asset definition not found in a code location';
+  const {materializeOption, observeOption} = optionsForExecuteButton(
+    definition ? [definition] : [],
+    {skipAllTerm: true},
+  );
 
   const {
     featureContext: {canSeeMaterializeAction},
@@ -137,30 +147,19 @@ export const useExecuteAssetMenuItem = (
 
   const materialize = useMaterializationAction();
   const observe = useObserveAction();
+  const loading = materialize.loading || observe.loading;
+
+  const [option, action] =
+    materializeOption.disabledReason && !observeOption.disabledReason
+      ? [observeOption, observe.onClick]
+      : [materializeOption, materialize.onClick];
+
+  const disabledMessage = definition
+    ? option.disabledReason
+    : 'Asset definition not found in a code location';
 
   if (!canSeeMaterializeAction) {
     return {executeItem: null, launchpadElement: null};
-  }
-
-  if (definition?.isExecutable && definition.isObservable && definition.hasMaterializePermission) {
-    return {
-      launchpadElement: null,
-      executeItem: (
-        <MenuItem
-          text="Observe"
-          icon={observe.loading ? <Spinner purpose="body-text" /> : 'observation'}
-          disabled={observe.loading}
-          onClick={(e) => {
-            void showSharedToaster({
-              intent: 'primary',
-              message: 'Initiating observation',
-              icon: 'observation',
-            });
-            observe.onClick([{path}], e);
-          }}
-        />
-      ),
-    };
   }
 
   return {
@@ -173,20 +172,19 @@ export const useExecuteAssetMenuItem = (
         useDisabledButtonTooltipFix
       >
         <MenuItem
-          text="Materialize"
-          icon={materialize.loading ? <Spinner purpose="body-text" /> : 'materialization'}
-          disabled={!!disabledMessage || materialize.loading}
+          text={option.label}
+          icon={loading ? <Spinner purpose="body-text" /> : option.icon}
+          disabled={!!disabledMessage || loading}
           onClick={(e) => {
             if (!definition) {
               return;
             }
             void showSharedToaster({
               intent: 'primary',
-              message: 'Initiating materialization',
-              icon: 'materialization',
+              message: `Initiating...`,
             });
 
-            materialize.onClick([{path}], e);
+            action([definition.assetKey], e);
           }}
         />
       </Tooltip>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -19,7 +19,6 @@ import {useAllAssets} from './AssetsCatalogTable';
 import {AssetAutomaterializePolicyPage} from './AutoMaterializePolicyPage/AssetAutomaterializePolicyPage';
 import {ChangedReasonsTag} from './ChangedReasons';
 import {LaunchAssetExecutionButton} from './LaunchAssetExecutionButton';
-import {LaunchAssetObservationButton} from './LaunchAssetObservationButton';
 import {UNDERLYING_OPS_ASSET_NODE_FRAGMENT} from './UnderlyingOpsOrGraph';
 import {AssetChecks} from './asset-checks/AssetChecks';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
@@ -279,7 +278,12 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
   }, [path, selectedTab, setCurrentPage]);
 
   const wipe = useWipeModal(
-    definition ? {assetKey: definition.assetKey, repository: definition.repository} : null,
+    definition && !definition.isObservable
+      ? {
+          assetKey: definition.assetKey,
+          repository: definition.repository,
+        }
+      : null,
     refresh,
   );
 
@@ -292,7 +296,7 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
   );
 
   const reportEvents = useReportEventsModal(
-    definition && repoAddress
+    definition && !definition.isObservable && repoAddress
       ? {
           assetKey: definition.assetKey,
           isPartitioned: definition.isPartitioned,
@@ -336,13 +340,8 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
           </div>
         }
         right={
-          <Box flex={{direction: 'row'}}>
-            {cachedOrLiveDefinition && cachedOrLiveDefinition.isObservable ? (
-              <LaunchAssetObservationButton
-                primary
-                scope={{all: [cachedOrLiveDefinition], skipAllTerm: true}}
-              />
-            ) : cachedOrLiveDefinition && cachedOrLiveDefinition.jobNames.length > 0 && upstream ? (
+          <Box style={{margin: '-4px 0'}} flex={{direction: 'row', gap: 8}}>
+            {cachedOrLiveDefinition && cachedOrLiveDefinition.jobNames.length > 0 && upstream ? (
               <LaunchAssetExecutionButton
                 scope={{all: [cachedOrLiveDefinition]}}
                 showChangedAndMissingOption={false}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetTables.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetTables.fixtures.ts
@@ -248,6 +248,7 @@ export const AssetCatalogTableMockAssets: Asset[] = [
     definition: buildAssetNode({
       id: 'test.py.repo.["good_asset"]',
       groupName: 'GROUP2',
+      isExecutable: true,
       partitionDefinition: null,
       hasMaterializePermission: true,
       computeKind: 'snowflake',
@@ -269,6 +270,7 @@ export const AssetCatalogTableMockAssets: Asset[] = [
         cronScheduleTimezone: null,
       }),
       hasMaterializePermission: true,
+      isExecutable: true,
       computeKind: null,
       description: null,
       repository,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetTables.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetTables.test.tsx
@@ -49,7 +49,7 @@ describe('AssetTable', () => {
             <MemoryRouter>
               <MockedProvider mocks={MOCKS}>
                 <WorkspaceProvider>
-                  <AssetsCatalogTable prefixPath={['dashboards']} setPrefixPath={() => {}} />
+                  <AssetsCatalogTable prefixPath={[]} setPrefixPath={() => {}} />
                 </WorkspaceProvider>
               </MockedProvider>
             </MemoryRouter>
@@ -63,17 +63,21 @@ describe('AssetTable', () => {
         'Materialize selected',
       );
 
-      const row1 = await screen.findByTestId(`row-dashboards/cost_dashboard`);
+      const row1 = await screen.findByTestId(`row-good_asset`);
       const checkbox1 = row1.querySelector('input[type=checkbox]') as HTMLInputElement;
       await userEvent.click(checkbox1);
 
       expect(await screen.findByTestId('materialize-button')).toHaveTextContent('Materialize');
 
-      const row2 = await screen.findByTestId(`row-dashboards/traffic_dashboard`);
+      const row2 = await screen.findByTestId(`row-late_asset`);
       const checkbox2 = row2.querySelector('input[type=checkbox]') as HTMLInputElement;
       await userEvent.click(checkbox2);
 
-      expect(await screen.findByTestId('materialize-button')).toHaveTextContent('Materialize (2)');
+      expect(await screen.findByTestId('materialize-button')).toBeEnabled();
+
+      expect(await screen.findByTestId('materialize-button')).toHaveTextContent(
+        'Materialize selected (2)',
+      );
     });
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useObserveAction.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useObserveAction.ts
@@ -1,9 +1,7 @@
-import {Button, Icon, Spinner, Tooltip} from '@dagster-io/ui-components';
-import {useContext, useState} from 'react';
+import {useState} from 'react';
 import {useLaunchWithTelemetry} from 'shared/launchpad/useLaunchWithTelemetry.oss';
 
 import {
-  AssetsInScope,
   LAUNCH_ASSET_LOADER_QUERY,
   buildAssetCollisionsAlert,
   executionParamsForAssetJob,
@@ -16,14 +14,13 @@ import {
   LaunchAssetLoaderQuery,
   LaunchAssetLoaderQueryVariables,
 } from './types/LaunchAssetExecutionButton.types';
-import {ApolloClient, useApolloClient} from '../apollo-client';
-import {CloudOSSContext} from '../app/CloudOSSContext';
+import {useApolloClient} from '../apollo-client';
 import {showCustomAlert} from '../app/CustomAlertProvider';
 import {LaunchPipelineExecutionMutationVariables} from '../runs/types/RunUtils.types';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 
-type ObserveAssetsState =
+export type ObserveAssetsState =
   | {type: 'none'}
   | {type: 'loading'}
   | {type: 'error'; error: string}
@@ -37,7 +34,7 @@ export const useObserveAction = (preferredJobName?: string) => {
   const client = useApolloClient();
   const [state, setState] = useState<ObserveAssetsState>({type: 'none'});
 
-  const onClick = async (assetKeys: AssetKey[], e: React.MouseEvent<any>) => {
+  const onClick = async (assetKeys: AssetKey[], _: React.MouseEvent<any>) => {
     if (state.type === 'loading') {
       return;
     }
@@ -45,7 +42,7 @@ export const useObserveAction = (preferredJobName?: string) => {
 
     const result = await client.query<LaunchAssetLoaderQuery, LaunchAssetLoaderQueryVariables>({
       query: LAUNCH_ASSET_LOADER_QUERY,
-      variables: {assetKeys},
+      variables: {assetKeys: assetKeys.map(asAssetKeyInput)},
     });
 
     if (result.data.assetNodeDefinitionCollisions.length) {
@@ -55,9 +52,8 @@ export const useObserveAction = (preferredJobName?: string) => {
     }
 
     const assets = result.data.assetNodes;
-    const forceLaunchpad = e.shiftKey;
 
-    const next = await stateForObservingAssets(client, assets, forceLaunchpad, preferredJobName);
+    const next = await stateForObservingAssets(assets, preferredJobName);
 
     if (next.type === 'error') {
       showCustomAlert({
@@ -79,68 +75,8 @@ export const useObserveAction = (preferredJobName?: string) => {
   return {onClick, loading: state.type === 'loading'};
 };
 
-export const LaunchAssetObservationButton = ({
-  scope,
-  preferredJobName,
-  primary = false,
-}: {
-  scope: AssetsInScope;
-  primary?: boolean;
-  preferredJobName?: string;
-}) => {
-  const {onClick, loading} = useObserveAction(preferredJobName);
-  const scopeAssets = 'selected' in scope ? scope.selected : scope.all;
-
-  const {
-    featureContext: {canSeeMaterializeAction},
-  } = useContext(CloudOSSContext);
-
-  if (!canSeeMaterializeAction) {
-    return null;
-  }
-
-  if (!scopeAssets.length) {
-    return <></>;
-  }
-
-  const count = scopeAssets.length > 1 ? ` (${scopeAssets.length})` : '';
-  const label =
-    'selected' in scope
-      ? `Observe selected${count}`
-      : scope.skipAllTerm
-      ? `Observe${count}`
-      : `Observe sources ${count}`;
-
-  const hasMaterializePermission = scopeAssets.every((a) => a.hasMaterializePermission);
-  if (!hasMaterializePermission) {
-    return (
-      <Tooltip content="You do not have permission to observe source assets">
-        <Button
-          intent={primary ? 'primary' : undefined}
-          icon={<Icon name="observation" />}
-          disabled
-        >
-          {label}
-        </Button>
-      </Tooltip>
-    );
-  }
-
-  return (
-    <Button
-      intent={primary ? 'primary' : undefined}
-      onClick={(e) => onClick(scopeAssets.map(asAssetKeyInput), e)}
-      icon={loading ? <Spinner purpose="body-text" /> : <Icon name="observation" />}
-    >
-      {label}
-    </Button>
-  );
-};
-
 async function stateForObservingAssets(
-  _client: ApolloClient<any>,
   assets: LaunchAssetExecutionAssetNodeFragment[],
-  _forceLaunchpad: boolean,
   preferredJobName?: string,
 ): Promise<ObserveAssetsState> {
   if (assets.some((x) => !x.isObservable)) {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useReportEventsModal.tsx
@@ -47,19 +47,23 @@ type Asset = {
 
 export function useReportEventsModal(asset: Asset | null, onEventReported?: () => void) {
   const [isOpen, setIsOpen] = useState(false);
-  const isPartitioned = asset?.isPartitioned;
   const hasReportRunlessAssetEventPermission = asset?.hasReportRunlessAssetEventPermission;
 
   const dropdownOptions = useMemo(
-    () => [
-      {
-        label: isPartitioned ? 'Report materialization events' : 'Report materialization event',
-        icon: <Icon name="asset_non_sda" />,
-        onClick: () => setIsOpen(true),
-        disabled: !hasReportRunlessAssetEventPermission,
-      },
-    ],
-    [isPartitioned, hasReportRunlessAssetEventPermission],
+    () =>
+      asset
+        ? [
+            {
+              label: asset.isPartitioned
+                ? 'Report materialization events'
+                : 'Report materialization event',
+              icon: <Icon name="asset_non_sda" />,
+              disabled: !hasReportRunlessAssetEventPermission,
+              onClick: () => setIsOpen(true),
+            },
+          ]
+        : [],
+    [asset, hasReportRunlessAssetEventPermission],
   );
 
   const element = asset ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useWipeModal.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useWipeModal.tsx
@@ -28,18 +28,19 @@ export function useWipeModal(
         onComplete={refresh}
       />
     ),
-    dropdownOptions: canSeeWipeMaterializationAction
-      ? [
-          <MenuDivider key="wipe-divider" />,
-          <MenuItem
-            key="wipe"
-            text="Wipe materializations"
-            icon={<Icon name="delete" color={Colors.accentRed()} />}
-            disabled={!canWipeAssets}
-            intent="danger"
-            onClick={() => setShowing(true)}
-          />,
-        ]
-      : ([] as JSX.Element[]),
+    dropdownOptions:
+      opts && canSeeWipeMaterializationAction
+        ? [
+            <MenuDivider key="wipe-divider" />,
+            <MenuItem
+              key="wipe"
+              text="Wipe materializations"
+              icon={<Icon name="delete" color={Colors.accentRed()} />}
+              disabled={!canWipeAssets}
+              intent="danger"
+              onClick={() => setShowing(true)}
+            />,
+          ]
+        : ([] as JSX.Element[]),
   };
 }


### PR DESCRIPTION
## Summary & Motivation

Related: https://linear.app/dagster-labs/issue/FE-517/remove-observe-sources-button-add-to-materialize-all-dropdown

Loom:
https://www.loom.com/share/2e044d1117734c2dbfff4fb4bef2a570

This PR folds the Observe Sources button into the Materialize button, which brings the Observe option to the asset catalog! I also updated the asset menus to use the same logic for building their menu items so the behavior is consistent. 

## How I Tested These Changes

- There's pretty good test coverage of this button and it's updated + still passing

- I tested this manually with observable, materializable, external, and non-SDA assets to kick the tires :-) 