### PR TITLE
[rfc] Add AssetSelection.from_definitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -2,9 +2,8 @@ import collections.abc
 import operator
 from abc import ABC, abstractmethod
 from functools import reduce
-from typing import AbstractSet, Iterable, List, Optional, Sequence, Union, cast
+from typing import TYPE_CHECKING, AbstractSet, Iterable, List, Optional, Sequence, Union, cast
 
-from dagster._core.definitions.definitions_class import Definitions
 from typing_extensions import TypeAlias, TypeGuard
 
 import dagster._check as check
@@ -30,6 +29,9 @@ from dagster._core.selector.subset_selector import (
 )
 from dagster._model import DagsterModel
 from dagster._serdes.serdes import whitelist_for_serdes
+
+if TYPE_CHECKING:
+    from dagster._core.definitions.definitions_class import Definitions
 
 CoercibleToAssetSelection: TypeAlias = Union[
     str,
@@ -150,7 +152,7 @@ class AssetSelection(ABC, DagsterModel):
 
     @public
     @staticmethod
-    def from_definitions(defs: Definitions) -> "AssetSelection":
+    def from_definitions(defs: "Definitions") -> "AssetSelection":
         """Returns a selection that includes all of the assets and asset checks in a
         Definitions object.
 
@@ -165,8 +167,10 @@ class AssetSelection(ABC, DagsterModel):
                 AssetSelection.from_definitions(my_definitions)
 
         """
-        graph= defs.get_asset_graph()
-        return AssetSelection.assets(*graph.all_asset_keys) | AssetSelection.checks(*graph.asset_check_keys)
+        graph = defs.get_asset_graph()
+        return AssetSelection.assets(*graph.all_asset_keys) | AssetSelection.checks(
+            *graph.asset_check_keys
+        )
 
     @public
     @staticmethod

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from functools import reduce
 from typing import AbstractSet, Iterable, List, Optional, Sequence, Union, cast
 
+from dagster._core.definitions.definitions_class import Definitions
 from typing_extensions import TypeAlias, TypeGuard
 
 import dagster._check as check
@@ -146,6 +147,26 @@ class AssetSelection(ABC, DagsterModel):
                 )
 
         return KeysAssetSelection(selected_keys=selected_keys)
+
+    @public
+    @staticmethod
+    def from_definitions(defs: Definitions) -> "AssetSelection":
+        """Returns a selection that includes all of the assets and asset checks in a
+        Definitions object.
+
+        Args:
+            defs (Definitions): The definitions to select.
+
+        Examples:
+            .. code-block:: python
+
+                my_definitions = Definitions(...)
+
+                AssetSelection.from_definitions(my_definitions)
+
+        """
+        graph= defs.get_asset_graph()
+        return AssetSelection.assets(*graph.all_asset_keys) | AssetSelection.checks(*graph.asset_check_keys)
 
     @public
     @staticmethod

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -43,6 +43,7 @@ from dagster._core.definitions.asset_selection import (
 )
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
+from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetKey
 from dagster._serdes import deserialize_value
 from dagster._serdes.serdes import _WHITELIST_MAP
@@ -144,6 +145,16 @@ def test_asset_selection_all(all_assets: _AssetList):
 def test_asset_selection_and(all_assets: _AssetList):
     sel = AssetSelection.assets("alice", "bob") & AssetSelection.assets("bob", "candace")
     assert sel.resolve(all_assets) == _asset_keys_of({bob})
+
+
+def test_asset_selection_definitions(all_assets: _AssetList):
+    my_defs = Definitions(assets=[earth, alice, bob])
+    sel = AssetSelection.from_definitions(my_defs)
+    assert sel.resolve(all_assets) == _asset_keys_of([earth, alice, bob])
+
+    my_other_defs = Definitions(assets=[zebra])
+    sel = sel | AssetSelection.from_definitions(my_other_defs)
+    assert sel.resolve(all_assets) == _asset_keys_of([earth, alice, bob, zebra])
 
 
 def test_asset_selection_downstream(all_assets: _AssetList):

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_selection.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_selection.py
@@ -10,6 +10,8 @@ from dagster import (
     define_asset_job,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSpec
+from dagster._core.definitions.asset_graph import AssetGraph
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 from dagster._core.errors import DagsterInvalidSubsetError
 
@@ -82,6 +84,20 @@ def test_job_with_asset_and_all_its_checks():
     assert {check_eval.asset_check_key for check_eval in check_evals} == {
         AssetCheckKey(asset1.key, "asset1_check1"),
         AssetCheckKey(asset1.key, "asset1_check2"),
+    }
+
+
+def test_asset_selection_definitions() -> None:
+    my_defs = Definitions(assets=[asset1])
+    sel = AssetSelection.from_definitions(my_defs)
+    assert sel.resolve([asset1, asset2, asset1_check1, asset1_check2, asset2_check1]) == {
+        AssetKey("asset1")
+    }
+    assert sel.resolve_checks(
+        AssetGraph.from_assets([asset1, asset2, asset1_check1, asset1_check2, asset2_check1])
+    ) == {
+        AssetCheckKey(AssetKey("asset1"), "asset1_check1"),
+        AssetCheckKey(AssetKey("asset1"), "asset1_check2"),
     }
 
 


### PR DESCRIPTION
## Summary

Introduces `AssetSelection.from_definitions(my_defs)`, which produces a selection that selects all assets and checks from the given `Definitions` object.

This feels much "safer" to recommend than `AssetSelection.all` in a world where the list of assets is unclear - does `.all` select all assets in the `Definitions` object that the schedule is defined in, or in the entire code location? Users might expect the former but get the latter.

Motivated by an Airlift use-case:
```python
merged_defs = Definitions.merge(
    load_csv_to_duckdb_defs(
       ...
    ),
    dbt_defs(
       ...
    ),
    export_duckdb_to_csv_defs(
       ...
    ),
)

rebuild_customers_list_schedule = ScheduleDefinition(
    name="rebuild_customers_list_schedule",
    target=AssetSelection.from_definitions(merged_defs),
    # Alternative is AssetSelection.assets(*merged_defs.get_asset_graph().all_asset_keys),
    cron_schedule="0 0 * * *",
)

return Definitions.merge(
    merged_defs,
    Definitions(schedules=[rebuild_customers_list_schedule]),
)


```

## Test Plan

Few unit tests
