### PR TITLE
pin pydantic < 2.9.0

### DIFF
--- a/examples/temp_pins.txt
+++ b/examples/temp_pins.txt
@@ -11,3 +11,4 @@
 # temporarily introduce pins for these tests until the next version of
 # Dagster is published to PyPI.
 responses==0.23.1
+pydantic<2.9.0

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -110,7 +110,7 @@ setup(
         "universal_pathlib; python_version<'3.12'",
         "universal_pathlib>=0.2.0; python_version>='3.12'",
         # https://github.com/pydantic/pydantic/issues/5821
-        "pydantic>1.10.0,!= 1.10.7,<3",
+        "pydantic>1.10.0,!= 1.10.7,<2.9.0",
         "rich",
         "filelock",
         f"dagster-pipes{pin}",

--- a/python_modules/libraries/dagster-datahub/setup.py
+++ b/python_modules/libraries/dagster-datahub/setup.py
@@ -42,7 +42,7 @@ setup(
         f"dagster{pin}",
         "packaging",
         "requests",
-        "pydantic>=1.10.0,<3.0.0",
+        "pydantic>=1.10.0,<2.9.0",
     ],
     extras_require={},
     zip_safe=False,


### PR DESCRIPTION
## Summary & Motivation

pydantic 2.9.0 (released 2024-09-05) introduces some breaking changes causing 

| `TableMetadataSet` is not fully defined; you should define `TableColumn`, then call `TableMetadataSet.model_rebuild()`.

pinning to <2.9.0 should fix this

## How I Tested These Changes

existing tests