### PR TITLE
[5/n][dagster-sigma] Add cacheable assets loading methods for Sigma assets

### DIFF
--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -237,7 +237,7 @@ class SigmaCacheableAssetsDefinition(CacheableAssetsDefinition):
         super().__init__(unique_id=f"sigma_{self._organization.client_id}")
 
     def compute_cacheable_data(self) -> Sequence[AssetsDefinitionCacheableData]:
-        organization_data = self._organization.get_organization_data()
+        organization_data = self._organization.build_organization_data()
         return [
             AssetsDefinitionCacheableData(
                 extra_metadata={

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -119,7 +119,7 @@ class SigmaOrganization(ConfigurableResource):
         return self.fetch_json(f"workbooks/{workbook_id}/queries")["entries"]
 
     @cached_method
-    def get_organization_data(self) -> SigmaOrganizationData:
+    def build_organization_data(self) -> SigmaOrganizationData:
         raw_workbooks = self.fetch_workbooks()
 
         dataset_inode_to_name: Mapping[str, str] = {}

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -32,6 +32,11 @@ class SigmaDataset:
     inputs: AbstractSet[str]
 
 
+def _inode_from_url(url: str) -> str:
+    """Builds a Sigma internal inode value from a Sigma URL."""
+    return f'inode-{url.split("/")[-1]}'
+
+
 @record
 class SigmaOrganizationData:
     workbooks: List[SigmaWorkbook]
@@ -118,9 +123,9 @@ class SigmaOrganization(ConfigurableResource):
         raw_workbooks = self.fetch_workbooks()
 
         dataset_inode_to_name: Mapping[str, str] = {}
-        columns_by_dataset = defaultdict(set)
-        deps_by_dataset = defaultdict(set)
-        dataset_element_to_name: Mapping[str, str] = {}
+        columns_by_dataset_inode = defaultdict(set)
+        deps_by_dataset_inode = defaultdict(set)
+        dataset_element_to_inode: Mapping[str, str] = {}
 
         workbooks: List[SigmaWorkbook] = []
 
@@ -138,9 +143,9 @@ class SigmaOrganization(ConfigurableResource):
                     )
                     for inode, item in lineage["dependencies"].items():
                         if item.get("type") == "dataset":
-                            workbook_deps.add(item["name"])
+                            workbook_deps.add(item["nodeId"])
                             dataset_inode_to_name[inode] = item["name"]
-                            dataset_element_to_name[element["elementId"]] = item["name"]
+                            dataset_element_to_inode[element["elementId"]] = item["nodeId"]
 
                     # We can't query the list of columns in a dataset directly, so we have to build a partial
                     # list from the columns which appear in any workbook.
@@ -151,7 +156,7 @@ class SigmaOrganization(ConfigurableResource):
                         split = column["columnId"].split("/")
                         if len(split) == 2:
                             inode, column_name = split
-                            columns_by_dataset[dataset_inode_to_name[inode]].add(column_name)
+                            columns_by_dataset_inode[inode].add(column_name)
 
             # Finally, we extract the list of tables used in each query in the workbook with
             # the help of sqlglot. Each query is associated with an "element", or section of the
@@ -169,20 +174,20 @@ class SigmaOrganization(ConfigurableResource):
                     ]
                 )
 
-                deps_by_dataset[dataset_element_to_name[element_id]] = deps_by_dataset[
-                    dataset_element_to_name[element_id]
+                deps_by_dataset_inode[dataset_element_to_inode[element_id]] = deps_by_dataset_inode[
+                    dataset_element_to_inode[element_id]
                 ].union(table_deps)
 
             workbooks.append(SigmaWorkbook(properties=workbook, datasets=workbook_deps))
 
         datasets: List[SigmaDataset] = []
         for dataset in self.fetch_datasets():
-            name = dataset["name"]
+            inode = _inode_from_url(dataset["url"])
             datasets.append(
                 SigmaDataset(
                     properties=dataset,
-                    columns=columns_by_dataset.get(name, set()),
-                    inputs=deps_by_dataset[name],
+                    columns=columns_by_dataset_inode.get(inode, set()),
+                    inputs=deps_by_dataset_inode[inode],
                 )
             )
 

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -1,9 +1,13 @@
+from collections import defaultdict
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import AbstractSet, Any, Dict, List, Mapping, Optional
 
 import requests
 from dagster import ConfigurableResource
+from dagster._record import record
+from dagster._utils.cached_method import cached_method
 from pydantic import Field, PrivateAttr
+from sqlglot import exp, parse_one
 
 
 class SigmaCloudType(Enum):
@@ -13,6 +17,25 @@ class SigmaCloudType(Enum):
     AWS_UK = "https://api.uk.aws.sigmacomputing.com"
     AZURE_US = "https://api.us.azure.sigmacomputing.com"
     GCP = "https://api.sigmacomputing.com"
+
+
+@record
+class SigmaWorkbook:
+    properties: Dict[str, Any]
+    datasets: AbstractSet[str]
+
+
+@record
+class SigmaDataset:
+    properties: Dict[str, Any]
+    columns: AbstractSet[str]
+    inputs: AbstractSet[str]
+
+
+@record
+class SigmaOrganizationData:
+    workbooks: List[SigmaWorkbook]
+    datasets: List[SigmaDataset]
 
 
 class SigmaOrganization(ConfigurableResource):
@@ -59,4 +82,108 @@ class SigmaOrganization(ConfigurableResource):
             headers={"Accept": "application/json", "Authorization": f"Bearer {self.api_token}"},
         )
         response.raise_for_status()
+
         return response.json()
+
+    @cached_method
+    def fetch_workbooks(self) -> List[Dict[str, Any]]:
+        return self.fetch_json("workbooks")["entries"]
+
+    @cached_method
+    def fetch_datasets(self) -> List[Dict[str, Any]]:
+        return self.fetch_json("datasets")["entries"]
+
+    @cached_method
+    def fetch_pages_for_workbook(self, workbook_id: str) -> List[Dict[str, Any]]:
+        return self.fetch_json(f"workbooks/{workbook_id}/pages")["entries"]
+
+    @cached_method
+    def fetch_elements_for_page(self, workbook_id: str, page_id: str) -> List[Dict[str, Any]]:
+        return self.fetch_json(f"workbooks/{workbook_id}/pages/{page_id}/elements")["entries"]
+
+    @cached_method
+    def fetch_lineage_for_element(self, workbook_id: str, element_id: str) -> Dict[str, Any]:
+        return self.fetch_json(f"workbooks/{workbook_id}/lineage/elements/{element_id}")
+
+    @cached_method
+    def fetch_columns_for_element(self, workbook_id: str, element_id: str) -> List[Dict[str, Any]]:
+        return self.fetch_json(f"workbooks/{workbook_id}/elements/{element_id}/columns")["entries"]
+
+    @cached_method
+    def fetch_queries_for_workbook(self, workbook_id: str) -> List[Dict[str, Any]]:
+        return self.fetch_json(f"workbooks/{workbook_id}/queries")["entries"]
+
+    @cached_method
+    def get_organization_data(self) -> SigmaOrganizationData:
+        raw_workbooks = self.fetch_workbooks()
+
+        dataset_inode_to_name: Mapping[str, str] = {}
+        columns_by_dataset = defaultdict(set)
+        deps_by_dataset = defaultdict(set)
+        dataset_element_to_name: Mapping[str, str] = {}
+
+        workbooks: List[SigmaWorkbook] = []
+
+        # Unfortunately, Sigma's API does not nicely model the relationship between various assets.
+        # We have to do some manual work to infer these relationships ourselves.
+        for workbook in raw_workbooks:
+            workbook_deps = set()
+            pages = self.fetch_pages_for_workbook(workbook["workbookId"])
+            for page in pages:
+                elements = self.fetch_elements_for_page(workbook["workbookId"], page["pageId"])
+                for element in elements:
+                    # We extract the list of dataset dependencies from the lineage of each workbook.
+                    lineage = self.fetch_lineage_for_element(
+                        workbook["workbookId"], element["elementId"]
+                    )
+                    for inode, item in lineage["dependencies"].items():
+                        if item.get("type") == "dataset":
+                            workbook_deps.add(item["name"])
+                            dataset_inode_to_name[inode] = item["name"]
+                            dataset_element_to_name[element["elementId"]] = item["name"]
+
+                    # We can't query the list of columns in a dataset directly, so we have to build a partial
+                    # list from the columns which appear in any workbook.
+                    columns = self.fetch_columns_for_element(
+                        workbook["workbookId"], element["elementId"]
+                    )
+                    for column in columns:
+                        split = column["columnId"].split("/")
+                        if len(split) == 2:
+                            inode, column_name = split
+                            columns_by_dataset[dataset_inode_to_name[inode]].add(column_name)
+
+            # Finally, we extract the list of tables used in each query in the workbook with
+            # the help of sqlglot. Each query is associated with an "element", or section of the
+            # workbook. We know which dataset each element is associated with, so we can infer
+            # the dataset for each query, and from there build a list of tables which the dataset
+            # depends on.
+            queries = self.fetch_queries_for_workbook(workbook["workbookId"])
+            for query in queries:
+                element_id = query["elementId"]
+                table_deps = set(
+                    [
+                        f"{table.catalog}.{table.db}.{table.this}"
+                        for table in list(parse_one(query["sql"]).find_all(exp.Table))
+                        if table.catalog
+                    ]
+                )
+
+                deps_by_dataset[dataset_element_to_name[element_id]] = deps_by_dataset[
+                    dataset_element_to_name[element_id]
+                ].union(table_deps)
+
+            workbooks.append(SigmaWorkbook(properties=workbook, datasets=workbook_deps))
+
+        datasets: List[SigmaDataset] = []
+        for dataset in self.fetch_datasets():
+            name = dataset["name"]
+            datasets.append(
+                SigmaDataset(
+                    properties=dataset,
+                    columns=columns_by_dataset.get(name, set()),
+                    inputs=deps_by_dataset[name],
+                )
+            )
+
+        return SigmaOrganizationData(workbooks=workbooks, datasets=datasets)

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -1,13 +1,19 @@
 from collections import defaultdict
 from enum import Enum
-from typing import AbstractSet, Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 import requests
 from dagster import ConfigurableResource
-from dagster._record import record
 from dagster._utils.cached_method import cached_method
 from pydantic import Field, PrivateAttr
 from sqlglot import exp, parse_one
+
+from dagster_sigma.translator import (
+    SigmaDataset,
+    SigmaOrganizationData,
+    SigmaWorkbook,
+    _inode_from_url,
+)
 
 
 class SigmaCloudType(Enum):
@@ -17,30 +23,6 @@ class SigmaCloudType(Enum):
     AWS_UK = "https://api.uk.aws.sigmacomputing.com"
     AZURE_US = "https://api.us.azure.sigmacomputing.com"
     GCP = "https://api.sigmacomputing.com"
-
-
-@record
-class SigmaWorkbook:
-    properties: Dict[str, Any]
-    datasets: AbstractSet[str]
-
-
-@record
-class SigmaDataset:
-    properties: Dict[str, Any]
-    columns: AbstractSet[str]
-    inputs: AbstractSet[str]
-
-
-def _inode_from_url(url: str) -> str:
-    """Builds a Sigma internal inode value from a Sigma URL."""
-    return f'inode-{url.split("/")[-1]}'
-
-
-@record
-class SigmaOrganizationData:
-    workbooks: List[SigmaWorkbook]
-    datasets: List[SigmaDataset]
 
 
 class SigmaOrganization(ConfigurableResource):
@@ -87,7 +69,6 @@ class SigmaOrganization(ConfigurableResource):
             headers={"Accept": "application/json", "Authorization": f"Bearer {self.api_token}"},
         )
         response.raise_for_status()
-
         return response.json()
 
     @cached_method

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/translator.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/translator.py
@@ -1,0 +1,103 @@
+import re
+from typing import AbstractSet, Any, Dict, List
+
+from dagster import AssetKey, AssetSpec, MetadataValue, TableSchema
+from dagster._core.definitions.metadata.metadata_set import TableMetadataSet
+from dagster._core.definitions.metadata.table import TableColumn
+from dagster._core.definitions.tags import build_kind_tag
+from dagster._record import record
+from dagster._utils.cached_method import cached_method
+from dagster._vendored.dateutil.parser import isoparse
+
+
+def _clean_asset_name(name: str) -> str:
+    """Cleans an input to be a valid Dagster asset name."""
+    return re.sub(r"[^A-Za-z0-9_]+", "_", name)
+
+
+def _inode_from_url(url: str) -> str:
+    """Builds a Sigma internal inode value from a Sigma URL."""
+    return f'inode-{url.split("/")[-1]}'
+
+
+@record
+class SigmaWorkbook:
+    properties: Dict[str, Any]
+    datasets: AbstractSet[str]
+
+
+@record
+class SigmaDataset:
+    properties: Dict[str, Any]
+    columns: AbstractSet[str]
+    inputs: AbstractSet[str]
+
+
+@record
+class SigmaOrganizationData:
+    workbooks: List[SigmaWorkbook]
+    datasets: List[SigmaDataset]
+
+    @cached_method
+    def get_datasets_by_inode(self) -> Dict[str, SigmaDataset]:
+        return {_inode_from_url(dataset.properties["url"]): dataset for dataset in self.datasets}
+
+
+class DagsterSigmaTranslator:
+    """Translator class which converts raw response data from the Sigma API into AssetSpecs.
+    Subclass this class to provide custom translation logic.
+    """
+
+    def __init__(self, context: SigmaOrganizationData):
+        self._context = context
+
+    @property
+    def organization_data(self) -> SigmaOrganizationData:
+        return self._context
+
+    def get_workbook_key(self, data: SigmaWorkbook) -> AssetKey:
+        return AssetKey(_clean_asset_name(data.properties["name"]))
+
+    def get_workbook_spec(self, data: SigmaWorkbook) -> AssetSpec:
+        metadata = {
+            "dagster_sigma/web_url": MetadataValue.url(data.properties["url"]),
+            "dagster_sigma/version": data.properties["latestVersion"],
+            "dagster_sigma/created_at": MetadataValue.timestamp(
+                isoparse(data.properties["createdAt"])
+            ),
+        }
+        datasets = [self._context.get_datasets_by_inode()[inode] for inode in data.datasets]
+        return AssetSpec(
+            key=self.get_workbook_key(data),
+            metadata=metadata,
+            tags={
+                **build_kind_tag("sigma"),
+            },
+            deps={self.get_dataset_key(dataset) for dataset in datasets},
+        )
+
+    def get_dataset_key(self, data: SigmaDataset) -> AssetKey:
+        return AssetKey(_clean_asset_name(data.properties["name"]))
+
+    def get_dataset_spec(self, data: SigmaDataset) -> AssetSpec:
+        metadata = {
+            "dagster_sigma/web_url": MetadataValue.url(data.properties["url"]),
+            "dagster_sigma/created_at": MetadataValue.timestamp(
+                isoparse(data.properties["createdAt"])
+            ),
+            **TableMetadataSet(
+                column_schema=TableSchema(
+                    columns=[TableColumn(name=column_name) for column_name in sorted(data.columns)]
+                )
+            ),
+        }
+
+        return AssetSpec(
+            key=self.get_dataset_key(data),
+            metadata=metadata,
+            tags={
+                **build_kind_tag("sigma"),
+            },
+            deps={AssetKey(input_name.lower().split(".")) for input_name in data.inputs},
+            description=data.properties.get("description"),
+        )

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/translator.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/translator.py
@@ -6,6 +6,7 @@ from dagster._core.definitions.metadata.metadata_set import TableMetadataSet
 from dagster._core.definitions.metadata.table import TableColumn
 from dagster._core.definitions.tags import build_kind_tag
 from dagster._record import record
+from dagster._serdes.serdes import whitelist_for_serdes
 from dagster._utils.cached_method import cached_method
 from dagster._vendored.dateutil.parser import isoparse
 
@@ -20,12 +21,14 @@ def _inode_from_url(url: str) -> str:
     return f'inode-{url.split("/")[-1]}'
 
 
+@whitelist_for_serdes
 @record
 class SigmaWorkbook:
     properties: Dict[str, Any]
     datasets: AbstractSet[str]
 
 
+@whitelist_for_serdes
 @record
 class SigmaDataset:
     properties: Dict[str, Any]

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/conftest.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/conftest.py
@@ -29,48 +29,46 @@ def _build_paginated_response(items: List[Dict[str, Any]]) -> Dict[str, Any]:
     }
 
 
+SAMPLE_WORKBOOK_DATA = {
+    "workbookId": "4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e",
+    "workbookUrlId": "2opi6VLEne4BaPyj00US50",
+    "createdBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+    "updatedBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+    "createdAt": "2024-09-12T21:22:49.072Z",
+    "updatedAt": "2024-09-12T22:20:39.848Z",
+    "name": "Sample Workbook",
+    "url": "https://app.sigmacomputing.com/dagster-labs/workbook/2opi6VLEne4BaPyj00US50",
+    "path": "My Documents",
+    "latestVersion": 5,
+    "ownerId": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+}
+
+SAMPLE_DATASET_INODE = "inode-Iq557kfHN8KRu76HdGSWi"
+SAMPLE_DATASET_DATA = {
+    "datasetId": "178a6bb5-c0e7-4bef-a739-f12710492f16",
+    "createdBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+    "updatedBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+    "createdAt": "2024-09-12T21:16:17.830Z",
+    "updatedAt": "2024-09-12T21:19:31.000Z",
+    "name": "Orders Dataset",
+    "description": "Wow, cool orders dataset",
+    "url": "https://app.sigmacomputing.com/dagster-labs/b/Iq557kfHN8KRu76HdGSWi",
+}
+
+
 @pytest.fixture(name="sigma_sample_data")
 def sigma_sample_data_fixture() -> None:
     # Single workbook, dataset
     responses.add(
         method=responses.GET,
         url="https://aws-api.sigmacomputing.com/v2/workbooks",
-        json=_build_paginated_response(
-            [
-                {
-                    "workbookId": "4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e",
-                    "workbookUrlId": "2opi6VLEne4BaPyj00US50",
-                    "createdBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
-                    "updatedBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
-                    "createdAt": "2024-09-12T21:22:49.072Z",
-                    "updatedAt": "2024-09-12T22:20:39.848Z",
-                    "name": "Sample Workbook",
-                    "url": "https://app.sigmacomputing.com/dagster-labs/workbook/2opi6VLEne4BaPyj00US50",
-                    "path": "My Documents",
-                    "latestVersion": 5,
-                    "ownerId": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
-                }
-            ]
-        ),
+        json=_build_paginated_response([SAMPLE_WORKBOOK_DATA]),
         status=200,
     )
     responses.add(
         method=responses.GET,
         url="https://aws-api.sigmacomputing.com/v2/datasets",
-        json=_build_paginated_response(
-            [
-                {
-                    "datasetId": "178a6bb5-c0e7-4bef-a739-f12710492f16",
-                    "createdBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
-                    "updatedBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
-                    "createdAt": "2024-09-12T21:16:17.830Z",
-                    "updatedAt": "2024-09-12T21:19:31.000Z",
-                    "name": "Orders Dataset",
-                    "description": "",
-                    "url": "https://app.sigmacomputing.com/dagster-labs/b/Iq557kfHN8KRu76HdGSWi",
-                }
-            ]
-        ),
+        json=_build_paginated_response([SAMPLE_DATASET_DATA]),
         status=200,
     )
 

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/conftest.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/conftest.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Any, Dict, List
 
 import pytest
 import responses
@@ -17,3 +18,196 @@ def sigma_auth_fixture() -> str:
     )
 
     return fake_access_token
+
+
+def _build_paginated_response(items: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return {
+        "entries": items,
+        "hasMore": False,
+        "total": len(items),
+        "nextPage": None,
+    }
+
+
+@pytest.fixture(name="sigma_sample_data")
+def sigma_sample_data_fixture() -> None:
+    # Single workbook, dataset
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks",
+        json=_build_paginated_response(
+            [
+                {
+                    "workbookId": "4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e",
+                    "workbookUrlId": "2opi6VLEne4BaPyj00US50",
+                    "createdBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+                    "updatedBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+                    "createdAt": "2024-09-12T21:22:49.072Z",
+                    "updatedAt": "2024-09-12T22:20:39.848Z",
+                    "name": "Sample Workbook",
+                    "url": "https://app.sigmacomputing.com/dagster-labs/workbook/2opi6VLEne4BaPyj00US50",
+                    "path": "My Documents",
+                    "latestVersion": 5,
+                    "ownerId": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+                }
+            ]
+        ),
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/datasets",
+        json=_build_paginated_response(
+            [
+                {
+                    "datasetId": "178a6bb5-c0e7-4bef-a739-f12710492f16",
+                    "createdBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+                    "updatedBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+                    "createdAt": "2024-09-12T21:16:17.830Z",
+                    "updatedAt": "2024-09-12T21:19:31.000Z",
+                    "name": "Orders Dataset",
+                    "description": "",
+                    "url": "https://app.sigmacomputing.com/dagster-labs/b/Iq557kfHN8KRu76HdGSWi",
+                }
+            ]
+        ),
+        status=200,
+    )
+
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/pages",
+        json=_build_paginated_response([{"pageId": "qwMyyHBCuC", "name": "Page 1"}]),
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/pages/qwMyyHBCuC/elements",
+        json=_build_paginated_response(
+            [
+                {
+                    "elementId": "_MuHPbskp0",
+                    "type": "table",
+                    "name": "sample elementl",
+                    "columns": [
+                        "Order Id",
+                        "Customer Id",
+                        "workbook renamed date",
+                        "Modified Date",
+                    ],
+                    "vizualizationType": "levelTable",
+                },
+                {
+                    "elementId": "V29pknzHb6",
+                    "type": "visualization",
+                    "name": "Count of Order Date by Status",
+                    "columns": [
+                        "Order Id",
+                        "Customer Id",
+                        "Order Date",
+                        "Status",
+                        "Modified Date",
+                        "Count of Order Date",
+                    ],
+                    "vizualizationType": "bar",
+                },
+            ]
+        ),
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/lineage/elements/_MuHPbskp0",
+        json={
+            "dependencies": {
+                "qy_ARjTKcT": {
+                    "nodeId": "qy_ARjTKcT",
+                    "type": "sheet",
+                    "name": "sample elementl",
+                    "elementId": "_MuHPbskp0",
+                },
+                "inode-Iq557kfHN8KRu76HdGSWi": {
+                    "nodeId": "inode-Iq557kfHN8KRu76HdGSWi",
+                    "type": "dataset",
+                    "name": "Orders Dataset",
+                },
+            },
+            "edges": [
+                {"source": "inode-Iq557kfHN8KRu76HdGSWi", "target": "qy_ARjTKcT", "type": "source"}
+            ],
+        },
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/elements/_MuHPbskp0/columns",
+        json=_build_paginated_response(
+            [
+                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Order Id", "label": "Order Id"},
+                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Customer Id", "label": "Customer Id"},
+                {
+                    "columnId": "inode-Iq557kfHN8KRu76HdGSWi/Order Date",
+                    "label": "workbook renamed date",
+                },
+                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Modified Date", "label": "Modified Date"},
+            ]
+        ),
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/lineage/elements/V29pknzHb6",
+        json={
+            "dependencies": {
+                "SBvQYKT6ui": {
+                    "nodeId": "SBvQYKT6ui",
+                    "type": "sheet",
+                    "name": "Count of Order Date by Status",
+                    "elementId": "V29pknzHb6",
+                },
+                "inode-Iq557kfHN8KRu76HdGSWi": {
+                    "nodeId": "inode-Iq557kfHN8KRu76HdGSWi",
+                    "type": "dataset",
+                    "name": "Orders Dataset",
+                },
+            },
+            "edges": [
+                {"source": "inode-Iq557kfHN8KRu76HdGSWi", "target": "SBvQYKT6ui", "type": "source"}
+            ],
+        },
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/elements/V29pknzHb6/columns",
+        json=_build_paginated_response(
+            [
+                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Order Id", "label": "Order Id"},
+                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Customer Id", "label": "Customer Id"},
+                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Order Date", "label": "Order Date"},
+                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Status", "label": "Status"},
+                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Modified Date", "label": "Modified Date"},
+                {"columnId": "VBKAHQgx58", "label": "Count of Order Date"},
+            ]
+        ),
+        status=200,
+    )
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/queries",
+        json=_build_paginated_response(
+            [
+                {
+                    "elementId": "_MuHPbskp0",
+                    "name": "sample elementl",
+                    "sql": 'select ORDER_ID_7 "Order Id", CUSTOMER_ID_8 "Customer Id", CAST_DATE_TO_DATETIME_9 "workbook renamed date", CAST_DATE_TO_DATETIME_11 "Modified Date" from (select ORDER_ID ORDER_ID_7, CUSTOMER_ID CUSTOMER_ID_8, ORDER_DATE::timestamp_ltz CAST_DATE_TO_DATETIME_9, ORDER_DATE::timestamp_ltz CAST_DATE_TO_DATETIME_11 from (select * from TESTDB.JAFFLE_SHOP.STG_ORDERS STG_ORDERS limit 1000) Q1) Q2 limit 1000\n\n-- Sigma \u03a3 {"request-id":"69ac9a35-64b3-4840-a53d-3aed43a575ec","email":"ben@dagsterlabs.com"}',
+                },
+                {
+                    "elementId": "V29pknzHb6",
+                    "name": "Count of Order Date by Status",
+                    "sql": 'with Q1 as (select ORDER_ID, CUSTOMER_ID, STATUS, ORDER_DATE::timestamp_ltz CAST_DATE_TO_DATETIME_5, ORDER_DATE::timestamp_ltz CAST_DATE_TO_DATETIME_6 from TESTDB.JAFFLE_SHOP.STG_ORDERS STG_ORDERS) select STATUS_10 "Status", COUNT_22 "Count of Order Date", ORDER_ID_7 "Order Id", CUSTOMER_ID_8 "Customer Id", CAST_DATE_TO_DATETIME_7 "Order Date", CAST_DATE_TO_DATETIME_8 "Modified Date" from (select Q3.ORDER_ID_7 ORDER_ID_7, Q3.CUSTOMER_ID_8 CUSTOMER_ID_8, Q3.CAST_DATE_TO_DATETIME_7 CAST_DATE_TO_DATETIME_7, Q3.STATUS_10 STATUS_10, Q3.CAST_DATE_TO_DATETIME_8 CAST_DATE_TO_DATETIME_8, Q6.COUNT_22 COUNT_22, Q6.STATUS_11 STATUS_11 from (select ORDER_ID ORDER_ID_7, CUSTOMER_ID CUSTOMER_ID_8, CAST_DATE_TO_DATETIME_6 CAST_DATE_TO_DATETIME_7, STATUS STATUS_10, CAST_DATE_TO_DATETIME_5 CAST_DATE_TO_DATETIME_8 from Q1 Q2 order by STATUS_10 asc limit 1000) Q3 left join (select count(CAST_DATE_TO_DATETIME_7) COUNT_22, STATUS_10 STATUS_11 from (select CAST_DATE_TO_DATETIME_6 CAST_DATE_TO_DATETIME_7, STATUS STATUS_10 from Q1 Q4) Q5 group by STATUS_10) Q6 on equal_null(Q3.STATUS_10, Q6.STATUS_11)) Q8 order by STATUS_10 asc limit 1000\n\n-- Sigma \u03a3 {"request-id":"69ac9a35-64b3-4840-a53d-3aed43a575ec","email":"ben@dagsterlabs.com"}',
+                },
+            ]
+        ),
+        status=200,
+    )

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/pending_repo.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/pending_repo.py
@@ -1,0 +1,34 @@
+import uuid
+from typing import cast
+
+from dagster import asset, define_asset_job
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.repository_definition.repository_definition import (
+    PendingRepositoryDefinition,
+)
+from dagster_sigma import SigmaCloudType, SigmaOrganization
+
+fake_client_id = uuid.uuid4().hex
+fake_client_secret = uuid.uuid4().hex
+
+fake_token = uuid.uuid4().hex
+resource = SigmaOrganization(
+    cloud_type=SigmaCloudType.AWS_US,
+    client_id=fake_client_id,
+    client_secret=fake_client_secret,
+)
+sigma_defs = resource.build_defs()
+
+
+@asset
+def my_materializable_asset():
+    pass
+
+
+pending_repo_from_cached_asset_metadata = cast(
+    PendingRepositoryDefinition,
+    Definitions.merge(
+        Definitions(assets=[my_materializable_asset], jobs=[define_asset_job("all_asset_job")]),
+        sigma_defs,
+    ).get_inner_repository(),
+)

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_asset_specs.py
@@ -1,0 +1,14 @@
+import responses
+from dagster._core.instance_for_test import instance_for_test
+
+
+@responses.activate
+def test_load_assets_organization_data(sigma_auth_token: str, sigma_sample_data: None) -> None:
+    with instance_for_test() as _instance:
+        from dagster_sigma_tests.pending_repo import pending_repo_from_cached_asset_metadata
+
+        # first, we resolve the repository to generate our cached metadata
+        repository_def = pending_repo_from_cached_asset_metadata.compute_repository_definition()
+
+        # 2 Sigma external assets, one materializable asset
+        assert len(repository_def.assets_defs_by_key) == 2 + 1

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_placeholder.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_placeholder.py
@@ -1,2 +1,0 @@
-def test_placeholder():
-    pass

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
@@ -67,7 +67,7 @@ def test_model_organization_data(sigma_auth_token: str, sigma_sample_data: None)
         client_secret=fake_client_secret,
     )
 
-    data = resource.get_organization_data()
+    data = resource.build_organization_data()
 
     assert len(data.workbooks) == 1
     assert data.workbooks[0].properties["name"] == "Sample Workbook"

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
@@ -53,3 +53,32 @@ def test_basic_fetch(sigma_auth_token: str) -> None:
 
     assert len(responses.calls) == 2
     assert responses.calls[1].request.headers["Authorization"] == f"Bearer {sigma_auth_token}"
+
+
+@responses.activate
+def test_model_organization_data(sigma_auth_token: str, sigma_sample_data: None) -> None:
+    fake_client_id = uuid.uuid4().hex
+    fake_client_secret = uuid.uuid4().hex
+
+    resource = SigmaOrganization(
+        cloud_type=SigmaCloudType.AWS_US,
+        client_id=fake_client_id,
+        client_secret=fake_client_secret,
+    )
+
+    data = resource.get_organization_data()
+
+    assert len(data.workbooks) == 1
+    assert data.workbooks[0].properties["name"] == "Sample Workbook"
+    assert data.workbooks[0].datasets == {"Orders Dataset"}
+
+    assert len(data.datasets) == 1
+    assert data.datasets[0].properties["name"] == "Orders Dataset"
+    assert data.datasets[0].columns == {
+        "Customer Id",
+        "Order Date",
+        "Order Id",
+        "Modified Date",
+        "Status",
+    }
+    assert data.datasets[0].inputs == {"TESTDB.JAFFLE_SHOP.STG_ORDERS"}

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
@@ -2,6 +2,7 @@ import uuid
 
 import responses
 from dagster_sigma import SigmaCloudType, SigmaOrganization
+from dagster_sigma.resource import _inode_from_url
 
 
 @responses.activate
@@ -70,9 +71,10 @@ def test_model_organization_data(sigma_auth_token: str, sigma_sample_data: None)
 
     assert len(data.workbooks) == 1
     assert data.workbooks[0].properties["name"] == "Sample Workbook"
-    assert data.workbooks[0].datasets == {"Orders Dataset"}
 
     assert len(data.datasets) == 1
+    assert data.workbooks[0].datasets == {_inode_from_url(data.datasets[0].properties["url"])}
+
     assert data.datasets[0].properties["name"] == "Orders Dataset"
     assert data.datasets[0].columns == {
         "Customer Id",

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_translator.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_translator.py
@@ -1,0 +1,92 @@
+from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.metadata.table import TableColumn, TableSchema
+from dagster._core.definitions.tags import build_kind_tag_key
+from dagster_sigma.translator import (
+    DagsterSigmaTranslator,
+    SigmaDataset,
+    SigmaOrganizationData,
+    SigmaWorkbook,
+)
+
+from dagster_sigma_tests.conftest import (
+    SAMPLE_DATASET_DATA,
+    SAMPLE_DATASET_INODE,
+    SAMPLE_WORKBOOK_DATA,
+)
+
+
+def test_workbook_translation() -> None:
+    sample_workbook = SigmaWorkbook(
+        properties=SAMPLE_WORKBOOK_DATA,
+        datasets={SAMPLE_DATASET_INODE},
+    )
+
+    sample_dataset = SigmaDataset(properties=SAMPLE_DATASET_DATA, columns=set(), inputs=set())
+
+    translator = DagsterSigmaTranslator(
+        SigmaOrganizationData(workbooks=[sample_workbook], datasets=[sample_dataset])
+    )
+
+    asset_spec = translator.get_workbook_spec(sample_workbook)
+
+    assert asset_spec.key.path == ["Sample_Workbook"]
+    assert asset_spec.metadata["dagster_sigma/web_url"].value == SAMPLE_WORKBOOK_DATA["url"]
+    assert asset_spec.metadata["dagster_sigma/version"] == 5
+    assert asset_spec.metadata["dagster_sigma/created_at"].value == 1726176169.072
+    assert build_kind_tag_key("sigma") in asset_spec.tags
+    assert {dep.asset_key for dep in asset_spec.deps} == {AssetKey(["Orders_Dataset"])}
+
+
+def test_dataset_translation() -> None:
+    sample_dataset = SigmaDataset(
+        properties=SAMPLE_DATASET_DATA,
+        columns={"user_id", "date", "order_id"},
+        inputs={"TESTDB.JAFFLE_SHOP.STG_ORDERS"},
+    )
+
+    translator = DagsterSigmaTranslator(
+        SigmaOrganizationData(workbooks=[], datasets=[sample_dataset])
+    )
+
+    asset_spec = translator.get_dataset_spec(sample_dataset)
+
+    assert asset_spec.key.path == ["Orders_Dataset"]
+    assert asset_spec.metadata["dagster_sigma/web_url"].value == SAMPLE_DATASET_DATA["url"]
+    assert asset_spec.metadata["dagster_sigma/created_at"].value == 1726175777.83
+    assert asset_spec.metadata["dagster/column_schema"] == TableSchema(
+        columns=[
+            TableColumn(name="date"),
+            TableColumn(name="order_id"),
+            TableColumn(name="user_id"),
+        ]
+    )
+
+    assert asset_spec.description == "Wow, cool orders dataset"
+
+    assert build_kind_tag_key("sigma") in asset_spec.tags
+    assert {dep.asset_key for dep in asset_spec.deps} == {
+        AssetKey(["testdb", "jaffle_shop", "stg_orders"])
+    }
+
+
+def test_dataset_translation_custom_translator() -> None:
+    class MyCustomTranslator(DagsterSigmaTranslator):
+        def get_dataset_key(self, data: SigmaDataset) -> AssetKey:
+            return super().get_dataset_key(data).with_prefix("sigma")
+
+        def get_dataset_spec(self, data: SigmaDataset) -> AssetSpec:
+            return super().get_dataset_spec(data)._replace(description="Custom description")
+
+    sample_dataset = SigmaDataset(
+        properties=SAMPLE_DATASET_DATA,
+        columns={"user_id", "date", "order_id"},
+        inputs={"TESTDB.JAFFLE_SHOP.STG_ORDERS"},
+    )
+
+    translator = MyCustomTranslator(SigmaOrganizationData(workbooks=[], datasets=[sample_dataset]))
+
+    asset_spec = translator.get_dataset_spec(sample_dataset)
+
+    assert asset_spec.key.path == ["sigma", "Orders_Dataset"]
+    assert asset_spec.description == "Custom description"

--- a/python_modules/libraries/dagster-sigma/setup.py
+++ b/python_modules/libraries/dagster-sigma/setup.py
@@ -37,6 +37,7 @@ setup(
     packages=find_packages(exclude=["dagster_sigma_tests*"]),
     install_requires=[
         f"dagster{pin}",
+        "sqlglot",
     ],
     include_package_data=True,
     python_requires=">=3.8,<3.13",


### PR DESCRIPTION
## Summary

Introduces basic cacheable `Definitions` building method for `dagster-sigma`. This mostly relies on logic defined in earlier PRs in the stack - just invokes the translator etc.

```python
resource = SigmaOrganization(
    cloud_type=SigmaCloudType.AWS_US,
    client_id=fake_client_id,
    client_secret=fake_client_secret,
)
defs = resource.build_defs()
```

## Test Plan

New unit test.


## Changelog

> NOCHANGELOG

