### PR TITLE
[dagster-pipes] separate `get_params` and `read_messages`

### DIFF
--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -78,8 +78,8 @@ class PipesMessageHandler:
         self._opened_payload: Optional[PipesOpenedData] = None
 
     @contextmanager
-    def handle_messages(self) -> Iterator[PipesParams]:
-        with self._message_reader.read_messages(self) as params:
+    def handle_messages(self, extra_params: Optional[PipesParams] = None) -> Iterator[PipesParams]:
+        with self._message_reader.read_messages(self, extra_params=extra_params) as params:
             yield params
 
     def get_reported_results(self) -> Sequence[PipesExecutionResult]:
@@ -272,8 +272,14 @@ class PipesSession:
     context_data: PipesContextData
     message_handler: PipesMessageHandler
     context_injector_params: PipesParams
-    message_reader_params: PipesParams
     context: OpExecutionContext
+    message_reader_params: PipesParams
+
+    @contextmanager
+    def read_messages(self, extra_params: Optional[PipesParams] = None):
+        """Context manager for reading messages from an external process."""
+        with self.message_handler.handle_messages(extra_params=extra_params) as params:
+            yield params
 
     @public
     def get_bootstrap_env_vars(self) -> Mapping[str, str]:


### PR DESCRIPTION
## Summary & Motivation

Currently we expect `MessageReader.read_messages` to do 2 things at the same time:
- read messages - makes sense right?
- yield parameters to pass to the `MessageWriter` - this is problematic, because sometimes reading can only happen after the external process has been launched (see my notes in [Notion](https://www.notion.so/dagster/Maturing-Pipes-Plan-e9cea819b7c348178f870a0993263861?pvs=4#12e3aea926f541ffbcd1059af0726387)), but the `MessageWriter` parameters have to be set before starting it.

So, I would like to separate these 2 things into 2 different methods.

This will allow us to reuse the same `MessageWriter` for both cases (messages location known in advance and only after external process has been started).

This is going to be useful for EMR Pipes I'm working on since I could reuse the excellent `PipesS3MessageReader` to read logs from S3 which are written by AWS EMR.

The `CloudWatchMessageReader` was adjusted to demonstrate the new ability to call `.read_messages` manually after the external process has been launched. The tests involving this MessageReader are passing. 

Tasks:
- [x] prepare params for message writer in `PipesMessageReader.get_params`, call it inside `open_pipes_session`
- [x] add `PipesMessageReader.read_location_known` `@property` 
- [x] add `extra_params` argument to `CloudWatchMesssageReader.read_messages` for params which are only known after the external process has been launched
- [x] showcase the new logic with `CloudWatchMesssageReader`
- [x] rename `PipesMessageReader.get_params` -> `PipesMessageReader.get_writer_params`
- [ ] add this method to all `MessageReader`s 
- [ ] `MessageReader.read_messages` doesn't have to be a `@contextmanager` anymore
- [ ] update docs
---

The new logic for calling `.read_messages` after the external process has been launched is the following: 

```python
    with open_pipes_session(
            context=context,
            message_reader=self._message_reader,
            context_injector=self._context_injector,
            extras=extras,
        ) as session:
            response = ... # launch external process, get some information from it about the messages location. 
            # Example with imaginary service:
            extra_params = {
                "log_group": f"{response['log_group']}/output",
                "log_stream": response['run_id'],
                "start_time": int(response['start_timestamp']),
            }

            # maybe we should somehow hide this logic inside `open_pipes_session`
            if not self._message_reader.read_location_known:
                with session.read_messages(extra_params=extra_params):
                    pass
```

Now we don't need to do checks like `isinstance(self._message_reader, CloudWatchMessageReader)` anymore. 
We can just dump all runtime params into `extra_params` (and hope they don't collide for different MessageReaders but that's really unlikely) 

## How I Tested These Changes
Existing tests should pass.

## Changelog [New | Bug | Docs]

> Replace this message with a changelog entry, or `NOCHANGELOG`
