### PR TITLE
Support SourceAsset in dag_defs

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/dag_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/dag_defs.py
@@ -7,6 +7,7 @@ from dagster import (
     _check as check,
 )
 from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
+from dagster._core.definitions.source_asset import SourceAsset
 
 from dagster_airlift.core.utils import DAG_ID_TAG, TASK_ID_TAG
 
@@ -21,20 +22,7 @@ class TaskDefs:
 
 def apply_tags_to_all_specs(defs: Definitions, tags: Dict[str, str]) -> Definitions:
     return Definitions(
-        assets=[
-            # Right now we make assumptions that we only support AssetSpec and AssetsDefinition
-            # in orchesrated_defs.
-            # https://linear.app/dagster-labs/issue/FOU-369/support-cacheableassetsdefinition-and-sourceasset-in-airlift
-            assets_def_with_af_tags(
-                check.inst(
-                    asset,
-                    (AssetSpec, AssetsDefinition, CacheableAssetsDefinition),
-                    "Only supports AssetSpec and AssetsDefinition right now",
-                ),
-                tags,
-            )
-            for asset in (defs.assets or [])
-        ],
+        assets=[assets_def_with_af_tags(asset, tags) for asset in (defs.assets or [])],
         resources=defs.resources,
         sensors=defs.sensors,
         schedules=defs.schedules,
@@ -45,16 +33,35 @@ def apply_tags_to_all_specs(defs: Definitions, tags: Dict[str, str]) -> Definiti
     )
 
 
+def source_asset_with_tags(source_asset: SourceAsset, tags: Mapping[str, str]) -> SourceAsset:
+    return SourceAsset(
+        key=source_asset.key,
+        metadata=source_asset.raw_metadata,
+        io_manager_key=source_asset.io_manager_key,
+        io_manager_def=source_asset.io_manager_def,
+        description=source_asset.description,
+        partitions_def=source_asset.partitions_def,
+        group_name=source_asset.group_name,
+        resource_defs=source_asset.resource_defs,
+        observe_fn=source_asset.observe_fn,
+        auto_observe_interval_minutes=source_asset.auto_observe_interval_minutes,
+        tags={**(source_asset.tags or {}), **tags},
+        _required_resource_keys=source_asset._required_resource_keys,  # noqa
+    )
+
+
 def assets_def_with_af_tags(
-    assets_def: Union[AssetsDefinition, AssetSpec, CacheableAssetsDefinition],
+    assets_def: Union[AssetsDefinition, AssetSpec, CacheableAssetsDefinition, SourceAsset],
     tags: Mapping[str, str],
-) -> Union[AssetsDefinition, AssetSpec, CacheableAssetsDefinition]:
+) -> Union[AssetsDefinition, AssetSpec, CacheableAssetsDefinition, SourceAsset]:
     if isinstance(assets_def, AssetSpec):
         return spec_with_tags(assets_def, tags)
     if isinstance(assets_def, AssetsDefinition):
         return assets_def.map_asset_specs(lambda spec: spec_with_tags(spec, tags))
     if isinstance(assets_def, CacheableAssetsDefinition):
         return SpecWithTagsCacheableAssetsDefinition(assets_def, tags)
+    if isinstance(assets_def, SourceAsset):
+        return source_asset_with_tags(assets_def, tags)
 
     check.failed(f"Unexpected type {type(assets_def)}")
 

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_dag_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_dag_defs.py
@@ -7,6 +7,7 @@ from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
     CacheableAssetsDefinition,
 )
+from dagster._core.definitions.source_asset import SourceAsset
 from dagster_airlift.core import dag_defs, task_defs
 from dagster_airlift.core.utils import DAG_ID_TAG, TASK_ID_TAG
 
@@ -105,4 +106,19 @@ def test_dag_defs_cacheable_assets() -> None:
     assert assets_def_asset_2.specs_by_key[AssetKey("asset_2")].tags == {
         "airlift/dag_id": "dag1",
         "airlift/task_id": "task2",
+    }
+
+
+def test_dag_defs_source_asset() -> None:
+    defs = dag_defs(
+        "dag1",
+        task_defs("task1", Definitions(assets=[SourceAsset("asset_1")])),
+    )
+
+    assets_def_asset_1 = defs.get_asset_graph().assets_def_for_key(AssetKey("asset_1"))
+    assert isinstance(assets_def_asset_1, AssetsDefinition)
+    assert assets_def_asset_1.key == AssetKey("asset_1")
+    assert assets_def_asset_1.specs_by_key[AssetKey("asset_1")].tags == {
+        "airlift/dag_id": "dag1",
+        "airlift/task_id": "task1",
     }


### PR DESCRIPTION
## Summary & Motivation

We want to support all the asset types in `dag_defs` without changing core dagster. Unfortunately SourceAssets are not easily copyable, so I went through the external assets factory method and and then cycled back to an AssetSpec.

## How I Tested These Changes

BK

## Changelog [New | Bug | Docs]

NOCHANGELOG
