### PR TITLE
[PLUS-1363] Generate asset definition diff information

### DIFF
--- a/python_modules/dagster/dagster/_check/builder.py
+++ b/python_modules/dagster/dagster/_check/builder.py
@@ -260,6 +260,8 @@ def build_check_call_str(
     name: str,
     eval_ctx: EvalContext,
 ) -> str:
+    from dagster._record import _RECORD_MARKER_FIELD
+
     # assumes this module is in global/local scope as check
     origin = get_origin(ttype)
     args = get_args(ttype)
@@ -313,6 +315,11 @@ def build_check_call_str(
             return f'check.mapping_param({name}, "{name}", {_name(pair_left)}, {_name(pair_right)})'
         elif origin is collections.abc.Set:
             return f'check.set_param({name}, "{name}", {_name(single)})'
+        elif hasattr(origin, _RECORD_MARKER_FIELD):
+            it = _name(ttype)
+            return (
+                f'{name} if isinstance({name}, {it}) else check.inst_param({name}, "{name}", {it})'
+            )
         elif origin in (UnionType, Union):
             # optional
             if pair_right is type(None):

--- a/python_modules/dagster/dagster/_check/builder.py
+++ b/python_modules/dagster/dagster/_check/builder.py
@@ -260,8 +260,6 @@ def build_check_call_str(
     name: str,
     eval_ctx: EvalContext,
 ) -> str:
-    from dagster._record import _RECORD_MARKER_FIELD
-
     # assumes this module is in global/local scope as check
     origin = get_origin(ttype)
     args = get_args(ttype)
@@ -315,11 +313,6 @@ def build_check_call_str(
             return f'check.mapping_param({name}, "{name}", {_name(pair_left)}, {_name(pair_right)})'
         elif origin is collections.abc.Set:
             return f'check.set_param({name}, "{name}", {_name(single)})'
-        elif hasattr(origin, _RECORD_MARKER_FIELD):
-            it = _name(ttype)
-            return (
-                f'{name} if isinstance({name}, {it}) else check.inst_param({name}, "{name}", {it})'
-            )
         elif origin in (UnionType, Union):
             # optional
             if pair_right is type(None):

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -69,7 +69,7 @@ class AssetDefinitionDiff:
     """Represents the diff information for changes between assets.
 
     Change types in change_types should have diff info for their corresponding fields
-    if details are requested.
+    if diff info is requested.
 
     "NEW" and "REMOVED" change types do not have diff info.
     """
@@ -170,7 +170,7 @@ class AssetGraphDiffer:
         )
 
     def _compare_base_and_branch_assets(
-        self, asset_key: "AssetKey", include_details: bool = False
+        self, asset_key: "AssetKey", include_diff: bool = False
     ) -> AssetDefinitionDiff:
         """Computes the diff between a branch deployment asset and the
         corresponding base deployment asset.
@@ -198,14 +198,14 @@ class AssetGraphDiffer:
 
         if branch_asset.code_version != base_asset.code_version:
             change_types.add(AssetDefinitionChangeType.CODE_VERSION)
-            if include_details:
+            if include_diff:
                 code_version_diff = ValueDiff(
                     old=base_asset.code_version, new=branch_asset.code_version
                 )
 
         if branch_asset.parent_keys != base_asset.parent_keys:
             change_types.add(AssetDefinitionChangeType.DEPENDENCIES)
-            if include_details:
+            if include_diff:
                 dependencies_diff = DictDiff(
                     added_keys=branch_asset.parent_keys - base_asset.parent_keys,
                     changed_keys=set(),
@@ -220,7 +220,7 @@ class AssetGraphDiffer:
                     asset_key, upstream_asset
                 ) != self.base_asset_graph.get_partition_mapping(asset_key, upstream_asset):
                     change_types.add(AssetDefinitionChangeType.DEPENDENCIES)
-                    if include_details:
+                    if include_diff:
                         dependencies_diff = DictDiff(
                             added_keys=set(),
                             changed_keys={upstream_asset},
@@ -230,7 +230,7 @@ class AssetGraphDiffer:
 
         if branch_asset.partitions_def != base_asset.partitions_def:
             change_types.add(AssetDefinitionChangeType.PARTITIONS_DEFINITION)
-            if include_details:
+            if include_diff:
                 partitions_definition_diff = ValueDiff(
                     old=type(base_asset.partitions_def).__name__
                     if base_asset.partitions_def
@@ -242,7 +242,7 @@ class AssetGraphDiffer:
 
         if branch_asset.tags != base_asset.tags:
             change_types.add(AssetDefinitionChangeType.TAGS)
-            if include_details:
+            if include_diff:
                 added, changed, removed = self._get_map_keys_diff(
                     base_asset.tags, branch_asset.tags
                 )
@@ -250,7 +250,7 @@ class AssetGraphDiffer:
 
         if branch_asset.metadata != base_asset.metadata:
             change_types.add(AssetDefinitionChangeType.METADATA)
-            if include_details:
+            if include_diff:
                 added, changed, removed = self._get_map_keys_diff(
                     base_asset.metadata, branch_asset.metadata
                 )
@@ -280,9 +280,9 @@ class AssetGraphDiffer:
         """Returns list of AssetDefinitionChangeType for asset_key as compared to the base deployment."""
         return list(self._compare_base_and_branch_assets(asset_key).change_types)
 
-    def get_changes_for_asset_with_details(self, asset_key: "AssetKey") -> AssetDefinitionDiff:
-        """Returns list of AssetDefinitionChangeDetail for asset_key as compared to the base deployment."""
-        return self._compare_base_and_branch_assets(asset_key, include_details=True)
+    def get_changes_for_asset_with_diff(self, asset_key: "AssetKey") -> AssetDefinitionDiff:
+        """Returns list of AssetDefinitionDiff for asset_key as compared to the base deployment."""
+        return self._compare_base_and_branch_assets(asset_key, include_diff=True)
 
     @property
     def branch_asset_graph(self) -> "RemoteAssetGraph":

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import AbstractSet, Any, Callable, Mapping, Optional, Sequence, Set, Tuple, Union
+from typing import AbstractSet, Any, Callable, Mapping, NamedTuple, Optional, Sequence, Set, Union
 
 import dagster._check as check
 from dagster._core.definitions.events import AssetKey
@@ -92,6 +92,12 @@ AssetDefinitionChangeDetail = Union[
     AssetDefinitionChangeDetailMetadata,
     AssetDefinitionChangeDetailRemoved,
 ]
+
+
+class MappedKeyDiff(NamedTuple):
+    added: Set[str]
+    changed: Set[str]
+    removed: Set[str]
 
 
 def _get_external_repo_from_context(
@@ -282,12 +288,12 @@ class AssetGraphDiffer:
 
     def _get_map_keys_diff(
         self, base: Mapping[str, Any], branch: Mapping[str, Any]
-    ) -> Tuple[Set[str], Set[str], Set[str]]:
+    ) -> MappedKeyDiff:
         """Returns the added, changed, and removed keys in the branch map compared to the base map."""
         added = set(branch.keys()) - set(base.keys())
         changed = {key for key in branch.keys() if key in base and branch[key] != base[key]}
         removed = set(base.keys()) - set(branch.keys())
-        return added, changed, removed
+        return MappedKeyDiff(added, changed, removed)
 
     def get_changes_for_asset(self, asset_key: "AssetKey") -> Sequence[AssetDefinitionChangeType]:
         """Returns list of AssetDefinitionChangeType for asset_key as compared to the base deployment."""

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import AbstractSet, Any, Callable, Mapping, NamedTuple, Optional, Sequence, Set, Union
+from typing import Any, Callable, Mapping, NamedTuple, Optional, Sequence, Set, Union
 
 import dagster._check as check
 from dagster._core.definitions.events import AssetKey
@@ -45,9 +45,9 @@ class AssetDefinitionChangeDetailCodeVersion:
 @record
 class AssetDefinitionChangeDetailDependencies:
     change_type: AssetDefinitionChangeType = AssetDefinitionChangeType.DEPENDENCIES
-    added: AbstractSet[AssetKey] = set()
-    changed: AbstractSet[AssetKey] = set()
-    removed: AbstractSet[AssetKey] = set()
+    added: Sequence[AssetKey] = []
+    changed: Sequence[AssetKey] = []
+    removed: Sequence[AssetKey] = []
 
 
 @whitelist_for_serdes
@@ -222,8 +222,8 @@ class AssetGraphDiffer:
             if include_details:
                 changes.append(
                     AssetDefinitionChangeDetailDependencies(
-                        added=branch_asset.parent_keys - base_asset.parent_keys,
-                        removed=base_asset.parent_keys - branch_asset.parent_keys,
+                        added=list(branch_asset.parent_keys - base_asset.parent_keys),
+                        removed=list(base_asset.parent_keys - branch_asset.parent_keys),
                     )
                 )
             else:
@@ -237,7 +237,7 @@ class AssetGraphDiffer:
                 ) != self.base_asset_graph.get_partition_mapping(asset_key, upstream_asset):
                     if include_details:
                         changes.append(
-                            AssetDefinitionChangeDetailDependencies(changed={upstream_asset})
+                            AssetDefinitionChangeDetailDependencies(changed=[upstream_asset])
                         )
                     else:
                         changes.append(AssetDefinitionChangeDetailDependencies())

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -1,17 +1,14 @@
 from enum import Enum
-from typing import TYPE_CHECKING, AbstractSet, Callable, Mapping, Optional, Sequence, Union
+from typing import AbstractSet, Any, Callable, Mapping, Optional, Sequence, Set, Tuple, Union
 
 import dagster._check as check
-from dagster._core.definitions.metadata import ArbitraryMetadataMapping
+from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.remote_representation import ExternalRepository
 from dagster._core.workspace.context import BaseWorkspaceRequestContext
 from dagster._record import record
 from dagster._serdes import whitelist_for_serdes
-
-if TYPE_CHECKING:
-    from dagster._core.definitions.events import AssetKey
 
 
 @whitelist_for_serdes
@@ -40,42 +37,43 @@ class AssetDefinitionChangeDetailNew:
 @record
 class AssetDefinitionChangeDetailCodeVersion:
     change_type: AssetDefinitionChangeType = AssetDefinitionChangeType.CODE_VERSION
-    base_value: Optional[str]
-    branch_value: Optional[str]
+    base_value: Optional[str] = None
+    branch_value: Optional[str] = None
 
 
 @whitelist_for_serdes
 @record
 class AssetDefinitionChangeDetailDependencies:
-    """Represents the detailed information about the specific changes between base and branch assets."""
-
     change_type: AssetDefinitionChangeType = AssetDefinitionChangeType.DEPENDENCIES
-    base_value: Optional[AbstractSet["AssetKey"]]
-    branch_value: Optional[AbstractSet["AssetKey"]]
+    added: AbstractSet[AssetKey] = set()
+    changed: AbstractSet[AssetKey] = set()
+    removed: AbstractSet[AssetKey] = set()
 
 
 @whitelist_for_serdes
 @record
 class AssetDefinitionChangeDetailPartitionsDefinition:
     change_type: AssetDefinitionChangeType = AssetDefinitionChangeType.PARTITIONS_DEFINITION
-    base_value: Optional[str]
-    branch_value: Optional[str]
+    base_value: Optional[str] = None
+    branch_value: Optional[str] = None
 
 
 @whitelist_for_serdes
 @record
 class AssetDefinitionChangeDetailTags:
     change_type: AssetDefinitionChangeType = AssetDefinitionChangeType.TAGS
-    base_value: Mapping[str, str]
-    branch_value: Mapping[str, str]
+    added: Sequence[str] = []
+    changed: Sequence[str] = []
+    removed: Sequence[str] = []
 
 
 @whitelist_for_serdes
 @record
 class AssetDefinitionChangeDetailMetadata:
     change_type: AssetDefinitionChangeType = AssetDefinitionChangeType.METADATA
-    base_value: ArbitraryMetadataMapping
-    branch_value: ArbitraryMetadataMapping
+    added: Sequence[str] = []
+    changed: Sequence[str] = []
+    removed: Sequence[str] = []
 
 
 @whitelist_for_serdes
@@ -84,6 +82,7 @@ class AssetDefinitionChangeDetailRemoved:
     change_type: AssetDefinitionChangeType = AssetDefinitionChangeType.REMOVED
 
 
+"""Represents the diff information for changes between base and branch assets."""
 AssetDefinitionChangeDetail = Union[
     AssetDefinitionChangeDetailNew,
     AssetDefinitionChangeDetailCodeVersion,
@@ -183,54 +182,7 @@ class AssetGraphDiffer:
         )
 
     def _compare_base_and_branch_assets(
-        self, asset_key: "AssetKey"
-    ) -> Sequence[AssetDefinitionChangeType]:
-        """Computes the diff between a branch deployment asset and the
-        corresponding base deployment asset.
-        """
-        if self.base_asset_graph is None:
-            # if the base asset graph is None, it is because the asset graph in the branch deployment
-            # is new and doesn't exist in the base deployment. Thus all assets are new.
-            return [AssetDefinitionChangeType.NEW]
-
-        if asset_key not in self.base_asset_graph.all_asset_keys:
-            return [AssetDefinitionChangeType.NEW]
-
-        if asset_key not in self.branch_asset_graph.all_asset_keys:
-            return [AssetDefinitionChangeType.REMOVED]
-
-        branch_asset = self.branch_asset_graph.get(asset_key)
-        base_asset = self.base_asset_graph.get(asset_key)
-
-        changes = []
-        if branch_asset.code_version != base_asset.code_version:
-            changes.append(AssetDefinitionChangeType.CODE_VERSION)
-
-        if branch_asset.parent_keys != base_asset.parent_keys:
-            changes.append(AssetDefinitionChangeType.DEPENDENCIES)
-        else:
-            # if the set of upstream dependencies is different, then we don't need to check if the partition mappings
-            # for dependencies have changed since ChangeReason.DEPENDENCIES is already in the list of changes
-            for upstream_asset in branch_asset.parent_keys:
-                if self.branch_asset_graph.get_partition_mapping(
-                    asset_key, upstream_asset
-                ) != self.base_asset_graph.get_partition_mapping(asset_key, upstream_asset):
-                    changes.append(AssetDefinitionChangeType.DEPENDENCIES)
-                    break
-
-        if branch_asset.partitions_def != base_asset.partitions_def:
-            changes.append(AssetDefinitionChangeType.PARTITIONS_DEFINITION)
-
-        if branch_asset.tags != base_asset.tags:
-            changes.append(AssetDefinitionChangeType.TAGS)
-
-        if branch_asset.metadata != base_asset.metadata:
-            changes.append(AssetDefinitionChangeType.METADATA)
-
-        return changes
-
-    def _compare_base_and_branch_assets_detail(
-        self, asset_key: "AssetKey"
+        self, asset_key: "AssetKey", include_details: bool = False
     ) -> Sequence[AssetDefinitionChangeDetail]:
         """Computes the diff between a branch deployment asset and the
         corresponding base deployment asset.
@@ -251,67 +203,101 @@ class AssetGraphDiffer:
 
         changes: Sequence[AssetDefinitionChangeDetail] = []
         if branch_asset.code_version != base_asset.code_version:
-            changes.append(
-                AssetDefinitionChangeDetailCodeVersion(
-                    base_value=base_asset.code_version, branch_value=branch_asset.code_version
+            if include_details:
+                changes.append(
+                    AssetDefinitionChangeDetailCodeVersion(
+                        base_value=base_asset.code_version, branch_value=branch_asset.code_version
+                    )
                 )
-            )
+            else:
+                changes.append(AssetDefinitionChangeDetailCodeVersion())
 
         if branch_asset.parent_keys != base_asset.parent_keys:
-            changes.append(
-                AssetDefinitionChangeDetailDependencies(
-                    base_value=base_asset.parent_keys, branch_value=branch_asset.parent_keys
+            if include_details:
+                changes.append(
+                    AssetDefinitionChangeDetailDependencies(
+                        added=branch_asset.parent_keys - base_asset.parent_keys,
+                        removed=base_asset.parent_keys - branch_asset.parent_keys,
+                    )
                 )
-            )
-        # else:
-        #     # if the set of upstream dependencies is different, then we don't need to check if the partition mappings
-        #     # for dependencies have changed since ChangeReason.DEPENDENCIES is already in the list of changes
-        #     for upstream_asset in branch_asset.parent_keys:
-        #         if self.branch_asset_graph.get_partition_mapping(
-        #             asset_key, upstream_asset
-        #         ) != self.base_asset_graph.get_partition_mapping(asset_key, upstream_asset):
-        #             changes.append(AssetDefinitionChangeType.DEPENDENCIES)
-        #             break
+            else:
+                changes.append(AssetDefinitionChangeDetailDependencies())
+        else:
+            # if the set of upstream dependencies is different, then we don't need to check if the partition mappings
+            # for dependencies have changed since ChangeReason.DEPENDENCIES is already in the list of changes
+            for upstream_asset in branch_asset.parent_keys:
+                if self.branch_asset_graph.get_partition_mapping(
+                    asset_key, upstream_asset
+                ) != self.base_asset_graph.get_partition_mapping(asset_key, upstream_asset):
+                    if include_details:
+                        changes.append(
+                            AssetDefinitionChangeDetailDependencies(changed={upstream_asset})
+                        )
+                    else:
+                        changes.append(AssetDefinitionChangeDetailDependencies())
+                    break
 
         if branch_asset.partitions_def != base_asset.partitions_def:
-            changes.append(
-                AssetDefinitionChangeDetailPartitionsDefinition(
-                    base_value=type(base_asset.partitions_def).__name__
-                    if base_asset.partitions_def
-                    else None,
-                    branch_value=type(branch_asset.partitions_def).__name__
-                    if branch_asset.partitions_def
-                    else None,
+            if include_details:
+                changes.append(
+                    AssetDefinitionChangeDetailPartitionsDefinition(
+                        base_value=type(base_asset.partitions_def).__name__
+                        if base_asset.partitions_def
+                        else None,
+                        branch_value=type(branch_asset.partitions_def).__name__
+                        if branch_asset.partitions_def
+                        else None,
+                    )
                 )
-            )
+            else:
+                changes.append(AssetDefinitionChangeDetailPartitionsDefinition())
 
         if branch_asset.tags != base_asset.tags:
-            changes.append(
-                AssetDefinitionChangeDetailTags(
-                    base_value=base_asset.tags, branch_value=branch_asset.tags
+            if include_details:
+                added, changed, removed = self._get_map_keys_diff(
+                    base_asset.tags, branch_asset.tags
                 )
-            )
+                changes.append(
+                    AssetDefinitionChangeDetailTags(
+                        added=list(added), changed=list(changed), removed=list(removed)
+                    )
+                )
+            else:
+                changes.append(AssetDefinitionChangeDetailTags())
 
         if branch_asset.metadata != base_asset.metadata:
-            changes.append(
-                AssetDefinitionChangeDetailMetadata(
-                    base_value=base_asset.metadata, branch_value=branch_asset.metadata
+            if include_details:
+                added, changed, removed = self._get_map_keys_diff(
+                    base_asset.metadata, branch_asset.metadata
                 )
-            )
+                changes.append(
+                    AssetDefinitionChangeDetailMetadata(
+                        added=list(added), changed=list(changed), removed=list(removed)
+                    )
+                )
+            else:
+                changes.append(AssetDefinitionChangeDetailMetadata())
 
         return changes
 
-    def get_changes_for_asset(
-        self, asset_key: "AssetKey", include_details=False
-    ) -> Sequence[AssetDefinitionChangeType]:
-        """Returns list of ChangeReasons for asset_key as compared to the base deployment."""
-        return self._compare_base_and_branch_assets(asset_key)
+    def _get_map_keys_diff(
+        self, base: Mapping[str, Any], branch: Mapping[str, Any]
+    ) -> Tuple[Set[str], Set[str], Set[str]]:
+        """Returns the added, changed, and removed keys in the branch map compared to the base map."""
+        added = set(branch.keys()) - set(base.keys())
+        changed = {key for key in branch.keys() if key in base and branch[key] != base[key]}
+        removed = set(base.keys()) - set(branch.keys())
+        return added, changed, removed
 
-    def get_changes_for_asset_detail(
+    def get_changes_for_asset(self, asset_key: "AssetKey") -> Sequence[AssetDefinitionChangeType]:
+        """Returns list of AssetDefinitionChangeType for asset_key as compared to the base deployment."""
+        return [change.change_type for change in self._compare_base_and_branch_assets(asset_key)]
+
+    def get_changes_for_asset_with_details(
         self, asset_key: "AssetKey"
     ) -> Sequence[AssetDefinitionChangeDetail]:
         """Returns list of AssetDefinitionChangeDetail for asset_key as compared to the base deployment."""
-        return self._compare_base_and_branch_assets_detail(asset_key)
+        return self._compare_base_and_branch_assets(asset_key, include_details=True)
 
     @property
     def branch_asset_graph(self) -> "RemoteAssetGraph":

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -40,9 +40,9 @@ class AssetDefinitionChangeType(Enum):
 
 
 class MappedKeyDiff(NamedTuple):
-    added: Set[str]
-    changed: Set[str]
-    removed: Set[str]
+    added: AbstractSet[str]
+    changed: AbstractSet[str]
+    removed: AbstractSet[str]
 
 
 T = TypeVar("T")

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -176,7 +176,7 @@ def test_new_asset_connected(instance):
         AssetDefinitionChangeDetailNew()
     ]
     assert differ.get_changes_for_asset_with_details(AssetKey("downstream")) == [
-        AssetDefinitionChangeDetailDependencies(added={AssetKey("new_asset")})
+        AssetDefinitionChangeDetailDependencies(added=[AssetKey("new_asset")])
     ]
     assert len(differ.get_changes_for_asset_with_details(AssetKey("upstream"))) == 0
 
@@ -219,7 +219,7 @@ def test_change_inputs(instance):
     ]
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
     assert differ.get_changes_for_asset_with_details(AssetKey("downstream")) == [
-        AssetDefinitionChangeDetailDependencies(removed={AssetKey("upstream")})
+        AssetDefinitionChangeDetailDependencies(removed=[AssetKey("upstream")])
     ]
     assert len(differ.get_changes_for_asset_with_details(AssetKey("upstream"))) == 0
 
@@ -244,7 +244,7 @@ def test_multiple_changes_for_one_asset(instance):
             base_value="1",
             branch_value="2",
         ),
-        AssetDefinitionChangeDetailDependencies(removed={AssetKey("upstream")}),
+        AssetDefinitionChangeDetailDependencies(removed=[AssetKey("upstream")]),
     ]
     assert len(differ.get_changes_for_asset_with_details(AssetKey("upstream"))) == 0
 
@@ -331,7 +331,7 @@ def test_multiple_code_locations(instance):
         AssetDefinitionChangeDetailNew()
     ]
     assert differ.get_changes_for_asset_with_details(AssetKey("downstream")) == [
-        AssetDefinitionChangeDetailDependencies(added={AssetKey("new_asset")})
+        AssetDefinitionChangeDetailDependencies(added=[AssetKey("new_asset")])
     ]
     assert len(differ.get_changes_for_asset_with_details(AssetKey("upstream"))) == 0
 
@@ -445,17 +445,17 @@ def test_change_partition_mapping(instance):
     ]
     assert len(differ.get_changes_for_asset_with_details(AssetKey("daily_upstream"))) == 0
     assert differ.get_changes_for_asset_with_details(AssetKey("daily_downstream")) == [
-        AssetDefinitionChangeDetailDependencies(changed={AssetKey("daily_upstream")})
+        AssetDefinitionChangeDetailDependencies(changed=[AssetKey("daily_upstream")])
     ]
     assert len(differ.get_changes_for_asset_with_details(AssetKey("static_upstream"))) == 0
     assert differ.get_changes_for_asset_with_details(AssetKey("static_downstream")) == [
-        AssetDefinitionChangeDetailDependencies(changed={AssetKey("static_upstream")})
+        AssetDefinitionChangeDetailDependencies(changed=[AssetKey("static_upstream")])
     ]
     assert (
         len(differ.get_changes_for_asset_with_details(AssetKey("multi_partitioned_upstream"))) == 0
     )
     assert differ.get_changes_for_asset_with_details(AssetKey("multi_partitioned_downstream")) == [
-        AssetDefinitionChangeDetailDependencies(changed={AssetKey("multi_partitioned_upstream")})
+        AssetDefinitionChangeDetailDependencies(changed=[AssetKey("multi_partitioned_upstream")])
     ]
 
 

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -127,10 +127,10 @@ def test_new_asset(instance):
 
     assert differ.get_changes_for_asset(AssetKey("new_asset")) == [AssetDefinitionChangeType.NEW]
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
-    assert differ.get_changes_for_asset_with_details(AssetKey("new_asset")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("new_asset")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.NEW}
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
         change_types=set()
     )
 
@@ -149,10 +149,10 @@ def test_removed_asset(instance) -> None:
         AssetDefinitionChangeType.REMOVED
     ]
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
-    assert differ.get_changes_for_asset_with_details(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.REMOVED}
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
         change_types=set()
     )
 
@@ -172,16 +172,16 @@ def test_new_asset_connected(instance):
         AssetDefinitionChangeType.DEPENDENCIES
     ]
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
-    assert differ.get_changes_for_asset_with_details(AssetKey("new_asset")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("new_asset")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.NEW},
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.DEPENDENCIES},
         dependencies=DictDiff(
             added_keys={AssetKey("new_asset")}, changed_keys=set(), removed_keys=set()
         ),
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
         change_types=set()
     )
 
@@ -200,11 +200,11 @@ def test_update_code_version(instance):
         AssetDefinitionChangeType.CODE_VERSION
     ]
     assert len(differ.get_changes_for_asset(AssetKey("downstream"))) == 0
-    assert differ.get_changes_for_asset_with_details(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.CODE_VERSION},
         code_version=ValueDiff(old="1", new="2"),
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
         change_types=set()
     )
 
@@ -223,13 +223,13 @@ def test_change_inputs(instance):
         AssetDefinitionChangeType.DEPENDENCIES
     ]
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
-    assert differ.get_changes_for_asset_with_details(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.DEPENDENCIES},
         dependencies=DictDiff(
             added_keys=set(), changed_keys=set(), removed_keys={AssetKey("upstream")}
         ),
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
         change_types=set()
     )
 
@@ -249,7 +249,7 @@ def test_multiple_changes_for_one_asset(instance):
         AssetDefinitionChangeType.DEPENDENCIES,
     }
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
-    assert differ.get_changes_for_asset_with_details(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
         change_types={
             AssetDefinitionChangeType.DEPENDENCIES,
             AssetDefinitionChangeType.CODE_VERSION,
@@ -259,7 +259,7 @@ def test_multiple_changes_for_one_asset(instance):
             added_keys=set(), changed_keys=set(), removed_keys={AssetKey("upstream")}
         ),
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
         change_types=set()
     )
 
@@ -278,11 +278,11 @@ def test_change_then_revert(instance):
         AssetDefinitionChangeType.CODE_VERSION
     ]
     assert len(differ.get_changes_for_asset(AssetKey("downstream"))) == 0
-    assert differ.get_changes_for_asset_with_details(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.CODE_VERSION},
         code_version=ValueDiff(old="1", new="2"),
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
         change_types=set()
     )
 
@@ -295,10 +295,10 @@ def test_change_then_revert(instance):
 
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
     assert len(differ.get_changes_for_asset(AssetKey("downstream"))) == 0
-    assert differ.get_changes_for_asset_with_details(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
         change_types=set()
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
         change_types=set()
     )
 
@@ -316,14 +316,14 @@ def test_large_asset_graph(instance):
     for i in range(6, 1000):
         key = AssetKey(f"asset_{i}")
         assert differ.get_changes_for_asset(key) == [AssetDefinitionChangeType.DEPENDENCIES]
-        assert differ.get_changes_for_asset_with_details(key).change_types == {
+        assert differ.get_changes_for_asset_with_diff(key).change_types == {
             AssetDefinitionChangeType.DEPENDENCIES
         }
 
     for i in range(6):
         key = AssetKey(f"asset_{i}")
         assert len(differ.get_changes_for_asset(key)) == 0
-        assert differ.get_changes_for_asset_with_details(key) == AssetDefinitionDiff(
+        assert differ.get_changes_for_asset_with_diff(key) == AssetDefinitionDiff(
             change_types=set()
         )
 
@@ -347,16 +347,16 @@ def test_multiple_code_locations(instance):
         AssetDefinitionChangeType.DEPENDENCIES
     ]
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
-    assert differ.get_changes_for_asset_with_details(AssetKey("new_asset")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("new_asset")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.NEW},
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.DEPENDENCIES},
         dependencies=DictDiff(
             added_keys={AssetKey("new_asset")}, changed_keys=set(), removed_keys=set()
         ),
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
         change_types=set()
     )
 
@@ -371,13 +371,13 @@ def test_new_code_location(instance):
     assert differ.get_changes_for_asset(AssetKey("new_asset")) == [AssetDefinitionChangeType.NEW]
     assert differ.get_changes_for_asset(AssetKey("upstream")) == [AssetDefinitionChangeType.NEW]
     assert differ.get_changes_for_asset(AssetKey("downstream")) == [AssetDefinitionChangeType.NEW]
-    assert differ.get_changes_for_asset_with_details(AssetKey("new_asset")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("new_asset")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.NEW},
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.NEW},
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.NEW},
     )
 
@@ -409,7 +409,7 @@ def test_change_partitions_definitions(instance):
     assert differ.get_changes_for_asset(AssetKey("multi_partitioned_downstream")) == [
         AssetDefinitionChangeType.PARTITIONS_DEFINITION
     ]
-    assert differ.get_changes_for_asset_with_details(
+    assert differ.get_changes_for_asset_with_diff(
         AssetKey("daily_upstream")
     ) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.PARTITIONS_DEFINITION},
@@ -417,7 +417,7 @@ def test_change_partitions_definitions(instance):
             old="TimeWindowPartitionsDefinition", new="TimeWindowPartitionsDefinition"
         ),
     )
-    assert differ.get_changes_for_asset_with_details(
+    assert differ.get_changes_for_asset_with_diff(
         AssetKey("daily_downstream")
     ) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.PARTITIONS_DEFINITION},
@@ -425,7 +425,7 @@ def test_change_partitions_definitions(instance):
             old="TimeWindowPartitionsDefinition", new="TimeWindowPartitionsDefinition"
         ),
     )
-    assert differ.get_changes_for_asset_with_details(
+    assert differ.get_changes_for_asset_with_diff(
         AssetKey("static_upstream")
     ) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.PARTITIONS_DEFINITION},
@@ -433,7 +433,7 @@ def test_change_partitions_definitions(instance):
             old="StaticPartitionsDefinition", new="StaticPartitionsDefinition"
         ),
     )
-    assert differ.get_changes_for_asset_with_details(
+    assert differ.get_changes_for_asset_with_diff(
         AssetKey("static_downstream")
     ) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.PARTITIONS_DEFINITION},
@@ -441,7 +441,7 @@ def test_change_partitions_definitions(instance):
             old="StaticPartitionsDefinition", new="StaticPartitionsDefinition"
         ),
     )
-    assert differ.get_changes_for_asset_with_details(
+    assert differ.get_changes_for_asset_with_diff(
         AssetKey("multi_partitioned_upstream")
     ) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.PARTITIONS_DEFINITION},
@@ -449,7 +449,7 @@ def test_change_partitions_definitions(instance):
             old="MultiPartitionsDefinition", new="MultiPartitionsDefinition"
         ),
     )
-    assert differ.get_changes_for_asset_with_details(
+    assert differ.get_changes_for_asset_with_diff(
         AssetKey("multi_partitioned_downstream")
     ) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.PARTITIONS_DEFINITION},
@@ -480,10 +480,10 @@ def test_change_partition_mapping(instance):
     assert differ.get_changes_for_asset(AssetKey("multi_partitioned_downstream")) == [
         AssetDefinitionChangeType.DEPENDENCIES
     ]
-    assert differ.get_changes_for_asset_with_details(
+    assert differ.get_changes_for_asset_with_diff(
         AssetKey("daily_upstream")
     ) == AssetDefinitionDiff(change_types=set())
-    assert differ.get_changes_for_asset_with_details(
+    assert differ.get_changes_for_asset_with_diff(
         AssetKey("daily_downstream")
     ) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.DEPENDENCIES},
@@ -491,10 +491,10 @@ def test_change_partition_mapping(instance):
             added_keys=set(), changed_keys={AssetKey("daily_upstream")}, removed_keys=set()
         ),
     )
-    assert differ.get_changes_for_asset_with_details(
+    assert differ.get_changes_for_asset_with_diff(
         AssetKey("static_upstream")
     ) == AssetDefinitionDiff(change_types=set())
-    assert differ.get_changes_for_asset_with_details(
+    assert differ.get_changes_for_asset_with_diff(
         AssetKey("static_downstream")
     ) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.DEPENDENCIES},
@@ -502,10 +502,10 @@ def test_change_partition_mapping(instance):
             added_keys=set(), changed_keys={AssetKey("static_upstream")}, removed_keys=set()
         ),
     )
-    assert differ.get_changes_for_asset_with_details(
+    assert differ.get_changes_for_asset_with_diff(
         AssetKey("multi_partitioned_upstream")
     ) == AssetDefinitionDiff(change_types=set())
-    assert differ.get_changes_for_asset_with_details(
+    assert differ.get_changes_for_asset_with_diff(
         AssetKey("multi_partitioned_downstream")
     ) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.DEPENDENCIES},
@@ -529,23 +529,23 @@ def test_change_tags(instance):
     assert differ.get_changes_for_asset(AssetKey("fruits")) == [AssetDefinitionChangeType.TAGS]
     assert differ.get_changes_for_asset(AssetKey("letters")) == [AssetDefinitionChangeType.TAGS]
     assert len(differ.get_changes_for_asset(AssetKey("numbers"))) == 0
-    assert differ.get_changes_for_asset_with_details(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.TAGS},
         tags=DictDiff(added_keys=set(), changed_keys=set(), removed_keys={"one"}),
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.TAGS},
         tags=DictDiff(added_keys=set(), changed_keys={"baz"}, removed_keys=set()),
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("fruits")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("fruits")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.TAGS},
         tags=DictDiff(added_keys={"green"}, changed_keys=set(), removed_keys={"red"}),
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("letters")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("letters")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.TAGS},
         tags=DictDiff(added_keys={"c"}, changed_keys=set(), removed_keys=set()),
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("numbers")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("numbers")) == AssetDefinitionDiff(
         change_types=set()
     )
 
@@ -568,7 +568,7 @@ def test_change_metadata(instance):
     assert differ.get_changes_for_asset(AssetKey("fruits")) == [AssetDefinitionChangeType.METADATA]
     assert differ.get_changes_for_asset(AssetKey("letters")) == [AssetDefinitionChangeType.METADATA]
     assert len(differ.get_changes_for_asset(AssetKey("numbers"))) == 0
-    assert differ.get_changes_for_asset_with_details(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.METADATA},
         metadata=DictDiff(
             added_keys=set(),
@@ -576,7 +576,7 @@ def test_change_metadata(instance):
             removed_keys={"one"},
         ),
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.METADATA},
         metadata=DictDiff(
             added_keys=set(),
@@ -584,7 +584,7 @@ def test_change_metadata(instance):
             removed_keys=set(),
         ),
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("fruits")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("fruits")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.METADATA},
         metadata=DictDiff(
             added_keys={"green"},
@@ -592,7 +592,7 @@ def test_change_metadata(instance):
             removed_keys={"red"},
         ),
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("letters")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("letters")) == AssetDefinitionDiff(
         change_types={AssetDefinitionChangeType.METADATA},
         metadata=DictDiff(
             added_keys={"c"},
@@ -600,6 +600,6 @@ def test_change_metadata(instance):
             removed_keys=set(),
         ),
     )
-    assert differ.get_changes_for_asset_with_details(AssetKey("numbers")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("numbers")) == AssetDefinitionDiff(
         change_types=set()
     )

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -316,15 +316,16 @@ def test_large_asset_graph(instance):
     for i in range(6, 1000):
         key = AssetKey(f"asset_{i}")
         assert differ.get_changes_for_asset(key) == [AssetDefinitionChangeType.DEPENDENCIES]
-        assert (
-            differ.get_changes_for_asset_with_details(key)[0].change_type
-            == AssetDefinitionChangeType.DEPENDENCIES
-        )
+        assert differ.get_changes_for_asset_with_details(key).change_types == {
+            AssetDefinitionChangeType.DEPENDENCIES
+        }
 
     for i in range(6):
         key = AssetKey(f"asset_{i}")
         assert len(differ.get_changes_for_asset(key)) == 0
-        assert len(differ.get_changes_for_asset_with_details(key)) == 0
+        assert differ.get_changes_for_asset_with_details(key) == AssetDefinitionDiff(
+            change_types=set()
+        )
 
 
 def test_multiple_code_locations(instance):


### PR DESCRIPTION
## Summary & Motivation
Currently, `AssetGraphDiffer` only a list of `AssetDefinitionChangeType` that have changed between a base and branch workspace. We want to also provide the content diff of those changes.

## How I Tested These Changes
```
pytest python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
```

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [x] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
