### PR TITLE
[dagster-airlift] 0.0.21 and revamped release process

### DIFF
--- a/examples/experimental/dagster-airlift/Makefile
+++ b/examples/experimental/dagster-airlift/Makefile
@@ -1,5 +1,35 @@
 # Makefile
 
+# Uploads the package to PyPI after bumping the latest version in setup.py.
 adhoc_pypi:
 	@chmod +x scripts/increment_pypi_version.sh
 	@./scripts/increment_pypi_version.sh
+
+# Mirrors the tutorial to the dagster-airlift-tutorial repo: https://github.com/dagster-io/airlift-tutorial
+mirror_tutorial:
+	@chmod +x scripts/mirror_tutorial.sh
+	@./scripts/mirror_tutorial.sh
+
+# Runs the full release process for dagster-airlift.
+# - Enforces that we're on master
+# - Bumps the version in setup.py
+# - Pushes the changes to PyPI
+# - Mirrors the tutorial to the dagster-airlift-tutorial repo
+# - Creates a release branch
+# - Pushes the release branch to origin
+adhoc_release:
+	@if [ "$$(git rev-parse --abbrev-ref HEAD)" != "master" ]; then \
+		echo "Error: Not on master branch. Please switch to master before running this command."; \
+		exit 1; \
+	fi
+	@echo "Releasing dagster-airlift..."
+	@make adhoc_pypi
+	@echo "Mirroring tutorial..."
+	@make mirror_tutorial 
+	@git add .
+	@git checkout -b airlift-$$(./scripts/extract_pypi_version.sh)
+	@git commit -m "[dagster-airlift] $$(./scripts/extract_pypi_version.sh)"
+	@git push origin airlift-$$(./scripts/extract_pypi_version.sh)
+	echo "Airlift release branch created. Please create a PR and merge it to master."
+	@echo "Returning to master branch..."
+	@git checkout master

--- a/examples/experimental/dagster-airlift/scripts/mirror_tutorial.sh
+++ b/examples/experimental/dagster-airlift/scripts/mirror_tutorial.sh
@@ -49,7 +49,7 @@ git add .
 
 echo "Committing with version $version..."
 # Commit message is the version number
-git commit -m "$version"
+git commit -m "$version" --allow-empty
 
 echo "Pushing to origin..."
 # Push to origin

--- a/examples/experimental/dagster-airlift/setup.py
+++ b/examples/experimental/dagster-airlift/setup.py
@@ -13,7 +13,7 @@ airflow_dep_list = [
 
 setup(
     name="dagster-airlift",
-    version="0.0.16",
+    version="0.0.21",
     author="Dagster Labs",
     author_email="hello@dagsterlabs.com",
     license="Apache-2.0",


### PR DESCRIPTION
Adds an additional makefile command which will run entire release process off of master and create a new branch to increment pypi version.
The release process:
- Ensure we're on master so we can get a reproducible release
- Run adhoc_pypi commands to release to pypi
- Run mirror_tutorial script to mirror tutorial to github repo
- Create a new branch called airlift-<release_num> which increments airlift version
- Push branch to remote
- go back to master

Tested this by upgrading pypi. Took a few tries to get everything working hence 0.0.21.

You can try this out by running `make adhoc_release`

Also includes https://github.com/dagster-io/dagster/pull/24187.