### PR TITLE
[dagster-airlift][refactor] always construct assetsdefinition

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor.py
@@ -30,7 +30,7 @@ from dagster._time import datetime_from_timestamp, get_current_datetime, get_cur
 
 from dagster_airlift.constants import MIGRATED_TAG
 from dagster_airlift.core.airflow_instance import AirflowInstance
-from dagster_airlift.core.utils import get_couplings_from_asset
+from dagster_airlift.core.utils import get_couplings_from_assets_def
 
 MAIN_LOOP_TIMEOUT_SECONDS = DEFAULT_SENSOR_GRPC_TIMEOUT - 20
 DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS = 1
@@ -164,7 +164,7 @@ def get_unmigrated_info(
     for assets_def in repository_def.assets_defs_by_key.values():
         # We could be more specific about the checks here to ensure that there's only one asset key
         # specifying the dag, and that all others have a task id.
-        couplings = get_couplings_from_asset(assets_def)
+        couplings = get_couplings_from_assets_def(assets_def)
         dag_id: Optional[str] = next(
             iter({spec.metadata.get("Dag ID") for spec in assets_def.specs})
         )

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
@@ -1,8 +1,7 @@
-from typing import List, Optional, Sequence, Union, cast
+from typing import List, Optional, Sequence, cast
 
 from dagster import (
     AssetsDefinition,
-    AssetSpec,
     JsonMetadataValue,
     _check as check,
 )
@@ -17,18 +16,17 @@ def convert_to_valid_dagster_name(name: str) -> str:
     return "".join(c if VALID_NAME_REGEX.match(c) else "__" if c == "/" else "_" for c in name)
 
 
-def get_couplings_from_asset(
-    asset: Union[AssetsDefinition, AssetSpec],
+def get_couplings_from_assets_def(
+    asset: AssetsDefinition,
 ) -> Optional[Sequence[AirflowCoupling]]:
-    specs = asset.specs if isinstance(asset, AssetsDefinition) else [asset]
     asset_name = (
         asset.node_def.name
         if isinstance(asset, AssetsDefinition) and asset.is_executable
         else asset.key.to_user_string()
     )
-    if any(AIRFLOW_COUPLING_METADATA_KEY in spec.metadata for spec in specs):
+    if any(AIRFLOW_COUPLING_METADATA_KEY in spec.metadata for spec in asset.specs):
         prop: Optional[JsonMetadataValue] = None
-        for spec in specs:
+        for spec in asset.specs:
             if prop is None:
                 prop = spec.metadata[AIRFLOW_COUPLING_METADATA_KEY]
             else:

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
@@ -63,7 +63,7 @@ def build_definitions_airflow_asset_graph(
                 )
                 if create_assets_defs:
 
-                    @multi_asset(specs=[spec])
+                    @multi_asset(specs=[spec], name=f"{task_id}_{asset_key}")
                     def _asset():
                         return None
 

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 from dagster import AssetKey, AssetSpec, JsonMetadataValue, asset, multi_asset
 from dagster._check.functions import CheckError
 from dagster_airlift.constants import AIRFLOW_COUPLING_METADATA_KEY
-from dagster_airlift.core.utils import get_couplings_from_asset
+from dagster_airlift.core.utils import get_couplings_from_assets_def
 
 
 def test_no_convention() -> None:
@@ -12,7 +12,7 @@ def test_no_convention() -> None:
     def no_op():
         pass
 
-    assert get_couplings_from_asset(no_op) is None
+    assert get_couplings_from_assets_def(no_op) is None
 
 
 def test_retrieve_by_asset_metadata() -> None:
@@ -25,7 +25,7 @@ def test_retrieve_by_asset_metadata() -> None:
     def one_spec():
         pass
 
-    assert get_couplings_from_asset(one_spec) == [("print_dag", "print_task")]
+    assert get_couplings_from_assets_def(one_spec) == [("print_dag", "print_task")]
 
     # 2. Multiple spec retrieval, all specs match
     @multi_asset(
@@ -47,7 +47,7 @@ def test_retrieve_by_asset_metadata() -> None:
     def multi_spec_pass():
         pass
 
-    assert get_couplings_from_asset(multi_spec_pass) == [("print_dag", "print_task")]
+    assert get_couplings_from_assets_def(multi_spec_pass) == [("print_dag", "print_task")]
 
     # 3. Multiple spec retrieval but with different tasks/dags
     @multi_asset(
@@ -70,7 +70,7 @@ def test_retrieve_by_asset_metadata() -> None:
         pass
 
     with pytest.raises(CheckError):
-        get_couplings_from_asset(multi_spec_mismatch)
+        get_couplings_from_assets_def(multi_spec_mismatch)
 
     # 5. Multiple spec retrieval, not all have tags set
     @multi_asset(
@@ -88,4 +88,4 @@ def test_retrieve_by_asset_metadata() -> None:
         pass
 
     with pytest.raises(CheckError):
-        get_couplings_from_asset(multi_spec_task_mismatch)
+        get_couplings_from_assets_def(multi_spec_task_mismatch)

--- a/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/airflow_dags/migration_state/dbt_dag.yaml-e
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/airflow_dags/migration_state/dbt_dag.yaml-e
@@ -1,3 +1,0 @@
-tasks:
-  - id: build_dbt_models
-    migrated: True 

--- a/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/airflow_dags/migration_state/load_lakehouse.yaml-e
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/airflow_dags/migration_state/load_lakehouse.yaml-e
@@ -1,3 +1,0 @@
-tasks:
-  - id: load_iris
-    migrated: True 


### PR DESCRIPTION
## Summary & Motivation
Change cacheable assets codepath to always expect fully qualified assetsdefinitions. To achieve this, coerce within the merge step of dag defs.

This simplifies a lot of code paths and generally feels good.
## Changelog
`NOCHANGELOG`
