### PR TITLE
[dagster-airlift] remove naming convention

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/defs_from_airflow.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/defs_from_airflow.py
@@ -25,12 +25,6 @@ def build_defs_from_airflow_instance(
 
     Each airflow dag will be represented as a dagster asset, and each dag run will be represented as an asset materialization. A :py:class:`dagster.SensorDefinition` provided in the returned Definitions will be used to poll for dag runs.
 
-    The provided orchestrated defs are expected to contain fully qualified :py:class:`dagster.AssetsDefinition` objects, each of which should be mapped to a task and dag in the provided airflow instance. Using the airflow instance,
-    dagster will provide dependency information between the assets representing tasks, and the dags that they contain. The included :py:class:`dagster.SensorDefinition` will poll for dag runs and materialize runs including each task as an asset for that task.
-
-    There are two ways that the mapping can be done on a provided definition:
-    1. By using the `airlift/dag_id` and `airlift/task_id` op tags on the underlying :py:class:`dagster.NodeDefinition` for the asset.
-    2. By using an opinionated naming format on the :py:class:`dagster.NodeDefinition` for the asset. The naming format is `dag_id__task_id`.
 
     Args:
         airflow_instance (AirflowInstance): The airflow instance to peer with.

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
@@ -17,41 +17,11 @@ def convert_to_valid_dagster_name(name: str) -> str:
 
 
 def get_task_id_from_asset(asset: Union[AssetsDefinition, AssetSpec]) -> Optional[str]:
-    return _get_prop_from_asset(asset, TASK_ID_METADATA_KEY, 1)
+    return prop_from_metadata(asset, TASK_ID_METADATA_KEY)
 
 
 def get_dag_id_from_asset(asset: Union[AssetsDefinition, AssetSpec]) -> Optional[str]:
-    return _get_prop_from_asset(asset, DAG_ID_METADATA_KEY, 0)
-
-
-def _get_prop_from_asset(
-    asset: Union[AssetSpec, AssetsDefinition], prop_metadata_key: str, position: int
-) -> Optional[str]:
-    prop_from_asset_tags = prop_from_metadata(asset, prop_metadata_key)
-    if isinstance(asset, AssetSpec) or not asset.is_executable:
-        return prop_from_asset_tags
-    prop_from_op_tags = None
-    if asset.node_def.tags and prop_metadata_key in asset.node_def.tags:
-        prop_from_op_tags = asset.node_def.tags[prop_metadata_key]
-    prop_from_name = None
-    if len(asset.node_def.name.split("__")) == 2:
-        prop_from_name = asset.node_def.name.split("__")[position]
-    if prop_from_asset_tags and prop_from_op_tags:
-        check.invariant(
-            prop_from_asset_tags == prop_from_op_tags,
-            f"ID mismatch between asset tags and op tags: {prop_from_asset_tags} != {prop_from_op_tags}",
-        )
-    if prop_from_asset_tags and prop_from_name:
-        check.invariant(
-            prop_from_asset_tags == prop_from_name,
-            f"ID mismatch between tags and name: {prop_from_asset_tags} != {prop_from_name}",
-        )
-    if prop_from_op_tags and prop_from_name:
-        check.invariant(
-            prop_from_op_tags == prop_from_name,
-            f"ID mismatch between op tags and name: {prop_from_op_tags} != {prop_from_name}",
-        )
-    return prop_from_asset_tags or prop_from_op_tags or prop_from_name
+    return prop_from_metadata(asset, DAG_ID_METADATA_KEY)
 
 
 def prop_from_metadata(

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/base_proxy_operator.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/base_proxy_operator.py
@@ -46,7 +46,6 @@ class BaseProxyToDagsterOperator(BaseOperator, ABC):
 
     def launch_runs_for_task(self, context: Context, dag_id: str, task_id: str) -> None:
         """Launches runs for the given task in Dagster."""
-        expected_op_name = f"{dag_id}__{task_id}"
         session = self._get_validated_session(context)
 
         dagster_url = self.get_dagster_url(context)
@@ -64,8 +63,7 @@ class BaseProxyToDagsterOperator(BaseOperator, ABC):
                 for entry in asset_node["metadataEntries"]
                 if entry["__typename"] == "TextMetadataEntry"
             }
-            # match assets based on conventional dag_id__task_id naming or based on explicit tags
-            if asset_node["opName"] == expected_op_name or (
+            if (
                 text_metadata_entries.get(DAG_ID_METADATA_KEY) == dag_id
                 and text_metadata_entries.get(TASK_ID_METADATA_KEY) == task_id
             ):

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/gql_queries.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/gql_queries.py
@@ -18,7 +18,6 @@ query AssetNodeQuery {
             }
             __typename
         }
-        opName
         jobs {
             id
             name

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/operator_test_project/dagster_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/operator_test_project/dagster_defs.py
@@ -1,7 +1,8 @@
 from dagster import Definitions, asset
+from dagster_airlift.constants import DAG_ID_METADATA_KEY, TASK_ID_METADATA_KEY
 
 
-@asset
+@asset(metadata={DAG_ID_METADATA_KEY: "the_dag", TASK_ID_METADATA_KEY: "some_task"})
 def the_dag__some_task():
     return "asset_value"
 
@@ -11,7 +12,7 @@ def unrelated():
     return "unrelated_value"
 
 
-@asset
+@asset(metadata={DAG_ID_METADATA_KEY: "the_dag", TASK_ID_METADATA_KEY: "other_task"})
 def the_dag__other_task():
     return "other_task_value"
 

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_build_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_build_defs.py
@@ -46,11 +46,6 @@ def some_schedule():
 
 
 @asset
-def dag__task():
-    pass
-
-
-@asset
 def a():
     pass
 
@@ -60,11 +55,6 @@ b_spec = AssetSpec(key="b")
 
 @asset_check(asset=a)
 def a_check():
-    pass
-
-
-@asset_check(asset=dag__task)
-def other_check():
     pass
 
 


### PR DESCRIPTION
## Summary & Motivation
Remove convention-based approaches for setting dag id and task ID.

## Changelog
`NOCHANGELOG`

