### PR TITLE
fix beta docs build

### DIFF
--- a/docs/docs-beta/README.md
+++ b/docs/docs-beta/README.md
@@ -116,4 +116,4 @@ To build the site for production:
 yarn build
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+This command generates static content into the `build` directory and can be served using any static contents hosting service. This also checks for any broken links in the documentation.

--- a/docs/docs-beta/docs/intro.md
+++ b/docs/docs-beta/docs/intro.md
@@ -11,13 +11,12 @@ import { Card, CardGroup } from '@site/src/components/Cards';
 
 Dagster is a data orchestrator built for data engineers, with integrated lineage, observability, a declarative programming model and best-in-class testability.
 
-
 <CodeExample filePath="getting-started/hello-world.py" language="python" />
 
 ## Get started
 
 <CardGroup cols={3}>
-  <Card title="Quickstart" href="/tutorial/quick-start">
+  <Card title="Quickstart" href="/getting-started/quickstart">
       Build your first Dagster pipeline in our Quickstart tutorial.
   </Card>
   <Card title="Thinking in Assets"  href="/concepts/assets/thinking-in-assets">

--- a/docs/docs-beta/src/components/Cards.tsx
+++ b/docs/docs-beta/src/components/Cards.tsx
@@ -8,7 +8,7 @@ interface CardProps {
   children: React.ReactNode;
 }
 
-const Card: React.FC<CardProps> = ({ title, icon, href, children }) => (
+const Card: React.FC<CardProps> = ({title, icon, href, children}) => (
   <Link to={href} className="card">
     <h3>{title}</h3>
     <i className={`icon-${icon}`}></i>
@@ -21,10 +21,8 @@ interface CardGroupProps {
   children: React.ReactNode;
 }
 
-const CardGroup: React.FC<CardGroupProps> = ({ cols, children }) => (
-  <div className={`card-group cols-${cols}`}>
-    {children}
-  </div>
+const CardGroup: React.FC<CardGroupProps> = ({cols, children}) => (
+  <div className={`card-group cols-${cols}`}>{children}</div>
 );
 
-export { Card, CardGroup };
+export {Card, CardGroup};

--- a/docs/docs-beta/src/components/CodeExample.tsx
+++ b/docs/docs-beta/src/components/CodeExample.tsx
@@ -2,47 +2,47 @@ import React from 'react';
 import CodeBlock from '@theme/CodeBlock';
 
 interface CodeExampleProps {
-    filePath: string;
-    language?: string;
-    title?: string;
+  filePath: string;
+  language?: string;
+  title?: string;
 }
 
-const CodeExample: React.FC<CodeExampleProps> = ({ filePath, language, title }) => {
-    const [content, setContent] = React.useState<string>('');
-    const [error, setError] = React.useState<string | null>(null);
+const CodeExample: React.FC<CodeExampleProps> = ({filePath, language, title}) => {
+  const [content, setContent] = React.useState<string>('');
+  const [error, setError] = React.useState<string | null>(null);
 
-    language = language || 'python';
+  language = language || 'python';
 
-    React.useEffect(() => {
-        // Adjust the import path to start from the docs directory
-        import(`!!raw-loader!/../../examples/docs_beta_snippets/docs_beta_snippets/${filePath}`)
-            .then((module) => {
-                const lines = module.default.split('\n').map((line) => {
-                    return line.replaceAll(/#.*?noqa.*?$/g, '');
-                });
-                const mainIndex = lines.findIndex((line) => line.trim().startsWith('if __name__ == '));
-                const strippedContent =
-                    mainIndex !== -1 ? lines.slice(0, mainIndex).join('\n') : lines.join('\n');
-                setContent(strippedContent);
-                setError(null);
-            })
-            .catch((error) => {
-                console.error(`Error loading file: ${filePath}`, error);
-                setError(
-                    `Failed to load file: ${filePath}. Please check if the file exists and the path is correct.`,
-                );
-            });
-    }, [filePath]);
+  React.useEffect(() => {
+    // Adjust the import path to start from the docs directory
+    import(`!!raw-loader!/../../examples/docs_beta_snippets/docs_beta_snippets/${filePath}`)
+      .then((module) => {
+        const lines = module.default.split('\n').map((line) => {
+          return line.replaceAll(/#.*?noqa.*?$/g, '');
+        });
+        const mainIndex = lines.findIndex((line) => line.trim().startsWith('if __name__ == '));
+        const strippedContent =
+          mainIndex !== -1 ? lines.slice(0, mainIndex).join('\n') : lines.join('\n');
+        setContent(strippedContent);
+        setError(null);
+      })
+      .catch((error) => {
+        console.error(`Error loading file: ${filePath}`, error);
+        setError(
+          `Failed to load file: ${filePath}. Please check if the file exists and the path is correct.`,
+        );
+      });
+  }, [filePath]);
 
-    if (error) {
-        return <div style={{ color: 'red', padding: '1rem', border: '1px solid red' }}>{error}</div>;
-    }
+  if (error) {
+    return <div style={{color: 'red', padding: '1rem', border: '1px solid red'}}>{error}</div>;
+  }
 
-    return (
-        <CodeBlock language={language} title={title}>
-            {content || 'Loading...'}
-        </CodeBlock>
-    );
+  return (
+    <CodeBlock language={language} title={title}>
+      {content || 'Loading...'}
+    </CodeBlock>
+  );
 };
 
 export default CodeExample;


### PR DESCRIPTION
## Summary & Motivation
fix master beta docs build:
- fixed broken link (seems an oversight intro'ed from https://github.com/dagster-io/dagster/pull/24267)
- ran `yarn lint`, `yarn build`

## How I Tested These Changes
`yarn build` passes


- before: https://vercel.com/elementl/dagster-docs-beta/8XXsNCL1WTPyenbCKJtCH1YaxBsy?filter=errors
   ```
    Exhaustive list of all broken links found:
     - Broken link on source page path = /:
        -> linking to /tutorial/quick-start
   ```
- after: https://vercel.com/elementl/dagster-docs-beta/ARCKGoxukSyZt1wvM1aGqJ9fsHXk is green and https://dagster-docs-beta-4qfhiknub-elementl.vercel.app/ builds

## Changelog

`NOCHANGELOG`
