### PR TITLE
[lazy-defs] `@definitions` decorator and `DecoratorLoadContext`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/definitions_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/definitions_decorator.py
@@ -1,0 +1,82 @@
+from typing import Callable, overload
+
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.definitions_loader import (
+    DefinitionsLoadContext,
+    DefinitionsLoader,
+    DefinitionsLoadFn,
+)
+
+# We type this with Callable instead of DefinitionsLoader because we are treating DefinitionsLoader
+# as an internal implementation detail.
+
+
+@overload
+def definitions(
+    fn: Callable[[DefinitionsLoadContext], Definitions],
+) -> Callable[[DefinitionsLoadContext], Definitions]: ...
+
+
+@overload
+def definitions(fn: Callable[[], Definitions]) -> Callable[[], Definitions]: ...
+
+
+def definitions(fn: DefinitionsLoadFn) -> DefinitionsLoadFn:
+    """Marks a function as an entry point for loading a set of Dagster definitions.
+
+    A @definitions-decorated function can perform arbitrary computation to produce a set of
+    Definitions. It is executed during startup of a Dagster process, and optionally receives
+    a DefinitionsLoadContext object as argument.
+
+    The DefinitionsLoadContext is useful when instantiating the Definitions in worker processes
+    spawned from a parent code server process. The standard pattern is to perform expensive
+    computations (such as making an external API request) a single time at code server load and to
+    cache the result by calling `with_metadata` on the returned Definitions object. This metadata
+    is then made available on DefinitionsLoadContext.code_location_metadata in child processes.
+
+    As with plain `Definitions` objects, there can be only one @definitions-decorated function per
+    module if that module is being loaded as a Dagster code location.
+
+    Returns:
+        Union[Callable[[DefinitionsLoadContext], Definitions], Callable[[], Definitions]]: A
+            callable with the same signature as the decorated function.
+
+    Examples:
+        .. code-block:: python
+
+            from dagster import AssetSpec, Definitions, DefinitionsLoadContext, asset, definitions, external_assets_from_specs
+
+            WORKSPACE_ID = "my_workspace"
+            FOO_METADATA_KEY_PREFIX = "foo"
+
+            # Simple model of an external service foo
+            def fetch_foo_defs_metadata(workspace_id: str):
+                if workspace_id == WORKSPACE_ID:
+                    return [{"id": "alpha"}, {"id": "beta"}]
+                else:
+                    raise Exception("Unknown workspace")
+
+            def get_foo_defs(context: DefinitionsLoadContext, workspace_id: str) -> Definitions:
+                metadata_key = f"{FOO_METADATA_KEY_PREFIX}/{workspace_id}"
+                payload = context.code_location_metadata.get(metadata_key) or fetch_foo_defs_metadata(workspace_id)
+                asset_specs = [AssetSpec(item["id"]) for item in payload]
+                assets = external_assets_from_specs(asset_specs)
+                return Definitions(
+                    assets=assets,
+                ).with_metadata(
+                    {metadata_key: payload}
+                )
+
+            @definitions
+            def defs(context: DefinitionsLoadContext):
+
+                @asset
+                def regular_asset(): ...
+
+                return Definitions.merge(
+                    get_foo_defs(context, WORKSPACE_ID),
+                    Definitions(assets=[regular_asset]),
+                )
+
+    """
+    return DefinitionsLoader(load_fn=fn)

--- a/python_modules/dagster/dagster/_core/definitions/definitions_loader.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_loader.py
@@ -1,0 +1,67 @@
+from typing import TYPE_CHECKING, Callable, Optional, Union
+
+from typing_extensions import TypeAlias
+
+from dagster._core.decorator_utils import get_function_params
+from dagster._core.definitions.decorators.op_decorator import is_context_provided
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.errors import DagsterInvalidInvocationError, DagsterInvariantViolationError
+from dagster._record import record
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.repository_definition import RepositoryLoadData
+
+DefinitionsLoadFn: TypeAlias = Union[
+    Callable[["DefinitionsLoadContext"], Definitions],
+    Callable[[], Definitions],
+]
+
+
+class DefinitionsLoadContext:
+    """Holds data that's made available to Definitions-loading code when a DefinitionsLoader is
+    invoked.
+    User construction of this object is not supported.
+    """
+
+    def __init__(self, repository_load_data: Optional["RepositoryLoadData"] = None):
+        self._repository_load_data = repository_load_data
+
+
+@record
+class DefinitionsLoader:
+    """An object that can be invoked to load a set of definitions."""
+
+    load_fn: DefinitionsLoadFn
+
+    @property
+    def has_context_param(self) -> bool:
+        return is_context_provided(get_function_params(self.load_fn))
+
+    def __call__(self, context: Optional[DefinitionsLoadContext] = None) -> Definitions:
+        """Load a set of definitions using the load_fn provided at construction time.
+
+        Args:
+            context (Optional[DefinitionsLoadContext]): If the load_fn requires a context object,
+                this object must be provided. If the load_fn does not require a context object,
+                this object must be None.
+
+        Returns:
+            Definitions: The loaded definitions.
+        """
+        if self.has_context_param:
+            if context is None:
+                raise DagsterInvalidInvocationError(
+                    "Invoked a DefinitionsLoader that requires a DefinitionsLoadContext without providing one."
+                )
+            result = self.load_fn(context)  # type: ignore  # (has_context_param type-checker illegible)
+        else:
+            if context is not None:
+                raise DagsterInvalidInvocationError(
+                    "Passed a DefinitionsLoadContext to a DefinitionsLoader that does not accept one."
+                )
+            result = self.load_fn()  # type: ignore  # (has_context_param type-checker illegible)
+        if not isinstance(result, Definitions):
+            raise DagsterInvariantViolationError(
+                "DefinitionsLoader must return a Definitions object"
+            )
+        return result

--- a/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
+++ b/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
@@ -5,6 +5,7 @@ from typing import Callable, NamedTuple, Optional, Sequence, Tuple, Type, Union
 from dagster import DagsterInvariantViolationError, GraphDefinition, RepositoryDefinition
 from dagster._core.code_pointer import load_python_file, load_python_module
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.definitions_loader import DefinitionsLoader
 from dagster._core.definitions.load_assets_from_modules import assets_from_modules
 from dagster._core.definitions.repository_definition import PendingRepositoryDefinition
 
@@ -49,6 +50,16 @@ def loadable_targets_from_python_package(
 
 def loadable_targets_from_loaded_module(module: ModuleType) -> Sequence[LoadableTarget]:
     from dagster._core.definitions import JobDefinition
+
+    loadable_def_loaders = _loadable_targets_of_type(module, DefinitionsLoader)
+
+    if loadable_def_loaders:
+        if len(loadable_def_loaders) > 1:
+            raise DagsterInvariantViolationError(
+                "Cannot have more than one function decorated with @definitions defined in module scope"
+            )
+
+        return loadable_def_loaders
 
     loadable_defs = _loadable_targets_of_type(module, Definitions)
 
@@ -103,7 +114,7 @@ def loadable_targets_from_loaded_module(module: ModuleType) -> Sequence[Loadable
         return [LoadableTarget(LOAD_ALL_ASSETS, [*module_assets, *module_source_assets])]
 
     raise DagsterInvariantViolationError(
-        "No repositories, jobs, pipelines, graphs, or asset definitions found in "
+        "No Definitions, function decorated with @definitions, RepositoryDefinition, Job, Pipeline, Graph, or AssetsDefinition found in "
         f'"{module.__name__}".'
     )
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_execute_command.py
@@ -290,7 +290,7 @@ def test_attribute_is_wrong_thing():
         with pytest.raises(
             DagsterInvariantViolationError,
             match=re.escape(
-                "Loadable attributes must be either a JobDefinition, GraphDefinition,"
+                "Loadable attributes must be either a JobDefinition, GraphDefinition, Definitions, function decorated with @definitions,"
                 " or RepositoryDefinition. Got 123."
             ),
         ):
@@ -311,7 +311,7 @@ def test_attribute_fn_returns_wrong_thing():
         with pytest.raises(
             DagsterInvariantViolationError,
             match=re.escape(
-                "Loadable attributes must be either a JobDefinition, GraphDefinition,"
+                "Loadable attributes must be either a JobDefinition, GraphDefinition, Definitions, function decorated with @definitions,"
                 " or RepositoryDefinition."
             ),
         ):

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/definitions_loader_no_context.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/definitions_loader_no_context.py
@@ -1,0 +1,10 @@
+from dagster import Definitions, asset
+from dagster._core.definitions.decorators.definitions_decorator import definitions
+
+
+@definitions
+def defs() -> Definitions:
+    @asset
+    def asset1(): ...
+
+    return Definitions(assets=[asset1])

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/definitions_loader_with_context.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/definitions_loader_with_context.py
@@ -1,0 +1,11 @@
+from dagster import Definitions, asset
+from dagster._core.definitions.decorators.definitions_decorator import definitions
+from dagster._core.definitions.definitions_loader import DefinitionsLoadContext
+
+
+@definitions
+def defs(context: DefinitionsLoadContext) -> Definitions:
+    @asset
+    def asset1(): ...
+
+    return Definitions(assets=[asset1])

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
@@ -122,7 +122,7 @@ def test_no_loadable_targets():
 
     assert (
         str(exc_info.value)
-        == 'No repositories, jobs, pipelines, graphs, or asset definitions found in "nada".'
+        == 'No Definitions, function decorated with @definitions, RepositoryDefinition, Job, Pipeline, Graph, or AssetsDefinition found in "nada".'
     )
 
 
@@ -258,3 +258,22 @@ def test_local_directory_file():
 
     with alter_sys_path(to_add=[os.path.dirname(path)], to_remove=[]):
         loadable_targets_from_python_file(path, working_directory=os.path.dirname(path))
+
+
+@pytest.mark.parametrize(
+    "filename", ["definitions_loader_with_context.py", "definitions_loader_no_context.py"]
+)
+def test_definitions_loader(filename):
+    module_path = file_relative_path(__file__, filename)
+    loadable_targets = loadable_targets_from_python_file(module_path)
+
+    assert len(loadable_targets) == 1
+    symbol = loadable_targets[0].attribute
+    assert symbol == "defs"
+
+    repo_def = repository_def_from_pointer(
+        CodePointer.from_python_file(module_path, symbol, None), None
+    )
+
+    assert isinstance(repo_def, RepositoryDefinition)
+    assert len(repo_def.assets_defs_by_key) == 1

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_loader.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_loader.py
@@ -1,0 +1,27 @@
+import pytest
+from dagster._core.definitions.decorators.definitions_decorator import definitions
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.definitions_loader import DefinitionsLoadContext
+from dagster._core.errors import DagsterInvalidInvocationError
+
+
+def test_invoke_definitions_loader_with_context():
+    @definitions
+    def defs(context: DefinitionsLoadContext) -> Definitions:
+        return Definitions()
+
+    assert defs(DefinitionsLoadContext())
+
+    with pytest.raises(DagsterInvalidInvocationError, match="requires a DefinitionsLoadContext"):
+        defs()
+
+
+def test_invoke_definitions_loader_no_context():
+    @definitions
+    def defs() -> Definitions:
+        return Definitions()
+
+    assert defs()
+
+    with pytest.raises(DagsterInvalidInvocationError, match="Passed a DefinitionsLoadContext"):
+        defs(DefinitionsLoadContext())

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
@@ -118,7 +118,7 @@ def test_bad_target():
     with pytest.raises(
         DagsterInvariantViolationError,
         match=re.escape(
-            "Loadable attributes must be either a JobDefinition, GraphDefinition,"
+            "Loadable attributes must be either a JobDefinition, GraphDefinition, Definitions, function decorated with @definitions,"
             " or RepositoryDefinition. Got None."
         ),
     ):


### PR DESCRIPTION
## Summary & Motivation

Base of `Definitions` lazy load stack.

Adds a `@definitions` decorator that returns a `DefinitionsLoader` object. This is a bare-bones object that wraps a `load_fn`. The `load_fn` optionally accepts a `DefinitionsLoadContext` instance and is expected to return a `Definitions` instance.

```
### some_code_location.py

@definitions
def defs(context: DefinitionsLoadContext) -> Definitions:
    return Definitions(
        ...
    )
```

The loader is resolved to a `RepositoryDefinition` at the same point where all other loadable targets are, in `repository_def_from_target_def`.

This PR borrows heavily from @sryza's #23678. The main difference is that I aimed to keep it as minimal as possible:

- I create `DefinitionsLoadContext` only at the moment it is needed rather than threading it through multiple entry points.
- I have omitted the `load_type` param of `DefinitionsLoadContext` from Sandy's PR since I do not actually use it in this PR (python_modules/dagster/dagster/_core/definitions/definitions_load_context.py).

The names also are of course up for debate-- I prefer `@definitions` in keeping with the simple declarative style of our other decorators. The returned object is a `DefinitionsLoader` since `DefinitionsDefinition` wouldn't work.

## How I Tested These Changes

New unit tests.

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
