### PR TITLE
Add AssetCheckNode to AssetGraph classes

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -11,7 +11,12 @@ from dagster._core.definitions.asset_spec import (
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicy
-from dagster._core.definitions.base_asset_graph import BaseAssetGraph, BaseAssetNode, EntityKey
+from dagster._core.definitions.base_asset_graph import (
+    AssetCheckNode,
+    BaseAssetGraph,
+    BaseAssetNode,
+    EntityKey,
+)
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
 )
@@ -161,6 +166,10 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
         assets_defs_by_check_key: Mapping[AssetCheckKey, AssetsDefinition],
     ):
         self._asset_nodes_by_key = asset_nodes_by_key
+        self._asset_check_nodes_by_key = {
+            k: AssetCheckNode(k, v.get_spec_for_check_key(k).blocking)
+            for k, v in assets_defs_by_check_key.items()
+        }
         self._assets_defs_by_check_key = assets_defs_by_check_key
 
     @staticmethod

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -22,7 +22,12 @@ from dagster._core.definitions.asset_job import IMPLICIT_ASSET_JOB_NAME
 from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicy
-from dagster._core.definitions.base_asset_graph import BaseAssetGraph, BaseAssetNode, EntityKey
+from dagster._core.definitions.base_asset_graph import (
+    AssetCheckNode,
+    BaseAssetGraph,
+    BaseAssetNode,
+    EntityKey,
+)
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
 )
@@ -229,6 +234,9 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
     ):
         self._asset_nodes_by_key = asset_nodes_by_key
         self._asset_checks_by_key = asset_checks_by_key
+        self._asset_check_nodes_by_key = {
+            k: AssetCheckNode(k, v.blocking) for k, v in asset_checks_by_key.items()
+        }
         self._asset_check_execution_sets_by_key = asset_check_execution_sets_by_key
 
     @classmethod


### PR DESCRIPTION
## Summary & Motivation

As title -- this adds a new AssetCheckNode which you can access using BaseAssetGraph.get(check_key).

While both AssetGraph and RemoteAssetGraph had information regarding the checks they contained, there was no unified interface for getting information about a specific check. More properties can be added in the future, but for now I just went with the bare minimum.

## How I Tested These Changes

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
