### PR TITLE
Correctly account for end_offset when deciding which partition key to look for in a freshness-based asset check

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/time_partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/time_partition.py
@@ -155,7 +155,7 @@ def _build_freshness_multi_check(
                 deadline.timestamp(), tz=partitions_def.timezone
             )
             last_completed_time_window = check.not_none(
-                partitions_def.get_prev_partition_window(deadline_in_partitions_def_tz)
+                partitions_def.get_last_partition_window(current_time=deadline_in_partitions_def_tz)
             )
             expected_partition_key = partitions_def.get_partition_key_range_for_time_window(
                 last_completed_time_window


### PR DESCRIPTION
Summary:
The current logic returns the last partition window that ends before the deadline, but I think what we actually want here is the most recent partition *at the time of* the deadline. The former does not correctly account for the end_offset shifting over the last partition window - the latter does. This PR makes that change.

Resolves https://github.com/dagster-io/dagster/issues/24394.

Test Plan: Adding a new test case now

## Summary & Motivation

## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
