### PR TITLE
[resources] Ensure process_config_and_initialize handles nested resources, env vars properly

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/init.py
+++ b/python_modules/dagster/dagster/_core/execution/context/init.py
@@ -149,6 +149,7 @@ class UnboundInitResourceContext(InitResourceContext):
 
         if isinstance(resources, Resources):
             check.failed("Should not have a Resources object directly from this initialization")
+        self._raw_resources = resources
 
         self._resource_defs = wrap_resources_for_execution(
             check.opt_mapping_param(resources, "resources")
@@ -221,6 +222,13 @@ class UnboundInitResourceContext(InitResourceContext):
     @property
     def run_id(self) -> Optional[str]:
         return None
+
+    def replace_config(self, config: Any) -> "UnboundInitResourceContext":
+        return UnboundInitResourceContext(
+            resource_config=config,
+            resources=self._raw_resources,
+            instance=self.instance,
+        )
 
 
 def build_init_resource_context(


### PR DESCRIPTION
## Summary

Updates the implementation of `process_config_and_initialize`, a utility which we use to ready up configurable resources outside of the runtime context (e.g. to load assets from external tools). It now properly handles nested resources, and has a contextmanager variant to handle setup/teardown.

## Test Plan

New unit tests.