### PR TITLE
[ui] Plug in new code location pages behind a flag

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/FeatureFlags.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/FeatureFlags.oss.tsx
@@ -4,4 +4,5 @@ export enum FeatureFlag {
   flagSidebarResources = 'flagSidebarResources',
   flagDisableAutoLoadDefaults = 'flagDisableAutoLoadDefaults',
   flagSettingsPage = 'flagSettingsPage',
+  flagCodeLocationPage = 'flagCodeLocationPage',
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
@@ -37,4 +37,8 @@ export const useVisibleFeatureFlagRows = () => [
     ),
     flagType: FeatureFlag.flagSettingsPage,
   },
+  {
+    key: 'New code location page',
+    flagType: FeatureFlag.flagCodeLocationPage,
+  },
 ];

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefinitionsNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefinitionsNav.tsx
@@ -1,4 +1,5 @@
 import {Box, Icon, Tag} from '@dagster-io/ui-components';
+import {useLocation} from 'react-router-dom';
 
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {SideNavItem, SideNavItemConfig} from '../ui/SideNavItem';
@@ -14,6 +15,7 @@ interface Props {
 
 export const CodeLocationDefinitionsNav = (props: Props) => {
   const {repoAddress, repository} = props;
+  const {pathname} = useLocation();
   const jobCount = repository.pipelines.filter(({name}) => !isHiddenAssetGroupJob(name)).length;
   const scheduleCount = repository.schedules.length;
   const sensorCount = repository.sensors.length;
@@ -79,7 +81,13 @@ export const CodeLocationDefinitionsNav = (props: Props) => {
     <>
       <Box padding={{bottom: 12}}>
         {items.map((item) => {
-          return <SideNavItem key={item.key} item={item} active={false} />;
+          return (
+            <SideNavItem
+              key={item.key}
+              item={item}
+              active={item.type === 'link' && pathname === item.path}
+            />
+          );
         })}
       </Box>
     </>

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationOverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationOverviewRoot.tsx
@@ -4,10 +4,11 @@ import {
   FontFamily,
   MiddleTruncate,
   Mono,
+  SpinnerWithText,
   StyledRawCodeMirror,
   Table,
 } from '@dagster-io/ui-components';
-import {useMemo} from 'react';
+import {useContext, useMemo} from 'react';
 import {CodeLocationServerSection} from 'shared/code-location/CodeLocationServerSection.oss';
 import {CodeLocationTabs} from 'shared/code-location/CodeLocationTabs.oss';
 import {createGlobalStyle} from 'styled-components';
@@ -16,8 +17,10 @@ import * as yaml from 'yaml';
 import {CodeLocationOverviewSectionHeader} from './CodeLocationOverviewSectionHeader';
 import {CodeLocationPageHeader} from './CodeLocationPageHeader';
 import {TimeFromNow} from '../ui/TimeFromNow';
+import {CodeLocationNotFound} from '../workspace/CodeLocationNotFound';
 import {LocationStatus} from '../workspace/CodeLocationRowSet';
-import {WorkspaceRepositoryLocationNode} from '../workspace/WorkspaceContext';
+import {WorkspaceContext, WorkspaceRepositoryLocationNode} from '../workspace/WorkspaceContext';
+import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 import {LocationStatusEntryFragment} from '../workspace/types/WorkspaceQueries.types';
 
@@ -116,18 +119,55 @@ export const CodeLocationOverviewRoot = (props: Props) => {
       ) : null}
       <CodeLocationOverviewSectionHeader label="Metadata" border="bottom" />
       <CodeLocationMetadataStyle />
-      <StyledRawCodeMirror
-        options={{readOnly: true, lineNumbers: false}}
-        theme={['code-location-metadata']}
-        value={metadataAsYaml}
-      />
+      <div style={{height: '320px'}}>
+        <StyledRawCodeMirror
+          options={{readOnly: true, lineNumbers: false}}
+          theme={['code-location-metadata']}
+          value={metadataAsYaml}
+        />
+      </div>
     </>
   );
 };
+
+const QueryfulCodeLocationOverviewRoot = ({repoAddress}: {repoAddress: RepoAddress}) => {
+  const {locationEntries, locationStatuses, loading} = useContext(WorkspaceContext);
+  const locationEntry = locationEntries.find((entry) => entry.name === repoAddress.location);
+  const locationStatus = locationStatuses[repoAddress.location];
+
+  if (!locationEntry || !locationStatus) {
+    const displayName = repoAddressAsHumanString(repoAddress);
+    if (loading) {
+      return (
+        <Box padding={64} flex={{direction: 'row', justifyContent: 'center'}}>
+          <SpinnerWithText label={`Loading ${displayName}…`} />
+        </Box>
+      );
+    }
+
+    return (
+      <Box padding={64} flex={{direction: 'row', justifyContent: 'center'}}>
+        <CodeLocationNotFound repoAddress={repoAddress} />
+      </Box>
+    );
+  }
+
+  return (
+    <CodeLocationOverviewRoot
+      repoAddress={repoAddress}
+      locationEntry={locationEntry}
+      locationStatus={locationStatus}
+    />
+  );
+};
+
+// eslint-disable-next-line import/no-default-export
+export default QueryfulCodeLocationOverviewRoot;
 
 const CodeLocationMetadataStyle = createGlobalStyle`
   .CodeMirror.cm-s-code-location-metadata.cm-s-code-location-metadata {
     background-color: ${Colors.backgroundDefault()};
     padding: 12px 20px;
+    height: 300px;
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/CodeLocationNotFound.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/CodeLocationNotFound.tsx
@@ -1,0 +1,25 @@
+import {Box, NonIdealState} from '@dagster-io/ui-components';
+import {Link} from 'react-router-dom';
+
+import {repoAddressAsHumanString} from './repoAddressAsString';
+import {RepoAddress} from './types';
+
+export const CodeLocationNotFound = ({repoAddress}: {repoAddress: RepoAddress}) => {
+  const displayName = repoAddressAsHumanString(repoAddress);
+  return (
+    <NonIdealState
+      icon="code_location"
+      title="Code location not found"
+      description={
+        <Box flex={{direction: 'column', gap: 12}} style={{wordBreak: 'break-word'}}>
+          <div>
+            Code location <strong>{displayName}</strong> is not available in this workspace.
+          </div>
+          <div>
+            Check your <Link to="/deployment">deployment settings</Link> for errors.
+          </div>
+        </Box>
+      }
+    />
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext.tsx
@@ -9,6 +9,7 @@ import {RepoAddress} from './types';
 import {
   CodeLocationStatusQuery,
   CodeLocationStatusQueryVariables,
+  LocationStatusEntryFragment,
   LocationWorkspaceQuery,
   LocationWorkspaceQueryVariables,
   WorkspaceLocationFragment,
@@ -52,6 +53,7 @@ type SetVisibleOrHiddenFn = (repoAddresses: RepoAddress[]) => void;
 type WorkspaceState = {
   loading: boolean;
   locationEntries: WorkspaceRepositoryLocationNode[];
+  locationStatuses: Record<string, LocationStatusEntryFragment>;
   allRepos: DagsterRepoOption[];
   visibleRepos: DagsterRepoOption[];
   data: Record<string, WorkspaceLocationNodeFragment | PythonErrorFragment>;
@@ -314,6 +316,7 @@ export const WorkspaceProvider = ({children}: {children: React.ReactNode}) => {
           Object.keys(locationStatuses).every((locationName) => locationEntriesData[locationName])
         ),
         locationEntries,
+        locationStatuses,
         allRepos,
         visibleRepos,
         toggleVisible,

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceRoot.tsx
@@ -1,6 +1,7 @@
-import {Box, MainContent, NonIdealState} from '@dagster-io/ui-components';
+import {Box, MainContent, NonIdealState, SpinnerWithText} from '@dagster-io/ui-components';
 import {useContext} from 'react';
 import {Redirect, Switch, useParams} from 'react-router-dom';
+import {CodeLocationNotFound} from 'shared/workspace/CodeLocationNotFound';
 
 import {GraphRoot} from './GraphRoot';
 import {WorkspaceAssetsRoot} from './WorkspaceAssetsRoot';
@@ -13,8 +14,11 @@ import {WorkspaceSensorsRoot} from './WorkspaceSensorsRoot';
 import {repoAddressAsHumanString} from './repoAddressAsString';
 import {repoAddressFromPath} from './repoAddressFromPath';
 import {workspacePathFromAddress} from './workspacePath';
+import {useFeatureFlags} from '../app/Flags';
 import {Route} from '../app/Route';
 import {AssetGroupRoot} from '../assets/AssetGroupRoot';
+import {CodeLocationDefinitionsRoot} from '../code-location/CodeLocationDefinitionsRoot';
+import CodeLocationOverviewRoot from '../code-location/CodeLocationOverviewRoot';
 import {PipelineRoot} from '../pipelines/PipelineRoot';
 import {ResourceRoot} from '../resources/ResourceRoot';
 import {WorkspaceResourcesRoot} from '../resources/WorkspaceResourcesRoot';
@@ -25,6 +29,7 @@ const RepoRouteContainer = () => {
   const {repoPath} = useParams<{repoPath: string}>();
   const workspaceState = useContext(WorkspaceContext);
   const addressForPath = repoAddressFromPath(repoPath);
+  const {flagCodeLocationPage} = useFeatureFlags();
 
   const {loading} = workspaceState;
 
@@ -56,48 +61,24 @@ const RepoRouteContainer = () => {
 
   // If we don't have any active code locations, or if our active repo does not match
   // the repo path in the URL, it means we aren't able to load this repo.
-  if (!matchingRepo && !loading) {
+  if (!matchingRepo) {
+    if (loading) {
+      return (
+        <Box padding={{vertical: 64}} flex={{direction: 'row', justifyContent: 'center'}}>
+          <SpinnerWithText label={`Loading ${repoAddressAsHumanString(addressForPath)}…`} />
+        </Box>
+      );
+    }
+
     return (
       <Box padding={{vertical: 64}}>
-        <NonIdealState
-          icon="error"
-          title="Unknown code location"
-          description={
-            <div>
-              <div>
-                <strong>{repoAddressAsHumanString(addressForPath)}</strong>
-              </div>
-              {'  is not loaded in the current workspace.'}
-            </div>
-          }
-        />
+        <CodeLocationNotFound repoAddress={addressForPath} />
       </Box>
     );
   }
 
   return (
     <Switch>
-      <Route path="/locations/:repoPath/resources" exact>
-        <WorkspaceResourcesRoot repoAddress={addressForPath} />
-      </Route>
-      <Route path="/locations/:repoPath/assets" exact>
-        <WorkspaceAssetsRoot repoAddress={addressForPath} />
-      </Route>
-      <Route path="/locations/:repoPath/jobs" exact>
-        <WorkspaceJobsRoot repoAddress={addressForPath} />
-      </Route>
-      <Route path="/locations/:repoPath/schedules" exact>
-        <WorkspaceSchedulesRoot repoAddress={addressForPath} />
-      </Route>
-      <Route path="/locations/:repoPath/sensors" exact>
-        <WorkspaceSensorsRoot repoAddress={addressForPath} />
-      </Route>
-      <Route path="/locations/:repoPath/graphs" exact>
-        <WorkspaceGraphsRoot repoAddress={addressForPath} />
-      </Route>
-      <Route path="/locations/:repoPath/ops/:name?" exact>
-        <WorkspaceOpsRoot repoAddress={addressForPath} />
-      </Route>
       <Route path="/locations/:repoPath/graphs/(/?.*)">
         <GraphRoot repoAddress={addressForPath} />
       </Route>
@@ -130,6 +111,60 @@ const RepoRouteContainer = () => {
       >
         <AssetGroupRoot repoAddress={addressForPath} tab="lineage" />
       </Route>
+      {flagCodeLocationPage ? (
+        <>
+          <Route path="/locations/:repoPath" exact>
+            <CodeLocationOverviewRoot repoAddress={addressForPath} />
+          </Route>
+          <Route path="/locations/:repoPath/definitions" exact>
+            <Redirect to={workspacePathFromAddress(addressForPath, '/assets')} />
+          </Route>
+          <Route
+            path={[
+              '/locations/:repoPath/assets',
+              '/locations/:repoPath/jobs',
+              '/locations/:repoPath/resources',
+              '/locations/:repoPath/schedules',
+              '/locations/:repoPath/sensors',
+              '/locations/:repoPath/graphs',
+              '/locations/:repoPath/ops/:name?',
+            ]}
+            exact
+          >
+            <CodeLocationDefinitionsRoot
+              repoAddress={addressForPath}
+              repository={matchingRepo.repository}
+            />
+          </Route>
+        </>
+      ) : (
+        <>
+          <Route path="/locations/:repoPath" exact>
+            <Redirect to={workspacePathFromAddress(addressForPath, '/assets')} />
+          </Route>
+          <Route path="/locations/:repoPath/resources" exact>
+            <WorkspaceResourcesRoot repoAddress={addressForPath} />
+          </Route>
+          <Route path="/locations/:repoPath/assets" exact>
+            <WorkspaceAssetsRoot repoAddress={addressForPath} />
+          </Route>
+          <Route path="/locations/:repoPath/jobs" exact>
+            <WorkspaceJobsRoot repoAddress={addressForPath} />
+          </Route>
+          <Route path="/locations/:repoPath/schedules" exact>
+            <WorkspaceSchedulesRoot repoAddress={addressForPath} />
+          </Route>
+          <Route path="/locations/:repoPath/sensors" exact>
+            <WorkspaceSensorsRoot repoAddress={addressForPath} />
+          </Route>
+          <Route path="/locations/:repoPath/graphs" exact>
+            <WorkspaceGraphsRoot repoAddress={addressForPath} />
+          </Route>
+          <Route path="/locations/:repoPath/ops/:name?" exact>
+            <WorkspaceOpsRoot repoAddress={addressForPath} />
+          </Route>
+        </>
+      )}
       <Route path={['/locations/:repoPath/*', '/locations/:repoPath/']}>
         <Redirect to={workspacePathFromAddress(addressForPath, '/assets')} />
       </Route>


### PR DESCRIPTION
## Summary & Motivation

Behind a feature flag, plug in the new Code Location pages at `/location/:repoPath/...`.

<img width="1167" alt="Screenshot 2024-08-30 at 13 51 47" src="https://github.com/user-attachments/assets/2cdcf79c-791b-47f5-8a3b-81c51a421e83">

<img width="1165" alt="Screenshot 2024-08-30 at 13 51 56" src="https://github.com/user-attachments/assets/7d53f66e-6af9-43f8-ac05-484c7a26d6f4">

## How I Tested These Changes

With flag disabled, click around from `/locations` to various code locations and verify correct routing and behavior throughout, including clicking to individual jobs, schedules, etc.

With flag enabled, verify same. Verify that the new overview page is the new destination when clicking into a code location, and that the "Definitions" tab behaves correctly.

## Changelog [New | Bug | Docs]

`NOCHANGELOG`

No changelog because this is flagged for now and not quite ready for people to use.
