### PR TITLE
Add a "hasReportRunlessAssetEventPermission' field to GrapheneAssetNode

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -677,6 +677,7 @@ type AssetNode {
   staleCausesByPartition(partitions: [String!]): [[StaleCause!]!]
   type: DagsterType
   hasMaterializePermission: Boolean!
+  hasReportRunlessAssetEventPermission: Boolean!
   hasAssetChecks: Boolean!
   assetChecksOrError(limit: Int, pipeline: PipelineSelector): AssetChecksOrError!
   currentAutoMaterializeEvaluationId: Int

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -441,6 +441,7 @@ export type AssetNode = {
   groupName: Scalars['String']['output'];
   hasAssetChecks: Scalars['Boolean']['output'];
   hasMaterializePermission: Scalars['Boolean']['output'];
+  hasReportRunlessAssetEventPermission: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
   isExecutable: Scalars['Boolean']['output'];
   isMaterializable: Scalars['Boolean']['output'];
@@ -6507,6 +6508,10 @@ export const buildAssetNode = (
     hasMaterializePermission:
       overrides && overrides.hasOwnProperty('hasMaterializePermission')
         ? overrides.hasMaterializePermission!
+        : false,
+    hasReportRunlessAssetEventPermission:
+      overrides && overrides.hasOwnProperty('hasReportRunlessAssetEventPermission')
+        ? overrides.hasReportRunlessAssetEventPermission!
         : false,
     id:
       overrides && overrides.hasOwnProperty('id')

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -329,6 +329,8 @@ class GrapheneAssetNode(graphene.ObjectType):
     )
     type = graphene.Field(GrapheneDagsterType)
     hasMaterializePermission = graphene.NonNull(graphene.Boolean)
+    hasReportRunlessAssetEventPermission = graphene.NonNull(graphene.Boolean)
+
     # the acutal checks are listed in the assetChecksOrError resolver. We use this boolean
     # to show/hide the checks tab. We plan to remove this field once we always show the checks tab.
     hasAssetChecks = graphene.NonNull(graphene.Boolean)
@@ -561,6 +563,14 @@ class GrapheneAssetNode(graphene.ObjectType):
     ) -> bool:
         return graphene_info.context.has_permission_for_location(
             Permissions.LAUNCH_PIPELINE_EXECUTION, self._repository_location.name
+        )
+
+    def resolve_hasReportRunlessAssetEventPermission(
+        self,
+        graphene_info: ResolveInfo,
+    ) -> bool:
+        return graphene_info.context.has_permission_for_location(
+            Permissions.REPORT_RUNLESS_ASSET_EVENTS, self._repository_location.name
         )
 
     def resolve_assetMaterializationUsedData(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -255,6 +255,7 @@ GET_ASSET_NODES_FROM_KEYS = """
         assetNodes(pipeline: $pipelineSelector, assetKeys: $assetKeys) {
             id
             hasMaterializePermission
+            hasReportRunlessAssetEventPermission
         }
     }
 """
@@ -1196,6 +1197,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         asset_node = result.data["assetNodes"][0]
         assert asset_node["id"] == 'test.test_repo.["asset_one"]'
         assert asset_node["hasMaterializePermission"]
+        assert asset_node["hasReportRunlessAssetEventPermission"]
 
         result = execute_dagster_graphql(
             graphql_context,


### PR DESCRIPTION
We should be checking this instead of the global permission when deciding whether or not to allow the "Report materialization" button. This PR handles the addition of the backend field for that.

Test Plan: New test case

## Changelog

NOCHANGELOG