### PR TITLE
Cleanup Header components on all pages

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.tsx
@@ -20,7 +20,7 @@ export const PageHeader = (props: Props) => {
   return (
     <PageHeaderContainer
       background={Colors.backgroundLight()}
-      padding={{left: 24, right: 24}}
+      padding={{horizontal: 24}}
       border="bottom"
     >
       {title && (

--- a/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.tsx
@@ -6,7 +6,7 @@ import {Colors} from './Color';
 import {IconName} from './Icon';
 
 interface Props {
-  title: React.ReactNode;
+  title?: React.ReactNode;
   tags?: React.ReactNode;
   icon?: IconName;
   description?: React.ReactNode;
@@ -20,16 +20,21 @@ export const PageHeader = (props: Props) => {
   return (
     <PageHeaderContainer
       background={Colors.backgroundLight()}
-      padding={{top: 16, left: 24, right: 12}}
+      padding={{left: 24, right: 24}}
       border="bottom"
     >
-      <Box flex={{direction: 'row', justifyContent: 'space-between'}} padding={{bottom: 16}}>
-        <Box flex={{direction: 'row', alignItems: 'center', gap: 12, wrap: 'wrap'}}>
-          {title}
-          {tags}
+      {title && (
+        <Box
+          style={{minHeight: 52, alignContent: 'center'}}
+          flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
+        >
+          <Box flex={{direction: 'row', alignItems: 'center', gap: 12, wrap: 'wrap'}}>
+            {title}
+            {tags}
+          </Box>
+          {right}
         </Box>
-        {right}
-      </Box>
+      )}
       {tabs}
     </PageHeaderContainer>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
@@ -72,7 +72,7 @@ export const AssetPageHeader = ({
   return (
     <PageHeader
       title={
-        <Box flex={{alignItems: 'center', gap: 4}} style={{maxWidth: '600px', marginBottom: 4}}>
+        <Box flex={{alignItems: 'center', gap: 4}} style={{maxWidth: '600px'}}>
           <Title>
             <BreadcrumbsWithSlashes
               items={breadcrumbs}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
@@ -151,7 +151,7 @@ export const AssetTable = ({
         <Box
           background={Colors.backgroundDefault()}
           flex={{alignItems: 'center', gap: 12}}
-          padding={{vertical: 8, left: 24, right: 12}}
+          padding={{vertical: 12, left: 24, right: 24}}
           style={{position: 'sticky', top: 0, zIndex: 1}}
         >
           {actionBarComponents}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
@@ -151,7 +151,7 @@ export const AssetTable = ({
         <Box
           background={Colors.backgroundDefault()}
           flex={{alignItems: 'center', gap: 12}}
-          padding={{vertical: 12, left: 24, right: 24}}
+          padding={{vertical: 12, horizontal: 24}}
           style={{position: 'sticky', top: 0, zIndex: 1}}
         >
           {actionBarComponents}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -325,7 +325,7 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
           </Box>
         }
         right={
-          <Box style={{margin: '-4px 0'}} flex={{direction: 'row', gap: 8}}>
+          <Box flex={{direction: 'row'}}>
             {definition && definition.isObservable ? (
               <LaunchAssetObservationButton
                 primary

--- a/js_modules/dagster-ui/packages/ui-core/src/automation/MergedAutomationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/MergedAutomationRoot.tsx
@@ -1,4 +1,12 @@
-import {Box, NonIdealState, SpinnerWithText, TextInput, Tooltip} from '@dagster-io/ui-components';
+import {
+  Box,
+  Heading,
+  NonIdealState,
+  PageHeader,
+  SpinnerWithText,
+  TextInput,
+  Tooltip,
+} from '@dagster-io/ui-components';
 import {useContext, useMemo} from 'react';
 
 import {AutomationBulkActionMenu} from './AutomationBulkActionMenu';
@@ -282,8 +290,9 @@ export const MergedAutomationRoot = () => {
 
   return (
     <Box flex={{direction: 'column'}} style={{height: '100%', overflow: 'hidden'}}>
+      <PageHeader title={<Heading>Automation</Heading>} />
       <Box
-        padding={{horizontal: 24, vertical: 16}}
+        padding={{horizontal: 24, vertical: 12}}
         flex={{
           direction: 'row',
           alignItems: 'center',

--- a/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/jobs/JobsPageContent.tsx
@@ -150,7 +150,7 @@ export const JobsPageContent = () => {
   return (
     <>
       <Box
-        padding={{horizontal: 24, vertical: 16}}
+        padding={{horizontal: 24, vertical: 12}}
         flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between', grow: 0}}
       >
         <Box flex={{direction: 'row', gap: 12, alignItems: 'center'}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/PipelineNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/PipelineNav.tsx
@@ -1,6 +1,6 @@
 import {Box, Heading, PageHeader, Tag} from '@dagster-io/ui-components';
 import {useContext} from 'react';
-import {useRouteMatch} from 'react-router-dom';
+import {Link, useRouteMatch} from 'react-router-dom';
 
 import {JobMetadata} from './JobMetadata';
 import {RepositoryLink} from './RepositoryLink';
@@ -52,7 +52,7 @@ export const PipelineNav = (props: Props) => {
       <PageHeader
         title={
           <Heading style={{display: 'flex', flexDirection: 'row', gap: 4}}>
-            <a href="/jobs">Jobs</a>
+            <Link to="/jobs">Jobs</Link>
             <span>/</span>
             {pipelineName}
           </Heading>

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/PipelineNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/PipelineNav.tsx
@@ -50,7 +50,13 @@ export const PipelineNav = (props: Props) => {
   return (
     <>
       <PageHeader
-        title={<Heading>{pipelineName}</Heading>}
+        title={
+          <Heading style={{display: 'flex', flexDirection: 'row', gap: 4}}>
+            <a href="/jobs">Jobs</a>
+            <span>/</span>
+            {pipelineName}
+          </Heading>
+        }
         tags={
           <Box flex={{direction: 'row', alignItems: 'center', gap: 8, wrap: 'wrap'}}>
             <Tag icon="job">

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewPageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewPageHeader.tsx
@@ -1,4 +1,4 @@
-import {Box, Heading, PageHeader} from '@dagster-io/ui-components';
+import {Box, PageHeader} from '@dagster-io/ui-components';
 import React from 'react';
 import {OverviewPageAlerts} from 'shared/overview/OverviewPageAlerts.oss';
 
@@ -13,7 +13,6 @@ export const OverviewPageHeader = ({
   Omit<React.ComponentProps<typeof PageHeader>, 'title'>) => {
   return (
     <PageHeader
-      title={<Heading>Overview</Heading>}
       tabs={
         <Box flex={{direction: 'column', gap: 8}}>
           <OverviewTabs tab={tab} queryData={queryData} refreshState={refreshState} />

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
@@ -67,7 +67,7 @@ export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TDa
         <TabLink id="backfills" title="Backfills" to="/overview/backfills" />
       </Tabs>
       {refreshState ? (
-        <Box padding={{bottom: 8}}>
+        <Box style={{alignSelf: 'center'}}>
           <QueryRefreshCountdown refreshState={refreshState} />
         </Box>
       ) : null}

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTimelineRoot.tsx
@@ -140,7 +140,7 @@ export const OverviewTimelineRoot = ({Header}: Props) => {
     <>
       <Header refreshState={refreshState} />
       <Box
-        padding={{horizontal: 24, vertical: 16}}
+        padding={{horizontal: 24, vertical: 12}}
         flex={{alignItems: 'center', justifyContent: 'space-between', gap: 16}}
       >
         <Box flex={{direction: 'row', alignItems: 'center', gap: 12, grow: 0}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
@@ -102,8 +102,10 @@ export const RunRoot = () => {
       >
         <PageHeader
           title={
-            <Heading style={{fontFamily: FontFamily.monospace, fontSize: '16px'}}>
-              {runId.slice(0, 8)}
+            <Heading style={{display: 'flex', flexDirection: 'row', gap: 6}}>
+              <a href="/runs">Runs</a>
+              <span>/</span>
+              <span style={{fontFamily: FontFamily.monospace}}>{runId.slice(0, 8)}</span>
             </Heading>
           }
           tags={

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
@@ -1,6 +1,6 @@
 import {Box, FontFamily, Heading, NonIdealState, PageHeader, Tag} from '@dagster-io/ui-components';
 import {useMemo} from 'react';
-import {useParams} from 'react-router-dom';
+import {Link, useParams} from 'react-router-dom';
 
 import {AssetCheckTagCollection, AssetKeyTagCollection} from './AssetTagCollections';
 import {Run} from './Run';
@@ -103,7 +103,7 @@ export const RunRoot = () => {
         <PageHeader
           title={
             <Heading style={{display: 'flex', flexDirection: 'row', gap: 6}}>
-              <a href="/runs">Runs</a>
+              <Link to="/runs">Runs</Link>
               <span>/</span>
               <span style={{fontFamily: FontFamily.monospace}}>{runId.slice(0, 8)}</span>
             </Heading>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTableActionBar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTableActionBar.tsx
@@ -25,7 +25,7 @@ export function RunTableActionBar({
       {bottom ? (
         <Box
           margin={{top: 12}}
-          padding={{left: 24, right: 24, top: 8}}
+          padding={{horizontal: 24, top: 8}}
           border="top"
           flex={{gap: 8, wrap: 'wrap'}}
         >

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTableActionBar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTableActionBar.tsx
@@ -19,13 +19,13 @@ export function RunTableActionBar({
           : {}
       }
     >
-      <Box flex={{alignItems: 'center', gap: 12}} padding={{left: 24, right: 12}}>
+      <Box flex={{alignItems: 'center', gap: 12}} padding={{left: 24, right: 24}}>
         {top}
       </Box>
       {bottom ? (
         <Box
           margin={{top: 12}}
-          padding={{left: 24, right: 12, top: 8}}
+          padding={{left: 24, right: 24, top: 8}}
           border="top"
           flex={{gap: 8, wrap: 'wrap'}}
         >

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTableActionBar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTableActionBar.tsx
@@ -19,7 +19,7 @@ export function RunTableActionBar({
           : {}
       }
     >
-      <Box flex={{alignItems: 'center', gap: 12}} padding={{left: 24, right: 24}}>
+      <Box flex={{alignItems: 'center', gap: 12}} padding={{horizontal: 24}}>
         {top}
       </Box>
       {bottom ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsRoot.tsx
@@ -165,10 +165,7 @@ export const RunsRoot = () => {
               error.networkError.statusCode === 400
             );
             return (
-              <Box
-                flex={{direction: 'column', gap: 32}}
-                padding={{vertical: 8, left: 24, right: 12}}
-              >
+              <Box flex={{direction: 'column', gap: 32}} padding={{vertical: 8, horizontal: 24}}>
                 {actionBar()}
                 <NonIdealState
                   icon="warning"

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleDetails.tsx
@@ -9,6 +9,7 @@ import {
   Tag,
 } from '@dagster-io/ui-components';
 import {useState} from 'react';
+import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {SchedulePartitionStatus} from './SchedulePartitionStatus';
@@ -48,7 +49,7 @@ export const ScheduleDetails = (props: {
       <PageHeader
         title={
           <Heading style={{display: 'flex', flexDirection: 'row', gap: 4}}>
-            <a href="/automation">Automation</a>
+            <Link to="/automation">Automation</Link>
             <span>/</span>
             {name}
           </Heading>

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleDetails.tsx
@@ -46,7 +46,13 @@ export const ScheduleDetails = (props: {
   return (
     <>
       <PageHeader
-        title={<Heading>{name}</Heading>}
+        title={
+          <Heading style={{display: 'flex', flexDirection: 'row', gap: 4}}>
+            <a href="/automation">Automation</a>
+            <span>/</span>
+            {name}
+          </Heading>
+        }
         tags={
           <Tag icon="schedule">
             Schedule in <RepositoryLink repoAddress={repoAddress} />

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
@@ -10,6 +10,7 @@ import {
   Tooltip,
 } from '@dagster-io/ui-components';
 import {useState} from 'react';
+import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {EditCursorDialog} from './EditCursorDialog';
@@ -99,7 +100,7 @@ export const SensorDetails = ({
       <PageHeader
         title={
           <Heading style={{display: 'flex', flexDirection: 'row', gap: 4}}>
-            <a href="/automation">Automation</a>
+            <Link to="/automation">Automation</Link>
             <span>/</span>
             {name}
           </Heading>

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
@@ -97,7 +97,13 @@ export const SensorDetails = ({
   return (
     <>
       <PageHeader
-        title={<Heading>{name}</Heading>}
+        title={
+          <Heading style={{display: 'flex', flexDirection: 'row', gap: 4}}>
+            <a href="/automation">Automation</a>
+            <span>/</span>
+            {name}
+          </Heading>
+        }
         icon="sensors"
         tags={
           <Tag icon="sensors">

--- a/js_modules/dagster-ui/packages/ui-core/src/settings/SettingsLayout.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/settings/SettingsLayout.tsx
@@ -11,7 +11,7 @@ export const SettingsLayout = ({left, main}: Props) => {
   return (
     <Box style={{height: '100%', overflow: 'hidden'}} flex={{direction: 'column'}}>
       <PageHeader
-        title={<Heading>Settings</Heading>}
+        title={<Heading>Deployment</Heading>}
         right={<ReloadAllButton label="Reload definitions" />}
       />
       <Box style={{overflow: 'hidden'}} flex={{direction: 'row', grow: 1}}>


### PR DESCRIPTION
## Summary & Motivation
- makes headers a consistent height everywhere
- adds breadcrumbs to runs, automations, and jobs

<img width="1309" alt="image" src="https://github.com/user-attachments/assets/07aceeb2-10ef-4a69-8f4a-1b793d43b733">
<img width="1306" alt="image" src="https://github.com/user-attachments/assets/a1588290-b319-4a01-888e-0660e4e5a14d">
<img width="1308" alt="image" src="https://github.com/user-attachments/assets/c110270f-0a85-4a97-84a1-b0b5927c51a5">

## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
