### PR TITLE
[ui] Untangle static set filter effect loops that lead to history.replace loop

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryPersistedState.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryPersistedState.tsx
@@ -109,8 +109,9 @@ export function useQueryPersistedState<T extends QueryPersistedDataType>(
       }
 
       // Check if the query has changed. If so, perform a replace. Otherwise, do nothing
-      // to ensure that we don't end up in a `replace` loop.
-      if (!areQueriesEqual(currentQueryString, next)) {
+      // to ensure that we don't end up in a `replace` loop. If we're not in prod, always run
+      // the `replace` so that we surface any unwanted loops during development.
+      if (process.env.NODE_ENV !== 'production' || !areQueriesEqual(currentQueryString, next)) {
         currentQueryString = next;
         history.replace(`${location.pathname}?${qs.stringify(next, {arrayFormat: 'brackets'})}`);
       }


### PR DESCRIPTION
## Summary & Motivation

Try to iron out issues with static set filter triggering state updates that can lead to `history.replace` loops. We papered over it by bailing from the loop in `useQueryPersistedState`, but it's better to try to get to the root of the issue.

## How I Tested These Changes

In Safari, load Insights with a known repro. Verify that the `replace` loop doesn't occur.

## Changelog [New | Bug | Docs]

NOCHANGELOG
