### PR TITLE
Undeprecate SourceAsset

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -167,7 +167,6 @@ def wrap_source_asset_observe_fn_in_op_compute_fn(
 @experimental_param(param="io_manager_def")
 @experimental_param(param="freshness_policy")
 @experimental_param(param="tags")
-@deprecated(breaking_version="2.0.0", additional_warn_text="Use AssetSpec instead.")
 class SourceAsset(ResourceAddable):
     """A SourceAsset represents an asset that will be loaded by (but not updated by) Dagster.
 


### PR DESCRIPTION
## Summary & Motivation

Proposing temporarily un-deprecating SourceAsset until there is a clearer succession plan. The current advice to use `AssetSpec` does not cover all use cases.

Even with the support of `io_manager_key` via metadata it still does not sufficiently explain the case of an observable source asset where `resource_def` and many other parameters could be used. I think we should undeprecate it until we have clearer answers.

## How I Tested These Changes

BK. Read docs.

## Changelog [New | Bug | Docs]

NOCHANGELOG
