### PR TITLE
Allow getting parent/child subsets with AssetCheckKeys

### DIFF
--- a/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
+++ b/python_modules/dagster/dagster/_utils/caching_instance_queryer.py
@@ -704,7 +704,7 @@ class CachingInstanceQueryer(DynamicPartitionsStore):
                 # we are mapping from the partitions of the parent asset to the partitions of
                 # the child asset
                 partition_mapping = self.asset_graph.get_partition_mapping(
-                    asset_key=child_asset_key, parent_asset_key=parent_asset_key
+                    key=child_asset_key, parent_asset_key=parent_asset_key
                 )
                 try:
                     child_partitions_subset = (

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -862,6 +862,6 @@ def test_cross_code_location_partition_mapping() -> None:
     )
 
     assert isinstance(
-        asset_graph.get_partition_mapping(asset_key=b.key, parent_asset_key=a.key),
+        asset_graph.get_partition_mapping(key=b.key, parent_asset_key=a.key),
         TimeWindowPartitionMapping,
     )


### PR DESCRIPTION
## Summary & Motivation

As title. This lets us do partition mappings to / from asset checks, meaning:

1. you can find the upstream partitions of the target asset from that asset's check
2. you can find the downstream subset of a given target check from that check's asset

At the moment, all asset checks are unpartitioned, and so these subsets will always be all or none. However, by modeling it in this way, we don't need to write any custom code to make it work this way, and can just rely on the existing partition mapping logic.

If in the future we decide that asset checks can be partitioned, then no changes will need to be made to these code paths.

## How I Tested These Changes

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
