### PR TITLE
Set up StepDelegatingExceutor to accept a default offset to guard against out-of-order insertion issues

### DIFF
--- a/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
+++ b/python_modules/dagster/dagster/_core/executor/step_delegating/step_delegating_executor.py
@@ -1,3 +1,5 @@
+import logging
+import math
 import os
 import sys
 import time
@@ -23,9 +25,9 @@ from dagster._utils.error import SerializableErrorInfo, serializable_error_info_
 if TYPE_CHECKING:
     from dagster._core.execution.plan.step import ExecutionStep
 
-DEFAULT_SLEEP_SECONDS = float(
-    os.environ.get("DAGSTER_STEP_DELEGATING_EXECUTOR_SLEEP_SECONDS", "1.0")
-)
+
+def _default_sleep_seconds():
+    return float(os.environ.get("DAGSTER_STEP_DELEGATING_EXECUTOR_SLEEP_SECONDS", "1.0"))
 
 
 class StepDelegatingExecutor(Executor):
@@ -58,7 +60,7 @@ class StepDelegatingExecutor(Executor):
 
         self._sleep_seconds = cast(
             float,
-            check.opt_float_param(sleep_seconds, "sleep_seconds", default=DEFAULT_SLEEP_SECONDS),
+            check.opt_float_param(sleep_seconds, "sleep_seconds", default=_default_sleep_seconds()),
         )
         self._check_step_health_interval_seconds = cast(
             int,
@@ -69,41 +71,27 @@ class StepDelegatingExecutor(Executor):
         self._should_verify_step = should_verify_step
 
         self._event_cursor: Optional[str] = None
-        self._pop_events_offset = int(os.getenv("DAGSTER_EXECUTOR_POP_EVENTS_OFFSET", "0"))
 
-        if self._pop_events_offset:
-            # ensure that the offset can never result in looping over the same events over and
-            # over again if every event is from this run
-            self._pop_events_limit = self._pop_events_offset + 1
-        else:
-            self._pop_events_limit = int(os.getenv("DAGSTER_EXECUTOR_POP_EVENTS_LIMIT", "1000"))
+        self._pop_events_limit = int(os.getenv("DAGSTER_EXECUTOR_POP_EVENTS_LIMIT", "1000"))
 
     @property
     def retries(self):
         return self._retries
 
+    def _get_pop_events_offset(self, instance: DagsterInstance):
+        if "DAGSTER_EXECUTOR_POP_EVENTS_OFFSET" in os.environ:
+            return int(os.environ["DAGSTER_EXECUTOR_POP_EVENTS_OFFSET"])
+        return instance.event_log_storage.default_run_scoped_event_tailer_offset()
+
     def _pop_events(
         self, instance: DagsterInstance, run_id: str, seen_storage_ids: Set[int]
     ) -> Sequence[DagsterEvent]:
-        adjusted_cursor = self._event_cursor
-
-        if self._pop_events_offset > 0 and self._event_cursor:
-            cursor_obj = EventLogCursor.parse(self._event_cursor)
-            check.invariant(
-                cursor_obj.is_id_cursor(),
-                "Applying a tailer offset only works with an id-based cursor",
-            )
-            adjusted_cursor = EventLogCursor.from_storage_id(
-                cursor_obj.storage_id() - self._pop_events_offset
-            ).to_string()
-
         conn = instance.get_records_for_run(
             run_id,
-            adjusted_cursor,
+            self._event_cursor,
             of_type=set(DagsterEventType),
             limit=self._pop_events_limit,
         )
-        self._event_cursor = conn.cursor
 
         dagster_events = [
             record.event_log_entry.dagster_event
@@ -111,7 +99,41 @@ class StepDelegatingExecutor(Executor):
             if record.event_log_entry.dagster_event and record.storage_id not in seen_storage_ids
         ]
 
-        seen_storage_ids.update(record.storage_id for record in conn.records)
+        returned_storage_ids = {record.storage_id for record in conn.records}
+
+        pop_events_offset = self._get_pop_events_offset(instance)
+
+        if not pop_events_offset:
+            self._event_cursor = conn.cursor
+        elif (
+            len(returned_storage_ids) == self._pop_events_limit
+            and returned_storage_ids <= seen_storage_ids
+        ):
+            # Start the next cursor halfway through the returned list
+            desired_next_storage_id = conn.records[
+                math.ceil(self._pop_events_limit / 2) - 1
+            ].storage_id
+            self._event_cursor = EventLogCursor.from_storage_id(desired_next_storage_id).to_string()
+
+            logging.getLogger("dagster").warn(
+                f"Event tailer query returned a list of {self._pop_events_limit} storage IDs that had already been returned before. Setting the cursor to {desired_next_storage_id} to ensure it advances."
+            )
+        else:
+            cursor_obj = EventLogCursor.parse(conn.cursor)
+            check.invariant(
+                cursor_obj.is_id_cursor(),
+                "Applying a tailer offset only works with an id-based cursor",
+            )
+            # Apply offset for next query (while also making sure that the cursor doesn't backtrack)
+            current_cursor_storage_id = (
+                EventLogCursor.parse(self._event_cursor).storage_id() if self._event_cursor else 0
+            )
+            new_storage_id = max(
+                current_cursor_storage_id, cursor_obj.storage_id() - pop_events_offset
+            )
+            self._event_cursor = EventLogCursor.from_storage_id(new_storage_id).to_string()
+
+        seen_storage_ids.update(returned_storage_ids)
 
         return dagster_events
 

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -631,3 +631,6 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     @property
     def handles_run_events_in_store_event(self) -> bool:
         return False
+
+    def default_run_scoped_event_tailer_offset(self) -> int:
+        return 0

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_step_delegating_executor.py
@@ -147,7 +147,8 @@ def test_execute_with_tailer_offset():
         with environ(
             {
                 "DAGSTER_EXECUTOR_POP_EVENTS_OFFSET": "100000",
-                "DAGSTER_EXECUTOR_POP_EVENTS_LIMIT": "2",  # limit env var is ignored since it is lower than the offset - if it was not ignored, the run would never finish
+                "DAGSTER_EXECUTOR_POP_EVENTS_LIMIT": "2",
+                "DAGSTER_STEP_DELEGATING_EXECUTOR_SLEEP_SECONDS": "0.001",
             }
         ):
             result = execute_job(


### PR DESCRIPTION
Summary:
- Pull the default value to use for the executor offset from the event log storage
- Fix an issue that occurred when where the limit was less than the offset, so that it becomes safe to set the default offset higher than the default limit - in rare situations where every event globally was from the same run, the offset scheme created situations where the offset would result in going back to only events that were from that run, so the cursor wouldn't actually advance on each run! To fix that, advance it so that it will go halfway through the returned list on the next iteration when this happens, to ensure that there is always forward progress no matter what.

## Summary & Motivation

## How I Tested These Changes

## Changelog [New | Bug | Docs]

> Replace this message with a changelog entry, or `NOCHANGELOG`
