### PR TITLE
feat(looker): implement cacheable assets

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker/cacheable_assets.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/cacheable_assets.py
@@ -1,0 +1,62 @@
+from typing import TYPE_CHECKING, Sequence
+
+from dagster import (
+    AssetsDefinition,
+    AssetSpec,
+    _check as check,
+    external_assets_from_specs,
+)
+from dagster._core.definitions.cacheable_assets import (
+    AssetsDefinitionCacheableData,
+    CacheableAssetsDefinition,
+)
+from looker_sdk.sdk.api40.models import LookmlModelExplore
+
+from dagster_looker.translator import LookerInstanceData
+
+if TYPE_CHECKING:
+    from dagster_looker.resource import LookerResource
+
+
+class LookerCacheableAssetsDefinition(CacheableAssetsDefinition):
+    def __init__(self, looker: "LookerResource"):
+        self._looker = looker
+        super().__init__(unique_id=self._looker.client_id)
+
+    def compute_cacheable_data(self) -> Sequence[AssetsDefinitionCacheableData]:
+        looker_instance_data = self._looker.fetch_looker_data()
+        return [
+            AssetsDefinitionCacheableData(
+                extra_metadata={
+                    explore_id: (
+                        self._looker.get_sdk()
+                        .serialize(api_model=explore_data)  # type: ignore
+                        .decode()
+                    )
+                }
+            )
+            for explore_id, explore_data in looker_instance_data.explores_by_id.items()
+        ]
+
+    def build_definitions(
+        self,
+        data: Sequence[AssetsDefinitionCacheableData],
+    ) -> Sequence[AssetsDefinition]:
+        a = LookerInstanceData(
+            explores_by_id={
+                explore_id: (
+                    self._looker.get_sdk().deserialize(
+                        data=explore_data,  # type: ignore
+                        structure=LookmlModelExplore,
+                    )
+                )
+                for entry in data
+                for explore_id, explore_data in check.not_none(entry.extra_metadata).items()
+            }
+        )
+
+        return [
+            *external_assets_from_specs(
+                [AssetSpec(key=explore_id) for explore_id, explore_data in a.explores_by_id.items()]
+            )
+        ]

--- a/python_modules/libraries/dagster-looker/dagster_looker/resource.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/resource.py
@@ -1,9 +1,22 @@
+from typing import TYPE_CHECKING, List, Sequence
+
 from dagster import ConfigurableResource
+from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
+from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils.cached_method import cached_method
+from dagster._utils.log import get_dagster_logger
 from looker_sdk import init40
 from looker_sdk.rtl.api_settings import ApiSettings, SettingsConfig
 from looker_sdk.sdk.api40.methods import Looker40SDK
 from pydantic import Field
+
+from dagster_looker.cacheable_assets import LookerCacheableAssetsDefinition
+from dagster_looker.translator import LookerInstanceData
+
+if TYPE_CHECKING:
+    from looker_sdk.sdk.api40.models import LookmlModelExplore
+
+logger = get_dagster_logger("dagster-looker")
 
 
 class LookerResource(ConfigurableResource):
@@ -12,7 +25,8 @@ class LookerResource(ConfigurableResource):
     """
 
     base_url: str = Field(
-        ..., description="Base URL for the Looker API. For example, https://your.cloud.looker.com."
+        ...,
+        description="Base URL for the Looker API. For example, https://your.cloud.looker.com.",
     )
     client_id: str = Field(..., description="Client ID for the Looker API.")
     client_secret: str = Field(..., description="Client secret for the Looker API.")
@@ -29,3 +43,35 @@ class LookerResource(ConfigurableResource):
                 }
 
         return init40(config_settings=DagsterLookerApiSettings())
+
+    def fetch_looker_data(self) -> LookerInstanceData:
+        sdk = self.get_sdk()
+
+        # Get explore names from models
+        explores_for_model = {
+            model.name: [explore.name for explore in (model.explores or []) if explore.name]
+            for model in sdk.all_lookml_models()
+            if model.name
+        }
+
+        # TODO: Fetch explores in parallel using asyncio
+        explore_data: List["LookmlModelExplore"] = []
+        for model_name, explore_names in explores_for_model.items():
+            for explore_name in explore_names:
+                try:
+                    explore_data.append(sdk.lookml_model_explore(model_name, explore_name))
+                except:
+                    logger.warning(
+                        f"Failed to fetch LookML explore '{explore_name}' for model '{model_name}'."
+                    )
+
+        # TODO: Get all the LookML views upstream of the explores
+        return LookerInstanceData(
+            explores_by_id={explore.id: explore for explore in explore_data if explore.id}
+        )
+
+    def build_assets(self) -> Sequence[CacheableAssetsDefinition]:
+        return [LookerCacheableAssetsDefinition(self)]
+
+    def build_defs(self) -> Definitions:
+        return Definitions(assets=self.build_assets())

--- a/python_modules/libraries/dagster-looker/dagster_looker/translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/translator.py
@@ -1,0 +1,14 @@
+from typing import Dict
+
+from dagster._record import record
+from looker_sdk.sdk.api40.models import LookmlModelExplore
+
+
+@record
+class LookerInstanceData:
+    """A record representing all content in a Looker instance.
+
+    Provided as context for the translator so that it can resolve dependencies between structures.
+    """
+
+    explores_by_id: Dict[str, LookmlModelExplore]

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/mock_looker_data.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/mock_looker_data.py
@@ -1,0 +1,12 @@
+from looker_sdk.sdk.api40.models import LookmlModel, LookmlModelExplore, LookmlModelNavExplore
+
+mock_lookml_models = [
+    LookmlModel(
+        explores=[
+            LookmlModelNavExplore(name="my_explore"),
+        ],
+        name="my_model",
+    )
+]
+
+mock_lookml_explore = LookmlModelExplore(id="my_model::my_explore")

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/test_cacheable_assets.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/test_cacheable_assets.py
@@ -1,0 +1,54 @@
+from typing import Iterator
+
+import pytest
+import responses
+from dagster_looker.resource import LookerResource
+
+from dagster_looker_tests.mock_looker_data import mock_lookml_explore, mock_lookml_models
+
+TEST_BASE_URL = "https://your.cloud.looker.com"
+
+
+@pytest.fixture(name="looker_resource")
+def looker_resource_fixture() -> LookerResource:
+    return LookerResource(
+        base_url=TEST_BASE_URL, client_id="client_id", client_secret="client_secret"
+    )
+
+
+@pytest.fixture(name="looker_instance_data_mocks")
+def looker_instance_data_mocks_fixture(
+    looker_resource: LookerResource,
+) -> Iterator[responses.RequestsMock]:
+    with responses.RequestsMock() as response:
+        # Mock the login request
+        responses.add(method=responses.POST, url=f"{TEST_BASE_URL}/api/4.0/login", json={})
+
+        # Mock the request for all lookml models
+        responses.add(
+            method=responses.GET,
+            url=f"{TEST_BASE_URL}/api/4.0/lookml_models",
+            body=looker_resource.get_sdk().serialize(api_model=mock_lookml_models),  # type: ignore
+        )
+
+        # Mock the request for a single lookml explore
+        responses.add(
+            method=responses.GET,
+            url=f"{TEST_BASE_URL}/api/4.0/lookml_models/my_model/explores/my_explore",
+            body=looker_resource.get_sdk().serialize(api_model=mock_lookml_explore),  # type: ignore
+        )
+
+        yield response
+
+
+@responses.activate
+def test_build_defs(
+    looker_resource: LookerResource, looker_instance_data_mocks: responses.RequestsMock
+) -> None:
+    all_assets = looker_resource.build_defs().get_asset_graph().assets_defs
+
+    assert len(all_assets) == 1
+
+    explore_asset = all_assets[0]
+
+    assert explore_asset.key.path == ["my_model::my_explore"]

--- a/python_modules/libraries/dagster-looker/setup.py
+++ b/python_modules/libraries/dagster-looker/setup.py
@@ -41,6 +41,7 @@ setup(
         "lkml",
         "looker_sdk",
         "sqlglot",
+        "cattrs<23.2",  # https://github.com/looker-open-source/sdk-codegen/issues/1410
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
## Summary & Motivation
Implements cacheable assets for Looker. First, we represent all the explores as cacheable assets.

To populate the cache, we serialize the Looker API responses back to their JSON structured format using the Looker SDK. When retrieving from the cache, we can just deserialize them back to their corresponding classes.

In the following PRs, we will:

- Represent views as cacheable assets
- Represent dashboards as cacheable assets
- Add a custom translator for subsequent Looker structure types.

## How I Tested These Changes
pytest with mocks, local

## Changelog

NOCHANGELOG

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
