### PR TITLE
feat: future proofing the tag used to trigger run metrics collection

### DIFF
--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -36,6 +36,11 @@ from dagster._core.origin import (
     get_python_environment_entry_point,
 )
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
+from dagster._core.storage.tags import (
+    RUN_METRIC_TAGS,
+    RUN_METRICS_POLLING_INTERVAL_TAG,
+    RUN_METRICS_PYTHON_RUNTIME_TAG,
+)
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.utils import FuturesAwareThreadPoolExecutor
 from dagster._grpc import DagsterGrpcClient, DagsterGrpcServer
@@ -87,11 +92,11 @@ def execute_run_command(input_json: str) -> None:
 
 
 def _should_start_metrics_thread(dagster_run: DagsterRun) -> bool:
-    return get_boolean_tag_value(dagster_run.tags.get("dagster/run_metrics"))
+    return any(get_boolean_tag_value(dagster_run.tags.get(tag)) for tag in RUN_METRIC_TAGS)
 
 
 def _enable_python_runtime_metrics(dagster_run: DagsterRun) -> bool:
-    return get_boolean_tag_value(dagster_run.tags.get("dagster/python_runtime_metrics"))
+    return get_boolean_tag_value(dagster_run.tags.get(RUN_METRICS_PYTHON_RUNTIME_TAG))
 
 
 def _metrics_polling_interval(
@@ -100,7 +105,7 @@ def _metrics_polling_interval(
     try:
         return float(
             dagster_run.tags.get(
-                "dagster/run_metrics_polling_interval_seconds",
+                RUN_METRICS_POLLING_INTERVAL_TAG,
                 DEFAULT_RUN_METRICS_POLL_INTERVAL_SECONDS,
             )
         )

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -96,6 +96,9 @@ RUN_METRIC_TAGS = [
     f"{SYSTEM_TAG_PREFIX}run_metrics",
 ]
 
+RUN_METRICS_POLLING_INTERVAL_TAG = f"{HIDDEN_TAG_PREFIX}run_metrics_polling_interval"
+RUN_METRICS_PYTHON_RUNTIME_TAG = f"{HIDDEN_TAG_PREFIX}python_runtime_metrics"
+
 
 class TagType(Enum):
     # Custom tag provided by a user


### PR DESCRIPTION
## Summary & Motivation

We intend to change the triggering mechanism for starting a run metric collection thread from a public to a hidden tag.

## How I Tested These Changes

- [x] Manual testing
- [x] Must validate that the hidden tags are seen by the run

<img width="1489" alt="Screenshot 2024-09-23 at 10 26 32 AM" src="https://github.com/user-attachments/assets/57c68482-ee9a-4618-becc-cf2156d78ac1">


## Changelog

NOCHANGELOG