### PR TITLE
[docs-revamp] fix build by replacing missing images with placeholder.svg

### DIFF
--- a/docs/docs-beta/docs/guides/configuring-assets.md
+++ b/docs/docs-beta/docs/guides/configuring-assets.md
@@ -36,12 +36,11 @@ When launching a run using the Launchpad in the UI, you can provide a run config
 
 On any page with a **Materialize** button, click the **options menu > Open launchpad** to access the Launchpad:
 
-![Highlighted Open Launchpad option in the Materialize options menu of the Dagster UI](/images/build/access-launchpad.png)
+![Highlighted Open Launchpad option in the Materialize options menu of the Dagster UI](/img/placeholder.svg)
 
 This will open the Launchpad, where you can scaffold the config, customize its values, and manually materialize the asset:
 
-![Dagster Launchpad that configures an asset to have a lookback window of 7 days](/images/build/config-launchpad.png)
-
+![Dagster Launchpad that configures an asset to have a lookback window of 7 days](/img/placeholder.svg)
 
 ## Next steps
 


### PR DESCRIPTION
## Summary & Motivation

- Missing images were causing the Vercel deployment to fail; this replaces them with `placeholder.svg`

## How I Tested These Changes

## Changelog

NOCHANGELOG
