### PR TITLE
[sphinx] fix: check_public_method_has_docstring bug with mappingproxy type

### DIFF
--- a/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py
+++ b/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py
@@ -73,9 +73,9 @@ def record_error(env: BuildEnvironment, message: str) -> None:
 
 
 def check_public_method_has_docstring(env: BuildEnvironment, name: str, obj: object) -> None:
-    if name != "__init__" and not obj.__doc__:
+    if name != "__init__" and not hasattr(obj, "__doc__"):
         message = (
-            f"Docstring not found for {object.__name__}.{name}. "
+            f"Docstring not found for {obj.__name__}.{name}. "
             "All public methods and properties must have docstrings."
         )
         record_error(env, message)


### PR DESCRIPTION
This was a fun one. Essentially, a class __dict__ returns none when `__doc__` is called, eg. with `obj.__doc__`. Instead, you can assert that docs exist with `hasattr`. This was causing PipesContext and other classes to erroneously report no documentation.

## Summary & Motivation

Was getting these odd messages in Sphinx:
```
Docstring not found for object.__dict__. All public methods and properties must have docstrings.
Docstring not found for object.__enter__. All public methods and properties must have docstrings.
Docstring not found for object.__exit__. All public methods and properties must have docstrings.
Docstring not found for object._instance. All public methods and properties must have docstrings.
Docstring not found for object._write_message. All public methods and properties must have docstrings.
Docstring not found for object.__dict__. All public methods and properties must have docstrings.
Docstring not found for object.__doc__. All public methods and properties must have docstrings.
Docstring not found for object.load_context. All public methods and properties must have docstrings.
Docstring not found for object.load_context. All public methods and properties must have docstrings.
Docstring not found for object.__dict__. All public methods and properties must have docstrings.
Docstring not found for object.is_dagster_pipes_process. All public methods and properties must have docstrings.
Docstring not found for object.load_context_params. All public methods and properties must have docstrings.
Docstring not found for object.load_messages_params. All public methods and properties must have docstrings.
Docstring not found for object.__dict__. All public methods and properties must have docstrings.
Docstring not found for object.__doc__. All public methods and properties must have docstrings.
Docstring not found for object.open. All public methods and properties must have docstrings.
Docstring not found for object.make_channel. All public methods and properties must have docstrings.
Docstring not found for object.make_channel. All public methods and properties must have docstrings.
Docstring not found for object.get_opened_extras. All public methods and properties must have docstrings.
Docstring not found for object.make_channel. All public methods and properties must have docstrings.
Docstring not found for object.__dict__. All public methods and properties must have docstrings.
Docstring not found for object._upload_loop. All public methods and properties must have docstrings.
Docstring not found for object.buffered_upload_loop. All public methods and properties must have docstrings.
Docstring not found for object.flush_messages. All public methods and properties must have docstrings.
Docstring not found for object.upload_messages_chunk. All public methods and properties must have docstrings.
Docstring not found for object.write_message. All public methods and properties must have docstrings.
Docstring not found for object.upload_messages_chunk. All public methods and properties must have docstrings.
Docstring not found for object.write_message. All public methods and properties must have docstrings.
Docstring not found for object.write_message. All public methods and properties must have docstrings.
Docstring not found for object.upload_messages_chunk. All public methods and properties must have docstrings.
Docstring not found for object.__doc__. All public methods and properties must have docstrings.
Docstring not found for object.__doc__. All public methods and properties must have docstrings.
Docstring not found for object.end. All public methods and properties must have docstrings.
Docstring not found for object.start. All public methods and properties must have docstrings.
Docstring not found for object.end. All public methods and properties must have docstrings.
Docstring not found for object.start. All public methods and properties must have docstrings.
Docstring not found for object.end. All public methods and properties must have docstrings.
Docstring not found for object.start. All public methods and properties must have docstrings.
Docstring not found for object.end. All public methods and properties must have docstrings.
Docstring not found for object.start. All public methods and properties must have docstrings.
Docstring not found for object.end. All public methods and properties must have docstrings.
Docstring not found for object.start. All public methods and properties must have docstrings.
```

## How I Tested These Changes

`sphinx-build` before and after these changes. Messages no longer appear. 

## Changelog [New | Bug | Docs]

NOCHANGELOG