### PR TITLE
[lazy-defs] Add `metadata` field on `Definitions`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/repository_decorator.py
@@ -59,7 +59,7 @@ class _Repository:
         self,
         name: Optional[str] = None,
         description: Optional[str] = None,
-        metadata: Optional[Dict[str, RawMetadataValue]] = None,
+        metadata: Optional[Mapping[str, RawMetadataValue]] = None,
         default_executor_def: Optional[ExecutorDefinition] = None,
         default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
         top_level_resources: Optional[Mapping[str, ResourceDefinition]] = None,
@@ -228,7 +228,7 @@ def repository(
     *,
     name: Optional[str] = ...,
     description: Optional[str] = ...,
-    metadata: Optional[Dict[str, RawMetadataValue]] = ...,
+    metadata: Optional[Mapping[str, RawMetadataValue]] = ...,
     default_executor_def: Optional[ExecutorDefinition] = ...,
     default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = ...,
     _top_level_resources: Optional[Mapping[str, ResourceDefinition]] = ...,
@@ -245,7 +245,7 @@ def repository(
     *,
     name: Optional[str] = None,
     description: Optional[str] = None,
-    metadata: Optional[Dict[str, RawMetadataValue]] = None,
+    metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     default_executor_def: Optional[ExecutorDefinition] = None,
     default_logger_defs: Optional[Mapping[str, LoggerDefinition]] = None,
     _top_level_resources: Optional[Mapping[str, ResourceDefinition]] = None,
@@ -280,7 +280,8 @@ def repository(
         name (Optional[str]): The name of the repository. Defaults to the name of the decorated
             function.
         description (Optional[str]): A string description of the repository.
-        metadata (Optional[Dict[str, RawMetadataValue]]): Arbitrary metadata for the repository.
+        metadata (Optional[Dict[str, RawMetadataValue]]): Arbitrary metadata for the repository. Not
+            displayed in the UI but accessible on RepositoryDefinition at runtime.
         top_level_resources (Optional[Mapping[str, ResourceDefinition]]): A dict of top-level
             resource keys to defintions, for resources which should be displayed in the UI.
 

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -91,7 +91,8 @@ class RepositoryDefinition:
         name (str): The name of the repository.
         repository_data (RepositoryData): Contains the definitions making up the repository.
         description (Optional[str]): A string description of the repository.
-        metadata (Optional[MetadataMapping]): A map of arbitrary metadata for the repository.
+        metadata (Optional[MetadataMapping]): Arbitrary metadata for the repository. Not
+            displayed in the UI but accessible on RepositoryDefinition at runtime.
     """
 
     def __init__(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -45,6 +45,7 @@ from dagster._core.definitions.executor_definition import executor
 from dagster._core.definitions.external_asset import create_external_asset_from_source_asset
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.logger_definition import logger
+from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._core.definitions.partition import PartitionsDefinition, StaticPartitionsDefinition
 from dagster._core.definitions.repository_definition import (
     PendingRepositoryDefinition,
@@ -815,6 +816,7 @@ def test_merge():
         resources={"resource1": resource1},
         loggers={"logger1": logger1},
         executor=in_process_executor,
+        metadata={"foo": 1},
     )
     defs2 = Definitions(
         assets=[asset2],
@@ -823,6 +825,7 @@ def test_merge():
         sensors=[sensor2],
         resources={"resource2": resource2},
         loggers={"logger2": logger2},
+        metadata={"bar": 2},
     )
 
     merged = Definitions.merge(defs1, defs2)
@@ -835,6 +838,7 @@ def test_merge():
         loggers={"logger1": logger1, "logger2": logger2},
         executor=in_process_executor,
         asset_checks=[],
+        metadata={"foo": MetadataValue.int(1), "bar": MetadataValue.int(2)},
     )
 
 
@@ -1085,3 +1089,9 @@ def test_definitions_dedupe_reference_equality():
     assert len(defs.jobs) == 2
     assert len(defs.sensors) == 2
     assert len(defs.schedules) == 2
+
+
+def test_definitions_class_metadata():
+    defs = Definitions(metadata={"foo": "bar"})
+    assert defs.metadata == {"foo": MetadataValue.text("bar")}
+    assert defs.get_repository_def().metadata == {"foo": MetadataValue.text("bar")}


### PR DESCRIPTION
## Summary & Motivation

Adds a `metadata` field on `Definitions` to match the underlying `metadata` field on `RepositoryDefinition`. This supports upstack work on caching "code location metadata' on a `Definitions` object returned from a `DefinitionsLoader`.

## How I Tested These Changes

New unit tests.

## Changelog

NOCHANGELOG
