### PR TITLE
[sling] yield asset materialization / materialize result depending if asset or op

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -375,29 +375,20 @@ class SlingResource(ConfigurableResource):
 
             end_time = time.time()
 
-            has_asset_def: bool = bool(context and context.has_assets_def)
-
             # TODO: In the future, it'd be nice to yield these materializations as they come in
             # rather than waiting until the end of the replication
             for stream in stream_definition:
                 asset_key = dagster_sling_translator.get_asset_key(stream)
 
-                if has_asset_def:
-                    yield MaterializeResult(
-                        asset_key=asset_key,
-                        metadata={
-                            "elapsed_time": end_time - start_time,
-                            "stream_name": stream["name"],
-                        },
-                    )
+                metadata = {
+                    "elapsed_time": end_time - start_time,
+                    "stream_name": stream["name"],
+                }
+
+                if context.has_assets_def:
+                    yield MaterializeResult(asset_key=asset_key, metadata=metadata)
                 else:
-                    yield AssetMaterialization(
-                        asset_key=asset_key,
-                        metadata={
-                            "elapsed_time": end_time - start_time,
-                            "stream_name": stream["name"],
-                        },
-                    )
+                    yield AssetMaterialization(asset_key=asset_key, metadata=metadata)
 
     def stream_raw_logs(self) -> Generator[str, None, None]:
         """Returns a generator of raw logs from the Sling CLI."""

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -17,6 +17,7 @@ from dagster import (
     AssetMaterialization,
     ConfigurableResource,
     EnvVar,
+    MaterializeResult,
     OpExecutionContext,
     PermissiveConfig,
     get_dagster_logger,
@@ -32,7 +33,7 @@ from dagster_embedded_elt.sling.asset_decorator import (
     streams_with_default_dagster_meta,
 )
 from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
-from dagster_embedded_elt.sling.sling_event_iterator import SlingEventIterator
+from dagster_embedded_elt.sling.sling_event_iterator import SlingEventIterator, SlingEventType
 from dagster_embedded_elt.sling.sling_replication import SlingReplicationParam, validate_replication
 
 logger = get_dagster_logger()
@@ -294,7 +295,7 @@ class SlingResource(ConfigurableResource):
         replication_config: Optional[SlingReplicationParam] = None,
         dagster_sling_translator: Optional[DagsterSlingTranslator] = None,
         debug: bool = False,
-    ) -> SlingEventIterator[AssetMaterialization]:
+    ) -> SlingEventIterator[SlingEventType]:
         """Runs a Sling replication from the given replication config.
 
         Args:
@@ -304,7 +305,7 @@ class SlingResource(ConfigurableResource):
             debug: Whether to run the replication in debug mode.
 
         Returns:
-            Generator[Union[MaterializeResult, AssetMaterialization], None, None]: A generator of MaterializeResult or AssetMaterialization
+            SlingEventIterator[MaterializeResult]: A generator of MaterializeResult
         """
         if not (replication_config or dagster_sling_translator):
             metadata_by_key = context.assets_def.metadata_by_key
@@ -333,7 +334,7 @@ class SlingResource(ConfigurableResource):
         replication_config: Dict[str, Any],
         dagster_sling_translator: DagsterSlingTranslator,
         debug: bool,
-    ) -> Iterator[AssetMaterialization]:
+    ) -> Iterator[SlingEventType]:
         # if translator has not been defined on metadata _or_ through param, then use the default constructor
 
         # convert to dict to enable updating the index
@@ -374,14 +375,29 @@ class SlingResource(ConfigurableResource):
 
             end_time = time.time()
 
+            has_asset_def: bool = bool(context and context.has_assets_def)
+
             # TODO: In the future, it'd be nice to yield these materializations as they come in
             # rather than waiting until the end of the replication
             for stream in stream_definition:
-                output_name = dagster_sling_translator.get_asset_key(stream)
-                yield AssetMaterialization(
-                    asset_key=output_name,
-                    metadata={"elapsed_time": end_time - start_time, "stream_name": stream["name"]},
-                )
+                asset_key = dagster_sling_translator.get_asset_key(stream)
+
+                if has_asset_def:
+                    yield MaterializeResult(
+                        asset_key=asset_key,
+                        metadata={
+                            "elapsed_time": end_time - start_time,
+                            "stream_name": stream["name"],
+                        },
+                    )
+                else:
+                    yield AssetMaterialization(
+                        asset_key=asset_key,
+                        metadata={
+                            "elapsed_time": end_time - start_time,
+                            "stream_name": stream["name"],
+                        },
+                    )
 
     def stream_raw_logs(self) -> Generator[str, None, None]:
         """Returns a generator of raw logs from the Sling CLI."""

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, Generic, Iterator, Optional, Sequen
 
 from dagster import (
     AssetMaterialization,
+    MaterializeResult,
     _check as check,
 )
 from dagster._annotations import experimental, public
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
     from .resources import SlingResource
 
 
-SlingEventType = AssetMaterialization
+SlingEventType = Union[AssetMaterialization, MaterializeResult]
 
 # We define SlingEventIterator as a generic type for the sake of type hinting.
 # This is so that users who inspect the type of the return value of `SlingResource.replicate()`
@@ -73,17 +74,22 @@ SLING_COLUMN_PREFIX = "_sling_"
 
 
 def fetch_column_metadata(
-    materialization: AssetMaterialization,
+    materialization: SlingEventType,
     sling_cli: "SlingResource",
     replication_config: Dict[str, Any],
     context: Union[OpExecutionContext, AssetExecutionContext],
 ) -> Dict[str, Any]:
     target_name = replication_config["target"]
-    stream_name = cast(str, materialization.metadata["stream_name"].value)
+
+    if not materialization.metadata:
+        raise Exception("Missing required metadata to retrieve stream_name")
+
+    stream_name = cast(str, materialization.metadata["stream_name"])
 
     upstream_assets = set()
     if isinstance(context, AssetExecutionContext):
-        upstream_assets = context.assets_def.asset_deps[materialization.asset_key]
+        if materialization.asset_key:
+            upstream_assets = context.assets_def.asset_deps[materialization.asset_key]
 
     target_table_name = _get_target_table_name(stream_name, sling_cli)
 
@@ -172,7 +178,8 @@ class SlingEventIterator(Generic[T], abc.Iterator):
                 col_metadata = fetch_column_metadata(
                     event, self._sling_cli, self._replication_config, self._context
                 )
-                yield event.with_metadata({**col_metadata, **event.metadata})
+                if event.metadata:
+                    yield event._replace(metadata={**col_metadata, **event.metadata})
 
         return SlingEventIterator[T](
             _fetch_column_metadata(), self._sling_cli, self._replication_config, self._context


### PR DESCRIPTION
## Summary & Motivation

- Yielding `AssetMaterialization` for assets, as supported results have been limited in 1.8.1

## How I Tested These Changes

- `pytest`

## Changelog [Bug]

- Sling resource yields `MaterializeResult` for assets and `AssetMaterialization` for op
