### PR TITLE
[ui] Exclude docs-beta content from docs GH action

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -7,12 +7,14 @@ on:
       - docs-prod # prod
     paths:
       - docs/**
+      - "!docs/docs-beta/**" # Exclude docs-beta
       - examples/docs_snippets/**
       - CHANGES.md
       - .github/workflows/build-docs.yml
   pull_request:
     paths:
       - docs/**
+      - "!docs/docs-beta/**" # Exclude docs-beta
       - examples/docs_snippets/**
       - CHANGES.md
       - .github/workflows/build-docs.yml


### PR DESCRIPTION
## Summary & Motivation

Exclude `docs-beta` changes from the docs GitHub action. We don't want beta-only changes to trigger this action at all.

## How I Tested These Changes

Stack a docs-beta change on top of this, verify that the action doesn't run.

## Changelog [New | Bug | Docs]

> Replace this message with a changelog entry, or `NOCHANGELOG`
