### PR TITLE
[dagster-k8s] fix: Prevent job hang when Pod exits before init

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -528,7 +528,7 @@ class DagsterKubernetesClient:
         pod_name: str,
         namespace: str,
         wait_for_state: WaitForPodState = WaitForPodState.Ready,
-        wait_initial_timeout: float = DEFAULT_WAIT_TIMEOUT,
+        pod_launch_timeout: float = DEFAULT_WAIT_TIMEOUT,
         wait_timeout: float = DEFAULT_WAIT_TIMEOUT,
         wait_time_between_attempts: float = DEFAULT_WAIT_BETWEEN_ATTEMPTS,
         start_time: Any = None,
@@ -542,7 +542,7 @@ class DagsterKubernetesClient:
             namespace (str): Namespace in which the pod is located.
             wait_for_state (WaitForPodState, optional): Whether to wait for pod readiness or
                 termination. Defaults to waiting for readiness.
-            wait_initial_timeout (numeric, optional): Timeout after which to give up and raise exception
+            pod_launch_timeout (numeric, optional): Timeout after which to give up and raise exception
                 if the pod never appears. Defaults to DEFAULT_WAIT_TIMEOUT. Set to 0 to disable.
             wait_timeout (numeric, optional): Timeout after which to give up and raise exception.
                 Defaults to DEFAULT_WAIT_TIMEOUT. Set to 0 to disable.
@@ -561,7 +561,7 @@ class DagsterKubernetesClient:
         check.str_param(namespace, "namespace")
         check.inst_param(wait_for_state, "wait_for_state", WaitForPodState)
         check.numeric_param(wait_timeout, "wait_timeout")
-        check.numeric_param(wait_initial_timeout, "wait_initial_timeout")
+        check.numeric_param(pod_launch_timeout, "pod_launch_timeout")
         check.numeric_param(wait_time_between_attempts, "wait_time_between_attempts")
 
         self.logger(f'Waiting for pod "{pod_name}"')
@@ -579,7 +579,7 @@ class DagsterKubernetesClient:
             ).items
             pod = pods[0] if pods else None
 
-            if wait_initial_timeout and self.timer() - start > wait_initial_timeout:
+            if pod_launch_timeout and self.timer() - start > pod_launch_timeout:
                 raise DagsterK8sError(
                     f"Timed out while waiting for pod to become ready with pod info: {pod!s}"
                 )
@@ -603,7 +603,7 @@ class DagsterKubernetesClient:
             ).items
             pod = pods[0] if pods else None
             if pod is None:
-                raise DagsterK8sError("Pod was unexpectedly killed")
+                raise DagsterK8sError(f'Pod "{pod_name}" was unexpectedly killed')
 
             if wait_timeout and self.timer() - start > wait_timeout:
                 raise DagsterK8sError(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -525,21 +525,25 @@ class DagsterKubernetesClient:
 
     def wait_for_pod(
         self,
-        pod_name,
-        namespace,
-        wait_for_state=WaitForPodState.Ready,
-        wait_timeout=DEFAULT_WAIT_TIMEOUT,
-        wait_time_between_attempts=DEFAULT_WAIT_BETWEEN_ATTEMPTS,
-        start_time=None,
-        ignore_containers: Optional[Set] = None,
-    ):
+        pod_name: str,
+        namespace: str,
+        wait_for_state: WaitForPodState = WaitForPodState.Ready,
+        wait_initial_timeout: float = DEFAULT_WAIT_TIMEOUT,
+        wait_timeout: float = DEFAULT_WAIT_TIMEOUT,
+        wait_time_between_attempts: str = DEFAULT_WAIT_BETWEEN_ATTEMPTS,
+        start_time: Any = None,
+        ignore_containers: set | None = None,
+    ) -> None:
         """Wait for a pod to launch and be running, or wait for termination (useful for job pods).
 
         Args:
+        ----
             pod_name (str): Name of the pod to wait for.
             namespace (str): Namespace in which the pod is located.
             wait_for_state (WaitForPodState, optional): Whether to wait for pod readiness or
                 termination. Defaults to waiting for readiness.
+            wait_initial_timeout (numeric, optional): Timeout after which to give up and raise exception
+                if the pod never appears. Defaults to DEFAULT_WAIT_TIMEOUT. Set to 0 to disable.
             wait_timeout (numeric, optional): Timeout after which to give up and raise exception.
                 Defaults to DEFAULT_WAIT_TIMEOUT. Set to 0 to disable.
             wait_time_between_attempts (numeric, optional): Wait time between polling attempts. Defaults
@@ -549,15 +553,18 @@ class DagsterKubernetesClient:
                 when waiting for the pod to be ready/terminate.
 
         Raises:
+        ------
             DagsterK8sError: Raised when wait_timeout is exceeded or an error is encountered
+
         """
         check.str_param(pod_name, "pod_name")
         check.str_param(namespace, "namespace")
         check.inst_param(wait_for_state, "wait_for_state", WaitForPodState)
         check.numeric_param(wait_timeout, "wait_timeout")
+        check.numeric_param(wait_initial_timeout, "wait_initial_timeout")
         check.numeric_param(wait_time_between_attempts, "wait_time_between_attempts")
 
-        self.logger('Waiting for pod "%s"' % pod_name)
+        self.logger(f'Waiting for pod "{pod_name}"')
 
         start = start_time or self.timer()
 
@@ -568,17 +575,17 @@ class DagsterKubernetesClient:
 
         while True:
             pods = self.core_api.list_namespaced_pod(
-                namespace=namespace, field_selector="metadata.name=%s" % pod_name
+                namespace=namespace, field_selector=f"metadata.name={pod_name}"
             ).items
             pod = pods[0] if pods else None
 
-            if wait_timeout and self.timer() - start > wait_timeout:
+            if wait_initial_timeout and self.timer() - start > wait_initial_timeout:
                 raise DagsterK8sError(
-                    "Timed out while waiting for pod to become ready with pod info: %s" % str(pod)
+                    f"Timed out while waiting for pod to become ready with pod info: {pod!s}"
                 )
 
             if pod is None:
-                self.logger('Waiting for pod "%s" to launch...' % pod_name)
+                self.logger(f'Waiting for pod "{pod_name}" to launch...')
                 self.sleeper(wait_time_between_attempts)
                 continue
 
@@ -588,7 +595,20 @@ class DagsterKubernetesClient:
                 )
                 self.sleeper(wait_time_between_attempts)
                 continue
+            break
 
+        while True:
+            pods = self.core_api.list_namespaced_pod(
+                namespace=namespace, field_selector=f"metadata.name={pod_name}"
+            ).items
+            pod = pods[0] if pods else None
+            if pod is None:
+                raise DagsterK8sError("Pod was unexpectedly killed")
+
+            if wait_timeout and self.timer() - start > wait_timeout:
+                raise DagsterK8sError(
+                    f"Timed out while waiting for pod to get to status {wait_for_state} with pod info: {pod!s}"
+                )
             # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#containerstatus-v1-core
             all_statuses = []
             all_statuses.extend(pod.status.init_container_statuses or [])
@@ -614,11 +634,11 @@ class DagsterKubernetesClient:
                     # ready is boolean field of container status
                     ready = container_status.ready
                     if not ready:
-                        self.logger('Waiting for pod "%s" to become ready...' % pod_name)
+                        self.logger(f'Waiting for pod "{pod_name}" to become ready...')
                         self.sleeper(wait_time_between_attempts)
                         continue
                     else:
-                        self.logger('Pod "%s" is ready, done waiting' % pod_name)
+                        self.logger(f'Pod "{pod_name}" is ready, done waiting')
                         break
                 else:
                     check.invariant(
@@ -630,13 +650,13 @@ class DagsterKubernetesClient:
             elif state.waiting is not None:
                 # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#containerstatewaiting-v1-core
                 if state.waiting.reason == KubernetesWaitingReasons.PodInitializing:
-                    self.logger('Waiting for pod "%s" to initialize...' % pod_name)
+                    self.logger(f'Waiting for pod "{pod_name}" to initialize...')
                     self.sleeper(wait_time_between_attempts)
                     continue
                 if state.waiting.reason == KubernetesWaitingReasons.CreateContainerConfigError:
                     self.logger(
-                        'Pod "%s" is waiting due to a CreateContainerConfigError with message "%s"'
-                        " - trying again to see if it recovers" % (pod_name, state.waiting.message)
+                        f'Pod "{pod_name}" is waiting due to a CreateContainerConfigError with message "{state.waiting.message}"'
+                        " - trying again to see if it recovers"
                     )
                     self.sleeper(wait_time_between_attempts)
                     continue
@@ -662,7 +682,7 @@ class DagsterKubernetesClient:
                         f' Message="{state.waiting.message}"\n{debug_info}'
                     )
                 else:
-                    raise DagsterK8sError("Unknown issue: %s" % state.waiting)
+                    raise DagsterK8sError(f"Unknown issue: {state.waiting}")
 
             # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#containerstateterminated-v1-core
             elif state.terminated is not None:

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -530,9 +530,9 @@ class DagsterKubernetesClient:
         wait_for_state: WaitForPodState = WaitForPodState.Ready,
         wait_initial_timeout: float = DEFAULT_WAIT_TIMEOUT,
         wait_timeout: float = DEFAULT_WAIT_TIMEOUT,
-        wait_time_between_attempts: str = DEFAULT_WAIT_BETWEEN_ATTEMPTS,
+        wait_time_between_attempts: float = DEFAULT_WAIT_BETWEEN_ATTEMPTS,
         start_time: Any = None,
-        ignore_containers: set | None = None,
+        ignore_containers: Optional[Set] = None,
     ) -> None:
         """Wait for a pod to launch and be running, or wait for termination (useful for job pods).
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -461,7 +461,10 @@ def test_wait_for_pod_success():
 
     single_ready_running_pod = _pod_list_for_container_status(_ready_running_status())
 
-    mock_client.core_api.list_namespaced_pod.side_effect = [single_ready_running_pod, single_ready_running_pod]
+    mock_client.core_api.list_namespaced_pod.side_effect = [
+        single_ready_running_pod,
+        single_ready_running_pod,
+    ]
 
     pod_name = "a_pod"
 
@@ -479,7 +482,11 @@ def test_wait_for_launch_then_success():
     no_pods = V1PodList(items=[])
     single_ready_running_pod = _pod_list_for_container_status(_ready_running_status())
 
-    mock_client.core_api.list_namespaced_pod.side_effect = [no_pods, single_ready_running_pod, single_ready_running_pod]
+    mock_client.core_api.list_namespaced_pod.side_effect = [
+        no_pods,
+        single_ready_running_pod,
+        single_ready_running_pod,
+    ]
 
     pod_name = "a_pod"
 
@@ -540,7 +547,9 @@ def test_initial_timeout():
         mock_client.wait_for_pod(pod_name=pod_name, namespace="namespace")
 
     # value of pod info is big blob of serialized dict info
-    assert str(exc_info.value).startswith("Timed out while waiting for pod to become ready with pod info:")
+    assert str(exc_info.value).startswith(
+        "Timed out while waiting for pod to become ready with pod info:"
+    )
 
 
 def test_initial_timeout_with_no_pod():
@@ -685,7 +694,9 @@ def test_wait_for_termination_ready_then_terminate():
     pod_name = "a_pod"
     container_name = "a_name"
 
-    mock_client.wait_for_pod(pod_name=pod_name, namespace="namespace", wait_for_state=WaitForPodState.Terminated)
+    mock_client.wait_for_pod(
+        pod_name=pod_name, namespace="namespace", wait_for_state=WaitForPodState.Terminated
+    )
 
     assert_logger_calls(
         mock_client.logger,
@@ -704,7 +715,9 @@ def test_waiting_for_pod_initialize():
     mock_client = create_mocked_client(timer=create_timing_out_timer(num_good_ticks=3))
     single_waiting_pod = _pod_list_for_container_status(
         _create_status(
-            state=V1ContainerState(waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.PodInitializing)),
+            state=V1ContainerState(
+                waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.PodInitializing)
+            ),
             ready=False,
         )
     )
@@ -734,13 +747,17 @@ def test_waiting_for_pod_initialize():
 def test_waiting_for_pod_initialize_with_ignored_containers():
     mock_client = create_mocked_client(timer=create_timing_out_timer(num_good_ticks=4))
     ignored_waiting_container_status = _create_status(
-        state=V1ContainerState(waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.PodInitializing)),
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.PodInitializing)
+        ),
         ready=False,
         name="ignored",
     )
     ignored_ready = _ready_running_status(name="ignored")
     waiting_container_status = _create_status(
-        state=V1ContainerState(waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.PodInitializing)),
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.PodInitializing)
+        ),
         ready=False,
     )
     ready = _ready_running_status()
@@ -765,7 +782,9 @@ def test_waiting_for_pod_initialize_with_ignored_containers():
     ]
 
     pod_name = "a_pod"
-    mock_client.wait_for_pod(pod_name=pod_name, namespace="namespace", ignore_containers={"ignored"})
+    mock_client.wait_for_pod(
+        pod_name=pod_name, namespace="namespace", ignore_containers={"ignored"}
+    )
 
     assert_logger_calls(
         mock_client.logger,
@@ -820,7 +839,9 @@ def test_waiting_for_pod_container_creation():
     mock_client = create_mocked_client(timer=create_timing_out_timer(num_good_ticks=3))
     single_waiting_pod = _pod_list_for_container_status(
         _create_status(
-            state=V1ContainerState(waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.ContainerCreating)),
+            state=V1ContainerState(
+                waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.ContainerCreating)
+            ),
             ready=False,
         )
     )
@@ -927,6 +948,7 @@ def test_get_names_in_job():
 
     assert mock_client.get_pod_names_in_job("job", "namespace") == ["foo", "bar"]
 
+
 def test_wait_for_termination_pod_is_deleted():
     mock_client = create_mocked_client(timer=create_timing_out_timer(num_good_ticks=2))
 
@@ -935,12 +957,17 @@ def test_wait_for_termination_pod_is_deleted():
     )
 
     empty_pod_list = V1PodList(items=[])
-    mock_client.core_api.list_namespaced_pod.side_effect = [single_ready_running_pod, empty_pod_list]
+    mock_client.core_api.list_namespaced_pod.side_effect = [
+        single_ready_running_pod,
+        empty_pod_list,
+    ]
 
     pod_name = "a_pod"
 
     with pytest.raises(DagsterK8sError) as exc_info:
-        mock_client.wait_for_pod(pod_name=pod_name, namespace="namespace", wait_for_state=WaitForPodState.Terminated)
+        mock_client.wait_for_pod(
+            pod_name=pod_name, namespace="namespace", wait_for_state=WaitForPodState.Terminated
+        )
 
     assert str(exc_info.value).startswith(f'Pod "{pod_name}" was unexpectedly killed')
 
@@ -953,7 +980,10 @@ def test_wait_for_ready_pod_is_deleted():
     )
 
     empty_pod_list = V1PodList(items=[])
-    mock_client.core_api.list_namespaced_pod.side_effect = [single_not_ready_running_pod, empty_pod_list]
+    mock_client.core_api.list_namespaced_pod.side_effect = [
+        single_not_ready_running_pod,
+        empty_pod_list,
+    ]
 
     pod_name = "a_pod"
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -942,7 +942,7 @@ def test_wait_for_termination_pod_is_deleted():
     with pytest.raises(DagsterK8sError) as exc_info:
         mock_client.wait_for_pod(pod_name=pod_name, namespace="namespace", wait_for_state=WaitForPodState.Terminated)
 
-    assert str(exc_info.value).startswith("Pod was unexpectedly killed")
+    assert str(exc_info.value).startswith(f'Pod "{pod_name}" was unexpectedly killed')
 
 
 def test_wait_for_ready_pod_is_deleted():
@@ -960,4 +960,4 @@ def test_wait_for_ready_pod_is_deleted():
     with pytest.raises(DagsterK8sError) as exc_info:
         mock_client.wait_for_pod(pod_name=pod_name, namespace="namespace")
 
-    assert str(exc_info.value).startswith("Pod was unexpectedly killed")
+    assert str(exc_info.value).startswith(f'Pod "{pod_name}" was unexpectedly killed')


### PR DESCRIPTION
## Summary & Motivation
This is meant to address https://github.com/dagster-io/dagster/issues/22453

Previously, if a pod was Evicted by the Kubelet or force deleted before initialization was finished, the `wait_for_pod` function would simply wait forever, forcing us to kill the job.

To solve this, we added a wait timeout loop specifically for the initial pod creation. As soon as the pod is "seen" for the first time by the Kubernetes API, we break out of that loop and continue to the main logic loop of waiting for pod readiness.

If at any point in that second loop the pod no longer exists, we know that it was unexpectedly deleted, and thus we need to raise an error so that the job doesn't hang indefinitely.

## How I Tested These Changes
- Added unit tests 
- Ran successful jobs with these changes
- Killed pod on startup and confirmed that an error was raised, causing Dagster to retry the pod

```
$ python -m pytest python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
WARNING:root:Unable to detect CI environment.  No test analytics will be sent.
=========================================================================================================== test session starts ============================================================================================================
platform darwin -- Python 3.10.3, pytest-7.4.3, pluggy-1.3.0
rootdir: /Users/matthew.kuzyk/Code/Repo/mattk-dagster
configfile: pyproject.toml
plugins: syrupy-3.0.6, dependency-0.5.1, Faker-18.4.0, typeguard-4.1.5, mock-3.3.1, requests-mock-1.11.0, cov-2.10.1, xdist-3.3.1, buildkite-test-collector-0.1.7, anyio-4.2.0, rerunfailures-10.0
collected 35 items

python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py ...................................                                                                                                                 [100%]

--------------------------------------------------------------------------------------------------------- snapshot report summary ----------------------------------------------------------------------------------------------------------

====================================================================================================== 35 passed in 151.12s (0:02:31) ======================================================================================================
```
## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [x] `BUGFIX` _(Fixed job hang when Pod exits before init)_
- [ ] `DOCS` _(added or updated documentation)_
