### PR TITLE
[sphinx] Add additional node types to the MDX writer

### DIFF
--- a/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/configurable.py
+++ b/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/configurable.py
@@ -93,7 +93,7 @@ def config_field_to_lines(field, name=None) -> List[str]:
             if isinstance(val, dict):
                 ls = json.dumps(val, indent=4).split("\n")
                 lines.append("")
-                lines.append("    .. collapse:: Default Value:")
+                lines.append("        Default Value:")
                 lines.append("")
                 lines.append("        .. code-block:: javascript")
                 lines.append("")
@@ -108,7 +108,7 @@ def config_field_to_lines(field, name=None) -> List[str]:
         lines.append("")
         # for the top level, no need to indent
         indent = "    " if name else ""
-        lines.append(indent + ".. collapse:: Config Schema:")
+        lines.append(indent + "Config Schema:")
         for name, subfield in field.config_type.fields.items():
             # indent all of these lines to fit under the collapse block
             lines += [indent + "    " + line for line in config_field_to_lines(subfield, name=name)]

--- a/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/configurable.py
+++ b/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/configurable.py
@@ -93,7 +93,7 @@ def config_field_to_lines(field, name=None) -> List[str]:
             if isinstance(val, dict):
                 ls = json.dumps(val, indent=4).split("\n")
                 lines.append("")
-                lines.append("        Default Value:")
+                lines.append("    .. collapse:: Default Value:")
                 lines.append("")
                 lines.append("        .. code-block:: javascript")
                 lines.append("")
@@ -108,7 +108,7 @@ def config_field_to_lines(field, name=None) -> List[str]:
         lines.append("")
         # for the top level, no need to indent
         indent = "    " if name else ""
-        lines.append(indent + "Config Schema:")
+        lines.append(indent + ".. collapse:: Config Schema:")
         for name, subfield in field.config_type.fields.items():
             # indent all of these lines to fit under the collapse block
             lines += [indent + "    " + line for line in config_field_to_lines(subfield, name=name)]

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -106,8 +106,6 @@ extensions = [
     "sphinx_click.ext",
     # Dagster-labs-authored extension with custom directives and sphinx processing.
     "dagster_sphinx",
-    # Renders a collapsible HTML component. Used by autodoc_dagster.
-    "sphinx_toolbox.collapse",
     # Render MDX
     "sphinxcontrib.mdxbuilder",
 ]
@@ -154,6 +152,7 @@ autodoc_mock_imports = [
     "kubernetes",
     "lazy_object_proxy",
     "mlflow",
+    "mypy_boto3_glue",
     "mysql",
     "oauth2client",
     "orjson",

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -106,6 +106,7 @@ extensions = [
     "sphinx_click.ext",
     # Dagster-labs-authored extension with custom directives and sphinx processing.
     "dagster_sphinx",
+    "sphinx_toolbox.collapse",
     # Render MDX
     "sphinxcontrib.mdxbuilder",
 ]


### PR DESCRIPTION
## Summary & Motivation

Adds additional node types of the Sphinx MDX writer. This now runs without errors on all our existing RST files, meaning we can generate MDX from RST. 

The MDX files themselves are not ready yet, they will error if you try to load them into Docusaurus. More fixes will come to that in a future PR.

## How I Tested These Changes

Lots of local testing and previews

## Changelog [New | Bug | Docs]

> Replace this message with a changelog entry, or `NOCHANGELOG`
