### PR TITLE
filter by multiple statuses in BulkActionsFilter

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2397,7 +2397,7 @@ enum AssetEventType {
 }
 
 input BulkActionsFilter {
-  status: BulkActionStatus
+  statuses: [BulkActionStatus!]
   createdBefore: Float
   createdAfter: Float
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -733,7 +733,7 @@ export enum BulkActionStatus {
 export type BulkActionsFilter = {
   createdAfter?: InputMaybe<Scalars['Float']['input']>;
   createdBefore?: InputMaybe<Scalars['Float']['input']>;
-  status?: InputMaybe<BulkActionStatus>;
+  statuses?: InputMaybe<Array<BulkActionStatus>>;
 };
 
 export type CancelBackfillResult = CancelBackfillSuccess | PythonError | UnauthorizedError;
@@ -6984,10 +6984,7 @@ export const buildBulkActionsFilter = (
       overrides && overrides.hasOwnProperty('createdAfter') ? overrides.createdAfter! : 6.09,
     createdBefore:
       overrides && overrides.hasOwnProperty('createdBefore') ? overrides.createdBefore! : 1.5,
-    status:
-      overrides && overrides.hasOwnProperty('status')
-        ? overrides.status!
-        : BulkActionStatus.CANCELED,
+    statuses: overrides && overrides.hasOwnProperty('statuses') ? overrides.statuses! : [],
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -379,7 +379,9 @@ class GrapheneTagInput(graphene.InputObjectType):
 
 
 class GrapheneBulkActionsFilter(graphene.InputObjectType):
-    status = graphene.InputField("dagster_graphql.schema.backfill.GrapheneBulkActionStatus")
+    statuses = graphene.List(
+        graphene.NonNull("dagster_graphql.schema.backfill.GrapheneBulkActionStatus")
+    )
     createdBefore = graphene.InputField(graphene.Float)
     createdAfter = graphene.InputField(graphene.Float)
 
@@ -388,12 +390,14 @@ class GrapheneBulkActionsFilter(graphene.InputObjectType):
         name = "BulkActionsFilter"
 
     def to_selector(self):
-        status = BulkActionStatus[self.status.value] if self.status else None
+        statuses = (
+            [BulkActionStatus[status.value] for status in self.statuses] if self.statuses else None
+        )
         created_before = datetime_from_timestamp(self.createdBefore) if self.createdBefore else None
         created_after = datetime_from_timestamp(self.createdAfter) if self.createdAfter else None
 
         return BulkActionsFilter(
-            status=status,
+            statuses=statuses,
             created_before=created_before,
             created_after=created_after,
         )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -1203,5 +1203,5 @@ def test_get_backfills_with_filters():
             get_backfills_result = execute_dagster_graphql(
                 context,
                 BACKFILLS_WITH_FILTERS_QUERY,
-                variables={"filters": {"status": "REQUESTED"}},
+                variables={"filters": {"statuses": ["REQUESTED"]}},
             )

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -50,14 +50,14 @@ class BulkActionsFilter:
     all values will be permitted for that field.
 
     Args:
-        status (Optional[BulkActionStatus]): A status to filter by.
+        statuses (Optional[Sequence[BulkActionStatus]]): A list of statuses to filter by.
         created_before (Optional[DateTime]): Filter by bulk actions that were created before this datetime. Note that the
             create_time for each bulk action is stored in UTC.
         created_after (Optional[DateTime]): Filter by bulk actions that were created after this datetime. Note that the
             create_time for each bulk action is stored in UTC.
     """
 
-    status: Optional[BulkActionStatus] = None
+    statuses: Optional[Sequence[BulkActionStatus]] = None
     created_before: Optional[datetime] = None
     created_after: Optional[datetime] = None
 

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -846,7 +846,7 @@ class SqlRunStorage(RunStorage):
                 raise DagsterInvariantViolationError(
                     "Conflicting status filters provided to get_backfills. Choose one of status or BulkActionsFilter.statuses."
                 )
-            statuses = [status] or (filters.statuses if filters else None)
+            statuses = [status] if status else (filters.statuses if filters else None)
             assert statuses
             query = query.where(
                 BulkActionsTable.c.status.in_([status.value for status in statuses])

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -841,14 +841,16 @@ class SqlRunStorage(RunStorage):
     ) -> Sequence[PartitionBackfill]:
         check.opt_inst_param(status, "status", BulkActionStatus)
         query = db_select([BulkActionsTable.c.body, BulkActionsTable.c.timestamp])
-        if status or (filters and filters.status):
-            if status and filters and filters.status and status != filters.status:
+        if status or (filters and filters.statuses):
+            if status and filters and filters.statuses:
                 raise DagsterInvariantViolationError(
-                    "Conflicting status filters provided to get_backfills. Choose one of status or BulkActionsFilter.status."
+                    "Conflicting status filters provided to get_backfills. Choose one of status or BulkActionsFilter.statuses."
                 )
-            status = status or (filters.status if filters else None)
-            assert status
-            query = query.where(BulkActionsTable.c.status == status.value)
+            statuses = [status] or (filters.statuses if filters else None)
+            assert statuses
+            query = query.where(
+                BulkActionsTable.c.status.in_([status.value for status in statuses])
+            )
         if cursor:
             cursor_query = db_select([BulkActionsTable.c.id]).where(
                 BulkActionsTable.c.key == cursor

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -841,11 +841,11 @@ class SqlRunStorage(RunStorage):
     ) -> Sequence[PartitionBackfill]:
         check.opt_inst_param(status, "status", BulkActionStatus)
         query = db_select([BulkActionsTable.c.body, BulkActionsTable.c.timestamp])
+        if status and filters:
+            raise DagsterInvariantViolationError(
+                "Cannot provide status and filters to get_backfills. Please use filters rather than status."
+            )
         if status or (filters and filters.statuses):
-            if status and filters and filters.statuses:
-                raise DagsterInvariantViolationError(
-                    "Conflicting status filters provided to get_backfills. Choose one of status or BulkActionsFilter.statuses."
-                )
             statuses = [status] if status else (filters.statuses if filters else None)
             assert statuses
             query = query.where(

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -1353,26 +1353,73 @@ class TestRunStorage:
         )
         storage.add_backfill(one)
         assert (
-            len(storage.get_backfills(filters=BulkActionsFilter(status=BulkActionStatus.REQUESTED)))
+            len(
+                storage.get_backfills(
+                    filters=BulkActionsFilter(statuses=[BulkActionStatus.REQUESTED])
+                )
+            )
             == 1
         )
         assert (
-            len(storage.get_backfills(filters=BulkActionsFilter(status=BulkActionStatus.COMPLETED)))
+            len(
+                storage.get_backfills(
+                    filters=BulkActionsFilter(statuses=[BulkActionStatus.COMPLETED])
+                )
+            )
             == 0
         )
+        assert (
+            len(
+                storage.get_backfills(
+                    filters=BulkActionsFilter(
+                        statuses=[BulkActionStatus.COMPLETED, BulkActionStatus.REQUESTED]
+                    )
+                )
+            )
+            == 1
+        )
         backfills = storage.get_backfills(
-            filters=BulkActionsFilter(status=BulkActionStatus.REQUESTED)
+            filters=BulkActionsFilter(statuses=[BulkActionStatus.REQUESTED])
         )
         assert backfills[0] == one
 
         storage.update_backfill(one.with_status(status=BulkActionStatus.COMPLETED))
         assert (
-            len(storage.get_backfills(filters=BulkActionsFilter(status=BulkActionStatus.REQUESTED)))
+            len(
+                storage.get_backfills(
+                    filters=BulkActionsFilter(statuses=[BulkActionStatus.REQUESTED])
+                )
+            )
             == 0
         )
         assert (
-            len(storage.get_backfills(filters=BulkActionsFilter(status=BulkActionStatus.COMPLETED)))
+            len(
+                storage.get_backfills(
+                    filters=BulkActionsFilter(statuses=[BulkActionStatus.COMPLETED])
+                )
+            )
             == 1
+        )
+
+        two = PartitionBackfill(
+            "two",
+            partition_set_origin=origin,
+            status=BulkActionStatus.REQUESTED,
+            partition_names=["a", "b", "c"],
+            from_failure=False,
+            tags={},
+            backfill_timestamp=time.time(),
+        )
+        storage.add_backfill(two)
+        assert (
+            len(
+                storage.get_backfills(
+                    filters=BulkActionsFilter(
+                        statuses=[BulkActionStatus.COMPLETED, BulkActionStatus.REQUESTED]
+                    )
+                )
+            )
+            == 2
         )
 
     def test_backfill_created_time_filtering(self, storage: RunStorage):


### PR DESCRIPTION
## Summary & Motivation
You can select multiple statuses when you filter for runs in the UI, so we should support filtering backfills for multiple statuses. Alternatively we can wait until the dagster run status for a backfill is stored in the DB and then just allow filtering for multiple statuses of dagster run statuses

companion internal pr https://github.com/dagster-io/internal/pull/11113

## How I Tested These Changes
unit tests