### PR TITLE
[cleanup] Quarantine ValidAssetSubset class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -1,6 +1,4 @@
-import datetime
-import operator
-from typing import TYPE_CHECKING, AbstractSet, Any, Callable, NamedTuple, Optional, Union, cast
+from typing import AbstractSet, NamedTuple, Optional, Union, cast
 
 import dagster._check as check
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
@@ -12,9 +10,6 @@ from dagster._core.definitions.partition import (
 from dagster._core.definitions.time_window_partitions import BaseTimeWindowPartitionsSubset
 from dagster._model import InstanceOf
 from dagster._serdes.serdes import NamedTupleSerializer, whitelist_for_serdes
-
-if TYPE_CHECKING:
-    from dagster._core.instance import DynamicPartitionsStore
 
 
 class AssetSubsetSerializer(NamedTupleSerializer):
@@ -94,77 +89,6 @@ class AssetSubset(NamedTuple):
         else:
             return partitions_def is None
 
-    def _is_compatible_with_subset(self, other: "AssetSubset") -> bool:
-        if isinstance(other.value, (BaseTimeWindowPartitionsSubset, AllPartitionsSubset)):
-            return self.is_compatible_with_partitions_def(other.value.partitions_def)
-        else:
-            return self.is_partitioned == other.is_partitioned
-
-    def as_valid(self, partitions_def: Optional[PartitionsDefinition]) -> "ValidAssetSubset":
-        """Converts this AssetSubset to a ValidAssetSubset by returning a copy of this AssetSubset
-        if it is compatible with the given PartitionsDefinition, otherwise returns an empty subset.
-        """
-        if self.is_compatible_with_partitions_def(partitions_def):
-            return ValidAssetSubset(asset_key=self.asset_key, value=self.value)
-        else:
-            return ValidAssetSubset.empty(self.asset_key, partitions_def)
-
-    @staticmethod
-    def all(
-        asset_key: AssetKey,
-        partitions_def: Optional[PartitionsDefinition],
-        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
-        current_time: Optional[datetime.datetime] = None,
-    ) -> "ValidAssetSubset":
-        if partitions_def is None:
-            return ValidAssetSubset(asset_key=asset_key, value=True)
-        else:
-            if dynamic_partitions_store is None or current_time is None:
-                check.failed(
-                    "Must provide dynamic_partitions_store and current_time for partitioned assets."
-                )
-            return ValidAssetSubset(
-                asset_key=asset_key,
-                value=AllPartitionsSubset(partitions_def, dynamic_partitions_store, current_time),
-            )
-
-    @staticmethod
-    def empty(
-        asset_key: AssetKey, partitions_def: Optional[PartitionsDefinition]
-    ) -> "ValidAssetSubset":
-        if partitions_def is None:
-            return ValidAssetSubset(asset_key=asset_key, value=False)
-        else:
-            return ValidAssetSubset(asset_key=asset_key, value=partitions_def.empty_subset())
-
-    @staticmethod
-    def from_asset_partitions_set(
-        asset_key: AssetKey,
-        partitions_def: Optional[PartitionsDefinition],
-        asset_partitions_set: AbstractSet[AssetKeyPartitionKey],
-    ) -> "ValidAssetSubset":
-        return (
-            ValidAssetSubset.from_partition_keys(
-                asset_key=asset_key,
-                partitions_def=partitions_def,
-                partition_keys={
-                    ap.partition_key for ap in asset_partitions_set if ap.partition_key is not None
-                },
-            )
-            if partitions_def
-            else ValidAssetSubset(asset_key=asset_key, value=bool(asset_partitions_set))
-        )
-
-    @staticmethod
-    def from_partition_keys(
-        asset_key: AssetKey,
-        partitions_def: PartitionsDefinition,
-        partition_keys: AbstractSet[str],
-    ) -> "ValidAssetSubset":
-        return ValidAssetSubset(
-            asset_key=asset_key, value=partitions_def.subset_with_partition_keys(partition_keys)
-        )
-
     def __contains__(self, item: AssetKeyPartitionKey) -> bool:
         if not self.is_partitioned:
             return (
@@ -172,83 +96,3 @@ class AssetSubset(NamedTuple):
             )
         else:
             return item.asset_key == self.asset_key and item.partition_key in self.subset_value
-
-    def dict(self, **kwargs) -> dict:
-        # Must be overridden as the Pydantic implementation errors when encountering NamedTuples
-        # which have different fields than their __new__ method, which TimeWindowPartitionsSubset
-        # unfortunately has.
-        # This can likely be removed once TimeWindowPartitionsSubset is converted into a DagsterModel
-        return {"asset_key": self.asset_key, "value": self.value}
-
-    def __eq__(self, other: Any) -> bool:
-        # Pydantic 2.x does not handle this comparison correctly for some reason, just override it
-        if not isinstance(other, AssetSubset):
-            return False
-        return self.dict() == other.dict()
-
-
-@whitelist_for_serdes(serializer=AssetSubsetSerializer)
-class ValidAssetSubset(AssetSubset):
-    """Represents an AssetSubset which is known to be compatible with the current PartitionsDefinition
-    of the asset represents.
-
-    This class serializes to a regular AssetSubset, as it is unknown if this value will still be
-    valid in the process that deserializes it.
-
-    All operations act over the set of AssetKeyPartitionKeys that the operands represent if the
-    subsets are both ValidAssetSubsets. If the other operand cannot be coerced to a ValidAssetSubset,
-    it is treated as an empty subset.
-    """
-
-    def inverse(
-        self,
-        partitions_def: Optional[PartitionsDefinition],
-        current_time: Optional[datetime.datetime] = None,
-        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
-    ) -> "ValidAssetSubset":
-        """Returns the AssetSubset containing all asset partitions which are not in this AssetSubset."""
-        if partitions_def is None:
-            return self._replace(value=not self.bool_value)
-        else:
-            value = partitions_def.subset_with_partition_keys(
-                self.subset_value.get_partition_keys_not_in_subset(
-                    partitions_def,
-                    current_time=current_time,
-                    dynamic_partitions_store=dynamic_partitions_store,
-                )
-            )
-            return self._replace(value=value)
-
-    def _oper(self, other: "ValidAssetSubset", oper: Callable[..., Any]) -> "ValidAssetSubset":
-        value = oper(self.value, other.value)
-        return self._replace(value=value)
-
-    def __sub__(self, other: AssetSubset) -> "ValidAssetSubset":
-        """Returns an AssetSubset representing self.asset_partitions - other.asset_partitions."""
-        valid_other = self.get_valid(other)
-        if not self.is_partitioned:
-            return self._replace(value=self.bool_value and not valid_other.bool_value)
-        return self._oper(valid_other, operator.sub)
-
-    def __and__(self, other: AssetSubset) -> "ValidAssetSubset":
-        """Returns an AssetSubset representing self.asset_partitions & other.asset_partitions."""
-        return self._oper(self.get_valid(other), operator.and_)
-
-    def __or__(self, other: AssetSubset) -> "ValidAssetSubset":
-        """Returns an AssetSubset representing self.asset_partitions | other.asset_partitions."""
-        return self._oper(self.get_valid(other), operator.or_)
-
-    def get_valid(self, other: AssetSubset) -> "ValidAssetSubset":
-        """Creates a ValidAssetSubset from the given AssetSubset by returning a copy of the given
-        AssetSubset if it is compatible with this AssetSubset, otherwise returns an empty subset.
-        """
-        if isinstance(other, ValidAssetSubset):
-            return other
-        elif self._is_compatible_with_subset(other):
-            return ValidAssetSubset(asset_key=other.asset_key, value=other.value)
-        else:
-            return self._replace(
-                # unfortunately, this is the best way to get an empty partitions subset of an unknown
-                # type if you don't have access to the partitions definition
-                value=(self.subset_value - self.subset_value) if self.is_partitioned else False
-            )

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -26,7 +26,6 @@ from typing import (
 import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_key import AssetKey, AssetKeyOrCheckKey
-from dagster._core.definitions.asset_subset import ValidAssetSubset
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
@@ -330,73 +329,6 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
             AssetKeyPartitionKey(asset_key, partition_key)
             for partition_key in partition_keys_in_range
         ]
-
-    def get_parent_asset_subset(
-        self,
-        child_asset_subset: ValidAssetSubset,
-        parent_asset_key: AssetKey,
-        dynamic_partitions_store: DynamicPartitionsStore,
-        current_time: datetime,
-    ) -> ValidAssetSubset:
-        """Given a child AssetSubset, returns the corresponding parent AssetSubset, based on the
-        relevant PartitionMapping.
-        """
-        child_asset_key = child_asset_subset.asset_key
-        child_partitions_def = self.get(child_asset_key).partitions_def
-        parent_partitions_def = self.get(parent_asset_key).partitions_def
-
-        if parent_partitions_def is None:
-            return ValidAssetSubset(
-                asset_key=parent_asset_key, value=not child_asset_subset.is_empty
-            )
-
-        partition_mapping = self.get_partition_mapping(child_asset_key, parent_asset_key)
-        parent_partitions_subset = (
-            partition_mapping.get_upstream_mapped_partitions_result_for_partitions(
-                child_asset_subset.subset_value if child_partitions_def is not None else None,
-                downstream_partitions_def=child_partitions_def,
-                upstream_partitions_def=parent_partitions_def,
-                dynamic_partitions_store=dynamic_partitions_store,
-                current_time=current_time,
-            )
-        ).partitions_subset
-
-        return ValidAssetSubset(asset_key=parent_asset_key, value=parent_partitions_subset)
-
-    def get_child_asset_subset(
-        self,
-        parent_asset_subset: ValidAssetSubset,
-        child_asset_key: AssetKey,
-        dynamic_partitions_store: DynamicPartitionsStore,
-        current_time: datetime,
-    ) -> ValidAssetSubset:
-        """Given a parent AssetSubset, returns the corresponding child AssetSubset, based on the
-        relevant PartitionMapping.
-        """
-        parent_asset_key = parent_asset_subset.asset_key
-        parent_partitions_def = self.get(parent_asset_key).partitions_def
-        child_partitions_def = self.get(child_asset_key).partitions_def
-
-        if parent_partitions_def is None:
-            if parent_asset_subset.size > 0:
-                return ValidAssetSubset.all(
-                    child_asset_key, child_partitions_def, dynamic_partitions_store, current_time
-                )
-            else:
-                return ValidAssetSubset.empty(child_asset_key, child_partitions_def)
-
-        if child_partitions_def is None:
-            return ValidAssetSubset(asset_key=child_asset_key, value=parent_asset_subset.size > 0)
-        else:
-            partition_mapping = self.get_partition_mapping(child_asset_key, parent_asset_key)
-            child_partitions_subset = partition_mapping.get_downstream_partitions_for_partitions(
-                parent_asset_subset.subset_value,
-                parent_partitions_def,
-                downstream_partitions_def=child_partitions_def,
-                dynamic_partitions_store=dynamic_partitions_store,
-                current_time=current_time,
-            )
-            return ValidAssetSubset(asset_key=child_asset_key, value=child_partitions_subset)
 
     def get_children_partitions(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -568,7 +568,7 @@ class AutomationResult:
 
     @property
     def true_subset(self) -> AssetSubset:
-        return self.true_slice.convert_to_valid_asset_subset()
+        return self.true_slice.convert_to_asset_subset()
 
     @property
     def start_timestamp(self) -> float:
@@ -599,9 +599,7 @@ class AutomationResult:
             self.condition_unique_id,
             self.condition.description,
             _compute_subset_value_str(self.true_subset),
-            _compute_subset_value_str(
-                self._context.candidate_slice.convert_to_valid_asset_subset()
-            ),
+            _compute_subset_value_str(self._context.candidate_slice.convert_to_asset_subset()),
             *(_compute_subset_with_metadata_value_str(swm) for swm in self._subsets_with_metadata),
             *(child_result.value_hash for child_result in self._child_results),
         ]
@@ -615,7 +613,7 @@ class AutomationResult:
         return AutomationConditionNodeCursor(
             true_subset=self.true_subset,
             candidate_subset=get_serializable_candidate_subset(
-                self._context.candidate_slice.convert_to_valid_asset_subset()
+                self._context.candidate_slice.convert_to_asset_subset()
             ),
             subsets_with_metadata=self._subsets_with_metadata,
             extra_state=self._extra_state,
@@ -627,7 +625,7 @@ class AutomationResult:
             condition_snapshot=self.condition.get_node_snapshot(self.condition_unique_id),
             true_subset=self.true_subset,
             candidate_subset=get_serializable_candidate_subset(
-                self._context.candidate_slice.convert_to_valid_asset_subset()
+                self._context.candidate_slice.convert_to_asset_subset()
             ),
             subsets_with_metadata=self._subsets_with_metadata,
             start_timestamp=self._start_timestamp,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
@@ -97,9 +97,7 @@ class AutomationContext:
             parent_context=self,
             _cursor=self._cursor,
             _legacy_context=self._legacy_context.for_child(
-                child_condition,
-                condition_unqiue_id,
-                candidate_slice.convert_to_valid_asset_subset(),
+                child_condition, condition_unqiue_id, candidate_slice
             )
             if self._legacy_context
             else None,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/valid_asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/valid_asset_subset.py
@@ -1,0 +1,147 @@
+import datetime
+import operator
+from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Optional
+
+import dagster._check as check
+from dagster._core.definitions.asset_subset import AssetSubset, AssetSubsetSerializer
+from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
+from dagster._core.definitions.partition import AllPartitionsSubset, PartitionsDefinition
+from dagster._core.definitions.time_window_partitions import BaseTimeWindowPartitionsSubset
+from dagster._serdes.serdes import whitelist_for_serdes
+
+if TYPE_CHECKING:
+    from dagster._core.instance import DynamicPartitionsStore
+
+
+@whitelist_for_serdes(serializer=AssetSubsetSerializer)
+class ValidAssetSubset(AssetSubset):
+    """Legacy construct used for doing operations over AssetSubsets that are known to be valid. This
+    functionality is subsumed by AssetSlice.
+    """
+
+    def inverse(
+        self,
+        partitions_def: Optional[PartitionsDefinition],
+        current_time: Optional[datetime.datetime] = None,
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
+    ) -> "ValidAssetSubset":
+        """Returns the AssetSubset containing all asset partitions which are not in this AssetSubset."""
+        if partitions_def is None:
+            return self._replace(value=not self.bool_value)
+        else:
+            value = partitions_def.subset_with_partition_keys(
+                self.subset_value.get_partition_keys_not_in_subset(
+                    partitions_def,
+                    current_time=current_time,
+                    dynamic_partitions_store=dynamic_partitions_store,
+                )
+            )
+            return self._replace(value=value)
+
+    def _oper(self, other: "ValidAssetSubset", oper: Callable[..., Any]) -> "ValidAssetSubset":
+        value = oper(self.value, other.value)
+        return self._replace(value=value)
+
+    def __sub__(self, other: AssetSubset) -> "ValidAssetSubset":
+        """Returns an AssetSubset representing self.asset_partitions - other.asset_partitions."""
+        valid_other = self.get_valid(other)
+        if not self.is_partitioned:
+            return self._replace(value=self.bool_value and not valid_other.bool_value)
+        return self._oper(valid_other, operator.sub)
+
+    def __and__(self, other: AssetSubset) -> "ValidAssetSubset":
+        """Returns an AssetSubset representing self.asset_partitions & other.asset_partitions."""
+        return self._oper(self.get_valid(other), operator.and_)
+
+    def __or__(self, other: AssetSubset) -> "ValidAssetSubset":
+        """Returns an AssetSubset representing self.asset_partitions | other.asset_partitions."""
+        return self._oper(self.get_valid(other), operator.or_)
+
+    @staticmethod
+    def coerce_from_subset(
+        subset: AssetSubset, partitions_def: Optional[PartitionsDefinition]
+    ) -> "ValidAssetSubset":
+        """Converts an AssetSubset to a ValidAssetSubset by returning a copy of this AssetSubset
+        if it is compatible with the given PartitionsDefinition, otherwise returns an empty subset.
+        """
+        if subset.is_compatible_with_partitions_def(partitions_def):
+            return ValidAssetSubset(asset_key=subset.asset_key, value=subset.value)
+        else:
+            return ValidAssetSubset.empty(subset.asset_key, partitions_def)
+
+    def _is_compatible_with_subset(self, other: "AssetSubset") -> bool:
+        if isinstance(other.value, (BaseTimeWindowPartitionsSubset, AllPartitionsSubset)):
+            return self.is_compatible_with_partitions_def(other.value.partitions_def)
+        else:
+            return self.is_partitioned == other.is_partitioned
+
+    def get_valid(self, other: AssetSubset) -> "ValidAssetSubset":
+        """Creates a ValidAssetSubset from the given AssetSubset by returning a replace of the given
+        AssetSubset if it is compatible with this AssetSubset, otherwise returns an empty subset.
+        """
+        if isinstance(other, ValidAssetSubset):
+            return other
+        elif self._is_compatible_with_subset(other):
+            return ValidAssetSubset(asset_key=other.asset_key, value=other.value)
+        else:
+            return self._replace(
+                # unfortunately, this is the best way to get an empty partitions subset of an unknown
+                # type if you don't have access to the partitions definition
+                value=(self.subset_value - self.subset_value) if self.is_partitioned else False,
+            )
+
+    @staticmethod
+    def all(
+        asset_key: AssetKey,
+        partitions_def: Optional[PartitionsDefinition],
+        dynamic_partitions_store: Optional["DynamicPartitionsStore"] = None,
+        current_time: Optional[datetime.datetime] = None,
+    ) -> "ValidAssetSubset":
+        if partitions_def is None:
+            return ValidAssetSubset(asset_key=asset_key, value=True)
+        else:
+            if dynamic_partitions_store is None or current_time is None:
+                check.failed(
+                    "Must provide dynamic_partitions_store and current_time for partitioned assets."
+                )
+            return ValidAssetSubset(
+                asset_key=asset_key,
+                value=AllPartitionsSubset(partitions_def, dynamic_partitions_store, current_time),
+            )
+
+    @staticmethod
+    def empty(
+        asset_key: AssetKey, partitions_def: Optional[PartitionsDefinition]
+    ) -> "ValidAssetSubset":
+        if partitions_def is None:
+            return ValidAssetSubset(asset_key=asset_key, value=False)
+        else:
+            return ValidAssetSubset(asset_key=asset_key, value=partitions_def.empty_subset())
+
+    @staticmethod
+    def from_asset_partitions_set(
+        asset_key: AssetKey,
+        partitions_def: Optional[PartitionsDefinition],
+        asset_partitions_set: AbstractSet[AssetKeyPartitionKey],
+    ) -> "ValidAssetSubset":
+        return (
+            ValidAssetSubset.from_partition_keys(
+                asset_key=asset_key,
+                partitions_def=partitions_def,
+                partition_keys={
+                    ap.partition_key for ap in asset_partitions_set if ap.partition_key is not None
+                },
+            )
+            if partitions_def
+            else ValidAssetSubset(asset_key=asset_key, value=bool(asset_partitions_set))
+        )
+
+    @staticmethod
+    def from_partition_keys(
+        asset_key: AssetKey,
+        partitions_def: PartitionsDefinition,
+        partition_keys: AbstractSet[str],
+    ) -> "ValidAssetSubset":
+        return ValidAssetSubset(
+            asset_key=asset_key, value=partitions_def.subset_with_partition_keys(partition_keys)
+        )

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -11,7 +11,9 @@
 import datetime
 from typing import TYPE_CHECKING, AbstractSet, Optional, Sequence, Tuple
 
-from dagster._core.definitions.asset_subset import AssetSubset, ValidAssetSubset
+from dagster._core.definitions.declarative_automation.legacy.valid_asset_subset import (
+    ValidAssetSubset,
+)
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.time_window_partitions import TimeWindow
@@ -227,9 +229,9 @@ def freshness_evaluation_results_for_asset_key(
         and expected_data_time >= execution_period.start
         and evaluation_data is not None
     ):
-        all_subset = AssetSubset.all(asset_key, None)
+        all_subset = ValidAssetSubset.all(asset_key, None)
         return (
-            AssetSubset.all(asset_key, None),
+            ValidAssetSubset.all(asset_key, None),
             [AssetSubsetWithMetadata(subset=all_subset, metadata=evaluation_data.metadata)],
         )
     else:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_subset.py
@@ -12,7 +12,10 @@ from dagster import (
     PartitionsDefinition,
     StaticPartitionsDefinition,
 )
-from dagster._core.definitions.asset_subset import AssetSubset, ValidAssetSubset
+from dagster._core.definitions.asset_subset import AssetSubset
+from dagster._core.definitions.declarative_automation.legacy.valid_asset_subset import (
+    ValidAssetSubset,
+)
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.partition import AllPartitionsSubset, DefaultPartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
@@ -41,7 +44,7 @@ partitions_defs = [
 @pytest.mark.parametrize("partitions_def", partitions_defs)
 def test_empty_subset_subset(partitions_def: Optional[PartitionsDefinition]) -> None:
     key = AssetKey(["foo"])
-    empty_subset = AssetSubset.empty(key, partitions_def)
+    empty_subset = ValidAssetSubset.empty(key, partitions_def)
     assert empty_subset.size == 0
 
     partition_keys = {None} if partitions_def is None else partitions_def.get_partition_keys()
@@ -54,7 +57,7 @@ def test_empty_subset_subset(partitions_def: Optional[PartitionsDefinition]) -> 
 @pytest.mark.parametrize("partitions_def", partitions_defs)
 def test_all_subset(partitions_def: Optional[PartitionsDefinition]) -> None:
     key = AssetKey(["foo"])
-    all_subset = AssetSubset.all(
+    all_subset = ValidAssetSubset.all(
         key, partitions_def, DagsterInstance.ephemeral(), datetime.datetime.now()
     )
     partition_keys = {None} if partitions_def is None else partitions_def.get_partition_keys()
@@ -80,14 +83,18 @@ def test_operations(
 ) -> None:
     key = AssetKey(["foo"])
     subset_a = (
-        AssetSubset.all(key, partitions_def, DagsterInstance.ephemeral(), datetime.datetime.now())
+        ValidAssetSubset.all(
+            key, partitions_def, DagsterInstance.ephemeral(), datetime.datetime.now()
+        )
         if first_all
-        else AssetSubset.empty(key, partitions_def)
+        else ValidAssetSubset.empty(key, partitions_def)
     )
     subset_b = (
-        AssetSubset.all(key, partitions_def, DagsterInstance.ephemeral(), datetime.datetime.now())
+        ValidAssetSubset.all(
+            key, partitions_def, DagsterInstance.ephemeral(), datetime.datetime.now()
+        )
         if second_all
-        else AssetSubset.empty(key, partitions_def)
+        else ValidAssetSubset.empty(key, partitions_def)
     )
 
     actual_asset_partitions = operation(subset_a, subset_b).asset_partitions

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
@@ -11,12 +11,14 @@ from dagster._core.definitions.asset_daemon_cursor import (
     AssetDaemonCursor,
     backcompat_deserialize_asset_daemon_cursor_str,
 )
-from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeRuleEvaluationData,
 )
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
+from dagster._core.definitions.declarative_automation.legacy.valid_asset_subset import (
+    ValidAssetSubset,
+)
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AssetSubsetWithMetadata,
     AutomationConditionEvaluation,
@@ -89,7 +91,7 @@ class AssetRuleEvaluationSpec(NamedTuple):
         """Returns a tuple of the resolved AutoMaterializeRuleEvaluation for this spec and the
         partitions that it applies to.
         """
-        subset = AssetSubset.from_asset_partitions_set(
+        subset = ValidAssetSubset.from_asset_partitions_set(
             asset_key,
             asset_graph.get(asset_key).partitions_def,
             {

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
@@ -9,7 +9,6 @@ from dagster import AssetKey
 from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
 from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
-from dagster._core.definitions.asset_subset import AssetSubset
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.declarative_automation.automation_condition import (
@@ -66,11 +65,7 @@ class AutomationConditionScenarioState(ScenarioState):
             ap_by_key[ap.asset_key].add(ap)
         return {
             asset_key: mock.MagicMock(
-                true_slice=asset_graph_view.get_asset_slice_from_subset(
-                    AssetSubset.from_asset_partitions_set(
-                        asset_key, asset_graph_view.asset_graph.get(asset_key).partitions_def, aps
-                    )
-                ),
+                true_slice=asset_graph_view.get_asset_slice_from_asset_partitions(aps),
                 cursor=None,
             )
             for asset_key, aps in ap_by_key.items()


### PR DESCRIPTION
## Summary & Motivation

The ValidAssetSubset class existed to enable us to do operations over subsets of assets that we knew to be valid. The AssetSlice class does the same thing, making ValidAssetSubset redundant and a lot of code to comprehend.

Removing this entirely would require updating all the internal auto_materialize_rule_impls, so for now this just hides the ValidAssetSubset in a legacy folder and reduces dependence on it throughout the rest of the codebase.

## How I Tested These Changes

## Changelog [New | Bug | Docs]

NOCHANGELOG
