### PR TITLE
enable launch backfill graphql mutation to target multiple partition ranges per asset

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2315,7 +2315,8 @@ input PartitionsByAssetSelector {
 }
 
 input PartitionsSelector {
-  range: PartitionRangeSelector!
+  range: PartitionRangeSelector
+  ranges: [PartitionRangeSelector!]
 }
 
 input PartitionRangeSelector {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -3316,7 +3316,8 @@ export type PartitionsByAssetSelector = {
 export type PartitionsOrError = Partitions | PythonError;
 
 export type PartitionsSelector = {
-  range: PartitionRangeSelector;
+  range?: InputMaybe<PartitionRangeSelector>;
+  ranges?: InputMaybe<Array<PartitionRangeSelector>>;
 };
 
 export type PathMetadataEntry = MetadataEntry & {
@@ -11207,6 +11208,7 @@ export const buildPartitionsSelector = (
         : relationshipsToOmit.has('PartitionRangeSelector')
         ? ({} as PartitionRangeSelector)
         : buildPartitionRangeSelector({}, relationshipsToOmit),
+    ranges: overrides && overrides.hasOwnProperty('ranges') ? overrides.ranges! : [],
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -170,7 +170,8 @@ class GraphenePartitionRangeSelector(graphene.InputObjectType):
 
 
 class GraphenePartitionsSelector(graphene.InputObjectType):
-    range = graphene.NonNull(GraphenePartitionRangeSelector)
+    range = graphene.InputField(GraphenePartitionRangeSelector)
+    ranges = graphene.InputField(graphene.List(graphene.NonNull(GraphenePartitionRangeSelector)))
 
     class Meta:
         description = """This type represents a partitions selection."""

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -481,29 +481,23 @@ class AssetBackfillData(NamedTuple):
         for partitions_by_asset_selector in partitions_by_assets:
             asset_key = partitions_by_asset_selector.asset_key
             partitions = partitions_by_asset_selector.partitions
-            partition_def = asset_graph.get(asset_key).partitions_def
-            if partitions and partition_def:
-                if partitions.partition_range:
-                    # a range of partitions is selected
-                    partition_keys_in_range = partition_def.get_partition_keys_in_range(
+            partitions_def = asset_graph.get(asset_key).partitions_def
+            if partitions and partitions_def:
+                partitions_subset = partitions_def.empty_subset()
+                for partition_range in partitions.ranges:
+                    partitions_subset = partitions_subset.with_partition_key_range(
+                        partitions_def=partitions_def,
                         partition_key_range=PartitionKeyRange(
-                            start=partitions.partition_range.start,
-                            end=partitions.partition_range.end,
+                            start=partition_range.start,
+                            end=partition_range.end,
                         ),
                         dynamic_partitions_store=dynamic_partitions_store,
                     )
-                    partition_subset_in_range = partition_def.subset_with_partition_keys(
-                        partition_keys_in_range
-                    )
-                    partitions_subsets_by_asset_key.update({asset_key: partition_subset_in_range})
-                else:
-                    raise DagsterBackfillFailedError(
-                        "partitions_by_asset_selector does not have a partition range selected"
-                    )
-            elif partition_def:
+                    partitions_subsets_by_asset_key[asset_key] = partitions_subset
+            elif partitions_def:
                 # no partitions selected for partitioned asset, we will select all partitions
-                all_partitions = partition_def.subset_with_all_partitions()
-                partitions_subsets_by_asset_key.update({asset_key: all_partitions})
+                all_partitions = partitions_def.subset_with_all_partitions()
+                partitions_subsets_by_asset_key[asset_key] = all_partitions
             else:
                 # asset is not partitioned
                 non_partitioned_asset_keys.add(asset_key)

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -2108,7 +2108,7 @@ def test_asset_backfill_with_single_run_backfill_policy(
         partitions_by_assets=[
             PartitionsByAssetSelector(
                 asset_with_single_run_backfill_policy.key,
-                PartitionsSelector(PartitionRangeSelector(partitions[0], partitions[-1])),
+                PartitionsSelector([PartitionRangeSelector(partitions[0], partitions[-1])]),
             )
         ],
         title=None,


### PR DESCRIPTION
## Summary & Motivation

Motivated by a user request. This makes it possible to request multiple ranges of partitions for an asset within a single launch backfill mutation. This is already supported by the underlying backfill machinery, so it's just a matter of exposing it at the graphql layer.

The fact that `GraphenePartitionsSelector` already has a `range` parameter is a little bit unfortunate, because now we have to support both `range` and `ranges`. While this isn't technically a public API, I know that some users rely on it, so I don't want to break it in a patch release.

I am still not an expert in the way of GraphQL - is there any way to enforce at the GraphQL layer that they can't supply both `range` and `ranges`?

## How I Tested These Changes

## Changelog

NOCHANGELOG
