### PR TITLE
[refactor] Cleanup AssetDaemonContext / rename to AutomationTickEvaluationContext

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -3,9 +3,6 @@ from typing import Any, Mapping, Optional, cast
 import dagster._check as check
 from dagster._annotations import experimental
 from dagster._core.definitions.asset_selection import AssetSelection, CoercibleToAssetSelection
-from dagster._core.definitions.declarative_automation.automation_condition_evaluator import (
-    AutomationConditionEvaluator,
-)
 from dagster._core.definitions.run_request import SensorResult
 from dagster._core.definitions.sensor_definition import (
     DefaultSensorStatus,
@@ -17,7 +14,9 @@ from dagster._core.definitions.utils import check_valid_name, normalize_tags
 
 
 def evaluate_automation_conditions(context: SensorEvaluationContext):
-    from dagster._core.definitions.asset_daemon_context import build_run_requests
+    from dagster._core.definitions.automation_tick_evaluation_context import (
+        AutomationTickEvaluationContext,
+    )
     from dagster._daemon.asset_daemon import (
         asset_daemon_cursor_from_instigator_serialized_cursor,
         asset_daemon_cursor_to_instigator_serialized_cursor,
@@ -28,37 +27,17 @@ def evaluate_automation_conditions(context: SensorEvaluationContext):
         context.cursor,
         asset_graph,
     )
-
-    evaluator = AutomationConditionEvaluator(
-        asset_graph=asset_graph,
-        instance=context.instance,
-        entity_keys=asset_graph.all_asset_keys,
-        logger=context.log,
-        cursor=cursor,
-    )
-    results, entity_subsets = evaluator.evaluate()
-    new_cursor = cursor.with_updates(
+    run_requests, new_cursor, updated_evaluations = AutomationTickEvaluationContext(
         evaluation_id=cursor.evaluation_id,
-        evaluation_timestamp=evaluator.evaluation_time.timestamp(),
-        newly_observe_requested_asset_keys=[],  # skip for now, hopefully forever
-        condition_cursors=[result.get_new_cursor() for result in results],
-    )
-    run_requests = build_run_requests(
-        entity_subsets=entity_subsets,
+        instance=context.instance,
         asset_graph=asset_graph,
-        # tick_id and sensor tags should get set in daemon
-        run_tags=context.instance.auto_materialize_run_tags,
-    )
-    # only record evaluation results where something changed
-    updated_evaluations = []
-    for result in results:
-        previous_cursor = cursor.get_previous_condition_cursor(result.key)
-        if (
-            previous_cursor is None
-            or previous_cursor.result_value_hash != result.value_hash
-            or not result.true_subset.is_empty
-        ):
-            updated_evaluations.append(result.serializable_evaluation)
+        cursor=cursor,
+        materialize_run_tags=context.instance.auto_materialize_run_tags,
+        observe_run_tags={},
+        auto_observe_asset_keys=set(),
+        auto_materialize_asset_keys=asset_graph.all_asset_keys,
+        logger=context.log,
+    ).evaluate()
 
     return SensorResult(
         run_requests=run_requests,

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -22,12 +22,12 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster._core.definitions.asset_daemon_context import (
+from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.asset_selection import KeysAssetSelection
+from dagster._core.definitions.automation_tick_evaluation_context import (
     build_run_requests_from_asset_partitions,
     build_run_requests_with_backfill_policies,
 )
-from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
-from dagster._core.definitions.asset_selection import KeysAssetSelection
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.events import AssetKey, AssetKeyPartitionKey
 from dagster._core.definitions.partition import PartitionsDefinition, PartitionsSubset

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -11,11 +11,13 @@ from types import TracebackType
 from typing import Any, Dict, Mapping, Optional, Sequence, Set, Tuple, Type, cast
 
 import dagster._check as check
-from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
 from dagster._core.definitions.asset_daemon_cursor import (
     AssetDaemonCursor,
     LegacyAssetDaemonCursorWrapper,
     backcompat_deserialize_asset_daemon_cursor_str,
+)
+from dagster._core.definitions.automation_tick_evaluation_context import (
+    AutomationTickEvaluationContext,
 )
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.events import AssetKey
@@ -931,7 +933,7 @@ class AssetDaemon(DagsterDaemon):
         else:
             sensor_tags = {SENSOR_NAME_TAG: sensor.name, **sensor.run_tags} if sensor else {}
 
-            run_requests, new_cursor, evaluations = AssetDaemonContext(
+            run_requests, new_cursor, evaluations = AutomationTickEvaluationContext(
                 evaluation_id=evaluation_id,
                 asset_graph=asset_graph,
                 auto_materialize_asset_keys=auto_materialize_asset_keys,

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, NamedTuple, Optional, Sequence, Tuple, Type, c
 
 import dagster._check as check
 from dagster import AssetKey, DagsterInstance, RunRequest, RunsFilter
-from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
 from dagster._core.definitions.asset_daemon_cursor import (
     AssetDaemonCursor,
     backcompat_deserialize_asset_daemon_cursor_str,
@@ -14,6 +13,9 @@ from dagster._core.definitions.asset_daemon_cursor import (
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeRuleEvaluationData,
+)
+from dagster._core.definitions.automation_tick_evaluation_context import (
+    AutomationTickEvaluationContext,
 )
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.declarative_automation.legacy.valid_asset_subset import (
@@ -142,7 +144,7 @@ class AssetDaemonScenarioState(ScenarioState):
                 self.serialized_cursor, self.asset_graph, 0
             )
 
-        new_run_requests, new_cursor, new_evaluations = AssetDaemonContext(
+        new_run_requests, new_cursor, new_evaluations = AutomationTickEvaluationContext(
             evaluation_id=cursor.evaluation_id + 1,
             asset_graph=self.asset_graph,
             auto_materialize_asset_keys={

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/base_scenario.py
@@ -44,7 +44,6 @@ from dagster import (
     repository,
 )
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
-from dagster._core.definitions.asset_daemon_context import AssetDaemonContext
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
@@ -54,6 +53,9 @@ from dagster._core.definitions.auto_materialize_rule_evaluation import (
     AutoMaterializeDecisionType,
     AutoMaterializeRuleEvaluation,
     AutoMaterializeRuleEvaluationData,
+)
+from dagster._core.definitions.automation_tick_evaluation_context import (
+    AutomationTickEvaluationContext,
 )
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.data_version import DataVersionsByPartition
@@ -401,7 +403,7 @@ class AssetReconciliationScenario(
                 "auto_materialize_respect_materialization_data_versions",
                 new=lambda: self.respect_materialization_data_versions,
             ):
-                run_requests, cursor, evaluations = AssetDaemonContext(
+                run_requests, cursor, evaluations = AutomationTickEvaluationContext(
                     evaluation_id=cursor.evaluation_id + 1,
                     asset_graph=asset_graph,
                     auto_materialize_asset_keys=auto_materialize_asset_keys,


### PR DESCRIPTION
## Summary & Motivation

This cleans up the AssetDaemonContext object a bit more, and renames it such that it's suitable for use in the user-code version of this feature.

## How I Tested These Changes

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
