### PR TITLE
[docs-beta] README change regarding lint:fix

### DIFF
--- a/docs/docs-beta/.eslintrc.js
+++ b/docs/docs-beta/.eslintrc.js
@@ -1,6 +1,11 @@
 module.exports = {
   parser: '@babel/eslint-parser',
-  extends: ['plugin:react/recommended', 'plugin:@docusaurus/recommended', 'plugin:mdx/recommended'],
+  extends: [
+    'plugin:react/recommended',
+    'plugin:@docusaurus/recommended',
+    'plugin:mdx/recommended',
+    'plugin:prettier/recommended',
+  ],
   rules: {
     'import/no-default-export': 'off',
     'react/react-in-jsx-scope': 'off',

--- a/docs/docs-beta/README.md
+++ b/docs/docs-beta/README.md
@@ -63,15 +63,12 @@ This command starts a local development server and opens up a browser window. Mo
 To check the documentation for different issues, use the following:
 
 ```bash
-## Lints Markdown content using prettier
+## Lints all content, applies lint autofixes and prettier changes
 yarn lint
 
 ## Lints documentation content using Vale Server
 ## Checks for style guide adherence, grammar, spelling, etc.
-yarn lint:vale
-
-## Autofixes issues caught by prettier
-yarn lint:fix
+yarn vale
 ```
 
 To include code snippets, use the following format:

--- a/docs/docs-beta/package.json
+++ b/docs/docs-beta/package.json
@@ -12,11 +12,10 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "lint:tsc": "tsc --noEmit",
-    "lint:vale": "vale ./docs --ext=.md,.mdx",
-    "lint:eslint": "eslint . --ext=.tsx,.ts,.js,.md,.mdx",
-    "lint": "prettier . --check && yarn run lint:tsc && yarn run lint:eslint",
-    "lint:fix": "prettier . --write && yarn run lint:eslint --fix"
+    "ts": "tsc -p . --noEmit",
+    "vale": "vale ./docs --ext=.md,.mdx",
+    "lint": "eslint . --ext=.tsx,.ts,.js,.md,.mdx --fix",
+    "lint-and-vale": "yarn run lint && yarn run vale"
   },
   "dependencies": {
     "@docusaurus/core": "3.5.2",
@@ -47,7 +46,9 @@
     "@types/react": "^18.3.4",
     "@typescript-eslint/parser": "^8.0.1",
     "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-mdx": "^3.1.5",
+    "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.35.0",
     "globals": "^15.9.0",
     "prettier": "^3.3.3",

--- a/docs/docs-beta/yarn.lock
+++ b/docs/docs-beta/yarn.lock
@@ -6042,7 +6042,9 @@ __metadata:
     docusaurus-plugin-image-zoom: "npm:^2.0.0"
     docusaurus-plugin-sass: "npm:^0.2.5"
     eslint: "npm:^8.57.0"
+    eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-mdx: "npm:^3.1.5"
+    eslint-plugin-prettier: "npm:^5.2.1"
     eslint-plugin-react: "npm:^7.35.0"
     globals: "npm:^15.9.0"
     modern-normalize: "npm:^2.0.0"
@@ -6823,6 +6825,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-config-prettier@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "eslint-config-prettier@npm:9.1.0"
+  peerDependencies:
+    eslint: ">=7.0.0"
+  bin:
+    eslint-config-prettier: bin/cli.js
+  checksum: 10c0/6d332694b36bc9ac6fdb18d3ca2f6ac42afa2ad61f0493e89226950a7091e38981b66bac2b47ba39d15b73fff2cd32c78b850a9cf9eed9ca9a96bfb2f3a2f10d
+  languageName: node
+  linkType: hard
+
 "eslint-mdx@npm:^3.1.5":
   version: 3.1.5
   resolution: "eslint-mdx@npm:3.1.5"
@@ -6873,6 +6886,26 @@ __metadata:
   peerDependencies:
     eslint: ">=8.0.0"
   checksum: 10c0/261e3ffee01bae7839b1357a7fb00ab23438d3b6fe6ad65b97dd06fbf2501571b95313914b0e41bf489ffd26d250acc7dfefc2f492247e6c2c343560a93693ce
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-prettier@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "eslint-plugin-prettier@npm:5.2.1"
+  dependencies:
+    prettier-linter-helpers: "npm:^1.0.0"
+    synckit: "npm:^0.9.1"
+  peerDependencies:
+    "@types/eslint": ">=8.0.0"
+    eslint: ">=8.0.0"
+    eslint-config-prettier: "*"
+    prettier: ">=3.0.0"
+  peerDependenciesMeta:
+    "@types/eslint":
+      optional: true
+    eslint-config-prettier:
+      optional: true
+  checksum: 10c0/4bc8bbaf5bb556c9c501dcdff369137763c49ccaf544f9fa91400360ed5e3a3f1234ab59690e06beca5b1b7e6f6356978cdd3b02af6aba3edea2ffe69ca6e8b2
   languageName: node
   linkType: hard
 
@@ -7241,6 +7274,13 @@ __metadata:
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
+  languageName: node
+  linkType: hard
+
+"fast-diff@npm:^1.1.2":
+  version: 1.3.0
+  resolution: "fast-diff@npm:1.3.0"
+  checksum: 10c0/5c19af237edb5d5effda008c891a18a585f74bf12953be57923f17a3a4d0979565fc64dbc73b9e20926b9d895f5b690c618cbb969af0cf022e3222471220ad29
   languageName: node
   linkType: hard
 
@@ -12335,6 +12375,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier-linter-helpers@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "prettier-linter-helpers@npm:1.0.0"
+  dependencies:
+    fast-diff: "npm:^1.1.2"
+  checksum: 10c0/81e0027d731b7b3697ccd2129470ed9913ecb111e4ec175a12f0fcfab0096516373bf0af2fef132af50cafb0a905b74ff57996d615f59512bb9ac7378fcc64ab
+  languageName: node
+  linkType: hard
+
 "prettier@npm:^3.0.1, prettier@npm:^3.3.3":
   version: 3.3.3
   resolution: "prettier@npm:3.3.3"
@@ -14305,7 +14354,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"synckit@npm:^0.9.0":
+"synckit@npm:^0.9.0, synckit@npm:^0.9.1":
   version: 0.9.1
   resolution: "synckit@npm:0.9.1"
   dependencies:


### PR DESCRIPTION
## Summary & Motivation

Modified yarn commands. Now:

- `ts` runs TypeScript
- `lint` applies prettier changes and autofixes
- `vale` checks value
- `lint-and-vale` is a combination of the two above

## How I Tested These Changes

Run the commands, verify that they behave as expected.

## Changelog [New | Bug | Docs]

NOCHANGELOG
