### PR TITLE
Generic AutomationContext, AutomationResult, AutomationCondition

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -684,7 +684,7 @@ class TestAssetConditionEvaluations(ExecutingGraphQLContextTestMatrix):
         assert rootNode["expandedLabel"] == [
             "(in_latest_time_window)",
             "AND",
-            "(((newly_missing) OR (any_deps_updated)) SINCE (handled))",
+            "(((newly_missing) OR (any_deps_updated)) SINCE ((newly_requested) OR (newly_updated)))",
             "AND",
             "(NOT (any_deps_missing))",
             "AND",

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -684,7 +684,7 @@ class TestAssetConditionEvaluations(ExecutingGraphQLContextTestMatrix):
         assert rootNode["expandedLabel"] == [
             "(in_latest_time_window)",
             "AND",
-            "(((newly_missing) OR (any_deps_updated)) SINCE ((newly_requested) OR (newly_updated)))",
+            "(((newly_missing) OR (any_deps_updated)) SINCE (handled))",
             "AND",
             "(NOT (any_deps_missing))",
             "AND",

--- a/python_modules/dagster/dagster/_core/definitions/asset_key.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_key.py
@@ -198,4 +198,4 @@ class AssetCheckKey(NamedTuple):
 
 
 EntityKey = Union[AssetKey, AssetCheckKey]
-T_EntityKey = TypeVar("T_EntityKey", AssetKey, AssetCheckKey)
+T_EntityKey = TypeVar("T_EntityKey", AssetKey, AssetCheckKey, EntityKey)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
@@ -151,7 +151,7 @@ class LegacyRuleEvaluationContext:
         self,
         child_condition: "AutomationCondition",
         child_unique_id: str,
-        candidate_slice: EntitySlice[AssetKey],
+        candidate_slice: EntitySlice,
     ) -> "LegacyRuleEvaluationContext":
         return dataclasses.replace(
             self,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/rule_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/rule_condition.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
@@ -5,7 +6,6 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationCondition,
     AutomationResult,
 )
-from dagster._record import record
 from dagster._serdes.serdes import whitelist_for_serdes
 from dagster._utils.security import non_secure_md5_hash_str
 
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 @whitelist_for_serdes
-@record
+@dataclass(frozen=True)
 class RuleCondition(AutomationCondition):
     """This class represents the condition that a particular AutoMaterializeRule is satisfied."""
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
@@ -1,17 +1,18 @@
+from dataclasses import dataclass
 from typing import Optional
 
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
     AutomationResult,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
-from dagster._record import record
 from dagster._serdes.serdes import whitelist_for_serdes
 
 
 @whitelist_for_serdes
-@record
-class CodeVersionChangedCondition(AutomationCondition):
+@dataclass(frozen=True)
+class CodeVersionChangedCondition(AutomationCondition[AssetKey]):
     label: Optional[str] = None
 
     @property
@@ -22,7 +23,7 @@ class CodeVersionChangedCondition(AutomationCondition):
     def name(self) -> str:
         return "code_version_changed"
 
-    def evaluate(self, context: AutomationContext) -> AutomationResult:
+    def evaluate(self, context: AutomationContext) -> AutomationResult[AssetKey]:
         previous_code_version = context.cursor
         current_code_version = context.asset_graph.get(context.key).code_version
         if previous_code_version is None or previous_code_version == current_code_version:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
@@ -1,20 +1,14 @@
-from dataclasses import dataclass
-from typing import Optional
-
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.declarative_automation.automation_condition import (
-    AutomationCondition,
     AutomationResult,
+    BuiltinAutomationCondition,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._serdes.serdes import whitelist_for_serdes
 
 
 @whitelist_for_serdes
-@dataclass(frozen=True)
-class CodeVersionChangedCondition(AutomationCondition[AssetKey]):
-    label: Optional[str] = None
-
+class CodeVersionChangedCondition(BuiltinAutomationCondition[AssetKey]):
     @property
     def description(self) -> str:
         return "Asset code version changed since previous tick"

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
@@ -1,13 +1,12 @@
 import datetime
 from abc import abstractmethod
-from dataclasses import dataclass
 from typing import Optional
 
 from dagster._core.asset_graph_view.asset_graph_view import EntitySlice
 from dagster._core.definitions.asset_key import AssetKey, T_EntityKey
 from dagster._core.definitions.declarative_automation.automation_condition import (
-    AutomationCondition,
     AutomationResult,
+    BuiltinAutomationCondition,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._core.definitions.declarative_automation.utils import SerializableTimeDelta
@@ -15,7 +14,7 @@ from dagster._serdes.serdes import whitelist_for_serdes
 from dagster._utils.schedules import reverse_cron_string_iterator
 
 
-class SliceAutomationCondition(AutomationCondition[T_EntityKey]):
+class SliceAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     """Base class for simple conditions which compute a simple slice of the asset graph."""
 
     @property
@@ -38,10 +37,7 @@ class SliceAutomationCondition(AutomationCondition[T_EntityKey]):
 
 
 @whitelist_for_serdes
-@dataclass(frozen=True)
 class MissingAutomationCondition(SliceAutomationCondition[AssetKey]):
-    label: Optional[str] = None
-
     @property
     def description(self) -> str:
         return "Missing"
@@ -57,10 +53,7 @@ class MissingAutomationCondition(SliceAutomationCondition[AssetKey]):
 
 
 @whitelist_for_serdes
-@dataclass(frozen=True)
 class InProgressAutomationCondition(SliceAutomationCondition[AssetKey]):
-    label: Optional[str] = None
-
     @property
     def description(self) -> str:
         return "Part of an in-progress run"
@@ -74,10 +67,7 @@ class InProgressAutomationCondition(SliceAutomationCondition[AssetKey]):
 
 
 @whitelist_for_serdes
-@dataclass(frozen=True)
 class FailedAutomationCondition(SliceAutomationCondition[AssetKey]):
-    label: Optional[str] = None
-
     @property
     def description(self) -> str:
         return "Latest run failed"
@@ -91,10 +81,7 @@ class FailedAutomationCondition(SliceAutomationCondition[AssetKey]):
 
 
 @whitelist_for_serdes
-@dataclass(frozen=True)
 class WillBeRequestedCondition(SliceAutomationCondition[AssetKey]):
-    label: Optional[str] = None
-
     @property
     def description(self) -> str:
         return "Will be requested this tick"
@@ -127,10 +114,7 @@ class WillBeRequestedCondition(SliceAutomationCondition[AssetKey]):
 
 
 @whitelist_for_serdes
-@dataclass(frozen=True)
 class NewlyRequestedCondition(SliceAutomationCondition[AssetKey]):
-    label: Optional[str] = None
-
     @property
     def description(self) -> str:
         return "Was requested on the previous tick"
@@ -144,10 +128,7 @@ class NewlyRequestedCondition(SliceAutomationCondition[AssetKey]):
 
 
 @whitelist_for_serdes
-@dataclass(frozen=True)
 class NewlyUpdatedCondition(SliceAutomationCondition[AssetKey]):
-    label: Optional[str] = None
-
     @property
     def description(self) -> str:
         return "Updated since previous tick"
@@ -167,11 +148,9 @@ class NewlyUpdatedCondition(SliceAutomationCondition[AssetKey]):
 
 
 @whitelist_for_serdes
-@dataclass(frozen=True)
 class CronTickPassedCondition(SliceAutomationCondition):
     cron_schedule: str
     cron_timezone: str
-    label: Optional[str] = None
 
     @property
     def description(self) -> str:
@@ -203,10 +182,8 @@ class CronTickPassedCondition(SliceAutomationCondition):
 
 
 @whitelist_for_serdes
-@dataclass(frozen=True)
 class InLatestTimeWindowCondition(SliceAutomationCondition[AssetKey]):
     serializable_lookback_timedelta: Optional[SerializableTimeDelta] = None
-    label: Optional[str] = None
 
     @staticmethod
     def from_lookback_delta(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import AbstractSet, Mapping, Optional, Sequence
 
 from dagster._core.definitions.asset_key import AssetKey
@@ -6,12 +7,11 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     AutomationResult,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
-from dagster._record import record
 from dagster._serdes.serdes import whitelist_for_serdes
 
 
-@record
-class DownstreamConditionWrapperCondition(AutomationCondition):
+@dataclass(frozen=True)
+class DownstreamConditionWrapperCondition(AutomationCondition[AssetKey]):
     """Wrapper object which evaluates a condition against a dependency and returns a subset
     representing the subset of downstream asset which has at least one parent which evaluated to
     True.
@@ -33,7 +33,7 @@ class DownstreamConditionWrapperCondition(AutomationCondition):
     def requires_cursor(self) -> bool:
         return False
 
-    def evaluate(self, context: AutomationContext) -> AutomationResult:
+    def evaluate(self, context: AutomationContext[AssetKey]) -> AutomationResult[AssetKey]:
         child_result = self.operand.evaluate(
             context.for_child_condition(
                 child_condition=self.operand, child_index=0, candidate_slice=context.candidate_slice
@@ -45,8 +45,8 @@ class DownstreamConditionWrapperCondition(AutomationCondition):
 
 
 @whitelist_for_serdes
-@record
-class AnyDownstreamConditionsCondition(AutomationCondition):
+@dataclass(frozen=True)
+class AnyDownstreamConditionsCondition(AutomationCondition[AssetKey]):
     label: Optional[str] = None
 
     @property
@@ -62,7 +62,7 @@ class AnyDownstreamConditionsCondition(AutomationCondition):
         return False
 
     def _get_ignored_conditions(
-        self, context: AutomationContext
+        self, context: AutomationContext[AssetKey]
     ) -> AbstractSet[AutomationCondition]:
         """To avoid infinite recursion, we do not expand conditions which are already part of the
         evaluation hierarchy.
@@ -82,7 +82,7 @@ class AnyDownstreamConditionsCondition(AutomationCondition):
             if not condition.has_rule_condition
         }
 
-    def evaluate(self, context: AutomationContext) -> AutomationResult:
+    def evaluate(self, context: AutomationContext[AssetKey]) -> AutomationResult[AssetKey]:
         ignored_conditions = self._get_ignored_conditions(context)
         downstream_conditions = self._get_validated_downstream_conditions(
             context.asset_graph.get_downstream_automation_conditions(asset_key=context.key)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
@@ -1,17 +1,16 @@
-from dataclasses import dataclass
-from typing import AbstractSet, Mapping, Optional, Sequence
+from typing import AbstractSet, Mapping, Sequence
 
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
     AutomationResult,
+    BuiltinAutomationCondition,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._serdes.serdes import whitelist_for_serdes
 
 
-@dataclass(frozen=True)
-class DownstreamConditionWrapperCondition(AutomationCondition[AssetKey]):
+class DownstreamConditionWrapperCondition(BuiltinAutomationCondition[AssetKey]):
     """Wrapper object which evaluates a condition against a dependency and returns a subset
     representing the subset of downstream asset which has at least one parent which evaluated to
     True.
@@ -19,7 +18,6 @@ class DownstreamConditionWrapperCondition(AutomationCondition[AssetKey]):
 
     downstream_keys: Sequence[AssetKey]
     operand: AutomationCondition
-    label: Optional[str] = None
 
     @property
     def description(self) -> str:
@@ -45,10 +43,7 @@ class DownstreamConditionWrapperCondition(AutomationCondition[AssetKey]):
 
 
 @whitelist_for_serdes
-@dataclass(frozen=True)
-class AnyDownstreamConditionsCondition(AutomationCondition[AssetKey]):
-    label: Optional[str] = None
-
+class AnyDownstreamConditionsCondition(BuiltinAutomationCondition[AssetKey]):
     @property
     def description(self) -> str:
         return "Any downstream conditions"

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -1,23 +1,21 @@
-from dataclasses import dataclass
-from typing import List, Optional, Sequence
+from typing import List, Sequence
 
 import dagster._check as check
 from dagster._core.definitions.asset_key import T_EntityKey
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
     AutomationResult,
+    BuiltinAutomationCondition,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._serdes.serdes import whitelist_for_serdes
 
 
 @whitelist_for_serdes(storage_name="AndAssetCondition")
-@dataclass(frozen=True, eq=False)
-class AndAutomationCondition(AutomationCondition[T_EntityKey]):
+class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     """This class represents the condition that all of its children evaluate to true."""
 
     operands: Sequence[AutomationCondition[T_EntityKey]]
-    label: Optional[str] = None
 
     @property
     def description(self) -> str:
@@ -61,12 +59,10 @@ class AndAutomationCondition(AutomationCondition[T_EntityKey]):
 
 
 @whitelist_for_serdes(storage_name="OrAssetCondition")
-@dataclass(frozen=True)
-class OrAutomationCondition(AutomationCondition[T_EntityKey]):
+class OrAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     """This class represents the condition that any of its children evaluate to true."""
 
     operands: Sequence[AutomationCondition[T_EntityKey]]
-    label: Optional[str] = None
 
     @property
     def description(self) -> str:
@@ -99,12 +95,10 @@ class OrAutomationCondition(AutomationCondition[T_EntityKey]):
 
 
 @whitelist_for_serdes(storage_name="NotAssetCondition")
-@dataclass(frozen=True)
-class NotAutomationCondition(AutomationCondition[T_EntityKey]):
+class NotAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     """This class represents the condition that none of its children evaluate to true."""
 
     operand: AutomationCondition[T_EntityKey]
-    label: Optional[str] = None
 
     @property
     def description(self) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Optional, Sequence
 
 from dagster._core.asset_graph_view.asset_graph_view import EntitySlice
@@ -6,6 +5,7 @@ from dagster._core.definitions.asset_key import T_EntityKey
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
     AutomationResult,
+    BuiltinAutomationCondition,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._core.definitions.entity_subset import EntitySubset
@@ -13,10 +13,8 @@ from dagster._serdes.serdes import whitelist_for_serdes
 
 
 @whitelist_for_serdes
-@dataclass(frozen=True)
-class NewlyTrueCondition(AutomationCondition[T_EntityKey]):
+class NewlyTrueCondition(BuiltinAutomationCondition[T_EntityKey]):
     operand: AutomationCondition[T_EntityKey]
-    label: Optional[str] = None
 
     @property
     def description(self) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
@@ -1,21 +1,21 @@
+from dataclasses import dataclass
 from typing import Optional, Sequence
 
 from dagster._core.asset_graph_view.asset_graph_view import EntitySlice
-from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_key import T_EntityKey
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
     AutomationResult,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._core.definitions.entity_subset import EntitySubset
-from dagster._record import record
 from dagster._serdes.serdes import whitelist_for_serdes
 
 
 @whitelist_for_serdes
-@record
-class NewlyTrueCondition(AutomationCondition):
-    operand: AutomationCondition
+@dataclass(frozen=True)
+class NewlyTrueCondition(AutomationCondition[T_EntityKey]):
+    operand: AutomationCondition[T_EntityKey]
     label: Optional[str] = None
 
     @property
@@ -27,12 +27,12 @@ class NewlyTrueCondition(AutomationCondition):
         return "NEWLY_TRUE"
 
     @property
-    def children(self) -> Sequence[AutomationCondition]:
+    def children(self) -> Sequence[AutomationCondition[T_EntityKey]]:
         return [self.operand]
 
     def _get_previous_child_true_slice(
-        self, context: AutomationContext
-    ) -> Optional[EntitySlice[AssetKey]]:
+        self, context: AutomationContext[T_EntityKey]
+    ) -> Optional[EntitySlice[T_EntityKey]]:
         """Returns the true slice of the child from the previous tick, which is stored in the
         extra state field of the cursor.
         """

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
@@ -1,19 +1,20 @@
+from dataclasses import dataclass
 from typing import Optional, Sequence
 
+from dagster._core.definitions.asset_key import T_EntityKey
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
     AutomationResult,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
-from dagster._record import record
 from dagster._serdes.serdes import whitelist_for_serdes
 
 
 @whitelist_for_serdes
-@record
-class SinceCondition(AutomationCondition):
-    trigger_condition: AutomationCondition
-    reset_condition: AutomationCondition
+@dataclass(frozen=True)
+class SinceCondition(AutomationCondition[T_EntityKey]):
+    trigger_condition: AutomationCondition[T_EntityKey]
+    reset_condition: AutomationCondition[T_EntityKey]
     label: Optional[str] = None
 
     @property
@@ -27,10 +28,10 @@ class SinceCondition(AutomationCondition):
         return "SINCE"
 
     @property
-    def children(self) -> Sequence[AutomationCondition]:
+    def children(self) -> Sequence[AutomationCondition[T_EntityKey]]:
         return [self.trigger_condition, self.reset_condition]
 
-    def evaluate(self, context: AutomationContext) -> AutomationResult:
+    def evaluate(self, context: AutomationContext[T_EntityKey]) -> AutomationResult[T_EntityKey]:
         # must evaluate child condition over the entire slice to avoid missing state transitions
         child_candidate_slice = context.asset_graph_view.get_full_slice(key=context.key)
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
@@ -1,18 +1,17 @@
-from dataclasses import dataclass
 from typing import Optional, Sequence
 
 from dagster._core.definitions.asset_key import T_EntityKey
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
     AutomationResult,
+    BuiltinAutomationCondition,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
 from dagster._serdes.serdes import whitelist_for_serdes
 
 
 @whitelist_for_serdes
-@dataclass(frozen=True)
-class SinceCondition(AutomationCondition[T_EntityKey]):
+class SinceCondition(BuiltinAutomationCondition[T_EntityKey]):
     trigger_condition: AutomationCondition[T_EntityKey]
     reset_condition: AutomationCondition[T_EntityKey]
     label: Optional[str] = None


### PR DESCRIPTION
## Summary & Motivation

This updates all of the AutomationCondition-adjacent objects to be generic, allowing them to operate over any type of EntityKey (if applicable). This opens the door to creating AutomationConditions that operate over AssetCheckKeys.

Note that I had to divest from `@record` due to an issue with how they handle generics: https://github.com/dagster-io/dagster/pull/23832

In its place, I went with subclassing our old friend `DagsterModel`. The reasoning here is that pydantic handles generics / hashing / inheriting fields in a better way than `@dataclass`. The main concern with this in the past was perf, but we're not actually constructing many instances of the conditions themselves, so that's not a huge concern here.

I also created a separate `BuiltinAutomationCondition` class for our built-in conditions to avoid "polluting" the `AutomationCondition` class that users will subclass from (pydantic basemodels put a lot of constraints on objects that would be pretty unintuitive to run into).

## How I Tested These Changes

## Changelog [New | Bug | Docs]

NOCHANGELOG

