### PR TITLE
use compat mode when uv installing editable packages in make dev_install

### DIFF
--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -375,18 +375,6 @@ noteable-origami==1.1.5
 notebook==7.2.2
 notebook-shim==0.2.4
 numpy==1.26.4
-nvidia-cublas-cu12==12.1.3.1
-nvidia-cuda-cupti-cu12==12.1.105
-nvidia-cuda-nvrtc-cu12==12.1.105
-nvidia-cuda-runtime-cu12==12.1.105
-nvidia-cudnn-cu12==9.1.0.70
-nvidia-cufft-cu12==11.0.2.54
-nvidia-curand-cu12==10.3.2.106
-nvidia-cusolver-cu12==11.4.5.107
-nvidia-cusparse-cu12==12.1.0.106
-nvidia-nccl-cu12==2.20.5
-nvidia-nvjitlink-cu12==12.6.20
-nvidia-nvtx-cu12==12.1.105
 oauth2client==4.1.3
 oauthlib==3.2.2
 objgraph==3.6.1
@@ -588,7 +576,6 @@ tqdm==4.66.5
 traitlets==5.14.3
 trio==0.26.2
 trio-websocket==0.11.1
-triton==3.0.0
 -e examples/experimental/dagster-airlift/examples/tutorial-example
 -e examples/tutorial_notebook_assets
 twilio==9.2.4

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -155,6 +155,8 @@ def main(
     # image build!
     cmd = ["uv", "pip", "install"] + (["--system"] if system else []) + install_targets
 
+    cmd += ["--config-settings", "editable-mode=compat"]
+
     if quiet is not None:
         cmd.append(f'-{"q" * quiet}')
 

--- a/scripts/install_dev_python_modules.py
+++ b/scripts/install_dev_python_modules.py
@@ -155,6 +155,10 @@ def main(
     # image build!
     cmd = ["uv", "pip", "install"] + (["--system"] if system else []) + install_targets
 
+    # Force compat mode for editable installs to avoid
+    # polluting uv cache for pyright install
+    # See https://github.com/dagster-io/dagster/pull/24212
+    # and https://github.com/astral-sh/uv/issues/7028
     cmd += ["--config-settings", "editable-mode=compat"]
 
     if quiet is not None:


### PR DESCRIPTION
## Summary & Motivation

After wiping my pyright & base virtual envs, I was unable to get pyright working, hitting [strange errors that dagster imports were not found](https://dagsterlabs.slack.com/archives/C03A0D72A6T/p1724874346772169):

```python
/Users/ben/repos/dagster/python_modules/libraries/dagster-shell/dagster_shell/__init__.py:
  1:5: Import "dagster._core.libraries" could not be resolved (reportMissingImports)
```

Some Googling turned up that there are [multiple ways to install editable packages](https://github.com/astral-sh/uv/issues/3898) & the default behavior of `uv pip install` is to not install packages in compat mode, which pyright requires.

We [explicitly opt in in our pyright venv building code](https://github.com/dagster-io/dagster/blob/master/scripts/run-pyright.py#L304), but I'm wondering if my base editable installs not using compat mode has some bleed-over to my pyright venv (e.g. the editable install is shared)? Either way, making this change, rerunning `make dev_install` and then rerunning `make rebuild_pyright` seemed to fix my issues.


## Changelog [Bug]

`NOCHANGELOG`
