### PR TITLE
fix tick filter display

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/TickHistory.tsx
@@ -59,9 +59,9 @@ type InstigationTick = HistoryTickFragment;
 const PAGE_SIZE = 25;
 
 enum TickStatusDisplay {
-  ALL,
-  FAILED,
-  SUCCESS,
+  ALL = 'all',
+  FAILED = 'failed',
+  SUCCESS = 'success',
 }
 
 const STATUS_DISPLAY_MAP = {


### PR DESCRIPTION
## Summary & Motivation
Fixes the tick filter display, once selected

## How I Tested These Changes
Selected filter, saw that the selector displayed the correct label.

## Changelog [Bug]

NOCHANGELOG
