### PR TITLE
[3/n][dagster-sigma] Build out organization parsing logic

### DIFF
--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -9,6 +9,8 @@ from dagster._utils.cached_method import cached_method
 from pydantic import Field, PrivateAttr
 from sqlglot import exp, parse_one
 
+SIGMA_PARTNER_ID_TAG = {"X-Sigma-Partner-Id": "dagster"}
+
 
 class SigmaBaseUrl(str, Enum):
     """Enumeration of Sigma API base URLs for different cloud providers.
@@ -83,6 +85,7 @@ class SigmaOrganization(ConfigurableResource):
             headers={
                 "Accept": "application/json",
                 "Content-Type": "application/x-www-form-urlencoded",
+                **SIGMA_PARTNER_ID_TAG,
             },
             data={
                 "grant_type": "client_credentials",
@@ -104,7 +107,11 @@ class SigmaOrganization(ConfigurableResource):
         response = requests.request(
             method=method,
             url=f"{self.base_url}/v2/{endpoint}",
-            headers={"Accept": "application/json", "Authorization": f"Bearer {self.api_token}"},
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {self.api_token}",
+                **SIGMA_PARTNER_ID_TAG,
+            },
         )
         response.raise_for_status()
 

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -11,6 +11,11 @@ from sqlglot import exp, parse_one
 
 
 class SigmaBaseUrl(str, Enum):
+    """Enumeration of Sigma API base URLs for different cloud providers.
+
+    https://help.sigmacomputing.com/reference/get-started-sigma-api#identify-your-api-request-url
+    """
+
     AWS_US = "https://aws-api.sigmacomputing.com"
     AWS_CANADA = "https://api.ca.aws.sigmacomputing.com"
     AWS_EUROPE = "https://api.eu.aws.sigmacomputing.com"
@@ -21,12 +26,24 @@ class SigmaBaseUrl(str, Enum):
 
 @record
 class SigmaWorkbook:
+    """Represents a Sigma workbook, a collection of visualizations and queries
+    for data exploration and analysis.
+
+    https://help.sigmacomputing.com/docs/workbooks
+    """
+
     properties: Dict[str, Any]
     datasets: AbstractSet[str]
 
 
 @record
 class SigmaDataset:
+    """Represents a Sigma dataset, a centralized data definition which can
+    contain aggregations or other manipulations.
+
+    https://help.sigmacomputing.com/docs/datasets
+    """
+
     properties: Dict[str, Any]
     columns: AbstractSet[str]
     inputs: AbstractSet[str]
@@ -123,6 +140,9 @@ class SigmaOrganization(ConfigurableResource):
 
     @cached_method
     def build_organization_data(self) -> SigmaOrganizationData:
+        """Retrieves all workbooks and datasets in the Sigma organization and builds a
+        SigmaOrganizationData object representing the organization's assets.
+        """
         raw_workbooks = self.fetch_workbooks()
 
         dataset_inode_to_name: Mapping[str, str] = {}

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -122,7 +122,7 @@ class SigmaOrganization(ConfigurableResource):
         return self.fetch_json(f"workbooks/{workbook_id}/queries")["entries"]
 
     @cached_method
-    def get_organization_data(self) -> SigmaOrganizationData:
+    def build_organization_data(self) -> SigmaOrganizationData:
         raw_workbooks = self.fetch_workbooks()
 
         dataset_inode_to_name: Mapping[str, str] = {}

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/conftest.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/conftest.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Any, Dict, List
 
 import pytest
 import responses
@@ -17,3 +18,196 @@ def sigma_auth_fixture() -> str:
     )
 
     return fake_access_token
+
+
+def _build_paginated_response(items: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return {
+        "entries": items,
+        "hasMore": False,
+        "total": len(items),
+        "nextPage": None,
+    }
+
+
+@pytest.fixture(name="sigma_sample_data")
+def sigma_sample_data_fixture() -> None:
+    # Single workbook, dataset
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks",
+        json=_build_paginated_response(
+            [
+                {
+                    "workbookId": "4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e",
+                    "workbookUrlId": "2opi6VLEne4BaPyj00US50",
+                    "createdBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+                    "updatedBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+                    "createdAt": "2024-09-12T21:22:49.072Z",
+                    "updatedAt": "2024-09-12T22:20:39.848Z",
+                    "name": "Sample Workbook",
+                    "url": "https://app.sigmacomputing.com/dagster-labs/workbook/2opi6VLEne4BaPyj00US50",
+                    "path": "My Documents",
+                    "latestVersion": 5,
+                    "ownerId": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+                }
+            ]
+        ),
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/datasets",
+        json=_build_paginated_response(
+            [
+                {
+                    "datasetId": "178a6bb5-c0e7-4bef-a739-f12710492f16",
+                    "createdBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+                    "updatedBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+                    "createdAt": "2024-09-12T21:16:17.830Z",
+                    "updatedAt": "2024-09-12T21:19:31.000Z",
+                    "name": "Orders Dataset",
+                    "description": "",
+                    "url": "https://app.sigmacomputing.com/dagster-labs/b/Iq557kfHN8KRu76HdGSWi",
+                }
+            ]
+        ),
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/pages",
+        json=_build_paginated_response([{"pageId": "qwMyyHBCuC", "name": "Page 1"}]),
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/pages/qwMyyHBCuC/elements",
+        json=_build_paginated_response(
+            [
+                {
+                    "elementId": "_MuHPbskp0",
+                    "type": "table",
+                    "name": "sample elementl",
+                    "columns": [
+                        "Order Id",
+                        "Customer Id",
+                        "workbook renamed date",
+                        "Modified Date",
+                    ],
+                    "vizualizationType": "levelTable",
+                },
+                {
+                    "elementId": "V29pknzHb6",
+                    "type": "visualization",
+                    "name": "Count of Order Date by Status",
+                    "columns": [
+                        "Order Id",
+                        "Customer Id",
+                        "Order Date",
+                        "Status",
+                        "Modified Date",
+                        "Count of Order Date",
+                    ],
+                    "vizualizationType": "bar",
+                },
+            ]
+        ),
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/lineage/elements/_MuHPbskp0",
+        json={
+            "dependencies": {
+                "qy_ARjTKcT": {
+                    "nodeId": "qy_ARjTKcT",
+                    "type": "sheet",
+                    "name": "sample elementl",
+                    "elementId": "_MuHPbskp0",
+                },
+                "inode-Iq557kfHN8KRu76HdGSWi": {
+                    "nodeId": "inode-Iq557kfHN8KRu76HdGSWi",
+                    "type": "dataset",
+                    "name": "Orders Dataset",
+                },
+            },
+            "edges": [
+                {"source": "inode-Iq557kfHN8KRu76HdGSWi", "target": "qy_ARjTKcT", "type": "source"}
+            ],
+        },
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/elements/_MuHPbskp0/columns",
+        json=_build_paginated_response(
+            [
+                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Order Id", "label": "Order Id"},
+                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Customer Id", "label": "Customer Id"},
+                {
+                    "columnId": "inode-Iq557kfHN8KRu76HdGSWi/Order Date",
+                    "label": "workbook renamed date",
+                },
+                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Modified Date", "label": "Modified Date"},
+            ]
+        ),
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/lineage/elements/V29pknzHb6",
+        json={
+            "dependencies": {
+                "SBvQYKT6ui": {
+                    "nodeId": "SBvQYKT6ui",
+                    "type": "sheet",
+                    "name": "Count of Order Date by Status",
+                    "elementId": "V29pknzHb6",
+                },
+                "inode-Iq557kfHN8KRu76HdGSWi": {
+                    "nodeId": "inode-Iq557kfHN8KRu76HdGSWi",
+                    "type": "dataset",
+                    "name": "Orders Dataset",
+                },
+            },
+            "edges": [
+                {"source": "inode-Iq557kfHN8KRu76HdGSWi", "target": "SBvQYKT6ui", "type": "source"}
+            ],
+        },
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/elements/V29pknzHb6/columns",
+        json=_build_paginated_response(
+            [
+                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Order Id", "label": "Order Id"},
+                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Customer Id", "label": "Customer Id"},
+                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Order Date", "label": "Order Date"},
+                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Status", "label": "Status"},
+                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Modified Date", "label": "Modified Date"},
+                {"columnId": "VBKAHQgx58", "label": "Count of Order Date"},
+            ]
+        ),
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/queries",
+        json=_build_paginated_response(
+            [
+                {
+                    "elementId": "_MuHPbskp0",
+                    "name": "sample elementl",
+                    "sql": 'select ORDER_ID_7 "Order Id", CUSTOMER_ID_8 "Customer Id", CAST_DATE_TO_DATETIME_9 "workbook renamed date", CAST_DATE_TO_DATETIME_11 "Modified Date" from (select ORDER_ID ORDER_ID_7, CUSTOMER_ID CUSTOMER_ID_8, ORDER_DATE::timestamp_ltz CAST_DATE_TO_DATETIME_9, ORDER_DATE::timestamp_ltz CAST_DATE_TO_DATETIME_11 from (select * from TESTDB.JAFFLE_SHOP.STG_ORDERS STG_ORDERS limit 1000) Q1) Q2 limit 1000\n\n-- Sigma \u03a3 {"request-id":"69ac9a35-64b3-4840-a53d-3aed43a575ec","email":"ben@dagsterlabs.com"}',
+                },
+                {
+                    "elementId": "V29pknzHb6",
+                    "name": "Count of Order Date by Status",
+                    "sql": 'with Q1 as (select ORDER_ID, CUSTOMER_ID, STATUS, ORDER_DATE::timestamp_ltz CAST_DATE_TO_DATETIME_5, ORDER_DATE::timestamp_ltz CAST_DATE_TO_DATETIME_6 from TESTDB.JAFFLE_SHOP.STG_ORDERS STG_ORDERS) select STATUS_10 "Status", COUNT_22 "Count of Order Date", ORDER_ID_7 "Order Id", CUSTOMER_ID_8 "Customer Id", CAST_DATE_TO_DATETIME_7 "Order Date", CAST_DATE_TO_DATETIME_8 "Modified Date" from (select Q3.ORDER_ID_7 ORDER_ID_7, Q3.CUSTOMER_ID_8 CUSTOMER_ID_8, Q3.CAST_DATE_TO_DATETIME_7 CAST_DATE_TO_DATETIME_7, Q3.STATUS_10 STATUS_10, Q3.CAST_DATE_TO_DATETIME_8 CAST_DATE_TO_DATETIME_8, Q6.COUNT_22 COUNT_22, Q6.STATUS_11 STATUS_11 from (select ORDER_ID ORDER_ID_7, CUSTOMER_ID CUSTOMER_ID_8, CAST_DATE_TO_DATETIME_6 CAST_DATE_TO_DATETIME_7, STATUS STATUS_10, CAST_DATE_TO_DATETIME_5 CAST_DATE_TO_DATETIME_8 from Q1 Q2 order by STATUS_10 asc limit 1000) Q3 left join (select count(CAST_DATE_TO_DATETIME_7) COUNT_22, STATUS_10 STATUS_11 from (select CAST_DATE_TO_DATETIME_6 CAST_DATE_TO_DATETIME_7, STATUS STATUS_10 from Q1 Q4) Q5 group by STATUS_10) Q6 on equal_null(Q3.STATUS_10, Q6.STATUS_11)) Q8 order by STATUS_10 asc limit 1000\n\n-- Sigma \u03a3 {"request-id":"69ac9a35-64b3-4840-a53d-3aed43a575ec","email":"ben@dagsterlabs.com"}',
+                },
+            ]
+        ),
+        status=200,
+    )

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
@@ -67,7 +67,7 @@ def test_model_organization_data(sigma_auth_token: str, sigma_sample_data: None)
         client_secret=fake_client_secret,
     )
 
-    data = resource.get_organization_data()
+    data = resource.build_organization_data()
 
     assert len(data.workbooks) == 1
     assert data.workbooks[0].properties["name"] == "Sample Workbook"

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
@@ -53,3 +53,32 @@ def test_basic_fetch(sigma_auth_token: str) -> None:
 
     assert len(responses.calls) == 2
     assert responses.calls[1].request.headers["Authorization"] == f"Bearer {sigma_auth_token}"
+
+
+@responses.activate
+def test_model_organization_data(sigma_auth_token: str, sigma_sample_data: None) -> None:
+    fake_client_id = uuid.uuid4().hex
+    fake_client_secret = uuid.uuid4().hex
+
+    resource = SigmaOrganization(
+        cloud_type=SigmaCloudType.AWS_US,
+        client_id=fake_client_id,
+        client_secret=fake_client_secret,
+    )
+
+    data = resource.get_organization_data()
+
+    assert len(data.workbooks) == 1
+    assert data.workbooks[0].properties["name"] == "Sample Workbook"
+    assert data.workbooks[0].datasets == {"Orders Dataset"}
+
+    assert len(data.datasets) == 1
+    assert data.datasets[0].properties["name"] == "Orders Dataset"
+    assert data.datasets[0].columns == {
+        "Customer Id",
+        "Order Date",
+        "Order Id",
+        "Modified Date",
+        "Status",
+    }
+    assert data.datasets[0].inputs == {"TESTDB.JAFFLE_SHOP.STG_ORDERS"}

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
@@ -2,6 +2,7 @@ import uuid
 
 import responses
 from dagster_sigma import SigmaBaseUrl, SigmaOrganization
+from dagster_sigma.resource import _inode_from_url
 
 
 @responses.activate
@@ -61,7 +62,7 @@ def test_model_organization_data(sigma_auth_token: str, sigma_sample_data: None)
     fake_client_secret = uuid.uuid4().hex
 
     resource = SigmaOrganization(
-        cloud_type=SigmaCloudType.AWS_US,
+        base_url=SigmaBaseUrl.AWS_US,
         client_id=fake_client_id,
         client_secret=fake_client_secret,
     )
@@ -70,9 +71,10 @@ def test_model_organization_data(sigma_auth_token: str, sigma_sample_data: None)
 
     assert len(data.workbooks) == 1
     assert data.workbooks[0].properties["name"] == "Sample Workbook"
-    assert data.workbooks[0].datasets == {"Orders Dataset"}
 
     assert len(data.datasets) == 1
+    assert data.workbooks[0].datasets == {_inode_from_url(data.datasets[0].properties["url"])}
+
     assert data.datasets[0].properties["name"] == "Orders Dataset"
     assert data.datasets[0].columns == {
         "Customer Id",

--- a/python_modules/libraries/dagster-sigma/setup.py
+++ b/python_modules/libraries/dagster-sigma/setup.py
@@ -37,6 +37,7 @@ setup(
     packages=find_packages(exclude=["dagster_sigma_tests*"]),
     install_requires=[
         f"dagster{pin}",
+        "sqlglot",
     ],
     include_package_data=True,
     python_requires=">=3.8,<3.13",


### PR DESCRIPTION
## Summary

Introduces  `build_organization_data`, which does the under-the-hood heavy lifting of building the Sigma object model.

There are two main object types we care about in Sigma's ontology:  [datasets](https://help.sigmacomputing.com/docs/datasets).
 and [workbooks](https://help.sigmacomputing.com/docs/workbooks-overview).

Datasets are the Sigma equivalent of Power BI Semantic Models, they are views (optionally materializable, which we might want to handle later) which sit on top of tables or other data sources.

Workbooks consist of several pages composed of elements, each of which is a table or other visualization built from a dataset.

Sigma's APIs are a little cumbersome here - we'd like to build a relationship of dependencies from workbooks to datasets and datasets to raw source data, but few APIs exist for datasets. It sounds like these will be available in the future once the migration to [data models](https://help.sigmacomputing.com/docs/intro-to-data-models) is complete, but these don't have APIs yet.

For now, our procedure is:

- Build linkages from workbooks to the datasets they depend on
- Inspect the data columns used in workbooks to assemble a partial view of datasets' column schema (which is not directly available via API)
- Inspect the SQL queries used in each "element" in a workbook using `sqlglot`. Each source table referred to by the SQL query is a source table used by the dataset linked to that element.

## Test Plan

Unit test validating that our model of organization data matches expectations. Plan to add more complex unit tests.


## Changelog

> NOCHANGELOG

