### PR TITLE
AssetSlice -> EntitySlice

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -7,7 +7,7 @@ from typing_extensions import Self
 
 import dagster._check as check
 from dagster._annotations import experimental, public
-from dagster._core.asset_graph_view.asset_graph_view import AssetSlice
+from dagster._core.asset_graph_view.asset_graph_view import EntitySlice
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AssetSubsetWithMetadata,
@@ -518,7 +518,7 @@ class AutomationResult:
     def __init__(
         self,
         context: "AutomationContext",
-        true_slice: AssetSlice,
+        true_slice: EntitySlice[AssetKey],
         cursor: Optional[str] = None,
         child_results: Optional[Sequence["AutomationResult"]] = None,
         **kwargs,
@@ -528,7 +528,7 @@ class AutomationResult:
         )
 
         self._context = check.inst_param(context, "context", AutomationContext)
-        self._true_slice = check.inst_param(true_slice, "true_slice", AssetSlice)
+        self._true_slice = check.inst_param(true_slice, "true_slice", EntitySlice)
         self._child_results = check.opt_sequence_param(
             child_results, "child_results", of_type=AutomationResult
         )
@@ -560,10 +560,10 @@ class AutomationResult:
 
     @property
     def asset_key(self) -> AssetKey:
-        return self._true_slice.asset_key
+        return self._true_slice.key
 
     @property
-    def true_slice(self) -> AssetSlice:
+    def true_slice(self) -> EntitySlice[AssetKey]:
         return self._true_slice
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
@@ -18,7 +18,7 @@ from typing import (
     TypeVar,
 )
 
-from dagster._core.asset_graph_view.asset_graph_view import AssetSlice
+from dagster._core.asset_graph_view.asset_graph_view import EntitySlice
 from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
 from dagster._core.definitions.declarative_automation.legacy.valid_asset_subset import (
     ValidAssetSubset,
@@ -151,7 +151,7 @@ class LegacyRuleEvaluationContext:
         self,
         child_condition: "AutomationCondition",
         child_unique_id: str,
-        candidate_slice: AssetSlice,
+        candidate_slice: EntitySlice[AssetKey],
     ) -> "LegacyRuleEvaluationContext":
         return dataclasses.replace(
             self,
@@ -160,7 +160,7 @@ class LegacyRuleEvaluationContext:
             if self.cursor
             else None,
             candidate_subset=ValidAssetSubset(
-                key=candidate_slice.asset_key, value=candidate_slice.get_internal_value()
+                key=candidate_slice.key, value=candidate_slice.get_internal_value()
             ),
             root_ref=self.root_context,
             start_timestamp=get_current_timestamp(),

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/valid_asset_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/valid_asset_subset.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from dagster._core.instance import DynamicPartitionsStore
 
 
-@whitelist_for_serdes(serializer=EntitySubsetSerializer)
+@whitelist_for_serdes(serializer=EntitySubsetSerializer, storage_field_names={"key": "asset_key"})
 class ValidAssetSubset(EntitySubset[AssetKey]):
     """Legacy construct used for doing operations over EntitySubsets that are known to be valid. This
     functionality is subsumed by AssetSlice.

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
@@ -24,7 +24,7 @@ class CodeVersionChangedCondition(AutomationCondition):
 
     def evaluate(self, context: AutomationContext) -> AutomationResult:
         previous_code_version = context.cursor
-        current_code_version = context.asset_graph.get(context.asset_key).code_version
+        current_code_version = context.asset_graph.get(context.key).code_version
         if previous_code_version is None or previous_code_version == current_code_version:
             true_slice = context.get_empty_slice()
         else:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
@@ -85,7 +85,7 @@ class AnyDownstreamConditionsCondition(AutomationCondition):
     def evaluate(self, context: AutomationContext) -> AutomationResult:
         ignored_conditions = self._get_ignored_conditions(context)
         downstream_conditions = self._get_validated_downstream_conditions(
-            context.asset_graph.get_downstream_automation_conditions(asset_key=context.asset_key)
+            context.asset_graph.get_downstream_automation_conditions(asset_key=context.key)
         )
 
         true_slice = context.get_empty_slice()

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -48,7 +48,7 @@ class DepConditionWrapperCondition(AutomationCondition):
         dep_result = self.operand.evaluate(dep_context)
 
         # find all children of the true dep slice
-        true_slice = dep_result.true_slice.compute_child_slice(context.asset_key)
+        true_slice = dep_result.true_slice.compute_child_slice(context.key)
         return AutomationResult(context=context, true_slice=true_slice, child_results=[dep_result])
 
 
@@ -123,9 +123,7 @@ class AnyDepsCondition(DepCondition):
         dep_results = []
         true_slice = context.get_empty_slice()
 
-        for i, dep_key in enumerate(
-            sorted(self._get_dep_keys(context.asset_key, context.asset_graph))
-        ):
+        for i, dep_key in enumerate(sorted(self._get_dep_keys(context.key, context.asset_graph))):
             dep_condition = DepConditionWrapperCondition(dep_key=dep_key, operand=self.operand)
             dep_result = dep_condition.evaluate(
                 context.for_child_condition(
@@ -155,9 +153,7 @@ class AllDepsCondition(DepCondition):
         dep_results = []
         true_slice = context.candidate_slice
 
-        for i, dep_key in enumerate(
-            sorted(self._get_dep_keys(context.asset_key, context.asset_graph))
-        ):
+        for i, dep_key in enumerate(sorted(self._get_dep_keys(context.key, context.asset_graph))):
             dep_condition = DepConditionWrapperCondition(dep_key=dep_key, operand=self.operand)
             dep_result = dep_condition.evaluate(
                 context.for_child_condition(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
@@ -32,9 +32,7 @@ class SinceCondition(AutomationCondition):
 
     def evaluate(self, context: AutomationContext) -> AutomationResult:
         # must evaluate child condition over the entire slice to avoid missing state transitions
-        child_candidate_slice = context.asset_graph_view.get_asset_slice(
-            asset_key=context.asset_key
-        )
+        child_candidate_slice = context.asset_graph_view.get_full_slice(key=context.key)
 
         # compute result for trigger condition
         trigger_context = context.for_child_condition(

--- a/python_modules/dagster/dagster/_core/definitions/entity_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/entity_subset.py
@@ -12,6 +12,8 @@ from dagster._core.definitions.partition import (
 from dagster._core.definitions.time_window_partitions import BaseTimeWindowPartitionsSubset
 from dagster._serdes.serdes import DataclassSerializer, whitelist_for_serdes
 
+EntitySubsetValue = Union[bool, PartitionsSubset]
+
 
 class EntitySubsetSerializer(DataclassSerializer):
     """Ensures that the inner PartitionsSubset is converted to a serializable form if necessary."""
@@ -36,7 +38,7 @@ class EntitySubset(Generic[T_EntityKey]):
     """Represents a subset of a given EntityKey."""
 
     key: T_EntityKey
-    value: Union[bool, PartitionsSubset]
+    value: EntitySubsetValue
 
     @property
     def is_partitioned(self) -> bool:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_asset_slice.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_asset_slice.py
@@ -42,14 +42,14 @@ def test_operations(
     asset_graph_view = AssetGraphView.for_test(defs, instance)
 
     a = (
-        asset_graph_view.get_asset_slice(asset_key=foo.key)
+        asset_graph_view.get_full_slice(key=foo.key)
         if first_all
-        else asset_graph_view.get_empty_slice(asset_key=foo.key)
+        else asset_graph_view.get_empty_slice(key=foo.key)
     )
     b = (
-        asset_graph_view.get_asset_slice(asset_key=foo.key)
+        asset_graph_view.get_full_slice(key=foo.key)
         if second_all
-        else asset_graph_view.get_empty_slice(asset_key=foo.key)
+        else asset_graph_view.get_empty_slice(key=foo.key)
     )
 
     def _assert_matches_operation(res, oper):

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
@@ -47,20 +47,18 @@ def test_slice_traversal_static_partitions() -> None:
 
     asset_graph_view_t0 = AssetGraphView.for_test(defs, instance)
     assert (
-        asset_graph_view_t0.get_asset_slice(
-            asset_key=up_numbers.key
-        ).expensively_compute_partition_keys()
+        asset_graph_view_t0.get_full_slice(key=up_numbers.key).expensively_compute_partition_keys()
         == number_keys
     )
     assert (
-        asset_graph_view_t0.get_asset_slice(
-            asset_key=down_letters.key
+        asset_graph_view_t0.get_full_slice(
+            key=down_letters.key
         ).expensively_compute_partition_keys()
         == letter_keys
     )
 
     # from full up to down
-    up_slice = asset_graph_view_t0.get_asset_slice(asset_key=up_numbers.key)
+    up_slice = asset_graph_view_t0.get_full_slice(key=up_numbers.key)
     assert up_slice.expensively_compute_partition_keys() == {"1", "2", "3"}
     assert up_slice.compute_child_slice(down_letters.key).expensively_compute_partition_keys() == {
         "a",
@@ -69,7 +67,7 @@ def test_slice_traversal_static_partitions() -> None:
     }
 
     # from full up to down
-    down_slice = asset_graph_view_t0.get_asset_slice(asset_key=down_letters.key)
+    down_slice = asset_graph_view_t0.get_full_slice(key=down_letters.key)
     assert down_slice.expensively_compute_partition_keys() == {"a", "b", "c"}
     assert down_slice.compute_parent_slice(up_numbers.key).expensively_compute_partition_keys() == {
         "1",
@@ -100,15 +98,15 @@ def test_only_partition_keys() -> None:
 
     asset_graph_view_t0 = AssetGraphView.for_test(defs, instance)
 
-    assert asset_graph_view_t0.get_asset_slice(
-        asset_key=up_numbers.key
+    assert asset_graph_view_t0.get_full_slice(
+        key=up_numbers.key
     ).compute_intersection_with_partition_keys({"1", "2"}).expensively_compute_partition_keys() == {
         "1",
         "2",
     }
 
-    assert asset_graph_view_t0.get_asset_slice(
-        asset_key=up_numbers.key
+    assert asset_graph_view_t0.get_full_slice(
+        key=up_numbers.key
     ).compute_intersection_with_partition_keys({"3"}).expensively_compute_partition_keys() == set(
         ["3"]
     )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_dep_condition.py
@@ -37,16 +37,16 @@ def get_hardcoded_condition():
             return "..."
 
         def evaluate(self, context: AutomationContext) -> AutomationResult:
-            filtered_true_set = {akpk for akpk in true_set if akpk.asset_key == context.asset_key}
+            filtered_true_set = {akpk for akpk in true_set if akpk.asset_key == context.key}
             if context.partitions_def:
                 true_slice = context.candidate_slice.compute_intersection_with_partition_keys(
                     {apk.partition_key for apk in filtered_true_set}
                 )
             else:
                 true_slice = (
-                    context.asset_graph_view.get_asset_slice(asset_key=context.asset_key)
+                    context.asset_graph_view.get_full_slice(key=context.key)
                     if filtered_true_set
-                    else context.asset_graph_view.get_empty_slice(asset_key=context.asset_key)
+                    else context.asset_graph_view.get_empty_slice(key=context.key)
                 )
             return AutomationResult(context, true_slice=true_slice)
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
@@ -104,7 +104,7 @@ def test_serialize_definitions_with_user_code_asset_condition() -> None:
     class MyAutomationCondition(AutomationCondition):
         def evaluate(self, context: AutomationContext) -> AutomationResult:
             return AutomationResult(
-                context, context.asset_graph_view.get_asset_slice(asset_key=context.asset_key)
+                context, context.asset_graph_view.get_full_slice(key=context.key)
             )
 
     automation_condition = AutomationCondition.eager() | MyAutomationCondition()

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
@@ -295,8 +295,8 @@ class AssetDaemonScenarioState(ScenarioState):
         )
 
     def _log_assertion_error(self, expected: Sequence[Any], actual: Sequence[Any]) -> None:
-        expected_str = "\n\n".join("\t" + str(rr) for rr in expected)
-        actual_str = "\n\n".join("\t" + str(rr) for rr in actual)
+        expected_str = "\n\n".join("\t" + str(serialize_value(rr)) for rr in expected)
+        actual_str = "\n\n".join("\t" + str(serialize_value(rr)) for rr in actual)
         message = f"\nExpected: \n\n{expected_str}\n\nActual: \n\n{actual_str}\n"
         self.logger.error(message)
 
@@ -481,8 +481,8 @@ class AssetDaemonScenarioState(ScenarioState):
 
         except:
             self._log_assertion_error(
-                sorted(expected_subsets_with_metadata, key=lambda x: str(x)),
-                sorted(actual_subsets_with_metadata, key=lambda x: str(x)),
+                sorted(expected_subsets_with_metadata, key=lambda x: str(serialize_value(x))),
+                sorted(actual_subsets_with_metadata, key=lambda x: str(serialize_value(x))),
             )
             raise
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
@@ -65,7 +65,7 @@ class AutomationConditionScenarioState(ScenarioState):
             ap_by_key[ap.asset_key].add(ap)
         return {
             asset_key: mock.MagicMock(
-                true_slice=asset_graph_view.get_asset_slice_from_asset_partitions(aps),
+                true_slice=asset_graph_view.get_asset_slice_from_asset_partitions(asset_key, aps),
                 cursor=None,
             )
             for asset_key, aps in ap_by_key.items()


### PR DESCRIPTION
## Summary & Motivation

Similar to the previous PR, but this time for AssetSlice. This lets us create and use slices of arbitrary EntityKeys. To help make this a bit simpler, I refactored the internal representation of an AssetSlice / EntitySlice to store a separate key/value so that the type system could independently understand the key type. I also removed some unused methods / code paths to aovid needing to refactor them . In particular, I removed the `time_windows` property of AssetSlice as it was unused outside of tests. We can always bring that back if we find a use for it.


## How I Tested These Changes

## Changelog [New | Bug | Docs]

NOCHANGELOG
