### PR TITLE
RFC: Higher-level pattern for state-backed definitions and an adapter to expose them as CacheableAssetsDefinition

### DIFF
--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/__init__.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/__init__.py
@@ -1,6 +1,9 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
-from dagster_powerbi.resource import PowerBIWorkspace as PowerBIWorkspace
+from dagster_powerbi.resource import (
+    PowerBIWorkspace as PowerBIWorkspace,
+    load_powerbi_defs as load_powerbi_defs,
+)
 from dagster_powerbi.translator import DagsterPowerBITranslator as DagsterPowerBITranslator
 
 # Move back to version.py and edit setup.py once we are ready to publish.

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/__init__.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/__init__.py
@@ -1,9 +1,6 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
-from dagster_powerbi.resource import (
-    PowerBIWorkspace as PowerBIWorkspace,
-    load_powerbi_defs as load_powerbi_defs,
-)
+from dagster_powerbi.resource import PowerBIWorkspace as PowerBIWorkspace
 from dagster_powerbi.translator import DagsterPowerBITranslator as DagsterPowerBITranslator
 
 # Move back to version.py and edit setup.py once we are ready to publish.

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
@@ -1,6 +1,6 @@
 import re
 import time
-from typing import Any, Dict, Sequence, Type
+from typing import Any, Dict, Mapping, Sequence, Type
 
 import requests
 from dagster import (
@@ -15,6 +15,7 @@ from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
     CacheableAssetsDefinition,
 )
+from dagster._core.definitions.definitions_loader import DefinitionsLoadContext
 from dagster._core.definitions.events import Failure
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._utils.cached_method import cached_method
@@ -233,6 +234,68 @@ class PowerBIWorkspace(ConfigurableResource):
         )
 
 
+def _workspace_data_to_cacheable_data(
+    workspace_data: PowerBIWorkspaceData,
+) -> Sequence[Mapping[str, Any]]:
+    return [
+        data.to_cached_data()
+        for data in [
+            *workspace_data.dashboards_by_id.values(),
+            *workspace_data.reports_by_id.values(),
+            *workspace_data.semantic_models_by_id.values(),
+            *workspace_data.data_sources_by_id.values(),
+        ]
+    ]
+
+
+def _build_assets_defs_from_workspace_data(
+    workspace_data: PowerBIWorkspaceData,
+    workspace: PowerBIWorkspace,
+    translator_cls: Type[DagsterPowerBITranslator],
+    enable_refresh_semantic_models: bool,
+) -> Sequence[AssetsDefinition]:
+    translator = translator_cls(context=workspace_data)
+
+    if enable_refresh_semantic_models:
+        all_external_data = [
+            *workspace_data.dashboards_by_id.values(),
+            *workspace_data.reports_by_id.values(),
+            *workspace_data.data_sources_by_id.values(),
+        ]
+        all_executable_data = [*workspace_data.semantic_models_by_id.values()]
+    else:
+        all_external_data = [
+            *workspace_data.dashboards_by_id.values(),
+            *workspace_data.reports_by_id.values(),
+            *workspace_data.data_sources_by_id.values(),
+            *workspace_data.semantic_models_by_id.values(),
+        ]
+        all_executable_data = []
+
+    all_external_asset_specs = [translator.get_asset_spec(content) for content in all_external_data]
+    all_executable_asset_specs = [
+        translator.get_asset_spec(content) for content in all_executable_data
+    ]
+
+    executable_assets = []
+    for content, spec in zip(all_executable_data, all_executable_asset_specs):
+        dataset_id = content.properties["id"]
+
+        @multi_asset(
+            specs=[spec],
+            name="_".join(spec.key.path),
+            resource_defs={"power_bi": workspace.get_resource_definition()},
+        )
+        def asset_fn(context: AssetExecutionContext, power_bi: PowerBIWorkspace) -> None:
+            power_bi.trigger_refresh(dataset_id)
+            power_bi.poll_refresh(dataset_id)
+            context.log.info("Refresh completed.")
+
+        executable_assets.append(asset_fn)
+
+    return [*external_assets_from_specs(all_external_asset_specs), *executable_assets]
+
+
 class PowerBICacheableAssetsDefinition(CacheableAssetsDefinition):
     def __init__(
         self,
@@ -248,13 +311,8 @@ class PowerBICacheableAssetsDefinition(CacheableAssetsDefinition):
     def compute_cacheable_data(self) -> Sequence[AssetsDefinitionCacheableData]:
         workspace_data: PowerBIWorkspaceData = self._workspace.fetch_powerbi_workspace_data()
         return [
-            AssetsDefinitionCacheableData(extra_metadata=data.to_cached_data())
-            for data in [
-                *workspace_data.dashboards_by_id.values(),
-                *workspace_data.reports_by_id.values(),
-                *workspace_data.semantic_models_by_id.values(),
-                *workspace_data.data_sources_by_id.values(),
-            ]
+            AssetsDefinitionCacheableData(extra_metadata=data)
+            for data in _workspace_data_to_cacheable_data(workspace_data)
         ]
 
     def build_definitions(
@@ -268,46 +326,40 @@ class PowerBICacheableAssetsDefinition(CacheableAssetsDefinition):
                 for entry in data
             ],
         )
+        return _build_assets_defs_from_workspace_data(
+            workspace_data,
+            self._workspace,
+            self._translator_cls,
+            self._enable_refresh_semantic_models,
+        )
 
-        translator = self._translator_cls(context=workspace_data)
 
-        if self._enable_refresh_semantic_models:
-            all_external_data = [
-                *workspace_data.dashboards_by_id.values(),
-                *workspace_data.reports_by_id.values(),
-                *workspace_data.data_sources_by_id.values(),
-            ]
-            all_executable_data = [*workspace_data.semantic_models_by_id.values()]
-        else:
-            all_external_data = [
-                *workspace_data.dashboards_by_id.values(),
-                *workspace_data.reports_by_id.values(),
-                *workspace_data.data_sources_by_id.values(),
-                *workspace_data.semantic_models_by_id.values(),
-            ]
-            all_executable_data = []
+POWER_BI_SOURCE_METADATA_KEY_PREFIX = "__power_bi"
 
-        all_external_asset_specs = [
-            translator.get_asset_spec(content) for content in all_external_data
-        ]
-        all_executable_asset_specs = [
-            translator.get_asset_spec(content) for content in all_executable_data
-        ]
 
-        executable_assets = []
-        for content, spec in zip(all_executable_data, all_executable_asset_specs):
-            dataset_id = content.properties["id"]
+def load_powerbi_defs(
+    context: DefinitionsLoadContext,
+    api_token: str,
+    workspace_id: str,
+    enable_refresh_semantic_models: bool,
+) -> Definitions:
+    cache_key = f"{POWER_BI_SOURCE_METADATA_KEY_PREFIX}/{workspace_id}"
+    workspace = PowerBIWorkspace(api_token=api_token, workspace_id=workspace_id)
+    if cache_key in context.cached_source_metadata:
+        payload = context.cached_source_metadata[cache_key]
+        workspace_data = PowerBIWorkspaceData.from_content_data(
+            workspace_id,
+            [PowerBIContentData.from_cached_data(entry) for entry in payload],
+        )
+    else:
+        workspace_data = workspace.fetch_powerbi_workspace_data()
 
-            @multi_asset(
-                specs=[spec],
-                name="_".join(spec.key.path),
-                resource_defs={"power_bi": self._workspace.get_resource_definition()},
-            )
-            def asset_fn(context: AssetExecutionContext, power_bi: PowerBIWorkspace) -> None:
-                power_bi.trigger_refresh(dataset_id)
-                power_bi.poll_refresh(dataset_id)
-                context.log.info("Refresh completed.")
-
-            executable_assets.append(asset_fn)
-
-        return [*external_assets_from_specs(all_external_asset_specs), *executable_assets]
+    assets_defs = _build_assets_defs_from_workspace_data(
+        workspace_data,
+        workspace,
+        DagsterPowerBITranslator,
+        enable_refresh_semantic_models,
+    )
+    return Definitions(assets=assets_defs).with_source_metadata(
+        {cache_key: _workspace_data_to_cacheable_data(workspace_data)}
+    )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
@@ -15,7 +15,7 @@ from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
     CacheableAssetsDefinition,
 )
-from dagster._core.definitions.definitions_loader import DefinitionsLoadContext
+from dagster._core.definitions.definitions_loader import DefinitionsLoadContext, DefinitionsLoadType
 from dagster._core.definitions.events import Failure
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._utils.cached_method import cached_method
@@ -345,8 +345,11 @@ def load_powerbi_defs(
 ) -> Definitions:
     cache_key = f"{POWER_BI_SOURCE_METADATA_KEY_PREFIX}/{workspace_id}"
     workspace = PowerBIWorkspace(api_token=api_token, workspace_id=workspace_id)
-    if cache_key in context.cached_source_metadata:
-        payload = context.cached_source_metadata[cache_key]
+    if (
+        context.load_type == DefinitionsLoadType.RECONSTRUCTION
+        and cache_key in context.reconstruction_metadata
+    ):
+        payload = context.reconstruction_metadata[cache_key]
         workspace_data = PowerBIWorkspaceData.from_content_data(
             workspace_id,
             [PowerBIContentData.from_cached_data(entry) for entry in payload],
@@ -360,6 +363,6 @@ def load_powerbi_defs(
         DagsterPowerBITranslator,
         enable_refresh_semantic_models,
     )
-    return Definitions(assets=assets_defs).with_source_metadata(
+    return Definitions(assets=assets_defs).with_reconstruction_metadata(
         {cache_key: _workspace_data_to_cacheable_data(workspace_data)}
     )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/state_backed_loader.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/state_backed_loader.py
@@ -1,0 +1,63 @@
+from abc import ABC, abstractmethod
+from typing import Generic, Sequence, Type, TypeVar
+
+from dagster import (
+    AssetsDefinition,
+    Definitions,
+    _check as check,
+)
+from dagster._core.definitions.cacheable_assets import (
+    AssetsDefinitionCacheableData,
+    CacheableAssetsDefinition,
+)
+from dagster._core.definitions.definitions_loader import DefinitionsLoadContext, DefinitionsLoadType
+
+TState = TypeVar("TState")
+
+
+def cacheable_assets_def_from_loader(
+    loader: "StateBackedDefinitionsLoader[TState]", state_type: Type[TState]
+) -> CacheableAssetsDefinition:
+    return StateBackedDefinitionsLoaderAdapterCacheableAssetsDefinition(loader, state_type)
+
+
+class StateBackedDefinitionsLoaderAdapterCacheableAssetsDefinition(
+    Generic[TState], CacheableAssetsDefinition
+):
+    def __init__(self, loader: "StateBackedDefinitionsLoader[TState]", state_type: Type[TState]):
+        self._loader = loader
+        self._state_type = state_type
+        super().__init__(unique_id=self._loader.defs_key)
+
+    def compute_cacheable_data(self) -> Sequence[AssetsDefinitionCacheableData]:
+        state = self._loader.fetch_backing_state()
+        return [AssetsDefinitionCacheableData(extra_metadata={self._loader.defs_key: state})]
+
+    def build_definitions(
+        self,
+        data: Sequence[AssetsDefinitionCacheableData],
+    ) -> Sequence[AssetsDefinition]:
+        state = check.inst(
+            check.not_none(data[0].extra_metadata)[self._loader.defs_key], self._state_type
+        )
+        return self._loader.defs_from_state(state).get_asset_graph().assets_defs
+
+
+class StateBackedDefinitionsLoader(ABC, Generic[TState]):
+    def __init__(self, defs_key: str):
+        self.defs_key = defs_key
+
+    @abstractmethod
+    def fetch_backing_state(self) -> TState: ...
+
+    @abstractmethod
+    def defs_from_state(self, state: TState) -> Definitions: ...
+
+    def build_defs(self, context: DefinitionsLoadContext) -> Definitions:
+        state = (
+            context.reconstruction_metadata[self.defs_key]
+            if context.load_type == DefinitionsLoadType.RECONSTRUCTION
+            and self.defs_key in context.reconstruction_metadata
+            else self.fetch_backing_state()
+        )
+        return self.defs_from_state(state).with_reconstruction_metadata({self.defs_key: state})

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -1,12 +1,13 @@
 import re
 import urllib.parse
 from enum import Enum
-from typing import Any, Dict, Mapping, Sequence
+from typing import Any, Dict, Sequence
 
 from dagster import _check as check
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._record import record
+from dagster._serdes.serdes import whitelist_for_serdes
 
 
 def _get_last_filepath_component(path: str) -> str:
@@ -24,6 +25,7 @@ def _clean_asset_name(name: str) -> str:
     return re.sub(r"[^A-Za-z0-9_]+", "_", name)
 
 
+@whitelist_for_serdes
 class PowerBIContentType(Enum):
     """Enum representing each object in PowerBI's ontology, generically referred to as "content" by the API."""
 
@@ -33,6 +35,7 @@ class PowerBIContentType(Enum):
     DATA_SOURCE = "data_source"
 
 
+@whitelist_for_serdes
 @record
 class PowerBIContentData:
     """A record representing a piece of content in PowerBI.
@@ -42,17 +45,8 @@ class PowerBIContentData:
     content_type: PowerBIContentType
     properties: Dict[str, Any]
 
-    def to_cached_data(self) -> Dict[str, Any]:
-        return {"content_type": self.content_type.value, "properties": self.properties}
 
-    @classmethod
-    def from_cached_data(cls, data: Mapping[Any, Any]) -> "PowerBIContentData":
-        return cls(
-            content_type=PowerBIContentType(data["content_type"]),
-            properties=data["properties"],
-        )
-
-
+@whitelist_for_serdes
 @record
 class PowerBIWorkspaceData:
     """A record representing all content in a PowerBI workspace.

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/pending_repo.py
@@ -2,11 +2,14 @@ import uuid
 from typing import cast
 
 from dagster import asset, define_asset_job
+from dagster._core.definitions.decorators.definitions_decorator import definitions
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.definitions_loader import DefinitionsLoadContext
 from dagster._core.definitions.repository_definition.repository_definition import (
     PendingRepositoryDefinition,
 )
 from dagster_powerbi import PowerBIWorkspace
+from dagster_powerbi.resource import load_powerbi_defs
 
 fake_token = uuid.uuid4().hex
 resource = PowerBIWorkspace(
@@ -28,3 +31,18 @@ pending_repo_from_cached_asset_metadata = cast(
         pbi_defs,
     ).get_inner_repository(),
 )
+
+
+@definitions
+def source_metadata_defs(context: DefinitionsLoadContext) -> Definitions:
+    pbi_defs = load_powerbi_defs(
+        context,
+        api_token=fake_token,
+        workspace_id="a2122b8f-d7e1-42e8-be2b-a5e636ca3221",
+        enable_refresh_semantic_models=False,
+    )
+
+    return Definitions.merge(
+        Definitions(assets=[my_materializable_asset], jobs=[define_asset_job("all_asset_job")]),
+        pbi_defs,
+    )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -5,7 +5,7 @@ import pytest
 import responses
 from dagster import materialize
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.definitions_loader import DefinitionsLoadContext
+from dagster._core.definitions.definitions_loader import DefinitionsLoadContext, DefinitionsLoadType
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
 from dagster._core.definitions.repository_definition.repository_definition import (
     PendingRepositoryDefinition,
@@ -169,7 +169,9 @@ def test_using_cached_source_metadata(workspace_data_api_mocks: responses.Reques
 
         pending_repo = cast(
             PendingRepositoryDefinition,
-            source_metadata_defs(DefinitionsLoadContext()).get_inner_repository(),
+            source_metadata_defs(
+                DefinitionsLoadContext(load_type=DefinitionsLoadType.INITIALIZATION)
+            ).get_inner_repository(),
         )
 
         # first, we resolve the repository to generate our cached metadata

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -1,10 +1,15 @@
 import uuid
+from typing import cast
 
 import pytest
 import responses
 from dagster import materialize
 from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.definitions_loader import DefinitionsLoadContext
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
+from dagster._core.definitions.repository_definition.repository_definition import (
+    PendingRepositoryDefinition,
+)
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.instance_for_test import instance_for_test
@@ -134,6 +139,52 @@ def test_using_cached_asset_data(workspace_data_api_mocks: responses.RequestsMoc
         recon_repo = ReconstructableRepository.for_file(
             file_relative_path(__file__, "pending_repo.py"),
             fn_name="pending_repo_from_cached_asset_metadata",
+        )
+        recon_job = ReconstructableJob(repository=recon_repo, job_name="all_asset_job")
+
+        execution_plan = create_execution_plan(recon_job, repository_load_data=repository_load_data)
+
+        run = instance.create_run_for_job(job_def=job_def, execution_plan=execution_plan)
+
+        events = execute_plan(
+            execution_plan=execution_plan,
+            job=recon_job,
+            dagster_run=run,
+            instance=instance,
+        )
+
+        assert (
+            len([event for event in events if event.event_type == DagsterEventType.STEP_SUCCESS])
+            == 1
+        ), "Expected two successful steps"
+
+        assert len(workspace_data_api_mocks.calls) == 5
+
+
+def test_using_cached_source_metadata(workspace_data_api_mocks: responses.RequestsMock) -> None:
+    with instance_for_test() as instance:
+        assert len(workspace_data_api_mocks.calls) == 0
+
+        from dagster_powerbi_tests.pending_repo import source_metadata_defs
+
+        pending_repo = cast(
+            PendingRepositoryDefinition,
+            source_metadata_defs(DefinitionsLoadContext()).get_inner_repository(),
+        )
+
+        # first, we resolve the repository to generate our cached metadata
+        repository_def = pending_repo.compute_repository_definition()
+        assert len(workspace_data_api_mocks.calls) == 5
+
+        # 5 PowerBI external assets, one materializable asset
+        assert len(repository_def.assets_defs_by_key) == 5 + 1
+
+        job_def = repository_def.get_job("all_asset_job")
+        repository_load_data = repository_def.repository_load_data
+
+        recon_repo = ReconstructableRepository.for_file(
+            file_relative_path(__file__, "pending_repo.py"),
+            fn_name="source_metadata_defs",
         )
         recon_job = ReconstructableJob(repository=recon_repo, job_name="all_asset_job")
 

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -120,7 +120,7 @@ def test_refreshable_semantic_model(
     assert result.success is success
 
 
-def test_using_cached_asset_data(workspace_data_api_mocks: responses.RequestsMock) -> None:
+def test_using_cacheable_assets_defs(workspace_data_api_mocks: responses.RequestsMock) -> None:
     with instance_for_test() as instance:
         assert len(workspace_data_api_mocks.calls) == 0
 
@@ -161,7 +161,7 @@ def test_using_cached_asset_data(workspace_data_api_mocks: responses.RequestsMoc
         assert len(workspace_data_api_mocks.calls) == 5
 
 
-def test_using_cached_source_metadata(workspace_data_api_mocks: responses.RequestsMock) -> None:
+def test_using_reconstruction_metadata(workspace_data_api_mocks: responses.RequestsMock) -> None:
     with instance_for_test() as instance:
         assert len(workspace_data_api_mocks.calls) == 0
 


### PR DESCRIPTION
## Summary & Motivation

@smackesey Just wanted to show you what a slightly higher-level, opt-in pattern would look like. It's a little "Java-y", but it makes an adapter pattern quite straightforward in terms of the _inverse_ adapter where we want to write loaders in the new style but provide a backwards-compat version for people who do not want to migrate to the new entry point style. I think that will make the transition smoother. This adapter also provides an escape hook for people who do not want to thread context objects through.

## How I Tested These Changes

BK

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
