### PR TITLE
[docs] Clarify that monitor_all_code_locations is scoped to a deployment

### DIFF
--- a/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
+++ b/docs/content/concepts/partitions-schedules-sensors/sensors.mdx
@@ -627,7 +627,7 @@ def code_location_a_data_update_failure_sensor():
     send_slack_alert()
 ```
 
-You can also monitor every job in your Dagster instance by specifying `monitor_all_code_locations=True` on the sensor decorator. Note that `monitor_all_code_locations` cannot be used along with jobs specified via `monitored_jobs`.
+You can also monitor every job in your Dagster deployment by specifying `monitor_all_code_locations=True` on the sensor decorator. Note that `monitor_all_code_locations` cannot be used along with jobs specified via `monitored_jobs`.
 
 ```python file=/concepts/partitions_schedules_sensors/sensors/sensors.py startafter=start_instance_sensor endbefore=end_instance_sensor
 @run_status_sensor(
@@ -635,7 +635,7 @@ You can also monitor every job in your Dagster instance by specifying `monitor_a
     run_status=DagsterRunStatus.SUCCESS,
 )
 def sensor_monitor_all_code_locations():
-    # when any job in the Dagster instance succeeds, this sensor will trigger
+    # when any job in the Dagster deployment succeeds, this sensor will trigger
     send_slack_alert()
 ```
 

--- a/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
+++ b/examples/docs_snippets/docs_snippets/concepts/partitions_schedules_sensors/sensors/sensors.py
@@ -253,7 +253,7 @@ def code_location_a_data_update_failure_sensor():
     run_status=DagsterRunStatus.SUCCESS,
 )
 def sensor_monitor_all_code_locations():
-    # when any job in the Dagster instance succeeds, this sensor will trigger
+    # when any job in the Dagster deployment succeeds, this sensor will trigger
     send_slack_alert()
 
 

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -513,7 +513,7 @@ def run_failure_sensor(
             Defaults to None, which means the alert will be sent when any job in the current
             repository fails.
         monitor_all_code_locations (bool): If set to True, the sensor will monitor all runs in the
-            Dagster instance. If set to True, an error will be raised if you also specify
+            Dagster deployment. If set to True, an error will be raised if you also specify
             monitored_jobs or job_selection. Defaults to False.
         job_selection (Optional[List[Union[JobDefinition, GraphDefinition, RepositorySelector, JobSelector, CodeLocationSelector]]]):
             (deprecated in favor of monitored_jobs) The jobs in the current repository that will be
@@ -596,7 +596,7 @@ class RunStatusSensorDefinition(SensorDefinition):
             The jobs in the current repository that will be monitored by this sensor. Defaults to
             None, which means the alert will be sent when any job in the repository fails.
         monitor_all_code_locations (bool): If set to True, the sensor will monitor all runs in the
-            Dagster instance. If set to True, an error will be raised if you also specify
+            Dagster deployment. If set to True, an error will be raised if you also specify
             monitored_jobs or job_selection. Defaults to False.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
             status can be overridden from the Dagster UI or via the GraphQL API.
@@ -1042,7 +1042,7 @@ def run_status_sensor(
             Jobs in the current code locations that will be monitored by this sensor. Defaults to None, which means the alert will
             be sent when any job in the code location matches the requested run_status. Jobs in external repositories can be monitored by using
             RepositorySelector or JobSelector.
-        monitor_all_code_locations (Optional[bool]): If set to True, the sensor will monitor all runs in the Dagster instance.
+        monitor_all_code_locations (Optional[bool]): If set to True, the sensor will monitor all runs in the Dagster deployment.
             If set to True, an error will be raised if you also specify monitored_jobs or job_selection.
             Defaults to False.
         job_selection (Optional[List[Union[JobDefinition, GraphDefinition, RepositorySelector, JobSelector, CodeLocationSelector]]]):

--- a/python_modules/dagster/dagster/_utils/alert.py
+++ b/python_modules/dagster/dagster/_utils/alert.py
@@ -150,7 +150,7 @@ def make_email_on_run_failure_sensor(
             be sent when any job in the repository fails. To monitor jobs in external repositories,
             use RepositorySelector and JobSelector.
         monitor_all_code_locations (bool): If set to True, the sensor will monitor all runs in the
-            Dagster instance. If set to True, an error will be raised if you also specify
+            Dagster deployment. If set to True, an error will be raised if you also specify
             monitored_jobs or job_selection. Defaults to False.
         job_selection (Optional[List[Union[JobDefinition, GraphDefinition, JobDefinition,  RepositorySelector, JobSelector]]]):
             (deprecated in favor of monitored_jobs) The jobs that will be monitored by this failure

--- a/python_modules/libraries/dagster-msteams/dagster_msteams/sensors.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams/sensors.py
@@ -83,7 +83,7 @@ def make_teams_on_run_failure_sensor(
             which means the alert will be sent when any job in the repository matches the requested
             run_status. To monitor jobs in external repositories, use RepositorySelector and JobSelector.
         monitor_all_code_locations (bool): If set to True, the sensor will monitor all runs in the
-            Dagster instance. If set to True, an error will be raised if you also specify
+            Dagster deployment. If set to True, an error will be raised if you also specify
             monitored_jobs or job_selection. Defaults to False.
         webserver_base_url: (Optional[str]): The base url of your webserver instance. Specify this to allow
             messages to include deeplinks to the failed run.

--- a/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack/sensors.py
@@ -181,7 +181,7 @@ def make_slack_on_run_failure_sensor(
             The jobs in the current repository that will be monitored by this failure sensor. Defaults to None, which means the alert will
             be sent when any job in the repository fails.
         monitor_all_code_locations (bool): If set to True, the sensor will monitor all runs in the
-            Dagster instance. If set to True, an error will be raised if you also specify
+            Dagster deployment. If set to True, an error will be raised if you also specify
             monitored_jobs or job_selection. Defaults to False.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
             status can be overridden from Dagit or via the GraphQL API.


### PR DESCRIPTION
## Summary & Motivation
Clarifies scope to a specific deployment. Previous description of applying to Dagster "instance" could be interpreted as applying to all deployments.

## How I Tested These Changes
👀

## Changelog

NOCHANGELOG
