### PR TITLE
[dagster-airlift] relax constraint around unique couplings per assetsdefinition

### DIFF
--- a/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/airflow_dags/migration_state/dbt_dag.yaml-e
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/airflow_dags/migration_state/dbt_dag.yaml-e
@@ -1,0 +1,3 @@
+tasks:
+  - id: build_dbt_models
+    migrated: False 

--- a/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/airflow_dags/migration_state/load_lakehouse.yaml-e
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/airflow_dags/migration_state/load_lakehouse.yaml-e
@@ -1,0 +1,3 @@
+tasks:
+  - id: load_iris
+    migrated: False 


### PR DESCRIPTION
## Summary & Motivation
This simplifies code quite a bit IMO. No longer expect that each assetspec on a given assetsdefinition points at the same repo.
## How I Tested These Changes
Existing tests. I'd like to add some more sensor behavioral tests to make sure everything works as expected there.
## Changelog
`NOCHANGELOG`
