### PR TITLE
[Docs] Fix automating-assets-schedules-jobs

### DIFF
--- a/docs/content/concepts/automation/schedules/automating-assets-schedules-jobs.mdx
+++ b/docs/content/concepts/automation/schedules/automating-assets-schedules-jobs.mdx
@@ -132,6 +132,7 @@ defs = Definitions(
     assets=[orders_asset, users_asset],
     jobs=[ecommerce_job],
     schedules=[ecommerce_schedule],
+)
 ```
 
 ---

--- a/docs/content/concepts/automation/schedules/automating-assets-schedules-jobs.mdx
+++ b/docs/content/concepts/automation/schedules/automating-assets-schedules-jobs.mdx
@@ -41,7 +41,6 @@ Let's assume we already have a few assets in our project in a group named `ecomm
 def orders_asset():
     return 1
 
-
 @asset(group_name="ecommerce_assets")
 def users_asset():
     return 2
@@ -115,20 +114,20 @@ from dagster import (
 def orders_asset():
     return 1
 
-
 @asset(group_name="ecommerce_assets")
 def users_asset():
     return 2
 
+ecommerce_job = define_asset_job(
+    "ecommerce_job", AssetSelection.groups("ecommerce_assets")
+)
 
+ecommerce_schedule = ScheduleDefinition(
+    job=ecommerce_job,
+    cron_schedule="15 5 * * 1-5",
+    default_status=DefaultScheduleStatus.RUNNING,
+)
 
-# end_job
-
-
-# start_schedule
-
-
-# start_definitions
 defs = Definitions(
     assets=[orders_asset, users_asset],
     jobs=[ecommerce_job],


### PR DESCRIPTION
## Summary & Motivation

The documentation at https://docs.dagster.io/concepts/automation/schedules/automating-assets-schedules-jobs is incomplete with `define_asset_job` and `ScheduleDefinition` missing from the step 3 code summary.

## How I Tested These Changes

N/A

## Changelog [New | Bug | Docs]

NOCHANGELOG
