### PR TITLE
Move retry policy to snapshots

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -48,7 +48,6 @@ from dagster._core.definitions.hook_definition import HookDefinition
 from dagster._core.definitions.logger_definition import LoggerDefinition
 from dagster._core.definitions.metadata import MetadataValue, RawMetadataValue, normalize_metadata
 from dagster._core.definitions.node_definition import NodeDefinition
-from dagster._core.definitions.op_definition import OpDefinition
 from dagster._core.definitions.op_selection import OpSelection, get_graph_subset
 from dagster._core.definitions.partition import (
     DynamicPartitionsDefinition,
@@ -579,17 +578,7 @@ class JobDefinition(IHasInternalInit):
         return frozenset(hook_defs)
 
     def get_retry_policy_for_handle(self, handle: NodeHandle) -> Optional[RetryPolicy]:
-        node = self.get_node(handle)
-        definition = node.definition
-
-        if node.retry_policy:
-            return node.retry_policy
-        elif isinstance(definition, OpDefinition) and definition.retry_policy:
-            return definition.retry_policy
-
-        # could be expanded to look in graph containers
-        else:
-            return self._op_retry_policy
+        return self.get_job_snapshot().get_retry_policy_for_node(handle.name)
 
     # make Callable for decorator reference updates
     def __call__(self, *args, **kwargs):

--- a/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/dep_snapshot.py
@@ -1,9 +1,10 @@
 from collections import defaultdict
-from typing import DefaultDict, Dict, List, Mapping, NamedTuple, Sequence
+from typing import DefaultDict, Dict, List, Mapping, NamedTuple, Optional, Sequence
 
 import dagster._check as check
 from dagster._core.definitions import GraphDefinition
 from dagster._core.definitions.dependency import DependencyType, Node, NodeInput
+from dagster._core.definitions.policy import RetryPolicy
 from dagster._serdes import whitelist_for_serdes
 
 
@@ -36,6 +37,7 @@ def build_node_invocation_snap(graph_def: GraphDefinition, node: Node) -> "NodeI
         tags=node.tags,
         input_dep_snaps=input_def_snaps,
         is_dynamic_mapped=dep_structure.is_dynamic_mapped(node.name),
+        retry_policy=node.retry_policy,
     )
 
 
@@ -213,6 +215,7 @@ class NodeInvocationSnap(
             ("tags", Mapping[str, str]),
             ("input_dep_snaps", Sequence[InputDependencySnap]),
             ("is_dynamic_mapped", bool),
+            ("retry_policy", Optional[RetryPolicy]),
         ],
     )
 ):
@@ -223,6 +226,7 @@ class NodeInvocationSnap(
         tags: Mapping[str, str],
         input_dep_snaps: Sequence[InputDependencySnap],
         is_dynamic_mapped: bool = False,
+        retry_policy: Optional[RetryPolicy] = None,
     ):
         return super(NodeInvocationSnap, cls).__new__(
             cls,
@@ -233,6 +237,7 @@ class NodeInvocationSnap(
                 input_dep_snaps, "input_dep_snaps", of_type=InputDependencySnap
             ),
             is_dynamic_mapped=check.bool_param(is_dynamic_mapped, "is_dynamic_mapped"),
+            retry_policy=check.opt_inst_param(retry_policy, "retry_policy", RetryPolicy),
         )
 
     def input_dep_snap(self, input_name: str) -> InputDependencySnap:

--- a/python_modules/dagster/dagster/_core/snap/node.py
+++ b/python_modules/dagster/dagster/_core/snap/node.py
@@ -16,6 +16,7 @@ from dagster._core.definitions.metadata import (
     MetadataValue,
     normalize_metadata,
 )
+from dagster._core.definitions.policy import RetryPolicy
 from dagster._core.snap.dep_snapshot import (
     DependencyStructureSnapshot,
     build_dep_structure_snapshot_from_graph_def,
@@ -252,6 +253,7 @@ class OpDefSnap(
             ("tags", Mapping[str, object]),
             ("required_resource_keys", Sequence[str]),
             ("config_field_snap", Optional[ConfigFieldSnap]),
+            ("retry_policy", Optional[RetryPolicy]),
         ],
     )
 ):
@@ -264,6 +266,7 @@ class OpDefSnap(
         tags: Mapping[str, str],
         required_resource_keys: Sequence[str],
         config_field_snap: Optional[ConfigFieldSnap],
+        retry_policy: Optional[RetryPolicy] = None,
     ):
         return super(OpDefSnap, cls).__new__(
             cls,
@@ -280,6 +283,7 @@ class OpDefSnap(
             config_field_snap=check.opt_inst_param(
                 config_field_snap, "config_field_snap", ConfigFieldSnap
             ),
+            retry_policy=check.opt_inst_param(retry_policy, "retry_policy", RetryPolicy),
         )
 
     def get_input_snap(self, name: str) -> InputDefSnap:
@@ -381,6 +385,7 @@ def build_op_def_snap(op_def: OpDefinition) -> OpDefSnap:
             if op_def.has_config_field
             else None
         ),
+        retry_policy=op_def.retry_policy,
     )
 
 


### PR DESCRIPTION
Summary:
Not sure if we actually need this since the run worker is not a host process, but you could imagine this opening us up to doing things like displaying retry policies in the UI or being smarter about retrying certain steps during daemon-initiated run retries.

## Summary & Motivation

## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
