### PR TITLE
[definition-tags] Add `tags` param to SensorDefinition and subclasses/decorators

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3020,6 +3020,7 @@ type Sensor {
   metadata: SensorMetadata!
   sensorType: SensorType!
   assetSelection: AssetSelection
+  tags: [DefinitionTag!]!
 }
 
 type Target {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -4955,6 +4955,7 @@ export type Sensor = {
   nextTick: Maybe<DryRunInstigationTick>;
   sensorState: InstigationState;
   sensorType: SensorType;
+  tags: Array<DefinitionTag>;
   targets: Maybe<Array<Target>>;
 };
 
@@ -13957,6 +13958,7 @@ export const buildSensor = (
       overrides && overrides.hasOwnProperty('sensorType')
         ? overrides.sensorType!
         : SensorType.ASSET,
+    tags: overrides && overrides.hasOwnProperty('tags') ? overrides.tags! : [],
     targets: overrides && overrides.hasOwnProperty('targets') ? overrides.targets! : [],
   };
 };

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Sequence
 
 import dagster._check as check
 import graphene
@@ -38,6 +38,7 @@ from dagster_graphql.schema.instigation import (
     GrapheneInstigationState,
     GrapheneInstigationStatus,
 )
+from dagster_graphql.schema.tags import GrapheneDefinitionTag
 from dagster_graphql.schema.util import ResolveInfo, non_null_list
 
 
@@ -84,6 +85,7 @@ class GrapheneSensor(graphene.ObjectType):
     metadata = graphene.NonNull(GrapheneSensorMetadata)
     sensorType = graphene.NonNull(GrapheneSensorType)
     assetSelection = graphene.Field(GrapheneAssetSelection)
+    tags = non_null_list(GrapheneDefinitionTag)
 
     class Meta:
         name = "Sensor"
@@ -147,6 +149,12 @@ class GrapheneSensor(graphene.ObjectType):
 
     def resolve_nextTick(self, graphene_info: ResolveInfo):
         return get_sensor_next_tick(graphene_info, self._sensor_state)
+
+    def resolve_tags(self, _graphene_info: ResolveInfo) -> Sequence[GrapheneDefinitionTag]:
+        return [
+            GrapheneDefinitionTag(key, value)
+            for key, value in (self._external_sensor.tags or {}).items()
+        ]
 
 
 class GrapheneSensorOrError(graphene.Union):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_sensors.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_sensors.ambr
@@ -4,7 +4,7 @@
     '__typename': 'Sensor',
     'assetSelection': None,
     'minIntervalSeconds': 30,
-    'name': 'always_no_config_sensor',
+    'name': 'always_no_config_sensor_with_tags',
     'nextTick': None,
     'sensorState': dict({
       'runs': list([
@@ -15,6 +15,12 @@
       ]),
     }),
     'sensorType': 'STANDARD',
+    'tags': list([
+      dict({
+        'key': 'foo',
+        'value': 'bar',
+      }),
+    ]),
     'targets': list([
       dict({
         'mode': 'default',
@@ -49,7 +55,7 @@
     dict({
       'description': None,
       'minIntervalSeconds': 30,
-      'name': 'always_no_config_sensor',
+      'name': 'always_no_config_sensor_with_tags',
       'sensorState': dict({
         'runs': list([
         ]),

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1127,8 +1127,8 @@ def define_schedules():
 
 
 def define_sensors():
-    @sensor(job_name="no_config_job")
-    def always_no_config_sensor(_):
+    @sensor(job_name="no_config_job", tags={"foo": "bar"})
+    def always_no_config_sensor_with_tags(_):
         return RunRequest(
             run_key=None,
             tags={"test": "1234"},
@@ -1247,7 +1247,7 @@ def define_sensors():
     )
 
     return [
-        always_no_config_sensor,
+        always_no_config_sensor_with_tags,
         always_error_sensor,
         once_no_config_sensor,
         never_no_config_sensor,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
@@ -108,7 +108,7 @@ class TestNextTickRepository(NonLaunchableGraphQLContextTestMatrix):
             repository_selector["repositoryLocationName"]
         ).get_repository(repository_selector["repositoryName"])
 
-        sensor_name = "always_no_config_sensor"
+        sensor_name = "always_no_config_sensor_with_tags"
         external_sensor = external_repository.get_external_sensor(sensor_name)
         selector = infer_instigation_selector(graphql_context, sensor_name)
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Callable, NamedTuple, Optional, Sequence, Set
+from typing import Any, Callable, Mapping, NamedTuple, Optional, Sequence, Set
 
 import dagster._check as check
 from dagster._annotations import public
@@ -65,6 +65,8 @@ class AssetSensorDefinition(SensorDefinition):
             object to target with this sensor.
         jobs (Optional[Sequence[Union[GraphDefinition, JobDefinition, UnresolvedAssetJobDefinition]]]):
             (experimental) A list of jobs to be executed when the sensor fires.
+        tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
+            be used for searching and filtering in the UI.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
             status can be overridden from the Dagster UI or via the GraphQL API.
     """
@@ -84,6 +86,7 @@ class AssetSensorDefinition(SensorDefinition):
         jobs: Optional[Sequence[ExecutableDefinition]] = None,
         default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
         required_resource_keys: Optional[Set[str]] = None,
+        tags: Optional[Mapping[str, str]] = None,
     ):
         self._asset_key = check.inst_param(asset_key, "asset_key", AssetKey)
 
@@ -163,6 +166,7 @@ class AssetSensorDefinition(SensorDefinition):
             jobs=jobs,
             default_status=default_status,
             required_resource_keys=combined_required_resource_keys,
+            tags=tags,
         )
 
     @public

--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -64,7 +64,9 @@ class AutomationConditionSensorDefinition(SensorDefinition):
         name: The name of the sensor.
         asset_selection (Union[str, Sequence[str], Sequence[AssetKey], Sequence[Union[AssetsDefinition, SourceAsset]], AssetSelection]):
             The assets to evaluate AutomationConditions of and request runs for.
-        run_tags: Optional[Mapping[str, Any]] = None,
+        tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
+            be used for searching and filtering in the UI.
+        run_tags (Optional[Mapping[str, Any]]): Tags that will be automatically attached to runs launched by this sensor.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
             status can be overridden from the Dagster UI or via the GraphQL API.
         minimum_interval_seconds (Optional[int]): The frequency at which to try to evaluate the
@@ -78,6 +80,7 @@ class AutomationConditionSensorDefinition(SensorDefinition):
         name: str,
         *,
         asset_selection: CoercibleToAssetSelection,
+        tags: Optional[Mapping[str, str]] = None,
         run_tags: Optional[Mapping[str, Any]] = None,
         default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
         minimum_interval_seconds: Optional[int] = None,
@@ -100,6 +103,7 @@ class AutomationConditionSensorDefinition(SensorDefinition):
             default_status=default_status,
             required_resource_keys=None,
             asset_selection=asset_selection,
+            tags=tags,
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -1,7 +1,7 @@
 import collections.abc
 import inspect
 from functools import update_wrapper
-from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Set, Union
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, Sequence, Set, Union
 
 import dagster._check as check
 from dagster._annotations import experimental, experimental_param
@@ -44,6 +44,7 @@ def sensor(
     default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
     asset_selection: Optional[CoercibleToAssetSelection] = None,
     required_resource_keys: Optional[Set[str]] = None,
+    tags: Optional[Mapping[str, str]] = None,
     target: Optional[
         Union[
             "CoercibleToAssetSelection",
@@ -80,6 +81,8 @@ def sensor(
         asset_selection (Optional[Union[str, Sequence[str], Sequence[AssetKey], Sequence[Union[AssetsDefinition, SourceAsset]], AssetSelection]]):
             (Experimental) an asset selection to launch a run for if the sensor condition is met.
             This can be provided instead of specifying a job.
+        tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
+            be used for searching and filtering in the UI.
         target (Optional[Union[CoercibleToAssetSelection, AssetsDefinition, JobDefinition, UnresolvedAssetJobDefinition]]):
             The target that the sensor will execute.
             It can take :py:class:`~dagster.AssetSelection` objects and anything coercible to it (e.g. `str`, `Sequence[str]`, `AssetKey`, `AssetsDefinition`).
@@ -102,6 +105,7 @@ def sensor(
             default_status=default_status,
             asset_selection=asset_selection,
             required_resource_keys=required_resource_keys,
+            tags=tags,
             target=target,
         )
 
@@ -123,6 +127,7 @@ def asset_sensor(
     jobs: Optional[Sequence[ExecutableDefinition]] = None,
     default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
     required_resource_keys: Optional[Set[str]] = None,
+    tags: Optional[Mapping[str, str]] = None,
 ) -> Callable[
     [
         AssetMaterializationFunction,
@@ -159,6 +164,8 @@ def asset_sensor(
             (experimental) A list of jobs to be executed when the sensor fires.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
             status can be overridden from the Dagster UI or via the GraphQL API.
+        tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
+            be used for searching and filtering in the UI. Values that are not already strings will be serialized as JSON.
 
 
     Example:
@@ -228,6 +235,7 @@ def asset_sensor(
             jobs=jobs,
             default_status=default_status,
             required_resource_keys=required_resource_keys,
+            tags=tags,
         )
 
     return inner
@@ -246,6 +254,7 @@ def multi_asset_sensor(
     default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
     request_assets: Optional[AssetSelection] = None,
     required_resource_keys: Optional[Set[str]] = None,
+    tags: Optional[Mapping[str, str]] = None,
 ) -> Callable[
     [
         MultiAssetMaterializationFunction,
@@ -282,6 +291,8 @@ def multi_asset_sensor(
             status can be overridden from the Dagster UI or via the GraphQL API.
         request_assets (Optional[AssetSelection]): (Experimental) an asset selection to launch a run
             for if the sensor condition is met. This can be provided instead of specifying a job.
+        tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
+            be used for searching and filtering in the UI.
     """
     check.opt_str_param(name, "name")
 
@@ -310,6 +321,7 @@ def multi_asset_sensor(
             default_status=default_status,
             request_assets=request_assets,
             required_resource_keys=required_resource_keys,
+            tags=tags,
         )
         update_wrapper(sensor_def, wrapped=fn)
         return sensor_def

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -1133,6 +1133,8 @@ class MultiAssetSensorDefinition(SensorDefinition):
             status can be overridden from the Dagster UI or via the GraphQL API.
         request_assets (Optional[AssetSelection]): (Experimental) an asset selection to launch a run
             for if the sensor condition is met. This can be provided instead of specifying a job.
+        tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
+            be used for searching and filtering in the UI.
     """
 
     def __init__(
@@ -1148,6 +1150,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
         default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
         request_assets: Optional[AssetSelection] = None,
         required_resource_keys: Optional[Set[str]] = None,
+        tags: Optional[Mapping[str, str]] = None,
     ):
         resource_arg_names: Set[str] = {
             arg.name for arg in get_resource_args(asset_materialization_fn)
@@ -1254,6 +1257,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
             default_status=default_status,
             asset_selection=request_assets,
             required_resource_keys=combined_required_resource_keys,
+            tags=tags,
         )
 
     def __call__(self, *args, **kwargs) -> AssetMaterializationFunctionReturn:

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -441,6 +441,7 @@ def run_failure_sensor(
     request_job: Optional[ExecutableDefinition] = None,
     request_jobs: Optional[Sequence[ExecutableDefinition]] = None,
     monitor_all_repositories: bool = False,
+    tags: Optional[Mapping[str, str]] = None,
 ) -> Callable[
     [RunFailureSensorEvaluationFn],
     SensorDefinition,
@@ -490,6 +491,7 @@ def run_failure_sensor(
     request_job: Optional[ExecutableDefinition] = None,
     request_jobs: Optional[Sequence[ExecutableDefinition]] = None,
     monitor_all_repositories: Optional[bool] = None,
+    tags: Optional[Mapping[str, str]] = None,
 ) -> Union[
     SensorDefinition,
     Callable[
@@ -528,6 +530,8 @@ def run_failure_sensor(
         monitor_all_repositories (bool): (deprecated in favor of monitor_all_code_locations) If set to True,
             the sensor will monitor all runs in the Dagster instance. If set to True, an error will be raised if you also specify
             monitored_jobs or job_selection. Defaults to False.
+        tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
+            be used for searching and filtering in the UI.
     """
 
     def inner(
@@ -557,6 +561,7 @@ def run_failure_sensor(
             default_status=default_status,
             request_job=request_job,
             request_jobs=request_jobs,
+            tags=tags,
         )
         @functools.wraps(fn)
         def _run_failure_sensor(*args, **kwargs) -> Any:
@@ -602,6 +607,8 @@ class RunStatusSensorDefinition(SensorDefinition):
             status can be overridden from the Dagster UI or via the GraphQL API.
         request_job (Optional[Union[GraphDefinition, JobDefinition]]): The job a RunRequest should
             execute if yielded from the sensor.
+        tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
+            be used for searching and filtering in the UI.
         request_jobs (Optional[Sequence[Union[GraphDefinition, JobDefinition]]]): (experimental)
             A list of jobs to be executed if RunRequests are yielded from the sensor.
     """
@@ -629,6 +636,7 @@ class RunStatusSensorDefinition(SensorDefinition):
         default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
         request_job: Optional[ExecutableDefinition] = None,
         request_jobs: Optional[Sequence[ExecutableDefinition]] = None,
+        tags: Optional[Mapping[str, str]] = None,
         required_resource_keys: Optional[Set[str]] = None,
     ):
         from dagster._core.definitions.selector import (
@@ -954,6 +962,7 @@ class RunStatusSensorDefinition(SensorDefinition):
             job=request_job,
             jobs=request_jobs,
             required_resource_keys=combined_required_resource_keys,
+            tags=tags,
         )
 
     def __call__(self, *args, **kwargs) -> RawSensorEvaluationFunctionReturn:
@@ -1022,6 +1031,7 @@ def run_status_sensor(
     request_job: Optional[ExecutableDefinition] = None,
     request_jobs: Optional[Sequence[ExecutableDefinition]] = None,
     monitor_all_repositories: Optional[bool] = None,
+    tags: Optional[Mapping[str, str]] = None,
 ) -> Callable[
     [RunStatusSensorEvaluationFunction],
     RunStatusSensorDefinition,
@@ -1058,6 +1068,8 @@ def run_status_sensor(
         monitor_all_repositories (Optional[bool]): (deprecated in favor of monitor_all_code_locations) If set to True, the sensor will monitor all runs in the Dagster instance.
             If set to True, an error will be raised if you also specify monitored_jobs or job_selection.
             Defaults to False.
+        tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
+            be used for searching and filtering in the UI.
     """
 
     def inner(
@@ -1091,6 +1103,7 @@ def run_status_sensor(
             default_status=default_status,
             request_job=request_job,
             request_jobs=request_jobs,
+            tags=tags,
         )
 
     return inner

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -1098,6 +1098,10 @@ class ExternalSensor:
         return self._external_sensor_data.metadata
 
     @property
+    def tags(self) -> Mapping[str, str]:
+        return self._external_sensor_data.tags
+
+    @property
     def default_status(self) -> DefaultSensorStatus:
         return self._external_sensor_data.default_status or DefaultSensorStatus.STOPPED
 

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -452,6 +452,7 @@ class SensorSnap(IHaveNew):
     default_status: Optional[DefaultSensorStatus]
     sensor_type: Optional[SensorType]
     asset_selection: Optional[AssetSelection]
+    tags: Mapping[str, str]
     run_tags: Mapping[str, str]
 
     def __new__(
@@ -467,6 +468,7 @@ class SensorSnap(IHaveNew):
         default_status: Optional[DefaultSensorStatus] = None,
         sensor_type: Optional[SensorType] = None,
         asset_selection: Optional[AssetSelection] = None,
+        tags: Optional[Mapping[str, str]] = None,
         run_tags: Optional[Mapping[str, str]] = None,
     ):
         if job_name and not target_dict:
@@ -506,6 +508,7 @@ class SensorSnap(IHaveNew):
             ),
             sensor_type=sensor_type,
             asset_selection=asset_selection,
+            tags=tags or {},
             run_tags=run_tags or {},
         )
 
@@ -564,6 +567,7 @@ class SensorSnap(IHaveNew):
             default_status=sensor_def.default_status,
             sensor_type=sensor_def.sensor_type,
             asset_selection=serializable_asset_selection,
+            tags=sensor_def.tags,
             run_tags=(
                 sensor_def.run_tags
                 if isinstance(sensor_def, AutomationConditionSensorDefinition)

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_sensor_decorator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_sensor_decorator.py
@@ -33,3 +33,12 @@ def test_jobless_sensor_uses_eval_fn_name():
         pass
 
     assert my_sensor.name == "my_sensor"
+
+
+def test_sensor_tags():
+    @sensor(tags={"foo": "bar"})
+    def my_sensor():
+        pass
+
+    # auto-serialized to JSON
+    assert my_sensor.tags == {"foo": "bar"}

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_result.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_sensor_result.py
@@ -309,3 +309,13 @@ def test_asset_materialization_in_sensor_direct_invocation() -> None:
 
     instance = DagsterInstance.ephemeral()
     a_sensor(build_sensor_context(instance=instance))
+
+
+def test_sensor_tags_not_on_run_request():
+    @sensor(target="foo", tags={"foo": "bar"})
+    def my_sensor():
+        return RunRequest()
+
+    with instance_for_test() as instance:
+        result = my_sensor.evaluate_tick(build_sensor_context(instance))
+        assert "foo" not in result.run_requests[0].tags


### PR DESCRIPTION
## Summary & Motivation

Add new `tags` parameter to `SensorDefinition` and associated classes.

The `tags` parameter represents strictly definition tags-- it is under no circumstances automatically attached to runs emitted from the sensor. This can be interpreted as matching the behavior on `ScheduleDefinition` (added upstack), where `tags` are _only_ auto-appended as run tags if a custom evaluation function is not provided (this is for backcompat reasons). We don't have to worry about this case with sensors since there are no instances without custom evaluation functions.

Note that there is one sensor type (`AutomationConditionSensor`) that already has a `run_tags` parameter. That did not interfere with this PR since it is under the `run_tags` name, but it's odd that this is the only sensor type with `run_tags` and warrants discussion elsewhere.

## How I Tested These Changes

Modified existing unit tests.

## Changelog

`SensorDefinition` and all of its variants/decorators now accept a `tags` parameter. The tags annotate the definition and can be used to search and filter in the UI.

- [x] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
