### PR TITLE
Add --no-cache option to run_pyright script

### DIFF
--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -375,18 +375,6 @@ noteable-origami==1.1.5
 notebook==7.2.2
 notebook-shim==0.2.4
 numpy==1.26.4
-nvidia-cublas-cu12==12.1.3.1
-nvidia-cuda-cupti-cu12==12.1.105
-nvidia-cuda-nvrtc-cu12==12.1.105
-nvidia-cuda-runtime-cu12==12.1.105
-nvidia-cudnn-cu12==9.1.0.70
-nvidia-cufft-cu12==11.0.2.54
-nvidia-curand-cu12==10.3.2.106
-nvidia-cusolver-cu12==11.4.5.107
-nvidia-cusparse-cu12==12.1.0.106
-nvidia-nccl-cu12==2.20.5
-nvidia-nvjitlink-cu12==12.6.20
-nvidia-nvtx-cu12==12.1.105
 oauth2client==4.1.3
 oauthlib==3.2.2
 objgraph==3.6.1
@@ -588,7 +576,6 @@ tqdm==4.66.5
 traitlets==5.14.3
 trio==0.26.2
 trio-websocket==0.11.1
-triton==3.0.0
 -e examples/experimental/dagster-airlift/examples/tutorial-example
 -e examples/tutorial_notebook_assets
 twilio==9.2.4


### PR DESCRIPTION
## Summary & Motivation

The `uv` cache can cause subtle problems sometimes when rebuilding pyright environments. Rebuilding envs without using the cache can fix an apparently intractable problem. This PR adds `--no-cache` as an arg to `run-pyright.py`. This is intended for rare use as an escape hatch for pyright env problems-- it makes rebuilding the envs much more slow.

See this issue I posted over at `uv` for some info about why you might want to use this: https://github.com/astral-sh/uv/issues/7028

## How I Tested These Changes

My pyright was (unresolvable imports for all dagster packages). After rebuilding my env with `--no-cache` the problem went away. The issue was that the cache seemed to be holding `pth` files for our dagster editables that did not respect `editable_mode=compat` and were incorrectly formatted for pyright.

## Changelog [New | Bug | Docs]

NOCHANGELOG
