### PR TITLE
[airlift] allow DAG names with hyphens

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_instance.py
@@ -1,18 +1,17 @@
 import datetime
 import json
 from abc import ABC
+from functools import cached_property
 from typing import Any, Dict, List
 
-from functools import cached_property
 import requests
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.errors import DagsterError
 from dagster._record import record
 from dagster._time import get_current_datetime
 
-from .utils import convert_to_valid_dagster_name
-
 from ..migration_state import DagMigrationState
+from .utils import convert_to_valid_dagster_name
 
 TERMINAL_STATES = {"success", "failed", "skipped", "up_for_retry", "up_for_reschedule"}
 

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_instance.py
@@ -3,11 +3,14 @@ import json
 from abc import ABC
 from typing import Any, Dict, List
 
+from functools import cached_property
 import requests
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.errors import DagsterError
 from dagster._record import record
 from dagster._time import get_current_datetime
+
+from .utils import convert_to_valid_dagster_name
 
 from ..migration_state import DagMigrationState
 
@@ -181,10 +184,15 @@ class DagInfo:
     def url(self) -> str:
         return f"{self.webserver_url}/dags/{self.dag_id}"
 
+    @cached_property
+    def dagster_safe_dag_id(self) -> str:
+        """Name based on the dag_id that is safe to use in dagster."""
+        return convert_to_valid_dagster_name(self.dag_id)
+
     @property
     def dag_asset_key(self) -> AssetKey:
         # Conventional asset key representing a successful run of an airfow dag.
-        return AssetKey(["airflow_instance", "dag", self.dag_id])
+        return AssetKey(["airflow_instance", "dag", self.dagster_safe_dag_id])
 
     @property
     def migration_state(self) -> DagMigrationState:

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
@@ -5,11 +5,15 @@ from dagster import (
     AssetSpec,
     _check as check,
 )
+from dagster._core.definitions.utils import VALID_NAME_REGEX
 
 MIGRATED_TAG = "airlift/task_migrated"
 DAG_ID_TAG = "airlift/dag_id"
 TASK_ID_TAG = "airlift/task_id"
 
+def convert_to_valid_dagster_name(name: str) -> str:
+    """Converts a name to a valid dagster name by replacing invalid characters with underscores."""
+    return "".join(c if VALID_NAME_REGEX.match(c) else "_" for c in name)
 
 def get_task_id_from_asset(asset: Union[AssetsDefinition, AssetSpec]) -> Optional[str]:
     return _get_prop_from_asset(asset, TASK_ID_TAG, 1)

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
@@ -11,9 +11,11 @@ MIGRATED_TAG = "airlift/task_migrated"
 DAG_ID_TAG = "airlift/dag_id"
 TASK_ID_TAG = "airlift/task_id"
 
+
 def convert_to_valid_dagster_name(name: str) -> str:
     """Converts a name to a valid dagster name by replacing invalid characters with underscores."""
     return "".join(c if VALID_NAME_REGEX.match(c) else "_" for c in name)
+
 
 def get_task_id_from_asset(asset: Union[AssetsDefinition, AssetSpec]) -> Optional[str]:
     return _get_prop_from_asset(asset, TASK_ID_TAG, 1)

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_dag_asset_keys.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_dag_asset_keys.py
@@ -1,0 +1,13 @@
+from dagster._core.definitions.utils import check_valid_name
+from dagster_airlift.core.airflow_instance import DagInfo
+
+def test_dag_info_asset_key() -> None:
+    # Airflow allows "exclusively alphanumeric characters, dashes, dots and underscores (all ASCII)"
+    dag_info_hyphen = DagInfo(webserver_url="", dag_id="my-test-dag-id", metadata={})
+    assert check_valid_name(dag_info_hyphen.dag_asset_key.to_user_string().replace("/", "__"))
+
+    dag_info_slash = DagInfo(webserver_url="", dag_id="my-test/dag-id", metadata={})
+    assert check_valid_name(dag_info_slash.dag_asset_key.to_user_string().replace("/", "__"))
+
+    dag_info_dot = DagInfo(webserver_url="", dag_id="my-test.dag-id", metadata={})
+    assert check_valid_name(dag_info_dot.dag_asset_key.to_user_string().replace("/", "__"))

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_dag_asset_keys.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_dag_asset_keys.py
@@ -1,6 +1,7 @@
 from dagster._core.definitions.utils import check_valid_name
 from dagster_airlift.core.airflow_instance import DagInfo
 
+
 def test_dag_info_asset_key() -> None:
     # Airflow allows "exclusively alphanumeric characters, dashes, dots and underscores (all ASCII)"
     dag_info_hyphen = DagInfo(webserver_url="", dag_id="my-test-dag-id", metadata={})


### PR DESCRIPTION
## Summary

Preprocesses DAG ids to ensure they comply with allowed Dagster chars.

## Test Plan

unit test of DagInfo key, new integration test which previously failed


## Changelog [Bug]

`NOCHANGELOG`
