### PR TITLE
Fix time range partition selection input resetting when partition health data updates

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeInput.tsx
@@ -18,12 +18,18 @@ export const DimensionRangeInput = ({
   isTimeseries: boolean;
 }) => {
   const [valueString, setValueString] = React.useState('');
+
+  const valueJSON = React.useMemo(() => JSON.stringify(value), [value]);
   const partitionNameJSON = React.useMemo(() => JSON.stringify(partitionKeys), [partitionKeys]);
 
   React.useEffect(() => {
+    // Only reset the valueString if the valueJSON meaningfully changes
     const partitionNameArr = JSON.parse(partitionNameJSON);
-    setValueString(isTimeseries ? partitionsToText(value, partitionNameArr) : value.join(', '));
-  }, [value, partitionNameJSON, isTimeseries]);
+    const valueArr = JSON.parse(valueJSON);
+    setValueString(
+      isTimeseries ? partitionsToText(valueArr, partitionNameArr) : valueArr.join(', '),
+    );
+  }, [valueJSON, partitionNameJSON, isTimeseries]);
 
   const placeholder = React.useMemo(() => {
     return partitionKeys.length === 0
@@ -53,7 +59,10 @@ export const DimensionRangeInput = ({
       placeholder={placeholder}
       value={valueString}
       style={{display: 'flex', width: '100%', flex: 1, flexGrow: 1}}
-      onChange={(e) => setValueString(e.currentTarget.value)}
+      onChange={(e) => {
+        console.log('setValueString(e.currentTarget.value)', e.currentTarget.value);
+        setValueString(e.currentTarget.value);
+      }}
       onKeyDown={onKeyDown}
       onBlur={tryCommit}
       rightElement={

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/DimensionRangeInput.tsx
@@ -60,7 +60,6 @@ export const DimensionRangeInput = ({
       value={valueString}
       style={{display: 'flex', width: '100%', flex: 1, flexGrow: 1}}
       onChange={(e) => {
-        console.log('setValueString(e.currentTarget.value)', e.currentTarget.value);
         setValueString(e.currentTarget.value);
       }}
       onKeyDown={onKeyDown}


### PR DESCRIPTION
## Summary & Motivation
As titled fixes a bug where the selection input keeps resetting. This is due to partition health data being fetched serially for many assets. As each asset comes in that constrains the available partitions to select from which changes the available values for the input. The problem is that, in the case were looking at, every asset has the same partition definition, so we end up creating a new values array which triggers the `useEffect` that resets the text input, however the values array is a new reference but otherwise it has the exact same values. To get around this issue I'm json.stringifying the values array same as we already do to the partition names array (for the same reason I suspect).

## How I Tested These Changes

Used app-proxy to make sure the repro from https://linear.app/dagster-labs/issue/FE-536/partition-date-input-selection-resets-when-modifying-dates goes away.

## Changelog [New | Bug | Docs]
NOCHANGELOG