### PR TITLE
default the value of run_ids to None for RunsFilter

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -532,7 +532,7 @@ class RunsFilter(IHaveNew, LegacyNamedTupleMixin):
 
     """
 
-    run_ids: Sequence[str]
+    run_ids: Optional[Sequence[str]]
     job_name: Optional[str]
     statuses: Sequence[DagsterRunStatus]
     tags: Mapping[str, Union[str, Sequence[str]]]
@@ -558,7 +558,7 @@ class RunsFilter(IHaveNew, LegacyNamedTupleMixin):
 
         return super().__new__(
             cls,
-            run_ids=run_ids or [],
+            run_ids=run_ids,
             job_name=job_name,
             statuses=statuses or [],
             tags=tags or {},


### PR DESCRIPTION
## Summary & Motivation
this change is motivated by some work i'm doing on the runs feed where i need to replace one of the values in the RunsFilter. However, the current `__new__` for the runs filter assigns `[]` as the value for `run_ids` if None is passed. When `copy(filters, created_before=updated_created_before)` is called, a new `RunsFilter` is constructed with `[]` passed as the value for `run_ids` which causes the `check` to fail. 

associated internal pr https://github.com/dagster-io/internal/pull/11683


## How I Tested These Changes
existing tests

## Changelog

NOCHANGELOG
