### PR TITLE
update build-docs-revamp gh action to only publish prod on master

### DIFF
--- a/.github/workflows/build-docs-revamp.yml
+++ b/.github/workflows/build-docs-revamp.yml
@@ -94,10 +94,8 @@ jobs:
 
       - name: Publish to Vercel Production
         uses: amondnet/vercel-action@v25
-        if: |
-          github.event_name == 'pull_request' || 
-          (github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/heads/docs-prod')))
-
+        # only deploy to production on master (TODO: switch to docs-prod when beta goes live)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Summary & Motivation
mirrors https://github.com/dagster-io/dagster/blob/master/.github/workflows/build-docs.yml#L107
but on "master". we will switch to "docs-prod" when we go live (so the main site is versioned on every release)

## How I Tested These Changes

## Changelog
`NOCHANGELOG`