### PR TITLE
[bugfix] k8s client wait_for_pod correctly handles multiple initcontainers

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -570,6 +570,7 @@ class DagsterKubernetesClient:
 
         # A set of container names that have exited.
         exited_containers = set()
+        ready_initcontainers = set()
         ignore_containers = ignore_containers or set()
         error_logs = []
 
@@ -613,6 +614,7 @@ class DagsterKubernetesClient:
             all_statuses = []
             all_statuses.extend(pod.status.init_container_statuses or [])
             all_statuses.extend(pod.status.container_statuses or [])
+            initcontainer_count = len(pod.status.init_container_statuses or [])
 
             # Filter out ignored containers
             all_statuses = [s for s in all_statuses if s.name not in ignore_containers]
@@ -623,7 +625,7 @@ class DagsterKubernetesClient:
             #
             # In case we are waiting for the pod to be ready, we will exit after
             # the first container in this list is ready.
-            container_status = next(s for s in all_statuses if s.name not in exited_containers)
+            container_status = next(s for s in all_statuses if s.name not in exited_containers | ready_initcontainers)
 
             # State checks below, see:
             # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#containerstate-v1-core
@@ -638,8 +640,12 @@ class DagsterKubernetesClient:
                         self.sleeper(wait_time_between_attempts)
                         continue
                     else:
-                        self.logger(f'Pod "{pod_name}" is ready, done waiting')
-                        break
+                        if initcontainer_count > 0 and len(ready_initcontainers) < initcontainer_count:
+                            ready_initcontainers.add(container_status.name)
+                        if len(ready_initcontainers) == initcontainer_count:
+                            self.logger(f'Pod "{pod_name}" is ready, done waiting')
+                            break
+
                 else:
                     check.invariant(
                         wait_for_state == WaitForPodState.Terminated, "New invalid WaitForPodState"

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/client.py
@@ -625,7 +625,9 @@ class DagsterKubernetesClient:
             #
             # In case we are waiting for the pod to be ready, we will exit after
             # the first container in this list is ready.
-            container_status = next(s for s in all_statuses if s.name not in exited_containers | ready_initcontainers)
+            container_status = next(
+                s for s in all_statuses if s.name not in exited_containers | ready_initcontainers
+            )
 
             # State checks below, see:
             # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#containerstate-v1-core
@@ -640,7 +642,10 @@ class DagsterKubernetesClient:
                         self.sleeper(wait_time_between_attempts)
                         continue
                     else:
-                        if initcontainer_count > 0 and len(ready_initcontainers) < initcontainer_count:
+                        if (
+                            initcontainer_count > 0
+                            and len(ready_initcontainers) < initcontainer_count
+                        ):
                             ready_initcontainers.add(container_status.name)
                         if len(ready_initcontainers) == initcontainer_count:
                             self.logger(f'Pod "{pod_name}" is ready, done waiting')

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -834,6 +834,143 @@ def test_waiting_for_pod_initialize_with_init_container():
     # slept only once
     assert len(mock_client.sleeper.mock_calls) == 1
 
+def test_wait_for_pod_initialize_with_multiple_init_containers():
+    mock_client = create_mocked_client(timer=create_timing_out_timer(num_good_ticks=4))
+    waiting_container_status = _create_status(
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.PodInitializing)
+        ),
+        ready=False,
+    )
+    waiting_initcontainer1_status = _create_status(
+        name="init1",
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.PodInitializing)
+        ),
+        ready=False,
+    )
+    waiting_initcontainer2_status = _create_status(
+        name="init2",
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.PodInitializing)
+        ),
+        ready=False,
+    )
+    ready_initcontainer1_status = _ready_running_status(name="init1")
+    ready_initcontainer2_status = _ready_running_status(name="init2")
+
+    two_waiting_inits_pod = _pod_list_for_container_status(
+        waiting_container_status,
+        init_container_statuses=[
+            waiting_initcontainer1_status,
+            waiting_initcontainer2_status
+        ]
+    )
+    single_init_ready_waiting_pod = _pod_list_for_container_status(
+        waiting_container_status,
+        init_container_statuses=[
+            ready_initcontainer1_status,
+            waiting_initcontainer2_status
+        ]
+    )
+    both_init_ready_waiting_pod = _pod_list_for_container_status(
+        waiting_container_status,
+        init_container_statuses=[
+            ready_initcontainer1_status,
+            ready_initcontainer2_status
+        ]
+    )
+    
+    mock_client.core_api.list_namespaced_pod.side_effect = [
+        two_waiting_inits_pod,
+        two_waiting_inits_pod,
+        single_init_ready_waiting_pod,
+        both_init_ready_waiting_pod,
+    ]
+
+    pod_name = "a_pod"
+    mock_client.wait_for_pod(pod_name=pod_name, namespace="namespace")
+
+    assert_logger_calls(
+        mock_client.logger,
+        [
+            f'Waiting for pod "{pod_name}"',
+            f'Waiting for pod "{pod_name}" to initialize...',
+            f'Pod "{pod_name}" is ready, done waiting',
+        ],
+    )
+
+# Container states are evaluated in the order that they are in the pod manifest, but
+# it's possible that the second initcontainer can finish first and we test that here.
+def test_wait_for_pod_initialize_with_multiple_init_containers_backwards():
+    mock_client = create_mocked_client(timer=create_timing_out_timer(num_good_ticks=5))
+    waiting_container_status = _create_status(
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.PodInitializing)
+        ),
+        ready=False,
+    )
+    waiting_initcontainer1_status = _create_status(
+        name="init1",
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.PodInitializing)
+        ),
+        ready=False,
+    )
+    waiting_initcontainer2_status = _create_status(
+        name="init2",
+        state=V1ContainerState(
+            waiting=V1ContainerStateWaiting(reason=KubernetesWaitingReasons.PodInitializing)
+        ),
+        ready=False,
+    )
+    ready_initcontainer1_status = _ready_running_status(name="init1")
+    ready_initcontainer2_status = _ready_running_status(name="init2")
+
+    two_waiting_inits_pod = _pod_list_for_container_status(
+        waiting_container_status,
+        init_container_statuses=[
+            waiting_initcontainer1_status,
+            waiting_initcontainer2_status
+        ]
+    )
+    single_init_ready_waiting_pod = _pod_list_for_container_status(
+        waiting_container_status,
+        init_container_statuses=[
+            waiting_initcontainer1_status,
+            ready_initcontainer2_status
+        ]
+    )
+    both_init_ready_waiting_pod = _pod_list_for_container_status(
+        waiting_container_status,
+        init_container_statuses=[
+            ready_initcontainer1_status,
+            ready_initcontainer2_status
+        ]
+    )
+    
+    # we need an extra side effect here compared to the above test since
+    # there's an extra loop iteration
+    mock_client.core_api.list_namespaced_pod.side_effect = [
+        two_waiting_inits_pod,
+        two_waiting_inits_pod,
+        single_init_ready_waiting_pod,
+        both_init_ready_waiting_pod,
+        both_init_ready_waiting_pod,
+    ]
+
+    pod_name = "a_pod"
+    mock_client.wait_for_pod(pod_name=pod_name, namespace="namespace")
+
+    assert_logger_calls(
+        mock_client.logger,
+        [
+            f'Waiting for pod "{pod_name}"',
+            f'Waiting for pod "{pod_name}" to initialize...',
+            f'Waiting for pod "{pod_name}" to initialize...',
+            f'Pod "{pod_name}" is ready, done waiting',
+        ],
+    )
 
 def test_waiting_for_pod_container_creation():
     mock_client = create_mocked_client(timer=create_timing_out_timer(num_good_ticks=3))

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_client.py
@@ -834,6 +834,7 @@ def test_waiting_for_pod_initialize_with_init_container():
     # slept only once
     assert len(mock_client.sleeper.mock_calls) == 1
 
+
 def test_wait_for_pod_initialize_with_multiple_init_containers():
     mock_client = create_mocked_client(timer=create_timing_out_timer(num_good_ticks=4))
     waiting_container_status = _create_status(
@@ -861,26 +862,17 @@ def test_wait_for_pod_initialize_with_multiple_init_containers():
 
     two_waiting_inits_pod = _pod_list_for_container_status(
         waiting_container_status,
-        init_container_statuses=[
-            waiting_initcontainer1_status,
-            waiting_initcontainer2_status
-        ]
+        init_container_statuses=[waiting_initcontainer1_status, waiting_initcontainer2_status],
     )
     single_init_ready_waiting_pod = _pod_list_for_container_status(
         waiting_container_status,
-        init_container_statuses=[
-            ready_initcontainer1_status,
-            waiting_initcontainer2_status
-        ]
+        init_container_statuses=[ready_initcontainer1_status, waiting_initcontainer2_status],
     )
     both_init_ready_waiting_pod = _pod_list_for_container_status(
         waiting_container_status,
-        init_container_statuses=[
-            ready_initcontainer1_status,
-            ready_initcontainer2_status
-        ]
+        init_container_statuses=[ready_initcontainer1_status, ready_initcontainer2_status],
     )
-    
+
     mock_client.core_api.list_namespaced_pod.side_effect = [
         two_waiting_inits_pod,
         two_waiting_inits_pod,
@@ -899,6 +891,7 @@ def test_wait_for_pod_initialize_with_multiple_init_containers():
             f'Pod "{pod_name}" is ready, done waiting',
         ],
     )
+
 
 # Container states are evaluated in the order that they are in the pod manifest, but
 # it's possible that the second initcontainer can finish first and we test that here.
@@ -929,26 +922,17 @@ def test_wait_for_pod_initialize_with_multiple_init_containers_backwards():
 
     two_waiting_inits_pod = _pod_list_for_container_status(
         waiting_container_status,
-        init_container_statuses=[
-            waiting_initcontainer1_status,
-            waiting_initcontainer2_status
-        ]
+        init_container_statuses=[waiting_initcontainer1_status, waiting_initcontainer2_status],
     )
     single_init_ready_waiting_pod = _pod_list_for_container_status(
         waiting_container_status,
-        init_container_statuses=[
-            waiting_initcontainer1_status,
-            ready_initcontainer2_status
-        ]
+        init_container_statuses=[waiting_initcontainer1_status, ready_initcontainer2_status],
     )
     both_init_ready_waiting_pod = _pod_list_for_container_status(
         waiting_container_status,
-        init_container_statuses=[
-            ready_initcontainer1_status,
-            ready_initcontainer2_status
-        ]
+        init_container_statuses=[ready_initcontainer1_status, ready_initcontainer2_status],
     )
-    
+
     # we need an extra side effect here compared to the above test since
     # there's an extra loop iteration
     mock_client.core_api.list_namespaced_pod.side_effect = [
@@ -971,6 +955,7 @@ def test_wait_for_pod_initialize_with_multiple_init_containers_backwards():
             f'Pod "{pod_name}" is ready, done waiting',
         ],
     )
+
 
 def test_waiting_for_pod_container_creation():
     mock_client = create_mocked_client(timer=create_timing_out_timer(num_good_ticks=3))


### PR DESCRIPTION
## Summary & Motivation

Addresses #23497. The `wait_for_pod` implementation currently erroneously assumes that the pod will be ready after one `initContainer` is ready. I added a set to track completed `initContainers` and compare the completed container count to the number of found statuses reported by the API.

## How I Tested These Changes

Added two tests to `test_client.py` with multiple initcontainers. The second test has the second container succeed before the first. I also ran code by Oren in the linked issue, but patched my `wait_for_pod` implementation in.

## Changelog

- [x] `BUGFIX` `wait_for_pod` now correctly waits for multiple initContainers to be ready instead of just the first.
