### PR TITLE
fix: label dagster/image is correctly set when image is provided from user_defined_k8s_config

### DIFF
--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_executor.py
@@ -152,5 +152,6 @@ def test_per_step_k8s_config(kubeconfig_file):
     created_containers = expected_mock.call_args.kwargs["body"].spec.template.spec.containers
     assert len(created_containers) == 1
     container = created_containers[0]
+    assert container.image == "some-job-image:tag"
     assert container.resources.limits == {"cpu": "222m", "memory": "222Mi"}
     assert container.resources.requests == {"cpu": "111m", "memory": "111Mi"}

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
@@ -323,12 +323,13 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
     )
 
     # Construct Dagster run tags with user defined k8s config.
+    expected_image = "different_image:tag"
     expected_resources = {
         "requests": {"cpu": "250m", "memory": "64Mi"},
         "limits": {"cpu": "500m", "memory": "2560Mi"},
     }
     user_defined_k8s_config = UserDefinedDagsterK8sConfig(
-        container_config={"resources": expected_resources},
+        container_config={"image": expected_image, "resources": expected_resources},
     )
     user_defined_k8s_config_json = json.dumps(user_defined_k8s_config.to_dict())
     tags = {"dagster-k8s/config": user_defined_k8s_config_json}
@@ -367,7 +368,7 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
             celery_k8s_run_launcher.launch_run(LaunchRunContext(run, workspace))
 
             updated_run = instance.get_run_by_id(run.run_id)
-            assert updated_run.tags[DOCKER_IMAGE_TAG] == "fake-image-name"
+            assert updated_run.tags[DOCKER_IMAGE_TAG] == expected_image
 
             # Check that user defined k8s config was passed down to the k8s job.
             mock_method_calls = mock_k8s_client_batch_api.method_calls

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -225,12 +225,6 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
         job_config = container_context.get_k8s_job_config(
             job_image=repository_origin.container_image, run_launcher=self
         )
-        job_image = job_config.job_image
-        if job_image:  # expected to be set
-            self._instance.add_run_tags(
-                run.run_id,
-                {DOCKER_IMAGE_TAG: job_image},
-            )
 
         labels = {
             "dagster/job": job_origin.job_name,
@@ -255,6 +249,12 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
                     "value": job_origin.job_name,
                 },
             ],
+        )
+
+        # Set docker/image tag here, as it can also be provided by `user_defined_k8s_config`.
+        self._instance.add_run_tags(
+            run.run_id,
+            {DOCKER_IMAGE_TAG: job.spec.template.spec.containers[0].image},
         )
 
         namespace = check.not_none(container_context.namespace)

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
@@ -419,12 +419,13 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
     )
 
     # Construct Dagster run tags with user defined k8s config.
+    expected_image = "different_image:tag"
     expected_resources = {
         "requests": {"cpu": "250m", "memory": "64Mi"},
         "limits": {"cpu": "500m", "memory": "2560Mi"},
     }
     user_defined_k8s_config = UserDefinedDagsterK8sConfig(
-        container_config={"resources": expected_resources},
+        container_config={"image": expected_image, "resources": expected_resources},
         pod_spec_config={"scheduler_name": "test-scheduler-2"},
     )
     user_defined_k8s_config_json = json.dumps(user_defined_k8s_config.to_dict())
@@ -462,7 +463,7 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
             k8s_run_launcher.launch_run(LaunchRunContext(run, workspace))
 
             updated_run = instance.get_run_by_id(run.run_id)
-            assert updated_run.tags[DOCKER_IMAGE_TAG] == "fake_job_image"
+            assert updated_run.tags[DOCKER_IMAGE_TAG] == expected_image
 
         # Check that user defined k8s config was passed down to the k8s job.
         mock_method_calls = mock_k8s_client_batch_api.method_calls


### PR DESCRIPTION
## Summary & Motivation
If I explicitly set tag `dagster-k8s/config:{"container_config": {"image": "my_image:latest"}}`,
once the job starts, additional tag dagster/image with current (wrong) code location image is added.
![image](https://github.com/user-attachments/assets/99f9d721-2598-4a9a-97d3-61f785b47f21)

Discussed here: https://github.com/dagster-io/dagster/discussions/24006#discussioncomment-10479249


## How I Tested These Changes
Found all usages of `from dagster._core.storage.tags import DOCKER_IMAGE_TAG`.
Found tests that mention `user_defined` and extended them to cover case when image is explicitly set from UI as:
```
"dagster-k8s/config": {"container_config": {"image": "myregistry/myimage:mytag"}}
```

## Changelog [Bug]
[dagster-k8s, dagster-celery-k8s] label `dagster/image` is correctly set when image is provided from user_defined_k8s_config
