### PR TITLE
[dagster-airlift] allow all retrieval methods of task/dag

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
@@ -1,6 +1,9 @@
 from typing import Optional
 
-from dagster import AssetsDefinition
+from dagster import (
+    AssetsDefinition,
+    _check as check,
+)
 
 MIGRATED_TAG = "airlift/task_migrated"
 DAG_ID_TAG = "airlift/dag_id"
@@ -8,16 +11,51 @@ TASK_ID_TAG = "airlift/task_id"
 
 
 def get_task_id_from_asset(assets_def: AssetsDefinition) -> Optional[str]:
-    if assets_def.node_def.tags and "airlift/task_id" in assets_def.node_def.tags:
-        return assets_def.node_def.tags["airlift/task_id"]
-    if len(assets_def.node_def.name.split("__")) == 2:
-        return assets_def.node_def.name.split("__")[1]
-    return None
+    return _get_prop_from_asset(assets_def, TASK_ID_TAG, 1)
 
 
 def get_dag_id_from_asset(assets_def: AssetsDefinition) -> Optional[str]:
-    if assets_def.node_def.tags and "airlift/dag_id" in assets_def.node_def.tags:
-        return assets_def.node_def.tags["airlift/dag_id"]
+    return _get_prop_from_asset(assets_def, DAG_ID_TAG, 0)
+
+
+def _get_prop_from_asset(
+    assets_def: AssetsDefinition, prop_tag: str, position: int
+) -> Optional[str]:
+    prop_from_tags = None
+    if any(prop_tag in spec.tags for spec in assets_def.specs):
+        prop = None
+        for spec in assets_def.specs:
+            if prop is None:
+                prop = spec.tags[prop_tag]
+            else:
+                if spec.tags.get(prop_tag) is None:
+                    check.failed(
+                        f"Missing {prop_tag} tag in spec {spec.key} for {assets_def.node_def.name}"
+                    )
+                check.invariant(
+                    prop == spec.tags[prop_tag],
+                    f"Task ID mismatch within same AssetsDefinition: {prop} != {spec.tags[prop_tag]}",
+                )
+        prop_from_tags = prop
+    prop_from_op_tags = None
+    if assets_def.node_def.tags and prop_tag in assets_def.node_def.tags:
+        prop_from_op_tags = assets_def.node_def.tags[prop_tag]
+    prop_from_name = None
     if len(assets_def.node_def.name.split("__")) == 2:
-        return assets_def.node_def.name.split("__")[0]
-    return None
+        prop_from_name = assets_def.node_def.name.split("__")[position]
+    if prop_from_tags and prop_from_op_tags:
+        check.invariant(
+            prop_from_tags == prop_from_op_tags,
+            f"ID mismatch between asset tags and op tags: {prop_from_tags} != {prop_from_op_tags}",
+        )
+    if prop_from_tags and prop_from_name:
+        check.invariant(
+            prop_from_tags == prop_from_name,
+            f"ID mismatch between tags and name: {prop_from_tags} != {prop_from_name}",
+        )
+    if prop_from_op_tags and prop_from_name:
+        check.invariant(
+            prop_from_op_tags == prop_from_name,
+            f"ID mismatch between op tags and name: {prop_from_op_tags} != {prop_from_name}",
+        )
+    return prop_from_tags or prop_from_op_tags or prop_from_name

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_utils.py
@@ -1,0 +1,147 @@
+import pytest
+from dagster import AssetKey, AssetSpec, asset, multi_asset
+from dagster._check.functions import CheckError
+from dagster_airlift.core.utils import get_dag_id_from_asset, get_task_id_from_asset
+
+
+def test_no_convention() -> None:
+    """Test that we don't error when no convention method for setting dag and task id are provided."""
+
+    @asset
+    def no_op():
+        pass
+
+    assert get_dag_id_from_asset(no_op) is None
+    assert get_task_id_from_asset(no_op) is None
+
+
+def test_retrieve_by_asset_tag() -> None:
+    """Test that we can retrieve the dag and task id from the asset tags. Test that error edge cases are properly handled."""
+
+    # 1. Single spec retrieval
+    @asset(tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"})
+    def one_spec():
+        pass
+
+    assert get_dag_id_from_asset(one_spec) == "print_dag"
+    assert get_task_id_from_asset(one_spec) == "print_task"
+
+    # 2. Multiple spec retrieval, all specs match
+    @multi_asset(
+        specs=[
+            AssetSpec(
+                key=AssetKey(["simple"]),
+                tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"},
+            ),
+            AssetSpec(
+                key=AssetKey(["other"]),
+                tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"},
+            ),
+        ]
+    )
+    def multi_spec_pass():
+        pass
+
+    assert get_dag_id_from_asset(multi_spec_pass) == "print_dag"
+    assert get_task_id_from_asset(multi_spec_pass) == "print_task"
+
+    # 3. Multiple spec retrieval but with different tasks/dags
+    @multi_asset(
+        specs=[
+            AssetSpec(
+                key=AssetKey(["simple"]),
+                tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"},
+            ),
+            AssetSpec(
+                key=AssetKey(["other"]),
+                tags={"airlift/dag_id": "other_dag", "airlift/task_id": "other_task"},
+            ),
+        ]
+    )
+    def multi_spec_mismatch():
+        pass
+
+    with pytest.raises(CheckError):
+        get_dag_id_from_asset(multi_spec_mismatch)
+    with pytest.raises(CheckError):
+        get_task_id_from_asset(multi_spec_mismatch)
+
+    # 5. Multiple spec retrieval, not all have tags set
+    @multi_asset(
+        specs=[
+            AssetSpec(
+                key=AssetKey(["simple"]),
+                tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"},
+            ),
+            AssetSpec(key=AssetKey(["other"])),
+        ]
+    )
+    def multi_spec_task_mismatch():
+        pass
+
+    with pytest.raises(CheckError):
+        get_dag_id_from_asset(multi_spec_task_mismatch)
+
+    with pytest.raises(CheckError):
+        get_task_id_from_asset(multi_spec_task_mismatch)
+
+
+def test_retrieve_by_op_tag() -> None:
+    """Test that we can retrieve the dag and task id from the op tags."""
+
+    @asset(op_tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"})
+    def the_asset():
+        pass
+
+    assert get_dag_id_from_asset(the_asset) == "print_dag"
+    assert get_task_id_from_asset(the_asset) == "print_task"
+
+
+def test_retrieve_by_name() -> None:
+    """Test that we can retrieve the dag and task id from the name."""
+
+    @asset
+    def print_dag__print_task():
+        pass
+
+    assert get_dag_id_from_asset(print_dag__print_task) == "print_dag"
+    assert get_task_id_from_asset(print_dag__print_task) == "print_task"
+
+
+def test_op_asset_tag_mismatch() -> None:
+    @asset(
+        tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"},
+        op_tags={"airlift/dag_id": "other_dag", "airlift/task_id": "other_task"},
+    )
+    def mismatched():
+        pass
+
+    with pytest.raises(CheckError):
+        get_dag_id_from_asset(mismatched)
+
+    with pytest.raises(CheckError):
+        get_task_id_from_asset(mismatched)
+
+
+def test_op_asset_name_mismatch() -> None:
+    @asset(tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"})
+    def other_dag__other_task():
+        pass
+
+    with pytest.raises(CheckError):
+        get_dag_id_from_asset(other_dag__other_task)
+
+    with pytest.raises(CheckError):
+        get_task_id_from_asset(other_dag__other_task)
+
+
+def test_op_tag_name_mismatch() -> None:
+    @asset(op_tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"})
+    def other_dag__other_task():
+        pass
+
+    with pytest.raises(CheckError):
+        get_dag_id_from_asset(other_dag__other_task)
+
+    with pytest.raises(CheckError):
+        get_task_id_from_asset(other_dag__other_task)


### PR DESCRIPTION
Allow task/dag to be set by name, op tag, or asset tag.

Simple unit tests for the util methods.