### PR TITLE
[rename] EntitySubset -> SerializableEntitySubset, EntitySlice -> EntitySubset

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
@@ -6,7 +6,7 @@ import graphene
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AutomationConditionEvaluation,
 )
-from dagster._core.definitions.entity_subset import EntitySubset
+from dagster._core.definitions.entity_subset import SerializableEntitySubset
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.scheduler.instigation import AutoMaterializeAssetEvaluationRecord
 
@@ -47,7 +47,7 @@ class GrapheneUnpartitionedAssetConditionEvaluationNode(graphene.ObjectType):
         self._evaluation = evaluation
         if evaluation.true_subset.size > 0:
             status = AssetConditionEvaluationStatus.TRUE
-        elif isinstance(evaluation.candidate_subset, EntitySubset) and (
+        elif isinstance(evaluation.candidate_subset, SerializableEntitySubset) and (
             evaluation.candidate_subset.size > 0
         ):
             status = AssetConditionEvaluationStatus.FALSE
@@ -98,7 +98,7 @@ class GraphenePartitionedAssetConditionEvaluationNode(graphene.ObjectType):
             endTimestamp=evaluation.end_timestamp,
             numTrue=evaluation.true_subset.size,
             numCandidates=evaluation.candidate_subset.size
-            if isinstance(evaluation.candidate_subset, EntitySubset)
+            if isinstance(evaluation.candidate_subset, SerializableEntitySubset)
             else None,
             childUniqueIds=[
                 child.condition_snapshot.unique_id for child in evaluation.child_evaluations
@@ -131,7 +131,7 @@ class GrapheneSpecificPartitionAssetConditionEvaluationNode(graphene.ObjectType)
         elif partition_key in evaluation.true_subset.subset_value:
             status = AssetConditionEvaluationStatus.TRUE
         elif (
-            not isinstance(evaluation.candidate_subset, EntitySubset)
+            not isinstance(evaluation.candidate_subset, SerializableEntitySubset)
             or partition_key in evaluation.candidate_subset.subset_value
         ):
             status = AssetConditionEvaluationStatus.FALSE
@@ -236,7 +236,7 @@ class GrapheneAutomationConditionEvaluationNode(graphene.ObjectType):
             endTimestamp=evaluation.end_timestamp,
             numTrue=evaluation.true_subset.size,
             numCandidates=evaluation.candidate_subset.size
-            if isinstance(evaluation.candidate_subset, EntitySubset)
+            if isinstance(evaluation.candidate_subset, SerializableEntitySubset)
             else None,
             isPartitioned=evaluation.true_subset.is_partitioned,
             childUniqueIds=[

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -11,7 +11,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     AutomationConditionNodeSnapshot,
     HistoricalAllPartitionsSubsetSentinel,
 )
-from dagster._core.definitions.entity_subset import EntitySubset
+from dagster._core.definitions.entity_subset import SerializableEntitySubset
 from dagster._core.definitions.partition import PartitionsDefinition, StaticPartitionsDefinition
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.definitions.sensor_definition import SensorType
@@ -431,11 +431,11 @@ class TestAssetConditionEvaluations(ExecutingGraphQLContextTestMatrix):
                 description=description,
                 unique_id=str(random.randint(0, 100000000)),
             ),
-            true_subset=EntitySubset(
+            true_subset=SerializableEntitySubset(
                 key=asset_key,
                 value=partitions_def.subset_with_partition_keys(true_partition_keys),
             ),
-            candidate_subset=EntitySubset(
+            candidate_subset=SerializableEntitySubset(
                 key=asset_key,
                 value=partitions_def.subset_with_partition_keys(candidate_partition_keys),
             )

--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -229,7 +229,7 @@ class AssetDaemonContext:
             if (
                 previous_cursor is None
                 or previous_cursor.result_value_hash != result.value_hash
-                or not result.true_slice.is_empty
+                or not result.true_subset.is_empty
             ):
                 updated_evaluations.append(result.serializable_evaluation)
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -17,7 +17,7 @@ from typing import (
 
 from dagster import _check as check
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
-from dagster._core.definitions.entity_subset import EntitySubset
+from dagster._core.definitions.entity_subset import SerializableEntitySubset
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset
 from dagster._core.errors import DagsterDefinitionChangedDeserializationError
@@ -75,15 +75,17 @@ class AssetGraphSubset(NamedTuple):
 
     def get_asset_subset(
         self, asset_key: AssetKey, asset_graph: BaseAssetGraph
-    ) -> EntitySubset[AssetKey]:
+    ) -> SerializableEntitySubset[AssetKey]:
         """Returns an AssetSubset representing the subset of a specific asset that this
         AssetGraphSubset contains.
         """
         partitions_def = asset_graph.get(asset_key).partitions_def
         if partitions_def is None:
-            return EntitySubset(key=asset_key, value=asset_key in self.non_partitioned_asset_keys)
+            return SerializableEntitySubset(
+                key=asset_key, value=asset_key in self.non_partitioned_asset_keys
+            )
         else:
-            return EntitySubset(
+            return SerializableEntitySubset(
                 key=asset_key,
                 value=self.partitions_subsets_by_asset_key.get(
                     asset_key, partitions_def.empty_subset()
@@ -117,7 +119,7 @@ class AssetGraphSubset(NamedTuple):
 
     def iterate_asset_subsets(
         self, asset_graph: BaseAssetGraph
-    ) -> Iterable[EntitySubset[AssetKey]]:
+    ) -> Iterable[SerializableEntitySubset[AssetKey]]:
         """Returns an Iterable of AssetSubsets representing the subset of each asset that this
         AssetGraphSubset contains.
         """

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_evaluation.py
@@ -8,7 +8,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     AutomationConditionNodeSnapshot,
     HistoricalAllPartitionsSubsetSentinel,
 )
-from dagster._core.definitions.entity_subset import EntitySubset
+from dagster._core.definitions.entity_subset import SerializableEntitySubset
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataMapping, MetadataValue
 from dagster._serdes.serdes import (
@@ -130,7 +130,7 @@ class BackcompatAutoMaterializeAssetEvaluationSerializer(NamedTupleSerializer):
                 condition_snapshot=AutomationConditionNodeSnapshot("", "", "", None, None),
                 start_timestamp=None,
                 end_timestamp=None,
-                true_subset=EntitySubset(key=AssetKey("unknown"), value=False),
+                true_subset=SerializableEntitySubset(key=AssetKey("unknown"), value=False),
                 candidate_subset=HistoricalAllPartitionsSubsetSentinel(),
                 subsets_with_metadata=[],
                 child_evaluations=[],

--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -88,7 +88,7 @@ def evaluate_automation_conditions(context: SensorEvaluationContext):
         if (
             previous_cursor is None
             or previous_cursor.result_value_hash != result.value_hash
-            or not result.true_slice.is_empty
+            or not result.true_subset.is_empty
         ):
             updated_evaluations.append(result.serializable_evaluation)
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -128,10 +128,10 @@ class AutomationConditionEvaluator:
                     f"Error while evaluating conditions for asset {asset_key.to_user_string()}"
                 ) from e
 
-            num_requested = result.true_slice.size
+            num_requested = result.true_subset.size
             log_fn = self.logger.info if num_requested > 0 else self.logger.debug
 
-            to_request_asset_partitions = result.true_slice.expensively_compute_asset_partitions()
+            to_request_asset_partitions = result.true_subset.expensively_compute_asset_partitions()
             to_request_str = ",".join(
                 [(ap.partition_key or "No partition") for ap in to_request_asset_partitions]
             )
@@ -165,7 +165,7 @@ class AutomationConditionEvaluator:
                         ].set_internal_serializable_subset_override(neighbor_true_subset)
                     self.to_request |= {
                         ap._replace(asset_key=neighbor_key)
-                        for ap in result.true_slice.expensively_compute_asset_partitions()
+                        for ap in result.true_subset.expensively_compute_asset_partitions()
                     }
 
         return list(self.current_results_by_key.values()), self.to_request
@@ -208,6 +208,6 @@ class AutomationConditionEvaluator:
 
         result = automation_condition.evaluate(context)
         expected_data_time = get_expected_data_time_for_asset_key(
-            legacy_context, will_materialize=result.true_slice.size > 0
+            legacy_context, will_materialize=result.true_subset.size > 0
         )
         return result, expected_data_time

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/rule_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/rule_condition.py
@@ -36,7 +36,7 @@ class RuleCondition(BuiltinAutomationCondition[AssetKey]):
         # Allow for access to legacy context in legacy rule evaluation
         evaluation_result = self.rule.evaluate_for_asset(context)
         context.log.debug(
-            f"Rule returned {evaluation_result.true_slice.size} partitions "
+            f"Rule returned {evaluation_result.true_subset.size} partitions "
             f"({evaluation_result.end_timestamp - evaluation_result.start_timestamp:.2f} seconds)"
         )
         return evaluation_result

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/code_version_changed_condition.py
@@ -21,8 +21,8 @@ class CodeVersionChangedCondition(BuiltinAutomationCondition[AssetKey]):
         previous_code_version = context.cursor
         current_code_version = context.asset_graph.get(context.key).code_version
         if previous_code_version is None or previous_code_version == current_code_version:
-            true_slice = context.get_empty_slice()
+            true_subset = context.get_empty_subset()
         else:
-            true_slice = context.candidate_slice
+            true_subset = context.candidate_subset
 
-        return AutomationResult(context, true_slice, cursor=current_code_version)
+        return AutomationResult(context, true_subset, cursor=current_code_version)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
@@ -34,11 +34,13 @@ class DownstreamConditionWrapperCondition(BuiltinAutomationCondition[AssetKey]):
     def evaluate(self, context: AutomationContext[AssetKey]) -> AutomationResult[AssetKey]:
         child_result = self.operand.evaluate(
             context.for_child_condition(
-                child_condition=self.operand, child_index=0, candidate_slice=context.candidate_slice
+                child_condition=self.operand,
+                child_index=0,
+                candidate_subset=context.candidate_subset,
             )
         )
         return AutomationResult(
-            context=context, true_slice=child_result.true_slice, child_results=[child_result]
+            context=context, true_subset=child_result.true_subset, child_results=[child_result]
         )
 
 
@@ -83,7 +85,7 @@ class AnyDownstreamConditionsCondition(BuiltinAutomationCondition[AssetKey]):
             context.asset_graph.get_downstream_automation_conditions(asset_key=context.key)
         )
 
-        true_slice = context.get_empty_slice()
+        true_subset = context.get_empty_subset()
         child_results = []
         for i, (downstream_condition, asset_keys) in enumerate(
             sorted(downstream_conditions.items(), key=lambda x: sorted(x[1]))
@@ -96,11 +98,13 @@ class AnyDownstreamConditionsCondition(BuiltinAutomationCondition[AssetKey]):
             child_context = context.for_child_condition(
                 child_condition=child_condition,
                 child_index=i,
-                candidate_slice=context.candidate_slice,
+                candidate_subset=context.candidate_subset,
             )
             child_result = child_condition.evaluate(child_context)
 
             child_results.append(child_result)
-            true_slice = true_slice.compute_union(child_result.true_slice)
+            true_subset = true_subset.compute_union(child_result.true_subset)
 
-        return AutomationResult(context=context, true_slice=true_slice, child_results=child_results)
+        return AutomationResult(
+            context=context, true_subset=true_subset, child_results=child_results
+        )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -35,15 +35,15 @@ class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
 
     def evaluate(self, context: AutomationContext[T_EntityKey]) -> AutomationResult[T_EntityKey]:
         child_results: List[AutomationResult] = []
-        true_slice = context.candidate_slice
+        true_subset = context.candidate_subset
         for i, child in enumerate(self.children):
             child_context = context.for_child_condition(
-                child_condition=child, child_index=i, candidate_slice=true_slice
+                child_condition=child, child_index=i, candidate_subset=true_subset
             )
             child_result = child.evaluate(child_context)
             child_results.append(child_result)
-            true_slice = true_slice.compute_intersection(child_result.true_slice)
-        return AutomationResult(context, true_slice, child_results=child_results)
+            true_subset = true_subset.compute_intersection(child_result.true_subset)
+        return AutomationResult(context, true_subset, child_results=child_results)
 
     def without(self, condition: AutomationCondition) -> "AndAutomationCondition":
         """Returns a copy of this condition without the specified child condition."""
@@ -82,16 +82,16 @@ class OrAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
 
     def evaluate(self, context: AutomationContext[T_EntityKey]) -> AutomationResult[T_EntityKey]:
         child_results: List[AutomationResult] = []
-        true_slice = context.get_empty_slice()
+        true_subset = context.get_empty_subset()
         for i, child in enumerate(self.children):
             child_context = context.for_child_condition(
-                child_condition=child, child_index=i, candidate_slice=context.candidate_slice
+                child_condition=child, child_index=i, candidate_subset=context.candidate_subset
             )
             child_result = child.evaluate(child_context)
             child_results.append(child_result)
-            true_slice = true_slice.compute_union(child_result.true_slice)
+            true_subset = true_subset.compute_union(child_result.true_subset)
 
-        return AutomationResult(context, true_slice, child_results=child_results)
+        return AutomationResult(context, true_subset, child_results=child_results)
 
 
 @whitelist_for_serdes(storage_name="NotAssetCondition")
@@ -114,9 +114,9 @@ class NotAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
 
     def evaluate(self, context: AutomationContext[T_EntityKey]) -> AutomationResult[T_EntityKey]:
         child_context = context.for_child_condition(
-            child_condition=self.operand, child_index=0, candidate_slice=context.candidate_slice
+            child_condition=self.operand, child_index=0, candidate_subset=context.candidate_subset
         )
         child_result = self.operand.evaluate(child_context)
-        true_slice = context.candidate_slice.compute_difference(child_result.true_slice)
+        true_subset = context.candidate_subset.compute_difference(child_result.true_subset)
 
-        return AutomationResult(context, true_slice, child_results=[child_result])
+        return AutomationResult(context, true_subset, child_results=[child_result])

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
@@ -1,6 +1,6 @@
 from typing import Optional, Sequence
 
-from dagster._core.asset_graph_view.asset_graph_view import EntitySlice
+from dagster._core.asset_graph_view.asset_graph_view import EntitySubset
 from dagster._core.definitions.asset_key import T_EntityKey
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
@@ -8,7 +8,7 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     BuiltinAutomationCondition,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
-from dagster._core.definitions.entity_subset import EntitySubset
+from dagster._core.definitions.entity_subset import SerializableEntitySubset
 from dagster._serdes.serdes import whitelist_for_serdes
 
 
@@ -28,35 +28,35 @@ class NewlyTrueCondition(BuiltinAutomationCondition[T_EntityKey]):
     def children(self) -> Sequence[AutomationCondition[T_EntityKey]]:
         return [self.operand]
 
-    def _get_previous_child_true_slice(
+    def _get_previous_child_true_subset(
         self, context: AutomationContext[T_EntityKey]
-    ) -> Optional[EntitySlice[T_EntityKey]]:
-        """Returns the true slice of the child from the previous tick, which is stored in the
+    ) -> Optional[EntitySubset[T_EntityKey]]:
+        """Returns the true subset of the child from the previous tick, which is stored in the
         extra state field of the cursor.
         """
-        true_subset = context.get_structured_cursor(as_type=EntitySubset)
+        true_subset = context.get_structured_cursor(as_type=SerializableEntitySubset)
         if not true_subset:
             return None
-        return context.asset_graph_view.get_slice_from_subset(true_subset)
+        return context.asset_graph_view.get_subset_from_serializable_subset(true_subset)
 
     def evaluate(self, context: AutomationContext) -> AutomationResult:
         # evaluate child condition
         child_context = context.for_child_condition(
             self.operand,
             child_index=0,
-            # must evaluate child condition over the entire slice to avoid missing state transitions
-            candidate_slice=context.asset_graph_view.get_full_slice(key=context.key),
+            # must evaluate child condition over the entire subset to avoid missing state transitions
+            candidate_subset=context.asset_graph_view.get_full_subset(key=context.key),
         )
         child_result = self.operand.evaluate(child_context)
 
         # get the set of asset partitions of the child which newly became true
-        newly_true_child_slice = child_result.true_slice.compute_difference(
-            self._get_previous_child_true_slice(context) or context.get_empty_slice()
+        newly_true_child_subset = child_result.true_subset.compute_difference(
+            self._get_previous_child_true_subset(context) or context.get_empty_subset()
         )
 
         return AutomationResult(
             context=context,
-            true_slice=context.candidate_slice.compute_intersection(newly_true_child_slice),
+            true_subset=context.candidate_subset.compute_intersection(newly_true_child_subset),
             child_results=[child_result],
-            structured_cursor=child_result.true_slice.convert_to_serializable_subset(),
+            structured_cursor=child_result.true_subset.convert_to_serializable_subset(),
         )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
@@ -31,29 +31,29 @@ class SinceCondition(BuiltinAutomationCondition[T_EntityKey]):
         return [self.trigger_condition, self.reset_condition]
 
     def evaluate(self, context: AutomationContext[T_EntityKey]) -> AutomationResult[T_EntityKey]:
-        # must evaluate child condition over the entire slice to avoid missing state transitions
-        child_candidate_slice = context.asset_graph_view.get_full_slice(key=context.key)
+        # must evaluate child condition over the entire subset to avoid missing state transitions
+        child_candidate_subset = context.asset_graph_view.get_full_subset(key=context.key)
 
         # compute result for trigger condition
         trigger_context = context.for_child_condition(
-            self.trigger_condition, child_index=0, candidate_slice=child_candidate_slice
+            self.trigger_condition, child_index=0, candidate_subset=child_candidate_subset
         )
         trigger_result = self.trigger_condition.evaluate(trigger_context)
 
         # compute result for reset condition
         reset_context = context.for_child_condition(
-            self.reset_condition, child_index=1, candidate_slice=child_candidate_slice
+            self.reset_condition, child_index=1, candidate_subset=child_candidate_subset
         )
         reset_result = self.reset_condition.evaluate(reset_context)
 
-        # take the previous slice that this was true for
-        true_slice = context.previous_true_slice or context.get_empty_slice()
+        # take the previous subset that this was true for
+        true_subset = context.previous_true_subset or context.get_empty_subset()
 
         # add in any newly true trigger asset partitions
-        true_slice = true_slice.compute_union(trigger_result.true_slice)
+        true_subset = true_subset.compute_union(trigger_result.true_subset)
         # remove any newly true reset asset partitions
-        true_slice = true_slice.compute_difference(reset_result.true_slice)
+        true_subset = true_subset.compute_difference(reset_result.true_subset)
 
         return AutomationResult(
-            context=context, true_slice=true_slice, child_results=[trigger_result, reset_result]
+            context=context, true_subset=true_subset, child_results=[trigger_result, reset_result]
         )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/serialized_objects.py
@@ -15,7 +15,7 @@ from typing import (
 )
 
 from dagster._core.asset_graph_view.asset_graph_view import TemporalContext
-from dagster._core.definitions.entity_subset import EntitySubset
+from dagster._core.definitions.entity_subset import SerializableEntitySubset
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataMapping, MetadataValue
 from dagster._core.definitions.partition import AllPartitionsSubset
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
         AutomationContext,
     )
 
-StructuredCursor = Union[str, EntitySubset, Sequence[EntitySubset]]
+StructuredCursor = Union[str, SerializableEntitySubset, Sequence[SerializableEntitySubset]]
 T_StructuredCursor = TypeVar("T_StructuredCursor", bound=StructuredCursor)
 
 
@@ -44,10 +44,10 @@ class HistoricalAllPartitionsSubsetSentinel:
 
 
 def get_serializable_candidate_subset(
-    candidate_subset: Union[EntitySubset, HistoricalAllPartitionsSubsetSentinel],
-) -> Union[EntitySubset, HistoricalAllPartitionsSubsetSentinel]:
+    candidate_subset: Union[SerializableEntitySubset, HistoricalAllPartitionsSubsetSentinel],
+) -> Union[SerializableEntitySubset, HistoricalAllPartitionsSubsetSentinel]:
     """Do not serialize the candidate subset directly if it is an AllPartitionsSubset."""
-    if isinstance(candidate_subset, EntitySubset) and isinstance(
+    if isinstance(candidate_subset, SerializableEntitySubset) and isinstance(
         candidate_subset.value, AllPartitionsSubset
     ):
         return HistoricalAllPartitionsSubsetSentinel()
@@ -77,7 +77,7 @@ class AutomationConditionSnapshot(NamedTuple):
 class AssetSubsetWithMetadata(NamedTuple):
     """An asset subset with metadata that corresponds to it."""
 
-    subset: EntitySubset
+    subset: SerializableEntitySubset
     metadata: MetadataMapping
 
     @property
@@ -93,8 +93,10 @@ class AutomationConditionEvaluation(NamedTuple):
     start_timestamp: Optional[float]
     end_timestamp: Optional[float]
 
-    true_subset: EntitySubset[AssetKey]
-    candidate_subset: Union[EntitySubset[AssetKey], HistoricalAllPartitionsSubsetSentinel]
+    true_subset: SerializableEntitySubset[AssetKey]
+    candidate_subset: Union[
+        SerializableEntitySubset[AssetKey], HistoricalAllPartitionsSubsetSentinel
+    ]
     subsets_with_metadata: Sequence[AssetSubsetWithMetadata]
 
     child_evaluations: Sequence["AutomationConditionEvaluation"]
@@ -166,14 +168,14 @@ class AutomationConditionEvaluationState:
         return self.previous_evaluation.asset_key
 
     @property
-    def true_subset(self) -> EntitySubset:
+    def true_subset(self) -> SerializableEntitySubset:
         return self.previous_evaluation.true_subset
 
 
 @whitelist_for_serdes
 class AutomationConditionNodeCursor(NamedTuple):
-    true_subset: EntitySubset
-    candidate_subset: Union[EntitySubset, HistoricalAllPartitionsSubsetSentinel]
+    true_subset: SerializableEntitySubset
+    candidate_subset: Union[SerializableEntitySubset, HistoricalAllPartitionsSubsetSentinel]
     subsets_with_metadata: Sequence[AssetSubsetWithMetadata]
     extra_state: Optional[StructuredCursor]
 
@@ -201,7 +203,7 @@ class AutomationConditionCursor(NamedTuple):
             has changed since the last time this was evaluated.
     """
 
-    previous_requested_subset: EntitySubset
+    previous_requested_subset: SerializableEntitySubset
     effective_timestamp: float
     last_event_id: Optional[int]
 
@@ -251,7 +253,7 @@ class AutomationConditionCursor(NamedTuple):
             return node_cursors
 
         return AutomationConditionCursor(
-            previous_requested_subset=result.true_slice.convert_to_serializable_subset(),
+            previous_requested_subset=result.true_subset.convert_to_serializable_subset(),
             effective_timestamp=context.evaluation_time.timestamp(),
             last_event_id=context.max_storage_id,
             node_cursors_by_unique_id=_gather_node_cursors(result),

--- a/python_modules/dagster/dagster/_core/definitions/entity_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/entity_subset.py
@@ -22,7 +22,7 @@ class EntitySubsetSerializer(DataclassSerializer):
         # backcompat
         return "AssetSubset"
 
-    def before_pack(self, value: "EntitySubset") -> "EntitySubset":
+    def before_pack(self, value: "SerializableEntitySubset") -> "SerializableEntitySubset":
         if value.is_partitioned:
             return replace(value, value=value.subset_value.to_serializable_subset())
         return value
@@ -34,8 +34,8 @@ class EntitySubsetSerializer(DataclassSerializer):
     old_storage_names={"AssetSubset"},
 )
 @dataclass(frozen=True)
-class EntitySubset(Generic[T_EntityKey]):
-    """Represents a subset of a given EntityKey."""
+class SerializableEntitySubset(Generic[T_EntityKey]):
+    """Represents a serializable subset of a given EntityKey."""
 
     key: T_EntityKey
     value: EntitySubsetValue

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -9,7 +9,7 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     AutomationConditionEvaluation,
     AutomationConditionNodeSnapshot,
 )
-from dagster._core.definitions.entity_subset import EntitySubset
+from dagster._core.definitions.entity_subset import SerializableEntitySubset
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.remote_representation import (
@@ -745,8 +745,12 @@ class TestScheduleStorage:
                 asset_evaluations=[
                     AutomationConditionEvaluation(
                         condition_snapshot=condition_snapshot,
-                        true_subset=EntitySubset(key=AssetKey("asset_one"), value=False),
-                        candidate_subset=EntitySubset(key=AssetKey("asset_one"), value=False),
+                        true_subset=SerializableEntitySubset(
+                            key=AssetKey("asset_one"), value=False
+                        ),
+                        candidate_subset=SerializableEntitySubset(
+                            key=AssetKey("asset_one"), value=False
+                        ),
                         start_timestamp=0,
                         end_timestamp=1,
                         subsets_with_metadata=[],
@@ -754,13 +758,17 @@ class TestScheduleStorage:
                     ).with_run_ids(set()),
                     AutomationConditionEvaluation(
                         condition_snapshot=condition_snapshot,
-                        true_subset=EntitySubset(key=AssetKey("asset_two"), value=True),
-                        candidate_subset=EntitySubset(key=AssetKey("asset_two"), value=True),
+                        true_subset=SerializableEntitySubset(key=AssetKey("asset_two"), value=True),
+                        candidate_subset=SerializableEntitySubset(
+                            key=AssetKey("asset_two"), value=True
+                        ),
                         start_timestamp=0,
                         end_timestamp=1,
                         subsets_with_metadata=[
                             AssetSubsetWithMetadata(
-                                subset=EntitySubset(key=AssetKey("asset_two"), value=True),
+                                subset=SerializableEntitySubset(
+                                    key=AssetKey("asset_two"), value=True
+                                ),
                                 metadata={"foo": MetadataValue.text("bar")},
                             )
                         ],
@@ -811,8 +819,10 @@ class TestScheduleStorage:
                     condition_snapshot=condition_snapshot,
                     start_timestamp=0,
                     end_timestamp=1,
-                    true_subset=EntitySubset(key=AssetKey("asset_one"), value=True),
-                    candidate_subset=EntitySubset(key=AssetKey("asset_one"), value=True),
+                    true_subset=SerializableEntitySubset(key=AssetKey("asset_one"), value=True),
+                    candidate_subset=SerializableEntitySubset(
+                        key=AssetKey("asset_one"), value=True
+                    ),
                     subsets_with_metadata=[],
                     child_evaluations=[],
                 ).with_run_ids(set()),
@@ -846,8 +856,8 @@ class TestScheduleStorage:
             ),
             start_timestamp=0,
             end_timestamp=1,
-            true_subset=EntitySubset(key=AssetKey("asset_one"), value=True),
-            candidate_subset=EntitySubset(key=AssetKey("asset_one"), value=True),
+            true_subset=SerializableEntitySubset(key=AssetKey("asset_one"), value=True),
+            candidate_subset=SerializableEntitySubset(key=AssetKey("asset_one"), value=True),
             subsets_with_metadata=[],
             child_evaluations=[],
         ).with_run_ids(set())
@@ -858,8 +868,8 @@ class TestScheduleStorage:
             ),
             start_timestamp=0,
             end_timestamp=1,
-            true_subset=EntitySubset(key=AssetKey("asset_three"), value=True),
-            candidate_subset=EntitySubset(key=AssetKey("asset_three"), value=True),
+            true_subset=SerializableEntitySubset(key=AssetKey("asset_three"), value=True),
+            candidate_subset=SerializableEntitySubset(key=AssetKey("asset_three"), value=True),
             subsets_with_metadata=[],
             child_evaluations=[],
         ).with_run_ids(set())
@@ -893,7 +903,7 @@ class TestScheduleStorage:
 
         partitions_def = StaticPartitionsDefinition(["a", "b"])
         subset = partitions_def.empty_subset().with_partition_keys(["a"])
-        asset_subset = EntitySubset(key=AssetKey("asset_two"), value=subset)
+        asset_subset = SerializableEntitySubset(key=AssetKey("asset_two"), value=subset)
         asset_subset_with_metadata = AssetSubsetWithMetadata(
             subset=asset_subset,
             metadata={
@@ -945,8 +955,10 @@ class TestScheduleStorage:
                     ),
                     start_timestamp=0,
                     end_timestamp=1,
-                    true_subset=EntitySubset(key=AssetKey("asset_one"), value=True),
-                    candidate_subset=EntitySubset(key=AssetKey("asset_one"), value=True),
+                    true_subset=SerializableEntitySubset(key=AssetKey("asset_one"), value=True),
+                    candidate_subset=SerializableEntitySubset(
+                        key=AssetKey("asset_one"), value=True
+                    ),
                     subsets_with_metadata=[],
                     child_evaluations=[],
                 ).with_run_ids(set()),

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_asset_slice.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_asset_slice.py
@@ -42,14 +42,14 @@ def test_operations(
     asset_graph_view = AssetGraphView.for_test(defs, instance)
 
     a = (
-        asset_graph_view.get_full_slice(key=foo.key)
+        asset_graph_view.get_full_subset(key=foo.key)
         if first_all
-        else asset_graph_view.get_empty_slice(key=foo.key)
+        else asset_graph_view.get_empty_subset(key=foo.key)
     )
     b = (
-        asset_graph_view.get_full_slice(key=foo.key)
+        asset_graph_view.get_full_subset(key=foo.key)
         if second_all
-        else asset_graph_view.get_empty_slice(key=foo.key)
+        else asset_graph_view.get_empty_subset(key=foo.key)
     )
 
     def _assert_matches_operation(res, oper):

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
@@ -26,7 +26,7 @@ def test_basic_construction_and_identity() -> None:
     assert asset_graph_view_t0.asset_graph.all_asset_keys == {an_asset.key}
 
 
-def test_slice_traversal_static_partitions() -> None:
+def test_subset_traversal_static_partitions() -> None:
     number_keys = {"1", "2", "3"}
     letter_keys = {"a", "b", "c"}
     number_static_partitions_def = StaticPartitionsDefinition(list(number_keys))
@@ -47,41 +47,45 @@ def test_slice_traversal_static_partitions() -> None:
 
     asset_graph_view_t0 = AssetGraphView.for_test(defs, instance)
     assert (
-        asset_graph_view_t0.get_full_slice(key=up_numbers.key).expensively_compute_partition_keys()
+        asset_graph_view_t0.get_full_subset(key=up_numbers.key).expensively_compute_partition_keys()
         == number_keys
     )
     assert (
-        asset_graph_view_t0.get_full_slice(
+        asset_graph_view_t0.get_full_subset(
             key=down_letters.key
         ).expensively_compute_partition_keys()
         == letter_keys
     )
 
     # from full up to down
-    up_slice = asset_graph_view_t0.get_full_slice(key=up_numbers.key)
-    assert up_slice.expensively_compute_partition_keys() == {"1", "2", "3"}
-    assert up_slice.compute_child_slice(down_letters.key).expensively_compute_partition_keys() == {
+    up_subset = asset_graph_view_t0.get_full_subset(key=up_numbers.key)
+    assert up_subset.expensively_compute_partition_keys() == {"1", "2", "3"}
+    assert up_subset.compute_child_subset(
+        down_letters.key
+    ).expensively_compute_partition_keys() == {
         "a",
         "b",
         "c",
     }
 
     # from full up to down
-    down_slice = asset_graph_view_t0.get_full_slice(key=down_letters.key)
-    assert down_slice.expensively_compute_partition_keys() == {"a", "b", "c"}
-    assert down_slice.compute_parent_slice(up_numbers.key).expensively_compute_partition_keys() == {
+    down_subset = asset_graph_view_t0.get_full_subset(key=down_letters.key)
+    assert down_subset.expensively_compute_partition_keys() == {"a", "b", "c"}
+    assert down_subset.compute_parent_subset(
+        up_numbers.key
+    ).expensively_compute_partition_keys() == {
         "1",
         "2",
         "3",
     }
 
     # subset of up to subset of down
-    assert up_slice.compute_intersection_with_partition_keys({"2"}).compute_child_slice(
+    assert up_subset.compute_intersection_with_partition_keys({"2"}).compute_child_subset(
         down_letters.key
     ).expensively_compute_partition_keys() == {"b"}
 
     # subset of down to subset of up
-    assert down_slice.compute_intersection_with_partition_keys({"b"}).compute_parent_slice(
+    assert down_subset.compute_intersection_with_partition_keys({"b"}).compute_parent_subset(
         up_numbers.key
     ).expensively_compute_partition_keys() == {"2"}
 
@@ -98,14 +102,14 @@ def test_only_partition_keys() -> None:
 
     asset_graph_view_t0 = AssetGraphView.for_test(defs, instance)
 
-    assert asset_graph_view_t0.get_full_slice(
+    assert asset_graph_view_t0.get_full_subset(
         key=up_numbers.key
     ).compute_intersection_with_partition_keys({"1", "2"}).expensively_compute_partition_keys() == {
         "1",
         "2",
     }
 
-    assert asset_graph_view_t0.get_full_slice(
+    assert asset_graph_view_t0.get_full_subset(
         key=up_numbers.key
     ).compute_intersection_with_partition_keys({"3"}).expensively_compute_partition_keys() == set(
         ["3"]

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_entity_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_entity_subset.py
@@ -14,7 +14,7 @@ from dagster import (
 from dagster._core.definitions.declarative_automation.legacy.valid_asset_subset import (
     ValidAssetSubset,
 )
-from dagster._core.definitions.entity_subset import EntitySubset
+from dagster._core.definitions.entity_subset import SerializableEntitySubset
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.partition import AllPartitionsSubset, DefaultPartitionsSubset
 from dagster._core.definitions.time_window_partitions import (
@@ -105,14 +105,14 @@ def test_serialization(value, use_valid_asset_subset) -> None:
     if use_valid_asset_subset:
         asset_subset = ValidAssetSubset(key=AssetKey("foo"), value=value)
     else:
-        asset_subset = EntitySubset(key=AssetKey("foo"), value=value)
+        asset_subset = SerializableEntitySubset(key=AssetKey("foo"), value=value)
 
     serialized_asset_subset = serialize_value(asset_subset)
     assert "ValidAssetSubset" not in serialized_asset_subset
 
-    round_trip_asset_subset = deserialize_value(serialized_asset_subset, EntitySubset)
+    round_trip_asset_subset = deserialize_value(serialized_asset_subset, SerializableEntitySubset)
 
-    assert isinstance(round_trip_asset_subset, EntitySubset)
+    assert isinstance(round_trip_asset_subset, SerializableEntitySubset)
     # should always be deserialized as an AssetSubset
     assert not isinstance(round_trip_asset_subset, ValidAssetSubset)
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_code_version_changed_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_code_version_changed_condition.py
@@ -15,31 +15,31 @@ def test_code_version_changed_condition() -> None:
 
     # not changed
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # still not changed
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # newly changed
     state = state.with_asset_properties(code_version="2")
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # not newly changed
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # newly changed
     state = state.with_asset_properties(code_version="3")
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # newly changed
     state = state.with_asset_properties(code_version="2")
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # not newly changed
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_dep_condition.py
@@ -39,16 +39,16 @@ def get_hardcoded_condition():
         def evaluate(self, context: AutomationContext) -> AutomationResult:
             filtered_true_set = {akpk for akpk in true_set if akpk.asset_key == context.key}
             if context.partitions_def:
-                true_slice = context.candidate_slice.compute_intersection_with_partition_keys(
+                true_subset = context.candidate_subset.compute_intersection_with_partition_keys(
                     {apk.partition_key for apk in filtered_true_set}
                 )
             else:
-                true_slice = (
-                    context.asset_graph_view.get_full_slice(key=context.key)
+                true_subset = (
+                    context.asset_graph_view.get_full_subset(key=context.key)
                     if filtered_true_set
-                    else context.asset_graph_view.get_empty_slice(key=context.key)
+                    else context.asset_graph_view.get_empty_subset(key=context.key)
                 )
-            return AutomationResult(context, true_slice=true_slice)
+            return AutomationResult(context, true_subset=true_subset)
 
     return HardcodedCondition(), true_set
 
@@ -67,20 +67,20 @@ def test_dep_missing_unpartitioned(is_any: bool) -> None:
 
     # neither parent is true
     state, result = state.evaluate("C")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # one parent true, still one false
     true_set.add(AssetKeyPartitionKey(AssetKey("A")))
     state, result = state.evaluate("C")
     if is_any:
-        assert result.true_slice.size == 1
+        assert result.true_subset.size == 1
     else:
-        assert result.true_slice.size == 0
+        assert result.true_subset.size == 0
 
     # both parents true
     true_set.add(AssetKeyPartitionKey(AssetKey("B")))
     state, result = state.evaluate("C")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
 
 @pytest.mark.parametrize("is_any", [True, False])
@@ -97,41 +97,41 @@ def test_dep_missing_partitioned(is_any: bool) -> None:
 
     # no parents true
     state, result = state.evaluate("C")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     true_set.add(AssetKeyPartitionKey(AssetKey("A"), "1"))
     state, result = state.evaluate("C")
     if is_any:
         # one parent is true for partition 1
-        assert result.true_slice.size == 1
+        assert result.true_subset.size == 1
     else:
         # neither 1 nor 2 have all parents true
-        assert result.true_slice.size == 0
+        assert result.true_subset.size == 0
 
     true_set.add(AssetKeyPartitionKey(AssetKey("A"), "2"))
     state, result = state.evaluate("C")
     if is_any:
         # both partitions 1 and 2 have at least one true parent
-        assert result.true_slice.size == 2
+        assert result.true_subset.size == 2
     else:
         # neither 1 nor 2 have all parents true
-        assert result.true_slice.size == 0
+        assert result.true_subset.size == 0
 
     true_set.add(AssetKeyPartitionKey(AssetKey("B"), "1"))
     state, result = state.evaluate("C")
     if is_any:
-        assert result.true_slice.size == 2
+        assert result.true_subset.size == 2
     else:
         # now partition 1 has all parents true
-        assert result.true_slice.size == 1
+        assert result.true_subset.size == 1
 
     true_set.add(AssetKeyPartitionKey(AssetKey("B"), "2"))
     state, result = state.evaluate("C")
     if is_any:
-        assert result.true_slice.size == 2
+        assert result.true_subset.size == 2
     else:
         # now partition 2 has all parents true
-        assert result.true_slice.size == 2
+        assert result.true_subset.size == 2
 
 
 @pytest.mark.parametrize("is_any", [True, False])
@@ -171,10 +171,10 @@ def test_dep_missing_partitioned_selections(
     ).with_asset_properties(partitions_def=two_partitions_def)
     # all parents are missing
     state, result = state.evaluate("C")
-    assert result.true_slice.size == expected_initial_result_size
+    assert result.true_subset.size == expected_initial_result_size
     state = state.with_runs(*(run_request(s[0], s[1]) for s in materialized_asset_partitions))
     state, result = state.evaluate("C")
-    assert result.true_slice.size == expected_final_result_size
+    assert result.true_subset.size == expected_final_result_size
 
 
 complex_scenario_spec = ScenarioSpec(
@@ -198,17 +198,17 @@ def test_dep_missing_complex_include() -> None:
 
     # all start off as missing
     state, result = state.evaluate("downstream")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # A materialized, D and E still missing
     state = state.with_runs(run_request(["A"]))
     state, result = state.evaluate("downstream")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # D and E materialized, and all the other missing things are in the exclude selection
     state = state.with_runs(run_request(["D", "E"]))
     state, result = state.evaluate("downstream")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
 
 def test_dep_missing_complex_exclude() -> None:
@@ -220,14 +220,14 @@ def test_dep_missing_complex_exclude() -> None:
 
     # all start off as missing
     state, result = state.evaluate("downstream")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # B materialized, C still missing
     state = state.with_runs(run_request(["B"]))
     state, result = state.evaluate("downstream")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # C materialized, and all the other missing things are in the exclude selection
     state = state.with_runs(run_request(["C"]))
     state, result = state.evaluate("downstream")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_eager_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_eager_condition.py
@@ -21,41 +21,41 @@ def test_eager_unpartitioned() -> None:
 
     # parent hasn't updated yet
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # parent updated, now can execute
     state = state.with_runs(run_request("A"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # B has not yet materialized, but it has been requested, so don't request again
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # same as above
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # now B has been materialized, so really shouldn't execute again
     state = state.with_runs(
         *(
             run_request(ak, pk)
-            for ak, pk in result.true_slice.expensively_compute_asset_partitions()
+            for ak, pk in result.true_subset.expensively_compute_asset_partitions()
         )
     )
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # A gets materialized again before the hour, execute B again
     state = state.with_runs(run_request("A"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
     # however, B fails
     state = state.with_failed_run_for_asset("B")
 
     # do not try to materialize B again immediately
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
 
 def test_eager_hourly_partitioned() -> None:
@@ -71,40 +71,40 @@ def test_eager_hourly_partitioned() -> None:
 
     # parent hasn't updated yet
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # historical parent updated, doesn't matter
     state = state.with_runs(run_request("A", "2019-07-05-00:00"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # latest parent updated, now can execute
     state = state.with_runs(run_request("A", "2020-02-02-00:00"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
     state = state.with_runs(
         *(
             run_request(ak, pk)
-            for ak, pk in result.true_slice.expensively_compute_asset_partitions()
+            for ak, pk in result.true_subset.expensively_compute_asset_partitions()
         )
     )
 
     # now B has been materialized, so don't execute again
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # new partition comes into being, parent hasn't been materialized yet
     state = state.with_current_time_advanced(hours=1)
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # parent gets materialized, B requested
     state = state.with_runs(run_request("A", "2020-02-02-01:00"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
     # but it fails
     state = state.with_failed_run_for_asset("B", "2020-02-02-01:00")
 
     # B does not get immediately requested again
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_failed_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_failed_condition.py
@@ -21,17 +21,17 @@ def test_failed_unpartitioned() -> None:
 
     # no failed partitions
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # now a partition fails
     state = state.with_failed_run_for_asset("A")
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # the next run completes successfully
     state = state.with_runs(run_request("A"))
     _, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
 
 def test_in_progress_static_partitioned() -> None:
@@ -41,20 +41,20 @@ def test_in_progress_static_partitioned() -> None:
 
     # no failed_runs
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # now one partition fails
     state = state.with_failed_run_for_asset("A", partition_key="1")
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
-    assert result.true_slice.expensively_compute_asset_partitions() == {
+    assert result.true_subset.size == 1
+    assert result.true_subset.expensively_compute_asset_partitions() == {
         AssetKeyPartitionKey(AssetKey("A"), "1")
     }
 
     # now that partition succeeds
     state = state.with_runs(run_request("A", partition_key="1"))
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # now both partitions fail
     state = state.with_failed_run_for_asset(
@@ -65,7 +65,7 @@ def test_in_progress_static_partitioned() -> None:
         partition_key="2",
     )
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 2
+    assert result.true_subset.size == 2
 
     # now both partitions succeed
     state = state.with_runs(
@@ -73,4 +73,4 @@ def test_in_progress_static_partitioned() -> None:
         run_request("A", partition_key="2"),
     )
     _, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_in_progress_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_in_progress_condition.py
@@ -18,17 +18,17 @@ def test_in_progress_unpartitioned() -> None:
 
     # no run in progress
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # run now in progress
     state = state.with_in_progress_run_for_asset("A")
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # run completes
     state = state.with_in_progress_runs_completed()
     _, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
 
 def test_in_progress_static_partitioned() -> None:
@@ -39,20 +39,20 @@ def test_in_progress_static_partitioned() -> None:
     # no run in progress
     state, result = state.evaluate("A")
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # now in progress
     state = state.with_in_progress_run_for_asset("A", partition_key="1")
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
-    assert result.true_slice.expensively_compute_asset_partitions() == {
+    assert result.true_subset.size == 1
+    assert result.true_subset.expensively_compute_asset_partitions() == {
         AssetKeyPartitionKey(AssetKey("A"), "1")
     }
 
     # run completes
     state = state.with_in_progress_runs_completed()
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # now both in progress
     state = state.with_in_progress_run_for_asset(
@@ -63,9 +63,9 @@ def test_in_progress_static_partitioned() -> None:
         partition_key="2",
     )
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 2
+    assert result.true_subset.size == 2
 
     # both runs complete
     state = state.with_in_progress_runs_completed()
     _, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_latest_time_window_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_latest_time_window_condition.py
@@ -21,7 +21,7 @@ def test_in_latest_time_window_unpartitioned() -> None:
     )
 
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
 
 def test_in_latest_time_window_unpartitioned_lookback() -> None:
@@ -33,7 +33,7 @@ def test_in_latest_time_window_unpartitioned_lookback() -> None:
     )
 
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
 
 def test_in_latest_time_window_static_partitioned() -> None:
@@ -42,7 +42,7 @@ def test_in_latest_time_window_static_partitioned() -> None:
     ).with_asset_properties(partitions_def=two_partitions_def)
 
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 2
+    assert result.true_subset.size == 2
 
 
 def test_in_latest_time_window_static_partitioned_lookback() -> None:
@@ -54,7 +54,7 @@ def test_in_latest_time_window_static_partitioned_lookback() -> None:
     ).with_asset_properties(partitions_def=two_partitions_def)
 
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 2
+    assert result.true_subset.size == 2
 
 
 def test_in_latest_time_window_time_partitioned() -> None:
@@ -65,19 +65,19 @@ def test_in_latest_time_window_time_partitioned() -> None:
     # no partitions exist yet
     state = state.with_current_time(time_partitions_start_datetime)
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     state = state.with_current_time("2020-02-02T01:00:00")
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
-    assert result.true_slice.expensively_compute_asset_partitions() == {
+    assert result.true_subset.size == 1
+    assert result.true_subset.expensively_compute_asset_partitions() == {
         AssetKeyPartitionKey(AssetKey("A"), "2020-02-01")
     }
 
     state = state.with_current_time_advanced(days=5)
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
-    assert result.true_slice.expensively_compute_asset_partitions() == {
+    assert result.true_subset.size == 1
+    assert result.true_subset.expensively_compute_asset_partitions() == {
         AssetKeyPartitionKey(AssetKey("A"), "2020-02-06")
     }
 
@@ -93,12 +93,12 @@ def test_in_latest_time_window_time_partitioned_lookback() -> None:
     # no partitions exist yet
     state = state.with_current_time(time_partitions_start_datetime)
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     state = state.with_current_time("2020-02-07T01:00:00")
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 3
-    assert result.true_slice.expensively_compute_asset_partitions() == {
+    assert result.true_subset.size == 3
+    assert result.true_subset.expensively_compute_asset_partitions() == {
         AssetKeyPartitionKey(AssetKey("A"), "2020-02-06"),
         AssetKeyPartitionKey(AssetKey("A"), "2020-02-05"),
         AssetKeyPartitionKey(AssetKey("A"), "2020-02-04"),
@@ -106,8 +106,8 @@ def test_in_latest_time_window_time_partitioned_lookback() -> None:
 
     state = state.with_current_time_advanced(days=5)
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 3
-    assert result.true_slice.expensively_compute_asset_partitions() == {
+    assert result.true_subset.size == 3
+    assert result.true_subset.expensively_compute_asset_partitions() == {
         AssetKeyPartitionKey(AssetKey("A"), "2020-02-11"),
         AssetKeyPartitionKey(AssetKey("A"), "2020-02-10"),
         AssetKeyPartitionKey(AssetKey("A"), "2020-02-09"),

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_missing_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_missing_condition.py
@@ -18,11 +18,11 @@ def test_missing_unpartitioned() -> None:
     )
 
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     state = state.with_runs(run_request("A"))
     _, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
 
 def test_missing_partitioned() -> None:
@@ -31,17 +31,17 @@ def test_missing_partitioned() -> None:
     ).with_asset_properties(partitions_def=two_partitions_def)
 
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 2
+    assert result.true_subset.size == 2
 
     state = state.with_runs(run_request("A", "1"))
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # same partition materialized again
     state = state.with_runs(run_request("A", "1"))
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     state = state.with_runs(run_request("A", "2"))
     _, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_newly_requested_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_newly_requested_condition.py
@@ -30,23 +30,23 @@ def test_requested_previous_tick() -> None:
 
     # was not requested on the previous tick, as there was no tick
     state, result = state.evaluate("A")
-    assert get_result(result).true_slice.size == 0
+    assert get_result(result).true_subset.size == 0
 
     # still was not requested on the previous tick
     state, result = state.evaluate("A")
-    assert get_result(result).true_slice.size == 0
+    assert get_result(result).true_subset.size == 0
 
     # now we ensure that the asset does get requested this tick
     true_set.add(AssetKeyPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
     # requested this tick, not the previous tick
-    assert get_result(result).true_slice.size == 0
+    assert get_result(result).true_subset.size == 0
     true_set.remove(AssetKeyPartitionKey(AssetKey("A")))
 
     # requested on the previous tick
     state, result = state.evaluate("A")
-    assert get_result(result).true_slice.size == 1
+    assert get_result(result).true_subset.size == 1
 
     # requested two ticks ago
     state, result = state.evaluate("A")
-    assert get_result(result).true_slice.size == 0
+    assert get_result(result).true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_newly_true_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_newly_true_condition.py
@@ -21,39 +21,39 @@ def test_newly_true_condition() -> None:
 
     # nothing true
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # becomes true
     true_set.add(AssetKeyPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # now on the next tick, this asset is no longer newly true
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # see above
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # see above
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # now condition becomes false, result still false
     true_set.remove(AssetKeyPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # see above
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # becomes true again
     true_set.add(AssetKeyPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # no longer newly true
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_newly_updated_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_newly_updated_condition.py
@@ -16,33 +16,33 @@ def test_newly_updated_condition() -> None:
 
     # not updated
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # newly updated
     state = state.with_reported_materialization("A")
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # not newly updated
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # still not newly updated
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # newly updated twice in a row
     state = state.with_reported_materialization("A")
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     state = state.with_reported_materialization("A")
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # not newly updated
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
 
 def test_newly_updated_condition_data_version() -> None:
@@ -55,32 +55,32 @@ def test_newly_updated_condition_data_version() -> None:
 
     # not updated
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # newly updated
     state = state.with_reported_observation("A", data_version="1")
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # not newly updated
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # same data version, not newly updated
     state = state.with_reported_observation("A", data_version="1")
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # new data version
     state = state.with_reported_observation("A", data_version="2")
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # new data version
     state = state.with_reported_observation("A", data_version="3")
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # no new data version
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_on_cron_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_on_cron_condition.py
@@ -21,42 +21,42 @@ def test_on_cron_unpartitioned() -> None:
 
     # no cron boundary crossed
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # now crossed a cron boundary parent hasn't updated yet
     state = state.with_current_time_advanced(minutes=10)
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # parent updated, now can execute
     state = state.with_runs(run_request("A"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
     state = state.with_runs(
         *(
             run_request(ak, pk)
-            for ak, pk in result.true_slice.expensively_compute_asset_partitions()
+            for ak, pk in result.true_subset.expensively_compute_asset_partitions()
         )
     )
 
     # now B has been materialized, so don't execute again
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # A gets materialized again before the hour, so don't execute B again
     state = state.with_runs(run_request("A"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # now a new cron tick, but A still hasn't been materialized since the hour
     state = state.with_current_time_advanced(hours=1)
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # A gets materialized again after the hour, so execute B again
     state = state.with_runs(run_request("A"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
 
 def test_on_cron_hourly_partitioned() -> None:
@@ -72,44 +72,44 @@ def test_on_cron_hourly_partitioned() -> None:
 
     # no cron boundary crossed
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # now crossed a cron boundary parent hasn't updated yet
     state = state.with_current_time_advanced(minutes=10)
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # historical parent updated, doesn't matter
     state = state.with_runs(run_request("A", "2019-07-05-00:00"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # latest parent updated, now can execute
     state = state.with_runs(run_request("A", "2020-02-02-00:00"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
     state = state.with_runs(
         *(
             run_request(ak, pk)
-            for ak, pk in result.true_slice.expensively_compute_asset_partitions()
+            for ak, pk in result.true_subset.expensively_compute_asset_partitions()
         )
     )
 
     # now B has been materialized, so don't execute again
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # now a new cron tick, but A still hasn't been materialized since the hour
     state = state.with_current_time_advanced(hours=1)
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # A gets materialized with the previous partition after the hour, but that doesn't matter
     state = state.with_runs(run_request("A", "2020-02-02-00:00"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # A gets materialized with the latest partition, fire
     state = state.with_runs(run_request("A", "2020-02-02-01:00"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_on_missing_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_on_missing_condition.py
@@ -21,40 +21,40 @@ def test_on_missing_unpartitioned() -> None:
 
     # parent hasn't materialized yet
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # parent materialized, now can execute
     state = state.with_runs(run_request("A"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # B has not yet materialized, but it has been requested, so don't request again
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # same as above
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # parent materialized again, no impact
     state = state.with_runs(run_request("A"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # now B has been materialized, so really shouldn't execute again
     state = state.with_runs(
         *(
             run_request(ak, pk)
-            for ak, pk in result.true_slice.expensively_compute_asset_partitions()
+            for ak, pk in result.true_subset.expensively_compute_asset_partitions()
         )
     )
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # parent materialized again, no impact
     state = state.with_runs(run_request("A"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
 
 def test_on_missing_hourly_partitioned() -> None:
@@ -70,36 +70,36 @@ def test_on_missing_hourly_partitioned() -> None:
 
     # parent hasn't updated yet
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # historical parent updated, doesn't matter
     state = state.with_runs(run_request("A", "2019-07-05-00:00"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # latest parent updated, now can execute
     state = state.with_runs(run_request("A", "2020-02-02-00:00"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # B has been requested, so don't request again
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # new partition comes into being, parent hasn't been materialized yet
     state = state.with_current_time_advanced(hours=1)
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # latest parent updated, now can execute
     state = state.with_runs(run_request("A", "2020-02-02-01:00"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # latest parent updated again, don't re execute
     state = state.with_runs(run_request("A", "2020-02-02-01:00"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
 
 def test_on_missing_without_time_limit() -> None:
@@ -117,14 +117,14 @@ def test_on_missing_without_time_limit() -> None:
 
     # parent hasn't updated yet
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # historical parents updated, matters
     state = state.with_runs(run_request("A", "2019-07-05-00:00"))
     state = state.with_runs(run_request("A", "2019-04-05-00:00"))
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 2
+    assert result.true_subset.size == 2
 
     # B has been requested, so don't request again
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_since_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_since_condition.py
@@ -24,42 +24,42 @@ def test_since_condition_unpartitioned() -> None:
 
     # nothing true
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # primary becomes true, but reference has never been true
     true_set_primary.add(AssetKeyPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
     true_set_primary.remove(AssetKeyPartitionKey(AssetKey("A")))
 
     # reference becomes true, and it's after primary
     true_set_reference.add(AssetKeyPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
     true_set_reference.remove(AssetKeyPartitionKey(AssetKey("A")))
 
     # primary becomes true again, and it's since reference has become true
     true_set_primary.add(AssetKeyPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
     true_set_primary.remove(AssetKeyPartitionKey(AssetKey("A")))
 
     # remains true on the neprimaryt evaluation
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # primary becomes true again, still doesn't change anything
     true_set_primary.add(AssetKeyPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
     true_set_primary.remove(AssetKeyPartitionKey(AssetKey("A")))
 
     # now reference becomes true again
     true_set_reference.add(AssetKeyPartitionKey(AssetKey("A")))
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
     true_set_reference.remove(AssetKeyPartitionKey(AssetKey("A")))
 
     # remains false on the neprimaryt evaluation
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_updated_since_cron_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_updated_since_cron_condition.py
@@ -21,25 +21,25 @@ def test_updated_since_cron_unpartitioned() -> None:
     ).with_current_time("2020-02-02T00:55:00")
 
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # now pass a cron tick, still haven't updated since that time
     state = state.with_current_time_advanced(minutes=10)
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # now A is updated, so have been updated since cron tick
     state = state.with_runs(run_request("A"))
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # new cron tick, no longer materialized since it
     state = state.with_current_time_advanced(hours=1)
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
 
 def test_updated_since_cron_partitioned() -> None:
@@ -55,42 +55,42 @@ def test_updated_since_cron_partitioned() -> None:
     )
 
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # now pass a cron tick, still haven't updated since that time
     state = state.with_current_time_advanced(minutes=10)
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # one materialized
     state = state.with_runs(run_request("A", "1"))
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # now both materialized
     state = state.with_runs(run_request("A", "2"))
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 2
+    assert result.true_subset.size == 2
 
     # nothing changed
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 2
+    assert result.true_subset.size == 2
 
     # A 1 materialized again before the hour
     state = state.with_runs(run_request("A", "1"))
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 2
+    assert result.true_subset.size == 2
 
     # new hour passes, nothing materialized since then
     state = state.with_current_time_advanced(hours=1)
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # A 2 materialized again after the hour
     state = state.with_runs(run_request("A", "2"))
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
     # nothing changed
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_will_be_requested_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_will_be_requested_condition.py
@@ -16,12 +16,12 @@ def test_will_be_requested_unpartitioned() -> None:
 
     # no requested parents
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # parent is requested
     state = state.with_requested_asset_partitions([AssetKeyPartitionKey(AssetKey("A"))])
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
 
 
 def test_will_be_requested_static_partitioned() -> None:
@@ -32,13 +32,13 @@ def test_will_be_requested_static_partitioned() -> None:
 
     # no requested parents
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # one requested parent
     state = state.with_requested_asset_partitions([AssetKeyPartitionKey(AssetKey("A"), "1")])
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 1
-    assert result.true_slice.expensively_compute_asset_partitions() == {
+    assert result.true_subset.size == 1
+    assert result.true_subset.expensively_compute_asset_partitions() == {
         AssetKeyPartitionKey(AssetKey("B"), "1")
     }
 
@@ -47,7 +47,7 @@ def test_will_be_requested_static_partitioned() -> None:
         [AssetKeyPartitionKey(AssetKey("A"), "1"), AssetKeyPartitionKey(AssetKey("A"), "2")]
     )
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 2
+    assert result.true_subset.size == 2
 
 
 def test_will_be_requested_different_partitions() -> None:
@@ -58,16 +58,16 @@ def test_will_be_requested_different_partitions() -> None:
 
     # no requested parents
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # one requested parent, but can't execute in same run
     state = state.with_requested_asset_partitions([AssetKeyPartitionKey(AssetKey("A"), "1")])
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
     # two requested parents, but can't execute in same run
     state = state.with_requested_asset_partitions(
         [AssetKeyPartitionKey(AssetKey("A"), "1"), AssetKeyPartitionKey(AssetKey("A"), "2")]
     )
     state, result = state.evaluate("B")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
@@ -32,22 +32,22 @@ def test_missing_unpartitioned() -> None:
     )
 
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
     original_value_hash = result.value_hash
 
     # still true
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 1
+    assert result.true_subset.size == 1
     assert result.value_hash == original_value_hash
 
     # after a run of A it's now False
     state, result = state.with_runs(run_request("A")).evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
     assert result.value_hash != original_value_hash
 
     # if we evaluate from scratch, it's also False
     _, result = state.without_cursor().evaluate("A")
-    assert result.true_slice.size == 0
+    assert result.true_subset.size == 0
 
 
 def test_missing_time_partitioned() -> None:
@@ -61,22 +61,22 @@ def test_missing_time_partitioned() -> None:
     )
 
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 6
+    assert result.true_subset.size == 6
 
     # still true
     state, result = state.evaluate("A")
-    assert result.true_slice.size == 6
+    assert result.true_subset.size == 6
 
     # after two runs of A those partitions are now False
     state, result = state.with_runs(
         run_request("A", day_partition_key(time_partitions_start_datetime, 1)),
         run_request("A", day_partition_key(time_partitions_start_datetime, 3)),
     ).evaluate("A")
-    assert result.true_slice.size == 4
+    assert result.true_subset.size == 4
 
     # if we evaluate from scratch, they're still False
     _, result = state.without_cursor().evaluate("A")
-    assert result.true_slice.size == 4
+    assert result.true_subset.size == 4
 
 
 def test_serialize_definitions_with_asset_condition() -> None:
@@ -104,7 +104,7 @@ def test_serialize_definitions_with_user_code_asset_condition() -> None:
     class MyAutomationCondition(AutomationCondition):
         def evaluate(self, context: AutomationContext) -> AutomationResult:
             return AutomationResult(
-                context, context.asset_graph_view.get_full_slice(key=context.key)
+                context, context.asset_graph_view.get_full_subset(key=context.key)
             )
 
     automation_condition = AutomationCondition.eager() | MyAutomationCondition()

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/user_defined/test_user_defined_automation_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/user_defined/test_user_defined_automation_condition.py
@@ -10,12 +10,12 @@ def test_cursoring() -> None:
         def evaluate(self, context: AutomationContext) -> AutomationResult:
             if context.cursor == "hi":
                 cursor = None
-                true_slice = context.candidate_slice
+                true_subset = context.candidate_subset
             else:
                 cursor = "hi"
-                true_slice = context.get_empty_slice()
+                true_subset = context.get_empty_subset()
 
-            return AutomationResult(context, true_slice=true_slice, cursor=cursor)
+            return AutomationResult(context, true_subset=true_subset, cursor=cursor)
 
     @asset(automation_condition=MyAutomationCondition())
     def my_asset() -> None: ...
@@ -40,7 +40,7 @@ def test_logging(caplog) -> None:
             context.log.debug("DEBUG_THING")
             context.log.info("INFO_THING")
 
-            return AutomationResult(context, true_slice=context.get_empty_slice())
+            return AutomationResult(context, true_subset=context.get_empty_subset())
 
     @asset(automation_condition=MyAutomationCondition())
     def my_asset() -> None: ...

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
@@ -44,7 +44,7 @@ class FalseAutomationCondition(AutomationCondition):
         return ""
 
     def evaluate(self, context: AutomationContext) -> AutomationResult:
-        return AutomationResult(context, true_slice=context.get_empty_slice())
+        return AutomationResult(context, true_subset=context.get_empty_subset())
 
 
 @dataclass(frozen=True)
@@ -65,7 +65,7 @@ class AutomationConditionScenarioState(ScenarioState):
             ap_by_key[ap.asset_key].add(ap)
         return {
             asset_key: mock.MagicMock(
-                true_slice=asset_graph_view.get_asset_slice_from_asset_partitions(asset_key, aps),
+                true_subset=asset_graph_view.get_asset_subset_from_asset_partitions(asset_key, aps),
                 cursor=None,
             )
             for asset_key, aps in ap_by_key.items()

--- a/scripts/object_profile.py
+++ b/scripts/object_profile.py
@@ -10,14 +10,14 @@ from tempfile import TemporaryDirectory
 # for a model object from a NamedTuple to a dataclass or pydantic model (DagsterModel).
 import memray  # type: ignore
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.entity_subset import EntitySubset
+from dagster._core.definitions.entity_subset import SerializableEntitySubset
 
 fixed_key = AssetKey("asset_key")
 
 
 def make_one(i: int = 0):
     """Create an instance of the object you want to profile."""
-    return EntitySubset(key=fixed_key, value=False)
+    return SerializableEntitySubset(key=fixed_key, value=False)
 
 
 def make_n(n: int):


### PR DESCRIPTION
## Summary & Motivation

As title, this renames EntitySubset to SerializableEntitySubset, which frees up the EntitySubset name for EntitySlice.

In general, SerializableEntitySubset is best treated as a pure serialization format, which should swiftly be converted back into an object enriched with an AssetGraphView as soon as possible. If that's the case, we should use the "EntitySubset" name for the thing that users will actually be interacting with, as "Slice" is not as accurate of a name.

## How I Tested These Changes

## Changelog [New | Bug | Docs]

NOCHANGELOG
