### PR TITLE
[dagster-airlift] sensor fix

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
@@ -184,3 +184,11 @@ def assert_expected_key_order(
     mats: Sequence[AssetMaterialization], expected_key_order: Sequence[str]
 ) -> None:
     assert [mat.asset_key.to_user_string() for mat in mats] == expected_key_order
+
+
+def make_asset(key, deps):
+    @asset(key=key, deps=deps)
+    def the_asset():
+        pass
+
+    return the_asset


### PR DESCRIPTION
Fixes the unsynced issue with the sensor. We need to sort first by timestamp, then by topological order, for the case of dependencies within the same task.

Tested by verifying the unsynced issue went away in dbt example.