### PR TITLE
on run page, fix misleading lineage label

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/AssetTagCollections.tsx
@@ -96,7 +96,7 @@ export const AssetKeyTagCollection = React.memo((props: AssetKeyTagCollectionPro
               to: assetDetailsPathForKey(assetKey),
             },
             {
-              label: 'View downstream lineage',
+              label: 'View lineage',
               to: assetDetailsPathForKey(assetKey, {
                 view: 'lineage',
                 lineageScope: 'downstream',
@@ -131,7 +131,7 @@ export const AssetKeyTagCollection = React.memo((props: AssetKeyTagCollectionPro
             onClick: () => setShowMore(true),
           },
           {
-            label: 'View downstream lineage',
+            label: 'View lineage',
             to: globalAssetGraphPathForAssetsAndDescendants(assetKeys),
           },
         ]}


### PR DESCRIPTION
## Summary & Motivation

On the run page, if you hover over "N assets", you see these labels:

<img width="260" alt="image" src="https://github.com/user-attachments/assets/ef1c2534-1de5-4302-bb1d-2b396cd90cfa">

I think "View downstream lineage" is misleading, and it should just be "View lineage"

## How I Tested These Changes

## Changelog [New | Bug | Docs]

> Replace this message with a changelog entry, or `NOCHANGELOG`
