### PR TITLE
Allow AutomationConditionEvaluation[AssetCheckKey] to be stored in the database

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_key.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_key.py
@@ -64,6 +64,9 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
 
     def to_string(self) -> str:
         """E.g. '["first_component", "second_component"]'."""
+        return self.to_db_string()
+
+    def to_db_string(self) -> str:
         return seven.json.dumps(self.path)
 
     def to_user_string(self) -> str:
@@ -196,6 +199,28 @@ class AssetCheckKey(NamedTuple):
         asset_key_str, name = user_string.split(":")
         return AssetCheckKey(AssetKey.from_user_string(asset_key_str), name)
 
+    @staticmethod
+    def from_db_string(db_string: str) -> Optional["AssetCheckKey"]:
+        try:
+            values = seven.json.loads(db_string)
+            if isinstance(values, dict) and values.keys() == {"asset_key", "check_name"}:
+                return AssetCheckKey(
+                    asset_key=check.not_none(AssetKey.from_db_string(values["asset_key"])),
+                    name=check.inst(values["check_name"], str),
+                )
+            else:
+                return None
+        except seven.JSONDecodeError:
+            return None
+
+    def to_db_string(self) -> str:
+        return seven.json.dumps({"asset_key": self.asset_key.to_string(), "check_name": self.name})
+
 
 EntityKey = Union[AssetKey, AssetCheckKey]
 T_EntityKey = TypeVar("T_EntityKey", AssetKey, AssetCheckKey, EntityKey)
+
+
+def entity_key_from_db_string(db_string: str) -> EntityKey:
+    check_key = AssetCheckKey.from_db_string(db_string)
+    return check_key if check_key else check.not_none(AssetKey.from_db_string(db_string))

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -17,7 +17,7 @@ from typing_extensions import TypeAlias
 
 import dagster._check as check
 from dagster._core.definitions import RunRequest
-from dagster._core.definitions.asset_key import T_EntityKey
+from dagster._core.definitions.asset_key import T_EntityKey, entity_key_from_db_string
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AutomationConditionEvaluationWithRunIds,
 )
@@ -788,8 +788,7 @@ class AutoMaterializeAssetEvaluationRecord(Generic[T_EntityKey]):
             serialized_evaluation_body=row["asset_evaluation_body"],
             evaluation_id=row["evaluation_id"],
             timestamp=utc_datetime_from_naive(row["create_timestamp"]).timestamp(),
-            # for now, only AssetKeys are stored in these rows
-            key=check.not_none(AssetKey.from_db_string(row["asset_key"])),
+            key=entity_key_from_db_string(row["asset_key"]),
         )
 
     def get_evaluation_with_run_ids(self) -> AutomationConditionEvaluationWithRunIds[T_EntityKey]:

--- a/python_modules/dagster/dagster/_utils/test/schedule_storage.py
+++ b/python_modules/dagster/dagster/_utils/test/schedule_storage.py
@@ -925,7 +925,6 @@ class TestScheduleStorage:
             == asset_subset_with_metadata
         )
 
-    @pytest.mark.xfail()
     def test_automation_condition_evaluations_check_key(self, storage) -> None:
         if not self.can_store_auto_materialize_asset_evaluations():
             pytest.skip("Storage cannot store auto materialize asset evaluations")
@@ -957,6 +956,7 @@ class TestScheduleStorage:
         res = storage.get_auto_materialize_asset_evaluations(key=check_key, limit=100)
         assert len(res) == 1
 
+        assert res[0].key == check_key
         assert res[0].get_evaluation_with_run_ids().evaluation.key == check_key
         assert res[0].evaluation_id == 10
         assert res[0].get_evaluation_with_run_ids().evaluation.true_subset.size == 1

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_entity_key.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_entity_key.py
@@ -1,0 +1,32 @@
+import pytest
+from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey, entity_key_from_db_string
+
+
+@pytest.mark.parametrize(
+    "check_key,expected",
+    [
+        (AssetKey("a"), '["a"]'),
+        (AssetKey(['a/b/c"d', 'e":-.f']), '["a/b/c\\"d", "e\\":-.f"]'),
+        (AssetCheckKey(AssetKey("a"), "b"), '{"asset_key": "[\\"a\\"]", "check_name": "b"}'),
+        (
+            AssetCheckKey(AssetKey(['a/b/c"d', 'e":-.f']), "b9!*:z7)'&xz\"./x/y"),
+            '{"asset_key": "[\\"a/b/c\\\\\\"d\\", \\"e\\\\\\":-.f\\"]", "check_name": "b9!*:z7)\'&xz\\"./x/y"}',
+        ),
+    ],
+)
+def test_valid_db_strings(check_key: AssetCheckKey, expected: str) -> None:
+    """Note: the expected string values should never be updated, as they are
+    stored in the database forever.
+    """
+    assert check_key.to_db_string() == expected
+    assert entity_key_from_db_string(check_key.to_db_string()) == check_key
+
+
+def test_invalid_db_strings() -> None:
+    # note: AssetKey has a catch-all method for converting any string to an asset key,
+    # so we're just making sure that that holds up and doesn't produce weird AssetCheckKeys
+    assert entity_key_from_db_string("random_stuff") == AssetKey("random_stuff")
+    assert entity_key_from_db_string('{"asset_key": "[\\"a\\"]"}') == AssetKey(["asset_key", "a"])
+    assert entity_key_from_db_string(
+        '{"asset_key": "[\\"a\\"]", "check_name": "b", "other": 1}'
+    ) == AssetKey(["asset_key", "a", "check_name", "b", "other", "1"])

--- a/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql/schedule_storage/schedule_storage.py
@@ -5,7 +5,7 @@ import sqlalchemy as db
 import sqlalchemy.dialects as db_dialects
 import sqlalchemy.pool as db_pool
 from dagster._config.config_schema import UserConfigSchema
-from dagster._core.definitions.asset_key import AssetKey, EntityKey
+from dagster._core.definitions.asset_key import EntityKey
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AutomationConditionEvaluationWithRunIds,
 )
@@ -185,13 +185,11 @@ class MySQLScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             [
                 {
                     "evaluation_id": evaluation_id,
-                    "asset_key": evaluation.key.to_string(),
+                    "asset_key": evaluation.key.to_db_string(),
                     "asset_evaluation_body": serialize_value(evaluation),
                     "num_requested": evaluation.num_requested,
                 }
                 for evaluation in asset_evaluations
-                # this guard will be removed upstack
-                if isinstance(evaluation.key, AssetKey)
             ]
         )
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres/schedule_storage/schedule_storage.py
@@ -5,7 +5,7 @@ import sqlalchemy as db
 import sqlalchemy.dialects as db_dialects
 import sqlalchemy.pool as db_pool
 from dagster._config.config_schema import UserConfigSchema
-from dagster._core.definitions.asset_key import AssetKey, EntityKey
+from dagster._core.definitions.asset_key import EntityKey
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AutomationConditionEvaluationWithRunIds,
 )
@@ -193,13 +193,11 @@ class PostgresScheduleStorage(SqlScheduleStorage, ConfigurableClass):
             [
                 {
                     "evaluation_id": evaluation_id,
-                    "asset_key": evaluation.key.to_string(),
+                    "asset_key": evaluation.key.to_db_string(),
                     "asset_evaluation_body": serialize_value(evaluation),
                     "num_requested": evaluation.num_requested,
                 }
                 for evaluation in asset_evaluations
-                # this guard will be removed upstack
-                if isinstance(evaluation.key, AssetKey)
             ]
         )
         upsert_stmt = insert_stmt.on_conflict_do_update(


### PR DESCRIPTION
## Summary & Motivation

This builds off the previous PR and actually lets these things be stored to / queried from the database.

Curious if people have better ideas for the serialization format. At the very least, it's under test so if something changes we'll know.

## How I Tested These Changes

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
