### PR TITLE
[ui] Fix ops navigation in new code location defs page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefinitionsMain.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefinitionsMain.tsx
@@ -40,7 +40,7 @@ export const CodeLocationDefinitionsMain = ({repoAddress, repository}: Props) =>
         <Route path="/locations/:repoPath/graphs">
           <CodeLocationGraphsList repoAddress={repoAddress} />
         </Route>
-        <Route path="/locations/:repoPath/ops">
+        <Route path="/locations/:repoPath/ops/:name?">
           <CodeLocationOpsView repoAddress={repoAddress} />
         </Route>
       </Switch>


### PR DESCRIPTION
## Summary & Motivation

Repair the `:name` param on the ops explorer in the new code location page.

## How I Tested These Changes

View code location with ops, click on an op. Verify that it shows the details correctly.

## Changelog

NOCHANGELOG