### PR TITLE
[refactor] Simplify AutomationConditionEvaluator

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -716,6 +716,18 @@ class AutomationResult(Generic[T_EntityKey]):
             self.true_subset.convert_to_serializable_subset() or self._serializable_subset_override
         )
 
+    def compute_legacy_expected_data_time(self) -> Optional[datetime.datetime]:
+        from dagster._core.definitions.freshness_based_auto_materialize import (
+            get_expected_data_time_for_asset_key,
+        )
+
+        legacy_context = self._context._legacy_context  # noqa
+        if legacy_context:
+            return get_expected_data_time_for_asset_key(
+                legacy_context, will_materialize=not self.true_subset.is_empty
+            )
+        return None
+
 
 def _compute_subset_value_str(subset: SerializableEntitySubset) -> str:
     """Computes a unique string representing a given AssetSubsets. This string will be equal for

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
@@ -102,7 +102,7 @@ class WillBeRequestedCondition(SubsetAutomationCondition[AssetKey]):
         )
 
     def compute_subset(self, context: AutomationContext) -> EntitySubset[AssetKey]:
-        current_result = context.current_tick_results_by_key.get(context.key)
+        current_result = context.current_results_by_key.get(context.key)
         if (
             current_result
             and current_result.true_subset


### PR DESCRIPTION
## Summary & Motivation

Refactors the `.create()` method on the context objects and reorganizes the code a bit more to my liking.

There's an unfortunate complication here caused by a weird thing that we do with non-subsettable multi assets, which is that if any asset decides to materialize, we materialize all of its neighbors as well.

If I could go back in time, I might not have implemented this behavior at all, but I think for now we're essentially stuck with it. Future attempts may be made to hide this nasty logic away more thoroughly.

## How I Tested These Changes

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
