### PR TITLE
[4/k][ui] Hide kind tags by default from asset view

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
@@ -18,6 +18,7 @@ export const isCanonicalComputeKindTag = (tag: DefinitionTag) =>
 export const isCanonicalStorageKindTag = (tag: DefinitionTag) => tag.key === STORAGE_KIND_TAG;
 
 export const isKindTag = (tag: DefinitionTag) => tag.key.startsWith(KIND_TAG_PREFIX);
+export const isSystemTag = isKindTag;
 export const getKindFromTag = (tag: DefinitionTag) => tag.key.slice(KIND_TAG_PREFIX.length);
 
 export const AssetComputeKindTag = ({


### PR DESCRIPTION
## Summary

Adds a new collapsible "system tags" section to the tags pane in the asset sidebar. This is used currently solely for kind tags, which are hidden by default.
<img width="326" alt="Screenshot 2024-09-06 at 11 26 05 AM" src="https://github.com/user-attachments/assets/c2495b90-6a8d-46e9-9fca-ece9cd2c8b3c">
<img width="341" alt="Screenshot 2024-09-06 at 11 25 58 AM" src="https://github.com/user-attachments/assets/676cb9a1-f035-462c-bba7-3e3aa4783440">



## Test Plan

Tested locally.