### PR TITLE
Ignore legacy AutoMaterializePolicies in AnyDownstreamConditions

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_any_downstream_conditions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_any_downstream_conditions.py
@@ -8,6 +8,7 @@ from dagster import (
     evaluate_automation_conditions,
 )
 from dagster._core.definitions.asset_key import CoercibleToAssetKey
+from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
 from dagster._core.definitions.declarative_automation.operators.boolean_operators import (
     AndAutomationCondition,
@@ -37,6 +38,23 @@ def test_basic() -> None:
     a_result = _get_result(a.key, result.results)
     assert len(a_result.child_results) == 1
     assert a_result.child_results[0].child_results[0].condition == cond2
+
+
+def test_basic_with_amp() -> None:
+    cond1 = AutomationCondition.any_downstream_conditions()
+    cond2 = AutoMaterializePolicy.eager()
+
+    @asset(automation_condition=cond1)
+    def a(): ...
+
+    @asset(auto_materialize_policy=cond2, deps=[a])
+    def b(): ...
+
+    result = evaluate_automation_conditions([a, b], instance=DagsterInstance.ephemeral())
+
+    a_result = _get_result(a.key, result.results)
+    # do not pick up child result
+    assert len(a_result.child_results) == 0
 
 
 def test_multiple_downstreams() -> None:


### PR DESCRIPTION
## Summary & Motivation

Due to how we gate access to the legacy context object, and the fact that the "fully resolved" automation condition is not available until we execute the AnyDownstreamConditions condition (because we need access to the full asset graph), this would previously cause errors.

These errors are weird, as the method says "any downstream *conditions*", whereas the downstream causing that failure has an AutoMaterializePolicy, not a condition.

This change just ignores AMPs that are found downstream, avoiding the error

## How I Tested These Changes

## Changelog

Fixed issue which could cause errors when using `AutomationCondition.any_downstream_condition()` with downstream `AutoMaterializePolicy` objects.

- [ ] `NEW` _(added new feature or capability)_
- [x] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
