### PR TITLE
[ui] Fix edit cursor save state

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/EditCursorDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/EditCursorDialog.tsx
@@ -35,13 +35,12 @@ export const EditCursorDialog = ({
   onClose: () => void;
 }) => {
   const [cursorValue, setCursorValue] = useState(cursor);
-  const [isSaving, setIsSaving] = useState(false);
-  const [requestSet] = useMutation<SetSensorCursorMutation, SetSensorCursorMutationVariables>(
-    SET_CURSOR_MUTATION,
-  );
+  const [requestSet, {loading: isSaving}] = useMutation<
+    SetSensorCursorMutation,
+    SetSensorCursorMutationVariables
+  >(SET_CURSOR_MUTATION);
 
   const onSave = async () => {
-    setIsSaving(true);
     const {data} = await requestSet({
       variables: {sensorSelector, cursor: cursorValue},
     });


### PR DESCRIPTION
## Summary & Motivation

We're not resetting the loading state on the edit-cursor mutation on sensors, so if you edit the sensor, then open the dialog again, the save button is never re-enabled.

Fix this by using the `loading` value from the mutation itself, instead of a separate state value.

## How I Tested These Changes

Edit a sensor cursor, save it. Verify brief loading state, success of the save mutatation, dialog closure, and toaster. Reopen dialog, verify that the button is enabled and I can save a new value.

## Changelog

- [ ] `BUGFIX` [ui] Fixed a bug where it was not possible to update a sensor cursor more than once in a single page view.