### PR TITLE
Fix filesystem observer on watchdog 5.0

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/consolidated_sqlite_event_log.py
@@ -139,7 +139,7 @@ class ConsolidatedSqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
             self._obs = Observer()
             self._obs.start()
             self._obs.schedule(
-                ConsolidatedSqliteEventLogStorageWatchdog(self), self._base_dir, True
+                ConsolidatedSqliteEventLogStorageWatchdog(self), self._base_dir, recursive=True
             )
 
         self._watchers[run_id][callback] = cursor

--- a/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/sqlite/sqlite_event_log.py
@@ -471,7 +471,7 @@ class SqliteEventLogStorage(SqlEventLogStorage, ConfigurableClass):
         watchdog = SqliteEventLogStorageWatchdog(self, run_id, callback, cursor)
         self._watchers[run_id][callback] = (
             watchdog,
-            self._obs.schedule(watchdog, self._base_dir, True),
+            self._obs.schedule(watchdog, self._base_dir, recursive=True),
         )
 
     def end_watch(self, run_id: str, handler: EventHandlerFn) -> None:

--- a/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
+++ b/python_modules/dagster/dagster/_core/storage/local_compute_log_manager.py
@@ -321,7 +321,7 @@ class LocalComputeLogSubscriptionManager:
         )
 
         if not self._observer:
-            self._observer = PollingObserver(self._manager.polling_timeout)
+            self._observer = PollingObserver(timeout=self._manager.polling_timeout)
             self._observer.start()
 
         ensure_dir(directory)


### PR DESCRIPTION
Summary:
This was changed to a kwarg in watchdog 5.0 instead of a positional arg. Resolves https://github.com/dagster-io/dagster/issues/23957.

Test Plan:
View run logs streaming in on watchdog 5.0 and <5.0

## Summary & Motivation

## How I Tested These Changes

## Changelog [Bug]

Fixed an issue where viewing run logs with the latest 5.0 release of the watchdog package raised an exception.
