### PR TITLE
display new bulk action statuses in UI

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
@@ -43,7 +43,7 @@ const labelForBackfillStatus = (key: BulkActionStatus) => {
     case BulkActionStatus.REQUESTED:
       return 'In progress';
     case BulkActionStatus.COMPLETED_SUCCESS:
-      return 'Succeeded';
+      return 'Success';
     case BulkActionStatus.COMPLETED_FAILED:
       return 'Failed';
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
@@ -42,6 +42,10 @@ const labelForBackfillStatus = (key: BulkActionStatus) => {
       return 'Failed';
     case BulkActionStatus.REQUESTED:
       return 'In progress';
+    case BulkActionStatus.COMPLETED_SUCCESS:
+      return 'Succeeded';
+    case BulkActionStatus.COMPLETED_FAILED:
+      return 'Failed';
   }
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillStatusTagForPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillStatusTagForPage.tsx
@@ -39,6 +39,10 @@ export const BackfillStatusTagForPage = ({backfill}: {backfill: BackfillState}) 
       return errorState('Failed');
     case BulkActionStatus.COMPLETED:
       return <Tag intent="success">Completed</Tag>;
+    case BulkActionStatus.COMPLETED_SUCCESS:
+      return <Tag intent="success">Succeeded</Tag>;
+    case BulkActionStatus.COMPLETED_FAILED:
+      return errorState('Failed');
     default:
       return <Tag>{status}</Tag>;
   }


### PR DESCRIPTION
## Summary & Motivation
Updates the FE to display the `COMPLETED_SUCCESS` and `COMPLETED_FAILED` statuses in the downstream PR

## How I Tested These Changes
Backfill run after updating the UI shows `Succeeded` status. Backfill run before the UI update is still `Completed`. Note that we changed the language to `Success` instead of `Succeeded` so this screenshot is slightly out of date

<img width="1576" alt="Screenshot 2024-09-12 at 12 40 50 PM" src="https://github.com/user-attachments/assets/fbf63a4f-17da-4428-9feb-11c7da7c186c">


## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
