### PR TITLE
[1/4] Update typescript codegen to export a hash of the query version in our generated typescript files.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/.gitignore
+++ b/js_modules/dagster-ui/packages/ui-core/.gitignore
@@ -23,3 +23,5 @@ yarn-debug.log*
 yarn-error.log*
 
 src/tsconfig.json
+
+client.json

--- a/js_modules/dagster-ui/packages/ui-core/codegen.ts
+++ b/js_modules/dagster-ui/packages/ui-core/codegen.ts
@@ -63,6 +63,16 @@ const config: CodegenConfig = {
         },
       ],
     },
+    './client.json': {
+      plugins: [
+        {
+          'persisted-query-ids': {
+            algorithm: 'sha256',
+            output: 'client',
+          },
+        },
+      ],
+    },
   },
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/package.json
+++ b/js_modules/dagster-ui/packages/ui-core/package.json
@@ -50,6 +50,7 @@
     "fake-indexeddb": "^4.0.2",
     "fuse.js": "^6.4.2",
     "graphql": "^16.8.1",
+    "graphql-codegen-persisted-query-ids": "^0.2.0",
     "highlight.js": "11.6.0",
     "idb-lru-cache": "^0.1.0",
     "lodash": "^4.17.15",

--- a/js_modules/dagster-ui/packages/ui-core/src/app/types/Permissions.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/types/Permissions.types.ts
@@ -36,3 +36,5 @@ export type PermissionFragment = {
   value: boolean;
   disabledReason: string | null;
 };
+
+export const PermissionsQueryVersion = '505a351d43369bd83e7d4ff2d974368d2a754a85661dfb077a26d1a11ff2f714';

--- a/js_modules/dagster-ui/packages/ui-core/src/app/types/Telemetry.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/types/Telemetry.types.ts
@@ -24,3 +24,5 @@ export type LogTelemetryMutation = {
         }>;
       };
 };
+
+export const LogTelemetryMutationVersion = 'b7bec91d7a5e9e8fb3ad41bb5b7fa1eb1e067c530a8f4cd52a76fde6475462c3';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetBaseDataProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetBaseDataProvider.types.ts
@@ -166,3 +166,5 @@ export type AssetGraphLiveQuery = {
     } | null;
   }>;
 };
+
+export const AssetGraphLiveQueryVersion = 'cf42c8b34b97b7bb696ba56e0b363eaa15b58df4bbb384e58ca49811da7ccc01';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetStaleStatusDataProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/types/AssetStaleStatusDataProvider.types.ts
@@ -36,3 +36,5 @@ export type AssetStaleStatusDataQuery = {
     }>;
   }>;
 };
+
+export const AssetStaleStatusDataQueryVersion = '0168440bb72ae79664e8ba33f41a85f99398d0838b0baaa611b16a4dbb15b004';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetGraphJobSidebar.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetGraphJobSidebar.types.ts
@@ -1314,3 +1314,5 @@ export type AssetGraphSidebarQuery = {
         }>;
       };
 };
+
+export const AssetGraphSidebarQueryVersion = '326a86f91db2f640d45b58bc2d2e3dd23b4c7fd4aff3286ec1b9655791f75345';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetRunLogObserver.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/AssetRunLogObserver.types.ts
@@ -70,3 +70,5 @@ export type AssetLiveRunLogsSubscription = {
         >;
       };
 };
+
+export const AssetLiveRunLogsSubscriptionVersion = '4b78f566975bdd949f6d1fde8de10b6db89a2db3fe678cc5033fedfc16f0ba12';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/SidebarAssetInfo.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/SidebarAssetInfo.types.ts
@@ -32284,3 +32284,5 @@ export type SidebarAssetQuery = {
       }
     | {__typename: 'AssetNotFoundError'};
 };
+
+export const SidebarAssetQueryVersion = '6bc1debc744cdb40a889e99ef429b8cf95307aa027b1566cfab952fdc95ea5ea';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useAssetGraphData.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useAssetGraphData.types.ts
@@ -73,3 +73,5 @@ export type AssetNodeForGraphQueryFragment = {
   dependedByKeys: Array<{__typename: 'AssetKey'; path: Array<string>}>;
   assetKey: {__typename: 'AssetKey'; path: Array<string>};
 };
+
+export const AssetGraphQueryVersion = '26030b5c565bdc4d84b54b2c9a7e8172562cf7434912511768bde20875d47b44';

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useFindAssetLocation.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/types/useFindAssetLocation.types.ts
@@ -28,3 +28,5 @@ export type AssetForNavigationQuery = {
       }
     | {__typename: 'AssetNotFoundError'};
 };
+
+export const AssetForNavigationQueryVersion = 'eb695ab88044ddd7068ea0dc1e2482eaba1fcb11b83de11050ff52f55e83ed3d';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeMiddlePanelWithData.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeMiddlePanelWithData.types.ts
@@ -21,3 +21,5 @@ export type FullPartitionsQuery = {
       }
     | {__typename: 'AssetNotFoundError'};
 };
+
+export const FullPartitionsQueryVersion = 'bfe939600c7396798b3c92b0e8335e639c9d76479c1cecaabc309a83c8f7ca4d';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRequestedPartitionsLink.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRequestedPartitionsLink.types.ts
@@ -37,3 +37,5 @@ export type RunStatusAndTagsFragment = {
   status: Types.RunStatus;
   tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
 };
+
+export const RunStatusAndPartitionKeyVersion = '4642abda7da52fb70cc0a47c19cd5bf2fd8b854bb104b6a73eb8545fcd0146b2';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRunTag.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRunTag.types.ts
@@ -13,3 +13,5 @@ export type RunStatusOnlyQuery = {
     | {__typename: 'Run'; id: string; status: Types.RunStatus}
     | {__typename: 'RunNotFoundError'};
 };
+
+export const RunStatusOnlyQueryVersion = 'e0000c8f2600dbe29f305febb04cca005e08da6a7ce03ec20476c59d607495c0';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRunsTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/AutomaterializeRunsTable.types.ts
@@ -45,3 +45,5 @@ export type AutomaterializeRunFragment = {
   endTime: number | null;
   updateTime: number | null;
 };
+
+export const AutomaterializeRunsQueryVersion = '213e0a8e4d88de599b4740ba7d0d4bfac14defebcc8f3813eecc13696b9f17d9';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/GetEvaluationsQuery.types.ts
@@ -1522,3 +1522,7 @@ export type GetEvaluationsSpecificPartitionQuery = {
     >;
   } | null;
 };
+
+export const GetEvaluationsQueryVersion = '7245007702d5b47f77048aa7fb61a01c5b139974f96b562b89f06c42af68c924';
+
+export const GetEvaluationsSpecificPartitionQueryVersion = '12b4456c4cf6852a8dc9f7e2ec0a46b4272e10558de5512695c40cdc7de1ff0f';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/PartitionSubsetListQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/types/PartitionSubsetListQuery.types.ts
@@ -12,3 +12,5 @@ export type PartitionSubsetListQuery = {
   __typename: 'Query';
   truePartitionsForAutomationConditionEvaluationNode: Array<string>;
 };
+
+export const PartitionSubsetListQueryVersion = 'a99c32a24510b715ad4a4d31421bdd663549665193b4a40bfee5e8238b586313';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetCheckDetailModal.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetCheckDetailModal.types.ts
@@ -351,3 +351,5 @@ export type AssetCheckDetailsQuery = {
     } | null;
   }>;
 };
+
+export const AssetCheckDetailsQueryVersion = '371e01d6e3718d0ef48652ec614938af424d77ce9bc4e459f0f43c21309aedda';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/asset-checks/types/AssetChecks.types.ts
@@ -226,3 +226,5 @@ export type AssetChecksQuery = {
       }
     | {__typename: 'AssetNotFoundError'};
 };
+
+export const AssetChecksQueryVersion = 'c72f90a5642aff4514b7b7e7529a960554d75aa0543485a8d6e40c613385df65';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/types/AssetDaemonTicksQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/types/AssetDaemonTicksQuery.types.ts
@@ -68,3 +68,5 @@ export type AssetDaemonTicksQuery = {
     }>;
   }>;
 };
+
+export const AssetDaemonTicksQueryVersion = '399ac77e660d40eba32c2ab06db2a2936a71e660d93ec108364eec1fdfc16788';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/types/AutomaterializationTickDetailDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/types/AutomaterializationTickDetailDialog.types.ts
@@ -26,3 +26,5 @@ export type AssetGroupAndLocationQuery = {
       }
     | {__typename: 'AssetNotFoundError'};
 };
+
+export const AssetGroupAndLocationQueryVersion = '584b27ecda9ff883e92f2d8858520a543ea0be07d39e1b4c0fc5d802231bb602';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/lineage/types/useColumnLineageDataForAssets.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/lineage/types/useColumnLineageDataForAssets.types.ts
@@ -96,3 +96,5 @@ export type AssetColumnLineageQuery = {
     }>;
   }>;
 };
+
+export const AssetColumnLineageVersion = 'c88c38558eb5d45b3c51b125853bc0df120213c4b8f5933a264525c3689bcef1';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetDefinedInMultipleReposNotice.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetDefinedInMultipleReposNotice.types.ts
@@ -19,3 +19,5 @@ export type AssetDefinitionCollisionQuery = {
     }>;
   }>;
 };
+
+export const AssetDefinitionCollisionQueryVersion = '84027ea05480797a69eb150ce07ac7dfd40d6007a8107f90a6c558cf3a2662f5';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetGroupRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetGroupRoot.types.ts
@@ -14,3 +14,5 @@ export type AssetGroupMetadataQuery = {
     autoMaterializePolicy: {__typename: 'AutoMaterializePolicy'} | null;
   }>;
 };
+
+export const AssetGroupMetadataQueryVersion = '260d747ab8d454c1fe55a5a5fa6e11a548a301ea44740566c0c43756cca363eb';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetMaterializationUpstreamData.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetMaterializationUpstreamData.types.ts
@@ -39,3 +39,5 @@ export type AssetMaterializationUpstreamQuery = {
       }
     | {__typename: 'AssetNotFoundError'};
 };
+
+export const AssetMaterializationUpstreamQueryVersion = '754bab88738acc8d310c71f577ac3cf06dc57950bb1f98a18844e6e00bae756d';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetPartitionDetail.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetPartitionDetail.types.ts
@@ -442,3 +442,7 @@ export type AssetPartitionStaleQuery = {
       }
     | {__typename: 'AssetNotFoundError'};
 };
+
+export const AssetPartitionDetailQueryVersion = 'b49c58aafc8743640c067d5897b931ad98adcc3584193afad7fb96424a1ee010';
+
+export const AssetPartitionStaleQueryVersion = '4215f4014e9d7592142e1775c4b07377703e913389396f9ca14dc6bb779ce764';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetView.types.ts
@@ -32435,3 +32435,5 @@ export type AssetViewDefinitionNodeFragment = {
       }
     | null;
 };
+
+export const AssetViewDefinitionQueryVersion = 'dab33604a3e92e8b13b7276a7fe5dd43430a3e17012ac0961634c30a1c963d60';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetsCatalogTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetsCatalogTable.types.ts
@@ -141,3 +141,7 @@ export type AssetCatalogGroupTableNodeFragment = {
     location: {__typename: 'RepositoryLocation'; id: string; name: string};
   };
 };
+
+export const AssetCatalogTableQueryVersion = 'cfd5521d8ee27fcedd151411a6e6956f60508098660ca1661ad13abef69b112c';
+
+export const AssetCatalogGroupTableQueryVersion = 'e55e65bc1c234fbd28895642deebe9bb45c68de4c31aa2c31b9b6a4d306d90e0';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetsOverviewRoot.oss.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetsOverviewRoot.oss.types.ts
@@ -12,3 +12,5 @@ export type AssetsOverviewRootQuery = {
     | {__typename: 'Asset'; id: string; key: {__typename: 'AssetKey'; path: Array<string>}}
     | {__typename: 'AssetNotFoundError'};
 };
+
+export const AssetsOverviewRootQueryVersion = '77ab0417c979b92c9ec01cd76a0f49b59f5b8ce7af775cab7e9b3e57b7871f7d';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AutoMaterializeSensorFlag.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AutoMaterializeSensorFlag.types.ts
@@ -8,3 +8,5 @@ export type AutoMaterializeSensorFlagQuery = {
   __typename: 'Query';
   instance: {__typename: 'Instance'; id: string; useAutoMaterializeSensors: boolean};
 };
+
+export const AutoMaterializeSensorFlagVersion = '961162c030e7e3c35be91db37c1990ad31b53cb8225d216fece2bdc2a6210bce';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/BackfillPreviewModal.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/BackfillPreviewModal.types.ts
@@ -19,3 +19,5 @@ export type BackfillPreviewQuery = {
     } | null;
   }>;
 };
+
+export const BackfillPreviewQueryVersion = '21a636242bab27144e5627361658207b708cc3e60c149f8901e476c3d9d0b021';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/CalculateUnsyncedDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/CalculateUnsyncedDialog.types.ts
@@ -23,3 +23,5 @@ export type AssetStaleStatusQuery = {
     } | null;
   }>;
 };
+
+export const AssetStaleStatusQueryVersion = '2c0792a380368dfd0b6c892bd7c18f86bb34e599a2f8b020852b4a6285defa37';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/DeleteDynamicPartitionsDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/DeleteDynamicPartitionsDialog.types.ts
@@ -24,3 +24,7 @@ export type DeleteDynamicPartitionsMutation = {
       }
     | {__typename: 'UnauthorizedError'; message: string};
 };
+
+export const DeleteDynamicPartitionsMutationVersion = 'dc34ce729a12d80db6cabbb4ed9093ee29b9c4e2c6843074b13b67b454b61471';
+
+export const DeleteVersion = '3c61c79b99122910e754a8863e80dc5ed479a0c23cc1a9d9878d91e603fc0dfe';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/LaunchAssetChoosePartitionsDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/LaunchAssetChoosePartitionsDialog.types.ts
@@ -35,3 +35,5 @@ export type LaunchAssetWarningsQuery = {
     runLauncher: {__typename: 'RunLauncher'; name: string} | null;
   };
 };
+
+export const LaunchAssetWarningsQueryVersion = '1924efd011a8fa46372d16674bca736ef10e46d3aff77430b0bd24461359813e';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/LaunchAssetExecutionButton.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/LaunchAssetExecutionButton.types.ts
@@ -2462,3 +2462,11 @@ export type LaunchAssetCheckUpstreamQuery = {
     assetMaterializations: Array<{__typename: 'MaterializationEvent'; runId: string}>;
   }>;
 };
+
+export const LaunchAssetLoaderQueryVersion = 'ae6a5d5eaf00ec9eeefaf3e7dc85a7710eb3647608aa00e3ded59877a289d645';
+
+export const LaunchAssetLoaderJobQueryVersion = '112371f3f0c11b7467940b71e83cba8abf678aed019820af94fdee4f99531841';
+
+export const LaunchAssetLoaderResourceQueryVersion = '8576f24034a63da1480b19a7c66dc2af2f5d532aa2ba294ffe7bef5ca92e1366';
+
+export const LaunchAssetCheckUpstreamQueryVersion = 'afb78499f0bf86942fc7f1ff7261c34caec2bd1e4aabb05c95a2db6acc811aaa';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/OverdueTag.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/OverdueTag.types.ts
@@ -34,3 +34,5 @@ export type OverduePopoverQuery = {
       }
     | {__typename: 'AssetNotFoundError'};
 };
+
+export const OverduePopoverQueryVersion = '3c8359e1adfab8237e4b26508489f07c09b24069373064c6c94d645312ae9296';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/RunningBackfillsNotice.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/RunningBackfillsNotice.types.ts
@@ -18,3 +18,5 @@ export type RunningBackfillsNoticeQuery = {
       }
     | {__typename: 'PythonError'};
 };
+
+export const RunningBackfillsNoticeQueryVersion = 'edaaca1d6474672ae342eb3887f2aed16fbb502b704a603986d21f14bc10ee53';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useAutomaterializeDaemonStatus.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useAutomaterializeDaemonStatus.types.ts
@@ -17,3 +17,7 @@ export type SetAutoMaterializePausedMutation = {
   __typename: 'Mutation';
   setAutoMaterializePaused: boolean;
 };
+
+export const GetAutoMaterializePausedQueryVersion = '50f74183f54031274136ab855701d01f26642a6d958d7452ae13aa6c40ca349d';
+
+export const SetAutoMaterializePausedMutationVersion = '144afc0d6f43dfa6d437c0e7f621e4f19ffb48c7f75669d2e3d742c115aa7b4b';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useLatestPartitionEvents.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useLatestPartitionEvents.types.ts
@@ -355,3 +355,5 @@ export type AssetOverviewMetadataEventsQuery = {
       }
     | {__typename: 'AssetNotFoundError'};
 };
+
+export const AssetOverviewMetadataEventsQueryVersion = 'e7101ed64187bdd880ae916392eb01ec95928f6b127b6e54c51a34af5a5fa053';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/usePartitionHealthData.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/usePartitionHealthData.types.ts
@@ -68,3 +68,5 @@ export type PartitionHealthQuery = {
       }
     | {__typename: 'AssetNotFoundError'};
 };
+
+export const PartitionHealthQueryVersion = '4f37a772c8f0e07cf2d76c18915a2a9c393fa8ea6a7b2ad355b80a225c8fe2af';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/usePartitionNameForPipeline.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/usePartitionNameForPipeline.types.ts
@@ -33,3 +33,5 @@ export type AssetJobPartitionSetsQuery = {
         }>;
       };
 };
+
+export const AssetJobPartitionSetsQueryVersion = '43286e824ac1f7d1b30c6744ad472c034d8ed257675a720ac53bcf929e0bc7f7';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useRecentAssetEvents.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useRecentAssetEvents.types.ts
@@ -760,3 +760,5 @@ export type AssetEventsQuery = {
       }
     | {__typename: 'AssetNotFoundError'};
 };
+
+export const AssetEventsQueryVersion = 'e8ff6854e6cfcd19485a2c33aa4db5c3b12fc7d0696b76279ff777001bca18e0';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useReportEventsModal.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useReportEventsModal.types.ts
@@ -50,3 +50,7 @@ export type ReportEventMutation = {
       }
     | {__typename: 'UnauthorizedError'; message: string};
 };
+
+export const ReportEventPartitionDefinitionQueryVersion = 'e306421344493a9986106de14bca90ec554505d6f1965991ba502725edc41c95';
+
+export const ReportEventMutationVersion = '80b4987cdf27ec8fac25eb6b98b996bd4fdeb4cbfff605d647da5d4bb8244cb0';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/useWipeAssets.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/useWipeAssets.types.ts
@@ -31,3 +31,5 @@ export type AssetWipeMutation = {
     | {__typename: 'UnauthorizedError'}
     | {__typename: 'UnsupportedOperationError'};
 };
+
+export const AssetWipeMutationVersion = 'accefb0c47b3d4a980d16965e8af565afed787a8a987a03570df876bd734dc8f';

--- a/js_modules/dagster-ui/packages/ui-core/src/gantt/types/RunGroupPanel.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/gantt/types/RunGroupPanel.types.ts
@@ -52,3 +52,5 @@ export type RunGroupPanelRunFragment = {
   updateTime: number | null;
   tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
 };
+
+export const RunGroupPanelQueryVersion = 'c454b4e4c3d881b2a78361c5868212f734c458291a3cb28be8ba4a63030eb004';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillLogsTab.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillLogsTab.types.ts
@@ -28,3 +28,5 @@ export type BackfillLogsPageQuery = {
       }
     | {__typename: 'PythonError'; message: string};
 };
+
+export const BackfillLogsPageQueryVersion = 'f09a06b9d26011fa0d65199eb0dfc799216e28541f1c9c32bba6c93d2d856c91';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPage.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPage.types.ts
@@ -159,3 +159,7 @@ export type BackfillPartitionsForAssetKeyQuery = {
       }
     | {__typename: 'PythonError'};
 };
+
+export const BackfillStatusesByAssetVersion = 'f785cda54d7032605fd180e1d1641151836651e3da314fcf8393cf3c43ab9bb4';
+
+export const BackfillPartitionsForAssetKeyVersion = '672b7141fd1dfb275a4ef6ae3e8fc1eaa0707270c1fd329ed6b66058e2376e55';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPartitionsTab.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillPartitionsTab.types.ts
@@ -22,3 +22,5 @@ export type BackfillPartitionsForAssetKeyQuery = {
       }
     | {__typename: 'PythonError'};
 };
+
+export const BackfillPartitionsForAssetKeyVersion = '672b7141fd1dfb275a4ef6ae3e8fc1eaa0707270c1fd329ed6b66058e2376e55';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillRow.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillRow.types.ts
@@ -22,3 +22,5 @@ export type SingleBackfillQuery = {
       }
     | {__typename: 'PythonError'};
 };
+
+export const SingleBackfillQueryVersion = 'c2b27d4666926a1c0bfd0c7cfabf9840c67e33a0a374651ee8e52bdec395aa56';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillTerminationDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillTerminationDialog.types.ts
@@ -30,3 +30,5 @@ export type CancelBackfillMutation = {
       }
     | {__typename: 'UnauthorizedError'};
 };
+
+export const CancelBackfillVersion = '138f5ba5d38b0d939a6a0bf34769cf36c16bb99225204e28e5ab5fcd8baf3194';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillUtils.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/types/BackfillUtils.types.ts
@@ -94,3 +94,5 @@ export type LaunchPartitionBackfillMutation = {
     | {__typename: 'RunConflict'; message: string}
     | {__typename: 'UnauthorizedError'; message: string};
 };
+
+export const LaunchPartitionBackfillVersion = '12402e3e19e32ede40dbc04673d452c2d4b3e6a09509c80fdd065c92e3640daa';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceBackfills.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceBackfills.types.ts
@@ -64,3 +64,5 @@ export type InstanceBackfillsQuery = {
         }>;
       };
 };
+
+export const InstanceBackfillsQueryVersion = '944d836e7cc69aa542d893f9ab84f46e766fb370cfb63be15bd03d67e1b0cff9';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceConcurrency.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceConcurrency.types.ts
@@ -117,3 +117,17 @@ export type RunsForConcurrencyKeyQuery = {
         results: Array<{__typename: 'Run'; id: string; status: Types.RunStatus}>;
       };
 };
+
+export const InstanceConcurrencyLimitsQueryVersion = 'eff036379500d5b400ba5a0d3f4f22fad1bd42efefbeeafa16b43ca8b160c312';
+
+export const SetConcurrencyLimitVersion = '758e6bfdb936dff3e4e38f8e1fb447548710a2b2c66fbcad9d4f264a10a61044';
+
+export const DeleteConcurrencyLimitVersion = '03397142bc71bc17649f43dd17aabf4ea771436ebc4ee1cb40eff2c2848d7b4d';
+
+export const FreeConcurrencySlotsVersion = '7363c435dba06ed2a4be96e1d9bf1f1f8d9c90533b80ff42896fe9d50879d60e';
+
+export const ConcurrencyKeyDetailsQueryVersion = '52af385169eb4399ef46e98eb206f911c7fd1562c3a86a971ef038a32a7ff12e';
+
+export const RunsForConcurrencyKeyQueryVersion = '35ebd16622a13c6aaa35577c7694bf8ffdeb16921b46c6040a407bb3095eaf75';
+
+export const DeleteVersion = '3c61c79b99122910e754a8863e80dc5ed479a0c23cc1a9d9878d91e603fc0dfe';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceConfig.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceConfig.types.ts
@@ -9,3 +9,5 @@ export type InstanceConfigQuery = {
   version: string;
   instance: {__typename: 'Instance'; id: string; info: string | null};
 };
+
+export const InstanceConfigQueryVersion = 'bcc75f020d292abb1e2d27cf924ec84a3c1a48f7f24a216e5ec0ed2864becc7a';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceHealthPage.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/InstanceHealthPage.types.ts
@@ -34,3 +34,5 @@ export type InstanceHealthQuery = {
     };
   };
 };
+
+export const InstanceHealthQueryVersion = '287f4e065bba5aba76b6c1e1a58f0f929c0b37e0065b75d5e5fd8a5bc69617b9';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/JobMenu.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/JobMenu.types.ts
@@ -31,3 +31,5 @@ export type RunReExecutionQuery = {
       }
     | {__typename: 'RunNotFoundError'};
 };
+
+export const RunReExecutionQueryVersion = '95f0a988be27f8d33377eec80eaac91bcbd709e73098e0b12f05f71c4f732077';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/StepSummaryForRun.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/StepSummaryForRun.types.ts
@@ -23,3 +23,5 @@ export type StepSummaryForRunQuery = {
       }
     | {__typename: 'RunNotFoundError'};
 };
+
+export const StepSummaryForRunQueryVersion = '2890d0cd46c1f4d8b350a5fec57a0558ac3054e0ca93278998d66a54b2ebedbd';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/VirtualizedInstanceConcurrencyTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/VirtualizedInstanceConcurrencyTable.types.ts
@@ -27,3 +27,5 @@ export type SingleConcurrencyKeyQuery = {
     };
   };
 };
+
+export const SingleConcurrencyKeyQueryVersion = 'fd72bd62ac87f3c72ec589610c7c52398643740f1f2904b04e1e293b08daf763';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/useCanSeeConfig.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/useCanSeeConfig.types.ts
@@ -8,3 +8,5 @@ export type InstanceConfigHasInfoQuery = {
   __typename: 'Query';
   instance: {__typename: 'Instance'; id: string; hasInfo: boolean};
 };
+
+export const InstanceConfigHasInfoVersion = '771982a9ee439781255f82986d55aa6a75ab2929d784f2cd27b40f537baf7f27';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/useDaemonStatus.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/useDaemonStatus.types.ts
@@ -40,3 +40,5 @@ export type InstanceWarningQuery = {
       }
     | {__typename: 'PythonError'};
 };
+
+export const InstanceWarningQueryVersion = '7ead177b08f678cb85bfebac63b1b25fff6c60c50c862a3c3d20d8d701463823';

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/types/useRunQueueConfig.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/types/useRunQueueConfig.types.ts
@@ -18,3 +18,5 @@ export type InstanceRunQueueConfigQuery = {
     } | null;
   };
 };
+
+export const InstanceRunQueueConfigVersion = '51de03303f49487cecbfbcd9a6624b8999779a88412c035aced402cb295e40c5';

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/types/InstigationTick.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/types/InstigationTick.types.ts
@@ -77,3 +77,5 @@ export type LaunchedRunListQuery = {
         }>;
       };
 };
+
+export const LaunchedRunListQueryVersion = 'e4ae437ebe25fa33cb6b3f658cf90b5c9ce035ae9c03ceb519129a61c585325a';

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/types/TickDetailsDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/types/TickDetailsDialog.types.ts
@@ -50,3 +50,5 @@ export type SelectedTickQuery = {
     | {__typename: 'InstigationStateNotFoundError'}
     | {__typename: 'PythonError'};
 };
+
+export const SelectedTickQueryVersion = '4a6a1911d0769b8b5bb17ed1415d3691da3d029d6760ab42dc56de6431fc1fb6';

--- a/js_modules/dagster-ui/packages/ui-core/src/instigation/types/TickHistory.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/instigation/types/TickHistory.types.ts
@@ -65,3 +65,5 @@ export type TickHistoryQuery = {
         }>;
       };
 };
+
+export const TickHistoryQueryVersion = '4dff0791129120937abefb56bf6b21102cd3b67f81f7285763f01d6467f850e8';

--- a/js_modules/dagster-ui/packages/ui-core/src/jobs/types/JobsPageContent.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/jobs/types/JobsPageContent.types.ts
@@ -54,3 +54,5 @@ export type OverviewJobsQuery = {
         }>;
       };
 };
+
+export const OverviewJobsQueryVersion = 'd3bc0af22121e31483422a5681cf80671a6cdae56da120acd353c042c07fc45b';

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/ConfigEditorConfigPicker.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/ConfigEditorConfigPicker.types.ts
@@ -111,3 +111,7 @@ export type PartitionSetForConfigEditorFragment = {
   mode: string;
   solidSelection: Array<string> | null;
 };
+
+export const ConfigPartitionsQueryVersion = 'b2982b87aa317ad4df2f4227ac4285280de352fa571e952f56f9f85e2a0096fc';
+
+export const ConfigPartitionsAssetsQueryVersion = '02438f2590d14870b0df3107680c2d33da2c7a492a3f8a507c591f7ad4555409';

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/ConfigFetch.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/ConfigFetch.types.ts
@@ -102,3 +102,7 @@ export type ConfigPartitionSelectionQuery = {
     | {__typename: 'PartitionSetNotFoundError'}
     | {__typename: 'PythonError'};
 };
+
+export const ConfigPartitionForAssetJobQueryVersion = '367eaeeb62b9e2339ab6c07a1e315310fd1a095b7ba7c8fa7a1e51282ca84796';
+
+export const ConfigPartitionSelectionQueryVersion = '54bfeba0e497a1ee185cf7d7fa251ce81cffdf97a3f234b5022f3c619e29ebd5';

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/LaunchpadAllowedRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/LaunchpadAllowedRoot.types.ts
@@ -98,3 +98,5 @@ export type LaunchpadSessionPipelineFragment = {
   }>;
   tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
 };
+
+export const LaunchpadRootQueryVersion = '0ce31bd283202c8126b2d0a64ceda9eceeb212f56f0fd3a0af255026121b4f6e';

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/LaunchpadSession.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/LaunchpadSession.types.ts
@@ -318,3 +318,7 @@ export type LaunchpadSessionModeNotFoundFragment = {
   __typename: 'ModeNotFoundError';
   message: string;
 };
+
+export const PreviewConfigQueryVersion = 'd6d9fe33524d42b5159e04c018897ec90d991ebe6c2b46e5e5d736fc30f49c77';
+
+export const PipelineExecutionConfigSchemaQueryVersion = 'a6fabdacce7f63c8ecbac472835a022f11de013a5625a8db9155832262035d08';

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/LaunchpadSetupFromRunRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/LaunchpadSetupFromRunRoot.types.ts
@@ -28,3 +28,5 @@ export type ConfigForRunQuery = {
       }
     | {__typename: 'RunNotFoundError'};
 };
+
+export const ConfigForRunQueryVersion = '3c4bb0f771599d50a7e4c05b683f8f7b4b3f0ab844b85501bb85527707a4982a';

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/OpSelector.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/types/OpSelector.types.ts
@@ -169,3 +169,5 @@ export type OpSelectorQuery = {
         }>;
       };
 };
+
+export const OpSelectorQueryVersion = 'f1b601d74e6ffb2854418109f56c90bc7feb37cbabd9a4b60dd7075aa45fcadf';

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/types/JobMetadata.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/types/JobMetadata.types.ts
@@ -137,3 +137,5 @@ export type RunMetadataFragment = {
     key: {__typename: 'AssetKey'; path: Array<string>};
   }>;
 };
+
+export const JobMetadataQueryVersion = 'e44915164a1174b291978e4bee269eb293e3953dc6d5fa5831a731b2533e1bf5';

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/types/LatestRunTag.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/types/LatestRunTag.types.ts
@@ -24,3 +24,5 @@ export type LatestRunTagQuery = {
         }>;
       };
 };
+
+export const LatestRunTagQueryVersion = '6b18755e69bb01ee63d4ef02333c219a8c935b087e938b5da89ca99b95824e60';

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/types/LeftNavItem.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/types/LeftNavItem.types.ts
@@ -23,3 +23,5 @@ export type InstigationStatesQuery = {
       }
     | {__typename: 'PythonError'; message: string; stack: Array<string>};
 };
+
+export const InstigationStatesQueryVersion = '98c41676dfb3c489e46455a3c2716e375050c9bed2d73e74c765453f2c63d0da';

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/types/RepositoryLocationStateObserver.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/types/RepositoryLocationStateObserver.types.ts
@@ -17,3 +17,5 @@ export type LocationStateChangeSubscription = {
     };
   };
 };
+
+export const LocationStateChangeSubscriptionVersion = 'd6cb6b73be1c484a2f592e60be15fb89b344e385f703ce2c92516e2779df8217';

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/types/VersionNumber.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/types/VersionNumber.types.ts
@@ -5,3 +5,5 @@ import * as Types from '../../graphql/types';
 export type VersionNumberQueryVariables = Types.Exact<{[key: string]: never}>;
 
 export type VersionNumberQuery = {__typename: 'Query'; version: string};
+
+export const VersionNumberQueryVersion = '1947790817d11313027a8addb9ceb992f0c79e96f3aa6b99cbece967e3458c40';

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/types/useRepositoryLocationReload.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/types/useRepositoryLocationReload.types.ts
@@ -139,3 +139,9 @@ export type ReloadRepositoryLocationMutation = {
           | null;
       };
 };
+
+export const RepositoryLocationStatusQueryVersion = '7129557ca993e0638a147e30c6fe3bdff04a929d4e6775c3e4e5dc9fa3c88d94';
+
+export const ReloadWorkspaceMutationVersion = '763808cb236e2d60a426cd891a4f60efd6851a755345d4a3ef019549f35e0a5e';
+
+export const ReloadRepositoryLocationMutationVersion = '19f0c7c1764ac7327424133d498295b6417cb00ef06d88f30a458a7d33926e26';

--- a/js_modules/dagster-ui/packages/ui-core/src/ops/types/OpDetailsRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ops/types/OpDetailsRoot.types.ts
@@ -720,3 +720,5 @@ export type UsedSolidDetailsQuery = {
       }
     | {__typename: 'RepositoryNotFoundError'};
 };
+
+export const UsedSolidDetailsQueryVersion = '075b7d054775a58ed6aff12a1a912cf17ec6f40b722a97344db0c51507579c95';

--- a/js_modules/dagster-ui/packages/ui-core/src/ops/types/OpsRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ops/types/OpsRoot.types.ts
@@ -242,3 +242,5 @@ export type OpsRootUsedSolidFragment = {
     pipeline: {__typename: 'Pipeline'; id: string; isJob: boolean; name: string};
   }>;
 };
+
+export const OpsRootQueryVersion = 'a8ce0cedc4ebcc5ed0007d8795360ce5635ceefe1882802f88162b457f2058a4';

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/types/OverviewResourcesRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/types/OverviewResourcesRoot.types.ts
@@ -60,3 +60,5 @@ export type OverviewResourcesQuery = {
         }>;
       };
 };
+
+export const OverviewResourcesQueryVersion = '38594d66ef4f0161f6cd670cb369ce161f1f4a2b012080af70fb446f600b8cf0';

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/types/OverviewSchedules.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/types/OverviewSchedules.types.ts
@@ -89,3 +89,5 @@ export type OverviewSchedulesQuery = {
     };
   };
 };
+
+export const OverviewSchedulesQueryVersion = '04a2e4a6537d8d9de9aecfb08bb82bebf73767cf1858b3eddd0c063779129c39';

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/types/OverviewSensors.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/types/OverviewSensors.types.ts
@@ -90,3 +90,5 @@ export type OverviewSensorsQuery = {
     };
   };
 };
+
+export const OverviewSensorsQueryVersion = 'a4165ae0c5e53e870380e53b7cab308203a28d002f81f0d5e4e767c7d91a3029';

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/types/BackfillMessaging.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/types/BackfillMessaging.types.ts
@@ -33,3 +33,5 @@ export type UsingDefaultLauncherAlertInstanceFragment = {
   runQueuingSupported: boolean;
   runLauncher: {__typename: 'RunLauncher'; name: string} | null;
 };
+
+export const DaemonNotRunningAlertQueryVersion = 'f016870739b8816036750fb916c536889c862b5d591bf7c552f5cdefde693539';

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/types/BackfillSelector.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/types/BackfillSelector.types.ts
@@ -170,3 +170,5 @@ export type BackfillSelectorQuery = {
     };
   };
 };
+
+export const BackfillSelectorQueryVersion = '715413ccaeb3a6d4b6d9b6ff9aa6cb98ab40e2d4ee1469a9883182f9d3f540b6';

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/types/CreatePartitionDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/types/CreatePartitionDialog.types.ts
@@ -16,3 +16,5 @@ export type AddDynamicPartitionMutation = {
     | {__typename: 'PythonError'; message: string; stack: Array<string>}
     | {__typename: 'UnauthorizedError'; message: string};
 };
+
+export const AddDynamicPartitionMutationVersion = '09fbfa963ad43c7fecfc8e4f780e1ca98ffcea9f0b04e916c78061667cb250eb';

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/types/JobBackfillsTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/types/JobBackfillsTable.types.ts
@@ -59,3 +59,5 @@ export type JobBackfillsQuery = {
     | {__typename: 'PartitionSetNotFoundError'}
     | {__typename: 'PythonError'};
 };
+
+export const JobBackfillsQueryVersion = '9faca72d06cc7e1fb5423ea3b7f71d6ade5645bcbbe03322e092811de3ba36bd';

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/types/OpJobPartitionsView.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/types/OpJobPartitionsView.types.ts
@@ -109,3 +109,5 @@ export type OpJobPartitionStatusFragment = {
   runStatus: Types.RunStatus | null;
   runDuration: number | null;
 };
+
+export const PartitionsStatusQueryVersion = 'b51624d0ee6d3afd7bfd67307b3391318d53e7e3d977d3605f8a405d38c5969e';

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/types/PartitionRunList.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/types/PartitionRunList.types.ts
@@ -57,3 +57,5 @@ export type PartitionRunListQuery = {
         }>;
       };
 };
+
+export const PartitionRunListQueryVersion = 'a767fc2c778f8dc83fe1c265924cd6e5944e3e0daf6a94b14eda6f45a409f4ec';

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/types/PartitionStepStatus.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/types/PartitionStepStatus.types.ts
@@ -159,3 +159,5 @@ export type PartitionStepStatusPipelineQuery = {
     | {__typename: 'PipelineSnapshotNotFoundError'}
     | {__typename: 'PythonError'};
 };
+
+export const PartitionStepStatusPipelineQueryVersion = 'd5ef608096052079835b7080ed72204eab4168a32953d065b398ae7de975c0fb';

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/types/usePartitionStepQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/types/usePartitionStepQuery.types.ts
@@ -41,3 +41,5 @@ export type PartitionStepLoaderQuery = {
         }>;
       };
 };
+
+export const PartitionStepLoaderQueryVersion = 'c81bb54e0d99fe562bdeab9ae126f737c827cb034601c62cd7a6962ac93a9e48';

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/PipelineExplorerRoot.oss.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/PipelineExplorerRoot.oss.types.ts
@@ -1601,3 +1601,5 @@ export type PipelineExplorerRootQuery = {
         }>;
       };
 };
+
+export const PipelineExplorerRootQueryVersion = 'f351896aa934dd97af817742b8d069bd5876a9315933e98aa988931c90ad17c2';

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/PipelineRunsRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/PipelineRunsRoot.types.ts
@@ -59,3 +59,5 @@ export type PipelineRunsRootQuery = {
         }>;
       };
 };
+
+export const PipelineRunsRootQueryVersion = '1bd4f2bf438e93ad548322f890922479027e7636517b360fd8910a12600c5f95';

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/SidebarOp.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/SidebarOp.types.ts
@@ -5471,3 +5471,7 @@ export type SidebarGraphOpQuery = {
     | {__typename: 'GraphNotFoundError'}
     | {__typename: 'PythonError'};
 };
+
+export const SidebarPipelineOpQueryVersion = 'e7c81b4abaefc0eeea9128b4e39c74a1c68d7b28f154ac5ad9cd2d5182d48d5f';
+
+export const SidebarGraphOpQueryVersion = 'c53856856bea89e1eb944ab02f6e175a8dbccc99ee4c8600f0df96e05535be89';

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/SidebarOpExecutionGraphs.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/types/SidebarOpExecutionGraphs.types.ts
@@ -35,3 +35,5 @@ export type SidebarOpGraphsQuery = {
     | {__typename: 'PipelineNotFoundError'}
     | {__typename: 'PythonError'};
 };
+
+export const SidebarOpGraphsQueryVersion = '3feca8de1ac2e1f479a0a6b88b76e731da4162cb717f7174e5f232527cc6ce52';

--- a/js_modules/dagster-ui/packages/ui-core/src/resources/types/ResourceRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/types/ResourceRoot.types.ts
@@ -116,3 +116,5 @@ export type ResourceRootQuery = {
       }
     | {__typename: 'ResourceNotFoundError'};
 };
+
+export const ResourceRootQueryVersion = '43f17e6a448c083d86843c38edbae83098853097a8a7a5f3ef3a3238e3880bff';

--- a/js_modules/dagster-ui/packages/ui-core/src/resources/types/WorkspaceResourcesRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/resources/types/WorkspaceResourcesRoot.types.ts
@@ -50,3 +50,5 @@ export type WorkspaceResourcesQuery = {
       }
     | {__typename: 'RepositoryNotFoundError'};
 };
+
+export const WorkspaceResourcesQueryVersion = 'c5f1870a354eb3cf1a94291c56f4477d3462fcece7145bd372b07ef1563f7bd6';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/types/RunActionButtonsTestQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/types/RunActionButtonsTestQuery.types.ts
@@ -75,3 +75,5 @@ export type RunActionButtonsTestQuery = {
       }
     | {__typename: 'RunNotFoundError'};
 };
+
+export const RunActionButtonsTestQueryVersion = 'a10ee12da7843c87453578a2723bd3f9db19215ad9f50ac897d0979ac6187365';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/CapturedLogPanel.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/CapturedLogPanel.types.ts
@@ -54,3 +54,9 @@ export type CapturedLogsQuery = {
     cursor: string | null;
   };
 };
+
+export const CapturedLogsSubscriptionVersion = 'fa5e55b59e9d8632ae71a8387c54230ba71e6f57849a974225ba039808acfa93';
+
+export const CapturedLogsMetadataQueryVersion = 'b59ada7585593473002a7b044f09daa85f160445cbc9a4e8ffe0b46d51875cb1';
+
+export const CapturedLogsQueryVersion = '872b617b4f33ee5f6feeba9a4c76ec986fca357695a114e3d7b63172e4600b57';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsProvider.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/LogsProvider.types.ts
@@ -9981,3 +9981,7 @@ export type RunLogsQuery = {
     | {__typename: 'PythonError'; message: string; stack: Array<string>}
     | {__typename: 'RunNotFoundError'};
 };
+
+export const PipelineRunLogsSubscriptionVersion = '24c8a33ddd3d1b204589488bc967577f5a3ff8d183d12591c7b74ca7bbd30458';
+
+export const RunLogsQueryVersion = 'a7e61774ee31f4b2f9c2354ce17ed62b14b404a11de9a576d66702b5664a059e';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/QueuedRunCriteriaQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/QueuedRunCriteriaQuery.types.ts
@@ -18,3 +18,5 @@ export type QueuedRunCriteriaQuery = {
       }
     | {__typename: 'RunNotFoundError'};
 };
+
+export const QueuedRunCriteriaQueryVersion = 'da19aeed8a0a7e6f47619c6ba9efd721345481d8f08223282ea774e468400f21';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/QueuedRunsBanners.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/QueuedRunsBanners.types.ts
@@ -22,3 +22,5 @@ export type QueueDaemonStatusQuery = {
     };
   };
 };
+
+export const QueueDaemonStatusQueryVersion = 'aa51c596ee907346e60e2fe173bba10ae2ead067d45109225a2cd400a2278841';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunActionsMenu.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunActionsMenu.types.ts
@@ -26,3 +26,5 @@ export type PipelineEnvironmentQuery = {
       }
     | {__typename: 'RunNotFoundError'};
 };
+
+export const PipelineEnvironmentQueryVersion = '762f0cd2639e98c470cecdb3d2f7ca4609bd77be7f916e0134021bd0b589da59';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunAssetTags.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunAssetTags.types.ts
@@ -21,3 +21,5 @@ export type RunAssetsQuery = {
       }
     | {__typename: 'RunNotFoundError'};
 };
+
+export const RunAssetsQueryVersion = '53c1e7814d451dfd58fb2427dcb326a1e9628c8bbc91b3b9c76f8d6c7b75e278';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunListTabs.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunListTabs.types.ts
@@ -18,3 +18,5 @@ export type RunTabsCountQuery = {
     | {__typename: 'PythonError'}
     | {__typename: 'Runs'; count: number | null};
 };
+
+export const RunTabsCountQueryVersion = '5fe1760a3bf0494fb98e3c09f31add5138f9f31d59507a8b25186e2103bebbb4';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunRoot.types.ts
@@ -77,3 +77,5 @@ export type RunRootQuery = {
       }
     | {__typename: 'RunNotFoundError'};
 };
+
+export const RunRootQueryVersion = 'b6d9cd067c92c1608b185d8386a54867378dfdbc4caea5e7e1799699031e40b0';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunStats.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunStats.types.ts
@@ -45,3 +45,5 @@ export type RunStatsQuery = {
       }
     | {__typename: 'RunNotFoundError'; message: string};
 };
+
+export const RunStatsQueryVersion = '75e80f740a79607de9e1152f9b7074d319197fbc219784c767c1abd5553e9a49';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunUtils.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunUtils.types.ts
@@ -165,3 +165,11 @@ export type RunTimeFragment = {
   endTime: number | null;
   updateTime: number | null;
 };
+
+export const LaunchPipelineExecutionVersion = '292088c4a697aca6be1d3bbc0cfc45d8a13cdb2e75cfedc64b68c6245ea34f89';
+
+export const DeleteVersion = '3c61c79b99122910e754a8863e80dc5ed479a0c23cc1a9d9878d91e603fc0dfe';
+
+export const TerminateVersion = '67acf403eb320a93c9a9aa07f675a1557e0887d499cd5598f1d5ff360afc15c0';
+
+export const LaunchPipelineReexecutionVersion = 'd21e4ecaf3d1d163c4772f1d847dbdcbdaa9a40e6de0808a064ae767adf0c311';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsFilterInput.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsFilterInput.types.ts
@@ -26,3 +26,7 @@ export type RunTagValuesQuery = {
       }
     | null;
 };
+
+export const RunTagKeysQueryVersion = '833a405f7cb8f30c0901bc8a272edb51ac5281ebdf563e3017eace5d6976b2a9';
+
+export const RunTagValuesQueryVersion = '0c0a9998c215bb801eb0adcd5449c0ac4cf1e8efbc6d0fcc5fb6d76fcc95cb92';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/ScheduledRunListRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/ScheduledRunListRoot.types.ts
@@ -73,3 +73,5 @@ export type ScheduledRunsListQuery = {
       }
     | {__typename: 'RepositoryNotFoundError'};
 };
+
+export const ScheduledRunsListQueryVersion = '2650d8ebdfc444fe76fcf8acd9ff54f9ecacdb680b1d83e3f487cb71dd0c7eae';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/TerminateAllRunsButton.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/TerminateAllRunsButton.types.ts
@@ -21,3 +21,7 @@ export type TerminateRunIdsQuery = {
         }>;
       };
 };
+
+export const TerminateVersion = '67acf403eb320a93c9a9aa07f675a1557e0887d499cd5598f1d5ff360afc15c0';
+
+export const TerminateRunIdsQueryVersion = 'd38573af47f3ab2f2b11d90cb85ce8426307e2384e67a5b20e2bf67d5c1054bb';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/usePaginatedRunsTableRuns.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/usePaginatedRunsTableRuns.types.ts
@@ -59,3 +59,5 @@ export type RunsRootQuery = {
         }>;
       };
 };
+
+export const RunsRootQueryVersion = '1e4b08de38e10b8cfd771e756150925d8925d5cdb87650397782f6f030399901';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsForTimeline.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/useRunsForTimeline.types.ts
@@ -143,3 +143,9 @@ export type FutureTicksQuery = {
         }>;
       };
 };
+
+export const OngoingRunTimelineQueryVersion = '055420e85ba799b294bab52c01d3f4a4470580606a40483031c35777d88d527f';
+
+export const CompletedRunTimelineQueryVersion = 'a551b5ebeb919ea7ea4ca74385d3711d6a7e4f0e4042c04ab43bf9b939f4975c';
+
+export const FutureTicksQueryVersion = '9b947053273ecaa20ef19df02f0aa8e6f33b8a1628175987670e3c73a350e640';

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleAssetSelectionsQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleAssetSelectionsQuery.types.ts
@@ -53,3 +53,5 @@ export type ScheduleAssetSelectionQuery = {
       }
     | {__typename: 'ScheduleNotFoundError'};
 };
+
+export const ScheduleAssetSelectionQueryVersion = 'ff337e4645f6881b8240ef02dc13ef8dcdee46de71badedd37eb811bab741b87';

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleMutations.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleMutations.types.ts
@@ -91,3 +91,9 @@ export type ResetScheduleMutation = {
       }
     | {__typename: 'UnauthorizedError'; message: string};
 };
+
+export const StartThisScheduleVersion = '85ef7cd6041adc25adff7ea24b2434e2a6dfae5700b3a8d5683ba069d81890a7';
+
+export const StopScheduleVersion = 'd2d45e914fce611fa1adfffd488af554e29d4ee87220636fb841c668e4b83832';
+
+export const ResetScheduleVersion = '4de0dab719e737defe9787ab0b0bcef44f5384c92b2dd1c0bc0942643681b09b';

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/types/SchedulePartitionStatus.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/types/SchedulePartitionStatus.types.ts
@@ -64,3 +64,5 @@ export type SchedulePartitionStatusResultFragment = {
   partitionName: string;
   runStatus: Types.RunStatus | null;
 };
+
+export const SchedulePartitionStatusQueryVersion = 'f5440153ccc2480dfdd8c6a7e9371c7276d1d27016e3820c0ba1488523e55d5b';

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleRoot.types.ts
@@ -161,3 +161,7 @@ export type PreviousRunsForScheduleQuery = {
         }>;
       };
 };
+
+export const ScheduleRootQueryVersion = 'b54dfb64f816baa5c52c4676dcbd3808477130cab5237a5b96b988ec002adafc';
+
+export const PreviousRunsForScheduleQueryVersion = '7955ced58f846514ce4272707e9682b6bd66f53a26b4f6ff3754f1581f5ef92f';

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleSwitch.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/types/ScheduleSwitch.types.ts
@@ -36,3 +36,5 @@ export type ScheduleStateQuery = {
     | {__typename: 'InstigationStateNotFoundError'}
     | {__typename: 'PythonError'};
 };
+
+export const ScheduleStateQueryVersion = '75bc752d4f1df0fc2829736c14a4c2f707981571eb83a9139fa7048d202b3491';

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/types/SchedulesNextTicks.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/types/SchedulesNextTicks.types.ts
@@ -104,3 +104,5 @@ export type ScheduleFutureTickRunRequestFragment = {
   runConfigYaml: string;
   tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
 };
+
+export const ScheduleTickConfigQueryVersion = 'acdec3206ff12d652fe6657c8c51202a65b652b9575625d1f024014bbb828788';

--- a/js_modules/dagster-ui/packages/ui-core/src/scripts/generateGraphQLTypes.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/scripts/generateGraphQLTypes.ts
@@ -1,5 +1,6 @@
 import {execSync} from 'child_process';
-import {writeFileSync} from 'fs';
+import {readFileSync, readdirSync, statSync, writeFileSync} from 'fs';
+import path from 'path';
 
 import {buildClientSchema, getIntrospectionQuery, printSchema} from 'graphql';
 
@@ -46,3 +47,65 @@ console.log('Generating TypeScript types…');
 execSync('yarn graphql-codegen', {stdio: 'inherit'});
 
 console.log('Done!');
+
+function exportHashesAsVersionVariables() {
+  const CLIENT_JSON_PATH = './client.json';
+  const SRC_DIR = './src';
+
+  // Load the client.json which contains the hashes for each query/mutation
+  const queryHashMap = JSON.parse(readFileSync(CLIENT_JSON_PATH, 'utf-8'));
+
+  // Function to recursively find all .types.ts files
+  const findTypeFiles = (dir: string): string[] => {
+    let results: string[] = [];
+    const list = readdirSync(dir);
+
+    list.forEach((file) => {
+      const filePath = path.join(dir, file);
+      const stat = statSync(filePath);
+
+      if (stat && stat.isDirectory()) {
+        // Recursively search in subdirectories
+        results = results.concat(findTypeFiles(filePath));
+      } else if (filePath.endsWith('.types.ts')) {
+        results.push(filePath);
+      }
+    });
+
+    return results;
+  };
+
+  // Function to process .types.ts files and append version hashes
+  const processTypeFiles = (files: string[], queryHashMap: Record<string, string>) => {
+    files.forEach((filePath) => {
+      let content = readFileSync(filePath, 'utf-8');
+
+      // Look for the query/mutation type name in the file
+      Object.entries(queryHashMap).forEach(([operationName, hash]) => {
+        const typeRegex = new RegExp(`export type ${operationName}`, 'g');
+
+        if (typeRegex.test(content)) {
+          // Add the version constant
+          const versionConstant = `\nexport const ${operationName}Version = '${hash}';\n`;
+
+          // Append the version constant to the file if it doesn't already exist
+          if (!content.includes(`${operationName}Version`)) {
+            content += versionConstant;
+            writeFileSync(filePath, content);
+            console.log(`Updated ${filePath} with ${operationName}Version`);
+          }
+        }
+      });
+    });
+  };
+
+  // Recursively find all `.types.ts` files in the src directory
+  const typeFiles = findTypeFiles(SRC_DIR);
+
+  // Process all `.types.ts` files to find queries/mutations and add version constants
+  processTypeFiles(typeFiles, queryHashMap);
+
+  console.log('Type files updated with version hashes.');
+}
+
+exportHashesAsVersionVariables();

--- a/js_modules/dagster-ui/packages/ui-core/src/search/types/useGlobalSearch.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/types/useGlobalSearch.types.ts
@@ -142,3 +142,7 @@ export type SearchAssetFragment = {
     };
   } | null;
 };
+
+export const SearchPrimaryQueryVersion = '5d98265169496aabdee190894e504f0dd6205c3a8be462c5eac2a6c9c0c75f4a';
+
+export const SearchSecondaryQueryVersion = '39a75cb3ec146190c7dab171af1761a0f63a080aa8dbf379066223a6ac4af7e9';

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/AssetSensorTicksQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/AssetSensorTicksQuery.types.ts
@@ -63,3 +63,5 @@ export type AssetSensorTicksQuery = {
     | {__typename: 'SensorNotFoundError'}
     | {__typename: 'UnauthorizedError'};
 };
+
+export const AssetSensorTicksQueryVersion = 'ee952c7c0076a23f9d5940ad472a6b580989c0d241dc598dbefa5bf3734673d0';

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/EditCursorDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/EditCursorDialog.types.ts
@@ -36,3 +36,5 @@ export type SetSensorCursorMutation = {
     | {__typename: 'SensorNotFoundError'}
     | {__typename: 'UnauthorizedError'};
 };
+
+export const SetSensorCursorMutationVersion = 'a2982d2698c645a5d39b60415792c233abd90f85d2a2ac7cd626d88c3d3362a2';

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorMutations.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorMutations.types.ts
@@ -93,3 +93,9 @@ export type ResetSensorMutation = {
     | {__typename: 'SensorNotFoundError'; message: string}
     | {__typename: 'UnauthorizedError'; message: string};
 };
+
+export const StartSensorVersion = 'd091651f745822f99d00968a3d5bd8bc68c11061bdcb2391d06f5ef6f5775ed9';
+
+export const StopRunningSensorVersion = '810e2b80630b6c8f5a037fbf31eb2d8ece51d4168973270e6d2249e45d064b81';
+
+export const ResetSensorVersion = 'fba64da1f1979a7c53b618ba02c58cb72bd20c06220eeeef0318b15b502e3783';

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorPreviousRuns.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorPreviousRuns.types.ts
@@ -50,3 +50,5 @@ export type PreviousRunsForSensorQuery = {
         }>;
       };
 };
+
+export const PreviousRunsForSensorQueryVersion = 'f35e444f6c30827ce07db188568d5e62537b0f47e4b7e75d1b442e42c6353552';

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorRoot.types.ts
@@ -181,3 +181,7 @@ export type SensorAssetSelectionQuery = {
     | {__typename: 'SensorNotFoundError'}
     | {__typename: 'UnauthorizedError'};
 };
+
+export const SensorRootQueryVersion = 'fd32c8557a75c273133137c289091357635f3be0af17b9a57b052087f8e9d023';
+
+export const SensorAssetSelectionQueryVersion = 'a3410d20906553473a54e9045ecb19e92d08defefc17c2d9f1802338147ed470';

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorStateQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/types/SensorStateQuery.types.ts
@@ -22,3 +22,5 @@ export type SensorStateQuery = {
     | {__typename: 'InstigationStateNotFoundError'}
     | {__typename: 'PythonError'};
 };
+
+export const SensorStateQueryVersion = '867ed8f85db89c801fcd6f099356971c9c8a64ce52e6c61e6b73dc18680439aa';

--- a/js_modules/dagster-ui/packages/ui-core/src/snapshots/types/SnapshotNav.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/snapshots/types/SnapshotNav.types.ts
@@ -14,3 +14,5 @@ export type SnapshotQuery = {
     | {__typename: 'PipelineSnapshotNotFoundError'}
     | {__typename: 'PythonError'};
 };
+
+export const SnapshotQueryVersion = '6ada4abd4592a558d98b2557ec511e87c9420bab5cbc155ec8473c55bd820a7a';

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/types/EvaluateScheduleDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/types/EvaluateScheduleDialog.types.ts
@@ -63,3 +63,5 @@ export type ScheduleDryRunMutation = {
       }
     | {__typename: 'ScheduleNotFoundError'; scheduleName: string};
 };
+
+export const ScheduleDryRunMutationVersion = 'e3302c9049fc8be5d14fb6bd6d56198083c086c239018f3d564ae9987c28f11b';

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/types/SensorDryRunDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/types/SensorDryRunDialog.types.ts
@@ -62,3 +62,5 @@ export type DynamicPartitionRequestFragment = {
   partitionsDefName: string;
   type: Types.DynamicPartitionsRequestType;
 };
+
+export const SensorDryRunMutationVersion = '018c498063838a146dbc76607bc84c92c235eaa73a3859b1c94b469bc76f5170';

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/types/TickLogDialog.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/types/TickLogDialog.types.ts
@@ -33,3 +33,5 @@ export type TickLogEventsQuery = {
     | {__typename: 'InstigationStateNotFoundError'}
     | {__typename: 'PythonError'};
 };
+
+export const TickLogEventsQueryVersion = '6936bcc874ba79150ed1164ccd1afabdab836920b9c98b07cc22b0775443d1b7';

--- a/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/types/TypeExplorerContainer.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/types/TypeExplorerContainer.types.ts
@@ -1297,3 +1297,5 @@ export type TypeExplorerContainerQuery = {
     | {__typename: 'PipelineNotFoundError'}
     | {__typename: 'PythonError'};
 };
+
+export const TypeExplorerContainerQueryVersion = '5d2f11df92b7138d1d4415354615f4329ccb84bbc4b0a5c98bb3f5e56f0c694b';

--- a/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/types/TypeListContainer.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/typeexplorer/types/TypeListContainer.types.ts
@@ -42,3 +42,5 @@ export type TypeListContainerQuery = {
     | {__typename: 'PipelineNotFoundError'}
     | {__typename: 'PythonError'};
 };
+
+export const TypeListContainerQueryVersion = 'c92c874af7b1e7be221281fa265743a9c426f909ffc7500f302540ef9a6cf8f2';

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/types/WorkspaceQueries.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/types/WorkspaceQueries.types.ts
@@ -465,3 +465,7 @@ export type LocationStatusEntryFragment = {
   loadStatus: Types.RepositoryLocationLoadStatus;
   updateTimestamp: number;
 };
+
+export const LocationWorkspaceQueryVersion = '58140198e643d07c92d272b5eb521271149e048ae111762cfd9cef728e618a8f';
+
+export const CodeLocationStatusQueryVersion = 'eed7ef3f101620565b5893d9ccb83719bd0e1db5c6d66116d2027822bc2593a7';

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/GraphRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/GraphRoot.types.ts
@@ -1435,3 +1435,5 @@ export type GraphExplorerRootQuery = {
         }>;
       };
 };
+
+export const GraphExplorerRootQueryVersion = 'd413a7149d339afaa3e7b52caa8be6f62d6fcfe9ff25ab62e268d4e5c9785643';

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedGraphTable.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedGraphTable.types.ts
@@ -13,3 +13,5 @@ export type SingleGraphQuery = {
     | {__typename: 'GraphNotFoundError'}
     | {__typename: 'PythonError'};
 };
+
+export const SingleGraphQueryVersion = 'f1d47e63982c085807a7013c1581574e1284fe12344ea9752349c57aff0e0b2b';

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedJobRow.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedJobRow.types.ts
@@ -59,3 +59,5 @@ export type SingleJobQuery = {
     | {__typename: 'PipelineNotFoundError'}
     | {__typename: 'PythonError'};
 };
+
+export const SingleJobQueryVersion = '5ff8f070e59507f5369f1a19abb9a72cfa12439ab04a08dc340866885f6e4702';

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedScheduleRow.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedScheduleRow.types.ts
@@ -60,3 +60,5 @@ export type SingleScheduleQuery = {
       }
     | {__typename: 'ScheduleNotFoundError'};
 };
+
+export const SingleScheduleQueryVersion = '508a47e32ce04ba5be52c66cd592b74147bf98ec85b9f5d0e4db45172bd9a897';

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedSensorRow.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/VirtualizedSensorRow.types.ts
@@ -68,3 +68,5 @@ export type SingleSensorQuery = {
     | {__typename: 'SensorNotFoundError'}
     | {__typename: 'UnauthorizedError'};
 };
+
+export const SingleSensorQueryVersion = 'dbda5ba47d4ba10f8c527c9a7cd45fba0811276441a17a8ac6f173ed588f025b';

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceAssetsQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceAssetsQuery.types.ts
@@ -96,3 +96,5 @@ export type WorkspaceAssetsQuery = {
       }
     | {__typename: 'RepositoryNotFoundError'};
 };
+
+export const WorkspaceAssetsQueryVersion = 'a81f51b53f9e7ba6152ccdc8756d8a723363a574893143c329d316c11c0a28ed';

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceGraphsQuery.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceGraphsQuery.types.ts
@@ -76,3 +76,5 @@ export type WorkspaceGraphsQuery = {
       }
     | {__typename: 'RepositoryNotFoundError'};
 };
+
+export const WorkspaceGraphsQueryVersion = 'ccbef870f327b56beb0d781a476c8afbbc22ff2621181c8576861daaf7667ecf';

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceJobsRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceJobsRoot.types.ts
@@ -27,3 +27,5 @@ export type WorkspaceJobsQuery = {
       }
     | {__typename: 'RepositoryNotFoundError'};
 };
+
+export const WorkspaceJobsQueryVersion = '637f616d6d4eba194cf80bbb292f579f864d3b16aeb0b40cdf108d8100ba9b1c';

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceSchedulesRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceSchedulesRoot.types.ts
@@ -40,3 +40,5 @@ export type WorkspaceSchedulesQuery = {
       }
     | {__typename: 'RepositoryNotFoundError'};
 };
+
+export const WorkspaceSchedulesQueryVersion = '213cb3c1a2ffd6d9a6fbe20cd58eab746d53b6ab04d7d498c3c4f1f9d4a850d3';

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceSensorsRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/types/WorkspaceSensorsRoot.types.ts
@@ -40,3 +40,5 @@ export type WorkspaceSensorsQuery = {
       }
     | {__typename: 'RepositoryNotFoundError'};
 };
+
+export const WorkspaceSensorsQueryVersion = '2c8ef3f0111c4524514ff762d542810e95d429cc421e60893a3a4bbb39bb9849';

--- a/js_modules/dagster-ui/yarn.lock
+++ b/js_modules/dagster-ui/yarn.lock
@@ -3812,6 +3812,7 @@ __metadata:
     faker: "npm:5.5.3"
     fuse.js: "npm:^6.4.2"
     graphql: "npm:^16.8.1"
+    graphql-codegen-persisted-query-ids: "npm:^0.2.0"
     graphql-codegen-typescript-mock-data: "npm:^3.7.1"
     graphql-config: "npm:^5.0.3"
     graphql-tag: "npm:^2.10.1"
@@ -4306,6 +4307,22 @@ __metadata:
   peerDependencies:
     graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
   checksum: 10/184736c4e212db508752e418965c18c8ab8dee1b491dd819d69994b654978234cd44028b37eff1aa99638a92bc33b5138316272ddc9654ecc8e5a00d9fada620
+  languageName: node
+  linkType: hard
+
+"@graphql-codegen/plugin-helpers@npm:^5.0.0":
+  version: 5.0.4
+  resolution: "@graphql-codegen/plugin-helpers@npm:5.0.4"
+  dependencies:
+    "@graphql-tools/utils": "npm:^10.0.0"
+    change-case-all: "npm:1.0.15"
+    common-tags: "npm:1.8.2"
+    import-from: "npm:4.0.0"
+    lodash: "npm:~4.17.0"
+    tslib: "npm:~2.6.0"
+  peerDependencies:
+    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: 10/8162bffc76bf0d6cd9ff83c98b8a5e5eadbb1bc0de2d273480af937a27ca8fbf74aae72a617303a9d4121b9914eb9af065858f07c0ac13cd169b53a9bcead799
   languageName: node
   linkType: hard
 
@@ -14089,6 +14106,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graphql-codegen-persisted-query-ids@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "graphql-codegen-persisted-query-ids@npm:0.2.0"
+  dependencies:
+    "@graphql-codegen/plugin-helpers": "npm:^5.0.0"
+    "@graphql-tools/apollo-engine-loader": "npm:^8.0.0"
+    graphql: "npm:^16.7.1"
+  checksum: 10/5be470334fda5fbdddc1e609e7c4ed5d961992f14922d41233ae35e20298f9a3e5a54081aa6e811a1eca17c666e0d9dd03791f477eea82abd0df386bcd8fffe0
+  languageName: node
+  linkType: hard
+
 "graphql-codegen-typescript-mock-data@npm:^3.7.1":
   version: 3.7.1
   resolution: "graphql-codegen-typescript-mock-data@npm:3.7.1"
@@ -14192,6 +14220,13 @@ __metadata:
   version: 16.8.1
   resolution: "graphql@npm:16.8.1"
   checksum: 10/7a09d3ec5f75061afe2bd2421a2d53cf37273d2ecaad8f34febea1f1ac205dfec2834aec3419fa0a10fcc9fb345863b2f893562fb07ea825da2ae82f6392893c
+  languageName: node
+  linkType: hard
+
+"graphql@npm:^16.7.1":
+  version: 16.9.0
+  resolution: "graphql@npm:16.9.0"
+  checksum: 10/5833f82bb6c31bec120bbf9cd400eda873e1bb7ef5c17974fa262cd82dc68728fda5d4cb859dc8aaa4c4fe4f6fe1103a9c47efc01a12c02ae5cb581d8e4029e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary & Motivation

We want to use these hashes as keys to our indexeddb caches to avoid loading cached data for an older schema. This PR updates our codegen script to export those hashes from the type files.


## How I Tested These Changes

Ran the script, inspected this PR. 

<img width="1391" alt="Screenshot 2024-09-12 at 12 12 35 PM" src="https://github.com/user-attachments/assets/9ed6dc35-0530-47ea-98fc-2aff5e8202cd">


## Changelog
NOCHANGELOG