### PR TITLE
refactor: run metric threads startup and shutdown

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -353,6 +353,10 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
     def get_daemon_heartbeats(self) -> Mapping[str, DaemonHeartbeat]:
         """Latest heartbeats of all daemon types."""
 
+    def supports_run_telemetry(self) -> bool:
+        """Whether the storage supports run telemetry."""
+        return False
+
     def add_run_telemetry(
         self,
         run_telemetry: RunTelemetryData,

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_run_metrics_thread.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_run_metrics_thread.py
@@ -135,32 +135,33 @@ def test_start_run_metrics_thread(dagster_instance, dagster_run, mock_container_
     logger = logging.getLogger("test_run_metrics")
     logger.setLevel(logging.DEBUG)
 
-    with patch(
-        "dagster._core.execution.run_metrics_thread._get_container_metrics",
-        return_value=mock_container_metrics,
-    ):
+    with patch.object(dagster_instance.run_storage, "supports_run_telemetry", return_value=True):
         with patch(
-            "dagster._core.execution.run_metrics_thread._process_is_containerized",
-            return_value=True,
+            "dagster._core.execution.run_metrics_thread._get_container_metrics",
+            return_value=mock_container_metrics,
         ):
-            thread, shutdown = run_metrics_thread.start_run_metrics_thread(
-                dagster_instance,
-                dagster_run,
-                logger=logger,
-                container_metrics_enabled=True,
-                polling_interval=2.0,
-            )
+            with patch(
+                "dagster._core.execution.run_metrics_thread._process_is_containerized",
+                return_value=True,
+            ):
+                thread, shutdown = run_metrics_thread.start_run_metrics_thread(
+                    dagster_instance,
+                    dagster_run,
+                    logger=logger,
+                    polling_interval=2.0,
+                )
 
-            time.sleep(0.1)
+                time.sleep(0.1)
 
-            assert thread.is_alive()
+                assert thread.is_alive()
+                assert "Starting run metrics thread" in caplog.messages[0]
 
-            time.sleep(0.1)
-            shutdown.set()
+                time.sleep(0.1)
+                shutdown.set()
 
-            thread.join()
-            assert thread.is_alive() is False
-            assert "Starting run metrics thread" in caplog.messages[0]
+                thread.join()
+                assert thread.is_alive() is False
+                assert "Shutting down metrics capture thread" in caplog.messages[-1]
 
 
 def test_report_run_metrics(dagster_instance: DagsterInstance, dagster_run: DagsterRun):


### PR DESCRIPTION
## Summary & Motivation

- ensure that the run telemetry function is supported by the instance before starting the thread
- refactors the run metrics thread functionality to reduce code duplication.
- adjusts the default polling intervals. 

Replaces: https://github.com/dagster-io/dagster/pull/23503 - revert behavior to starting the metric collection thread only if the dagster/run_metrics tag is set.

## How I Tested These Changes

- BK
- Manual testing (retested 2024/09/17)

## Changelog

NOCHANGELOG
