### PR TITLE
[1/k][ui] Pull, display generic kinds in place of compute kind

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -18,7 +18,7 @@ import {ChangedReasonsTag, MinimalNodeChangedDot} from '../assets/ChangedReasons
 import {MinimalNodeStaleDot, StaleReasonsTag, isAssetStale} from '../assets/Stale';
 import {AssetChecksStatusSummary} from '../assets/asset-checks/AssetChecksStatusSummary';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
-import {AssetComputeKindTag} from '../graph/KindTags';
+import {AssetKind} from '../graph/KindTags';
 import {StaticSetFilter} from '../ui/BaseFilters/useStaticSetFilter';
 import {markdownToPlaintext} from '../ui/markdownToPlaintext';
 
@@ -28,7 +28,7 @@ interface Props {
   computeKindTagsFilter?: StaticSetFilter<string>;
 }
 
-export const AssetNode = React.memo(({definition, selected, computeKindTagsFilter}: Props) => {
+export const AssetNode = React.memo(({definition, selected}: Props) => {
   const {liveData} = useAssetLiveData(definition.assetKey);
   return (
     <AssetInsetForHoverEffect>
@@ -64,11 +64,13 @@ export const AssetNode = React.memo(({definition, selected, computeKindTagsFilte
           )}
         </AssetNodeBox>
         <Box flex={{direction: 'row-reverse', gap: 8}}>
-          <AssetComputeKindTag
-            definition={definition}
-            style={{position: 'relative', paddingTop: 7, margin: 0}}
-            currentPageFilter={computeKindTagsFilter}
-          />
+          {definition.kinds.map((kind) => (
+            <AssetKind
+              key={kind}
+              kind={kind}
+              style={{position: 'relative', paddingTop: 7, margin: 0}}
+            />
+          ))}
         </Box>
       </AssetNodeContainer>
     </AssetInsetForHoverEffect>
@@ -260,6 +262,7 @@ export const ASSET_NODE_FRAGMENT = gql`
       key
       value
     }
+    kinds
   }
 
   fragment AssetNodeKey on AssetKey {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetNode.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetNode.types.ts
@@ -16,6 +16,7 @@ export type AssetNodeFragment = {
   isPartitioned: boolean;
   isObservable: boolean;
   isMaterializable: boolean;
+  kinds: Array<string>;
   assetKey: {__typename: 'AssetKey'; path: Array<string>};
   tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useAssetGraphData.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useAssetGraphData.types.ts
@@ -25,6 +25,7 @@ export type AssetGraphQuery = {
     isPartitioned: boolean;
     isObservable: boolean;
     isMaterializable: boolean;
+    kinds: Array<string>;
     tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
     owners: Array<
       {__typename: 'TeamAssetOwner'; team: string} | {__typename: 'UserAssetOwner'; email: string}
@@ -57,6 +58,7 @@ export type AssetNodeForGraphQueryFragment = {
   isPartitioned: boolean;
   isObservable: boolean;
   isMaterializable: boolean;
+  kinds: Array<string>;
   tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
   owners: Array<
     {__typename: 'TeamAssetOwner'; team: string} | {__typename: 'UserAssetOwner'; email: string}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTableFragment.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTableFragment.tsx
@@ -31,6 +31,7 @@ export const ASSET_TABLE_DEFINITION_FRAGMENT = gql`
       key
       value
     }
+    kinds
     repository {
       id
       name

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetNodeDefinition.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetNodeDefinition.types.ts
@@ -18,6 +18,7 @@ export type AssetNodeDefinitionFragment = {
   computeKind: string | null;
   isPartitioned: boolean;
   isObservable: boolean;
+  kinds: Array<string>;
   tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
   owners: Array<
     {__typename: 'TeamAssetOwner'; team: string} | {__typename: 'UserAssetOwner'; email: string}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetTableFragment.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetTableFragment.types.ts
@@ -14,6 +14,7 @@ export type AssetTableDefinitionFragment = {
   computeKind: string | null;
   hasMaterializePermission: boolean;
   description: string | null;
+  kinds: Array<string>;
   partitionDefinition: {
     __typename: 'PartitionDefinition';
     description: string;
@@ -51,6 +52,7 @@ export type AssetTableFragment = {
     computeKind: string | null;
     hasMaterializePermission: boolean;
     description: string | null;
+    kinds: Array<string>;
     partitionDefinition: {
       __typename: 'PartitionDefinition';
       description: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
@@ -34,6 +34,7 @@ export type AssetViewDefinitionQuery = {
           computeKind: string | null;
           isPartitioned: boolean;
           isObservable: boolean;
+          kinds: Array<string>;
           partitionDefinition: {
             __typename: 'PartitionDefinition';
             description: string;
@@ -16313,6 +16314,7 @@ export type AssetViewDefinitionNodeFragment = {
   computeKind: string | null;
   isPartitioned: boolean;
   isObservable: boolean;
+  kinds: Array<string>;
   partitionDefinition: {
     __typename: 'PartitionDefinition';
     description: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetsCatalogTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetsCatalogTable.types.ts
@@ -29,6 +29,7 @@ export type AssetCatalogTableQuery = {
             computeKind: string | null;
             hasMaterializePermission: boolean;
             description: string | null;
+            kinds: Array<string>;
             partitionDefinition: {
               __typename: 'PartitionDefinition';
               description: string;
@@ -82,6 +83,7 @@ export type AssetCatalogGroupTableQuery = {
     computeKind: string | null;
     hasMaterializePermission: boolean;
     description: string | null;
+    kinds: Array<string>;
     assetKey: {__typename: 'AssetKey'; path: Array<string>};
     partitionDefinition: {
       __typename: 'PartitionDefinition';
@@ -117,6 +119,7 @@ export type AssetCatalogGroupTableNodeFragment = {
   computeKind: string | null;
   hasMaterializePermission: boolean;
   description: string | null;
+  kinds: Array<string>;
   assetKey: {__typename: 'AssetKey'; path: Array<string>};
   partitionDefinition: {
     __typename: 'PartitionDefinition';

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
@@ -10,10 +10,14 @@ export const LEGACY_COMPUTE_KIND_TAG = 'kind';
 export const COMPUTE_KIND_TAG = 'dagster/compute_kind';
 export const STORAGE_KIND_TAG = 'dagster/storage_kind';
 
+export const KIND_TAG_PREFIX = `dagster/kind/`;
+
 // Older code servers may be using the legacy compute kind tag, so we need to check for both
 export const isCanonicalComputeKindTag = (tag: DefinitionTag) =>
   tag.key === COMPUTE_KIND_TAG || tag.key === LEGACY_COMPUTE_KIND_TAG;
 export const isCanonicalStorageKindTag = (tag: DefinitionTag) => tag.key === STORAGE_KIND_TAG;
+
+export const isKindTag = (tag: DefinitionTag) => tag.key.startsWith(KIND_TAG_PREFIX);
 
 export const AssetComputeKindTag = ({
   definition,
@@ -88,7 +92,7 @@ export const AssetStorageKindTag = ({
   reduceText?: boolean;
   reversed?: boolean;
   linkToFilteredAssetsTable?: boolean;
-  currentPageFilter?: StaticSetFilter<DefinitionTag>;
+  currentPageFilter?: StaticSetFilter<string>;
 }) => {
   return (
     <Tooltip
@@ -115,6 +119,54 @@ export const AssetStorageKindTag = ({
         tags={[
           {
             label: storageKind,
+            onClick: () => {},
+          },
+        ]}
+      />
+    </Tooltip>
+  );
+};
+
+export const AssetKind = ({
+  kind,
+  style,
+  linkToFilteredAssetsTable: shouldLink,
+  currentPageFilter,
+  ...rest
+}: {
+  kind: string;
+  style: React.CSSProperties;
+  reduceColor?: boolean;
+  reduceText?: boolean;
+  reversed?: boolean;
+  linkToFilteredAssetsTable?: boolean;
+  currentPageFilter?: StaticSetFilter<string>;
+}) => {
+  return (
+    <Tooltip
+      content={
+        currentPageFilter ? (
+          <>
+            Filter to <CaptionMono>{kind}</CaptionMono> assets
+          </>
+        ) : shouldLink ? (
+          <>
+            View all <CaptionMono>{kind}</CaptionMono> assets
+          </>
+        ) : (
+          <>
+            Storage kind <CaptionMono>{kind}</CaptionMono>
+          </>
+        )
+      }
+      placement="bottom"
+    >
+      <OpTags
+        style={{...style, cursor: shouldLink || currentPageFilter ? 'pointer' : 'default'}}
+        {...rest}
+        tags={[
+          {
+            label: kind,
             onClick: () => {},
           },
         ]}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -21,7 +21,7 @@ import {StaleReasonsLabel} from '../assets/Stale';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {AssetTableDefinitionFragment} from '../assets/types/AssetTableFragment.types';
 import {AssetViewType} from '../assets/useAssetView';
-import {AssetComputeKindTag} from '../graph/KindTags';
+import {AssetKind} from '../graph/KindTags';
 import {AssetKeyInput} from '../graphql/types';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
@@ -82,6 +82,7 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
       onToggleChecked({checked, shiftKey});
     }
   };
+  const kinds = definition?.kinds;
 
   return (
     <Row $height={height} $start={start} data-testid={testId(`row-${tokenForAssetKey({path})}`)}>
@@ -102,14 +103,18 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
                 textStyle="middle-truncate"
               />
             </div>
-            {definition && (
-              <AssetComputeKindTag
-                reduceColor
-                reduceText
-                definition={definition}
-                style={{position: 'relative'}}
-                currentPageFilter={computeKindFilter}
-              />
+            {kinds && (
+              <>
+                {kinds?.map((kind) => (
+                  <AssetKind
+                    key={kind}
+                    reduceColor
+                    reduceText
+                    kind={kind}
+                    style={{position: 'relative'}}
+                  />
+                ))}
+              </>
             )}
           </Box>
           <div

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceAssetsQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceAssetsQuery.types.ts
@@ -14,6 +14,7 @@ export type RepoAssetTableFragment = {
   computeKind: string | null;
   hasMaterializePermission: boolean;
   description: string | null;
+  kinds: Array<string>;
   assetKey: {__typename: 'AssetKey'; path: Array<string>};
   partitionDefinition: {
     __typename: 'PartitionDefinition';
@@ -69,6 +70,7 @@ export type WorkspaceAssetsQuery = {
           computeKind: string | null;
           hasMaterializePermission: boolean;
           description: string | null;
+          kinds: Array<string>;
           assetKey: {__typename: 'AssetKey'; path: Array<string>};
           partitionDefinition: {
             __typename: 'PartitionDefinition';


### PR DESCRIPTION
## Summary

Begin moving from compute kinds to kinds by requesting the list of kinds from GraphQL (introduced in #24154, a superset of the compute kind) and then displaying those in place of the compute kind tags in the asset graph and asset list.

## Changelog 
`NOCHANGELOG`
