### PR TITLE
[DOC-381] make titles optional in CodeExamples

### DIFF
--- a/docs/docs-beta/src/components/CodeExample.tsx
+++ b/docs/docs-beta/src/components/CodeExample.tsx
@@ -35,7 +35,7 @@ const CodeExample: React.FC<CodeExampleProps> = ({filePath, language, title}) =>
   }
 
   return (
-    <CodeBlock language={language} title={title || filePath}>
+    <CodeBlock language={language} title={title}>
       {content || 'Loading...'}
     </CodeBlock>
   );


### PR DESCRIPTION
## Summary

Addresses https://linear.app/dagster-labs/issue/DOC-381/component-make-titles-optional-in-codeexamples. This turns out to be very easy, we just don't pass the title to the underlying component :)



<img width="750" alt="Screenshot 2024-08-26 at 4 29 23 PM" src="https://github.com/user-attachments/assets/982fc148-1531-4786-b5fd-a386b1d93e03">

