### PR TITLE
[graphql] fix issue with instigator state

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
@@ -5,6 +5,7 @@ from dagster._core.definitions.instigation_logger import get_instigation_log_rec
 from dagster._core.definitions.selector import InstigatorSelector
 from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR
 from dagster._core.remote_representation.external import CompoundID
+from dagster._core.scheduler.instigation import InstigatorStatus
 
 if TYPE_CHECKING:
     from dagster_graphql.schema.instigation import (
@@ -32,7 +33,9 @@ def get_instigator_state_by_selector(
             origin_id=instigator_id.external_origin_id,
             selector_id=instigator_id.selector_id,
         )
-        if state:
+        # if the state tells us the status on its own short cut and return it
+        # if its declared in code we need the full snapshot to resolve
+        if state and state.status in (InstigatorStatus.STOPPED, InstigatorStatus.RUNNING):
             return GrapheneInstigationState(state)
 
     location = graphene_info.context.get_code_location(selector.location_name)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_sensors.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_sensors.ambr
@@ -364,6 +364,26 @@
     dict({
       'description': None,
       'minIntervalSeconds': 30,
+      'name': 'stopped_in_code_sensor',
+      'sensorState': dict({
+        'runs': list([
+        ]),
+        'runsCount': 0,
+        'status': 'STOPPED',
+        'ticks': list([
+        ]),
+      }),
+      'targets': list([
+        dict({
+          'mode': 'default',
+          'pipelineName': 'no_config_job',
+          'solidSelection': None,
+        }),
+      ]),
+    }),
+    dict({
+      'description': None,
+      'minIntervalSeconds': 30,
       'name': 'the_failure_sensor',
       'sensorState': dict({
         'runs': list([

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1191,6 +1191,13 @@ def define_sensors():
             tags={"test": "1234"},
         )
 
+    @sensor(job_name="no_config_job", default_status=DefaultSensorStatus.STOPPED)
+    def stopped_in_code_sensor(_):
+        return RunRequest(
+            run_key=None,
+            tags={"test": "1234"},
+        )
+
     @sensor(job_name="no_config_job")
     def logging_sensor(context):
         context.log.info("hello hello")
@@ -1248,6 +1255,7 @@ def define_sensors():
         multi_no_config_sensor,
         custom_interval_sensor,
         running_in_code_sensor,
+        stopped_in_code_sensor,
         logging_sensor,
         update_cursor_sensor,
         run_status,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -528,6 +528,22 @@ query TickDynamicPartitionsRequestResultsQuery($sensorSelector: SensorSelector!)
 }
 """
 
+INSTIGATION_STATE_QUERY = """
+query InstigationStateQuery($instigationSelector: InstigationSelector! $id: String) {
+  instigationStateOrError(instigationSelector: $instigationSelector id: $id) {
+    __typename
+    ... on PythonError {
+      message
+      stack
+    }
+    ... on InstigationState {
+        id
+        status
+    }
+  }
+}
+"""
+
 
 class TestSensors(NonLaunchableGraphQLContextTestMatrix):
     @pytest.mark.parametrize(
@@ -1037,6 +1053,92 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
         assert instigator_state.status == InstigatorStatus.DECLARED_IN_CODE
         assert start_result.data["resetSensor"]["canReset"] is False
         assert start_result.data["resetSensor"]["sensorState"]["status"] == "RUNNING"
+
+    def test_sensor_with_default_status_stopped(self, graphql_context: WorkspaceRequestContext):
+        sensor_selector = infer_sensor_selector(graphql_context, "stopped_in_code_sensor")
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_SENSOR_STATUS_QUERY,
+            variables={"sensorSelector": sensor_selector},
+        )
+
+        assert result.data["sensorOrError"]["defaultStatus"] == "STOPPED"
+        assert result.data["sensorOrError"]["canReset"] is False
+        assert result.data["sensorOrError"]["sensorState"]["status"] == "STOPPED"
+        assert result.data["sensorOrError"]["sensorState"]["hasStartPermission"] is True
+        assert result.data["sensorOrError"]["sensorState"]["hasStopPermission"] is True
+
+        sensor_id = result.data["sensorOrError"]["sensorState"]["id"]
+        instigation_selector = {
+            "name": sensor_selector["sensorName"],
+            "repositoryLocationName": sensor_selector["repositoryLocationName"],
+            "repositoryName": sensor_selector["repositoryName"],
+        }
+        state_result = execute_dagster_graphql(
+            graphql_context,
+            INSTIGATION_STATE_QUERY,
+            variables={
+                "instigationSelector": instigation_selector,
+                "id": sensor_id,
+            },
+        )
+        assert state_result.data["instigationStateOrError"]["__typename"] == "InstigationState"
+        assert state_result.data["instigationStateOrError"]["status"] == "STOPPED"
+
+        stop_result = execute_dagster_graphql(
+            graphql_context,
+            START_SENSORS_QUERY,
+            variables={"sensorSelector": sensor_selector},
+        )
+
+        assert stop_result.data["startSensor"]["sensorState"]["status"] == "RUNNING"
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_SENSOR_STATUS_QUERY,
+            variables={"sensorSelector": sensor_selector},
+        )
+
+        assert result.data["sensorOrError"]["canReset"] is True
+
+        state_result = execute_dagster_graphql(
+            graphql_context,
+            INSTIGATION_STATE_QUERY,
+            variables={
+                "instigationSelector": instigation_selector,
+                "id": sensor_id,
+            },
+        )
+        assert state_result.data["instigationStateOrError"]["__typename"] == "InstigationState"
+        assert state_result.data["instigationStateOrError"]["status"] == "RUNNING"
+
+        # Now can be restarted
+        start_result = execute_dagster_graphql(
+            graphql_context,
+            RESET_SENSORS_QUERY,
+            variables={"sensorSelector": sensor_selector},
+        )
+
+        cid = CompoundID.from_string(sensor_id)
+        instigator_state = graphql_context.instance.get_instigator_state(
+            cid.external_origin_id, cid.selector_id
+        )
+
+        assert instigator_state
+        assert instigator_state.status == InstigatorStatus.DECLARED_IN_CODE
+        assert start_result.data["resetSensor"]["canReset"] is False
+        assert start_result.data["resetSensor"]["sensorState"]["status"] == "STOPPED"
+
+        state_result = execute_dagster_graphql(
+            graphql_context,
+            INSTIGATION_STATE_QUERY,
+            variables={
+                "instigationSelector": instigation_selector,
+                "id": sensor_id,
+            },
+        )
+        assert state_result.data["instigationStateOrError"]["__typename"] == "InstigationState"
+        assert state_result.data["instigationStateOrError"]["status"] == "STOPPED"
 
 
 def test_sensor_next_ticks(graphql_context: WorkspaceRequestContext):


### PR DESCRIPTION
due to modifications to the state made by `get_current_instigator_state` we can only short cut return if the persisted state entry is on or off

## How I Tested These Changes

added test that previously failed 

## Changelog

[dagster-webserver] Fix an issue where the incorrect sensor/schedule state would appear when using `DefaultScheduleStatus.STOPPED` / `DefaultSensorStatus.STOPPED` after performing a reset 

- [X] `BUGFIX`
