### PR TITLE
increase default value of DAGSTER_DBT_TERMINATION_TIMEOUT_SECONDS and make it configurable

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_invocation.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_invocation.py
@@ -29,7 +29,9 @@ from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
 from dagster_dbt.errors import DagsterDbtCliRuntimeError
 
 PARTIAL_PARSE_FILE_NAME = "partial_parse.msgpack"
-DAGSTER_DBT_TERMINATION_TIMEOUT_SECONDS = 2
+DAGSTER_DBT_TERMINATION_TIMEOUT_SECONDS = int(
+    os.getenv("DAGSTER_DBT_TERMINATION_TIMEOUT_SECONDS", "25")
+)
 DEFAULT_EVENT_POSTPROCESSING_THREADPOOL_SIZE: Final[int] = 4
 
 
@@ -426,9 +428,9 @@ class DbtCliInvocation:
 
         except DagsterExecutionInterruptedError:
             logger.info(f"Forwarding interrupt signal to dbt command: `{self.dbt_command}`.")
-
             self.process.send_signal(signal.SIGINT)
             self.process.wait(timeout=self.termination_timeout_seconds)
+            logger.info(f"dbt process terminated with exit code `{self.process.returncode}`.")
 
             raise
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
@@ -144,6 +144,11 @@ def test_dbt_cli_subprocess_cleanup(
         dbt_cli_invocation_1.wait()
 
     assert "Forwarding interrupt signal to dbt command" in caplog.text
+    assert (
+        f"dbt process terminated with exit code `{dbt_cli_invocation_1.process.returncode}`."
+        in caplog.text
+    )
+
     assert dbt_cli_invocation_1.process.returncode < 0
 
 

--- a/python_modules/libraries/dagster-sdf/dagster_sdf/sdf_cli_invocation.py
+++ b/python_modules/libraries/dagster-sdf/dagster_sdf/sdf_cli_invocation.py
@@ -1,3 +1,4 @@
+import os
 import signal
 import subprocess
 import sys
@@ -20,7 +21,9 @@ from dagster_sdf.sdf_information_schema import SdfInformationSchema
 
 logger = get_dagster_logger()
 
-DAGSTER_SDF_TERMINATION_TIMEOUT_SECONDS = 2
+DAGSTER_SDF_TERMINATION_TIMEOUT_SECONDS = int(
+    os.getenv("DAGSTER_SDF_TERMINATION_TIMEOUT_SECONDS", "25")
+)
 
 
 @dataclass
@@ -240,6 +243,8 @@ class SdfCliInvocation:
 
             self.process.send_signal(signal.SIGINT)
             self.process.wait(timeout=self.termination_timeout_seconds)
+
+            logger.info(f"sdf process terminated with exit code `{self.process.returncode}`.")
 
             raise
 


### PR DESCRIPTION
Summary:
This is currently set to only 2 seconds which is very tight - you could imagine cleanly terminating a running dbt process that is doing a bunch of stuff taking a lot longer. Increase the default and make it configurable via env var.

Test Plan: Terminate a running dbt job, watch it still finish

## Summary & Motivation

## How I Tested These Changes

## Changelog [New]

[dagster-dbt] Increased the default timeout when terminating a run that is running a `dbt` subprocess to wait 25 seconds for the subprocess to cleanly terminate. Previously, it would only wait 2 seconds.
[dagster-sdf] Increased the default timeout when terminating a run that is running an `sdf` subprocess to wait 25 seconds for the subprocess to cleanly terminate. Previously, it would only wait 2 seconds.