### PR TITLE
RFC: Class-based dlt integration

### DIFF
--- a/docs/content/integrations/embedded-elt/dlt.mdx
+++ b/docs/content/integrations/embedded-elt/dlt.mdx
@@ -322,13 +322,11 @@ That said, here is an example of using static named partitions from a dlt source
 from typing import Iterable, Optional
 
 import dlt
-from dagster_embedded_elt.dlt import DagsterDltResource, dlt_assets
+from dagster_embedded_elt.dlt import DagsterDltResource
 from dagster_embedded_elt.dlt.computation import ComputationContext
 from dagster_embedded_elt.dlt.dlt_computation import RunDlt
 
-from dagster import AssetExecutionContext, StaticPartitionsDefinition
-from dagster._core.definitions.asset_check_result import AssetCheckResult
-from dagster._core.definitions.result import AssetResult
+from dagster import MaterializeResult, StaticPartitionsDefinition
 
 color_partitions = StaticPartitionsDefinition(["red", "green", "blue"])
 
@@ -353,9 +351,9 @@ dlt_pipeline = dlt.pipeline(
 
 
 class PartitionedRunDlt(RunDlt):
-    def stream(self, context: ComputationContext) -> Iterable:
+    def stream(self, context: ComputationContext) -> Iterable[MaterializeResult]:
         color = context.partition_key
-        yield from DagsterDltResource().run(
+        yield from DagsterDltResource().stream(
             context=context, dlt_source=example_dlt_source(color=color)
         )
 

--- a/docs/content/integrations/embedded-elt/dlt.mdx
+++ b/docs/content/integrations/embedded-elt/dlt.mdx
@@ -237,16 +237,8 @@ The <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" />
 For example, to change how the name of the asset is derived, you can override the <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" method="get_asset_key" /> method, or if you would like to change the key of the upstream source asset, you can override the <PyObject module="dagster_embedded_elt.dlt" object="DagsterDltTranslator" method="get_deps_assets_keys" /> method.
 
 ```python file=/integrations/embedded_elt/dlt_dagster_translator.py
-from collections.abc import Iterable
-
 import dlt
-from dagster_embedded_elt.dlt import (
-    DagsterDltResource,
-    DagsterDltTranslator,
-    dlt_assets,
-)
-
-from dagster import AssetExecutionContext, AssetKey
+from dagster_embedded_elt.dlt.dlt_computation import RunDlt
 
 
 @dlt.source
@@ -256,29 +248,26 @@ def example_dlt_source():
     return example_resource
 
 
-class CustomDagsterDltTranslator(DagsterDltTranslator):
-    def get_asset_key(self, resource: DagsterDltResource) -> AssetKey:
-        """Overrides asset key to be the dlt resource name."""
-        return AssetKey(f"{resource.name}")
-
-    def get_deps_asset_keys(self, resource: DagsterDltResource) -> Iterable[AssetKey]:
-        """Overrides upstream asset key to be a single source asset."""
-        return [AssetKey("common_upstream_dlt_dependency")]
-
-
-@dlt_assets(
-    name="example_dlt_assets",
-    dlt_source=example_dlt_source(),
-    dlt_pipeline=dlt.pipeline(
-        pipeline_name="example_pipeline_name",
-        dataset_name="example_dataset_name",
-        destination="snowflake",
-        progress="log",
-    ),
-    dagster_dlt_translator=CustomDagsterDltTranslator(),
+dlt_source = example_dlt_source()
+dlt_pipeline = dlt.pipeline(
+    pipeline_name="example_pipeline_name",
+    dataset_name="example_dataset_name",
+    destination="snowflake",
+    progress="log",
 )
-def dlt_example_assets(context: AssetExecutionContext, dlt: DagsterDltResource):
-    yield from dlt.run(context=context)
+source_asset_key = "common_upstream_dlt_dependency"
+RunDlt(
+    name="example_dlt_assets",
+    dlt_source=dlt_source,
+    dlt_pipeline=dlt_pipeline,
+    specs=[
+        RunDlt.default_spec(dlt_source, dlt_pipeline, dlt_resource)._replace(
+            key=dlt_resource.name,  # overrides asset key to be resource name
+            deps=[source_asset_key],  # overrides upstream to be single source asset
+        )
+        for dlt_resource in dlt_source.resources.values()
+    ],
+)
 ```
 
 In this example, we customized the translator to change how the dlt assets' names are defined. We also hard-coded the asset dependency upstream of our assets to provide a fan-out model from a single dependency to our dlt assets.
@@ -330,12 +319,16 @@ While still an experimental feature, it is possible to use partitions within you
 That said, here is an example of using static named partitions from a dlt source.
 
 ```python file=/integrations/embedded_elt/dlt_partitions.py
-from typing import Optional
+from typing import Iterable, Optional
 
 import dlt
 from dagster_embedded_elt.dlt import DagsterDltResource, dlt_assets
+from dagster_embedded_elt.dlt.computation import ComputationContext
+from dagster_embedded_elt.dlt.dlt_computation import RunDlt
 
 from dagster import AssetExecutionContext, StaticPartitionsDefinition
+from dagster._core.definitions.asset_check_result import AssetCheckResult
+from dagster._core.definitions.result import AssetResult
 
 color_partitions = StaticPartitionsDefinition(["red", "green", "blue"])
 
@@ -351,19 +344,30 @@ def example_dlt_source(color: Optional[str] = None):
             ...
 
 
-@dlt_assets(
-    dlt_source=example_dlt_source(),
-    name="example_dlt_assets",
-    dlt_pipeline=dlt.pipeline(
-        pipeline_name="example_pipeline_name",
-        dataset_name="example_dataset_name",
-        destination="snowflake",
-    ),
-    partitions_def=color_partitions,
+dlt_source = example_dlt_source()
+dlt_pipeline = dlt.pipeline(
+    pipeline_name="example_pipeline_name",
+    dataset_name="example_dataset_name",
+    destination="snowflake",
 )
-def compute(context: AssetExecutionContext, dlt: DagsterDltResource):
-    color = context.partition_key
-    yield from dlt.run(context=context, dlt_source=example_dlt_source(color=color))
+
+
+class PartitionedRunDlt(RunDlt):
+    def stream(self, context: ComputationContext) -> Iterable:
+        color = context.partition_key
+        yield from DagsterDltResource().run(
+            context=context, dlt_source=example_dlt_source(color=color)
+        )
+
+
+PartitionedRunDlt(
+    name="example_dlt_assets",
+    dlt_source=dlt_source,
+    dlt_pipeline=dlt_pipeline,
+    specs=RunDlt.default_specs(dlt_source, dlt_pipeline).replace(
+        partitions_def=color_partitions
+    ),
+)
 ```
 
 ## What's next?

--- a/examples/docs_snippets/docs_snippets/integrations/embedded_elt/dlt_partitions.py
+++ b/examples/docs_snippets/docs_snippets/integrations/embedded_elt/dlt_partitions.py
@@ -1,13 +1,11 @@
 from typing import Iterable, Optional
 
 import dlt
-from dagster_embedded_elt.dlt import DagsterDltResource, dlt_assets
+from dagster_embedded_elt.dlt import DagsterDltResource
 from dagster_embedded_elt.dlt.computation import ComputationContext
 from dagster_embedded_elt.dlt.dlt_computation import RunDlt
 
-from dagster import AssetExecutionContext, StaticPartitionsDefinition
-from dagster._core.definitions.asset_check_result import AssetCheckResult
-from dagster._core.definitions.result import AssetResult
+from dagster import MaterializeResult, StaticPartitionsDefinition
 
 color_partitions = StaticPartitionsDefinition(["red", "green", "blue"])
 
@@ -32,9 +30,9 @@ dlt_pipeline = dlt.pipeline(
 
 
 class PartitionedRunDlt(RunDlt):
-    def stream(self, context: ComputationContext) -> Iterable:
+    def stream(self, context: ComputationContext) -> Iterable[MaterializeResult]:
         color = context.partition_key
-        yield from DagsterDltResource().run(
+        yield from DagsterDltResource().stream(
             context=context, dlt_source=example_dlt_source(color=color)
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -223,3 +223,6 @@ class AssetSpec(
             if self.automation_condition
             else None
         )
+
+    def with_metadata(self, metadata: Mapping[str, Any]) -> "AssetSpec":
+        return self._replace(metadata={**self.metadata, **metadata})

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/computation.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/computation.py
@@ -1,0 +1,156 @@
+import hashlib
+from functools import cached_property
+from typing import Callable, Iterable, List, Optional, Sequence, Union
+
+from dagster import (
+    AssetSpec,
+    _check as check,
+)
+from dagster._config.config_schema import UserConfigSchema
+from dagster._core.definitions.asset_check_result import AssetCheckResult
+from dagster._core.definitions.asset_check_spec import AssetCheckSpec
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.decorators.asset_decorator import multi_asset
+from dagster._core.definitions.materialize import materialize
+from dagster._core.definitions.result import MaterializeResult, ObserveResult
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
+from typing_extensions import TypeAlias
+
+
+class Specs:
+    def __init__(self, specs: Sequence[Union[AssetSpec, AssetCheckSpec]]):
+        self.specs = list(
+            check.opt_sequence_param(specs, "specs", of_type=(AssetSpec, AssetCheckSpec)) or []
+        )
+
+    def replace(self, **kwargs) -> "Specs":
+        self.specs = [spec._replace(**kwargs) for spec in self.specs]
+        return self
+
+    def with_tags(self, tags: dict) -> "Specs":
+        self.specs = [
+            spec._replace(tags={**spec.tags, **tags}) if isinstance(spec, AssetSpec) else spec
+            for spec in self.specs
+        ]
+        return self
+
+    def with_metadata(self, metadata: dict) -> "Specs":
+        self.specs = [
+            spec._replace(metadata={**(spec.metadata or {}), **metadata}) for spec in self.specs
+        ]
+        return self
+
+    def apply(
+        self, f: Callable[[Union[AssetSpec, AssetCheckSpec]], Union[AssetSpec, AssetCheckSpec]]
+    ) -> "Specs":
+        self.specs = [f(spec) for spec in self.specs]
+        return self
+
+    def to_list(self) -> List[Union[AssetSpec, AssetCheckSpec]]:
+        return self.specs
+
+
+class ComputationContext:
+    def __init__(self, context: AssetExecutionContext):
+        self._ae_context = context
+
+    def to_asset_execution_context(self) -> AssetExecutionContext:
+        return self._ae_context
+
+
+def iterate_comps(specs: Sequence[Union[AssetSpec, AssetCheckSpec]]) -> Iterable[str]:
+    return [
+        spec.get_python_identifier()
+        if isinstance(spec, AssetCheckSpec)
+        else spec.key.to_python_identifier()
+        for spec in specs
+    ]
+
+
+def unique_name(specs: Sequence[Union[AssetSpec, AssetCheckSpec]]) -> str:
+    return hashlib.sha256("_".join(sorted(set(iterate_comps(specs)))).encode()).hexdigest()[:32]
+
+
+SpecsArg: TypeAlias = Union[Specs, Sequence[Union[AssetSpec, AssetCheckSpec]]]
+SpecResult: TypeAlias = Union[MaterializeResult, AssetCheckResult, ObserveResult]
+
+
+class ComputationResult:
+    def __init__(self, spec_results: Sequence[SpecResult], execution_metadata=None) -> None:
+        self.spec_results = list(
+            check.opt_sequence_param(spec_results, "spec_results", of_type=SpecResult) or []
+        )
+        self.execution_metadata = execution_metadata or {}
+
+
+class ExecutionComplete:
+    def __init__(self, execution_metadata=None) -> None:
+        self.execution_metadata = execution_metadata or {}
+
+
+class Computation:
+    def __init__(
+        self,
+        *,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        specs: SpecsArg,
+        tags: Optional[dict] = None,
+        config_schema: Optional[UserConfigSchema] = None,
+    ):
+        self.specs: List[Union[AssetSpec, AssetCheckSpec]] = (
+            specs.to_list()
+            if isinstance(specs, Specs)
+            else list(check.sequence_param(specs, "specs", of_type=(AssetSpec, AssetCheckSpec)))
+        )
+        self.name = name or unique_name(self.specs)
+        self.tags = tags
+        self.config_schema = config_schema
+        self.description = description
+
+    @property
+    def asset_specs(self) -> List[AssetSpec]:
+        return [spec for spec in self.specs if isinstance(spec, AssetSpec)]
+
+    @property
+    def asset_check_specs(self) -> List[AssetCheckSpec]:
+        return [spec for spec in self.specs if isinstance(spec, AssetCheckSpec)]
+
+    def execute(self, context: ComputationContext, **kwargs) -> ComputationResult:
+        results_or_complete = list(self.stream(context, **kwargs))
+
+        complete = next(
+            (result for result in results_or_complete if isinstance(result, ExecutionComplete)),
+            None,
+        )
+        return ComputationResult(
+            spec_results=[
+                result for result in results_or_complete if isinstance(result, SpecResult)
+            ],
+            execution_metadata=complete.execution_metadata if complete else None,
+        )
+
+    def stream(
+        self, context: ComputationContext, **kwargs
+    ) -> Iterable[Union[SpecResult, ExecutionComplete]]: ...
+
+    def test(self) -> ExecuteInProcessResult:
+        return materialize([self.assets_def])
+
+    @cached_property
+    def assets_def(self) -> AssetsDefinition:
+        @multi_asset(
+            name=self.name,
+            specs=self.asset_specs,
+            check_specs=self.asset_check_specs,
+            op_tags=self.tags,
+            config_schema=self.config_schema,
+            description=self.description,
+        )
+        def inst(context: AssetExecutionContext):
+            for r in self.stream(ComputationContext(context)):
+                if isinstance(r, SpecResult):
+                    yield r
+
+        return inst

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/computation.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/computation.py
@@ -58,6 +58,11 @@ class ComputationContext:
     def __init__(self, context: AssetExecutionContext):
         self._ae_context = context
 
+    # this property here to not freak people out temporarily
+    @property
+    def partition_key(self) -> Optional[str]:
+        return self._ae_context.partition_key
+
     def to_asset_execution_context(self) -> AssetExecutionContext:
         return self._ae_context
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/computation.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/computation.py
@@ -18,6 +18,7 @@ from dagster._core.execution.execute_in_process_result import ExecuteInProcessRe
 from typing_extensions import TypeAlias
 
 
+# Helper class to do group operations to a collection of specs
 class Specs:
     def __init__(self, specs: Sequence[Union[AssetSpec, AssetCheckSpec]]):
         self.specs = list(
@@ -54,6 +55,8 @@ class Specs:
         return [spec for spec in self.specs if isinstance(spec, AssetSpec)]
 
 
+# This might appear like overkill right now, but this would be our opportunity
+# to have a sane context api
 class ComputationContext:
     def __init__(self, context: AssetExecutionContext):
         self._ae_context = context

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/computation.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/computation.py
@@ -50,6 +50,9 @@ class Specs:
     def to_list(self) -> List[Union[AssetSpec, AssetCheckSpec]]:
         return self.specs
 
+    def to_asset_specs(self) -> List[AssetSpec]:
+        return [spec for spec in self.specs if isinstance(spec, AssetSpec)]
+
 
 class ComputationContext:
     def __init__(self, context: AssetExecutionContext):
@@ -135,8 +138,9 @@ class Computation:
         self, context: ComputationContext, **kwargs
     ) -> Iterable[Union[SpecResult, ExecutionComplete]]: ...
 
-    def test(self) -> ExecuteInProcessResult:
-        return materialize([self.assets_def])
+    def test(self, partitions: Optional[str] = None) -> ExecuteInProcessResult:
+        # TODO handle all partition varietals (list, range)
+        return materialize([self.assets_def], partition_key=partitions)
 
     @cached_property
     def assets_def(self) -> AssetsDefinition:

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/constants.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/constants.py
@@ -1,4 +1,3 @@
 META_KEY_SOURCE = "dagster_dlt/source"
-META_KEY_SOURCE_RESOURCE = "dagster_dlt/source_resource"
 META_KEY_PIPELINE = "dagster_dlt/pipeline"
 META_KEY_TRANSLATOR = "dagster_dlt/translator"

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/constants.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/constants.py
@@ -1,3 +1,4 @@
 META_KEY_SOURCE = "dagster_dlt/source"
+META_KEY_SOURCE_RESOURCE = "dagster_dlt/source_resource"
 META_KEY_PIPELINE = "dagster_dlt/pipeline"
 META_KEY_TRANSLATOR = "dagster_dlt/translator"

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/dlt_computation.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/dlt_computation.py
@@ -37,36 +37,7 @@ def get_description(resource: DltResource) -> Optional[str]:
     return None
 
 
-class Dlt(Computation):
-    @classmethod
-    def default_specs(cls, dlt_source: DltSource, dlt_pipeline: Pipeline) -> Specs:
-        return Specs(
-            [
-                Dlt.default_spec(dlt_source, dlt_pipeline, resource)
-                for resource in dlt_source.selected_resources.values()
-            ]
-        )
-
-    @classmethod
-    def default_spec(
-        cls, dlt_source: DltSource, dlt_pipeline: Pipeline, dlt_resource: DltResource
-    ) -> AssetSpec:
-        return AssetSpec(
-            key=f"dlt_{dlt_resource.source_name}_{dlt_resource.name}",
-            deps=get_upstream_deps(dlt_resource),
-            description=get_description(dlt_resource),
-            metadata={
-                META_KEY_SOURCE: dlt_source,
-                META_KEY_PIPELINE: dlt_pipeline,
-                META_KEY_TRANSLATOR: None,
-            },
-            tags={
-                "dagster/compute_kind": dlt_pipeline.destination.destination_name,
-            },
-        )
-
-
-class RunDlt(Dlt):
+class RunDlt(Computation):
     """Asset Factory for using data load tool (dlt).
 
     Args:
@@ -116,6 +87,33 @@ class RunDlt(Dlt):
                 specs=RunDlt.default_specs().replace(group_name="github"),
             )
     """
+
+    @classmethod
+    def default_specs(cls, dlt_source: DltSource, dlt_pipeline: Pipeline) -> Specs:
+        return Specs(
+            [
+                RunDlt.default_spec(dlt_source, dlt_pipeline, resource)
+                for resource in dlt_source.selected_resources.values()
+            ]
+        )
+
+    @classmethod
+    def default_spec(
+        cls, dlt_source: DltSource, dlt_pipeline: Pipeline, dlt_resource: DltResource
+    ) -> AssetSpec:
+        return AssetSpec(
+            key=f"dlt_{dlt_resource.source_name}_{dlt_resource.name}",
+            deps=get_upstream_deps(dlt_resource),
+            description=get_description(dlt_resource),
+            metadata={
+                META_KEY_SOURCE: dlt_source,
+                META_KEY_PIPELINE: dlt_pipeline,
+                META_KEY_TRANSLATOR: None,
+            },
+            tags={
+                "dagster/compute_kind": dlt_pipeline.destination.destination_name,
+            },
+        )
 
     def __init__(
         self,

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/dlt_computation.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/dlt_computation.py
@@ -1,0 +1,139 @@
+from typing import Iterable, Optional, Union
+
+from dagster import (
+    AssetKey,
+    AssetSpec,
+    MaterializeResult,
+    _check as check,
+)
+from dagster._core.definitions.asset_check_result import AssetCheckResult
+from dagster._core.definitions.result import AssetResult
+from dlt.extract.resource import DltResource
+from dlt.extract.source import DltSource
+from dlt.pipeline.pipeline import Pipeline
+
+from dagster_embedded_elt.dlt.translator import DagsterDltTranslator
+
+from .computation import Computation, ComputationContext, Specs, SpecsArg
+from .constants import META_KEY_PIPELINE, META_KEY_SOURCE
+from .resource import DagsterDltResource
+
+
+def get_upstream_deps(resource: DltResource) -> Iterable[AssetKey]:
+    if resource.is_transformer:
+        pipe = resource._pipe  # noqa: SLF001
+        while pipe.has_parent:
+            pipe = pipe.parent
+        return [AssetKey(f"{resource.source_name}_{pipe.name}")]
+    return [AssetKey(f"{resource.source_name}_{resource.name}")]
+
+
+def get_description(resource: DltResource) -> Optional[str]:
+    pipe = resource._pipe  # noqa: SLF001
+    # If the function underlying the resource is a single callable,
+    # return the docstring of the callable.
+    if len(pipe.steps) == 1 and callable(pipe.steps[0]):
+        return pipe.steps[0].__doc__
+    return None
+
+
+class Dlt(Computation):
+    @classmethod
+    def default_specs(cls, dlt_source: DltSource, dlt_pipeline: Pipeline) -> Specs:
+        return Specs(
+            [
+                AssetSpec(
+                    key=f"dlt_{resource.source_name}_{resource.name}",
+                    deps=get_upstream_deps(resource),
+                    description=get_description(resource),
+                    group_name=None,
+                    metadata={
+                        META_KEY_SOURCE: dlt_source,
+                        META_KEY_PIPELINE: dlt_pipeline,
+                    },
+                    owners=None,
+                    tags={
+                        "dagster/compute_kind": dlt_pipeline.destination.destination_name,
+                    },
+                )
+                for resource in dlt_source.selected_resources.values()
+            ]
+        )
+
+
+class RunDlt(Dlt):
+    """Asset Factory for using data load tool (dlt).
+
+    Args:
+        dlt_source (DltSource): The DltSource to be ingested.
+        dlt_pipeline (Pipeline): The dlt Pipeline defining the destination parameters.
+        name (Optional[str], optional): The name of the op.
+        group_name (Optional[str], optional): The name of the asset group.
+        dlt_dagster_translator (DltDagsterTranslator, optional): Customization object for defining asset parameters from dlt resources.
+
+    Examples:
+        Loading Hubspot data to Snowflake with an auto materialize policy using the dlt verified source:
+
+        .. code-block:: python
+
+            RunDlt(
+                name="hubspot",
+                dlt_source=hubspot(include_history=True),
+                dlt_pipeline=pipeline(
+                    pipeline_name="hubspot",
+                    dataset_name="hubspot",
+                    destination="snowflake",
+                    progress="log",
+                ),
+                specs=RunDlt.default_specs().replace(
+                    group_name="hubspot"
+                    auto_materialize_policy=AutoMaterializePolicy.eager().with_rules(
+                        AutoMaterializeRule.materialize_on_cron("0 0 * * *")
+                    )
+                ),
+            )
+
+        Loading Github issues to snowflake:
+
+        .. code-block:: python
+
+            RunDlt(
+                name="github",
+                dlt_source=github_reactions(
+                    "dagster-io", "dagster", items_per_page=100, max_items=250
+                ),
+                dlt_pipeline=pipeline(
+                    pipeline_name="github_issues",
+                    dataset_name="github",
+                    destination="snowflake",
+                    progress="log",
+                ),
+                specs=RunDlt.default_specs().replace(group_name="github"),
+            )
+    """
+
+    def __init__(
+        self,
+        *,
+        name: Optional[str] = None,
+        specs: Optional[SpecsArg] = None,
+        dlt_source: DltSource,
+        dlt_pipeline: Pipeline,
+    ):
+        self.dlt_source = dlt_source
+        self.dlt_pipeline = dlt_pipeline
+        super().__init__(name=name, specs=specs or self.default_specs(dlt_source, dlt_pipeline))
+
+    def stream(self, context: ComputationContext) -> Iterable[Union[AssetResult, AssetCheckResult]]:
+        dlt = DagsterDltResource()
+        for result in dlt.run(
+            context=context.to_asset_execution_context(),
+            dlt_source=self.dlt_source,
+            # provide dummy instance of this
+            dagster_dlt_translator=DagsterDltTranslator(),
+        ):
+            yield check.inst(
+                result,
+                MaterializeResult,
+                "Only MaterializeResult is supported since dlt is in an asset computation",
+            )

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/dlt_computation.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/dlt_computation.py
@@ -132,7 +132,7 @@ class RunDlt(Computation):
         for result in dlt.run(
             context=context.to_asset_execution_context(),
             dlt_source=self.dlt_source,
-            # provide dummy instance of this
+            # provide dummy instance of this to avoid spurious exception
             dagster_dlt_translator=DagsterDltTranslator(),
         ):
             yield check.inst(

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
@@ -148,7 +148,7 @@ class DagsterDltResource(ConfigurableResource):
                 dlt_pipeline or first_asset_metadata.get(META_KEY_PIPELINE), Pipeline
             )
             dagster_dlt_translator = check.inst(
-                dagster_dlt_translator or first_asset_metadata.get(META_KEY_TRANSLATOR),
+                dagster_dlt_translator or first_asset_metadata.get(META_KEY_TRANSLATOR) or DagsterDltTranslator(),
                 DagsterDltTranslator,
             )
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/resource.py
@@ -112,10 +112,28 @@ class DagsterDltResource(ConfigurableResource):
 
         return base_metadata
 
+    # computation-friendly api
+    def stream(
+        self,
+        context: Union[OpExecutionContext, AssetExecutionContext, ComputationContext],
+        dlt_source: Optional[DltSource] = None,
+        dlt_pipeline: Optional[Pipeline] = None,
+        **kwargs,
+    ) -> Iterator[MaterializeResult]:
+        for r in self.run(
+            context=context.to_asset_execution_context()
+            if isinstance(context, ComputationContext)
+            else context,
+            dlt_source=dlt_source,
+            dlt_pipeline=dlt_pipeline,
+            **kwargs,
+        ):
+            yield check.inst(r, MaterializeResult)
+
     @public
     def run(
         self,
-        context: Union[OpExecutionContext, AssetExecutionContext, ComputationContext],
+        context: Union[OpExecutionContext, AssetExecutionContext],
         dlt_source: Optional[DltSource] = None,
         dlt_pipeline: Optional[Pipeline] = None,
         dagster_dlt_translator: Optional[DagsterDltTranslator] = None,

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_asset_decorator.py
@@ -125,9 +125,9 @@ def test_get_materialize_policy(dlt_pipeline: Pipeline):
         dlt_source=pipeline(),
         dlt_pipeline=dlt_pipeline,
         specs=RunDlt.default_specs(dlt_source=pipeline(), dlt_pipeline=dlt_pipeline).replace(
-            automation_condition=AutoMaterializePolicy.eager().with_rules(
-                AutoMaterializeRule.materialize_on_cron("0 1 * * *")
-            ).to_automation_condition()
+            automation_condition=AutoMaterializePolicy.eager()
+            .with_rules(AutoMaterializeRule.materialize_on_cron("0 1 * * *"))
+            .to_automation_condition()
         ),
     ).assets_def
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_asset_decorator.py
@@ -33,7 +33,6 @@ def test_example_pipeline_asset_keys(dlt_pipeline: Pipeline) -> None:
     } == RunDlt(dlt_source=pipeline(), dlt_pipeline=dlt_pipeline).assets_def.keys
 
 
-
 def test_example_pipeline_deps(dlt_pipeline: Pipeline) -> None:
     # Since repo_issues is a transform of the repo data, its upstream
     # asset key should be the repo data asset key as well.
@@ -41,7 +40,6 @@ def test_example_pipeline_deps(dlt_pipeline: Pipeline) -> None:
         AssetKey("dlt_pipeline_repos"): {AssetKey("pipeline_repos")},
         AssetKey("dlt_pipeline_repo_issues"): {AssetKey("pipeline_repos")},
     } == RunDlt(dlt_source=pipeline(), dlt_pipeline=dlt_pipeline).assets_def.asset_deps
-
 
 
 def test_example_pipeline_descs(dlt_pipeline: Pipeline) -> None:
@@ -135,7 +133,6 @@ def test_get_materialize_policy(dlt_pipeline: Pipeline):
 
     for item in assets.auto_materialize_policies_by_key.values():
         assert "0 1 * * *" in str(item)
-
 
 
 def test_example_pipeline_has_required_metadata_keys(dlt_pipeline: Pipeline):
@@ -321,12 +318,11 @@ def test_partitioned_materialization(dlt_pipeline: Pipeline) -> None:
             dagster_dlt_resource = DagsterDltResource()
             yield from dagster_dlt_resource.run(context=asset_context, dlt_source=pipeline(month))
 
-
     async def run_partition(year: str):
         return PartitionedDltRun(
-            specs=RunDlt.default_specs(
-                dlt_source=pipeline(), dlt_pipeline=dlt_pipeline
-            ).replace(partitions_def=MonthlyPartitionsDefinition(start_date="2022-08-09")),
+            specs=RunDlt.default_specs(dlt_source=pipeline(), dlt_pipeline=dlt_pipeline).replace(
+                partitions_def=MonthlyPartitionsDefinition(start_date="2022-08-09")
+            ),
             dlt_source=pipeline(),
             dlt_pipeline=dlt_pipeline,
         ).test(partitions=year)

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_asset_decorator.py
@@ -125,9 +125,9 @@ def test_get_materialize_policy(dlt_pipeline: Pipeline):
         dlt_source=pipeline(),
         dlt_pipeline=dlt_pipeline,
         specs=RunDlt.default_specs(dlt_source=pipeline(), dlt_pipeline=dlt_pipeline).replace(
-            auto_materialize_policy=AutoMaterializePolicy.eager().with_rules(
+            automation_condition=AutoMaterializePolicy.eager().with_rules(
                 AutoMaterializeRule.materialize_on_cron("0 1 * * *")
-            )
+            ).to_automation_condition()
         ),
     ).assets_def
 


### PR DESCRIPTION
## Summary & Motivation

This is a follow up to our discussion yesterday in product staff to show how this would look in practical application. 

The idea here is a new API for definition factories. Instead of decorator-based approaches. 

This PR also includes a new `Specs` class whose purpose is to group specs together and apply operations across them.

A few advantages here, which I will speak to inline comments as well.

* The default case is strictly instantiating a single class, rather than having to copy and paste a decorated function with a generator etc. This is simpler.
* There is no need for a translator. Instead you just create specs and pass them around. I have included the `Specs` helper class to assist with applications of properties across many specs.
* When you need to write custom code typing is much clearer as you are overriding a function rather than than implicit typing contracts that our decorators impose.
* Separation of metadata and compute. Clarifies things both large and small. It's small thing but the fact that computations and specs each have separate `tags` attributes rather tham `op_tags` on `multi_asset` communicates a much more clear mental model.

## How I Tested These Changes

BK

## Changelog [New | Bug | Docs]
NOCHANGELOG
