### PR TITLE
[docs] indicate Run Monitoring enabled by default in Dagster+

### DIFF
--- a/docs/content/dagster-plus/deployment/agents/amazon-ecs.mdx
+++ b/docs/content/dagster-plus/deployment/agents/amazon-ecs.mdx
@@ -15,7 +15,7 @@ This agent is appropriate for scaled production deployments; ECS is a good choic
   ></ArticleListItem>
   <ArticleListItem
     title="Creating an Amazon ECS agent in an existing VPC"
-    href="dagster-cloud/deployment/agents/amazon-ecs/creating-ecs-agent-existing-vpc"
+    href="dagster-plus/deployment/agents/amazon-ecs/creating-ecs-agent-existing-vpc"
   ></ArticleListItem>
   <ArticleListItem
     title="Manually provisioning an Amazon ECS agent (Advanced)"

--- a/docs/content/dagster-plus/deployment/agents/amazon-ecs.mdx
+++ b/docs/content/dagster-plus/deployment/agents/amazon-ecs.mdx
@@ -15,7 +15,7 @@ This agent is appropriate for scaled production deployments; ECS is a good choic
   ></ArticleListItem>
   <ArticleListItem
     title="Creating an Amazon ECS agent in an existing VPC"
-    href="dagster-plus/deployment/agents/amazon-ecs/creating-ecs-agent-existing-vpc"
+    href="dagster-cloud/deployment/agents/amazon-ecs/creating-ecs-agent-existing-vpc"
   ></ArticleListItem>
   <ArticleListItem
     title="Manually provisioning an Amazon ECS agent (Advanced)"

--- a/docs/content/deployment/run-monitoring.mdx
+++ b/docs/content/deployment/run-monitoring.mdx
@@ -23,7 +23,7 @@ run_monitoring:
 
 <Note>
   In Dagster+ Run Monitoring is enabled by default and can be configured in{" "}
-  <a href="https://docs.dagster.io/dagster-plus/managing-deployments/deployment-settings-reference#dagster-deployment-settings-referenceg">
+  <a href="https://docs.dagster.io/dagster-plus/managing-deployments/deployment-settings-reference">
     deployment settings
   </a>
   .

--- a/docs/content/deployment/run-monitoring.mdx
+++ b/docs/content/deployment/run-monitoring.mdx
@@ -21,6 +21,14 @@ run_monitoring:
   poll_interval_seconds: 120
 ```
 
+<Note>
+  In Dagster+ Run Monitoring is enabled by default and can be configured in{" "}
+  <a href="https://docs.dagster.io/dagster-plus/managing-deployments/deployment-settings-reference#dagster-deployment-settings-referenceg">
+    deployment settings
+  </a>
+  .
+</Note>
+
 ## Run start timeouts
 
 When Dagster launches a run, the run stays in STARTING status until the run worker spins up and marks the run as STARTED. In the event that some failure causes the run worker to not spin up, the run might be stuck in STARTING status. The `start_timeout_seconds` offers a time limit for how long runs can hang in this state before being marked as failed.


### PR DESCRIPTION
## Summary & Motivation
Dagster+ users get confused by the instruction to enable Run Monitoring as the doc is specific to OSS.

## How I Tested These Changes
👀

## Changelog [Docs]
NOCHANGELOG
