### PR TITLE
Change logger behavior so that setting a default logger in a Definitions object actually sticks, without needing to set run config

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/logger_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/logger_definition.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
     from dagster._core.definitions import JobDefinition
     from dagster._core.execution.context.logger import InitLoggerContext, UnboundInitLoggerContext
+    from dagster._core.instance import DagsterInstance
 
     InitLoggerFunction = Callable[[InitLoggerContext], logging.Logger]
 
@@ -67,7 +68,7 @@ class LoggerDefinition(AnonymousConfigurableDefinition):
                 args[0],
                 context_param_name,
                 UnboundInitLoggerContext,
-                default=UnboundInitLoggerContext(logger_config=None, job_def=None),
+                default=UnboundInitLoggerContext(logger_config=None, job_def=None, instance=None),
             )
             return logger_invocation_result(self, context)
         else:
@@ -79,7 +80,11 @@ class LoggerDefinition(AnonymousConfigurableDefinition):
                 kwargs[context_param_name],
                 context_param_name,
                 UnboundInitLoggerContext,
-                default=UnboundInitLoggerContext(logger_config=None, job_def=None),
+                default=UnboundInitLoggerContext(
+                    logger_config=None,
+                    job_def=None,
+                    instance=None,
+                ),
             )
 
             return logger_invocation_result(self, context)
@@ -161,6 +166,7 @@ def logger(
 def build_init_logger_context(
     logger_config: Any = None,
     job_def: Optional["JobDefinition"] = None,
+    instance: Optional["DagsterInstance"] = None,
 ) -> "UnboundInitLoggerContext":
     """Builds logger initialization context from provided parameters.
 
@@ -184,4 +190,4 @@ def build_init_logger_context(
 
     check.opt_inst_param(job_def, "job_def", JobDefinition)
 
-    return UnboundInitLoggerContext(logger_config=logger_config, job_def=job_def)
+    return UnboundInitLoggerContext(logger_config=logger_config, job_def=job_def, instance=instance)

--- a/python_modules/dagster/dagster/_core/definitions/logger_invocation.py
+++ b/python_modules/dagster/dagster/_core/definitions/logger_invocation.py
@@ -8,7 +8,11 @@ def logger_invocation_result(logger_def: LoggerDefinition, init_context: Unbound
     logger_config = resolve_bound_config(init_context.logger_config, logger_def)
 
     bound_context = InitLoggerContext(
-        logger_config, logger_def, init_context.job_def, init_context.run_id
+        logger_config,
+        logger_def,
+        init_context.job_def,
+        init_context.run_id,
+        init_context.instance,
     )
 
     return logger_def.logger_fn(bound_context)

--- a/python_modules/dagster/dagster/_core/definitions/run_config.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_config.py
@@ -107,7 +107,7 @@ class RunConfigSchemaCreationData(NamedTuple):
 def define_logger_dictionary_cls(creation_data: RunConfigSchemaCreationData) -> Shape:
     return Shape(
         {
-            logger_name: def_config_field(logger_definition, is_required=False)
+            logger_name: def_config_field(logger_definition, is_required=None)
             for logger_name, logger_definition in creation_data.logger_defs.items()
         }
     )

--- a/python_modules/dagster/dagster/_core/execution/context_creation_job.py
+++ b/python_modules/dagster/dagster/_core/execution/context_creation_job.py
@@ -70,7 +70,10 @@ def initialize_console_manager(
         loggers.append(
             logger_def.logger_fn(
                 InitLoggerContext(
-                    logger_config, logger_def, run_id=dagster_run.run_id if dagster_run else None
+                    logger_config,
+                    logger_def,
+                    run_id=dagster_run.run_id if dagster_run else None,
+                    instance=instance,
                 )
             )
         )
@@ -470,6 +473,7 @@ def create_log_manager(
                         logger_def,
                         job_def=job_def,
                         run_id=dagster_run.run_id,
+                        instance=context_creation_data.instance,
                     )
                 )
             )
@@ -483,6 +487,7 @@ def create_log_manager(
                         logger_def,
                         job_def=job_def,
                         run_id=dagster_run.run_id,
+                        instance=context_creation_data.instance,
                     )
                 )
             )
@@ -515,6 +520,7 @@ def create_context_free_log_manager(
                     logger_def,
                     job_def=None,
                     run_id=dagster_run.run_id,
+                    instance=instance,
                 )
             )
         ]

--- a/python_modules/dagster/dagster/_core/execution/host_mode.py
+++ b/python_modules/dagster/dagster/_core/execution/host_mode.py
@@ -101,6 +101,7 @@ def host_mode_execution_context_event_generator(
                     job_def=None,
                     logger_def=logger_def,
                     run_id=pipeline_run.run_id,
+                    instance=instance,
                 )
             )
         )

--- a/python_modules/dagster/dagster/_loggers/__init__.py
+++ b/python_modules/dagster/dagster/_loggers/__init__.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
             "log_level": Field(
                 str,
                 is_required=False,
-                default_value="INFO",
                 description="The logger's threshold.",
             ),
             "name": Field(
@@ -44,9 +43,11 @@ def colored_console_logger(init_context: "InitLoggerContext") -> logging.Logger:
     """This logger provides support for sending Dagster logs to stdout in a colored format. It is
     included by default on jobs which do not otherwise specify loggers.
     """
+    log_level = init_context.logger_config.get("log_level", init_context.default_log_level)
+
     return create_console_logger(
         name=init_context.logger_config["name"],
-        level=coerce_valid_log_level(init_context.logger_config["log_level"]),
+        level=coerce_valid_log_level(log_level),
     )
 
 
@@ -56,7 +57,6 @@ def colored_console_logger(init_context: "InitLoggerContext") -> logging.Logger:
             "log_level": Field(
                 str,
                 is_required=False,
-                default_value="INFO",
                 description="The logger's threshold.",
             ),
             "name": Field(
@@ -89,7 +89,8 @@ def json_console_logger(init_context: "InitLoggerContext") -> logging.Logger:
                 hello_op()
 
     """
-    level = coerce_valid_log_level(init_context.logger_config["log_level"])
+    log_level = init_context.logger_config.get("log_level", init_context.default_log_level)
+    level = coerce_valid_log_level(log_level)
     name = init_context.logger_config["name"]
 
     klass = logging.getLoggerClass()


### PR DESCRIPTION
Summary:
Right now if you customize a logger on a job, you also need to set additional configuration on the run when launching the job in order for it to actually use that logger and not fall back to the detault system logger. This is quite different than what happens when you set an executor on a job, and is generally confusing.

This PR instead makes setting logger config more like executor config - if you set it, it is assumed that you want to use that logger, and applies that configuraiton as the default even if no configuration is set.

The main blocker here is probably that this could be considered a breaking change - before, when you specified a logger on a job you were giving your self the option of opting into it, and now you are overriding whatever loggers you set as the default loggers.

## Summary & Motivation

## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
