### PR TITLE
fix(dbt): account for no database

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -451,20 +451,16 @@ def default_metadata_from_dbt_resource_props(
             ]
         )
 
-    relation_name: Optional[str] = None
-
-    if (
-        "database" in dbt_resource_props
-        and "schema" in dbt_resource_props
-        and "alias" in dbt_resource_props
-    ):
-        relation_name = ".".join(
-            [
-                dbt_resource_props["database"],
-                dbt_resource_props["schema"],
-                dbt_resource_props["alias"],
-            ]
-        )
+    relation_parts = [
+        relation_part
+        for relation_part in [
+            dbt_resource_props.get("database"),
+            dbt_resource_props.get("schema"),
+            dbt_resource_props.get("alias"),
+        ]
+        if relation_part
+    ]
+    relation_name = ".".join(relation_parts) if relation_parts else None
 
     return {
         **TableMetadataSet(


### PR DESCRIPTION
## Summary & Motivation

For some dbt data platforms the database is none. This change reduces the `relation_name` to `schema.alias` when `database.schema.alias` is not possible.

Resolves https://github.com/dagster-io/dagster/issues/23047

## How I Tested These Changes

In my local dagster + dbt setup.

## Changelog [Bug]

[dagster-dbt] account for no database
