### PR TITLE
Update name property of DepConditionWrapperCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -29,8 +29,12 @@ class DepConditionWrapperCondition(AutomationCondition):
     label: Optional[str] = None
 
     @property
+    def name(self) -> str:
+        return self.dep_key.to_user_string()
+
+    @property
     def description(self) -> str:
-        return f"{self.dep_key.to_user_string()}"
+        return self.dep_key.to_user_string()
 
     def evaluate(self, context: AutomationContext) -> AutomationResult:
         # only evaluate parents of the current candidates


### PR DESCRIPTION
## Summary & Motivation

The `name` property is now favored in the UI over `description`, and has a default value of the name of the class. This meant that in rows where we evaluated something against a specfic asset, it would render as DepConditionWrapperCondition instead of the asset name.

## How I Tested These Changes

looked at the UI

## Changelog

[ui] Fixed an issue that would cause some AutomationCondition evaluations to be labeled `DepConditionWrapperCondition` instead of the key that they were evaluated against.

- [ ] `NEW` _(added new feature or capability)_
- [x] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
