### PR TITLE
Generic serialized AutomationCondition objects

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_condition_evaluations.py
@@ -41,7 +41,7 @@ def _get_graphene_records_from_evaluations(
     graphene_info: "ResolveInfo",
     evaluation_records: Sequence[AutoMaterializeAssetEvaluationRecord],
 ) -> GrapheneAssetConditionEvaluationRecords:
-    asset_keys = {record.asset_key for record in evaluation_records}
+    asset_keys = {record.key for record in evaluation_records}
 
     partitions_defs = {}
 
@@ -56,9 +56,7 @@ def _get_graphene_records_from_evaluations(
 
     return GrapheneAssetConditionEvaluationRecords(
         records=[
-            GrapheneAssetConditionEvaluationRecord(
-                evaluation, partitions_defs[evaluation.asset_key]
-            )
+            GrapheneAssetConditionEvaluationRecord(evaluation, partitions_defs[evaluation.key])
             for evaluation in evaluation_records
         ]
     )
@@ -97,7 +95,7 @@ def fetch_true_partitions_for_evaluation_node(
             schedule_storage.get_auto_materialize_asset_evaluations(
                 # there is no method to get a specific evaluation by id, so instead get the first
                 # evaluation before evaluation_id + 1
-                asset_key,
+                key=asset_key,
                 cursor=evaluation_id + 1,
                 limit=1,
             )
@@ -132,7 +130,7 @@ def fetch_asset_condition_evaluation_records_for_asset_key(
     return _get_graphene_records_from_evaluations(
         graphene_info,
         schedule_storage.get_auto_materialize_asset_evaluations(
-            asset_key=asset_key,
+            key=asset_key,
             limit=limit,
             cursor=int(cursor) if cursor else None,
         ),

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_auto_materialize_asset_evaluations.py
@@ -60,7 +60,7 @@ def fetch_auto_materialize_asset_evaluations(
     return _get_graphene_records_from_evaluations(
         graphene_info,
         schedule_storage.get_auto_materialize_asset_evaluations(
-            asset_key=asset_key,
+            key=asset_key,
             limit=limit,
             cursor=int(cursor) if cursor else None,
         ),

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_condition_evaluations.py
@@ -283,7 +283,7 @@ class GrapheneAssetConditionEvaluationRecord(graphene.ObjectType):
             evaluationId=record.evaluation_id,
             timestamp=record.timestamp,
             runIds=evaluation_with_run_ids.run_ids,
-            assetKey=GrapheneAssetKey(path=record.asset_key.path),
+            assetKey=GrapheneAssetKey(path=record.key.path),
             numRequested=root_evaluation.true_subset.size,
             startTimestamp=root_evaluation.start_timestamp,
             endTimestamp=root_evaluation.end_timestamp,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/auto_materialize_asset_evaluations.py
@@ -240,7 +240,7 @@ class GrapheneAutoMaterializeAssetEvaluationRecord(graphene.ObjectType):
             timestamp=record.timestamp,
             runIds=evaluation_with_run_ids.run_ids,
             rules=sorted(rules, key=lambda rule: rule.className),
-            assetKey=GrapheneAssetKey(path=record.asset_key.path),
+            assetKey=GrapheneAssetKey(path=record.key.path),
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
@@ -162,7 +162,7 @@ class AutomationTickEvaluationContext:
 
     def _get_updated_evaluations(
         self, results: Iterable[AutomationResult]
-    ) -> Sequence[AutomationConditionEvaluation]:
+    ) -> Sequence[AutomationConditionEvaluation[EntityKey]]:
         # only record evaluation results where something changed
         updated_evaluations = []
         for result in results:
@@ -177,7 +177,9 @@ class AutomationTickEvaluationContext:
 
     def evaluate(
         self,
-    ) -> Tuple[Sequence[RunRequest], AssetDaemonCursor, Sequence[AutomationConditionEvaluation]]:
+    ) -> Tuple[
+        Sequence[RunRequest], AssetDaemonCursor, Sequence[AutomationConditionEvaluation[EntityKey]]
+    ]:
         observe_run_requests = self._legacy_build_auto_observe_run_requests()
         results, entity_subsets = self._evaluator.evaluate()
 

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -20,6 +20,7 @@ from dagster._annotations import PublicAttr, experimental_param
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.asset_key import EntityKey
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AutomationConditionEvaluation,
 )
@@ -369,7 +370,10 @@ class SensorResult(
                 "asset_events",
                 List[Union[AssetObservation, AssetMaterialization, AssetCheckEvaluation]],
             ),
-            ("automation_condition_evaluations", Optional[Sequence[AutomationConditionEvaluation]]),
+            (
+                "automation_condition_evaluations",
+                Optional[Sequence[AutomationConditionEvaluation[EntityKey]]],
+            ),
         ],
     )
 ):

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Set, Tu
 from dagster import _check as check
 from dagster._config.config_schema import UserConfigSchema
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
+from dagster._core.definitions.asset_key import EntityKey
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AutomationConditionEvaluationWithRunIds,
 )
@@ -810,10 +811,10 @@ class LegacyScheduleStorage(ScheduleStorage, ConfigurableClass):
         )
 
     def get_auto_materialize_asset_evaluations(
-        self, asset_key: AssetKey, limit: int, cursor: Optional[int] = None
+        self, key: EntityKey, limit: int, cursor: Optional[int] = None
     ) -> Sequence["AutoMaterializeAssetEvaluationRecord"]:
         return self._storage.schedule_storage.get_auto_materialize_asset_evaluations(
-            asset_key, limit, cursor
+            key, limit, cursor
         )
 
     def get_auto_materialize_evaluations_for_evaluation_id(

--- a/python_modules/dagster/dagster/_core/storage/schedules/base.py
+++ b/python_modules/dagster/dagster/_core/storage/schedules/base.py
@@ -1,7 +1,7 @@
 import abc
 from typing import Mapping, Optional, Sequence, Set
 
-from dagster import AssetKey
+from dagster._core.definitions.asset_key import EntityKey, T_EntityKey
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AutomationConditionEvaluationWithRunIds,
 )
@@ -158,14 +158,14 @@ class ScheduleStorage(abc.ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     def add_auto_materialize_asset_evaluations(
         self,
         evaluation_id: int,
-        asset_evaluations: Sequence[AutomationConditionEvaluationWithRunIds],
+        asset_evaluations: Sequence[AutomationConditionEvaluationWithRunIds[EntityKey]],
     ) -> None:
         """Add asset policy evaluations to storage."""
 
     @abc.abstractmethod
     def get_auto_materialize_asset_evaluations(
-        self, asset_key: AssetKey, limit: int, cursor: Optional[int] = None
-    ) -> Sequence[AutoMaterializeAssetEvaluationRecord]:
+        self, key: T_EntityKey, limit: int, cursor: Optional[int] = None
+    ) -> Sequence[AutoMaterializeAssetEvaluationRecord[T_EntityKey]]:
         """Get the policy evaluations for a given asset.
 
         Args:

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -5,6 +5,7 @@ import pytest
 
 from dagster import StaticPartitionsDefinition
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
+from dagster._core.definitions.asset_key import AssetCheckKey
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AssetSubsetWithMetadata,
     AutomationConditionEvaluation,
@@ -778,37 +779,29 @@ class TestScheduleStorage:
             )
 
             res = storage.get_auto_materialize_asset_evaluations(
-                asset_key=AssetKey("asset_one"), limit=100
+                key=AssetKey("asset_one"), limit=100
             )
             assert len(res) == 1
-            assert res[0].get_evaluation_with_run_ids().evaluation.asset_key == AssetKey(
-                "asset_one"
-            )
+            assert res[0].get_evaluation_with_run_ids().evaluation.key == AssetKey("asset_one")
             assert res[0].evaluation_id == 10
             assert res[0].get_evaluation_with_run_ids().evaluation.true_subset.size == 0
 
             res = storage.get_auto_materialize_asset_evaluations(
-                asset_key=AssetKey("asset_two"), limit=100
+                key=AssetKey("asset_two"), limit=100
             )
             assert len(res) == 1
-            assert res[0].get_evaluation_with_run_ids().evaluation.asset_key == AssetKey(
-                "asset_two"
-            )
+            assert res[0].get_evaluation_with_run_ids().evaluation.key == AssetKey("asset_two")
             assert res[0].evaluation_id == 10
             assert res[0].get_evaluation_with_run_ids().evaluation.true_subset.size == 1
 
             res = storage.get_auto_materialize_evaluations_for_evaluation_id(evaluation_id=10)
 
             assert len(res) == 2
-            assert res[0].get_evaluation_with_run_ids().evaluation.asset_key == AssetKey(
-                "asset_one"
-            )
+            assert res[0].get_evaluation_with_run_ids().evaluation.key == AssetKey("asset_one")
             assert res[0].evaluation_id == 10
             assert res[0].get_evaluation_with_run_ids().evaluation.true_subset.size == 0
 
-            assert res[1].get_evaluation_with_run_ids().evaluation.asset_key == AssetKey(
-                "asset_two"
-            )
+            assert res[1].get_evaluation_with_run_ids().evaluation.key == AssetKey("asset_two")
             assert res[1].evaluation_id == 10
             assert res[1].get_evaluation_with_run_ids().evaluation.true_subset.size == 1
 
@@ -829,21 +822,17 @@ class TestScheduleStorage:
             ],
         )
 
-        res = storage.get_auto_materialize_asset_evaluations(
-            asset_key=AssetKey("asset_one"), limit=100
-        )
+        res = storage.get_auto_materialize_asset_evaluations(key=AssetKey("asset_one"), limit=100)
         assert len(res) == 2
         assert res[0].evaluation_id == 11
         assert res[1].evaluation_id == 10
 
-        res = storage.get_auto_materialize_asset_evaluations(
-            asset_key=AssetKey("asset_one"), limit=1
-        )
+        res = storage.get_auto_materialize_asset_evaluations(key=AssetKey("asset_one"), limit=1)
         assert len(res) == 1
         assert res[0].evaluation_id == 11
 
         res = storage.get_auto_materialize_asset_evaluations(
-            asset_key=AssetKey("asset_one"), limit=1, cursor=11
+            key=AssetKey("asset_one"), limit=1, cursor=11
         )
         assert len(res) == 1
         assert res[0].evaluation_id == 10
@@ -882,16 +871,12 @@ class TestScheduleStorage:
             ],
         )
 
-        res = storage.get_auto_materialize_asset_evaluations(
-            asset_key=AssetKey("asset_one"), limit=100
-        )
+        res = storage.get_auto_materialize_asset_evaluations(key=AssetKey("asset_one"), limit=100)
         assert len(res) == 2
         assert res[0].evaluation_id == 11
         assert res[0].get_evaluation_with_run_ids().evaluation == eval_one.evaluation
 
-        res = storage.get_auto_materialize_asset_evaluations(
-            asset_key=AssetKey("asset_three"), limit=100
-        )
+        res = storage.get_auto_materialize_asset_evaluations(key=AssetKey("asset_three"), limit=100)
 
         assert len(res) == 1
         assert res[0].evaluation_id == 11
@@ -929,11 +914,9 @@ class TestScheduleStorage:
             ],
         )
 
-        res = storage.get_auto_materialize_asset_evaluations(
-            asset_key=AssetKey("asset_two"), limit=100
-        )
+        res = storage.get_auto_materialize_asset_evaluations(key=AssetKey("asset_two"), limit=100)
         assert len(res) == 1
-        assert res[0].get_evaluation_with_run_ids().evaluation.asset_key == AssetKey("asset_two")
+        assert res[0].get_evaluation_with_run_ids().evaluation.key == AssetKey("asset_two")
         assert res[0].evaluation_id == 10
         assert res[0].get_evaluation_with_run_ids().evaluation.true_subset.size == 1
 
@@ -941,6 +924,42 @@ class TestScheduleStorage:
             res[0].get_evaluation_with_run_ids().evaluation.subsets_with_metadata[0]
             == asset_subset_with_metadata
         )
+
+    @pytest.mark.xfail()
+    def test_automation_condition_evaluations_check_key(self, storage) -> None:
+        if not self.can_store_auto_materialize_asset_evaluations():
+            pytest.skip("Storage cannot store auto materialize asset evaluations")
+
+        check_key = AssetCheckKey(AssetKey("asset_two"), "check_one")
+        entity_subset = SerializableEntitySubset(key=check_key, value=True)
+
+        storage.add_auto_materialize_asset_evaluations(
+            evaluation_id=10,
+            asset_evaluations=[
+                AutomationConditionEvaluation(
+                    condition_snapshot=AutomationConditionNodeSnapshot(
+                        class_name="foo", description="bar", unique_id=""
+                    ),
+                    start_timestamp=0,
+                    end_timestamp=1,
+                    true_subset=entity_subset,
+                    candidate_subset=entity_subset,
+                    subsets_with_metadata=[],
+                    child_evaluations=[],
+                ).with_run_ids(set()),
+            ],
+        )
+
+        res = storage.get_auto_materialize_asset_evaluations(key=check_key.asset_key, limit=100)
+        assert len(res) == 0  # stored for the check key, not the asset key
+
+        # this is expected to fail until the next PR in the stack
+        res = storage.get_auto_materialize_asset_evaluations(key=check_key, limit=100)
+        assert len(res) == 1
+
+        assert res[0].get_evaluation_with_run_ids().evaluation.key == check_key
+        assert res[0].evaluation_id == 10
+        assert res[0].get_evaluation_with_run_ids().evaluation.true_subset.size == 1
 
     def test_purge_asset_evaluations(self, storage) -> None:
         if not self.can_purge():
@@ -969,16 +988,12 @@ class TestScheduleStorage:
             before=(get_current_datetime() - relativedelta(hours=10)).timestamp()
         )
 
-        res = storage.get_auto_materialize_asset_evaluations(
-            asset_key=AssetKey("asset_one"), limit=100
-        )
+        res = storage.get_auto_materialize_asset_evaluations(key=AssetKey("asset_one"), limit=100)
         assert len(res) == 1
 
         storage.purge_asset_evaluations(
             before=(get_current_datetime() + relativedelta(minutes=10)).timestamp()
         )
 
-        res = storage.get_auto_materialize_asset_evaluations(
-            asset_key=AssetKey("asset_one"), limit=100
-        )
+        res = storage.get_auto_materialize_asset_evaluations(key=AssetKey("asset_one"), limit=100)
         assert len(res) == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_asset_daemon_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_asset_daemon_failure_recovery.py
@@ -496,10 +496,10 @@ def test_asset_daemon_crash_recovery(daemon_not_paused_instance, crash_location)
     sorted_runs = sorted(runs[: len(scenario.expected_run_requests)], key=sort_run_key_fn)
 
     evaluations = instance.schedule_storage.get_auto_materialize_asset_evaluations(
-        asset_key=AssetKey("hourly"), limit=100
+        key=AssetKey("hourly"), limit=100
     )
     assert len(evaluations) == 1
-    assert evaluations[0].get_evaluation_with_run_ids().evaluation.asset_key == AssetKey("hourly")
+    assert evaluations[0].get_evaluation_with_run_ids().evaluation.key == AssetKey("hourly")
     assert evaluations[0].get_evaluation_with_run_ids().run_ids == {
         run.run_id for run in sorted_runs
     }
@@ -605,10 +605,10 @@ def test_asset_daemon_exception_recovery(daemon_not_paused_instance, crash_locat
     sorted_runs = sorted(runs[: len(scenario.expected_run_requests)], key=sort_run_key_fn)
 
     evaluations = instance.schedule_storage.get_auto_materialize_asset_evaluations(
-        asset_key=AssetKey("hourly"), limit=100
+        key=AssetKey("hourly"), limit=100
     )
     assert len(evaluations) == 1
-    assert evaluations[0].get_evaluation_with_run_ids().evaluation.asset_key == AssetKey("hourly")
+    assert evaluations[0].get_evaluation_with_run_ids().evaluation.key == AssetKey("hourly")
     assert evaluations[0].get_evaluation_with_run_ids().run_ids == {
         run.run_id for run in sorted_runs
     }

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
@@ -401,7 +401,7 @@ class AssetDaemonScenarioState(ScenarioState):
                     for e in check.not_none(
                         self.instance.schedule_storage
                     ).get_auto_materialize_evaluations_for_evaluation_id(current_evaluation_id)
-                    if e.asset_key == key
+                    if e.key == key
                 ]
             )
         )
@@ -420,7 +420,7 @@ class AssetDaemonScenarioState(ScenarioState):
         checked against the actual evaluation.
         """
         asset_key = AssetKey.from_coercible(key)
-        actual_evaluation = next((e for e in self.evaluations if e.asset_key == asset_key), None)
+        actual_evaluation = next((e for e in self.evaluations if e.key == asset_key), None)
 
         if actual_evaluation is None:
             try:

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -5,6 +5,7 @@ import sqlalchemy as db
 import sqlalchemy.dialects as db_dialects
 import sqlalchemy.pool as db_pool
 from dagster._config.config_schema import UserConfigSchema
+from dagster._core.definitions.asset_key import AssetKey, EntityKey
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AutomationConditionEvaluationWithRunIds,
 )
@@ -174,8 +175,8 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
     def add_auto_materialize_asset_evaluations(
         self,
         evaluation_id: int,
-        asset_evaluations: Sequence[AutomationConditionEvaluationWithRunIds],
-    ):
+        asset_evaluations: Sequence[AutomationConditionEvaluationWithRunIds[EntityKey]],
+    ) -> None:
         if not asset_evaluations:
             return
 
@@ -184,11 +185,13 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             [
                 {
                     "evaluation_id": evaluation_id,
-                    "asset_key": evaluation.asset_key.to_string(),
+                    "asset_key": evaluation.key.to_string(),
                     "asset_evaluation_body": serialize_value(evaluation),
                     "num_requested": evaluation.num_requested,
                 }
                 for evaluation in asset_evaluations
+                # this guard will be removed upstack
+                if isinstance(evaluation.key, AssetKey)
             ]
         )
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -5,6 +5,7 @@ import sqlalchemy as db
 import sqlalchemy.dialects as db_dialects
 import sqlalchemy.pool as db_pool
 from dagster._config.config_schema import UserConfigSchema
+from dagster._core.definitions.asset_key import AssetKey, EntityKey
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AutomationConditionEvaluationWithRunIds,
 )
@@ -183,7 +184,7 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
     def add_auto_materialize_asset_evaluations(
         self,
         evaluation_id: int,
-        asset_evaluations: Sequence[AutomationConditionEvaluationWithRunIds],
+        asset_evaluations: Sequence[AutomationConditionEvaluationWithRunIds[EntityKey]],
     ):
         if not asset_evaluations:
             return
@@ -192,11 +193,13 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             [
                 {
                     "evaluation_id": evaluation_id,
-                    "asset_key": evaluation.asset_key.to_string(),
+                    "asset_key": evaluation.key.to_string(),
                     "asset_evaluation_body": serialize_value(evaluation),
                     "num_requested": evaluation.num_requested,
                 }
                 for evaluation in asset_evaluations
+                # this guard will be removed upstack
+                if isinstance(evaluation.key, AssetKey)
             ]
         )
         upsert_stmt = insert_stmt.on_conflict_do_update(


### PR DESCRIPTION
## Summary & Motivation

This allows the serialized objects within the system to be generic (i.e. support either assets or asset checks).

This does not implement a method for storing AutomationConditionEvaluation objects that target AssetCheckKeys, as this will be handled in the next PR in the stack.

## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
