### PR TITLE
[definition-tags] Add definition tags to `ScheduleDefinition`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -1631,6 +1631,7 @@ type Schedule {
   futureTick(tickTimestamp: Int!): DryRunInstigationTick!
   potentialTickTimestamps(startTimestamp: Float, upperLimit: Int, lowerLimit: Int): [Float!]!
   assetSelection: AssetSelection
+  tags: [DefinitionTag!]!
 }
 
 enum InstigationStatus {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -4839,6 +4839,7 @@ export type Schedule = {
   potentialTickTimestamps: Array<Scalars['Float']['output']>;
   scheduleState: InstigationState;
   solidSelection: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  tags: Array<DefinitionTag>;
 };
 
 export type ScheduleFutureTickArgs = {
@@ -13717,6 +13718,7 @@ export const buildSchedule = (
         : buildInstigationState({}, relationshipsToOmit),
     solidSelection:
       overrides && overrides.hasOwnProperty('solidSelection') ? overrides.solidSelection! : [],
+    tags: overrides && overrides.hasOwnProperty('tags') ? overrides.tags! : [],
   };
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -1,5 +1,5 @@
 import time
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 import dagster._check as check
 import graphene
@@ -22,6 +22,7 @@ from dagster_graphql.schema.instigation import (
     GrapheneInstigationState,
     GrapheneInstigationStatus,
 )
+from dagster_graphql.schema.tags import GrapheneDefinitionTag
 from dagster_graphql.schema.util import ResolveInfo, non_null_list
 
 
@@ -54,6 +55,7 @@ class GrapheneSchedule(graphene.ObjectType):
         lower_limit=graphene.Int(),
     )
     assetSelection = graphene.Field(GrapheneAssetSelection)
+    tags = non_null_list(GrapheneDefinitionTag)
 
     class Meta:
         name = "Schedule"
@@ -221,6 +223,12 @@ class GrapheneSchedule(graphene.ObjectType):
         ]
 
         return tick_times
+
+    def resolve_tags(self, _graphene_info: ResolveInfo) -> Sequence[GrapheneDefinitionTag]:
+        return [
+            GrapheneDefinitionTag(key, value)
+            for key, value in (self._external_schedule.tags or {}).items()
+        ]
 
 
 class GrapheneScheduleOrError(graphene.Union):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1055,8 +1055,9 @@ def define_schedules():
         cron_schedule="@daily",
         job_name="no_config_job",
         execution_timezone="US/Central",
+        tags={"foo": "bar"},
     )
-    def timezone_schedule(_context):
+    def timezone_schedule_with_tags(_context):
         return {}
 
     tagged_job_schedule = ScheduleDefinition(
@@ -1115,7 +1116,7 @@ def define_schedules():
         tagged_job_schedule,
         tagged_job_override_schedule,
         tags_error_schedule,
-        timezone_schedule,
+        timezone_schedule_with_tags,
         invalid_config_schedule,
         running_in_code_schedule,
         composite_cron_schedule,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/schedule_decorator.py
@@ -81,8 +81,8 @@ def schedule(
             ``['45 23 * * 6', '30 9 * * 0']`` for a schedule that runs at 11:45 PM every Saturday and
             9:30 AM every Sunday.
         name (Optional[str]): The name of the schedule.
-        tags (Optional[Dict[str, str]]): A dictionary of tags (string key-value pairs) to attach
-            to the scheduled runs.
+        tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the schedule and can
+            be used for searching and filtering in the UI.
         tags_fn (Optional[Callable[[ScheduleEvaluationContext], Optional[Dict[str, str]]]]): A function
             that generates tags to attach to the schedule's runs. Takes a
             :py:class:`~dagster.ScheduleEvaluationContext` and returns a dictionary of tags (string
@@ -193,8 +193,8 @@ def schedule(
             required_resource_keys=required_resource_keys,
             run_config=None,  # cannot supply run_config or run_config_fn to decorator
             run_config_fn=None,
-            tags=None,  # cannot supply tags or tags_fn to decorator
-            tags_fn=None,
+            tags=tags,
+            tags_fn=None,  # cannot supply tags or tags_fn to decorator
             should_execute=None,  # already encompassed in evaluation_fn
             target=target,
         )

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -863,6 +863,10 @@ class ExternalSchedule:
     def handle(self) -> InstigatorHandle:
         return self._handle
 
+    @property
+    def tags(self) -> Mapping[str, str]:
+        return self._external_schedule_data.tags
+
     def get_external_origin(self) -> RemoteInstigatorOrigin:
         return self.handle.get_external_origin()
 

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -338,6 +338,7 @@ class ScheduleSnap(IHaveNew):
     description: Optional[str]
     default_status: Optional[DefaultScheduleStatus]
     asset_selection: Optional[AssetSelection]
+    tags: Mapping[str, str]
 
     def __new__(
         cls,
@@ -352,6 +353,7 @@ class ScheduleSnap(IHaveNew):
         description: Optional[str] = None,
         default_status: Optional[DefaultScheduleStatus] = None,
         asset_selection: Optional[AssetSelection] = None,
+        tags: Optional[Mapping[str, str]] = None,
     ):
         if asset_selection is not None:
             check.invariant(
@@ -377,6 +379,7 @@ class ScheduleSnap(IHaveNew):
                 else None
             ),
             asset_selection=asset_selection,
+            tags=tags or {},
         )
 
     @classmethod
@@ -407,6 +410,7 @@ class ScheduleSnap(IHaveNew):
             description=schedule_def.description,
             default_status=schedule_def.default_status,
             asset_selection=serializable_asset_selection,
+            tags=schedule_def.tags,
         )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
@@ -2289,7 +2289,8 @@
         "name": "foo_schedule",
         "partition_set_name": null,
         "pipeline_name": "foo_job",
-        "solid_selection": null
+        "solid_selection": null,
+        "tags": {}
       }
     ],
     "external_sensor_datas": [],

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_schedule.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_schedule.py
@@ -195,7 +195,7 @@ def test_invalid_tag_keys():
         def my_tag_schedule():
             return {}
 
-        assert len(caught_warnings) == 1
+        assert len(caught_warnings) == 2
         warning = caught_warnings[0]
         assert "Non-compliant tag keys like ['my_tag&', 'my_tag#'] are deprecated" in str(
             warning.message

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -320,6 +320,22 @@ def many_requests_schedule(context):
     ]
 
 
+@schedule(
+    cron_schedule="@daily",
+    job_name="the_job",
+    tags={"foo": "bar"},
+)
+def tags_and_eval_fn_schedule(context):
+    return RunRequest()
+
+
+tags_and_no_eval_fn_schedule = ScheduleDefinition(
+    cron_schedule="@daily",
+    job_name="the_job",
+    tags={"foo": "bar"},
+)
+
+
 def define_multi_run_schedule():
     def gen_runs(context):
         if not context.scheduled_execution_time:


### PR DESCRIPTION
## Summary & Motivation

Tweak the behavior of `tags` on `ScheduleDefinition` to make them act as "definition tags", as opposed to "run tags".

Downstack we add `tags` to `SensorDefinition`. This was straightforward because there was no pre-existing `tags` param. The situation is more complex for schedules-- `ScheduleDefinition` has a preexisting `tags` parameter that effectively acts as "run tags", i.e. if set it is attached to runs launched from the schedule.

However, if `tags` _and_ a custom execution function are set, then `ScheduleDefinition` errors on construction. Further, due to an apparent past mistake, if `tags` is passed to the `@schedule` decorator, then it is simply ignored in all but the case where the schedule returns a dict run config (an old and possibly not-even-supported anymore API)?

This actually works in our favor in this PR, where the aim is for `tags` to represent definition tags only as often as possible. New behavior:

- We relax the constraint where `ScheduleDefinition` cannot receive both `tags` and a custom `evaluation_fn`. Instead, if both of these are set, the `tags` act as pure definition tags-- they are not attached to any emitted `RunRequest`.
- If no custom evaluation fn is provided, then tags both act as definition tags _and_ get automatically appended to emitted `RunRequests`. This isn't great but is necessary for backcompat.

NOTE: though a `tags` param was already present on `ScheduleDefinition`, it wasn't exposed on the remote representation. This PR adds that exposure, which is necessary for the tags to function as "definition tags".

## How I Tested These Changes

New unit tests.

## Changelog

It is now possible to set both `tags` and a custom `execution_fn` on a `ScheduleDefinition`. Schedule `tags` are intended to annotate the definition and can be used to search and filter in the UI. They will not be attached to run requests emitted from the schedule if a custom `execution_fn` is provided. If no custom `execution_fn` is provided, then for back-compatibility the tags will also be automatically attached to run requests emitted from the schedule.

- [x] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
