### PR TITLE
[Search] Don't show "No results" while search is loading

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -223,7 +223,7 @@ export const SearchDialog = () => {
             queryString={queryString}
             results={renderedResults}
             onClickResult={onClickResult}
-            loading={loading}
+            searching={loading || state.searching}
           />
         </Container>
       </Overlay>

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchDialog.tsx
@@ -223,6 +223,7 @@ export const SearchDialog = () => {
             queryString={queryString}
             results={renderedResults}
             onClickResult={onClickResult}
+            loading={loading}
           />
         </Container>
       </Overlay>

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
@@ -232,14 +232,14 @@ export type SearchResultsProps<T extends ResultType> = {
   onClickResult: (result: T) => void;
   queryString: string;
   results: T[];
-  loading: boolean;
+  searching: boolean;
 };
 
 export const SearchResults = <T extends ResultType>(props: SearchResultsProps<T>) => {
-  const {highlight, onClickResult, queryString, results, loading} = props;
+  const {highlight, onClickResult, queryString, results, searching} = props;
 
   if (!results.length && queryString) {
-    if (loading) {
+    if (searching) {
       return;
     }
     return <NoResults>No results</NoResults>;

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
@@ -232,10 +232,15 @@ export type SearchResultsProps<T extends ResultType> = {
   onClickResult: (result: T) => void;
   queryString: string;
   results: T[];
+  loading: boolean;
 };
 
 export const SearchResults = <T extends ResultType>(props: SearchResultsProps<T>) => {
-  const {highlight, onClickResult, queryString, results} = props;
+  const {highlight, onClickResult, queryString, results, loading} = props;
+
+  if (loading) {
+    return;
+  }
 
   if (!results.length && queryString) {
     return <NoResults>No results</NoResults>;

--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
@@ -238,11 +238,10 @@ export type SearchResultsProps<T extends ResultType> = {
 export const SearchResults = <T extends ResultType>(props: SearchResultsProps<T>) => {
   const {highlight, onClickResult, queryString, results, loading} = props;
 
-  if (loading) {
-    return;
-  }
-
   if (!results.length && queryString) {
+    if (loading) {
+      return;
+    }
     return <NoResults>No results</NoResults>;
   }
 


### PR DESCRIPTION
## Summary & Motivation

As titled

## How I Tested These Changes

If results are loading then don't show the "No results message".

## Changelog [New | Bug | Docs]

NOCHANGELOG
