### PR TITLE
[6/n][dagster-tableau] use asset caching logic for Tableau assets

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -277,7 +277,7 @@ class BaseTableauWorkspace(ConfigurableResource):
     username: str = Field(..., description="The username to authenticate to Tableau Workspace.")
     site_name: str = Field(..., description="The name of the Tableau site to use.")
 
-    _client: Union[TableauCloudClient, TableauServerClient] = PrivateAttr(default=None)
+    _client: Optional[Union[TableauCloudClient, TableauServerClient]] = PrivateAttr(default=None)
 
     @abstractmethod
     def build_client(self) -> None:

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -6,9 +6,18 @@ from typing import Any, Dict, Mapping, Optional, Sequence, Type, Union, cast
 
 import jwt
 import requests
-from dagster import ConfigurableResource
+from dagster import (
+    AssetsDefinition,
+    ConfigurableResource,
+    Definitions,
+    _check as check,
+    external_assets_from_specs,
+)
 from dagster._annotations import experimental
-from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.cacheable_assets import (
+    AssetsDefinitionCacheableData,
+    CacheableAssetsDefinition,
+)
 from dagster._utils.cached_method import cached_method
 from pydantic import Field, PrivateAttr
 
@@ -323,37 +332,47 @@ class BaseTableauWorkspace(ConfigurableResource):
                                     properties=published_data_source_data,
                                 )
 
-        return TableauWorkspaceData(
-            site_name=self.site_name,
-            workbooks_by_id=workbooks_by_id,
-            views_by_id=views_by_id,
-            data_sources_by_id=data_sources_by_id,
+        return TableauWorkspaceData.from_content_data(
+            self.site_name,
+            list(workbooks_by_id.values())
+            + list(views_by_id.values())
+            + list(data_sources_by_id.values()),
         )
 
-    def build_asset_specs(
+    def build_assets(
         self,
-        dagster_tableau_translator: Type[DagsterTableauTranslator] = DagsterTableauTranslator,
-    ) -> Sequence[AssetSpec]:
-        """Fetches Tableau content from the workspace and translates it into AssetSpecs,
-        using the provided translator.
-        Future work will cache this data to avoid repeated calls to the Tableau API.
+        dagster_tableau_translator: Type[DagsterTableauTranslator],
+    ) -> Sequence[CacheableAssetsDefinition]:
+        """Returns a set of CacheableAssetsDefinition which will load Tableau content from
+        the workspace and translates it into AssetSpecs, using the provided translator.
 
         Args:
             dagster_tableau_translator (Type[DagsterTableauTranslator]): The translator to use
                 to convert Tableau content into AssetSpecs. Defaults to DagsterTableauTranslator.
 
         Returns:
-            Sequence[AssetSpec]: A list of AssetSpecs representing the Tableau content.
+            Sequence[CacheableAssetsDefinition]: A list of CacheableAssetsDefinitions which
+                will load the Tableau content.
         """
-        workspace_data = self.fetch_tableau_workspace_data()
-        translator = dagster_tableau_translator(context=workspace_data)
+        return [TableauCacheableAssetsDefinition(self, dagster_tableau_translator)]
 
-        all_content = [
-            *workspace_data.views_by_id.values(),
-            *workspace_data.data_sources_by_id.values(),
-        ]
+    def build_defs(
+        self, dagster_tableau_translator: Type[DagsterTableauTranslator] = DagsterTableauTranslator
+    ) -> Definitions:
+        """Returns a Definitions object which will load Tableau content from
+        the workspace and translate it into assets, using the provided translator.
 
-        return [translator.get_asset_spec(content) for content in all_content]
+        Args:
+            dagster_tableau_translator (Type[DagsterTableauTranslator]): The translator to use
+                to convert Tableau content into AssetSpecs. Defaults to DagsterTableauTranslator.
+
+        Returns:
+            Definitions: A Definitions object which will build and return the Power BI content.
+        """
+        defs = Definitions(
+            assets=self.build_assets(dagster_tableau_translator=dagster_tableau_translator)
+        )
+        return defs
 
 
 @experimental
@@ -391,4 +410,44 @@ class TableauServerWorkspace(BaseTableauWorkspace):
             username=self.username,
             site_name=self.site_name,
             server_name=self.server_name,
+        )
+
+
+class TableauCacheableAssetsDefinition(CacheableAssetsDefinition):
+    def __init__(self, workspace: BaseTableauWorkspace, translator: Type[DagsterTableauTranslator]):
+        self._workspace = workspace
+        self._translator_cls = translator
+        super().__init__(unique_id=self._workspace.site_name)
+
+    def compute_cacheable_data(self) -> Sequence[AssetsDefinitionCacheableData]:
+        workspace_data: TableauWorkspaceData = self._workspace.fetch_tableau_workspace_data()
+        return [
+            AssetsDefinitionCacheableData(extra_metadata=data.to_cached_data())
+            for data in [
+                *workspace_data.workbooks_by_id.values(),
+                *workspace_data.views_by_id.values(),
+                *workspace_data.data_sources_by_id.values(),
+            ]
+        ]
+
+    def build_definitions(
+        self, data: Sequence[AssetsDefinitionCacheableData]
+    ) -> Sequence[AssetsDefinition]:
+        workspace_data = TableauWorkspaceData.from_content_data(
+            self._workspace.site_name,
+            [
+                TableauContentData.from_cached_data(check.not_none(entry.extra_metadata))
+                for entry in data
+            ],
+        )
+
+        translator = self._translator_cls(context=workspace_data)
+
+        all_content = [
+            *workspace_data.views_by_id.values(),
+            *workspace_data.data_sources_by_id.values(),
+        ]
+
+        return external_assets_from_specs(
+            [translator.get_asset_spec(content) for content in all_content]
         )

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
@@ -61,17 +61,17 @@ class TableauWorkspaceData:
         return cls(
             site_name=site_name,
             workbooks_by_id={
-                workbook.properties["id"]: workbook
+                workbook.properties["luid"]: workbook
                 for workbook in content_data
                 if workbook.content_type == TableauContentType.WORKBOOK
             },
             views_by_id={
-                view.properties["id"]: view
+                view.properties["luid"]: view
                 for view in content_data
                 if view.content_type == TableauContentType.VIEW
             },
             data_sources_by_id={
-                data_source.properties["id"]: data_source
+                data_source.properties["luid"]: data_source
                 for data_source in content_data
                 if data_source.content_type == TableauContentType.DATA_SOURCE
             },

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
@@ -4,13 +4,15 @@ from typing import Callable, Iterator
 
 import pytest
 import responses
-from dagster_tableau.resources import TABLEAU_REST_API_VERSION
 from dagster_tableau.translator import TableauContentData, TableauContentType, TableauWorkspaceData
 
-FAKE_PERSONAL_ACCESS_TOKEN_NAME = "fake_pat"
-FAKE_PERSONAL_ACCESS_TOKEN_VALUE = uuid.uuid4().hex
+FAKE_CONNECTED_APP_CLIENT_ID = uuid.uuid4().hex
+FAKE_CONNECTED_APP_SECRET_ID = uuid.uuid4().hex
+FAKE_CONNECTED_APP_SECRET_VALUE = uuid.uuid4().hex
+FAKE_USERNAME = "fake_username"
 FAKE_SITE_NAME = "fake_site_name"
 FAKE_POD_NAME = "fake_pod_name"
+
 
 SAMPLE_DATA_SOURCE = {
     "luid": "0f5660c7-2b05-4ff0-90ce-3199226956c6",
@@ -98,12 +100,11 @@ def workspace_data_fixture(site_name: str) -> TableauWorkspaceData:
 @pytest.fixture(
     name="workspace_data_api_mocks_fn",
 )
-def workspace_data_api_mocks_fn_fixture(site_id: str, workbook_id: str, api_token: str) -> Callable:
+def workspace_data_api_mocks_fn_fixture(site_id: str, api_token: str) -> Callable:
     @contextlib.contextmanager
     def _method(
         client,
         site_id: str = site_id,
-        workbook_id: str = workbook_id,
         api_token: str = api_token,
     ) -> Iterator[responses.RequestsMock]:
         with responses.RequestsMock() as response:
@@ -128,23 +129,9 @@ def workspace_data_api_mocks_fn_fixture(site_id: str, workbook_id: str, api_toke
             response.add(
                 method=responses.POST,
                 url=f"{client.rest_api_base_url}/auth/signout",
-                json={},
-                url=f"{api_base_url}/auth/signout",
                 status=200,
             )
 
             yield response
 
     return _method
-
-
-@pytest.fixture(
-    name="workspace_data_api_mocks_pending_repo",
-)
-def workspace_data_api_mocks_pending_repo_fixture(
-    workspace_data_api_mocks_fn: Callable,
-) -> Iterator[responses.RequestsMock]:
-    yield from workspace_data_api_mocks_fn(
-        api_base_url=f"https://{FAKE_POD_NAME}.online.tableau.com/api/{TABLEAU_API_VERSION}",
-        site_id="None",
-    )

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
@@ -1,9 +1,10 @@
 import contextlib
 import uuid
-from typing import Callable, Iterator
+from typing import Callable, Iterator, Union
 
 import pytest
 import responses
+from dagster_tableau.resources import TableauCloudClient, TableauServerClient
 from dagster_tableau.translator import TableauContentData, TableauContentType, TableauWorkspaceData
 
 FAKE_CONNECTED_APP_CLIENT_ID = uuid.uuid4().hex
@@ -103,7 +104,7 @@ def workspace_data_fixture(site_name: str) -> TableauWorkspaceData:
 def workspace_data_api_mocks_fn_fixture(site_id: str, api_token: str) -> Callable:
     @contextlib.contextmanager
     def _method(
-        client,
+        client: Union[TableauCloudClient, TableauServerClient],
         site_id: str = site_id,
         api_token: str = api_token,
     ) -> Iterator[responses.RequestsMock]:

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/pending_repo.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/pending_repo.py
@@ -25,6 +25,7 @@ resource.sign_in()
 pbi_defs = resource.build_defs()
 resource.sign_out()
 
+
 @asset
 def my_materializable_asset():
     pass

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/pending_repo.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/pending_repo.py
@@ -1,0 +1,39 @@
+from typing import cast
+
+from dagster import asset, define_asset_job
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.repository_definition.repository_definition import (
+    PendingRepositoryDefinition,
+)
+from dagster_tableau import TableauCloudWorkspace
+
+from dagster_tableau_tests.conftest import (
+    FAKE_PERSONAL_ACCESS_TOKEN_NAME,
+    FAKE_PERSONAL_ACCESS_TOKEN_VALUE,
+    FAKE_POD_NAME,
+    FAKE_SITE_NAME,
+)
+
+resource = TableauCloudWorkspace(
+    personal_access_token_name=FAKE_PERSONAL_ACCESS_TOKEN_NAME,
+    personal_access_token_value=FAKE_PERSONAL_ACCESS_TOKEN_VALUE,
+    site_name=FAKE_SITE_NAME,
+    pod_name=FAKE_POD_NAME,
+)
+
+resource.sign_in()
+pbi_defs = resource.build_defs()
+resource.sign_out()
+
+@asset
+def my_materializable_asset():
+    pass
+
+
+pending_repo_from_cached_asset_metadata = cast(
+    PendingRepositoryDefinition,
+    Definitions.merge(
+        Definitions(assets=[my_materializable_asset], jobs=[define_asset_job("all_asset_job")]),
+        pbi_defs,
+    ).get_inner_repository(),
+)

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/pending_repo.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/pending_repo.py
@@ -8,22 +8,24 @@ from dagster._core.definitions.repository_definition.repository_definition impor
 from dagster_tableau import TableauCloudWorkspace
 
 from dagster_tableau_tests.conftest import (
-    FAKE_PERSONAL_ACCESS_TOKEN_NAME,
-    FAKE_PERSONAL_ACCESS_TOKEN_VALUE,
+    FAKE_CONNECTED_APP_CLIENT_ID,
+    FAKE_CONNECTED_APP_SECRET_ID,
+    FAKE_CONNECTED_APP_SECRET_VALUE,
     FAKE_POD_NAME,
     FAKE_SITE_NAME,
+    FAKE_USERNAME,
 )
 
 resource = TableauCloudWorkspace(
-    personal_access_token_name=FAKE_PERSONAL_ACCESS_TOKEN_NAME,
-    personal_access_token_value=FAKE_PERSONAL_ACCESS_TOKEN_VALUE,
+    connected_app_client_id=FAKE_CONNECTED_APP_CLIENT_ID,
+    connected_app_secret_id=FAKE_CONNECTED_APP_SECRET_ID,
+    connected_app_secret_value=FAKE_CONNECTED_APP_SECRET_VALUE,
+    username=FAKE_USERNAME,
     site_name=FAKE_SITE_NAME,
     pod_name=FAKE_POD_NAME,
 )
 
-resource.sign_in()
 pbi_defs = resource.build_defs()
-resource.sign_out()
 
 
 @asset

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -95,7 +95,9 @@ def test_translator_spec(
         assert data_source_asset.key.path == ["superstore_datasource"]
 
 
-def test_using_cached_asset_data(workspace_data_api_mocks_pending_repo: responses.RequestsMock) -> None:
+def test_using_cached_asset_data(
+    workspace_data_api_mocks_pending_repo: responses.RequestsMock,
+) -> None:
     with instance_for_test() as instance:
         assert len(workspace_data_api_mocks_pending_repo.calls) == 0
 
@@ -129,11 +131,9 @@ def test_using_cached_asset_data(workspace_data_api_mocks_pending_repo: response
         )
 
         assert (
-                len([event for event in events if event.event_type == DagsterEventType.STEP_SUCCESS])
-                == 1
+            len([event for event in events if event.event_type == DagsterEventType.STEP_SUCCESS])
+            == 1
         ), "Expected two successful steps"
 
         # Two more calls, for when the resource signs in and out in the pending.repo.py
         assert len(workspace_data_api_mocks_pending_repo.calls) == 7
-
-

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -1,7 +1,7 @@
 # ruff: noqa: SLF001
 
 import uuid
-from typing import Callable, Type, Union
+from typing import Callable, Type, Union, Mapping
 
 import pytest
 import responses
@@ -35,7 +35,7 @@ def test_fetch_tableau_workspace_data(
     connected_app_secret_value = uuid.uuid4().hex
     username = "fake_username"
 
-    resource_args = {
+    resource_args: Mapping[str, object] = {
         "connected_app_client_id": connected_app_client_id,
         "connected_app_secret_id": connected_app_secret_id,
         "connected_app_secret_value": connected_app_secret_value,
@@ -76,7 +76,7 @@ def test_translator_spec(
     connected_app_secret_value = uuid.uuid4().hex
     username = "fake_username"
 
-    resource_args = {
+    resource_args: Mapping[str, object] = {
         "connected_app_client_id": connected_app_client_id,
         "connected_app_secret_id": connected_app_secret_id,
         "connected_app_secret_value": connected_app_secret_value,

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -1,7 +1,7 @@
 # ruff: noqa: SLF001
 
 import uuid
-from typing import Callable, Type, Union, Mapping
+from typing import Callable, Mapping, Type, Union
 
 import pytest
 import responses

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -89,51 +89,61 @@ def test_translator_spec(
         view_asset = next(asset for asset in all_assets if "workbook" in asset.key.path[0])
         assert view_asset.key.path == ["test_workbook", "view", "sales"]
 
-        data_source_asset = next(
-            asset for asset in all_assets if "datasource" in asset.key.path[0]
-        )
+        data_source_asset = next(asset for asset in all_assets if "datasource" in asset.key.path[0])
         assert data_source_asset.key.path == ["superstore_datasource"]
 
 
+@pytest.mark.usefixtures("workspace_data_api_mocks_fn")
 def test_using_cached_asset_data(
-    workspace_data_api_mocks_pending_repo: responses.RequestsMock,
+    workspace_data_api_mocks_fn,
 ) -> None:
     with instance_for_test() as instance:
-        assert len(workspace_data_api_mocks_pending_repo.calls) == 0
-
-        from dagster_tableau_tests.pending_repo import pending_repo_from_cached_asset_metadata
-
-        # first, we resolve the repository to generate our cached metadata
-        repository_def = pending_repo_from_cached_asset_metadata.compute_repository_definition()
-        assert len(workspace_data_api_mocks_pending_repo.calls) == 5
-
-        # 2 Tableau external assets, one materializable asset
-        assert len(repository_def.assets_defs_by_key) == 2 + 1
-
-        job_def = repository_def.get_job("all_asset_job")
-        repository_load_data = repository_def.repository_load_data
-
-        recon_repo = ReconstructableRepository.for_file(
-            file_relative_path(__file__, "pending_repo.py"),
-            fn_name="pending_repo_from_cached_asset_metadata",
-        )
-        recon_job = ReconstructableJob(repository=recon_repo, job_name="all_asset_job")
-
-        execution_plan = create_execution_plan(recon_job, repository_load_data=repository_load_data)
-
-        run = instance.create_run_for_job(job_def=job_def, execution_plan=execution_plan)
-
-        events = execute_plan(
-            execution_plan=execution_plan,
-            job=recon_job,
-            dagster_run=run,
-            instance=instance,
+        from dagster_tableau_tests.pending_repo import (
+            pending_repo_from_cached_asset_metadata,
+            resource,
         )
 
-        assert (
-            len([event for event in events if event.event_type == DagsterEventType.STEP_SUCCESS])
-            == 1
-        ), "Expected two successful steps"
+        # Must initialize the resource's client before passing it to the mock response function
+        resource.build_client()
+        with workspace_data_api_mocks_fn(client=resource._client) as response:
+            # Remove the resource's client to properly test the pending repo
+            resource._client = None
+            assert len(response.calls) == 0
 
-        # Two more calls, for when the resource signs in and out in the pending.repo.py
-        assert len(workspace_data_api_mocks_pending_repo.calls) == 7
+            # first, we resolve the repository to generate our cached metadata
+            repository_def = pending_repo_from_cached_asset_metadata.compute_repository_definition()
+            assert len(response.calls) == 4
+
+            # 2 Tableau external assets, one materializable asset
+            assert len(repository_def.assets_defs_by_key) == 2 + 1
+
+            job_def = repository_def.get_job("all_asset_job")
+            repository_load_data = repository_def.repository_load_data
+
+            recon_repo = ReconstructableRepository.for_file(
+                file_relative_path(__file__, "pending_repo.py"),
+                fn_name="pending_repo_from_cached_asset_metadata",
+            )
+            recon_job = ReconstructableJob(repository=recon_repo, job_name="all_asset_job")
+
+            execution_plan = create_execution_plan(
+                recon_job, repository_load_data=repository_load_data
+            )
+
+            run = instance.create_run_for_job(job_def=job_def, execution_plan=execution_plan)
+
+            events = execute_plan(
+                execution_plan=execution_plan,
+                job=recon_job,
+                dagster_run=run,
+                instance=instance,
+            )
+
+            assert (
+                len(
+                    [event for event in events if event.event_type == DagsterEventType.STEP_SUCCESS]
+                )
+                == 1
+            ), "Expected two successful steps"
+
+            assert len(response.calls) == 4

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -1,7 +1,7 @@
 # ruff: noqa: SLF001
 
 import uuid
-from typing import Callable, Mapping, Type, Union
+from typing import Callable, Type, Union
 
 import pytest
 import responses
@@ -35,7 +35,7 @@ def test_fetch_tableau_workspace_data(
     connected_app_secret_value = uuid.uuid4().hex
     username = "fake_username"
 
-    resource_args: Mapping[str, object] = {
+    resource_args = {
         "connected_app_client_id": connected_app_client_id,
         "connected_app_secret_id": connected_app_secret_id,
         "connected_app_secret_value": connected_app_secret_value,
@@ -44,7 +44,7 @@ def test_fetch_tableau_workspace_data(
         host_key: host_value,
     }
 
-    resource = clazz(**resource_args)
+    resource = clazz(**resource_args)  # type: ignore
     resource.build_client()
 
     with workspace_data_api_mocks_fn(client=resource._client):
@@ -76,7 +76,7 @@ def test_translator_spec(
     connected_app_secret_value = uuid.uuid4().hex
     username = "fake_username"
 
-    resource_args: Mapping[str, object] = {
+    resource_args = {
         "connected_app_client_id": connected_app_client_id,
         "connected_app_secret_id": connected_app_secret_id,
         "connected_app_secret_value": connected_app_secret_value,
@@ -85,7 +85,7 @@ def test_translator_spec(
         host_key: host_value,
     }
 
-    resource = clazz(**resource_args)
+    resource = clazz(**resource_args)  # type: ignore
     resource.build_client()
 
     with workspace_data_api_mocks_fn(client=resource._client):

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -1,6 +1,7 @@
 # ruff: noqa: SLF001
 
 import uuid
+from typing import Callable, Type, Union
 
 import pytest
 import responses
@@ -23,7 +24,11 @@ from dagster_tableau import TableauCloudWorkspace, TableauServerWorkspace
 @pytest.mark.usefixtures("site_name")
 @pytest.mark.usefixtures("workspace_data_api_mocks_fn")
 def test_fetch_tableau_workspace_data(
-    clazz, host_key, host_value, site_name, workspace_data_api_mocks_fn
+    clazz: Union[Type[TableauCloudWorkspace], Type[TableauServerWorkspace]],
+    host_key: str,
+    host_value: str,
+    site_name: str,
+    workspace_data_api_mocks_fn: Callable,
 ) -> None:
     connected_app_client_id = uuid.uuid4().hex
     connected_app_secret_id = uuid.uuid4().hex
@@ -60,7 +65,11 @@ def test_fetch_tableau_workspace_data(
 @pytest.mark.usefixtures("site_name")
 @pytest.mark.usefixtures("workspace_data_api_mocks_fn")
 def test_translator_spec(
-    clazz, host_key, host_value, site_name, workspace_data_api_mocks_fn
+    clazz: Union[Type[TableauCloudWorkspace], Type[TableauServerWorkspace]],
+    host_key: str,
+    host_value: str,
+    site_name: str,
+    workspace_data_api_mocks_fn: Callable,
 ) -> None:
     connected_app_client_id = uuid.uuid4().hex
     connected_app_secret_id = uuid.uuid4().hex
@@ -95,7 +104,7 @@ def test_translator_spec(
 
 @pytest.mark.usefixtures("workspace_data_api_mocks_fn")
 def test_using_cached_asset_data(
-    workspace_data_api_mocks_fn,
+    workspace_data_api_mocks_fn: Callable,
 ) -> None:
     with instance_for_test() as instance:
         from dagster_tableau_tests.pending_repo import (

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
@@ -1,7 +1,7 @@
 # ruff: noqa: SLF001
 
 import uuid
-from typing import Callable, Mapping, Type, Union
+from typing import Callable, Type, Union
 
 import pytest
 import responses
@@ -35,7 +35,7 @@ def test_basic_resource_request(
     connected_app_secret_value = uuid.uuid4().hex
     username = "fake_username"
 
-    resource_args: Mapping[str, object] = {
+    resource_args = {
         "connected_app_client_id": connected_app_client_id,
         "connected_app_secret_id": connected_app_secret_id,
         "connected_app_secret_value": connected_app_secret_value,
@@ -44,7 +44,7 @@ def test_basic_resource_request(
         host_key: host_value,
     }
 
-    resource = clazz(**resource_args)
+    resource = clazz(**resource_args)  # type: ignore
 
     # Must initialize the resource's client before passing it to the mock responses
     resource.build_client()

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
@@ -1,7 +1,7 @@
 # ruff: noqa: SLF001
 
 import uuid
-from typing import Callable, Type, Union
+from typing import Callable, Mapping, Type, Union
 
 import pytest
 import responses

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
@@ -35,7 +35,7 @@ def test_basic_resource_request(
     connected_app_secret_value = uuid.uuid4().hex
     username = "fake_username"
 
-    resource_args = {
+    resource_args: Mapping[str, object] = {
         "connected_app_client_id": connected_app_client_id,
         "connected_app_secret_id": connected_app_secret_id,
         "connected_app_secret_value": connected_app_secret_value,

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
@@ -1,6 +1,7 @@
 # ruff: noqa: SLF001
 
 import uuid
+from typing import Callable, Type, Union
 
 import pytest
 import responses
@@ -21,7 +22,13 @@ from dagster_tableau import TableauCloudWorkspace, TableauServerWorkspace
 @pytest.mark.usefixtures("workbook_id")
 @pytest.mark.usefixtures("workspace_data_api_mocks_fn")
 def test_basic_resource_request(
-    clazz, host_key, host_value, site_name, api_token, workbook_id, workspace_data_api_mocks_fn
+    clazz: Union[Type[TableauCloudWorkspace], Type[TableauServerWorkspace]],
+    host_key: str,
+    host_value: str,
+    site_name: str,
+    api_token: str,
+    workbook_id: str,
+    workspace_data_api_mocks_fn: Callable,
 ) -> None:
     connected_app_client_id = uuid.uuid4().hex
     connected_app_secret_id = uuid.uuid4().hex


### PR DESCRIPTION
## Summary & Motivation

Adds cacheable assets definitions to ensure that Tableau data is only fetched from the API once.

```python
workspace = TableauCloudWorkspace(
    connected_app_client_id=...,
    connected_app_secret_id=...,
    connected_app_secret_value=...,
    username=...,
    site_name=..., 
    pod_name=...,
)

defs = workspace.build_defs()
```

## Test Plan

BK with additional tests

## How I Tested These Changes

## Changelog

NOCHANGELOG

