### PR TITLE
[DOCS-423] Fix `make quick_pyright` when editing docs

### DIFF
--- a/examples/docs_beta_snippets/setup.py
+++ b/examples/docs_beta_snippets/setup.py
@@ -15,9 +15,5 @@ setup(
     ],
     packages=find_packages(exclude=["test"]),
     install_requires=["dagster-cloud"],
-    extras_require={
-        "test": [
-            "pytest",
-        ]
-    },
+    extras_require={"test": ["pytest"]},
 )

--- a/scripts/run-pyright.py
+++ b/scripts/run-pyright.py
@@ -260,17 +260,16 @@ def map_paths_to_envs(paths: Sequence[str]) -> Mapping[str, Sequence[str]]:
     env_path_map: Dict[str, List[str]] = {}
     for path in paths:
         if os.path.isdir(path) or os.path.splitext(path)[1] in [".py", ".pyi"]:
-            try:
-                env = next(
-                    (
-                        env_path_spec["env"]
-                        for env_path_spec in env_path_specs
-                        if match_path(path, env_path_spec)
-                    )
-                )
-            except StopIteration:
-                raise Exception(f"Could not find environment that matched path: {path}.")
-            env_path_map.setdefault(env, []).append(path)
+            env = next(
+                (
+                    env_path_spec["env"]
+                    for env_path_spec in env_path_specs
+                    if match_path(path, env_path_spec)
+                ),
+                None,
+            )
+            if env:
+                env_path_map.setdefault(env, []).append(path)
     return env_path_map
 
 


### PR DESCRIPTION
## Summary & Motivation

As title -- this makes precommit hooks work when modifying things in the docs_beta_snippets directory (which is explicitly excluded from pyright as it requires dagster-cloud). It's totally expected in some cases for there to be no environment which maps to a particular file, in the case where we are explicitly excluding that file's directory from type checking.

Note that the function I modified is only used in the quick_pyright script not the full pyright build that we run in CI, so this leniancy will not impact the overall correctness of anything, it's just a matter of avoiding local errors.

## How I Tested These Changes

## Changelog [New | Bug | Docs]

NOCHANGELOG
