### PR TITLE
switch get_event_records => fetch_materializations for multi asset sensors (#22779)

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -871,8 +871,7 @@ class MultiAssetSensorCursorAdvances:
         context: MultiAssetSensorEvaluationContext,
         initial_cursor: MultiAssetSensorContextCursor,
     ) -> MultiAssetSensorAssetCursorComponent:
-        from dagster._core.events import DagsterEventType
-        from dagster._core.storage.event_log.base import EventRecordsFilter
+        from dagster._core.event_api import AssetRecordsFilter
 
         advanced_records: Set[int] = self._advanced_record_ids_by_key.get(asset_key, set())
         if len(advanced_records) == 0:
@@ -893,19 +892,26 @@ class MultiAssetSensorCursorAdvances:
             latest_unconsumed_record_by_partition = (
                 initial_asset_cursor.trailing_unconsumed_partitioned_event_ids
             )
-            unconsumed_events = list(context.get_trailing_unconsumed_events(asset_key)) + list(
-                context.instance.get_event_records(
-                    EventRecordsFilter(
-                        event_type=DagsterEventType.ASSET_MATERIALIZATION,
+
+            materialization_events = []
+            has_more = True
+            cursor = None
+            while has_more:
+                result = context.instance.fetch_materializations(
+                    AssetRecordsFilter(
                         asset_key=asset_key,
-                        after_cursor=latest_consumed_event_id_at_tick_start,
-                        before_cursor=greatest_consumed_event_id_in_tick,
+                        after_storage_id=latest_consumed_event_id_at_tick_start,
+                        before_storage_id=greatest_consumed_event_id_in_tick,
                     ),
                     ascending=True,
+                    limit=FETCH_MATERIALIZATION_BATCH_SIZE,
+                    cursor=cursor,
                 )
-                if greatest_consumed_event_id_in_tick
-                > (latest_consumed_event_id_at_tick_start or 0)
-                else []
+                cursor = result.cursor
+                has_more = result.has_more
+                materialization_events.extend(result.records)
+            unconsumed_events = list(context.get_trailing_unconsumed_events(asset_key)) + list(
+                materialization_events
             )
 
             # Iterate through events in ascending order, storing the latest unconsumed


### PR DESCRIPTION
## Summary & Motivation
Uses a fetch batch limit of 1000, to prevent overfetching.

The last vestige of framework calls to `get_event_records`.

## How I Tested These Changes
BK

## Changelog [New]

* Changed data fetching in the multi-asset sensor definition to be less likely to timeout queries against the asset history storage.
