### PR TITLE
[lazy-defs] Add reconstruction metadata to PowerBI integration

### DIFF
--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/__init__.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/__init__.py
@@ -4,6 +4,7 @@ from dagster_powerbi.resource import (
     PowerBIServicePrincipal as PowerBIServicePrincipal,
     PowerBIToken as PowerBIToken,
     PowerBIWorkspace as PowerBIWorkspace,
+    load_powerbi_defs as load_powerbi_defs,
 )
 from dagster_powerbi.translator import DagsterPowerBITranslator as DagsterPowerBITranslator
 

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
@@ -19,6 +19,7 @@ from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
     CacheableAssetsDefinition,
 )
+from dagster._core.definitions.definitions_loader import DefinitionsLoadContext
 from dagster._core.definitions.events import Failure
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._utils.cached_method import cached_method
@@ -302,6 +303,68 @@ class PowerBIWorkspace(ConfigurableResource):
         )
 
 
+def _workspace_data_to_cacheable_data(
+    workspace_data: PowerBIWorkspaceData,
+) -> Sequence[Mapping[str, Any]]:
+    return [
+        data.to_cached_data()
+        for data in [
+            *workspace_data.dashboards_by_id.values(),
+            *workspace_data.reports_by_id.values(),
+            *workspace_data.semantic_models_by_id.values(),
+            *workspace_data.data_sources_by_id.values(),
+        ]
+    ]
+
+
+def _build_assets_defs_from_workspace_data(
+    workspace_data: PowerBIWorkspaceData,
+    workspace: PowerBIWorkspace,
+    translator_cls: Type[DagsterPowerBITranslator],
+    enable_refresh_semantic_models: bool,
+) -> Sequence[AssetsDefinition]:
+    translator = translator_cls(context=workspace_data)
+
+    if enable_refresh_semantic_models:
+        all_external_data = [
+            *workspace_data.dashboards_by_id.values(),
+            *workspace_data.reports_by_id.values(),
+            *workspace_data.data_sources_by_id.values(),
+        ]
+        all_executable_data = [*workspace_data.semantic_models_by_id.values()]
+    else:
+        all_external_data = [
+            *workspace_data.dashboards_by_id.values(),
+            *workspace_data.reports_by_id.values(),
+            *workspace_data.data_sources_by_id.values(),
+            *workspace_data.semantic_models_by_id.values(),
+        ]
+        all_executable_data = []
+
+    all_external_asset_specs = [translator.get_asset_spec(content) for content in all_external_data]
+    all_executable_asset_specs = [
+        translator.get_asset_spec(content) for content in all_executable_data
+    ]
+
+    executable_assets = []
+    for content, spec in zip(all_executable_data, all_executable_asset_specs):
+        dataset_id = content.properties["id"]
+
+        @multi_asset(
+            specs=[spec],
+            name="_".join(spec.key.path),
+            resource_defs={"power_bi": workspace.get_resource_definition()},
+        )
+        def asset_fn(context: AssetExecutionContext, power_bi: PowerBIWorkspace) -> None:
+            power_bi.trigger_refresh(dataset_id)
+            power_bi.poll_refresh(dataset_id)
+            context.log.info("Refresh completed.")
+
+        executable_assets.append(asset_fn)
+
+    return [*external_assets_from_specs(all_external_asset_specs), *executable_assets]
+
+
 class PowerBICacheableAssetsDefinition(CacheableAssetsDefinition):
     def __init__(
         self,
@@ -333,13 +396,8 @@ class PowerBICacheableAssetsDefinition(CacheableAssetsDefinition):
 
         workspace_data: PowerBIWorkspaceData = workspace.fetch_powerbi_workspace_data()
         return [
-            AssetsDefinitionCacheableData(extra_metadata=data.to_cached_data())
-            for data in [
-                *workspace_data.dashboards_by_id.values(),
-                *workspace_data.reports_by_id.values(),
-                *workspace_data.semantic_models_by_id.values(),
-                *workspace_data.data_sources_by_id.values(),
-            ]
+            AssetsDefinitionCacheableData(extra_metadata=data)
+            for data in _workspace_data_to_cacheable_data(workspace_data)
         ]
 
     def build_definitions(
@@ -353,50 +411,40 @@ class PowerBICacheableAssetsDefinition(CacheableAssetsDefinition):
                 for entry in data
             ],
         )
+        return _build_assets_defs_from_workspace_data(
+            workspace_data,
+            self._workspace,
+            self._translator_cls,
+            self._enable_refresh_semantic_models,
+        )
 
-        translator = self._translator_cls(context=workspace_data)
 
-        if self._enable_refresh_semantic_models:
-            all_external_data = [
-                *workspace_data.dashboards_by_id.values(),
-                *workspace_data.reports_by_id.values(),
-            ]
-            all_executable_data = [*workspace_data.semantic_models_by_id.values()]
-        else:
-            all_external_data = [
-                *workspace_data.dashboards_by_id.values(),
-                *workspace_data.reports_by_id.values(),
-                *workspace_data.semantic_models_by_id.values(),
-            ]
-            all_executable_data = []
+POWER_BI_SOURCE_METADATA_KEY_PREFIX = "__power_bi"
 
-        all_external_asset_specs = [
-            translator.get_asset_spec(content) for content in all_external_data
-        ]
-        all_executable_asset_specs = [
-            translator.get_asset_spec(content) for content in all_executable_data
-        ]
 
-        executable_assets = []
-        for content, spec in zip(all_executable_data, all_executable_asset_specs):
-            dataset_id = content.properties["id"]
+def load_powerbi_defs(
+    context: DefinitionsLoadContext,
+    api_token: str,
+    workspace_id: str,
+    enable_refresh_semantic_models: bool,
+) -> Definitions:
+    cache_key = f"{POWER_BI_SOURCE_METADATA_KEY_PREFIX}/{workspace_id}"
+    workspace = PowerBIWorkspace(api_token=api_token, workspace_id=workspace_id)
+    if cache_key in context.cached_source_metadata:
+        payload = context.cached_source_metadata[cache_key]
+        workspace_data = PowerBIWorkspaceData.from_content_data(
+            workspace_id,
+            [PowerBIContentData.from_cached_data(entry) for entry in payload],
+        )
+    else:
+        workspace_data = workspace.fetch_powerbi_workspace_data()
 
-            resource_key = f"power_bi_{self._workspace.workspace_id.replace('-','_')}"
-
-            @multi_asset(
-                specs=[spec],
-                name="_".join(spec.key.path),
-                resource_defs={resource_key: self._workspace.get_resource_definition()},
-            )
-            def asset_fn(context: AssetExecutionContext) -> None:
-                power_bi = cast(PowerBIWorkspace, getattr(context.resources, resource_key))
-                power_bi.trigger_refresh(dataset_id)
-                power_bi.poll_refresh(dataset_id)
-                context.log.info("Refresh completed.")
-
-            executable_assets.append(asset_fn)
-
-        return [
-            *external_assets_from_specs(all_external_asset_specs),
-            *executable_assets,
-        ]
+    assets_defs = _build_assets_defs_from_workspace_data(
+        workspace_data,
+        workspace,
+        DagsterPowerBITranslator,
+        enable_refresh_semantic_models,
+    )
+    return Definitions(assets=assets_defs).with_source_metadata(
+        {cache_key: _workspace_data_to_cacheable_data(workspace_data)}
+    )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -1,13 +1,14 @@
 import re
 import urllib.parse
 from enum import Enum
-from typing import Any, Dict, Mapping, Sequence
+from typing import Any, Dict, Sequence
 
 from dagster import _check as check
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._record import record
+from dagster._serdes.serdes import whitelist_for_serdes
 
 
 def _get_last_filepath_component(path: str) -> str:
@@ -25,6 +26,7 @@ def _clean_asset_name(name: str) -> str:
     return re.sub(r"[^A-Za-z0-9_]+", "_", name)
 
 
+@whitelist_for_serdes
 class PowerBIContentType(Enum):
     """Enum representing each object in PowerBI's ontology, generically referred to as "content" by the API."""
 
@@ -34,6 +36,7 @@ class PowerBIContentType(Enum):
     DATA_SOURCE = "data_source"
 
 
+@whitelist_for_serdes
 @record
 class PowerBIContentData:
     """A record representing a piece of content in PowerBI.
@@ -43,17 +46,8 @@ class PowerBIContentData:
     content_type: PowerBIContentType
     properties: Dict[str, Any]
 
-    def to_cached_data(self) -> Dict[str, Any]:
-        return {"content_type": self.content_type.value, "properties": self.properties}
 
-    @classmethod
-    def from_cached_data(cls, data: Mapping[Any, Any]) -> "PowerBIContentData":
-        return cls(
-            content_type=PowerBIContentType(data["content_type"]),
-            properties=data["properties"],
-        )
-
-
+@whitelist_for_serdes
 @record
 class PowerBIWorkspaceData:
     """A record representing all content in a PowerBI workspace.

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo.py
@@ -34,7 +34,7 @@ pending_repo_from_cached_asset_metadata = cast(
 
 
 @definitions
-def source_metadata_defs(context: DefinitionsLoadContext) -> Definitions:
+def reconstruction_metadata_defs(context: DefinitionsLoadContext) -> Definitions:
     pbi_defs = load_powerbi_defs(
         context,
         api_token=fake_token,

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo.py
@@ -2,11 +2,14 @@ import uuid
 from typing import cast
 
 from dagster import asset, define_asset_job
+from dagster._core.definitions.decorators.definitions_decorator import definitions
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.definitions_loader import DefinitionsLoadContext
 from dagster._core.definitions.repository_definition.repository_definition import (
     PendingRepositoryDefinition,
 )
 from dagster_powerbi import PowerBIToken, PowerBIWorkspace
+from dagster_powerbi.resource import load_powerbi_defs
 
 fake_token = uuid.uuid4().hex
 resource = PowerBIWorkspace(
@@ -28,3 +31,18 @@ pending_repo_from_cached_asset_metadata = cast(
         pbi_defs,
     ).get_inner_repository(),
 )
+
+
+@definitions
+def source_metadata_defs(context: DefinitionsLoadContext) -> Definitions:
+    pbi_defs = load_powerbi_defs(
+        context,
+        api_token=fake_token,
+        workspace_id="a2122b8f-d7e1-42e8-be2b-a5e636ca3221",
+        enable_refresh_semantic_models=False,
+    )
+
+    return Definitions.merge(
+        Definitions(assets=[my_materializable_asset], jobs=[define_asset_job("all_asset_job")]),
+        pbi_defs,
+    )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -5,7 +5,7 @@ import pytest
 import responses
 from dagster import materialize
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.definitions_loader import DefinitionsLoadContext
+from dagster._core.definitions.definitions_loader import DefinitionsLoadContext, DefinitionsLoadType
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
 from dagster._core.definitions.repository_definition.repository_definition import (
     PendingRepositoryDefinition,
@@ -201,7 +201,9 @@ def test_using_cached_source_metadata(workspace_data_api_mocks: responses.Reques
 
         pending_repo = cast(
             PendingRepositoryDefinition,
-            source_metadata_defs(DefinitionsLoadContext()).get_inner_repository(),
+            source_metadata_defs(
+                DefinitionsLoadContext(load_type=DefinitionsLoadType.INITIALIZATION)
+            ).get_inner_repository(),
         )
 
         # first, we resolve the repository to generate our cached metadata

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -122,7 +122,7 @@ def test_refreshable_semantic_model(
     assert result.success is success
 
 
-def test_using_cached_asset_data(workspace_data_api_mocks: responses.RequestsMock) -> None:
+def test_using_cacheable_assets_defs(workspace_data_api_mocks: responses.RequestsMock) -> None:
     with instance_for_test() as instance:
         assert len(workspace_data_api_mocks.calls) == 0
 
@@ -193,15 +193,16 @@ def test_two_workspaces(
         # 3 PowerBI external assets from first workspace, 1 from second
         assert len(repository_def.assets_defs_by_key) == 3 + 1
 
-def test_using_cached_source_metadata(workspace_data_api_mocks: responses.RequestsMock) -> None:
+
+def test_using_reconstruction_metadata(workspace_data_api_mocks: responses.RequestsMock) -> None:
     with instance_for_test() as instance:
         assert len(workspace_data_api_mocks.calls) == 0
 
-        from dagster_powerbi_tests.pending_repo import source_metadata_defs
+        from dagster_powerbi_tests.pending_repo import reconstruction_metadata_defs
 
         pending_repo = cast(
             PendingRepositoryDefinition,
-            source_metadata_defs(
+            reconstruction_metadata_defs(
                 DefinitionsLoadContext(load_type=DefinitionsLoadType.INITIALIZATION)
             ).get_inner_repository(),
         )
@@ -211,14 +212,14 @@ def test_using_cached_source_metadata(workspace_data_api_mocks: responses.Reques
         assert len(workspace_data_api_mocks.calls) == 5
 
         # 5 PowerBI external assets, one materializable asset
-        assert len(repository_def.assets_defs_by_key) == 5 + 1
+        assert len(repository_def.assets_defs_by_key) == 3 + 1
 
         job_def = repository_def.get_job("all_asset_job")
         repository_load_data = repository_def.repository_load_data
 
         recon_repo = ReconstructableRepository.for_file(
             file_relative_path(__file__, "pending_repo.py"),
-            fn_name="source_metadata_defs",
+            fn_name="reconstruction_metadata_defs",
         )
         recon_job = ReconstructableJob(repository=recon_repo, job_name="all_asset_job")
 
@@ -239,4 +240,3 @@ def test_using_cached_source_metadata(workspace_data_api_mocks: responses.Reques
         ), "Expected two successful steps"
 
         assert len(workspace_data_api_mocks.calls) == 5
->>>>>>> 966419961d ([lazy-defs] Add source metadata to PowerBI integration)

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -1,10 +1,15 @@
 import uuid
+from typing import cast
 
 import pytest
 import responses
 from dagster import materialize
 from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.definitions_loader import DefinitionsLoadContext
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
+from dagster._core.definitions.repository_definition.repository_definition import (
+    PendingRepositoryDefinition,
+)
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.instance_for_test import instance_for_test
@@ -187,3 +192,49 @@ def test_two_workspaces(
 
         # 3 PowerBI external assets from first workspace, 1 from second
         assert len(repository_def.assets_defs_by_key) == 3 + 1
+
+def test_using_cached_source_metadata(workspace_data_api_mocks: responses.RequestsMock) -> None:
+    with instance_for_test() as instance:
+        assert len(workspace_data_api_mocks.calls) == 0
+
+        from dagster_powerbi_tests.pending_repo import source_metadata_defs
+
+        pending_repo = cast(
+            PendingRepositoryDefinition,
+            source_metadata_defs(DefinitionsLoadContext()).get_inner_repository(),
+        )
+
+        # first, we resolve the repository to generate our cached metadata
+        repository_def = pending_repo.compute_repository_definition()
+        assert len(workspace_data_api_mocks.calls) == 5
+
+        # 5 PowerBI external assets, one materializable asset
+        assert len(repository_def.assets_defs_by_key) == 5 + 1
+
+        job_def = repository_def.get_job("all_asset_job")
+        repository_load_data = repository_def.repository_load_data
+
+        recon_repo = ReconstructableRepository.for_file(
+            file_relative_path(__file__, "pending_repo.py"),
+            fn_name="source_metadata_defs",
+        )
+        recon_job = ReconstructableJob(repository=recon_repo, job_name="all_asset_job")
+
+        execution_plan = create_execution_plan(recon_job, repository_load_data=repository_load_data)
+
+        run = instance.create_run_for_job(job_def=job_def, execution_plan=execution_plan)
+
+        events = execute_plan(
+            execution_plan=execution_plan,
+            job=recon_job,
+            dagster_run=run,
+            instance=instance,
+        )
+
+        assert (
+            len([event for event in events if event.event_type == DagsterEventType.STEP_SUCCESS])
+            == 1
+        ), "Expected two successful steps"
+
+        assert len(workspace_data_api_mocks.calls) == 5
+>>>>>>> 966419961d ([lazy-defs] Add source metadata to PowerBI integration)


### PR DESCRIPTION
## Summary & Motivation

Add a reconstruction metadata API to the PowerBI integration.

Also make the existing PowerBI data structures serializable to eliminate an extra layer of translation to plain dict/list for serialization.

The PowerBI integration already offers state-driven asset definitions using `CacheableAssetsDefinition`. This adds an alternative `load_powerbi_defs` function as an alternative that uses code location instead of `CacheableAssetsDefinition`. It is invoked like this:

```python
@definitions
def reconstruction_metadata_defs(context: DefinitionsLoadContext) -> Definitions:
    pbi_defs = load_powerbi_defs(
        context,
        api_token="token",
        workspace_id="my_workspace",
        enable_refresh_semantic_models=False,
    )

    return Definitions.merge(
        Definitions(assets=[my_materializable_asset], jobs=[define_asset_job("all_asset_job")]),
        pbi_defs,
    )
```

One outstanding question is how exactly to structure the API for `load_powerbi_defs`. I opted for a simple exported function that doesn't make you deal with any other abstractions, but the existing `CacheableAssetsDefinition` implementation has you do this:

```
cacheable_asset_defs = PowerBIWorkspace(
    api_token=...,
    workspace_id=...,
).build_defs()
```

It would be easy to use a similar API for the code location metadata version. I'm agnostic on this and we should do whatever is more idiomatic for our integrations.

## How I Tested These Changes

New unit test that follows same template as the test on `CacheableAssetsDefinition`.

## Changelog

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
