### PR TITLE
Fix error message when a sensor is paused due to being unable to reach the code server

### DIFF
--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -268,8 +268,8 @@ class SensorLaunchContext(AbstractContextManager):
             ):
                 try:
                     raise DagsterSensorDaemonError(
-                        f"Unable to reach the user code server for schedule {self._external_sensor.name}."
-                        " Schedule will resume execution once the server is available."
+                        f"Unable to reach the user code server for sensor {self._external_sensor.name}."
+                        " Sensor will resume execution once the server is available."
                     ) from exception_value
                 except:
                     error_data = DaemonErrorCapture.on_exception(sys.exc_info())


### PR DESCRIPTION
Summary:
Noticed this in a user report - these are sensors, not schedules

Test Plan: BK

## Summary & Motivation

## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
