### PR TITLE
Add kinds parameter to AssetSpec

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1769,10 +1769,8 @@ def fresh_diamond_bottom(fresh_diamond_left, fresh_diamond_right):
 
 @multi_asset(
     specs=[
-        AssetSpec(
-            key="first_kinds_key", tags={"dagster/kind/python": "", "dagster/kind/airflow": ""}
-        ),
-        AssetSpec(key="second_kinds_key", tags={"dagster/kind/python": ""}),
+        AssetSpec(key="first_kinds_key", kinds={"python", "airflow"}),
+        AssetSpec(key="second_kinds_key", kinds={"python"}),
     ],
 )
 def multi_asset_with_kinds():

--- a/python_modules/dagster/dagster/_core/definitions/asset_out.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_out.py
@@ -166,6 +166,7 @@ class AssetOut(
                 deps=deps,
                 auto_materialize_policy=None,
                 partitions_def=None,
+                kinds=None,
             )
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -72,6 +72,7 @@ class AssetExecutionType(Enum):
 
 @experimental_param(param="owners")
 @experimental_param(param="tags")
+@experimental_param(param="kinds")
 class AssetSpec(
     NamedTuple(
         "_AssetSpec",
@@ -122,6 +123,8 @@ class AssetSpec(
             e.g. `team:finops`.
         tags (Optional[Mapping[str, str]]): Tags for filtering and organizing. These tags are not
             attached to runs of the asset.
+        kinds: (Optional[Set[str]]): A list of strings representing the kinds of the asset. These
+            will be made visible in the Dagster UI.
         partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
             compose the asset.
     """
@@ -140,6 +143,7 @@ class AssetSpec(
         automation_condition: Optional[AutomationCondition] = None,
         owners: Optional[Sequence[str]] = None,
         tags: Optional[Mapping[str, str]] = None,
+        kinds: Optional[Set[str]] = None,
         # TODO: FOU-243
         auto_materialize_policy: Optional[AutoMaterializePolicy] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
@@ -155,7 +159,14 @@ class AssetSpec(
         for owner in owners:
             validate_asset_owner(owner, key)
 
-        kind_tags = {tag_key for tag_key in (tags or {}).keys() if tag_key.startswith(KIND_PREFIX)}
+        tags_with_kinds = {
+            **(validate_tags_strict(tags) or {}),
+            **{f"{KIND_PREFIX}{kind}": "" for kind in kinds or []},
+        }
+
+        kind_tags = {
+            tag_key for tag_key in tags_with_kinds.keys() if tag_key.startswith(KIND_PREFIX)
+        }
         if kind_tags is not None and len(kind_tags) > 3:
             raise DagsterInvalidDefinitionError("Assets can have at most three kinds currently.")
 
@@ -179,7 +190,7 @@ class AssetSpec(
                 AutomationCondition,
             ),
             owners=owners,
-            tags=validate_tags_strict(tags) or {},
+            tags=tags_with_kinds,
             partitions_def=check.opt_inst_param(
                 partitions_def, "partitions_def", PartitionsDefinition
             ),
@@ -199,6 +210,7 @@ class AssetSpec(
         automation_condition: Optional[AutomationCondition],
         owners: Optional[Sequence[str]],
         tags: Optional[Mapping[str, str]],
+        kinds: Optional[Set[str]],
         auto_materialize_policy: Optional[AutoMaterializePolicy],
         partitions_def: Optional[PartitionsDefinition],
     ) -> "AssetSpec":
@@ -215,6 +227,7 @@ class AssetSpec(
             automation_condition=automation_condition,
             owners=owners,
             tags=tags,
+            kinds=kinds,
             partitions_def=partitions_def,
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1764,6 +1764,7 @@ def _asset_specs_from_attr_key_params(
                     skippable=False,
                     auto_materialize_policy=None,
                     partitions_def=None,
+                    kinds=None,
                 )
             )
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2291,7 +2291,7 @@ def test_asset_spec_with_tags():
 
 
 def test_asset_spec_with_kinds() -> None:
-    @multi_asset(specs=[AssetSpec("asset1", tags={"dagster/kind/python": ""})])
+    @multi_asset(specs=[AssetSpec("asset1", kinds={"python"})])
     def assets(): ...
 
     assert assets.specs_by_key[AssetKey("asset1")].kinds == {"python"}
@@ -2301,17 +2301,7 @@ def test_asset_spec_with_kinds() -> None:
     ):
 
         @multi_asset(
-            specs=[
-                AssetSpec(
-                    "asset1",
-                    tags={
-                        "dagster/kind/python": "",
-                        "dagster/kind/snowflake": "",
-                        "dagster/kind/bigquery": "",
-                        "dagster/kind/airflow": "",
-                    },
-                )
-            ]
+            specs=[AssetSpec("asset1", kinds={"python", "snowflake", "bigquery", "airflow"})]
         )
         def assets2(): ...
 
@@ -2320,10 +2310,7 @@ def test_asset_spec_with_kinds() -> None:
         match="Can not specify compute_kind on both the @multi_asset and kinds on AssetSpecs.",
     ):
 
-        @multi_asset(
-            compute_kind="my_compute_kind",
-            specs=[AssetSpec("asset1", tags={"dagster/kind/python": ""})],
-        )
+        @multi_asset(compute_kind="my_compute_kind", specs=[AssetSpec("asset1", kinds={"python"})])
         def assets3(): ...
 
 


### PR DESCRIPTION
## Summary

Introduces a `kinds` parameter to `AssetSpec`, sugar which converts immediately into the kind tags introduced in #23779. This PR properly introduces kinds as a user-facing input, so hoping to center conversation around those APIs here.

## Test Plan

Unit tests.

