### PR TITLE
remove state for removed schedules

### DIFF
--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -340,13 +340,11 @@ def launch_scheduled_runs(
             # don't clean up state if its last iteration time is within a grace period
             continue
 
-        # don't clean up state if its location is an error state
-        if location_name not in error_locations:
-            logger.info(
-                f"Removing state for schedule {state.instigator_name} that is "
-                f"no longer present in {location_name}."
-            )
-            instance.delete_instigator_state(state.instigator_origin_id, state.selector_id)
+        logger.info(
+            f"Removing state for schedule {state.instigator_name} that is "
+            f"no longer present in {location_name}."
+        )
+        instance.delete_instigator_state(state.instigator_origin_id, state.selector_id)
 
     if not running_schedules:
         yield

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -310,22 +310,21 @@ def launch_scheduled_runs(
         elif location_entry.load_error:
             error_locations.add(location_entry.origin.location_name)
 
-    # Remove any schedule states that were previously created with DECLARED_IN_CODE
-    # and can no longer be found in the workspace (so that if they are later added
-    # back again, their timestamps will start at the correct place)
+    # Remove any schedule states that were previously created and can no longer
+    # be found in the workspace (so that if they are later added back again,
+    # their timestamps will start at the correct place)
     states_to_delete = [
         schedule_state
         for selector_id, schedule_state in all_schedule_states.items()
         if selector_id not in schedules
-        and schedule_state.status == InstigatorStatus.DECLARED_IN_CODE
     ]
     for state in states_to_delete:
         location_name = state.origin.repository_origin.code_location_origin.location_name
-        # don't clean up auto running state if its location is an error state
+        # don't clean up state if its location is an error state
         if location_name not in error_locations:
             logger.info(
-                f"Removing state for automatically running schedule {state.instigator_name} "
-                f"that is no longer present in {location_name}."
+                f"Removing state for schedule {state.instigator_name} that is "
+                f"no longer present in {location_name}."
             )
             instance.delete_instigator_state(state.instigator_origin_id, state.selector_id)
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -818,26 +818,26 @@ def test_removing_schedule_state(instance: DagsterInstance, executor: ThreadPool
         ).code_location
         assert code_location
         external_repo = code_location.get_repository("the_repo")
-        running_schedule = external_repo.get_external_schedule("simple_schedule")
-        stopped_schedule = external_repo.get_external_schedule("simple_schedule_no_timezone")
+        running_schedule = external_repo.get_schedule("simple_schedule")
+        stopped_schedule = external_repo.get_schedule("simple_schedule_no_timezone")
 
         assert len(instance.all_instigator_state()) == 0
 
         def _get_ticks(external_schedule):
             return instance.get_ticks(
-                external_schedule.get_external_origin().get_id(), external_schedule.selector_id
+                external_schedule.get_remote_origin().get_id(), external_schedule.selector_id
             )
 
         def _get_state(external_schedule):
             return instance.get_instigator_state(
-                external_schedule.get_external_origin().get_id(), external_schedule.selector_id
+                external_schedule.get_remote_origin().get_id(), external_schedule.selector_id
             )
 
         with freeze_time(initial_datetime):
             instance.start_schedule(running_schedule)
             instance.start_schedule(stopped_schedule)
             instance.stop_schedule(
-                stopped_schedule.get_external_origin().get_id(),
+                stopped_schedule.get_remote_origin().get_id(),
                 stopped_schedule.selector_id,
                 stopped_schedule,
             )
@@ -1080,13 +1080,6 @@ def test_status_in_code_schedule(instance: DagsterInstance, executor: ThreadPool
         with freeze_time(freeze_datetime):
             # The schedule remains, within the 12h grace period
             evaluate_schedules(empty_workspace_ctx, executor, get_current_datetime())
-            assert len(instance.all_instigator_state()) == 1
-
-        # The ticks remain, but the schedule state is removed
-        with freeze_time(day_after_last_evaluation):
-            evaluate_schedules(empty_workspace_ctx, executor, get_current_datetime())
-            ticks = instance.get_ticks(always_running_origin.get_id(), running_schedule.selector_id)
-            assert len(ticks) == 2
             assert len(instance.all_instigator_state()) == 0
 
 


### PR DESCRIPTION
## Summary & Motivation
Make more consistent the behavior of schedules removed from (and thus added back to) code locations.

This PR wipes schedule state for schedules removed from code locations.

The schedule state row contains:
1) the status of the schedule (e.g. on/off)
2) the start time of the schedule (should we try to go back and make up for missed ticks in the recent past)

This does NOT affect tick history.

## How I Tested These Changes
BK

## Changelog

- [ ] `BUGFIX` Removing a schedule from the workspace now eventually clears (after a configurable grace period) from the DB the started/stopped state and the start time for that schedule.  Previously, this was only true for schedules whose status was set in code and not manually overridden.  This caused confusing situations where schedules could be manually turned on, removed from its code location, then added back to the code location at a later date.  The schedule, instead of using its default status, would inherit the status from before (when the schedule was previously part of the code location).
