### PR TITLE
[dagster-embedded-elt] allow deferred fetch of row count using Sling

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -276,6 +276,23 @@ class SlingResource(ConfigurableResource):
         )
         return self._parse_json_table_output(json.loads(output.strip()))
 
+    def get_row_count_for_table(self, target_name: str, table_name: str) -> int:
+        """Queries the target connection to get the row count for a given table.
+
+        Args:
+            target_name (str): The name of the target connection to use.
+            table_name (str): The name of the table to fetch the row count for.
+
+        Returns:
+            int: The number of rows in the table.
+        """
+        select_stmt: str = f"select count(*) as ct from {table_name}"
+        output = self.run_sling_cli(
+            ["conns", "exec", target_name, select_stmt],
+            force_json=True,
+        )
+        return int(self._parse_json_table_output(json.loads(output.strip()))[0]["ct"])
+
     def run_sling_cli(self, args: Sequence[str], force_json: bool = False) -> str:
         """Runs the Sling CLI with the given arguments and returns the output.
 

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_fetch_metadata.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_fetch_metadata.py
@@ -124,3 +124,91 @@ def test_fetch_column_metadata_failure(
         assert not any(["dagster/column_schema" in metadata for metadata in metadatas]), str(
             metadatas
         )
+
+
+def test_fetch_row_count(
+    csv_to_sqlite_dataworks_replication: SlingReplicationParam,
+    path_to_temp_sqlite_db: str,
+):
+    from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingResource
+
+    @sling_assets(replication_config=csv_to_sqlite_dataworks_replication)
+    def my_sling_assets(context: AssetExecutionContext, sling: SlingResource):
+        yield from sling.replicate(context=context).fetch_row_count()
+
+    sling_resource = SlingResource(
+        connections=[
+            SlingConnectionResource(type="file", name="SLING_FILE"),
+            SlingConnectionResource(
+                type="sqlite",
+                name="SLING_SQLITE",
+                connection_string=f"sqlite://{path_to_temp_sqlite_db}",
+            ),
+        ]
+    )
+    res = materialize(
+        [my_sling_assets],
+        resources={"sling": sling_resource},
+    )
+
+    assert res.success
+    asset_materializations = res.get_asset_materialization_events()
+    assert len(asset_materializations) == 3
+
+    metadatas = [
+        asset_materialization.step_materialization_data.materialization.metadata
+        for asset_materialization in asset_materializations
+    ]
+    assert all(["dagster/row_count" in metadata for metadata in metadatas]), str(metadatas)
+
+    products_key = AssetKey(["target", "main", "products"])
+    products_metadata = next(
+        mat for mat in asset_materializations if mat.asset_key and mat.asset_key == products_key
+    ).step_materialization_data.materialization.metadata
+
+    assert products_metadata["dagster/row_count"].value == 4
+
+
+def test_fetch_row_count_failure(
+    csv_to_sqlite_dataworks_replication: SlingReplicationParam,
+    path_to_temp_sqlite_db: str,
+):
+    with mock.patch(
+        "dagster_embedded_elt.sling.resources.SlingResource.get_row_count_for_table",
+        side_effect=Exception("test error"),
+    ):
+        from dagster_embedded_elt.sling.resources import SlingConnectionResource, SlingResource
+
+        sling_resource = SlingResource(
+            connections=[
+                SlingConnectionResource(type="file", name="SLING_FILE"),
+                SlingConnectionResource(
+                    type="sqlite",
+                    name="SLING_SQLITE",
+                    connection_string=f"sqlite://{path_to_temp_sqlite_db}",
+                ),
+            ]
+        )
+
+        @sling_assets(replication_config=csv_to_sqlite_dataworks_replication)
+        def my_sling_assets(context: AssetExecutionContext, sling: SlingResource):
+            yield from sling.replicate(context=context).fetch_row_count().fetch_column_metadata()
+
+        res = materialize(
+            [my_sling_assets],
+            resources={"sling": sling_resource},
+        )
+
+        # Assert run succeeds but no row count metadata is attached
+        assert res.success
+        asset_materializations = res.get_asset_materialization_events()
+        assert len(asset_materializations) == 3
+
+        metadatas = [
+            asset_materialization.step_materialization_data.materialization.metadata
+            for asset_materialization in asset_materializations
+        ]
+        assert not any(["dagster/row_count" in metadata for metadata in metadatas]), str(metadatas)
+
+        # Ensure subsequent column metadata is still attached
+        assert all(["dagster/column_schema" in metadata for metadata in metadatas]), str(metadatas)


### PR DESCRIPTION
## Summary

Uses Sling's built-in `exec` CLI command to query the Sling target table to get a row count. Follows existing pattern of deferred metadata fetches, though we might want to start doing this behavior by default. Leaves that decision to a future PR.


```python
@sling_assets(replication_config=replication_config)
def my_assets(context, sling: SlingResource):
    yield from sling.replicate(context=context).fetch_row_count()
```

Under the hood, invokes `sling conns exec [target conn] 'select count(*) from [target table]``, which uses Sling's underlying db adapters to query the target.

Similar to #23388, this fetch is synchronous and only happens after the sync completes, since this is when materializations are yielded. A future improvement could yield materializations as they happen and fetch the metadata right away.



## Test Plan

New unit tests.