### PR TITLE
[refactor] Return Iterable[EntitySubset] from evaluate() method

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/entity_subset.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/entity_subset.py
@@ -122,6 +122,10 @@ class EntitySubset(Generic[T_EntityKey]):
         else:
             return self._value.is_empty
 
+    @property
+    def is_partitioned(self) -> bool:
+        return isinstance(self._value, PartitionsSubset)
+
     def get_internal_value(self) -> Union[bool, PartitionsSubset]:
         return self._value
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_subset.py
@@ -16,6 +16,7 @@ from typing import (
 )
 
 from dagster import _check as check
+from dagster._core.asset_graph_view.entity_subset import EntitySubset
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
@@ -267,6 +268,23 @@ class AssetGraphSubset(NamedTuple):
                 for asset_key, partition_keys in partitions_by_asset_key.items()
             },
             non_partitioned_asset_keys=non_partitioned_asset_keys,
+        )
+
+    @classmethod
+    def from_entity_subsets(
+        cls, entity_subsets: Iterable[EntitySubset[AssetKey]]
+    ) -> "AssetGraphSubset":
+        return AssetGraphSubset(
+            partitions_subsets_by_asset_key={
+                subset.key: subset.get_internal_subset_value()
+                for subset in entity_subsets
+                if subset.is_partitioned and not subset.is_empty
+            },
+            non_partitioned_asset_keys={
+                subset.key
+                for subset in entity_subsets
+                if not subset.is_partitioned and not subset.is_empty
+            },
         )
 
     @classmethod

--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -56,7 +56,7 @@ def evaluate_automation_conditions(context: SensorEvaluationContext):
         auto_materialize_run_tags={},
         request_backfills=context.instance.da_request_backfills(),
     )
-    results, to_request = evaluator.evaluate()
+    results, entity_subsets = evaluator.evaluate()
     new_cursor = cursor.with_updates(
         evaluation_id=cursor.evaluation_id,
         evaluation_timestamp=asset_graph_view.effective_dt.timestamp(),
@@ -64,7 +64,7 @@ def evaluate_automation_conditions(context: SensorEvaluationContext):
         condition_cursors=[result.get_new_cursor() for result in results],
     )
     run_requests = build_run_requests(
-        asset_partitions=to_request,
+        entity_subsets=entity_subsets,
         asset_graph=asset_graph,
         # tick_id and sensor tags should get set in daemon
         run_tags=context.instance.auto_materialize_run_tags,

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -23,7 +23,7 @@ from typing import (
 
 import dagster._check as check
 from dagster._core.definitions.asset_daemon_context import (
-    build_run_requests,
+    build_run_requests_from_asset_partitions,
     build_run_requests_with_backfill_policies,
 )
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
@@ -1495,7 +1495,7 @@ def execute_asset_backfill_iteration_inner(
             )
         # When any of the assets do not have backfill policies, we fall back to the default behavior of
         # backfilling them partition by partition.
-        run_requests = build_run_requests(
+        run_requests = build_run_requests_from_asset_partitions(
             asset_partitions=asset_partitions_to_request,
             asset_graph=asset_graph,
             run_tags={},

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_any_downstream_conditions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_any_downstream_conditions.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Iterable
 
 from dagster import (
     AssetKey,
@@ -15,7 +15,7 @@ from dagster._core.definitions.declarative_automation.operators.boolean_operator
 )
 
 
-def _get_result(key: CoercibleToAssetKey, results: Sequence[AutomationResult]) -> AutomationResult:
+def _get_result(key: CoercibleToAssetKey, results: Iterable[AutomationResult]) -> AutomationResult:
     key = AssetKey.from_coercible(key)
     for result in results:
         if result.asset_key == key:


### PR DESCRIPTION
## Summary & Motivation

This is the next stop on the train to letting AssetChecks get automated. We need a way for the system to return a value that will cause both regular assets and checks to be executed. Iterable[EntitySubset] can do this, while AbstractSet[AssetPartitionKey] cannot.

## How I Tested These Changes

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
