### PR TITLE
Default name of dbt multi asset to build_{project_name}

### DIFF
--- a/examples/experimental/dagster-airlift/README.md
+++ b/examples/experimental/dagster-airlift/README.md
@@ -170,7 +170,6 @@ defs = build_defs_from_airflow_instance(
         task_defs(
             "build_dbt_models",
             dbt_defs(
-                name="build_dbt_models",
                 manifest=dbt_project_path() / "target" / "manifest.json",
                 project=DbtProject(dbt_project_path()),
             ),
@@ -254,7 +253,6 @@ defs = build_defs_from_airflow_instance(
         task_defs(
             "build_dbt_models",
             dbt_defs(
-                name="build_dbt_models",
                 manifest=dbt_project_path() / "target" / "manifest.json",
                 project=DbtProject(dbt_project_path()),
             ),

--- a/examples/experimental/dagster-airlift/dagster_airlift/dbt/multi_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/dbt/multi_asset.py
@@ -1,3 +1,5 @@
+from typing import Optional
+import yaml
 from dagster import AssetExecutionContext, Definitions
 from dagster_dbt import (
     DagsterDbtTranslator,
@@ -13,8 +15,17 @@ def dbt_defs(
     *,
     manifest: DbtManifestParam,
     project: DbtProject,
-    name: str,  # TODO get default name from project file
+    name: Optional[str],
 ) -> Definitions:
+    if not name:
+        with open(project.project_dir.joinpath("dbt_project.yml")) as file:
+            dbt_project_yml = yaml.safe_load(file)
+            if "name" not in dbt_project_yml:
+                raise ValueError("name not found in dbt_project.yml")
+            if not dbt_project_yml["name"]:
+                raise ValueError("name in dbt_project.yml is empty")
+            name = dbt_project_yml["name"]
+
     @dbt_assets(
         name=name,
         manifest=manifest,

--- a/examples/experimental/dagster-airlift/dagster_airlift/dbt/multi_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/dbt/multi_asset.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 import yaml
 from dagster import AssetExecutionContext, Definitions
 from dagster_dbt import (
@@ -15,7 +16,7 @@ def dbt_defs(
     *,
     manifest: DbtManifestParam,
     project: DbtProject,
-    name: Optional[str],
+    name: Optional[str] = None,
 ) -> Definitions:
     if not name:
         with open(project.project_dir.joinpath("dbt_project.yml")) as file:
@@ -24,7 +25,7 @@ def dbt_defs(
                 raise ValueError("name not found in dbt_project.yml")
             if not dbt_project_yml["name"]:
                 raise ValueError("name in dbt_project.yml is empty")
-            name = dbt_project_yml["name"]
+            name = f"build_{dbt_project_yml['name']}"
 
     @dbt_assets(
         name=name,

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_dbt_multi_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_dbt_multi_asset.py
@@ -35,7 +35,6 @@ def test_load_dbt_project(dbt_project_dir: Path, dbt_project: None) -> None:
         dbt_project_dir
     ), "Expected dbt project dir to be set as env var"
     defs = dbt_defs(
-        name="my_dbt_multi_asset",
         manifest=dbt_project_dir / "target" / "manifest.json",
         project=DbtProject(project_dir=dbt_project_dir),
     )
@@ -44,7 +43,7 @@ def test_load_dbt_project(dbt_project_dir: Path, dbt_project: None) -> None:
     assert len(all_assets) == 1
     assets_def = all_assets[0]
     assert isinstance(assets_def, AssetsDefinition)
-    assert assets_def.node_def.name == "my_dbt_multi_asset"
+    assert assets_def.node_def.name == "build_jaffle_shop"
     assert assets_def.is_executable
     specs_list = list(assets_def.specs)
     # In jaffle shop, there are 8 dbt models.

--- a/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/complete.py
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/complete.py
@@ -19,7 +19,6 @@ defs = Definitions.merge(
         columns=IRIS_COLUMNS,
     ),
     dbt_defs(
-        name="build_dbt_models",
         manifest=dbt_manifest_path(),
         project=DbtProject(dbt_project_path()),
     ),

--- a/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/migrate.py
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/migrate.py
@@ -53,7 +53,6 @@ defs = build_defs_from_airflow_instance(
             task_defs(
                 "build_dbt_models",
                 dbt_defs(
-                    name="build_dbt_models",
                     manifest=dbt_manifest_path(),
                     project=DbtProject(dbt_project_path()),
                 ),

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/definitions.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/definitions.py
@@ -52,7 +52,6 @@ defs = build_defs_from_airflow_instance(
         task_defs(
             "build_dbt_models",
             dbt_defs(
-                name="build_dbt_models",
                 manifest=dbt_project_path() / "target" / "manifest.json",
                 project=DbtProject(dbt_project_path()),
             ),


### PR DESCRIPTION
## Summary & Motivation

Make the name of the multi-asset node backing dbt_assets, by default "build_{project_name}". E.g. "build_jaffle_shop"

## How I Tested These Changes

BK

## Changelog [New | Bug | Docs]

NOCHANGELOG
