### PR TITLE
[dagster-airlift] display airflow kind on assets when no recorded migration state

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_cacheable_assets_def.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_cacheable_assets_def.py
@@ -380,7 +380,7 @@ def construct_assets_with_task_migration_info_applied(
             # metadata fields from the original spec it was built from after deserializing.
             cacheable_specs.task_asset_specs[spec.key].to_asset_spec(
                 additional_metadata=spec.metadata,
-                additional_tags=airflow_kind_dict() if overall_migration_status == "False" else {},
+                additional_tags=airflow_kind_dict() if overall_migration_status != "True" else {},
             )
             for spec in specs
         ]


### PR DESCRIPTION
## Summary

Gives us kind tags on airflow assets even before migration starts (when this status is empty)