### PR TITLE
Fix deserialization of ignored invalid fields

### DIFF
--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -477,6 +477,7 @@ class UnpackContext:
     def clear_ignored_unknown_values(self, obj: T) -> T:
         if isinstance(obj, UnknownSerdesValue):
             self.observed_unknown_serdes_values.discard(obj)
+            self.clear_ignored_unknown_values(obj.value)
         elif isinstance(obj, (list, set, frozenset)):
             for inner in obj:
                 self.clear_ignored_unknown_values(inner)


### PR DESCRIPTION
## Summary & Motivation

The added test fails before the change, and succeeds after. The basic issue is that sub-fields of invalid fields can also be invalid, so we need to recurse into the object in order to avoid errors.

## How I Tested These Changes

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
