### PR TITLE
RFC: LoadableDefs

### DIFF
--- a/loadable_example.py
+++ b/loadable_example.py
@@ -1,0 +1,207 @@
+from typing import List, Mapping, Sequence, Union
+
+from dagster import _check as check
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.cacheable_assets import (
+    AssetsDefinitionCacheableData,
+    CacheableAssetsDefinition,
+)
+from dagster._core.definitions.decorators.asset_decorator import asset, multi_asset
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.loadable import (
+    AssetSpecRecord,
+    DefLoadingContext,
+    DefsRecord,
+    LoadableCacheableAssetsDefinitionAdapter,
+    LoadableDefs,
+    load_defs,
+)
+from dagster._core.definitions.time_window_partitions import (
+    DailyPartitionsDefinition,
+    HourlyPartitionsDefinition,
+)
+from dagster._core.instance import DagsterInstance
+
+
+def fetch_table_names_from_rest_api() -> List[str]:
+    return ["lakehouse_a"]
+
+
+class LakehouseDefs(LoadableDefs):
+    def __init__(self) -> None:
+        super().__init__(external_source_key="lakehouse_api")
+
+    def compute_defs_record(self, context: DefLoadingContext) -> DefsRecord:
+        return DefsRecord(
+            asset_spec_records=[
+                AssetSpecRecord(key=AssetKey(table_name))
+                for table_name in fetch_table_names_from_rest_api()
+            ]
+        )
+
+    def definitions_from_record(self, defs_record: DefsRecord) -> Definitions:
+        @multi_asset(specs=defs_record.to_asset_specs())
+        def an_asset() -> None: ...
+
+        return Definitions(assets=[an_asset])
+
+
+@asset
+def another_asset() -> None: ...
+
+
+def loadable_legacy_system_defs() -> LoadableDefs:
+    # imagine you had an existing class LegacySystemCacheableAssetsDefinition
+    # that you did not want to modify
+    class LegacySystemCacheableAssetsDefinition(CacheableAssetsDefinition):
+        def compute_cacheable_data(self) -> Sequence[AssetsDefinitionCacheableData]:
+            return [AssetsDefinitionCacheableData(extra_metadata={"value": "legacy_a"})]
+
+        def build_definitions(
+            self, data: Sequence[AssetsDefinitionCacheableData]
+        ) -> Sequence[AssetsDefinition]:
+            value = (
+                check.inst(next(iter(data)), AssetsDefinitionCacheableData).extra_metadata or {}
+            )["value"]
+
+            @asset(name=value)
+            def an_asset() -> None: ...
+
+            return [an_asset]
+
+    # Here is how you would adapt it:
+    return LoadableCacheableAssetsDefinitionAdapter(
+        LegacySystemCacheableAssetsDefinition("ksjdkfsjdklfjslkdjf")
+    )
+
+
+daily_partitions_def = DailyPartitionsDefinition(start_date="2021-01-01")
+
+
+class HardedPartitionedDefs(LoadableDefs):
+    def __init__(self) -> None:
+        super().__init__(external_source_key="partitioned_api")
+
+    def compute_defs_record(self, context: DefLoadingContext) -> DefsRecord:
+        return DefsRecord(
+            asset_spec_records=[AssetSpecRecord(key=AssetKey("some_partitioned_table"))]
+        )
+
+    def definitions_from_record(self, defs_record: DefsRecord) -> Definitions:
+        @multi_asset(specs=defs_record.to_asset_specs(partitions_def=daily_partitions_def))
+        def blah_blah_blah() -> None: ...
+
+        return Definitions(assets=[blah_blah_blah])
+
+
+hourly_partition_def = HourlyPartitionsDefinition(start_date="2021-01-01-01:00")
+
+
+class PartitioningDeterminedByAPI(LoadableDefs):
+    def __init__(self) -> None:
+        super().__init__(external_source_key="partitioning_api_2")
+
+    def compute_defs_record(self, context: DefLoadingContext) -> DefsRecord:
+        # imagine the string "hourly" or "daily" was returned by the API
+        # but you want the source of truth for all partitiong to be in Python
+        return DefsRecord(
+            asset_spec_records=[
+                AssetSpecRecord(
+                    key=AssetKey("some_partitioned_table_1"), metadata={"partitioning": "hourly"}
+                ),
+                AssetSpecRecord(
+                    key=AssetKey("some_partitioned_table_2"), metadata={"partitioning": "daily"}
+                ),
+            ]
+        )
+
+    def definitions_from_record(self, defs_record: DefsRecord) -> Definitions:
+        def _apply_partitioning(spec: AssetSpec) -> AssetSpec:
+            if spec.metadata.get("partitioning") == "hourly":
+                return spec._replace(partitions_def=hourly_partition_def)
+            elif spec.metadata.get("partitioning") == "daily":
+                return spec._replace(partitions_def=daily_partitions_def)
+            else:
+                return spec
+
+        @multi_asset(
+            specs=[
+                _apply_partitioning(spec)
+                for spec in defs_record.to_asset_specs(partitions_def=daily_partitions_def)
+            ]
+        )
+        def blah_blah_blah() -> None: ...
+
+        return Definitions(assets=[blah_blah_blah])
+
+
+# we can make context optional
+def defs(context: DefLoadingContext) -> Definitions:
+    # This is now a vanilla definitions object.
+    legacy_system_defs = loadable_legacy_system_defs().load(context)
+    # so here you could do things like build derived asset checks from them
+    lake_house_defs = LakehouseDefs().load(context)
+
+    return Definitions.merge(
+        Definitions(assets=[another_asset]),
+        legacy_system_defs,
+        lake_house_defs,
+        HardedPartitionedDefs().load(context),
+    )
+
+
+def defs_using_helper(context: DefLoadingContext) -> Definitions:
+    # convienence function to load all the defs and merge them
+    # Definitions.load_all(...)
+    return load_all(
+        context,
+        loadable_legacy_system_defs(),
+        LakehouseDefs(),
+        HardedPartitionedDefs(),
+        Definitions(assets=[another_asset]),
+    )
+
+
+def load_all(context: DefLoadingContext, *defs: Union[LoadableDefs, Definitions]) -> Definitions:
+    return Definitions.merge(*[d.load(context) if isinstance(d, LoadableDefs) else d for d in defs])
+
+
+if __name__ == "__main__":
+    # how you would call in tests
+    assert isinstance(load_defs(defs), Definitions)
+
+    instance = DagsterInstance.get()
+    # save the definitions to the instance
+    assert isinstance(
+        defs(DefLoadingContext(load_from_storage=False, instance=instance)), Definitions
+    )
+
+    # load from storage
+    assert isinstance(
+        defs(DefLoadingContext(load_from_storage=True, instance=instance)), Definitions
+    )
+
+    def _raise() -> Mapping[str, str]:
+        raise Exception("should not be called")
+
+    # make storage load fail
+    instance.run_storage.get_cursor_values = lambda *args, **kwargs: _raise()
+
+    # doesn't touch storage
+    assert isinstance(
+        defs(DefLoadingContext(load_from_storage=False, instance=instance)), Definitions
+    )
+
+    # does touch storage, fails
+    caught = False
+    try:
+        assert isinstance(
+            defs(DefLoadingContext(load_from_storage=True, instance=instance)), Definitions
+        )
+    except Exception as e:
+        caught = True
+        assert "should not be called" in str(e)
+
+    assert caught

--- a/python_modules/dagster/dagster/_core/definitions/loadable.py
+++ b/python_modules/dagster/dagster/_core/definitions/loadable.py
@@ -1,0 +1,122 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, Sequence
+
+from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._record import record
+from dagster._serdes.serdes import deserialize_value, serialize_value, whitelist_for_serdes
+
+if TYPE_CHECKING:
+    from dagster._core.instance import DagsterInstance
+
+
+@whitelist_for_serdes
+@record
+class AssetSpecRecord:
+    key: AssetKey
+    metadata: Optional[Mapping[str, Any]] = None
+
+
+@whitelist_for_serdes
+@record
+class AssetCheckSpecRecord:
+    key: AssetCheckKey
+
+
+# TODO support partitions and other more complex objects
+@whitelist_for_serdes
+@record
+class DefsRecord:
+    asset_spec_records: Optional[Sequence[AssetSpecRecord]] = None
+    # asset_check_specs: Optional[Sequence[AssetCheckSpec]] = None
+    # for backwards compat and weird shit
+    extra: Any = None
+
+    def to_asset_specs(self, **additional_values) -> Sequence[AssetSpec]:
+        return [
+            AssetSpec(key=asr.key, metadata=asr.metadata)._replace(**additional_values)
+            for asr in (self.asset_spec_records or [])
+        ]
+
+
+@dataclass
+class DefLoadingContext:
+    load_from_storage: bool
+    instance: "DagsterInstance"
+
+
+@dataclass
+class DefinitionsFnWrapper:
+    def_fn: Callable
+
+
+def fetch_defs_record(instance: "DagsterInstance", key: str) -> Optional[DefsRecord]:
+    str_value = instance.run_storage.get_cursor_values({key}).get(key)
+    if not str_value:
+        return None
+    return deserialize_value(str_value, as_type=DefsRecord)
+
+
+def store_defs_record(instance: "DagsterInstance", key: str, defs_record: DefsRecord) -> None:
+    serialized = serialize_value(defs_record)
+    return instance.run_storage.set_cursor_values({key: serialized})
+
+
+class LoadableDefs(ABC):
+    def __init__(self, external_source_key: str):
+        self.external_source_key = external_source_key
+
+    # This invokes against potentially unreliable APIS, like an API call. Or potentially slow APIs, like a dbt manifest parse.
+    # We could also add new APIs/UI that invokes this without a full code server reload
+    @abstractmethod
+    def compute_defs_record(self, context: DefLoadingContext) -> DefsRecord: ...
+
+    @abstractmethod
+    def definitions_from_record(self, defs_record: DefsRecord) -> Definitions: ...
+
+    def load(self, context: DefLoadingContext) -> Definitions:
+        # The system will set load_from_storage to true in cases like run worker loads
+        if context.load_from_storage:
+            defs_record = fetch_defs_record(context.instance, self._get_key())
+            if not defs_record:
+                raise Exception(f"Could not load defs record for {self._get_key()}")
+            return self.definitions_from_record(defs_record)
+
+        defs_record = self.compute_defs_record(context)
+        definitions = self.definitions_from_record(defs_record)
+
+        store_defs_record(context.instance, self._get_key(), defs_record)
+
+        # only return if successfully stored
+        return definitions
+
+    # This is a problematic bit. Probably should construct from context with repo and location name etc.
+    def _get_key(self) -> str:
+        return f"loadable_defs/{self.external_source_key}"
+
+
+class LoadableCacheableAssetsDefinitionAdapter(LoadableDefs):
+    def __init__(self, cacheable_assets_def: CacheableAssetsDefinition):
+        self.cacheable_assets_def = cacheable_assets_def
+        super().__init__(external_source_key=self.cacheable_assets_def.unique_id)
+
+    def compute_defs_record(self, context: DefLoadingContext) -> DefsRecord:
+        datas = self.cacheable_assets_def.compute_cacheable_data()
+        return DefsRecord(extra=datas)
+
+    def definitions_from_record(self, defs_record: DefsRecord) -> Definitions:
+        assets_defs = self.cacheable_assets_def.build_definitions(defs_record.extra)
+        return Definitions(assets=assets_defs)
+
+
+def load_defs(
+    defs_fn: Callable[[DefLoadingContext], Definitions],
+    instance: Optional["DagsterInstance"] = None,
+) -> Definitions:
+    from dagster._core.instance import DagsterInstance
+
+    instance = instance or DagsterInstance.get()
+    return defs_fn(DefLoadingContext(load_from_storage=False, instance=instance))


### PR DESCRIPTION
## Summary & Motivation

We've been discussing different ways of lazy loading definitions and I wanted to flesh out some ideas I've had in this direction.

* There is a new entry point. A function call defs. It optionally takes a context object provided by the system. This is the new default entry point. We change all examples and docs to use it.
* New class `LoadableDefs` that used when you want to create a basket of `Definitions` backed by an external source of some kind.

The contract of `LoadableDefs` has the following behavior:

* In order to use it you need to build a subclass. 
 * You must provide a key for storage in the superclass `__init__`. Note: I wish we could get away without needing this. All ears for alt implementation ideas)
  * You must override `compute_defs_record`, which is the code that hits whatever unreliable backend is the source of truth for definitions. This returns `DefsRecord`.
   * You must override `definitions_from_record`, with takes a `DefsRecord` and returns a `Definitions` object.

`DefsRecord` builds on the spec system and make it very convenient to convert to lists of specs. We built up a new (lightweight) layer of classes called "SpecRecord". This is the format we persist spec info into our db and (eventually) event log. This makes a contract pretty easy to define:

1) You write a function that fetches specs records from the external source.
2) You write a function that takes those specs records and produces a `Defintitons` object.

The machinery takes care of storing that `DefsRecord` object to our key value store (this stashes it in cursor storage for now). 

It is also very easy/triviai/automatic to convert spec records to specs in most cases.

By standardizing on this storage format we could also build tools to visualize and manage persisted specs, which I think will become necessary as more critical integrations rely on this and people need to debug things. This is also a logical building block for a more generalized state-driven definition infrastructure.

For the default case where you don't need to anything fancy, you can use a convenience method to load all the loadable defs and merge them:

```python
def fetch_table_names_from_rest_api() -> List[str]:
    # imagine this calling requests or something
    return ["lakehouse_a"]

class LakehouseDefs(LoadableDefs):
    def __init__(self) -> None:
        super().__init__(external_source_key="lakehouse_api")

    def compute_defs_record(self, context: DefLoadingContext) -> DefsRecord:
        return DefsRecord(
            asset_spec_records=[
                AssetSpecRecord(key=AssetKey(table_name))
                for table_name in fetch_table_names_from_rest_api()
            ]
        )

    def definitions_from_record(self, defs_record: DefsRecord) -> Definitions:
        @multi_asset(specs=defs_record.to_asset_specs())
        def an_asset() -> None: ...

        return Definitions(assets=[an_asset])
```

Both `Definitions` and `LoadableDefinitions` can be combined in conveniences apis like `load_all`.

```python
def defs(context: DefLoadingContext) -> Definitions:
    # convienence function to load all the defs and merge them
    # Definitions.load_all(...)
    return load_all(
        context,
        loadable_legacy_system_defs(),
        LakehouseDefs(),
        HardedPartitionedDefs(),
        Definitions(assets=[another_asset]),
    )
```

However if you need to do things like evaluate defs and then pass them to other factories, you can do that as well.

```python
def defs(context: DefLoadingContext) -> Definitions:
    # This is now a vanilla definitions object.
    legacy_system_defs = loadable_legacy_system_defs().load(context)

    return Definitions.merge(
        legacy_system_defs,
        Definitions(asset_checks=build_freshness_checks(legacy_system_defs))
    )
```

It may be worth examining having the `context` argument. While inconsistent with the rest of Dagster, we could manage a global context stack on the users behalf. This would eliminate the need to thread a context object everywhere, but it is also magical global state that encourages "spooky action at a distance". But refactoring definitions creation code to have access to the context is annoying, and you have to do it the moment you bring integrations that have loadable definitions.


Another important utility here is `LoadableCacheableAssetsDefinitionAdapter` which would allow us to wrap existing `CacheableAssetsDefinition` instances:

e.g.

```python
    return LoadableCacheableAssetsDefinitionAdapter(
        LegacySystemCacheableAssetsDefinition("ksjdkfsjdklfjslkdjf")
    )
```

This adapter is quite simple and I think proves the benefits of this approach. It contains the complexity blast radius of CacheableAssetsDefinition, eliminates the need for the various and sundry subclasses of that class. Once everything is ported to this adapter we will be able to delete a huge amount of code.

Proposed plan of action

* Do the work to flesh out this diff. We need to do quite a bit of instance threading. We should also add a decorator to make a `defs` function so we don't rely solely on a hardcoded name.
* Immediately move all docs and examples to `def defs` instead of `defs = `. It is better anyways since by default it will avoid import-based side effects in unit testing scenarios and so forth.
* Port all existing `CacheableAssetDefinition` instances to the provided adapter and deprecate any API that returns CacheableAssetsDefinition immediately. Once this is done an we can delete an enormous amount of complexity in the codebase. `PendingRepositoryDefinition` and all the chicanery around it can be eliminated.

## How I Tested These Changes

loadable_example.py

I also refactored Airlift on top of this was fairly pleased *(https://app.graphite.dev/github/pr/dagster-io/dagster/23887/Try-airlift-cacheables-on-new-abstraction) aside from having to refactor examples and tests to deal with the context.

## Changelog [New | Bug | Docs]

NOCHANGELOG
