### PR TITLE
avoid gRPCs when resolving partition tags for implicit asset jobs

### DIFF
--- a/python_modules/dagster/dagster/_api/snapshot_partition.py
+++ b/python_modules/dagster/dagster/_api/snapshot_partition.py
@@ -1,7 +1,6 @@
-from typing import TYPE_CHECKING, AbstractSet, Optional, Sequence
+from typing import TYPE_CHECKING, Sequence
 
 import dagster._check as check
-from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.errors import DagsterUserCodeProcessError
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.external_data import (
@@ -24,7 +23,6 @@ def sync_get_external_partition_names_grpc(
     api_client: "DagsterGrpcClient",
     repository_handle: RepositoryHandle,
     job_name: str,
-    selected_asset_keys: Optional[AbstractSet[AssetKey]],
 ) -> ExternalPartitionNamesData:
     from dagster._grpc.client import DagsterGrpcClient
 
@@ -38,7 +36,6 @@ def sync_get_external_partition_names_grpc(
                 repository_origin=repository_origin,
                 job_name=job_name,
                 partition_set_name=external_partition_set_name_for_job_name(job_name),
-                selected_asset_keys=selected_asset_keys,
             ),
         ),
         (ExternalPartitionNamesData, ExternalPartitionExecutionErrorData),
@@ -71,7 +68,6 @@ def sync_get_external_partition_config_grpc(
                 partition_set_name=external_partition_set_name_for_job_name(job_name),
                 partition_name=partition_name,
                 instance_ref=instance.get_ref(),
-                selected_asset_keys=None,
             ),
         ),
         (ExternalPartitionConfigData, ExternalPartitionExecutionErrorData),
@@ -88,7 +84,6 @@ def sync_get_external_partition_tags_grpc(
     job_name: str,
     partition_name: str,
     instance: DagsterInstance,
-    selected_asset_keys: Optional[AbstractSet[AssetKey]],
 ) -> ExternalPartitionTagsData:
     from dagster._grpc.client import DagsterGrpcClient
 
@@ -106,7 +101,6 @@ def sync_get_external_partition_tags_grpc(
                 partition_set_name=external_partition_set_name_for_job_name(job_name),
                 partition_name=partition_name,
                 instance_ref=instance.get_ref(),
-                selected_asset_keys=selected_asset_keys,
             ),
         ),
         (ExternalPartitionTagsData, ExternalPartitionExecutionErrorData),

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -436,6 +436,26 @@ class ExternalRepository:
         selected_asset_keys: Optional[AbstractSet[AssetKey]],
         instance: DagsterInstance,
     ) -> Sequence[str]:
+        return self._get_partitions_def_for_job(
+            job_name=job_name, selected_asset_keys=selected_asset_keys
+        ).get_partition_keys(dynamic_partitions_store=instance)
+
+    def get_partition_tags_for_implicit_asset_job(
+        self,
+        job_name: str,
+        selected_asset_keys: Optional[AbstractSet[AssetKey]],
+        instance: DagsterInstance,
+        partition_name: str,
+    ) -> Mapping[str, str]:
+        return self._get_partitions_def_for_job(
+            job_name=job_name, selected_asset_keys=selected_asset_keys
+        ).get_tags_for_partition_key(partition_name)
+
+    def _get_partitions_def_for_job(
+        self,
+        job_name: str,
+        selected_asset_keys: Optional[AbstractSet[AssetKey]],
+    ) -> PartitionsDefinition:
         asset_nodes = self.get_external_asset_nodes(job_name)
         unique_partitions_defs: Set[PartitionsDefinition] = set()
         for asset_node in asset_nodes:
@@ -448,9 +468,7 @@ class ExternalRepository:
                 )
 
         if len(unique_partitions_defs) == 1:
-            return next(iter(unique_partitions_defs)).get_partition_keys(
-                dynamic_partitions_store=instance
-            )
+            return next(iter(unique_partitions_defs))
         else:
             check.failed(
                 "There is no PartitionsDefinition shared by all the provided assets."

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -448,9 +448,7 @@ def get_partition_config(
 
 
 def get_partition_names(
-    repo_def: RepositoryDefinition,
-    job_name: str,
-    selected_asset_keys: Optional[AbstractSet[AssetKey]],
+    repo_def: RepositoryDefinition, job_name: str
 ) -> Union[ExternalPartitionNamesData, ExternalPartitionExecutionErrorData]:
     try:
         job_def = repo_def.get_job(job_name)
@@ -463,7 +461,7 @@ def get_partition_names(
             ),
         ):
             return ExternalPartitionNamesData(
-                partition_names=job_def.get_partition_keys(selected_asset_keys)
+                partition_names=job_def.get_partition_keys(selected_asset_keys=None)
             )
     except Exception:
         return ExternalPartitionExecutionErrorData(
@@ -475,7 +473,6 @@ def get_partition_tags(
     repo_def: RepositoryDefinition,
     job_name: str,
     partition_name: str,
-    selected_asset_keys: Optional[AbstractSet[AssetKey]],
     instance_ref: Optional[InstanceRef] = None,
 ) -> Union[ExternalPartitionTagsData, ExternalPartitionExecutionErrorData]:
     try:
@@ -488,9 +485,7 @@ def get_partition_tags(
                 f" partitioned config on job '{job_def.name}'"
             ),
         ):
-            tags = job_def.get_tags_for_partition_key(
-                partition_name, selected_asset_keys=selected_asset_keys
-            )
+            tags = job_def.get_tags_for_partition_key(partition_name, selected_asset_keys=None)
             return ExternalPartitionTagsData(name=partition_name, tags=tags)
 
     except Exception:

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -636,7 +636,6 @@ class DagsterApiServer(DagsterApiServicer):
             serialized_response = serialize_value(
                 get_partition_names(
                     self._get_repo_for_origin(partition_names_args.repository_origin),
-                    selected_asset_keys=partition_names_args.selected_asset_keys,
                     job_name=partition_names_args.get_job_name(),
                 )
             )
@@ -733,7 +732,6 @@ class DagsterApiServer(DagsterApiServicer):
                     self._get_repo_for_origin(partition_args.repository_origin),
                     job_name=partition_args.get_job_name(),
                     partition_name=partition_args.partition_name,
-                    selected_asset_keys=partition_args.selected_asset_keys,
                     instance_ref=instance_ref,
                 )
             )

--- a/python_modules/dagster/dagster/_grpc/types.py
+++ b/python_modules/dagster/dagster/_grpc/types.py
@@ -413,11 +413,6 @@ class PartitionArgs(
             ("partition_name", str),
             ("job_name", Optional[str]),
             ("instance_ref", Optional[InstanceRef]),
-            # This is introduced in the same release that we're making it possible for an asset job
-            # to target assets with different PartitionsDefinitions. Prior user code versions can
-            # (and do) safely ignore this parameter, because, in those versions, the job name on its
-            # own is enough to specify which PartitionsDefinition to use.
-            ("selected_asset_keys", Optional[AbstractSet[AssetKey]]),
         ],
     )
 ):
@@ -428,7 +423,6 @@ class PartitionArgs(
         partition_name: str,
         job_name: Optional[str] = None,
         instance_ref: Optional[InstanceRef] = None,
-        selected_asset_keys: Optional[AbstractSet[AssetKey]] = None,
     ):
         return super(PartitionArgs, cls).__new__(
             cls,
@@ -441,9 +435,6 @@ class PartitionArgs(
             job_name=check.opt_str_param(job_name, "job_name"),
             partition_name=check.str_param(partition_name, "partition_name"),
             instance_ref=check.opt_inst_param(instance_ref, "instance_ref", InstanceRef),
-            selected_asset_keys=check.opt_nullable_set_param(
-                selected_asset_keys, "selected_asset_keys", of_type=AssetKey
-            ),
         )
 
     def get_job_name(self) -> str:
@@ -466,7 +457,6 @@ class PartitionNamesArgs(
             # (and do) safely ignore this parameter, because, in those versions, the job name on its
             # own is enough to specify which PartitionsDefinition to use.
             ("job_name", Optional[str]),
-            ("selected_asset_keys", Optional[AbstractSet[AssetKey]]),
         ],
     )
 ):
@@ -475,7 +465,6 @@ class PartitionNamesArgs(
         repository_origin: RemoteRepositoryOrigin,
         partition_set_name: str,
         job_name: Optional[str] = None,
-        selected_asset_keys: Optional[AbstractSet[AssetKey]] = None,
     ):
         return super(PartitionNamesArgs, cls).__new__(
             cls,
@@ -484,9 +473,6 @@ class PartitionNamesArgs(
             ),
             job_name=check.opt_str_param(job_name, "job_name"),
             partition_set_name=check.str_param(partition_set_name, "partition_set_name"),
-            selected_asset_keys=check.opt_nullable_set_param(
-                selected_asset_keys, "selected_asset_keys", of_type=AssetKey
-            ),
         )
 
     def get_job_name(self) -> str:

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
@@ -52,7 +52,7 @@ def test_external_partition_names_grpc(instance: DagsterInstance):
     with get_bar_repo_code_location(instance) as code_location:
         repository_handle = code_location.get_repository("bar_repo").handle
         data = sync_get_external_partition_names_grpc(
-            code_location.client, repository_handle, "baz", None
+            code_location.client, repository_handle, "baz"
         )
         assert isinstance(data, ExternalPartitionNamesData)
         assert data.partition_names == list(string.ascii_lowercase)
@@ -97,10 +97,7 @@ def test_external_partition_names_deserialize_error_grpc(instance: DagsterInstan
         result = deserialize_value(
             api_client.external_partition_names(
                 partition_names_args=PartitionNamesArgs(
-                    repository_origin=repository_origin,
-                    job_name="foo",
-                    partition_set_name="foo_partition_set",
-                    selected_asset_keys=None,
+                    repository_origin=repository_origin, partition_set_name="foo_partition_set"
                 )._replace(repository_origin="INVALID"),
             )
         )
@@ -170,11 +167,9 @@ def test_external_partition_config_deserialize_error_grpc(instance: DagsterInsta
             api_client.external_partition_config(
                 partition_args=PartitionArgs(
                     repository_origin=repository_handle.get_external_origin(),
-                    job_name="foo",
                     partition_set_name="foo_partition_set",
                     partition_name="bar",
                     instance_ref=instance.get_ref(),
-                    selected_asset_keys=None,
                 )._replace(repository_origin="INVALID"),
             )
         )
@@ -192,7 +187,6 @@ def test_external_partitions_tags_grpc(instance: DagsterInstance):
             "baz",
             "c",
             instance=instance,
-            selected_asset_keys=None,
         )
         assert isinstance(data, ExternalPartitionTagsData)
         assert data.tags
@@ -244,11 +238,9 @@ def test_external_partitions_tags_deserialize_error_grpc(instance: DagsterInstan
             api_client.external_partition_tags(
                 partition_args=PartitionArgs(
                     repository_origin=repository_origin,
-                    job_name="fooba",
                     partition_set_name="fooba_partition_set",
                     partition_name="c",
                     instance_ref=instance.get_ref(),
-                    selected_asset_keys=None,
                 )._replace(repository_origin="INVALID"),
             )
         )
@@ -261,7 +253,7 @@ def test_external_partitions_tags_error_grpc(instance: DagsterInstance):
 
         with pytest.raises(DagsterUserCodeProcessError):
             sync_get_external_partition_tags_grpc(
-                code_location.client, repository_handle, "error_partition_tags", "c", instance, None
+                code_location.client, repository_handle, "error_partition_tags", "c", instance
             )
 
 
@@ -325,7 +317,7 @@ def test_dynamic_partition_set_grpc(instance: DagsterInstance):
         assert data.run_config == {}
 
         data = sync_get_external_partition_tags_grpc(
-            code_location.client, repository_handle, "dynamic_job", "a", instance, None
+            code_location.client, repository_handle, "dynamic_job", "a", instance
         )
         assert isinstance(data, ExternalPartitionTagsData)
         assert data.tags


### PR DESCRIPTION
## Summary & Motivation

We discovered that backcompatibility for the single-implicit-asset-job change is actually a three-body problem, between the host processes, agent, and user code processes:
- It's now possible for a job to target asset definitions with different `PartitionsDefinitions`
- You need a `PartitionsDefinition` to resolve the run tags for a given partition
- This means that, to get the run tags corresponding to a particular partition, you need to know what assets the run is targeting
- Jobs can be assigned custom functions that determine run tags for a partition
- These custom functions mean that, at least sometimes, there needs to be a gRPC to the user code process to resolve the tags for a partitioned run
- Currently, we always gRPC to the user code process to resolve the tags for a partitioned run
- In a recent change, we added an `selected_asset_keys` field to the gRPC param to resolve the tags. We also added a required `job_name` field, with the goal of one day far into the future being able to remove the `partition_set_name` field.
- Then we encountered the three-body problem: the agent re-serializes the parameter object, and older agent versions don't know about the `selected_asset_key` or `job_name` parameters, so they gets stripped, which means that the user code process doesn't receive it, which means that the user code process will fail to deserialize the parameters object (because of the required `job_name` parameter) and, even if it could deserialize it, wouldn't know what asset keys were selected to resolve the tags for the partition.

Ok, so what do we do? Luckily, there are only two kinds of jobs out there:
- Jobs that definitely do not have custom tags-for-partition functions. Currently, all jobs that might have assets with different `PartitionsDefinition`s are implicit asset jobs, which fall into this category.
- Jobs that might have custom tags-for-partition function.

This means that, in the case that `selected_asset_keys` are needed to resolve partition tags, a gRPC is not needed.

So this PR does a couple things:
- It computes the partition tags on _on the host process_ for implicit asset jobs, which means we can avoid gRPC entirely.
- It removes `selected_asset_keys` from `PartitionArgs` and `PartitionNamesArgs`. This reflects the fact that we can't rely on it making it across the gRPC boundary, because it get stripped out by older agents. It's no longer needed, because the only scenarios where it used to be needed are now scenarios where we avoid gRPC in the first place.

## How I Tested These Changes

## Changelog [New | Bug | Docs]

NOCHANGELOG
