### PR TITLE
[dagster-airlift] local migration state

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_cacheable_assets_def.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_cacheable_assets_def.py
@@ -295,7 +295,7 @@ def construct_cacheable_assets_and_infer_dependencies(
                 },
                 tags={
                     **spec.tags,
-                    MIGRATED_TAG: str(migration_state_for_task),
+                    MIGRATED_TAG: str(bool(migration_state_for_task)),
                 },
                 deps=spec_deps,
                 group_name=spec.group_name,

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_instance.py
@@ -1,7 +1,9 @@
 import datetime
 import json
+import os
 from abc import ABC
 from functools import cached_property
+from pathlib import Path
 from typing import Any, Dict, List, Sequence
 
 import requests
@@ -10,7 +12,11 @@ from dagster._core.errors import DagsterError
 from dagster._record import record
 from dagster._time import get_current_datetime
 
-from dagster_airlift.migration_state import AirflowMigrationState, DagMigrationState
+from dagster_airlift.migration_state import (
+    AirflowMigrationState,
+    DagMigrationState,
+    load_migration_state_from_yaml,
+)
 
 from .utils import convert_to_valid_dagster_name
 
@@ -80,7 +86,39 @@ class AirflowInstance:
                 "Failed to fetch variables. Status code: {response.status_code}, Message: {response.text}"
             )
 
+    def configuration(self) -> Dict[str, Any]:
+        response = self.auth_backend.get_session().get(
+            f"{self.get_api_url()}/config", headers={"Accept": "application/json"}
+        )
+        if response.status_code == 200:
+            return response.json()
+        else:
+            raise DagsterError(
+                "Failed to fetch configuration. Status code: {response.status_code}, Message: {response.text}"
+            )
+
+    def is_using_sqlite_backend(self) -> bool:
+        config = self.configuration()
+        database_section = next(
+            iter(section for section in config["sections"] if section["name"] == "database")
+        )
+        sql_alchemy_conn = next(
+            iter(
+                section
+                for section in database_section["options"]
+                if section["key"] == "sql_alchemy_conn"
+            )
+        )
+        return sql_alchemy_conn["value"].startswith("sqlite")
+
     def get_migration_state(self) -> AirflowMigrationState:
+        if self.is_using_sqlite_backend():
+            local_migration_dir = os.getenv("DAGSTER_AIRLIFT_MIGRATION_STATE_DIR")
+            if local_migration_dir is None:
+                raise DagsterError(
+                    "Using sqlite backend, but missing DAGSTER_AIRLIFT_MIGRATION_STATE_DIR env var. When using sqlite backend, you must set this env var to point to the directory containing the migration state."
+                )
+            return load_migration_state_from_yaml(Path(local_migration_dir))
         variables = self.list_variables()
         dag_dict = {}
         for var_dict in variables:

--- a/examples/experimental/dagster-airlift/dagster_airlift/test/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/test/__init__.py
@@ -1,5 +1,4 @@
 from .airflow_test_instance import (
-    DEFAULT_TEST_CONFIG as DEFAULT_TEST_CONFIG,
     AirflowInstanceFake as AirflowInstanceFake,
     DummyAuthBackend as DummyAuthBackend,
     make_dag_info as make_dag_info,

--- a/examples/experimental/dagster-airlift/dagster_airlift/test/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/test/__init__.py
@@ -1,4 +1,5 @@
 from .airflow_test_instance import (
+    DEFAULT_TEST_CONFIG as DEFAULT_TEST_CONFIG,
     AirflowInstanceFake as AirflowInstanceFake,
     DummyAuthBackend as DummyAuthBackend,
     make_dag_info as make_dag_info,

--- a/examples/experimental/dagster-airlift/dagster_airlift/test/airflow_test_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/test/airflow_test_instance.py
@@ -8,12 +8,6 @@ from dagster_airlift.core import AirflowInstance
 from dagster_airlift.core.airflow_instance import DagInfo, DagRun, TaskInfo, TaskInstance
 from dagster_airlift.core.basic_auth import AirflowAuthBackend
 
-DEFAULT_TEST_CONFIG = {
-    "sections": [
-        {"name": "database", "options": [{"key": "sql_alchemy_conn", "value": "postgres://"}]},
-    ],
-}
-
 
 class DummyAuthBackend(AirflowAuthBackend):
     def get_session(self) -> requests.Session:
@@ -33,7 +27,6 @@ class AirflowInstanceFake(AirflowInstance):
         task_instances: List[TaskInstance],
         dag_runs: List[DagRun],
         variables: List[Dict[str, Any]] = [],
-        config: Dict[str, Any] = {},
     ) -> None:
         self._dag_infos_by_dag_id = {dag_info.dag_id: dag_info for dag_info in dag_infos}
         self._task_infos_by_dag_and_task_id = {
@@ -51,7 +44,6 @@ class AirflowInstanceFake(AirflowInstance):
             self._dag_runs_by_dag_id[dag_run.dag_id].append(dag_run)
         self._dag_infos_by_file_token = {dag_info.file_token: dag_info for dag_info in dag_infos}
         self._variables = variables
-        self._config = config
         super().__init__(
             auth_backend=DummyAuthBackend(),
             name="test_instance",
@@ -62,9 +54,6 @@ class AirflowInstanceFake(AirflowInstance):
 
     def list_variables(self) -> List[Dict[str, Any]]:
         return self._variables
-
-    def configuration(self) -> Dict[str, Any]:
-        return self._config
 
     def get_dag_runs(self, dag_id: str, start_date: datetime, end_date: datetime) -> List[DagRun]:
         if dag_id not in self._dag_runs_by_dag_id:
@@ -195,7 +184,6 @@ def make_dag_run(dag_id: str, run_id: str, start_date: datetime, end_date: datet
 def make_instance(
     dag_and_task_structure: Dict[str, List[str]],
     dag_runs: List[DagRun] = [],
-    config: Dict[str, Any] = DEFAULT_TEST_CONFIG,
 ) -> AirflowInstanceFake:
     """Constructs DagInfo, TaskInfo, and TaskInstance objects from provided data.
 
@@ -232,5 +220,4 @@ def make_instance(
         task_infos=task_infos,
         task_instances=task_instances,
         dag_runs=dag_runs,
-        config=config,
     )

--- a/examples/experimental/dagster-airlift/dagster_airlift/test/airflow_test_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/test/airflow_test_instance.py
@@ -8,6 +8,12 @@ from dagster_airlift.core import AirflowInstance
 from dagster_airlift.core.airflow_instance import DagInfo, DagRun, TaskInfo, TaskInstance
 from dagster_airlift.core.basic_auth import AirflowAuthBackend
 
+DEFAULT_TEST_CONFIG = {
+    "sections": [
+        {"name": "database", "options": [{"key": "sql_alchemy_conn", "value": "postgres://"}]},
+    ],
+}
+
 
 class DummyAuthBackend(AirflowAuthBackend):
     def get_session(self) -> requests.Session:
@@ -27,6 +33,7 @@ class AirflowInstanceFake(AirflowInstance):
         task_instances: List[TaskInstance],
         dag_runs: List[DagRun],
         variables: List[Dict[str, Any]] = [],
+        config: Dict[str, Any] = {},
     ) -> None:
         self._dag_infos_by_dag_id = {dag_info.dag_id: dag_info for dag_info in dag_infos}
         self._task_infos_by_dag_and_task_id = {
@@ -44,6 +51,7 @@ class AirflowInstanceFake(AirflowInstance):
             self._dag_runs_by_dag_id[dag_run.dag_id].append(dag_run)
         self._dag_infos_by_file_token = {dag_info.file_token: dag_info for dag_info in dag_infos}
         self._variables = variables
+        self._config = config
         super().__init__(
             auth_backend=DummyAuthBackend(),
             name="test_instance",
@@ -54,6 +62,9 @@ class AirflowInstanceFake(AirflowInstance):
 
     def list_variables(self) -> List[Dict[str, Any]]:
         return self._variables
+
+    def configuration(self) -> Dict[str, Any]:
+        return self._config
 
     def get_dag_runs(self, dag_id: str, start_date: datetime, end_date: datetime) -> List[DagRun]:
         if dag_id not in self._dag_runs_by_dag_id:
@@ -184,6 +195,7 @@ def make_dag_run(dag_id: str, run_id: str, start_date: datetime, end_date: datet
 def make_instance(
     dag_and_task_structure: Dict[str, List[str]],
     dag_runs: List[DagRun] = [],
+    config: Dict[str, Any] = DEFAULT_TEST_CONFIG,
 ) -> AirflowInstanceFake:
     """Constructs DagInfo, TaskInfo, and TaskInstance objects from provided data.
 
@@ -220,4 +232,5 @@ def make_instance(
         task_infos=task_infos,
         task_instances=task_instances,
         dag_runs=dag_runs,
+        config=config,
     )

--- a/examples/experimental/dagster-airlift/dagster_airlift/test/shared_fixtures.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/test/shared_fixtures.py
@@ -4,7 +4,7 @@ import subprocess
 import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Callable, Generator
+from typing import Any, Callable, Generator, Optional
 
 import mock
 import pytest
@@ -139,12 +139,18 @@ def setup_dagster(dagster_home: str, dagster_defs_path: str) -> Generator[Any, N
 VAR_DICT = {}
 
 
-def dummy_get_var(key: str) -> str:
-    return VAR_DICT[key]
+def dummy_get_var(key: str) -> Optional[str]:
+    return VAR_DICT.get(key)
 
 
 def dummy_set_var(key: str, value: str, session: Any) -> None:
     return VAR_DICT.update({key: value})
+
+
+@pytest.fixture
+def sqlite_backend():
+    with environ({"AIRFLOW__CORE__SQL_ALCHEMY_CONN": "sqlite://"}):
+        yield
 
 
 @pytest.fixture

--- a/examples/experimental/dagster-airlift/dagster_airlift/utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/utils.py
@@ -1,0 +1,10 @@
+import os
+from pathlib import Path
+from typing import Optional
+
+DAGSTER_AIRLIFT_MIGRATION_STATE_DIR_ENV_VAR = "DAGSTER_AIRLIFT_MIGRATION_STATE_DIR"
+
+
+def get_local_migration_state_dir() -> Optional[Path]:
+    migration_dir = os.getenv(DAGSTER_AIRLIFT_MIGRATION_STATE_DIR_ENV_VAR)
+    return Path(migration_dir) if migration_dir else None

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Dict, List, Sequence, Tuple, Union
+from typing import Any, Dict, List, Sequence, Tuple, Union
 
 from dagster import (
     AssetKey,
@@ -18,7 +18,7 @@ from dagster._core.definitions.repository_definition.repository_definition impor
 )
 from dagster._time import get_current_datetime
 from dagster_airlift.core import build_defs_from_airflow_instance
-from dagster_airlift.test import make_dag_run, make_instance
+from dagster_airlift.test import DEFAULT_TEST_CONFIG, make_dag_run, make_instance
 
 
 def strip_to_first_of_month(dt: datetime) -> datetime:
@@ -42,6 +42,7 @@ def build_definitions_airflow_asset_graph(
     assets_per_task: Dict[str, Dict[str, List[Tuple[str, List[str]]]]],
     additional_defs: Definitions = Definitions(),
     create_runs: bool = True,
+    config: Dict[str, Any] = DEFAULT_TEST_CONFIG,
 ) -> Definitions:
     specs = []
     dag_and_task_structure = defaultdict(list)
@@ -72,6 +73,7 @@ def build_definitions_airflow_asset_graph(
     instance = make_instance(
         dag_and_task_structure=dag_and_task_structure,
         dag_runs=runs,
+        config=config,
     )
     defs = Definitions.merge(
         additional_defs,

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Sequence, Tuple, Union
+from typing import Dict, List, Sequence, Tuple, Union
 
 from dagster import (
     AssetKey,
@@ -10,6 +10,7 @@ from dagster import (
     SensorEvaluationContext,
     SensorResult,
     build_sensor_context,
+    multi_asset,
 )
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.events import AssetMaterialization
@@ -18,7 +19,7 @@ from dagster._core.definitions.repository_definition.repository_definition impor
 )
 from dagster._time import get_current_datetime
 from dagster_airlift.core import build_defs_from_airflow_instance
-from dagster_airlift.test import DEFAULT_TEST_CONFIG, make_dag_run, make_instance
+from dagster_airlift.test import make_dag_run, make_instance
 
 
 def strip_to_first_of_month(dt: datetime) -> datetime:
@@ -42,21 +43,28 @@ def build_definitions_airflow_asset_graph(
     assets_per_task: Dict[str, Dict[str, List[Tuple[str, List[str]]]]],
     additional_defs: Definitions = Definitions(),
     create_runs: bool = True,
-    config: Dict[str, Any] = DEFAULT_TEST_CONFIG,
+    create_assets_defs: bool = True,
 ) -> Definitions:
-    specs = []
+    assets = []
     dag_and_task_structure = defaultdict(list)
     for dag_id, task_structure in assets_per_task.items():
         for task_id, asset_structure in task_structure.items():
             dag_and_task_structure[dag_id].append(task_id)
             for asset_key, deps in asset_structure:
-                specs.append(
-                    AssetSpec(
-                        asset_key,
-                        deps=deps,
-                        metadata={"airlift/dag_id": dag_id, "airlift/task_id": task_id},
-                    )
+                spec = AssetSpec(
+                    asset_key,
+                    deps=deps,
+                    metadata={"airlift/dag_id": dag_id, "airlift/task_id": task_id},
                 )
+                if create_assets_defs:
+
+                    @multi_asset(specs=[spec])
+                    def _asset():
+                        return None
+
+                    assets.append(_asset)
+                else:
+                    assets.append(spec)
     runs = (
         [
             make_dag_run(
@@ -73,11 +81,10 @@ def build_definitions_airflow_asset_graph(
     instance = make_instance(
         dag_and_task_structure=dag_and_task_structure,
         dag_runs=runs,
-        config=config,
     )
     defs = Definitions.merge(
         additional_defs,
-        Definitions(assets=specs),
+        Definitions(assets=assets),
     )
     return build_defs_from_airflow_instance(instance, defs=defs)
 

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/migration_state_for_sqlite_test/dag.yaml
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/migration_state_for_sqlite_test/dag.yaml
@@ -1,3 +1,3 @@
 tasks:
   - id: task
-    migrated: False 
+    migrated: True 

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/migration_state_for_sqlite_test/dag.yaml
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/migration_state_for_sqlite_test/dag.yaml
@@ -1,0 +1,3 @@
+tasks:
+  - id: task
+    migrated: False 

--- a/examples/experimental/dagster-airlift/examples/dbt-example/Makefile
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/Makefile
@@ -7,6 +7,7 @@ endef
 MAKEFILE_DIR := $(GET_MAKEFILE_DIR)
 export DAGSTER_HOME := $(MAKEFILE_DIR)/.dagster_home
 export AIRFLOW_HOME := $(MAKEFILE_DIR)/.airflow_home
+export DAGSTER_AIRLIFT_MIGRATION_STATE_DIR := $(MAKEFILE_DIR)/dbt_example/airflow_dags/migration_state
 export DBT_PROJECT_DIR := $(MAKEFILE_DIR)/dbt_example/shared/dbt
 export DBT_PROFILES_DIR := $(MAKEFILE_DIR)/dbt_example/shared/dbt
 export DAGSTER_URL := http://localhost:3333

--- a/examples/experimental/dagster-airlift/examples/perf-harness/.airflow_home/logs/scheduler/latest
+++ b/examples/experimental/dagster-airlift/examples/perf-harness/.airflow_home/logs/scheduler/latest
@@ -1,0 +1,1 @@
+/Users/christopherdecarolis/dagster/examples/experimental/dagster-airlift/examples/perf-harness/.airflow_home/logs/scheduler/2024-09-09

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/Makefile
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/Makefile
@@ -9,6 +9,7 @@ export TUTORIAL_EXAMPLE_DIR := $(MAKEFILE_DIR)
 export DAGSTER_HOME := $(MAKEFILE_DIR)/.dagster_home
 export AIRFLOW_HOME := $(MAKEFILE_DIR)/.airflow_home
 export TUTORIAL_DBT_PROJECT_DIR := $(MAKEFILE_DIR)/tutorial_example/shared/dbt
+export DAGSTER_AIRLIFT_MIGRATION_STATE_DIR := $(MAKEFILE_DIR)/tutorial_example/airflow_dags/migration_state
 export DBT_PROFILES_DIR := $(MAKEFILE_DIR)/tutorial_example/shared/dbt
 export DAGSTER_URL := http://localhost:3000
 


### PR DESCRIPTION
When sqlite is the airflow backend, expect that there will be an env var set to point dagster at the migration state folder.

How I tested this
Added unit tests for the airflow side as well as the dagster side.

`NOCHANGELOG`