### PR TITLE
[8/n][dagster-tableau] support dashboards in dagster-tableau

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
@@ -19,7 +19,8 @@ class TableauContentType(Enum):
     """Enum representing each object in Tableau's ontology."""
 
     WORKBOOK = "workbook"
-    VIEW = "view"
+    SHEET = "sheet"
+    DASHBOARD = "dashboard"
     DATA_SOURCE = "data_source"
 
 
@@ -51,7 +52,8 @@ class TableauWorkspaceData:
 
     site_name: str
     workbooks_by_id: Mapping[str, TableauContentData]
-    views_by_id: Mapping[str, TableauContentData]
+    sheets_by_id: Mapping[str, TableauContentData]
+    dashboards_by_id: Mapping[str, TableauContentData]
     data_sources_by_id: Mapping[str, TableauContentData]
 
     @classmethod
@@ -65,10 +67,15 @@ class TableauWorkspaceData:
                 for workbook in content_data
                 if workbook.content_type == TableauContentType.WORKBOOK
             },
-            views_by_id={
-                view.properties["luid"]: view
-                for view in content_data
-                if view.content_type == TableauContentType.VIEW
+            sheets_by_id={
+                sheet.properties["luid"]: sheet
+                for sheet in content_data
+                if sheet.content_type == TableauContentType.SHEET
+            },
+            dashboards_by_id={
+                dashboard.properties["luid"]: dashboard
+                for dashboard in content_data
+                if dashboard.content_type == TableauContentType.DASHBOARD
             },
             data_sources_by_id={
                 data_source.properties["luid"]: data_source
@@ -91,29 +98,31 @@ class DagsterTableauTranslator:
         return self._context
 
     def get_asset_spec(self, data: TableauContentData) -> AssetSpec:
-        if data.content_type == TableauContentType.VIEW:
-            return self.get_view_spec(data)
+        if data.content_type == TableauContentType.SHEET:
+            return self.get_sheet_spec(data)
+        elif data.content_type == TableauContentType.DASHBOARD:
+            return self.get_dashboard_spec(data)
         elif data.content_type == TableauContentType.DATA_SOURCE:
             return self.get_data_source_spec(data)
         else:
             check.assert_never(data.content_type)
 
-    def get_view_asset_key(self, data: TableauContentData) -> AssetKey:
+    def get_sheet_asset_key(self, data: TableauContentData) -> AssetKey:
         workbook_id = data.properties["workbook"]["luid"]
         workbook_data = self.workspace_data.workbooks_by_id[workbook_id]
         return AssetKey(
             [
                 _clean_asset_name(workbook_data.properties["name"]),
-                "view",
+                "sheet",
                 _clean_asset_name(data.properties["name"]),
             ]
         )
 
-    def get_view_spec(self, data: TableauContentData) -> AssetSpec:
-        view_embedded_data_sources = data.properties.get("parentEmbeddedDatasources", [])
+    def get_sheet_spec(self, data: TableauContentData) -> AssetSpec:
+        sheet_embedded_data_sources = data.properties.get("parentEmbeddedDatasources", [])
         data_source_ids = {
             published_data_source["luid"]
-            for embedded_data_source in view_embedded_data_sources
+            for embedded_data_source in sheet_embedded_data_sources
             for published_data_source in embedded_data_source.get("parentPublishedDatasources", [])
         }
 
@@ -123,8 +132,34 @@ class DagsterTableauTranslator:
         ]
 
         return AssetSpec(
-            key=self.get_view_asset_key(data),
+            key=self.get_sheet_asset_key(data),
             deps=data_source_keys if data_source_keys else None,
+            tags={"dagster/storage_kind": "tableau"},
+        )
+
+    def get_dashboard_asset_key(self, data: TableauContentData) -> AssetKey:
+        workbook_id = data.properties["workbook"]["luid"]
+        workbook_data = self.workspace_data.workbooks_by_id[workbook_id]
+        return AssetKey(
+            [
+                _clean_asset_name(workbook_data.properties["name"]),
+                "dashboard",
+                _clean_asset_name(data.properties["name"]),
+            ]
+        )
+
+    def get_dashboard_spec(self, data: TableauContentData) -> AssetSpec:
+        dashboard_upstream_sheets = data.properties.get("sheets", [])
+        sheet_ids = {sheet["luid"] for sheet in dashboard_upstream_sheets if sheet["luid"]}
+
+        sheet_keys = [
+            self.get_sheet_asset_key(self.workspace_data.sheets_by_id[sheet_id])
+            for sheet_id in sheet_ids
+        ]
+
+        return AssetSpec(
+            key=self.get_dashboard_asset_key(data),
+            deps=sheet_keys if sheet_keys else None,
             tags={"dagster/storage_kind": "tableau"},
         )
 

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
@@ -163,16 +163,16 @@ def workspace_data_fixture(site_name: str) -> TableauWorkspaceData:
     name="workspace_data_api_mocks_fn",
 )
 def workspace_data_api_mocks_fn_fixture(
-    site_id: str, api_token: str, workbook_id: str, sheet_id: str, dashboard_id: str
+    site_id: str, api_token: str, sheet_id: str, dashboard_id: str
 ) -> Callable:
     @contextlib.contextmanager
     def _method(
         client: Union[TableauCloudClient, TableauServerClient],
         site_id: str = site_id,
         api_token: str = api_token,
-        workbook_id: str = workbook_id,
         sheet_id: str = sheet_id,
         dashbord_id: str = dashboard_id,
+        include_views: bool = False,
     ) -> Iterator[responses.RequestsMock]:
         with responses.RequestsMock() as response:
             response.add(
@@ -188,18 +188,6 @@ def workspace_data_api_mocks_fn_fixture(
                 status=200,
             )
             response.add(
-                method=responses.GET,
-                url=f"{client.rest_api_base_url}/sites/{site_id}/views/{sheet_id}",
-                json=SAMPLE_VIEW_SHEET,
-                status=200,
-            )
-            response.add(
-                method=responses.GET,
-                url=f"{client.rest_api_base_url}/sites/{site_id}/views/{dashbord_id}",
-                json=SAMPLE_VIEW_DASHBOARD,
-                status=200,
-            )
-            response.add(
                 method=responses.POST,
                 url=f"{client.metadata_api_base_url}",
                 json={"data": {"workbooks": [SAMPLE_WORKBOOK]}},
@@ -210,6 +198,19 @@ def workspace_data_api_mocks_fn_fixture(
                 url=f"{client.rest_api_base_url}/auth/signout",
                 status=200,
             )
+            if include_views:
+                response.add(
+                    method=responses.GET,
+                    url=f"{client.rest_api_base_url}/sites/{site_id}/views/{sheet_id}",
+                    json=SAMPLE_VIEW_SHEET,
+                    status=200,
+                )
+                response.add(
+                    method=responses.GET,
+                    url=f"{client.rest_api_base_url}/sites/{site_id}/views/{dashbord_id}",
+                    json=SAMPLE_VIEW_DASHBOARD,
+                    status=200,
+                )
 
             yield response
 

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
@@ -20,7 +20,7 @@ SAMPLE_DATA_SOURCE = {
     "name": "Superstore Datasource",
 }
 
-SAMPLE_VIEW = {
+SAMPLE_SHEET = {
     "luid": "ae8a5f27-8b2f-44e9-aec3-94fe6c638f4f",
     "name": "Sales",
     "createdAt": "2024-09-05T21:33:26Z",
@@ -38,6 +38,17 @@ SAMPLE_VIEW = {
     "workbook": {"luid": "b75fc023-a7ca-4115-857b-4342028640d0"},
 }
 
+SAMPLE_DASHBOARD = {
+    "luid": "c9bf8403-5daf-427a-b3d6-2ce9bed7798f",
+    "name": "Dashboard_Sales",
+    "createdAt": "2024-09-06T14:38:42Z",
+    "updatedAt": "2024-09-13T00:15:23Z",
+    "path": "TestWorkbook/Dashboard_Sales",
+    "sheets": [{"luid": "ae8a5f27-8b2f-44e9-aec3-94fe6c638f4f"}],
+    "workbook": {"luid": "b75fc023-a7ca-4115-857b-4342028640d0"},
+}
+
+
 SAMPLE_WORKBOOK = {
     "luid": "b75fc023-a7ca-4115-857b-4342028640d0",
     "name": "Test Workbook",
@@ -46,12 +57,47 @@ SAMPLE_WORKBOOK = {
     "uri": "sites/49445/workbooks/690496",
     "sheets": [
         {
-            **SAMPLE_VIEW,
+            **SAMPLE_SHEET,
+        }
+    ],
+    "dashboards": [
+        {
+            **SAMPLE_DASHBOARD,
         }
     ],
 }
 
 SAMPLE_WORKBOOKS = {"workbooks": {"workbook": [{"id": "b75fc023-a7ca-4115-857b-4342028640d0"}]}}
+
+SAMPLE_VIEW_SHEET = {
+    "view": {
+        "workbook": {"id": "b75fc023-a7ca-4115-857b-4342028640d0"},
+        "owner": {"id": "2a59b27f-a842-4c7a-a6ed-8c9f814e6119"},
+        "tags": {},
+        "location": {"id": "7239fbb5-f0a3-426f-b9c0-05f829c6cd64", "type": "PersonalSpace"},
+        "id": "ae8a5f27-8b2f-44e9-aec3-94fe6c638f4f",
+        "name": "Sales",
+        "contentUrl": "TestWorkbook/sheets/Sales",
+        "createdAt": "2024-09-05T21:33:26Z",
+        "updatedAt": "2024-09-13T00:15:23Z",
+        "viewUrlName": "Sales",
+    }
+}
+
+SAMPLE_VIEW_DASHBOARD = {
+    "view": {
+        "workbook": {"id": "b75fc023-a7ca-4115-857b-4342028640d0"},
+        "owner": {"id": "2a59b27f-a842-4c7a-a6ed-8c9f814e6119"},
+        "tags": {},
+        "location": {"id": "7239fbb5-f0a3-426f-b9c0-05f829c6cd64", "type": "PersonalSpace"},
+        "id": "c9bf8403-5daf-427a-b3d6-2ce9bed7798f",
+        "name": "Dashboard_Sales",
+        "contentUrl": "TestWorkbook/sheets/Dashboard_Sales",
+        "createdAt": "2024-09-06T14:38:42Z",
+        "updatedAt": "2024-09-13T00:15:23Z",
+        "viewUrlName": "Test_Sales",
+    }
+}
 
 
 @pytest.fixture(name="site_name")
@@ -74,6 +120,16 @@ def workbook_id_fixture() -> str:
     return "b75fc023-a7ca-4115-857b-4342028640d0"
 
 
+@pytest.fixture(name="sheet_id")
+def sheet_id_fixture() -> str:
+    return "ae8a5f27-8b2f-44e9-aec3-94fe6c638f4f"
+
+
+@pytest.fixture(name="dashboard_id")
+def dashboard_id_fixture() -> str:
+    return "c9bf8403-5daf-427a-b3d6-2ce9bed7798f"
+
+
 @pytest.fixture(
     name="workspace_data",
 )
@@ -85,9 +141,14 @@ def workspace_data_fixture(site_name: str) -> TableauWorkspaceData:
                 content_type=TableauContentType.WORKBOOK, properties=SAMPLE_WORKBOOK
             )
         },
-        views_by_id={
-            SAMPLE_VIEW["luid"]: TableauContentData(
-                content_type=TableauContentType.VIEW, properties=SAMPLE_VIEW
+        sheets_by_id={
+            SAMPLE_SHEET["luid"]: TableauContentData(
+                content_type=TableauContentType.SHEET, properties=SAMPLE_SHEET
+            )
+        },
+        dashboards_by_id={
+            SAMPLE_DASHBOARD["luid"]: TableauContentData(
+                content_type=TableauContentType.DASHBOARD, properties=SAMPLE_DASHBOARD
             )
         },
         data_sources_by_id={
@@ -101,12 +162,17 @@ def workspace_data_fixture(site_name: str) -> TableauWorkspaceData:
 @pytest.fixture(
     name="workspace_data_api_mocks_fn",
 )
-def workspace_data_api_mocks_fn_fixture(site_id: str, api_token: str) -> Callable:
+def workspace_data_api_mocks_fn_fixture(
+    site_id: str, api_token: str, workbook_id: str, sheet_id: str, dashboard_id: str
+) -> Callable:
     @contextlib.contextmanager
     def _method(
         client: Union[TableauCloudClient, TableauServerClient],
         site_id: str = site_id,
         api_token: str = api_token,
+        workbook_id: str = workbook_id,
+        sheet_id: str = sheet_id,
+        dashbord_id: str = dashboard_id,
     ) -> Iterator[responses.RequestsMock]:
         with responses.RequestsMock() as response:
             response.add(
@@ -119,6 +185,18 @@ def workspace_data_api_mocks_fn_fixture(site_id: str, api_token: str) -> Callabl
                 method=responses.GET,
                 url=f"{client.rest_api_base_url}/sites/{site_id}/workbooks",
                 json=SAMPLE_WORKBOOKS,
+                status=200,
+            )
+            response.add(
+                method=responses.GET,
+                url=f"{client.rest_api_base_url}/sites/{site_id}/views/{sheet_id}",
+                json=SAMPLE_VIEW_SHEET,
+                status=200,
+            )
+            response.add(
+                method=responses.GET,
+                url=f"{client.rest_api_base_url}/sites/{site_id}/views/{dashbord_id}",
+                json=SAMPLE_VIEW_DASHBOARD,
                 status=200,
             )
             response.add(

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_pending_repo.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_pending_repo.py
@@ -32,8 +32,8 @@ def test_using_cached_asset_data(
             # 4 calls to creates the defs
             assert len(response.calls) == 4
 
-            # 2 Tableau external assets, one materializable asset
-            assert len(repository_def.assets_defs_by_key) == 2 + 1
+            # 1 Tableau external assets, 2 Tableau materializable asset and 1 Dagster materializable asset
+            assert len(repository_def.assets_defs_by_key) == 1 + 2 + 1
 
             job_def = repository_def.get_job("all_asset_job")
             repository_load_data = repository_def.repository_load_data
@@ -61,8 +61,8 @@ def test_using_cached_asset_data(
                 len(
                     [event for event in events if event.event_type == DagsterEventType.STEP_SUCCESS]
                 )
-                == 1
+                == 2
             ), "Expected two successful steps"
 
-            # 4 calls to create the defs + 3 calls to materialize the Tableau assets with 1 view
-            assert len(response.calls) == 4 + 3
+            # 4 calls to create the defs + 4 calls to materialize the Tableau assets with 1 sheet and 1 dashboard
+            assert len(response.calls) == 4 + 4

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_pending_repo.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_pending_repo.py
@@ -22,7 +22,7 @@ def test_using_cached_asset_data(
 
         # Must initialize the resource's client before passing it to the mock response function
         resource.build_client()
-        with workspace_data_api_mocks_fn(client=resource._client) as response:
+        with workspace_data_api_mocks_fn(client=resource._client, include_views=True) as response:
             # Remove the resource's client to properly test the pending repo
             resource._client = None
             assert len(response.calls) == 0

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_translator.py
@@ -4,17 +4,30 @@ from dagster_tableau import DagsterTableauTranslator
 from dagster_tableau.translator import TableauContentData, TableauWorkspaceData
 
 
-def test_translator_view_spec(workspace_data: TableauWorkspaceData) -> None:
-    view = next(iter(workspace_data.views_by_id.values()))
+def test_translator_sheet_spec(workspace_data: TableauWorkspaceData) -> None:
+    sheet = next(iter(workspace_data.sheets_by_id.values()))
 
     translator = DagsterTableauTranslator(workspace_data)
-    asset_spec = translator.get_asset_spec(view)
+    asset_spec = translator.get_asset_spec(sheet)
 
-    assert asset_spec.key.path == ["test_workbook", "view", "sales"]
+    assert asset_spec.key.path == ["test_workbook", "sheet", "sales"]
     assert asset_spec.tags == {"dagster/storage_kind": "tableau"}
     deps = list(asset_spec.deps)
     assert len(deps) == 1
     assert deps[0].asset_key == AssetKey(["superstore_datasource"])
+
+
+def test_translator_dashboard_spec(workspace_data: TableauWorkspaceData) -> None:
+    dashboard = next(iter(workspace_data.dashboards_by_id.values()))
+
+    translator = DagsterTableauTranslator(workspace_data)
+    asset_spec = translator.get_asset_spec(dashboard)
+
+    assert asset_spec.key.path == ["test_workbook", "dashboard", "dashboard_sales"]
+    assert asset_spec.tags == {"dagster/storage_kind": "tableau"}
+    deps = list(asset_spec.deps)
+    assert len(deps) == 1
+    assert deps[0].asset_key == AssetKey(["test_workbook", "sheet", "sales"])
 
 
 def test_translator_data_source_spec(workspace_data: TableauWorkspaceData) -> None:
@@ -30,16 +43,16 @@ def test_translator_data_source_spec(workspace_data: TableauWorkspaceData) -> No
 
 
 class MyCustomTranslator(DagsterTableauTranslator):
-    def get_view_spec(self, view: TableauContentData) -> AssetSpec:
-        return super().get_view_spec(view)._replace(metadata={"custom": "metadata"})
+    def get_sheet_spec(self, sheet: TableauContentData) -> AssetSpec:
+        return super().get_sheet_spec(sheet)._replace(metadata={"custom": "metadata"})
 
 
 def test_translator_custom_metadata(workspace_data: TableauWorkspaceData) -> None:
-    view = next(iter(workspace_data.views_by_id.values()))
+    sheet = next(iter(workspace_data.sheets_by_id.values()))
 
     translator = MyCustomTranslator(workspace_data)
-    asset_spec = translator.get_asset_spec(view)
+    asset_spec = translator.get_asset_spec(sheet)
 
     assert asset_spec.metadata == {"custom": "metadata"}
-    assert asset_spec.key.path == ["test_workbook", "view", "sales"]
+    assert asset_spec.key.path == ["test_workbook", "sheet", "sales"]
     assert asset_spec.tags == {"dagster/storage_kind": "tableau"}


### PR DESCRIPTION
## Summary & Motivation

Initial implementation in previous PRs was using the PAT auth + REST API to fetch workbooks and views.

Updating the previous PRs in favor of the JWT auth + Metadata API + REST API, we were fetching workbooks and sheets as views (sheets are a subtype of views).

This PR add the necessary code to support dashboards using the JWT + Metadata + REST approach.

## How I Tested These Changes

BK with updated tests

## Changelog

NOCHANGELOG