### PR TITLE
Add grpcio pin in dagster-dbt

### DIFF
--- a/python_modules/libraries/dagster-dbt/setup.py
+++ b/python_modules/libraries/dagster-dbt/setup.py
@@ -52,6 +52,11 @@ setup(
         "sqlglot[rs]",
         "typer>=0.9.0",
         "packaging",
+        # Require grpcio<1.65.0 to avoid conflicts with grpcio-health-checking==1.64.3 installed by this library.
+        # See in https://github.com/dagster-io/dagster/issues/23854
+        "grpcio<1.65.0",
+        # Add pin to grpcio-health-checking as a safety net.
+        "grpcio-health-checking<1.65.0",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
## Summary & Motivation

This PR pins `grpcio<1.65.0` in `dagster-dbt` to fix issue #23854. Also pins `grpcio-health-checking` as a safety net in the future.

Without this change, `grpcio==1.66.0` and `grpcio-health-checking==1.62.3` in Dagster 1.8.2.

## How I Tested These Changes

make dev_install

## Changelog [New | Bug | Docs]

`NOCHANGELOG`
