### PR TITLE
Add sync capabilities to DataLoader class

### DIFF
--- a/python_modules/dagster/dagster/_core/loader.py
+++ b/python_modules/dagster/dagster/_core/loader.py
@@ -1,11 +1,11 @@
 from abc import ABC, abstractmethod
 from functools import partial
-from typing import TYPE_CHECKING, Dict, Generic, Iterable, Optional, Type, TypeVar
+from typing import TYPE_CHECKING, Dict, Generic, Iterable, Optional, Tuple, Type, TypeVar
 
 from typing_extensions import Self
 
 import dagster._check as check
-from dagster._utils.aiodataloader import DataLoader
+from dagster._utils.aiodataloader import BlockingDataLoader, DataLoader
 
 TResult = TypeVar("TResult")
 TKey = TypeVar("TKey")
@@ -55,19 +55,22 @@ class LoadingContext(ABC):
 
     @property
     @abstractmethod
-    def loaders(self) -> Dict[Type, DataLoader]:
+    def loaders(self) -> Dict[Type, Tuple[DataLoader, BlockingDataLoader]]:
         raise NotImplementedError()
 
-    def get_loader_for(self, ttype: Type["InstanceLoadableBy"]) -> DataLoader:
+    def get_loaders_for(
+        self, ttype: Type["InstanceLoadableBy"]
+    ) -> Tuple[DataLoader, BlockingDataLoader]:
         if ttype not in self.loaders:
             if not issubclass(ttype, InstanceLoadableBy):
                 check.failed(f"{ttype} is not Loadable")
 
-            self.loaders[ttype] = DataLoader(
-                batch_load_fn=partial(
-                    ttype._batch_load,  # noqa
-                    instance=self.instance,
-                ),
+            batch_load_fn = partial(ttype._batch_load, instance=self.instance)  # noqa
+            blocking_batch_load_fn = partial(ttype._blocking_batch_load, instance=self.instance)  # noqa
+
+            self.loaders[ttype] = (
+                DataLoader(batch_load_fn=batch_load_fn),
+                BlockingDataLoader(batch_load_fn=blocking_batch_load_fn),
             )
 
         return self.loaders[ttype]
@@ -80,18 +83,28 @@ class InstanceLoadableBy(ABC, Generic[TKey]):
     """Make An object Loadable by ID of type TKey using a DagsterInstance."""
 
     @classmethod
-    @abstractmethod
     async def _batch_load(
-        cls,
-        keys: Iterable[TKey],
-        instance: "DagsterInstance",
+        cls, keys: Iterable[TKey], instance: "DagsterInstance"
     ) -> Iterable[Optional[Self]]:
+        return cls._blocking_batch_load(keys, instance)
+
+    @classmethod
+    @abstractmethod
+    def _blocking_batch_load(
+        cls, keys: Iterable[TKey], instance: "DagsterInstance"
+    ) -> Iterable[Optional[Self]]:
+        # There is no good way of turning an async function into a sync one that
+        # will allow us to execute that sync function inside of a broader async context.
+        #
+        # In the spirit of allowing incremental migration from a fully-sync pattern to
+        # an async one, we provide two separate functions here to allow sync and async
+        # calls to coexist.
         raise NotImplementedError()
 
     @classmethod
     async def gen(cls, context: LoadingContext, id: TKey) -> Self:
         """Fetch an object by its id."""
-        loader = context.get_loader_for(cls)
+        loader, _ = context.get_loaders_for(cls)
         return await loader.load(id)
 
     @classmethod
@@ -99,5 +112,25 @@ class InstanceLoadableBy(ABC, Generic[TKey]):
         cls, context: LoadingContext, ids: Iterable[TKey]
     ) -> Iterable[Optional[Self]]:
         """Fetch N objects by their id."""
-        loader = context.get_loader_for(cls)
+        loader, _ = context.get_loaders_for(cls)
         return await loader.load_many(ids)
+
+    @classmethod
+    def blocking_get(cls, context: LoadingContext, id: TKey) -> Optional[Self]:
+        """Fetch an object by its id."""
+        _, blocking_loader = context.get_loaders_for(cls)
+        return blocking_loader.blocking_load(id)
+
+    @classmethod
+    def blocking_get_many(cls, context: LoadingContext, ids: Iterable[TKey]) -> Iterable[Self]:
+        """Fetch N objects by their id."""
+        # in the future, can consider priming the non-blocking loader with the results of this
+        # sync call
+        _, blocking_loader = context.get_loaders_for(cls)
+        return filter(None, blocking_loader.blocking_load_many(ids))
+
+    @classmethod
+    def prepare(cls, context: LoadingContext, ids: Iterable[TKey]) -> None:
+        """Ensure the provided ids will be fetched on the next blocking query."""
+        _, blocking_loader = context.get_loaders_for(cls)
+        blocking_loader.prepare(ids)

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -638,10 +638,8 @@ class RunRecord(
         )
 
     @classmethod
-    async def _batch_load(
-        cls,
-        keys: Iterable[str],
-        instance: "DagsterInstance",
+    def _blocking_batch_load(
+        cls, keys: Iterable[str], instance: "DagsterInstance"
     ) -> Iterable[Optional["RunRecord"]]:
         result_map: Dict[str, Optional[RunRecord]] = {run_id: None for run_id in keys}
 


### PR DESCRIPTION
## Summary & Motivation

This PR adds sync support for the DataLoader pattern.

The pattern itself is a very clean way of allowing us to avoid creating separate BatchXLoader objects and threading them through a bunch of different functions. However, it's not realistic (at least in the short term) to have all callsites which require this sort of caching behavior to be async. So adding this capability allows sync code to take advantage of a shared cache without major refactors.

One explicit choice made here is that it is *not* required to call "prepare" before doing a synchronous query, which differs a bit from our existing BatchXLoader objects, which require you to add your keys beforehand, otherwise they'll error.

Personally, I think this works out a lot nicer in practice, as it avoids an entire class of runtime errors, at the cost of making it a bit less visible if you do something inefficient. In reality, a lot existing callsites just add the key right before doing the query, which just feels painful.

Needed to add a separate _blocking_batch_load method because it's not possible to turn an async function into a sync function in a completely safe way.

## How I Tested These Changes

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
