### PR TITLE
add `job_name` property to partition backfill

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -171,6 +171,7 @@ def create_and_launch_partition_backfill(
             asset_selection=asset_selection,
             title=backfill_params.get("title"),
             description=backfill_params.get("description"),
+            job_name=external_partition_set.job_name,
         )
 
         if backfill_params.get("forceSynchronousSubmission"):

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -171,7 +171,6 @@ def create_and_launch_partition_backfill(
             asset_selection=asset_selection,
             title=backfill_params.get("title"),
             description=backfill_params.get("description"),
-            job_name=external_partition_set.job_name,
         )
 
         if backfill_params.get("forceSynchronousSubmission"):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -377,7 +377,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
     )
     jobName = graphene.Field(
         graphene.String(),
-        description="Included to comply with RunsFeedEntry interface. Duplicate of partitionSetName.",
+        description="Included to comply with RunsFeedEntry interface.",
     )
     assetCheckSelection = graphene.List(
         graphene.NonNull("dagster_graphql.schema.asset_checks.GrapheneAssetCheckHandle")
@@ -392,7 +392,9 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         super().__init__(
             id=backfill_job.backfill_id,
             partitionSetName=backfill_job.partition_set_name,
-            jobName=backfill_job.partition_set_name,
+            jobName=backfill_job.job_name
+            if backfill_job.job_name
+            else backfill_job.partition_set_name,
             status=backfill_job.status.value,
             fromFailure=bool(backfill_job.from_failure),
             reexecutionSteps=backfill_job.reexecution_steps,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -392,9 +392,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         super().__init__(
             id=backfill_job.backfill_id,
             partitionSetName=backfill_job.partition_set_name,
-            jobName=backfill_job.job_name
-            if backfill_job.job_name
-            else backfill_job.partition_set_name,
+            jobName=backfill_job.job_name,
             status=backfill_job.status.value,
             fromFailure=bool(backfill_job.from_failure),
             reexecutionSteps=backfill_job.reexecution_steps,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -11,7 +11,6 @@ from dagster import (
     define_asset_job,
 )
 from dagster._core.definitions.asset_graph import AssetGraph
-from dagster._core.definitions.asset_job import IMPLICIT_ASSET_JOB_NAME
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.execution.asset_backfill import (
@@ -1223,7 +1222,7 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
 
         stored_backfill = graphql_context.instance.get_backfill(backfill_id)
-        assert stored_backfill.job_name == IMPLICIT_ASSET_JOB_NAME
+        assert stored_backfill.job_name is None
 
     def test_set_title_and_description_for_backfill_invalid_title(self, graphql_context):
         title = "Title with invalid characters * %"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -11,6 +11,7 @@ from dagster import (
     define_asset_job,
 )
 from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_job import IMPLICIT_ASSET_JOB_NAME
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.execution.asset_backfill import (
@@ -1173,6 +1174,56 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         assert result.data["partitionBackfillOrError"]["id"] == backfill_id
         assert result.data["partitionBackfillOrError"]["title"] == title
         assert result.data["partitionBackfillOrError"]["description"] == description
+
+    def test_job_name_correctly_set(self, graphql_context):
+        repository_selector = infer_repository_selector(graphql_context)
+        result = execute_dagster_graphql(
+            graphql_context,
+            LAUNCH_PARTITION_BACKFILL_MUTATION,
+            variables={
+                "backfillParams": {
+                    "selector": {
+                        "repositorySelector": repository_selector,
+                        "partitionSetName": "integers_partition_set",
+                    },
+                    "partitionNames": ["2", "3"],
+                }
+            },
+        )
+
+        assert not result.errors
+        assert result.data
+        assert result.data["launchPartitionBackfill"]["__typename"] == "LaunchBackfillSuccess"
+        backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
+
+        stored_backfill = graphql_context.instance.get_backfill(backfill_id)
+        assert stored_backfill.job_name == "integers"
+
+    def test_job_name_correctly_set_for_asset_backfills(self, graphql_context):
+        asset_keys = [
+            AssetKey("unpartitioned_upstream_of_partitioned"),
+            AssetKey("upstream_daily_partitioned_asset"),
+            AssetKey("downstream_weekly_partitioned_asset"),
+        ]
+        partitions = ["2023-01-09"]
+        result = execute_dagster_graphql(
+            graphql_context,
+            LAUNCH_PARTITION_BACKFILL_MUTATION,
+            variables={
+                "backfillParams": {
+                    "partitionNames": partitions,
+                    "assetSelection": [asset_key.to_graphql_input() for asset_key in asset_keys],
+                }
+            },
+        )
+
+        assert not result.errors
+        assert result.data
+        assert result.data["launchPartitionBackfill"]["__typename"] == "LaunchBackfillSuccess"
+        backfill_id = result.data["launchPartitionBackfill"]["backfillId"]
+
+        stored_backfill = graphql_context.instance.get_backfill(backfill_id)
+        assert stored_backfill.job_name == IMPLICIT_ASSET_JOB_NAME
 
     def test_set_title_and_description_for_backfill_invalid_title(self, graphql_context):
         title = "Title with invalid characters * %"

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -5,6 +5,7 @@ from typing import Mapping, NamedTuple, Optional, Sequence, Union
 from dagster import _check as check
 from dagster._core.definitions import AssetKey
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
+from dagster._core.definitions.asset_job import IMPLICIT_ASSET_JOB_NAME
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.run_request import RunRequest
@@ -77,6 +78,7 @@ class PartitionBackfill(
             ("asset_selection", Optional[Sequence[AssetKey]]),
             ("title", Optional[str]),
             ("description", Optional[str]),
+            ("job_name", Optional[str]),
             # fields that are only used by job backfills
             ("partition_set_origin", Optional[RemotePartitionSetOrigin]),
             ("partition_names", Optional[Sequence[str]]),
@@ -102,6 +104,7 @@ class PartitionBackfill(
         asset_selection: Optional[Sequence[AssetKey]] = None,
         title: Optional[str] = None,
         description: Optional[str] = None,
+        job_name: Optional[str] = None,
         partition_set_origin: Optional[RemotePartitionSetOrigin] = None,
         partition_names: Optional[Sequence[str]] = None,
         last_submitted_partition_name: Optional[str] = None,
@@ -136,6 +139,7 @@ class PartitionBackfill(
             ),
             title=check_valid_title(title),
             description=check.opt_str_param(description, "description"),
+            job_name=check.opt_str_param(job_name, "job_name"),
             partition_set_origin=check.opt_inst_param(
                 partition_set_origin, "partition_set_origin", RemotePartitionSetOrigin
             ),
@@ -417,6 +421,7 @@ class PartitionBackfill(
             asset_backfill_data=asset_backfill_data,
             title=title,
             description=description,
+            job_name=IMPLICIT_ASSET_JOB_NAME,
         )
 
     @classmethod
@@ -448,6 +453,7 @@ class PartitionBackfill(
             asset_selection=[selector.asset_key for selector in partitions_by_assets],
             title=title,
             description=description,
+            job_name=IMPLICIT_ASSET_JOB_NAME,
         )
 
     @classmethod
@@ -477,4 +483,5 @@ class PartitionBackfill(
             asset_selection=list(asset_graph_subset.asset_keys),
             title=title,
             description=description,
+            job_name=IMPLICIT_ASSET_JOB_NAME,
         )

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -5,7 +5,6 @@ from typing import Mapping, NamedTuple, Optional, Sequence, Union
 from dagster import _check as check
 from dagster._core.definitions import AssetKey
 from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
-from dagster._core.definitions.asset_job import IMPLICIT_ASSET_JOB_NAME
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.partition import PartitionsSubset
 from dagster._core.definitions.run_request import RunRequest
@@ -206,7 +205,7 @@ class PartitionBackfill(
     @property
     def job_name(self) -> Optional[str]:
         if self.is_asset_backfill:
-            return IMPLICIT_ASSET_JOB_NAME
+            return None
         return (
             job_name_for_external_partition_set_name(self.partition_set_name)
             if self.partition_set_name


### PR DESCRIPTION
## Summary & Motivation
Adds a `job_name` property to PartitionBackfill. In addition to filtering by job name for storage implementations that store the job name, this will let us display the name of the job in the UI for job backfills rather than the name of the partition set. 

associated internal pr https://github.com/dagster-io/internal/pull/11617

## How I Tested These Changes

## Changelog

NOCHANGELOG