### PR TITLE
Add retryOnAssetOrOpFailure to helm chart

### DIFF
--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -80,6 +80,12 @@ class Schedules(BaseModel):
     numSubmitWorkers: Optional[int]
 
 
+class RunRetries(BaseModel):
+    enabled: bool
+    maxRetries: Optional[int]
+    retryOnAssetOrOpFailure: Optional[bool]
+
+
 class Daemon(BaseModel):
     enabled: bool
     image: kubernetes.Image
@@ -101,7 +107,7 @@ class Daemon(BaseModel):
     startupProbe: kubernetes.StartupProbe
     annotations: kubernetes.Annotations
     runMonitoring: Dict[str, Any]
-    runRetries: Dict[str, Any]
+    runRetries: RunRetries
     sensors: Sensors
     schedules: Schedules
     schedulerName: Optional[str]

--- a/helm/dagster/templates/configmap-instance.yaml
+++ b/helm/dagster/templates/configmap-instance.yaml
@@ -107,6 +107,9 @@ data:
       {{- if $runRetries.maxRetries }}
       max_retries: {{ $runRetries.maxRetries }}
       {{- end }}
+      {{- if hasKey $runRetries "retryOnAssetOrOpFailure" }}
+      retry_on_asset_or_op_failure: {{ $runRetries.retryOnAssetOrOpFailure }}
+      {{- end }}
     {{- end }}
 
     {{- $sensors := .Values.dagsterDaemon.sensors }}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -2720,6 +2720,41 @@
                 }
             ]
         },
+        "RunRetries": {
+            "title": "RunRetries",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
+                },
+                "maxRetries": {
+                    "title": "Maxretries",
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "retryOnAssetOrOpFailure": {
+                    "title": "Retryonassetoropfailure",
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "enabled"
+            ]
+        },
         "Sensors": {
             "title": "Sensors",
             "type": "object",
@@ -2888,8 +2923,7 @@
                     "type": "object"
                 },
                 "runRetries": {
-                    "title": "Runretries",
-                    "type": "object"
+                    "$ref": "#/definitions/RunRetries"
                 },
                 "sensors": {
                     "$ref": "#/definitions/Sensors"


### PR DESCRIPTION
Summary:
Allows you to set the retry_on_asset_or_op_failure config when deploying on k8s.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes

## Changelog [New]

[dagster-k8s] Added support for setting `dagsterDaemon.runRetries.retryOnAssetOrOpFailure` to False in the Dagster Helm chart to [prevent op retries and run retries from simultaneously firing on the same failure.](https://docs.dagster.io/deployment/run-retries#combining-op-and-run-retries)