### PR TITLE
[ui] Sensor history: Fix tick ID variable

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickDetailsDialog.tsx
@@ -61,7 +61,7 @@ export const TickDetailsDialog = ({tickId, isOpen, instigationSelector, onClose}
 };
 
 interface InnerProps {
-  tickId: number | undefined;
+  tickId: string | undefined;
   instigationSelector: InstigationSelector;
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -308,9 +308,9 @@ export const TickHistoryTimeline = ({
   afterTimestamp?: number;
   statuses?: InstigationTickStatus[];
 }) => {
-  const [selectedTickId, setSelectedTickId] = useQueryPersistedState<number | undefined>({
+  const [selectedTickId, setSelectedTickId] = useQueryPersistedState<string | undefined>({
     encode: (tickId) => ({tickId}),
-    decode: (qs) => (qs['tickId'] ? Number(qs['tickId']) : undefined),
+    decode: (qs) => qs['tickId'] ?? undefined,
   });
 
   const [pollingPaused, pausePolling] = React.useState<boolean>(false);
@@ -364,7 +364,7 @@ export const TickHistoryTimeline = ({
   const {ticks = []} = data.instigationStateOrError;
 
   const onTickClick = (tick?: InstigationTick) => {
-    setSelectedTickId(tick ? Number(tick.tickId) : undefined);
+    setSelectedTickId(tick ? tick.tickId : undefined);
   };
 
   const onTickHover = (tick?: InstigationTick) => {
@@ -376,6 +376,7 @@ export const TickHistoryTimeline = ({
       pausePolling(true);
     }
   };
+
   return (
     <>
       <TickDetailsDialog
@@ -512,7 +513,7 @@ function TickRow({
           ) : null}
           <TickDetailsDialog
             isOpen={showResults}
-            tickId={Number(tick.tickId)}
+            tickId={tick.tickId}
             instigationSelector={instigationSelector}
             onClose={() => {
               setShowResults(false);

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/TickTagForRun.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/TickTagForRun.tsx
@@ -32,7 +32,7 @@ export const TickTagForRun = ({instigationSelector, instigationType, tickId}: Pr
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
         instigationSelector={instigationSelector}
-        tickId={Number(tickId)}
+        tickId={tickId}
       />
     </>
   );


### PR DESCRIPTION
## Summary & Motivation

There is a bug on the sensor tick table where clicking to view a run requested for a tick can show information about an unrelated tick.

This is because sensor tick IDs can be larger than JavaScript's `Number.MAX_SAFE_INTEGER`, but they're being cast to `Number` for the GraphQL variable. JS may cast the value to a number that doesn't match the intended value, resulting in the wrong tick ID being sent in the query.

We shouldn't be trying to represent them as `number` in JS. The GraphQL input type expects it to be a BigInt, and we can just pass a string for that.

## How I Tested These Changes

View sensor tick history with ticks that have tick IDs being cast to incorrect values. Verify that the values are now correct, and that when I click to view runs requested for the tick, the query variable and rendered output are correct.