### PR TITLE
Remove tsconfig for cloud resolutions when running OSS

### DIFF
--- a/js_modules/dagster-ui/package.json
+++ b/js_modules/dagster-ui/package.json
@@ -8,7 +8,8 @@
     "build-with-profiling": "yarn workspace @dagster-io/app-oss build --profile && yarn post-build",
     "post-build": "cd ../../python_modules/dagster-webserver/dagster_webserver && rm -rf webapp && mkdir -p webapp && cp -r ../../../js_modules/dagster-ui/packages/app-oss/build ./webapp/ && mkdir -p webapp/build/vendor && cp -r graphiql ./webapp/build/vendor && cp ../../../js_modules/dagster-ui/packages/app-oss/csp-header.txt ./webapp/build",
     "lint": "yarn workspace @dagster-io/app-oss lint && yarn workspace @dagster-io/ui-core lint && yarn workspace @dagster-io/ui-components lint",
-    "start": "yarn workspace @dagster-io/app-oss start",
+    "remove-cloud-resolutions": "rm -rf ./packages/ui-core/src/tsconfig.json",
+    "start": "yarn remove-cloud-resolutions && yarn workspace @dagster-io/app-oss start",
     "ts": "yarn workspace @dagster-io/app-oss ts && yarn workspace @dagster-io/ui-components ts",
     "postinstall": "patch-package"
   },


### PR DESCRIPTION
## Summary & Motivation

Whenever we run cloud we call `yarn generate-resolutions` which inserts a gitignore'd `.tsconfig.json` file inside `ui-core/src`. This config file remaps all of the shared imports to their `.cloud.tsx` counterparts. Since this file is  in `.gitignore` it never gets removed which you'd want to happen if you were developing solely in OSS. To make that happen I'm making `yarn start` automatically remove the config file. Note that this doesn't affect the ability to run both OSS and Cloud at the same time.

## How I Tested These Changes
yarn start