### PR TITLE
[typo] asset selection syntax upstream->downstream

### DIFF
--- a/docs/content/concepts/assets/asset-selection-syntax.mdx
+++ b/docs/content/concepts/assets/asset-selection-syntax.mdx
@@ -109,7 +109,7 @@ A query includes a list of clauses. Clauses are separated by commas, except in t
       </td>
       <td>
         A plus sign (<code>+</code>) following an asset key selects an asset and
-        one layer upstream of the asset.
+        one layer downstream of the asset.
         <br></br>
         <br></br>
         Including multiple <code>+</code>s will select that number of downstream


### PR DESCRIPTION
Just noticed this typo, figured even if these are legacy some of the copy might get moved over, so thought I'd fix
