### PR TITLE
Revert "pin pydantic < 2.9.0 (#24258)", replace with pydantic < 2.10.0

### DIFF
--- a/examples/temp_pins.txt
+++ b/examples/temp_pins.txt
@@ -11,4 +11,6 @@
 # temporarily introduce pins for these tests until the next version of
 # Dagster is published to PyPI.
 responses==0.23.1
+
+# pydantic 2.9.0 release briefly broke dagster
 pydantic<2.9.0

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -110,7 +110,7 @@ setup(
         "universal_pathlib; python_version<'3.12'",
         "universal_pathlib>=0.2.0; python_version>='3.12'",
         # https://github.com/pydantic/pydantic/issues/5821
-        "pydantic>1.10.0,!= 1.10.7,<2.9.0",
+        "pydantic>1.10.0,!=1.10.7,<2.10",
         "rich",
         "filelock",
         f"dagster-pipes{pin}",

--- a/python_modules/libraries/dagster-datahub/setup.py
+++ b/python_modules/libraries/dagster-datahub/setup.py
@@ -42,7 +42,6 @@ setup(
         f"dagster{pin}",
         "packaging",
         "requests",
-        "pydantic>=1.10.0,<2.9.0",
     ],
     extras_require={},
     zip_safe=False,


### PR DESCRIPTION
This reverts commit 0875c0b3ca05938e7c81ffb32578ec711c0ce2eb.

## Summary & Motivation

## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
