### PR TITLE
[dagster-k8s] test fixes

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_utils.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_utils.py
@@ -70,7 +70,7 @@ def test_wait_for_pod(cluster_provider, namespace):
         )
 
         with pytest.raises(
-            DagsterK8sError, match="Timed out while waiting for pod to become ready"
+            DagsterK8sError, match="Timed out while waiting for pod to get to status READY"
         ):
             api_client.core_api.create_namespaced_pod(
                 body=construct_pod_manifest("sayhi3", 'sleep 5; echo "hello world"'),

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -607,7 +607,7 @@ class DagsterKubernetesClient:
 
             if wait_timeout and self.timer() - start > wait_timeout:
                 raise DagsterK8sError(
-                    f"Timed out while waiting for pod to get to status {wait_for_state} with pod info: {pod!s}"
+                    f"Timed out while waiting for pod to get to status {wait_for_state.value} with pod info: {pod!s}"
                 )
             # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#containerstatus-v1-core
             all_statuses = []


### PR DESCRIPTION
follow-up to https://github.com/dagster-io/dagster/pull/24280 for internal integration tests that we dont run on external contributions 

tweaks an error to use the enum value instead of print the enum since the enum name in the message felt repetitive. 



## How I Tested These Changes

bk
