### PR TITLE
Remove all type: ignores and noqa in airlift test

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_python_multi_assets.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_python_multi_assets.py
@@ -27,9 +27,9 @@ def test_python_multi_asset_factory() -> None:
         name="test_task", asset_specs=[asset_spec], python_callable=compute_fn
     )
 
-    assets = check.is_list(defs.assets, of_type=AssetsDefinition)
-    assert len(assets) == 1
-    assets_def = assets[0]
+    assets_defs = check.is_list(defs.assets, of_type=AssetsDefinition)
+    assert len(assets_defs) == 1
+    assets_def = assets_defs[0]
     assert assets_def.is_executable
     assert len(list(assets_def.specs)) == 1
     assert assets_def.node_def.name == "test_task"

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_python_multi_assets.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_python_multi_assets.py
@@ -33,7 +33,7 @@ def test_python_multi_asset_factory() -> None:
     assert assets_def.is_executable
     assert len(list(assets_def.specs)) == 1
     assert assets_def.node_def.name == "test_task"
-    spec = list(assets_def.specs)[0]  # noqa
+    spec = next(iter(assets_def.specs))
     assert spec.key == AssetKey(["my", "asset"])
     assert spec.deps == [AssetDep(asset=AssetKey(["upstream", "asset"]))]
     result = defs.get_implicit_global_asset_job_def().execute_in_process()

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_python_multi_assets.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_python_multi_assets.py
@@ -1,4 +1,10 @@
-from dagster import AssetDep, AssetKey, AssetsDefinition, AssetSpec
+from dagster import (
+    AssetDep,
+    AssetKey,
+    AssetsDefinition,
+    AssetSpec,
+    _check as check,
+)
 from dagster_airlift.core.python_callable import defs_for_python_callable
 
 from dagster_airlift_tests.unit_tests.multi_asset_python import compute_fn
@@ -21,10 +27,11 @@ def test_python_multi_asset_factory() -> None:
         name="test_task", asset_specs=[asset_spec], python_callable=compute_fn
     )
 
-    assert len(defs.assets) == 1  # type: ignore
-    assets_def: AssetsDefinition = defs.assets[0]  # type: ignore
+    assets = check.is_list(defs.assets, of_type=AssetsDefinition)
+    assert len(assets) == 1
+    assets_def: AssetsDefinition = assets[0]
     assert assets_def.is_executable
-    assert len(assets_def.specs) == 1  # type: ignore
+    assert len(list(assets_def.specs)) == 1
     assert assets_def.node_def.name == "test_task"
     spec = list(assets_def.specs)[0]  # noqa
     assert spec.key == AssetKey(["my", "asset"])

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_python_multi_assets.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_python_multi_assets.py
@@ -29,7 +29,7 @@ def test_python_multi_asset_factory() -> None:
 
     assets = check.is_list(defs.assets, of_type=AssetsDefinition)
     assert len(assets) == 1
-    assets_def: AssetsDefinition = assets[0]
+    assets_def = assets[0]
     assert assets_def.is_executable
     assert len(list(assets_def.specs)) == 1
     assert assets_def.node_def.name == "test_task"


### PR DESCRIPTION
## Summary & Motivation

Improving the test logic here so that `noqa` and `type: ignore` are not required.

## How I Tested These Changes

BK

## Changelog [New | Bug | Docs]

NOCHANGELOG