### PR TITLE
[chore] print changes wanted by ruff during CI check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ ruff:
 	ruff format .
 
 check_ruff:
-	ruff check .
-	ruff format --check .
+	ruff check --diff .
+	ruff format --diff --check .
 
 check_prettier:
 #NOTE:  excludes README.md because it's a symlink


### PR DESCRIPTION
## Summary & Motivation

Adding `--diff` option to `ruff check` and `ruff format` CI checks. This will cause `ruff` to print a diff for proposed changes which is easy to copy and share with contributors. 

## How I Tested These Changes

## Changelog

NOCHANGELOG
