### PR TITLE
[ui] Try to guard against history loop in useQueryPersistedState

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryPersistedState.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryPersistedState.tsx
@@ -5,6 +5,7 @@ import {useCallback, useMemo, useRef} from 'react';
 import {useHistory, useLocation} from 'react-router-dom';
 
 import {useSetStateUpdateCallback} from './useSetStateUpdateCallback';
+import {COMMON_COLLATOR} from '../app/Util';
 
 export type QueryPersistedDataType =
   | {[key: string]: any}
@@ -107,9 +108,12 @@ export function useQueryPersistedState<T extends QueryPersistedDataType>(
         }
       }
 
-      currentQueryString = next;
-
-      history.replace(`${location.pathname}?${qs.stringify(next, {arrayFormat: 'brackets'})}`);
+      // Check if the query has changed. If so, perform a replace. Otherwise, do nothing
+      // to ensure that we don't end up in a `replace` loop.
+      if (!areQueriesEqual(currentQueryString, next)) {
+        currentQueryString = next;
+        history.replace(`${location.pathname}?${qs.stringify(next, {arrayFormat: 'brackets'})}`);
+      }
     },
     [history, encode, location.pathname, options],
   );
@@ -118,6 +122,20 @@ export function useQueryPersistedState<T extends QueryPersistedDataType>(
     valueRef.current = qsDecoded;
   }
   return [valueRef.current, useSetStateUpdateCallback(valueRef.current, onChangeRef)];
+}
+
+// Stringify two query objects to check whether they have the same value. Explicitly sort the
+// keys, since key order is otherwise undefined.
+function areQueriesEqual(queryA: {[key: string]: any}, queryB: {[key: string]: any}) {
+  const stringA = qs.stringify(queryA, {
+    arrayFormat: 'brackets',
+    sort: (a, b) => COMMON_COLLATOR.compare(a, b),
+  });
+  const stringB = qs.stringify(queryB, {
+    arrayFormat: 'brackets',
+    sort: (a, b) => COMMON_COLLATOR.compare(a, b),
+  });
+  return stringA === stringB;
 }
 
 function inferTypeOfQueryParam<T>(q: any): T {


### PR DESCRIPTION
## Summary & Motivation

Try to avoid the `history.replace` loop in `useQueryPersistedState` by bailing out if the query is unchanged.

I think we're ending up in a situation where URL querystring updates are triggering effects that lead to querystring updates, but without any actual changes to the query values. With no guard in place to ensure that we don't hammer `history.replace`, we just keep calling it. This can lead to an error when fires too much, which can kill the page.

Instead, just skip the `history.replace` call if the previous query and new query are the same. This is done with a `qs.stringify()` comparison.

## How I Tested These Changes

View Insights, with lots of query params in the URL. Verify that when I change filters, even though the change handler fires a lot, `history.replace` only fires once.

## Changelog [New | Bug | Docs]

Bug:

[ui] Prevent excessive `history.replaceState()` calls when viewing pages with filters.
