### PR TITLE
[dagster-airlift] fix name sanitization

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_cacheable_assets_def.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_cacheable_assets_def.py
@@ -31,6 +31,7 @@ from dagster._serdes.serdes import (
     unpack_value,
 )
 
+from dagster_airlift.core.utils import convert_to_valid_dagster_name
 from dagster_airlift.migration_state import AirflowMigrationState
 
 from .airflow_instance import AirflowInstance, DagInfo, TaskInfo
@@ -194,7 +195,7 @@ class AirflowCacheableAssetsDefinition(CacheableAssetsDefinition):
             new_assets_defs.append(
                 build_airflow_asset_from_specs(
                     specs=[dag_spec.to_asset_spec({})],
-                    name=key.to_user_string().replace("/", "__"),
+                    name=convert_to_valid_dagster_name(key.to_user_string()),
                     tags={DAG_ID_TAG: dag_id},
                 )
             )
@@ -416,7 +417,7 @@ def construct_assets_with_task_migration_info_applied(
             new_assets_defs.append(
                 build_airflow_asset_from_specs(
                     specs=new_specs,
-                    name=f"{overall_dag_id}__{overall_task_id}",
+                    name=convert_to_valid_dagster_name(f"{overall_dag_id}__{overall_task_id}"),
                     tags=asset.node_def.tags if isinstance(asset, AssetsDefinition) else {},
                 )
             )

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
@@ -13,8 +13,8 @@ TASK_ID_TAG = "airlift/task_id"
 
 
 def convert_to_valid_dagster_name(name: str) -> str:
-    """Converts a name to a valid dagster name by replacing invalid characters with underscores."""
-    return "".join(c if VALID_NAME_REGEX.match(c) else "_" for c in name)
+    """Converts a name to a valid dagster name by replacing invalid characters with underscores. / is converted to a double underscore."""
+    return "".join(c if VALID_NAME_REGEX.match(c) else "__" if c == "/" else "_" for c in name)
 
 
 def get_task_id_from_asset(asset: Union[AssetsDefinition, AssetSpec]) -> Optional[str]:


### PR DESCRIPTION
Fix the name sanitization process when creating node defs.

Adds a test of a declared mapping between asset and dag with hyphenated name, and conversion.