### PR TITLE
[dagster-airlift][rfc] airflow mapping

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/constants.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/constants.py
@@ -1,3 +1,4 @@
 MIGRATED_TAG = "airlift/task_migrated"
 DAG_ID_METADATA_KEY = "airlift/dag_id"
 TASK_ID_METADATA_KEY = "airlift/task_id"
+AIRFLOW_MAPPING_METADATA_KEY = "airlift/mapping"

--- a/examples/experimental/dagster-airlift/dagster_airlift/utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/utils.py
@@ -1,0 +1,130 @@
+from enum import Enum
+from typing import Any, Dict, List, Mapping, Optional, Union
+
+from dagster import (
+    AssetSpec,
+    JsonMetadataValue,
+    _check as check,
+)
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._record import record
+
+from dagster_airlift.constants import AIRFLOW_MAPPING_METADATA_KEY
+
+
+class MappingType(Enum):
+    DAG = "dag"
+    TASK = "task"
+
+
+@record
+class MapsToDag:
+    dag_id: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"type": MappingType.DAG.value, "dag_id": self.dag_id}
+
+    @staticmethod
+    def from_dict(value: Dict[str, Any]) -> "MapsToDag":
+        return MapsToDag(dag_id=value["dag_id"])
+
+
+@record
+class MapsToTask:
+    dag_id: str
+    task_id: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"type": MappingType.TASK.value, "dag_id": self.dag_id, "task_id": self.task_id}
+
+    @staticmethod
+    def from_dict(value: Dict[str, Any]) -> "MapsToTask":
+        return MapsToTask(dag_id=value["dag_id"], task_id=value["task_id"])
+
+
+MapsToAirflow = Union[MapsToDag, MapsToTask]
+
+
+def from_dict(value: Dict[str, Any]) -> MapsToAirflow:
+    return (
+        MapsToDag.from_dict(value)
+        if value["type"] == MappingType.DAG.value
+        else MapsToTask.from_dict(value)
+    )
+
+
+def mappings_from_asset(asset: Union[AssetSpec, AssetsDefinition]) -> Optional[List[MapsToAirflow]]:
+    """Extract mappings from the metadata of an asset spec."""
+    spec = asset if isinstance(asset, AssetSpec) else next(iter(asset.specs))
+    if AIRFLOW_MAPPING_METADATA_KEY not in spec.metadata:
+        return None
+    metadata_list = check.list_param(
+        check.inst(
+            spec.metadata[AIRFLOW_MAPPING_METADATA_KEY],
+            JsonMetadataValue,
+            "Expected airflow mapping to be a JsonMetadataValue",
+        ).value,
+        "expected airflow mapping to be a list",
+        of_type=dict,
+    )
+
+    return [from_dict(mapping) for mapping in metadata_list]
+
+
+def task_mappings_from_asset(asset: Union[AssetSpec, AssetsDefinition]) -> List[MapsToTask]:
+    return check.list_param(mappings_from_asset(asset), "mappings", of_type=MapsToTask)
+
+
+def dag_mappings_from_asset(asset: Union[AssetSpec, AssetsDefinition]) -> List[MapsToDag]:
+    return check.list_param(mappings_from_asset(asset), "mappings", of_type=MapsToDag)
+
+
+def map_to_task(*, spec: AssetSpec, dag_id: str, task_id: str) -> AssetSpec:
+    """Add a mapping from the asset to a task in an Airflow DAG. Respects existing mappings."""
+    return _extract_metadata_and_add_mapping(
+        spec=spec, mapping=MapsToTask(dag_id=dag_id, task_id=task_id)
+    )
+
+
+def map_to_dag(*, spec: AssetSpec, dag_id: str) -> AssetSpec:
+    """Add a mapping from the asset to a DAG in Airflow. Respects existing mappings."""
+    return _extract_metadata_and_add_mapping(spec=spec, mapping=MapsToDag(dag_id=dag_id))
+
+
+def _extract_metadata_and_add_mapping(*, spec: AssetSpec, mapping: MapsToAirflow) -> AssetSpec:
+    """Add a mapping to the asset. Respects existing mappings."""
+    new_mappings = (mappings_from_asset(spec) or []) + [mapping]
+    check.invariant(
+        all(isinstance(mapping, MapsToDag) for mapping in new_mappings)
+        or all(isinstance(mapping, MapsToTask) for mapping in new_mappings),
+        "All mappings must be of the same type",
+    )
+    return spec_with_metadata(
+        spec,
+        {
+            AIRFLOW_MAPPING_METADATA_KEY: JsonMetadataValue(
+                [mapping.to_dict() for mapping in (mappings_from_asset(spec) or []) + [mapping]]
+            )
+        },
+    )
+
+
+def spec_with_metadata(spec: AssetSpec, metadata: Mapping[str, Any]) -> "AssetSpec":
+    return spec._replace(metadata={**spec.metadata, **metadata})
+
+
+def maps_to_dag_metadata(dag_id: str) -> Mapping[str, Any]:
+    return {AIRFLOW_MAPPING_METADATA_KEY: JsonMetadataValue([MapsToDag(dag_id=dag_id).to_dict()])}
+
+
+def maps_to_task_metadata(dag_id: str, task_id: str) -> Mapping[str, Any]:
+    return {
+        AIRFLOW_MAPPING_METADATA_KEY: JsonMetadataValue(
+            [MapsToTask(dag_id=dag_id, task_id=task_id).to_dict()]
+        )
+    }
+
+
+def is_task_mapped(asset: Union[AssetSpec, AssetsDefinition]) -> bool:
+    mappings = mappings_from_asset(asset)
+    return isinstance(next(iter(mappings)), MapsToTask) if mappings else False

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_dag_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_dag_defs.py
@@ -1,8 +1,18 @@
-from dagster import AssetKey, AssetSpec, Definitions, multi_asset
+from typing import List, Sequence, Tuple
+from dagster import AssetKey, AssetSpec, Definitions, multi_asset, JsonMetadataValue
 from dagster._core.definitions.asset_key import CoercibleToAssetKey
-from dagster_airlift.constants import DAG_ID_METADATA_KEY, TASK_ID_METADATA_KEY
+from dagster_airlift.constants import AIRFLOW_MAPPING_METADATA_KEY
 from dagster_airlift.core import dag_defs, task_defs
 
+def build_valid_task_metadata(dag_and_tasks: List[Tuple[str, str]]) -> JsonMetadataValue:
+    return JsonMetadataValue(
+        [{"type": "task", "dag_id": dag_id, "task_id": task_id} for (dag_id, task_id) in dag_and_tasks]
+    )
+
+def build_valid_dag_metadata(dag_ids: Sequence[str]) -> JsonMetadataValue:
+    return JsonMetadataValue(
+        [{"type": "dag", "dag_id": dag_id} for dag_id in dag_ids]
+    )
 
 def from_specs(*specs: AssetSpec) -> Definitions:
     return Definitions(assets=specs)
@@ -18,8 +28,7 @@ def test_dag_def_spec() -> None:
         "dag_one",
         task_defs("task_one", from_specs(AssetSpec(key="asset_one"))),
     )
-    assert asset_spec(defs, "asset_one").metadata[DAG_ID_METADATA_KEY] == "dag_one"
-    assert asset_spec(defs, "asset_one").metadata[TASK_ID_METADATA_KEY] == "task_one"
+    assert asset_spec(defs, "asset_one").metadata[AIRFLOW_MAPPING_METADATA_KEY] == build_valid_task_metadata([("dag_one", "task_one")])
 
 
 def test_dag_def_multi_tasks_multi_specs() -> None:
@@ -28,12 +37,9 @@ def test_dag_def_multi_tasks_multi_specs() -> None:
         task_defs("task_one", from_specs(AssetSpec(key="asset_one"))),
         task_defs("task_two", from_specs(AssetSpec(key="asset_two"), AssetSpec(key="asset_three"))),
     )
-    assert asset_spec(defs, "asset_one").metadata[DAG_ID_METADATA_KEY] == "dag_one"
-    assert asset_spec(defs, "asset_one").metadata[TASK_ID_METADATA_KEY] == "task_one"
-    assert asset_spec(defs, "asset_two").metadata[DAG_ID_METADATA_KEY] == "dag_one"
-    assert asset_spec(defs, "asset_two").metadata[TASK_ID_METADATA_KEY] == "task_two"
-    assert asset_spec(defs, "asset_three").metadata[DAG_ID_METADATA_KEY] == "dag_one"
-    assert asset_spec(defs, "asset_three").metadata[TASK_ID_METADATA_KEY] == "task_two"
+    assert asset_spec(defs, "asset_one").metadata[AIRFLOW_MAPPING_METADATA_KEY] == build_valid_task_metadata([("dag_one", "task_one")])
+    assert asset_spec(defs, "asset_two").metadata[AIRFLOW_MAPPING_METADATA_KEY] == build_valid_task_metadata([("dag_one", "task_two")]) 
+    assert asset_spec(defs, "asset_three").metadata[AIRFLOW_MAPPING_METADATA_KEY] == build_valid_task_metadata([("dag_one", "task_two")])
 
 
 def test_dag_def_assets_def() -> None:
@@ -44,8 +50,8 @@ def test_dag_def_assets_def() -> None:
         "dag_one",
         task_defs("task_one", Definitions([an_asset])),
     )
-    assert asset_spec(defs, "asset_one").metadata[DAG_ID_METADATA_KEY] == "dag_one"
-    assert asset_spec(defs, "asset_one").metadata[TASK_ID_METADATA_KEY] == "task_one"
+    assert asset_spec(defs, "asset_one").metadata[AIRFLOW_MAPPING_METADATA_KEY] == build_valid_task_metadata([("dag_one", "task_one")])
+    assert asset_spec(defs, "asset_one").metadata[AIRFLOW_MAPPING_METADATA_KEY] == build_valid_task_metadata([("dag_one", "task_one")])
 
 
 def test_dag_def_defs() -> None:
@@ -56,8 +62,8 @@ def test_dag_def_defs() -> None:
         "dag_one",
         task_defs("task_one", Definitions(assets=[an_asset])),
     )
-    assert asset_spec(defs, "asset_one").metadata[DAG_ID_METADATA_KEY] == "dag_one"
-    assert asset_spec(defs, "asset_one").metadata[TASK_ID_METADATA_KEY] == "task_one"
+    assert asset_spec(defs, "asset_one").metadata[AIRFLOW_MAPPING_METADATA_KEY] == build_valid_task_metadata([("dag_one", "task_one")])
+    assert asset_spec(defs, "asset_one").metadata[AIRFLOW_MAPPING_METADATA_KEY] == build_valid_task_metadata([("dag_one", "task_one")])
 
 
 def test_dag_def_spec_override() -> None:
@@ -69,4 +75,13 @@ def test_dag_def_spec_override() -> None:
     assert defs.assets
     assert len(list(defs.assets)) == 1
     assert asset_spec(defs, "dag_spec").metadata["other"] == "metadata"
-    assert asset_spec(defs, "dag_spec").metadata[DAG_ID_METADATA_KEY] == "dag_one"
+    assert asset_spec(defs, "dag_spec").metadata[AIRFLOW_MAPPING_METADATA_KEY] == build_valid_dag_metadata(["dag_one"])
+
+def test_diff_tasks_same_spec() -> None:
+    """Test that when two tasks have the same AssetSpec, we combine the metadata to represent both tasks."""
+    defs = dag_defs(
+        "dag_one",
+        task_defs("task_one", from_specs(AssetSpec(key="asset_one"))),
+        task_defs("task_two", from_specs(AssetSpec(key="asset_one"))),
+    )
+    assert asset_spec(defs, "asset_one").metadata[AIRFLOW_MAPPING_METADATA_KEY] == build_valid_task_metadata([("dag_one", "task_one"), ("dag_one", "task_two")])


### PR DESCRIPTION
Be able to map multiple tasks and/or dags to the same asset. Want to validate direction here before I go much further.

I added a new framework that tries to formalize the notion of "mapping to an airflow task/dag" a bit more, and I think actually cleans up the code a bit. 

To test out this approach, I've implemented it underneath dag_defs and task_defs. Have not yet implemented equality checks, which I'm sure are going to be a nightmare since we're performing transformation earlier, so reference equality won't work (unless I change this somehow, which might end up being the simpler option. 

In any case, I wanted to validate direction before I went further.