### PR TITLE
Adding makefile for tutorial

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -366,6 +366,12 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             AvailablePythonVersion.V3_12,
         ],
     ),
+    PackageSpec(
+        "examples/experimental/dagster-airlift/examples/tutorial-example",
+        unsupported_python_versions=[
+            AvailablePythonVersion.V3_12,
+        ],
+    ),
 ]
 
 

--- a/examples/experimental/dagster-airlift/README.md
+++ b/examples/experimental/dagster-airlift/README.md
@@ -38,6 +38,28 @@ Airlift depends on the the availability of Airflow’s REST API. Airflow’s RES
 
 In the below guide, we'll be working with a sample project, found in [`examples/tutorial-example`](./examples/tutorial-example/).
 
+## Running airflow locally
+
+The tutorial example involves running a local airflow instance. This can be done by running the following commands from the root of the `examples/tutorial-example` directory.
+
+```bash
+make airflow_install
+```
+
+This command installs python packages required for running airflow.
+
+```bash
+make airflow_setup
+```
+
+This command scaffolds a local installation of airflow (setting AIRFLOW_HOME env var), and sets up a dbt project.
+
+```bash
+make airflow_run
+```
+
+Which runs `airflow standalone` with required env vars set.
+
 ## Peering
 
 The first step is to peer the Dagster code location and the Airflow instance, which will create an asset representation of each of your Airflow DAGs in Dagster. This process does not require any changes to your Airflow instance.

--- a/examples/experimental/dagster-airlift/dagster_airlift/migration_state.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/migration_state.py
@@ -54,14 +54,16 @@ class AirflowMigrationState(NamedTuple):
     def dag_has_migration_state(self, dag_id: str) -> bool:
         return self.get_migration_dict_for_dag(dag_id) is not None
 
-    def get_migration_dict_for_dag(self, dag_id: str) -> Optional[Dict[str, Dict[str, Any]]]:
+    def get_migration_dict_for_dag(
+        self, dag_id: str
+    ) -> Optional[Dict[str, Sequence[Dict[str, Any]]]]:
         if dag_id not in self.dags:
             return None
         return {
-            "tasks": {
-                task_id: {"migrated": task_state.migrated}
+            "tasks": [
+                {"migrated": task_state.migrated, "id": task_id}
                 for task_id, task_state in self.dags[dag_id].tasks.items()
-            }
+            ]
         }
 
 

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_migrating_dag_correctly_marked.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_migrating_dag_correctly_marked.py
@@ -32,10 +32,8 @@ def test_migrating_dag(airflow_instance: None) -> None:
     assert len(tags) == 1
     assert json.loads(tags[0]["name"]) == {
         "DAGSTER_MIGRATION_STATUS": {
-            "tasks": {
-                "print_task": {
-                    "migrated": False,
-                }
-            }
+            "tasks": [
+                {"id": "print_task", "migrated": False},
+            ]
         }
     }

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_migration_state.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_migration_state.py
@@ -1,7 +1,7 @@
-import yaml
 from pathlib import Path
 
 import pytest
+import yaml
 from dagster_airlift.core import load_migration_state_from_yaml
 from dagster_airlift.migration_state import (
     AirflowMigrationState,

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_migration_state.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_migration_state.py
@@ -1,3 +1,4 @@
+import yaml
 from pathlib import Path
 
 import pytest
@@ -40,3 +41,20 @@ def test_migration_state() -> None:
         incorrect_migration_file = Path(__file__).parent / "migration_state_yamls" / incorrect_dir
         with pytest.raises(MigrationStateParsingError, match="Error parsing migration yaml"):
             load_migration_state_from_yaml(incorrect_migration_file)
+
+
+def test_migration_state_from_yaml() -> None:
+    migration_dict = yaml.safe_load("""
+tasks:
+  - id: load_raw_customers
+    migrated: False
+  - id: build_dbt_models
+    migrated: False
+  - id: export_customers
+    migrated: True 
+ """)
+
+    migration_state = DagMigrationState.from_dict(migration_dict)
+    assert migration_state.is_task_migrated("load_raw_customers") is False
+    assert migration_state.is_task_migrated("build_dbt_models") is False
+    assert migration_state.is_task_migrated("export_customers") is True

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/Makefile
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/Makefile
@@ -14,32 +14,27 @@ export DAGSTER_URL := http://localhost:3333
 help:
 	@egrep -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-dbt_setup: ## Initialize dbt project
-	dbt seed
 
-dev_install:
+### TUTORIAL COMMANDS ###
+wipe: ## Wipe out all the files created by the Makefile
+	rm -rf $$AIRFLOW_HOME $$DAGSTER_HOME
+
+
+airflow_install:
 	pip install uv && \
-	uv pip install -e ../../../dagster-airlift
-	uv pip install -e .
+	uv pip install dagster-airlift[in-airflow] && \
+	uv pip install -e $(MAKEFILE_DIR)
 
-# make airflow home and dagster home directories within current directory, set up env vars, and then
-# set up airflow environment.
-setup_local_env:
+airflow_setup:
 	make wipe && \
 	mkdir -p $$AIRFLOW_HOME && \
 	mkdir -p $$DAGSTER_HOME && \
 	chmod +x ../../airflow_setup.sh && \
 	../../airflow_setup.sh $(MAKEFILE_DIR)/tutorial_example/airflow_dags && \
-	make dbt_setup
+	dbt seed
 
-run_airflow:
+airflow_run:
 	airflow standalone
 
-run_dagster_dev:
-	dagster dev -m tutorial_example.dagster_defs -p 3333
-
-wipe: ## Wipe out all the files created by the Makefile
-	rm -rf $$AIRFLOW_HOME $$DAGSTER_HOME
-
-wipe_dagster: ## Wipe out all the files created by the Makefile
-	rm -rf $$DAGSTER_HOME
+dagster_run:
+	dagster dev -m tutorial_example.dagster_defs.definitions -p 3333

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/airflow_dags/migration_state/rebuild_customers_list.yaml
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/airflow_dags/migration_state/rebuild_customers_list.yaml
@@ -1,7 +1,7 @@
-tasks:
-  load_raw_customers:
+  tasks:
+  - id: load_raw_customers
     migrated: False
-  build_dbt_models:
+  - id: build_dbt_models
     migrated: False
-  export_customers:
+  - id: export_customers
     migrated: False

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/conftest.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/conftest.py
@@ -10,7 +10,7 @@ from dagster._core.test_utils import environ
 @pytest.fixture(name="local_env")
 def local_env_fixture() -> Generator[None, None, None]:
     makefile_dir = Path(__file__).parent.parent
-    subprocess.run(["make", "setup_local_env"], cwd=makefile_dir, check=True)
+    subprocess.run(["make", "airflow_setup"], cwd=makefile_dir, check=True)
     with environ(
         {
             "AIRFLOW_HOME": str(makefile_dir / ".airflow_home"),


### PR DESCRIPTION
## Summary & Motivation

Adapted from https://github.com/dagster-io/dagster/pull/23944

This represents the minimal set of changes necessary to get tests working and the tutorial up and running.

* Adding tutorial-examples to the overall test suite.
* Adds local airflow setup to the README.md
* Updates makefile for the local airflow setup
* Fixes migration state format

## How I Tested These Changes

Manual spinup of tutorial-example. BK.

## Changelog [New | Bug | Docs]

NOCHANGELOG
