### PR TITLE
feat(dbt): use `project_dir` to override the `DBT_PROJECT_DIR` environment variable

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -627,6 +627,9 @@ class DbtCliResource(ConfigurableResource):
             # See https://docs.getdbt.com/docs/core/connect-data-platform/connection-profiles#advanced-customizing-a-profile-directory
             # for more information.
             **({"DBT_PROFILES_DIR": self.profiles_dir} if self.profiles_dir else {}),
+            # The DBT_PROJECT_DIR environment variable is set to the path containing the dbt project
+            # See https://docs.getdbt.com/reference/dbt_project.yml for more information.
+            **({"DBT_PROJECT_DIR": self.project_dir} if self.project_dir else {}),
         }
 
         selection_args: List[str] = []

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
@@ -258,6 +258,17 @@ def test_dbt_profiles_dir_configuration(profiles_dir: Union[str, Path]) -> None:
         )
 
 
+def test_dbt_project_dir_conflicting_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DBT_PROJECT_DIR", "nonexistent")
+    assert (
+        DbtCliResource(
+            project_dir=os.fspath(test_jaffle_shop_path),
+        )
+        .cli(["parse"])
+        .is_successful()
+    )
+
+
 def test_dbt_partial_parse(dbt: DbtCliResource) -> None:
     test_jaffle_shop_path.joinpath("target", PARTIAL_PARSE_FILE_NAME).unlink(missing_ok=True)
 


### PR DESCRIPTION
## Summary & Motivation

Addresses https://github.com/dagster-io/dagster/issues/23906

## How I Tested These Changes

Added a unit test that asserts that the cli is able to parse the project, even when `DBT_PROJECT_DIR` contains a nonexistent path.

## Changelog [ NEW ]

When instantiating `DbtCliResource`, the `project_dir` argument will now override the `DBT_PROJECT_DIR` environment variable if it exists in the local environment.
