### PR TITLE
[kinds] add kinds to asset sidebar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetNode.tsx
@@ -28,7 +28,7 @@ interface Props {
   kindFilter?: StaticSetFilter<string>;
 }
 
-export const AssetNode = React.memo(({definition, selected}: Props) => {
+export const AssetNode = React.memo(({definition, selected, kindFilter}: Props) => {
   const {liveData} = useAssetLiveData(definition.assetKey);
   return (
     <AssetInsetForHoverEffect>
@@ -69,6 +69,7 @@ export const AssetNode = React.memo(({definition, selected}: Props) => {
               key={kind}
               kind={kind}
               style={{position: 'relative', paddingTop: 7, margin: 0}}
+              currentPageFilter={kindFilter}
             />
           ))}
         </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -361,6 +361,18 @@ export const AssetNodeOverview = ({
           />
         )}
       </AttributeAndValue>
+      <AttributeAndValue label="Kinds">
+        {(assetNode.kinds.length > 1 || !assetNode.computeKind) &&
+          assetNode.kinds.map((kind) => (
+            <AssetKind
+              key={kind}
+              style={{position: 'relative'}}
+              kind={kind}
+              reduceColor
+              linkToFilteredAssetsTable
+            />
+          ))}
+      </AttributeAndValue>
       <AttributeAndValue label="Storage">
         {(relationIdentifierMetadata || uriMetadata || storageKindTag) && (
           <Box flex={{direction: 'column', gap: 4}} style={{minWidth: 0}}>


### PR DESCRIPTION
## Summary

Display an asset's kind tags in the sidebar, provided that the asset has at least one non-legacy-compute-kind tag.

![Screenshot 2024-09-10 at 7 59 27 AM](https://github.com/user-attachments/assets/412d4ef7-e479-4db0-84fe-e3487470a8e4)


## Test Plan

Tested locally.