### PR TITLE
[dagster-sigma] Fetch and assign default owners to workbooks

### DIFF
--- a/python_modules/libraries/dagster-sigma/dagster_sigma/translator.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/translator.py
@@ -1,5 +1,5 @@
 import re
-from typing import AbstractSet, Any, Dict, List
+from typing import AbstractSet, Any, Dict, List, Optional
 
 from dagster import AssetKey, AssetSpec, MetadataValue, TableSchema
 from dagster._core.definitions.metadata.metadata_set import TableMetadataSet
@@ -32,6 +32,7 @@ class SigmaWorkbook:
 
     properties: Dict[str, Any]
     datasets: AbstractSet[str]
+    owner_email: Optional[str]
 
 
 @whitelist_for_serdes
@@ -89,6 +90,7 @@ class DagsterSigmaTranslator:
                 **build_kind_tag("sigma"),
             },
             deps={self.get_dataset_key(dataset) for dataset in datasets},
+            owners=[data.owner_email] if data.owner_email else None,
         )
 
     def get_dataset_key(self, data: SigmaDataset) -> AssetKey:

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/conftest.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/conftest.py
@@ -209,3 +209,43 @@ def sigma_sample_data_fixture() -> None:
         ),
         status=200,
     )
+
+    responses.add(
+        method=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/members",
+        json=_build_paginated_response(
+            [
+                {
+                    "organizationId": "4d55c33f-dbb8-4426-9d70-97742e01f002",
+                    "memberId": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+                    "memberType": "admin",
+                    "firstName": "Ben",
+                    "lastName": "Pankow",
+                    "email": "ben@dagsterlabs.com",
+                    "profileImgUrl": None,
+                    "createdBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+                    "updatedBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+                    "createdAt": "2024-09-12T20:44:19.736Z",
+                    "updatedAt": "2024-09-12T20:44:19.736Z",
+                    "homeFolderId": "bd7e1b16-dad3-45d4-91e7-5687be2819cc",
+                    "userKind": "internal",
+                },
+                {
+                    "organizationId": "4d55c33f-dbb8-4426-9d70-97742e01f002",
+                    "memberId": "SigmaSchedulerRobot",
+                    "memberType": "admin",
+                    "firstName": "Scheduler",
+                    "lastName": "User",
+                    "email": "scheduler-robot@sigmacomputing.com",
+                    "profileImgUrl": None,
+                    "createdBy": "SigmaSchedulerRobot",
+                    "updatedBy": "SigmaSchedulerRobot",
+                    "createdAt": "2024-09-12T20:44:20.182Z",
+                    "updatedAt": "2024-09-12T20:44:20.182Z",
+                    "homeFolderId": "4537ec2e-ced7-4aa6-b511-ed0437e0165f",
+                    "userKind": "internal",
+                },
+            ]
+        ),
+        status=200,
+    )

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_asset_specs.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import responses
 from dagster._core.code_pointer import CodePointer
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.definitions_loader import DefinitionsLoadType
 from dagster._core.definitions.reconstruct import repository_def_from_pointer
 from dagster._core.instance_for_test import instance_for_test
@@ -21,6 +22,11 @@ def test_load_assets_organization_data(sigma_auth_token: str, sigma_sample_data:
 
         # 2 Sigma external assets, one materializable asset
         assert len(repository_def.assets_defs_by_key) == 2 + 1
+
+        workbook_key = AssetKey("Sample_Workbook")
+        assert repository_def.assets_defs_by_key[workbook_key].owners_by_key[workbook_key] == [
+            "ben@dagsterlabs.com"
+        ]
 
         calls = len(responses.calls)
 

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_translator.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_translator.py
@@ -20,6 +20,7 @@ def test_workbook_translation() -> None:
     sample_workbook = SigmaWorkbook(
         properties=SAMPLE_WORKBOOK_DATA,
         datasets={SAMPLE_DATASET_INODE},
+        owner_email="ben@dagsterlabs.com",
     )
 
     sample_dataset = SigmaDataset(properties=SAMPLE_DATASET_DATA, columns=set(), inputs=set())
@@ -36,6 +37,7 @@ def test_workbook_translation() -> None:
     assert asset_spec.metadata["dagster_sigma/created_at"].value == 1726176169.072
     assert build_kind_tag_key("sigma") in asset_spec.tags
     assert {dep.asset_key for dep in asset_spec.deps} == {AssetKey(["Orders_Dataset"])}
+    assert asset_spec.owners == ["ben@dagsterlabs.com"]
 
 
 def test_dataset_translation() -> None:


### PR DESCRIPTION
## Summary

Fetches and attaches owner metadata to Sigma workbooks, since it's available to us. Users can override these owners in a custom translator.

## Test Plan

New unit tests.