### PR TITLE
[StaticSetFilter] Remove potential layoutEffect infinite loop

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryPersistedState.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/hooks/useQueryPersistedState.tsx
@@ -109,8 +109,9 @@ export function useQueryPersistedState<T extends QueryPersistedDataType>(
       }
 
       // Check if the query has changed. If so, perform a replace. Otherwise, do nothing
-      // to ensure that we don't end up in a `replace` loop.
-      if (!areQueriesEqual(currentQueryString, next)) {
+      // to ensure that we don't end up in a `replace` loop. If we're not in prod, always run
+      // the `replace` so that we surface any unwanted loops during development.
+      if (process.env.NODE_ENV !== 'production' || !areQueriesEqual(currentQueryString, next)) {
         currentQueryString = next;
         history.replace(`${location.pathname}?${qs.stringify(next, {arrayFormat: 'brackets'})}`);
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useStaticSetFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useStaticSetFilter.tsx
@@ -69,7 +69,7 @@ export function useStaticSetFilter<TValue>({
   renderActiveStateLabel,
   filterBarTagLabel,
   isLoadingFilters,
-  state,
+  state: controlledState,
   getStringValue,
   getTooltipText,
   onStateChanged,
@@ -91,23 +91,25 @@ export function useStaticSetFilter<TValue>({
   }, [StaticFilterSorter, name, _unsortedValues]);
 
   // This filter can be used as both a controlled and an uncontrolled component necessitating an innerState for the uncontrolled case.
-  const [innerState, setState] = useState(() => new Set(state || []));
+  const [innerState, setInnerState] = useState(() => new Set(controlledState || []));
 
-  const isFirstRenderRef = useRef(true);
+  const isFirstLayoutEffectRender = useRef(true);
+  const isFirstEffectRender = useRef(true);
 
   useLayoutEffect(() => {
-    if (!isFirstRenderRef.current) {
+    if (!isFirstLayoutEffectRender.current) {
       onStateChanged?.(innerState);
     }
+    isFirstLayoutEffectRender.current = false;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [innerState]);
 
   useEffect(() => {
-    if (!isFirstRenderRef.current) {
-      setState(state ? new Set(state) : new Set());
+    if (!isFirstEffectRender.current) {
+      setInnerState(controlledState ? new Set(controlledState) : new Set());
     }
-    isFirstRenderRef.current = false;
-  }, [state]);
+    isFirstEffectRender.current = false;
+  }, [controlledState]);
 
   const currentQueryRef = useRef<string>('');
 
@@ -160,7 +162,9 @@ export function useStaticSetFilter<TValue>({
                   value={selectAllSymbol}
                   renderLabel={() => <>{selectAllText ?? 'Select all'}</>}
                   isForcedActive={
-                    (state instanceof Set ? state.size : state?.length) === allValues.length
+                    (controlledState instanceof Set
+                      ? controlledState.size
+                      : controlledState?.length) === allValues.length
                   }
                   filter={filterObjRef.current}
                   allowMultipleSelections={allowMultipleSelections}
@@ -196,13 +200,15 @@ export function useStaticSetFilter<TValue>({
             return true;
           });
           if (hasAnyUnselected) {
-            setState(new Set([...Array.from(state), ...selectResults.map(({value}) => value)]));
+            setInnerState(
+              new Set([...Array.from(state), ...selectResults.map(({value}) => value)]),
+            );
           } else {
             const stateCopy = new Set(state);
             selectResults.forEach(({value}) => {
               stateCopy.delete(value);
             });
-            setState(stateCopy);
+            setInnerState(stateCopy);
           }
           return;
         }
@@ -216,7 +222,7 @@ export function useStaticSetFilter<TValue>({
             newState.add(value);
           }
         }
-        setState(newState);
+        setInnerState(newState);
         if (closeOnSelect) {
           close();
         }
@@ -238,14 +244,14 @@ export function useStaticSetFilter<TValue>({
           getTooltipText={getTooltipText}
           renderLabel={renderActiveStateLabel || renderLabel}
           onRemove={() => {
-            setState(new Set());
+            setInnerState(new Set());
           }}
           icon={icon}
           matchType={matchType}
           filterBarTagLabel={filterBarTagLabel}
         />
       ),
-      setState,
+      setState: setInnerState,
       menuWidth,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary & Motivation
Fix potential infinite loop caused by useLayoutEffect and isFirstRenderRef. The layout and regular effects were both gated by isFirstRenderRef, but since the effect is responsible for setting this flag, React's behavior allows useLayoutEffect to loop. This PR separates the refs for layout and regular effects to prevent the looping issue.


## How I Tested These Changes

jest tests

## Changelog

NOCHANGELOG
