### PR TITLE
[2/n][dagster-tableau] Scaffold DagsterTableauTranslator class

### DIFF
--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -160,6 +160,7 @@ daff==1.3.46
 -e docs/sphinx/_ext/dagster-sphinx
 -e python_modules/libraries/dagster-ssh
 -e python_modules/dagster-test
+-e python_modules/libraries/dagster-tableau
 -e python_modules/libraries/dagster-twilio
 -e docs/dagster-ui-screenshot
 -e python_modules/libraries/dagster-wandb

--- a/pyright/master/requirements.txt
+++ b/pyright/master/requirements.txt
@@ -87,6 +87,7 @@
 -e python_modules/libraries/dagster-snowflake-pyspark/
 -e python_modules/libraries/dagster-spark/
 -e python_modules/libraries/dagster-ssh/
+-e python_modules/libraries/dagster-tableau
 -e python_modules/libraries/dagster-twilio/
 -e python_modules/libraries/dagster-wandb[dev]
 -e python_modules/libraries/dagstermill/

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/__init__.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/__init__.py
@@ -1,5 +1,7 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
+from dagster_tableau.translator import DagsterTableauTranslator as DagsterTableauTranslator
+
 # Move back to version.py and edit setup.py once we are ready to publish.
 __version__ = "1!0+dev"
 

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
@@ -31,7 +31,7 @@ class TableauWorkspaceData:
     Provided as context for the translator so that it can resolve dependencies between content.
     """
 
-    site_id: str
+    site_name: str
     workbooks_by_id: Dict[str, TableauContentData]
     views_by_id: Dict[str, TableauContentData]
     data_sources_by_id: Dict[str, TableauContentData]

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict
+from typing import Any, Mapping
 
 from dagster import _check as check
 from dagster._core.definitions.asset_key import AssetKey
@@ -22,7 +22,7 @@ class TableauContentData:
     """
 
     content_type: TableauContentType
-    properties: Dict[str, Any]
+    properties: Mapping[str, Any]
 
 
 @record
@@ -32,9 +32,9 @@ class TableauWorkspaceData:
     """
 
     site_name: str
-    workbooks_by_id: Dict[str, TableauContentData]
-    views_by_id: Dict[str, TableauContentData]
-    data_sources_by_id: Dict[str, TableauContentData]
+    workbooks_by_id: Mapping[str, TableauContentData]
+    views_by_id: Mapping[str, TableauContentData]
+    data_sources_by_id: Mapping[str, TableauContentData]
 
 
 class DagsterTableauTranslator:

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
@@ -1,0 +1,61 @@
+from enum import Enum
+from typing import Any, Dict
+
+from dagster import _check as check
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._record import record
+
+
+class TableauContentType(Enum):
+    """Enum representing each object in Tableau's ontology."""
+
+    VIEW = "view"
+    DATA_SOURCE = "data_source"
+
+
+@record
+class TableauContentData:
+    """A record representing a piece of content in Tableau.
+    Includes the content's type and data as returned from the API.
+    """
+
+    content_type: TableauContentType
+    properties: Dict[str, Any]
+
+
+@record
+class TableauWorkspaceData:
+    """A record representing all content in a Tableau workspace.
+    Provided as context for the translator so that it can resolve dependencies between content.
+    """
+
+    views_by_id: Dict[str, TableauContentData]
+    data_sources_by_id: Dict[str, TableauContentData]
+
+
+class DagsterTableauTranslator:
+    """Translator class which converts raw response data from the Tableau API into AssetSpecs.
+    Subclass this class to implement custom logic for each type of Tableau content.
+    """
+
+    def __init__(self, context: TableauWorkspaceData):
+        self._context = context
+
+    @property
+    def workspace_data(self) -> TableauWorkspaceData:
+        return self._context
+
+    def get_asset_spec(self, data: TableauContentData) -> AssetSpec:
+        if data.content_type == TableauContentType.VIEW:
+            return self.get_view_spec(data)
+        elif data.content_type == TableauContentType.DATA_SOURCE:
+            return self.get_data_source_spec(data)
+        else:
+            check.assert_never(data.content_type)
+
+    def get_view_asset_key(self, data: TableauContentData) -> AssetKey: ...
+    def get_view_spec(self, data: TableauContentData) -> AssetSpec: ...
+
+    def get_data_source_asset_key(self, data: TableauContentData) -> AssetKey: ...
+    def get_data_source_spec(self, data: TableauContentData) -> AssetSpec: ...

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
@@ -10,6 +10,7 @@ from dagster._record import record
 class TableauContentType(Enum):
     """Enum representing each object in Tableau's ontology."""
 
+    WORKBOOK = "workbook"
     VIEW = "view"
     DATA_SOURCE = "data_source"
 
@@ -30,6 +31,8 @@ class TableauWorkspaceData:
     Provided as context for the translator so that it can resolve dependencies between content.
     """
 
+    site_id: str
+    workbooks_by_id: Dict[str, TableauContentData]
     views_by_id: Dict[str, TableauContentData]
     data_sources_by_id: Dict[str, TableauContentData]
 


### PR DESCRIPTION
## Summary & Motivation

Builds out a very barebones translator class to build specs for Tableau assets.

The structure of the `DagsterTableauTranslator` is based on the `DagsterPowerBITranslator` introduced in #23245.

## How I Tested These Changes

Tests will be added in subsequent PRs.

## Changelog [New | Bug | Docs]

> Replace this message with a changelog entry, or `NOCHANGELOG`
