### PR TITLE
[docs-beta] Update docs-revamp GitHub action

### DIFF
--- a/.github/workflows/build-docs-revamp.yml
+++ b/.github/workflows/build-docs-revamp.yml
@@ -23,7 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     # Deploy to Vercel Previews on pull request, push to master branch
     steps:
-
       - name: Get branch preview subdomain
         env:
           HEAD_REF: ${{ github.head_ref }}
@@ -52,7 +51,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: 18  
+          node-version: 18
 
       - name: Lint Docs
         run: |
@@ -66,8 +65,8 @@ jobs:
           echo "Head ref is $GITHUB_HEAD_SHA"
           git fetch origin $GITHUB_HEAD_SHA
           # Compare the commit the branch is based on to its head to list changed files
-          CHANGED_MD_FILES=$(git diff --name-only HEAD~${{ github.event.pull_request.commits }} "$GITHUB_HEAD_SHA" -- '*.md')
-          CHANGES_ENTRY=$(echo "$CHANGED_MD_FILES" | sed 's/\.md$//' | sed 's/^docs-beta\/docs/- {{deploymentUrl}}/')
+          CHANGED_MD_FILES=$(git diff --name-only HEAD~${{ github.event.pull_request.commits }} "$GITHUB_HEAD_SHA" docs/docs-beta/docs/**/{*.md,*.mdx})
+          CHANGES_ENTRY=$(echo "$CHANGED_MD_FILES" | sed 's/\.mdx*$//' | sed 's/^docs\/docs-beta\/docs/- {{deploymentUrl}}/')
           CHANGES_ENTRY=$(echo -e "Preview available at {{deploymentUrl}}\n\nDirect link to changed pages:\n$CHANGES_ENTRY")
           echo "$CHANGES_ENTRY"
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
@@ -84,13 +83,12 @@ jobs:
           github.event_name == 'pull_request' || 
           (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/heads/docs-prod')))
         with:
-          github-comment: true
+          github-comment: ${{ github.event.pull_request && env.CHANGES_ENTRY || true }}
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_DOCS_NEXT_PROJECT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           scope: ${{ secrets.VERCEL_ORG_ID }}
-          alias-domains: ${{ env.BRANCH_PREVIEW_SUBDOMAIN }}.dagster.dagster-docs.io
 
       - name: Publish to Vercel Production
         uses: amondnet/vercel-action@v25


### PR DESCRIPTION
## Summary & Motivation

FIx the build-docs-revamp GitHub action:

- Make sure we find files within `docs/docs-beta` when diffing.
- Find both `md` and `mdx` files within `docs-beta` content, for display as preview URLs.
- Enable the preview link output for the PR comment.
- Remove the explicit `alias-domains` entry, which we don't actually need and which ends up creating a weird extra useless link because of the way the vercel action applies the preview URL. (It joins all aliases together and spits them out to replace the `{{deploymentUrl}}` marker.)

## How I Tested These Changes

Add md and mdx changes to this PR, push. Verify that the GH action behaves correctly, and produces correct links.

## Changelog [New | Bug | Docs]

`NOCHANGELOG`
