### PR TITLE
Add a watchdog<6 pin

### DIFF
--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -102,7 +102,7 @@ setup(
         "structlog",
         "sqlalchemy>=1.0,<3",
         "toposort>=1.0",
-        "watchdog>=0.8.3",
+        "watchdog>=0.8.3,<6",
         'psutil>=1.0; platform_system=="Windows"',
         # https://github.com/mhammond/pywin32/issues/1439
         'pywin32!=226; platform_system=="Windows"',


### PR DESCRIPTION
Summary:
Since watchdog 5 broke us, add a pin to prevent watchdog 6 someday from potentially breaking us.

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes

## Changelog [New | Bug | Docs]

> Replace this message with a changelog entry, or `NOCHANGELOG`
