### PR TITLE
Allow submit_asset_runs to submit runs targeting AssetCheckKeys

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -38,7 +38,7 @@ def evaluate_automation_conditions(
         materialize_run_tags=context.instance.auto_materialize_run_tags,
         observe_run_tags={},
         auto_observe_asset_keys=set(),
-        asset_selection=AssetSelection.all(),
+        asset_selection=sensor_def.asset_selection,
         logger=context.log,
     ).evaluate()
 

--- a/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
@@ -63,8 +63,9 @@ class AutomationTickEvaluationContext:
         resolved_entity_keys = {
             entity_key
             # for now, all checks of a given asset will be evaluated at the same time as it
-            for entity_key in asset_selection.resolve(asset_graph)
-            | asset_selection.resolve_checks(asset_graph)
+            for entity_key in (
+                asset_selection.resolve(asset_graph) | asset_selection.resolve_checks(asset_graph)
+            )
             if asset_graph.get(entity_key).automation_condition is not None
         }
         self._evaluation_id = evaluation_id

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -78,7 +78,7 @@ class BaseEntityNode(ABC, Generic[T_EntityKey]):
 
     @property
     @abstractmethod
-    def partition_mappings(self) -> Mapping[AssetKey, PartitionMapping]: ...
+    def partition_mappings(self) -> Mapping[EntityKey, PartitionMapping]: ...
 
     @property
     @abstractmethod
@@ -213,7 +213,7 @@ class AssetCheckNode(BaseEntityNode[AssetCheckKey]):
         return None
 
     @property
-    def partition_mappings(self) -> Mapping[AssetKey, PartitionMapping]:
+    def partition_mappings(self) -> Mapping[EntityKey, PartitionMapping]:
         return {}
 
     @property
@@ -364,7 +364,7 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
         return {a.group_name for a in self.asset_nodes if a.group_name is not None}
 
     def get_partition_mapping(
-        self, key: T_EntityKey, parent_asset_key: AssetKey
+        self, key: T_EntityKey, parent_asset_key: EntityKey
     ) -> PartitionMapping:
         node = self.get(key)
         return infer_partition_mapping(
@@ -800,10 +800,10 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
 
         return result, failed_reasons
 
-    def split_asset_keys_by_repository(
-        self, asset_keys: AbstractSet[AssetKey]
-    ) -> Sequence[AbstractSet[AssetKey]]:
-        return [asset_keys]
+    def split_entity_keys_by_repository(
+        self, keys: AbstractSet[EntityKey]
+    ) -> Sequence[AbstractSet[EntityKey]]:
+        return [keys]
 
     def __hash__(self) -> int:
         return id(self)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -128,12 +128,10 @@ class AutomationConditionEvaluator:
 
             result = self.current_results_by_key[entity_key]
             num_requested = result.true_subset.size
-            requested_str = ",".join(
-                [
-                    (ap.partition_key or "No partition")
-                    for ap in result.true_subset.expensively_compute_asset_partitions()
-                ]
-            )
+            if result.true_subset.is_partitioned:
+                requested_str = ",".join(result.true_subset.expensively_compute_partition_keys())
+            else:
+                requested_str = "(no partition)"
             log_fn = self.logger.info if num_requested > 0 else self.logger.debug
             log_fn(
                 f"{entity_key.to_user_string()} evaluation result: {num_requested} "

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/legacy/legacy_context.py
@@ -355,9 +355,9 @@ class LegacyRuleEvaluationContext:
 
     def materializable_in_same_run(self, child_key: AssetKey, parent_key: AssetKey) -> bool:
         """Returns whether a child asset can be materialized in the same run as a parent asset."""
-        from dagster._core.definitions.asset_graph import materializable_in_same_run
+        from dagster._core.definitions.asset_graph import executable_in_same_run
 
-        return materializable_in_same_run(self.asset_graph, child_key, parent_key)
+        return executable_in_same_run(self.asset_graph, child_key, parent_key)
 
     def get_parents_that_will_not_be_materialized_on_current_tick(
         self, *, asset_partition: AssetKeyPartitionKey

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
@@ -92,10 +92,10 @@ class WillBeRequestedCondition(SubsetAutomationCondition[AssetKey]):
 
     def _executable_with_root_context_key(self, context: AutomationContext) -> bool:
         # TODO: once we can launch backfills via the asset daemon, this can be removed
-        from dagster._core.definitions.asset_graph import materializable_in_same_run
+        from dagster._core.definitions.asset_graph import executable_in_same_run
 
         root_key = context.root_context.key
-        return materializable_in_same_run(
+        return executable_in_same_run(
             asset_graph=context.asset_graph_view.asset_graph,
             child_key=root_key,
             parent_key=context.key,

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -19,19 +19,19 @@ from typing import (
 import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_job import IMPLICIT_ASSET_JOB_NAME
+from dagster._core.definitions.asset_key import EntityKey
 from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.base_asset_graph import (
     AssetCheckNode,
+    AssetKey,
     BaseAssetGraph,
     BaseAssetNode,
-    EntityKey,
 )
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
 )
-from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
 from dagster._core.definitions.partition import PartitionsDefinition
@@ -231,6 +231,7 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
         asset_nodes_by_key: Mapping[AssetKey, RemoteAssetNode],
         asset_checks_by_key: Mapping[AssetCheckKey, "ExternalAssetCheck"],
         asset_check_execution_sets_by_key: Mapping[AssetCheckKey, AbstractSet[EntityKey]],
+        repository_handles_by_asset_check_key: Mapping[AssetCheckKey, RepositoryHandle],
     ):
         self._asset_nodes_by_key = asset_nodes_by_key
         self._asset_checks_by_key = asset_checks_by_key
@@ -239,23 +240,23 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
             for k, v in asset_checks_by_key.items()
         }
         self._asset_check_execution_sets_by_key = asset_check_execution_sets_by_key
+        self._repository_handles_by_asset_check_key = repository_handles_by_asset_check_key
 
     @classmethod
     def from_repository_handles_and_external_asset_nodes(
         cls,
-        repo_handle_external_asset_nodes: Sequence[Tuple[RepositoryHandle, "ExternalAssetNode"]],
-        external_asset_checks: Sequence["ExternalAssetCheck"],
+        repo_handle_assets: Sequence[Tuple[RepositoryHandle, "ExternalAssetNode"]],
+        repo_handle_asset_checks: Sequence[Tuple[RepositoryHandle, "ExternalAssetCheck"]],
     ) -> "RemoteAssetGraph":
-        _warn_on_duplicate_nodes(repo_handle_external_asset_nodes)
+        _warn_on_duplicate_nodes(repo_handle_assets)
 
         # Build an index of execution sets by key. An execution set is a set of assets and checks
         # that must be executed together. ExternalAssetNodes and ExternalAssetChecks already have an
         # optional execution_set_identifier set. A null execution_set_identifier indicates that the
         # node or check can be executed independently.
-        execution_sets_by_key = _build_execution_set_index(
-            (node for _, node in repo_handle_external_asset_nodes),
-            external_asset_checks,
-        )
+        assets = [asset for _, asset in repo_handle_assets]
+        asset_checks = [asset_check for _, asset_check in repo_handle_asset_checks]
+        execution_sets_by_key = _build_execution_set_index(assets, asset_checks)
 
         # Index all (RepositoryHandle, ExternalAssetNode) pairs by their asset key, then use this to
         # build the set of RemoteAssetNodes (indexed by key). Each RemoteAssetNode wraps the set of
@@ -265,11 +266,11 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
         ] = defaultdict(list)
 
         # Build the dependency graph of asset keys.
-        all_keys = {node.asset_key for _, node in repo_handle_external_asset_nodes}
+        all_keys = {asset.asset_key for asset in assets}
         upstream: Dict[AssetKey, Set[AssetKey]] = {key: set() for key in all_keys}
         downstream: Dict[AssetKey, Set[AssetKey]] = {key: set() for key in all_keys}
 
-        for repo_handle, node in repo_handle_external_asset_nodes:
+        for repo_handle, node in repo_handle_assets:
             repo_node_pairs_by_key[node.asset_key].append((repo_handle, node))
             for dep in node.dependencies:
                 upstream[node.asset_key].add(dep.upstream_asset_key)
@@ -277,10 +278,19 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
 
         dep_graph: DependencyGraph[AssetKey] = {"upstream": upstream, "downstream": downstream}
 
+        # Build the set of ExternalAssetChecks, indexed by key. Also the index of execution units for
+        # each asset check key.
         check_keys_by_asset_key: Dict[AssetKey, Set[AssetCheckKey]] = defaultdict(set)
-        for c in external_asset_checks:
-            check_keys_by_asset_key[c.asset_key].add(c.key)
+        asset_checks_by_key: Dict[AssetCheckKey, "ExternalAssetCheck"] = {}
+        repository_handles_by_asset_check_key: Dict[AssetCheckKey, RepositoryHandle] = {}
+        for repo_handle, asset_check in repo_handle_asset_checks:
+            asset_checks_by_key[asset_check.key] = asset_check
+            check_keys_by_asset_key[asset_check.asset_key].add(asset_check.key)
+            repository_handles_by_asset_check_key[asset_check.key] = repo_handle
 
+        asset_check_execution_sets_by_key = {
+            k: v for k, v in execution_sets_by_key.items() if isinstance(k, AssetCheckKey)
+        }
         # Build the set of RemoteAssetNodes in topological order so that each node can hold
         # references to its parents.
         asset_nodes_by_key = {
@@ -295,19 +305,11 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
             for key, repo_node_pairs in repo_node_pairs_by_key.items()
         }
 
-        # Build the set of ExternalAssetChecks, indexed by key. Also the index of execution units for
-        # each asset check key.
-        asset_checks_by_key: Dict[AssetCheckKey, "ExternalAssetCheck"] = {}
-        for asset_check in external_asset_checks:
-            asset_checks_by_key[asset_check.key] = asset_check
-        asset_check_execution_sets_by_key = {
-            k: v for k, v in execution_sets_by_key.items() if isinstance(k, AssetCheckKey)
-        }
-
         return cls(
             asset_nodes_by_key,
             asset_checks_by_key,
             asset_check_execution_sets_by_key,
+            repository_handles_by_asset_check_key,
         )
 
     ##### COMMON ASSET GRAPH INTERFACE
@@ -335,7 +337,7 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
 
     @cached_property
     def asset_check_keys(self) -> AbstractSet[AssetCheckKey]:
-        return {key for asset in self.asset_nodes for key in asset.check_keys}
+        return set(self._asset_checks_by_key.keys())
 
     def asset_keys_for_job(self, job_name: str) -> AbstractSet[AssetKey]:
         return {node.key for node in self.asset_nodes if job_name in node.job_names}
@@ -345,11 +347,14 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
         return {job_name for node in self.asset_nodes for job_name in node.job_names}
 
     @cached_property
-    def repository_handles_by_key(self) -> Mapping[AssetKey, RepositoryHandle]:
-        return {k: node.priority_repository_handle for k, node in self._asset_nodes_by_key.items()}
+    def repository_handles_by_key(self) -> Mapping[EntityKey, RepositoryHandle]:
+        return {
+            **{k: node.priority_repository_handle for k, node in self._asset_nodes_by_key.items()},
+            **self._repository_handles_by_asset_check_key,
+        }
 
-    def get_repository_handle(self, asset_key: AssetKey) -> RepositoryHandle:
-        return self.get(asset_key).priority_repository_handle
+    def get_repository_handle(self, key: EntityKey) -> RepositoryHandle:
+        return self.repository_handles_by_key[key]
 
     def get_materialization_job_names(self, asset_key: AssetKey) -> Sequence[str]:
         """Returns the names of jobs that materialize this asset."""
@@ -377,16 +382,14 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
         """
         return IMPLICIT_ASSET_JOB_NAME
 
-    def split_asset_keys_by_repository(
-        self, asset_keys: AbstractSet[AssetKey]
-    ) -> Sequence[AbstractSet[AssetKey]]:
-        asset_keys_by_repo = defaultdict(set)
-        for asset_key in asset_keys:
-            repo_handle = self.get_repository_handle(asset_key)
-            asset_keys_by_repo[(repo_handle.location_name, repo_handle.repository_name)].add(
-                asset_key
-            )
-        return list(asset_keys_by_repo.values())
+    def split_entity_keys_by_repository(
+        self, keys: AbstractSet[EntityKey]
+    ) -> Sequence[AbstractSet[EntityKey]]:
+        keys_by_repo = defaultdict(set)
+        for key in keys:
+            repo_handle = self.get_repository_handle(key)
+            keys_by_repo[(repo_handle.location_name, repo_handle.repository_name)].add(key)
+        return list(keys_by_repo.values())
 
 
 def _warn_on_duplicate_nodes(

--- a/python_modules/dagster/dagster/_core/definitions/run_request.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_request.py
@@ -243,6 +243,10 @@ class RunRequest(IHaveNew, LegacyNamedTupleMixin):
         else:
             return None
 
+    @property
+    def entity_keys(self) -> Sequence[EntityKey]:
+        return [*(self.asset_selection or []), *(self.asset_check_keys or [])]
+
     def requires_backfill_daemon(self) -> bool:
         """For now we always send RunRequests with an asset_graph_subset to the backfill daemon, but
         eventaully we will want to introspect on the asset_graph_subset to determine if we can

--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -1,10 +1,11 @@
 import logging
 import sys
 import time
-from typing import AbstractSet, Dict, NamedTuple, Optional, Sequence, cast
+from typing import AbstractSet, Dict, NamedTuple, Optional, Sequence
 
 import dagster._check as check
 from dagster._core.definitions.asset_job import IMPLICIT_ASSET_JOB_NAME
+from dagster._core.definitions.asset_key import EntityKey
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.definitions.run_request import RunRequest
@@ -37,17 +38,19 @@ def _get_implicit_job_name_for_assets(
     )
 
 
-def _get_execution_plan_asset_keys(
+def _get_execution_plan_entity_keys(
     execution_plan_snapshot: ExecutionPlanSnapshot,
-) -> AbstractSet[AssetKey]:
-    output_asset_keys = set()
+) -> AbstractSet[EntityKey]:
+    output_entity_keys = set()
     for step in execution_plan_snapshot.steps:
         if step.key in execution_plan_snapshot.step_keys_to_execute:
             for output in step.outputs:
-                asset_key = check.not_none(output.properties).asset_key
-                if asset_key:
-                    output_asset_keys.add(asset_key)
-    return output_asset_keys
+                output_properties = check.not_none(output.properties)
+                if output_properties.asset_key:
+                    output_entity_keys.add(output_properties.asset_key)
+                if output_properties.asset_check_key:
+                    output_entity_keys.add(output_properties.asset_check_key)
+    return output_entity_keys
 
 
 def _get_job_execution_data_from_run_request(
@@ -57,21 +60,22 @@ def _get_job_execution_data_from_run_request(
     workspace: BaseWorkspaceRequestContext,
     run_request_execution_data_cache: Dict[int, RunRequestExecutionData],
 ) -> RunRequestExecutionData:
-    repo_handle = asset_graph.get_repository_handle(
-        cast(Sequence[AssetKey], run_request.asset_selection)[0]
+    referenced_assets = list(
+        set(run_request.asset_selection or [])
+        | {asset_check_key.asset_key for asset_check_key in (run_request.asset_check_keys or [])}
     )
+    check.invariant(len(referenced_assets) > 0)
+    repo_handle = asset_graph.get_repository_handle(referenced_assets[0])
     location_name = repo_handle.code_location_origin.location_name
-    job_name = _get_implicit_job_name_for_assets(
-        asset_graph, cast(Sequence[AssetKey], run_request.asset_selection)
-    )
+    job_name = _get_implicit_job_name_for_assets(asset_graph, referenced_assets)
     if job_name is None:
         check.failed(
             "Could not find an implicit asset job for the given assets:"
             f" {run_request.asset_selection}"
         )
 
-    if not run_request.asset_selection:
-        check.failed("Expected RunRequest to have an asset selection")
+    if not referenced_assets:
+        check.failed("Expected RunRequest to have an asset selection or asset check keys")
 
     pipeline_selector = JobSubsetSelector(
         location_name=location_name,
@@ -120,7 +124,7 @@ def _create_asset_run(
     """
     from dagster._daemon.controller import RELOAD_WORKSPACE_INTERVAL
 
-    if not run_request.asset_selection:
+    if not run_request.asset_selection and not run_request.asset_check_keys:
         check.failed("Expected RunRequest to have an asset selection")
 
     for i in range(EXECUTION_PLAN_CREATION_RETRIES + 1):
@@ -162,17 +166,20 @@ def _create_asset_run(
         check_for_debug_crash(debug_crash_flags, f"EXECUTION_PLAN_CREATED_{run_request_index}")
 
         if not should_retry:
-            execution_plan_asset_keys = _get_execution_plan_asset_keys(
+            execution_plan_entity_keys = _get_execution_plan_entity_keys(
                 check.not_none(execution_data).external_execution_plan.execution_plan_snapshot
             )
 
             if not all(
-                key in execution_plan_asset_keys
-                for key in check.not_none(run_request.asset_selection)
+                key in execution_plan_entity_keys
+                for key in [
+                    *(run_request.asset_selection or []),
+                    *(run_request.asset_check_keys or []),
+                ]
             ):
                 logger.warning(
-                    f"Execution plan targeted the following keys: {execution_plan_asset_keys}, "
-                    "which did not include all assets on the run request, "
+                    f"Execution plan targeted the following keys: {execution_plan_entity_keys}, "
+                    "which did not include all assets / checks on the run request, "
                     "possibly because the code server is out of sync with the daemon. The daemon "
                     "periodically refreshes its representation of the workspace every "
                     f"{RELOAD_WORKSPACE_INTERVAL} seconds - pausing long enough "
@@ -201,8 +208,12 @@ def _create_asset_run(
                 status=DagsterRunStatus.NOT_STARTED,
                 external_job_origin=external_job.get_external_origin(),
                 job_code_origin=external_job.get_python_origin(),
-                asset_selection=frozenset(run_request.asset_selection),
-                asset_check_selection=None,
+                asset_selection=frozenset(run_request.asset_selection)
+                if run_request.asset_selection
+                else None,
+                asset_check_selection=frozenset(run_request.asset_check_keys)
+                if run_request.asset_check_keys
+                else None,
                 asset_graph=asset_graph,
             )
 
@@ -241,9 +252,12 @@ def submit_asset_run(
     that the created run targets the given asset selection.
     """
     check.invariant(not run_request.run_config, "Asset run requests have no custom run config")
-    asset_keys = check.not_none(run_request.asset_selection)
+    entity_keys: Sequence[EntityKey] = [
+        *(run_request.asset_selection or []),
+        *(run_request.asset_check_keys or []),
+    ]
 
-    check.invariant(len(asset_keys) > 0)
+    check.invariant(len(entity_keys) > 0)
 
     # check if the run already exists
     existing_run = instance.get_run_by_id(run_id) if run_id else None
@@ -282,10 +296,10 @@ def submit_asset_run(
     check_for_debug_crash(debug_crash_flags, "RUN_SUBMITTED")
     check_for_debug_crash(debug_crash_flags, f"RUN_SUBMITTED_{run_request_index}")
 
-    asset_key_str = ", ".join([asset_key.to_user_string() for asset_key in asset_keys])
+    asset_key_str = ", ".join([key.to_user_string() for key in entity_keys])
 
     logger.info(
-        f"Submitted run {run_to_submit.run_id} for assets {asset_key_str} with tags"
+        f"Submitted run {run_to_submit.run_id} for assets/checks {asset_key_str} with tags"
         f" {run_request.tags}"
     )
 

--- a/python_modules/dagster/dagster/_core/workspace/workspace.py
+++ b/python_modules/dagster/dagster/_core/workspace/workspace.py
@@ -67,20 +67,18 @@ class WorkspaceSnapshot:
             for code_location in code_locations
             for repo in code_location.get_repositories().values()
         )
-        repo_handle_external_asset_nodes: Sequence[
-            Tuple["RepositoryHandle", "ExternalAssetNode"]
-        ] = []
-        asset_checks: Sequence["ExternalAssetCheck"] = []
+        repo_handle_assets: Sequence[Tuple["RepositoryHandle", "ExternalAssetNode"]] = []
+        repo_handle_asset_checks: Sequence[Tuple["RepositoryHandle", "ExternalAssetCheck"]] = []
 
         for repo in repos:
             for external_asset_node in repo.get_external_asset_nodes():
-                repo_handle_external_asset_nodes.append((repo.handle, external_asset_node))
-
-            asset_checks.extend(repo.get_external_asset_checks())
+                repo_handle_assets.append((repo.handle, external_asset_node))
+            for external_asset_check in repo.get_external_asset_checks():
+                repo_handle_asset_checks.append((repo.handle, external_asset_check))
 
         return RemoteAssetGraph.from_repository_handles_and_external_asset_nodes(
-            repo_handle_external_asset_nodes=repo_handle_external_asset_nodes,
-            external_asset_checks=asset_checks,
+            repo_handle_assets=repo_handle_assets,
+            repo_handle_asset_checks=repo_handle_asset_checks,
         )
 
     def with_code_location(self, name: str, entry: CodeLocationEntry) -> "WorkspaceSnapshot":

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -944,7 +944,6 @@ class AssetDaemon(DagsterDaemon):
                 *{
                     key if isinstance(key, AssetKey) else key.asset_key
                     for key in auto_materialize_entity_keys
-                    if isinstance(key, AssetKey)
                 }
             )
             run_requests, new_cursor, evaluations = AutomationTickEvaluationContext(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -53,9 +53,12 @@ def to_external_asset_graph(assets, asset_checks=None) -> BaseAssetGraph:
     external_asset_nodes = external_asset_nodes_from_defs(repo.get_all_jobs(), repo.asset_graph)
     return RemoteAssetGraph.from_repository_handles_and_external_asset_nodes(
         [(MagicMock(), asset_node) for asset_node in external_asset_nodes],
-        external_asset_checks=external_asset_checks_from_defs(
-            repo.get_all_jobs(), repo.asset_graph
-        ),
+        [
+            (MagicMock(), asset_check)
+            for asset_check in external_asset_checks_from_defs(
+                repo.get_all_jobs(), repo.asset_graph
+            )
+        ],
     )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -748,7 +748,7 @@ def external_asset_graph_from_assets_by_repo_name(
         )
 
     return RemoteAssetGraph.from_repository_handles_and_external_asset_nodes(
-        from_repository_handles_and_external_asset_nodes, external_asset_checks=[]
+        from_repository_handles_and_external_asset_nodes, []
     )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/check_after_parent_updated.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/check_after_parent_updated.py
@@ -1,0 +1,21 @@
+import dagster as dg
+
+any_dep_newly_updated = dg.AutomationCondition.any_deps_match(
+    dg.AutomationCondition.newly_updated() | dg.AutomationCondition.will_be_requested()
+)
+
+
+@dg.asset
+def raw_files() -> None: ...
+
+
+@dg.asset(automation_condition=dg.AutomationCondition.eager(), deps=[raw_files])
+def processed_files() -> None: ...
+
+
+@dg.asset_check(asset=processed_files, automation_condition=any_dep_newly_updated)
+def row_count() -> dg.AssetCheckResult:
+    return dg.AssetCheckResult(passed=True)
+
+
+defs = dg.Definitions(assets=[raw_files, processed_files], asset_checks=[row_count])

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/check_on_other_location.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/check_on_other_location.py
@@ -1,0 +1,14 @@
+import dagster as dg
+
+any_dep_newly_updated = dg.AutomationCondition.any_deps_match(
+    dg.AutomationCondition.newly_updated() | dg.AutomationCondition.will_be_requested()
+)
+
+
+# processed_files exists in `check_after_parent_updated.py`
+@dg.asset_check(asset=dg.AssetKey("processed_files"), automation_condition=any_dep_newly_updated)
+def no_nulls() -> dg.AssetCheckResult:
+    return dg.AssetCheckResult(passed=True)
+
+
+defs = dg.Definitions(asset_checks=[no_nulls])

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -1,0 +1,293 @@
+import datetime
+import os
+import sys
+from contextlib import contextmanager
+from typing import AbstractSet, Mapping, Sequence, cast
+
+import dagster._check as check
+from dagster import AssetMaterialization, RunsFilter, instance_for_test
+from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
+from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey
+from dagster._core.definitions.sensor_definition import SensorType
+from dagster._core.remote_representation.external import ExternalSensor
+from dagster._core.remote_representation.origin import InProcessCodeLocationOrigin
+from dagster._core.scheduler.instigation import SensorInstigatorData
+from dagster._core.storage.dagster_run import DagsterRun
+from dagster._core.test_utils import (
+    InProcessTestWorkspaceLoadTarget,
+    SingleThreadPoolExecutor,
+    create_test_daemon_workspace_context,
+    freeze_time,
+    wait_for_futures,
+)
+from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+from dagster._core.utils import InheritContextThreadPoolExecutor
+from dagster._core.workspace.context import WorkspaceProcessContext, WorkspaceRequestContext
+from dagster._daemon.asset_daemon import (
+    AssetDaemon,
+    asset_daemon_cursor_from_instigator_serialized_cursor,
+)
+from dagster._time import get_current_datetime
+
+
+def get_code_location_origin(filename: str) -> InProcessCodeLocationOrigin:
+    return InProcessCodeLocationOrigin(
+        loadable_target_origin=LoadableTargetOrigin(
+            executable_path=sys.executable,
+            module_name=(
+                f"dagster_tests.definitions_tests.declarative_automation_tests.daemon_tests.definitions.{filename}"
+            ),
+            working_directory=os.getcwd(),
+        ),
+        location_name=filename,
+    )
+
+
+def _get_all_sensors(context: WorkspaceRequestContext) -> Sequence[ExternalSensor]:
+    external_sensors = []
+    for cl_name in context.get_code_location_entries():
+        external_sensors.extend(
+            next(
+                iter(context.get_code_location(cl_name).get_repositories().values())
+            ).get_external_sensors()
+        )
+    return external_sensors
+
+
+def _get_automation_sensors(context: WorkspaceRequestContext) -> Sequence[ExternalSensor]:
+    return [
+        sensor
+        for sensor in _get_all_sensors(context)
+        if sensor.sensor_type == SensorType.AUTO_MATERIALIZE
+    ]
+
+
+def _setup_instance(context: WorkspaceProcessContext) -> None:
+    """Does any initialization necessary."""
+    request_context = context.create_request_context()
+    sensors = _get_automation_sensors(request_context)
+    for sensor in sensors:
+        request_context.instance.start_sensor(sensor)
+
+
+@contextmanager
+def get_workspace_request_context(filenames: Sequence[str]):
+    with instance_for_test(
+        overrides={
+            "run_launcher": {
+                "module": "dagster._core.launcher.sync_in_memory_run_launcher",
+                "class": "SyncInMemoryRunLauncher",
+            },
+        }
+    ) as instance:
+        target = InProcessTestWorkspaceLoadTarget(
+            [get_code_location_origin(filename) for filename in filenames]
+        )
+        with create_test_daemon_workspace_context(
+            workspace_load_target=target, instance=instance
+        ) as workspace_context:
+            _setup_instance(workspace_context)
+            yield workspace_context
+
+
+@contextmanager
+def get_threadpool_executor():
+    with SingleThreadPoolExecutor() as executor:
+        yield executor
+
+
+def _execute_ticks(
+    context: WorkspaceProcessContext, threadpool_executor: InheritContextThreadPoolExecutor
+) -> None:
+    """Evaluates a single tick for all automation condition sensors across the workspace."""
+    futures = {}
+
+    list(
+        AssetDaemon(settings={}, pre_sensor_interval_seconds=0)._run_iteration_impl(  # noqa
+            context,
+            threadpool_executor=threadpool_executor,
+            amp_tick_futures=futures,
+            debug_crash_flags={},
+        )
+    )
+
+    wait_for_futures(futures)
+
+
+def _get_current_cursors(context: WorkspaceProcessContext) -> Mapping[str, AssetDaemonCursor]:
+    request_context = context.create_request_context()
+
+    cursors_by_name = {}
+    for sensor in _get_automation_sensors(request_context):
+        state = check.not_none(
+            context.instance.get_instigator_state(
+                sensor.get_external_origin_id(), sensor.selector_id
+            )
+        )
+        cursor = asset_daemon_cursor_from_instigator_serialized_cursor(
+            cast(SensorInstigatorData, check.not_none(state).instigator_data).cursor,
+            request_context.asset_graph,
+        )
+        cursors_by_name[f"{sensor.name}_{sensor.get_external_origin_id()}"] = cursor
+    return cursors_by_name
+
+
+def _get_latest_evaluation_ids(context: WorkspaceProcessContext) -> AbstractSet[int]:
+    return {cursor.evaluation_id for cursor in _get_current_cursors(context).values()}
+
+
+def _get_runs_for_latest_ticks(context: WorkspaceProcessContext) -> Sequence[DagsterRun]:
+    runs = []
+    for evaluation_id in _get_latest_evaluation_ids(context):
+        runs.extend(
+            context.instance.get_runs(
+                filters=RunsFilter(tags={"dagster/asset_evaluation_id": str(evaluation_id)})
+            )
+        )
+    return runs
+
+
+def test_checks_and_assets_in_same_run() -> None:
+    time = get_current_datetime()
+    with get_workspace_request_context(
+        ["check_after_parent_updated"]
+    ) as context, get_threadpool_executor() as executor:
+        assert _get_latest_evaluation_ids(context) == {0}
+        assert _get_runs_for_latest_ticks(context) == []
+
+        with freeze_time(time):
+            _execute_ticks(context, executor)
+
+            # nothing happening yet, as parent hasn't updated
+            assert _get_latest_evaluation_ids(context) == {1}
+            assert _get_runs_for_latest_ticks(context) == []
+
+        time += datetime.timedelta(seconds=30)
+        with freeze_time(time):
+            # now update the asset in the middle
+            context.instance.report_runless_asset_event(
+                AssetMaterialization(asset_key=AssetKey("processed_files"))
+            )
+
+            _execute_ticks(context, executor)
+
+            # should just request the check
+            assert _get_latest_evaluation_ids(context) == {2}
+            runs = _get_runs_for_latest_ticks(context)
+            assert len(runs) == 1
+            run = runs[0]
+            assert run.asset_check_selection == {
+                AssetCheckKey(AssetKey("processed_files"), "row_count")
+            }
+            assert len(run.asset_selection or []) == 0
+
+        time += datetime.timedelta(seconds=30)
+        with freeze_time(time):
+            # now update the asset at the top
+            context.instance.report_runless_asset_event(
+                AssetMaterialization(asset_key=AssetKey("raw_files"))
+            )
+
+            _execute_ticks(context, executor)
+
+            # should create a single run request targeting both the downstream asset
+            # and the associated check
+            assert _get_latest_evaluation_ids(context) == {3}
+            runs = _get_runs_for_latest_ticks(context)
+            assert len(runs) == 1
+            run = runs[0]
+            assert run.asset_selection == {AssetKey("processed_files")}
+            assert run.asset_check_selection == {
+                AssetCheckKey(AssetKey("processed_files"), "row_count")
+            }
+
+
+def test_cross_location_checks() -> None:
+    time = get_current_datetime()
+    with get_workspace_request_context(
+        ["check_on_other_location", "check_after_parent_updated"]
+    ) as context, get_threadpool_executor() as executor:
+        assert _get_latest_evaluation_ids(context) == {0}
+        assert _get_runs_for_latest_ticks(context) == []
+
+        with freeze_time(time):
+            _execute_ticks(context, executor)
+
+            # nothing happening yet, as parent hasn't updated
+            assert _get_latest_evaluation_ids(context) == {1, 2}
+            assert _get_runs_for_latest_ticks(context) == []
+
+        time += datetime.timedelta(seconds=30)
+        with freeze_time(time):
+            # now update the asset in the middle
+            context.instance.report_runless_asset_event(
+                AssetMaterialization(asset_key=AssetKey("processed_files"))
+            )
+
+            _execute_ticks(context, executor)
+
+            # should request both checks on processed_files, but one of the checks
+            # is in a different code location, so two separate runs should be created
+            assert _get_latest_evaluation_ids(context) == {3, 4}
+            runs = sorted(
+                _get_runs_for_latest_ticks(context),
+                key=lambda run: list(run.asset_check_selection or []),
+                reverse=True,
+            )
+            assert len(runs) == 2
+            # in location 1
+            assert runs[0].asset_check_selection == {
+                AssetCheckKey(AssetKey("processed_files"), "row_count")
+            }
+            assert len(runs[0].asset_selection or []) == 0
+            # in location 2
+            assert runs[1].asset_check_selection == {
+                AssetCheckKey(AssetKey("processed_files"), "no_nulls")
+            }
+            assert len(runs[1].asset_selection or []) == 0
+
+        time += datetime.timedelta(seconds=30)
+        with freeze_time(time):
+            # now update the asset at the top
+            context.instance.report_runless_asset_event(
+                AssetMaterialization(asset_key=AssetKey("raw_files"))
+            )
+
+            _execute_ticks(context, executor)
+
+            # should create a single run request targeting both the downstream asset
+            # and the associated check -- the check in the other location cannot
+            # be grouped with these and will need to wait
+            assert _get_latest_evaluation_ids(context) == {5, 6}
+            runs = _get_runs_for_latest_ticks(context)
+            assert len(runs) == 1
+            run = runs[0]
+            assert run.asset_selection == {AssetKey("processed_files")}
+            assert run.asset_check_selection == {
+                AssetCheckKey(AssetKey("processed_files"), "row_count")
+            }
+
+        time += datetime.timedelta(seconds=30)
+        with freeze_time(time):
+            _execute_ticks(context, executor)
+
+            # now, after processed_files gets materialized, the no_nulls check
+            # can be executed (and row_count also gets executed again because
+            # its condition has been set up poorly)
+            assert _get_latest_evaluation_ids(context) == {7, 8}
+            runs = sorted(
+                _get_runs_for_latest_ticks(context),
+                key=lambda run: list(run.asset_check_selection or []),
+                reverse=True,
+            )
+            assert len(runs) == 2
+            # in location 1
+            assert runs[0].asset_check_selection == {
+                AssetCheckKey(AssetKey("processed_files"), "row_count")
+            }
+            assert len(runs[0].asset_selection or []) == 0
+            # in location 2
+            assert runs[1].asset_check_selection == {
+                AssetCheckKey(AssetKey("processed_files"), "no_nulls")
+            }
+            assert len(runs[1].asset_selection or []) == 0


### PR DESCRIPTION
## Summary & Motivation

This fixes up some issues that I've been putting off downstack, in which the submit_asset_runs utility was being strict about requiring at least one asset key. There are now cases in which we want to submit asset checks with no asset keys, so this required some updates.

Added tests which demonstrate that:

a) runs can be successfully created that target both assets and checks
b) the system can launch the correct sets of runs even in "weird" cases (i.e. two checks are listening for updates from the same asset, but exist in different code locations)

## How I Tested These Changes

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
