### PR TITLE
Allow explicit mwaa client to be passed into MwaaSessionAuthBackend

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/mwaa/auth.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/mwaa/auth.py
@@ -37,7 +37,7 @@ class MwaaSessionAuthBackend(AirflowAuthBackend):
         self._session_info: Optional[Tuple[str, str]] = None
 
     @staticmethod
-    def for_local(region: str, env_name: str, profile_name: Optional[str] = None):
+    def from_profile(region: str, env_name: str, profile_name: Optional[str] = None):
         boto_session = boto3.Session(profile_name=profile_name, region_name=region)
         mwaa = boto_session.client("mwaa")
         return MwaaSessionAuthBackend(mwaa_client=mwaa, env_name=env_name)

--- a/examples/experimental/dagster-airlift/dagster_airlift/mwaa/auth.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/mwaa/auth.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 import boto3
 import requests
@@ -6,10 +6,8 @@ import requests
 from ..core.airflow_instance import AirflowAuthBackend
 
 
-def get_session_info(region: str, env_name: str, profile_name: Optional[str]) -> Tuple[str, str]:
+def get_session_info(mwaa: Any, env_name: str) -> Tuple[str, str]:
     # Initialize MWAA client and request a web login token
-    boto_session = boto3.Session(profile_name=profile_name, region_name=region)
-    mwaa = boto_session.client("mwaa")
     response = mwaa.create_web_login_token(Name=env_name)
 
     # Extract the web server hostname and login token
@@ -32,17 +30,22 @@ def get_session_info(region: str, env_name: str, profile_name: Optional[str]) ->
 
 
 class MwaaSessionAuthBackend(AirflowAuthBackend):
-    def __init__(self, region: str, env_name: str, profile_name: Optional[str] = None):
-        self.region = region
+    def __init__(self, mwaa_client: Any, env_name: str) -> None:
+        self.mwaa_client = mwaa_client
         self.env_name = env_name
-        self.profile_name = profile_name
         # Session info is generated when we either try to retrieve a session or retrieve the web server url
         self._session_info: Optional[Tuple[str, str]] = None
+
+    @staticmethod
+    def for_local(region: str, env_name: str, profile_name: Optional[str] = None):
+        boto_session = boto3.Session(profile_name=profile_name, region_name=region)
+        mwaa = boto_session.client("mwaa")
+        return MwaaSessionAuthBackend(mwaa_client=mwaa, env_name=env_name)
 
     def get_session(self) -> requests.Session:
         # Get the session info
         if not self._session_info:
-            self._session_info = get_session_info(self.region, self.env_name, self.profile_name)
+            self._session_info = get_session_info(mwaa=self.mwaa_client, env_name=self.env_name)
         session_cookie = self._session_info[1]
         # Create a new session
         session = requests.Session()
@@ -53,5 +56,5 @@ class MwaaSessionAuthBackend(AirflowAuthBackend):
 
     def get_webserver_url(self) -> str:
         if not self._session_info:
-            self._session_info = get_session_info(self.region, self.env_name, self.profile_name)
+            self._session_info = get_session_info(mwaa=self.mwaa_client, env_name=self.env_name)
         return f"https://{self._session_info[0]}"

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_mwaa_auth.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_mwaa_auth.py
@@ -6,7 +6,7 @@ def test_mwaa_session_auth() -> None:
     """Test output format of mwaa auth backend. Does not actually make any live requests to boto or exercise usage of aws apis in any way."""
     with mock.patch("dagster_airlift.mwaa.auth.get_session_info") as mock_get_session_info:
         mock_get_session_info.return_value = ("my-webserver-hostname", "my-session-cookie")
-        auth_backend = MwaaSessionAuthBackend(region="us-west-2", env_name="my-env")
+        auth_backend = MwaaSessionAuthBackend.for_local(region="us-west-2", env_name="my-env")
         session = auth_backend.get_session()
         assert session.cookies["session"] == "my-session-cookie"
         assert auth_backend.get_webserver_url() == "https://my-webserver-hostname"

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_mwaa_auth.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_mwaa_auth.py
@@ -3,7 +3,7 @@ import mock
 from dagster_airlift.mwaa import MwaaSessionAuthBackend
 
 
-def test_mwaa_session_auth() -> None:
+def test_mwaa_session_auth_from_profile() -> None:
     """Test output format of mwaa auth backend. Does not actually make any live requests to boto or exercise usage of aws apis in any way."""
     with mock.patch("dagster_airlift.mwaa.auth.get_session_info") as mock_get_session_info:
         mock_get_session_info.return_value = ("my-webserver-hostname", "my-session-cookie")

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_mwaa_auth.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_mwaa_auth.py
@@ -6,7 +6,7 @@ def test_mwaa_session_auth() -> None:
     """Test output format of mwaa auth backend. Does not actually make any live requests to boto or exercise usage of aws apis in any way."""
     with mock.patch("dagster_airlift.mwaa.auth.get_session_info") as mock_get_session_info:
         mock_get_session_info.return_value = ("my-webserver-hostname", "my-session-cookie")
-        auth_backend = MwaaSessionAuthBackend.for_local(region="us-west-2", env_name="my-env")
+        auth_backend = MwaaSessionAuthBackend.from_profile(region="us-west-2", env_name="my-env")
         session = auth_backend.get_session()
         assert session.cookies["session"] == "my-session-cookie"
         assert auth_backend.get_webserver_url() == "https://my-webserver-hostname"

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_mwaa_auth.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_mwaa_auth.py
@@ -1,3 +1,4 @@
+import boto3
 import mock
 from dagster_airlift.mwaa import MwaaSessionAuthBackend
 
@@ -7,6 +8,18 @@ def test_mwaa_session_auth() -> None:
     with mock.patch("dagster_airlift.mwaa.auth.get_session_info") as mock_get_session_info:
         mock_get_session_info.return_value = ("my-webserver-hostname", "my-session-cookie")
         auth_backend = MwaaSessionAuthBackend.from_profile(region="us-west-2", env_name="my-env")
+        session = auth_backend.get_session()
+        assert session.cookies["session"] == "my-session-cookie"
+        assert auth_backend.get_webserver_url() == "https://my-webserver-hostname"
+
+
+def test_mwaa_session_auth_direct_mwaa_client_creation() -> None:
+    """Test output format of mwaa auth backend. Does not actually make any live requests to boto or exercise usage of aws apis in any way."""
+    with mock.patch("dagster_airlift.mwaa.auth.get_session_info") as mock_get_session_info:
+        mock_get_session_info.return_value = ("my-webserver-hostname", "my-session-cookie")
+        boto_session = boto3.Session(region_name="us-west-2")
+        mwaa = boto_session.client("mwaa")
+        auth_backend = MwaaSessionAuthBackend(mwaa_client=mwaa, env_name="my-env")
         session = auth_backend.get_session()
         assert session.cookies["session"] == "my-session-cookie"
         assert auth_backend.get_webserver_url() == "https://my-webserver-hostname"

--- a/examples/experimental/dagster-airlift/examples/mwaa-example/mwaa_example/definitions.py
+++ b/examples/experimental/dagster-airlift/examples/mwaa-example/mwaa_example/definitions.py
@@ -4,7 +4,7 @@ from dagster_airlift.mwaa import MwaaSessionAuthBackend
 defs = build_defs_from_airflow_instance(
     airflow_instance=AirflowInstance(
         name="example-instance",
-        auth_backend=MwaaSessionAuthBackend.for_local(
+        auth_backend=MwaaSessionAuthBackend.from_profile(
             region="us-west-2", env_name="airlift-mwaa-example", profile_name="dev-cloud-admin"
         ),
     )

--- a/examples/experimental/dagster-airlift/examples/mwaa-example/mwaa_example/definitions.py
+++ b/examples/experimental/dagster-airlift/examples/mwaa-example/mwaa_example/definitions.py
@@ -4,7 +4,7 @@ from dagster_airlift.mwaa import MwaaSessionAuthBackend
 defs = build_defs_from_airflow_instance(
     airflow_instance=AirflowInstance(
         name="example-instance",
-        auth_backend=MwaaSessionAuthBackend(
+        auth_backend=MwaaSessionAuthBackend.for_local(
             region="us-west-2", env_name="airlift-mwaa-example", profile_name="dev-cloud-admin"
         ),
     )


### PR DESCRIPTION
## Summary & Motivation

Users need more flexibility when controlling auth and session configuration. Therefore we're making `MwaaSessionAuthBackend` parameterizable with a full session object. The old `__init__` is available for convenience in the static method `for_local`.

## How I Tested These Changes

BK

## Changelog [New | Bug | Docs]

NOCHANGELOG
