### PR TITLE
[bk] tweak docs beta snippets tox

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/dagster-plus/deployment/alerts/generate_alerts_doc.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/dagster-plus/deployment/alerts/generate_alerts_doc.py
@@ -1,10 +1,10 @@
 # This script is used to generate content in `alerts.md`. It creates and formats the cross-product
 # of all alert types and notification services. After adding a new alert type or service, just run
 # `python generate_alerts_doc.py` and the corresponding markdown file will be updated.
+from pathlib import Path
 from typing import Any, Mapping, NamedTuple, Optional, Sequence
 
 import yaml
-from path import Path
 
 
 class NotificationService(NamedTuple):
@@ -27,7 +27,7 @@ class AlertType(NamedTuple):
 
 BASE_PATH = "dagster-plus/deployment/alerts"
 DOCS_PATH = Path(__file__).parent.parent.parent.parent.parent.parent.parent / "docs"
-OUTPUT_PATH = DOCS_PATH / "docs-beta" / "docs" / BASE_PATH + ".md"
+OUTPUT_PATH = DOCS_PATH / "docs-beta" / "docs" / (BASE_PATH + ".md")
 
 NOTIFICATION_SERVICES = sorted(
     [

--- a/examples/docs_beta_snippets/setup.py
+++ b/examples/docs_beta_snippets/setup.py
@@ -14,6 +14,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["test"]),
-    install_requires=["dagster-cloud", "dagster-aws"],
-    extras_require={"test": ["pytest", "mock", "path", "dagster_snowflake"]},
+    # package not expected to be installed alone, dependencies for use managed in tox.ini
+    install_requires=[],
 )

--- a/examples/docs_beta_snippets/tox.ini
+++ b/examples/docs_beta_snippets/tox.ini
@@ -10,21 +10,22 @@ passenv =
     BUILDKITE*
 install_command = uv pip install {opts} {packages}
 deps =
-  source: -e ../../python_modules/dagster[test]
-  source: -e ../../python_modules/dagster-pipes
-  pypi: dagster[test]
-  jinja2
-  pyyaml
-  duckdb
+  -e ../../python_modules/dagster[test]
+  -e ../../python_modules/dagster-pipes
   -e ../../python_modules/dagster-graphql
   -e ../../python_modules/dagster-webserver
+  -e ../../python_modules/libraries/dagster-snowflake
+  -e ../../python_modules/libraries/dagster-duckdb
   -e ../../python_modules/libraries/dagster-duckdb-pandas
   -e ../../python_modules/libraries/dagster-embedded-elt
   -e ../../python_modules/libraries/dagster-aws
-  -e .[test]
+  -e .
 allowlist_externals =
   /bin/bash
   uv
 commands =
-  source: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
+  # install cloud packages out of band due to version conflicts between pypi and source
+  uv pip install dagster-cloud-cli --no-deps
+  uv pip install dagster-cloud --no-deps
+  /bin/bash -c '! pip list --exclude-editable | grep -e dagster | grep -v dagster-cloud'
   pytest -c ../../pyproject.toml -vv {posargs}

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -2,11 +2,11 @@ import os
 import re
 import sys
 from collections import defaultdict
+from pathlib import Path
 from typing import Iterator, List, Mapping, NamedTuple, Optional, Sequence
 
 import click
 import git
-from path import Path
 
 GITHUB_URL = "https://github.com/dagster-io/dagster"
 OSS_REPO = git.Repo(Path(__file__).parent.parent)


### PR DESCRIPTION
We want to test docs snippets against source as much as possible, but we need to special case `dagster-cloud` since its not in the repo. To do this we move dependency management to just `tox.ini` since this module only runs in the context of testing via tox.

Additionally i updated some `path` to `pathlib` since we don't depend on it else where and it doesn't seem worth the friction to users of requiring installing something outside of `dagster` / `dagster-X` when built in `pathlib` works just fine.

## Changelog [New | Bug | Docs]

NOCHANGELOG
