### PR TITLE
[dagster-databricks] Support existing clusters in Pipes

### DIFF
--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -581,8 +581,8 @@ def open_pipes_session(
             with open_pipes_session(
                 context=context,
                 extras={"foo": "bar"},
-                context_injector=ExtTempFileContextInjector(),
-                message_reader=ExtTempFileMessageReader(),
+                context_injector=PipesTempFileContextInjector(),
+                message_reader=PipesTempFileMessageReader(),
             ) as pipes_session:
                 subprocess.Popen(
                     ["/bin/python", "/path/to/script.py"],

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -6,7 +6,7 @@ import string
 import sys
 import time
 from contextlib import ExitStack, contextmanager
-from typing import Any, Iterator, Literal, Mapping, Optional, Sequence, TextIO
+from typing import Any, Dict, Iterator, Literal, Mapping, Optional, Sequence, Set, TextIO
 
 import dagster._check as check
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
@@ -18,6 +18,7 @@ from dagster._core.pipes.client import (
     PipesContextInjector,
     PipesMessageReader,
 )
+from dagster._core.pipes.context import PipesSession
 from dagster._core.pipes.utils import (
     PipesBlobStoreMessageReader,
     PipesChunkedLogReader,
@@ -84,7 +85,23 @@ class PipesDatabricksClient(PipesClient, TreatAsResourceParam):
 
     def get_default_message_reader(self, task: jobs.SubmitTask) -> "PipesDbfsMessageReader":
         # include log readers if the user is writing their logs to DBFS
-        if task.as_dict().get("new_cluster", {}).get("cluster_log_conf", {}).get("dbfs", None):
+
+        new_cluster_logging_configured = (
+            task.as_dict().get("new_cluster", {}).get("cluster_log_conf", {}).get("dbfs", None)
+        )
+
+        existing_cluster_has_logging_configured = False
+        if task.existing_cluster_id is not None:
+            cluster = self.client.clusters.get(cluster_id=task.existing_cluster_id).as_dict()
+
+            if cluster.get("cluster_log_conf", {}).get("dbfs", None):
+                existing_cluster_has_logging_configured = True
+
+        logging_configured = (
+            new_cluster_logging_configured or existing_cluster_has_logging_configured
+        )
+
+        if logging_configured:
             log_readers = [
                 PipesDbfsLogReader(
                     client=self.client,
@@ -116,10 +133,17 @@ class PipesDatabricksClient(PipesClient, TreatAsResourceParam):
 
         Args:
             task (databricks.sdk.service.jobs.SubmitTask): Specification of the databricks
-                task to run. Environment variables used by dagster-pipes will be set under the
-                `spark_env_vars` key of the `new_cluster` field (if there is an existing dictionary
-                here, the Pipes environment variables will be merged in). Everything else will be
-                passed unaltered under the `tasks` arg to `WorkspaceClient.jobs.submit`.
+                task to run. If `existing_cluster_id` key is set, Pipes bootstrap parameters will be
+                passed via task parameters, which are exposed as CLI arguments for Python scripts.
+                They are going to be merged with any existing parameters in the task.
+                See `Databricks documentation <https://docs.databricks.com/en/jobs/create-run-jobs.html#pass-parameters-to-a-databricks-job-task>`_
+                for more information. In order to initialize Pipes in the task, the task code must have
+                py:class:`dagster_pipes.PipesCliArgsParamsLoader` explicitly passed to
+                py:function:`dagster_pipes.open_pipes_session. If `existing_cluster_id` key is not set,
+                a new cluster will be created, and Pipes bootstrap parameters will be passed via environment
+                variables in `spark_env_vars` (if there is an existing dictionary here, the Pipes environment
+                variables will be merged in). This doesn't require any special setup in the task code.
+                All other fields will be passed unaltered under the `tasks` arg to `WorkspaceClient.jobs.submit`.
             context (OpExecutionContext): The context from the executing op or asset.
             extras (Optional[PipesExtras]): An optional dict of extra parameters to pass to the
                 subprocess.
@@ -138,11 +162,10 @@ class PipesDatabricksClient(PipesClient, TreatAsResourceParam):
             message_reader=message_reader,
         ) as pipes_session:
             submit_task_dict = task.as_dict()
-            submit_task_dict["new_cluster"]["spark_env_vars"] = {
-                **submit_task_dict["new_cluster"].get("spark_env_vars", {}),
-                **(self.env or {}),
-                **pipes_session.get_bootstrap_env_vars(),
-            }
+
+            submit_task_dict = self._enrich_submit_task_dict(
+                context=context, session=pipes_session, submit_task_dict=submit_task_dict
+            )
 
             task = jobs.SubmitTask.from_dict(submit_task_dict)
             run_id = self.client.jobs.submit(
@@ -159,6 +182,42 @@ class PipesDatabricksClient(PipesClient, TreatAsResourceParam):
                     self._poll_til_terminating(run_id)
 
         return PipesClientCompletedInvocation(pipes_session)
+
+    def _enrich_submit_task_dict(
+        self, context: OpExecutionContext, session: PipesSession, submit_task_dict: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        if "existing_cluster_id" in submit_task_dict:
+            # we can't set env vars on an existing cluster
+            # so we must use CLI to pass Pipes params
+            cli_args = session.get_bootstrap_cli_arguments()  # this is a mapping
+
+            for task_type in self.get_task_fields_which_support_cli_parameters():
+                if task_type in submit_task_dict:
+                    existing_params = submit_task_dict[task_type].get("parameters", [])
+
+                    # merge the existing parameters with the CLI arguments
+                    for key, value in cli_args.items():
+                        existing_params.extend([key, value])
+
+                    submit_task_dict[task_type]["parameters"] = existing_params
+                    context.log.debug(
+                        f'Passing Pipes bootstrap parameters via Databricks parameters as "{key}.parameters". Make sure to use the PipesCliArgsParamsLoader in the task.'
+                    )
+                    break
+
+        else:
+            pipes_env_vars = session.get_bootstrap_env_vars()
+
+            submit_task_dict["new_cluster"]["spark_env_vars"] = {
+                **submit_task_dict["new_cluster"].get("spark_env_vars", {}),
+                **(self.env or {}),
+                **pipes_env_vars,
+            }
+
+        return submit_task_dict
+
+    def get_task_fields_which_support_cli_parameters(self) -> Set[str]:
+        return {"spark_python_task", "python_wheel_task"}
 
     def _poll_til_success(self, context: OpExecutionContext, run_id: int) -> None:
         # poll the Databricks run until it reaches RunResultState.SUCCESS, raising otherwise

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/pipes.py
@@ -384,7 +384,7 @@ class PipesDbfsLogReader(PipesChunkedLogReader):
     Args:
         interval (float): interval in seconds between attempts to download a log chunk
         remote_log_name (Literal["stdout", "stderr"]): The name of the log file to read.
-        target_stream (TextIO): The stream to which to forward log chunk that have been read.
+        target_stream (TextIO): The stream to which to forward log chunks that have been read.
         client (WorkspaceClient): A databricks `WorkspaceClient` object.
     """
 

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
@@ -1,7 +1,9 @@
 import os
 import re
-from typing import Dict
+from contextlib import ExitStack, contextmanager
+from typing import Any, Dict, Iterator, Optional
 
+import dagster._check as check
 import pytest
 from dagster import AssetExecutionContext, asset, materialize
 from dagster._core.errors import DagsterPipesExecutionError
@@ -12,17 +14,36 @@ from dagster_databricks._test_utils import (
 )
 from dagster_databricks.pipes import PipesDatabricksClient
 from databricks.sdk import WorkspaceClient
-from databricks.sdk.service import jobs
+from databricks.sdk.service import compute, jobs
 
 IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 
 
 def script_fn():
+    import os
     import sys
 
-    from dagster_pipes import PipesDbfsContextLoader, PipesDbfsMessageWriter, open_dagster_pipes
+    from dagster_pipes import (
+        DAGSTER_PIPES_CONTEXT_ENV_VAR,
+        PipesCliArgsParamsLoader,
+        PipesDbfsContextLoader,
+        PipesDbfsMessageWriter,
+        PipesEnvVarParamsLoader,
+        open_dagster_pipes,
+    )
+
+    # To facilitate using the same script for testing in both the new cluster and existing cluster
+    # instances, , we dynamically configure the PipesParamsLoader here by checking for the presence
+    # of pipes-specific env vars. If these are set, we know we are in the new cluster case and load
+    # params via the env vars.
+    params_loader = (
+        PipesEnvVarParamsLoader()
+        if DAGSTER_PIPES_CONTEXT_ENV_VAR in os.environ
+        else PipesCliArgsParamsLoader()
+    )
 
     with open_dagster_pipes(
+        params_loader=params_loader,
         context_loader=PipesDbfsContextLoader(),
         message_writer=PipesDbfsMessageWriter(),
     ) as context:
@@ -45,18 +66,33 @@ CLUSTER_DEFAULTS = {
 TASK_KEY = "DAGSTER_PIPES_TASK"
 
 
+# Create a new cluster on Databricks, yield the cluster_id, and then terminate the cluster
+# on exit. This is useful for testing the PipesClient against an existing cluster.
+@contextmanager
+def temp_databricks_cluster(client: WorkspaceClient, forward_logs: bool) -> Iterator[str]:
+    cluster_id = None
+    try:
+        # Need to make sure that nested dicts are wrapped in their SDK objects here (see
+        # `use_inner_objects`). It's required by this API but apparently not by others. Hopefully
+        # updating to a newer SDK will alleviate some of the annoyances around mixed acceptance of
+        # objects from the SDK and their dict forms.
+        cluster_spec = make_new_cluster_spec(forward_logs, use_inner_objects=True)
+        cluster_details = client.clusters.create_and_wait(**cluster_spec)
+        cluster_id = check.not_none(cluster_details.cluster_id)
+        yield cluster_id
+    finally:
+        if cluster_id:
+            client.clusters.delete(cluster_id)
+
+
 def make_submit_task_dict(
-    script_path: str, dagster_pipes_whl_path: str, forward_logs: bool
-) -> Dict[str, object]:
-    cluster_settings = CLUSTER_DEFAULTS.copy()
-    if forward_logs:
-        cluster_settings["cluster_log_conf"] = {
-            "dbfs": {"destination": "dbfs:/cluster-logs"},
-        }
-    return {
-        "new_cluster": cluster_settings,
+    script_path: str,
+    dagster_pipes_whl_path: str,
+    forward_logs: bool,
+    cluster_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    submit_spec = {
         "libraries": [
-            # {"whl": DAGSTER_PIPES_WHL_PATH},
             {"whl": dagster_pipes_whl_path},
         ],
         "task_key": TASK_KEY,
@@ -65,16 +101,35 @@ def make_submit_task_dict(
             "source": jobs.Source.WORKSPACE,
         },
     }
+    if cluster_id:
+        submit_spec["existing_cluster_id"] = cluster_id
+    else:
+        submit_spec["new_cluster"] = make_new_cluster_spec(forward_logs)
+    return submit_spec
+
+
+def make_new_cluster_spec(forward_logs: bool, use_inner_objects: bool = False) -> Any:
+    cluster_spec = CLUSTER_DEFAULTS.copy()
+    if forward_logs:
+        log_conf = {"dbfs": {"destination": "dbfs:/cluster-logs"}}
+        cluster_spec["cluster_log_conf"] = (
+            compute.ClusterLogConf.from_dict(log_conf) if use_inner_objects else log_conf
+        )
+    return cluster_spec
 
 
 def make_submit_task(
-    script_path: str, dagster_pipes_whl_path: str, forward_logs: bool
+    script_path: str,
+    dagster_pipes_whl_path: str,
+    forward_logs: bool,
+    cluster_id: Optional[str] = None,
 ) -> jobs.SubmitTask:
     return jobs.SubmitTask.from_dict(
         make_submit_task_dict(
             script_path=script_path,
             dagster_pipes_whl_path=dagster_pipes_whl_path,
             forward_logs=forward_logs,
+            cluster_id=cluster_id,
         )
     )
 
@@ -83,17 +138,44 @@ def make_submit_task(
 # readers before it knows the task specification
 @pytest.mark.skipif(IS_BUILDKITE, reason="Not configured to run on BK yet.")
 @pytest.mark.parametrize("forward_logs", [True, False])
-def test_pipes_client(capsys, databricks_client: WorkspaceClient, forward_logs: bool):  # noqa: F811
+@pytest.mark.parametrize("use_existing_cluster", [True, False])
+def test_pipes_client(
+    capsys,
+    databricks_client: WorkspaceClient,  # noqa: F811
+    forward_logs: bool,
+    use_existing_cluster: bool,
+):
+    if use_existing_cluster and forward_logs:
+        # Two reasons for this: (a) logs are flushed every 5 minutes or on cluster termination.
+        # If cluster termination is not tied to the end of the launched job, there is no mechanism
+        # to wait for logs to be flushed. (b) The logs reader functions by forwarding stdout/stderr,
+        # which is shared across all jobs on the cluster-- so there is no way to scope the
+        # forwarding to just the target job.
+        pytest.skip("Testing existing cluster with log forwarding currently does not work.")
+
     @asset
     def number_x(context: AssetExecutionContext, pipes_client: PipesDatabricksClient):
-        with upload_dagster_pipes_whl(databricks_client) as dagster_pipes_whl_path:
-            with temp_dbfs_script(databricks_client, script_fn=script_fn) as script_path:
+        with ExitStack() as stack:
+            dagster_pipes_whl_path = stack.enter_context(
+                upload_dagster_pipes_whl(databricks_client)
+            )
+            script_path = stack.enter_context(
+                temp_dbfs_script(databricks_client, script_fn=script_fn)
+            )
+            if use_existing_cluster:
+                cluster_id = stack.enter_context(
+                    temp_databricks_cluster(databricks_client, forward_logs)
+                )
+                task = make_submit_task(
+                    script_path, dagster_pipes_whl_path, forward_logs, cluster_id
+                )
+            else:
                 task = make_submit_task(script_path, dagster_pipes_whl_path, forward_logs)
-                return pipes_client.run(
-                    task=task,
-                    context=context,
-                    extras={"multiplier": 2, "storage_root": "fake"},
-                ).get_results()
+            return pipes_client.run(
+                task=task,
+                context=context,
+                extras={"multiplier": 2, "storage_root": "fake"},
+            ).get_results()
 
     result = materialize(
         [number_x],


### PR DESCRIPTION
## Summary & Motivation

Right now Databricks Pipes create a new cluster for every invocation, because Databricks does not allow setting runtime environment variables for Pipes bootstrap params. 

This PR allows using existing clusters with Databricks Pipes. This is achieved by passing Pipes bootstrap params via Databricks [task parameters](https://docs.databricks.com/en/jobs/create-run-jobs.html#pass-parameters-to-a-databricks-job-task). These parameters are exposed to Python tasks as CLI args, so this feature requires using a `PipesCliArgsParamsLoader` in the task. Also, we do not support forwarding stdout/stderr from existing clusters (yet). 

Slack thread: https://dagsterlabs.slack.com/archives/C05M31J51J6/p1726501276959059

Resolve [FEAT-756](https://linear.app/dagster-labs/issue/FEAT-756/support-running-on-existing-clusters-in-databricks-pipes)

## How I Tested These Changes

I'm not really sure how to test this. The current tests do not run in CI, I guess @smackesey  had them set up locally? 

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [x] `NEW` _([dagster-databricks] Databricks Pipes now allow running tasks in existing clusters)_
- [x] `DOCS` _(added or updated documentation)_
