### PR TITLE
Fix immediate redirect away from partitions tab for non materializable asset

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -79,6 +79,8 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
   const defaultTab = 'overview';
   const selectedTab = params.view || defaultTab;
 
+  console.log({selectedTab});
+
   // Load the asset graph - a large graph for the Lineage tab, a small graph for the Definition tab
   // tab, or just the current node for other tabs. NOTE: Changing the query does not re-fetch data,
   // it just re-filters.
@@ -164,6 +166,9 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
   };
 
   const renderPartitionsTab = () => {
+    if (isLoading) {
+      return <AssetLoadingDefinitionState />;
+    }
     if (!definition?.isMaterializable) {
       return <Redirect to={assetDetailsPathForKey(assetKey, {view: 'events'})} />;
     }


### PR DESCRIPTION
## Summary & Motivation

We were not checking if the definition is done loading before doing this redirect which caused us to immediately redirect to the events tab.

## How I Tested These Changes

used cloud proxy

## Changelog [Bug]
[ui] Fixed a bug where we redirect away from the partitions tab for an asset if you visited it directly.
