### PR TITLE
[airlift] Standardize file structure of stage snippets

### DIFF
--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/stages/migrate.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/stages/migrate.py
@@ -27,9 +27,7 @@ def airflow_dags_path() -> Path:
     return Path(__file__).parent / "tutorial_example" / "airflow_dags"
 
 
-def load_csv_to_duckdb_defs(args: LoadCsvToDuckDbArgs) -> Definitions:
-    spec = AssetSpec(key=[args.duckdb_schema, args.table_name])
-
+def load_csv_to_duckdb_defs(spec: AssetSpec, args: LoadCsvToDuckDbArgs) -> Definitions:
     @multi_asset(name=f"load_{args.table_name}", specs=[spec])
     def _multi_asset() -> None:
         load_csv_to_duckdb(args)
@@ -37,12 +35,7 @@ def load_csv_to_duckdb_defs(args: LoadCsvToDuckDbArgs) -> Definitions:
     return Definitions(assets=[_multi_asset])
 
 
-def export_duckdb_to_csv_defs(args: ExportDuckDbToCsvArgs) -> Definitions:
-    spec = AssetSpec(
-        key=str(args.csv_path).rsplit("/", 2)[-1].replace(".", "_"),
-        deps=[args.table_name],
-    )
-
+def export_duckdb_to_csv_defs(spec: AssetSpec, args: ExportDuckDbToCsvArgs) -> Definitions:
     @multi_asset(name=f"export_{args.table_name}", specs=[spec])
     def _multi_asset() -> None:
         export_duckdb_to_csv(args)
@@ -50,20 +43,13 @@ def export_duckdb_to_csv_defs(args: ExportDuckDbToCsvArgs) -> Definitions:
     return Definitions(assets=[_multi_asset])
 
 
-defs = build_defs_from_airflow_instance(
-    airflow_instance=AirflowInstance(
-        auth_backend=BasicAuthBackend(
-            webserver_url="http://localhost:8080",
-            username="admin",
-            password="admin",
-        ),
-        name="airflow_instance_one",
-    ),
-    defs=dag_defs(
+def rebuild_customer_list_defs() -> Definitions:
+    return dag_defs(
         "rebuild_customers_list",
         task_defs(
             "load_raw_customers",
             load_csv_to_duckdb_defs(
+                AssetSpec(key=["raw_data", "raw_customers"]),
                 LoadCsvToDuckDbArgs(
                     table_name="raw_customers",
                     csv_path=airflow_dags_path() / "raw_customers.csv",
@@ -71,7 +57,7 @@ defs = build_defs_from_airflow_instance(
                     names=["id", "first_name", "last_name"],
                     duckdb_schema="raw_data",
                     duckdb_database_name="jaffle_shop",
-                )
+                ),
             ),
         ),
         task_defs(
@@ -85,16 +71,29 @@ defs = build_defs_from_airflow_instance(
         task_defs(
             "export_customers",
             export_duckdb_to_csv_defs(
+                AssetSpec(key="customers_csv", deps=["customers"]),
                 ExportDuckDbToCsvArgs(
                     table_name="customers",
                     csv_path=Path(os.environ["TUTORIAL_EXAMPLE_DIR"]) / "customers.csv",
                     duckdb_path=Path(os.environ["AIRFLOW_HOME"]) / "jaffle_shop.duckdb",
                     duckdb_schema="raw_data",
                     duckdb_database_name="jaffle_shop",
-                )
+                ),
             ),
         ),
+    )
+
+
+defs = build_defs_from_airflow_instance(
+    airflow_instance=AirflowInstance(
+        auth_backend=BasicAuthBackend(
+            webserver_url="http://localhost:8080",
+            username="admin",
+            password="admin",
+        ),
+        name="airflow_instance_one",
     ),
+    defs=rebuild_customer_list_defs(),
 )
 
 

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/stages/migrate_with_check.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/stages/migrate_with_check.py
@@ -36,9 +36,7 @@ def airflow_dags_path() -> Path:
     return Path(__file__).parent / "tutorial_example" / "airflow_dags"
 
 
-def load_csv_to_duckdb_defs(args: LoadCsvToDuckDbArgs) -> Definitions:
-    spec = AssetSpec(key=[args.duckdb_schema, args.table_name])
-
+def load_csv_to_duckdb_defs(spec: AssetSpec, args: LoadCsvToDuckDbArgs) -> Definitions:
     @multi_asset(name=f"load_{args.table_name}", specs=[spec])
     def _multi_asset() -> None:
         load_csv_to_duckdb(args)
@@ -46,12 +44,7 @@ def load_csv_to_duckdb_defs(args: LoadCsvToDuckDbArgs) -> Definitions:
     return Definitions(assets=[_multi_asset])
 
 
-def export_duckdb_to_csv_defs(args: ExportDuckDbToCsvArgs) -> Definitions:
-    spec = AssetSpec(
-        key=str(args.csv_path).rsplit("/", 2)[-1].replace(".", "_"),
-        deps=[args.table_name],
-    )
-
+def export_duckdb_to_csv_defs(spec: AssetSpec, args: ExportDuckDbToCsvArgs) -> Definitions:
     @multi_asset(name=f"export_{args.table_name}", specs=[spec])
     def _multi_asset() -> None:
         export_duckdb_to_csv(args)
@@ -81,6 +74,47 @@ def validate_exported_csv() -> AssetCheckResult:
     )
 
 
+def rebuild_customer_list_defs() -> Definitions:
+    return dag_defs(
+        "rebuild_customers_list",
+        task_defs(
+            "load_raw_customers",
+            load_csv_to_duckdb_defs(
+                AssetSpec(key=["raw_data", "raw_customers"]),
+                LoadCsvToDuckDbArgs(
+                    table_name="raw_customers",
+                    csv_path=airflow_dags_path() / "raw_customers.csv",
+                    duckdb_path=Path(os.environ["AIRFLOW_HOME"]) / "jaffle_shop.duckdb",
+                    names=["id", "first_name", "last_name"],
+                    duckdb_schema="raw_data",
+                    duckdb_database_name="jaffle_shop",
+                ),
+            ),
+        ),
+        task_defs(
+            "build_dbt_models",
+            # load rich set of assets from dbt project
+            dbt_defs(
+                manifest=dbt_project_path() / "target" / "manifest.json",
+                project=DbtProject(str(dbt_project_path().absolute())),
+            ),
+        ),
+        task_defs(
+            "export_customers",
+            export_duckdb_to_csv_defs(
+                AssetSpec(key="customers_csv", deps=["customers"]),
+                ExportDuckDbToCsvArgs(
+                    table_name="customers",
+                    csv_path=Path(os.environ["TUTORIAL_EXAMPLE_DIR"]) / "customers.csv",
+                    duckdb_path=Path(os.environ["AIRFLOW_HOME"]) / "jaffle_shop.duckdb",
+                    duckdb_schema="raw_data",
+                    duckdb_database_name="jaffle_shop",
+                ),
+            ),
+        ),
+    )
+
+
 defs = Definitions.merge(
     build_defs_from_airflow_instance(
         airflow_instance=AirflowInstance(
@@ -91,42 +125,7 @@ defs = Definitions.merge(
             ),
             name="airflow_instance_one",
         ),
-        defs=dag_defs(
-            "rebuild_customers_list",
-            task_defs(
-                "load_raw_customers",
-                load_csv_to_duckdb_defs(
-                    LoadCsvToDuckDbArgs(
-                        table_name="raw_customers",
-                        csv_path=airflow_dags_path() / "raw_customers.csv",
-                        duckdb_path=Path(os.environ["AIRFLOW_HOME"]) / "jaffle_shop.duckdb",
-                        names=["id", "first_name", "last_name"],
-                        duckdb_schema="raw_data",
-                        duckdb_database_name="jaffle_shop",
-                    )
-                ),
-            ),
-            task_defs(
-                "build_dbt_models",
-                # load rich set of assets from dbt project
-                dbt_defs(
-                    manifest=dbt_project_path() / "target" / "manifest.json",
-                    project=DbtProject(str(dbt_project_path().absolute())),
-                ),
-            ),
-            task_defs(
-                "export_customers",
-                export_duckdb_to_csv_defs(
-                    ExportDuckDbToCsvArgs(
-                        table_name="customers",
-                        csv_path=Path(os.environ["TUTORIAL_EXAMPLE_DIR"]) / "customers.csv",
-                        duckdb_path=Path(os.environ["AIRFLOW_HOME"]) / "jaffle_shop.duckdb",
-                        duckdb_schema="raw_data",
-                        duckdb_database_name="jaffle_shop",
-                    )
-                ),
-            ),
-        ),
+        defs=rebuild_customer_list_defs(),
     ),
     Definitions(asset_checks=[validate_exported_csv]),
 )

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/stages/observe.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/stages/observe.py
@@ -24,7 +24,11 @@ def rebuild_customer_list_defs() -> Definitions:
         "rebuild_customers_list",
         task_defs(
             "load_raw_customers",
-            Definitions(assets=[AssetSpec(key=["raw_data", "raw_customers"])]),
+            Definitions(
+                assets=[
+                    AssetSpec(key=["raw_data", "raw_customers"]),
+                ]
+            ),
         ),
         task_defs(
             "build_dbt_models",
@@ -37,7 +41,11 @@ def rebuild_customer_list_defs() -> Definitions:
         task_defs(
             "export_customers",
             # encode dependency on customers table
-            Definitions(assets=[AssetSpec(key="customers_csv", deps=["customers"])]),
+            Definitions(
+                assets=[
+                    AssetSpec(key="customers_csv", deps=["customers"]),
+                ]
+            ),
         ),
     )
 

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/stages/standalone.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/stages/standalone.py
@@ -20,9 +20,7 @@ def airflow_dags_path() -> Path:
     return Path(__file__).parent / "tutorial_example" / "airflow_dags"
 
 
-def load_csv_to_duckdb_defs(args: LoadCsvToDuckDbArgs) -> Definitions:
-    spec = AssetSpec(key=[args.duckdb_schema, args.table_name])
-
+def load_csv_to_duckdb_defs(spec: AssetSpec, args: LoadCsvToDuckDbArgs) -> Definitions:
     @multi_asset(name=f"load_{args.table_name}", specs=[spec])
     def _multi_asset() -> None:
         load_csv_to_duckdb(args)
@@ -30,12 +28,7 @@ def load_csv_to_duckdb_defs(args: LoadCsvToDuckDbArgs) -> Definitions:
     return Definitions(assets=[_multi_asset])
 
 
-def export_duckdb_to_csv_defs(args: ExportDuckDbToCsvArgs) -> Definitions:
-    spec = AssetSpec(
-        key=str(args.csv_path).rsplit("/", 2)[-1].replace(".", "_"),
-        deps=[args.table_name],
-    )
-
+def export_duckdb_to_csv_defs(spec: AssetSpec, args: ExportDuckDbToCsvArgs) -> Definitions:
     @multi_asset(name=f"export_{args.table_name}", specs=[spec])
     def _multi_asset() -> None:
         export_duckdb_to_csv(args)
@@ -43,9 +36,10 @@ def export_duckdb_to_csv_defs(args: ExportDuckDbToCsvArgs) -> Definitions:
     return Definitions(assets=[_multi_asset])
 
 
-def build_customers_list_defs() -> Definitions:
-    rebuild_customers_list_defs = Definitions.merge(
+def rebuild_customers_list_defs() -> Definitions:
+    asset_defs = Definitions.merge(
         load_csv_to_duckdb_defs(
+            AssetSpec(key=["raw_data", "raw_customers"]),
             LoadCsvToDuckDbArgs(
                 table_name="raw_customers",
                 csv_path=airflow_dags_path() / "raw_customers.csv",
@@ -53,33 +47,34 @@ def build_customers_list_defs() -> Definitions:
                 names=["id", "first_name", "last_name"],
                 duckdb_schema="raw_data",
                 duckdb_database_name="jaffle_shop",
-            )
+            ),
         ),
         dbt_defs(
             manifest=dbt_project_path() / "target" / "manifest.json",
             project=DbtProject(dbt_project_path().absolute()),
         ),
         export_duckdb_to_csv_defs(
+            AssetSpec(key="customers_csv", deps=["customers"]),
             ExportDuckDbToCsvArgs(
                 table_name="customers",
-                # TODO use env var?
                 csv_path=Path(os.environ["TUTORIAL_EXAMPLE_DIR"]) / "customers.csv",
                 duckdb_path=Path(os.environ["AIRFLOW_HOME"]) / "jaffle_shop.duckdb",
+                duckdb_schema="raw_data",
                 duckdb_database_name="jaffle_shop",
-            )
+            ),
         ),
     )
 
     rebuild_customers_list_schedule = ScheduleDefinition(
         name="rebuild_customers_list_schedule",
-        target=AssetSelection.assets(*rebuild_customers_list_defs.assets),  # type: ignore
+        target=AssetSelection.assets(*asset_defs.assets),  # type: ignore
         cron_schedule="0 0 * * *",
     )
 
     return Definitions.merge(
-        rebuild_customers_list_defs,
+        asset_defs,
         Definitions(schedules=[rebuild_customers_list_schedule]),
     )
 
 
-defs = build_customers_list_defs()
+defs = rebuild_customers_list_defs()


### PR DESCRIPTION
## Summary

Changes a few of the stages to standardize file structure and make the observation->migration step a little easier to understand.

In particular:
- Moves defs building to `rebuild_customers_list_defs` fn in each of the observe, migrate, standalone steps
- Moves the asset definition builder fns to use user-passed Specs instead of constructing them, reducing complexity + making observe->migrate step clearer


I think this is most clear viewing observe and then. migrate stages back to back:
https://github.com/dagster-io/dagster/blob/99c96ced310195c1ff3a2ed9cd893ec8a4bdf1a5/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/stages/observe.py#L22-L50
https://github.com/dagster-io/dagster/blob/99c96ced310195c1ff3a2ed9cd893ec8a4bdf1a5/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/stages/migrate.py#L46-L84

## Test Plan

existing e2e tests