### PR TITLE
Extract dags_def construction into separate file, write tests, and fix bugs

### DIFF
--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/build_dag_defs.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/build_dag_defs.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from dagster import Definitions
+from dagster_airlift.core import dag_defs, task_defs
+from dagster_airlift.dbt import dbt_defs
+from dagster_dbt import DbtProject
+
+from tutorial_example.dagster_defs.csv_to_duckdb_defs import load_csv_to_duckdb_defs
+
+from .duckdb_to_csv_defs import export_duckdb_to_csv_defs
+
+
+def build_dag_defs(dbt_project_path: Path, duckdb_path: Path) -> Definitions:
+    return dag_defs(
+        "rebuild_customers_list",
+        task_defs(
+            "load_raw_customers",
+            load_csv_to_duckdb_defs(
+                table_name="raw_customers",
+                csv_path=Path(__file__).parent.parent / "airflow_dags" / "raw_customers.csv",
+                duckdb_path=duckdb_path,
+                column_names=[
+                    "id",
+                    "first_name",
+                    "last_name",
+                ],
+                duckdb_schema="raw_data",
+                duckdb_database_name="jaffle_shop",
+            ),
+        ),
+        task_defs(
+            "build_dbt_models",
+            dbt_defs(
+                manifest=dbt_project_path / "target" / "manifest.json",
+                project=DbtProject(dbt_project_path),
+            ),
+        ),
+        task_defs(
+            "export_customers",
+            export_duckdb_to_csv_defs(
+                table_name="customers",
+                csv_path=Path(__file__).parent.parent / "airflow_dags" / "customers.csv",
+                duckdb_path=duckdb_path,
+                duckdb_database_name="jaffle_shop",
+            ),
+        ),
+    )

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/csv_to_duckdb_defs.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/csv_to_duckdb_defs.py
@@ -14,7 +14,10 @@ def load_csv_to_duckdb_defs(
     duckdb_schema: str,
     duckdb_database_name: str,
 ) -> Definitions:
-    @multi_asset(specs=[AssetSpec(key=AssetKey([duckdb_schema, table_name]))])
+    @multi_asset(
+        name=f"load_csv_to_duckdb_{table_name}",
+        specs=[AssetSpec(key=AssetKey([duckdb_schema, table_name]))],
+    )
     def _multi_asset() -> None:
         load_csv_to_duckdb(
             table_name=table_name,

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/definitions.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/definitions.py
@@ -1,20 +1,10 @@
 import os
 from pathlib import Path
 
-from dagster_airlift.core import (
-    AirflowInstance,
-    BasicAuthBackend,
-    build_defs_from_airflow_instance,
-    dag_defs,
-    task_defs,
-)
-from dagster_airlift.dbt import dbt_defs
-from dagster_dbt import DbtProject
+from dagster_airlift.core import AirflowInstance, BasicAuthBackend, build_defs_from_airflow_instance
 
-from tutorial_example.dagster_defs.csv_to_duckdb_defs import load_csv_to_duckdb_defs
-
+from .build_dag_defs import build_dag_defs
 from .constants import AIRFLOW_BASE_URL, AIRFLOW_INSTANCE_NAME, PASSWORD, USERNAME
-from .duckdb_to_csv_defs import export_duckdb_to_csv_defs
 
 airflow_instance = AirflowInstance(
     auth_backend=BasicAuthBackend(
@@ -32,38 +22,8 @@ def dbt_project_path() -> Path:
 
 defs = build_defs_from_airflow_instance(
     airflow_instance=airflow_instance,
-    defs=dag_defs(
-        "rebuild_customers_list",
-        task_defs(
-            "load_raw_customers",
-            load_csv_to_duckdb_defs(
-                table_name="raw_customers",
-                csv_path=Path(__file__).parent.parent / "airflow_dags" / "raw_customers.csv",
-                duckdb_path=Path(os.environ["AIRFLOW_HOME"]) / "jaffle_shop.duckdb",
-                column_names=[
-                    "id",
-                    "first_name",
-                    "last_name",
-                ],
-                duckdb_schema="raw_data",
-                duckdb_database_name="jaffle_shop",
-            ),
-        ),
-        task_defs(
-            "build_dbt_models",
-            dbt_defs(
-                manifest=dbt_project_path() / "target" / "manifest.json",
-                project=DbtProject(dbt_project_path()),
-            ),
-        ),
-        task_defs(
-            "export_customers",
-            export_duckdb_to_csv_defs(
-                table_name="customers",
-                csv_path=Path(__file__).parent.parent / "airflow_dags" / "customers.csv",
-                duckdb_path=Path(os.environ["AIRFLOW_HOME"]) / "jaffle_shop.duckdb",
-                duckdb_database_name="jaffle_shop",
-            ),
-        ),
+    defs=build_dag_defs(
+        dbt_project_path=dbt_project_path(),
+        duckdb_path=Path(os.environ["AIRFLOW_HOME"]) / "jaffle_shop.duckdb",
     ),
 )

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/duckdb_to_csv_defs.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/duckdb_to_csv_defs.py
@@ -20,6 +20,7 @@ def export_duckdb_to_csv_defs(
     )
 
     @multi_asset(
+        name=f"export_duckdb_to_csv_{table_name}",
         specs=[
             AssetSpec(
                 key=AssetKey([csv_path.name.replace(".", "_")]),

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/unit_tests/test_build_dag_defs.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/unit_tests/test_build_dag_defs.py
@@ -15,7 +15,7 @@ def dummy_duck_db_path() -> Path:
 def test_dag_defs_construction_and_node_defs() -> None:
     defs = build_dag_defs(
         dbt_project_path=example_root() / "tutorial_example" / "shared" / "dbt",
-        # not invoked during
+        # not invoked during construction of defs so dummy is ok
         duckdb_path=dummy_duck_db_path(),
     )
     assert isinstance(defs, Definitions)

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/unit_tests/test_duckdb_to_csv_defs.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/unit_tests/test_duckdb_to_csv_defs.py
@@ -1,5 +1,31 @@
-from tutorial_example.dagster_defs.duckdb_to_csv_defs import export_duckdb_to_csv_defs
+from pathlib import Path
+
+from dagster import Definitions
+from tutorial_example.dagster_defs.build_dag_defs import build_dag_defs
 
 
-def test_inclusion() -> None:
-    assert export_duckdb_to_csv_defs
+def example_root() -> Path:
+    return Path(__file__).parent.parent.parent
+
+
+def dummy_duck_db_path() -> Path:
+    return Path(__file__).parent / "does_not_exist.duckdb"
+
+
+def test_dag_defs_construction_and_node_defs() -> None:
+    defs = build_dag_defs(
+        dbt_project_path=example_root() / "tutorial_example" / "shared" / "dbt",
+        # not invoked during
+        duckdb_path=dummy_duck_db_path(),
+    )
+    assert isinstance(defs, Definitions)
+    Definitions.validate_loadable(defs)
+
+    load_raw_customers = defs.get_assets_def(["raw_data", "raw_customers"])
+    assert load_raw_customers.node_def.name == "load_csv_to_duckdb_raw_customers"
+
+    customers_csv = defs.get_assets_def(["customers_csv"])
+    assert customers_csv.node_def.name == "export_duckdb_to_csv_customers"
+
+    customers = defs.get_assets_def(["customers"])
+    assert customers.node_def.name == "build_jaffle_shop"


### PR DESCRIPTION
## Summary & Motivation

Takes advantage of new unit tests with fast feedback loops direction to create defs in isolated environment.

Without unique node names was getting this mystifying error:

```
E                       dagster._core.errors.DagsterInvalidDefinitionError: Invalid dependencies: node "_multi_asset_2" does not have output "raw_data__raw_customers". Listed as dependency for node "build_jaffle_shop input "raw_data_raw_customers"
```

This fixes that and provides convenient op names.

## How I Tested These Changes

BK

## Changelog [New | Bug | Docs]

NOCHANGELOG
