### PR TITLE
Expose AssetSpec on OutputContext

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -14,6 +14,7 @@ from typing import (
 
 import dagster._check as check
 from dagster._annotations import deprecated, deprecated_param, public
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.events import (
     AssetKey,
     AssetMaterialization,
@@ -366,6 +367,13 @@ class OutputContext:
             )
 
         return result
+
+    @public
+    @property
+    def asset_spec(self) -> AssetSpec:
+        """The ``AssetSpec`` that is being stored as an output."""
+        asset_key = self.asset_key
+        return self.step_context.job_def.asset_layer.get(asset_key).to_asset_spec()
 
     @property
     def step_context(self) -> "StepExecutionContext":

--- a/python_modules/dagster/dagster_tests/execution_tests/context_tests/test_output.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/context_tests/test_output.py
@@ -1,4 +1,15 @@
-from dagster import AssetKey, build_output_context
+from typing import Any
+
+from dagster import (
+    AssetKey,
+    AssetSpec,
+    IOManager,
+    OutputContext,
+    StaticPartitionsDefinition,
+    build_output_context,
+    materialize,
+)
+from dagster._core.execution.context.input import InputContext
 
 
 def test_build_output_context_asset_key():
@@ -7,3 +18,21 @@ def test_build_output_context_asset_key():
         ["apple", "banana"]
     )
     assert build_output_context(asset_key=AssetKey("apple")).asset_key == AssetKey("apple")
+
+
+def test_build_output_context_asset_spec():
+    asset_spec = AssetSpec(
+        key="key",
+        group_name="group",
+        code_version="code_version",
+        partitions_def=StaticPartitionsDefinition(["part1"]),
+    )
+
+    class TestIOManager(IOManager):
+        def handle_output(self, context: OutputContext, obj: object):
+            assert context.asset_spec == asset_spec
+
+        def load_input(self, context: InputContext) -> Any:
+            pass
+
+    materialize([asset_spec], resources={"io_manager": TestIOManager()})


### PR DESCRIPTION
## Summary & Motivation

Contributes to https://github.com/dagster-io/dagster/issues/23965. 

Exposes the `AssetSpec` on the `OutputContext`, which in turn contains things like the `code_version` and `partitions_definition`.

Some thoughts:
- The asset `PartitionsDefinition` and `AssetKey` are already exposed on the `OutputContext` directly, but they are also part of the `AssetSpec`. Maybe this makes the directly exposed properties superfluous in the long run?
- The way to get to the `AssetSpec` via `step_context.job_def.asset_layer` seems like a bit of a long way around. Perhaps the `AssetSpec` should be part of the `OutputContext` constructor and be attached directly as a property?

## How I Tested These Changes

Added a unit test to confirm that the `AssetSpec` is exposed on the `OutputContext` by checking with an io manager

## Changelog

`OutputContext` now exposes the `AssetSpec` of the asset that is being stored as an output

- [x] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
