### PR TITLE
Pull out the JsonFormatter used by json_console_logger into a top-level import

### DIFF
--- a/python_modules/dagster/dagster/__init__.py
+++ b/python_modules/dagster/dagster/__init__.py
@@ -598,6 +598,7 @@ from dagster._core.types.python_dict import Dict as Dict
 from dagster._core.types.python_set import Set as Set
 from dagster._core.types.python_tuple import Tuple as Tuple
 from dagster._loggers import (
+    JsonLogFormatter as JsonLogFormatter,
     colored_console_logger as colored_console_logger,
     default_loggers as default_loggers,
     default_system_loggers as default_system_loggers,


### PR DESCRIPTION
Summary:
This provides a way for you to specify the dagster-specific JsonFormatter that the json_console_logger uses as a formatter option under python_logs in your dagster.yaml file.

## Summary & Motivation

## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
