### PR TITLE
Remove forward imports in failed attempt to fix Pydantic 2.9 error

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/metadata_set.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/metadata_set.py
@@ -7,6 +7,8 @@ from typing_extensions import TypeVar
 from dagster import _check as check
 from dagster._core.definitions.metadata.metadata_value import (
     MetadataValue,
+    TableColumn as TableColumn,
+    TableColumnConstraints as TableColumnConstraints,
     TableColumnLineage,
     TableSchema,
 )


### PR DESCRIPTION
## Summary

Remove forward imports in a failed attempt to fix pydantic 2.9 complaints
