### PR TITLE
[dagster-airlift] normalize prefix

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/constants.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/constants.py
@@ -1,6 +1,7 @@
 from typing import Tuple
 
-MIGRATED_TAG = "airlift/task_migrated"
-DAG_ID_METADATA_KEY = "Dag ID"
-AIRFLOW_COUPLING_METADATA_KEY = "airlift/couplings"
+PKG_PREFIX = "dagster-airlift/"
+MIGRATED_TAG = f"{PKG_PREFIX}task_migrated"
+DAG_ID_METADATA_KEY = f"{PKG_PREFIX}/dag_id"
+AIRFLOW_COUPLING_METADATA_KEY = f"{PKG_PREFIX}couplings"
 AirflowCoupling = Tuple[str, str]

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_cacheable_assets_def.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_cacheable_assets_def.py
@@ -232,8 +232,8 @@ def get_cached_specs_for_dag(
     )
     metadata = {
         "Dag Info (raw)": JsonMetadataValue(dag_info.metadata),
-        DAG_ID_METADATA_KEY: dag_info.dag_id,
         "Link to DAG": UrlMetadataValue(dag_info.url),
+        "Dag ID": dag_info.dag_id,
     }
     # Attempt to retrieve source code from the DAG.
     metadata["Source Code"] = MarkdownMetadataValue(
@@ -430,6 +430,7 @@ def build_singular_task_metadata(
         DAG_ID_METADATA_KEY: task_info.dag_id,
         "Link to DAG": UrlMetadataValue(task_info.dag_url),
         "Task ID": task_info.task_id,
+        "Dag ID": task_info.dag_id,
     }
     task_level_metadata[
         "Computed in Task ID" if bool(migration_state) is False else "Triggered by Task ID"

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor.py
@@ -165,11 +165,11 @@ def get_unmigrated_info(
         # We could be more specific about the checks here to ensure that there's only one asset key
         # specifying the dag, and that all others have a task id.
         for spec in assets_def.specs:
-            dag_and_task_id_list = get_couplings_from_spec(spec)
-            dag_id: Optional[str] = spec.metadata.get("Dag ID")
-            if dag_and_task_id_list is None and dag_id is None:
+            couplings = get_couplings_from_spec(spec)
+            dag_id: Optional[str] = spec.metadata.get("dagster-airlift/dag_id")
+            if couplings is None and dag_id is None:
                 continue
-            if dag_and_task_id_list is None:
+            if couplings is None:
                 key_per_dag[cast(str, dag_id)] = (
                     assets_def.key
                 )  # There should only be one key in the case of a "dag" asset
@@ -178,7 +178,7 @@ def get_unmigrated_info(
                 if migration_state == "True":
                     continue
 
-                for dag_id, task_id in dag_and_task_id_list:
+                for dag_id, task_id in couplings:
                     task_keys_per_dag[dag_id].add((task_id, spec.key))
 
     for asset_check_key in repository_def.asset_checks_defs_by_key.keys():

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
@@ -62,11 +62,7 @@ def build_definitions_airflow_asset_graph(
             dag_and_task_structure[dag_id].append(task_id)
             assets = []
             for asset_key, deps in asset_structure:
-                spec = AssetSpec(
-                    asset_key,
-                    deps=deps,
-                    metadata={"airlift/dag_id": dag_id, "airlift/task_id": task_id},
-                )
+                spec = AssetSpec(asset_key, deps=deps)
                 if create_assets_defs:
 
                     @multi_asset(specs=[spec], name=f"{task_id}_{asset_key}")

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_build_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_build_defs.py
@@ -204,21 +204,21 @@ def test_transitive_asset_deps() -> None:
     assert [dep.asset_key for dep in next(iter(dag2_asset.specs)).deps] == [c_key]
     a_asset = repo_def.assets_defs_by_key[a_key]
     assert [dep.asset_key for dep in next(iter(a_asset.specs)).deps] == []
-    assert "airlift/dag_id" in next(iter(a_asset.specs)).metadata
-    assert next(iter(a_asset.specs)).metadata["airlift/dag_id"] == "dag1"
-    assert "airlift/task_id" in next(iter(a_asset.specs)).metadata
-    assert next(iter(a_asset.specs)).metadata["airlift/task_id"] == "task"
+    assert "Dag ID" in next(iter(a_asset.specs)).metadata
+    assert next(iter(a_asset.specs)).metadata["Dag ID"] == "dag1"
+    assert "dagster-airlift/task_id" in next(iter(a_asset.specs)).metadata
+    assert next(iter(a_asset.specs)).metadata["dagster-airlift/task_id"] == "task"
 
     b_asset = repo_def.assets_defs_by_key[b_key]
     assert [dep.asset_key for dep in next(iter(b_asset.specs)).deps] == [a_key]
-    assert "airlift/dag_id" not in next(iter(b_asset.specs)).metadata
-    assert "airlift/task_id" not in next(iter(b_asset.specs)).metadata
+    assert "Dag ID" not in next(iter(b_asset.specs)).metadata
+    assert "Computed in Task ID" not in next(iter(b_asset.specs)).metadata
     c_asset = repo_def.assets_defs_by_key[c_key]
     assert [dep.asset_key for dep in next(iter(c_asset.specs)).deps] == [b_key]
-    assert "airlift/dag_id" in next(iter(c_asset.specs)).metadata
-    assert next(iter(c_asset.specs)).metadata["airlift/dag_id"] == "dag2"
-    assert "airlift/task_id" in next(iter(c_asset.specs)).metadata
-    assert next(iter(c_asset.specs)).metadata["airlift/task_id"] == "task"
+    assert "Dag ID" in next(iter(c_asset.specs)).metadata
+    assert next(iter(c_asset.specs)).metadata["Dag ID"] == "dag2"
+    assert "dagster-airlift/task_id" in next(iter(c_asset.specs)).metadata
+    assert next(iter(c_asset.specs)).metadata["dagster-airlift/task_id"] == "task"
 
 
 def test_peered_dags() -> None:
@@ -311,7 +311,7 @@ def test_local_airflow_instance() -> None:
     repo_def = defs.get_repository_def()
     a_asset = repo_def.assets_defs_by_key[AssetKey("a")]
     # With no task migration info, the asset shouldn't even have the tag set.
-    assert next(iter(a_asset.specs)).tags.get("airlift/task_migrated") is None
+    assert next(iter(a_asset.specs)).tags.get("dagster-airlift/task_migrated") is None
 
     with environ(
         {
@@ -332,7 +332,7 @@ def test_local_airflow_instance() -> None:
         repo_def = defs.get_repository_def()
         assert len(repo_def.assets_defs_by_key) == 2
         task_asset = repo_def.assets_defs_by_key[AssetKey("a")]
-        assert next(iter(task_asset.specs)).tags.get("airlift/task_migrated") == "True"
+        assert next(iter(task_asset.specs)).tags.get("dagster-airlift/task_migrated") == "True"
 
 
 def test_multi_task_mapping() -> None:


### PR DESCRIPTION
## Summary & Motivation

Change the prefix for airlift tags/metadata to be `dagster-airlift`. Normalize "Dag ID" to be `dagster-airlift/dag_id` since it has system function now, and separately log metadata for Dag ID with a pretty name.
## How I Tested These Changes
Existing unit tests

## Changelog
`NOCHANGELOG`
