### PR TITLE
[docs/asset-sensors] always use black text for user evaluation function box

### DIFF
--- a/docs/docs-beta/docs/guides/automation/asset-sensors.md
+++ b/docs/docs-beta/docs/guides/automation/asset-sensors.md
@@ -51,7 +51,7 @@ The evaluation function of an asset sensor can be customized to include custom l
 stateDiagram-v2
     direction LR
 
-    classDef userDefined fill: lightblue
+    classDef userDefined fill:lightblue,color:black
 
     [*] --> AssetMaterialized
     AssetMaterialized --> [*]


### PR DESCRIPTION
## Summary & Motivation

The text in the "User Evaluation Function" box was hard to see in dark mode. 

## How I Tested These Changes

Before (dark mode): 

<img width="808" alt="Screenshot 2024-08-28 at 9 26 19 AM" src="https://github.com/user-attachments/assets/02d33d2f-2276-4c06-b2f9-2bc2d8ccd83c">

After (dark mode):

<img width="753" alt="Screenshot 2024-08-28 at 1 38 36 PM" src="https://github.com/user-attachments/assets/092ccc00-f0cc-467a-86d3-548ca3875748">

After (light mode): 

<img width="753" alt="Screenshot 2024-08-28 at 1 38 42 PM" src="https://github.com/user-attachments/assets/755863c7-bc1f-467d-a40c-21ab99ae518b">



## Changelog [New | Bug | Docs]

`NOCHANGELOG`
