### PR TITLE
AssetDaemon can produce runs targeting EntitySubset[AssetCheckKey]

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_cursor.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import TYPE_CHECKING, Mapping, NamedTuple, Optional, Sequence
 
+from dagster._core.definitions.asset_key import EntityKey
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.events import AssetKey
 from dagster._serdes.serdes import (
@@ -89,7 +90,7 @@ class AssetDaemonCursor:
         )
 
     @cached_property
-    def previous_condition_cursors_by_key(self) -> Mapping[AssetKey, "AutomationConditionCursor"]:
+    def previous_condition_cursors_by_key(self) -> Mapping[EntityKey, "AutomationConditionCursor"]:
         """Efficient lookup of previous cursor by asset key."""
         from dagster._core.definitions.declarative_automation.serialized_objects import (
             AutomationConditionCursor,
@@ -107,12 +108,12 @@ class AssetDaemonCursor:
             return {cursor.asset_key: cursor for cursor in self.previous_condition_cursors}
 
     def get_previous_condition_cursor(
-        self, asset_key: AssetKey
+        self, key: EntityKey
     ) -> Optional["AutomationConditionCursor"]:
         """Returns the AutomationConditionCursor associated with the given asset key. If no stored
         cursor exists, returns an empty cursor.
         """
-        return self.previous_condition_cursors_by_key.get(asset_key)
+        return self.previous_condition_cursors_by_key.get(key)
 
     def with_updates(
         self,

--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -72,7 +72,7 @@ def evaluate_automation_conditions(context: SensorEvaluationContext):
     # only record evaluation results where something changed
     updated_evaluations = []
     for result in results:
-        previous_cursor = cursor.get_previous_condition_cursor(result.asset_key)
+        previous_cursor = cursor.get_previous_condition_cursor(result.key)
         if (
             previous_cursor is None
             or previous_cursor.result_value_hash != result.value_hash

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -616,7 +616,7 @@ class AutomationResult(Generic[T_EntityKey]):
         self._serializable_subset_override: Optional[SerializableEntitySubset] = None
 
     @property
-    def asset_key(self) -> T_EntityKey:
+    def key(self) -> T_EntityKey:
         return self._true_subset.key
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -17,6 +17,7 @@ from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
 from dagster._core.asset_graph_view.entity_subset import EntitySubset
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
+from dagster._core.definitions.asset_key import EntityKey
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph, BaseAssetNode
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
@@ -108,7 +109,7 @@ class AutomationConditionEvaluator:
         self.instance_queryer.prefetch_asset_records(self.asset_records_to_prefetch)
         self.logger.info("Done prefetching asset records.")
 
-    def evaluate(self) -> Tuple[Iterable[AutomationResult], Iterable[EntitySubset[AssetKey]]]:
+    def evaluate(self) -> Tuple[Iterable[AutomationResult], Iterable[EntitySubset[EntityKey]]]:
         self.prefetch()
         for asset_key in self.asset_graph.toposorted_asset_keys:
             if asset_key not in self.asset_keys:
@@ -159,7 +160,7 @@ class AutomationConditionEvaluator:
     def _handle_execution_set(self, result: AutomationResult[AssetKey]) -> None:
         # if we need to materialize any partitions of a non-subsettable multi-asset, we need to
         # materialize all of them
-        asset_key = result.asset_key
+        asset_key = result.key
         execution_set_keys = self.asset_graph.get(asset_key).execution_set_asset_keys
 
         if len(execution_set_keys) > 1 and result.true_subset.size > 0:
@@ -189,7 +190,7 @@ class AutomationConditionEvaluator:
                 if extra:
                     self._execution_set_extras[neighbor_key].append(extra)
 
-    def _get_entity_subsets(self) -> Iterable[EntitySubset[AssetKey]]:
+    def _get_entity_subsets(self) -> Iterable[EntitySubset[EntityKey]]:
         subsets_by_key = {
             key: result.true_subset for key, result in self.current_results_by_key.items()
         }

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_any_downstream_conditions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_any_downstream_conditions.py
@@ -18,7 +18,7 @@ from dagster._core.definitions.declarative_automation.operators.boolean_operator
 def _get_result(key: CoercibleToAssetKey, results: Iterable[AutomationResult]) -> AutomationResult:
     key = AssetKey.from_coercible(key)
     for result in results:
-        if result.asset_key == key:
+        if result.key == key:
             return result
     assert False
 


### PR DESCRIPTION
## Summary & Motivation

As title -- this updates the return type to be Sequence[EntitySubset[EntityKey]], and updates the method for building run requests to process check keys in addition to asset keys.

Does not handle the case when this is running in "daemon mode" (i.e. checks can exist in different code locations), which is an explicit choice to avoid unnecessary complexity. The default behavior is for AutomationConditions to be evaluated against a single code location at a time, and so this is not an issue.

Tests will be done upstack.

## How I Tested These Changes

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
