### PR TITLE
[7/n][dagster-tableau] add materializable assets for Tableau

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -490,7 +490,9 @@ class TableauCacheableAssetsDefinition(CacheableAssetsDefinition):
                 for view_id in workspace_data.views_by_id.keys():
                     data = client.get_view(view_id)["view"]
                     yield ObserveResult(
-                        asset_key=translator.get_view_asset_key(workspace_data.views_by_id[view_id]),
+                        asset_key=translator.get_view_asset_key(
+                            workspace_data.views_by_id[view_id]
+                        ),
                         metadata={
                             "workbook_id": data["workbook"]["id"],
                             "owner_id": data["owner"]["id"],

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -485,20 +485,21 @@ class TableauCacheableAssetsDefinition(CacheableAssetsDefinition):
             resource_defs={"tableau": self._workspace.get_resource_definition()},
         )
         def _assets(context, tableau: BaseTableauWorkspace):
-            for view_id in workspace_data.views_by_id.keys():
-                data = tableau.get_view(view_id)["view"]
-                asset_key = translator.get_view_asset_key(workspace_data.views_by_id[view_id])
-                yield Output(
-                    value=None,
-                    output_name="__".join(asset_key.path),
-                    metadata={
-                        "workbook_id": data["workbook"]["id"],
-                        "owner_id": data["owner"]["id"],
-                        "name": data["name"],
-                        "contentUrl": data["contentUrl"],
-                        "createdAt": data["createdAt"],
-                        "updatedAt": data["updatedAt"],
-                    },
-                )
+            with tableau.get_client() as client:
+                for view_id in workspace_data.views_by_id.keys():
+                    data = client.get_view(view_id)["view"]
+                    asset_key = translator.get_view_asset_key(workspace_data.views_by_id[view_id])
+                    yield Output(
+                        value=None,
+                        output_name="__".join(asset_key.path),
+                        metadata={
+                            "workbook_id": data["workbook"]["id"],
+                            "owner_id": data["owner"]["id"],
+                            "name": data["name"],
+                            "contentUrl": data["contentUrl"],
+                            "createdAt": data["createdAt"],
+                            "updatedAt": data["updatedAt"],
+                        },
+                    )
 
         return [_assets]

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -10,7 +10,7 @@ from dagster import (
     AssetsDefinition,
     ConfigurableResource,
     Definitions,
-    Output,
+    ObserveResult,
     _check as check,
     external_assets_from_specs,
     multi_asset,
@@ -489,10 +489,8 @@ class TableauCacheableAssetsDefinition(CacheableAssetsDefinition):
             with tableau.get_client() as client:
                 for view_id in workspace_data.views_by_id.keys():
                     data = client.get_view(view_id)["view"]
-                    asset_key = translator.get_view_asset_key(workspace_data.views_by_id[view_id])
-                    yield Output(
-                        value=None,
-                        output_name="__".join(asset_key.path),
+                    yield ObserveResult(
+                        asset_key=translator.get_view_asset_key(workspace_data.views_by_id[view_id]),
                         metadata={
                             "workbook_id": data["workbook"]["id"],
                             "owner_id": data["owner"]["id"],

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -10,7 +10,6 @@ from dagster import (
     AssetsDefinition,
     ConfigurableResource,
     Definitions,
-    InitResourceContext,
     Output,
     _check as check,
     external_assets_from_specs,

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -299,8 +299,10 @@ class BaseTableauWorkspace(ConfigurableResource):
         if not self._client:
             self.build_client()
         self._client.sign_in()
-        yield self._client
-        self._client.sign_out()
+        try:
+            yield self._client
+        finally:
+            self._client.sign_out()
 
     def fetch_tableau_workspace_data(
         self,
@@ -483,7 +485,7 @@ class TableauCacheableAssetsDefinition(CacheableAssetsDefinition):
             ],
             resource_defs={"tableau": self._workspace.get_resource_definition()},
         )
-        def _assets(context, tableau: BaseTableauWorkspace):
+        def _assets(tableau: BaseTableauWorkspace):
             with tableau.get_client() as client:
                 for view_id in workspace_data.views_by_id.keys():
                     data = client.get_view(view_id)["view"]

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -5,11 +5,6 @@ from typing import Callable, Type, Union
 
 import pytest
 import responses
-from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
-from dagster._core.events import DagsterEventType
-from dagster._core.execution.api import create_execution_plan, execute_plan
-from dagster._core.instance_for_test import instance_for_test
-from dagster._utils import file_relative_path
 from dagster_tableau import TableauCloudWorkspace, TableauServerWorkspace
 
 
@@ -100,59 +95,3 @@ def test_translator_spec(
 
         data_source_asset = next(asset for asset in all_assets if "datasource" in asset.key.path[0])
         assert data_source_asset.key.path == ["superstore_datasource"]
-
-
-@pytest.mark.usefixtures("workspace_data_api_mocks_fn")
-def test_using_cached_asset_data(
-    workspace_data_api_mocks_fn: Callable,
-) -> None:
-    with instance_for_test() as instance:
-        from dagster_tableau_tests.pending_repo import (
-            pending_repo_from_cached_asset_metadata,
-            resource,
-        )
-
-        # Must initialize the resource's client before passing it to the mock response function
-        resource.build_client()
-        with workspace_data_api_mocks_fn(client=resource._client) as response:
-            # Remove the resource's client to properly test the pending repo
-            resource._client = None
-            assert len(response.calls) == 0
-
-            # first, we resolve the repository to generate our cached metadata
-            repository_def = pending_repo_from_cached_asset_metadata.compute_repository_definition()
-            assert len(response.calls) == 4
-
-            # 2 Tableau external assets, one materializable asset
-            assert len(repository_def.assets_defs_by_key) == 2 + 1
-
-            job_def = repository_def.get_job("all_asset_job")
-            repository_load_data = repository_def.repository_load_data
-
-            recon_repo = ReconstructableRepository.for_file(
-                file_relative_path(__file__, "pending_repo.py"),
-                fn_name="pending_repo_from_cached_asset_metadata",
-            )
-            recon_job = ReconstructableJob(repository=recon_repo, job_name="all_asset_job")
-
-            execution_plan = create_execution_plan(
-                recon_job, repository_load_data=repository_load_data
-            )
-
-            run = instance.create_run_for_job(job_def=job_def, execution_plan=execution_plan)
-
-            events = execute_plan(
-                execution_plan=execution_plan,
-                job=recon_job,
-                dagster_run=run,
-                instance=instance,
-            )
-
-            assert (
-                len(
-                    [event for event in events if event.event_type == DagsterEventType.STEP_SUCCESS]
-                )
-                == 1
-            ), "Expected two successful steps"
-
-            assert len(response.calls) == 4

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_pending_repo.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_pending_repo.py
@@ -1,0 +1,66 @@
+# ruff: noqa: SLF001
+
+import pytest
+from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
+from dagster._core.events import DagsterEventType
+from dagster._core.execution.api import create_execution_plan, execute_plan
+from dagster._core.instance_for_test import instance_for_test
+from dagster._utils import file_relative_path
+
+
+@pytest.mark.usefixtures("workspace_data_api_mocks_fn")
+def test_using_cached_asset_data(
+    workspace_data_api_mocks_fn,
+) -> None:
+    with instance_for_test() as instance:
+        from dagster_tableau_tests.pending_repo import (
+            pending_repo_from_cached_asset_metadata,
+            resource,
+        )
+
+        # Must initialize the resource's client before passing it to the mock response function
+        resource.build_client()
+        with workspace_data_api_mocks_fn(client=resource._client) as response:
+            # Remove the resource's client to properly test the pending repo
+            resource._client = None
+            assert len(response.calls) == 0
+
+            # first, we resolve the repository to generate our cached metadata
+            repository_def = pending_repo_from_cached_asset_metadata.compute_repository_definition()
+            # 4 calls to creates the defs
+            assert len(response.calls) == 4
+
+            # 2 Tableau external assets, one materializable asset
+            assert len(repository_def.assets_defs_by_key) == 2 + 1
+
+            job_def = repository_def.get_job("all_asset_job")
+            repository_load_data = repository_def.repository_load_data
+
+            recon_repo = ReconstructableRepository.for_file(
+                file_relative_path(__file__, "pending_repo.py"),
+                fn_name="pending_repo_from_cached_asset_metadata",
+            )
+            recon_job = ReconstructableJob(repository=recon_repo, job_name="all_asset_job")
+
+            execution_plan = create_execution_plan(
+                recon_job, repository_load_data=repository_load_data
+            )
+
+            run = instance.create_run_for_job(job_def=job_def, execution_plan=execution_plan)
+
+            events = execute_plan(
+                execution_plan=execution_plan,
+                job=recon_job,
+                dagster_run=run,
+                instance=instance,
+            )
+
+            assert (
+                len(
+                    [event for event in events if event.event_type == DagsterEventType.STEP_SUCCESS]
+                )
+                == 1
+            ), "Expected two successful steps"
+
+            # 4 calls to create the defs + 3 calls to materialize the Tableau assets with 1 view
+            assert len(response.calls) == 4 + 3

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_pending_repo.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_pending_repo.py
@@ -1,5 +1,7 @@
 # ruff: noqa: SLF001
 
+from typing import Callable
+
 import pytest
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
 from dagster._core.events import DagsterEventType
@@ -10,7 +12,7 @@ from dagster._utils import file_relative_path
 
 @pytest.mark.usefixtures("workspace_data_api_mocks_fn")
 def test_using_cached_asset_data(
-    workspace_data_api_mocks_fn,
+    workspace_data_api_mocks_fn: Callable,
 ) -> None:
     with instance_for_test() as instance:
         from dagster_tableau_tests.pending_repo import (


### PR DESCRIPTION
## Summary & Motivation

Implements a simple materializable asset definition in `build_defs()`. 

The View assets are materialized in Dagster: 
- Fetch the most recent version
- Materialize the Dagster asset
- Add the metadata using the Tableau API response.

```python
workspace = TableauCloudWorkspace(
    connected_app_client_id=...,
    connected_app_secret_id=...,
    connected_app_secret_value=...,
    username=...,
    site_name=..., 
    pod_name=...,
)

defs = workspace.build_defs()
```

## How I Tested These Changes

BK with updated tests

## Changelog

NOCHANGELOG