### PR TITLE
[5/n][dagster-sigma] Add lazy-loading build_defs fn

### DIFF
--- a/python_modules/libraries/dagster-sigma/dagster_sigma/translator.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/translator.py
@@ -6,6 +6,7 @@ from dagster._core.definitions.metadata.metadata_set import TableMetadataSet
 from dagster._core.definitions.metadata.table import TableColumn
 from dagster._core.definitions.tags import build_kind_tag
 from dagster._record import record
+from dagster._serdes.serdes import whitelist_for_serdes
 from dagster._utils.cached_method import cached_method
 from dagster._vendored.dateutil.parser import isoparse
 
@@ -20,6 +21,7 @@ def _inode_from_url(url: str) -> str:
     return f'inode-{url.split("/")[-1]}'
 
 
+@whitelist_for_serdes
 @record
 class SigmaWorkbook:
     """Represents a Sigma workbook, a collection of visualizations and queries
@@ -32,6 +34,7 @@ class SigmaWorkbook:
     datasets: AbstractSet[str]
 
 
+@whitelist_for_serdes
 @record
 class SigmaDataset:
     """Represents a Sigma dataset, a centralized data definition which can

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/pending_repo.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/pending_repo.py
@@ -1,0 +1,29 @@
+from dagster import asset, define_asset_job
+from dagster._core.definitions.decorators.definitions_decorator import definitions
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._core.definitions.definitions_loader import DefinitionsLoadContext
+from dagster_sigma import SigmaBaseUrl, SigmaOrganization
+
+fake_client_id = "fake_client_id"
+fake_client_secret = "fake_client_secret"
+
+fake_token = "fake_token"
+resource = SigmaOrganization(
+    base_url=SigmaBaseUrl.AWS_US,
+    client_id=fake_client_id,
+    client_secret=fake_client_secret,
+)
+
+
+@asset
+def my_materializable_asset():
+    pass
+
+
+@definitions
+def defs(context: DefinitionsLoadContext) -> Definitions:
+    sigma_defs = resource.build_defs(context)
+    return Definitions.merge(
+        Definitions(assets=[my_materializable_asset], jobs=[define_asset_job("all_asset_job")]),
+        sigma_defs,
+    )

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/pending_repo_2.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/pending_repo_2.py
@@ -1,0 +1,1 @@
+from dagster_sigma_tests.pending_repo import defs as defs

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_asset_specs.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import responses
+from dagster._core.code_pointer import CodePointer
+from dagster._core.definitions.definitions_loader import DefinitionsLoadType
+from dagster._core.definitions.reconstruct import repository_def_from_pointer
+from dagster._core.instance_for_test import instance_for_test
+
+
+@responses.activate
+def test_load_assets_organization_data(sigma_auth_token: str, sigma_sample_data: None) -> None:
+    with instance_for_test() as _instance:
+        # first, we resolve the repository to generate our cached metadata
+        repository_def = repository_def_from_pointer(
+            CodePointer.from_python_file(
+                str(Path(__file__).parent / "pending_repo.py"), "defs", None
+            ),
+            DefinitionsLoadType.INITIALIZATION,
+            None,
+        )
+
+        # 2 Sigma external assets, one materializable asset
+        assert len(repository_def.assets_defs_by_key) == 2 + 1
+
+        calls = len(responses.calls)
+
+        # Attempt to reconstruct - this should not call the expensive fetch functions
+        # Responses will error if we do, since the mocked endpoints are only set up to be called once
+        data = repository_def.repository_load_data
+
+        # We use a separate file here just to ensure we get a fresh load
+        recon_repository_def = repository_def_from_pointer(
+            CodePointer.from_python_file(
+                str(Path(__file__).parent / "pending_repo_2.py"), "defs", None
+            ),
+            DefinitionsLoadType.RECONSTRUCTION,
+            data,
+        )
+        assert len(recon_repository_def.assets_defs_by_key) == 2 + 1
+
+        assert len(responses.calls) == calls


### PR DESCRIPTION
## Summary

Introduces lazy-loading `build_defs` which users can use to get a set of assets for their Sigma organization:

```python
@definitions
def defs(context: DefinitionsLoadContext) -> Definitions:
    sigma_org = SigmaOrganization(
        cloud_type=SigmaCloudType.AWS_US,
        client_id=...,
        client_secret=...,
    )
    return sigma_org.build_defs(context)

```

This caches the expensive API fetches between loads.

## Test Plan

New unit test which ensures assets are built and cached properly.

## Changelog

NOCHANGELOG
