### PR TITLE
Make useIndexedDBCachedQuery integrate with performance tracking.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -15,7 +15,6 @@ import {usePrefixedCacheKey} from '../app/AppProvider';
 import {GraphQueryItem, filterByQuery} from '../app/GraphQueryImpl';
 import {AssetKey} from '../assets/types';
 import {AssetGroupSelector, PipelineSelector} from '../graphql/types';
-import {useBlockTraceUntilTrue} from '../performance/TraceContext';
 import {useIndexedDBCachedQuery} from '../search/useIndexedDBCachedQuery';
 
 export interface AssetGraphFetchScope {
@@ -48,7 +47,6 @@ export function useFullAssetGraphData(options: AssetGraphFetchScope) {
     ),
     version: 1,
   });
-  useBlockTraceUntilTrue('ASSET_GRAPH_QUERY', !fetchResult.loading);
 
   const nodes = fetchResult.data?.assetNodes;
   const queryItems = useMemo(() => (nodes ? buildGraphQueryItems(nodes) : []), [nodes]);
@@ -87,7 +85,6 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
     ),
     version: 1,
   });
-  useBlockTraceUntilTrue('ASSET_GRAPH_QUERY', !fetchResult.loading);
 
   const nodes = fetchResult.data?.assetNodes;
 


### PR DESCRIPTION
## Summary & Motivation

Only a couple call sites using this hook and they were using the performance tracking APIs directly. Lets move this into the hook so that callers don't need to think about it.

## How I Tested These Changes




## Changelog [New | Bug | Docs]
NOCHANGELOG
