### PR TITLE
docs: fix typo in whats-a-dependency.md

### DIFF
--- a/docs/dagster-university/pages/dagster-essentials/lesson-4/whats-a-dependency.md
+++ b/docs/dagster-university/pages/dagster-essentials/lesson-4/whats-a-dependency.md
@@ -19,7 +19,7 @@ To demonstrate, let’s take a look at a portion of the cookie pipeline.
   In this example, **flour**, **cookie dough**, and **cookies** are our assets. Let’s break down what’s happening here:
 
   - To make **cookie dough**, **flour** is required. Therefore, **cookie dough** is downstream - or dependent on - **flour.**
-  - To make **cookies**, **cookie dough** is required. Therefore, **cookie dough** is upstream - or **cookies** is dependent on - **cookie dough.**
+  - To make **cookies**, **cookie dough** is required. Therefore, **cookie dough** is upstream - or **cookies** is dependent on - **cookie.**
 
 - ![Cookie pipeline, labeled with different types of dependencies](/images/dagster-essentials/lesson-4/cookie-dependencies.png) {% rowspan=2 %}
 


### PR DESCRIPTION
## Summary & Motivation

A small typo in Dagster Essentials course.

## How I Tested These Changes

No tests required.

## Changelog

`DOCS` _fix small typo in upstream explanation_

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [x] `DOCS` _(added or updated documentation)_
