### PR TITLE
Gate duckdb-specific instance check in dagster-dbt in a way that doesn't require an import of a module that might not be present

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_event_iterator.py
@@ -277,14 +277,14 @@ class DbtEventIterator(Generic[T], abc.Iterator):
         # opening multiple connections to the same database when a write connection, such
         # as the one dbt uses, is open.
         event_stream = self
-        try:
+        if (
+            self._dbt_cli_invocation.adapter
+            and self._dbt_cli_invocation.adapter.__class__.__name__ == "DuckDBAdapter"
+        ):
             from dbt.adapters.duckdb import DuckDBAdapter
 
             if isinstance(self._dbt_cli_invocation.adapter, DuckDBAdapter):
                 event_stream = exhaust_iterator_and_yield_results_with_exception(self)
-
-        except ImportError:
-            pass
 
         def _threadpool_wrap_map_fn() -> (
             Iterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -379,7 +379,8 @@ class DbtCliResource(ConfigurableResource):
 
         # If the dbt adapter is DuckDB, set the access mode to READ_ONLY, since DuckDB only allows
         # simultaneous connections for read-only access.
-        try:
+
+        if config.credentials and config.credentials.__class__.__name__ == "DuckDBCredentials":
             from dbt.adapters.duckdb.credentials import DuckDBCredentials
 
             if isinstance(config.credentials, DuckDBCredentials):
@@ -390,12 +391,6 @@ class DbtCliResource(ConfigurableResource):
                 # working directory may not be the same as the dbt project directory
                 with pushd(self.project_dir):
                     config.credentials.path = os.fspath(Path(config.credentials.path).absolute())
-
-        except ImportError:
-            logger.warning(
-                "An error was encountered when creating a handle to the dbt adapter in Dagster.",
-                exc_info=True,
-            )
 
         cleanup_event_logger()
 


### PR DESCRIPTION
Summary:
Attempt to resolve https://github.com/dagster-io/dagster/issues/23952: Instead of attempting to import duckdb and logging a warning on importerror, do a bit of introspection on the relevant class and only try to import it if the class name matches.

Test Plan: could use some help with this from reviewers, I don't see any duckdb-specific tests in https://github.com/dagster-io/dagster/pull/21542

## Summary & Motivation

## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
