### PR TITLE
[1/4] Wrap useQuery/useLazyQuery + lint rule

### DIFF
--- a/js_modules/dagster-ui/packages/eslint-config/rules/index.js
+++ b/js_modules/dagster-ui/packages/eslint-config/rules/index.js
@@ -15,8 +15,7 @@ module.exports = {
       rules: {
         [`${projectName}/missing-graphql-variables-type`]: 'error',
         [`${projectName}/no-oss-imports`]: 'error',
-        // TODO (salazarm): Enable the rule fully after we publish this package and cloud migrates over
-        // [`${projectName}/no-apollo-client`]: 'error',
+        [`${projectName}/no-apollo-client`]: 'error',
       },
     },
   },

--- a/js_modules/dagster-ui/packages/eslint-config/rules/index.js
+++ b/js_modules/dagster-ui/packages/eslint-config/rules/index.js
@@ -4,6 +4,7 @@ const projectName = 'dagster-rules';
 const rules = {
   'missing-graphql-variables-type': require('./missing-graphql-variables-type').rule,
   'no-oss-imports': require('./no-oss-imports'),
+  'no-apollo-client': require('./no-apollo-client'),
 };
 
 module.exports = {
@@ -14,6 +15,8 @@ module.exports = {
       rules: {
         [`${projectName}/missing-graphql-variables-type`]: 'error',
         [`${projectName}/no-oss-imports`]: 'error',
+        // TODO (salazarm): Enable the rule fully after we publish this package and cloud migrates over
+        // [`${projectName}/no-apollo-client`]: 'error',
       },
     },
   },

--- a/js_modules/dagster-ui/packages/eslint-config/rules/no-apollo-client.js
+++ b/js_modules/dagster-ui/packages/eslint-config/rules/no-apollo-client.js
@@ -1,0 +1,60 @@
+/* eslint-disable */
+
+const fs = require('fs');
+const path = require('path');
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code', // This marks the rule as auto-fixable
+    messages: {
+      useWrappedApolloClient:
+        'Please use our wrapped apollo-client module which includes performance instrumentation.',
+    },
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (context.getFilename().endsWith('/apollo-client')) {
+          return;
+        }
+        if (node.source.value === '@apollo/client') {
+          context.report({
+            node,
+            messageId: 'useWrappedApolloClient',
+            fix(fixer) {
+              const currentFilePath = context.getFilename();
+              const relativeImportPath = findRelativeImportPath(
+                currentFilePath,
+                'src/apollo-client',
+                'index.tsx',
+              );
+
+              return fixer.replaceText(node.source, `'${relativeImportPath}'`);
+            },
+          });
+        }
+      },
+    };
+  },
+};
+
+function findRelativeImportPath(currentFilePath, targetDirName, targetFileName) {
+  let currentDir = path.dirname(currentFilePath);
+
+  while (currentDir !== path.parse(currentDir).root) {
+    const srcPath = path.join(currentDir, targetDirName);
+    const targetFilePath = path.join(srcPath, targetFileName);
+
+    if (fs.existsSync(targetFilePath)) {
+      return path.relative(path.dirname(currentFilePath), srcPath);
+    }
+
+    currentDir = path.dirname(currentDir);
+  }
+
+  // If we can't find the file then it means we're not in the ui-core package (we might be in cloud) so
+  // grab the import from @dagster-io/ui-core.
+
+  return '@dagster-io/ui-core/apollo-client';
+}

--- a/js_modules/dagster-ui/packages/eslint-config/rules/no-apollo-client.js
+++ b/js_modules/dagster-ui/packages/eslint-config/rules/no-apollo-client.js
@@ -6,7 +6,7 @@ const path = require('path');
 module.exports = {
   meta: {
     type: 'suggestion',
-    fixable: 'code', // This marks the rule as auto-fixable
+    fixable: 'code',
     messages: {
       useWrappedApolloClient:
         'Please use our wrapped apollo-client module which includes performance instrumentation.',

--- a/js_modules/dagster-ui/packages/ui-core/src/apollo-client/index.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/apollo-client/index.tsx
@@ -11,7 +11,6 @@ import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
 export * from '@apollo/client';
 
-// Extend the options type to include "blocking"
 interface ExtendedQueryOptions<TData = any, TVariables extends OperationVariables = any>
   extends QueryHookOptions<TData, TVariables> {
   blocking?: boolean;
@@ -27,7 +26,6 @@ export function useQuery<TData = any, TVariables extends OperationVariables = an
   options?: ExtendedQueryOptions<TData, TVariables>,
 ) {
   const {blocking = true, ...restOptions} = options || {};
-  // You can handle the "blocking" logic here if needed
   const queryResult = useQueryApollo<TData, TVariables>(query, restOptions);
   useBlockTraceOnQueryResult(queryResult, 'graphql', {
     skip: !blocking,
@@ -40,7 +38,6 @@ export function useLazyQuery<TData = any, TVariables extends OperationVariables 
   options?: ExtendedLazyQueryOptions<TData, TVariables>,
 ) {
   const {blocking = true, ...restOptions} = options || {};
-  // You can handle the "blocking" logic here if needed
   const result = useLazyQueryApollo<TData, TVariables>(query, restOptions);
   useBlockTraceOnQueryResult(result[1], 'graphql', {
     skip: !blocking,

--- a/js_modules/dagster-ui/packages/ui-core/src/apollo-client/index.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/apollo-client/index.tsx
@@ -1,0 +1,49 @@
+/* eslint-disable no-restricted-imports */
+import {
+  LazyQueryHookOptions,
+  OperationVariables,
+  QueryHookOptions,
+  useLazyQuery as useLazyQueryApollo,
+  useQuery as useQueryApollo,
+} from '@apollo/client';
+
+import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
+
+export * from '@apollo/client';
+
+// Extend the options type to include "blocking"
+interface ExtendedQueryOptions<TData = any, TVariables extends OperationVariables = any>
+  extends QueryHookOptions<TData, TVariables> {
+  blocking?: boolean;
+}
+
+interface ExtendedLazyQueryOptions<TData = any, TVariables extends OperationVariables = any>
+  extends LazyQueryHookOptions<TData, TVariables> {
+  blocking?: boolean;
+}
+
+export function useQuery<TData = any, TVariables extends OperationVariables = any>(
+  query: any,
+  options?: ExtendedQueryOptions<TData, TVariables>,
+) {
+  const {blocking = true, ...restOptions} = options || {};
+  // You can handle the "blocking" logic here if needed
+  const queryResult = useQueryApollo<TData, TVariables>(query, restOptions);
+  useBlockTraceOnQueryResult(queryResult, 'graphql', {
+    skip: !blocking,
+  });
+  return queryResult;
+}
+
+export function useLazyQuery<TData = any, TVariables extends OperationVariables = any>(
+  query: any,
+  options?: ExtendedLazyQueryOptions<TData, TVariables>,
+) {
+  const {blocking = true, ...restOptions} = options || {};
+  // You can handle the "blocking" logic here if needed
+  const result = useLazyQueryApollo<TData, TVariables>(query, restOptions);
+  useBlockTraceOnQueryResult(result[1], 'graphql', {
+    skip: !blocking,
+  });
+  return result;
+}


### PR DESCRIPTION
## Summary & Motivation

Wrapping `useQuery` and `useLazyQuery` to automatically integrate with our performance tracking so that we can get rid of `useBlockTraceOnQueryResult`

## How I Tested These Changes

I ran yarn lint --fix and saw it auto-fix all of the @apollo/client imports in ui-core. I will put these changes in the next PR to keep this one small.

## Changelog [New | Bug | Docs]
NOCHANGELOG
