### PR TITLE
Respect op/asset retry policy when a step crashes or fails a health check

### DIFF
--- a/python_modules/dagster-test/dagster_test/test_project/test_jobs/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_jobs/repo.py
@@ -17,6 +17,7 @@ from dagster import (
     IntSource,
     List,
     Output,
+    RetryPolicy,
     RetryRequested,
     file_relative_path,
     graph,
@@ -133,6 +134,9 @@ def apply_platform_settings(
         "factor": IntSource,
         "should_segfault": Field(bool, is_required=False, default_value=False),
     },
+    retry_policy=RetryPolicy(
+        max_retries=2,
+    ),
 )
 def multiply_the_word(context, word: str) -> str:
     if context.op_config.get("should_segfault"):

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -206,6 +206,14 @@ class IStepContext(IPlanContext):
     def node_handle(self) -> "NodeHandle":
         raise NotImplementedError()
 
+    @property
+    def op_retry_policy(self) -> Optional[RetryPolicy]:
+        # Currently this pulls the retry policy directly from the definition object -
+        # the retry policy would need to be moved to JobSnapshot or ExecutionPlanSnapshot
+        # in order for the run worker to be able to handle retries without direct
+        # access to user code
+        return self.job.get_definition().get_retry_policy_for_handle(self.node_handle)
+
 
 class PlanOrchestrationContext(IPlanContext):
     """Context for the orchestration of a run.

--- a/python_modules/dagster/dagster/_core/executor/base.py
+++ b/python_modules/dagster/dagster/_core/executor/base.py
@@ -1,13 +1,17 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Iterator
 
+from dagster import _check as check
 from dagster._annotations import public
+from dagster._core.execution.plan.objects import StepFailureData, StepRetryData
 from dagster._core.execution.retries import RetryMode
+from dagster._utils.error import SerializableErrorInfo
 
 if TYPE_CHECKING:
     from dagster._core.events import DagsterEvent
-    from dagster._core.execution.context.system import PlanOrchestrationContext
+    from dagster._core.execution.context.system import IStepContext, PlanOrchestrationContext
     from dagster._core.execution.plan.plan import ExecutionPlan
+    from dagster._core.execution.plan.state import KnownExecutionState
 
 
 class Executor(ABC):
@@ -36,3 +40,37 @@ class Executor(ABC):
 
         Returns: RetryMode
         """
+
+    def get_failure_or_retry_event_after_crash(
+        self,
+        step_context: "IStepContext",
+        err_info: SerializableErrorInfo,
+        known_state: "KnownExecutionState",
+    ):
+        from dagster._core.events import DagsterEvent
+
+        # determine the retry policy for the step if needed
+        retry_policy = step_context.op_retry_policy
+        retry_state = known_state.get_retry_state()
+        previous_attempt_count = retry_state.get_attempt_count(step_context.step.key)
+        should_retry = (
+            retry_policy
+            and not step_context.retry_mode.disabled
+            and previous_attempt_count < retry_policy.max_retries
+        )
+
+        if should_retry:
+            return DagsterEvent.step_retry_event(
+                step_context,
+                StepRetryData(
+                    error=err_info,
+                    seconds_to_wait=check.not_none(retry_policy).calculate_delay(
+                        previous_attempt_count + 1
+                    ),
+                ),
+            )
+        else:
+            return DagsterEvent.step_failure_event(
+                step_context=step_context,
+                step_failure_data=StepFailureData(error=err_info, user_failure_data=None),
+            )

--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -184,7 +184,7 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
 
         try:
             return self._get_client(container_context).containers.get(container_id)
-        except Exception:
+        except docker.errors.NotFound:
             return None
 
     def terminate(self, run_id):

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_docker_executor.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_docker_executor.py
@@ -18,7 +18,7 @@ from dagster_docker_tests.test_launch_docker import check_event_log_contains
 
 
 @pytest.mark.integration
-def test_docker_executor(aws_env):
+def test_docker_executor_success(aws_env):
     """Note that this test relies on having AWS credentials in the environment."""
     executor_config = {
         "execution": {
@@ -81,6 +81,33 @@ def test_docker_executor_check_step_health(aws_env):
             recon_job = get_test_project_recon_job("demo_job_docker", docker_image)
             with execute_job(recon_job, run_config=run_config, instance=instance) as result:
                 assert not result.success
+                run_logs = instance.all_logs(result.run_id)
+
+                check_event_log_contains(
+                    run_logs,
+                    [
+                        (
+                            "STEP_UP_FOR_RETRY",
+                            'Execution of step "multiply_the_word" failed and has requested a retry',
+                        ),
+                        (
+                            "STEP_RESTARTED",
+                            'Started re-execution (attempt # 2) of step "multiply_the_word"',
+                        ),
+                        (
+                            "STEP_UP_FOR_RETRY",
+                            'Execution of step "multiply_the_word" failed and has requested a retry',
+                        ),
+                        (
+                            "STEP_RESTARTED",
+                            'Started re-execution (attempt # 3) of step "multiply_the_word"',
+                        ),
+                        (
+                            "STEP_FAILURE",
+                            'Execution of step "multiply_the_word" failed.',
+                        ),
+                    ],
+                )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary & Motivation
Instead of always failing the step when it crashes, potentially emit a run retry event instead - I did not realize that the core of processing these retry events was already happening within the executor, so getting this working is just a matter of emitting the correct event.

Resolves https://github.com/dagster-io/dagster/issues/16168.

## How I Tested These Changes
New test cases

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- `BUGFIX` Fixed an issue where an op or asset RetryPolicy was not respected after the process executing the op or asset crashed instead of raising an exception.
