### PR TITLE
fix: add dagster-tableau to automation tox suite dependencies

### DIFF
--- a/python_modules/automation/tox.ini
+++ b/python_modules/automation/tox.ini
@@ -47,6 +47,7 @@ deps =
   -e ../libraries/dagster-slack
   -e ../libraries/dagster-spark
   -e ../libraries/dagster-ssh
+  -e ../libraries/dagster-tableau
   -e ../libraries/dagster-twilio
   -e ../libraries/dagstermill
   -e ../libraries/dagster-azure


### PR DESCRIPTION
## Summary & Motivation

This PR adds the dagster-tableau dependency to the automation tox suite instead of excluding it in #24248. Fixes the build.

## How I Tested These Changes

BK

## Changelog [New | Bug | Docs]

> Replace this message with a changelog entry, or `NOCHANGELOG`
