### PR TITLE
respect tick status filters in batch loaded sensors

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_ticks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_ticks.py
@@ -46,7 +46,7 @@ def get_instigation_ticks(
 
     statuses = [TickStatus(status) for status in status_strings] if status_strings else None
 
-    if batch_loader and limit and not cursor and not before and not after:
+    if batch_loader and limit and not cursor and not before and not after and not statuses:
         if instigator_type == InstigatorType.SENSOR:
             ticks = batch_loader.get_sensor_ticks(
                 instigator_origin_id,


### PR DESCRIPTION
## Summary & Motivation
Returning unfiltered tick statuses.

## How I Tested These Changes
BK

## Changelog
- [ ] `BUGFIX` fixed bug where the tick status filter for batch fetched graphql sensors was not being respected
