### PR TITLE
Ignore docs_beta_snippets examples

### DIFF
--- a/python_modules/dagster/dagster/_generate/download.py
+++ b/python_modules/dagster/dagster/_generate/download.py
@@ -9,7 +9,13 @@ import requests
 from .generate import _should_skip_file
 
 # Examples aren't that can't be downloaded from the dagster project CLI
-EXAMPLES_TO_IGNORE = ["docs_snippets", "experimental", "temp_pins.txt", "use_case_repository"]
+EXAMPLES_TO_IGNORE = [
+    "docs_snippets",
+    "docs_beta_snippets",
+    "experimental",
+    "temp_pins.txt",
+    "use_case_repository",
+]
 # Hardcoded list of available examples. The list is tested against the examples folder in this mono
 # repo to make sure it's up-to-date.
 AVAILABLE_EXAMPLES = [
@@ -19,21 +25,21 @@ AVAILABLE_EXAMPLES = [
     "assets_pandas_pyspark",
     "assets_pandas_type_metadata",
     "assets_smoke_test",
+    "deploy_docker",
+    "deploy_ecs",
+    "deploy_k8s",
+    "development_to_production",
+    "feature_graph_backed_assets",
+    "project_analytics",
+    "project_dagster_university_start",
+    "project_du_dbt_starter",
+    "project_fully_featured",
     "quickstart_aws",
     "quickstart_etl",
     "quickstart_gcp",
     "quickstart_snowflake",
     "tutorial",
     "tutorial_notebook_assets",
-    "deploy_docker",
-    "deploy_ecs",
-    "deploy_k8s",
-    "development_to_production",
-    "feature_graph_backed_assets",
-    "project_dagster_university_start",
-    "project_du_dbt_starter",
-    "project_fully_featured",
-    "project_analytics",
     "with_airflow",
     "with_great_expectations",
     "with_openai",

--- a/python_modules/dagster/dagster_tests/cli_tests/test_project_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_project_commands.py
@@ -140,7 +140,6 @@ def test_from_example_command_default_name():
 
 def test_available_examples_in_sync_with_example_folder():
     # ensure the list of AVAILABLE_EXAMPLES is in sync with the example folder minus EXAMPLES_TO_IGNORE
-    # run me
     example_folder = file_relative_path(__file__, "../../../../examples")
     available_examples_in_folder = [
         e


### PR DESCRIPTION
Fixes the broken Buildkite build. I assume we want to ignore these? If not, I'll stick them in the other list.