### PR TITLE
[dagster- snowflake-pandas] Fix Loading Empty Dataframe crashes Snowflake Pandas IO Manager #24172

### DIFF
--- a/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
+++ b/python_modules/libraries/dagster-snowflake-pandas/dagster_snowflake_pandas/snowflake_pandas_type_handler.py
@@ -113,20 +113,20 @@ class SnowflakePandasTypeHandler(DbTypeHandler[pd.DataFrame]):
                 lambda x: _convert_timestamp_to_string(x, column_types, table_slice.table),
                 axis="index",
             )
-
-        write_pandas(
-            conn=connection,
-            df=with_uppercase_cols,
-            # originally we used pd.to_sql with pd_writer method to write the df to snowflake. pd_writer
-            # forced the database, schema, and table name to be uppercase, so we mimic that behavior here for feature parity
-            # in the future we could allow non-uppercase names
-            table_name=table_slice.table.upper(),
-            schema=table_slice.schema.upper(),
-            database=table_slice.database.upper() if table_slice.database else None,
-            auto_create_table=True,
-            use_logical_type=True,
-            quote_identifiers=True,
-        )
+        if not obj.columns.empty:
+            write_pandas(
+                conn=connection,
+                df=with_uppercase_cols,
+                # originally we used pd.to_sql with pd_writer method to write the df to snowflake. pd_writer
+                # forced the database, schema, and table name to be uppercase, so we mimic that behavior here for feature parity
+                # in the future we could allow non-uppercase names
+                table_name=table_slice.table.upper(),
+                schema=table_slice.schema.upper(),
+                database=table_slice.database.upper() if table_slice.database else None,
+                auto_create_table=True,
+                use_logical_type=True,
+                quote_identifiers=True,
+            )
 
         return {
             # output object may be a slice/partition, so we output different metadata keys based on


### PR DESCRIPTION
## Summary & Motivation

Fix SnowflakePandasIOManager crashing when empty dataframes are sent to Snowflake

## How I Tested These Changes

- Unit test `test_handle_empty()` which sends empty dataframe
- Integration test `test_io_manager_with_snowflake_pandas_only_columns()` which sends columns but no data

## Changelog [Bug]

* Fixed bug where SnowflakePandasIOManager crashes when sent an empty data frame
