### PR TITLE
transitioning serverless to hybrid guide

### DIFF
--- a/docs/docs-beta/docs/dagster-plus/deployment/hybrid/agents/local.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/hybrid/agents/local.md
@@ -5,4 +5,63 @@ sidebar_position: 40
 sidebar_label: "Local"
 ---
 
-# Local agents
+You can set up a local agent to execute pipelines launched in Dagster+. This ensures that your user code is always executed on infrastructure you own. When a pipeline is executed, the local agent will create subprocesses to execute user code. However, it's important to keep in mind that  the local agent's ability to run user code is limited by the capacity of the machine on which it's running.
+
+Running a local agent can be a good choice if:
+- The expected load of your pipelines is relatively light (guaranteed to fit on a single node).
+- Your pipelines aren't computationally intensive and don't use much memory.
+- You can restart the agent when you update your code.
+
+:::note
+If you're running the local agent in production, make sure you've set up a supervisor to automatically restart the agent process if it crashes. You'll also want a system in place to alert you if the VM or container dies, or to automatically restart it.
+:::
+
+<details>
+  <summary>Prerequisites</summary>
+
+To follow the steps in this guide, you'll need:
+
+- **Organization Admin** permissions in your Dagster+ account.
+- **To install the `dagster-cloud` CLI** in the same environment where the agent will run. We recommend using a Python virtual environment for your Dagster application code and its dependencies.
+    ```bash
+    pip install dagster-cloud
+    ```
+
+</details>
+
+## Step 1: Generate an agent token
+
+Your local agent will need a token to authenticate with your Dagster+ account. To generate an agent token:
+1. Click the **user menu (your icon) -> Organization Settings**.
+2. In the **Organization Settings** page, click the **Tokens** tab.
+3. Click the **+ Create agent token** button.
+4. After the token has been created, click **Reveal token**.
+5. Copy the token and keep it somewhere handy. It will be used in Step 2.
+6. We recommend giving the agent token a description to distinguish it from other tokens in the future.
+
+
+## Step 2: Configure the local agent
+
+1. Create a directory to act as your Dagster home. We'll use `~/dagster_home` in the rest of this guide, but the directory can be located wherever you want.
+2. In the directory you created, create a `dagster.yaml` file with the following content:
+    <CodeExample filePath="dagster-plus/deployment/hybrid/agents/local_dagster.yaml" language="yaml" title="dagster.yaml" />
+3. In the file, fill in the following:
+    - `agent_token` - Add the agent token you created in Step 1.
+    - `deployment` - Enter the deployment name associated with this instance of the agent. In the preceding example, we specified `prod` as the deployment.
+
+4. Save the file.
+
+## Step 3: Run the agent
+
+To start the agent, run the following command and pass the path to the `dagster.yaml` file you created in Step 2:
+```bash
+dagster-cloud agent run ~/dagster_home/
+```
+
+To view the agent in Dagster+, click the Dagster icon in the top left to navigate to the **Deployment -> Agents** page. You should see the agent running in the **Agent statuses** section:
+
+SCREENSHOT
+
+## Next steps
+
+- Add a [code location](/todo) to your Dagster+ deployment.

--- a/docs/docs-beta/docs/dagster-plus/deployment/hybrid/agents/local.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/hybrid/agents/local.md
@@ -1,16 +1,18 @@
 ---
-title: "Local agents"
+title: "Running a Dagster+ agent locally"
 displayed_sidebar: "dagsterPlus"
 sidebar_position: 40
 sidebar_label: "Local"
 ---
 
-You can set up a local agent to execute pipelines launched in Dagster+. This ensures that your user code is always executed on infrastructure you own. When a pipeline is executed, the local agent will create subprocesses to execute user code. However, it's important to keep in mind that  the local agent's ability to run user code is limited by the capacity of the machine on which it's running.
+You can set up a local agent to execute pipelines launched in Dagster+. Local agents are a good way to experiment with Dagster+ locally before deploying a more scalable hybrid agent like [Kubernetes](dagster-plus/hybrid/agents/kubernetes) or [Amazon ECS](dagster-plus/hybrid/agents/amazon-ecs-new-vpc).
 
-Running a local agent can be a good choice if:
-- The expected load of your pipelines is relatively light (guaranteed to fit on a single node).
-- Your pipelines aren't computationally intensive and don't use much memory.
-- You can restart the agent when you update your code.
+:::warning
+Local agents aren't well suited for most production use cases. This is because local agents:
+- Don't have the same CI / CD update strategies as the other agents.
+- Need a separate process running on the sever hosting the agent to pull in changes to your Dagster project.
+- Need to be restarted to deploy changes.
+:::
 
 :::note
 If you're running the local agent in production, make sure you've set up a supervisor to automatically restart the agent process if it crashes. You'll also want a system in place to alert you if the VM or container dies, or to automatically restart it.
@@ -50,6 +52,8 @@ Your local agent will need a token to authenticate with your Dagster+ account. T
     - `deployment` - Enter the deployment name associated with this instance of the agent. In the preceding example, we specified `prod` as the deployment.
 
 4. Save the file.
+
+You can find more configuration options for `dagster.yaml` in the [`dagster.yaml` reference](/todo).
 
 ## Step 3: Run the agent
 

--- a/docs/docs-beta/docs/dagster-plus/deployment/hybrid/agents/local.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/hybrid/agents/local.md
@@ -5,17 +5,10 @@ sidebar_position: 40
 sidebar_label: "Local"
 ---
 
-You can set up a local agent to execute pipelines launched in Dagster+. Local agents are a good way to experiment with Dagster+ locally before deploying a more scalable hybrid agent like [Kubernetes](dagster-plus/hybrid/agents/kubernetes) or [Amazon ECS](dagster-plus/hybrid/agents/amazon-ecs-new-vpc).
-
-:::warning
-Local agents aren't well suited for most production use cases. This is because local agents:
-- Don't have the same CI / CD update strategies as the other agents.
-- Need a separate process running on the sever hosting the agent to pull in changes to your Dagster project.
-- Need to be restarted to deploy changes.
-:::
+You can set up a local agent to execute pipelines launched in Dagster+. Local agents are a good way to experiment with Dagster+ before deploying a more scalable hybrid agent like [Kubernetes](dagster-plus/hybrid/agents/kubernetes) or [Amazon ECS](dagster-plus/hybrid/agents/amazon-ecs-new-vpc).
 
 :::note
-If you're running the local agent in production, make sure you've set up a supervisor to automatically restart the agent process if it crashes. You'll also want a system in place to alert you if the VM or container dies, or to automatically restart it.
+Local agents aren't well suited for most production use cases. If you're running the local agent in production, make sure you've set up a supervisor to automatically restart the agent process if it crashes. You'll also want a system in place to alert you if the VM or container dies, or to automatically restart it.
 :::
 
 <details>
@@ -38,7 +31,7 @@ Your local agent will need a token to authenticate with your Dagster+ account. T
 2. In the **Organization Settings** page, click the **Tokens** tab.
 3. Click the **+ Create agent token** button.
 4. After the token has been created, click **Reveal token**.
-5. Copy the token and keep it somewhere handy. It will be used in Step 2.
+5. Save this token as an environment variable on the machine where the local agent will run. You can choose any name for this environment variable, but `$DAGSTER_AGENT_TOKEN` will be used in the rest of this guide.
 6. We recommend giving the agent token a description to distinguish it from other tokens in the future.
 
 
@@ -48,7 +41,7 @@ Your local agent will need a token to authenticate with your Dagster+ account. T
 2. In the directory you created, create a `dagster.yaml` file with the following content:
     <CodeExample filePath="dagster-plus/deployment/hybrid/agents/local_dagster.yaml" language="yaml" title="dagster.yaml" />
 3. In the file, fill in the following:
-    - `agent_token` - Add the agent token you created in Step 1.
+    - `agent_token.env` - Add the name of the environment variable storing the agent token you created in Step 1.
     - `deployment` - Enter the deployment name associated with this instance of the agent. In the preceding example, we specified `prod` as the deployment.
 
 4. Save the file.

--- a/docs/docs-beta/docs/dagster-plus/deployment/hybrid/agents/local.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/hybrid/agents/local.md
@@ -5,52 +5,61 @@ sidebar_position: 40
 sidebar_label: "Local"
 ---
 
-You can set up a local agent to execute pipelines launched in Dagster+. Local agents are a good way to experiment with Dagster+ before deploying a more scalable hybrid agent like [Kubernetes](dagster-plus/hybrid/agents/kubernetes) or [Amazon ECS](dagster-plus/hybrid/agents/amazon-ecs-new-vpc).
+Local agents are a good way to experiment with Dagster+ before deploying a more scalable Hybrid agent like [Kubernetes](/dagster-plus/deployment/hybrid/agents/kubernetes) or [Amazon ECS](/todo).
 
 :::note
-Local agents aren't well suited for most production use cases. If you're running the local agent in production, make sure you've set up a supervisor to automatically restart the agent process if it crashes. You'll also want a system in place to alert you if the VM or container dies, or to automatically restart it.
+Local agents aren't well suited for most production use cases. If you're running the local agent in production, make sure that:
+
+- You've set up a supervisor to automatically restart the agent process if it crashes
+- You're alerted if the VM or container dies, or to automatically restart it
 :::
+
+## What you'll learn
+
+- How to generate an agent token
+- How to configure the local agent
+- How to run the agent and confirm the setup was successful
 
 <details>
   <summary>Prerequisites</summary>
 
 To follow the steps in this guide, you'll need:
 
-- **Organization Admin** permissions in your Dagster+ account.
+- **Organization Admin** permissions in your Dagster+ account
 - **To install the `dagster-cloud` CLI** in the same environment where the agent will run. We recommend using a Python virtual environment for your Dagster application code and its dependencies.
+
     ```bash
     pip install dagster-cloud
     ```
-
 </details>
 
 ## Step 1: Generate an agent token
 
 Your local agent will need a token to authenticate with your Dagster+ account. To generate an agent token:
-1. Click the **user menu (your icon) -> Organization Settings**.
+
+1. Click the **user menu (your icon) > Organization Settings**.
 2. In the **Organization Settings** page, click the **Tokens** tab.
 3. Click the **+ Create agent token** button.
 4. After the token has been created, click **Reveal token**.
 5. Save this token as an environment variable on the machine where the local agent will run. You can choose any name for this environment variable, but `$DAGSTER_AGENT_TOKEN` will be used in the rest of this guide.
-6. We recommend giving the agent token a description to distinguish it from other tokens in the future.
-
+6. Give the agent token a description to distinguish it from other tokens in the future.
 
 ## Step 2: Configure the local agent
 
-1. Create a directory to act as your Dagster home. We'll use `~/dagster_home` in the rest of this guide, but the directory can be located wherever you want.
-2. In the directory you created, create a `dagster.yaml` file with the following content:
+1. Create a directory to act as your Dagster home. This guide uses `~/dagster_home`, but the directory can be located wherever you want.
+2. In the new directory, create a `dagster.yaml` file with the following:
     <CodeExample filePath="dagster-plus/deployment/hybrid/agents/local_dagster.yaml" language="yaml" title="dagster.yaml" />
 3. In the file, fill in the following:
-    - `agent_token.env` - Add the name of the environment variable storing the agent token you created in Step 1.
-    - `deployment` - Enter the deployment name associated with this instance of the agent. In the preceding example, we specified `prod` as the deployment.
-
+    - `agent_token.env` - The name of the environment variable storing the agent token you created in Step 1.
+    - `deployment` - The name of the deployment associated with this instance of the agent. In the preceding example, `prod` was used as the deployment.
 4. Save the file.
 
-You can find more configuration options for `dagster.yaml` in the [`dagster.yaml` reference](/todo).
+For more information about `dagster.yaml` configuration options, check out the [`dagster.yaml` reference](/todo).
 
 ### Alternative methods for setting the agent token
 
-If you don't want to specify your agent token with an environment variable in the `dagster.yaml`, you can pass it to the `dagster-cloud agent run` command:
+If you prefer not to specify the agent token by using an environment variable in `dagster.yaml`, pass it to the `dagster-cloud agent run` command:
+
 ```bash
 dagster-cloud agent run ~/dagster_home/ --agent-token <AGENT_TOKEN>
 ```
@@ -58,15 +67,15 @@ dagster-cloud agent run ~/dagster_home/ --agent-token <AGENT_TOKEN>
 ## Step 3: Run the agent
 
 To start the agent, run the following command and pass the path to the `dagster.yaml` file you created in Step 2:
+
 ```bash
 dagster-cloud agent run ~/dagster_home/
 ```
 
-To view the agent in Dagster+, click the Dagster icon in the top left to navigate to the **Deployment -> Agents** page. You should see the agent running in the **Agent statuses** section:
+To view the agent in Dagster+, click the Dagster icon in the top left to navigate to the **Deployment > Agents** page. You should see the agent running in the **Agent statuses** section:
 
-SCREENSHOT
-
+![Screenshot of Dagster Asset Lineage](/img/placeholder.svg)
 
 ## Next steps
 
-- Add a [code location](/todo) to your Dagster+ deployment.
+- Add a [code location](/todo) to your Dagster+ deployment

--- a/docs/docs-beta/docs/dagster-plus/deployment/hybrid/agents/local.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/hybrid/agents/local.md
@@ -48,6 +48,13 @@ Your local agent will need a token to authenticate with your Dagster+ account. T
 
 You can find more configuration options for `dagster.yaml` in the [`dagster.yaml` reference](/todo).
 
+### Alternative methods for setting the agent token
+
+If you don't want to specify your agent token with an environment variable in the `dagster.yaml`, you can pass it to the `dagster-cloud agent run` command:
+```bash
+dagster-cloud agent run ~/dagster_home/ --agent-token <AGENT_TOKEN>
+```
+
 ## Step 3: Run the agent
 
 To start the agent, run the following command and pass the path to the `dagster.yaml` file you created in Step 2:
@@ -58,6 +65,7 @@ dagster-cloud agent run ~/dagster_home/
 To view the agent in Dagster+, click the Dagster icon in the top left to navigate to the **Deployment -> Agents** page. You should see the agent running in the **Agent statuses** section:
 
 SCREENSHOT
+
 
 ## Next steps
 

--- a/docs/docs-beta/docs/dagster-plus/deployment/serverless/transition-hybrid.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/serverless/transition-hybrid.md
@@ -4,41 +4,51 @@ displayed_sidebar: "dagsterPlus"
 sidebar_position: 50
 ---
 
-After using a Dagster+ Serverless deployment, you may decide that you want to switch to a Hybrid deployment. A Hybrid deployment lets you use your own infrastructure to execute your code. You can switch from Serverless to Hybrid without loosing any of your execution history or metadata.
+After utilizing a Dagster+ [Serverless](/dagster-plus/deployment/serverless) deployment, you may decide to leverage your own infrastructure to execute your code. Transitioning to a Hybrid deployment requires only a few steps and can be done without any loss of execution history or metadata, allowing you to maintain continuity and control over your operations.
 
 :::warning
-Transitioning from Serverless to Hybrid requires some downtime when your Dagster+ deployment won't have an agent to execute user code.
+Transitioning from Serverless to Hybrid requires some downtime, as your Dagster+ deployment won't have an agent to execute user code.
 :::
+
+## What you'll learn
+
+- How to deactivate your Serverless agent
+- How to create a Hybrid agent
+- How to confirm that the Hybrid agent was set up successfully
 
 <details>
   <summary>Prerequisites</summary>
 
 To follow the steps in this guide, you'll need:
 
-- **Organization Admin** permissions in your Dagster+ account.
+- **Organization Admin** permissions in your Dagster+ account
 
 </details>
 
 ## Step 1: Deactivate your Serverless agent
-To deactivate the Serverless agent, navigate to the **Deployment -> Agents** page. Click the drop down arrow on the right of the page and select **Switch to hybrid**. It may take a few minutes for the agent to deactivate and be removed from the list of agents.
 
-PRODUCT NOTE - this arrow drop down is pretty small and easy to confuse with the one in the row for the agent
+1. In the Dagster+ UI, navigate to the **Deployment > Agents** page.
+2. Click the drop down arrow on the right of the page and select **Switch to Hybrid**.
+
+![PRODUCT NOTE - this arrow drop down is pretty small and easy to confuse with the one in the row for the agent](/img/placeholder.svg)
+
+It may take a few minutes for the agent to deactivate and be removed from the list of agents.
 
 ## Step 2: Create a Hybrid agent
-Next, you'll need to create a Hybrid agent to execute your code. There are several options for Hybrid agents. Follow the instructions for the agent of your choice to set up a Hybrid agent.
 
-- **Amazon Web Services agents(/todo)**. AWS agents launch user code as Amazon Elastic Container Service (ECS) tasks.
-- **[Docker agent](/dagster-plus/deployment/hybrid/agents/docker)**. Docker agents launch user code in Docker containers on your machine.
-- **[Kubernetes agent](/dagster-plus/deployment/hybrid/agents/kubernetes)**. Kubernetes agents launch user code on a Kubernetes cluster.
-- **[Local agent](/dagster-plus/deployment/hybrid/agents/local)**. Local agents launch user code in operating system subprocesses on your machine.
+Next, you'll need to create a Hybrid agent to execute your code. Follow the setup instructions for the agent of your choice:
 
+- **[Amazon Web Services (AWS)](/todo)**, which launches user code as Amazon Elastic Container Service (ECS) tasks.
+- **[Docker](/dagster-plus/deployment/hybrid/agents/docker)**, which launches user code in Docker containers on your machine
+- **[Kubernetes](/dagster-plus/deployment/hybrid/agents/kubernetes)**, which launches user code on a Kubernetes cluster
+- **[Local](/dagster-plus/deployment/hybrid/agents/local)**, which launches user code in operating system subprocesses on your machine
 
 ## Step 3: Confirm successful setup
 
-Once you have set up your Hybrid agent, navigate to the **Deployment -> Agents** page. You should see your new agent with the `RUNNING` status.
+Once you've set up a Hybrid agent, navigate to the **Deployment > Agents** page in the UI. The new agent should display in the list with a `RUNNING` status:
 
-SCREENSHOT
+![Screenshot](/img/placeholder.svg)
 
 ## Next steps
 
-- See all of the configuration options for [dagster.yaml](/todo).
+- Learn about the configuration options for [dagster.yaml](/todo)

--- a/docs/docs-beta/docs/dagster-plus/deployment/serverless/transition-hybrid.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/serverless/transition-hybrid.md
@@ -16,19 +16,23 @@ To follow the steps in this guide, you'll need:
 </details>
 
 ## Step 1: Deactivate your Serverless agent
-To deactivate the Serverless agent, navigate to the **Deployment -> Agents** page. Click the drop down arrow on the right of the page and select **Switch to hybrid**. This will deactivate the agent.
+To deactivate the Serverless agent, navigate to the **Deployment -> Agents** page. Click the drop down arrow on the right of the page and select **Switch to hybrid**. It may take a few minutes for the agent to deactivate and be removed from the list of agents.
+
+PRODUCT NOTE - this arrow drop down is pretty small and easy to confuse with the one in the row for the agent
 
 ## Step 2: Create a Hybrid agent
-In order to continue to use your Dagster+ account, you'll need to create a Hybrid agent to execute your code. There are many options for Hybrid agents. Follow the instructions for the agent of your choice to set up a Hybrid agent.
+Next, you'll need to create a Hybrid agent to execute your code. There are several options for Hybrid agents. Follow the instructions for the agent of your choice to set up a Hybrid agent.
 
-- **Amazon Web Services agents:**
+- **Amazon Web Services agents**. AWS agents launch user code as Amazon Elastic Container Service (ECS) tasks.
     - [Amazon ECS agent in a new VPC](/dagster-plus/deployment/hybrid/agents/amazon-ecs-new-vpc)
     - [Amazon ECS agent in an existing VPC](/dagster-plus/deployment/hybrid/agents/amazon-ecs-existing-vpc)
-- **[Docker agent](/dagster-plus/deployment/hybrid/agents/docker)**
-- **[Kubernetes agent](/dagster-plus/deployment/hybrid/agents/kubernetes)**
-- **[Local agent](/dagster-plus/deployment/hybrid/agents/local)**
+- **[Docker agent](/dagster-plus/deployment/hybrid/agents/docker)**. Docker agents launch user code in Docker containers on your machine.
+- **[Kubernetes agent](/dagster-plus/deployment/hybrid/agents/kubernetes)**. Kubernetes agents launch user code on a Kubernetes cluster.
+- **[Local agent](/dagster-plus/deployment/hybrid/agents/local)**. Local agents launch user code in operating system subprocesses on your machine.
 
 
 ## Step 3: Confirm successful setup
 
 Once you have set up your Hybrid agent, navigate to the **Deployment -> Agents** page. You should see your new agent with the `RUNNING` status.
+
+SCREENSHOT

--- a/docs/docs-beta/docs/dagster-plus/deployment/serverless/transition-hybrid.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/serverless/transition-hybrid.md
@@ -3,3 +3,32 @@ title: "Transitioning to Hybrid"
 displayed_sidebar: "dagsterPlus"
 sidebar_position: 50
 ---
+
+After using a Dagster+ Serverless deployment, you may decide that you want to switch to a Hybrid deployment. A Hybrid deployment lets you use your own infrastructure to execute your code. You can switch from Serverless to Hybrid without loosing any of your execution history or metadata.
+
+<details>
+  <summary>Prerequisites</summary>
+
+To follow the steps in this guide, you'll need:
+
+- **Organization Admin** permissions in your Dagster+ account.
+
+</details>
+
+## Step 1: Deactivate your Serverless agent
+To deactivate the Serverless agent, navigate to the **Deployment -> Agents** page. Click the drop down arrow on the right of the page and select **Switch to hybrid**. This will deactivate the agent.
+
+## Step 2: Create a Hybrid agent
+In order to continue to use your Dagster+ account, you'll need to create a Hybrid agent to execute your code. There are many options for Hybrid agents. Follow the instructions for the agent of your choice to set up a Hybrid agent.
+
+- **Amazon Web Services agents:**
+    - [Amazon ECS agent in a new VPC](/dagster-plus/deployment/hybrid/agents/amazon-ecs-new-vpc)
+    - [Amazon ECS agent in an existing VPC](/dagster-plus/deployment/hybrid/agents/amazon-ecs-existing-vpc)
+- **[Docker agent](/dagster-plus/deployment/hybrid/agents/docker)**
+- **[Kubernetes agent](/dagster-plus/deployment/hybrid/agents/kubernetes)**
+- **[Local agent](/dagster-plus/deployment/hybrid/agents/local)**
+
+
+## Step 3: Confirm successful setup
+
+Once you have set up your Hybrid agent, navigate to the **Deployment -> Agents** page. You should see your new agent with the `RUNNING` status.

--- a/docs/docs-beta/docs/dagster-plus/deployment/serverless/transition-hybrid.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/serverless/transition-hybrid.md
@@ -40,3 +40,7 @@ Next, you'll need to create a Hybrid agent to execute your code. There are sever
 Once you have set up your Hybrid agent, navigate to the **Deployment -> Agents** page. You should see your new agent with the `RUNNING` status.
 
 SCREENSHOT
+
+## Next steps
+
+- See all of the configuration options for [dagster.yaml](/todo).

--- a/docs/docs-beta/docs/dagster-plus/deployment/serverless/transition-hybrid.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/serverless/transition-hybrid.md
@@ -6,6 +6,10 @@ sidebar_position: 50
 
 After using a Dagster+ Serverless deployment, you may decide that you want to switch to a Hybrid deployment. A Hybrid deployment lets you use your own infrastructure to execute your code. You can switch from Serverless to Hybrid without loosing any of your execution history or metadata.
 
+:::warning
+Transitioning from Serverless to Hybrid requires some downtime when your Dagster+ deployment won't have an agent to execute user code.
+:::
+
 <details>
   <summary>Prerequisites</summary>
 

--- a/docs/docs-beta/docs/dagster-plus/deployment/serverless/transition-hybrid.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/serverless/transition-hybrid.md
@@ -27,9 +27,7 @@ PRODUCT NOTE - this arrow drop down is pretty small and easy to confuse with the
 ## Step 2: Create a Hybrid agent
 Next, you'll need to create a Hybrid agent to execute your code. There are several options for Hybrid agents. Follow the instructions for the agent of your choice to set up a Hybrid agent.
 
-- **Amazon Web Services agents**. AWS agents launch user code as Amazon Elastic Container Service (ECS) tasks.
-    - [Amazon ECS agent in a new VPC](/dagster-plus/deployment/hybrid/agents/amazon-ecs-new-vpc)
-    - [Amazon ECS agent in an existing VPC](/dagster-plus/deployment/hybrid/agents/amazon-ecs-existing-vpc)
+- **Amazon Web Services agents(/todo)**. AWS agents launch user code as Amazon Elastic Container Service (ECS) tasks.
 - **[Docker agent](/dagster-plus/deployment/hybrid/agents/docker)**. Docker agents launch user code in Docker containers on your machine.
 - **[Kubernetes agent](/dagster-plus/deployment/hybrid/agents/kubernetes)**. Kubernetes agents launch user code on a Kubernetes cluster.
 - **[Local agent](/dagster-plus/deployment/hybrid/agents/local)**. Local agents launch user code in operating system subprocesses on your machine.

--- a/examples/docs_beta_snippets/docs_beta_snippets/dagster-plus/deployment/hybrid/agents/local_dagster.yaml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/dagster-plus/deployment/hybrid/agents/local_dagster.yaml
@@ -1,0 +1,11 @@
+instance_class:
+  module: dagster_cloud.instance
+  class: DagsterCloudAgentInstance
+
+dagster_cloud_api:
+  agent_token: <YOUR_AGENT_TOKEN>
+  deployment: prod
+
+user_code_launcher:
+  module: dagster_cloud.workspace.user_code_launcher
+  class: ProcessUserCodeLauncher

--- a/examples/docs_beta_snippets/docs_beta_snippets/dagster-plus/deployment/hybrid/agents/local_dagster.yaml
+++ b/examples/docs_beta_snippets/docs_beta_snippets/dagster-plus/deployment/hybrid/agents/local_dagster.yaml
@@ -3,7 +3,8 @@ instance_class:
   class: DagsterCloudAgentInstance
 
 dagster_cloud_api:
-  agent_token: <YOUR_AGENT_TOKEN>
+  agent_token:
+    env: DAGSTER_AGENT_TOKEN
   deployment: prod
 
 user_code_launcher:


### PR DESCRIPTION
## Summary & Motivation
Guide for moving from serverless to hybrid. 

Also a guide for setting up the local agent since i went through this process to test that the transitioning guide didn't have any steps to add after making the agent, but then i couldn't set up the local agent with my org in canary bc the cli command was set to work with prod only

## How I Tested These Changes

## Changelog [New | Bug | Docs]

`NOCHANGELOG`
