### PR TITLE
Eliminiate combine defs

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/__init__.py
@@ -8,10 +8,7 @@ from .def_factory import (
     DefsFactory as DefsFactory,
     defs_from_factories as defs_from_factories,
 )
-from .defs_builders import (
-    combine_defs as combine_defs,
-    specs_from_task as specs_from_task,
-)
+from .defs_builders import specs_from_task as specs_from_task
 from .defs_from_airflow import (
     AirflowInstance as AirflowInstance,
     build_defs_from_airflow_instance as build_defs_from_airflow_instance,

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/defs_builders.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/defs_builders.py
@@ -1,12 +1,6 @@
 from typing import Sequence, Union
 
-from dagster import (
-    AssetChecksDefinition,
-    AssetsDefinition,
-    AssetSpec,
-    Definitions,
-    SensorDefinition,
-)
+from dagster import AssetSpec
 from dagster._core.definitions.asset_key import CoercibleToAssetKey
 from typing_extensions import TypeAlias
 
@@ -27,28 +21,3 @@ def specs_from_task(
         else AssetSpec(key=asset, tags={DAG_ID_TAG: dag_id, TASK_ID_TAG: task_id})
         for asset in assets
     ]
-
-
-def combine_defs(
-    *defs: Union[AssetChecksDefinition, AssetsDefinition, Definitions, AssetSpec, SensorDefinition],
-) -> Definitions:
-    """Combine provided :py:class:`Definitions` objects and assets into a single object, which contains all constituent definitions."""
-    assets = []
-    asset_checks = []
-    sensor_defs = []
-    for _def in defs:
-        if isinstance(_def, Definitions):
-            continue
-        elif isinstance(_def, AssetChecksDefinition):
-            asset_checks.append(_def)
-        elif isinstance(_def, (AssetsDefinition, AssetSpec)):
-            assets.append(_def)
-        elif isinstance(_def, SensorDefinition):
-            sensor_defs.append(_def)
-        else:
-            raise Exception(f"Unexpected type: {type(_def)}")
-
-    return Definitions.merge(
-        *[the_def for the_def in defs if isinstance(the_def, Definitions)],
-        Definitions(assets=assets, asset_checks=asset_checks, sensors=sensor_defs),
-    )

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
-from dagster import AssetKey, AssetSpec, Definitions, asset, asset_check, multi_asset
+from dagster import AssetKey, AssetSpec, asset, multi_asset
 from dagster._check.functions import CheckError
-from dagster_airlift.core import combine_defs, specs_from_task
+from dagster_airlift.core import specs_from_task
 from dagster_airlift.core.utils import get_dag_id_from_asset, get_task_id_from_asset
 
 
@@ -156,32 +156,3 @@ def test_specs_to_tasks() -> None:
     assert len(list(defs)) == 2
     spec = next(iter(defs))
     assert spec.tags["airlift/dag_id"] == "dag"
-
-
-def test_combine_defs() -> None:
-    """Tests functionality of combine_defs."""
-
-    @asset
-    def a():
-        pass
-
-    @asset
-    def b():
-        pass
-
-    @asset
-    def c():
-        pass
-
-    @asset_check(asset=a.key)
-    def the_check():
-        pass
-
-    b_defs = Definitions(assets=[b])
-    c_defs = Definitions(assets=[c])
-
-    defs = combine_defs(a, the_check, b_defs, c_defs)
-    assert defs.assets
-    assert len(list(defs.assets)) == 3
-    assert defs.asset_checks
-    assert len(list(defs.asset_checks)) == 1

--- a/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/complete.py
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/complete.py
@@ -1,17 +1,17 @@
-from dagster_airlift.core import combine_defs
+from dagster import Definitions
 from dagster_airlift.dbt import dbt_defs
 from dagster_dbt import DbtProject
 
 from dbt_example.dagster_defs.lakehouse import (
     defs_from_lakehouse,
-    lakehouse_existence_check,
+    lakehouse_existence_check_defs,
     specs_from_lakehouse,
 )
 from dbt_example.shared.load_iris import CSV_PATH, DB_PATH, IRIS_COLUMNS
 
 from .constants import dbt_manifest_path, dbt_project_path
 
-defs = combine_defs(
+defs = Definitions.merge(
     defs_from_lakehouse(
         specs=specs_from_lakehouse(csv_path=CSV_PATH),
         csv_path=CSV_PATH,
@@ -22,7 +22,7 @@ defs = combine_defs(
         manifest=dbt_manifest_path(),
         project=DbtProject(dbt_project_path()),
     ),
-    lakehouse_existence_check(
+    lakehouse_existence_check_defs(
         csv_path=CSV_PATH,
         duckdb_path=DB_PATH,
     ),

--- a/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/migrate.py
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/migrate.py
@@ -1,8 +1,8 @@
+from dagster._core.definitions.definitions_class import Definitions
 from dagster_airlift.core import (
     AirflowInstance,
     BasicAuthBackend,
     build_defs_from_airflow_instance,
-    combine_defs,
     dag_defs,
     task_defs,
 )
@@ -11,7 +11,7 @@ from dagster_dbt import DbtProject
 
 from dbt_example.dagster_defs.lakehouse import (
     defs_from_lakehouse,
-    lakehouse_existence_check,
+    lakehouse_existence_check_defs,
     specs_from_lakehouse,
 )
 from dbt_example.shared.load_iris import CSV_PATH, DB_PATH, IRIS_COLUMNS
@@ -35,7 +35,7 @@ airflow_instance = AirflowInstance(
 
 defs = build_defs_from_airflow_instance(
     airflow_instance=airflow_instance,
-    defs=combine_defs(
+    defs=Definitions.merge(
         dag_defs(
             "load_lakehouse",
             task_defs(
@@ -58,7 +58,7 @@ defs = build_defs_from_airflow_instance(
                 ),
             ),
         ),
-        lakehouse_existence_check(
+        lakehouse_existence_check_defs(
             csv_path=CSV_PATH,
             duckdb_path=DB_PATH,
         ),

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/definitions.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/definitions.py
@@ -5,7 +5,6 @@ from dagster_airlift.core import (
     AirflowInstance,
     BasicAuthBackend,
     build_defs_from_airflow_instance,
-    combine_defs,
     dag_defs,
     task_defs,
 )
@@ -33,39 +32,37 @@ def dbt_project_path() -> Path:
 
 defs = build_defs_from_airflow_instance(
     airflow_instance=airflow_instance,
-    defs=combine_defs(
-        dag_defs(
-            "rebuild_customers_list",
-            task_defs(
-                "load_raw_customers",
-                load_csv_to_duckdb_defs(
-                    table_name="raw_customers",
-                    csv_path=Path(__file__).parent.parent / "airflow_dags" / "raw_customers.csv",
-                    duckdb_path=Path(os.environ["AIRFLOW_HOME"]) / "jaffle_shop.duckdb",
-                    column_names=[
-                        "id",
-                        "first_name",
-                        "last_name",
-                    ],
-                    duckdb_schema="raw_data",
-                    duckdb_database_name="jaffle_shop",
-                ),
+    defs=dag_defs(
+        "rebuild_customers_list",
+        task_defs(
+            "load_raw_customers",
+            load_csv_to_duckdb_defs(
+                table_name="raw_customers",
+                csv_path=Path(__file__).parent.parent / "airflow_dags" / "raw_customers.csv",
+                duckdb_path=Path(os.environ["AIRFLOW_HOME"]) / "jaffle_shop.duckdb",
+                column_names=[
+                    "id",
+                    "first_name",
+                    "last_name",
+                ],
+                duckdb_schema="raw_data",
+                duckdb_database_name="jaffle_shop",
             ),
-            task_defs(
-                "build_dbt_models",
-                dbt_defs(
-                    manifest=dbt_project_path() / "target" / "manifest.json",
-                    project=DbtProject(dbt_project_path()),
-                ),
+        ),
+        task_defs(
+            "build_dbt_models",
+            dbt_defs(
+                manifest=dbt_project_path() / "target" / "manifest.json",
+                project=DbtProject(dbt_project_path()),
             ),
-            task_defs(
-                "export_customers",
-                export_duckdb_to_csv_defs(
-                    table_name="customers",
-                    csv_path=Path(__file__).parent.parent / "airflow_dags" / "customers.csv",
-                    duckdb_path=Path(os.environ["AIRFLOW_HOME"]) / "jaffle_shop.duckdb",
-                    duckdb_database_name="jaffle_shop",
-                ),
+        ),
+        task_defs(
+            "export_customers",
+            export_duckdb_to_csv_defs(
+                table_name="customers",
+                csv_path=Path(__file__).parent.parent / "airflow_dags" / "customers.csv",
+                duckdb_path=Path(os.environ["AIRFLOW_HOME"]) / "jaffle_shop.duckdb",
+                duckdb_database_name="jaffle_shop",
             ),
         ),
     ),


### PR DESCRIPTION
## Summary & Motivation

This eliminates `combine_defs` in airlift and instead relies on vanilla `Definitions.merge` which ends up with more clarity and less code overall. We may try a different way of "sugaring" this later, but `combine_defs` was not it.

## How I Tested These Changes

BK

## Changelog [New | Bug | Docs]

NOCHANGELOG
