### PR TITLE
Add group by query param on timeline overview

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
@@ -136,13 +136,6 @@ export const OverviewTimelineRoot = ({Header}: Props) => {
     [rows, visibleObjectKeys],
   );
 
-  // Runs on initial render to ensure groupBy query param is set.
-  React.useEffect(() => {
-    if (!new URLSearchParams(window.location.search).has('groupBy')) {
-      setGroupRunsBy(groupRunsBy);
-    }
-  }, [setGroupRunsBy, groupRunsBy]);
-
   return (
     <>
       <Header refreshState={refreshState} />

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
@@ -136,6 +136,13 @@ export const OverviewTimelineRoot = ({Header}: Props) => {
     [rows, visibleObjectKeys],
   );
 
+  // Runs on initial render to ensure groupBy query param is set.
+  React.useEffect(() => {
+    if (!new URLSearchParams(window.location.search).has('groupBy')) {
+      setGroupRunsBy(groupRunsBy);
+    }
+  }, [setGroupRunsBy, groupRunsBy]);
+
   return (
     <>
       <Header refreshState={refreshState} />

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/useGroupTimelineRunsBy.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/useGroupTimelineRunsBy.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useMemo} from 'react';
+import {useHistory} from 'react-router-dom';
 
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
 
@@ -23,12 +24,18 @@ export const useGroupTimelineRunsBy = (
     [defaultValue],
   );
 
+  const history = useHistory();
   const [groupRunsBy, setGroupRunsBy] = useStateWithStorage(storageKey, validate);
   const setGroupByWithDefault = useCallback(
     (value: GroupRunsBy) => {
       setGroupRunsBy(value || defaultValue);
+
+      // Update URL with selected group by field
+      const searchParams = new URLSearchParams(window.location.search);
+      searchParams.set('groupBy', value || defaultValue);
+      history.replace({search: searchParams.toString()});
     },
-    [defaultValue, setGroupRunsBy],
+    [defaultValue, setGroupRunsBy, history],
   );
 
   return useMemo(() => [groupRunsBy, setGroupByWithDefault], [groupRunsBy, setGroupByWithDefault]);

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/useGroupTimelineRunsBy.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/useGroupTimelineRunsBy.tsx
@@ -1,5 +1,4 @@
-import {useCallback, useMemo, useEffect} from 'react';
-import {useHistory} from 'react-router-dom';
+import {useCallback, useMemo} from 'react';
 
 import {useQueryAndLocalStoragePersistedState} from '../hooks/useQueryAndLocalStoragePersistedState';
 
@@ -23,7 +22,6 @@ export const useGroupTimelineRunsBy = (
     [defaultValue],
   );
 
-  const history = useHistory();
   const [groupRunsBy, setGroupRunsBy] = useQueryAndLocalStoragePersistedState<GroupRunsBy>({
     localStorageKey: GROUP_BY_KEY,
     queryKey: 'groupBy',
@@ -40,16 +38,8 @@ export const useGroupTimelineRunsBy = (
     (value: GroupRunsBy) => {
       setGroupRunsBy(value || defaultValue);
     },
-    [defaultValue, setGroupRunsBy, history],
+    [defaultValue, setGroupRunsBy],
   );
-
-  // Runs on initial render to ensure groupBy query param is set.
-  useEffect(() => {
-    const searchParams = new URLSearchParams(location.search);
-    if (!searchParams.has('groupBy')) {
-      setGroupByWithDefault(defaultValue);
-    }
-  }, [location.search, setGroupByWithDefault, defaultValue]);
 
   return useMemo(() => [groupRunsBy, setGroupByWithDefault], [groupRunsBy, setGroupByWithDefault]);
 };


### PR DESCRIPTION
## Summary & Motivation
![image](https://github.com/user-attachments/assets/f82a538f-5322-4fec-a0b7-0a19b7bf3f0d)

- Added groupBy query param in URL to help track how many people group by job vs. automation
- Linear: https://linear.app/dagster-labs/issue/FE-526/can-we-track-the-state-of-this-toggle-in-the-url-somehow

## How I Tested These Changes
1. On local, navigated to `/overview/activity/timeline` page and ensured URL changed to add query param (?groupBy=job)
2. On local, navigated to `/overview/activity/timeline` page and changed Group by selector and ensured query param in URL changed accordingly

## Changelog [New]

[ui] Added a feature that adds a query param (?groupBy=) on the Timeline Overview page based on the Group by selector
