### PR TITLE
Allow AssetCheck to have AutomationConditions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_spec.py
@@ -9,6 +9,9 @@ from dagster._serdes.serdes import whitelist_for_serdes
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_dep import AssetDep, CoercibleToAssetDep
     from dagster._core.definitions.assets import AssetsDefinition
+    from dagster._core.definitions.declarative_automation.automation_condition import (
+        AutomationCondition,
+    )
     from dagster._core.definitions.source_asset import SourceAsset
 
 
@@ -39,6 +42,7 @@ class AssetCheckSpec(
                 bool,
             ),
             ("metadata", PublicAttr[Optional[Mapping[str, Any]]]),
+            ("automation_condition", Optional["AutomationCondition[AssetCheckKey]"]),
         ],
     )
 ):
@@ -70,8 +74,12 @@ class AssetCheckSpec(
         additional_deps: Optional[Iterable["CoercibleToAssetDep"]] = None,
         blocking: bool = False,
         metadata: Optional[Mapping[str, Any]] = None,
+        automation_condition: Optional["AutomationCondition[AssetCheckKey]"] = None,
     ):
         from dagster._core.definitions.asset_dep import coerce_to_deps_and_check_duplicates
+        from dagster._core.definitions.declarative_automation.automation_condition import (
+            AutomationCondition,
+        )
 
         asset_key = AssetKey.from_coercible_or_definition(asset)
 
@@ -94,6 +102,9 @@ class AssetCheckSpec(
             additional_deps=additional_asset_deps,
             blocking=check.bool_param(blocking, "blocking"),
             metadata=check.opt_mapping_param(metadata, "metadata", key_type=str),
+            automation_condition=check.opt_inst_param(
+                automation_condition, "automation_condition", AutomationCondition
+            ),
         )
 
     def get_python_identifier(self) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -167,7 +167,11 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
     ):
         self._asset_nodes_by_key = asset_nodes_by_key
         self._asset_check_nodes_by_key = {
-            k: AssetCheckNode(k, v.get_spec_for_check_key(k).blocking)
+            k: AssetCheckNode(
+                k,
+                v.get_spec_for_check_key(k).blocking,
+                v.get_spec_for_check_key(k).automation_condition,
+            )
             for k, v in assets_defs_by_check_key.items()
         }
         self._assets_defs_by_check_key = assets_defs_by_check_key

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -80,6 +80,10 @@ class BaseEntityNode(ABC, Generic[T_EntityKey]):
     @abstractmethod
     def partition_mappings(self) -> Mapping[AssetKey, PartitionMapping]: ...
 
+    @property
+    @abstractmethod
+    def automation_condition(self) -> Optional["AutomationCondition[T_EntityKey]"]: ...
+
 
 class BaseAssetNode(BaseEntityNode[AssetKey]):
     key: AssetKey
@@ -140,10 +144,6 @@ class BaseAssetNode(BaseEntityNode[AssetKey]):
 
     @property
     @abstractmethod
-    def automation_condition(self) -> Optional["AutomationCondition"]: ...
-
-    @property
-    @abstractmethod
     def auto_observe_interval_minutes(self) -> Optional[float]: ...
 
     @property
@@ -173,9 +173,15 @@ class BaseAssetNode(BaseEntityNode[AssetKey]):
 
 
 class AssetCheckNode(BaseEntityNode[AssetCheckKey]):
-    def __init__(self, key: AssetCheckKey, blocking: bool):
+    def __init__(
+        self,
+        key: AssetCheckKey,
+        blocking: bool,
+        automation_condition: Optional["AutomationCondition[AssetCheckKey]"],
+    ):
         self.key = key
         self.blocking = blocking
+        self._automation_condition = automation_condition
 
     @property
     def partitions_def(self) -> Optional[PartitionsDefinition]:
@@ -185,6 +191,10 @@ class AssetCheckNode(BaseEntityNode[AssetCheckKey]):
     @property
     def partition_mappings(self) -> Mapping[AssetKey, PartitionMapping]:
         return {}
+
+    @property
+    def automation_condition(self) -> Optional["AutomationCondition[AssetCheckKey]"]:
+        return self._automation_condition
 
 
 T_AssetNode = TypeVar("T_AssetNode", bound=BaseAssetNode)

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -9,7 +9,11 @@ from dagster._core.definitions.asset_check_spec import AssetCheckSpec
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_dep import CoercibleToAssetDep
 from dagster._core.definitions.asset_in import AssetIn
+from dagster._core.definitions.asset_key import AssetCheckKey
 from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.definitions.declarative_automation.automation_condition import (
+    AutomationCondition,
+)
 from dagster._core.definitions.decorators.asset_decorator import make_asset_deps
 from dagster._core.definitions.decorators.decorator_assets_definition_builder import (
     DecoratorAssetsDefinitionBuilder,
@@ -104,6 +108,7 @@ def asset_check(
     op_tags: Optional[Mapping[str, Any]] = None,
     retry_policy: Optional[RetryPolicy] = None,
     metadata: Optional[Mapping[str, Any]] = None,
+    automation_condition: Optional[AutomationCondition[AssetCheckKey]] = None,
 ) -> Callable[[AssetCheckFunction], AssetChecksDefinition]:
     """Create a definition for how to execute an asset check.
 
@@ -139,7 +144,8 @@ def asset_check(
             the check, e.g. "dbt" or "spark".
         retry_policy (Optional[RetryPolicy]): The retry policy for the op that executes the check.
         metadata (Optional[Mapping[str, Any]]): A dictionary of static metadata for the check.
-
+        automation_condition (Optional[AutomationCondition]): An AutomationCondition which determines
+            when this check should be executed.
 
     Produces an :py:class:`AssetChecksDefinition` object.
 
@@ -202,6 +208,7 @@ def asset_check(
             additional_deps=additional_ins_and_deps,
             blocking=blocking,
             metadata=metadata,
+            automation_condition=automation_condition,
         )
 
         resource_defs_for_execution = wrap_resources_for_execution(resource_defs)

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -235,7 +235,8 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
         self._asset_nodes_by_key = asset_nodes_by_key
         self._asset_checks_by_key = asset_checks_by_key
         self._asset_check_nodes_by_key = {
-            k: AssetCheckNode(k, v.blocking) for k, v in asset_checks_by_key.items()
+            k: AssetCheckNode(k, v.blocking, v.automation_condition)
+            for k, v in asset_checks_by_key.items()
         }
         self._asset_check_execution_sets_by_key = asset_check_execution_sets_by_key
 

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -964,6 +964,7 @@ class ExternalAssetCheck(IHaveNew):
     job_names: Sequence[str]
     blocking: bool
     additional_asset_keys: Sequence[AssetKey]
+    automation_condition: Optional[AutomationCondition]
 
     def __new__(
         cls,
@@ -974,6 +975,7 @@ class ExternalAssetCheck(IHaveNew):
         job_names: Optional[Sequence[str]] = None,
         blocking: bool = False,
         additional_asset_keys: Optional[Sequence[AssetKey]] = None,
+        automation_condition: Optional[AutomationCondition] = None,
     ):
         return super().__new__(
             cls,
@@ -984,6 +986,7 @@ class ExternalAssetCheck(IHaveNew):
             job_names=job_names or [],
             blocking=blocking,
             additional_asset_keys=additional_asset_keys or [],
+            automation_condition=automation_condition,
         )
 
     @property
@@ -1379,6 +1382,7 @@ def external_asset_checks_from_defs(
                 job_names=job_names,
                 blocking=spec.blocking,
                 additional_asset_keys=[dep.asset_key for dep in spec.additional_deps],
+                automation_condition=spec.automation_condition,
             )
         )
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -8,6 +8,7 @@ from dagster import (
     AssetKey,
     AssetOut,
     AssetsDefinition,
+    AutomationCondition,
     DailyPartitionsDefinition,
     GraphOut,
     HourlyPartitionsDefinition,
@@ -707,7 +708,11 @@ def test_required_assets_and_checks_by_key_check_decorator(
     @asset_check(asset=asset0)
     def check0(): ...
 
-    @asset_check(asset=asset0, blocking=True)
+    @asset_check(
+        asset=asset0,
+        blocking=True,
+        automation_condition=AutomationCondition.cron_tick_passed("*/15 * * * *"),
+    )
     def check1(): ...
 
     asset_graph = asset_graph_from_assets([asset0, check0, check1])
@@ -728,6 +733,7 @@ def test_required_assets_and_checks_by_key_check_decorator(
     check_node = asset_graph.get(check1.check_key)
     assert check_node.blocking
     assert check_node.partitions_def is None
+    assert check_node.automation_condition == AutomationCondition.cron_tick_passed("*/15 * * * *")
 
 
 def test_required_assets_and_checks_by_key_asset_decorator(


### PR DESCRIPTION
## Summary & Motivation

As title. This exposes a new AutomationCondition argument to the AssetCheckSpec class (and the asset_check decorator).

Currently, this AutomationCondition does not get evaluated. That will happen later up stack.

## How I Tested These Changes

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
