### PR TITLE
refactor(looker): rename `DagsterLookerTranslator` to `DagsterLookerLkmlTranslator`

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-looker.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-looker.rst
@@ -14,4 +14,4 @@ Assets
 
 .. autofunction:: build_looker_asset_specs
 
-.. autoclass:: DagsterLookerTranslator
+.. autoclass:: DagsterLookerLkmlTranslator

--- a/python_modules/libraries/dagster-looker/dagster_looker/__init__.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/__init__.py
@@ -2,8 +2,8 @@ from dagster._core.libraries import DagsterLibraryRegistry
 
 from dagster_looker.api.resource import LookerResource as LookerResource
 from dagster_looker.lkml.asset_specs import build_looker_asset_specs as build_looker_asset_specs
-from dagster_looker.lkml.dagster_looker_translator import (
-    DagsterLookerTranslator as DagsterLookerTranslator,
+from dagster_looker.lkml.dagster_looker_lkml_translator import (
+    DagsterLookerLkmlTranslator as DagsterLookerLkmlTranslator,
     LookMLStructureType as LookMLStructureType,
 )
 from dagster_looker.version import __version__ as __version__

--- a/python_modules/libraries/dagster-looker/dagster_looker/lkml/asset_specs.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/lkml/asset_specs.py
@@ -9,14 +9,14 @@ from dagster_looker.lkml.asset_utils import (
     build_looker_explore_specs,
     build_looker_view_specs,
 )
-from dagster_looker.lkml.dagster_looker_translator import DagsterLookerTranslator
+from dagster_looker.lkml.dagster_looker_lkml_translator import DagsterLookerLkmlTranslator
 
 
 @experimental
 def build_looker_asset_specs(
     *,
     project_dir: Path,
-    dagster_looker_translator: Optional[DagsterLookerTranslator] = None,
+    dagster_looker_translator: Optional[DagsterLookerLkmlTranslator] = None,
 ) -> Sequence[AssetSpec]:
     """Build a list of asset specs from a set of Looker structures defined in a Looker project.
 
@@ -37,7 +37,7 @@ def build_looker_asset_specs(
             looker_specs = build_looker_asset_specs(project_dir=Path("my_looker_project"))
             looker_assets = external_assets_from_specs(looker_specs)
     """
-    dagster_looker_translator = dagster_looker_translator or DagsterLookerTranslator()
+    dagster_looker_translator = dagster_looker_translator or DagsterLookerLkmlTranslator()
 
     specs = [
         *build_looker_dashboard_specs(project_dir, dagster_looker_translator),

--- a/python_modules/libraries/dagster-looker/dagster_looker/lkml/asset_utils.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/lkml/asset_utils.py
@@ -5,12 +5,12 @@ import lkml
 import yaml
 from dagster import AssetSpec
 
-from dagster_looker.lkml.dagster_looker_translator import DagsterLookerTranslator
+from dagster_looker.lkml.dagster_looker_lkml_translator import DagsterLookerLkmlTranslator
 
 
 def build_looker_dashboard_specs(
     project_dir: Path,
-    dagster_looker_translator: DagsterLookerTranslator,
+    dagster_looker_translator: DagsterLookerLkmlTranslator,
 ) -> Sequence[AssetSpec]:
     looker_dashboard_specs: List[AssetSpec] = []
 
@@ -36,7 +36,7 @@ def build_looker_dashboard_specs(
 
 def build_looker_explore_specs(
     project_dir: Path,
-    dagster_looker_translator: DagsterLookerTranslator,
+    dagster_looker_translator: DagsterLookerLkmlTranslator,
 ) -> Sequence[AssetSpec]:
     looker_explore_specs: List[AssetSpec] = []
 
@@ -62,7 +62,7 @@ def build_looker_explore_specs(
 
 def build_looker_view_specs(
     project_dir: Path,
-    dagster_looker_translator: DagsterLookerTranslator,
+    dagster_looker_translator: DagsterLookerLkmlTranslator,
 ) -> Sequence[AssetSpec]:
     looker_view_specs: List[AssetSpec] = []
 

--- a/python_modules/libraries/dagster-looker/dagster_looker/lkml/dagster_looker_lkml_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/lkml/dagster_looker_lkml_translator.py
@@ -15,7 +15,7 @@ logger = logging.getLogger("dagster_looker")
 
 
 def build_deps_for_looker_dashboard(
-    dagster_looker_translator: "DagsterLookerTranslator",
+    dagster_looker_translator: "DagsterLookerLkmlTranslator",
     lookml_structure: Tuple[Path, LookMLStructureType, Mapping[str, Any]],
 ) -> Sequence[AssetKey]:
     lookml_view_path, _, lookml_dashboard_props = lookml_structure
@@ -41,7 +41,7 @@ def build_deps_for_looker_dashboard(
 
 
 def build_deps_for_looker_explore(
-    dagster_looker_translator: "DagsterLookerTranslator",
+    dagster_looker_translator: "DagsterLookerLkmlTranslator",
     lookml_structure: Tuple[Path, LookMLStructureType, Mapping[str, Any]],
 ) -> Sequence[AssetKey]:
     lookml_explore_path, _, lookml_explore_props = lookml_structure
@@ -69,7 +69,7 @@ def build_deps_for_looker_explore(
 
 
 def build_deps_for_looker_view(
-    dagster_looker_translator: "DagsterLookerTranslator",
+    dagster_looker_translator: "DagsterLookerLkmlTranslator",
     lookml_structure: Tuple[Path, LookMLStructureType, Mapping[str, Any]],
 ) -> Sequence[AssetKey]:
     lookml_view_path, _, lookml_view_props = lookml_structure
@@ -147,7 +147,7 @@ def build_deps_for_looker_view(
 
 
 @experimental
-class DagsterLookerTranslator:
+class DagsterLookerLkmlTranslator:
     """Holds a set of methods that derive Dagster asset definition metadata given a representation
     of a LookML structure (dashboards, explores, views).
 

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/lkml/test_asset_specs.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/lkml/test_asset_specs.py
@@ -4,8 +4,8 @@ from typing import Any, Mapping, Optional, Sequence, Tuple
 import pytest
 from dagster import AssetKey, Definitions
 from dagster_looker.lkml.asset_specs import build_looker_asset_specs
-from dagster_looker.lkml.dagster_looker_translator import (
-    DagsterLookerTranslator,
+from dagster_looker.lkml.dagster_looker_lkml_translator import (
+    DagsterLookerLkmlTranslator,
     LookMLStructureType,
 )
 
@@ -296,7 +296,7 @@ def test_asset_deps_exception_derived_table(caplog: pytest.LogCaptureFixture) ->
 
 
 def test_with_asset_key_replacements() -> None:
-    class CustomDagsterLookerTranslator(DagsterLookerTranslator):
+    class CustomDagsterLookerTranslator(DagsterLookerLkmlTranslator):
         def get_asset_key(
             self, lookml_structure: Tuple[Path, LookMLStructureType, Mapping[str, Any]]
         ) -> AssetKey:
@@ -314,7 +314,7 @@ def test_with_asset_key_replacements() -> None:
 
 
 def test_with_deps_replacements() -> None:
-    class CustomDagsterLookerTranslator(DagsterLookerTranslator):
+    class CustomDagsterLookerTranslator(DagsterLookerLkmlTranslator):
         def get_deps(self, _) -> Sequence[AssetKey]:
             return []
 
@@ -330,7 +330,7 @@ def test_with_deps_replacements() -> None:
 def test_with_description_replacements() -> None:
     expected_description = "customized description"
 
-    class CustomDagsterLookerTranslator(DagsterLookerTranslator):
+    class CustomDagsterLookerTranslator(DagsterLookerLkmlTranslator):
         def get_description(self, _) -> Optional[str]:
             return expected_description
 
@@ -346,7 +346,7 @@ def test_with_description_replacements() -> None:
 def test_with_metadata_replacements() -> None:
     expected_metadata = {"customized": "metadata"}
 
-    class CustomDagsterLookerTranslator(DagsterLookerTranslator):
+    class CustomDagsterLookerTranslator(DagsterLookerLkmlTranslator):
         def get_metadata(self, _) -> Optional[Mapping[str, Any]]:
             return expected_metadata
 
@@ -362,7 +362,7 @@ def test_with_metadata_replacements() -> None:
 def test_with_group_replacements() -> None:
     expected_group = "customized_group"
 
-    class CustomDagsterLookerTranslator(DagsterLookerTranslator):
+    class CustomDagsterLookerTranslator(DagsterLookerLkmlTranslator):
         def get_group_name(self, _) -> Optional[str]:
             return expected_group
 
@@ -378,7 +378,7 @@ def test_with_group_replacements() -> None:
 def test_with_owner_replacements() -> None:
     expected_owners = ["custom@custom.com"]
 
-    class CustomDagsterLookerTranslator(DagsterLookerTranslator):
+    class CustomDagsterLookerTranslator(DagsterLookerLkmlTranslator):
         def get_owners(self, _) -> Optional[Sequence[str]]:
             return expected_owners
 
@@ -394,7 +394,7 @@ def test_with_owner_replacements() -> None:
 def test_with_tag_replacements() -> None:
     expected_tags = {"customized": "tag"}
 
-    class CustomDagsterLookerTranslator(DagsterLookerTranslator):
+    class CustomDagsterLookerTranslator(DagsterLookerLkmlTranslator):
         def get_tags(self, _) -> Optional[Mapping[str, str]]:
             return expected_tags
 


### PR DESCRIPTION
## Summary & Motivation
We want to pave the way for a `DagsterLookerAPITranslator`. So start by clarifying the role of the existing `DagsterLookerTranslator` to be explicitly for `lkml`.

## How I Tested These Changes
existing pytest

## Changelog
NOCHANGELOG