### PR TITLE
Extend adls2 pickle io manager config

### DIFF
--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -209,7 +209,7 @@ class ADLS2PickleIOManager(ConfigurableIOManager):
 
 @deprecated(
     breaking_version="2.0",
-    additional_warn_text="Please use GCSPickleIOManager instead.",
+    additional_warn_text="Please use ADLS2PickleIOManager instead.",
 )
 class ConfigurablePickledObjectADLS2IOManager(ADLS2PickleIOManager):
     """Renamed to ADLS2PickleIOManager. See ADLS2PickleIOManager for documentation."""

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -179,6 +179,9 @@ class ADLS2PickleIOManager(ConfigurableIOManager):
     adls2_prefix: str = Field(
         default="dagster", description="ADLS Gen2 file system prefix to write to."
     )
+    lease_duration: int = Field(
+        description="Lease duration in seconds. Must be between 15 and 60 seconds or -1 for infinite."
+    )
 
     @classmethod
     def _is_dagster_maintained(cls) -> bool:
@@ -193,6 +196,7 @@ class ADLS2PickleIOManager(ConfigurableIOManager):
             self.adls2.blob_client,
             self.adls2.lease_client_constructor,
             self.adls2_prefix,
+            self.lease_duration,
         )
 
     def load_input(self, context: "InputContext") -> Any:
@@ -291,5 +295,6 @@ def adls2_pickle_io_manager(init_context):
         blob_client,
         lease_client,
         init_context.resource_config.get("adls2_prefix"),
+        init_context.resource_config.get("lease_duration"),
     )
     return pickled_io_manager

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -180,7 +180,8 @@ class ADLS2PickleIOManager(ConfigurableIOManager):
         default="dagster", description="ADLS Gen2 file system prefix to write to."
     )
     lease_duration: int = Field(
-        description="Lease duration in seconds. Must be between 15 and 60 seconds or -1 for infinite."
+        default=60,
+        description="Lease duration in seconds. Must be between 15 and 60 seconds or -1 for infinite.",
     )
 
     @classmethod


### PR DESCRIPTION
This PR adds the 'lease_duration' attribute to the ADLS2PickleIOManager 

## Summary & Motivation
This PR is a followup of #21150. The attribute 'lease_duration' is added to ADLS2PickleIOManager, so that it can be configured when the IO Manager is used as a dagster resource.

## How I Tested These Changes

Successfully run dagster-azure test with 20 passed and 3 skipped. 
