### PR TITLE
[refactor] Slim down AssetDaemonContext

### DIFF
--- a/integration_tests/test_suites/auto_materialize_perf_tests/test_asset_daemon_perf.py
+++ b/integration_tests/test_suites/auto_materialize_perf_tests/test_asset_daemon_perf.py
@@ -11,8 +11,10 @@ from dagster import (
     HourlyPartitionsDefinition,
     PartitionKeyRange,
 )
-from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
+from dagster._core.definitions.declarative_automation.automation_condition_evaluator import (
+    AutomationConditionEvaluator,
+)
 
 from auto_materialize_perf_tests.partition_mappings_galore_perf_scenario import (
     partition_mappings_galore_perf_scenario,
@@ -86,18 +88,11 @@ def test_auto_materialize_perf(scenario: PerfScenario):
     with scenario.instance_from_snapshot() as instance:
         start = time.time()
 
-        AssetDaemonContext(
-            evaluation_id=1,
+        AutomationConditionEvaluator(
+            entity_keys=AssetSelection.all().resolve(asset_graph),
             instance=instance,
             asset_graph=asset_graph,
             cursor=AssetDaemonCursor.empty(),
-            auto_materialize_asset_keys=AssetSelection.all().resolve(asset_graph),
-            materialize_run_tags=None,
-            auto_observe_asset_keys=set(),
-            observe_run_tags=None,
-            respect_materialization_data_versions=True,
-            logger=logging.getLogger("dagster.amp"),
-            evaluation_time=scenario.current_time,
         ).evaluate()
 
         end = time.time()

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
@@ -109,13 +109,13 @@ class LegacyRuleEvaluationContext:
                 instance_queryer,
                 instance_queryer.evaluation_time,
             ),
-            data_time_resolver=evaluator.data_time_resolver,
+            data_time_resolver=evaluator.legacy_data_time_resolver,
             instance_queryer=instance_queryer,
             current_results_by_key=evaluator.current_results_by_key,
             expected_data_time_mapping=evaluator.legacy_expected_data_time_by_key,
             start_timestamp=get_current_timestamp(),
-            respect_materialization_data_versions=evaluator.respect_materialization_data_versions,
-            auto_materialize_run_tags=evaluator.auto_materialize_run_tags,
+            respect_materialization_data_versions=evaluator.legacy_respect_materialization_data_versions,
+            auto_materialize_run_tags=evaluator.legacy_auto_materialize_run_tags,
             logger=evaluator.logger,
         )
 

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -946,9 +946,7 @@ class AssetDaemon(DagsterDaemon):
                 },
                 observe_run_tags={AUTO_OBSERVE_TAG: "true", **sensor_tags},
                 auto_observe_asset_keys=auto_observe_asset_keys,
-                respect_materialization_data_versions=instance.auto_materialize_respect_materialization_data_versions,
                 logger=self._logger,
-                request_backfills=request_backfills,
             ).evaluate()
 
             check.invariant(new_cursor.evaluation_id == evaluation_id)

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/legacy_tests/test_auto_observe.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/legacy_tests/test_auto_observe.py
@@ -101,7 +101,7 @@ def test_single_observable_source_asset_prior_recent_observe_requests(
     assert len(run_requests) == 0
 
 
-def test_reconcile():
+def test_reconcile() -> None:
     @observable_source_asset(auto_observe_interval_minutes=30)
     def asset1(): ...
 
@@ -115,11 +115,9 @@ def test_reconcile():
         auto_materialize_asset_keys=set(),
         instance=instance,
         cursor=AssetDaemonCursor.empty(),
-        materialize_run_tags=None,
+        materialize_run_tags={},
         observe_run_tags={"tag1": "tag_value"},
-        respect_materialization_data_versions=False,
         logger=logging.getLogger("dagster.amp"),
-        request_backfills=False,
     ).evaluate()
     assert len(run_requests) == 1
     assert run_requests[0].tags.get("tag1") == "tag_value"

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
@@ -159,9 +159,7 @@ class AssetDaemonScenarioState(ScenarioState):
                 for key in self.asset_graph.external_asset_keys
                 if self.asset_graph.get(key).auto_observe_interval_minutes is not None
             },
-            respect_materialization_data_versions=False,
             logger=self.logger,
-            request_backfills=self.request_backfills,
         ).evaluate()
         check.is_list(new_run_requests, of_type=RunRequest)
         check.inst(new_cursor, AssetDaemonCursor)


### PR DESCRIPTION
## Summary & Motivation

Makes it easier to construct an AutomationConditionEvaluator and simplifies the AssetDaemonContext object.

Previously, we were juggling a ton of parameters between these classes for essentially no reason.

## How I Tested These Changes

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
