### PR TITLE
Add kinds parameter to AssetSpec

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -297,6 +297,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     partitionStats = graphene.Field(GraphenePartitionStats)
     metadata_entries = non_null_list(GrapheneMetadataEntry)
     tags = non_null_list(GrapheneDefinitionTag)
+    kinds = non_null_list(graphene.String)
     op = graphene.Field(GrapheneSolidDefinition)
     opName = graphene.String()
     opNames = non_null_list(graphene.String)
@@ -1210,6 +1211,12 @@ class GrapheneAssetNode(graphene.ObjectType):
             GrapheneDefinitionTag(key, value)
             for key, value in (self._external_asset_node.tags or {}).items()
         ]
+
+    def resolve_kinds(self, _graphene_info: ResolveInfo) -> Sequence[str]:
+        kinds = list(self.external_asset_node.kinds)
+        if self._external_asset_node.compute_kind:
+            return list({self._external_asset_node.compute_kind, *kinds})
+        return list(kinds)
 
     def resolve_op(
         self, _graphene_info: ResolveInfo

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1758,6 +1758,17 @@ def fresh_diamond_bottom(fresh_diamond_left, fresh_diamond_right):
     return fresh_diamond_left + fresh_diamond_right
 
 
+@multi_asset(
+    specs=[
+        AssetSpec(key="first_kinds_key", kinds={"python", "airflow"}),
+        AssetSpec(key="second_kinds_key", kinds={"python"}),
+    ],
+    compute_kind="dbt",
+)
+def multi_asset_with_kinds():
+    return 1
+
+
 fresh_diamond_assets_job = define_asset_job(
     "fresh_diamond_assets_job", AssetSelection.assets(fresh_diamond_bottom).upstream()
 )
@@ -2071,6 +2082,7 @@ def define_assets():
         ungrouped_asset_3,
         grouped_asset_4,
         ungrouped_asset_5,
+        multi_asset_with_kinds,
     ]
 
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -80,6 +80,10 @@ class AssetNode(BaseAssetNode):
         return self._spec.tags
 
     @property
+    def kinds(self) -> Set[str]:
+        return self._spec.kinds
+
+    @property
     def owners(self) -> Sequence[str]:
         return self._spec.owners
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_out.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_out.py
@@ -162,6 +162,7 @@ class AssetOut(
                 deps=deps,
                 auto_materialize_policy=None,
                 partitions_def=None,
+                kinds=None,
             )
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, NamedTuple, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, NamedTuple, Optional, Sequence, Set
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, experimental_param
@@ -67,6 +67,7 @@ class AssetExecutionType(Enum):
 
 @experimental_param(param="owners")
 @experimental_param(param="tags")
+@experimental_param(param="kinds")
 class AssetSpec(
     NamedTuple(
         "_AssetSpec",
@@ -82,6 +83,7 @@ class AssetSpec(
             ("automation_condition", PublicAttr[Optional[AutomationCondition]]),
             ("owners", PublicAttr[Sequence[str]]),
             ("tags", PublicAttr[Mapping[str, str]]),
+            ("kinds", PublicAttr[Set[str]]),
             ("partitions_def", PublicAttr[Optional[PartitionsDefinition]]),
         ],
     ),
@@ -114,6 +116,8 @@ class AssetSpec(
             e.g. `team:finops`.
         tags (Optional[Mapping[str, str]]): Tags for filtering and organizing. These tags are not
             attached to runs of the asset.
+        kinds: (Optional[Set[str]]): A list of strings representing the kinds of the asset. These
+            will be made visible in the Dagster UI.
         partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
             compose the asset.
     """
@@ -132,6 +136,7 @@ class AssetSpec(
         automation_condition: Optional[AutomationCondition] = None,
         owners: Optional[Sequence[str]] = None,
         tags: Optional[Mapping[str, str]] = None,
+        kinds: Optional[Set[str]] = None,
         # TODO: FOU-243
         auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
@@ -166,6 +171,7 @@ class AssetSpec(
             ),
             owners=owners,
             tags=validate_tags_strict(tags) or {},
+            kinds=check.opt_set_param(kinds, "kinds", of_type=str),
             partitions_def=check.opt_inst_param(
                 partitions_def, "partitions_def", PartitionsDefinition
             ),
@@ -185,6 +191,7 @@ class AssetSpec(
         automation_condition: Optional[AutomationCondition],
         owners: Optional[Sequence[str]],
         tags: Optional[Mapping[str, str]],
+        kinds: Optional[Set[str]],
         auto_materialize_policy: Optional[AutoMaterializePolicy],
         partitions_def: Optional[PartitionsDefinition],
     ) -> "AssetSpec":
@@ -201,6 +208,7 @@ class AssetSpec(
             automation_condition=automation_condition,
             owners=owners,
             tags=tags,
+            kinds=kinds,
             partitions_def=partitions_def,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1762,6 +1762,7 @@ def _asset_specs_from_attr_key_params(
                     skippable=False,
                     auto_materialize_policy=None,
                     partitions_def=None,
+                    kinds=None,
                 )
             )
 

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -1044,6 +1044,7 @@ class ExternalAssetNode(IHaveNew):
     output_description: Optional[str]
     metadata: Mapping[str, MetadataValue]
     tags: Optional[Mapping[str, str]]
+    kinds: Sequence[str]
     group_name: str
     freshness_policy: Optional[FreshnessPolicy]
     is_source: bool
@@ -1077,6 +1078,7 @@ class ExternalAssetNode(IHaveNew):
         output_description: Optional[str] = None,
         metadata: Optional[Mapping[str, MetadataValue]] = None,
         tags: Optional[Mapping[str, str]] = None,
+        kinds: Optional[Sequence[str]] = None,
         group_name: Optional[str] = None,
         freshness_policy: Optional[FreshnessPolicy] = None,
         is_source: Optional[bool] = None,
@@ -1150,6 +1152,7 @@ class ExternalAssetNode(IHaveNew):
             output_name=output_name,
             output_description=output_description,
             metadata=metadata,
+            kinds=kinds or [],
             tags=tags or {},
             # Newer code always passes a string group name when constructing these, but we assign
             # the default here for backcompat.
@@ -1483,6 +1486,7 @@ def external_asset_nodes_from_defs(
                 output_name=output_name,
                 metadata=asset_node.metadata,
                 tags=asset_node.tags,
+                kinds=list(asset_node.kinds),
                 group_name=asset_node.group_name,
                 freshness_policy=asset_node.freshness_policy,
                 is_source=asset_node.is_external,


### PR DESCRIPTION
## Summary

Introduces a `kinds` parameter to `AssetSpec` which takes a set of strings representing compute, storage etc kinds, based on https://github.com/dagster-io/internal/discussions/10821#discussioncomment-10353301.

These kinds are piped through to the external asset layer and then through GraphQL where we can render them on the frontend.

## Test Plan

Unit tests, more forthcoming.
