### PR TITLE
Reorder status and filters params for get_backfills

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_backfills.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_backfills.py
@@ -20,10 +20,10 @@ def get_backfill(graphene_info: "ResolveInfo", backfill_id: str) -> "GraphenePar
 
 def get_backfills(
     graphene_info: "ResolveInfo",
-    status: Optional[BulkActionStatus] = None,
+    filters: Optional[BulkActionsFilter] = None,
     cursor: Optional[str] = None,
     limit: Optional[int] = None,
-    filters: Optional[BulkActionsFilter] = None,
+    status: Optional[BulkActionStatus] = None,
 ) -> "GraphenePartitionBackfills":
     from ..schema.backfill import GraphenePartitionBackfill, GraphenePartitionBackfills
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -3077,10 +3077,10 @@ class DagsterInstance(DynamicPartitionsStore):
     # backfill
     def get_backfills(
         self,
-        status: Optional["BulkActionStatus"] = None,
+        filters: Optional["BulkActionsFilter"] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
-        filters: Optional["BulkActionsFilter"] = None,
+        status: Optional["BulkActionStatus"] = None,
     ) -> Sequence["PartitionBackfill"]:
         return self._run_storage.get_backfills(
             status=status, cursor=cursor, limit=limit, filters=filters

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -313,12 +313,14 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
 
     def get_backfills(
         self,
-        status: Optional["BulkActionStatus"] = None,
+        filters: Optional["BulkActionsFilter"] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
-        filters: Optional["BulkActionsFilter"] = None,
+        status: Optional["BulkActionStatus"] = None,
     ) -> Sequence["PartitionBackfill"]:
-        return self._storage.run_storage.get_backfills(status, cursor, limit, filters=filters)
+        return self._storage.run_storage.get_backfills(
+            cursor=cursor, limit=limit, filters=filters, status=status
+        )
 
     def get_backfill(self, backfill_id: str) -> Optional["PartitionBackfill"]:
         return self._storage.run_storage.get_backfill(backfill_id)

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -370,10 +370,10 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
     @abstractmethod
     def get_backfills(
         self,
-        status: Optional[BulkActionStatus] = None,
+        filters: Optional[BulkActionsFilter] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
-        filters: Optional[BulkActionsFilter] = None,
+        status: Optional[BulkActionStatus] = None,
     ) -> Sequence[PartitionBackfill]:
         """Get a list of partition backfills."""
 

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -834,10 +834,10 @@ class SqlRunStorage(RunStorage):
 
     def get_backfills(
         self,
-        status: Optional[BulkActionStatus] = None,
+        filters: Optional[BulkActionsFilter] = None,
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
-        filters: Optional[BulkActionsFilter] = None,
+        status: Optional[BulkActionStatus] = None,
     ) -> Sequence[PartitionBackfill]:
         check.opt_inst_param(status, "status", BulkActionStatus)
         query = db_select([BulkActionsTable.c.body, BulkActionsTable.c.timestamp])

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -12,7 +12,7 @@ from dagster._core.errors import (
     DagsterUserCodeUnreachableError,
 )
 from dagster._core.execution.asset_backfill import execute_asset_backfill_iteration
-from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
+from dagster._core.execution.backfill import BulkActionsFilter, BulkActionStatus, PartitionBackfill
 from dagster._core.execution.job_backfill import execute_job_backfill_iteration
 from dagster._core.workspace.context import IWorkspaceProcessContext
 from dagster._daemon.utils import DaemonErrorCapture
@@ -53,8 +53,12 @@ def execute_backfill_iteration(
 ) -> Iterable[Optional[SerializableErrorInfo]]:
     instance = workspace_process_context.instance
 
-    in_progress_backfills = instance.get_backfills(status=BulkActionStatus.REQUESTED)
-    canceling_backfills = instance.get_backfills(status=BulkActionStatus.CANCELING)
+    in_progress_backfills = instance.get_backfills(
+        filters=BulkActionsFilter(statuses=[BulkActionStatus.REQUESTED])
+    )
+    canceling_backfills = instance.get_backfills(
+        filters=BulkActionsFilter(statuses=[BulkActionStatus.CANCELING])
+    )
 
     if not in_progress_backfills and not canceling_backfills:
         logger.debug("No backfill jobs in progress or canceling.")

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -535,11 +535,13 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         """Returns an AssetGraphSubset representing the set of assets that are currently targeted by
         an active asset backfill.
         """
-        from dagster._core.execution.backfill import BulkActionStatus
+        from dagster._core.execution.backfill import BulkActionsFilter, BulkActionStatus
 
         asset_backfills = [
             backfill
-            for backfill in self.instance.get_backfills(status=BulkActionStatus.REQUESTED)
+            for backfill in self.instance.get_backfills(
+                filters=BulkActionsFilter(statuses=[BulkActionStatus.REQUESTED])
+            )
             if backfill.is_asset_backfill
         ]
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -1329,6 +1329,7 @@ class TestRunStorage:
         )
         storage.add_backfill(one)
         assert len(storage.get_backfills()) == 1
+        # maintain a test that uses the old status parameter
         assert len(storage.get_backfills(status=BulkActionStatus.REQUESTED)) == 1
         backfill = storage.get_backfill(one.backfill_id)
         assert backfill == one


### PR DESCRIPTION
## Summary & Motivation
reorders the params to `get_backfills` so that `filters` comes before `status`. Also updates internal callsites to use the `filters` parameter. `get_backfills` is not marked public, so reordering params like this is probably ok? can choose not to go forward with this if it seems like too much of a change. 

companion internal pr https://github.com/dagster-io/internal/pull/11114

## How I Tested These Changes
