### PR TITLE
[graphql] use RemoteAssetGraph

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -31,8 +31,6 @@ from starlette.concurrency import (
     run_in_threadpool,  # can provide this indirectly if we dont want starlette dep in dagster-graphql
 )
 
-from dagster_graphql.implementation.fetch_assets import get_external_asset_node
-
 if TYPE_CHECKING:
     from dagster_graphql.schema.errors import GrapheneUnsupportedOperationError
     from dagster_graphql.schema.roots.mutation import GrapheneTerminateRunPolicy
@@ -347,7 +345,7 @@ def wipe_assets(
         if apr.partition_range is None:
             whole_assets_to_wipe.append(apr.asset_key)
         else:
-            node = check.not_none(get_external_asset_node(graphene_info, apr.asset_key))
+            node = graphene_info.context.asset_graph.external_asset_nodes_by_key[apr.asset_key]
             partitions_def = check.not_none(node.partitions_def_data).get_partitions_definition()
             partition_keys = partitions_def.get_partition_keys_in_range(apr.partition_range)
             try:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_asset_checks.py
@@ -1,28 +1,15 @@
-from typing import TYPE_CHECKING, Iterator, List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional
 
 from dagster import AssetKey
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.loader import LoadingContext
-from dagster._core.remote_representation.code_location import CodeLocation
-from dagster._core.remote_representation.external import ExternalRepository
-from dagster._core.remote_representation.external_data import ExternalAssetCheck
 from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecordStatus
 from dagster._core.storage.dagster_run import RunRecord
-from dagster._core.workspace.context import WorkspaceRequestContext
 
-from dagster_graphql.implementation.fetch_assets import repository_iter
 from dagster_graphql.schema.asset_checks import GrapheneAssetCheckExecution
 
 if TYPE_CHECKING:
     from dagster_graphql.schema.util import ResolveInfo
-
-
-def asset_checks_iter(
-    context: WorkspaceRequestContext,
-) -> Iterator[Tuple[CodeLocation, ExternalRepository, ExternalAssetCheck]]:
-    for location, repository in repository_iter(context):
-        for external_check in repository.external_repository_data.external_asset_checks or []:
-            yield (location, repository, external_check)
 
 
 def has_asset_checks(
@@ -31,7 +18,7 @@ def has_asset_checks(
 ) -> bool:
     return any(
         external_check.asset_key == asset_key
-        for _, _, external_check in asset_checks_iter(graphene_info.context)
+        for external_check in graphene_info.context.asset_graph.asset_checks
     )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -70,11 +70,11 @@ class RemoteAssetNode(BaseAssetNode):
 
     @property
     def description(self) -> Optional[str]:
-        return self._priority_node.description
+        return self.priority_node.description
 
     @property
     def group_name(self) -> str:
-        return self._priority_node.group_name or DEFAULT_GROUP_NAME
+        return self.priority_node.group_name or DEFAULT_GROUP_NAME
 
     @cached_property
     def is_materializable(self) -> bool:
@@ -94,23 +94,23 @@ class RemoteAssetNode(BaseAssetNode):
 
     @property
     def metadata(self) -> ArbitraryMetadataMapping:
-        return self._priority_node.metadata
+        return self.priority_node.metadata
 
     @property
     def tags(self) -> Mapping[str, str]:
-        return self._priority_node.tags or {}
+        return self.priority_node.tags or {}
 
     @property
     def owners(self) -> Sequence[str]:
-        return self._priority_node.owners or []
+        return self.priority_node.owners or []
 
     @property
     def is_partitioned(self) -> bool:
-        return self._priority_node.partitions_def_data is not None
+        return self.priority_node.partitions_def_data is not None
 
     @cached_property
     def partitions_def(self) -> Optional[PartitionsDefinition]:
-        external_def = self._priority_node.partitions_def_data
+        external_def = self.priority_node.partitions_def_data
         return external_def.get_partitions_definition() if external_def else None
 
     @property
@@ -128,7 +128,7 @@ class RemoteAssetNode(BaseAssetNode):
     def freshness_policy(self) -> Optional[FreshnessPolicy]:
         # It is currently not possible to access the freshness policy for an observation definition
         # if a materialization definition also exists. This needs to be fixed.
-        return self._priority_node.freshness_policy
+        return self.priority_node.freshness_policy
 
     @property
     def auto_materialize_policy(self) -> Optional[AutoMaterializePolicy]:
@@ -155,7 +155,7 @@ class RemoteAssetNode(BaseAssetNode):
     def code_version(self) -> Optional[str]:
         # It is currently not possible to access the code version for an observation definition if a
         # materialization definition also exists. This needs to be fixed.
-        return self._priority_node.code_version
+        return self.priority_node.code_version
 
     @property
     def check_keys(self) -> AbstractSet[AssetCheckKey]:
@@ -175,7 +175,7 @@ class RemoteAssetNode(BaseAssetNode):
     def job_names(self) -> Sequence[str]:
         # It is currently not possible to access the job names for an observation definition if a
         # materialization definition also exists. This needs to be fixed.
-        return self._priority_node.job_names if self.is_executable else []
+        return self.priority_node.job_names if self.is_executable else []
 
     @property
     def priority_repository_handle(self) -> RepositoryHandle:
@@ -193,10 +193,12 @@ class RemoteAssetNode(BaseAssetNode):
     def repository_handles(self) -> Sequence[RepositoryHandle]:
         return [repo_handle for repo_handle, _ in self._repo_node_pairs]
 
-    ##### HELPERS
+    @property
+    def repo_node_pairs(self) -> Sequence[Tuple[RepositoryHandle, "ExternalAssetNode"]]:
+        return self._repo_node_pairs
 
     @cached_property
-    def _priority_node(self) -> "ExternalAssetNode":
+    def priority_node(self) -> "ExternalAssetNode":
         # Return a materialization node if it exists, otherwise return an observable node if it
         # exists, otherwise return any node. This exists to preserve implicit behavior, where the
         # materialization node was previously preferred over the observable node. This is a
@@ -209,6 +211,8 @@ class RemoteAssetNode(BaseAssetNode):
                 (node for node in self._external_asset_nodes),
             )
         )
+
+    ##### HELPERS
 
     @cached_property
     def _materializable_node(self) -> "ExternalAssetNode":
@@ -329,11 +333,11 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
         # This exists to support existing callsites but it should be removed ASAP, since it exposes
         # `ExternalAssetNode` instances directly. All sites using this should use RemoteAssetNode
         # instead.
-        return {k: node._priority_node for k, node in self._asset_nodes_by_key.items()}  # noqa: SLF001
+        return {k: node.priority_node for k, node in self._asset_nodes_by_key.items()}
 
     @property
     def asset_checks(self) -> Sequence["ExternalAssetCheck"]:
-        return list(dict.fromkeys(self._asset_checks_by_key.values()))
+        return list(self._asset_checks_by_key.values())
 
     @cached_property
     def asset_check_keys(self) -> AbstractSet[AssetCheckKey]:

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -64,7 +64,7 @@ from dagster._utils.aiodataloader import DataLoader
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
 
 if TYPE_CHECKING:
-    from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
+    from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph, RemoteAssetNode
     from dagster._core.remote_representation import (
         ExternalPartitionConfigData,
         ExternalPartitionExecutionErrorData,
@@ -334,6 +334,12 @@ class BaseWorkspaceRequestContext(LoadingContext):
 
     def get_base_deployment_context(self) -> Optional["BaseWorkspaceRequestContext"]:
         return None
+
+    def get_asset_node(self, asset_key: AssetKey) -> Optional["RemoteAssetNode"]:
+        if not self.get_workspace_snapshot().asset_graph.has(asset_key):
+            return None
+
+        return self.get_workspace_snapshot().asset_graph.get(asset_key)
 
 
 class WorkspaceRequestContext(BaseWorkspaceRequestContext):


### PR DESCRIPTION
Consolidate our handling of the global asset graph in the code base by moving the GraphQL layer over to `RemoteAssetGraph` more directly. This setup also moves grabbing specific assets to a  `get_asset_node` on workspace request context, allowing it to be overrode in other implementations. 

## How I Tested These Changes

counting on existing coverage