### PR TITLE
Check-in minor repo of resource issue and mark suspect code

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_cacheable_assets_def.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_cacheable_assets_def.py
@@ -396,6 +396,8 @@ def construct_assets_with_task_migration_info_applied(
                 asset.is_executable,
                 f"For an asset to be marked as migrated, it must also be executable in dagster. Found unexecutable assets for task ID {task_id}.",
             )
+            # This is suspect. Should we not be using a full AssetsDefinition copy here.
+            # https://linear.app/dagster-labs/issue/FOU-372/investigate-suspect-code-in-construct-assets-with-task-migration-info
             new_assets_defs.append(
                 AssetsDefinition(
                     keys_by_input_name=asset.keys_by_input_name,

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/defs_from_airflow.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/defs_from_airflow.py
@@ -3,6 +3,7 @@ from typing import Optional
 from dagster import Definitions
 
 from dagster_airlift.core.sensor import build_airflow_polling_sensor
+from dagster_airlift.migration_state import AirflowMigrationState
 
 from ..migration_state import AirflowMigrationState
 from .airflow_cacheable_assets_def import DEFAULT_POLL_INTERVAL, AirflowCacheableAssetsDefinition
@@ -56,4 +57,5 @@ def build_defs_from_airflow_instance(
         jobs=defs.jobs if defs else None,
         executor=defs.executor if defs else None,
         loggers=defs.loggers if defs else None,
+        resources=defs.resources if defs else None,
     )

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/defs_from_airflow.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/defs_from_airflow.py
@@ -5,7 +5,6 @@ from dagster import Definitions
 from dagster_airlift.core.sensor import build_airflow_polling_sensor
 from dagster_airlift.migration_state import AirflowMigrationState
 
-from ..migration_state import AirflowMigrationState
 from .airflow_cacheable_assets_def import DEFAULT_POLL_INTERVAL, AirflowCacheableAssetsDefinition
 from .airflow_instance import AirflowInstance
 
@@ -46,9 +45,7 @@ def build_defs_from_airflow_instance(
         migration_state_override=migration_state_override,
     )
     # Now, we construct the sensor that will poll airflow for dag runs.
-    airflow_sensor = build_airflow_polling_sensor(
-        airflow_instance=airflow_instance,
-    )
+    airflow_sensor = build_airflow_polling_sensor(airflow_instance=airflow_instance)
     return Definitions(
         assets=[assets_defs],
         asset_checks=defs.asset_checks if defs else None,

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_dbt_defs_migrated.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_dbt_defs_migrated.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+from typing import List
+
+from dagster._core.definitions.definitions_class import Definitions
+from dagster_airlift.core.airflow_instance import DagInfo
+from dagster_airlift.core.dag_defs import dag_defs, task_defs
+from dagster_airlift.core.defs_from_airflow import build_defs_from_airflow_instance
+from dagster_airlift.dbt import dbt_defs
+from dagster_airlift.migration_state import (
+    AirflowMigrationState,
+    DagMigrationState,
+    TaskMigrationState,
+)
+from dagster_dbt.dbt_project import DbtProject
+
+from .conftest import make_test_instance
+
+
+def get_dbt_project_path() -> Path:
+    return Path(__file__).parent.parent / "integration_tests" / "dbt_project"
+
+
+def dummy_defs() -> Definitions:
+    return Definitions()
+
+
+def test_dbt_defs() -> None:
+    dbt_project_path = get_dbt_project_path()
+
+    dbt_defs_inst = dbt_defs(
+        manifest=dbt_project_path / "target" / "manifest.json",
+        project=DbtProject(dbt_project_path),
+    )
+
+    assert isinstance(dbt_defs_inst, Definitions)
+
+    def list_dags(self) -> List[DagInfo]:
+        return [
+            DagInfo(
+                webserver_url="http://localhost:8080",
+                dag_id="dag_one",
+                metadata={"file_token": "blah"},
+            ),
+            DagInfo(
+                webserver_url="http://localhost:8080",
+                dag_id="dag_two",
+                metadata={"file_token": "blah"},
+            ),
+        ]
+
+    test_airflow_instance = make_test_instance(list_dags_override=list_dags)
+
+    initial_defs = Definitions.merge(
+        dag_defs(
+            "dag_one",
+            task_defs("task_one", dbt_defs_inst),
+        ),
+        dag_defs(
+            "dag_two",
+            task_defs("task_two", dummy_defs()),
+        ),
+    )
+
+    assert set((initial_defs.resources or {}).keys()) == {"dbt"}
+
+    defs = build_defs_from_airflow_instance(
+        airflow_instance=test_airflow_instance,
+        defs=initial_defs,
+        migration_state_override=AirflowMigrationState(
+            {
+                "dag_one": DagMigrationState(
+                    {"task_one": TaskMigrationState("task_one", migrated=True)}
+                )
+            }
+        ),
+    )
+
+    assert isinstance(defs, Definitions)
+
+    Definitions.validate_loadable(defs)
+
+    assert set(defs.get_repository_def().get_top_level_resources().keys()) == {"dbt"}

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_load_dagster.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_load_dagster.py
@@ -1,4 +1,9 @@
+from dagster._core.definitions.definitions_class import Definitions
+
+
 def test_defs_loads(airflow_instance) -> None:
     from tutorial_example.dagster_defs.definitions import defs
 
     assert defs
+
+    Definitions.validate_loadable(defs)


### PR DESCRIPTION
## Summary & Motivation

We were not copied resources during the manual merge rountine in `build_defs_from_airflow_instance`. This fixes that a provides a minimal repro in a unit test environment. Also flagged another potential problematic miscopy and tracked in https://linear.app/dagster-labs/issue/FOU-372/investigate-suspect-code-in-construct-assets-with-task-migration-info.

## How I Tested These Changes

Ran

```python

import os
from pathlib import Path

from dagster import AssetSpec, Definitions
from dagster_airlift.core import (
    AirflowInstance,
    BasicAuthBackend,
    build_defs_from_airflow_instance,
    dag_defs,
    task_defs,
)
from dagster_airlift.dbt import dbt_defs
from dagster_dbt import DbtProject


def dbt_project_path() -> Path:
    env_val = os.getenv("DBT_PROJECT_DIR")
    assert env_val
    return Path(env_val)


def rebuild_customer_list_defs() -> Definitions:
    return dag_defs(
        "rebuild_customers_list",
        task_defs(
            "load_raw_customers",
            Definitions(
                assets=[
                    AssetSpec(key=["raw_data", "raw_customers"]),
                ]
            ),
        ),
        task_defs(
            "build_dbt_models",
            # load rich set of assets from dbt project
            dbt_defs(
                manifest=dbt_project_path() / "target" / "manifest.json",
                project=DbtProject(dbt_project_path()),
            ),
        ),
        task_defs(
            "export_customers",
            Definitions(
                assets=[
                    # encode dependency on customers output
                    AssetSpec(key="customers_csv", deps=["customers"]),
                ]
            ),
        ),
    )


defs = build_defs_from_airflow_instance(
    airflow_instance=AirflowInstance(
        auth_backend=BasicAuthBackend(
            webserver_url="http://localhost:8080",
            username="admin",
            password="admin",
        ),
        name="airflow_instance_one",
    ),
    defs=rebuild_customer_list_defs(),
)
```

Against the tutorial. Saw error without fix applied. Applied fix. It was fine.

Also BK

## Changelog [New | Bug | Docs]

NOCHANGELOG
