### PR TITLE
[5/n][dagster-tableau] implement non-cached asset-building fns for dagster-tableau

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -305,21 +305,22 @@ class BaseTableauWorkspace(ConfigurableResource):
                 )
 
                 for view_data in workbook_data["sheets"]:
-                    augmented_view_data = {**view_data, "workbook": {"luid": workbook_id}}
-                    views_by_id[view_data["luid"]] = TableauContentData(
-                        content_type=TableauContentType.VIEW, properties=augmented_view_data
-                    )
+                    view_id = view_data["luid"]
+                    if view_id:
+                        augmented_view_data = {**view_data, "workbook": {"luid": workbook_id}}
+                        views_by_id[view_id] = TableauContentData(
+                            content_type=TableauContentType.VIEW, properties=augmented_view_data
+                        )
 
                     for embedded_data_source_data in view_data.get("parentEmbeddedDatasources", []):
                         for published_data_source_data in embedded_data_source_data.get(
                             "parentPublishedDatasources", []
                         ):
-                            if published_data_source_data["luid"] not in data_sources_by_id:
-                                data_sources_by_id[published_data_source_data["luid"]] = (
-                                    TableauContentData(
-                                        content_type=TableauContentType.DATA_SOURCE,
-                                        properties=published_data_source_data,
-                                    )
+                            data_source_id = published_data_source_data["luid"]
+                            if data_source_id and data_source_id not in data_sources_by_id:
+                                data_sources_by_id[data_source_id] = TableauContentData(
+                                    content_type=TableauContentType.DATA_SOURCE,
+                                    properties=published_data_source_data,
                                 )
 
         return TableauWorkspaceData(

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -340,13 +340,9 @@ class BaseTableauWorkspace(ConfigurableResource):
         Returns:
             Sequence[AssetSpec]: A list of AssetSpecs representing the Tableau content.
         """
-        response = self.sign_in()
-        self._api_token = response["credentials"]["token"]
-        self._site_id = response["credentials"]["site"]["id"]
+        self.sign_in()
         workspace_data = self.fetch_tableau_workspace_data()
         self.sign_out()
-        self._api_token = None
-        self._site_id = None
         translator = dagster_tableau_translator(context=workspace_data)
 
         all_content = [

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -1,8 +1,8 @@
 import datetime
 import uuid
 from abc import abstractmethod
-from typing import Any, Dict, Mapping, Optional, Sequence, Type, Union, cast
 from contextlib import contextmanager
+from typing import Any, Dict, Mapping, Optional, Sequence, Type, Union, cast
 
 import jwt
 import requests

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -319,7 +319,7 @@ class BaseTableauWorkspace(ConfigurableResource):
                 )
 
         return TableauWorkspaceData(
-            site_id=self._site_id,
+            site_name=self.site_name,
             workbooks_by_id=workbooks_by_id,
             views_by_id=views_by_id,
             data_sources_by_id=data_sources_by_id,

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
@@ -99,7 +99,6 @@ def workspace_data_api_mocks_fixture(site_id: str, workbook_id: str, api_token: 
         api_token: str = api_token,
     ) -> Iterator[None]:
         with responses.RequestsMock() as response:
-
             response.add(
                 method=responses.POST,
                 url=f"{client.rest_api_base_url}/auth/signin",

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
@@ -99,7 +99,7 @@ def workspace_data_api_mocks_fixture(site_id: str, workbook_id: str, api_token: 
         site_id: str = site_id,
         workbook_id: str = workbook_id,
         api_token: str = api_token,
-    ) -> Iterator[None]:
+    ) -> Iterator[responses.RequestsMock]:
         with responses.RequestsMock() as response:
             response.add(
                 method=responses.POST,

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
@@ -93,43 +93,37 @@ def workspace_data_fixture(site_name: str) -> TableauWorkspaceData:
 )
 def workspace_data_api_mocks_fixture(site_id: str, workbook_id: str, api_token: str) -> Callable:
     def _method(
-        api_base_url,
+        client,
         site_id: str = site_id,
         workbook_id: str = workbook_id,
         api_token: str = api_token,
     ) -> Iterator[None]:
         with responses.RequestsMock() as response:
-            response.add(
-                method=responses.GET,
-                url=f"{api_base_url}/sites/{site_id}/workbooks",
-                json={"workbooks": {"workbook": [{**SAMPLE_WORKBOOK}]}},
-                status=200,
-            )
-
-            response.add(
-                method=responses.GET,
-                url=f"{api_base_url}/sites/{site_id}/workbooks/{workbook_id}",
-                json={"workbook": {**SAMPLE_WORKBOOK}},
-                status=200,
-            )
-
-            response.add(
-                method=responses.GET,
-                url=f"{api_base_url}/sites/{site_id}/workbooks/{workbook_id}/connections",
-                json=SAMPLE_CONNECTIONS,
-                status=200,
-            )
 
             response.add(
                 method=responses.POST,
-                url=f"{api_base_url}/auth/signin",
+                url=f"{client.rest_api_base_url}/auth/signin",
                 json={"credentials": {"site": {"id": site_id}, "token": api_token}},
                 status=200,
             )
-
+            response.add(
+                method=responses.GET,
+                url=f"{client.rest_api_base_url}/sites/{site_id}/workbooks",
+                json={},
+                status=200,
+            )
             response.add(
                 method=responses.POST,
-                url=f"{api_base_url}/auth/signout",
+                url=f"{client.metadata_api_base_url}",
+                json={
+                    "query": client.workbook_graphql_query,
+                    "variables": {"luid": workbook_id},
+                },
+                status=200,
+            )
+            response.add(
+                method=responses.POST,
+                url=f"{client.rest_api_base_url}/auth/signout",
                 json={},
                 status=200,
             )

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -4,60 +4,73 @@ import pytest
 import responses
 from dagster_tableau import TableauCloudWorkspace, TableauServerWorkspace
 
-from dagster_tableau_tests.conftest import SAMPLE_CONNECTIONS, SAMPLE_WORKBOOK
-
 
 @responses.activate
 @pytest.mark.parametrize(
-    "clazz,host_key,fake_host_value",
+    "clazz,host_key,host_value",
     [
         (TableauServerWorkspace, "server_name", "fake_server_name"),
         (TableauCloudWorkspace, "pod_name", "fake_pod_name"),
     ],
 )
-def test_fetch_tableau_workspace_data(clazz, host_key, fake_host_value) -> None:
+@pytest.mark.usefixtures("site_name")
+@pytest.mark.usefixtures("workspace_data_api_mocks_fn")
+def test_fetch_tableau_workspace_data(
+    clazz, host_key, host_value, site_name, workspace_data_api_mocks_fn
+) -> None:
     fake_personal_access_token_name = "fake_personal_access_token_name"
     fake_personal_access_token_value = uuid.uuid4().hex
-    fake_site_name = "fake_site_name"
 
     resource_args = {
         "personal_access_token_name": fake_personal_access_token_name,
         "personal_access_token_value": fake_personal_access_token_value,
-        "site_name": fake_site_name,
-        host_key: fake_host_value,
+        "site_name": site_name,
+        host_key: host_value,
     }
 
     resource = clazz(**resource_args)
 
-    # TODO fix after updating the resource
-    fake_site_id = "fake_site_id"
-    fake_api_token = "fake_api_token"
-    resource._site_id = fake_site_id  # noqa
-    resource._api_token = fake_api_token  # noqa
-
-    # TODO move to conftest as a fixture
-    responses.add(
-        method=responses.GET,
-        url=f"{resource.api_base_url}/sites/{fake_site_id}/workbooks",
-        json={"workbooks": {"workbook": [{**SAMPLE_WORKBOOK}]}},
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url=f"{resource.api_base_url}/sites/{fake_site_id}/workbooks/b75fc023-a7ca-4115-857b-4342028640d0",
-        json={"workbook": {**SAMPLE_WORKBOOK}},
-        status=200,
-    )
-
-    responses.add(
-        method=responses.GET,
-        url=f"{resource.api_base_url}/sites/{fake_site_id}/workbooks/b75fc023-a7ca-4115-857b-4342028640d0/connections",
-        json=SAMPLE_CONNECTIONS,
-        status=200,
-    )
+    yield from workspace_data_api_mocks_fn(api_base_url=resource.api_base_url)
 
     actual_workspace_data = resource.fetch_tableau_workspace_data()
     assert len(actual_workspace_data.workbooks_by_id) == 1
     assert len(actual_workspace_data.views_by_id) == 1
     assert len(actual_workspace_data.data_sources_by_id) == 1
+
+
+@responses.activate
+@pytest.mark.parametrize(
+    "clazz,host_key,host_value",
+    [
+        (TableauServerWorkspace, "server_name", "fake_server_name"),
+        (TableauCloudWorkspace, "pod_name", "fake_pod_name"),
+    ],
+)
+@pytest.mark.usefixtures("site_name")
+@pytest.mark.usefixtures("workspace_data_api_mocks_fn")
+def test_translator_spec(clazz, host_key, host_value, site_name, workspace_data_api_mocks_fn) -> None:
+    fake_personal_access_token_name = "fake_personal_access_token_name"
+    fake_personal_access_token_value = uuid.uuid4().hex
+
+    resource_args = {
+        "personal_access_token_name": fake_personal_access_token_name,
+        "personal_access_token_value": fake_personal_access_token_value,
+        "site_name": site_name,
+        host_key: host_value,
+    }
+
+    resource = clazz(**resource_args)
+
+    yield from workspace_data_api_mocks_fn(api_base_url=resource.api_base_url)
+
+    all_asset_specs = resource.build_asset_specs()
+
+    # 1 view and 1 data source
+    assert len(all_asset_specs) == 2
+
+    # Sanity check outputs, translator tests cover details here
+    view_spec = next(spec for spec in all_asset_specs if spec.key.path[0] == "view")
+    assert view_spec.key.path == ["view", "sales"]
+
+    data_source_spec = next(spec for spec in all_asset_specs if spec.key.path[0] == "data_source")
+    assert data_source_spec.key.path == ["superstore_datasource"]

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -48,7 +48,9 @@ def test_fetch_tableau_workspace_data(
 )
 @pytest.mark.usefixtures("site_name")
 @pytest.mark.usefixtures("workspace_data_api_mocks_fn")
-def test_translator_spec(clazz, host_key, host_value, site_name, workspace_data_api_mocks_fn) -> None:
+def test_translator_spec(
+    clazz, host_key, host_value, site_name, workspace_data_api_mocks_fn
+) -> None:
     fake_personal_access_token_name = "fake_personal_access_token_name"
     fake_personal_access_token_value = uuid.uuid4().hex
 

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -1,3 +1,5 @@
+# ruff: noqa: SLF001
+
 import uuid
 
 import pytest
@@ -18,24 +20,28 @@ from dagster_tableau import TableauCloudWorkspace, TableauServerWorkspace
 def test_fetch_tableau_workspace_data(
     clazz, host_key, host_value, site_name, workspace_data_api_mocks_fn
 ) -> None:
-    fake_personal_access_token_name = "fake_personal_access_token_name"
-    fake_personal_access_token_value = uuid.uuid4().hex
+    connected_app_client_id = uuid.uuid4().hex
+    connected_app_secret_id = uuid.uuid4().hex
+    connected_app_secret_value = uuid.uuid4().hex
+    username = "fake_username"
 
     resource_args = {
-        "personal_access_token_name": fake_personal_access_token_name,
-        "personal_access_token_value": fake_personal_access_token_value,
+        "connected_app_client_id": connected_app_client_id,
+        "connected_app_secret_id": connected_app_secret_id,
+        "connected_app_secret_value": connected_app_secret_value,
+        "username": username,
         "site_name": site_name,
         host_key: host_value,
     }
 
     resource = clazz(**resource_args)
+    resource.build_client()
 
-    yield from workspace_data_api_mocks_fn(api_base_url=resource.api_base_url)
-
-    actual_workspace_data = resource.fetch_tableau_workspace_data()
-    assert len(actual_workspace_data.workbooks_by_id) == 1
-    assert len(actual_workspace_data.views_by_id) == 1
-    assert len(actual_workspace_data.data_sources_by_id) == 1
+    with workspace_data_api_mocks_fn(client=resource._client):
+        actual_workspace_data = resource.fetch_tableau_workspace_data()
+        assert len(actual_workspace_data.workbooks_by_id) == 1
+        assert len(actual_workspace_data.views_by_id) == 1
+        assert len(actual_workspace_data.data_sources_by_id) == 1
 
 
 @responses.activate
@@ -51,28 +57,34 @@ def test_fetch_tableau_workspace_data(
 def test_translator_spec(
     clazz, host_key, host_value, site_name, workspace_data_api_mocks_fn
 ) -> None:
-    fake_personal_access_token_name = "fake_personal_access_token_name"
-    fake_personal_access_token_value = uuid.uuid4().hex
+    connected_app_client_id = uuid.uuid4().hex
+    connected_app_secret_id = uuid.uuid4().hex
+    connected_app_secret_value = uuid.uuid4().hex
+    username = "fake_username"
 
     resource_args = {
-        "personal_access_token_name": fake_personal_access_token_name,
-        "personal_access_token_value": fake_personal_access_token_value,
+        "connected_app_client_id": connected_app_client_id,
+        "connected_app_secret_id": connected_app_secret_id,
+        "connected_app_secret_value": connected_app_secret_value,
+        "username": username,
         "site_name": site_name,
         host_key: host_value,
     }
 
     resource = clazz(**resource_args)
+    resource.build_client()
 
-    yield from workspace_data_api_mocks_fn(api_base_url=resource.api_base_url)
+    with workspace_data_api_mocks_fn(client=resource._client):
+        all_asset_specs = resource.build_asset_specs()
 
-    all_asset_specs = resource.build_asset_specs()
+        # 1 view and 1 data source
+        assert len(all_asset_specs) == 2
 
-    # 1 view and 1 data source
-    assert len(all_asset_specs) == 2
+        # Sanity check outputs, translator tests cover details here
+        view_spec = next(spec for spec in all_asset_specs if "workbook" in spec.key.path[0])
+        assert view_spec.key.path == ["test_workbook", "view", "sales"]
 
-    # Sanity check outputs, translator tests cover details here
-    view_spec = next(spec for spec in all_asset_specs if spec.key.path[0] == "view")
-    assert view_spec.key.path == ["view", "sales"]
-
-    data_source_spec = next(spec for spec in all_asset_specs if spec.key.path[0] == "data_source")
-    assert data_source_spec.key.path == ["superstore_datasource"]
+        data_source_spec = next(
+            spec for spec in all_asset_specs if "datasource" in spec.key.path[0]
+        )
+        assert data_source_spec.key.path == ["superstore_datasource"]

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -1,0 +1,63 @@
+import uuid
+
+import pytest
+import responses
+from dagster_tableau import TableauCloudWorkspace, TableauServerWorkspace
+
+from dagster_tableau_tests.conftest import SAMPLE_CONNECTIONS, SAMPLE_WORKBOOK
+
+
+@responses.activate
+@pytest.mark.parametrize(
+    "clazz,host_key,fake_host_value",
+    [
+        (TableauServerWorkspace, "server_name", "fake_server_name"),
+        (TableauCloudWorkspace, "pod_name", "fake_pod_name"),
+    ],
+)
+def test_fetch_tableau_workspace_data(clazz, host_key, fake_host_value) -> None:
+    fake_personal_access_token_name = "fake_personal_access_token_name"
+    fake_personal_access_token_value = uuid.uuid4().hex
+    fake_site_name = "fake_site_name"
+
+    resource_args = {
+        "personal_access_token_name": fake_personal_access_token_name,
+        "personal_access_token_value": fake_personal_access_token_value,
+        "site_name": fake_site_name,
+        host_key: fake_host_value,
+    }
+
+    resource = clazz(**resource_args)
+
+    # TODO fix after updating the resource
+    fake_site_id = "fake_site_id"
+    fake_api_token = "fake_api_token"
+    resource._site_id = fake_site_id  # noqa
+    resource._api_token = fake_api_token  # noqa
+
+    # TODO move to conftest as a fixture
+    responses.add(
+        method=responses.GET,
+        url=f"{resource.api_base_url}/sites/{fake_site_id}/workbooks",
+        json={"workbooks": {"workbook": [{**SAMPLE_WORKBOOK}]}},
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url=f"{resource.api_base_url}/sites/{fake_site_id}/workbooks/b75fc023-a7ca-4115-857b-4342028640d0",
+        json={"workbook": {**SAMPLE_WORKBOOK}},
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url=f"{resource.api_base_url}/sites/{fake_site_id}/workbooks/b75fc023-a7ca-4115-857b-4342028640d0/connections",
+        json=SAMPLE_CONNECTIONS,
+        status=200,
+    )
+
+    actual_workspace_data = resource.fetch_tableau_workspace_data()
+    assert len(actual_workspace_data.workbooks_by_id) == 1
+    assert len(actual_workspace_data.views_by_id) == 1
+    assert len(actual_workspace_data.data_sources_by_id) == 1

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
@@ -43,7 +43,6 @@ def test_basic_resource_request(
     resource.build_client()
 
     with workspace_data_api_mocks_fn(client=resource._client) as response:
-
         # Remove the resource's client to properly test the resource
         resource._client = None
 

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
@@ -42,25 +42,25 @@ def test_basic_resource_request(
     # Must initialize the resource's client before passing it to the mock responses
     resource.build_client()
 
-    yield from workspace_data_api_mocks_fn(client=resource._client)
+    with workspace_data_api_mocks_fn(client=resource._client) as response:
 
-    # Remove the resource's client to properly test the resource
-    resource._client = None
+        # Remove the resource's client to properly test the resource
+        resource._client = None
 
-    @asset
-    def test_assets():
-        with resource.get_client() as client:
-            client.get_workbooks()
-            client.get_workbook(workbook_id=workbook_id)
+        @asset
+        def test_assets():
+            with resource.get_client() as client:
+                client.get_workbooks()
+                client.get_workbook(workbook_id=workbook_id)
 
-    with instance_for_test() as instance:
-        materialize(
-            [test_assets],
-            instance=instance,
-            resources={"tableau": resource},
-        )
+        with instance_for_test() as instance:
+            materialize(
+                [test_assets],
+                instance=instance,
+                resources={"tableau": resource},
+            )
 
-    assert len(responses.calls) == 4
-    assert "X-tableau-auth" not in responses.calls[0].request.headers
-    assert responses.calls[1].request.headers["X-tableau-auth"] == api_token
-    assert responses.calls[2].request.headers["X-tableau-auth"] == api_token
+        assert len(response.calls) == 4
+        assert "X-tableau-auth" not in response.calls[0].request.headers
+        assert response.calls[1].request.headers["X-tableau-auth"] == api_token
+        assert response.calls[2].request.headers["X-tableau-auth"] == api_token

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
@@ -23,7 +23,6 @@ from dagster_tableau import TableauCloudWorkspace, TableauServerWorkspace
 def test_basic_resource_request(
     clazz, host_key, host_value, site_name, api_token, workbook_id, workspace_data_api_mocks_fn
 ) -> None:
-
     connected_app_client_id = uuid.uuid4().hex
     connected_app_secret_id = uuid.uuid4().hex
     connected_app_secret_value = uuid.uuid4().hex


### PR DESCRIPTION
## Summary & Motivation

Adds the `build_asset_specs` function on the `TableauWorkspace` resource, which users can use to fetch a list of asset specs.

Subsequent PR #24385 will cache the metadata returned from the API.

```python
workspace = TableauCloudWorkspace(
    personal_access_token_name=...,
    personal_access_token_value=..., 
    site_name=..., 
    pod_name=...,
)

specs = workspace.build_asset_specs()

defs = Definitions(assets=external_assets_from_specs(specs))
```

## How I Tested These Changes

BK with additional unit tests.

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
