### PR TITLE
Docathon -- Add Search Styles

### DIFF
--- a/docs/docs-beta/src/styles/custom.scss
+++ b/docs/docs-beta/src/styles/custom.scss
@@ -31,6 +31,10 @@ hr {
 .navbar {
   box-shadow: none;
   border-bottom: 1px solid var(--theme-color-keyline);
+
+  .navbar__items {
+    max-height: 100%;
+  }
 }
 .navbar__inner {
   max-width: 100% !important;
@@ -84,6 +88,12 @@ hr {
 .theme-doc-markdown {
   margin: 0 auto;
   margin-top: 1rem;
+
+  img {
+    border: 1px solid var(--theme-color-keyline);
+    border-radius: 8px;
+    overflow: hidden;
+  }
 }
 
 /* Custom code for PyObject */
@@ -118,6 +128,40 @@ a.pyobject {
       color: var(--theme-color-accent-blue);
     }
   }
+}
+
+.DocSearch-Button {
+  border-radius: 8px !important;
+  background: var(--theme-color-background-default) !important;
+  border: 1px solid var(--theme-color-border-default) !important;
+  margin-left: 12px !important;
+
+  .DocSearch-Button .DocSearch-Search-Icon {
+    width: 18px !important;
+  }
+
+  &:hover,
+  &:focus {
+    background: var(--theme-color-background-light) !important;
+    box-shadow: none !important;
+    border: 1px solid var(--theme-color-text-lighter) !important;
+  }
+}
+.DocSearch-Hit-source {
+  color: var(--theme-color-text-light) !important;
+}
+
+.DocSearch-MagnifierLabel {
+  color: var(--theme-color-text-default) !important;
+  width: 20px;
+}
+
+.DocSearch-Hits mark {
+  color: var(--theme-color-accent-blue) !important;
+}
+
+.DocSearch-Cancel {
+  color: var(--theme-color-text-light) !important;
 }
 
 .footer {
@@ -258,10 +302,6 @@ a.pyobject {
   }
 }
 
-.card {
-  border: 1px solid rgba(200, 200, 200, 0.3);
-}
-
 .markdown .table-of-contents {
   li {
     list-style: none;
@@ -318,11 +358,6 @@ a.pyobject {
   }
 }
 
-@media (max-width: 950px) {
-  .navbar__items .navbar__brand {
-    margin: 0 auto;
-  }
-}
 table {
   thead {
     tr {
@@ -365,13 +400,6 @@ table {
   text-shadow: 0.5rem 0.5rem var(--theme-color-accent-blue);
 }
 
-@keyframes wiggle {
-  0% { transform: rotate(0deg); }
-  25% { transform: rotate(3deg); }
-  75% { transform: rotate(-3deg); }
-  100% { transform: rotate(0deg); }
-}
-
 .hover-wiggle {
   &:hover {
     animation: wiggle 2s linear infinite;
@@ -382,7 +410,7 @@ table {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  border: 1px solid rgba(200, 200, 200, 0.3);
+  border: 1px solid var(--theme-color-keyline);
   padding: 1rem;
 
   a {
@@ -446,6 +474,11 @@ table {
   .navbar__items .navbar__brand {
     margin: 0 auto;
   }
+
+  .navbar__items .navbar__brand {
+    margin: 0 auto;
+  }
+
   .footer__link-item {
     display: flex;
     justify-content: space-between;
@@ -454,5 +487,20 @@ table {
   }
   .footer__bottom {
     text-align: center;
+  }
+}
+
+@keyframes wiggle {
+  0% {
+    transform: rotate(0deg);
+  }
+  25% {
+    transform: rotate(3deg);
+  }
+  75% {
+    transform: rotate(-3deg);
+  }
+  100% {
+    transform: rotate(0deg);
   }
 }

--- a/docs/docs-beta/src/styles/theme-dark.scss
+++ b/docs/docs-beta/src/styles/theme-dark.scss
@@ -55,7 +55,6 @@
   //Top Navbar
   --ifm-navbar-height: 60px;
   --ifm-navbar-background-color: var(--theme-color-background-default);
-  --ifm-navbar-item-padding-horizontal: 8px;
 
   //Left Menu
   --ifm-menu-color: var(--theme-color-text-light);

--- a/docs/docs-beta/src/styles/theme-globals.scss
+++ b/docs/docs-beta/src/styles/theme-globals.scss
@@ -34,4 +34,12 @@
   --ifm-footer-padding-horizontal: 0px;
   --ifm-footer-link-color: var(--theme-color-text-lighter);
   --ifm-global-spacing: 24px;
+  --ifm-navbar-padding-vertical: 0px;
+  --ifm-navbar-item-padding-horizontal: 0px;
+  --ifm-navbar-item-padding-vertical: 20px;
+  --docsearch-highlight-color: var(--theme-color-background-gray) !important;
+  --docsearch-hit-active-color: var(--theme-color-text-default) !important;
+  --ifm-card-background-color: var(--theme-color-background-light);
+  --ifm-card-border-color: var(--theme-color-keyline);
+  --ifm-alert-padding-vertical: 16px;
 }

--- a/docs/docs-beta/src/styles/theme-light.scss
+++ b/docs/docs-beta/src/styles/theme-light.scss
@@ -60,8 +60,6 @@
   --ifm-link-color: var(--theme-color-link-default);
   --ifm-toc-link-color: var(--theme-color-text-light);
   --ifm-toc-border-color: var(--theme-color-keyline);
-  --ifm-navbar-item-padding-vertical: 19px;
-  --ifm-navbar-padding-vertical: 0px;
   --ifm-navbar-padding-horizontal: 20px;
   --ifm-navbar-link-color: var(--theme-color-text-light);
   --ifm-navbar-link-hover-color: var(--theme-color-text-default);
@@ -69,7 +67,6 @@
   //Top Navbar
   --ifm-navbar-height: 60px;
   --ifm-navbar-background-color: var(--theme-color-background-default);
-  --ifm-navbar-item-padding-horizontal: 8px;
 
   //Left Menu
   --ifm-menu-color: var(--theme-color-text-light);
@@ -81,7 +78,7 @@
 
   // docusaurus
   --docusaurus-highlighted-code-line-bg: var(--theme-color-background-gray);
-  
+
   // infima shadow levels
   // generated from https://www.joshwcomeau.com/shadow-palette/
   --shadow-color: 0deg 0% 63%;


### PR DESCRIPTION
## Summary & Motivation
Adds search styles, but does not actually add Search. Once Search is configured it'll look like this.

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/66f125f0-7b42-4f10-b7dd-20ba525d55f0">
<img width="1137" alt="image" src="https://github.com/user-attachments/assets/35b4303f-d9fc-4ade-a93e-37926b9e272d">



## How I Tested These Changes

## Changelog [New | Bug | Docs]

> Replace this message with a changelog entry, or `NOCHANGELOG`
