### PR TITLE
[3/k][ui] Hide kind tags from search results, filter list

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/search/BuildAssetSearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/BuildAssetSearchResults.tsx
@@ -1,5 +1,6 @@
 import {COMMON_COLLATOR} from '../app/Util';
 import {AssetTableDefinitionFragment} from '../assets/types/AssetTableFragment.types';
+import {isKindTag} from '../graph/KindTags';
 import {DefinitionTag} from '../graphql/types';
 import {buildTagString} from '../ui/tagAsString';
 import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
@@ -96,6 +97,10 @@ export function buildAssetCountBySection(assets: AssetDefinitionMetadata[]): Ass
       }
 
       assetDefinition.tags.forEach((tag) => {
+        // Skip kind tags
+        if (isKindTag(tag)) {
+          return;
+        }
         const stringifiedTag = JSON.stringify(tag);
         assetCountByTag.increment(stringifiedTag);
       });

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useAssetTagFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useAssetTagFilter.tsx
@@ -2,6 +2,7 @@ import isEqual from 'lodash/isEqual';
 import memoize from 'lodash/memoize';
 import {useMemo} from 'react';
 
+import {isKindTag} from '../../graph/KindTags';
 import {DefinitionTag} from '../../graphql/types';
 import {TruncatedTextWithFullTextOnHover} from '../../nav/getLeftNavItemsForOption';
 import {StaticBaseConfig, useStaticSetFilter} from '../BaseFilters/useStaticSetFilter';
@@ -53,7 +54,12 @@ export function useAssetTagsForAssets(
       Array.from(
         new Set(
           assets
-            .flatMap((a) => a.definition?.tags?.map((tag) => JSON.stringify(tag)) ?? [])
+            .flatMap(
+              (a) =>
+                a.definition?.tags
+                  ?.filter((tag) => !isKindTag(tag))
+                  .map((tag) => JSON.stringify(tag)) ?? [],
+            )
             .filter((o) => o),
         ),
       )


### PR DESCRIPTION
## Summary

Filters out the set of kind tags from the list of tags that the user can filter, and the list of tags that show up in the Catalog page categories, since these are represented by separate kinds filters and section, respectively.

## Test Plan

Tested locally.