### PR TITLE
Fix bug: "Asset Group list view shows entire catalog"

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -194,7 +194,6 @@ export const AssetsCatalogTable = ({
   setPrefixPath,
   groupSelector,
 }: AssetCatalogTableProps) => {
-  console.log({prefixPath, groupSelector});
   const setCurrentPage = useSetRecoilState(currentPageAtom);
   const {path} = useRouteMatch();
   useEffect(() => {
@@ -204,8 +203,6 @@ export const AssetsCatalogTable = ({
   const [view, setView] = useAssetView();
 
   const {assets, query, error} = useAllAssets({groupSelector});
-
-  console.log({assets});
 
   const {
     filtered: partiallyFiltered,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -90,6 +90,9 @@ export function useAllAssets({
   });
 
   const fetchAssets = useCallback(async () => {
+    if (groupSelector) {
+      return;
+    }
     try {
       const data = await fetchPaginatedData({
         async fetchData(cursor: string | null | undefined) {
@@ -134,11 +137,7 @@ export function useAllAssets({
         }));
       }
     }
-  }, [batchLimit, cacheManager, client]);
-
-  useEffect(() => {
-    fetchAssets();
-  }, [fetchAssets]);
+  }, [batchLimit, cacheManager, client, groupSelector]);
 
   const groupQuery = useCallback(async () => {
     if (!groupSelector) {
@@ -166,7 +165,7 @@ export function useAllAssets({
     onData(data);
   }, [groupSelector, client]);
 
-  return useMemo(() => {
+  const api = useMemo(() => {
     return {
       assets,
       error,
@@ -174,6 +173,14 @@ export function useAllAssets({
       query: groupSelector ? groupQuery : fetchAssets,
     };
   }, [assets, error, fetchAssets, groupQuery, groupSelector]);
+
+  const {query} = api;
+
+  useEffect(() => {
+    query();
+  }, [query]);
+
+  return api;
 }
 
 interface AssetCatalogTableProps {
@@ -187,6 +194,7 @@ export const AssetsCatalogTable = ({
   setPrefixPath,
   groupSelector,
 }: AssetCatalogTableProps) => {
+  console.log({prefixPath, groupSelector});
   const setCurrentPage = useSetRecoilState(currentPageAtom);
   const {path} = useRouteMatch();
   useEffect(() => {
@@ -196,6 +204,8 @@ export const AssetsCatalogTable = ({
   const [view, setView] = useAssetView();
 
   const {assets, query, error} = useAllAssets({groupSelector});
+
+  console.log({assets});
 
   const {
     filtered: partiallyFiltered,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -165,22 +165,20 @@ export function useAllAssets({
     onData(data);
   }, [groupSelector, client]);
 
-  const api = useMemo(() => {
-    return {
-      assets,
-      error,
-      loading: !assets && !error,
-      query: groupSelector ? groupQuery : fetchAssets,
-    };
-  }, [assets, error, fetchAssets, groupQuery, groupSelector]);
-
-  const {query} = api;
+  const query = groupSelector ? groupQuery : fetchAssets;
 
   useEffect(() => {
     query();
   }, [query]);
 
-  return api;
+  return useMemo(() => {
+    return {
+      assets,
+      error,
+      loading: !assets && !error,
+      query,
+    };
+  }, [assets, error, query]);
 }
 
 interface AssetCatalogTableProps {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -89,7 +89,7 @@ export function useAllAssets({
     ),
   });
 
-  const fetchAssets = useCallback(async () => {
+  const allAssetsQuery = useCallback(async () => {
     if (groupSelector) {
       return;
     }
@@ -165,7 +165,7 @@ export function useAllAssets({
     onData(data);
   }, [groupSelector, client]);
 
-  const query = groupSelector ? groupQuery : fetchAssets;
+  const query = groupSelector ? groupQuery : allAssetsQuery;
 
   useEffect(() => {
     query();


### PR DESCRIPTION
## Summary & Motivation
As titled.

The cause of this was an effect fetching all assets instead of using the `groupSelector` on initial load.

## How I Tested These Changes

loaded the list view for a group and made sure we filtered correctly.