### PR TITLE
fix GrapheneAssetNode.resolve_configFields

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -686,7 +686,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         ]
 
     def resolve_configField(self, _graphene_info: ResolveInfo) -> Optional[GrapheneConfigTypeField]:
-        if self.is_executable:
+        if not self.is_executable:
             return None
         external_pipeline = self.get_external_job()
         node_def_snap = self.get_node_definition_snap()

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -264,6 +264,9 @@ GET_ASSET_IS_EXECUTABLE = """
         assetNodes(assetKeys: $assetKeys) {
             id
             isExecutable
+            configField {
+                name
+            }
         }
     }
 """


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

The test change causes a graphql test to fail until the fix is applied.

## Changelog [Bug]

Fixed a bug that caused an "Asset must be part of at least one job" error when clicking on an external asset in the asset graph UI
