### PR TITLE
[dagster-powerbi] Add option to auth using a Service Principal

### DIFF
--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/__init__.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/__init__.py
@@ -1,8 +1,8 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
 from dagster_powerbi.resource import (
-    PowerBIServicePrincipalAuth as PowerBIServicePrincipalAuth,
-    PowerBITokenAuth as PowerBITokenAuth,
+    PowerBIServicePrincipal as PowerBIServicePrincipal,
+    PowerBIToken as PowerBIToken,
     PowerBIWorkspace as PowerBIWorkspace,
 )
 from dagster_powerbi.translator import DagsterPowerBITranslator as DagsterPowerBITranslator

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/__init__.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/__init__.py
@@ -1,6 +1,10 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
-from dagster_powerbi.resource import PowerBIWorkspace as PowerBIWorkspace
+from dagster_powerbi.resource import (
+    PowerBIServicePrincipalAuth as PowerBIServicePrincipalAuth,
+    PowerBITokenAuth as PowerBITokenAuth,
+    PowerBIWorkspace as PowerBIWorkspace,
+)
 from dagster_powerbi.translator import DagsterPowerBITranslator as DagsterPowerBITranslator
 
 # Move back to version.py and edit setup.py once we are ready to publish.

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo.py
@@ -6,11 +6,11 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.repository_definition.repository_definition import (
     PendingRepositoryDefinition,
 )
-from dagster_powerbi import PowerBIWorkspace
+from dagster_powerbi import PowerBITokenAuth, PowerBIWorkspace
 
 fake_token = uuid.uuid4().hex
 resource = PowerBIWorkspace(
-    api_token=fake_token,
+    auth=PowerBITokenAuth(api_token=fake_token),
     workspace_id="a2122b8f-d7e1-42e8-be2b-a5e636ca3221",
 )
 pbi_defs = resource.build_defs()

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo.py
@@ -6,11 +6,11 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.repository_definition.repository_definition import (
     PendingRepositoryDefinition,
 )
-from dagster_powerbi import PowerBITokenAuth, PowerBIWorkspace
+from dagster_powerbi import PowerBIToken, PowerBIWorkspace
 
 fake_token = uuid.uuid4().hex
 resource = PowerBIWorkspace(
-    auth=PowerBITokenAuth(api_token=fake_token),
+    credentials=PowerBIToken(api_token=fake_token),
     workspace_id="a2122b8f-d7e1-42e8-be2b-a5e636ca3221",
 )
 pbi_defs = resource.build_defs()

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo_two_workspaces.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo_two_workspaces.py
@@ -5,15 +5,15 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.repository_definition.repository_definition import (
     PendingRepositoryDefinition,
 )
-from dagster_powerbi import PowerBITokenAuth, PowerBIWorkspace
+from dagster_powerbi import PowerBIToken, PowerBIWorkspace
 
 fake_token = uuid.uuid4().hex
 resource = PowerBIWorkspace(
-    auth=PowerBITokenAuth(api_token=fake_token),
+    credentials=PowerBIToken(api_token=fake_token),
     workspace_id="a2122b8f-d7e1-42e8-be2b-a5e636ca3221",
 )
 resource_second_workspace = PowerBIWorkspace(
-    auth=PowerBITokenAuth(api_token=fake_token),
+    credentials=PowerBIToken(api_token=fake_token),
     workspace_id="c5322b8a-d7e1-42e8-be2b-a5e636ca3221",
 )
 

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo_two_workspaces.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo_two_workspaces.py
@@ -5,15 +5,15 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.repository_definition.repository_definition import (
     PendingRepositoryDefinition,
 )
-from dagster_powerbi import PowerBIWorkspace
+from dagster_powerbi import PowerBITokenAuth, PowerBIWorkspace
 
 fake_token = uuid.uuid4().hex
 resource = PowerBIWorkspace(
-    api_token=fake_token,
+    auth=PowerBITokenAuth(api_token=fake_token),
     workspace_id="a2122b8f-d7e1-42e8-be2b-a5e636ca3221",
 )
 resource_second_workspace = PowerBIWorkspace(
-    api_token=fake_token,
+    auth=PowerBITokenAuth(api_token=fake_token),
     workspace_id="c5322b8a-d7e1-42e8-be2b-a5e636ca3221",
 )
 

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -10,7 +10,7 @@ from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.instance_for_test import instance_for_test
 from dagster._utils import file_relative_path
 from dagster_powerbi import PowerBIWorkspace
-from dagster_powerbi.resource import BASE_API_URL
+from dagster_powerbi.resource import BASE_API_URL, PowerBITokenAuth
 
 from dagster_powerbi_tests.conftest import SAMPLE_SEMANTIC_MODEL
 
@@ -18,7 +18,7 @@ from dagster_powerbi_tests.conftest import SAMPLE_SEMANTIC_MODEL
 def test_fetch_powerbi_workspace_data(workspace_data_api_mocks: None, workspace_id: str) -> None:
     fake_token = uuid.uuid4().hex
     resource = PowerBIWorkspace(
-        api_token=fake_token,
+        auth=PowerBITokenAuth(api_token=fake_token),
         workspace_id=workspace_id,
     )
 
@@ -32,7 +32,7 @@ def test_fetch_powerbi_workspace_data(workspace_data_api_mocks: None, workspace_
 def test_translator_dashboard_spec(workspace_data_api_mocks: None, workspace_id: str) -> None:
     fake_token = uuid.uuid4().hex
     resource = PowerBIWorkspace(
-        api_token=fake_token,
+        auth=PowerBITokenAuth(api_token=fake_token),
         workspace_id=workspace_id,
     )
     all_assets = resource.build_defs().get_asset_graph().assets_defs
@@ -72,7 +72,9 @@ def test_refreshable_semantic_model(
 ) -> None:
     fake_token = uuid.uuid4().hex
     resource = PowerBIWorkspace(
-        api_token=fake_token, workspace_id=workspace_id, refresh_poll_interval=0
+        auth=PowerBITokenAuth(api_token=fake_token),
+        workspace_id=workspace_id,
+        refresh_poll_interval=0,
     )
     all_assets = (
         resource.build_defs(enable_refresh_semantic_models=True).get_asset_graph().assets_defs

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -10,7 +10,7 @@ from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.instance_for_test import instance_for_test
 from dagster._utils import file_relative_path
 from dagster_powerbi import PowerBIWorkspace
-from dagster_powerbi.resource import BASE_API_URL, PowerBITokenAuth
+from dagster_powerbi.resource import BASE_API_URL, PowerBIToken
 
 from dagster_powerbi_tests.conftest import SAMPLE_SEMANTIC_MODEL
 
@@ -18,7 +18,7 @@ from dagster_powerbi_tests.conftest import SAMPLE_SEMANTIC_MODEL
 def test_fetch_powerbi_workspace_data(workspace_data_api_mocks: None, workspace_id: str) -> None:
     fake_token = uuid.uuid4().hex
     resource = PowerBIWorkspace(
-        auth=PowerBITokenAuth(api_token=fake_token),
+        credentials=PowerBIToken(api_token=fake_token),
         workspace_id=workspace_id,
     )
 
@@ -32,7 +32,7 @@ def test_fetch_powerbi_workspace_data(workspace_data_api_mocks: None, workspace_
 def test_translator_dashboard_spec(workspace_data_api_mocks: None, workspace_id: str) -> None:
     fake_token = uuid.uuid4().hex
     resource = PowerBIWorkspace(
-        auth=PowerBITokenAuth(api_token=fake_token),
+        credentials=PowerBIToken(api_token=fake_token),
         workspace_id=workspace_id,
     )
     all_assets = resource.build_defs().get_asset_graph().assets_defs
@@ -72,7 +72,7 @@ def test_refreshable_semantic_model(
 ) -> None:
     fake_token = uuid.uuid4().hex
     resource = PowerBIWorkspace(
-        auth=PowerBITokenAuth(api_token=fake_token),
+        credentials=PowerBIToken(api_token=fake_token),
         workspace_id=workspace_id,
         refresh_poll_interval=0,
     )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_resource.py
@@ -2,7 +2,7 @@ import uuid
 
 import responses
 from dagster_powerbi import PowerBIWorkspace
-from dagster_powerbi.resource import BASE_API_URL
+from dagster_powerbi.resource import BASE_API_URL, PowerBITokenAuth
 
 
 @responses.activate
@@ -10,7 +10,7 @@ def test_basic_resource_request() -> None:
     fake_token = uuid.uuid4().hex
     fake_workspace_id = uuid.uuid4().hex
     resource = PowerBIWorkspace(
-        api_token=fake_token,
+        auth=PowerBITokenAuth(api_token=fake_token),
         workspace_id=fake_workspace_id,
     )
 

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_resource.py
@@ -5,8 +5,8 @@ from dagster_powerbi import PowerBIWorkspace
 from dagster_powerbi.resource import (
     BASE_API_URL,
     MICROSOFT_LOGIN_URL,
-    PowerBIServicePrincipalAuth,
-    PowerBITokenAuth,
+    PowerBIServicePrincipal,
+    PowerBIToken,
 )
 
 
@@ -15,7 +15,7 @@ def test_basic_resource_request() -> None:
     fake_token = uuid.uuid4().hex
     fake_workspace_id = uuid.uuid4().hex
     resource = PowerBIWorkspace(
-        auth=PowerBITokenAuth(api_token=fake_token),
+        credentials=PowerBIToken(api_token=fake_token),
         workspace_id=fake_workspace_id,
     )
 
@@ -41,7 +41,7 @@ def test_service_principal_auth() -> None:
     fake_tenant_id = uuid.uuid4().hex
 
     resource = PowerBIWorkspace(
-        auth=PowerBIServicePrincipalAuth(
+        credentials=PowerBIServicePrincipal(
             client_id=fake_client_id,
             client_secret=fake_client_secret,
             tenant_id=fake_tenant_id,

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_resource.py
@@ -2,7 +2,12 @@ import uuid
 
 import responses
 from dagster_powerbi import PowerBIWorkspace
-from dagster_powerbi.resource import BASE_API_URL, PowerBITokenAuth
+from dagster_powerbi.resource import (
+    BASE_API_URL,
+    MICROSOFT_LOGIN_URL,
+    PowerBIServicePrincipalAuth,
+    PowerBITokenAuth,
+)
 
 
 @responses.activate
@@ -25,3 +30,42 @@ def test_basic_resource_request() -> None:
 
     assert len(responses.calls) == 1
     assert responses.calls[0].request.headers["Authorization"] == f"Bearer {fake_token}"
+
+
+@responses.activate
+def test_service_principal_auth() -> None:
+    fake_token = uuid.uuid4().hex
+    fake_workspace_id = uuid.uuid4().hex
+    fake_client_id = uuid.uuid4().hex
+    fake_client_secret = uuid.uuid4().hex
+    fake_tenant_id = uuid.uuid4().hex
+
+    resource = PowerBIWorkspace(
+        auth=PowerBIServicePrincipalAuth(
+            client_id=fake_client_id,
+            client_secret=fake_client_secret,
+            tenant_id=fake_tenant_id,
+        ),
+        workspace_id=fake_workspace_id,
+    )
+
+    responses.add(
+        method=responses.POST,
+        url=MICROSOFT_LOGIN_URL.format(tenant_id=fake_tenant_id),
+        json={"access_token": fake_token},
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url=f"{BASE_API_URL}/groups/{fake_workspace_id}/reports",
+        json={},
+        status=200,
+    )
+
+    resource.get_reports()
+
+    assert len(responses.calls) == 2
+    assert fake_client_id in responses.calls[0].request.body
+    assert fake_client_secret in responses.calls[0].request.body
+    assert responses.calls[1].request.headers["Authorization"] == f"Bearer {fake_token}"


### PR DESCRIPTION
## Summary

Moves the PowerBI auth to a nested resource, which now has two options: direct API credential, or credentials for a Service Principal.

## Test Plan

New unit tests.