### PR TITLE
add 'pathType' field to 'dagsterWebserver' ingress

### DIFF
--- a/helm/dagster/templates/ingress.yaml
+++ b/helm/dagster/templates/ingress.yaml
@@ -58,6 +58,7 @@ spec:
                   number: {{ $_.Values.dagsterWebserver.service.port | default 80 }}
           {{- range $_.Values.ingress.dagsterWebserver.succeedingPaths }}
           - path: {{ .path }}
+            pathType: {{ $_.Values.ingress.dagsterWebserver.pathType }}
             backend:
               service:
                 name: {{ .serviceName }}

--- a/helm/dagster/templates/ingress.yaml
+++ b/helm/dagster/templates/ingress.yaml
@@ -58,7 +58,7 @@ spec:
                   number: {{ $_.Values.dagsterWebserver.service.port | default 80 }}
           {{- range $_.Values.ingress.dagsterWebserver.succeedingPaths }}
           - path: {{ .path }}
-            pathType: {{ $_.Values.ingress.dagsterWebserver.pathType }}
+            pathType: {{ .pathType }}
             backend:
               service:
                 name: {{ .serviceName }}


### PR DESCRIPTION
## Summary & Motivation
The 'PathType' field is missing from the ingress template for 'succeedingPaths' in 'dagsterWebserver' paths causing the helm deployment to fail if a 'succeedingPath'  has been declared in the input values file.

[Issue Link](https://github.com/dagster-io/dagster/issues/24420)

## How I Tested These Changes
- Added the 'pathType' field to and re-deployed the helm chart without error.
- Confirmed that the resulting ingress resource was created successfully.

## Changelog

Insert changelog entry or "NOCHANGELOG" here.
- [x] `BUGFIX` add 'pathType' field to 'dagsterWebserver' ingress in ingress.yaml