### PR TITLE
validate group name in AssetSpec

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -15,6 +15,7 @@ from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.utils import (
     resolve_automation_condition,
     validate_asset_owner,
+    validate_group_name,
     validate_tags_strict,
 )
 from dagster._serdes.serdes import whitelist_for_serdes
@@ -145,6 +146,8 @@ class AssetSpec(
 
         key = AssetKey.from_coercible(key)
         asset_deps = coerce_to_deps_and_check_duplicates(deps, key)
+
+        validate_group_name(group_name)
 
         owners = check.opt_sequence_param(owners, "owners", of_type=str)
         for owner in owners:

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -283,17 +283,21 @@ def validate_asset_owner(owner: str, key: "AssetKey") -> None:
         )
 
 
-def normalize_group_name(group_name: Optional[str]) -> str:
+def validate_group_name(group_name: Optional[str]) -> None:
     """Ensures a string name is valid and returns a default if no name provided."""
     if group_name:
         check_valid_chars(group_name)
-        return group_name
     elif group_name == "":
         raise DagsterInvalidDefinitionError(
-            "Empty asset group name was provided, which is not permitted."
+            "Empty asset group name was provided, which is not permitted. "
             "Set group_name=None to use the default group_name or set non-empty string"
         )
-    return DEFAULT_GROUP_NAME
+
+
+def normalize_group_name(group_name: Optional[str]) -> str:
+    """Ensures a string name is valid and returns a default if no name provided."""
+    validate_group_name(group_name)
+    return group_name or DEFAULT_GROUP_NAME
 
 
 def config_from_files(config_files: Sequence[str]) -> Mapping[str, Any]:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -879,7 +879,7 @@ def test_group_name_requirements():
     with pytest.raises(
         DagsterInvalidDefinitionError,
         match=(
-            "Empty asset group name was provided, which is not permitted."
+            "Empty asset group name was provided, which is not permitted. "
             "Set group_name=None to use the default group_name or set non-empty string"
         ),
     ):

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_spec.py
@@ -8,6 +8,17 @@ def test_validate_asset_owner() -> None:
         AssetSpec(key="asset1", owners=["owner@$#&*1"])
 
 
+def test_validate_group_name() -> None:
+    with pytest.raises(DagsterInvalidDefinitionError, match="is not a valid name"):
+        AssetSpec(key="asset1", group_name="group@$#&*1")
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="Empty asset group name was provided, which is not permitted",
+    ):
+        AssetSpec(key="asset1", group_name="")
+
+
 def test_resolve_automation_condition() -> None:
     ac_spec = AssetSpec(key="asset1", automation_condition=AutomationCondition.eager())
     assert isinstance(ac_spec.auto_materialize_policy, AutoMaterializePolicy)


### PR DESCRIPTION
## Summary & Motivation

See changelog

## How I Tested These Changes

## Changelog [New]

The `AssetSpec` constructor now raises an error if an invalid group name is provided, instead of an error being raised when constructing the `Definitions` object.
