### PR TITLE
[sling] lowercase col names, deps

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
@@ -109,10 +109,10 @@ def fetch_column_metadata(
                 upstream_asset_key = next(iter(upstream_assets))
                 column_lineage = TableColumnLineage(
                     deps_by_column={
-                        column_name: [
+                        column_name.lower(): [
                             TableColumnDep(
                                 asset_key=upstream_asset_key,
-                                column_name=column_name,
+                                column_name=column_name.lower(),
                             )
                         ]
                         for column_name in column_type_map.keys()
@@ -124,7 +124,7 @@ def fetch_column_metadata(
                 TableMetadataSet(
                     column_schema=TableSchema(
                         columns=[
-                            TableColumn(name=column_name, type=column_type)
+                            TableColumn(name=column_name.lower(), type=column_type)
                             for column_name, column_type in column_type_map.items()
                         ]
                     ),

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/replication_configs/csv_to_sqlite_config/dataworks/Products.csv
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/replication_configs/csv_to_sqlite_config/dataworks/Products.csv
@@ -1,4 +1,4 @@
-product_id,name,category,price
+product_id,NAME,category,PRICE
 101,Keyboard,Electronics,25.99
 102,Mouse,Electronics,12.50
 103,Notebook,Office Supplies,8.75


### PR DESCRIPTION
## Summary

Lowercases the column lineage and column schema column names for Sling for consistency and since in the UI we lowercase the names when we link them.

## Test Plan

Unit test.