### PR TITLE
Make airlift work on 1.7.15

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor.py
@@ -35,7 +35,7 @@ def build_airflow_polling_sensor(
         name="airflow_dag_status_sensor",
         minimum_interval_seconds=1,
         default_status=DefaultSensorStatus.RUNNING,
-        target="*",
+        asset_selection="*",
     )
     def airflow_dag_sensor(context: SensorEvaluationContext) -> SensorResult:
         """Sensor to report materialization events for each asset as new runs come in."""


### PR DESCRIPTION
## Summary & Motivation

We need to make airlift work on pre 1.8 for some early design partners. This does that by no tusing `target` on `sensor`.

## How I Tested These Changes

Ran tutorial with this environment:

```bash
(dagster-airlift) ➜  tutorial-example git:(make-airlift-compat-with-1.7) ✗ uv pip list | grep dagster
dagster                                  1.7.15
dagster-airlift                          0.0.11
dagster-dbt                              0.23.15
dagster-graphql                          1.7.15
dagster-pipes                            1.7.15
dagster-webserver                        1.7.15
tutorial-example                         0.0.0        /Users/schrockn/code/dagster-io/dagster/examples/experimental/dagster-airlift/examples/tutorial-example
```
## Changelog [New | Bug | Docs]

NOCHANGELOG
