### PR TITLE
[dagster-polars][dagster-pandera] Pandera / polars IO Manager compatibility and optional partitioned upstream asset

### DIFF
--- a/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera/__init__.py
@@ -124,6 +124,16 @@ def pandera_schema_to_dagster_type(
     tschema = _pandera_schema_to_table_schema(norm_schema)
     type_check_fn = _pandera_schema_to_type_check_fn(norm_schema, tschema)
 
+    typing_type = (
+        pl.DataFrame
+        if pa_polars
+        and (
+            isinstance(schema, pa_polars.DataFrameSchema)
+            or (isinstance(schema, type) and issubclass(schema, pa_polars.DataFrameModel))
+        )
+        else pd.DataFrame
+    )
+
     return DagsterType(
         type_check_fn=type_check_fn,
         name=name,
@@ -131,7 +141,7 @@ def pandera_schema_to_dagster_type(
         metadata={
             "schema": MetadataValue.table_schema(tschema),
         },
-        typing_type=pd.DataFrame,
+        typing_type=typing_type,
     )
 
 

--- a/python_modules/libraries/dagster-pandera/dagster_pandera_tests/test_dagster_pandera.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera_tests/test_dagster_pandera.py
@@ -115,6 +115,7 @@ def dagster_type():
 def test_pandera_schema_to_dagster_type(schema):
     dagster_type = pandera_schema_to_dagster_type(schema)
     assert isinstance(dagster_type, DagsterType)
+    assert dagster_type.typing_type == pd.DataFrame
     assert len(dagster_type.metadata) == 1
     schema_metadata = dagster_type.metadata["schema"]
     assert isinstance(schema_metadata, TableSchemaMetadataValue)

--- a/python_modules/libraries/dagster-pandera/dagster_pandera_tests/test_polars.py
+++ b/python_modules/libraries/dagster-pandera/dagster_pandera_tests/test_polars.py
@@ -118,6 +118,7 @@ def dagster_type():
 def test_pandera_schema_to_dagster_type(schema):
     dagster_type = pandera_schema_to_dagster_type(schema)
     assert isinstance(dagster_type, DagsterType)
+    assert dagster_type.typing_type == pl.DataFrame
     assert len(dagster_type.metadata) == 1
     schema_metadata = dagster_type.metadata["schema"]
     assert isinstance(schema_metadata, TableSchemaMetadataValue)

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/base.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/base.py
@@ -77,13 +77,19 @@ POLARS_LAZY_FRAME_ANNOTATIONS = [
 
 if sys.version_info >= (3, 9):
     POLARS_EAGER_FRAME_ANNOTATIONS.append(dict[str, pl.DataFrame])
+    POLARS_EAGER_FRAME_ANNOTATIONS.append(Dict[str, pl.DataFrame])
     POLARS_EAGER_FRAME_ANNOTATIONS.append(dict[str, Optional[pl.DataFrame]])
+    POLARS_EAGER_FRAME_ANNOTATIONS.append(Dict[str, Optional[pl.DataFrame]])
 
     POLARS_LAZY_FRAME_ANNOTATIONS.append(dict[str, pl.LazyFrame])
+    POLARS_LAZY_FRAME_ANNOTATIONS.append(Dict[str, pl.LazyFrame])
     POLARS_LAZY_FRAME_ANNOTATIONS.append(dict[str, Optional[pl.LazyFrame]])
+    POLARS_LAZY_FRAME_ANNOTATIONS.append(Dict[str, Optional[pl.LazyFrame]])
 
 
 def annotation_is_typing_optional(annotation) -> bool:
+    if get_origin(annotation) in (dict, Dict, Mapping):
+        return annotation_is_typing_optional(get_args(annotation)[1])
     return get_origin(annotation) == Union and type(None) in get_args(annotation)
 
 

--- a/python_modules/libraries/dagster-polars/dagster_polars_tests/test_upath_io_managers.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars_tests/test_upath_io_managers.py
@@ -177,6 +177,35 @@ def test_polars_upath_io_manager_input_dict_eager(
             partition_key=partition_key,
         )
 
+
+def test_polars_upath_io_manager_input_dict_optional_eager(
+    io_manager_and_df: Tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, df = io_manager_and_df
+    partition_keys = ["a", "b", "missing"]
+
+    @asset(io_manager_def=manager, partitions_def=StaticPartitionsDefinition(partition_keys))
+    def upstream(context: AssetExecutionContext) -> Optional[pl.DataFrame]:
+        return (
+            None
+            if context.partition_key == "missing"
+            else df.with_columns(pl.lit(context.partition_key).alias("partition"))
+        )
+
+    @asset(io_manager_def=manager)
+    def downstream(upstream: Dict[str, Optional[pl.DataFrame]]) -> pl.DataFrame:
+        dfs = []
+        for df in upstream.values():
+            assert isinstance(df, pl.DataFrame)
+            dfs.append(df)
+        return pl.concat(dfs)
+
+    for partition_key in partition_keys:
+        materialize(
+            [upstream],
+            partition_key=partition_key,
+        )
+
     materialize(
         [upstream.to_source_asset(), downstream],
     )
@@ -193,6 +222,39 @@ def test_polars_upath_io_manager_input_dict_lazy(
 
     @asset(io_manager_def=manager)
     def downstream(upstream: Dict[str, pl.LazyFrame]) -> pl.DataFrame:
+        dfs = []
+        for df in upstream.values():
+            assert isinstance(df, pl.LazyFrame)
+            dfs.append(df)
+        return pl.concat(dfs).collect()
+
+    for partition_key in ["a", "b"]:
+        materialize(
+            [upstream],
+            partition_key=partition_key,
+        )
+
+    materialize(
+        [upstream.to_source_asset(), downstream],
+    )
+
+
+def test_polars_upath_io_manager_input_dict_optional_lazy(
+    io_manager_and_df: Tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, df = io_manager_and_df
+    partition_keys = ["a", "b", "missing"]
+
+    @asset(io_manager_def=manager, partitions_def=StaticPartitionsDefinition(partition_keys))
+    def upstream(context: AssetExecutionContext) -> Optional[pl.DataFrame]:
+        return (
+            None
+            if context.partition_key == "missing"
+            else df.with_columns(pl.lit(context.partition_key).alias("partition"))
+        )
+
+    @asset(io_manager_def=manager)
+    def downstream(upstream: Dict[str, Optional[pl.LazyFrame]]) -> pl.DataFrame:
         dfs = []
         for df in upstream.values():
             assert isinstance(df, pl.LazyFrame)


### PR DESCRIPTION
## Summary & Motivation

When using both dagster-pandera and dagster-polars to build software-defined assets, there are small issues when using PolarsParquetIOManager with Pandera type validation:
- #23714
- #23711

## How I Tested These Changes

dagster-pandera: 
  - Ensure output typing_type from generated DagsterType follows the right DataFrame type (Pandas/Polars)

dagster-polars:
  - Test with input dict/partitioned upstream assets with Optional partitions