### PR TITLE
[ui] Disable sensor cursor editing based on code location permissions

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Permissions.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Permissions.tsx
@@ -104,6 +104,7 @@ export const extractPermissions = (
     canToggleAutoMaterialize: permissionOrFallback('toggle_auto_materialize'),
     canEditConcurrencyLimit: permissionOrFallback('edit_concurrency_limit'),
     canEditWorkspace: permissionOrFallback('edit_workspace'),
+    canUpdateSensorCursor: permissionOrFallback('update_sensor_cursor'),
   };
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleResetButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleResetButton.tsx
@@ -45,7 +45,10 @@ export const ScheduleResetButton = ({repoAddress, schedule}: Props) => {
     : DEFAULT_DISABLED_REASON;
 
   return (
-    <Tooltip content={tooltipContent} display="flex">
+    <Tooltip
+      content={<div style={{maxWidth: '500px', wordBreak: 'break-word'}}>{tooltipContent}</div>}
+      display="flex"
+    >
       <Button disabled={disabled} onClick={onClick}>
         Reset schedule status
       </Button>

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
@@ -17,6 +17,7 @@ import {SensorMonitoredAssets} from './SensorMonitoredAssets';
 import {SensorResetButton} from './SensorResetButton';
 import {SensorSwitch} from './SensorSwitch';
 import {SensorFragment} from './types/SensorFragment.types';
+import {usePermissionsForLocation} from '../app/Permissions';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
 import {AutomationTargetList} from '../automation/AutomationTargetList';
 import {AutomationAssetSelectionFragment} from '../automation/types/AutomationAssetSelectionFragment.types';
@@ -69,6 +70,13 @@ export const SensorDetails = ({
     sensorState: {status, ticks},
     metadata,
   } = sensor;
+
+  const {
+    permissions,
+    disabledReasons,
+    loading: loadingPermissions,
+  } = usePermissionsForLocation(repoAddress.location);
+  const {canUpdateSensorCursor} = permissions;
 
   const [isCursorEditing, setCursorEditing] = useState(false);
   const sensorSelector = {
@@ -214,9 +222,18 @@ export const SensorDetails = ({
                   <span style={{fontFamily: FontFamily.monospace, fontSize: '14px'}}>
                     {cursor ? cursor : 'None'}
                   </span>
-                  <Button icon={<Icon name="edit" />} onClick={() => setCursorEditing(true)}>
-                    Edit
-                  </Button>
+                  <Tooltip
+                    canShow={!canUpdateSensorCursor}
+                    content={disabledReasons.canUpdateSensorCursor}
+                  >
+                    <Button
+                      icon={<Icon name="edit" />}
+                      disabled={!canUpdateSensorCursor || loadingPermissions}
+                      onClick={() => setCursorEditing(true)}
+                    >
+                      Edit
+                    </Button>
+                  </Tooltip>
                 </Box>
                 <EditCursorDialog
                   isOpen={isCursorEditing}

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorResetButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorResetButton.tsx
@@ -42,7 +42,10 @@ export const SensorResetButton = ({repoAddress, sensor}: Props) => {
     : DEFAULT_DISABLED_REASON;
 
   return (
-    <Tooltip content={tooltipContent} display="flex">
+    <Tooltip
+      content={<div style={{maxWidth: '500px', wordBreak: 'break-word'}}>{tooltipContent}</div>}
+      display="flex"
+    >
       <Button disabled={disabled} onClick={onClick}>
         Reset sensor status
       </Button>


### PR DESCRIPTION
## Summary & Motivation

Disable the cursor editing button on sensors for users who don't have permission.

Also fixed the tooltip width on the "Reset sensor status" button, because with a very long object name, the tooltip is comically wide.

## How I Tested These Changes

View a sensor with viewer permissions, verify that the buttons are disabled and tooltip'd.

## Changelog

- [ ] `BUGFIX` [ui] Disabled sensor cursor edit button for non-permissioned users. Edits would fail on the backend anyway, but the disabled button is clearer.
