### PR TITLE
fix backfill run termination

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRow.tsx
@@ -75,9 +75,7 @@ export const BackfillRowLoader = (props: {
   const {data} = statusQueryResult;
   const {hasCancelableRuns} = React.useMemo(() => {
     if (data?.partitionBackfillOrError.__typename === 'PartitionBackfill') {
-      if ('partitionBackfill' in data.partitionBackfillOrError) {
-        return {hasCancelableRuns: data.partitionBackfillOrError.cancelableRuns.length > 0};
-      }
+      return {hasCancelableRuns: data.partitionBackfillOrError.cancelableRuns.length > 0};
     }
     return {hasCancelableRuns: false};
   }, [data]);

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -494,7 +494,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         from dagster_graphql.schema.pipelines.pipeline import GrapheneRun
 
         records = self._get_records(graphene_info)
-        return [GrapheneRun(record) for record in records if not record.dagster_run.is_cancelable]
+        return [GrapheneRun(record) for record in records if record.dagster_run.is_cancelable]
 
     def resolve_runs(self, graphene_info: ResolveInfo) -> "Sequence[GrapheneRun]":
         from dagster_graphql.schema.pipelines.pipeline import GrapheneRun


### PR DESCRIPTION
## Summary & Motivation
Could not cancel runs from a backfill - forced users to search on the runs page and cancel from there.

## How I Tested These Changes
Added a BK test for the `cancelableRuns` field.
Sanity checked with a test run.

## Changelog [Bug]

* Fixed a bug where in-progress runs from a backfill could not be terminated from the backfill UI.
