### PR TITLE
[docs-revamp] fix vale

### DIFF
--- a/docs/docs-beta/docs/guides/external-assets.md
+++ b/docs/docs-beta/docs/guides/external-assets.md
@@ -1,4 +1,4 @@
---
+---
 title: Representing external data sources with external assets
 sidebar_position: 80
 sidebar_label: 'External data sources'

--- a/docs/vale/styles/config/vocabularies/Dagster/accept.txt
+++ b/docs/vale/styles/config/vocabularies/Dagster/accept.txt
@@ -9,18 +9,17 @@ AWS Athena
 AWS CloudWatch
 AWS Glue
 AWS Lambda
+AWS Redshift
 AWS Secrets Manager
 AWS Systems Parameter Store
-AWS Redshift
-Airflow
 Airbyte
+Airflow
 Apache
 Azure Data Lake Storage Gen 2
 BigQuery
-chatbot
-Census
 CI/CD
 CLI[s]
+Census
 Crontab
 Cube
 DAG
@@ -36,46 +35,44 @@ Dockerfile
 DuckDB
 ECR
 ECS
-ECS
 EKS
-EMR
 ELT
+EMR
 Fivetran
 Flink
 GCR
+GCS
 GDPR
 GKE
 GitHub
 Google Cloud Platform
-GCS
-HashiCorp
-HashiCorp Vault
-Hightouch
 HIPAA
 HPC
+HashiCorp
+HashiCorp Vault
 Helm
+Hightouch
 Hudi
-IAM
 IAM
 JavaScript
 Jupyter
-Meltano
 Lakehouse
 Looker
-MLflow
 MLOps
+MLflow
+Meltano
 Microsoft Teams
 MongoDB
 MySQL
-Okta
 OLAP
 OLTP
+Okta
 OneLogin
-OpenAI
 Open Metadata
-Pandas
+OpenAI
 PEX
 PagerDuty
+Pandas
 Pandera
 PingOne
 Postgres
@@ -86,15 +83,15 @@ RDS
 REST API
 SCIM
 SDF
-Secoda
 SFTP
 SHA
 SLA
 SLAs
 SOC
-Spark
 SSH
+Secoda
 Snowflake
+Spark
 Tensorflow
 Trino
 Twilio
@@ -109,10 +106,12 @@ Weights & Biases
 [Ss]ubprocess
 \bDagster\b
 auditable
+chatbot
 composable
 dagster-.*
 dbt
 dbt Cloud
+deserialize
 dlt
 enqueue[ds]
 frontmatter
@@ -130,5 +129,6 @@ stdout
 substep
 toolchain
 uncomment
+unpartitioned
 vCPU
 vCPUs


### PR DESCRIPTION
## Summary & Motivation

- Fixes broken vale linter
    * Missing `-` in front matter
    * Adds unpartitioned and unserialized words to our `accept.txt`
    * Sorted the `accept.txt` file

## How I Tested These Changes

```
yarn vale
```

## Changelog

NOCHANGELOG