### PR TITLE
`tags` filtering for backfills

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -64,7 +64,6 @@ class BulkActionsFilter:
     created_before: Optional[datetime] = None
     created_after: Optional[datetime] = None
     tags: Optional[Mapping[str, Union[str, Sequence[str]]]] = None
-    job_name: Optional[str] = None
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -55,12 +55,15 @@ class BulkActionsFilter:
         created_before (Optional[DateTime]): Filter by bulk actions that were created before this datetime. Note that the
             create_time for each bulk action is stored in UTC.
         created_after (Optional[DateTime]): Filter by bulk actions that were created after this datetime. Note that the
-            create_time for each bulk action is stored in UTC.
+            create_time for each bulk action is stored in UTC.t
+        tags (Optional[Dict[str, Union[str, List[str]]]]):
+            A dictionary of tags to query by. All tags specified here must be present for a given bulk action to pass the filter.
     """
 
     statuses: Optional[Sequence[BulkActionStatus]] = None
     created_before: Optional[datetime] = None
     created_after: Optional[datetime] = None
+    tags: Mapping[str, Union[str, Sequence[str]]]
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -63,7 +63,8 @@ class BulkActionsFilter:
     statuses: Optional[Sequence[BulkActionStatus]] = None
     created_before: Optional[datetime] = None
     created_after: Optional[datetime] = None
-    tags: Mapping[str, Union[str, Sequence[str]]]
+    tags: Optional[Mapping[str, Union[str, Sequence[str]]]] = None
+    job_name: Optional[str] = None
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -879,7 +879,7 @@ class SqlRunStorage(RunStorage):
             # if len(backfill_ids) == 0:
             #     return []
 
-            query = query.where(BulkActionsTable.c.key.in_(backfills_with_tags_query.subquery()))
+            query = query.where(BulkActionsTable.c.key.in_(db_subquery(backfills_with_tags_query)))
 
         if status or (filters and filters.statuses):
             statuses = [status] if status else (filters.statuses if filters else None)

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -893,27 +893,6 @@ class SqlRunStorage(RunStorage):
 
             query.where(BulkActionsTable.c.key.in_(backfill_ids))
 
-        if filters and filters.job_name:
-            run_tags_table = RunTagsTable
-
-            run_tags_table = run_tags_table.join(
-                RunsTable,
-                db.and_(
-                    RunTagsTable.c.run_id == RunsTable.c.run_id,
-                    RunTagsTable.c.key == BACKFILL_ID_TAG,
-                    RunsTable.c.pipeline_name == filters.job_name,
-                ),
-            )
-
-            backfill_ids_query = db_select([RunTagsTable.c.value]).select_from(run_tags_table)
-            rows = self.fetchall(backfill_ids_query)
-            backfill_ids = [row["value"] for row in rows]
-
-            if len(backfill_ids) == 0:
-                return []
-
-            query.where(BulkActionsTable.c.key.in_(backfill_ids))
-
         if status or (filters and filters.statuses):
             statuses = [status] if status else (filters.statuses if filters else None)
             assert statuses

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -851,13 +851,9 @@ class SqlRunStorage(RunStorage):
             # applied to the runs the backfill launches. So we can query for runs that match the tags and
             # are also part of a backfill to find the backfills that match the tags.
 
-            backfills_with_tags_query = db_select(
-                [
-                    # RunTagsTable.c.run_id,
-                    # RunTagsTable.c.key,
-                    RunTagsTable.c.value
-                ]
-            ).where(RunTagsTable.c.key == BACKFILL_ID_TAG)
+            backfills_with_tags_query = db_select([RunTagsTable.c.value]).where(
+                RunTagsTable.c.key == BACKFILL_ID_TAG
+            )
 
             for i, (key, value) in enumerate(filters.tags.items()):
                 run_tags_alias = db.alias(RunTagsTable, f"run_tags_filter{i}")

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -873,12 +873,6 @@ class SqlRunStorage(RunStorage):
                     ),
                 )
 
-            # rows = self.fetchall(backfills_with_tags_query)
-            # backfill_ids = [row["value"] for row in rows]
-
-            # if len(backfill_ids) == 0:
-            #     return []
-
             query = query.where(BulkActionsTable.c.key.in_(db_subquery(backfills_with_tags_query)))
 
         if status or (filters and filters.statuses):

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -861,9 +861,7 @@ class SqlRunStorage(RunStorage):
 
             for i, (key, value) in enumerate(filters.tags.items()):
                 run_tags_alias = db.alias(RunTagsTable, f"run_tags_filter{i}")
-
-                backfills_with_tags_query = backfills_with_tags_query.join(
-                    run_tags_alias,
+                backfills_with_tags_query = backfills_with_tags_query.where(
                     db.and_(
                         RunTagsTable.c.run_id == run_tags_alias.c.run_id,
                         run_tags_alias.c.key == key,

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -852,7 +852,11 @@ class SqlRunStorage(RunStorage):
             # are also part of a backfill to find the backfills that match the tags.
 
             backfills_with_tags_query = db_select(
-                [RunTagsTable.c.run_id, RunTagsTable.c.key, RunTagsTable.c.value]
+                [
+                    # RunTagsTable.c.run_id,
+                    # RunTagsTable.c.key,
+                    RunTagsTable.c.value
+                ]
             ).where(RunTagsTable.c.key == BACKFILL_ID_TAG)
 
             for i, (key, value) in enumerate(filters.tags.items()):
@@ -869,7 +873,13 @@ class SqlRunStorage(RunStorage):
                     ),
                 )
 
-            query = query.where(BulkActionsTable.c.key.in_(backfills_with_tags_query))
+            # rows = self.fetchall(backfills_with_tags_query)
+            # backfill_ids = [row["value"] for row in rows]
+
+            # if len(backfill_ids) == 0:
+            #     return []
+
+            query = query.where(BulkActionsTable.c.key.in_(backfills_with_tags_query.subquery()))
 
         if status or (filters and filters.statuses):
             statuses = [status] if status else (filters.statuses if filters else None)

--- a/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
@@ -43,6 +43,11 @@ def create_legacy_run_storage():
 class TestSqliteRunStorage(TestRunStorage):
     __test__ = True
 
+    # TestSqliteRunStorage::test_backfill_simple_tags_filtering
+    # TestSqliteRunStorage::test_backfill_simple_job_name_filtering
+    # TestSqliteRunStorage::test_backfill_tags_on_runs_not_backfills_filtering
+    # TestSqliteRunStorage::test_backfill_tags_filtering_multiple_results
+
     @pytest.fixture(name="instance", scope="function")
     def instance(self):
         with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmpdir_path:

--- a/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
@@ -48,6 +48,9 @@ class TestSqliteRunStorage(TestRunStorage):
     # TestSqliteRunStorage::test_backfill_tags_on_runs_not_backfills_filtering
     # TestSqliteRunStorage::test_backfill_tags_filtering_multiple_results
 
+    def supports_backfill_tags_filtering_queries(self):
+        return True
+
     @pytest.fixture(name="instance", scope="function")
     def instance(self):
         with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmpdir_path:
@@ -64,6 +67,9 @@ class TestSqliteRunStorage(TestRunStorage):
 class TestInMemoryRunStorage(TestRunStorage):
     __test__ = True
 
+    def supports_backfill_tags_filtering_queries(self):
+        return True
+
     @pytest.fixture(name="instance", scope="function")
     def instance(self):
         with DagsterInstance.ephemeral() as the_instance:
@@ -79,6 +85,9 @@ class TestInMemoryRunStorage(TestRunStorage):
 
 class TestLegacyRunStorage(TestRunStorage):
     __test__ = True
+
+    def supports_backfill_tags_filtering_queries(self):
+        return True
 
     @pytest.fixture(name="instance", scope="function")
     def instance(self):

--- a/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
@@ -43,11 +43,6 @@ def create_legacy_run_storage():
 class TestSqliteRunStorage(TestRunStorage):
     __test__ = True
 
-    # TestSqliteRunStorage::test_backfill_simple_tags_filtering
-    # TestSqliteRunStorage::test_backfill_simple_job_name_filtering
-    # TestSqliteRunStorage::test_backfill_tags_on_runs_not_backfills_filtering
-    # TestSqliteRunStorage::test_backfill_tags_filtering_multiple_results
-
     def supports_backfill_tags_filtering_queries(self):
         return True
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -494,6 +494,9 @@ class TestEventLogStorage:
     def supports_offset_cursor_queries(self):
         return True
 
+    def supports_backfill_tags_filtering_queries(self):
+        return False
+
     def supports_multiple_event_type_queries(self):
         return True
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -494,9 +494,6 @@ class TestEventLogStorage:
     def supports_offset_cursor_queries(self):
         return True
 
-    def supports_backfill_tags_filtering_queries(self):
-        return False
-
     def supports_multiple_event_type_queries(self):
         return True
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -1489,6 +1489,8 @@ class TestRunStorage:
             assert backfill.backfill_timestamp > all_backfills[2].backfill_timestamp
 
     def test_backfill_simple_tags_filtering(self, storage: RunStorage):
+        if not self.supports_backfill_tags_filtering_queries():
+            pytest.skip("storage does not support filtering backfills by tag")
         origin = self.fake_partition_set_origin("fake_partition_set")
         backfills = storage.get_backfills()
         assert len(backfills) == 0
@@ -1537,6 +1539,8 @@ class TestRunStorage:
         assert len(backfill_with_tags) == 0
 
     def test_backfill_tags_on_runs_not_backfills_filtering(self, storage: RunStorage):
+        if not self.supports_backfill_tags_filtering_queries():
+            pytest.skip("storage does not support filtering backfills by tag")
         origin = self.fake_partition_set_origin("fake_partition_set")
         backfills = storage.get_backfills()
         assert len(backfills) == 0
@@ -1576,6 +1580,8 @@ class TestRunStorage:
         assert len(backfill_with_tags) == 0
 
     def test_backfill_tags_filtering_multiple_results(self, storage: RunStorage):
+        if not self.supports_backfill_tags_filtering_queries():
+            pytest.skip("storage does not support filtering backfills by tag")
         origin = self.fake_partition_set_origin("fake_partition_set")
         backfills = storage.get_backfills()
         assert len(backfills) == 0

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -90,6 +90,14 @@ class TestRunStorage:
     def can_delete_runs(self):
         return True
 
+    # Override for storages that support filtering backfills by tag
+    def supports_backfill_tags_filtering_queries(self):
+        return False
+
+    # Override for storages that support filtering backfills by job name
+    def supports_backfill_job_name_filtering_queries(self):
+        return False
+
     @staticmethod
     def fake_repo_target(repo_name=None):
         name = repo_name or "fake_repo_name"

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -32,6 +32,7 @@ from dagster._core.storage.runs.base import RunStorage
 from dagster._core.storage.runs.migration import REQUIRED_DATA_MIGRATIONS
 from dagster._core.storage.runs.sql_run_storage import SqlRunStorage
 from dagster._core.storage.tags import (
+    BACKFILL_ID_TAG,
     PARENT_RUN_ID_TAG,
     PARTITION_NAME_TAG,
     PARTITION_SET_TAG,
@@ -1486,6 +1487,191 @@ class TestRunStorage:
         assert len(created_after) == 2
         for backfill in created_after:
             assert backfill.backfill_timestamp > all_backfills[2].backfill_timestamp
+
+    def test_backfill_simple_tags_filtering(self, storage: RunStorage):
+        origin = self.fake_partition_set_origin("fake_partition_set")
+        backfills = storage.get_backfills()
+        assert len(backfills) == 0
+
+        backfill = PartitionBackfill(
+            "backfill_1",
+            partition_set_origin=origin,
+            status=BulkActionStatus.REQUESTED,
+            partition_names=["a", "b", "c"],
+            from_failure=False,
+            tags={"foo": "bar", "letter": "z"},
+            backfill_timestamp=time.time(),
+        )
+        storage.add_backfill(backfill)
+
+        run_id = make_new_run_id()
+        storage.add_run(
+            TestRunStorage.build_run(
+                run_id=run_id,
+                job_name="some_pipeline",
+                status=DagsterRunStatus.SUCCESS,
+                tags={"foo": "bar", "letter": "z", BACKFILL_ID_TAG: backfill.backfill_id},
+            )
+        )
+
+        backfill_with_tags = storage.get_backfills(filters=BulkActionsFilter(tags={"foo": "bar"}))
+        assert len(backfill_with_tags) == 1
+        assert backfill_with_tags[0].backfill_id == backfill.backfill_id
+        assert backfill_with_tags[0].tags == backfill.tags
+
+        backfill_with_tags = storage.get_backfills(
+            filters=BulkActionsFilter(tags={"letter": ["x", "y", "z"]})
+        )
+        assert len(backfill_with_tags) == 1
+        assert backfill_with_tags[0].backfill_id == backfill.backfill_id
+        assert backfill_with_tags[0].tags == backfill.tags
+
+        # test for a tag that doesn't exist
+
+        backfill_with_tags = storage.get_backfills(
+            filters=BulkActionsFilter(tags={"not": "present"})
+        )
+        assert len(backfill_with_tags) == 0
+
+        backfill_with_tags = storage.get_backfills(filters=BulkActionsFilter(tags={"foo": "no"}))
+        assert len(backfill_with_tags) == 0
+
+    def test_backfill_tags_on_runs_not_backfills_filtering(self, storage: RunStorage):
+        origin = self.fake_partition_set_origin("fake_partition_set")
+        backfills = storage.get_backfills()
+        assert len(backfills) == 0
+
+        backfill = PartitionBackfill(
+            "backfill_1",
+            partition_set_origin=origin,
+            status=BulkActionStatus.REQUESTED,
+            partition_names=["a", "b", "c"],
+            from_failure=False,
+            tags={"foo": "bar"},
+            backfill_timestamp=time.time(),
+        )
+        storage.add_backfill(backfill)
+
+        run_id = make_new_run_id()
+        storage.add_run(
+            TestRunStorage.build_run(
+                run_id=run_id,
+                job_name="some_pipeline",
+                status=DagsterRunStatus.SUCCESS,
+                tags={
+                    "foo": "bar",
+                    "baz": "qux",
+                    "letter": "z",
+                    BACKFILL_ID_TAG: backfill.backfill_id,
+                },
+            )
+        )
+
+        backfill_with_tags = storage.get_backfills(filters=BulkActionsFilter(tags={"baz": "qux"}))
+        assert len(backfill_with_tags) == 0
+
+        backfill_with_tags = storage.get_backfills(
+            filters=BulkActionsFilter(tags={"letter": ["x", "y", "z"]})
+        )
+        assert len(backfill_with_tags) == 0
+
+    def test_backfill_tags_filtering_multiple_results(self, storage: RunStorage):
+        origin = self.fake_partition_set_origin("fake_partition_set")
+        backfills = storage.get_backfills()
+        assert len(backfills) == 0
+
+        all_backfills = []
+        for i in range(3):
+            shared_tags = {"foo": "bar", "iter": str(i), "even": str(i % 2 == 0)}
+            backfill = PartitionBackfill(
+                f"backfill_{i}",
+                partition_set_origin=origin,
+                status=BulkActionStatus.REQUESTED,
+                partition_names=["a", "b", "c"],
+                from_failure=False,
+                tags=shared_tags,
+                backfill_timestamp=time.time(),
+            )
+            storage.add_backfill(backfill)
+            all_backfills.append(backfill)
+
+            storage.add_run(
+                TestRunStorage.build_run(
+                    run_id=make_new_run_id(),
+                    job_name="some_pipeline",
+                    status=DagsterRunStatus.SUCCESS,
+                    tags={**shared_tags, "letter": "z", BACKFILL_ID_TAG: backfill.backfill_id},
+                )
+            )
+
+        backfill_with_tags = storage.get_backfills(filters=BulkActionsFilter(tags={"foo": "bar"}))
+        assert len(backfill_with_tags) == 3
+
+        backfill_with_tags = storage.get_backfills(
+            filters=BulkActionsFilter(tags={"letter": ["x", "y", "z"]})
+        )
+        assert len(backfill_with_tags) == 0
+
+        backfill_with_tags = storage.get_backfills(filters=BulkActionsFilter(tags={"even": "True"}))
+        assert len(backfill_with_tags) == 2
+
+        backfill_with_tags = storage.get_backfills(
+            filters=BulkActionsFilter(tags={"iter": ["1", "2"]})
+        )
+        assert len(backfill_with_tags) == 2
+
+        backfill_with_tags = storage.get_backfills(
+            filters=BulkActionsFilter(tags={"not": "present"})
+        )
+        assert len(backfill_with_tags) == 0
+
+    def test_backfill_simple_job_name_filtering(self, storage: RunStorage):
+        origin = self.fake_partition_set_origin("fake_partition_set")
+        backfills = storage.get_backfills()
+        assert len(backfills) == 0
+
+        backfill = PartitionBackfill(
+            "backfill_1",
+            partition_set_origin=origin,
+            status=BulkActionStatus.REQUESTED,
+            partition_names=["a", "b", "c"],
+            from_failure=False,
+            tags={},
+            backfill_timestamp=time.time(),
+        )
+        storage.add_backfill(backfill)
+
+        run_id = make_new_run_id()
+        storage.add_run(
+            TestRunStorage.build_run(
+                run_id=run_id,
+                job_name="some_pipeline",
+                status=DagsterRunStatus.SUCCESS,
+                tags={BACKFILL_ID_TAG: backfill.backfill_id},
+            )
+        )
+
+        # a run for a different job that is not part of a backfill
+        storage.add_run(
+            TestRunStorage.build_run(
+                run_id=make_new_run_id(),
+                job_name="a_different_pipeline",
+                status=DagsterRunStatus.SUCCESS,
+            )
+        )
+
+        backfills_for_job = storage.get_backfills(
+            filters=BulkActionsFilter(job_name="some_pipeline")
+        )
+        assert len(backfills_for_job) == 1
+        assert backfills_for_job[0].backfill_id == backfill.backfill_id
+
+        # test for a job_name that doesn't match
+
+        backfills_for_job = storage.get_backfills(
+            filters=BulkActionsFilter(job_name="a_different_pipeline")
+        )
+        assert len(backfills_for_job) == 0
 
     def test_secondary_index(self, storage):
         self._skip_in_memory(storage)

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -1625,54 +1625,6 @@ class TestRunStorage:
         )
         assert len(backfill_with_tags) == 0
 
-    def test_backfill_simple_job_name_filtering(self, storage: RunStorage):
-        origin = self.fake_partition_set_origin("fake_partition_set")
-        backfills = storage.get_backfills()
-        assert len(backfills) == 0
-
-        backfill = PartitionBackfill(
-            "backfill_1",
-            partition_set_origin=origin,
-            status=BulkActionStatus.REQUESTED,
-            partition_names=["a", "b", "c"],
-            from_failure=False,
-            tags={},
-            backfill_timestamp=time.time(),
-        )
-        storage.add_backfill(backfill)
-
-        run_id = make_new_run_id()
-        storage.add_run(
-            TestRunStorage.build_run(
-                run_id=run_id,
-                job_name="some_pipeline",
-                status=DagsterRunStatus.SUCCESS,
-                tags={BACKFILL_ID_TAG: backfill.backfill_id},
-            )
-        )
-
-        # a run for a different job that is not part of a backfill
-        storage.add_run(
-            TestRunStorage.build_run(
-                run_id=make_new_run_id(),
-                job_name="a_different_pipeline",
-                status=DagsterRunStatus.SUCCESS,
-            )
-        )
-
-        backfills_for_job = storage.get_backfills(
-            filters=BulkActionsFilter(job_name="some_pipeline")
-        )
-        assert len(backfills_for_job) == 1
-        assert backfills_for_job[0].backfill_id == backfill.backfill_id
-
-        # test for a job_name that doesn't match
-
-        backfills_for_job = storage.get_backfills(
-            filters=BulkActionsFilter(job_name="a_different_pipeline")
-        )
-        assert len(backfills_for_job) == 0
-
     def test_secondary_index(self, storage):
         self._skip_in_memory(storage)
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -1621,6 +1621,11 @@ class TestRunStorage:
         assert len(backfill_with_tags) == 2
 
         backfill_with_tags = storage.get_backfills(
+            filters=BulkActionsFilter(tags={"iter": ["1", "2"], "even": "True"})
+        )
+        assert len(backfill_with_tags) == 1
+
+        backfill_with_tags = storage.get_backfills(
             filters=BulkActionsFilter(tags={"not": "present"})
         )
         assert len(backfill_with_tags) == 0

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_run_storage.py
@@ -14,6 +14,9 @@ TestRunStorage.__test__ = False
 class TestMySQLRunStorage(TestRunStorage):
     __test__ = True
 
+    def supports_backfill_tags_filtering_queries(self):
+        return True
+
     @pytest.fixture(name="instance", scope="function")
     def instance(self, conn_string):
         MySQLRunStorage.create_clean_storage(conn_string)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_run_storage.py
@@ -10,6 +10,9 @@ from dagster_tests.storage_tests.utils.run_storage import TestRunStorage
 class TestPostgresRunStorage(TestRunStorage):
     __test__ = True
 
+    def supports_backfill_tags_filtering_queries(self):
+        return True
+
     @pytest.fixture(name="instance", scope="function")
     def instance(self, conn_string):
         PostgresRunStorage.create_clean_storage(conn_string)


### PR DESCRIPTION
## Summary & Motivation
add the ability to filter backfills by tags by using the run tags table as a proxy.
All runs launched by a backfill have the backfill tags added to them. We can query the run tags table for runs that match the provided tags and have a backfill tag and use those backfill ids to filter the backfill table.

We have to do an additional check of the results at the end to ensure the filter tags are present on the backfill object, and were not added to the run in another way

## How I Tested These Changes

## Changelog

NOCHANGELOG


