### PR TITLE
Use bare entity values inside AssetSlice

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -80,12 +80,10 @@ class AssetGraphSubset(NamedTuple):
         """
         partitions_def = asset_graph.get(asset_key).partitions_def
         if partitions_def is None:
-            return AssetSubset(
-                asset_key=asset_key, value=asset_key in self.non_partitioned_asset_keys
-            )
+            return AssetSubset(key=asset_key, value=asset_key in self.non_partitioned_asset_keys)
         else:
             return AssetSubset(
-                asset_key=asset_key,
+                key=asset_key,
                 value=self.partitions_subsets_by_asset_key.get(
                     asset_key, partitions_def.empty_subset()
                 ),

--- a/python_modules/dagster/dagster/_core/definitions/asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_subset.py
@@ -12,6 +12,8 @@ from dagster._core.definitions.time_window_partitions import BaseTimeWindowParti
 from dagster._record import copy, record
 from dagster._serdes.serdes import NamedTupleSerializer, whitelist_for_serdes
 
+EntitySubsetValue = Union[bool, PartitionsSubset]
+
 
 class EntitySubsetSerializer(NamedTupleSerializer):
     """Ensures that the inner PartitionsSubset is converted to a serializable form if necessary."""
@@ -30,7 +32,7 @@ class EntitySubsetSerializer(NamedTupleSerializer):
 @record
 class EntitySubset:
     key: EntityKey
-    value: Union[bool, PartitionsSubset]
+    value: EntitySubsetValue
 
     @property
     def is_partitioned(self) -> bool:


### PR DESCRIPTION
## Summary & Motivation

This is essentially a refactor, which makes a fair amount of code simpler. Beyond cleaning things up, this is important because it lets us do type checking properly once we make AssetSlice Generic, as we can separately pass in a key of a specific type, rather than having to pass in an EntitySubset which will have a key of an unknown type.

This also makes EntitySubset and EntitySlice conceptually more similar, which paves the way for renaming EntitySlice to EntitySubset and EntitySubset to SerializableEntitySubset.

## How I Tested These Changes

## Changelog [New | Bug | Docs]

NOCHANGELOG
