### PR TITLE
[bugfix] Fix asset selection and asset check selection handling on sensor RunRequests

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor.py
@@ -36,7 +36,9 @@ def build_airflow_polling_sensor(
         name="airflow_dag_status_sensor",
         minimum_interval_seconds=1,
         default_status=DefaultSensorStatus.RUNNING,
-        # Tracking bug around this here: https://linear.app/dagster-labs/issue/FOU-376/make-airflow-polling-sensor-work-with-asset-selection=
+        # We use an empty asset_selection because: (1) we want airlift to support older dagster
+        # versions, so we don't use the 1.8+ `target` param; (2) the sensor will only ever execute
+        # asset checks, so we don't want the sensor to target any assets.
         asset_selection=AssetSelection.assets(),
     )
     def airflow_dag_sensor(context: SensorEvaluationContext) -> SensorResult:

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor.py
@@ -36,10 +36,8 @@ def build_airflow_polling_sensor(
         name="airflow_dag_status_sensor",
         minimum_interval_seconds=1,
         default_status=DefaultSensorStatus.RUNNING,
-        # We use an empty asset_selection because: (1) we want airlift to support older dagster
-        # versions, so we don't use the 1.8+ `target` param; (2) the sensor will only ever execute
-        # asset checks, so we don't want the sensor to target any assets.
-        asset_selection=AssetSelection.assets(),
+        # This sensor will only ever execute asset checks and not asset materializations.
+        asset_selection=AssetSelection.all_asset_checks(),
     )
     def airflow_dag_sensor(context: SensorEvaluationContext) -> SensorResult:
         """Sensor to report materialization events for each asset as new runs come in."""
@@ -119,9 +117,7 @@ def build_airflow_polling_sensor(
         context.update_cursor(str(current_date.timestamp()))
         return SensorResult(
             asset_events=[sorted_mat[1] for sorted_mat in sorted_mats],
-            run_requests=[
-                RunRequest(asset_check_keys=list(asset_check_keys_to_request), asset_selection=[])
-            ]
+            run_requests=[RunRequest(asset_check_keys=list(asset_check_keys_to_request))]
             if asset_check_keys_to_request
             else None,
         )

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -1394,7 +1394,7 @@ def _run_requests_with_base_asset_jobs(
     asset_graph = context.repository_def.asset_graph  # type: ignore  # (possible none)
     result = []
     for run_request in run_requests:
-        if run_request.asset_selection:
+        if run_request.asset_selection is not None:
             asset_keys = run_request.asset_selection
 
             unexpected_asset_keys = (

--- a/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/sensor_definition.py
@@ -30,6 +30,7 @@ from dagster._annotations import deprecated, deprecated_param, experimental_para
 from dagster._core.decorator_utils import get_function_params
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.asset_selection import (
+    AssetCheckKeysSelection,
     AssetSelection,
     CoercibleToAssetSelection,
     KeysAssetSelection,
@@ -73,7 +74,7 @@ from dagster._serdes import whitelist_for_serdes
 from dagster._time import get_current_datetime
 from dagster._utils import IHasInternalInit, normalize_to_repository
 from dagster._utils.merger import merge_dicts
-from dagster._utils.warnings import normalize_renamed_param
+from dagster._utils.warnings import deprecation_warning, normalize_renamed_param
 
 if TYPE_CHECKING:
     from dagster import ResourceDefinition
@@ -1408,11 +1409,30 @@ def _run_requests_with_base_asset_jobs(
         else:
             asset_keys = outer_asset_selection.resolve(asset_graph)
 
+        if run_request.asset_check_keys is not None:
+            asset_check_keys = run_request.asset_check_keys
+
+            unexpected_asset_check_keys = (
+                AssetCheckKeysSelection(selected_asset_check_keys=asset_check_keys)
+                - outer_asset_selection
+            ).resolve_checks(asset_graph)
+            if unexpected_asset_check_keys:
+                deprecation_warning(
+                    subject="Including asset check keys in a sensor RunRequest that are not a subset of the sensor asset_selection",
+                    breaking_version="1.9.0",
+                    additional_warn_text=f"Unexpected asset check keys: {unexpected_asset_check_keys}.",
+                )
+        else:
+            asset_check_keys = KeysAssetSelection(selected_keys=list(asset_keys)).resolve_checks(
+                asset_graph
+            )
+
         base_job = context.repository_def.get_implicit_job_def_for_assets(asset_keys)  # type: ignore  # (possible none)
         result.append(
             run_request.with_replaced_attrs(
                 job_name=base_job.name,  # type: ignore  # (possible none)
                 asset_selection=list(asset_keys),
+                asset_check_keys=list(asset_check_keys),
             )
         )
 


### PR DESCRIPTION
## Summary & Motivation

When a sensor targets an `asset_selection` (as opposed to a job, which is always targeted when using any other targeting param, including `target`), any `RunRequest` produced by its eval function undergoes an extra step of processing, where it is turned into a `RunRequest` targeting a base asset job.

This extra processing sets `asset_selection` on the new `RunRequest` if it is not already set. Prior to this PR, the check for it already being set was ignoring an `[]` value (since this is false in booleans). This was causing the `asset_selection` on the `RunRequest` to be reset to the `asset_selection` for the entire sensor, which is incorrect. Also, checking for unexpected asset check keys (keys not part of the match the sensor asset selection subset) was not being done.

This PR:

- Changes the boolean to check for `asset_selection=None` explicitly.
- Adds a check for unexpected asset check keys. This emits a warning instead of an error if unexpected keys are detected to avoid breakage.
- Changes the `asset_selection` for the dagster-airlift sensor to target all asset checks instead of the empty set of assets. The empty set of assets worked incidentally, targeting all asset checks actually makes sense. Note that this will continue to work against older versions of Dagster.

Fixes https://linear.app/dagster-labs/issue/FOU-376/make-airflow-polling-sensor-work-with-asset-selection=.

## How I Tested These Changes

Added unit tests.

Made sure this test in dagster-airlift started passing with the `asset_selection=*` change:

```
tutorial_example_tests/integration_tests/test_peer_with_check_e2e.py::test_peer_reflects_dag_completion_status_and_runs_check
```

## Changelog [Bug]

Fixed a bug where setting `asset_selection=[]` on `RunRequest` objects yielded from sensors using `asset_selection` did not work correctly.
