### PR TITLE
[dagster-airlift][rfc] use airflow variables to communicate migration state

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/base_proxy_operator.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/base_proxy_operator.py
@@ -97,7 +97,7 @@ class BaseProxyToDagsterOperator(BaseOperator, ABC):
                     "variables": {"executionParams": execution_params},
                 },
                 # Timeout in seconds
-                timeout=3,
+                timeout=10,
             )
             run_id = response.json()["data"]["launchPipelineExecution"]["run"]["id"]
             logger.debug(f"Launched run {run_id}...")

--- a/examples/experimental/dagster-airlift/dagster_airlift/migration_state.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/migration_state.py
@@ -18,6 +18,9 @@ class TaskMigrationState(NamedTuple):
             raise Exception("Expected 'migrated' key to be a boolean")
         return TaskMigrationState(task_id=task_dict["id"], migrated=task_dict["migrated"])
 
+    def to_dict(self) -> Dict[str, Any]:
+        return {"id": self.task_id, "migrated": self.migrated}
+
 
 class DagMigrationState(NamedTuple):
     tasks: Dict[str, TaskMigrationState]
@@ -35,6 +38,9 @@ class DagMigrationState(NamedTuple):
             task_migration_states[task_state.task_id] = task_state
         return DagMigrationState(tasks=task_migration_states)
 
+    def to_dict(self) -> Dict[str, Sequence[Dict[str, Any]]]:
+        return {"tasks": [task_state.to_dict() for task_state in self.tasks.values()]}
+
     def is_task_migrated(self, task_id: str) -> bool:
         if task_id not in self.tasks:
             return False
@@ -44,7 +50,7 @@ class DagMigrationState(NamedTuple):
 class AirflowMigrationState(NamedTuple):
     dags: Dict[str, DagMigrationState]
 
-    def get_migration_state_for_task(self, dag_id: str, task_id: str) -> Optional[bool]:
+    def get_migration_state_for_task(self, *, dag_id: str, task_id: str) -> Optional[bool]:
         if dag_id not in self.dags:
             return None
         if task_id not in self.dags[dag_id].tasks:

--- a/examples/experimental/dagster-airlift/dagster_airlift/test/airflow_test_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/test/airflow_test_instance.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
@@ -26,6 +26,7 @@ class AirflowInstanceFake(AirflowInstance):
         task_infos: List[TaskInfo],
         task_instances: List[TaskInstance],
         dag_runs: List[DagRun],
+        variables: List[Dict[str, Any]] = [],
     ) -> None:
         self._dag_infos_by_dag_id = {dag_info.dag_id: dag_info for dag_info in dag_infos}
         self._task_infos_by_dag_and_task_id = {
@@ -42,6 +43,7 @@ class AirflowInstanceFake(AirflowInstance):
         for dag_run in dag_runs:
             self._dag_runs_by_dag_id[dag_run.dag_id].append(dag_run)
         self._dag_infos_by_file_token = {dag_info.file_token: dag_info for dag_info in dag_infos}
+        self._variables = variables
         super().__init__(
             auth_backend=DummyAuthBackend(),
             name="test_instance",
@@ -49,6 +51,9 @@ class AirflowInstanceFake(AirflowInstance):
 
     def list_dags(self) -> List[DagInfo]:
         return list(self._dag_infos_by_dag_id.values())
+
+    def list_variables(self) -> List[Dict[str, Any]]:
+        return self._variables
 
     def get_dag_runs(self, dag_id: str, start_date: datetime, end_date: datetime) -> List[DagRun]:
         if dag_id not in self._dag_runs_by_dag_id:

--- a/examples/experimental/dagster-airlift/dagster_airlift/test/shared_fixtures.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/test/shared_fixtures.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Callable, Generator
 
+import mock
 import pytest
 import requests
 from dagster._core.test_utils import environ
@@ -128,3 +129,26 @@ def setup_dagster(dagster_home: str, dagster_defs_path: str) -> Generator[Any, N
     assert dagster_ready, "Dagster did not start within 30 seconds..."
     yield process
     os.killpg(process.pid, signal.SIGKILL)
+
+
+####################################################################################################
+# MISCELLANEOUS FIXTURES
+# Fixtures that are useful across contexts.
+####################################################################################################
+
+VAR_DICT = {}
+
+
+def dummy_get_var(key: str) -> str:
+    return VAR_DICT[key]
+
+
+def dummy_set_var(key: str, value: str, session: Any) -> None:
+    return VAR_DICT.update({key: value})
+
+
+@pytest.fixture
+def mock_airflow_variable():
+    with mock.patch("airflow.models.Variable.get", side_effect=dummy_get_var):
+        with mock.patch("airflow.models.Variable.set", side_effect=dummy_set_var):
+            yield

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/in_airflow_tests/test_mark_as_dagster_migrating.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/in_airflow_tests/test_mark_as_dagster_migrating.py
@@ -5,13 +5,14 @@ from airflow.operators.python import PythonOperator
 from dagster_airlift.in_airflow import mark_as_dagster_migrating
 from dagster_airlift.in_airflow.base_proxy_operator import BaseProxyToDagsterOperator
 from dagster_airlift.migration_state import AirflowMigrationState
+from dagster_airlift.test.shared_fixtures import VAR_DICT
 
 from dagster_airlift_tests.unit_tests.in_airflow_tests.conftest import (
     build_dags_dict_given_structure,
 )
 
 
-def test_mark_as_dagster_migrating() -> None:
+def test_mark_as_dagster_migrating(mock_airflow_variable: None) -> None:
     """Test that we can mark a set of dags as migrating to dagster, and as a result, operators are replaced and tags are added."""
     globals_fake = build_dags_dict_given_structure(
         {
@@ -36,15 +37,14 @@ def test_mark_as_dagster_migrating() -> None:
     assert isinstance(globals_fake["task_isnt_migrated"].task_dict["task"], PythonOperator)
     assert isinstance(globals_fake["should_be_ignored"].task_dict["task"], PythonOperator)
 
-    # Only task_is_migrated and task_isnt_migrated should have tags added.
-    assert len(globals_fake["task_is_migrated"].tags) == 1
-    assert len(globals_fake["task_isnt_migrated"].tags) == 1
-    assert len(globals_fake["should_be_ignored"].tags) == 0
-    assert json.loads(next(iter(globals_fake["task_is_migrated"].tags))) == {
-        "DAGSTER_MIGRATION_STATUS": {"tasks": [{"id": "task", "migrated": True}]}
-    }
-    assert json.loads(next(iter(globals_fake["task_isnt_migrated"].tags))) == {
-        "DAGSTER_MIGRATION_STATUS": {"tasks": [{"id": "task", "migrated": False}]}
+    # Check the variable store
+    assert VAR_DICT == {
+        "task_is_migrated_dagster_migration_state": json.dumps(
+            {"tasks": [{"id": "task", "migrated": True}]}
+        ),
+        "task_isnt_migrated_dagster_migration_state": json.dumps(
+            {"tasks": [{"id": "task", "migrated": False}]}
+        ),
     }
 
 

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_migrating_e2e.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_migrating_e2e.py
@@ -70,9 +70,16 @@ def test_migration_status(
         assert len(instance.list_dags()) == 1
         dag = instance.list_dags()[0]
         assert dag.dag_id == "rebuild_customers_list"
-        assert not dag.migration_state.is_task_migrated("load_raw_customers")
-        assert not dag.migration_state.is_task_migrated("build_dbt_models")
-        assert not dag.migration_state.is_task_migrated("export_customers")
+        migration_state = instance.get_migration_state()
+        assert not migration_state.get_migration_state_for_task(
+            dag_id="rebuild_customers_list", task_id="load_raw_customers"
+        )
+        assert not migration_state.get_migration_state_for_task(
+            dag_id="rebuild_customers_list", task_id="build_dbt_models"
+        )
+        assert not migration_state.get_migration_state_for_task(
+            dag_id="rebuild_customers_list", task_id="export_customers"
+        )
 
         _assert_dagster_migration_states_are(False)
 
@@ -81,9 +88,16 @@ def test_migration_status(
         dag = instance.list_dags()[0]
 
         assert dag.dag_id == "rebuild_customers_list"
-        assert dag.migration_state.is_task_migrated("load_raw_customers")
-        assert not dag.migration_state.is_task_migrated("build_dbt_models")
-        assert not dag.migration_state.is_task_migrated("export_customers")
+        migration_state = instance.get_migration_state()
+        assert migration_state.get_migration_state_for_task(
+            dag_id="rebuild_customers_list", task_id="load_raw_customers"
+        )
+        assert not migration_state.get_migration_state_for_task(
+            dag_id="rebuild_customers_list", task_id="build_dbt_models"
+        )
+        assert not migration_state.get_migration_state_for_task(
+            dag_id="rebuild_customers_list", task_id="export_customers"
+        )
 
         _assert_dagster_migration_states_are(
             True, where=lambda spec: spec.tags.get(TASK_ID_TAG) == "load_raw_customers"
@@ -96,9 +110,16 @@ def test_migration_status(
         assert len(instance.list_dags()) == 1
         dag = instance.list_dags()[0]
         assert dag.dag_id == "rebuild_customers_list"
-        assert not dag.migration_state.is_task_migrated("load_raw_customers")
-        assert dag.migration_state.is_task_migrated("build_dbt_models")
-        assert not dag.migration_state.is_task_migrated("export_customers")
+        migration_state = instance.get_migration_state()
+        assert not migration_state.get_migration_state_for_task(
+            dag_id="rebuild_customers_list", task_id="load_raw_customers"
+        )
+        assert migration_state.get_migration_state_for_task(
+            dag_id="rebuild_customers_list", task_id="build_dbt_models"
+        )
+        assert not migration_state.get_migration_state_for_task(
+            dag_id="rebuild_customers_list", task_id="export_customers"
+        )
 
         _assert_dagster_migration_states_are(
             True, where=lambda spec: spec.tags.get(TASK_ID_TAG) == "build_dbt_models"
@@ -111,9 +132,16 @@ def test_migration_status(
         assert len(instance.list_dags()) == 1
         dag = instance.list_dags()[0]
         assert dag.dag_id == "rebuild_customers_list"
-        assert dag.migration_state.is_task_migrated("load_raw_customers")
-        assert dag.migration_state.is_task_migrated("build_dbt_models")
-        assert dag.migration_state.is_task_migrated("export_customers")
+        migration_state = instance.get_migration_state()
+        assert migration_state.get_migration_state_for_task(
+            dag_id="rebuild_customers_list", task_id="load_raw_customers"
+        )
+        assert migration_state.get_migration_state_for_task(
+            dag_id="rebuild_customers_list", task_id="build_dbt_models"
+        )
+        assert migration_state.get_migration_state_for_task(
+            dag_id="rebuild_customers_list", task_id="export_customers"
+        )
 
         _assert_dagster_migration_states_are(True)
 

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/unit_tests/test_proxy_operators.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/unit_tests/test_proxy_operators.py
@@ -1,8 +1,8 @@
-from tutorial_example.custom_operator_examples.custom_proxy import CustomProxyToDagsterOperator
-from tutorial_example.custom_operator_examples.plus_proxy_operator import DagsterCloudProxyOperator
+def test_dagster_cloud_proxy_operator(mock_airflow_variable: None) -> None:
+    from tutorial_example.custom_operator_examples.plus_proxy_operator import (
+        DagsterCloudProxyOperator,
+    )
 
-
-def test_dagster_cloud_proxy_operator() -> None:
     operator = DagsterCloudProxyOperator(task_id="test_task")
     assert (
         operator.get_dagster_url(
@@ -26,7 +26,9 @@ def test_dagster_cloud_proxy_operator() -> None:
     )
 
 
-def test_custom_proxy_operator() -> None:
+def test_custom_proxy_operator(mock_airflow_variable: None) -> None:
+    from tutorial_example.custom_operator_examples.custom_proxy import CustomProxyToDagsterOperator
+
     operator = CustomProxyToDagsterOperator(task_id="test_task")
     assert (
         operator.get_dagster_url({"var": {"value": {"my_api_key": "test_key"}}})  # type: ignore


### PR DESCRIPTION
### Description
Switches out the tag descriptor to instead use variables for cross-process communication. 
Tags in mwaa have a 1224 char size limit; for large dags, we likely won't be able to fit migration state.
Instead, use airflow variables, which don't have a fixed size limit, and can be queried via the rest api. 
Variables don't have _no_ size limit however, they're stored in a KV store in airflow's metadata database, and are therefore limited by the maximum row size for the database backend. I think this should be more than enough for our needs, although for large numbers of dags it's possible the bulk fetch of variables that we do at the start of caching could be very expensive.
### How I tested this
Switched the unit testing to mock out airflow's variables, and ensure that variables are set under the correct conditions in `mark_as_dagster_migrating`. 
Also ran through the dbt-example and ensured that operator swizzling was still working.
### Changelog
`NOCHANGELOG`
### Screenshots
Here's what the variables look like in the airflow UI. Not the prettiest thing in the world:
![Screenshot 2024-09-04 at 3 47 48 PM](https://github.com/user-attachments/assets/6d8abffb-99ed-4aa0-a362-f5330ad27f73)

