### PR TITLE
fix docs-beta-tests

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/test_all_files_load.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/test_all_files_load.py
@@ -12,6 +12,9 @@ EXCLUDED_FILES = {
     f"{snippets_folder}/guides/data-modeling/asset-factories/python-asset-factory.py",
     f"{snippets_folder}/guides/data-modeling/asset-factories/simple-yaml-asset-factory.py",
     f"{snippets_folder}/guides/data-modeling/asset-factories/advanced-yaml-asset-factory.py",
+    # setuptools.setup() eventually parses the command line that caused setup() to be called.
+    # it errors because the command line for this test is for pytest and doesn't align with the arguments
+    # setup() expects. So omit files that call setup() since they cannot be loaded without errors.
     f"{snippets_folder}/dagster-plus/deployment/serverless/runtime-environment/data_files_setup.py",
     f"{snippets_folder}/dagster-plus/deployment/serverless/runtime-environment/example_setup.py",
 }

--- a/examples/docs_beta_snippets/docs_beta_snippets_tests/test_all_files_load.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets_tests/test_all_files_load.py
@@ -12,6 +12,8 @@ EXCLUDED_FILES = {
     f"{snippets_folder}/guides/data-modeling/asset-factories/python-asset-factory.py",
     f"{snippets_folder}/guides/data-modeling/asset-factories/simple-yaml-asset-factory.py",
     f"{snippets_folder}/guides/data-modeling/asset-factories/advanced-yaml-asset-factory.py",
+    f"{snippets_folder}/dagster-plus/deployment/serverless/runtime-environment/data_files_setup.py",
+    f"{snippets_folder}/dagster-plus/deployment/serverless/runtime-environment/example_setup.py",
 }
 
 


### PR DESCRIPTION
## Summary & Motivation
Omits files that call `setuptools.setup()` in them. This is because `setup()` calls a `distutils` function that tries to parse the command line of the command that resulted in `setup` being called. In the case of this test suite, it's a `pytest` command, which is not what `distutils` expects, do it raises an error.

## How I Tested These Changes

## Changelog [New | Bug | Docs]

`NOCHANGELOG`
