### PR TITLE
[docs-revamp] hide table of contents on landing page

### DIFF
--- a/docs/docs-beta/docs/intro.md
+++ b/docs/docs-beta/docs/intro.md
@@ -3,6 +3,7 @@ title: Overview
 description: Dagster's Documentation
 slug: /
 displayed_sidebar: 'docs'
+hide_table_of_contents: true
 ---
 
 import { Card, CardGroup } from '@site/src/components/Cards';


### PR DESCRIPTION
## Summary & Motivation

Before:
<img width="1912" alt="image" src="https://github.com/user-attachments/assets/ab7696f5-0b68-4346-a54d-a67169328e75">

After:
<img width="1916" alt="image" src="https://github.com/user-attachments/assets/dbd56180-36c0-46e8-9a1e-2e252ca21a50">

## How I Tested These Changes

## Changelog

NOCHANGELOG