### PR TITLE
Exclude dagster-tableau from telemetry test

### DIFF
--- a/python_modules/automation/automation_tests/telemetry/test_resource_telemetry.py
+++ b/python_modules/automation/automation_tests/telemetry/test_resource_telemetry.py
@@ -35,8 +35,9 @@ def test_resource_telemetry():
     libraries.remove("dagster_ge")
     # airflow isn't correctly installed in the BuildKite environment
     libraries.remove("dagster_airflow")
-    # new library, not added yet
+    # new libraries, not added yet
     libraries.remove("dagster_embedded_elt")
+    libraries.remove("dagster_tableau")
 
     resources_without_telemetry = []
 


### PR DESCRIPTION
## Summary & Motivation

dagster-tableau is not added in dev yet, will be done later. 

Merging #24186 broke the telemetry test, so excluding dagster-tableau for now.

## How I Tested These Changes

BK

## Changelog [New | Bug | Docs]

> Replace this message with a changelog entry, or `NOCHANGELOG`
