### PR TITLE
Update fuse worker to return all results if query string is empty.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/SearchResults.tsx
@@ -234,7 +234,13 @@ export type SearchResultsProps<T extends ResultType> = {
 };
 
 export const SearchResults = <T extends ResultType>(props: SearchResultsProps<T>) => {
-  const {highlight, onClickResult, queryString, results, searching} = props;
+  const {highlight, onClickResult, queryString, results: _results, searching} = props;
+
+  // Our fuse worker returns all results if we put in an empty string.
+  // This is to support AssetSearch in Cloud which allows showing all results for a particular filter.
+  // For OSS we don't want any results if the queryString is null so lets make the results an empty list in that
+  // case here
+  const results = queryString ? _results : [];
 
   if (!results.length && queryString) {
     if (searching) {

--- a/js_modules/dagster-ui/packages/ui-core/src/workers/fuseSearch.worker.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workers/fuseSearch.worker.ts
@@ -4,7 +4,8 @@
 
 import {Fuse} from '../search/fuse';
 
-let fuseObject: any = null;
+let fuseObject: null | Fuse<any> = null;
+let allResults: any = null;
 
 self.addEventListener('message', (event) => {
   const {data} = event;
@@ -16,16 +17,24 @@ self.addEventListener('message', (event) => {
       } else {
         fuseObject.setCollection(data.results);
       }
+      allResults = data.results.map(fakeFuseItem);
       self.postMessage({type: 'ready'});
       break;
     }
     case 'query': {
       if (fuseObject) {
         const {queryString} = data;
-        // Consider the empty string as returning no results.
-        const results = queryString ? fuseObject.search(queryString) : [];
+        console.log({allResults});
+        const results = queryString ? fuseObject.search(queryString) : allResults;
         self.postMessage({type: 'results', queryString, results});
       }
     }
   }
 });
+
+function fakeFuseItem<T>(item: T, refIndex: number = 0): Fuse.FuseResult<T> {
+  return {
+    item,
+    refIndex,
+  };
+}


### PR DESCRIPTION
## Summary & Motivation

In dagster+ asset search we reuse this worker and we want it to return all results in the empty string case because we then extract filter values from those results (eg: if you search for "Kind" we grab all the available kinds from the results and show those as results). 

## How I Tested These Changes

use this in dagster+
<img width="1029" alt="Screenshot 2024-09-17 at 12 43 09 PM" src="https://github.com/user-attachments/assets/548ba103-5175-41a8-9e45-bb35d83bbe0e">



## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
