### PR TITLE
explicit version_key on code location status and entry

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -1524,6 +1524,7 @@ type WorkspaceLocationEntry {
   loadStatus: RepositoryLocationLoadStatus!
   displayMetadata: [RepositoryMetadata!]!
   updatedTimestamp: Float!
+  versionKey: String!
   permissions: [Permission!]!
   featureFlags: [FeatureFlag!]!
 }
@@ -3368,6 +3369,7 @@ type WorkspaceLocationStatusEntry {
   name: String!
   loadStatus: RepositoryLocationLoadStatus!
   updateTimestamp: Float!
+  versionKey: String!
   permissions: [Permission!]!
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -5601,6 +5601,7 @@ export type WorkspaceLocationEntry = {
   name: Scalars['String']['output'];
   permissions: Array<Permission>;
   updatedTimestamp: Scalars['Float']['output'];
+  versionKey: Scalars['String']['output'];
 };
 
 export type WorkspaceLocationEntryOrError = PythonError | WorkspaceLocationEntry;
@@ -5619,6 +5620,7 @@ export type WorkspaceLocationStatusEntry = {
   name: Scalars['String']['output'];
   permissions: Array<Permission>;
   updateTimestamp: Scalars['Float']['output'];
+  versionKey: Scalars['String']['output'];
 };
 
 export type WorkspaceOrError = PythonError | Workspace;
@@ -15161,6 +15163,8 @@ export const buildWorkspaceLocationEntry = (
       overrides && overrides.hasOwnProperty('updatedTimestamp')
         ? overrides.updatedTimestamp!
         : 2.68,
+    versionKey:
+      overrides && overrides.hasOwnProperty('versionKey') ? overrides.versionKey! : 'enim',
   };
 };
 
@@ -15196,6 +15200,7 @@ export const buildWorkspaceLocationStatusEntry = (
     permissions: overrides && overrides.hasOwnProperty('permissions') ? overrides.permissions! : [],
     updateTimestamp:
       overrides && overrides.hasOwnProperty('updateTimestamp') ? overrides.updateTimestamp! : 7.09,
+    versionKey: overrides && overrides.hasOwnProperty('versionKey') ? overrides.versionKey! : 'nam',
   };
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/flattenCodeLocationRows.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/flattenCodeLocationRows.tsx
@@ -28,7 +28,7 @@ const flatten = (
 
     if (locationStatus.loadStatus === 'LOADING') {
       status = 'Updating';
-    } else if (locationEntry?.updatedTimestamp !== locationStatus.updateTimestamp) {
+    } else if (locationEntry?.versionKey !== locationStatus.versionKey) {
       status = 'Loading';
     } else if (locationEntry?.locationOrLoadError?.__typename === 'PythonError') {
       status = 'Failed';

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/CodeLocationRowSet.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/CodeLocationRowSet.tsx
@@ -117,7 +117,7 @@ export const LocationStatus = (props: {
     );
   }
 
-  if (locationOrError?.updatedTimestamp !== locationStatus.updateTimestamp) {
+  if (locationOrError?.versionKey !== locationStatus.versionKey) {
     return (
       <Tag minimal intent="primary">
         Loading…

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceContext.tsx
@@ -203,7 +203,7 @@ export const WorkspaceProvider = ({children}: {children: React.ReactNode}) => {
       const d = locationEntriesData[loc.name];
       const entry = d?.__typename === 'WorkspaceLocationEntry' ? d : null;
       return (
-        prev?.updateTimestamp !== loc.updateTimestamp ||
+        prev?.versionKey !== loc.versionKey ||
         prev?.loadStatus !== loc.loadStatus ||
         entry?.loadStatus !== loc.loadStatus
       );

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceQueries.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceQueries.tsx
@@ -21,6 +21,7 @@ export const LOCATION_WORKSPACE_QUERY = gql`
       ...WorkspaceDisplayMetadata
     }
     updatedTimestamp
+    versionKey
     featureFlags {
       name
       enabled
@@ -146,5 +147,6 @@ export const CODE_LOCATION_STATUS_QUERY = gql`
     name
     loadStatus
     updateTimestamp
+    versionKey
   }
 `;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/__tests__/WorkspaceContext.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/__tests__/WorkspaceContext.test.tsx
@@ -92,17 +92,20 @@ function getLocationMocks(updatedTimestamp = 0) {
   const location1 = buildWorkspaceLocationEntry({
     name: 'location1',
     updatedTimestamp,
+    versionKey: String(updatedTimestamp),
     locationOrLoadError: repositoryLocation1,
   });
   const location2 = buildWorkspaceLocationEntry({
     name: 'location2',
     updatedTimestamp,
+    versionKey: String(updatedTimestamp),
     locationOrLoadError: repositoryLocation2,
   });
 
   const location3 = buildWorkspaceLocationEntry({
     name: 'location3',
     updatedTimestamp,
+    versionKey: String(updatedTimestamp),
     locationOrLoadError: repositoryLocation3,
   });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/types/WorkspaceQueries.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/types/WorkspaceQueries.types.ts
@@ -25,6 +25,7 @@ export type LocationWorkspaceQuery = {
         name: string;
         loadStatus: Types.RepositoryLocationLoadStatus;
         updatedTimestamp: number;
+        versionKey: string;
         displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
         featureFlags: Array<{__typename: 'FeatureFlag'; name: string; enabled: boolean}>;
         locationOrLoadError:
@@ -135,6 +136,7 @@ export type WorkspaceLocationNodeFragment = {
   name: string;
   loadStatus: Types.RepositoryLocationLoadStatus;
   updatedTimestamp: number;
+  versionKey: string;
   displayMetadata: Array<{__typename: 'RepositoryMetadata'; key: string; value: string}>;
   featureFlags: Array<{__typename: 'FeatureFlag'; name: string; enabled: boolean}>;
   locationOrLoadError:
@@ -454,6 +456,7 @@ export type CodeLocationStatusQuery = {
           name: string;
           loadStatus: Types.RepositoryLocationLoadStatus;
           updateTimestamp: number;
+          versionKey: string;
         }>;
       };
 };
@@ -464,4 +467,5 @@ export type LocationStatusEntryFragment = {
   name: string;
   loadStatus: Types.RepositoryLocationLoadStatus;
   updateTimestamp: number;
+  versionKey: string;
 };

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -188,6 +188,7 @@ def fetch_location_statuses(
                     status_entry.load_status
                 ),
                 update_timestamp=status_entry.update_timestamp,
+                version_key=status_entry.version_key,
             )
             for status_entry in workspace_request_context.get_code_location_statuses()
         ]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -136,14 +136,28 @@ class GrapheneWorkspaceLocationStatusEntry(graphene.ObjectType):
     name = graphene.NonNull(graphene.String)
     loadStatus = graphene.NonNull(GrapheneRepositoryLocationLoadStatus)
     updateTimestamp = graphene.NonNull(graphene.Float)
+    versionKey = graphene.NonNull(graphene.String)
 
     permissions = graphene.Field(non_null_list(GraphenePermission))
 
     class Meta:
         name = "WorkspaceLocationStatusEntry"
 
-    def __init__(self, id, name, load_status, update_timestamp):
-        super().__init__(id=id, name=name, loadStatus=load_status, updateTimestamp=update_timestamp)
+    def __init__(
+        self,
+        id,
+        name,
+        load_status,
+        update_timestamp,
+        version_key,
+    ):
+        super().__init__(
+            id=id,
+            name=name,
+            loadStatus=load_status,
+            updateTimestamp=update_timestamp,
+            versionKey=version_key,
+        )
 
     def resolve_permissions(self, graphene_info):
         permissions = graphene_info.context.permissions_for_location(location_name=self.name)
@@ -181,6 +195,7 @@ class GrapheneWorkspaceLocationEntry(graphene.ObjectType):
     loadStatus = graphene.NonNull(GrapheneRepositoryLocationLoadStatus)
     displayMetadata = non_null_list(GrapheneRepositoryMetadata)
     updatedTimestamp = graphene.NonNull(graphene.Float)
+    versionKey = graphene.NonNull(graphene.String)
 
     permissions = graphene.Field(non_null_list(GraphenePermission))
 
@@ -216,8 +231,11 @@ class GrapheneWorkspaceLocationEntry(graphene.ObjectType):
             if value is not None
         ]
 
-    def resolve_updatedTimestamp(self, _):
+    def resolve_updatedTimestamp(self, _) -> float:
         return self._location_entry.update_timestamp
+
+    def resolve_versionKey(self, _) -> str:
+        return self._location_entry.version_key
 
     def resolve_permissions(self, graphene_info):
         permissions = graphene_info.context.permissions_for_location(location_name=self.name)
@@ -330,7 +348,8 @@ class GrapheneRepository(graphene.ObjectType):
         return [
             GraphenePipeline(pipeline)
             for pipeline in sorted(
-                self._repository.get_all_external_jobs(), key=lambda pipeline: pipeline.name
+                self._repository.get_all_external_jobs(),
+                key=lambda pipeline: pipeline.name,
             )
         ]
 
@@ -338,7 +357,8 @@ class GrapheneRepository(graphene.ObjectType):
         return [
             GrapheneJob(pipeline)
             for pipeline in sorted(
-                self._repository.get_all_external_jobs(), key=lambda pipeline: pipeline.name
+                self._repository.get_all_external_jobs(),
+                key=lambda pipeline: pipeline.name,
             )
         ]
 
@@ -406,7 +426,8 @@ class GrapheneRepository(graphene.ObjectType):
                 external_resource=resource,
             )
             for resource in sorted(
-                self._repository.get_external_resources(), key=lambda resource: resource.name
+                self._repository.get_external_resources(),
+                key=lambda resource: resource.name,
             )
             if resource.is_top_level
         ]
@@ -479,7 +500,11 @@ async def gen_location_state_changes(graphene_info: ResolveInfo):
 
 class GrapheneRepositoriesOrError(graphene.Union):
     class Meta:
-        types = (GrapheneRepositoryConnection, GrapheneRepositoryNotFoundError, GraphenePythonError)
+        types = (
+            GrapheneRepositoryConnection,
+            GrapheneRepositoryNotFoundError,
+            GraphenePythonError,
+        )
         name = "RepositoriesOrError"
 
 
@@ -491,7 +516,11 @@ class GrapheneWorkspaceOrError(graphene.Union):
 
 class GrapheneRepositoryOrError(graphene.Union):
     class Meta:
-        types = (GraphenePythonError, GrapheneRepository, GrapheneRepositoryNotFoundError)
+        types = (
+            GraphenePythonError,
+            GrapheneRepository,
+            GrapheneRepositoryNotFoundError,
+        )
         name = "RepositoryOrError"
 
 

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -678,7 +678,7 @@ class GrpcServerCodeLocation(CodeLocation):
         self._heartbeat = check.bool_param(heartbeat, "heartbeat")
         self._watch_server = check.bool_param(watch_server, "watch_server")
 
-        self.server_id = None
+        self._server_id = None
         self._external_repositories_data = None
 
         self._executable_path = None
@@ -697,7 +697,7 @@ class GrpcServerCodeLocation(CodeLocation):
             )
             list_repositories_response = sync_list_repositories_grpc(self.client)
 
-            self.server_id = server_id if server_id else sync_get_server_id(self.client)
+            self._server_id = server_id if server_id else sync_get_server_id(self.client)
             self.repository_names = set(
                 symbol.repository_name for symbol in list_repositories_response.repository_symbols
             )
@@ -748,6 +748,10 @@ class GrpcServerCodeLocation(CodeLocation):
         except:
             self.cleanup()
             raise
+
+    @property
+    def server_id(self) -> str:
+        return check.not_none(self._server_id)
 
     @property
     def origin(self) -> CodeLocationOrigin:

--- a/python_modules/dagster/dagster/_core/workspace/workspace.py
+++ b/python_modules/dagster/dagster/_core/workspace/workspace.py
@@ -1,9 +1,11 @@
 from abc import ABC, abstractmethod
 from enum import Enum
 from functools import cached_property
-from typing import TYPE_CHECKING, Mapping, NamedTuple, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Mapping, Optional, Sequence, Tuple
 
-from dagster._record import record
+from typing_extensions import Annotated
+
+from dagster._record import ImportFrom, record
 from dagster._utils.error import SerializableErrorInfo
 
 if TYPE_CHECKING:
@@ -22,16 +24,21 @@ class CodeLocationLoadStatus(Enum):
     LOADED = "LOADED"  # Finished loading (may be an error)
 
 
-class CodeLocationEntry(NamedTuple):
-    origin: "CodeLocationOrigin"
-    code_location: Optional["CodeLocation"]
+@record
+class CodeLocationEntry:
+    origin: Annotated["CodeLocationOrigin", ImportFrom("dagster._core.remote_representation")]
+    code_location: Optional[
+        Annotated["CodeLocation", ImportFrom("dagster._core.remote_representation")]
+    ]
     load_error: Optional[SerializableErrorInfo]
     load_status: CodeLocationLoadStatus
     display_metadata: Mapping[str, str]
     update_timestamp: float
+    version_key: str
 
 
-class CodeLocationStatusEntry(NamedTuple):
+@record
+class CodeLocationStatusEntry:
     """Slimmer version of WorkspaceLocationEntry, containing the minimum set of information required
     to know whether the workspace needs reloading.
     """
@@ -39,6 +46,7 @@ class CodeLocationStatusEntry(NamedTuple):
     location_name: str
     load_status: CodeLocationLoadStatus
     update_timestamp: float
+    version_key: str
 
 
 @record
@@ -107,4 +115,5 @@ def location_status_from_location_entry(
         location_name=entry.origin.location_name,
         load_status=entry.load_status,
         update_timestamp=entry.update_timestamp,
+        version_key=entry.version_key,
     )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -154,6 +154,7 @@ def _make_location_entry(defs_attr: str, instance: DagsterInstance):
         load_status=CodeLocationLoadStatus.LOADED,
         display_metadata={},
         update_timestamp=time.time(),
+        version_key="test",
     )
 
 

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -52,6 +52,7 @@ def _make_location_entry(scenario_name: str, definitions_file: str, instance: Da
         load_status=CodeLocationLoadStatus.LOADED,
         display_metadata={},
         update_timestamp=time.time(),
+        version_key="test",
     )
 
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -896,9 +896,8 @@ def test_status_in_code_schedule(instance: DagsterInstance, executor: ThreadPool
         # Now try with an error workspace - the job state should not be deleted
         # since its associated with an errored out location
         with freeze_time(freeze_datetime):
-            new_location_entry = workspace_context._workspace_snapshot.code_location_entries[  # noqa
-                "test_location"
-            ]._replace(
+            new_location_entry = copy(
+                workspace_context._workspace_snapshot.code_location_entries["test_location"],  # noqa
                 code_location=None,
                 load_error=SerializableErrorInfo("error", [], "error"),
             )


### PR DESCRIPTION
We were using update timestamp as a proxy for version which does not work when there are multiple web servers with their own derived timestamp. Instead use an explicit "version key" based on the user code server id which should correctly be representative of potential changes in definitions. 


fixes https://github.com/dagster-io/dagster/issues/23753

## How I Tested These Changes

* launch a code server
* 2 webservers pointed at that code server 
* nginx load balancing between those web servers 
* ensure the code locations table behaves as expected across multiple reloads as the user code server is restarted 


## Changelog
[dagster-webserver] fixes issue with code locations appearing in fluctuating incorrect state in deployments with multiple webserver processes 
- [X] `BUGFIX` 
