### PR TITLE
Improve k8s pipes pod name sanitization

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -1,5 +1,6 @@
 import os
 import random
+import re
 import string
 from contextlib import contextmanager
 from pathlib import Path
@@ -43,7 +44,7 @@ from dagster_k8s.utils import get_common_labels
 
 
 def get_pod_name(run_id: str, op_name: str):
-    clean_op_name = op_name.replace("_", "-")
+    clean_op_name = re.sub("[^a-z0-9-]", "", op_name.lower().replace("_", "-"))
     suffix = "".join(random.choice(string.digits) for i in range(10))
     return f"dagster-{run_id[:18]}-{clean_op_name[:20]}-{suffix}"
 


### PR DESCRIPTION
Summary:
Restrict additional characters in addition to just underscores (most notably, capital letters, but other non-alphanumeric characters as well).

Test Plan: New test case

## Summary & Motivation

## How I Tested These Changes

## Changelog [New | Bug | Docs]

> Replace this message with a changelog entry, or `NOCHANGELOG`
