### PR TITLE
[lazy-defs] Add a DefinitionsLoadType Enum

### DIFF
--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -24,6 +24,7 @@ from typing_extensions import Never, TypeAlias
 
 import dagster._check as check
 from dagster._core.code_pointer import CodePointer
+from dagster._core.definitions.definitions_loader import DefinitionsLoadType
 from dagster._core.definitions.reconstruct import repository_def_from_target_def
 from dagster._core.definitions.repository_definition import RepositoryDefinition
 from dagster._core.instance import DagsterInstance
@@ -569,7 +570,9 @@ def _get_code_pointer_dict_from_kwargs(kwargs: ClickArgMapping) -> Mapping[str, 
         return {
             cast(
                 RepositoryDefinition,
-                repository_def_from_target_def(loadable_target.target_definition),
+                repository_def_from_target_def(
+                    loadable_target.target_definition, DefinitionsLoadType.INITIALIZATION
+                ),
             ).name: CodePointer.from_python_file(
                 python_file, loadable_target.attribute, working_directory
             )
@@ -582,7 +585,9 @@ def _get_code_pointer_dict_from_kwargs(kwargs: ClickArgMapping) -> Mapping[str, 
         return {
             cast(
                 RepositoryDefinition,
-                repository_def_from_target_def(loadable_target.target_definition),
+                repository_def_from_target_def(
+                    loadable_target.target_definition, DefinitionsLoadType.INITIALIZATION
+                ),
             ).name: CodePointer.from_module(
                 module_name, loadable_target.attribute, working_directory
             )
@@ -595,7 +600,9 @@ def _get_code_pointer_dict_from_kwargs(kwargs: ClickArgMapping) -> Mapping[str, 
         return {
             cast(
                 RepositoryDefinition,
-                repository_def_from_target_def(loadable_target.target_definition),
+                repository_def_from_target_def(
+                    loadable_target.target_definition, DefinitionsLoadType.INITIALIZATION
+                ),
             ).name: CodePointer.from_python_package(
                 package_name, loadable_target.attribute, working_directory
             )

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
@@ -4,6 +4,7 @@ import sys
 import pytest
 from dagster import DagsterInvariantViolationError, RepositoryDefinition
 from dagster._core.code_pointer import CodePointer
+from dagster._core.definitions.definitions_loader import DefinitionsLoadType
 from dagster._core.definitions.reconstruct import repository_def_from_pointer
 from dagster._core.definitions.repository_definition import PendingRepositoryDefinition
 from dagster._core.errors import DagsterImportError
@@ -52,7 +53,8 @@ def test_single_job():
     assert symbol == "a_job"
 
     repo_def = repository_def_from_pointer(
-        CodePointer.from_python_file(single_job_path, symbol, None)
+        CodePointer.from_python_file(single_job_path, symbol, None),
+        DefinitionsLoadType.INITIALIZATION,
     )
 
     assert isinstance(repo_def, RepositoryDefinition)
@@ -81,7 +83,8 @@ def test_single_graph():
     assert symbol == "graph_one"
 
     repo_def = repository_def_from_pointer(
-        CodePointer.from_python_file(single_graph_path, symbol, None)
+        CodePointer.from_python_file(single_graph_path, symbol, None),
+        DefinitionsLoadType.INITIALIZATION,
     )
 
     assert isinstance(repo_def, RepositoryDefinition)
@@ -109,7 +112,10 @@ def test_multiple_assets():
     symbol = loadable_targets[0].attribute
     assert symbol == LOAD_ALL_ASSETS
 
-    repo_def = repository_def_from_pointer(CodePointer.from_python_file(path, symbol, None))
+    repo_def = repository_def_from_pointer(
+        CodePointer.from_python_file(path, symbol, None),
+        DefinitionsLoadType.INITIALIZATION,
+    )
 
     assert isinstance(repo_def, RepositoryDefinition)
     the_job = repo_def.get_implicit_global_asset_job_def()
@@ -180,7 +186,8 @@ def test_single_defs_in_file():
     assert symbol == "defs"
 
     repo_def = repository_def_from_pointer(
-        CodePointer.from_python_file(dagster_defs_path, symbol, None)
+        CodePointer.from_python_file(dagster_defs_path, symbol, None),
+        DefinitionsLoadType.INITIALIZATION,
     )
 
     assert isinstance(repo_def, RepositoryDefinition)
@@ -272,7 +279,9 @@ def test_definitions_loader(filename):
     assert symbol == "defs"
 
     repo_def = repository_def_from_pointer(
-        CodePointer.from_python_file(module_path, symbol, None), None
+        CodePointer.from_python_file(module_path, symbol, None),
+        DefinitionsLoadType.INITIALIZATION,
+        None,
     )
 
     assert isinstance(repo_def, RepositoryDefinition)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_loader.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_loader.py
@@ -1,8 +1,18 @@
 import pytest
+from dagster._core.code_pointer import CodePointer
+from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.decorators.definitions_decorator import definitions
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.definitions_loader import DefinitionsLoadContext
+from dagster._core.definitions.definitions_loader import DefinitionsLoadContext, DefinitionsLoadType
+from dagster._core.definitions.reconstruct import (
+    ReconstructableJob,
+    ReconstructableRepository,
+    repository_def_from_pointer,
+)
+from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.errors import DagsterInvalidInvocationError
+from dagster._core.execution.api import execute_job
+from dagster._core.instance_for_test import instance_for_test
 
 
 def test_invoke_definitions_loader_with_context():
@@ -10,7 +20,7 @@ def test_invoke_definitions_loader_with_context():
     def defs(context: DefinitionsLoadContext) -> Definitions:
         return Definitions()
 
-    assert defs(DefinitionsLoadContext())
+    assert defs(DefinitionsLoadContext(load_type=DefinitionsLoadType.INITIALIZATION))
 
     with pytest.raises(DagsterInvalidInvocationError, match="requires a DefinitionsLoadContext"):
         defs()
@@ -24,4 +34,34 @@ def test_invoke_definitions_loader_no_context():
     assert defs()
 
     with pytest.raises(DagsterInvalidInvocationError, match="Passed a DefinitionsLoadContext"):
-        defs(DefinitionsLoadContext())
+        defs(DefinitionsLoadContext(load_type=DefinitionsLoadType.INITIALIZATION))
+
+
+@definitions
+def load_type_test_defs(context: DefinitionsLoadContext) -> Definitions:
+    if not context.load_type == DefinitionsLoadType.INITIALIZATION:
+        raise Exception("Unexpected load type")
+
+    @asset
+    def foo(): ...
+
+    foo_job = define_asset_job("foo_job", [foo])
+
+    return Definitions(assets=[foo], jobs=[foo_job])
+
+
+def test_definitions_load_type():
+    pointer = CodePointer.from_python_file(__file__, "load_type_test_defs", None)
+
+    # Load type is INITIALIZATION so should not raise
+    assert repository_def_from_pointer(pointer, DefinitionsLoadType.INITIALIZATION, None)
+
+    recon_job = ReconstructableJob(
+        repository=ReconstructableRepository(pointer),
+        job_name="foo_job",
+    )
+
+    # Executing a job should cause the definitions to be loaded with a non-ROOT load type
+    with instance_for_test() as instance:
+        with pytest.raises(Exception, match="Unexpected load type"):
+            execute_job(recon_job, instance=instance)


### PR DESCRIPTION
## Summary & Motivation

Add a `DefinitionsLoadType` to the `DefinitionLoaderContext`. I am not sure of the final ontology but decided to start it off as simple as possible, with two values: `ROOT` and `RECONSTRUCTION`. This can be accessed in a `DefinitionsLoader` to condition initial construction vs reconstruction logic.

## How I Tested These Changes

New unit tests.

## Changelog

NOCHANGELOG