### PR TITLE
[dagster-airlift] use metadata instead of tags

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/constants.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/constants.py
@@ -1,3 +1,3 @@
 MIGRATED_TAG = "airlift/task_migrated"
-DAG_ID_TAG = "airlift/dag_id"
-TASK_ID_TAG = "airlift/task_id"
+DAG_ID_METADATA_KEY = "airlift/dag_id"
+TASK_ID_METADATA_KEY = "airlift/task_id"

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_cacheable_assets_def.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_cacheable_assets_def.py
@@ -33,7 +33,7 @@ from dagster._serdes.serdes import (
     unpack_value,
 )
 
-from dagster_airlift.constants import DAG_ID_TAG, MIGRATED_TAG, TASK_ID_TAG
+from dagster_airlift.constants import DAG_ID_METADATA_KEY, MIGRATED_TAG, TASK_ID_METADATA_KEY
 from dagster_airlift.core.airflow_instance import AirflowInstance, DagInfo, TaskInfo
 from dagster_airlift.core.utils import (
     convert_to_valid_dagster_name,
@@ -198,7 +198,7 @@ class AirflowCacheableAssetsDefinition(CacheableAssetsDefinition):
                 build_airflow_asset_from_specs(
                     specs=[dag_spec.to_asset_spec({})],
                     name=key.to_python_identifier(),
-                    tags={DAG_ID_TAG: dag_id},
+                    tags={DAG_ID_METADATA_KEY: dag_id},
                 )
             )
         return new_assets_defs + construct_assets_with_task_migration_info_applied(
@@ -236,7 +236,7 @@ def get_cached_spec_for_dag(
         asset_key=dag_info.dag_asset_key,
         description=f"A materialization corresponds to a successful run of airflow DAG {dag_info.dag_id}.",
         metadata=metadata,
-        tags={"dagster/compute_kind": "airflow", DAG_ID_TAG: dag_info.dag_id},
+        tags={"dagster/compute_kind": "airflow", DAG_ID_METADATA_KEY: dag_info.dag_id},
         deps=[CacheableAssetDep(asset_key=key) for key in leaf_asset_keys],
         group_name=None,
     )
@@ -309,12 +309,14 @@ def construct_cacheable_assets_and_infer_dependencies(
             cacheable_specs_per_asset_key[spec.key] = CacheableAssetSpec(
                 asset_key=spec.key,
                 description=spec.description,
-                metadata=task_level_metadata,
+                metadata={
+                    DAG_ID_METADATA_KEY: task_info.dag_id,
+                    TASK_ID_METADATA_KEY: task_info.task_id,
+                    **task_level_metadata,
+                },
                 tags={
                     **spec.tags,
                     MIGRATED_TAG: str(migration_state_for_task),
-                    DAG_ID_TAG: task_info.dag_id,
-                    TASK_ID_TAG: task_info.task_id,
                 },
                 deps=spec_deps,
                 group_name=spec.group_name,
@@ -375,20 +377,20 @@ def construct_assets_with_task_migration_info_applied(
             )
             overall_migration_status = new_spec.tags[MIGRATED_TAG]
             check.invariant(
-                DAG_ID_TAG in new_spec.tags,
+                DAG_ID_METADATA_KEY in new_spec.metadata,
                 f"Could not find dag ID for asset key {spec.key.to_user_string()}",
             )
-            dag_id = new_spec.tags[DAG_ID_TAG]
+            dag_id = new_spec.metadata[DAG_ID_METADATA_KEY]
             check.invariant(
                 overall_dag_id is None or overall_dag_id == dag_id,
                 "Expected all assets in an AssetsDefinition to have the same dag ID.",
             )
             overall_dag_id = dag_id
             check.invariant(
-                TASK_ID_TAG in new_spec.tags,
+                TASK_ID_METADATA_KEY in new_spec.metadata,
                 f"Could not find task ID for asset key {spec.key.to_user_string()}",
             )
-            task_id = new_spec.tags[TASK_ID_TAG]
+            task_id = new_spec.metadata[TASK_ID_METADATA_KEY]
             check.invariant(
                 overall_task_id is None or overall_task_id == task_id,
                 f"Expected all assets in an AssetsDefinition to have the same task ID. Found {overall_task_id} and {task_id}.",

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/defs_builders.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/defs_builders.py
@@ -4,7 +4,7 @@ from dagster import AssetSpec
 from dagster._core.definitions.asset_key import CoercibleToAssetKey
 from typing_extensions import TypeAlias
 
-from dagster_airlift.constants import DAG_ID_TAG, TASK_ID_TAG
+from dagster_airlift.constants import DAG_ID_METADATA_KEY, TASK_ID_METADATA_KEY
 
 CoercibleToAssetSpec: TypeAlias = Union[AssetSpec, CoercibleToAssetKey]
 
@@ -18,6 +18,8 @@ def specs_from_task(
     return [
         asset
         if isinstance(asset, AssetSpec)
-        else AssetSpec(key=asset, tags={DAG_ID_TAG: dag_id, TASK_ID_TAG: task_id})
+        else AssetSpec(
+            key=asset, metadata={DAG_ID_METADATA_KEY: dag_id, TASK_ID_METADATA_KEY: task_id}
+        )
         for asset in assets
     ]

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/base_proxy_operator.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/base_proxy_operator.py
@@ -8,7 +8,7 @@ import requests
 from airflow.models.operator import BaseOperator
 from airflow.utils.context import Context
 
-from dagster_airlift.constants import DAG_ID_TAG, TASK_ID_TAG
+from dagster_airlift.constants import DAG_ID_METADATA_KEY, TASK_ID_METADATA_KEY
 
 from .gql_queries import ASSET_NODES_QUERY, RUNS_QUERY, TRIGGER_ASSETS_MUTATION, VERIFICATION_QUERY
 
@@ -59,10 +59,15 @@ class BaseProxyToDagsterOperator(BaseOperator, ABC):
             timeout=3,
         )
         for asset_node in response.json()["data"]["assetNodes"]:
-            tags = {tag["key"]: tag["value"] for tag in asset_node["tags"]}
+            text_metadata_entries = {
+                entry["label"]: entry["text"]
+                for entry in asset_node["metadataEntries"]
+                if entry["__typename"] == "TextMetadataEntry"
+            }
             # match assets based on conventional dag_id__task_id naming or based on explicit tags
             if asset_node["opName"] == expected_op_name or (
-                tags.get(DAG_ID_TAG) == dag_id and tags.get(TASK_ID_TAG) == task_id
+                text_metadata_entries.get(DAG_ID_METADATA_KEY) == dag_id
+                and text_metadata_entries.get(TASK_ID_METADATA_KEY) == task_id
             ):
                 repo_location = asset_node["jobs"][0]["repository"]["location"]["name"]
                 repo_name = asset_node["jobs"][0]["repository"]["name"]

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/gql_queries.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/gql_queries.py
@@ -11,9 +11,12 @@ query AssetNodeQuery {
         assetKey {
             path
         }
-        tags {
-            key
-            value
+        metadataEntries {
+            ... on TextMetadataEntry {
+                label
+                text
+            }
+            __typename
         }
         opName
         jobs {

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
@@ -48,7 +48,7 @@ def build_definitions_airflow_asset_graph(
                     AssetSpec(
                         asset_key,
                         deps=deps,
-                        tags={"airlift/dag_id": dag_id, "airlift/task_id": task_id},
+                        metadata={"airlift/dag_id": dag_id, "airlift/task_id": task_id},
                     )
                 )
     instance = make_instance(

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_build_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_build_defs.py
@@ -114,7 +114,7 @@ def test_coerce_specs() -> None:
     """Test that asset specs are properly coerced into asset keys."""
     # Initialize an airflow instance with a dag "dag", which contains a task "task". There are no task instances or runs.
 
-    spec = AssetSpec(key="a", tags={"airlift/dag_id": "dag", "airlift/task_id": "task"})
+    spec = AssetSpec(key="a", metadata={"airlift/dag_id": "dag", "airlift/task_id": "task"})
     defs = build_defs_from_airflow_instance(
         airflow_instance=make_instance({"dag": ["task"]}),
         defs=Definitions(
@@ -133,7 +133,8 @@ def test_invalid_dagster_named_tasks_and_dags() -> None:
     """Test that invalid dagster names are converted to valid names."""
     a = AssetKey("a")
     spec = AssetSpec(
-        key=a, tags={"airlift/dag_id": "dag-with-hyphens", "airlift/task_id": "task-with-hyphens"}
+        key=a,
+        metadata={"airlift/dag_id": "dag-with-hyphens", "airlift/task_id": "task-with-hyphens"},
     )
     defs = build_defs_from_airflow_instance(
         airflow_instance=make_instance({"dag-with-hyphens": ["task-with-hyphens"]}),
@@ -219,21 +220,21 @@ def test_transitive_asset_deps() -> None:
     assert [dep.asset_key for dep in next(iter(dag2_asset.specs)).deps] == [c_key]
     a_asset = repo_def.assets_defs_by_key[a_key]
     assert [dep.asset_key for dep in next(iter(a_asset.specs)).deps] == []
-    assert "airlift/dag_id" in next(iter(a_asset.specs)).tags
-    assert next(iter(a_asset.specs)).tags["airlift/dag_id"] == "dag1"
-    assert "airlift/task_id" in next(iter(a_asset.specs)).tags
-    assert next(iter(a_asset.specs)).tags["airlift/task_id"] == "task"
+    assert "airlift/dag_id" in next(iter(a_asset.specs)).metadata
+    assert next(iter(a_asset.specs)).metadata["airlift/dag_id"] == "dag1"
+    assert "airlift/task_id" in next(iter(a_asset.specs)).metadata
+    assert next(iter(a_asset.specs)).metadata["airlift/task_id"] == "task"
 
     b_asset = repo_def.assets_defs_by_key[b_key]
     assert [dep.asset_key for dep in next(iter(b_asset.specs)).deps] == [a_key]
-    assert "airlift/dag_id" not in next(iter(b_asset.specs)).tags
-    assert "airlift/task_id" not in next(iter(b_asset.specs)).tags
+    assert "airlift/dag_id" not in next(iter(b_asset.specs)).metadata
+    assert "airlift/task_id" not in next(iter(b_asset.specs)).metadata
     c_asset = repo_def.assets_defs_by_key[c_key]
     assert [dep.asset_key for dep in next(iter(c_asset.specs)).deps] == [b_key]
-    assert "airlift/dag_id" in next(iter(c_asset.specs)).tags
-    assert next(iter(c_asset.specs)).tags["airlift/dag_id"] == "dag2"
-    assert "airlift/task_id" in next(iter(c_asset.specs)).tags
-    assert next(iter(c_asset.specs)).tags["airlift/task_id"] == "task"
+    assert "airlift/dag_id" in next(iter(c_asset.specs)).metadata
+    assert next(iter(c_asset.specs)).metadata["airlift/dag_id"] == "dag2"
+    assert "airlift/task_id" in next(iter(c_asset.specs)).metadata
+    assert next(iter(c_asset.specs)).metadata["airlift/task_id"] == "task"
 
 
 def test_peered_dags() -> None:

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_dag_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_dag_defs.py
@@ -1,6 +1,6 @@
 from dagster import AssetKey, AssetSpec, Definitions, multi_asset
 from dagster._core.definitions.asset_key import CoercibleToAssetKey
-from dagster_airlift.constants import DAG_ID_TAG, TASK_ID_TAG
+from dagster_airlift.constants import DAG_ID_METADATA_KEY, TASK_ID_METADATA_KEY
 from dagster_airlift.core import dag_defs, task_defs
 
 
@@ -18,8 +18,8 @@ def test_dag_def_spec() -> None:
         "dag_one",
         task_defs("task_one", from_specs(AssetSpec(key="asset_one"))),
     )
-    assert asset_spec(defs, "asset_one").tags[DAG_ID_TAG] == "dag_one"
-    assert asset_spec(defs, "asset_one").tags[TASK_ID_TAG] == "task_one"
+    assert asset_spec(defs, "asset_one").metadata[DAG_ID_METADATA_KEY] == "dag_one"
+    assert asset_spec(defs, "asset_one").metadata[TASK_ID_METADATA_KEY] == "task_one"
 
 
 def test_dag_def_multi_tasks_multi_specs() -> None:
@@ -28,12 +28,12 @@ def test_dag_def_multi_tasks_multi_specs() -> None:
         task_defs("task_one", from_specs(AssetSpec(key="asset_one"))),
         task_defs("task_two", from_specs(AssetSpec(key="asset_two"), AssetSpec(key="asset_three"))),
     )
-    assert asset_spec(defs, "asset_one").tags[DAG_ID_TAG] == "dag_one"
-    assert asset_spec(defs, "asset_one").tags[TASK_ID_TAG] == "task_one"
-    assert asset_spec(defs, "asset_two").tags[DAG_ID_TAG] == "dag_one"
-    assert asset_spec(defs, "asset_two").tags[TASK_ID_TAG] == "task_two"
-    assert asset_spec(defs, "asset_three").tags[DAG_ID_TAG] == "dag_one"
-    assert asset_spec(defs, "asset_three").tags[TASK_ID_TAG] == "task_two"
+    assert asset_spec(defs, "asset_one").metadata[DAG_ID_METADATA_KEY] == "dag_one"
+    assert asset_spec(defs, "asset_one").metadata[TASK_ID_METADATA_KEY] == "task_one"
+    assert asset_spec(defs, "asset_two").metadata[DAG_ID_METADATA_KEY] == "dag_one"
+    assert asset_spec(defs, "asset_two").metadata[TASK_ID_METADATA_KEY] == "task_two"
+    assert asset_spec(defs, "asset_three").metadata[DAG_ID_METADATA_KEY] == "dag_one"
+    assert asset_spec(defs, "asset_three").metadata[TASK_ID_METADATA_KEY] == "task_two"
 
 
 def test_dag_def_assets_def() -> None:
@@ -44,8 +44,8 @@ def test_dag_def_assets_def() -> None:
         "dag_one",
         task_defs("task_one", Definitions([an_asset])),
     )
-    assert asset_spec(defs, "asset_one").tags[DAG_ID_TAG] == "dag_one"
-    assert asset_spec(defs, "asset_one").tags[TASK_ID_TAG] == "task_one"
+    assert asset_spec(defs, "asset_one").metadata[DAG_ID_METADATA_KEY] == "dag_one"
+    assert asset_spec(defs, "asset_one").metadata[TASK_ID_METADATA_KEY] == "task_one"
 
 
 def test_dag_def_defs() -> None:
@@ -56,5 +56,5 @@ def test_dag_def_defs() -> None:
         "dag_one",
         task_defs("task_one", Definitions(assets=[an_asset])),
     )
-    assert asset_spec(defs, "asset_one").tags[DAG_ID_TAG] == "dag_one"
-    assert asset_spec(defs, "asset_one").tags[TASK_ID_TAG] == "task_one"
+    assert asset_spec(defs, "asset_one").metadata[DAG_ID_METADATA_KEY] == "dag_one"
+    assert asset_spec(defs, "asset_one").metadata[TASK_ID_METADATA_KEY] == "task_one"

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_utils.py
@@ -20,7 +20,7 @@ def test_retrieve_by_asset_tag() -> None:
     """Test that we can retrieve the dag and task id from the asset tags. Test that error edge cases are properly handled."""
 
     # 1. Single spec retrieval
-    @asset(tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"})
+    @asset(metadata={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"})
     def one_spec():
         pass
 
@@ -32,11 +32,11 @@ def test_retrieve_by_asset_tag() -> None:
         specs=[
             AssetSpec(
                 key=AssetKey(["simple"]),
-                tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"},
+                metadata={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"},
             ),
             AssetSpec(
                 key=AssetKey(["other"]),
-                tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"},
+                metadata={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"},
             ),
         ]
     )
@@ -51,11 +51,11 @@ def test_retrieve_by_asset_tag() -> None:
         specs=[
             AssetSpec(
                 key=AssetKey(["simple"]),
-                tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"},
+                metadata={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"},
             ),
             AssetSpec(
                 key=AssetKey(["other"]),
-                tags={"airlift/dag_id": "other_dag", "airlift/task_id": "other_task"},
+                metadata={"airlift/dag_id": "other_dag", "airlift/task_id": "other_task"},
             ),
         ]
     )
@@ -72,7 +72,7 @@ def test_retrieve_by_asset_tag() -> None:
         specs=[
             AssetSpec(
                 key=AssetKey(["simple"]),
-                tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"},
+                metadata={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"},
             ),
             AssetSpec(key=AssetKey(["other"])),
         ]
@@ -111,7 +111,7 @@ def test_retrieve_by_name() -> None:
 
 def test_op_asset_tag_mismatch() -> None:
     @asset(
-        tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"},
+        metadata={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"},
         op_tags={"airlift/dag_id": "other_dag", "airlift/task_id": "other_task"},
     )
     def mismatched():
@@ -125,7 +125,7 @@ def test_op_asset_tag_mismatch() -> None:
 
 
 def test_op_asset_name_mismatch() -> None:
-    @asset(tags={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"})
+    @asset(metadata={"airlift/dag_id": "print_dag", "airlift/task_id": "print_task"})
     def other_dag__other_task():
         pass
 
@@ -155,4 +155,4 @@ def test_specs_to_tasks() -> None:
     assert all(isinstance(_def, AssetSpec) for _def in defs)
     assert len(list(defs)) == 2
     spec = next(iter(defs))
-    assert spec.tags["airlift/dag_id"] == "dag"
+    assert spec.metadata["airlift/dag_id"] == "dag"

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_migrating_e2e.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_migrating_e2e.py
@@ -7,7 +7,7 @@ import pytest
 from dagster import DagsterInstance
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.storage.dagster_run import DagsterRunStatus
-from dagster_airlift.constants import MIGRATED_TAG, TASK_ID_TAG
+from dagster_airlift.constants import MIGRATED_TAG, TASK_ID_METADATA_KEY
 from dagster_airlift.core import AirflowInstance, BasicAuthBackend
 
 from .utils import (
@@ -100,10 +100,10 @@ def test_migration_status(
         )
 
         _assert_dagster_migration_states_are(
-            True, where=lambda spec: spec.tags.get(TASK_ID_TAG) == "load_raw_customers"
+            True, where=lambda spec: spec.tags.get(TASK_ID_METADATA_KEY) == "load_raw_customers"
         )
         _assert_dagster_migration_states_are(
-            False, where=lambda spec: spec.tags.get(TASK_ID_TAG) != "load_raw_customers"
+            False, where=lambda spec: spec.tags.get(TASK_ID_METADATA_KEY) != "load_raw_customers"
         )
 
     with mark_tasks_migrated({"build_dbt_models"}):
@@ -122,10 +122,10 @@ def test_migration_status(
         )
 
         _assert_dagster_migration_states_are(
-            True, where=lambda spec: spec.tags.get(TASK_ID_TAG) == "build_dbt_models"
+            True, where=lambda spec: spec.tags.get(TASK_ID_METADATA_KEY) == "build_dbt_models"
         )
         _assert_dagster_migration_states_are(
-            False, where=lambda spec: spec.tags.get(TASK_ID_TAG) != "build_dbt_models"
+            False, where=lambda spec: spec.tags.get(TASK_ID_METADATA_KEY) != "build_dbt_models"
         )
 
     with mark_tasks_migrated({"load_raw_customers", "build_dbt_models", "export_customers"}):


### PR DESCRIPTION
## Summary & Motivation
Airflow dag/task ids can go over our 63 character limit for tags. Instead, move to checking metadata.

## How I Tested These Changes
Updated all callsites and unit tests. Ran dbt-example successfully.

## Changelog [New | Bug | Docs]
`NOCHANGELOG`
