### PR TITLE
AutomationConditionEvaluator operate over EntityKeys

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_daemon_context.py
@@ -173,7 +173,7 @@ class AssetDaemonContext:
 
         evaluator = AutomationConditionEvaluator(
             asset_graph=self.asset_graph,
-            asset_keys=self.auto_materialize_asset_keys,
+            entity_keys=self.auto_materialize_asset_keys,
             asset_graph_view=self.asset_graph_view,
             logger=self._logger,
             cursor=self.cursor,

--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -47,7 +47,7 @@ def evaluate_automation_conditions(context: SensorEvaluationContext):
 
     evaluator = AutomationConditionEvaluator(
         asset_graph=asset_graph,
-        asset_keys=asset_graph.all_asset_keys,
+        entity_keys=asset_graph.all_asset_keys,
         asset_graph_view=asset_graph_view,
         logger=context.log,
         data_time_resolver=data_time_resolver,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
@@ -130,7 +130,7 @@ def evaluate_automation_conditions(
     )
     evaluator = AutomationConditionEvaluator(
         asset_graph=asset_graph,
-        asset_keys={
+        entity_keys={
             key
             for key in asset_selection.resolve(asset_graph)
             if asset_graph.get(key).automation_condition is not None

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
@@ -21,6 +21,7 @@ from typing import (
 import dagster._check as check
 from dagster._core.asset_graph_view.entity_subset import EntitySubset
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
+from dagster._core.definitions.asset_key import EntityKey
 from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
 from dagster._core.definitions.declarative_automation.legacy.valid_asset_subset import (
     ValidAssetSubset,
@@ -76,7 +77,7 @@ class LegacyRuleEvaluationContext:
     instance_queryer: "CachingInstanceQueryer"
     data_time_resolver: "CachingDataTimeResolver"
 
-    current_results_by_key: Mapping[AssetKey, AutomationResult]
+    current_results_by_key: Mapping[EntityKey, AutomationResult]
     expected_data_time_mapping: Mapping[AssetKey, Optional[datetime.datetime]]
 
     start_timestamp: float

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, AbstractSet, Any, Optional
 
 import dagster._check as check
 from dagster._core.definitions.asset_key import AssetKey, T_EntityKey
-from dagster._core.definitions.base_asset_graph import BaseAssetGraph
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph, BaseAssetNode
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
     AutomationResult,
@@ -99,11 +99,10 @@ class DepCondition(BuiltinAutomationCondition[T_EntityKey]):
         )
         return self.model_copy(update={"ignore_selection": ignore_selection})
 
-    def _get_dep_keys(self, key: T_EntityKey, asset_graph: BaseAssetGraph) -> AbstractSet[AssetKey]:
-        if isinstance(key, AssetKey):
-            dep_keys = asset_graph.get(key).parent_keys
-        else:
-            dep_keys = {asset_graph.get(key).key.asset_key}
+    def _get_dep_keys(
+        self, key: T_EntityKey, asset_graph: BaseAssetGraph[BaseAssetNode]
+    ) -> AbstractSet[AssetKey]:
+        dep_keys = asset_graph.get(key).parent_entity_keys
         if self.allow_selection is not None:
             dep_keys &= self.allow_selection.resolve(asset_graph)
         if self.ignore_selection is not None:

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
@@ -107,7 +107,7 @@ class AutomationConditionScenarioState(ScenarioState):
             )
             evaluator = AutomationConditionEvaluator(
                 asset_graph=asset_graph,
-                asset_keys=asset_graph.all_asset_keys,
+                entity_keys=asset_graph.all_asset_keys,
                 asset_graph_view=asset_graph_view,
                 logger=self.logger,
                 data_time_resolver=CachingDataTimeResolver(instance_queryer),
@@ -119,7 +119,7 @@ class AutomationConditionScenarioState(ScenarioState):
                 request_backfills=self.instance.da_request_backfills(),
             )
             evaluator.current_results_by_key = self._get_current_results_by_key(asset_graph_view)  # type: ignore
-            context = AutomationContext.create(asset_key=asset_key, evaluator=evaluator)
+            context = AutomationContext.create(key=asset_key, evaluator=evaluator)
 
             full_result = asset_condition.evaluate(context)
             new_state = dataclasses.replace(self, condition_cursor=full_result.get_new_cursor())


### PR DESCRIPTION
## Summary & Motivation

This updates the BaseAssetGraph class to produce a dependency graph of all entities (not just AssetKeys), allowing us to topologically sort the entire graph.

Note that I am using `parent_entity_keys` instead of `parent_keys`, because we use `parent_keys` / `child_keys` all over the codebase and historically this has just meant asset keys.

Worth considering renaming those to `parent_asset_keys` and `child_asset_keys`, but that felt like it was outside the scope of this PR.

## How I Tested These Changes

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
