### PR TITLE
[airlift] add e2e tests for peer, observe, migrate steps

### DIFF
--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tox.ini
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tox.ini
@@ -21,6 +21,9 @@ deps =
 allowlist_externals =
   /bin/bash
   uv
+  make
 commands =
+  # We need to rebuild the UI to ensure that the dagster-webserver can run
+  make -C ../../../../.. rebuild_ui
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../../../pyproject.toml ./tutorial_example_tests --snapshot-warn-unused -vv {posargs}

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/airflow_dags/dags.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/airflow_dags/dags.py
@@ -85,7 +85,12 @@ default_args = {
 }
 DBT_DIR = os.getenv("TUTORIAL_DBT_PROJECT_DIR")
 # Create the DAG with the specified schedule interval
-dag = DAG("rebuild_customers_list", default_args=default_args, schedule_interval=None)
+dag = DAG(
+    "rebuild_customers_list",
+    default_args=default_args,
+    schedule_interval=None,
+    is_paused_upon_creation=False,
+)
 
 
 load_raw_customers = LoadCSVToDuckDB(

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/conftest.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/conftest.py
@@ -21,9 +21,12 @@ def local_env_fixture(makefile_dir: Path) -> Generator[None, None, None]:
     subprocess.run(["make", "airflow_setup"], cwd=makefile_dir, check=True)
     with environ(
         {
+            "MAKEFILE_DIR": str(makefile_dir),
             "AIRFLOW_HOME": str(makefile_dir / ".airflow_home"),
             "TUTORIAL_DBT_PROJECT_DIR": str(makefile_dir / "tutorial_example" / "shared" / "dbt"),
+            "DBT_PROFILES_DIR": str(makefile_dir / "tutorial_example" / "shared" / "dbt"),
             "DAGSTER_HOME": str(makefile_dir / ".dagster_home"),
+            "DAGSTER_URL": "http://localhost:3333",
         }
     ):
         yield

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_load_dagster.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_load_dagster.py
@@ -9,7 +9,7 @@ def test_peer_loads(airflow_instance) -> None:
     Definitions.validate_loadable(defs)
 
     # representation of dag
-    assert len(defs.get_repository_def().assets_defs_by_key) == 1
+    assert len(defs.get_all_asset_specs()) == 1
 
 
 def test_observe_loads(airflow_instance) -> None:
@@ -20,7 +20,7 @@ def test_observe_loads(airflow_instance) -> None:
     Definitions.validate_loadable(defs)
 
     # representation of dag + 9 assets
-    assert len(defs.get_repository_def().assets_defs_by_key) == 10
+    assert len(defs.get_all_asset_specs()) == 10
 
 
 def test_migrate_loads(airflow_instance) -> None:
@@ -31,7 +31,7 @@ def test_migrate_loads(airflow_instance) -> None:
     Definitions.validate_loadable(defs)
 
     # representation of dag + 9 assets
-    assert len(defs.get_repository_def().assets_defs_by_key) == 10
+    assert len(defs.get_all_asset_specs()) == 10
 
 
 def test_standalone_loads(airflow_instance) -> None:
@@ -42,4 +42,4 @@ def test_standalone_loads(airflow_instance) -> None:
     Definitions.validate_loadable(defs)
 
     # 1 fewer, since no representation of the overall DAG
-    assert len(defs.get_repository_def().assets_defs_by_key) == 9
+    assert len(defs.get_all_asset_specs()) == 9

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_migrating_e2e.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_migrating_e2e.py
@@ -4,10 +4,10 @@ import time
 from pathlib import Path
 from typing import AbstractSet, Callable, Iterable, Optional
 
-from dagster._core.storage.dagster_run import DagsterRunStatus
 import pytest
 from dagster import DagsterInstance
 from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster_airlift.core import AirflowInstance, BasicAuthBackend
 from dagster_airlift.core.utils import MIGRATED_TAG, TASK_ID_TAG
 

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_observing_e2e.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_observing_e2e.py
@@ -1,0 +1,33 @@
+import time
+from pathlib import Path
+
+import pytest
+from dagster import DagsterInstance
+
+from .utils import start_run_and_wait_for_completion
+
+
+@pytest.fixture(name="dagster_defs_path")
+def setup_dagster_defs_path(makefile_dir: Path) -> str:
+    return str(makefile_dir / "tutorial_example" / "dagster_defs" / "stages" / "observe.py")
+
+
+def test_observe_reflects_dag_completion_status(airflow_instance: None, dagster_dev: None) -> None:
+    instance = DagsterInstance.get()
+
+    from tutorial_example.dagster_defs.stages.observe import defs
+
+    all_keys = [spec.key for spec in defs.get_all_asset_specs()]
+    assert len(all_keys) == 10
+
+    mat_events = instance.get_latest_materialization_events(asset_keys=all_keys)
+    for key, event in mat_events.items():
+        assert event is None, f"Materialization event for {key} is not None"
+
+    start_run_and_wait_for_completion("rebuild_customers_list")
+
+    time.sleep(10)
+
+    mat_events = instance.get_latest_materialization_events(asset_keys=all_keys)
+    for key, event in mat_events.items():
+        assert event is not None, f"Materialization event for {key} is None"

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_peering_e2e.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_peering_e2e.py
@@ -1,0 +1,30 @@
+import time
+from pathlib import Path
+
+import pytest
+from dagster import AssetKey, DagsterInstance
+
+from .utils import start_run_and_wait_for_completion
+
+
+@pytest.fixture(name="dagster_defs_path")
+def setup_dagster_defs_path(makefile_dir: Path) -> str:
+    return str(makefile_dir / "tutorial_example" / "dagster_defs" / "stages" / "peer.py")
+
+
+def test_peer_reflects_dag_completion_status(airflow_instance: None, dagster_dev: None) -> None:
+    instance = DagsterInstance.get()
+
+    mat_event = instance.get_latest_materialization_event(
+        AssetKey(["airflow_instance", "dag", "rebuild_customers_list"])
+    )
+    assert mat_event is None
+
+    start_run_and_wait_for_completion("rebuild_customers_list")
+
+    time.sleep(10)
+
+    mat_event = instance.get_latest_materialization_event(
+        AssetKey(["airflow_instance", "dag", "rebuild_customers_list"])
+    )
+    assert mat_event is not None

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/utils.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/utils.py
@@ -1,0 +1,29 @@
+import time
+
+import requests
+from dagster._time import get_current_timestamp
+
+
+def start_run_and_wait_for_completion(dag_id: str) -> None:
+    response = requests.post(
+        f"http://localhost:8080/api/v1/dags/{dag_id}/dagRuns", auth=("admin", "admin"), json={}
+    )
+    assert response.status_code == 200, response.json()
+    # Wait until the run enters a terminal state
+    terminal_status = None
+    start_time = get_current_timestamp()
+    while get_current_timestamp() - start_time < 30:
+        response = requests.get(
+            f"http://localhost:8080/api/v1/dags/{dag_id}/dagRuns", auth=("admin", "admin")
+        )
+        assert response.status_code == 200, response.json()
+        dag_runs = response.json()["dag_runs"]
+        if dag_runs[0]["state"] in ["success", "failed"]:
+            terminal_status = dag_runs[0]["state"]
+            break
+        time.sleep(1)
+    assert terminal_status == "success", (
+        "Never reached terminal status"
+        if terminal_status is None
+        else f"terminal status was {terminal_status}"
+    )

--- a/examples/experimental/dagster-airlift/tox.ini
+++ b/examples/experimental/dagster-airlift/tox.ini
@@ -21,6 +21,7 @@ allowlist_externals =
   /bin/bash
   uv
 commands =
+  # We need to rebuild the UI to ensure that the dagster-webserver can run
   make -C ../../.. rebuild_ui
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
   pytest -c ../../../pyproject.toml ./dagster_airlift_tests --snapshot-warn-unused -vv {posargs}


### PR DESCRIPTION
## Summary

Adds e2e test suites which fully spin up Dagster + Airflow for each of the peer, observe, migrate steps and ensures that:

(1) run state transfers over properly once a DAG run completes
(2) migrated steps run in Dagster rather that in Airflow
