### PR TITLE
[refactor] Use InstanceLoadableBy for AssetCheckExecutionRecord

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
@@ -1,20 +1,17 @@
 from typing import Iterable, Iterator, List, Mapping, Optional, Tuple, cast
 
 from dagster import _check as check
-from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
-from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.selector import RepositorySelector
-from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.code_location import CodeLocation
 from dagster._core.remote_representation.external import ExternalRepository
 from dagster._core.remote_representation.external_data import ExternalAssetCheck
 from dagster._core.storage.asset_check_execution_record import (
     AssetCheckExecutionRecord,
-    AssetCheckExecutionResolvedStatus,
+    AssetCheckExecutionRecordStatus,
     AssetCheckInstanceSupport,
 )
-from dagster._core.storage.event_log.base import AssetRecord
+from dagster._core.storage.dagster_run import RunRecord
 from dagster._core.workspace.context import WorkspaceRequestContext
 from packaging import version
 
@@ -23,7 +20,6 @@ from dagster_graphql.schema.asset_checks import (
     AssetChecksOrErrorUnion,
     GrapheneAssetCheck,
     GrapheneAssetCheckCanExecuteIndividually,
-    GrapheneAssetCheckExecution,
     GrapheneAssetCheckNeedsAgentUpgradeError,
     GrapheneAssetCheckNeedsMigrationError,
     GrapheneAssetCheckNeedsUserCodeUpgrade,
@@ -110,13 +106,21 @@ class AssetChecksLoader:
                     :limit_per_asset
                 ]
 
+        # prefetch the checks and prepare the runs that will be needed to resolve their statuses
+        # note: this would not be necessary if this was async
         all_check_keys = [
             external_check.key
             for external_checks in external_checks_by_asset_key.values()
             for external_check in external_checks
         ]
-        execution_loader = AssetChecksExecutionForLatestMaterializationLoader(
-            self._context.instance, check_keys=all_check_keys
+        check_records = AssetCheckExecutionRecord.blocking_get_many(self._context, all_check_keys)
+        RunRecord.prepare(
+            self._context,
+            [
+                r.run_id
+                for r in check_records
+                if r.status == AssetCheckExecutionRecordStatus.PLANNED
+            ],
         )
 
         asset_graph = self._context.asset_graph
@@ -141,7 +145,6 @@ class AssetChecksLoader:
                         GrapheneAssetCheck(
                             asset_check=external_check,
                             can_execute_individually=can_execute_individually,
-                            execution_loader=execution_loader,
                         )
                     )
                 graphene_checks[asset_key] = GrapheneAssetChecks(checks=graphene_checks_for_asset)
@@ -169,128 +172,3 @@ class AssetChecksLoader:
         )
 
         return self._checks[asset_key]
-
-
-def _execution_targets_latest_materialization(
-    instance: DagsterInstance,
-    asset_record: Optional[AssetRecord],
-    execution: AssetCheckExecutionRecord,
-    resolved_status: AssetCheckExecutionResolvedStatus,
-) -> bool:
-    # always show in progress checks
-    if resolved_status == AssetCheckExecutionResolvedStatus.IN_PROGRESS:
-        return True
-
-    latest_materialization = (
-        asset_record.asset_entry.last_materialization_record if asset_record else None
-    )
-
-    if not latest_materialization:
-        # asset hasn't been materialized yet, so no reason to hide the check
-        return True
-
-    # If the check is executed in the same run as the materialization, then show it.
-    # This is a workaround to support the 'stage then promote' graph asset pattern,
-    # where checks happen before a materialization.
-    latest_materialization_run_id = latest_materialization.event_log_entry.run_id
-    if latest_materialization_run_id == execution.run_id:
-        return True
-
-    if resolved_status in [
-        AssetCheckExecutionResolvedStatus.SUCCEEDED,
-        AssetCheckExecutionResolvedStatus.FAILED,
-    ]:
-        evaluation = cast(
-            AssetCheckEvaluation,
-            check.not_none(check.not_none(execution.event).dagster_event).event_specific_data,
-        )
-        if not evaluation.target_materialization_data:
-            # check ran before the materialization was created
-            return False
-
-        # if the check matches the latest materialization, then show it
-        return (
-            evaluation.target_materialization_data.storage_id == latest_materialization.storage_id
-        )
-
-    # in this case the evaluation didn't complete, so we don't have target_materialization_data
-    elif resolved_status in [
-        AssetCheckExecutionResolvedStatus.EXECUTION_FAILED,
-        AssetCheckExecutionResolvedStatus.SKIPPED,
-    ]:
-        # As a last ditch effort, check if the check's run was launched after the materialization's
-        latest_materialization_run_record = instance.get_run_record_by_id(
-            latest_materialization_run_id
-        )
-        execution_run_record = instance.get_run_record_by_id(execution.run_id)
-        return bool(
-            latest_materialization_run_record
-            and execution_run_record
-            and execution_run_record.create_timestamp
-            > latest_materialization_run_record.create_timestamp
-        )
-
-    else:
-        check.failed(f"Unexpected check status {resolved_status}")
-
-
-class AssetChecksExecutionForLatestMaterializationLoader:
-    def __init__(self, instance: DagsterInstance, check_keys: List[AssetCheckKey]):
-        self._instance = instance
-        self._check_keys = check_keys
-        self._executions: Optional[
-            Mapping[AssetCheckKey, Optional[GrapheneAssetCheckExecution]]
-        ] = None
-
-    def _fetch_executions(self) -> Mapping[AssetCheckKey, Optional[GrapheneAssetCheckExecution]]:
-        from dagster_graphql.implementation.fetch_asset_checks import (
-            get_asset_check_execution_statuses_by_id,
-        )
-
-        latest_executions_by_check_key = (
-            self._instance.event_log_storage.get_latest_asset_check_execution_by_key(
-                self._check_keys
-            )
-        )
-        statuses_by_execution_id = get_asset_check_execution_statuses_by_id(
-            self._instance, list(latest_executions_by_check_key.values())
-        )
-        asset_records_by_asset_key = {
-            record.asset_entry.asset_key: record
-            for record in self._instance.get_asset_records(
-                list({ck.asset_key for ck in self._check_keys})
-            )
-        }
-
-        self._executions = {}
-        for check_key in self._check_keys:
-            execution = latest_executions_by_check_key.get(check_key)
-            if not execution:
-                self._executions[check_key] = None
-            else:
-                resolved_status = statuses_by_execution_id[execution.id]
-                self._executions[check_key] = (
-                    GrapheneAssetCheckExecution(execution, resolved_status)
-                    if _execution_targets_latest_materialization(
-                        instance=self._instance,
-                        asset_record=asset_records_by_asset_key.get(check_key.asset_key),
-                        execution=execution,
-                        resolved_status=resolved_status,
-                    )
-                    else None
-                )
-
-        return self._executions
-
-    def get_execution_for_latest_materialization(
-        self, check_key: AssetCheckKey
-    ) -> Optional[GrapheneAssetCheckExecution]:
-        if self._executions is None:
-            self._executions = self._fetch_executions()
-
-        check.invariant(
-            check_key in self._executions,
-            f"Check key {check_key} not included in this loader.",
-        )
-
-        return self._executions[check_key]

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
@@ -1,18 +1,13 @@
-from typing import TYPE_CHECKING, Iterator, List, Mapping, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Iterator, List, Optional, Tuple
 
-import dagster._check as check
 from dagster import AssetKey
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
-from dagster._core.instance import DagsterInstance
+from dagster._core.loader import LoadingContext
 from dagster._core.remote_representation.code_location import CodeLocation
 from dagster._core.remote_representation.external import ExternalRepository
 from dagster._core.remote_representation.external_data import ExternalAssetCheck
-from dagster._core.storage.asset_check_execution_record import (
-    AssetCheckExecutionRecord,
-    AssetCheckExecutionRecordStatus,
-    AssetCheckExecutionResolvedStatus,
-)
-from dagster._core.storage.dagster_run import DagsterRunStatus, RunsFilter
+from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecordStatus
+from dagster._core.storage.dagster_run import RunRecord
 from dagster._core.workspace.context import WorkspaceRequestContext
 
 from dagster_graphql.implementation.fetch_assets import repository_iter
@@ -40,65 +35,21 @@ def has_asset_checks(
     )
 
 
-# fetch all statuses at once in order to batch the run query
-def get_asset_check_execution_statuses_by_id(
-    instance: DagsterInstance, executions: Sequence[AssetCheckExecutionRecord]
-) -> Mapping[int, AssetCheckExecutionResolvedStatus]:
-    planned_status_executions = [
-        e for e in executions if e.status == AssetCheckExecutionRecordStatus.PLANNED
-    ]
-    if planned_status_executions:
-        planned_status_run_ids = list({e.run_id for e in planned_status_executions})
-        planned_execution_runs_by_run_id = {
-            r.run_id: r
-            for r in instance.get_runs(filters=RunsFilter(run_ids=planned_status_run_ids))
-        }
-    else:
-        planned_execution_runs_by_run_id = {}
-
-    def _status_for_execution(
-        execution: AssetCheckExecutionRecord,
-    ) -> AssetCheckExecutionResolvedStatus:
-        record_status = execution.status
-
-        if record_status == AssetCheckExecutionRecordStatus.SUCCEEDED:
-            return AssetCheckExecutionResolvedStatus.SUCCEEDED
-        elif record_status == AssetCheckExecutionRecordStatus.FAILED:
-            return AssetCheckExecutionResolvedStatus.FAILED
-        # Asset checks stay in PLANNED status until the evaluation event arrives. Check if the run is
-        # still active, and if not, return the actual status.
-        elif record_status == AssetCheckExecutionRecordStatus.PLANNED:
-            run = planned_execution_runs_by_run_id.get(execution.run_id)
-
-            if not run:
-                # The run was deleted before it finished
-                return AssetCheckExecutionResolvedStatus.SKIPPED
-            elif run.is_finished:
-                if run.status == DagsterRunStatus.FAILURE:
-                    return AssetCheckExecutionResolvedStatus.EXECUTION_FAILED
-                else:
-                    return AssetCheckExecutionResolvedStatus.SKIPPED
-            else:
-                return AssetCheckExecutionResolvedStatus.IN_PROGRESS
-
-        else:
-            check.failed(f"Unexpected status {record_status}")
-
-    return {e.id: _status_for_execution(e) for e in executions}
-
-
 def fetch_asset_check_executions(
-    instance: DagsterInstance, asset_check_key: AssetCheckKey, limit: int, cursor: Optional[str]
+    loading_context: LoadingContext,
+    asset_check_key: AssetCheckKey,
+    limit: int,
+    cursor: Optional[str],
 ) -> List[GrapheneAssetCheckExecution]:
-    executions = instance.event_log_storage.get_asset_check_execution_history(
+    check_records = loading_context.instance.event_log_storage.get_asset_check_execution_history(
         check_key=asset_check_key,
         limit=limit,
         cursor=int(cursor) if cursor else None,
     )
-    statuses = get_asset_check_execution_statuses_by_id(instance, executions)
 
-    res = []
-    for execution in executions:
-        res.append(GrapheneAssetCheckExecution(execution, statuses[execution.id]))
+    RunRecord.prepare(
+        loading_context,
+        [r.run_id for r in check_records if r.status == AssetCheckExecutionRecordStatus.PLANNED],
+    )
 
-    return res
+    return [GrapheneAssetCheckExecution(check_record) for check_record in check_records]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Sequence, Union, cast
+from typing import Optional, Sequence, Union, cast
 
 import dagster._check as check
 import graphene
@@ -8,6 +8,7 @@ from dagster._core.definitions.asset_check_evaluation import (
     AssetCheckEvaluationTargetMaterializationData,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSeverity
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.events import DagsterEventType
 from dagster._core.remote_representation.external_data import ExternalAssetCheck
 from dagster._core.storage.asset_check_execution_record import (
@@ -20,11 +21,6 @@ from dagster_graphql.schema.asset_key import GrapheneAssetKey
 from dagster_graphql.schema.errors import GrapheneError
 from dagster_graphql.schema.metadata import GrapheneMetadataEntry
 from dagster_graphql.schema.util import ResolveInfo, non_null_list
-
-if TYPE_CHECKING:
-    from dagster_graphql.implementation.asset_checks_loader import (
-        AssetChecksExecutionForLatestMaterializationLoader,
-    )
 
 GrapheneAssetCheckExecutionResolvedStatus = graphene.Enum.from_enum(
     AssetCheckExecutionResolvedStatus
@@ -100,15 +96,11 @@ class GrapheneAssetCheckExecution(graphene.ObjectType):
     class Meta:
         name = "AssetCheckExecution"
 
-    def __init__(
-        self,
-        execution: AssetCheckExecutionRecord,
-        status: AssetCheckExecutionResolvedStatus,
-    ):
+    def __init__(self, execution: AssetCheckExecutionRecord):
         super().__init__()
+        self._execution = execution
         self.id = str(execution.id)
         self.runId = execution.run_id
-        self.status = status
         self.evaluation = (
             GrapheneAssetCheckEvaluation(execution.event)
             if execution.event
@@ -117,6 +109,9 @@ class GrapheneAssetCheckExecution(graphene.ObjectType):
         )
         self.timestamp = execution.create_timestamp
         self.stepKey = execution.event.step_key if execution.event else None
+
+    def resolve_status(self, graphene_info: "ResolveInfo") -> AssetCheckExecutionResolvedStatus:
+        return self._execution.resolve_status(graphene_info.context)
 
 
 class GrapheneAssetCheckCanExecuteIndividually(graphene.Enum):
@@ -141,17 +136,11 @@ class GrapheneAssetCheck(graphene.ObjectType):
     class Meta:
         name = "AssetCheck"
 
-    def __init__(
-        self,
-        asset_check: ExternalAssetCheck,
-        can_execute_individually,
-        execution_loader: "AssetChecksExecutionForLatestMaterializationLoader",
-    ):
+    def __init__(self, asset_check: ExternalAssetCheck, can_execute_individually):
         self._asset_check = asset_check
         self._can_execute_individually = can_execute_individually
-        self._execution_loader = execution_loader
 
-    def resolve_assetKey(self, _):
+    def resolve_assetKey(self, _) -> AssetKey:
         return self._asset_check.asset_key
 
     def resolve_name(self, _) -> str:
@@ -163,11 +152,14 @@ class GrapheneAssetCheck(graphene.ObjectType):
     def resolve_jobNames(self, _) -> Sequence[str]:
         return self._asset_check.job_names
 
-    def resolve_executionForLatestMaterialization(
-        self, _graphene_info: ResolveInfo
+    async def resolve_executionForLatestMaterialization(
+        self, graphene_info: ResolveInfo
     ) -> Optional[GrapheneAssetCheckExecution]:
-        return self._execution_loader.get_execution_for_latest_materialization(
-            self._asset_check.key
+        record = await AssetCheckExecutionRecord.gen(graphene_info.context, self._asset_check.key)
+        return (
+            GrapheneAssetCheckExecution(record)
+            if record and record.targets_latest_materialization(graphene_info.context)
+            else None
         )
 
     def resolve_canExecuteIndividually(self, _) -> GrapheneAssetCheckCanExecuteIndividually:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -1305,7 +1305,7 @@ class GrapheneQuery(graphene.ObjectType):
         cursor: Optional[str] = None,
     ):
         return fetch_asset_check_executions(
-            graphene_info.context.instance,
+            graphene_info.context,
             asset_check_key=AssetCheckKey(
                 asset_key=AssetKey.from_graphql_input(assetKey), name=checkName
             ),

--- a/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
@@ -1,8 +1,13 @@
 import enum
-from typing import NamedTuple, Optional
+from typing import Iterable, NamedTuple, Optional, cast
 
 import dagster._check as check
+from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
+from dagster._core.definitions.asset_key import AssetCheckKey
 from dagster._core.events.log import DagsterEventType, EventLogEntry
+from dagster._core.instance import DagsterInstance
+from dagster._core.loader import InstanceLoadableBy, LoadingContext
+from dagster._core.storage.dagster_run import DagsterRunStatus, RunRecord
 from dagster._serdes.serdes import deserialize_value
 from dagster._time import utc_datetime_from_naive
 
@@ -37,6 +42,7 @@ class AssetCheckExecutionRecord(
     NamedTuple(
         "_AssetCheckExecutionRecord",
         [
+            ("key", AssetCheckKey),
             ("id", int),
             ("run_id", str),
             ("status", AssetCheckExecutionRecordStatus),
@@ -46,16 +52,19 @@ class AssetCheckExecutionRecord(
             ("event", Optional[EventLogEntry]),
             ("create_timestamp", float),
         ],
-    )
+    ),
+    InstanceLoadableBy[AssetCheckKey],
 ):
     def __new__(
         cls,
+        key: AssetCheckKey,
         id: int,
         run_id: str,
         status: AssetCheckExecutionRecordStatus,
         event: Optional[EventLogEntry],
         create_timestamp: float,
     ):
+        check.inst_param(key, "key", AssetCheckKey)
         check.int_param(id, "id")
         check.str_param(run_id, "run_id")
         check.inst_param(status, "status", AssetCheckExecutionRecordStatus)
@@ -81,6 +90,7 @@ class AssetCheckExecutionRecord(
 
         return super(AssetCheckExecutionRecord, cls).__new__(
             cls,
+            key=key,
             id=id,
             run_id=run_id,
             status=status,
@@ -88,9 +98,19 @@ class AssetCheckExecutionRecord(
             create_timestamp=create_timestamp,
         )
 
+    @property
+    def evaluation(self) -> Optional[AssetCheckEvaluation]:
+        if self.event and self.event.dagster_event:
+            return cast(
+                AssetCheckEvaluation,
+                self.event.dagster_event.event_specific_data,
+            )
+        return None
+
     @classmethod
-    def from_db_row(cls, row) -> "AssetCheckExecutionRecord":
+    def from_db_row(cls, row, key: AssetCheckKey) -> "AssetCheckExecutionRecord":
         return cls(
+            key=key,
             id=row["id"],
             run_id=row["run_id"],
             status=AssetCheckExecutionRecordStatus(row["execution_status"]),
@@ -101,3 +121,91 @@ class AssetCheckExecutionRecord(
             ),
             create_timestamp=utc_datetime_from_naive(row["create_timestamp"]).timestamp(),
         )
+
+    @classmethod
+    def _blocking_batch_load(
+        cls, keys: Iterable[AssetCheckKey], instance: DagsterInstance
+    ) -> Iterable[Optional["AssetCheckExecutionRecord"]]:
+        records_by_key = instance.event_log_storage.get_latest_asset_check_execution_by_key(
+            list(keys)
+        )
+        return [records_by_key.get(key) for key in keys]
+
+    def resolve_status(self, loading_context: LoadingContext) -> AssetCheckExecutionResolvedStatus:
+        if self.status == AssetCheckExecutionRecordStatus.SUCCEEDED:
+            return AssetCheckExecutionResolvedStatus.SUCCEEDED
+        elif self.status == AssetCheckExecutionRecordStatus.FAILED:
+            return AssetCheckExecutionResolvedStatus.FAILED
+        elif self.status == AssetCheckExecutionRecordStatus.PLANNED:
+            # Asset checks stay in PLANNED status until the evaluation event arrives.
+            # Check if the run is still active, and if not, return the actual status.
+            run_record = RunRecord.blocking_get(loading_context, self.run_id)
+            if not run_record:
+                # Run deleted
+                return AssetCheckExecutionResolvedStatus.SKIPPED
+
+            run = run_record.dagster_run
+            if run.is_finished:
+                return (
+                    AssetCheckExecutionResolvedStatus.EXECUTION_FAILED
+                    if run.status == DagsterRunStatus.FAILURE
+                    else AssetCheckExecutionResolvedStatus.SKIPPED
+                )
+            else:
+                return AssetCheckExecutionResolvedStatus.IN_PROGRESS
+        else:
+            check.failed(f"Unexpected status {self.status}")
+
+    def targets_latest_materialization(self, loading_context: LoadingContext) -> bool:
+        from dagster._core.storage.event_log.base import AssetRecord
+
+        resolved_status = self.resolve_status(loading_context)
+        if resolved_status == AssetCheckExecutionResolvedStatus.IN_PROGRESS:
+            # all in-progress checks execute against the latest version
+            return True
+
+        asset_record = AssetRecord.blocking_get(loading_context, self.key.asset_key)
+        latest_materialization = (
+            asset_record.asset_entry.last_materialization_record if asset_record else None
+        )
+        if not latest_materialization:
+            # no previous materialization, so it's executing against the lastest version
+            return True
+
+        latest_materialization_run_id = latest_materialization.event_log_entry.run_id
+        if latest_materialization_run_id == self.run_id:
+            # part of the same run
+            return True
+
+        if resolved_status in [
+            AssetCheckExecutionResolvedStatus.SUCCEEDED,
+            AssetCheckExecutionResolvedStatus.FAILED,
+        ]:
+            evaluation = check.not_none(self.evaluation)
+            if not evaluation.target_materialization_data:
+                # check ran before the materialization was created
+                return False
+            else:
+                # check matches the latest materialization id
+                return (
+                    evaluation.target_materialization_data.storage_id
+                    == latest_materialization.storage_id
+                )
+        elif resolved_status in [
+            AssetCheckExecutionResolvedStatus.EXECUTION_FAILED,
+            AssetCheckExecutionResolvedStatus.SKIPPED,
+        ]:
+            # the evaluation didn't complete, so we don't have target_materialization_data, so check if
+            # the check's run executed after the materializations as a fallback
+            latest_materialization_run_record = RunRecord.blocking_get(
+                loading_context, latest_materialization_run_id
+            )
+            check_run_record = RunRecord.blocking_get(loading_context, self.run_id)
+            return bool(
+                latest_materialization_run_record
+                and check_run_record
+                and check_run_record.create_timestamp
+                > latest_materialization_run_record.create_timestamp
+            )
+        else:
+            check.failed(f"Unexpected check status {resolved_status}")


### PR DESCRIPTION
## Summary & Motivation

As title. This lets us get rid of a lot of complicated and bespoke code used for caching objects of different types.

Note that there is some weirdness that remains that requires us to eagerly prefetch data up front.

## How I Tested These Changes

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
