### PR TITLE
[refactor] Remove CachingStaleStatusResolver from AssetGraphView

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -27,7 +27,6 @@ from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.backfill_policy import BackfillPolicy, BackfillPolicyType
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.data_time import CachingDataTimeResolver
-from dagster._core.definitions.data_version import CachingStaleStatusResolver
 from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AutomationConditionEvaluation,
@@ -102,15 +101,13 @@ class AssetDaemonContext:
         )
         self._data_time_resolver = CachingDataTimeResolver(self.instance_queryer)
 
-        stale_resolver = CachingStaleStatusResolver(
-            instance=instance, asset_graph=asset_graph, instance_queryer=self.instance_queryer
-        )
         self._asset_graph_view = AssetGraphView(
             temporal_context=TemporalContext(
                 effective_dt=self.instance_queryer.evaluation_time,
                 last_event_id=instance.event_log_storage.get_maximum_record_id(),
             ),
-            stale_resolver=stale_resolver,
+            instance=instance,
+            asset_graph=asset_graph,
         )
         self._data_time_resolver = CachingDataTimeResolver(self.instance_queryer)
         self._cursor = cursor

--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -5,7 +5,6 @@ from dagster._annotations import experimental
 from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView, TemporalContext
 from dagster._core.definitions.asset_selection import AssetSelection, CoercibleToAssetSelection
 from dagster._core.definitions.data_time import CachingDataTimeResolver
-from dagster._core.definitions.data_version import CachingStaleStatusResolver
 from dagster._core.definitions.declarative_automation.automation_condition_evaluator import (
     AutomationConditionEvaluator,
 )
@@ -18,7 +17,6 @@ from dagster._core.definitions.sensor_definition import (
 )
 from dagster._core.definitions.utils import check_valid_name, normalize_tags
 from dagster._time import get_current_datetime
-from dagster._utils.caching_instance_queryer import CachingInstanceQueryer
 
 
 def evaluate_automation_conditions(context: SensorEvaluationContext):
@@ -30,23 +28,13 @@ def evaluate_automation_conditions(context: SensorEvaluationContext):
 
     asset_graph = check.not_none(context.repository_def).asset_graph
 
-    instance_queryer = CachingInstanceQueryer(
-        context.instance,
-        asset_graph,
-        evaluation_time=get_current_datetime(),
-        logger=context.log,
-    )
-
     asset_graph_view = AssetGraphView(
-        stale_resolver=CachingStaleStatusResolver(
-            instance=context.instance,
-            asset_graph=asset_graph,
-            instance_queryer=instance_queryer,
-        ),
         temporal_context=TemporalContext(
-            effective_dt=instance_queryer.evaluation_time,
+            effective_dt=get_current_datetime(),
             last_event_id=None,
         ),
+        instance=context.instance,
+        asset_graph=asset_graph,
     )
 
     data_time_resolver = CachingDataTimeResolver(
@@ -71,7 +59,7 @@ def evaluate_automation_conditions(context: SensorEvaluationContext):
     results, to_request = evaluator.evaluate()
     new_cursor = cursor.with_updates(
         evaluation_id=cursor.evaluation_id,
-        evaluation_timestamp=instance_queryer.evaluation_time.timestamp(),
+        evaluation_timestamp=asset_graph_view.effective_dt.timestamp(),
         newly_observe_requested_asset_keys=[],  # skip for now, hopefully forever
         condition_cursors=[result.get_new_cursor() for result in results],
     )

--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -71,6 +71,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
         asset_graph: BaseAssetGraph,
         evaluation_time: Optional[datetime] = None,
         logger: Optional[logging.Logger] = None,
+        asset_record_loader: Optional[BatchAssetRecordLoader] = None,
     ):
         self._instance = instance
         self._asset_graph = asset_graph

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
@@ -20,8 +20,7 @@ def test_basic_construction_and_identity() -> None:
     assert asset_graph_view_t0.effective_dt == effective_dt
     assert asset_graph_view_t0.last_event_id == last_event_id
 
-    # hiding stale resolver deliberately but want to test instance object identity
-    assert asset_graph_view_t0._stale_resolver.instance_queryer.instance is instance  # noqa: SLF001
+    assert asset_graph_view_t0._instance is instance  # noqa: SLF001
 
     assert asset_graph_view_t0.asset_graph.all_asset_keys == {an_asset.key}
 


### PR DESCRIPTION
## Summary & Motivation

As title. This simplifies the process of constructing an AssetGraphView -- you just need to pass in an AssetGraph and a DagsterInstance.

Currently, no stale status calculation is done within the view object, but if/when we change that, we'll construct the object responsible for doing that querying within the AssetGraphView.

## How I Tested These Changes

## Changelog [New | Bug | Docs]

NOCHANGELOG
