### PR TITLE
[Run Timeline] Only commit data to cache after all data is fetched.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -139,7 +139,7 @@ export const useRunsForTimeline = ({
       }>
     > = new WeakMap();
 
-    const result = await fetchPaginatedBucketData({
+    return await fetchPaginatedBucketData({
       buckets: buckets
         .filter((bucket) => !completedRunsCache.isCompleteRange(bucket[0], bucket[1]))
         .map((bucket) => {
@@ -227,8 +227,6 @@ export const useRunsForTimeline = ({
         };
       },
     });
-
-    return result;
   }, [batchLimit, buckets, client, completedRunsCache, runsFilter]);
 
   // If the user paginates backwards quickly then there will be multiple outstanding fetches

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -205,10 +205,11 @@ export const useRunsForTimeline = ({
         const nextCursor = hasMoreData ? runs[runs.length - 1]!.id : undefined;
 
         const accumulatedData = dataToCommitToCacheByBucket.get(bucket) ?? [];
+        dataToCommitToCacheByBucket.set(bucket, accumulatedData);
+
         if (hasMoreData) {
           // If there are runs lets accumulate this data to commit to the cache later
           // once all of the runs for this bucket have been fetched.
-          dataToCommitToCacheByBucket.set(bucket, accumulatedData);
           accumulatedData.push({updatedAfter, updatedBefore, runs});
         } else {
           // If there is no more data lets commit all of the accumulated data to the cache


### PR DESCRIPTION
## Summary & Motivation

While looking at this code again I realized there's an edge case due to the paginated logic. In particular it's possible that the user closes the tab before we've paginated across all runs for a specific time period. When this happens we will have partially committed data to the cache. 

Nobody reported this issue.

## How I Tested These Changes

Added a jest test that previously failed.

## Changelog [New | Bug | Docs]
NOCHANGELOG
