### PR TITLE
[docathon] include http header x-robots-tag noindex for production de…

### DIFF
--- a/docs/docs-beta/vercel.json
+++ b/docs/docs-beta/vercel.json
@@ -1,0 +1,13 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "x-robots-tag",
+          "value": "noindex"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
…ployment

## Summary & Motivation

- Avoid indexing of beta docs

🤞 that Vercel will auto-magically pick up the configuration at this location.

References

- https://vercel.com/docs/edge-network/headers#x-robots-tag
- https://vercel.com/docs/projects/project-configuration#headers

## Changelog [New | Bug | Docs]

NOCHANGELOG