### PR TITLE
Set virtualized row height dynamically for runs feed

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
@@ -144,13 +144,15 @@ export const RunsFeedRoot = () => {
               }
               return (
                 <Row $height={size} $start={start} data-key={key} key={key}>
-                  <RunsFeedRow
-                    key={key}
-                    entry={entry}
-                    checked={checkedIds.has(entry.id)}
-                    onToggleChecked={onToggleFactory(entry.id)}
-                    refetch={refreshState.refetch}
-                  />
+                  <div ref={rowVirtualizer.measureElement} data-index={index}>
+                    <RunsFeedRow
+                      key={key}
+                      entry={entry}
+                      checked={checkedIds.has(entry.id)}
+                      onToggleChecked={onToggleFactory(entry.id)}
+                      refetch={refreshState.refetch}
+                    />
+                  </div>
                 </Row>
               );
             })}


### PR DESCRIPTION
## Summary & Motivation

As titled, previously we were hardcoding the height to 84px.

## How I Tested These Changes

before:
<img width="1728" alt="Screenshot 2024-09-18 at 2 32 47 PM" src="https://github.com/user-attachments/assets/ac305fa7-1adc-4b4c-9ff2-3ab29b94d89c">


after:
<img width="1728" alt="Screenshot 2024-09-18 at 2 31 09 PM" src="https://github.com/user-attachments/assets/79749d1f-0482-4bf2-9a96-b99097416e09">


## Changelog

NOCHANGELOG