### PR TITLE
[ui] Fix CodeLocationNotFound import path

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceRoot.tsx
@@ -1,8 +1,8 @@
 import {Box, MainContent, NonIdealState, SpinnerWithText} from '@dagster-io/ui-components';
 import {useContext} from 'react';
 import {Redirect, Switch, useParams} from 'react-router-dom';
-import {CodeLocationNotFound} from 'shared/workspace/CodeLocationNotFound';
 
+import {CodeLocationNotFound} from './CodeLocationNotFound';
 import {GraphRoot} from './GraphRoot';
 import {WorkspaceAssetsRoot} from './WorkspaceAssetsRoot';
 import {WorkspaceContext} from './WorkspaceContext';


### PR DESCRIPTION
## Summary & Motivation

This shouldn't be imported from `shared`, vscode just auto-added it that way.

## How I Tested These Changes

Load Plus app, verify that the error is gone.

## Changelog [New | Bug | Docs]

`NOCHANGELOG`
