### PR TITLE
Update coding-practice-trips-by-week-asset.md

### DIFF
--- a/docs/dagster-university/pages/dagster-essentials/lesson-4/coding-practice-trips-by-week-asset.md
+++ b/docs/dagster-university/pages/dagster-essentials/lesson-4/coding-practice-trips-by-week-asset.md
@@ -63,16 +63,12 @@ from . import constants
 
 import pandas as pd
 
-@asset(
-    deps=["taxi_trips"]
-)
+@asset(deps=["taxi_trips"])
 def trips_by_week() -> None:
     conn = duckdb.connect(os.getenv("DUCKDB_DATABASE"))
 
     current_date = datetime.strptime("2023-03-01", constants.DATE_FORMAT)
     end_date = datetime.strptime("2023-04-01", constants.DATE_FORMAT)
-
-    result = pd.DataFrame()
 
     while current_date < end_date:
         current_date_str = current_date.strftime(constants.DATE_FORMAT)
@@ -85,26 +81,40 @@ def trips_by_week() -> None:
 
         data_for_week = conn.execute(query).fetch_df()
 
-        aggregate = data_for_week.agg({
-            "vendor_id": "count",
-            "total_amount": "sum",
-            "trip_distance": "sum",
-            "passenger_count": "sum"
-        }).rename({"vendor_id": "num_trips"}).to_frame().T # type: ignore
+        aggregate = (
+            data_for_week.agg(
+                {
+                    "vendor_id": "count",
+                    "total_amount": "sum",
+                    "trip_distance": "sum",
+                    "passenger_count": "sum",
+                }
+            )
+            .rename({"vendor_id": "num_trips"})
+            .to_frame()
+            .T
+        )  # type: ignore
 
-        aggregate["period"] = current_date
+        aggregate["period"] = current_date_str
 
-        result = pd.concat([result, aggregate])
+        # clean up the formatting of the dataframe
+        aggregate["num_trips"] = aggregate["num_trips"].astype(int)
+        aggregate["passenger_count"] = aggregate["passenger_count"].astype(int)
+        aggregate["total_amount"] = aggregate["total_amount"].round(2).astype(float)
+        aggregate["trip_distance"] = aggregate["trip_distance"].round(2).astype(float)
+        aggregate = aggregate[
+            ["period", "num_trips", "total_amount", "trip_distance", "passenger_count"]
+        ]
+        aggregate = aggregate.sort_values(by="period")
+
+        try:
+            # If the file already exists, append to it, but replace the existing month's data
+            existing = pd.read_csv(constants.TRIPS_BY_WEEK_FILE_PATH)
+            existing = existing[existing["period"] != current_date_str]
+            existing = pd.concat([existing, aggregate]).sort_values(by="period")
+            existing.to_csv(constants.TRIPS_BY_WEEK_FILE_PATH, index=False)
+        except FileNotFoundError:
+            aggregate.to_csv(constants.TRIPS_BY_WEEK_FILE_PATH, index=False)
 
         current_date += timedelta(days=7)
-
-    # clean up the formatting of the dataframe
-    result['num_trips'] = result['num_trips'].astype(int)
-    result['passenger_count'] = result['passenger_count'].astype(int)
-    result['total_amount'] = result['total_amount'].round(2).astype(float)
-    result['trip_distance'] = result['trip_distance'].round(2).astype(float)
-    result = result[["period", "num_trips", "total_amount", "trip_distance", "passenger_count"]]
-    result = result.sort_values(by="period")
-
-    result.to_csv(constants.TRIPS_BY_WEEK_FILE_PATH, index=False)
 ```

--- a/docs/dagster-university/pages/dagster-essentials/lesson-4/coding-practice-trips-by-week-asset.md
+++ b/docs/dagster-university/pages/dagster-essentials/lesson-4/coding-practice-trips-by-week-asset.md
@@ -63,7 +63,9 @@ from . import constants
 
 import pandas as pd
 
-@asset(deps=["taxi_trips"])
+@asset(
+    deps=["taxi_trips"]
+)
 def trips_by_week() -> None:
     conn = duckdb.connect(os.getenv("DUCKDB_DATABASE"))
 


### PR DESCRIPTION
Adapt the solution to address the requirement of not loading the full data into memory.

## Summary & Motivation

The challenge asks to design the code assuming that the whole trips data does not fit into memory but a week of data does. When fetching data from the database, the previous solution did the good job of filtering week data, but then went on to append this data to a initially empty dataframe. That approach would still find the same memory overflow.

## How I Tested These Changes

Defined a trips by week asset in the local project following the Dagster University Course and successfully materialized it.

## Changelog [New | Bug | Docs]

`NOCHANGELOG`
