### PR TITLE
[docs-revamp] introduce announcement bar

### DIFF
--- a/docs/docs-beta/docusaurus.config.ts
+++ b/docs/docs-beta/docusaurus.config.ts
@@ -27,7 +27,7 @@ const config: Config = {
   themeConfig: {
     announcementBar: {
       id: 'announcementBar',
-      content: `<b>This is the preview of the new documentation site. If you have any feedback, please let us know on <a target="_blank" href="https://github.com/dagster-io/dagster/issues/new/choose">GitHub</a>. The legacy documentation can be found at <a target="_blank" href="https://docs.dagster.io/">docs.dagster.io</a>.</b>`,
+      content: `<b>This is the preview of the new documentation site. If you have any feedback, please let us know on <a target="_blank" href="https://github.com/dagster-io/dagster/discussions/23031">GitHub</a>. The current documentation can be found at <a target="_blank" href="https://docs.dagster.io/">docs.dagster.io</a>.</b>`,
     },
     colorMode: {
       defaultMode: 'light',

--- a/docs/docs-beta/docusaurus.config.ts
+++ b/docs/docs-beta/docusaurus.config.ts
@@ -25,6 +25,10 @@ const config: Config = {
     require.resolve('docusaurus-plugin-image-zoom'),
   ],
   themeConfig: {
+    announcementBar: {
+      id: 'announcementBar',
+      content: `<b>You are viewing a preview of our new docs site. If you have any feedback, please let us know on <a target="_blank" href="https://github.com/dagster-io/dagster/issues/new/choose">GitHub</a>. If you are looking for the legacy docs, go <a target="_blank" href="https://docs.dagster.io/">here</a>!</b>`,
+    },
     colorMode: {
       defaultMode: 'light',
       disableSwitch: false,

--- a/docs/docs-beta/docusaurus.config.ts
+++ b/docs/docs-beta/docusaurus.config.ts
@@ -27,7 +27,9 @@ const config: Config = {
   themeConfig: {
     announcementBar: {
       id: 'announcementBar',
-      content: `<b>This is the preview of the new documentation site. If you have any feedback, please let us know on <a target="_blank" href="https://github.com/dagster-io/dagster/discussions/23031">GitHub</a>. The current documentation can be found at <a target="_blank" href="https://docs.dagster.io/">docs.dagster.io</a>.</b>`,
+      // TODO - once discussion has been created update link
+      //content: `<b>This is the preview of the new documentation site. If you have any feedback, please let us know on <a target="_blank" href="https://github.com/dagster-io/dagster/discussions/23031">GitHub</a>. The current documentation can be found at <a target="_blank" href="https://docs.dagster.io/">docs.dagster.io</a>.</b>`,
+      content: `<b>This is the preview of the new documentation site. The current documentation can be found at <a target="_blank" href="https://docs.dagster.io/">docs.dagster.io</a>.</b>`,
     },
     colorMode: {
       defaultMode: 'light',

--- a/docs/docs-beta/docusaurus.config.ts
+++ b/docs/docs-beta/docusaurus.config.ts
@@ -27,7 +27,7 @@ const config: Config = {
   themeConfig: {
     announcementBar: {
       id: 'announcementBar',
-      content: `<b>You are viewing a preview of our new docs site. If you have any feedback, please let us know on <a target="_blank" href="https://github.com/dagster-io/dagster/issues/new/choose">GitHub</a>. If you are looking for the legacy docs, go <a target="_blank" href="https://docs.dagster.io/">here</a>!</b>`,
+      content: `<b>This is the preview of the new documentation site. If you have any feedback, please let us know on <a target="_blank" href="https://github.com/dagster-io/dagster/issues/new/choose">GitHub</a>. The legacy documentation can be found at <a target="_blank" href="https://docs.dagster.io/">docs.dagster.io</a>.</b>`,
     },
     colorMode: {
       defaultMode: 'light',

--- a/docs/docs-beta/src/styles/custom.scss
+++ b/docs/docs-beta/src/styles/custom.scss
@@ -655,3 +655,9 @@ span {
 .hidden {
   display: none !important;
 }
+
+/* Announcement bar */
+div[class^='announcementBar_'] {
+  height: 40px;
+  background-color: var(--theme-color-background-red);
+}


### PR DESCRIPTION
## Summary & Motivation

- Introduces a warning announcement bar to notify users that work is ongoing

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/bb159df1-a94d-488b-957b-0b402133d210">

## How I Tested These Changes

## Changelog

NOCHANGELOG

