### PR TITLE
[1/n] rename get_workspace_snapshot() to get_code_location_entries()

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -159,7 +159,7 @@ def fetch_workspace(workspace_request_context: BaseWorkspaceRequestContext) -> "
 
     nodes = [
         GrapheneWorkspaceLocationEntry(entry)
-        for entry in workspace_request_context.get_workspace_snapshot().values()
+        for entry in workspace_request_context.get_code_location_entries().values()
     ]
 
     return GrapheneWorkspace(locationEntries=nodes)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_shutdown_repository_location.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/test_shutdown_repository_location.py
@@ -33,7 +33,7 @@ class TestShutdownRepositoryLocationReadOnly(ReadonlyGraphQLContextTestMatrix):
 
 class TestShutdownRepositoryLocation(BaseTestSuite):
     def test_shutdown_repository_location(self, graphql_client, graphql_context):
-        origin = next(iter(graphql_context.get_workspace_snapshot().values())).origin
+        origin = next(iter(graphql_context.get_code_location_entries().values())).origin
         origin.create_client().heartbeat()
 
         result = graphql_client.shutdown_repository_location("test")

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -629,7 +629,7 @@ def create_asset_backfill_data_from_asset_partitions(
 def _get_unloadable_location_names(context: IWorkspace, logger: logging.Logger) -> Sequence[str]:
     location_entries_by_name = {
         location_entry.origin.location_name: location_entry
-        for location_entry in context.get_workspace_snapshot().values()
+        for location_entry in context.get_code_location_entries().values()
     }
     unloadable_location_names = []
 

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -529,7 +529,7 @@ def load_external_repo(
     workspace_context: WorkspaceProcessContext, repo_name: str
 ) -> ExternalRepository:
     code_location_entry = next(
-        iter(workspace_context.create_request_context().get_workspace_snapshot().values())
+        iter(workspace_context.create_request_context().get_code_location_entries().values())
     )
     assert code_location_entry.code_location, code_location_entry.load_error
     return code_location_entry.code_location.get_repository(repo_name)

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -95,7 +95,7 @@ class BaseWorkspaceRequestContext(IWorkspace, LoadingContext):
         pass
 
     @abstractmethod
-    def get_workspace_snapshot(self) -> Mapping[str, CodeLocationEntry]:
+    def get_code_location_entries(self) -> Mapping[str, CodeLocationEntry]:
         pass
 
     @abstractmethod
@@ -176,17 +176,19 @@ class BaseWorkspaceRequestContext(IWorkspace, LoadingContext):
     def code_locations(self) -> Sequence[CodeLocation]:
         return [
             entry.code_location
-            for entry in self.get_workspace_snapshot().values()
+            for entry in self.get_code_location_entries().values()
             if entry.code_location
         ]
 
     @property
     def code_location_names(self) -> Sequence[str]:
-        return list(self.get_workspace_snapshot())
+        return list(self.get_code_location_entries())
 
     def code_location_errors(self) -> Sequence[SerializableErrorInfo]:
         return [
-            entry.load_error for entry in self.get_workspace_snapshot().values() if entry.load_error
+            entry.load_error
+            for entry in self.get_code_location_entries().values()
+            if entry.load_error
         ]
 
     def has_code_location_error(self, name: str) -> bool:
@@ -373,7 +375,7 @@ class WorkspaceRequestContext(BaseWorkspaceRequestContext):
     def instance(self) -> DagsterInstance:
         return self._instance
 
-    def get_workspace_snapshot(self) -> Mapping[str, CodeLocationEntry]:
+    def get_code_location_entries(self) -> Mapping[str, CodeLocationEntry]:
         return self._workspace_snapshot
 
     def get_location_entry(self, name: str) -> Optional[CodeLocationEntry]:

--- a/python_modules/dagster/dagster/_core/workspace/workspace.py
+++ b/python_modules/dagster/dagster/_core/workspace/workspace.py
@@ -48,7 +48,7 @@ class IWorkspace(ABC):
         """Return the CodeLocation for the given location name, or raise an error if there is an error loading it."""
 
     @abstractmethod
-    def get_workspace_snapshot(self) -> Mapping[str, CodeLocationEntry]:
+    def get_code_location_entries(self) -> Mapping[str, CodeLocationEntry]:
         """Return an entry for each location in the workspace."""
 
     @abstractmethod
@@ -62,7 +62,7 @@ class IWorkspace(ABC):
 
         code_locations = (
             location_entry.code_location
-            for location_entry in self.get_workspace_snapshot().values()
+            for location_entry in self.get_code_location_entries().values()
             if location_entry.code_location
         )
         repos = (

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -472,7 +472,7 @@ class AssetDaemon(DagsterDaemon):
         if use_auto_materialize_sensors:
             workspace_snapshot = {
                 location_entry.origin.location_name: location_entry
-                for location_entry in workspace.get_workspace_snapshot().values()
+                for location_entry in workspace.get_code_location_entries().values()
             }
 
             eligible_sensors_and_repos = []

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -363,7 +363,7 @@ def execute_sensor_iteration(
     workspace_snapshot = {
         location_entry.origin.location_name: location_entry
         for location_entry in workspace_process_context.create_request_context()
-        .get_workspace_snapshot()
+        .get_code_location_entries()
         .values()
     }
 

--- a/python_modules/dagster/dagster/_daemon/workspace.py
+++ b/python_modules/dagster/dagster/_daemon/workspace.py
@@ -28,7 +28,7 @@ class BaseDaemonWorkspace(IWorkspace):
     def __enter__(self):
         return self
 
-    def get_workspace_snapshot(self) -> Mapping[str, CodeLocationEntry]:
+    def get_code_location_entries(self) -> Mapping[str, CodeLocationEntry]:
         if self._location_entries is None:
             self._location_entries = self._load_workspace()
         return dict(self._location_entries)
@@ -45,7 +45,7 @@ class BaseDaemonWorkspace(IWorkspace):
         pass
 
     def get_workspace_copy_for_iteration(self):
-        return DaemonIterationWorkspace(self.get_workspace_snapshot())
+        return DaemonIterationWorkspace(self.get_code_location_entries())
 
     def get_code_location(self, location_name: str) -> CodeLocation:
         if self._location_entries is None:

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -271,7 +271,7 @@ def launch_scheduled_runs(
     workspace_snapshot = {
         location_entry.origin.location_name: location_entry
         for location_entry in workspace_process_context.create_request_context()
-        .get_workspace_snapshot()
+        .get_code_location_entries()
         .values()
     }
 

--- a/python_modules/dagster/dagster_tests/core_tests/workspace_tests/test_request_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/workspace_tests/test_request_context.py
@@ -90,7 +90,7 @@ def _location_with_mocked_versions(dagster_library_versions: Mapping[str, str]):
 
 
 def test_feature_flags(workspace_request_context):
-    workspace_snapshot = workspace_request_context.get_workspace_snapshot()
+    workspace_snapshot = workspace_request_context.get_code_location_entries()
 
     error_loc = workspace_snapshot["error_loc"]
     assert get_feature_flags_for_location(error_loc) == {

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
@@ -364,7 +364,7 @@ def external_repo_fixture(workspace_context_struct_resources: WorkspaceProcessCo
     repo_loc = next(
         iter(
             workspace_context_struct_resources.create_request_context()
-            .get_workspace_snapshot()
+            .get_code_location_entries()
             .values()
         )
     ).code_location

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -68,7 +68,7 @@ def instance_with_sensors(overrides=None, attribute="the_repo"):
                     next(
                         iter(
                             workspace_context.create_request_context()
-                            .get_workspace_snapshot()
+                            .get_code_location_entries()
                             .values()
                         )
                     ).code_location
@@ -113,7 +113,7 @@ def instance_with_multiple_code_locations(
             location_infos: Dict[str, CodeLocationInfoForSensorTest] = {}
 
             for code_location_entry in (
-                workspace_context.create_request_context().get_workspace_snapshot().values()
+                workspace_context.create_request_context().get_code_location_entries().values()
             ):
                 code_location: CodeLocation = check.not_none(code_location_entry.code_location)
                 location_infos[code_location.name] = CodeLocationInfoForSensorTest(

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -2632,7 +2632,7 @@ def test_status_in_code_sensor(executor, instance):
         instance=instance,
     ) as workspace_context:
         external_repo = next(
-            iter(workspace_context.create_request_context().get_workspace_snapshot().values())
+            iter(workspace_context.create_request_context().get_code_location_entries().values())
         ).code_location.get_repository("the_status_in_code_repo")
 
         with freeze_time(freeze_datetime):
@@ -2907,7 +2907,9 @@ def test_repository_namespacing(executor):
         )
 
         full_location = next(
-            iter(full_workspace_context.create_request_context().get_workspace_snapshot().values())
+            iter(
+                full_workspace_context.create_request_context().get_code_location_entries().values()
+            )
         ).code_location
         external_repo = full_location.get_repository("the_repo")
         other_repo = full_location.get_repository("the_other_repo")

--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -63,7 +63,7 @@ def external_repo_fixture(
     yield cast(
         CodeLocation,
         next(
-            iter(workspace_context.create_request_context().get_workspace_snapshot().values())
+            iter(workspace_context.create_request_context().get_code_location_entries().values())
         ).code_location,
     ).get_repository("the_repo")
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
@@ -74,7 +74,7 @@ def workspace_fixture(
 @pytest.fixture(name="external_repo", scope="session")
 def external_repo_fixture(workspace_context: WorkspaceProcessContext) -> ExternalRepository:
     return next(
-        iter(workspace_context.create_request_context().get_workspace_snapshot().values())
+        iter(workspace_context.create_request_context().get_code_location_entries().values())
     ).code_location.get_repository(  # type: ignore  # (possible none)
         "the_repo"
     )

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_pythonic_resources.py
@@ -142,7 +142,7 @@ def external_repo_fixture(workspace_context_struct_resources: WorkspaceProcessCo
     repo_loc = next(
         iter(
             workspace_context_struct_resources.create_request_context()
-            .get_workspace_snapshot()
+            .get_code_location_entries()
             .values()
         )
     ).code_location

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -751,7 +751,7 @@ def test_status_in_code_schedule(instance: DagsterInstance, executor: ThreadPool
         instance,
     ) as workspace_context:
         code_location = next(
-            iter(workspace_context.create_request_context().get_workspace_snapshot().values())
+            iter(workspace_context.create_request_context().get_code_location_entries().values())
         ).code_location
         assert code_location
         external_repo = code_location.get_repository("the_status_in_code_repo")
@@ -929,7 +929,7 @@ def test_change_default_status(instance: DagsterInstance, executor: ThreadPoolEx
         instance,
     ) as workspace_context:
         code_location = next(
-            iter(workspace_context.create_request_context().get_workspace_snapshot().values())
+            iter(workspace_context.create_request_context().get_code_location_entries().values())
         ).code_location
         assert code_location
         external_repo = code_location.get_repository("the_status_in_code_repo")
@@ -1005,7 +1005,7 @@ def test_repository_namespacing(instance: DagsterInstance, executor):
                 next(
                     iter(
                         full_workspace_context.create_request_context()
-                        .get_workspace_snapshot()
+                        .get_code_location_entries()
                         .values()
                     )
                 ).code_location,
@@ -1194,12 +1194,12 @@ def test_schedule_mutation(
     executor: ThreadPoolExecutor,
 ):
     repo_one = next(
-        iter(workspace_one.create_request_context().get_workspace_snapshot().values())
+        iter(workspace_one.create_request_context().get_code_location_entries().values())
     ).code_location.get_repository(  # type: ignore
         "the_repo"
     )
     repo_two = next(
-        iter(workspace_two.create_request_context().get_workspace_snapshot().values())
+        iter(workspace_two.create_request_context().get_code_location_entries().values())
     ).code_location.get_repository(  # type: ignore
         "the_repo"
     )
@@ -1531,7 +1531,7 @@ class TestSchedulerRun:
         executor: ThreadPoolExecutor,
     ):
         code_location = next(
-            iter(workspace_context.create_request_context().get_workspace_snapshot().values())
+            iter(workspace_context.create_request_context().get_code_location_entries().values())
         ).code_location
         assert code_location is not None
         external_repo = code_location.get_repository("the_repo")


### PR DESCRIPTION
Summary:
- Paves the way to use a WorkspaceSnapshot object with the entries in it in a way that is not extremely confusing.

## Summary & Motivation

## How I Tested These Changes

## Changelog [New | Bug | Docs]

> Replace this message with a changelog entry, or `NOCHANGELOG`
