### PR TITLE
Add an opt-in delay after compute logs finish to ensure that the captured logs are redirected back to stdout/stderr

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/compute_logs.py
+++ b/python_modules/dagster/dagster/_core/execution/compute_logs.py
@@ -139,6 +139,11 @@ def execute_posix_tail(path, stream):
 
         yield (tail_process.pid, watcher_process.pid)
     finally:
+        # The posix tail process has default interval check 1s, which may lead to missing logs on stdout/stderr.
+        # Allow users to add delay before killing tail process.
+        # More here: https://github.com/dagster-io/dagster/issues/23336
+        time.sleep(float(os.getenv("DAGSTER_COMPUTE_LOG_TAIL_WAIT_AFTER_FINISH", "0")))
+
         if tail_process:
             _clean_up_subprocess(tail_process)
 


### PR DESCRIPTION
## Summary & Motivation
https://github.com/dagster-io/dagster/issues/23336

## How I Tested These Changes
- I work on mac (comes with posix tail instead of gnu tail), so I [installed gnu tail](https://apple.stackexchange.com/questions/410513/in-mac-how-to-do-tail-f-pid-to-terminate-after-process-exit-like-linux) to run with `--pid` locally.

```
 ~ > tail --help                                                                                                                                                                  ✔  22:36:02
tail: unrecognized option `--help'
usage: tail [-F | -f | -r] [-q] [-b # | -c # | -n #] [file ...]
 ~ > gtail --help                                                                                                                                                               1 ✘  22:36:06
Usage: gtail [OPTION]... [FILE]...
Print the last 10 lines of each FILE to standard output.
With more than one FILE, precede each with a header giving the file name.

With no FILE, or when FILE is -, read standard input.

Mandatory arguments to long options are mandatory for short options too.
  -c, --bytes=[+]NUM       output the last NUM bytes; or use -c +NUM to
                             output starting with byte NUM of each file
  -f, --follow[={name|descriptor}]
                           output appended data as the file grows;
                             an absent option argument means 'descriptor'
  -F                       same as --follow=name --retry
  -n, --lines=[+]NUM       output the last NUM lines, instead of the last 10;
                             or use -n +NUM to skip NUM-1 lines at the start
      --max-unchanged-stats=N
                           with --follow=name, reopen a FILE which has not
                             changed size after N (default 5) iterations
                             to see if it has been unlinked or renamed
                             (this is the usual case of rotated log files);
                             with inotify, this option is rarely useful
      --pid=PID            with -f, terminate after process ID, PID dies;
                             can be repeated to watch multiple processes
  -q, --quiet, --silent    never output headers giving file names
      --retry              keep trying to open a file if it is inaccessible
  -s, --sleep-interval=N   with -f, sleep for approximately N seconds
                             (default 1.0) between iterations;
                             with inotify and --pid=P, check process P at
                             least once every N seconds
  -v, --verbose            always output headers giving file names
  -z, --zero-terminated    line delimiter is NUL, not newline
      --help        display this help and exit
      --version     output version information and exit
```
- I validated that `--pid` param behaves as expected.
- Discovered there is a `--s` param with default 1.0s. As shown in gif below, the tail process has visible delays. It might be one of reasons why logs were incomplete (tail process was killed from python too fast).
![current_interval_1s](https://github.com/user-attachments/assets/442a15ac-47d9-44ef-a5d7-5dadc7e4d22c)
- When run with `--s 0.01`, the tail process forwards logs much smoothly. (I would prefer to explicitly set a tighter loop, because I expect the kubernetes container to stop all other processes when main cmd completes).
![faster_interval_0 01s](https://github.com/user-attachments/assets/982cc751-6d7d-4283-a56d-9c2021c03f80)

- Build a dev package and installed it to my code deployment.
- Run a dagster job with multiprocessor executor and 5 steps.
- Shelled into dagster job pod and inspected processes.
<img width="1544" alt="Screenshot 2024-09-17 at 22 17 45" src="https://github.com/user-attachments/assets/04b4d5cb-9c10-4d55-81b3-4b19a2e914b5">

- ❗️ As tail process finishes with --pid, it keeps hanging as a zombie (`[tail]<defunct>`). I am not 100% sure how big problem it could be, but better raising it here.
- In master branch, it is solved with this piece of code, but I don't want to terminate it (that's why I use --pid). Any advice welcome, @gibsondan.https://github.com/dagster-io/dagster/blob/20e8596e810ded6327052e7c622c39b940241c28/python_modules/dagster/dagster/_core/execution/compute_logs.py#L143

- ✅ `STEP_SUCCESS` events are now visible in grafana (collected from stdout/stderr).

## Changelog

`BUGFIX`(compute_log): incomplete stdout/stderr logs tailed from files
