### PR TITLE
feat(dbt): add materialization type kinds

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -774,6 +774,7 @@ def build_dbt_multi_asset_args(
         dbt_group_resource_props = (
             dbt_group_resource_props_by_group_name.get(dbt_group_name) if dbt_group_name else None
         )
+        dbt_materialization_type = dbt_resource_props.get("config", {}).get("materialized")
 
         output_name = dagster_name_fn(dbt_resource_props)
         asset_key = dagster_dbt_translator.get_asset_key(dbt_resource_props)
@@ -818,6 +819,7 @@ def build_dbt_multi_asset_args(
             tags={
                 **build_kind_tag("dbt"),
                 **(build_kind_tag(dbt_adapter_type) if dbt_adapter_type else {}),
+                **(build_kind_tag(dbt_materialization_type) if dbt_materialization_type else {}),
                 **dagster_dbt_translator.get_tags(dbt_resource_props),
             },
             group_name=dagster_dbt_translator.get_group_name(dbt_resource_props),

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -838,18 +838,26 @@ def test_dbt_config_tags(test_meta_config_manifest: Dict[str, Any]) -> None:
     assert expected_specs_by_key[AssetKey("customers")].tags == {
         "foo": "",
         "bar-baz": "",
+        **build_kind_tag("table"),
         **build_kind_tag("duckdb"),
         **build_kind_tag("dbt"),
     }
     assert my_dbt_assets.tags_by_key[AssetKey("customers")] == {
         "foo": "",
         "bar-baz": "",
+        **build_kind_tag("table"),
         **build_kind_tag("duckdb"),
         **build_kind_tag("dbt"),
     }
     for asset_key in my_dbt_assets.keys - {AssetKey("customers")}:
+        dbt_resource_props_by_asset_key = {
+            DagsterDbtTranslator().get_asset_key(dbt_resource_props): dbt_resource_props
+            for dbt_resource_props in test_meta_config_manifest["nodes"].values()
+        }
+
         assert has_kind(my_dbt_assets.tags_by_key[asset_key], "duckdb")
         assert expected_specs_by_key[asset_key].tags == {
+            **build_kind_tag(dbt_resource_props_by_asset_key[asset_key]["config"]["materialized"]),
             **build_kind_tag("duckdb"),
             **build_kind_tag("dbt"),
         }


### PR DESCRIPTION
## Summary & Motivation

Make use of https://github.com/dagster-io/dagster/pull/24440 for `dagster-dbt`.

<img width="1345" alt="Screenshot 2024-09-12 at 1 55 25 PM" src="https://github.com/user-attachments/assets/ba47d60e-c491-419a-a14a-69b578d1b57f">


## How I Tested These Changes
pytest

## Changelog

[dagster-dbt] dbt materialization type (e.g. `view`, `table`, `incremental`) now appears as a kind tag in the Dagster UI.

- [x] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
