### PR TITLE
Fix assets_dbt_python example definitions

### DIFF
--- a/examples/assets_dbt_python/assets_dbt_python/definitions.py
+++ b/examples/assets_dbt_python/assets_dbt_python/definitions.py
@@ -49,7 +49,7 @@ resources = {
 }
 
 defs = Definitions(
-    assets=[dbt_project_assets, *forecasting_assets],
+    assets=[dbt_project_assets, *forecasting_assets, *raw_data_assets],
     resources=resources,
     asset_checks=all_assets_checks,
     schedules=[


### PR DESCRIPTION
## Summary & Motivation
- Fixed missing asset `raw_data_assets` in definitions for `assets_dbt_python` example
- `raw_data_assets` was imported in `definitions.py` but was not included in the definitions assets

## How I Tested These Changes
- Loaded `raw_data_assets` example locally

## Changelog [Bug]
- [examples] Fixed missing assets in `assets_dbt_python` example
