### PR TITLE
[docs] - Add link to Migration guides page

### DIFF
--- a/docs/content/guides/migrations.mdx
+++ b/docs/content/guides/migrations.mdx
@@ -2,7 +2,7 @@
 title: Migrating to Dagster guides | Dagster Docs
 ---
 
-# Migrating to Dagster guides
+# Migrating to Dagster
 
 Explore your options for migrating from other platforms to Dagster.
 
@@ -10,4 +10,7 @@ Explore your options for migrating from other platforms to Dagster.
 
 ## Migrating from Airflow to Dagster
 
-Curious how you can migrate your Airflow pipelines to Dagster? Explore how [Migrating from Airflow to Dagster](/guides/migrations/migrating-airflow-to-dagster) to learn more.
+Curious how you can migrate your Airflow pipelines to Dagster?
+
+- Learn how to perform [a lift-and-shift migration of Airflow to Dagster](/guides/migrations/migrating-airflow-to-dagster)
+- Learn how to leverage the features of [Dagster and Airflow together using Dagster Pipes](/guides/migrations/observe-your-airflow-pipelines-with-dagster)

--- a/docs/content/guides/migrations/observe-your-airflow-pipelines-with-dagster.mdx
+++ b/docs/content/guides/migrations/observe-your-airflow-pipelines-with-dagster.mdx
@@ -7,7 +7,7 @@ description: "Learn how to leverage the features of Dagster and Airflow together
 
 Dagster can act as a single entry point to all orchestration platforms in use at your organization. By injecting a small amount of code into your existing pipelines, you can report events to Dagster, where you can then visualize the full lineage of pipelines. This can be particularly useful if you have multiple Apache Airflow environments, and hope to build a catalog and observation platform through Dagster.
 
-### Emitting materialization events from Airflow to Dagster
+## Emitting materialization events from Airflow to Dagster
 
 Imagine you have a large number of pipelines written in Apache Airflow and wish to introduce Dagster into your stack. By using custom Airflow operators, you can continue to run your existing pipelines while you work toward migrating them off Airflow, or while building new pipelines in Dagster that are tightly integrated with your legacy systems.
 


### PR DESCRIPTION
## Summary & Motivation

This PR adds a link for the Airflow + Pipes guide to the Migration guides page.

## How I Tested These Changes

## Changelog [New | Bug | Docs]

NOCHANGELOG
