### PR TITLE
[dagster-airlift] load_airflow_defs internal component refactor

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/dag_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/dag_asset.py
@@ -1,0 +1,90 @@
+from typing import Any, Dict, List, Mapping, Set
+
+from dagster import AssetKey, JsonMetadataValue, MarkdownMetadataValue
+from dagster._core.definitions.metadata.metadata_value import UrlMetadataValue
+
+from dagster_airlift.constants import DAG_ID_METADATA_KEY
+from dagster_airlift.core.airflow_instance import AirflowInstance, DagInfo
+from dagster_airlift.core.serialization_utils import AssetSpecData, CacheableAssetDep
+from dagster_airlift.core.utils import airflow_kind_dict
+
+
+def dag_asset_spec_data(
+    airflow_instance: AirflowInstance,
+    task_asset_keys_in_dag: Set[AssetKey],
+    downstreams_asset_dependency_graph: Dict[AssetKey, Set[AssetKey]],
+    dag_info: DagInfo,
+) -> AssetSpecData:
+    leaf_asset_keys = get_leaf_assets_for_dag(
+        asset_keys_in_dag=task_asset_keys_in_dag,
+        downstreams_asset_dependency_graph=downstreams_asset_dependency_graph,
+    )
+
+    return AssetSpecData(
+        asset_key=dag_info.dag_asset_key,
+        description=dag_description(dag_info),
+        metadata=dag_asset_metadata(airflow_instance, dag_info),
+        tags=airflow_kind_dict(),
+        deps=[CacheableAssetDep(asset_key=leaf_asset_key) for leaf_asset_key in leaf_asset_keys],
+    )
+
+
+def dag_description(dag_info: DagInfo) -> str:
+    return f"""
+    A materialization corresponds to a successful run of airflow DAG {dag_info.dag_id}.
+    """
+
+
+def dag_asset_metadata(airflow_instance: AirflowInstance, dag_info: DagInfo) -> Mapping[str, Any]:
+    metadata = {
+        "Dag Info (raw)": JsonMetadataValue(dag_info.metadata),
+        "Dag ID": dag_info.dag_id,
+        "Link to DAG": UrlMetadataValue(dag_info.url),
+        DAG_ID_METADATA_KEY: dag_info.dag_id,
+    }
+    source_code = airflow_instance.get_dag_source_code(dag_info.metadata["file_token"])
+    # Attempt to retrieve source code from the DAG.
+    metadata["Source Code"] = MarkdownMetadataValue(
+        f"""
+```python
+{source_code}
+```
+            """
+    )
+    return metadata
+
+
+def get_leaf_assets_for_dag(
+    asset_keys_in_dag: Set[AssetKey],
+    downstreams_asset_dependency_graph: Dict[AssetKey, Set[AssetKey]],
+) -> List[AssetKey]:
+    # An asset is a "leaf" for the dag if it has no transitive dependencies _within_ the dag. It may have
+    # dependencies _outside_ the dag.
+    leaf_assets = []
+    cache = {}
+    for asset_key in asset_keys_in_dag:
+        if (
+            get_transitive_dependencies_for_asset(
+                asset_key, downstreams_asset_dependency_graph, cache
+            ).intersection(asset_keys_in_dag)
+            == set()
+        ):
+            leaf_assets.append(asset_key)
+    return leaf_assets
+
+
+def get_transitive_dependencies_for_asset(
+    asset_key: AssetKey,
+    downstreams_asset_dependency_graph: Dict[AssetKey, Set[AssetKey]],
+    cache: Dict[AssetKey, Set[AssetKey]],
+) -> Set[AssetKey]:
+    if asset_key in cache:
+        return cache[asset_key]
+    transitive_deps = set()
+    for dep in downstreams_asset_dependency_graph[asset_key]:
+        transitive_deps.add(dep)
+        transitive_deps.update(
+            get_transitive_dependencies_for_asset(dep, downstreams_asset_dependency_graph, cache)
+        )
+    cache[asset_key] = transitive_deps
+    return transitive_deps

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
@@ -1,49 +1,33 @@
 from collections import defaultdict
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Union
+from typing import Dict, Iterator, List, Mapping, Optional, Sequence, Set, Union
 
 from dagster import (
-    AssetDep,
     AssetKey,
     AssetsDefinition,
     AssetSpec,
     Definitions,
-    JsonMetadataValue,
-    MarkdownMetadataValue,
     _check as check,
     external_asset_from_spec,
 )
 from dagster._core.definitions.definitions_loader import DefinitionsLoadContext, DefinitionsLoadType
-from dagster._core.definitions.metadata.metadata_value import UrlMetadataValue
 from dagster._record import record
 from dagster._serdes import deserialize_value, serialize_value, whitelist_for_serdes
-from dagster._serdes.serdes import (
-    FieldSerializer,
-    JsonSerializableValue,
-    PackableValue,
-    SerializableNonScalarKeyMapping,
-    UnpackContext,
-    WhitelistMap,
-    pack_value,
-    unpack_value,
-)
 from dagster._utils.warnings import suppress_dagster_warnings
 
-from dagster_airlift.constants import (
-    AIRFLOW_SOURCE_METADATA_KEY_PREFIX,
-    DAG_ID_METADATA_KEY,
-    MIGRATED_TAG,
-    TASK_ID_METADATA_KEY,
-)
-from dagster_airlift.core.airflow_instance import AirflowInstance, DagInfo, TaskInfo
+from dagster_airlift.constants import AIRFLOW_SOURCE_METADATA_KEY_PREFIX
+from dagster_airlift.core.airflow_instance import AirflowInstance, TaskInfo
+from dagster_airlift.core.dag_asset import dag_asset_spec_data
 from dagster_airlift.core.sensor import (
     DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
     build_airflow_polling_sensor,
 )
-from dagster_airlift.core.utils import (
-    airflow_kind_dict,
-    get_dag_id_from_asset,
-    get_task_id_from_asset,
+from dagster_airlift.core.serialization_utils import (
+    AssetSpecData,
+    ExistingAssetKeyAirflowData,
+    GenericAssetKeyMappingSerializer,
 )
+from dagster_airlift.core.task_asset import get_airflow_data_for_task_mapped_spec
+from dagster_airlift.core.utils import get_dag_id_from_asset, get_task_id_from_asset
 from dagster_airlift.migration_state import AirflowMigrationState
 
 
@@ -56,11 +40,11 @@ def build_defs_from_airflow_instance(
 ) -> Definitions:
     defs = defs or Definitions()
     context = DefinitionsLoadContext.get()
-    definitions_metadata = _get_or_create_definitions_metadata(
+    serialized_data = _get_or_create_serialized_data(
         context, _metadata_key(airflow_instance), airflow_instance, defs
     )
     return definitions_from_metadata(
-        context, definitions_metadata, defs, airflow_instance, sensor_minimum_interval_seconds
+        serialized_data, defs, airflow_instance, sensor_minimum_interval_seconds
     )
 
 
@@ -68,67 +52,63 @@ def _metadata_key(airflow_instance: AirflowInstance) -> str:
     return f"{AIRFLOW_SOURCE_METADATA_KEY_PREFIX}/{airflow_instance.name}"
 
 
-def _get_or_create_definitions_metadata(
+def _get_or_create_serialized_data(
     context: DefinitionsLoadContext,
     metadata_key: str,
     airflow_instance: AirflowInstance,
     defs: Definitions,
-) -> "CacheableSpecs":
+) -> "_SerializedData":
     if (
         context.load_type == DefinitionsLoadType.RECONSTRUCTION
         and metadata_key in context.reconstruction_metadata
     ):
-        return deserialize_value(context.reconstruction_metadata[metadata_key], CacheableSpecs)
+        return deserialize_value(context.reconstruction_metadata[metadata_key], _SerializedData)
     else:
-        return compute_cacheable_assets(airflow_instance=airflow_instance, defs=defs)
+        return compute_serialized_data(airflow_instance=airflow_instance, defs=defs)
 
 
-def compute_cacheable_assets(
+def compute_serialized_data(
     airflow_instance: AirflowInstance, defs: Definitions
-) -> "CacheableSpecs":
+) -> "_SerializedData":
     migration_state = airflow_instance.get_migration_state()
     dag_infos = {dag.dag_id: dag for dag in airflow_instance.list_dags()}
-    cacheable_task_data = construct_cacheable_assets_and_infer_dependencies(
+
+    # Do a pass over the passed-in definitions to compute the asset graph, the assets corresponding to tasks in each dag,
+    # and additional transformations to perform to each asset spec (e.g. adding metadata).
+    serializable_data = serializable_data_from_defs(
         definitions=defs,
         migration_state=migration_state,
         airflow_instance=airflow_instance,
-        dag_infos=dag_infos,
     )
 
-    cacheable_dag_spec_per_key: Dict[AssetKey, CacheableAssetSpec] = {}
+    serializable_specs = []
+    # Construct serializable specs for each dag.
     for dag in dag_infos.values():
-        source_code = airflow_instance.get_dag_source_code(dag.metadata["file_token"])
-        cacheable_dag_spec_per_key[dag.dag_asset_key] = get_cached_spec_for_dag(
+        spec = dag_asset_spec_data(
             airflow_instance=airflow_instance,
-            task_asset_keys_in_dag=cacheable_task_data.all_asset_keys_per_dag_id.get(
-                dag.dag_id, set()
-            ),
-            downstreams_asset_dependency_graph=cacheable_task_data.downstreams_asset_dependency_graph,
+            task_asset_keys_in_dag=serializable_data.keys_in_dag.get(dag.dag_id, set()),
+            downstreams_asset_dependency_graph=serializable_data.downstreams_asset_graph,
             dag_info=dag,
-            source_code=source_code,
         )
-    return CacheableSpecs(
-        dag_cacheable_asset_specs=cacheable_dag_spec_per_key,
-        task_cacheable_asset_specs=cacheable_task_data.cacheable_specs_per_asset_key,
+        serializable_specs.append(spec)
+        for dep in spec.deps:
+            serializable_data.downstreams_asset_graph[dep.asset_key].add(dag.dag_asset_key)
+
+    return _SerializedData(
+        airflow_datas_per_existing_asset_key=serializable_data.per_existing_asset_key_airflow_data,
+        new_asset_datas=serializable_specs,
     )
 
 
 def definitions_from_metadata(
-    context: DefinitionsLoadContext,
-    definitions_metadata: "CacheableSpecs",
+    definitions_metadata: "_SerializedData",
     defs: Definitions,
     airflow_instance: AirflowInstance,
     sensor_minimum_interval_seconds: int,
 ) -> Definitions:
-    new_assets_defs = [
-        external_asset_from_spec(
-            cacheable_dag_spec.to_asset_spec(additional_metadata={}),
-        )
-        for cacheable_dag_spec in definitions_metadata.dag_cacheable_asset_specs.values()
-    ]
-    assets_defs = new_assets_defs + construct_assets_with_task_migration_info_applied(
+    assets_defs = construct_all_assets(
         definitions=defs,
-        cacheable_specs=definitions_metadata,
+        serialized_data=definitions_metadata,
     )
     return defs_with_assets_and_sensor(
         defs, assets_defs, airflow_instance, sensor_minimum_interval_seconds, definitions_metadata
@@ -140,7 +120,7 @@ def defs_with_assets_and_sensor(
     assets_defs: List[AssetsDefinition],
     airflow_instance: AirflowInstance,
     sensor_minimum_interval_seconds: int,
-    definitions_metadata: "CacheableSpecs",
+    definitions_metadata: "_SerializedData",
 ) -> Definitions:
     airflow_sensor = build_airflow_polling_sensor(
         airflow_instance=airflow_instance, minimum_interval_seconds=sensor_minimum_interval_seconds
@@ -159,139 +139,46 @@ def defs_with_assets_and_sensor(
     )
 
 
-# We serialize dictionaries as json, and json doesn't know how to serialize AssetKeys. So we wrap the mapping
-# to be able to serialize this dictionary with "non scalar" keys.
-class CacheableSpecMappingSerializer(FieldSerializer):
-    def pack(
-        self,
-        mapping: Mapping[str, "CacheableAssetSpec"],
-        whitelist_map: WhitelistMap,
-        descent_path: str,
-    ) -> JsonSerializableValue:
-        return pack_value(SerializableNonScalarKeyMapping(mapping), whitelist_map, descent_path)
-
-    def unpack(
-        self,
-        unpacked_value: JsonSerializableValue,
-        whitelist_map: WhitelistMap,
-        context: UnpackContext,
-    ) -> PackableValue:
-        return unpack_value(unpacked_value, dict, whitelist_map, context)
-
-
 @whitelist_for_serdes(
     field_serializers={
-        "task_cacheable_asset_specs": CacheableSpecMappingSerializer,
-        "dag_cacheable_asset_specs": CacheableSpecMappingSerializer,
+        "airflow_datas_per_existing_asset_key": GenericAssetKeyMappingSerializer,
     }
 )
 @record
-class CacheableSpecs:
-    task_cacheable_asset_specs: Dict[AssetKey, "CacheableAssetSpec"]
-    dag_cacheable_asset_specs: Dict[AssetKey, "CacheableAssetSpec"]
+class _SerializedData:
+    """Data that will be serialized and cached to avoid repeated calls to the Airflow API,
+    and repeated scans of passed-in Definitions objects.
+    """
 
-
-@whitelist_for_serdes
-@record
-class CacheableAssetSpec:
-    # A dumbed down version of AssetSpec that can be serialized easily to and from a dictionary.
-    asset_key: AssetKey
-    description: Optional[str]
-    metadata: Mapping[str, Any]
-    tags: Mapping[str, str]
-    deps: Optional[Sequence["CacheableAssetDep"]]
-    group_name: Optional[str]
-
-    def to_asset_spec(
-        self, *, additional_metadata: Mapping[str, Any] = {}, additional_tags: Dict[str, Any] = {}
-    ) -> AssetSpec:
-        return AssetSpec(
-            key=self.asset_key,
-            description=self.description,
-            metadata={**additional_metadata, **self.metadata},
-            tags={**additional_tags, **self.tags},
-            deps=[AssetDep(asset=dep.asset_key) for dep in self.deps] if self.deps else [],
-            group_name=self.group_name,
-        )
-
-    @staticmethod
-    def from_asset_spec(asset_spec: AssetSpec) -> "CacheableAssetSpec":
-        return CacheableAssetSpec(
-            asset_key=asset_spec.key,
-            description=asset_spec.description,
-            metadata=asset_spec.metadata,
-            tags=asset_spec.tags,
-            deps=[CacheableAssetDep.from_asset_dep(dep) for dep in asset_spec.deps],
-            group_name=asset_spec.group_name,
-        )
-
-
-@whitelist_for_serdes
-@record
-class CacheableAssetDep:
-    # A dumbed down version of AssetDep that can be serialized easily to and from a dictionary.
-    asset_key: AssetKey
-
-    @staticmethod
-    def from_asset_dep(asset_dep: AssetDep) -> "CacheableAssetDep":
-        return CacheableAssetDep(asset_key=asset_dep.asset_key)
-
-
-def get_cached_spec_for_dag(
-    airflow_instance: AirflowInstance,
-    task_asset_keys_in_dag: Set[AssetKey],
-    downstreams_asset_dependency_graph: Dict[AssetKey, Set[AssetKey]],
-    dag_info: DagInfo,
-    source_code: str,
-) -> CacheableAssetSpec:
-    leaf_asset_keys = get_leaf_assets_for_dag(
-        asset_keys_in_dag=task_asset_keys_in_dag,
-        downstreams_asset_dependency_graph=downstreams_asset_dependency_graph,
-    )
-    metadata = {
-        "Dag Info (raw)": JsonMetadataValue(dag_info.metadata),
-        "Dag ID": dag_info.dag_id,
-        "Link to DAG": UrlMetadataValue(dag_info.url),
-        DAG_ID_METADATA_KEY: dag_info.dag_id,
-    }
-    # Attempt to retrieve source code from the DAG.
-    metadata["Source Code"] = MarkdownMetadataValue(
-        f"""
-```python
-{source_code}
-```
-            """
-    )
-
-    return CacheableAssetSpec(
-        asset_key=dag_info.dag_asset_key,
-        description=f"A materialization corresponds to a successful run of airflow DAG {dag_info.dag_id}.",
-        metadata=metadata,
-        tags=airflow_kind_dict(),
-        deps=[CacheableAssetDep(asset_key=key) for key in leaf_asset_keys],
-        group_name=None,
-    )
+    airflow_datas_per_existing_asset_key: Dict[AssetKey, "ExistingAssetKeyAirflowData"]
+    new_asset_datas: Sequence[AssetSpecData]
 
 
 @record
-class _CacheableData:
-    cacheable_specs_per_asset_key: Dict[AssetKey, CacheableAssetSpec] = {}
-    all_asset_keys_per_dag_id: Dict[str, Set[AssetKey]] = {}
-    downstreams_asset_dependency_graph: Dict[AssetKey, Set[AssetKey]] = {}
+class _AirflowDataForDefs:
+    """Serializable data that represents information gleaned from the passed-in Definitions object."""
+
+    # Once over the serialization boundary, these will be combined with an original AssetSpec to create the final AssetSpec.
+    # In practice, we attach task-level metadata to the AssetSpecs.
+    per_existing_asset_key_airflow_data: Dict[AssetKey, ExistingAssetKeyAirflowData] = {}
+    # These are the assets which map to tasks within a given dag.
+    keys_in_dag: Dict[str, Set[AssetKey]] = {}
+    # This is the asset dependency graph, which we use to determine the leaf assets for a given dag.
+    downstreams_asset_graph: Dict[AssetKey, Set[AssetKey]] = {}
 
 
-def construct_cacheable_assets_and_infer_dependencies(
-    definitions: Optional[Definitions],
+def serializable_data_from_defs(
+    definitions: Definitions,
     migration_state: AirflowMigrationState,
     airflow_instance: AirflowInstance,
-    dag_infos: Dict[str, DagInfo],
-) -> _CacheableData:
+) -> _AirflowDataForDefs:
+    """Compute data from definitions that can be cached and used to construct the "final" definitions,
+    without calls to the airflow rest API.
+    """
     downstreams_asset_dependency_graph: Dict[AssetKey, Set[AssetKey]] = defaultdict(set)
-    cacheable_specs_per_asset_key: Dict[AssetKey, CacheableAssetSpec] = {}
+    per_asset_key_airflow_data: Dict[AssetKey, ExistingAssetKeyAirflowData] = {}
     all_asset_keys_per_dag_id: Dict[str, Set[AssetKey]] = defaultdict(set)
-    if not definitions or not definitions.assets:
-        return _CacheableData()
-    for asset in definitions.assets:
+    for asset in definitions.assets or []:
         asset = check.inst(  # noqa: PLW2901
             asset,
             (AssetsDefinition, AssetSpec),
@@ -300,155 +187,66 @@ def construct_cacheable_assets_and_infer_dependencies(
         task_info = get_task_info_for_asset(airflow_instance, asset)
         if task_info is None:
             continue
-        task_level_metadata = {
-            "Task Info (raw)": JsonMetadataValue(task_info.metadata),
-            # In this case,
-            "Dag ID": task_info.dag_id,
-            "Link to DAG": UrlMetadataValue(task_info.dag_url),
-        }
         migration_state_for_task = migration_state.get_migration_state_for_task(
             dag_id=task_info.dag_id, task_id=task_info.task_id
         )
-        task_level_metadata[
-            "Computed in Task ID" if migration_state_for_task is False else "Triggered by Task ID"
-        ] = task_info.task_id
         specs = asset.specs if isinstance(asset, AssetsDefinition) else [asset]
         for spec in specs:
-            spec_deps = []
-            for dep in spec.deps:
-                spec_deps.append(CacheableAssetDep.from_asset_dep(dep))
-                downstreams_asset_dependency_graph[dep.asset_key].add(spec.key)
-            cacheable_specs_per_asset_key[spec.key] = CacheableAssetSpec(
-                asset_key=spec.key,
-                description=spec.description,
-                metadata={
-                    DAG_ID_METADATA_KEY: task_info.dag_id,
-                    TASK_ID_METADATA_KEY: task_info.task_id,
-                    **task_level_metadata,
-                },
-                tags={
-                    **spec.tags,
-                    MIGRATED_TAG: str(bool(migration_state_for_task)),
-                },
-                deps=spec_deps,
-                group_name=spec.group_name,
+            per_asset_key_airflow_data[spec.key] = get_airflow_data_for_task_mapped_spec(
+                task_info=task_info,
+                migration_state=migration_state_for_task,
+                spec=spec,
             )
+            for dep in spec.deps:
+                downstreams_asset_dependency_graph[dep.asset_key].add(spec.key)
             all_asset_keys_per_dag_id[task_info.dag_id].add(spec.key)
-    return _CacheableData(
-        cacheable_specs_per_asset_key=cacheable_specs_per_asset_key,
-        all_asset_keys_per_dag_id=all_asset_keys_per_dag_id,
-        downstreams_asset_dependency_graph=downstreams_asset_dependency_graph,
+    return _AirflowDataForDefs(
+        per_existing_asset_key_airflow_data=per_asset_key_airflow_data,
+        keys_in_dag=all_asset_keys_per_dag_id,
+        downstreams_asset_graph=downstreams_asset_dependency_graph,
     )
 
 
-def construct_assets_with_task_migration_info_applied(
-    definitions: Optional[Definitions],
-    cacheable_specs: CacheableSpecs,
+def construct_all_assets(
+    definitions: Definitions,
+    serialized_data: _SerializedData,
 ) -> List[AssetsDefinition]:
-    if not definitions or not definitions.assets:
-        return []
+    return list(
+        _apply_airflow_data_to_specs(
+            definitions, serialized_data.airflow_datas_per_existing_asset_key
+        )
+    ) + list(_construct_specs_from_data(serialized_data.new_asset_datas))
 
-    new_assets_defs = []
-    for asset in definitions.assets:
+
+def _apply_airflow_data_to_specs(
+    definitions: Definitions,
+    airflow_datas_per_asset_key: Mapping[AssetKey, ExistingAssetKeyAirflowData],
+) -> Iterator[AssetsDefinition]:
+    """Apply asset spec transformations to the asset definitions."""
+
+    def _map_spec(spec: AssetSpec) -> AssetSpec:
+        if spec.key in airflow_datas_per_asset_key:
+            return airflow_datas_per_asset_key[spec.key].apply_to_spec(spec)
+        return spec
+
+    for asset in definitions.assets or []:
         asset = check.inst(  # noqa: PLW2901
             asset,
             (AssetSpec, AssetsDefinition),
             "Expected orchestrated defs to all be AssetsDefinitions or AssetSpecs.",
         )
-        dag_id = get_dag_id_from_asset(asset)
-        if dag_id is None:
-            # The cacheable assets abstraction can only handle returning a list of assetsdefinitions, not specs. So if specs are passed in,
-            # we need to coerce them.
-            if isinstance(asset, AssetSpec):
-                new_assets_defs.append(external_asset_from_spec(asset))
-            else:
-                new_assets_defs.append(asset)
-            continue
-        overall_migration_status = None
-        overall_task_id = None
-        overall_dag_id = None
-        new_specs = []
-        specs = asset.specs if isinstance(asset, AssetsDefinition) else [asset]
-        for spec in specs:
-            cacheable_spec = check.not_none(
-                cacheable_specs.task_cacheable_asset_specs.get(spec.key),
-                f"Could not find cacheable spec for asset key {spec.key.to_user_string()}",
-            )
+        assets_def = (
+            asset if isinstance(asset, AssetsDefinition) else external_asset_from_spec(asset)
+        )
+        yield assets_def.map_asset_specs(_map_spec)
 
-            check.invariant(
-                MIGRATED_TAG in cacheable_spec.tags,
-                f"Could not find migrated status for asset key {spec.key.to_user_string()}",
-            )
-            check.invariant(
-                overall_migration_status is None
-                or overall_migration_status == cacheable_spec.tags[MIGRATED_TAG],
-                "Expected all assets in an AssetsDefinition (and therefore the same task) to have the same migration status.",
-            )
-            overall_migration_status = cacheable_spec.tags[MIGRATED_TAG]
-            check.invariant(
-                DAG_ID_METADATA_KEY in cacheable_spec.metadata,
-                f"Could not find dag ID for asset key {spec.key.to_user_string()}",
-            )
-            dag_id = cacheable_spec.metadata[DAG_ID_METADATA_KEY]
-            check.invariant(
-                overall_dag_id is None or overall_dag_id == dag_id,
-                "Expected all assets in an AssetsDefinition to have the same dag ID.",
-            )
-            overall_dag_id = dag_id
-            check.invariant(
-                TASK_ID_METADATA_KEY in cacheable_spec.metadata,
-                f"Could not find task ID for asset key {cacheable_spec.asset_key.to_user_string()}",
-            )
-            task_id = cacheable_spec.metadata[TASK_ID_METADATA_KEY]
-            check.invariant(
-                overall_task_id is None or overall_task_id == task_id,
-                f"Expected all assets in an AssetsDefinition to have the same task ID. Found {overall_task_id} and {task_id}.",
-            )
-            overall_task_id = task_id
 
-        # We don't coerce to a bool here since bool("False") is True.
-        new_specs = [
-            # We allow arbitrary (non-serdes) metadata in asset specs, which makes them non-serializable.
-            # This means we need to "combine" the metadata from the cacheable spec with the non-serializable
-            # metadata fields from the original spec it was built from after deserializing.
-            cacheable_specs.task_cacheable_asset_specs[spec.key].to_asset_spec(
-                additional_metadata=spec.metadata,
-                additional_tags=airflow_kind_dict() if overall_migration_status != "True" else {},
-            )
-            for spec in specs
-        ]
-        if overall_migration_status == "True":
-            asset = check.inst(  # noqa: PLW2901
-                asset,
-                AssetsDefinition,
-                f"For an asset to be migrated, it must be an AssetsDefinition. Found an AssetSpec for task ID {task_id}.",
-            )
-            check.invariant(
-                asset.is_executable,
-                f"For an asset to be marked as migrated, it must also be executable in dagster. Found unexecutable assets for task ID {task_id}.",
-            )
-            # This is suspect. Should we not be using a full AssetsDefinition copy here.
-            # https://linear.app/dagster-labs/issue/FOU-372/investigate-suspect-code-in-construct-assets-with-task-migration-info
-            new_assets_defs.append(
-                AssetsDefinition(
-                    keys_by_input_name=asset.keys_by_input_name,
-                    keys_by_output_name=asset.keys_by_output_name,
-                    node_def=asset.node_def,
-                    partitions_def=asset.partitions_def,
-                    specs=[
-                        # We allow arbitrary (non-serdes) metadata in asset specs, which makes them non-serializable.
-                        # This means we need to "combine" the metadata from the cacheable spec with the non-serializable
-                        # metadata fields from the original spec it was built from after deserializing.
-                        cacheable_specs.task_cacheable_asset_specs[spec.key].to_asset_spec(
-                            additional_metadata=spec.metadata
-                        )
-                        for spec in specs
-                    ],
-                )
-            )
-        else:
-            new_assets_defs.extend(external_asset_from_spec(spec) for spec in new_specs)
-    return new_assets_defs
+def _construct_specs_from_data(
+    spec_datas: Sequence[AssetSpecData],
+) -> Iterator[AssetsDefinition]:
+    """Construct fully qualified AssetsDefinition objects (one per spec) from serializable specs."""
+    for spec_data in spec_datas:
+        yield external_asset_from_spec(spec_data.to_asset_spec())
 
 
 # We expect that every asset which is passed to this function has all relevant specs mapped to a task.
@@ -460,39 +258,3 @@ def get_task_info_for_asset(
     if task_id is None or dag_id is None:
         return None
     return airflow_instance.get_task_info(dag_id, task_id)
-
-
-def get_leaf_assets_for_dag(
-    asset_keys_in_dag: Set[AssetKey],
-    downstreams_asset_dependency_graph: Dict[AssetKey, Set[AssetKey]],
-) -> List[AssetKey]:
-    # An asset is a "leaf" for the dag if it has no transitive dependencies _within_ the dag. It may have
-    # dependencies _outside_ the dag.
-    leaf_assets = []
-    cache = {}
-    for asset_key in asset_keys_in_dag:
-        if (
-            get_transitive_dependencies_for_asset(
-                asset_key, downstreams_asset_dependency_graph, cache
-            ).intersection(asset_keys_in_dag)
-            == set()
-        ):
-            leaf_assets.append(asset_key)
-    return leaf_assets
-
-
-def get_transitive_dependencies_for_asset(
-    asset_key: AssetKey,
-    downstreams_asset_dependency_graph: Dict[AssetKey, Set[AssetKey]],
-    cache: Dict[AssetKey, Set[AssetKey]],
-) -> Set[AssetKey]:
-    if asset_key in cache:
-        return cache[asset_key]
-    transitive_deps = set()
-    for dep in downstreams_asset_dependency_graph[asset_key]:
-        transitive_deps.add(dep)
-        transitive_deps.update(
-            get_transitive_dependencies_for_asset(dep, downstreams_asset_dependency_graph, cache)
-        )
-    cache[asset_key] = transitive_deps
-    return transitive_deps

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization_utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization_utils.py
@@ -1,0 +1,107 @@
+from typing import Any, Mapping, Optional, Sequence
+
+from dagster import AssetDep, AssetKey, AssetSpec
+from dagster._record import record
+from dagster._serdes import whitelist_for_serdes
+from dagster._serdes.serdes import (
+    FieldSerializer,
+    JsonSerializableValue,
+    PackableValue,
+    SerializableNonScalarKeyMapping,
+    UnpackContext,
+    WhitelistMap,
+    pack_value,
+    unpack_value,
+)
+from dagster._utils.merger import merge_dicts
+
+
+# We serialize dictionaries as json, and json doesn't know how to serialize AssetKeys. So we wrap the mapping
+# to be able to serialize this dictionary with "non scalar" keys.
+class CacheableSpecMappingSerializer(FieldSerializer):
+    def pack(
+        self,
+        mapping: Mapping[str, "AssetSpecData"],
+        whitelist_map: WhitelistMap,
+        descent_path: str,
+    ) -> JsonSerializableValue:
+        return pack_value(SerializableNonScalarKeyMapping(mapping), whitelist_map, descent_path)
+
+    def unpack(
+        self,
+        unpacked_value: JsonSerializableValue,
+        whitelist_map: WhitelistMap,
+        context: UnpackContext,
+    ) -> PackableValue:
+        return unpack_value(unpacked_value, dict, whitelist_map, context)
+
+
+class GenericAssetKeyMappingSerializer(FieldSerializer):
+    """Can be used for any mapping with AssetKey keys."""
+
+    def pack(
+        self,
+        data: Mapping[str, Any],
+        whitelist_map: WhitelistMap,
+        descent_path: str,
+    ) -> JsonSerializableValue:
+        return pack_value(SerializableNonScalarKeyMapping(data), whitelist_map, descent_path)
+
+    def unpack(
+        self,
+        unpacked_value: JsonSerializableValue,
+        whitelist_map: WhitelistMap,
+        context: UnpackContext,
+    ) -> PackableValue:
+        return unpack_value(unpacked_value, dict, whitelist_map, context)
+
+
+@whitelist_for_serdes
+@record
+class AssetSpecData:
+    """Serializable data that can be used to construct a fully qualified AssetSpec."""
+
+    asset_key: AssetKey
+    description: Optional[str]
+    metadata: Mapping[str, Any]
+    tags: Mapping[str, str]
+    deps: Sequence["CacheableAssetDep"]
+
+    def to_asset_spec(self) -> AssetSpec:
+        return AssetSpec(
+            key=self.asset_key,
+            description=self.description,
+            metadata=self.metadata,
+            tags=self.tags,
+            deps=[AssetDep(asset=dep.asset_key) for dep in self.deps] if self.deps else [],
+        )
+
+
+@whitelist_for_serdes
+@record
+class ExistingAssetKeyAirflowData:
+    """Additional data retrieved from airflow that once over the serialization boundary, we can combine with the original asset spec."""
+
+    asset_key: AssetKey
+    additional_metadata: Mapping[str, Any]
+    additional_tags: Mapping[str, str]
+
+    def apply_to_spec(self, spec: AssetSpec) -> AssetSpec:
+        return AssetSpec(
+            key=self.asset_key,
+            description=spec.description,
+            metadata=merge_dicts(spec.metadata, self.additional_metadata),
+            tags=merge_dicts(spec.tags, self.additional_tags),
+            deps=spec.deps,
+        )
+
+
+@whitelist_for_serdes
+@record
+class CacheableAssetDep:
+    # A dumbed down version of AssetDep that can be serialized easily to and from a dictionary.
+    asset_key: AssetKey
+
+    @staticmethod
+    def from_asset_dep(asset_dep: AssetDep) -> "CacheableAssetDep":
+        return CacheableAssetDep(asset_key=asset_dep.asset_key)

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/task_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/task_asset.py
@@ -1,0 +1,37 @@
+from typing import Any, Mapping, Optional
+
+from dagster import AssetSpec, JsonMetadataValue
+from dagster._core.definitions.metadata.metadata_value import UrlMetadataValue
+
+from dagster_airlift.constants import MIGRATED_TAG
+from dagster_airlift.core.airflow_instance import TaskInfo
+from dagster_airlift.core.serialization_utils import ExistingAssetKeyAirflowData
+from dagster_airlift.core.utils import airflow_kind_dict
+
+
+def get_airflow_data_for_task_mapped_spec(
+    task_info: TaskInfo,
+    migration_state: Optional[bool],
+    spec: AssetSpec,
+) -> ExistingAssetKeyAirflowData:
+    tags = airflow_kind_dict() if not migration_state else {}
+    if migration_state is not None:
+        tags[MIGRATED_TAG] = str(bool(migration_state))
+    return ExistingAssetKeyAirflowData(
+        asset_key=spec.key,
+        additional_metadata=task_asset_metadata(task_info, migration_state),
+        additional_tags=tags,
+    )
+
+
+def task_asset_metadata(task_info: TaskInfo, migration_state: Optional[bool]) -> Mapping[str, Any]:
+    task_level_metadata = {
+        "Task Info (raw)": JsonMetadataValue(task_info.metadata),
+        # In this case,
+        "Dag ID": task_info.dag_id,
+        "Link to DAG": UrlMetadataValue(task_info.dag_url),
+    }
+    task_level_metadata[
+        "Computed in Task ID" if not migration_state else "Triggered by Task ID"
+    ] = task_info.task_id
+    return task_level_metadata

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
@@ -5,6 +5,7 @@ from dagster import (
     AssetSpec,
     _check as check,
 )
+from dagster._core.definitions.external_asset import external_asset_from_spec
 from dagster._core.definitions.utils import VALID_NAME_REGEX
 from dagster._core.storage.tags import KIND_PREFIX
 
@@ -45,7 +46,7 @@ def prop_from_metadata(
                     )
                 check.invariant(
                     prop == spec.metadata[prop_metadata_key],
-                    f"Task ID mismatch within same AssetsDefinition: {prop} != {spec.metadata[prop_metadata_key]}",
+                    f"Metadata mismatch within same AssetsDefinition: {prop} != {spec.metadata[prop_metadata_key]}",
                 )
         return prop
     return None
@@ -53,3 +54,9 @@ def prop_from_metadata(
 
 def airflow_kind_dict() -> dict:
     return {f"{KIND_PREFIX}airflow": ""}
+
+
+def coerce_to_definition(asset: Union[AssetSpec, AssetsDefinition]) -> AssetsDefinition:
+    if isinstance(asset, AssetSpec):
+        return external_asset_from_spec(asset)
+    return asset

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
@@ -37,7 +37,7 @@ def fully_loaded_repo_from_airflow_asset_graph(
     additional_defs: Definitions = Definitions(),
     create_runs: bool = True,
 ) -> RepositoryDefinition:
-    defs = build_definitions_airflow_asset_graph(
+    defs = load_definitions_airflow_asset_graph(
         assets_per_task, additional_defs=additional_defs, create_runs=create_runs
     )
     repo_def = defs.get_repository_def()
@@ -45,7 +45,7 @@ def fully_loaded_repo_from_airflow_asset_graph(
     return repo_def
 
 
-def build_definitions_airflow_asset_graph(
+def load_definitions_airflow_asset_graph(
     assets_per_task: Dict[str, Dict[str, List[Tuple[str, List[str]]]]],
     additional_defs: Definitions = Definitions(),
     create_runs: bool = True,
@@ -64,7 +64,7 @@ def build_definitions_airflow_asset_graph(
                 )
                 if create_assets_defs:
 
-                    @multi_asset(specs=[spec])
+                    @multi_asset(specs=[spec], name=f"{spec.key.to_python_identifier()}_asset")
                     def _asset():
                         return None
 


### PR DESCRIPTION
Refactor some core components of airlift for readability. This is a pretty big PR, but everything is interrelated so it's hard to break apart. Line change is a bit misleading, the actual code deletion here is more significant, but since I broke out into multiple files, there's at least 50 odd lines of imports getting added. 
- Split out the relatively massive and confusingly named defs_from_airflow.py file into more well-structured, smaller files which take on a specific vertical of functionality (dag_asset, task_asset, etc).
- Add a new serdes class `ExistingAssetKeyAirflowData`, rename `CacheableAssetSpec` to `SerializableAssetSpec` to better reflect our internal language.
- Rename all references to 'cache*' to 'serialize*', again to reflect our internal language and distance from cacheable assets, which is no longer in use here.
- Reorient building the serialized data around two distinct stages:
   - figuring out what transformations need to occur to passed-in Definitions (adding metadata, tags, etc)
   - figuring out what additional specs we need to add.
   - When the code is restructured in this way, I think it much better sets us up for future PRs where we add task peering and dag overrides for example. Reorients language around what we're actually doing rather than the conceptual overhead.
- Greatly simplify the step of building definitions _from_ the serialized data by not attempting to transform existing AssetsDefinitions into AssetSpecs.

Overall I think this refactor makes the code significantly more readable, and sets us up for future PRs much better.

## How I tested this
Existing test suite. Required minimal to no changes.

## Changelog
`NOCHANGELOG`


 