### PR TITLE
[sphinx-mdx-builder] support inline flags

### DIFF
--- a/docs/docs-beta/src/styles/custom.scss
+++ b/docs/docs-beta/src/styles/custom.scss
@@ -612,3 +612,42 @@ dd code {
     }
   }
 }
+
+
+/**
+ * api docs: inline flag
+ *
+ * available options:
+ * - info
+ * - danger
+ * - warning
+ */
+
+span {
+  &.flag {
+    font-weight: var(--ifm-font-weight-semibold);
+    border-radius: 8px;
+    padding-left: 4px;
+    padding-right: 4px;
+  }
+
+  &.flag-info {
+    background-color: var(--theme-color-background-cyan);
+    border: 1px solid var(--theme-color-text-cyan);
+    color: var(--theme-color-text-cyan);
+
+  }
+
+  &.flag-danger {
+    background-color: var(--theme-color-background-red);
+    border: 1px solid var(--theme-color-text-red);
+    color: var(--theme-color-text-red);
+  }
+
+  &.flag-warning {
+    background-color: var(--theme-color-background-yellow);
+    border: 1px solid var(--theme-color-text-yellow);
+    color: var(--theme-color-text-yellow);
+  }
+
+}

--- a/docs/docs-beta/src/styles/custom.scss
+++ b/docs/docs-beta/src/styles/custom.scss
@@ -633,20 +633,17 @@ span {
 
   &.flag-info {
     background-color: var(--theme-color-background-cyan);
-    border: 1px solid var(--theme-color-text-cyan);
     color: var(--theme-color-text-cyan);
 
   }
 
   &.flag-danger {
     background-color: var(--theme-color-background-red);
-    border: 1px solid var(--theme-color-text-red);
     color: var(--theme-color-text-red);
   }
 
   &.flag-warning {
     background-color: var(--theme-color-background-yellow);
-    border: 1px solid var(--theme-color-text-yellow);
     color: var(--theme-color-text-yellow);
   }
 

--- a/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/writers/mdx.py
+++ b/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/writers/mdx.py
@@ -839,21 +839,28 @@ class MdxTranslator(SphinxTranslator):
         self.current_row.append(text.replace("\n", ""))
         self.stateindent.pop()
 
-    # Dagster specific nodes
-    ###########################################################################
-    # TODO: Move these out of this module and extract out docusaurus
-    # style admonitions
+    ####################################################################################################
+    #                                         Dagster Specific                                         #
+    ####################################################################################################
+
+    # TODO: Move these out of this module and extract out docusaurus style admonitions
+
+    def _flag_to_level(self, flag_type: str) -> str:
+        """Maps flag type to style that will be using in CSS and admonitions."""
+        level = "info"
+        if flag_type == "experimental":
+            level = "warning"
+        if flag_type == "deprecated":
+            level = "danger"
+        return level
+
     def visit_flag(self, node: Element) -> None:
         flag_type = node.attributes["flag_type"]
         message = node.attributes["message"].replace(":::", "")
-        set_flag = "info"
-        if flag_type == "experimental":
-            set_flag = "danger"
-        if flag_type == "deprecated":
-            set_flag = "warning"
+        level = self._flag_to_level(flag_type)
 
         self.new_state()
-        self.add_text(f":::{set_flag}[{flag_type}]\n")
+        self.add_text(f":::{level}[{flag_type}]\n")
         self.add_text(f"{message}\n")
 
     def depart_flag(self, node: Element) -> None:
@@ -861,10 +868,13 @@ class MdxTranslator(SphinxTranslator):
         self.end_state(wrap=False)
 
     def visit_inline_flag(self, node: Element) -> None:
-        self.log_visit(node)
+        flag_type = node.attributes["flag_type"]
+        level = self._flag_to_level(flag_type)
+        self.add_text(f'<span className="flag flag-{level}">')
+        self.add_text(node.attributes["flag_type"])
 
     def depart_inline_flag(self, node: Element) -> None:
-        pass
+        self.add_text("</span>")
 
     def visit_collapse_node(self, node: Element) -> None:
         raise nodes.SkipNode

--- a/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/writers/mdx.py
+++ b/docs/sphinx/_ext/sphinx-mdx-builder/sphinxcontrib/mdxbuilder/writers/mdx.py
@@ -234,9 +234,20 @@ class MdxTranslator(SphinxTranslator):
         raise nodes.SkipNode
 
     def visit_Text(self, node: nodes.Text) -> None:
+        # print("->", type(node.parent), node.parent)
         if isinstance(node.parent, nodes.reference):
             return
+
         content = node.astext()
+
+        # Skip render of messages from `dagster_sphinx` `inject_param_flag`
+        # https://github.com/dagster-io/dagster/blob/colton/inline-flags/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/docstring_flags.py#L36-L63
+        if "This parameter may break" in content:
+            return
+
+        if "This parameter will be removed" in content:
+            return
+
         if self.in_literal:
             content = node.astext().replace("<", "\\<").replace("{", "\\{")
         self.add_text(content)
@@ -839,9 +850,9 @@ class MdxTranslator(SphinxTranslator):
         self.current_row.append(text.replace("\n", ""))
         self.stateindent.pop()
 
-    ####################################################################################################
-    #                                         Dagster Specific                                         #
-    ####################################################################################################
+    ########################
+    #   Dagster specific   #
+    ########################
 
     # TODO: Move these out of this module and extract out docusaurus style admonitions
 


### PR DESCRIPTION
## Summary & Motivation

Render inline flags coming from `dagster_sphinx` custom package.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/8uYb05u2cFYvF82VTjME/395a0ef3-2a4e-43ad-a011-87779465b21c.png)

## How I Tested These Changes

## Changelog

NOCHANGELOG