### PR TITLE
No longer support op-level tags

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
@@ -111,9 +111,12 @@ def build_task_asset(
     task_id: str,
     dag_id: str,
 ) -> AssetsDefinition:
-    asset_specs = [AssetSpec(key=key, deps=deps) for key, deps in deps_graph.items()]
+    asset_specs = [
+        AssetSpec(key=key, deps=deps, tags={"airlift/task_id": task_id, "airlift/dag_id": dag_id})
+        for key, deps in deps_graph.items()
+    ]
 
-    @multi_asset(specs=asset_specs, op_tags={"airlift/task_id": task_id, "airlift/dag_id": dag_id})
+    @multi_asset(specs=asset_specs)
     def asset_fn():
         pass
 
@@ -123,7 +126,7 @@ def build_task_asset(
 def build_dag_asset(
     dag_id: str,
 ) -> AssetsDefinition:
-    @asset(op_tags={"airlift/dag_id": dag_id}, key=dag_id)
+    @asset(tags={"airlift/dag_id": dag_id}, key=dag_id)
     def asset_fn():
         pass
 

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_utils.py
@@ -87,67 +87,6 @@ def test_retrieve_by_asset_tag() -> None:
         get_task_id_from_asset(multi_spec_task_mismatch)
 
 
-def test_retrieve_by_op_tag() -> None:
-    """Test that we can retrieve the dag and task id from the op tags."""
-
-    @asset(op_tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"})
-    def the_asset():
-        pass
-
-    assert get_dag_id_from_asset(the_asset) == "print_dag"
-    assert get_task_id_from_asset(the_asset) == "print_task"
-
-
-def test_retrieve_by_name() -> None:
-    """Test that we can retrieve the dag and task id from the name."""
-
-    @asset
-    def print_dag__print_task():
-        pass
-
-    assert get_dag_id_from_asset(print_dag__print_task) == "print_dag"
-    assert get_task_id_from_asset(print_dag__print_task) == "print_task"
-
-
-def test_op_asset_tag_mismatch() -> None:
-    @asset(
-        tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"},
-        op_tags={"airlift/dag_id": "other_dag", "airlift/task_id": "other_task"},
-    )
-    def mismatched():
-        pass
-
-    with pytest.raises(CheckError):
-        get_dag_id_from_asset(mismatched)
-
-    with pytest.raises(CheckError):
-        get_task_id_from_asset(mismatched)
-
-
-def test_op_asset_name_mismatch() -> None:
-    @asset(tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"})
-    def other_dag__other_task():
-        pass
-
-    with pytest.raises(CheckError):
-        get_dag_id_from_asset(other_dag__other_task)
-
-    with pytest.raises(CheckError):
-        get_task_id_from_asset(other_dag__other_task)
-
-
-def test_op_tag_name_mismatch() -> None:
-    @asset(op_tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"})
-    def other_dag__other_task():
-        pass
-
-    with pytest.raises(CheckError):
-        get_dag_id_from_asset(other_dag__other_task)
-
-    with pytest.raises(CheckError):
-        get_task_id_from_asset(other_dag__other_task)
-
-
 def test_specs_to_tasks() -> None:
     """Tests basic conversion of specs to tasks."""
     specs = ["1", AssetSpec(key=AssetKey(["2"]))]


### PR DESCRIPTION
## Summary & Motivation

Previously we supported a naming convention where we would parse out dag_id and task_id from the name of the backing node. Baking this into the core was not a great idea. Eliminating this feature eliminates a lot of nasty code.

## How I Tested These Changes

BK

## Changelog [New | Bug | Docs]

NOCHANGELOG
