### PR TITLE
[DA] Add `on_missing` prebuilt condition

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_on_missing_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_on_missing_condition.py
@@ -1,0 +1,99 @@
+from dagster import AutomationCondition
+
+from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils.automation_condition_scenario import (
+    AutomationConditionScenarioState,
+)
+from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils.base_scenario import (
+    run_request,
+)
+from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils.scenario_specs import (
+    hourly_partitions_def,
+    two_assets_in_sequence,
+)
+
+
+def test_on_missing_unpartitioned() -> None:
+    state = AutomationConditionScenarioState(
+        two_assets_in_sequence,
+        automation_condition=AutomationCondition.on_missing(),
+        ensure_empty_result=False,
+    )
+
+    # parent hasn't materialized yet
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # parent materialized, now can execute
+    state = state.with_runs(run_request("A"))
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 1
+
+    # B has not yet materialized, but it has been requested, so don't request again
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # same as above
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # parent materialized again, no impact
+    state = state.with_runs(run_request("A"))
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # now B has been materialized, so really shouldn't execute again
+    state = state.with_runs(
+        *(run_request(ak, pk) for ak, pk in result.true_subset.asset_partitions)
+    )
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # parent materialized again, no impact
+    state = state.with_runs(run_request("A"))
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+
+def test_on_missing_hourly_partitioned() -> None:
+    state = (
+        AutomationConditionScenarioState(
+            two_assets_in_sequence,
+            automation_condition=AutomationCondition.on_missing(),
+            ensure_empty_result=False,
+        )
+        .with_asset_properties(partitions_def=hourly_partitions_def)
+        .with_current_time("2020-02-02T01:05:00")
+    )
+
+    # parent hasn't updated yet
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # historical parent updated, doesn't matter
+    state = state.with_runs(run_request("A", "2019-07-05-00:00"))
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # latest parent updated, now can execute
+    state = state.with_runs(run_request("A", "2020-02-02-00:00"))
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 1
+
+    # B has been requested, so don't request again
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # new partition comes into being, parent hasn't been materialized yet
+    state = state.with_current_time_advanced(hours=1)
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0
+
+    # latest parent updated, now can execute
+    state = state.with_runs(run_request("A", "2020-02-02-01:00"))
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 1
+
+    # latest parent updated again, don't re execute
+    state = state.with_runs(run_request("A", "2020-02-02-01:00"))
+    state, result = state.evaluate("B")
+    assert result.true_subset.size == 0


### PR DESCRIPTION
## Summary & Motivation

Adds a new static constructor for a fairly-common situation. Users want new partitions to get filled in as soon as possible, but never want a partition to get re-materialized.

You could achieve that behavior with AutomationCondition.eager() & AutomationCondition.missing(), but that would result in a much more complex policy than necessary. This is a much cleaner (and more performant) option, and gives first-class support to a common use case

## How I Tested These Changes

## Changelog [New]

Added `AutomationCondition.on_missing()`, which materializes an asset partition as soon as all of its parent partitions are filled in.
