### PR TITLE
[lazy-defs] Add new reconstruction metadata API on Definitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/definitions_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/definitions_decorator.py
@@ -24,17 +24,18 @@ def definitions(fn: Callable[[], Definitions]) -> Callable[[], Definitions]: ...
 def definitions(fn: DefinitionsLoadFn) -> DefinitionsLoadFn:
     """Marks a function as an entry point for loading a set of Dagster definitions.
 
-    A @definitions-decorated function can perform arbitrary computation to produce a set of
+    A `@definitions`-decorated function can perform arbitrary computation to produce a set of
     Definitions. It is executed during startup of a Dagster process, and optionally receives
     a DefinitionsLoadContext object as argument.
 
-    The DefinitionsLoadContext is useful when instantiating the Definitions in worker processes
+    The DefinitionsLoadContext is useful when reconstructing the Definitions in worker processes
     spawned from a parent code server process. The standard pattern is to perform expensive
-    computations (such as making an external API request) a single time at code server load and to
-    cache the result by calling `with_metadata` on the returned Definitions object. This metadata
-    is then made available on DefinitionsLoadContext.code_location_metadata in child processes.
+    computations (such as making an external API request) a single time at code server
+    initialization and to cache the result by calling `with_reconstruction_metadata` on the returned
+    Definitions object. This metadata is then made available on
+    `DefinitionsLoadContext.reconstruction_metadata` in child processes.
 
-    As with plain `Definitions` objects, there can be only one @definitions-decorated function per
+    As with plain `Definitions` objects, there can be only one `@definitions`-decorated function per
     module if that module is being loaded as a Dagster code location.
 
     Returns:
@@ -44,10 +45,19 @@ def definitions(fn: DefinitionsLoadFn) -> DefinitionsLoadFn:
     Examples:
         .. code-block:: python
 
-            from dagster import AssetSpec, Definitions, DefinitionsLoadContext, asset, definitions, external_assets_from_specs
+            from dagster import (
+                AssetSpec,
+                Definitions,
+                DefinitionsLoadContext,
+                DefinitionsLoadType,
+                asset,
+                definitions,
+                external_assets_from_specs,
+            )
 
             WORKSPACE_ID = "my_workspace"
             FOO_METADATA_KEY_PREFIX = "foo"
+
 
             # Simple model of an external service foo
             def fetch_foo_defs_metadata(workspace_id: str):
@@ -56,20 +66,25 @@ def definitions(fn: DefinitionsLoadFn) -> DefinitionsLoadFn:
                 else:
                     raise Exception("Unknown workspace")
 
+
             def get_foo_defs(context: DefinitionsLoadContext, workspace_id: str) -> Definitions:
                 metadata_key = f"{FOO_METADATA_KEY_PREFIX}/{workspace_id}"
-                payload = context.code_location_metadata.get(metadata_key) or fetch_foo_defs_metadata(workspace_id)
+                if (
+                    context.load_type == DefinitionsLoadType.RECONSTRUCTION
+                    and metadata_key in context.reconstruction_metadata
+                ):
+                    payload = context.reconstruction_metadata[metadata_key]
+                else:
+                    payload = fetch_foo_defs_metadata(workspace_id)
                 asset_specs = [AssetSpec(item["id"]) for item in payload]
                 assets = external_assets_from_specs(asset_specs)
                 return Definitions(
                     assets=assets,
-                ).with_metadata(
-                    {metadata_key: payload}
-                )
+                ).with_reconstruction_metadata({metadata_key: payload})
+
 
             @definitions
             def defs(context: DefinitionsLoadContext):
-
                 @asset
                 def regular_asset(): ...
 

--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -106,6 +106,7 @@ class _Repository:
     ) -> Union[RepositoryDefinition, PendingRepositoryDefinition]:
         from dagster._core.definitions import AssetsDefinition, SourceAsset
         from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
+        from dagster._core.definitions.definitions_class import DEFINITIONS_SOURCE_METADATA_KEY
 
         check.callable_param(fn, "fn")
 
@@ -118,7 +119,7 @@ class _Repository:
         if isinstance(repository_definitions, list):
             bad_defns = []
             repository_defns = []
-            defer_repository_data = False
+            defer_repository_data = bool(self.metadata.get(DEFINITIONS_SOURCE_METADATA_KEY))
             for i, definition in enumerate(_flatten(repository_definitions)):
                 if isinstance(definition, CacheableAssetsDefinition):
                     defer_repository_data = True

--- a/python_modules/dagster/dagster/_core/definitions/definitions_loader.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_loader.py
@@ -1,5 +1,9 @@
+<<<<<<< HEAD
 from enum import Enum
 from typing import TYPE_CHECKING, Callable, Optional, Union
+=======
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, Union
+>>>>>>> c67676d21d ([lazy-defs] Add support for source metadata on Definitions)
 
 from typing_extensions import TypeAlias
 
@@ -56,6 +60,15 @@ class DefinitionsLoadContext:
     def load_type(self) -> DefinitionsLoadType:
         """DefinitionsLoadType: Classifier for scenario in which Definitions are being loaded."""
         return self._load_type
+
+    @property
+    def cached_source_metadata(self) -> Mapping[str, Any]:
+        """Mapping[str, Any]: A dictionary containing the cached payloads from external sources of
+        definition metadata.
+        """
+        return (
+            self._repository_load_data.cached_source_metadata if self._repository_load_data else {}
+        )
 
 
 @record

--- a/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
@@ -1,3 +1,4 @@
+import pytest
 from dagster import (
     AssetKey,
     GraphDefinition,
@@ -15,6 +16,10 @@ from dagster import (
     UrlMetadataValue,
     op,
 )
+from dagster._core.definitions.metadata.metadata_value import (
+    CodeLocationReconstructionMetadataValue,
+)
+from dagster._core.errors import DagsterInvalidMetadata
 from dagster._serdes.serdes import deserialize_value, serialize_value
 
 
@@ -105,6 +110,16 @@ def test_table_schema_metadata_value():
 def test_json_metadata_value():
     assert JsonMetadataValue({"a": "b"}).data == {"a": "b"}
     assert JsonMetadataValue({"a": "b"}).value == {"a": "b"}
+
+
+def test_code_location_reconstruction_metadata_value():
+    assert CodeLocationReconstructionMetadataValue({"a": "b"}).data == {"a": "b"}
+    assert CodeLocationReconstructionMetadataValue({"a": "b"}).value == {"a": "b"}
+    assert CodeLocationReconstructionMetadataValue("abc").data == "abc"
+    assert CodeLocationReconstructionMetadataValue(1).data == 1
+
+    with pytest.raises(DagsterInvalidMetadata, match="not JSON-serializable"):
+        CodeLocationReconstructionMetadataValue(object())
 
 
 def test_serdes_json_metadata():

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_loader.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_loader.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from dagster._core.code_pointer import CodePointer
 from dagster._core.definitions.decorators.asset_decorator import asset
@@ -8,11 +10,102 @@ from dagster._core.definitions.reconstruct import (
     ReconstructableJob,
     ReconstructableRepository,
     repository_def_from_pointer,
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_selection import AssetSelection
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.decorators.asset_decorator import asset
+from dagster._core.definitions.decorators.definitions_decorator import definitions
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.definitions_loader import DefinitionsLoadContext
+from dagster._core.definitions.external_asset import external_assets_from_specs
+from dagster._core.definitions.reconstruct import (
+    ReconstructableRepository,
+    repository_def_from_target_def,
+)
+from dagster._core.definitions.repository_definition.repository_definition import (
+    PendingRepositoryDefinition,
+    RepositoryDefinition,
+    RepositoryLoadData,
 )
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.execution.api import execute_job
 from dagster._core.instance_for_test import instance_for_test
+
+FOO_INTEGRATION_SOURCE_KEY = "foo_integration"
+
+WORKSPACE_ID = "my_workspace"
+
+
+def _fetch_foo_integration_asset_info(workspace_id: str):
+    if workspace_id == WORKSPACE_ID:
+        return [{"id": "alpha"}, {"id": "beta"}]
+    else:
+        raise Exception("Unknown workspace")
+
+
+# This function would be provided by integration lib dagster-foo
+def _get_foo_integration_defs(context: DefinitionsLoadContext, workspace_id: str) -> Definitions:
+    cache_key = f"{FOO_INTEGRATION_SOURCE_KEY}/{workspace_id}"
+    payload = context.cached_source_metadata.get(cache_key) or _fetch_foo_integration_asset_info(
+        workspace_id
+    )
+    asset_specs = [AssetSpec(item["id"]) for item in payload]
+    assets = external_assets_from_specs(asset_specs)
+    return Definitions(
+        assets=assets,
+    ).with_source_metadata({cache_key: payload})
+
+
+@definitions
+def source_metadata_defs(context: DefinitionsLoadContext):
+    @asset
+    def regular_asset(): ...
+
+    all_asset_job = define_asset_job("all_assets", selection=AssetSelection.all())
+
+    return Definitions.merge(
+        _get_foo_integration_defs(context, WORKSPACE_ID),
+        Definitions(assets=[regular_asset], jobs=[all_asset_job]),
+    )
+
+
+# ########################
+# ##### TESTS
+# ########################
+
+
+def test_defs_source_metadata():
+    repo = repository_def_from_target_def(source_metadata_defs)
+    assert repo
+    assert repo.assets_defs_by_key.keys() == {
+        AssetKey("regular_asset"),
+        AssetKey("alpha"),
+        AssetKey("beta"),
+    }
+
+    defs = source_metadata_defs(context=DefinitionsLoadContext())
+    inner_repo = defs.get_inner_repository()
+    assert isinstance(inner_repo, PendingRepositoryDefinition)
+
+    recon_repo = ReconstructableRepository.for_file(__file__, "source_metadata_defs")
+    assert isinstance(recon_repo.get_definition(), RepositoryDefinition)
+
+    repo_load_data = RepositoryLoadData(
+        cacheable_asset_data={},
+        cached_source_metadata={
+            f"{FOO_INTEGRATION_SOURCE_KEY}/{WORKSPACE_ID}": _fetch_foo_integration_asset_info(
+                WORKSPACE_ID
+            )
+        },
+    )
+
+    # Ensure we don't call the expensive fetch function when we have the data cached
+    with patch(
+        "dagster_tests.definitions_tests.test_definitions_loader._fetch_foo_integration_asset_info"
+    ) as mock_fetch:
+        inner_repo.reconstruct_repository_definition(repository_load_data=repo_load_data)
+        mock_fetch.assert_not_called()
 
 
 def test_invoke_definitions_loader_with_context():

--- a/python_modules/dagster/dagster_tests/general_tests/test_pending_repository.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_pending_repository.py
@@ -96,7 +96,7 @@ def test_resolve_missing_key():
     with pytest.raises(check.CheckError, match="No metadata found"):
         pending_repo.reconstruct_repository_definition(
             repository_load_data=RepositoryLoadData(
-                cached_data_by_key={
+                cacheable_asset_data={
                     "a": [
                         AssetsDefinitionCacheableData(
                             keys_by_input_name={"upstream": AssetKey("upstream")},
@@ -119,7 +119,7 @@ def test_resolve_wrong_data():
     ):
         pending_repo.reconstruct_repository_definition(
             repository_load_data=RepositoryLoadData(
-                cached_data_by_key={
+                cacheable_asset_data={
                     "a": [
                         AssetsDefinitionCacheableData(
                             keys_by_input_name={"upstream": AssetKey("upstream")},


### PR DESCRIPTION
## Summary & Motivation

Add reconstruction metadata to `Definitions`, a new API for representing data underlying state-driven definitions from third-party sources. This allows potentially expensive external service calls underlying state-driven definitions to be made once in the code server, with the result reused when reconstructing `Definitions` again in child processes (run workers and step workers). Credit to @sryza for many of the ideas behind this API.

This is intended as a replacement for the existing `CacheableAssetsDefinition` API. Key differences:

- Code location metadata must be used with a `DefinitionsLoader` (`@definitions`) to work correctly
- Code location metadata can be used for metadata underlying any definition, not just assets.
- Code location metadata does not needs pseudo-definitions like `CacheableAssetDefinition` to ever be included in a `Definitions` object.

## Details

Consider this simple model of a third party service containing holding some data we wish to represent as assets in Dagster:

```python
WORKSPACE_ID = "my_workspace"

def fetch_foo_integration_asset_info(workspace_id: str):
    if workspace_id == WORKSPACE_ID:
        return [{"id": "alpha"}, {"id": "beta"}]
    else:
        raise Exception("Unknown workspace")
```

To represent it using source metadata:

```python
FOO_INTEGRATION_SOURCE_KEY = "foo_integration"

# This function would be provided by integration lib dagster-foo
def get_foo_integration_defs(context: DefinitionsLoadContext, workspace_id: str) -> Definitions:
    cache_key = f"{FOO_INTEGRATION_SOURCE_KEY}/{workspace_id}"
    if context.load_type == DefinitionsLoadType.RECONSTRUCTION and cache_key in context.reconstruction_metadata:
        payload = context.code_location_metadata[cache_key]
    else:
        payload = fetch_foo_integration_asset_info(workspace_id)
    asset_specs = [AssetSpec(item["id"]) for item in payload]
    assets = external_assets_from_specs(asset_specs)
    return Definitions(
        assets=assets,
    ).with_reconstruction_metadata(
        {cache_key: payload}
    )

@definitions
def defs(context: DefinitionsLoadContext):

    @asset
    def regular_asset(): ...

    return Definitions.merge(
        get_foo_integration_defs(context, WORKSPACE_ID),
        Definitions(assets=[regular_asset]),
    )
```

To represent this using the `CacheableAssetsDefinition` system:

```python
# This class would be provided by integration lib dagster-foo
class FooIntegrationCacheableAssetsDefinition(CacheableAssetsDefinition):
    def compute_cacheable_data(self) -> Sequence[AssetsDefinitionCacheableData]:
         payload = fetch_foo_integration_asset_info(self.unique_id)
         return [
            AssetsDefinitionCacheableData(extra_metadata={"id": item["id"]})
            for item in payload
        ]

    def build_definitions(self, data: Sequence[AssetsDefinitionCacheableData]):
        asset_specs = [AssetSpec(item.extra_metadata["id"]) for item in data]
        return external_assets_from_specs(asset_specs)

@definitions
def defs(context):

    @asset
    def regular_asset(): ...

    foo_integration_cacheable_assets = FooIntegrationCacheableAssetsDefinition(
        unique_id=WORKSPACE_ID
    )

    return Definitions(
        assets=[regular_asset, foo_integration_cacheable_assets],
    )
```

### Mechanism

- A `DefinitionsLoader` must be used for to define our `Definitions`. This is because only the loader function receives a `DefinitionsLoadContext`, which is the access point for reconstruction metadata.
- Integrations provide a function that accepts (a) a `DefinitionsLoadContext`; (b) credentials/API call params to retrieve a remote payload.
    - The function must return a `Definitions` object containing the third-party-sourced definitions.
    - In a reconstruction context, the function is expected to check `DefinitionsLoadContext.reconstruction_metadata` on the `DefinitionsLoadContext` for the payload and retrieve the remote payload on cache miss. Accesing `reconstruction_metadata` in an initialization context is an error.
    - The function adds metadata by calling `with_reconstruction_metadata()` on the returned object: `Definitions(...).with_metadata({<key>: <payload>})`. `with_reconstruction_metadata` wraps the passed value in `CodeLocationReconstructionMetadataValue` and sticks it on `Definitions.metadata`.
- If reconstruction metadata is stashed on a `Definitions`, then the `Definitions` object will generate a `PendingRepositoryDefinition` instead of a `RepositoryDefinition`. This is the same behavior as if any `CacheableAssetsDefinition` are detected in the definitions.
    - Using `PendingRepositoryDefinition` allows us to reuse the internal plumbing we already have for moving cached cached definition metadata cross-process: `RepositoryLoadData`.
- Any reconstruction metadata attached to `Definitions` gets attached to `RepositoryLoadData`, from which it is exposed on `DefinitionsLoadContext`. `RepositoryLoadData.cached_data_by_key` was renamed to `cacheable_asset_data`, since there are now two kinds of cached data. I didn't simply include source data in `cached_data_by_key` because the typing of this field is too restrictive, with values required to be `Sequence[AssetsDefinitionCacheableData]`.

## How I Tested These Changes

New unit tests.

## Changelog

New source metadata API for instantiating definitions backed by external APIs.

- [x] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
