### PR TITLE
[dagster-polars] refactor logic for loading various types with a new `TypeRouter` system

### DIFF
--- a/python_modules/libraries/dagster-polars/dagster_polars/__init__.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/__init__.py
@@ -2,27 +2,14 @@ from dagster._core.libraries import DagsterLibraryRegistry
 
 from dagster_polars.io_managers.base import BasePolarsUPathIOManager
 from dagster_polars.io_managers.parquet import PolarsParquetIOManager
-from dagster_polars.types import (
-    DataFramePartitions,
-    DataFramePartitionsWithMetadata,
-    DataFrameWithMetadata,
-    LazyFramePartitions,
-    LazyFramePartitionsWithMetadata,
-    LazyFrameWithMetadata,
-    StorageMetadata,
-)
+from dagster_polars.types import DataFramePartitions, LazyFramePartitions
 from dagster_polars.version import __version__
 
 __all__ = [
     "PolarsParquetIOManager",
     "BasePolarsUPathIOManager",
-    "StorageMetadata",
-    "DataFrameWithMetadata",
-    "LazyFrameWithMetadata",
     "DataFramePartitions",
     "LazyFramePartitions",
-    "DataFramePartitionsWithMetadata",
-    "LazyFramePartitionsWithMetadata",
     "__version__",
 ]
 

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/__init__.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/__init__.py
@@ -12,8 +12,11 @@ try:
     from dagster_polars.io_managers.delta import DeltaWriteMode, PolarsDeltaIOManager  # noqa
 
     __all__.extend(["DeltaWriteMode", "PolarsDeltaIOManager"])
-except ImportError:
-    pass
+except ImportError as e:
+    if "deltalake" in str(e):
+        pass
+    else:
+        raise e
 
 
 try:
@@ -24,5 +27,8 @@ try:
     )
 
     __all__.extend(["PolarsBigQueryIOManager", "PolarsBigQueryTypeHandler"])
-except ImportError:
-    pass
+except ImportError as e:
+    if "google-cloud-bigquery" in str(e):
+        pass
+    else:
+        raise e

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/base.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/base.py
@@ -12,8 +12,15 @@ from typing import (
     cast,
     get_args,
     get_origin,
-    overload,
+    overload, Callable, Generic, TypeVar, List,
+
 )
+
+
+if sys.version_info >= (3, 9):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
 import polars as pl
 from dagster import (
@@ -33,99 +40,197 @@ from pydantic.fields import Field
 from dagster_polars.io_managers.utils import get_polars_metadata
 from dagster_polars.types import (
     DataFramePartitions,
-    DataFramePartitionsWithMetadata,
     LazyFramePartitions,
-    LazyFramePartitionsWithMetadata,
     LazyFrameWithMetadata,
-    StorageMetadata,
 )
+
+try:
+    import pandera
+
+    PANDERA_INSTALLED = True
+except ImportError:
+    PANDERA_INSTALLED = False
+
 
 if TYPE_CHECKING:
     from upath import UPath
 
-POLARS_EAGER_FRAME_ANNOTATIONS = [
-    pl.DataFrame,
-    Optional[pl.DataFrame],
-    # common default types
-    Any,
-    type(None),
-    None,
-    # multiple partitions
-    Dict[str, pl.DataFrame],
-    Mapping[str, pl.DataFrame],
-    DataFramePartitions,
-    # DataFrame + metadata
-    Tuple[pl.DataFrame, StorageMetadata],
-    Optional[Tuple[pl.DataFrame, StorageMetadata]],
-    # multiple partitions + metadata
-    DataFramePartitionsWithMetadata,
+
+T = TypeVar("T")
+
+
+# dump_to_path signature
+F_D: TypeAlias = Callable[[OutputContext, T, "UPath"], None]
+
+# load_from_path signature
+F_L: TypeAlias = Callable[[InputContext, "UPath"], T]
+
+
+class BaseTypeRouter(Generic[T]):
+    """
+    Specifies how to apply a given dump/load operation to a given type annotation.
+    """
+
+    def __init__(self, context: Union[InputContext, OutputContext], type_to_resolve: Any):
+        self.context = context
+        self.type_to_resolve = type_to_resolve
+
+    @abstractmethod
+    def match(self) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    @property
+    def is_root_type(self) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    @property
+    def parent_type(self) -> Any:
+        raise NotImplementedError
+
+    def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
+        dump_fn(self.context, obj, path)
+
+    def load(self, path: "UPath", load_fn: F_L) -> T:
+        return load_fn(self.context, path)
+
+
+class TypeRouter(BaseTypeRouter, Generic[T]):
+    """
+    Specifies how to apply a given dump/load operation to a given type annotation.
+    This base class trivially calls the dump/load functions if the type matches the most simple cases.
+    """
+
+    def match(self) -> bool:
+        return self.type_to_resolve in [
+            pl.DataFrame,
+            pl.LazyFrame,
+            Any,
+            type(None),
+            None,
+        ]
+
+    @property
+    def is_root_type(self) -> bool:
+        return True
+
+
+class OptionalTypeRouter(TypeRouter):
+    """
+    Handles Optional type annotations with a noop if the object is None or missing in storage.
+    """
+
+    def match(self) -> bool:
+        return get_origin(self.type_to_resolve) == Union and type(None) in get_args(self.type_to_resolve)
+
+    @property
+    def is_root_type(self) -> bool:
+        return False
+
+    def parent_type(self) -> Any:
+        return get_args(self.type_to_resolve)[0]
+
+    def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
+        if obj is None:
+            self.context.log.warning(f"Skipping saving optional output at {path} as it is None")
+            return
+        else:
+            router = resolve_type_router(self.context, self.parent_type)
+            router.dump(obj, path, dump_fn)
+
+    def load(self, path: "UPath", load_fn: F_L) -> T:
+        if not path.exists():
+            self.context.log.warning(f"Skipping loading optional input at {path} as it is missing")
+            return None
+        else:
+            router = resolve_type_router(self.context, self.parent_type)
+            return router.load(path, load_fn)
+
+
+class DictTypeRouter(TypeRouter):
+    """
+    Handles loading partitions as dictionaries of DataFrames.
+    """
+
+    def match(self) -> bool:
+        return get_origin(self.type_to_resolve) in (dict, Dict, Mapping)
+
+    @property
+    def is_root_type(self) -> bool:
+        return False
+
+    @property
+    def parent_type(self) -> Any:
+        return get_args(self.type_to_resolve)[1]
+
+
+class PanderaTypeRouter(TypeRouter):
+    """
+    Handles loading Pandera DataFrames.
+    """
+
+    def match(self) -> bool:
+        try:
+            import pandera
+            import pandera.typing.polars
+
+            return (
+                    get_origin(self.type_to_resolve) == pandera.typing.polars.LazyFrame
+                    and issubclass(get_args(self.type_to_resolve)[0], pandera.DataFrameModel)
+            )
+        except ImportError:
+            return False
+
+    @property
+    def is_root_type(self) -> bool:
+        return True
+
+    def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
+        if isinstance()
+        router = resolve_type_router(self.context, self.parent_type)
+        router.dump(obj, path, dump_fn)
+
+    def load(self, path: "UPath", load_fn: F_L) -> T:
+        if not path.exists():
+            self.context.log.warning(f"Skipping loading optional input at {path} as it is missing")
+            return None
+        else:
+            router = resolve_type_router(self.context, self.parent_type)
+            return router.load(path, load_fn)
+
+
+TYPE_ROUTERS = [
+    TypeRouter,
+    OptionalTypeRouter,
+    DictTypeRouter,
 ]
 
-POLARS_LAZY_FRAME_ANNOTATIONS = [
-    pl.LazyFrame,
-    Optional[pl.LazyFrame],
-    # multiple partitions
-    Dict[str, pl.LazyFrame],
-    Mapping[str, pl.LazyFrame],
-    LazyFramePartitions,
-    # LazyFrame + metadata
-    Tuple[pl.LazyFrame, StorageMetadata],
-    Optional[Tuple[pl.LazyFrame, StorageMetadata]],
-    # multiple partitions + metadata
-    LazyFramePartitionsWithMetadata,
-]
+if PANDERA_INSTALLED:
+    TYPE_ROUTERS.append(PanderaTypeRo`uter)
 
 
-if sys.version_info >= (3, 9):
-    POLARS_EAGER_FRAME_ANNOTATIONS.append(dict[str, pl.DataFrame])
-    POLARS_EAGER_FRAME_ANNOTATIONS.append(dict[str, Optional[pl.DataFrame]])
+def resolve_type_router(context: Union[InputContext, OutputContext], type_to_resolve: Any) -> TypeRouter:
+    """
+    Finds the correct TypeRouter for the given context.
+    """
 
-    POLARS_LAZY_FRAME_ANNOTATIONS.append(dict[str, pl.LazyFrame])
-    POLARS_LAZY_FRAME_ANNOTATIONS.append(dict[str, Optional[pl.LazyFrame]])
+    # try each router class in order of increasing complexity
+    for router_class in [
+        TypeRouter,
+        OptionalTypeRouter,
+        ...
+    ]:
+        router = router_class(context, type_to_resolve)
 
-
-def annotation_is_typing_optional(annotation) -> bool:
-    return get_origin(annotation) == Union and type(None) in get_args(annotation)
-
-
-def annotation_is_tuple(annotation) -> bool:
-    return get_origin(annotation) in (Tuple, tuple)
-
-
-def annotation_for_multiple_partitions(annotation) -> bool:
-    if not annotation_is_typing_optional(annotation):
-        return annotation_is_tuple(annotation) and get_origin(annotation) in (dict, Dict, Mapping)
-    else:
-        inner_annotation = get_args(annotation)[0]
-        return annotation_is_tuple(inner_annotation) and get_origin(inner_annotation) in (
-            dict,
-            Dict,
-            Mapping,
-        )
-
-
-def annotation_is_tuple_with_metadata(annotation) -> bool:
-    if annotation_is_typing_optional(annotation):
-        annotation = get_args(annotation)[0]
-
-    return annotation_is_tuple(annotation) and get_origin(get_args(annotation)[1]) in [
-        dict,
-        Dict,
-        Mapping,
-    ]
-
-
-def annotation_for_storage_metadata(annotation) -> bool:
-    # first unwrap the Optional type
-    if annotation_is_typing_optional(annotation):
-        annotation = get_args(annotation)[0]
-
-    if not annotation_for_multiple_partitions(annotation):
-        return annotation_is_tuple_with_metadata(annotation)
-    else:
-        # unwrap the partitions
-        annotation = get_args(annotation)[1]
-        return annotation_is_tuple_with_metadata(annotation)
+        if not router.match():
+            continue
+        else:
+            if router.is_root_type:
+                return router
+            else:
+                # recursively resolve the parent type
+                return resolve_type_router(context, router.parent_type)
 
 
 def _process_env_vars(config: Mapping[str, Any]) -> Dict[str, Any]:
@@ -196,7 +301,6 @@ class BasePolarsUPathIOManager(ConfigurableIOManager, UPathIOManager):
         context: OutputContext,
         df: pl.DataFrame,
         path: "UPath",
-        metadata: Optional[StorageMetadata] = None,
     ): ...
 
     @abstractmethod
@@ -205,24 +309,23 @@ class BasePolarsUPathIOManager(ConfigurableIOManager, UPathIOManager):
         context: OutputContext,
         df: pl.LazyFrame,
         path: "UPath",
-        metadata: Optional[StorageMetadata] = None,
     ): ...
 
     @overload
     @abstractmethod
     def scan_df_from_path(
-        self, path: "UPath", context: InputContext, with_metadata: Literal[None, False]
+        self, path: "UPath", context: InputContext,
     ) -> pl.LazyFrame: ...
 
     @overload
     @abstractmethod
     def scan_df_from_path(
-        self, path: "UPath", context: InputContext, with_metadata: Literal[True]
+        self, path: "UPath", context: InputContext,
     ) -> LazyFrameWithMetadata: ...
 
     @abstractmethod
     def scan_df_from_path(
-        self, path: "UPath", context: InputContext, with_metadata: Optional[bool] = False
+        self, path: "UPath", context: InputContext,
     ) -> Union[pl.LazyFrame, LazyFrameWithMetadata]: ...
 
     def dump_to_path(
@@ -355,9 +458,3 @@ class BasePolarsUPathIOManager(ConfigurableIOManager, UPathIOManager):
                 if df is not None
                 else {"missing": MetadataValue.bool(True)}
             )
-
-    def get_missing_optional_input_log_message(self, context: InputContext, path: "UPath") -> str:
-        return f"Optional input {context.name} at {path} doesn't exist in the filesystem and won't be loaded!"
-
-    def get_optional_output_none_log_message(self, context: OutputContext, path: "UPath") -> str:
-        return f"The object for the optional output {context.name} is None, so it won't be saved to {path}!"

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/base.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/base.py
@@ -1,26 +1,5 @@
-import sys
 from abc import abstractmethod
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Literal,
-    Mapping,
-    Optional,
-    Tuple,
-    Union,
-    cast,
-    get_args,
-    get_origin,
-    overload, Callable, Generic, TypeVar, List,
-
-)
-
-
-if sys.version_info >= (3, 9):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Tuple, Union
 
 import polars as pl
 from dagster import (
@@ -33,204 +12,14 @@ from dagster import (
     UPathIOManager,
     _check as check,
 )
-from dagster._utils.warnings import deprecation_warning
 from pydantic import PrivateAttr
 from pydantic.fields import Field
 
+from dagster_polars.io_managers.type_routers import TypeRouter, resolve_type_router
 from dagster_polars.io_managers.utils import get_polars_metadata
-from dagster_polars.types import (
-    DataFramePartitions,
-    LazyFramePartitions,
-    LazyFrameWithMetadata,
-)
-
-try:
-    import pandera
-
-    PANDERA_INSTALLED = True
-except ImportError:
-    PANDERA_INSTALLED = False
-
 
 if TYPE_CHECKING:
     from upath import UPath
-
-
-T = TypeVar("T")
-
-
-# dump_to_path signature
-F_D: TypeAlias = Callable[[OutputContext, T, "UPath"], None]
-
-# load_from_path signature
-F_L: TypeAlias = Callable[[InputContext, "UPath"], T]
-
-
-class BaseTypeRouter(Generic[T]):
-    """
-    Specifies how to apply a given dump/load operation to a given type annotation.
-    """
-
-    def __init__(self, context: Union[InputContext, OutputContext], type_to_resolve: Any):
-        self.context = context
-        self.type_to_resolve = type_to_resolve
-
-    @abstractmethod
-    def match(self) -> bool:
-        raise NotImplementedError
-
-    @abstractmethod
-    @property
-    def is_root_type(self) -> bool:
-        raise NotImplementedError
-
-    @abstractmethod
-    @property
-    def parent_type(self) -> Any:
-        raise NotImplementedError
-
-    def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
-        dump_fn(self.context, obj, path)
-
-    def load(self, path: "UPath", load_fn: F_L) -> T:
-        return load_fn(self.context, path)
-
-
-class TypeRouter(BaseTypeRouter, Generic[T]):
-    """
-    Specifies how to apply a given dump/load operation to a given type annotation.
-    This base class trivially calls the dump/load functions if the type matches the most simple cases.
-    """
-
-    def match(self) -> bool:
-        return self.type_to_resolve in [
-            pl.DataFrame,
-            pl.LazyFrame,
-            Any,
-            type(None),
-            None,
-        ]
-
-    @property
-    def is_root_type(self) -> bool:
-        return True
-
-
-class OptionalTypeRouter(TypeRouter):
-    """
-    Handles Optional type annotations with a noop if the object is None or missing in storage.
-    """
-
-    def match(self) -> bool:
-        return get_origin(self.type_to_resolve) == Union and type(None) in get_args(self.type_to_resolve)
-
-    @property
-    def is_root_type(self) -> bool:
-        return False
-
-    def parent_type(self) -> Any:
-        return get_args(self.type_to_resolve)[0]
-
-    def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
-        if obj is None:
-            self.context.log.warning(f"Skipping saving optional output at {path} as it is None")
-            return
-        else:
-            router = resolve_type_router(self.context, self.parent_type)
-            router.dump(obj, path, dump_fn)
-
-    def load(self, path: "UPath", load_fn: F_L) -> T:
-        if not path.exists():
-            self.context.log.warning(f"Skipping loading optional input at {path} as it is missing")
-            return None
-        else:
-            router = resolve_type_router(self.context, self.parent_type)
-            return router.load(path, load_fn)
-
-
-class DictTypeRouter(TypeRouter):
-    """
-    Handles loading partitions as dictionaries of DataFrames.
-    """
-
-    def match(self) -> bool:
-        return get_origin(self.type_to_resolve) in (dict, Dict, Mapping)
-
-    @property
-    def is_root_type(self) -> bool:
-        return False
-
-    @property
-    def parent_type(self) -> Any:
-        return get_args(self.type_to_resolve)[1]
-
-
-class PanderaTypeRouter(TypeRouter):
-    """
-    Handles loading Pandera DataFrames.
-    """
-
-    def match(self) -> bool:
-        try:
-            import pandera
-            import pandera.typing.polars
-
-            return (
-                    get_origin(self.type_to_resolve) == pandera.typing.polars.LazyFrame
-                    and issubclass(get_args(self.type_to_resolve)[0], pandera.DataFrameModel)
-            )
-        except ImportError:
-            return False
-
-    @property
-    def is_root_type(self) -> bool:
-        return True
-
-    def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
-        if isinstance()
-        router = resolve_type_router(self.context, self.parent_type)
-        router.dump(obj, path, dump_fn)
-
-    def load(self, path: "UPath", load_fn: F_L) -> T:
-        if not path.exists():
-            self.context.log.warning(f"Skipping loading optional input at {path} as it is missing")
-            return None
-        else:
-            router = resolve_type_router(self.context, self.parent_type)
-            return router.load(path, load_fn)
-
-
-TYPE_ROUTERS = [
-    TypeRouter,
-    OptionalTypeRouter,
-    DictTypeRouter,
-]
-
-if PANDERA_INSTALLED:
-    TYPE_ROUTERS.append(PanderaTypeRo`uter)
-
-
-def resolve_type_router(context: Union[InputContext, OutputContext], type_to_resolve: Any) -> TypeRouter:
-    """
-    Finds the correct TypeRouter for the given context.
-    """
-
-    # try each router class in order of increasing complexity
-    for router_class in [
-        TypeRouter,
-        OptionalTypeRouter,
-        ...
-    ]:
-        router = router_class(context, type_to_resolve)
-
-        if not router.match():
-            continue
-        else:
-            if router.is_root_type:
-                return router
-            else:
-                # recursively resolve the parent type
-                return resolve_type_router(context, router.parent_type)
 
 
 def _process_env_vars(config: Mapping[str, Any]) -> Dict[str, Any]:
@@ -241,14 +30,6 @@ def _process_env_vars(config: Mapping[str, Any]) -> Dict[str, Any]:
         else:
             out[key] = value
     return out
-
-
-def emit_storage_metadata_deprecation_warning() -> None:
-    deprecation_warning(
-        subject="dagster-polars storage metadata",
-        breaking_version="0.25.0",
-        additional_warn_text="Please use a multi-output asset or op to save metadata.",
-    )
 
 
 class BasePolarsUPathIOManager(ConfigurableIOManager, UPathIOManager):
@@ -311,22 +92,27 @@ class BasePolarsUPathIOManager(ConfigurableIOManager, UPathIOManager):
         path: "UPath",
     ): ...
 
-    @overload
     @abstractmethod
     def scan_df_from_path(
-        self, path: "UPath", context: InputContext,
+        self,
+        path: "UPath",
+        context: InputContext,
     ) -> pl.LazyFrame: ...
 
-    @overload
-    @abstractmethod
-    def scan_df_from_path(
-        self, path: "UPath", context: InputContext,
-    ) -> LazyFrameWithMetadata: ...
-
-    @abstractmethod
-    def scan_df_from_path(
-        self, path: "UPath", context: InputContext,
-    ) -> Union[pl.LazyFrame, LazyFrameWithMetadata]: ...
+    def type_router_is_eager(self, type_router: TypeRouter) -> bool:
+        if type_router.is_base_type:
+            if type_router.typing_type in [Any, type(None), None] or issubclass(
+                type_router.typing_type, pl.DataFrame
+            ):
+                return True
+            elif issubclass(type_router.typing_type, pl.LazyFrame):
+                return False
+            else:
+                raise NotImplementedError(
+                    f"Can't determine if type annotation {type_router.typing_type} corresponds to an eager or lazy DataFrame"
+                )
+        else:
+            return self.type_router_is_eager(type_router.parent_type_router)
 
     def dump_to_path(
         self,
@@ -341,52 +127,14 @@ class BasePolarsUPathIOManager(ConfigurableIOManager, UPathIOManager):
         ],
         path: "UPath",
     ):
-        if self.needs_output_metadata(context):
-            emit_storage_metadata_deprecation_warning()
+        type_router = resolve_type_router(context, context.dagster_type.typing_type)
 
-        typing_type = context.dagster_type.typing_type
-
-        if annotation_is_typing_optional(typing_type) and (
-            obj is None or annotation_for_storage_metadata(typing_type) and obj[0] is None
-        ):
-            context.log.warning(self.get_optional_output_none_log_message(context, path))
-            return
+        if self.type_router_is_eager(type_router):
+            dump_fn = self.write_df_to_path
         else:
-            assert obj is not None, "output should not be None if it's type is not Optional"
-            if not annotation_for_storage_metadata(typing_type):
-                if typing_type in POLARS_EAGER_FRAME_ANNOTATIONS:
-                    obj = cast(pl.DataFrame, obj)
-                    df = obj
-                    self.write_df_to_path(context=context, df=df, path=path)
-                elif typing_type in POLARS_LAZY_FRAME_ANNOTATIONS:
-                    obj = cast(pl.LazyFrame, obj)
-                    df = obj
-                    self.sink_df_to_path(context=context, df=df, path=path)
-                else:
-                    raise NotImplementedError(
-                        f"dump_df_to_path for {typing_type} is not implemented"
-                    )
-            else:
-                if not annotation_is_typing_optional(typing_type):
-                    frame_type = get_args(typing_type)[0]
-                else:
-                    frame_type = get_args(get_args(typing_type)[0])[0]
+            dump_fn = self.sink_df_to_path
 
-                if frame_type in POLARS_EAGER_FRAME_ANNOTATIONS:
-                    obj = cast(Tuple[pl.DataFrame, Dict[str, Any]], obj)
-                    df, metadata = obj
-                    self.write_df_to_path(context=context, df=df, path=path, metadata=metadata)
-                elif frame_type in POLARS_LAZY_FRAME_ANNOTATIONS:
-                    obj = cast(Tuple[pl.LazyFrame, Dict[str, Any]], obj)
-                    df, metadata = obj
-                    self.sink_df_to_path(context=context, df=df, path=path, metadata=metadata)
-                else:
-                    raise NotImplementedError(
-                        f"dump_df_to_path for {typing_type} is not implemented"
-                    )
-
-    def needs_output_metadata(self, context: Union[InputContext, OutputContext]) -> bool:
-        return annotation_for_storage_metadata(context.dagster_type.typing_type)
+        type_router.dump(obj, path, dump_fn)
 
     def load_from_path(
         self, context: InputContext, path: "UPath"
@@ -397,51 +145,21 @@ class BasePolarsUPathIOManager(ConfigurableIOManager, UPathIOManager):
         Tuple[pl.LazyFrame, Dict[str, Any]],
         None,
     ]:
-        if self.needs_output_metadata(context):
-            emit_storage_metadata_deprecation_warning()
+        type_router = resolve_type_router(context, context.dagster_type.typing_type)
 
-        if annotation_is_typing_optional(context.dagster_type.typing_type) and not path.exists():
-            context.log.warning(self.get_missing_optional_input_log_message(context, path))
-            return None
-
-        # missing files detection in UPathIOManager doesn't work with `LazyFrame`
-        # since the FileNotFoundError is raised only when calling `.collect()` outside of the UPathIOManager
-        # as a workaround, we check if the file exists and if not, we raise the error here
-        if context.dagster_type.typing_type in POLARS_LAZY_FRAME_ANNOTATIONS and not path.exists():
-            raise FileNotFoundError(f"File {path} does not exist")
-
-        assert context.definition_metadata is not None
-
-        metadata: Optional[StorageMetadata] = None
-
-        return_storage_metadata = self.needs_output_metadata(context)
-        if not return_storage_metadata:
-            ldf = self.scan_df_from_path(path=path, context=context)  # type: ignore
-        else:
-            ldf, metadata = self.scan_df_from_path(path=path, context=context, with_metadata=True)
+        ldf = type_router.load(path, self.scan_df_from_path)
 
         columns = context.definition_metadata.get("columns")
         if columns is not None:
             context.log.debug(f"Loading {columns=}")
             ldf = ldf.select(columns)
 
-        if context.dagster_type.typing_type in POLARS_EAGER_FRAME_ANNOTATIONS:
-            if not return_storage_metadata:
-                return ldf.collect()
-            else:
-                assert metadata is not None
-                return ldf.collect(), metadata
-
-        elif context.dagster_type.typing_type in POLARS_LAZY_FRAME_ANNOTATIONS:
-            if not return_storage_metadata:
-                return ldf
-            else:
-                assert metadata is not None
-                return ldf, metadata
+        if ldf is None:
+            return None
+        elif self.type_router_is_eager(type_router) and ldf is not None:
+            return ldf.collect()
         else:
-            raise NotImplementedError(
-                f"Can't load object for type annotation {context.dagster_type.typing_type}"
-            )
+            return ldf
 
     def get_metadata(
         self, context: OutputContext, obj: Union[pl.DataFrame, pl.LazyFrame, None]
@@ -449,12 +167,8 @@ class BasePolarsUPathIOManager(ConfigurableIOManager, UPathIOManager):
         if obj is None:
             return {"missing": MetadataValue.bool(True)}
         else:
-            if annotation_for_storage_metadata(context.dagster_type.typing_type):
-                df = obj[0]
-            else:
-                df = obj
             return (
-                get_polars_metadata(context, df)
-                if df is not None
+                get_polars_metadata(context, obj)
+                if obj is not None
                 else {"missing": MetadataValue.bool(True)}
             )

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/delta.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/delta.py
@@ -1,8 +1,7 @@
-import json
 from collections import defaultdict
 from enum import Enum
 from pprint import pformat
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Sequence, Tuple, Union, overload
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple, Union
 
 import polars as pl
 from dagster import InputContext, MetadataValue, MultiPartitionKey, OutputContext
@@ -11,21 +10,23 @@ from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.storage.upath_io_manager import is_dict_type
 
 from dagster_polars.io_managers.base import BasePolarsUPathIOManager
-from dagster_polars.types import DataFrameWithMetadata, LazyFrameWithMetadata, StorageMetadata
 
 try:
     from deltalake import DeltaTable
     from deltalake.exceptions import TableNotFoundError
 except ImportError as e:
-    raise ImportError("Install 'dagster-polars[deltalake]' to use DeltaLake functionality") from e
+    if "deltalake" in str(e):
+        raise ImportError(
+            "Install 'dagster-polars[deltalake]' to use DeltaLake functionality"
+        ) from e
+    else:
+        raise e
 
 if TYPE_CHECKING:
     from upath import UPath
 
 
-DAGSTER_POLARS_STORAGE_METADATA_SUBDIR = ".dagster_polars_metadata"
-
-SINGLE_LOADING_TYPES = (pl.DataFrame, pl.LazyFrame, LazyFrameWithMetadata, DataFrameWithMetadata)
+SINGLE_LOADING_TYPES = (pl.DataFrame, pl.LazyFrame)
 
 
 class DeltaWriteMode(str, Enum):
@@ -47,7 +48,6 @@ class PolarsDeltaIOManager(BasePolarsUPathIOManager):
        The `partition_by` value will be used in `delta_write_options` of `pl.DataFrame.write_delta` and `pyarrow_options` of `pl.scan_detla`).
        When using a one-dimensional `PartitionsDefinition`, it should be a single string like "column`. When using a `MultiPartitionsDefinition`,
        it should be a dict with dimension to column names mapping, like `{"dimension": "column"}`.
-     - **Deprecated, will be removed in 0.25.0**: writing/reading custom metadata to/from `.dagster_polars_metadata/<version>.json` file in the DeltaLake table directory.
 
     Install `dagster-polars[delta]` to use this IOManager.
 
@@ -156,18 +156,16 @@ class PolarsDeltaIOManager(BasePolarsUPathIOManager):
         context: OutputContext,
         df: pl.LazyFrame,
         path: "UPath",
-        metadata: Optional[StorageMetadata] = None,
     ):
         context_metadata = context.definition_metadata or {}
         streaming = context_metadata.get("streaming", False)
-        return self.write_df_to_path(context, df.collect(streaming=streaming), path, metadata)
+        return self.write_df_to_path(context, df.collect(streaming=streaming), path)
 
     def write_df_to_path(
         self,
         context: OutputContext,
         df: pl.DataFrame,
         path: "UPath",
-        metadata: Optional[StorageMetadata] = None,  # why is metadata passed
     ):
         context_metadata = context.definition_metadata or {}
         delta_write_options = context_metadata.get(
@@ -222,34 +220,18 @@ class PolarsDeltaIOManager(BasePolarsUPathIOManager):
             ).version()
         context.add_output_metadata({"version": current_version})
 
-        if metadata is not None:
-            metadata_path = self.get_storage_metadata_path(path, current_version)
-            metadata_path.parent.mkdir(parents=True, exist_ok=True)
-            metadata_path.write_text(json.dumps(metadata))
-
-    @overload
-    def scan_df_from_path(
-        self, path: "UPath", context: InputContext, with_metadata: Literal[None, False]
-    ) -> pl.LazyFrame: ...
-
-    @overload
-    def scan_df_from_path(
-        self, path: "UPath", context: InputContext, with_metadata: Literal[True]
-    ) -> LazyFrameWithMetadata: ...
-
     def scan_df_from_path(
         self,
         path: "UPath",
         context: InputContext,
-        with_metadata: Optional[bool] = False,
-    ) -> Union[pl.LazyFrame, LazyFrameWithMetadata]:
+    ) -> pl.LazyFrame:
         """This method scans a DeltaLake table into a `polars.LazyFrame`.
         It can be called in 3 different situations:
         1. with an unpartitioned asset
         2. with a partitioned asset without native partitioning enabled - multiple times on nested .delta tables
         3. with a partitioned asset and with native partitioning enabled - a single time on the .delta table.
 
-        In the (3) optin we apply partition filters to only load mapped partitions
+        In the (3) option we apply partition filters to only load mapped partitions
         """
         assert context.upstream_output is not None
         assert context.upstream_output.definition_metadata is not None
@@ -287,25 +269,13 @@ class PolarsDeltaIOManager(BasePolarsUPathIOManager):
         if delta_table_options:
             context.log.debug("Reading with delta_table_options: {delta_table_options}")
 
-        ldf = pl.scan_delta(
+        return pl.scan_delta(
             str(path),
             version=version,
             delta_table_options=delta_table_options,
             pyarrow_options=pyarrow_options,
             storage_options=self.storage_options,
         )
-
-        if with_metadata:
-            version = self.get_delta_version_to_load(path, context)
-            metadata_path = self.get_storage_metadata_path(path, version)
-            if metadata_path.exists():
-                metadata = json.loads(metadata_path.read_text())
-            else:
-                metadata = {}
-            return ldf, metadata
-
-        else:
-            return ldf
 
     def load_partitions(self, context: InputContext):
         assert context.upstream_output is not None
@@ -442,6 +412,3 @@ class PolarsDeltaIOManager(BasePolarsUPathIOManager):
             ).version()
         else:
             return version
-
-    def get_storage_metadata_path(self, path: "UPath", version: int) -> "UPath":
-        return path / DAGSTER_POLARS_STORAGE_METADATA_SUBDIR / f"{version}.json"

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/parquet.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/parquet.py
@@ -1,17 +1,13 @@
-import json
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
 
 import polars as pl
 import pyarrow.dataset as ds
-import pyarrow.parquet as pq
 from dagster import InputContext, OutputContext
 from dagster._annotations import experimental
 from fsspec.implementations.local import LocalFileSystem
 from packaging.version import Version
-from pyarrow import Table
 
 from dagster_polars.io_managers.base import BasePolarsUPathIOManager
-from dagster_polars.types import LazyFrameWithMetadata, StorageMetadata
 
 if TYPE_CHECKING:
     from upath import UPath
@@ -86,7 +82,7 @@ class PolarsParquetIOManager(BasePolarsUPathIOManager):
      - All features provided by :py:class:`~dagster_polars.BasePolarsUPathIOManager`.
      - All read/write options can be set via corresponding metadata or config parameters (metadata takes precedence).
      - Supports reading partitioned Parquet datasets (for example, often produced by Spark).
-     - **Deprecated, will be removed in 0.25.0**: reading/writing custom metadata in the Parquet file's schema as json-serialized bytes at `"dagster_polars_metadata"` key.
+     - Supports reading/writing custom metadata in the Parquet file's schema as json-serialized bytes at `"dagster_polars_metadata"` key.
 
     Examples:
         .. code-block:: python
@@ -122,6 +118,7 @@ class PolarsParquetIOManager(BasePolarsUPathIOManager):
                     "partition_by": ["year", "month", "day"]
                 }
             )
+
     """
 
     extension: str = ".parquet"
@@ -131,43 +128,35 @@ class PolarsParquetIOManager(BasePolarsUPathIOManager):
         context: OutputContext,
         df: pl.LazyFrame,
         path: "UPath",
-        metadata: Optional[StorageMetadata] = None,
     ):
         context_metadata = context.definition_metadata or {}
 
-        if metadata is not None:
-            context.log.warning(
-                "Sink not possible with StorageMetadata, instead it's dispatched to pyarrow writer."
-            )
-            return self.write_df_to_path(context, df.collect(), path, metadata)
-        else:
-            fs = path.fs if hasattr(path, "fs") else None
-            if isinstance(fs, LocalFileSystem):
-                compression = context_metadata.get("compression", "zstd")
-                compression_level = context_metadata.get("compression_level")
-                statistics = context_metadata.get("statistics", False)
-                row_group_size = context_metadata.get("row_group_size")
+        fs = path.fs if hasattr(path, "fs") else None
+        if isinstance(fs, LocalFileSystem):
+            compression = context_metadata.get("compression", "zstd")
+            compression_level = context_metadata.get("compression_level")
+            statistics = context_metadata.get("statistics", False)
+            row_group_size = context_metadata.get("row_group_size")
 
-                df.sink_parquet(
-                    str(path),
-                    compression=compression,
-                    compression_level=compression_level,
-                    statistics=statistics,
-                    row_group_size=row_group_size,
-                )
-            else:
-                # TODO(ion): add sink_parquet once this PR gets merged: https://github.com/pola-rs/polars/pull/11519
-                context.log.warning(
-                    "Cloud sink is not possible yet, instead it's dispatched to pyarrow writer which collects it into memory first.",
-                )
-                return self.write_df_to_path(context, df.collect(), path, metadata)
+            df.sink_parquet(
+                str(path),
+                compression=compression,
+                compression_level=compression_level,
+                statistics=statistics,
+                row_group_size=row_group_size,
+            )
+        else:
+            # TODO(ion): add sink_parquet once this PR gets merged: https://github.com/pola-rs/polars/pull/11519
+            context.log.warning(
+                "Cloud sink is not possible yet, instead it's dispatched to pyarrow writer which collects it into memory first.",
+            )
+            return self.write_df_to_path(context, df.collect(), path)
 
     def write_df_to_path(
         self,
         context: OutputContext,
         df: pl.DataFrame,
         path: "UPath",
-        metadata: Optional[StorageMetadata] = None,
     ):
         context_metadata = context.definition_metadata or {}
         compression = context_metadata.get("compression", "zstd")
@@ -178,120 +167,39 @@ class PolarsParquetIOManager(BasePolarsUPathIOManager):
 
         fs = path.fs if hasattr(path, "fs") else None
 
-        if metadata is not None:
-            table: Table = df.to_arrow()
-            context.log.warning("StorageMetadata is passed, so the PyArrow writer is used.")
-            existing_metadata = (
-                table.schema.metadata.to_dict() if table.schema.metadata is not None else {}
+        if pyarrow_options is not None:
+            pyarrow_options["filesystem"] = fs
+            df.write_parquet(
+                str(path),
+                compression=compression,  # type: ignore
+                compression_level=compression_level,
+                statistics=statistics,
+                row_group_size=row_group_size,
+                use_pyarrow=True,
+                pyarrow_options=pyarrow_options,
             )
-            existing_metadata.update({DAGSTER_POLARS_STORAGE_METADATA_KEY: json.dumps(metadata)})
-            table = table.replace_schema_metadata(existing_metadata)
-
-            if pyarrow_options is not None and pyarrow_options.get("partition_cols"):
-                pyarrow_options["compression"] = (
-                    None if compression == "uncompressed" else compression
-                )
-                pyarrow_options["compression_level"] = compression_level
-                pyarrow_options["write_statistics"] = statistics
-                pyarrow_options["row_group_size"] = row_group_size
-                pq.write_to_dataset(
-                    table=table,
-                    root_path=str(path),
-                    fs=fs,
-                    **(pyarrow_options or {}),
-                )
-            else:
-                pq.write_table(
-                    table=table,
-                    where=str(path),
-                    row_group_size=row_group_size,
-                    compression=None if compression == "uncompressed" else compression,
+        elif fs is not None:
+            with fs.open(str(path), mode="wb") as f:
+                df.write_parquet(
+                    f,
+                    compression=compression,  # type: ignore
                     compression_level=compression_level,
-                    write_statistics=statistics,
-                    filesystem=fs,
-                    **(pyarrow_options or {}),
+                    statistics=statistics,
+                    row_group_size=row_group_size,
                 )
         else:
-            if pyarrow_options is not None:
-                pyarrow_options["filesystem"] = fs
-                df.write_parquet(
-                    str(path),
-                    compression=compression,  # type: ignore
-                    compression_level=compression_level,
-                    statistics=statistics,
-                    row_group_size=row_group_size,
-                    use_pyarrow=True,
-                    pyarrow_options=pyarrow_options,
-                )
-            elif fs is not None:
-                with fs.open(str(path), mode="wb") as f:
-                    df.write_parquet(
-                        f,
-                        compression=compression,  # type: ignore
-                        compression_level=compression_level,
-                        statistics=statistics,
-                        row_group_size=row_group_size,
-                    )
-            else:
-                df.write_parquet(
-                    str(path),
-                    compression=compression,  # type: ignore
-                    compression_level=compression_level,
-                    statistics=statistics,
-                    row_group_size=row_group_size,
-                )
-
-    @overload
-    def scan_df_from_path(
-        self, path: "UPath", context: InputContext, with_metadata: Literal[None, False]
-    ) -> pl.LazyFrame: ...
-
-    @overload
-    def scan_df_from_path(
-        self, path: "UPath", context: InputContext, with_metadata: Literal[True]
-    ) -> LazyFrameWithMetadata: ...
+            df.write_parquet(
+                str(path),
+                compression=compression,  # type: ignore
+                compression_level=compression_level,
+                statistics=statistics,
+                row_group_size=row_group_size,
+            )
 
     def scan_df_from_path(
         self,
         path: "UPath",
         context: InputContext,
-        with_metadata: Optional[bool] = False,
         partition_key: Optional[str] = None,
-    ) -> Union[pl.LazyFrame, LazyFrameWithMetadata]:
-        ldf = scan_parquet(path, context)
-
-        if not with_metadata:
-            return ldf
-        else:
-            ds = get_pyarrow_dataset(path, context)
-            dagster_polars_metadata = (
-                ds.schema.metadata.get(DAGSTER_POLARS_STORAGE_METADATA_KEY.encode("utf-8"))
-                if ds.schema.metadata is not None
-                else None
-            )
-
-            metadata = (
-                json.loads(dagster_polars_metadata) if dagster_polars_metadata is not None else {}
-            )
-
-            return ldf, metadata
-
-    @classmethod
-    def read_parquet_metadata(cls, path: "UPath") -> StorageMetadata:
-        """Just a helper method to read metadata from a parquet file.
-
-        Is not used internally, but is helpful for reading Parquet metadata from outside of Dagster.
-        :param path:
-        :return:
-        """
-        metadata = pq.read_metadata(
-            str(path), filesystem=path.fs if hasattr(path, "fs") else None
-        ).metadata
-
-        dagster_polars_metadata = (
-            metadata.get(DAGSTER_POLARS_STORAGE_METADATA_KEY.encode("utf-8"))
-            if metadata is not None
-            else None
-        )
-
-        return json.loads(dagster_polars_metadata) if dagster_polars_metadata is not None else {}
+    ) -> Union[pl.LazyFrame]:
+        return scan_parquet(path, context)

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/parquet.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/parquet.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, cast
 
 import polars as pl
 import pyarrow.dataset as ds
@@ -201,5 +201,5 @@ class PolarsParquetIOManager(BasePolarsUPathIOManager):
         path: "UPath",
         context: InputContext,
         partition_key: Optional[str] = None,
-    ) -> Union[pl.LazyFrame]:
+    ) -> pl.LazyFrame:
         return scan_parquet(path, context)

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_routers.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_routers.py
@@ -165,6 +165,8 @@ class PanderaTypeRouter(BaseTypeRouter, Generic[T]):
     """Handles loading Pandera DataFrames."""
 
     def match(self) -> bool:
+        raise NotImplementedError("Generic types are not supported by Dagster type system. See https://github.com/dagster-io/dagster/issues/22694")
+
         try:
             import pandera
             import pandera.typing.polars

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_routers.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_routers.py
@@ -1,0 +1,219 @@
+import sys
+from abc import abstractmethod
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Mapping,
+    Type,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+)
+
+if sys.version_info >= (3, 9):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+
+import polars as pl
+from dagster import InputContext, OutputContext
+
+try:
+    import pandera
+
+    PANDERA_INSTALLED = True
+except ImportError:
+    PANDERA_INSTALLED = False
+
+
+if TYPE_CHECKING:
+    from upath import UPath
+
+
+T = TypeVar("T")
+
+
+# dump_to_path signature
+F_D: TypeAlias = Callable[[OutputContext, T, "UPath"], None]
+
+# load_from_path signature
+F_L: TypeAlias = Callable[["UPath", InputContext], T]
+
+
+class BaseTypeRouter(Generic[T]):
+    """Specifies how to apply a given dump/load operation to a given type annotation."""
+
+    def __init__(self, context: Union[InputContext, OutputContext], typing_type: Any):
+        self.context = context
+        self.typing_type = typing_type
+
+    @abstractmethod
+    def match(self) -> bool:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def is_root_type(self) -> bool:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def parent_type(self) -> Any:
+        raise NotImplementedError
+
+    @property
+    def parent_type_router(self) -> "TypeRouter":
+        return resolve_type_router(self.context, self.parent_type)
+
+    @property
+    def is_eager(self) -> bool:
+        if self.is_root_type:
+            return self.typing_type in [Any, type(None), None] or issubclass(
+                self.typing_type, pl.DataFrame
+            )
+        else:
+            return self.parent_type_router.is_eager
+
+    @property
+    def is_lazy(self) -> bool:
+        if self.is_root_type:
+            return issubclass(self.typing_type, pl.LazyFrame)
+        else:
+            return self.parent_type_router.is_lazy
+
+    def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
+        if self.is_root_type:
+            dump_fn(self.context, obj, path)
+        else:
+            self.parent_type_router.dump(obj, path, dump_fn)
+
+    def load(self, path: "UPath", load_fn: F_L) -> T:
+        if self.is_root_type:
+            return load_fn(path, self.context)
+        else:
+            return self.parent_type_router.load(path, load_fn)
+
+
+class TypeRouter(BaseTypeRouter, Generic[T]):
+    """Specifies how to apply a given dump/load operation to a given type annotation.
+    This base class trivially calls the dump/load functions if the type matches the most simple cases.
+    """
+
+    def match(self) -> bool:
+        return self.typing_type in [
+            pl.DataFrame,
+            pl.LazyFrame,
+            Any,
+            type(None),
+            None,
+        ]
+
+    @property
+    def is_root_type(self) -> bool:
+        return True
+
+
+class OptionalTypeRouter(BaseTypeRouter, Generic[T]):
+    """Handles Optional type annotations with a noop if the object is None or missing in storage."""
+
+    def match(self) -> bool:
+        return get_origin(self.typing_type) == Union and type(None) in get_args(self.typing_type)
+
+    @property
+    def is_root_type(self) -> bool:
+        return False
+
+    @property
+    def parent_type(self) -> Any:
+        return get_args(self.typing_type)[0]
+
+    def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
+        if obj is None:
+            self.context.log.warning(f"Skipping saving optional output at {path} as it is None")
+            return
+        else:
+            self.parent_type_router.dump(obj, path, dump_fn)
+
+    def load(self, path: "UPath", load_fn: F_L) -> T:
+        if not path.exists():
+            self.context.log.warning(f"Skipping loading optional input at {path} as it is missing")
+            return None
+        else:
+            return self.parent_type_router.load(path, load_fn)
+
+
+class DictTypeRouter(BaseTypeRouter, Generic[T]):
+    """Handles loading partitions as dictionaries of DataFrames."""
+
+    def match(self) -> bool:
+        return get_origin(self.typing_type) in (dict, Dict, Mapping)
+
+    @property
+    def is_root_type(self) -> bool:
+        return False
+
+    @property
+    def parent_type(self) -> Any:
+        return get_args(self.typing_type)[1]
+
+
+class PanderaTypeRouter(BaseTypeRouter, Generic[T]):
+    """Handles loading Pandera DataFrames."""
+
+    def match(self) -> bool:
+        try:
+            import pandera
+            import pandera.typing.polars
+
+            return get_origin(self.typing_type) in [
+                pandera.typing.polars.LazyFrame,
+                pandera.typing.polars.DataFrame,
+            ] and issubclass(get_args(self.typing_type)[0], pandera.DataFrameModel)
+        except ImportError:
+            return False
+
+    @property
+    def is_root_type(self) -> bool:
+        return True
+
+    @property
+    def pandera_schema(self) -> Type[pandera.DataFrameModel]:
+        return get_args(self.typing_type)[0]
+
+    def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
+        obj = self.pandera_schema.to_schema().validate(obj)
+        router = resolve_type_router(self.context, self.parent_type)
+        router.dump(obj, path, dump_fn)
+
+    def load(self, path: "UPath", load_fn: F_L) -> T:
+        router = resolve_type_router(self.context, self.parent_type)
+        obj = router.load(path, load_fn)
+        return self.pandera_schema.to_schema().validate(obj)
+
+
+TYPE_ROUTERS = [
+    TypeRouter,
+    OptionalTypeRouter,
+    DictTypeRouter,
+]
+
+if PANDERA_INSTALLED:
+    TYPE_ROUTERS.insert(0, PanderaTypeRouter)  # make sure to add before the base TypeRouter
+
+
+def resolve_type_router(
+    context: Union[InputContext, OutputContext], type_to_resolve: Any
+) -> TypeRouter:
+    """Finds the first matching TypeRouter for the given type."""
+    # try each router class in order of increasing complexity
+    for router_class in TYPE_ROUTERS:
+        router = router_class(context, type_to_resolve)
+
+        if router.match():
+            return router
+
+    raise RuntimeError(f"Could not resolve type router for {type_to_resolve}")

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_routers.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_routers.py
@@ -7,9 +7,9 @@ from typing import (
     Dict,
     Generic,
     Mapping,
-    Type,
     TypeVar,
     Union,
+    cast,
     get_args,
     get_origin,
 )
@@ -21,14 +21,6 @@ else:
 
 import polars as pl
 from dagster import InputContext, OutputContext
-
-try:
-    import pandera
-
-    PANDERA_INSTALLED = True
-except ImportError:
-    PANDERA_INSTALLED = False
-
 
 if TYPE_CHECKING:
     from upath import UPath
@@ -45,90 +37,75 @@ F_L: TypeAlias = Callable[["UPath", InputContext], T]
 
 
 class BaseTypeRouter(Generic[T]):
-    """Specifies how to apply a given dump/load operation to a given type annotation."""
+    """Specifies how to apply a given dump/load operation to a given type annotation.
+    This base class trivially calls the dump/load functions if the type matches the most simple cases.
+    """
 
     def __init__(self, context: Union[InputContext, OutputContext], typing_type: Any):
         self.context = context
         self.typing_type = typing_type
 
+    @staticmethod
     @abstractmethod
-    def match(self) -> bool:
+    def match(context: Union[InputContext, OutputContext], typing_type: Any) -> bool:
         raise NotImplementedError
 
     @property
     @abstractmethod
-    def is_root_type(self) -> bool:
+    def is_base_type(self) -> bool:
         raise NotImplementedError
 
     @property
     @abstractmethod
-    def parent_type(self) -> Any:
+    def inner_type(self) -> Any:
         raise NotImplementedError
 
     @property
     def parent_type_router(self) -> "TypeRouter":
-        return resolve_type_router(self.context, self.parent_type)
-
-    @property
-    def is_eager(self) -> bool:
-        if self.is_root_type:
-            return self.typing_type in [Any, type(None), None] or issubclass(
-                self.typing_type, pl.DataFrame
-            )
-        else:
-            return self.parent_type_router.is_eager
-
-    @property
-    def is_lazy(self) -> bool:
-        if self.is_root_type:
-            return issubclass(self.typing_type, pl.LazyFrame)
-        else:
-            return self.parent_type_router.is_lazy
+        return resolve_type_router(self.context, self.inner_type)
 
     def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
-        if self.is_root_type:
-            dump_fn(self.context, obj, path)
+        if self.is_base_type:
+            dump_fn(cast(OutputContext, self.context), obj, path)
         else:
             self.parent_type_router.dump(obj, path, dump_fn)
 
     def load(self, path: "UPath", load_fn: F_L) -> T:
-        if self.is_root_type:
-            return load_fn(path, self.context)
+        if self.is_base_type:
+            return load_fn(path, cast(InputContext, self.context))
         else:
             return self.parent_type_router.load(path, load_fn)
 
 
 class TypeRouter(BaseTypeRouter, Generic[T]):
-    """Specifies how to apply a given dump/load operation to a given type annotation.
-    This base class trivially calls the dump/load functions if the type matches the most simple cases.
-    """
+    """Handles default types."""
 
-    def match(self) -> bool:
-        return self.typing_type in [
-            pl.DataFrame,
-            pl.LazyFrame,
+    @staticmethod
+    def match(context: Union[InputContext, OutputContext], typing_type: Any) -> bool:
+        return typing_type in [
             Any,
             type(None),
             None,
         ]
 
     @property
-    def is_root_type(self) -> bool:
+    def is_base_type(self) -> bool:
         return True
 
 
 class OptionalTypeRouter(BaseTypeRouter, Generic[T]):
     """Handles Optional type annotations with a noop if the object is None or missing in storage."""
 
-    def match(self) -> bool:
-        return get_origin(self.typing_type) == Union and type(None) in get_args(self.typing_type)
+    @staticmethod
+    def match(context: Union[InputContext, OutputContext], typing_type: Any) -> bool:
+        return get_origin(typing_type) == Union and type(None) in get_args(typing_type)
 
     @property
-    def is_root_type(self) -> bool:
+    def is_base_type(self) -> bool:
         return False
 
     @property
-    def parent_type(self) -> Any:
+    def inner_type(self) -> Any:
         return get_args(self.typing_type)[0]
 
     def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
@@ -141,7 +118,7 @@ class OptionalTypeRouter(BaseTypeRouter, Generic[T]):
     def load(self, path: "UPath", load_fn: F_L) -> T:
         if not path.exists():
             self.context.log.warning(f"Skipping loading optional input at {path} as it is missing")
-            return None
+            return None  # type: ignore
         else:
             return self.parent_type_router.load(path, load_fn)
 
@@ -149,62 +126,35 @@ class OptionalTypeRouter(BaseTypeRouter, Generic[T]):
 class DictTypeRouter(BaseTypeRouter, Generic[T]):
     """Handles loading partitions as dictionaries of DataFrames."""
 
-    def match(self) -> bool:
-        return get_origin(self.typing_type) in (dict, Dict, Mapping)
+    @staticmethod
+    def match(context: Union[InputContext, OutputContext], typing_type: Any) -> bool:
+        return get_origin(typing_type) in (dict, Dict, Mapping)
 
     @property
-    def is_root_type(self) -> bool:
+    def is_base_type(self) -> bool:
         return False
 
     @property
-    def parent_type(self) -> Any:
+    def inner_type(self) -> Any:
         return get_args(self.typing_type)[1]
 
 
-class PanderaTypeRouter(BaseTypeRouter, Generic[T]):
-    """Handles loading Pandera DataFrames."""
+class PolarsTypeRouter(BaseTypeRouter, Generic[T]):
+    """Handles Polars DataFrames."""
 
-    def match(self) -> bool:
-        raise NotImplementedError("Generic types are not supported by Dagster type system. See https://github.com/dagster-io/dagster/issues/22694")
-
-        try:
-            import pandera
-            import pandera.typing.polars
-
-            return get_origin(self.typing_type) in [
-                pandera.typing.polars.LazyFrame,
-                pandera.typing.polars.DataFrame,
-            ] and issubclass(get_args(self.typing_type)[0], pandera.DataFrameModel)
-        except ImportError:
-            return False
+    @staticmethod
+    def match(context: Union[InputContext, OutputContext], typing_type: Any) -> bool:
+        return typing_type in [
+            pl.DataFrame,
+            pl.LazyFrame,
+        ]
 
     @property
-    def is_root_type(self) -> bool:
+    def is_base_type(self) -> bool:
         return True
 
-    @property
-    def pandera_schema(self) -> Type[pandera.DataFrameModel]:
-        return get_args(self.typing_type)[0]
 
-    def dump(self, obj: T, path: "UPath", dump_fn: F_D) -> None:
-        obj = self.pandera_schema.to_schema().validate(obj)
-        router = resolve_type_router(self.context, self.parent_type)
-        router.dump(obj, path, dump_fn)
-
-    def load(self, path: "UPath", load_fn: F_L) -> T:
-        router = resolve_type_router(self.context, self.parent_type)
-        obj = router.load(path, load_fn)
-        return self.pandera_schema.to_schema().validate(obj)
-
-
-TYPE_ROUTERS = [
-    TypeRouter,
-    OptionalTypeRouter,
-    DictTypeRouter,
-]
-
-if PANDERA_INSTALLED:
-    TYPE_ROUTERS.insert(0, PanderaTypeRouter)  # make sure to add before the base TypeRouter
+TYPE_ROUTERS = [TypeRouter, OptionalTypeRouter, DictTypeRouter, PolarsTypeRouter]
 
 
 def resolve_type_router(
@@ -213,9 +163,7 @@ def resolve_type_router(
     """Finds the first matching TypeRouter for the given type."""
     # try each router class in order of increasing complexity
     for router_class in TYPE_ROUTERS:
-        router = router_class(context, type_to_resolve)
-
-        if router.match():
-            return router
+        if router_class.match(context, type_to_resolve):
+            return router_class(context, type_to_resolve)
 
     raise RuntimeError(f"Could not resolve type router for {type_to_resolve}")

--- a/python_modules/libraries/dagster-polars/dagster_polars/types.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/types.py
@@ -8,7 +8,6 @@ else:
 
 import polars as pl
 
-StorageMetadata: TypeAlias = Dict[str, Any]
 DataFrameWithMetadata: TypeAlias = Tuple[pl.DataFrame, StorageMetadata]
 LazyFrameWithMetadata: TypeAlias = Tuple[pl.LazyFrame, StorageMetadata]
 DataFramePartitions: TypeAlias = Dict[str, pl.DataFrame]
@@ -17,11 +16,6 @@ LazyFramePartitions: TypeAlias = Dict[str, pl.LazyFrame]
 LazyFramePartitionsWithMetadata: TypeAlias = Dict[str, LazyFrameWithMetadata]
 
 __all__ = [
-    "StorageMetadata",
-    "DataFrameWithMetadata",
-    "LazyFrameWithMetadata",
     "DataFramePartitions",
-    "DataFramePartitionsWithMetadata",
     "LazyFramePartitions",
-    "LazyFramePartitionsWithMetadata",
 ]

--- a/python_modules/libraries/dagster-polars/dagster_polars/types.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/types.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Dict, Tuple
+from typing import Dict
 
 if sys.version_info < (3, 10):
     from typing_extensions import TypeAlias
@@ -8,12 +8,8 @@ else:
 
 import polars as pl
 
-DataFrameWithMetadata: TypeAlias = Tuple[pl.DataFrame, StorageMetadata]
-LazyFrameWithMetadata: TypeAlias = Tuple[pl.LazyFrame, StorageMetadata]
 DataFramePartitions: TypeAlias = Dict[str, pl.DataFrame]
-DataFramePartitionsWithMetadata: TypeAlias = Dict[str, DataFrameWithMetadata]
 LazyFramePartitions: TypeAlias = Dict[str, pl.LazyFrame]
-LazyFramePartitionsWithMetadata: TypeAlias = Dict[str, LazyFrameWithMetadata]
 
 __all__ = [
     "DataFramePartitions",

--- a/python_modules/libraries/dagster-polars/dagster_polars_tests/test_upath_io_managers_lazy.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars_tests/test_upath_io_managers_lazy.py
@@ -3,6 +3,7 @@ from typing import Dict, Optional, Tuple
 
 import polars as pl
 import polars.testing as pl_testing
+import pytest
 from dagster import (
     AssetExecutionContext,
     AssetIn,
@@ -303,4 +304,43 @@ def test_upath_io_manager_multi_partitions_definition_load_multiple_partitions(
     materialize(
         [upstream.to_source_asset(), downstream],
         partition_key=MultiPartitionKey({"time": str(today - timedelta(days=2)), "static": "a"}),
+    )
+
+
+def test_polars_upath_io_manager_input_dict_optional_lazy(
+    io_manager_and_df: Tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, df = io_manager_and_df
+    partition_keys = ["a", "b", "missing"]
+
+    if isinstance(manager, PolarsDeltaIOManager):
+        pytest.skip("PolarsDeltaIOManager does not read partitions as dictionaries")
+
+    @asset(io_manager_def=manager, partitions_def=StaticPartitionsDefinition(partition_keys))
+    def upstream(context: AssetExecutionContext) -> Optional[pl.DataFrame]:
+        return (
+            None
+            if context.partition_key == "missing"
+            else df.with_columns(pl.lit(context.partition_key).alias("partition"))
+        )
+
+    @asset(
+        io_manager_def=manager,
+        ins={"upstream": AssetIn(metadata={"allow_missing_partitions": True})},
+    )
+    def downstream(upstream: Dict[str, pl.LazyFrame]) -> pl.DataFrame:
+        dfs = []
+        for df in upstream.values():
+            assert isinstance(df, pl.LazyFrame)
+            dfs.append(df)
+        return pl.concat(dfs).collect()
+
+    for partition_key in ["a", "b"]:
+        materialize(
+            [upstream],
+            partition_key=partition_key,
+        )
+
+    materialize(
+        [upstream.to_source_asset(), downstream],
     )

--- a/python_modules/libraries/dagster-polars/dagster_polars_tests/test_upath_io_managers_lazy.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars_tests/test_upath_io_managers_lazy.py
@@ -3,7 +3,6 @@ from typing import Dict, Optional, Tuple
 
 import polars as pl
 import polars.testing as pl_testing
-import pytest
 from dagster import (
     AssetExecutionContext,
     AssetIn,
@@ -24,10 +23,9 @@ from dagster_polars import (
     LazyFramePartitions,
     PolarsDeltaIOManager,
     PolarsParquetIOManager,
-    StorageMetadata,
 )
 
-from dagster_polars_tests.utils import DEPRECATED_STORAGE_METADATA_STRING, get_saved_path
+from dagster_polars_tests.utils import get_saved_path
 
 
 def test_polars_upath_io_manager_stats_metadata(
@@ -254,86 +252,6 @@ def test_polars_upath_io_manager_output_optional_lazy(
     )
 
 
-IO_MANAGERS_SUPPORTING_STORAGE_METADATA = (
-    PolarsParquetIOManager,
-    PolarsDeltaIOManager,
-)
-
-
-def check_skip_storage_metadata_test(io_manager_def: BasePolarsUPathIOManager):
-    if not isinstance(io_manager_def, IO_MANAGERS_SUPPORTING_STORAGE_METADATA):
-        pytest.skip(f"Only {IO_MANAGERS_SUPPORTING_STORAGE_METADATA} support storage metadata")
-
-
-@pytest.fixture
-def metadata() -> StorageMetadata:
-    return {"a": 1, "b": "2", "c": [1, 2, 3], "d": {"e": 1}, "f": [1, 2, 3, {"g": 1}]}
-
-
-def test_upath_io_manager_storage_metadata_lazy(
-    io_manager_and_lazy_df: Tuple[BasePolarsUPathIOManager, pl.LazyFrame], metadata: StorageMetadata
-):
-    io_manager_def, df = io_manager_and_lazy_df
-    check_skip_storage_metadata_test(io_manager_def)
-
-    @asset(io_manager_def=io_manager_def)
-    def upstream() -> Tuple[pl.LazyFrame, StorageMetadata]:
-        return df, metadata
-
-    @asset(io_manager_def=io_manager_def)
-    def downstream(upstream: Tuple[pl.LazyFrame, StorageMetadata]) -> None:
-        loaded_df, upstream_metadata = upstream
-        assert upstream_metadata == metadata
-        pl_testing.assert_frame_equal(loaded_df.collect(), df.collect())
-
-    with pytest.warns(match=DEPRECATED_STORAGE_METADATA_STRING):
-        materialize(
-            [upstream, downstream],
-        )
-
-
-def test_upath_io_manager_storage_metadata_optional_lazy_exists(
-    io_manager_and_lazy_df: Tuple[BasePolarsUPathIOManager, pl.LazyFrame], metadata: StorageMetadata
-):
-    io_manager_def, df = io_manager_and_lazy_df
-    check_skip_storage_metadata_test(io_manager_def)
-
-    @asset(io_manager_def=io_manager_def)
-    def upstream() -> Optional[Tuple[pl.LazyFrame, StorageMetadata]]:
-        return df, metadata
-
-    @asset(io_manager_def=io_manager_def)
-    def downstream(upstream: Optional[Tuple[pl.LazyFrame, StorageMetadata]]) -> None:
-        assert upstream is not None
-        df, upstream_metadata = upstream
-        assert upstream_metadata == metadata
-
-    with pytest.warns(match=DEPRECATED_STORAGE_METADATA_STRING):
-        materialize(
-            [upstream, downstream],
-        )
-
-
-def test_upath_io_manager_storage_metadata_optional_lazy_missing(
-    io_manager_and_lazy_df: Tuple[BasePolarsUPathIOManager, pl.LazyFrame], metadata: StorageMetadata
-):
-    io_manager_def, df = io_manager_and_lazy_df
-    check_skip_storage_metadata_test(io_manager_def)
-
-    @asset(io_manager_def=io_manager_def)
-    def upstream() -> Optional[Tuple[pl.LazyFrame, StorageMetadata]]:
-        return None
-
-    @asset(io_manager_def=io_manager_def)
-    def downstream(upstream: Optional[Tuple[pl.LazyFrame, StorageMetadata]]) -> None:
-        assert upstream is None
-
-    with pytest.warns(match=DEPRECATED_STORAGE_METADATA_STRING):
-        materialize(
-            [upstream, downstream],
-        )
-
-
 def test_upath_io_manager_multi_partitions_definition_load_multiple_partitions(
     io_manager_and_lazy_df: Tuple[BasePolarsUPathIOManager, pl.LazyFrame],
 ):
@@ -385,43 +303,4 @@ def test_upath_io_manager_multi_partitions_definition_load_multiple_partitions(
     materialize(
         [upstream.to_source_asset(), downstream],
         partition_key=MultiPartitionKey({"time": str(today - timedelta(days=2)), "static": "a"}),
-    )
-
-
-def test_polars_upath_io_manager_input_dict_optional_lazy(
-    io_manager_and_df: Tuple[BasePolarsUPathIOManager, pl.DataFrame],
-):
-    manager, df = io_manager_and_df
-    partition_keys = ["a", "b", "missing"]
-
-    if isinstance(manager, PolarsDeltaIOManager):
-        pytest.skip("PolarsDeltaIOManager does not read partitions as dictionaries")
-
-    @asset(io_manager_def=manager, partitions_def=StaticPartitionsDefinition(partition_keys))
-    def upstream(context: AssetExecutionContext) -> Optional[pl.DataFrame]:
-        return (
-            None
-            if context.partition_key == "missing"
-            else df.with_columns(pl.lit(context.partition_key).alias("partition"))
-        )
-
-    @asset(
-        io_manager_def=manager,
-        ins={"upstream": AssetIn(metadata={"allow_missing_partitions": True})},
-    )
-    def downstream(upstream: Dict[str, pl.LazyFrame]) -> pl.DataFrame:
-        dfs = []
-        for df in upstream.values():
-            assert isinstance(df, pl.LazyFrame)
-            dfs.append(df)
-        return pl.concat(dfs).collect()
-
-    for partition_key in ["a", "b"]:
-        materialize(
-            [upstream],
-            partition_key=partition_key,
-        )
-
-    materialize(
-        [upstream.to_source_asset(), downstream],
     )


### PR DESCRIPTION
## Summary & Motivation

This PR: 
 - :art: refactors logic around loading Optional, Dict, Eager, Lazy, and Pandera-typed DataFrames (currently blocked by #22694) with new recursive `TypeRouter` (needs a better name?) helper class. This made the base IOManager logic much cleaner while supporting all combinations of these types. Also, `TypeRouter` can potentially be used in the `BigQuery` IOManager, and in general in other non-upath IOManagers.
 - :boom: [TBD] drops support for storing extra metadata in storage as it became too hard to maintain. Extra jsons can be stored in separate assets. This decision is debatable and not final. 

I think `dagster-polars` is a good playground for this `TypeRouter` system. We can test if it's powerful and versatile enough here, specially with the upcoming support for native Parquet partitioning (`polars` recently received proper hive partitions loading support) and implementing IOManagers for other table formats such as Apache Iceberg. 

If this design is proven valuable, we can think about pulling it into the `UPathIOManager`. 

## How I Tested These Changes
Existing tests pass, proving the `TypeRouter` recursive type resolution to be correct. 

## Changelog [Breaking]

[dagster-polars]  dropped support for saving storage-level arbitrary metadata
