### PR TITLE
[ui] Display lowercase compute and storage kinds and correctly map icons

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/search/BuildAssetSearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/BuildAssetSearchResults.tsx
@@ -98,12 +98,12 @@ export function buildAssetCountBySection(assets: AssetDefinitionMetadata[]): Ass
 
       const computeKind = assetDefinition.computeKind;
       if (computeKind) {
-        assetCountByComputeKind.increment(computeKind);
+        assetCountByComputeKind.increment(computeKind.toLowerCase());
       }
 
       assetDefinition.tags.forEach((tag) => {
         if (isCanonicalStorageKindTag(tag)) {
-          assetCountByStorageKind.increment(tag.value);
+          assetCountByStorageKind.increment(tag.value.toLowerCase());
         } else {
           const stringifiedTag = JSON.stringify(tag);
           assetCountByTag.increment(stringifiedTag);


### PR DESCRIPTION
## Summary & Motivation

Fixes https://linear.app/dagster-labs/issue/FE-503/compute-kind-buttons-not-showing-proper-icon-on-catalog-when-they-are

The asset catalog was not grouping `compute_kind: SQL` and `compute_kind: sql` together. The uppercase version also did not not have a corresponding image.

I don't think compute_kind or storage_kind are ever meant to have uppercase letters, so the easiest solution to fix both the grouping and the icons is to lowercase the strings before grouping.


## How I Tested These Changes

I reproduced this by specifying SQL vs sql compute_kind on a few assets. I also verified that the asset catalog search is also case insensitive. 
