### PR TITLE
[RFC] exploration of lazy loading + external service integration and state-driven blueprints

### DIFF
--- a/airbyte-decorator.py
+++ b/airbyte-decorator.py
@@ -1,0 +1,94 @@
+from datetime import datetime, timedelta
+from typing import Any, Callable, Mapping, Optional
+
+from dagster import (
+    AssetExecutionContext,
+    Definitions,
+    DefinitionsLoadContext,
+    DefinitionSource,
+    DefinitionsReloadRequest,
+    JsonMetadataValue,
+    SensorResult,
+    build_last_update_freshness_checks,
+    defs_loader,
+    sensor,
+)
+
+####################################################################################################
+# This is code that would live inside the dagster-airbyte library
+####################################################################################################
+
+
+class AirbyteWorkspace:
+    def __init__(self, name: str):
+        self._name = name
+
+    def build_defs(
+        self, context: DefinitionsLoadContext, execution_fn: Optional[Callable] = None
+    ) -> Definitions:
+        existing_source: DefinitionSource = context.get_loaded_definition_source(self._name)
+        if existing_source:
+            # we end up here inside step worker and run worker
+            airbyte_workspace_info = existing_source.metadata["dagster_airbyte/workspace"].value
+        else:
+            # we end up here inside the code server
+            airbyte_workspace_info = self._fetch_workspace_info()
+
+        return self._build_defs_from_workspace_info(airbyte_workspace_info, execution_fn)
+
+    def _build_defs_from_workspace_info(
+        self, workspace_info: Mapping[str, Any], execution_fn: Optional[Callable]
+    ) -> Definitions:
+        if execution_fn is None:
+
+            def _default_execution_fn(context):
+                yield from self.sync(context).stream()
+
+            execution_fn = _default_execution_fn
+
+        assets = []  # build AssetsDefinition using execution_fn
+        return Definitions(
+            assets=assets,
+            sources=[
+                DefinitionSource(
+                    name=self._name,
+                    metadata={"dagster_airbyte/workspace": JsonMetadataValue(workspace_info)},
+                )
+            ],
+        )
+
+    def _fetch_workspace_info(self):
+        """Fetches data from Airbyte that can be used to construct a set of asset definitions."""
+        return {}
+
+    def sync(self, context: AssetExecutionContext):
+        pass
+
+
+####################################################################################################
+# This is code that a user would write
+####################################################################################################
+
+
+workspace = AirbyteWorkspace(name="workspace1")
+
+
+@sensor()
+def my_reload_code_location_sensor(context):
+    last_reload = datetime.strptime(context.cursor, "%Y-%m-%d %H:%M:%S.%f")
+    if datetime.now() - last_reload > timedelta(minutes=5):
+        return SensorResult(
+            definitions_reload_requests=[DefinitionsReloadRequest.self()],
+            cursor=str(datetime.now()),
+        )
+
+
+@defs_loader
+def defs(context: DefinitionsLoadContext) -> Definitions:
+    airbyte_defs = workspace.build_defs(context)
+    freshness_checks = build_last_update_freshness_checks(airbyte_defs.assets)
+
+    return Definitions.merge(
+        airbyte_defs,
+        Definitions(asset_checks=freshness_checks, sensors=[my_reload_code_location_sensor]),
+    )

--- a/state-driven-blueprints-decorator.py
+++ b/state-driven-blueprints-decorator.py
@@ -1,0 +1,65 @@
+from typing import Any, Mapping
+
+from dagster import (
+    Definitions,
+    DefinitionsLoadContext,
+    DefinitionSource,
+    JsonMetadataValue,
+    build_last_update_freshness_checks,
+    defs_loader,
+)
+
+####################################################################################################
+# This is code that would live inside the core Dagster library of dagster-blueprints package
+####################################################################################################
+
+
+class StateDrivenBlueprintsLoader:
+    def __init__(self, name: str, schema):
+        self._name = name
+        self._schema = schema
+
+    def build_defs(self, context: DefinitionsLoadContext) -> Definitions:
+        existing_source: DefinitionSource = context.get_loaded_definition_source(self._name)
+        if existing_source:
+            # we end up here inside step worker and run worker
+
+            # note that we don't want to fetch from the blueprints store in this case, because the
+            # blueprints store could have been updated since the enclosing run was launched.
+            blueprints = existing_source.metadata["blueprints"].value
+        else:
+            # we end up here inside the code server
+            blueprints = context.get_blueprints_from_blueprints_store()
+
+        return self._build_defs_from_blueprints(blueprints)
+
+    def _build_defs_from_blueprints(self, blueprints: Mapping[str, Any]) -> Definitions:
+        assets = []  # build AssetsDefinition using blueprints
+        return Definitions(
+            assets=assets,
+            sources=[
+                DefinitionSource(
+                    name=self._name,
+                    metadata={
+                        "blueprints": JsonMetadataValue(blueprints),
+                        "schema": JsonMetadataValue(self._schema),
+                    },
+                )
+            ],
+        )
+
+
+####################################################################################################
+# This is code that a user would write
+####################################################################################################
+
+
+embedded_elt_blueprints_loader = StateDrivenBlueprintsLoader(name="embedded_elt")
+
+
+@defs_loader
+def defs(context: DefinitionsLoadContext) -> Definitions:
+    defs_from_blueprints = embedded_elt_blueprints_loader.build_defs(context)
+    freshness_checks = build_last_update_freshness_checks(defs_from_blueprints.assets)
+
+    return Definitions.merge(defs_from_blueprints, Definitions(asset_checks=freshness_checks))


### PR DESCRIPTION
## Summary & Motivation

This PR is an exploration of hypothetical APIs for loading definitions. It consists of two explorations:
- A sketch of an integration (Airbyte) that pulls asset definitions from an external service
- A sketch of a blueprints-loader that pulls blueprints from a state store

It imagines two new concepts:
- `@defs_loader` – basically the same as in https://github.com/dagster-io/dagster/pull/23678. It's basically a wrapped function that accepts a `DefinitionLoadContext` and returns a `Definitions`.
- `DefinitionSource`, an object that can be included on a `Definitions` object that represents a "source" of a set of definitions, like an Airbyte workspace, dbt project, or blueprint-based factory. It has a name and arbitrary metadata. This is useful for a couple things:
  - When loading definitions in the step worker, the defs loader can use the `DefinitionsLoadContext` to fetch the `DefinitionSource` that was returned by the code server during the corresponding "Reload definitions" operation. It can use the metadata on this cached `DefinitionSource` to reconstruct the definitions, rather than hitting the external service.
  - Metadata on the `DefinitionSource`, like blueprint schema, can power future HTTP API- and UI-based blueprints functionality.

It also imagines the ability for a `SensorResult` to include a `DefinitionsReloadRequest`, so that users don't need to use the GraphQL API to automatically reload their definitions.

## How I Tested These Changes
