### PR TITLE
Create LatestCheckStatusCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
@@ -45,7 +45,7 @@ class EvaluateAutomationConditionsResult:
     @property
     def total_requested(self) -> int:
         """Returns the total number of asset partitions requested during this evaluation."""
-        return len(self._requested_asset_partitions)
+        return sum(result.true_subset.size for result in self.results)
 
     def get_requested_partitions(self, asset_key: AssetKey) -> AbstractSet[Optional[str]]:
         """Returns the specific partition keys requested for the given asset during this evaluation."""
@@ -121,6 +121,7 @@ def evaluate_automation_conditions(
         entity_keys={
             key
             for key in asset_selection.resolve(asset_graph)
+            | asset_selection.resolve_checks(asset_graph)
             if asset_graph.get(key).automation_condition is not None
         },
         evaluation_time=evaluation_time,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/check_automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/check_automation_condition.py
@@ -1,0 +1,44 @@
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.asset_key import AssetCheckKey
+    from dagster._core.definitions.declarative_automation.automation_condition import (
+        AutomationCondition,
+    )
+
+
+class CheckAutomationCondition:
+    """Helper class to provide static constructors for AutomationConditions that target AssetChecks."""
+
+    @staticmethod
+    def _status_condition(status_value: Optional[str]) -> "AutomationCondition[AssetCheckKey]":
+        """Helper method to defer imports."""
+        from dagster._core.definitions.declarative_automation.operands.slice_conditions import (
+            LatestCheckStatusCondition,
+        )
+        from dagster._core.storage.asset_check_execution_record import (
+            AssetCheckExecutionResolvedStatus,
+        )
+
+        status = AssetCheckExecutionResolvedStatus(status_value) if status_value else None
+        return LatestCheckStatusCondition(target_status=status)
+
+    @staticmethod
+    def not_executed() -> "AutomationCondition[AssetCheckKey]":
+        return CheckAutomationCondition._status_condition(None)
+
+    @staticmethod
+    def in_progress() -> "AutomationCondition[AssetCheckKey]":
+        return CheckAutomationCondition._status_condition("IN_PROGRESS")
+
+    @staticmethod
+    def succeeded() -> "AutomationCondition[AssetCheckKey]":
+        return CheckAutomationCondition._status_condition("SUCCEEDED")
+
+    @staticmethod
+    def skipped() -> "AutomationCondition[AssetCheckKey]":
+        return CheckAutomationCondition._status_condition("SKIPPED")
+
+    @staticmethod
+    def failed() -> "AutomationCondition[AssetCheckKey]":
+        return CheckAutomationCondition._status_condition("FAILED")

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/__init__.py
@@ -6,6 +6,7 @@ from dagster._core.definitions.declarative_automation.operands.slice_conditions 
     FailedAutomationCondition as FailedAutomationCondition,
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,
     InProgressAutomationCondition as InProgressAutomationCondition,
+    LatestCheckStatusCondition as LatestCheckStatusCondition,
     MissingAutomationCondition as MissingAutomationCondition,
     NewlyRequestedCondition as NewlyRequestedCondition,
     NewlyUpdatedCondition as NewlyUpdatedCondition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
@@ -1,9 +1,9 @@
 import datetime
 from abc import abstractmethod
-from typing import Optional
+from typing import Any, Optional
 
 from dagster._core.asset_graph_view.entity_subset import EntitySubset
-from dagster._core.definitions.asset_key import AssetKey, T_EntityKey
+from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey, T_EntityKey
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationResult,
     BuiltinAutomationCondition,
@@ -87,7 +87,7 @@ class FailedAutomationCondition(SubsetAutomationCondition[AssetKey]):
 
 @whitelist_for_serdes
 @record
-class WillBeRequestedCondition(SubsetAutomationCondition[AssetKey]):
+class WillBeRequestedCondition(SubsetAutomationCondition):
     @property
     def description(self) -> str:
         return "Will be requested this tick"
@@ -107,7 +107,7 @@ class WillBeRequestedCondition(SubsetAutomationCondition[AssetKey]):
             parent_key=context.key,
         )
 
-    def compute_subset(self, context: AutomationContext) -> EntitySubset[AssetKey]:
+    def compute_subset(self, context: AutomationContext) -> EntitySubset:
         current_result = context.current_results_by_key.get(context.key)
         if (
             current_result
@@ -229,3 +229,24 @@ class InLatestTimeWindowCondition(SubsetAutomationCondition[AssetKey]):
         return context.asset_graph_view.compute_latest_time_window_subset(
             context.key, lookback_delta=self.lookback_timedelta
         )
+
+
+class LatestCheckStatusCondition(SubsetAutomationCondition[AssetCheckKey]):
+    target_status: Optional[Any]
+
+    def compute_subset(
+        self, context: AutomationContext[AssetCheckKey]
+    ) -> EntitySubset[AssetCheckKey]:
+        from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecord
+
+        loading_context = context.asset_graph_view
+        latest_record = AssetCheckExecutionRecord.blocking_get(loading_context, context.key)
+        resolved_status = (
+            latest_record.resolve_status(loading_context)
+            if latest_record and latest_record.targets_latest_materialization(loading_context)
+            else None
+        )
+        if resolved_status == self.target_status:
+            return context.candidate_subset
+        else:
+            return context.get_empty_subset()

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_check_status_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_check_status_condition.py
@@ -1,0 +1,182 @@
+import pytest
+from dagster import (
+    AssetCheckKey,
+    AssetCheckResult,
+    AssetCheckSpec,
+    AssetExecutionContext,
+    AssetKey,
+    AutomationCondition,
+    Definitions,
+    asset,
+    asset_check,
+    evaluate_automation_conditions,
+    instance_for_test,
+)
+from dagster._core.definitions.result import MaterializeResult
+from dagster._core.storage.asset_check_execution_record import (
+    AssetCheckExecutionResolvedStatus as ACS,
+)
+
+
+def _get_defs(status: ACS, automation_condition: AutomationCondition) -> Definitions:
+    @asset
+    def a() -> None: ...
+
+    @asset_check(asset=a, automation_condition=automation_condition)
+    def some_check() -> AssetCheckResult:
+        if status == ACS.SUCCEEDED:
+            return AssetCheckResult(passed=True)
+        elif status == ACS.FAILED:
+            return AssetCheckResult(passed=False)
+        elif status == ACS.EXECUTION_FAILED:
+            raise Exception("fail")
+        else:
+            raise Exception(f"unexpected status {status}")
+
+    return Definitions(assets=[a], asset_checks=[some_check])
+
+
+@pytest.mark.parametrize(
+    "status, automation_condition",
+    [
+        (ACS.SUCCEEDED, AutomationCondition.check.succeeded()),
+        (ACS.FAILED, AutomationCondition.check.failed()),
+    ],
+)
+def test_status_conditions_basic(status: ACS, automation_condition: AutomationCondition) -> None:
+    defs = _get_defs(status, automation_condition)
+    asset_job = defs.get_implicit_global_asset_job_def()
+    a_job = asset_job.get_subset(asset_selection={AssetKey("a")}, asset_check_selection=set())
+    some_check_job = asset_job.get_subset(
+        asset_check_selection={AssetCheckKey(AssetKey("a"), "some_check")}
+    )
+
+    with instance_for_test() as instance:
+        # no status as there hasn't been a materialization yet
+        assert evaluate_automation_conditions(defs, instance).total_requested == 0
+
+        a_job.execute_in_process(instance=instance)
+
+        # no status as the check hasn't executed yet
+        assert evaluate_automation_conditions(defs, instance).total_requested == 0
+
+        some_check_job.execute_in_process(instance=instance, raise_on_error=False)
+
+        # now the check gets requested because it has a status matching the condition
+        assert evaluate_automation_conditions(defs, instance).total_requested == 1
+
+        a_job.execute_in_process(instance=instance)
+
+        # now the check has been executed less recently than the asset, so it goes back to false
+        assert evaluate_automation_conditions(defs, instance).total_requested == 0
+
+
+def test_check_not_executed() -> None:
+    @asset(
+        automation_condition=~AutomationCondition.any_checks_match(
+            AutomationCondition.check.not_executed(),
+        )
+    )
+    def A() -> None: ...
+
+    @asset_check(asset=A)
+    def c0() -> AssetCheckResult:
+        return AssetCheckResult(check_name="c0", passed=True)
+
+    @asset_check(asset=A)
+    def c1() -> AssetCheckResult:
+        return AssetCheckResult(check_name="c1", passed=True)
+
+    @asset_check(asset=A)
+    def c2() -> AssetCheckResult:
+        return AssetCheckResult(check_name="c2", passed=True)
+
+    defs = Definitions(assets=[A], asset_checks=[c0, c1, c2])
+    asset_job = defs.get_implicit_global_asset_job_def()
+
+    with instance_for_test() as instance:
+        # no checks executed
+        assert evaluate_automation_conditions(defs, instance).total_requested == 0
+
+        asset_job.get_subset(
+            asset_check_selection={AssetCheckKey(AssetKey("A"), name="c0")}
+        ).execute_in_process(instance=instance)
+
+        asset_job.get_subset(
+            asset_check_selection={AssetCheckKey(AssetKey("A"), name="c1")}
+        ).execute_in_process(instance=instance)
+
+        # still one check not executed
+        assert evaluate_automation_conditions(defs, instance).total_requested == 0
+
+        asset_job.get_subset(
+            asset_check_selection={AssetCheckKey(AssetKey("A"), name="c2")}
+        ).execute_in_process(instance=instance)
+
+        # all checks executed
+        assert evaluate_automation_conditions(defs, instance).total_requested == 1
+
+
+def test_all_deps_blocking_checks_succeeded() -> None:
+    @asset(
+        check_specs=[
+            AssetCheckSpec(name="b", asset="A", blocking=True),
+            AssetCheckSpec(name="nb", asset="A", blocking=False),
+        ]
+    )
+    def A(context: AssetExecutionContext):
+        return MaterializeResult(
+            check_results=[
+                AssetCheckResult(check_name="b", passed="a_fail_b" not in context.run_tags),
+                AssetCheckResult(check_name="nb", passed="a_fail_nb" not in context.run_tags),
+            ]
+        )
+
+    @asset(
+        check_specs=[
+            AssetCheckSpec(name="b", asset="B", blocking=True),
+            AssetCheckSpec(name="nb", asset="B", blocking=False),
+        ]
+    )
+    def B(context: AssetExecutionContext):
+        return MaterializeResult(
+            check_results=[
+                AssetCheckResult(check_name="b", passed="b_fail_b" not in context.run_tags),
+                AssetCheckResult(check_name="nb", passed="b_fail_nb" not in context.run_tags),
+            ]
+        )
+
+    @asset(
+        deps=[A, B],
+        automation_condition=AutomationCondition.eager()
+        & AutomationCondition.all_deps_blocking_checks_succeeded(),
+    )
+    def C() -> None: ...
+
+    defs = Definitions(assets=[A, B, C])
+    a_b_job = defs.get_implicit_global_asset_job_def().get_subset(
+        asset_selection={AssetKey("A"), AssetKey("B")}
+    )
+
+    with instance_for_test() as instance:
+        # no checks have executed
+        result = evaluate_automation_conditions(defs=defs, instance=instance)
+        assert result.total_requested == 0
+
+        a_b_job.execute_in_process(instance=instance)
+
+        # now all checks have executed successfully
+        result = evaluate_automation_conditions(defs=defs, instance=instance)
+        assert result.total_requested == 1
+
+        # now a non-blocking check fails, still ok to execute
+        a_b_job.execute_in_process(instance=instance, tags={"a_fail_nb": "True"})
+        result = evaluate_automation_conditions(defs=defs, instance=instance)
+        assert result.total_requested == 1
+
+        # now a blocking check fails, don't execute
+        a_b_job.execute_in_process(
+            instance=instance, tags={"b_fail_b": "True"}, raise_on_error=False
+        )
+        result = evaluate_automation_conditions(defs=defs, instance=instance)
+        assert result.total_requested == 0


### PR DESCRIPTION
## Summary & Motivation

This creates the first AutomationCondition that operates directly on checks. It allows users to incorporate the status of the latest check that targeted the current version of the asset.

Two larger changes worth discussing:

1. I added an `all_deps_blocking_checks_succeeded` pre-built condition which should solve the long-standing user request of making "AMP" not materialize assets in the case that upstream blocking checks have failed
2. For check status conditions, I went with a syntax of `AutomationCondition.check.<status>`. I agonized about alternatives for awhile, with the main sticking point being that it means slightly different things for an asset to fail / succeed / be in progress than it means for an asset check to be in one of those statuses. Thus, we need to distinguish between `AutomationCondition.in_progress` (which is asset-specific) and `AutomationCondition.check.in_progress`. I thought `AutomationCondition.check_in_progress` felt a little off, almost like it's saying "A check on an asset is currently in progress" rather than "This is a check that is currently in progress."

Very open to alternatives though.

## How I Tested These Changes

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
