### PR TITLE
[docs] MaterializationResult should be MaterializeResult

### DIFF
--- a/docs/content/concepts/dagster-pipes/dagster-pipes-details-and-customization.mdx
+++ b/docs/content/concepts/dagster-pipes/dagster-pipes-details-and-customization.mdx
@@ -279,7 +279,7 @@ with open_dagster_pipes(
 
     # ... business logic
 
-    # Creates a `MaterializationResult` on the orchestration side. Notice no value for the asset is
+    # Creates a `MaterializeResult` on the orchestration side. Notice no value for the asset is
     # included. Pipes only supports reporting that a materialization occurred and associated
     # metadata.
     pipes.report_asset_materialization(

--- a/docs/content/concepts/dagster-pipes/databricks.mdx
+++ b/docs/content/concepts/dagster-pipes/databricks.mdx
@@ -289,7 +289,7 @@ To use <PyObject object="open_pipes_session" />:
 1. Your Databricks job be launched within the scope of the <PyObject object="open_pipes_session" /> context manager; and
 2. Your job is launched on a cluster containing the environment variables available on the yielded `pipes_session`
 
-While your Databricks code is running, any calls to `report_asset_materialization` in the external script are streamed back to Dagster, causing a `MaterializationResult` object to be buffered on the `pipes_session`. You can either:
+While your Databricks code is running, any calls to `report_asset_materialization` in the external script are streamed back to Dagster, causing a `MaterializeResult` object to be buffered on the `pipes_session`. You can either:
 
 - Leave these objects buffered until execution is complete (**Option 1** in below example code), or
 - Stream them to Dagster machinery during execution by calling `yield pipes_session.get_results()` (**Option 2**)

--- a/docs/dagster-university/pages/dagster-essentials/extra-credit/materialization-metadata.md
+++ b/docs/dagster-university/pages/dagster-essentials/extra-credit/materialization-metadata.md
@@ -80,7 +80,7 @@ Let’s add metadata to the `taxi_trips_file` asset to demonstrate further. This
 
    Let’s break down what’s happening here:
 
-   - Rather than returning nothing, we'll return some information about the materialization that happened with the `MaterializationResult` class.
+   - Rather than returning nothing, we'll return some information about the materialization that happened with the `MaterializeResult` class.
    - The `metadata` parameter accepts a `dict`, where the key is the label or name of the metadata and the value is the data itself. In this case, the key is `Number of records`. The value in this example is everything after `Number of records`.
    - Using `MetadataValue.int`, the value of the `num_rows` variable is typed as an integer. This tells Dagster to render the data as an integer.
 

--- a/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/dagster_pipes_details_and_customization/session_lifecycle_external.py
+++ b/examples/docs_snippets/docs_snippets/guides/dagster/dagster_pipes/dagster_pipes_details_and_customization/session_lifecycle_external.py
@@ -21,7 +21,7 @@ with open_dagster_pipes(
 
     # ... business logic
 
-    # Creates a `MaterializationResult` on the orchestration side. Notice no value for the asset is
+    # Creates a `MaterializeResult` on the orchestration side. Notice no value for the asset is
     # included. Pipes only supports reporting that a materialization occurred and associated
     # metadata.
     pipes.report_asset_materialization(


### PR DESCRIPTION
The class is "MaterializeResult" not MaterializationResult, this just fixes up some places that reference it incorrectly (noticed in the dagsterU lesson here: https://courses.dagster.io/courses/take/dagster-essentials/multimedia/48235027-materialization-metadata)
