### PR TITLE
chore(dbt): add logging if adapter is not created

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -683,8 +683,10 @@ class DbtCliResource(ConfigurableResource):
                 adapter = self._initialize_adapter(cli_vars)
 
             except:
-                # defer exceptions until they can be raised in the runtime context of the invocation
-                pass
+                logger.warning(
+                    "An error was encountered when creating a handle to the dbt adapter in Dagster.",
+                    exc_info=True,
+                )
 
             return DbtCliInvocation.run(
                 args=full_dbt_args,


### PR DESCRIPTION
## Summary & Motivation
I put the logging statement in https://github.com/dagster-io/dagster/pull/23615 in the wrong place.

## How I Tested These Changes
N/A

## Changelog

NOCHANGELOG
