### PR TITLE
[dagster-airlift] tutorial auth

### DIFF
--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/airflow_dags/custom_proxy.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/airflow_dags/custom_proxy.py
@@ -1,0 +1,24 @@
+import requests
+from airflow.utils.context import Context
+from dagster_airlift.in_airflow import BaseProxyToDagsterOperator, mark_as_dagster_migrating
+
+
+class CustomProxyToDagsterOperator(BaseProxyToDagsterOperator):
+    def get_dagster_session(self, context: Context) -> requests.Session:
+        if "var" not in context:
+            raise ValueError("No variables found in context")
+        api_key = context["var"]["value"].get("my_api_key")
+        session = requests.Session()
+        session.headers.update({"Authorization": f"Bearer {api_key}"})
+        return session
+
+    def get_dagster_url(self, context: Context) -> str:
+        return "https://dagster.example.com/"
+
+
+...
+
+# At the end of your dag file
+mark_as_dagster_migrating(
+    global_vars=globals(), migration_state=..., dagster_operator_klass=CustomProxyToDagsterOperator
+)


### PR DESCRIPTION
Add a section on custom auth to the tutorial. This could be genericized for sure since there are other potential uses for a subclass of the proxy, but to keep it use-case driven.