### PR TITLE
[definition-tags] Add new `run_tags` param to JobDefinition and associated constructs

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_monitoring_daemon_examples.py
+++ b/examples/docs_snippets/docs_snippets_tests/deploying_tests/test_monitoring_daemon_examples.py
@@ -5,4 +5,4 @@ from docs_snippets.deploying.monitoring_daemon.run_timeouts import asset_job, my
 def test_run_timeouts():
     assert my_job.execute_in_process().success
     assert my_job.tags[MAX_RUNTIME_SECONDS_TAG] == "10"
-    assert asset_job.tags[MAX_RUNTIME_SECONDS_TAG] == 10
+    assert asset_job.tags[MAX_RUNTIME_SECONDS_TAG] == "10"

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -1080,6 +1080,7 @@ type Pipeline implements SolidContainer & IPipelineSnapshot {
   sensors: [Sensor!]!
   parentSnapshotId: String
   graphName: String!
+  runTags: [PipelineTag!]!
   presets: [PipelinePreset!]!
   isJob: Boolean!
   isAssetJob: Boolean!
@@ -1375,6 +1376,7 @@ type PipelineSnapshot implements SolidContainer & IPipelineSnapshot & PipelineRe
   parentSnapshotId: String
   graphName: String!
   solidSelection: [String!]
+  runTags: [PipelineTag!]!
 }
 
 union PipelineSnapshotOrError =
@@ -2149,6 +2151,7 @@ type Job implements SolidContainer & IPipelineSnapshot {
   sensors: [Sensor!]!
   parentSnapshotId: String
   graphName: String!
+  runTags: [PipelineTag!]!
   presets: [PipelinePreset!]!
   isJob: Boolean!
   isAssetJob: Boolean!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2096,6 +2096,7 @@ export type Job = IPipelineSnapshot &
     pipelineSnapshotId: Scalars['String']['output'];
     presets: Array<PipelinePreset>;
     repository: Repository;
+    runTags: Array<PipelineTag>;
     runs: Array<Run>;
     schedules: Array<Schedule>;
     sensors: Array<Sensor>;
@@ -3393,6 +3394,7 @@ export type Pipeline = IPipelineSnapshot &
     pipelineSnapshotId: Scalars['String']['output'];
     presets: Array<PipelinePreset>;
     repository: Repository;
+    runTags: Array<PipelineTag>;
     runs: Array<Run>;
     schedules: Array<Schedule>;
     sensors: Array<Sensor>;
@@ -3626,6 +3628,7 @@ export type PipelineSnapshot = IPipelineSnapshot &
     name: Scalars['String']['output'];
     parentSnapshotId: Maybe<Scalars['String']['output']>;
     pipelineSnapshotId: Scalars['String']['output'];
+    runTags: Array<PipelineTag>;
     runs: Array<Run>;
     schedules: Array<Schedule>;
     sensors: Array<Sensor>;
@@ -9177,6 +9180,7 @@ export const buildJob = (
         : relationshipsToOmit.has('Repository')
         ? ({} as Repository)
         : buildRepository({}, relationshipsToOmit),
+    runTags: overrides && overrides.hasOwnProperty('runTags') ? overrides.runTags! : [],
     runs: overrides && overrides.hasOwnProperty('runs') ? overrides.runs! : [],
     schedules: overrides && overrides.hasOwnProperty('schedules') ? overrides.schedules! : [],
     sensors: overrides && overrides.hasOwnProperty('sensors') ? overrides.sensors! : [],
@@ -11362,6 +11366,7 @@ export const buildPipeline = (
         : relationshipsToOmit.has('Repository')
         ? ({} as Repository)
         : buildRepository({}, relationshipsToOmit),
+    runTags: overrides && overrides.hasOwnProperty('runTags') ? overrides.runTags! : [],
     runs: overrides && overrides.hasOwnProperty('runs') ? overrides.runs! : [],
     schedules: overrides && overrides.hasOwnProperty('schedules') ? overrides.schedules! : [],
     sensors: overrides && overrides.hasOwnProperty('sensors') ? overrides.sensors! : [],
@@ -11770,6 +11775,7 @@ export const buildPipelineSnapshot = (
       overrides && overrides.hasOwnProperty('pipelineSnapshotId')
         ? overrides.pipelineSnapshotId!
         : 'labore',
+    runTags: overrides && overrides.hasOwnProperty('runTags') ? overrides.runTags! : [],
     runs: overrides && overrides.hasOwnProperty('runs') ? overrides.runs! : [],
     schedules: overrides && overrides.hasOwnProperty('schedules') ? overrides.schedules! : [],
     sensors: overrides && overrides.hasOwnProperty('sensors') ? overrides.sensors! : [],

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -650,6 +650,7 @@ class GrapheneIPipelineSnapshotMixin:
         handleID=graphene.Argument(graphene.NonNull(graphene.String)),
     )
     tags = non_null_list(GraphenePipelineTag)
+    run_tags = non_null_list(GraphenePipelineTag)
     metadata_entries = non_null_list(GrapheneMetadataEntry)
     runs = graphene.Field(
         non_null_list(GrapheneRun),
@@ -753,6 +754,13 @@ class GrapheneIPipelineSnapshotMixin:
         return [
             GraphenePipelineTag(key=key, value=value)
             for key, value in represented_pipeline.job_snapshot.tags.items()
+        ]
+
+    def resolve_run_tags(self, _graphene_info: ResolveInfo):
+        represented_pipeline = self.get_represented_job()
+        return [
+            GraphenePipelineTag(key=key, value=value)
+            for key, value in (represented_pipeline.job_snapshot.run_tags or {}).items()
         ]
 
     def resolve_metadata_entries(self, _graphene_info: ResolveInfo) -> List[GrapheneMetadataEntry]:

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_all_snapshot_ids.ambr
@@ -6318,6 +6318,7 @@
       }
     ],
     "name": "no_multipartitions_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -6356,7 +6357,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[103]
-  '7ef1abf462d45da506f4a41346fc463df457dada'
+  'f53f6915917e179ab89bae44c345e79603f8d42d'
 # ---
 # name: test_all_snapshot_ids[104]
   '''
@@ -8209,6 +8210,7 @@
       }
     ],
     "name": "observation_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -8247,7 +8249,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[107]
-  '56cbc6f2f1527ce32e89fff3a1c260a90797e26a'
+  '77bb631e77718a35cfd31049d03241709f9454ea'
 # ---
 # name: test_all_snapshot_ids[108]
   '''
@@ -9158,6 +9160,7 @@
       }
     ],
     "name": "output_then_hang_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -9198,7 +9201,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[109]
-  '557106a5e60ddca8f667e9daae445616f1f6a120'
+  'c5cbcfa0e6f1c8658773ba21a9a70fd1b7c517eb'
 # ---
 # name: test_all_snapshot_ids[10]
   '''
@@ -10988,6 +10991,7 @@
       }
     ],
     "name": "partition_materialization_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -11026,7 +11030,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[111]
-  'd006ed500ce7bd68754d2c5ef1ad29ca176a0e69'
+  '8b0a6d0b6366a3178821e74b13782124ffa5d0fd'
 # ---
 # name: test_all_snapshot_ids[112]
   '''
@@ -24369,6 +24373,7 @@
       }
     ],
     "name": "static_partitioned_assets_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -24515,7 +24520,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[137]
-  '91aa79ab9d26309c5caa7ea69daa1741fda34362'
+  '95fba788e86b9b4bb2de437436dbf5be782e1f02'
 # ---
 # name: test_all_snapshot_ids[138]
   '''
@@ -26194,6 +26199,9 @@
       }
     ],
     "name": "tagged_job",
+    "run_tags": {
+      "baz": "quux"
+    },
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -26234,7 +26242,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[141]
-  '8e516c94a1e0d32aabc7ea8d8fc27d68afdb45cf'
+  'c3320c44d5fa6c508dfda564e67bc67747b9891c'
 # ---
 # name: test_all_snapshot_ids[142]
   '''
@@ -27260,6 +27268,7 @@
       }
     ],
     "name": "time_partitioned_assets_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -27332,7 +27341,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[143]
-  'cf5f6596eead075696e683b33db56a830ea834d4'
+  '81ecba8b867d1179f0998c86b85a1176aa946456'
 # ---
 # name: test_all_snapshot_ids[144]
   '''
@@ -28358,6 +28367,7 @@
       }
     ],
     "name": "two_assets_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -28430,7 +28440,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[145]
-  'a273aada46419892fdf5bbc48d0878f0e1eecba7'
+  'ce839b23a887f29520c71238335886cbe80337ef'
 # ---
 # name: test_all_snapshot_ids[146]
   '''
@@ -30492,6 +30502,7 @@
       }
     ],
     "name": "typed_assets",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -30606,7 +30617,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[149]
-  '1e553a1a3208ae523ef9d8257bcdf009fab236d2'
+  'dedb9fc5a6627950d8d31dce78af887c18c25160'
 # ---
 # name: test_all_snapshot_ids[14]
   '''
@@ -31625,6 +31636,7 @@
       }
     ],
     "name": "checked_multi_asset_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -31687,7 +31699,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[15]
-  '91e422f2d9b8074941369b90949c58d1e11db034'
+  'c77559c3ffec162d2580606b6cc7aeaf8ab8d9e0'
 # ---
 # name: test_all_snapshot_ids[16]
   '''
@@ -40075,6 +40087,7 @@
       }
     ],
     "name": "__anonymous_asset_job_jobless_schedule",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -41993,6 +42006,7 @@
       }
     ],
     "name": "dynamic_in_multipartitions_success_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -42065,7 +42079,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[33]
-  '38cc700dbc638b2251a61d4112bf2543164e4aa1'
+  '155cb67915656dd22c1d24cac01603648f423b0b'
 # ---
 # name: test_all_snapshot_ids[34]
   '''
@@ -44299,6 +44313,7 @@
       }
     ],
     "name": "dynamic_partitioned_assets_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -44371,7 +44386,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[37]
-  '17fceed1b04705a2ee89a1748860a9a466a0f144'
+  '226bfaa0b42ce356abd18ab86046686cc2c2b9b2'
 # ---
 # name: test_all_snapshot_ids[38]
   '''
@@ -45595,7 +45610,7 @@
   'effe11fd9b8a40682bc8041fcfdaf25f68be4612'
 # ---
 # name: test_all_snapshot_ids[3]
-  '897cefd372caacf2f37ac44731548066b67fa2fd'
+  'fc5c2d069b423eb651fd1b8e68f1537d8ecfdd82'
 # ---
 # name: test_all_snapshot_ids[40]
   '''
@@ -46598,6 +46613,7 @@
       }
     ],
     "name": "executable_test_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -46643,7 +46659,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[41]
-  'b9a0f1ad3f31b0d09659cbcac7d55542a1831b2b'
+  '5c546683c0858a71f27c63a4b294926e1de6a1e1'
 # ---
 # name: test_all_snapshot_ids[42]
   '''
@@ -47639,6 +47655,7 @@
       }
     ],
     "name": "fail_partition_materialization_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -47677,7 +47694,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[43]
-  'e9016541365b463cd2c5ba175e1a8f9b861e2333'
+  '39c8061a712382691a1d8203efadcec978be2173'
 # ---
 # name: test_all_snapshot_ids[44]
   '''
@@ -48774,6 +48791,7 @@
       }
     ],
     "name": "failure_assets_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -48920,7 +48938,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[45]
-  '074faf0cae91a885ddfd97b9e0173f685ea24676'
+  'f07b5f3e9fe1aaec2d455ef01bac50f38db70300'
 # ---
 # name: test_all_snapshot_ids[46]
   '''
@@ -50022,6 +50040,7 @@
       }
     ],
     "name": "foo_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -50188,7 +50207,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[47]
-  '5d7abe02cce403ab7e2f1436c0e3060f766395a8'
+  '7ba20030eeecab26afcfd3cd5a68be1d2f48c427'
 # ---
 # name: test_all_snapshot_ids[48]
   '''
@@ -51293,6 +51312,7 @@
       }
     ],
     "name": "fresh_diamond_assets_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -51446,7 +51466,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[49]
-  '3870f53cc527621d6dc489dbc6980dc72912b085'
+  'a670207753e19f723023819135333b4ac71a281b'
 # ---
 # name: test_all_snapshot_ids[4]
   '''
@@ -52442,6 +52462,7 @@
       }
     ],
     "name": "__anonymous_asset_job_jobless_sensor",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -53567,6 +53588,7 @@
       }
     ],
     "name": "hanging_graph_asset_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [
@@ -53792,7 +53814,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[51]
-  '973fd7484dc9a218cd19ab0344a593053fded3dc'
+  '8d5778a9040bf5a8f2eb894cca019573f72cafb7'
 # ---
 # name: test_all_snapshot_ids[52]
   '''
@@ -54770,6 +54792,7 @@
       }
     ],
     "name": "hanging_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -54885,7 +54908,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[53]
-  '065b896532a7dc8172d7865d74f08375cb96ce96'
+  '2a4c830fed93036921f36e4ff15172e452f21460'
 # ---
 # name: test_all_snapshot_ids[54]
   '''
@@ -55796,6 +55819,7 @@
       }
     ],
     "name": "hanging_partition_asset_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -55836,7 +55860,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[55]
-  'd0700b0d774bc626fd21c3e043778dc00e050e9b'
+  '3fcb711d337cb03bedf5ff7e5ec64b30eefc9ec8'
 # ---
 # name: test_all_snapshot_ids[56]
   '''
@@ -57665,7 +57689,7 @@
   'dc190868e8887ba5ac3669da13473252cd0ab098'
 # ---
 # name: test_all_snapshot_ids[5]
-  '058ff6bc3f0d0dfc1471085bf87f59549eb3cc96'
+  'c23e75a6d1d7a9b89528399a9d27bcc9c90a178e'
 # ---
 # name: test_all_snapshot_ids[60]
   '''
@@ -60421,6 +60445,7 @@
       }
     ],
     "name": "integers_asset_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -60459,7 +60484,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[65]
-  '26b8a0f326020f6af764ac2174883f2e7aaad5a7'
+  '10e316cc85a348c2e9f5c5ec1a076bfe7e036ff2'
 # ---
 # name: test_all_snapshot_ids[66]
   '''
@@ -63320,6 +63345,7 @@
       }
     ],
     "name": "asset_check_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -68023,7 +68049,7 @@
   '1c4b82d393f7eacd9a358e3d82925d2afb9afbc0'
 # ---
 # name: test_all_snapshot_ids[7]
-  'feeab464031ab4e4abbe56cf5d3fe7539c6cd688'
+  '8023256507d183317343a2f6c4703a5ac3800eaf'
 # ---
 # name: test_all_snapshot_ids[80]
   '''
@@ -72763,6 +72789,7 @@
       }
     ],
     "name": "multipartitions_fail_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -72801,7 +72828,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[89]
-  'd583f0bb3aa30af2f5f652e9c65cd3c39b21a8cd'
+  '17bea22424bd5aa8995cc8ae08cd2e0c1be7c019'
 # ---
 # name: test_all_snapshot_ids[8]
   '''
@@ -74681,6 +74708,7 @@
       }
     ],
     "name": "multipartitions_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -74753,7 +74781,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[91]
-  'ca7929c6d4c55692a092000474ada02b6c4047c5'
+  '7fc53a5a9f9ab514b23b938f7fa68cd5fd2f464d'
 # ---
 # name: test_all_snapshot_ids[92]
   '''
@@ -75817,6 +75845,7 @@
       }
     ],
     "name": "named_groups_job",
+    "run_tags": {},
     "solid_definitions_snapshot": {
       "__class__": "SolidDefinitionsSnapshot",
       "composite_solid_def_snaps": [],
@@ -75963,7 +75992,7 @@
   '''
 # ---
 # name: test_all_snapshot_ids[93]
-  '8c005fb808a1945e5a62fbac517836a242e27901'
+  'f08d1a06b69649912ba8b056d76b8c7809954c31'
 # ---
 # name: test_all_snapshot_ids[94]
   '''

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_pipeline_snapshot.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_pipeline_snapshot.ambr
@@ -30,9 +30,6 @@
           "key": "Nothing"
         },
         {
-          "key": "PoorMansDataFrame"
-        },
-        {
           "key": "String"
         }
       ],
@@ -42,25 +39,30 @@
           "name": "default"
         }
       ],
-      "name": "csv_hello_world",
-      "pipelineSnapshotId": "9d2930f7c072c5a01688d84b725c49d4ae718c65",
+      "name": "tagged_job",
+      "pipelineSnapshotId": "c3320c44d5fa6c508dfda564e67bc67747b9891c",
+      "runTags": [
+        {
+          "key": "baz",
+          "value": "quux"
+        }
+      ],
       "solidHandles": [
         {
-          "handleID": "sum_op"
-        },
-        {
-          "handleID": "sum_sq_op"
+          "handleID": "simple_op"
         }
       ],
       "solids": [
         {
-          "name": "sum_op"
-        },
-        {
-          "name": "sum_sq_op"
+          "name": "simple_op"
         }
       ],
-      "tags": []
+      "tags": [
+        {
+          "key": "foo",
+          "value": "bar"
+        }
+      ]
     }
   }
   '''
@@ -108,6 +110,7 @@
       ],
       "name": "noop_job",
       "pipelineSnapshotId": "dbc0d71fefa48d56ff94e517235980f1bbf0d8e8",
+      "runTags": [],
       "solidHandles": [
         {
           "handleID": "noop_op"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -865,7 +865,7 @@ def retry_multi_output_job():
     no_output.alias("grandchild_fail")(passthrough.alias("child_fail")(fail))
 
 
-@job(tags={"foo": "bar"})
+@job(tags={"foo": "bar"}, run_tags={"baz": "quux"})
 def tagged_job():
     @op
     def simple_op():

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_pipeline_snapshot.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_pipeline_snapshot.py
@@ -26,6 +26,7 @@ query PipelineSnapshotQueryBySnapshotID($snapshotId: String!) {
             modes { name }
             solidHandles { handleID }
             tags { key value }
+            runTags { key value }
         }
         ... on PipelineSnapshotNotFoundError {
             snapshotId
@@ -47,6 +48,7 @@ query PipelineSnapshotQueryByActivePipelineName($activePipelineSelector: Pipelin
             modes { name }
             solidHandles { handleID }
             tags { key value }
+            runTags { key value }
         }
         ... on PipelineSnapshotNotFoundError {
             snapshotId
@@ -107,7 +109,7 @@ def test_fetch_snapshot_or_error_by_active_pipeline_name_success(
         SNAPSHOT_OR_ERROR_QUERY_BY_PIPELINE_NAME,
         {
             "activePipelineSelector": {
-                "pipelineName": "csv_hello_world",
+                "pipelineName": "tagged_job",
                 "repositoryName": main_repo_name(),
                 "repositoryLocationName": main_repo_location_name(),
             }
@@ -117,7 +119,9 @@ def test_fetch_snapshot_or_error_by_active_pipeline_name_success(
     assert not result.errors
     assert result.data
     assert result.data["pipelineSnapshotOrError"]["__typename"] == "PipelineSnapshot"
-    assert result.data["pipelineSnapshotOrError"]["name"] == "csv_hello_world"
+    assert result.data["pipelineSnapshotOrError"]["name"] == "tagged_job"
+    assert result.data["pipelineSnapshotOrError"]["tags"] == [{"key": "foo", "value": "bar"}]
+    assert result.data["pipelineSnapshotOrError"]["runTags"] == [{"key": "baz", "value": "quux"}]
 
     snapshot.assert_match(pretty_dump(result.data))
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_job.py
@@ -95,6 +95,7 @@ def build_asset_job(
         Union[ConfigMapping, Mapping[str, object], PartitionedConfig, "RunConfig"]
     ] = None,
     tags: Optional[Mapping[str, str]] = None,
+    run_tags: Optional[Mapping[str, str]] = None,
     metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     executor_def: Optional[ExecutorDefinition] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
@@ -189,6 +190,7 @@ def build_asset_job(
             resource_defs=all_resource_defs,
             config=config,
             tags=tags,
+            run_tags=run_tags,
             executor_def=executor_def,
             partitions_def=partitions_def,
             asset_layer=asset_layer,
@@ -198,11 +200,11 @@ def build_asset_job(
             hooks=original_job.hook_defs,
             op_retry_policy=original_job.op_retry_policy,
         )
-
     return graph.to_job(
         resource_defs=all_resource_defs,
         config=config,
         tags=tags,
+        run_tags=run_tags,
         metadata=metadata,
         executor_def=executor_def,
         partitions_def=partitions_def,

--- a/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/job_decorator.py
@@ -25,6 +25,7 @@ class _Job:
         name: Optional[str] = None,
         description: Optional[str] = None,
         tags: Optional[Mapping[str, Any]] = None,
+        run_tags: Optional[Mapping[str, Any]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
         config: Optional[
@@ -42,6 +43,7 @@ class _Job:
         self.name = name
         self.description = description
         self.tags = normalize_tags(tags, warning_stacklevel=4)
+        self.run_tags = run_tags
         self.metadata = metadata
         self.resource_defs = resource_defs
         self.config = convert_config_input(config)
@@ -87,7 +89,7 @@ class _Job:
             output_mappings=output_mappings,
             config=config_mapping,
             positional_inputs=positional_inputs,
-            tags=self.tags,
+            tags=self.run_tags,
             input_assets=input_assets,
         )
 
@@ -96,6 +98,7 @@ class _Job:
             resource_defs=self.resource_defs,
             config=self.config,
             tags=self.tags,
+            run_tags=self.run_tags,
             metadata=self.metadata,
             logger_defs=self.logger_defs,
             executor_def=self.executor_def,
@@ -120,6 +123,7 @@ def job(
     resource_defs: Optional[Mapping[str, object]] = ...,
     config: Union[ConfigMapping, Mapping[str, Any], "RunConfig", "PartitionedConfig"] = ...,
     tags: Optional[Mapping[str, Any]] = ...,
+    run_tags: Optional[Mapping[str, Any]] = ...,
     metadata: Optional[Mapping[str, RawMetadataValue]] = ...,
     logger_defs: Optional[Mapping[str, LoggerDefinition]] = ...,
     executor_def: Optional["ExecutorDefinition"] = ...,
@@ -139,7 +143,8 @@ def job(
     config: Optional[
         Union[ConfigMapping, Mapping[str, Any], "RunConfig", "PartitionedConfig"]
     ] = None,
-    tags: Optional[Mapping[str, Any]] = None,
+    tags: Optional[Mapping[str, str]] = None,
+    run_tags: Optional[Mapping[str, str]] = None,
     metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
     executor_def: Optional["ExecutorDefinition"] = None,
@@ -184,11 +189,15 @@ def job(
             values that can parameterize the job, as well as a function for mapping those
             values to the base config. The values provided will be viewable and editable in the
             Dagster UI, so be careful with secrets.
-        tags (Optional[Dict[str, Any]]):
-            Arbitrary information that will be attached to the execution of the Job.
-            Values that are not strings will be json encoded and must meet the criteria that
-            `json.loads(json.dumps(value)) == value`.  These tag values may be overwritten by tag
-            values provided at invocation time.
+        tags (Optional[Mapping[str, object]]): A set of key-value tags that annotate the job and can
+            be used for searching and filtering in the UI. Values that are not already strings will
+            be serialized as JSON. If `run_tags` is not set, then the content of `tags` will also be
+            automatically appended to the tags of any runs of this job.
+        run_tags (Optional[Mapping[str, object]]):
+            A set of key-value tags that will be automatically attached to runs launched by this
+            job. Values that are not already strings will be serialized as JSON. These tag values
+            may be overwritten by tag values provided at invocation time. If `run_tags` is set, then
+            `tags` are not automatically appended to the tags of any runs of this job.
         metadata (Optional[Dict[str, RawMetadataValue]]):
             Arbitrary information that will be attached to the JobDefinition and be viewable in the Dagster UI.
             Keys must be strings, and values must be python primitive types or one of the provided
@@ -232,6 +241,7 @@ def job(
         resource_defs=wrap_resources_for_execution(resource_defs),
         config=config,
         tags=tags,
+        run_tags=run_tags,
         metadata=metadata,
         logger_defs=logger_defs,
         executor_def=executor_def,

--- a/python_modules/dagster/dagster/_core/definitions/graph_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/graph_definition.py
@@ -623,6 +623,7 @@ class GraphDefinition(NodeDefinition):
         partitions_def: Optional["PartitionsDefinition"] = None,
         asset_layer: Optional["AssetLayer"] = None,
         input_values: Optional[Mapping[str, object]] = None,
+        run_tags: Optional[Mapping[str, object]] = None,
         _asset_selection_data: Optional[AssetSelectionData] = None,
     ) -> "JobDefinition":
         """Make this graph in to an executable Job by providing remaining components required for execution.
@@ -652,11 +653,15 @@ class GraphDefinition(NodeDefinition):
                 values that can parameterize the job, as well as a function for mapping those
                 values to the base config. The values provided will be viewable and editable in the
                 Dagster UI, so be careful with secrets.
-            tags (Optional[Mapping[str, Any]]):
-                Arbitrary information that will be attached to the execution of the Job.
-                Values that are not strings will be json encoded and must meet the criteria that
-                `json.loads(json.dumps(value)) == value`.  These tag values may be overwritten by tag
-                values provided at invocation time.
+            tags (Optional[Mapping[str, object]]): A set of key-value tags that annotate the job and can
+                be used for searching and filtering in the UI. Values that are not already strings will
+                be serialized as JSON. If `run_tags` is not set, then the content of `tags` will also be
+                automatically appended to the tags of any runs of this job.
+            run_tags (Optional[Mapping[str, object]]):
+                A set of key-value tags that will be automatically attached to runs launched by this
+                job. Values that are not already strings will be serialized as JSON. These tag values
+                may be overwritten by tag values provided at invocation time. If `run_tags` is set, then
+                `tags` are not automatically appended to the tags of any runs of this job.
             metadata (Optional[Mapping[str, RawMetadataValue]]):
                 Arbitrary information that will be attached to the JobDefinition and be viewable in the Dagster UI.
                 Keys must be strings, and values must be python primitive types or one of the provided
@@ -684,7 +689,6 @@ class GraphDefinition(NodeDefinition):
         from dagster._core.execution.build_resources import wrap_resources_for_execution
 
         wrapped_resource_defs = wrap_resources_for_execution(resource_defs)
-
         return JobDefinition.dagster_internal_init(
             name=name,
             description=description or self.description,
@@ -695,6 +699,7 @@ class GraphDefinition(NodeDefinition):
             config=config,
             partitions_def=partitions_def,
             tags=tags,
+            run_tags=run_tags,
             metadata=metadata,
             hook_defs=hooks,
             op_retry_policy=op_retry_policy,

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -109,6 +109,7 @@ class JobDefinition(IHasInternalInit):
     _graph_def: GraphDefinition
     _description: Optional[str]
     _tags: Mapping[str, str]
+    _run_tags: Optional[Mapping[str, str]]
     _metadata: Mapping[str, MetadataValue]
     _current_level_node_defs: Sequence[NodeDefinition]
     _hook_defs: AbstractSet[HookDefinition]
@@ -134,6 +135,7 @@ class JobDefinition(IHasInternalInit):
         description: Optional[str] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
         tags: Union[NormalizedTags, Optional[Mapping[str, Any]]] = None,
+        run_tags: Union[NormalizedTags, Optional[Mapping[str, Any]]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         hook_defs: Optional[AbstractSet[HookDefinition]] = None,
         op_retry_policy: Optional[RetryPolicy] = None,
@@ -175,7 +177,10 @@ class JobDefinition(IHasInternalInit):
         # tags and description can exist on graph as well, but since
         # same graph may be in multiple jobs, keep separate layer
         self._description = check.opt_str_param(description, "description")
-        self._tags = normalize_tags(tags).tags
+
+        self._tags = tags.tags if isinstance(tags, NormalizedTags) else normalize_tags(tags).tags
+        self._run_tags = run_tags.tags if isinstance(run_tags, NormalizedTags) else run_tags
+
         self._metadata = normalize_metadata(
             check.opt_mapping_param(metadata, "metadata", key_type=str)
         )
@@ -275,6 +280,7 @@ class JobDefinition(IHasInternalInit):
         description: Optional[str],
         partitions_def: Optional[PartitionsDefinition],
         tags: Union[NormalizedTags, Optional[Mapping[str, Any]]],
+        run_tags: Union[NormalizedTags, Optional[Mapping[str, Any]]],
         metadata: Optional[Mapping[str, RawMetadataValue]],
         hook_defs: Optional[AbstractSet[HookDefinition]],
         op_retry_policy: Optional[RetryPolicy],
@@ -293,6 +299,7 @@ class JobDefinition(IHasInternalInit):
             description=description,
             partitions_def=partitions_def,
             tags=tags,
+            run_tags=run_tags,
             metadata=metadata,
             hook_defs=hook_defs,
             op_retry_policy=op_retry_policy,
@@ -306,9 +313,37 @@ class JobDefinition(IHasInternalInit):
     def name(self) -> str:
         return self._name
 
-    @property
+    # If `run_tags` is set (not None), then `tags` and `run_tags` are separate specifications of
+    # "definition" and "run" tags respectively. Otherwise, `tags` is used for both.
+    # This is for backcompat with old behavior prior to the introduction of `run_tags`.
+    #
+    # We need to preserve the distinction between None and {} values for `run_tags` so that the
+    # same logic can be applied in the host process receiving a snapshot of this job. Therefore
+    # we store an extra flag `_has_separately_defined_run_tags` which we use to control snapshot
+    # generation.
+    @cached_property
     def tags(self) -> Mapping[str, str]:
-        return merge_dicts(self._graph_def.tags, self._tags)
+        if self._run_tags is None:
+            return {**self._graph_def.tags, **self._tags}
+        else:
+            return self._tags
+
+    @cached_property
+    def run_tags(self) -> Mapping[str, str]:
+        if self._run_tags is None:
+            return self.tags
+        else:
+            return normalize_tags({**self._graph_def.tags, **self._run_tags}).tags
+
+    # This property exists for backcompat purposes. If it is False, then we omit run_tags when
+    # generating a job snapshot. This lets host processes distinguish between None and {} `run_tags`
+    # values, which have different semantics:
+    #
+    # - run_tags=None (`tags` will be used for run tags)
+    # - run_tags={} (empty dict will be used for run tags), which have different semantics.
+    @property
+    def has_separately_defined_run_tags(self) -> bool:
+        return self._run_tags is not None
 
     @property
     def metadata(self) -> Mapping[str, MetadataValue]:
@@ -684,6 +719,7 @@ class JobDefinition(IHasInternalInit):
             hook_defs=self.hook_defs,
             config=self.config_mapping or self.partitioned_config or self.run_config,
             tags=self.tags,
+            run_tags=self._run_tags,
             op_retry_policy=self._op_retry_policy,
             asset_layer=self.asset_layer,
             input_values=input_values,
@@ -699,7 +735,7 @@ class JobDefinition(IHasInternalInit):
             asset_selection=frozenset(asset_selection) if asset_selection else None,
         )
 
-        merged_tags = merge_dicts(self.tags, tags or {})
+        merged_run_tags = merge_dicts(self.run_tags, tags or {})
         if partition_key:
             ephemeral_job.validate_partition_key(
                 partition_key,
@@ -715,13 +751,13 @@ class JobDefinition(IHasInternalInit):
                 run_config = self.partitioned_config.get_run_config_for_partition_key(partition_key)
 
             if self.partitioned_config:
-                merged_tags.update(
+                merged_run_tags.update(
                     self.partitioned_config.get_tags_for_partition_key(
                         partition_key, job_name=self.name
                     )
                 )
             else:
-                merged_tags.update(tags_for_partition_key)
+                merged_run_tags.update(tags_for_partition_key)
 
         return core_execute_in_process(
             ephemeral_job=ephemeral_job,
@@ -729,7 +765,7 @@ class JobDefinition(IHasInternalInit):
             instance=instance,
             output_capturing_enabled=True,
             raise_on_error=raise_on_error,
-            run_tags=merged_tags,
+            run_tags=merged_run_tags,
             run_id=run_id,
             asset_selection=frozenset(asset_selection),
         )
@@ -1036,6 +1072,7 @@ class JobDefinition(IHasInternalInit):
             name=self._name,
             description=self.description,
             tags=self.tags,
+            run_tags=self._run_tags,
             metadata=self._metadata,
             hook_defs=self.hook_defs,
             op_retry_policy=self._op_retry_policy,

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -17,6 +17,7 @@ from dagster._core.definitions.partition import PartitionedConfig, PartitionsDef
 from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.run_request import RunRequest
+from dagster._core.definitions.utils import normalize_tags
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.instance import DynamicPartitionsStore
 
@@ -38,7 +39,8 @@ class UnresolvedAssetJobDefinition(
                 Optional[Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig"]],
             ),
             ("description", Optional[str]),
-            ("tags", Optional[Mapping[str, Any]]),
+            ("tags", Optional[Mapping[str, str]]),
+            ("run_tags", Optional[Mapping[str, str]]),
             ("metadata", Optional[Mapping[str, RawMetadataValue]]),
             ("partitions_def", Optional[PartitionsDefinition]),
             ("executor_def", Optional[ExecutorDefinition]),
@@ -55,7 +57,8 @@ class UnresolvedAssetJobDefinition(
             Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig", "RunConfig"]
         ] = None,
         description: Optional[str] = None,
-        tags: Optional[Mapping[str, Any]] = None,
+        tags: Optional[Mapping[str, str]] = None,
+        run_tags: Optional[Mapping[str, str]] = None,
         metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         partitions_def: Optional[PartitionsDefinition] = None,
         executor_def: Optional[ExecutorDefinition] = None,
@@ -65,13 +68,19 @@ class UnresolvedAssetJobDefinition(
         from dagster._core.definitions import ExecutorDefinition
         from dagster._core.definitions.run_config import convert_config_input
 
+        tags = check.opt_mapping_param(tags, "tags")
+        # If `run_tags` is set, then we use it, otherwise `tags` acts as both definition tags and
+        # run tags. This is for backcompat with old behavior prior to the introduction of
+        # `run_tags`.
+        run_tags = check.mapping_param(run_tags, "run_tags") if run_tags else tags
         return super(UnresolvedAssetJobDefinition, cls).__new__(
             cls,
             name=check.str_param(name, "name"),
             selection=check.inst_param(selection, "selection", AssetSelection),
             config=convert_config_input(config),
             description=check.opt_str_param(description, "description"),
-            tags=check.opt_mapping_param(tags, "tags"),
+            tags=tags,
+            run_tags=run_tags,
             metadata=check.opt_mapping_param(metadata, "metadata"),
             partitions_def=check.opt_inst_param(
                 partitions_def, "partitions_def", PartitionsDefinition
@@ -218,6 +227,7 @@ class UnresolvedAssetJobDefinition(
             config=self.config,
             description=self.description,
             tags=self.tags,
+            run_tags=self.run_tags,
             metadata=self.metadata,
             partitions_def=self.partitions_def,
             executor_def=self.executor_def or default_executor_def,
@@ -240,7 +250,8 @@ def define_asset_job(
         Union[ConfigMapping, Mapping[str, Any], "PartitionedConfig", "RunConfig"]
     ] = None,
     description: Optional[str] = None,
-    tags: Optional[Mapping[str, Any]] = None,
+    tags: Optional[Mapping[str, object]] = None,
+    run_tags: Optional[Mapping[str, object]] = None,
     metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
     executor_def: Optional[ExecutorDefinition] = None,
@@ -284,11 +295,15 @@ def define_asset_job(
             If a :py:class:`ConfigMapping` object is provided, then the schema for the job's run config is
             determined by the config mapping, and the ConfigMapping, which should return
             configuration in the standard format to configure the job.
-        tags (Optional[Mapping[str, Any]]):
-            Arbitrary information that will be attached to the execution of the Job.
-            Values that are not strings will be json encoded and must meet the criteria that
-            `json.loads(json.dumps(value)) == value`.  These tag values may be overwritten by tag
-            values provided at invocation time.
+        tags (Optional[Mapping[str, object]]): A set of key-value tags that annotate the job and can
+            be used for searching and filtering in the UI. Values that are not already strings will
+            be serialized as JSON. If `run_tags` is not set, then the content of `tags` will also be
+            automatically appended to the tags of any runs of this job.
+        run_tags (Optional[Mapping[str, object]]):
+            A set of key-value tags that will be automatically attached to runs launched by this
+            job. Values that are not already strings will be serialized as JSON. These tag values
+            may be overwritten by tag values provided at invocation time. If `run_tags` is set, then
+            `tags` are not automatically appended to the tags of any runs of this job.
         metadata (Optional[Mapping[str, RawMetadataValue]]): Arbitrary metadata about the job.
             Keys are displayed string labels, and values are one of the following: string, float,
             int, JSON-serializable dict, JSON-serializable list, and one of the data classes
@@ -373,7 +388,9 @@ def define_asset_job(
         selection=resolved_selection,
         config=config,
         description=description,
-        tags=tags,
+        tags=normalize_tags(tags).tags,
+        # Need to preserve None value
+        run_tags=normalize_tags(run_tags).tags if run_tags is not None else None,
         metadata=metadata,
         partitions_def=partitions_def,
         executor_def=executor_def,

--- a/python_modules/dagster/dagster/_core/execution/api.py
+++ b/python_modules/dagster/dagster/_core/execution/api.py
@@ -920,7 +920,7 @@ def _check_execute_job_args(
     tags = check.opt_mapping_param(tags, "tags", key_type=str)
     check.opt_sequence_param(op_selection, "op_selection", of_type=str)
 
-    tags = merge_dicts(job_def.tags, tags)
+    tags = merge_dicts(job_def.run_tags, tags)
 
     # generate job subset from the given op_selection
     if op_selection:

--- a/python_modules/dagster/dagster/_core/execution/execute_in_process.py
+++ b/python_modules/dagster/dagster/_core/execution/execute_in_process.py
@@ -50,7 +50,7 @@ def core_execute_in_process(
         run = execute_instance.create_run_for_job(
             job_def=job_def,
             run_config=run_config,
-            tags={**job_def.tags, **(run_tags or {})},
+            tags={**job_def.run_tags, **(run_tags or {})},
             run_id=run_id,
             asset_selection=asset_selection,
             execution_plan=execution_plan,

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -625,6 +625,14 @@ class ExternalJob(RepresentedJob):
         return self._job_index.job_snapshot.tags
 
     @property
+    def run_tags(self) -> Mapping[str, str]:
+        snapshot_tags = self._job_index.job_snapshot.run_tags
+        # Snapshot tags will be None for snapshots originating from old code servers before the
+        # introduction of run tags. In these cases, the job definition tags are treated as run tags
+        # to maintain backcompat.
+        return snapshot_tags if snapshot_tags is not None else self.tags
+
+    @property
     def metadata(self) -> Mapping[str, MetadataValue]:
         return self._job_index.job_snapshot.metadata
 

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -1311,7 +1311,7 @@ def _create_sensor_run(
     execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
 
     job_tags = normalize_tags(
-        external_job.tags or {}, allow_reserved_tags=False, warn_on_deprecated_tags=False
+        external_job.run_tags or {}, allow_reserved_tags=False, warn_on_deprecated_tags=False
     ).tags
     tags = merge_dicts(
         merge_dicts(job_tags, run_request.tags),

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -944,7 +944,7 @@ def _create_scheduler_run(
 
     tags = merge_dicts(
         normalize_tags(
-            external_job.tags, allow_reserved_tags=False, warn_on_deprecated_tags=False
+            external_job.run_tags, allow_reserved_tags=False, warn_on_deprecated_tags=False
         ).tags
         or {},
         schedule_tags,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_unresolved_asset_job.py
@@ -492,8 +492,10 @@ def test_executor_def():
 
 def test_tags():
     my_tags = {"foo": "bar"}
-    job = create_test_asset_job([foo], tags=my_tags)
+    my_run_tags = {"baz": "quux"}
+    job = create_test_asset_job([foo], tags=my_tags, run_tags=my_run_tags)
     assert job.tags == my_tags
+    assert job.run_tags == my_run_tags
 
 
 def test_description():

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_job_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_job_snap.py
@@ -46,6 +46,7 @@ def test_empty_job_snap_props(snapshot):
     assert job_snapshot.name == "noop_job"
     assert job_snapshot.description is None
     assert job_snapshot.tags == {}
+    assert job_snapshot.run_tags is None
 
     assert job_snapshot == serialize_rt(job_snapshot)
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_job.py
@@ -78,14 +78,30 @@ def test_job_tags():
         pass
 
     @job(tags={"my_tag": "yes"})
-    def basic_job():
+    def job_with_tags():
         basic()
 
+    assert job_with_tags.tags == {"my_tag": "yes"}
+    assert job_with_tags.run_tags == {"my_tag": "yes"}
+
+    @job(tags={"my_tag": "yes"}, run_tags={"my_run_tag": "yes"})
+    def job_with_tags_and_run_tags():
+        basic()
+
+    assert job_with_tags_and_run_tags.tags == {"my_tag": "yes"}
+    assert job_with_tags_and_run_tags.run_tags == {"my_run_tag": "yes"}
+
     with DagsterInstance.ephemeral() as instance:
-        result = basic_job.execute_in_process(instance=instance)
+        result = job_with_tags.execute_in_process(instance=instance)
         assert result.success
         run = instance.get_runs()[0]
         assert run.tags.get("my_tag") == "yes"
+
+        result = job_with_tags_and_run_tags.execute_in_process(instance=instance)
+        assert result.success
+        run = instance.get_runs()[0]
+        assert "my_tag" not in run.tags
+        assert run.tags.get("my_run_tag") == "yes"
 
 
 def test_job_system_tags():

--- a/python_modules/dagster/dagster_tests/execution_tests/execute_job_tests/test_job.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/execute_job_tests/test_job.py
@@ -263,3 +263,25 @@ def test_coerce_resource_graph_to_job() -> None:
 
     assert a_job.execute_in_process().success
     assert executed["yes"]
+
+
+def test_job_tag_transfer():
+    @op
+    def my_op(): ...
+
+    @graph
+    def my_graph():
+        my_op()
+
+    my_job_tags_only = my_graph.to_job(tags={"foo": "bar"})
+    assert my_job_tags_only.execute_in_process().dagster_run.tags == {"foo": "bar"}
+
+    my_job_tags_and_empty_run_tags = my_graph.to_job(tags={"foo": "bar"}, run_tags={})
+    assert my_job_tags_and_empty_run_tags.execute_in_process().dagster_run.tags == {}
+
+    my_job_tags_and_nonempty_run_tags = my_graph.to_job(
+        tags={"foo": "bar"}, run_tags={"baz": "quux"}
+    )
+    assert my_job_tags_and_nonempty_run_tags.execute_in_process().dagster_run.tags == {
+        "baz": "quux"
+    }


### PR DESCRIPTION
## Summary & Motivation

Add `run_tags` param to `JobDefinition` and associated decorators/functions.

The purpose of this is to introduce separate "definition tag" functionality for `JobDefinition`. Currently `JobDefinition` has a `tags` param where the tags are automatically attached to all runs for the job (i.e. act as "run tags". To support separate "definition tags" and "run tags" while maintaining backcompatibility, this PR introduces the following behavior:

- if the new `run_tags` param is set, only `run_tags` will act as run tags, and `tags` will act only as definition tags
- if `run_tags` is not set, then `tags` acts as both definition and run tags

Note that if `run_tags` is set but the host process is on a version prior to release of this PR, then it will not work correctly-- the definition tags will be used as the run tags.

## How I Tested These Changes

New unit tests.

## Changelog

`JobDefinition`, `@job`, and `define_asset_job` now take a `run_tags` parameter. If `run_tags` are defined, they will be attached to all runs of the job, and `tags` will not be.  If `run_tags` is not set, then `tags` are attached to all runs of the job (status quo behavior). This change enables the separation of definition-level and run-level tags on jobs.

- [x] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_