### PR TITLE
feat(looker): implement dashboards as cacheable assets

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker/api/cacheable_assets.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/cacheable_assets.py
@@ -9,7 +9,7 @@ from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
     CacheableAssetsDefinition,
 )
-from looker_sdk.sdk.api40.models import LookmlModelExplore
+from looker_sdk.sdk.api40.models import Dashboard, LookmlModelExplore
 
 from dagster_looker.api.dagster_looker_api_translator import (
     DagsterLookerApiTranslator,
@@ -32,41 +32,73 @@ class LookerCacheableAssetsDefinition(CacheableAssetsDefinition):
 
     def compute_cacheable_data(self) -> Sequence[AssetsDefinitionCacheableData]:
         looker_instance_data = self._looker.fetch_looker_data()
+
         return [
             AssetsDefinitionCacheableData(
                 extra_metadata={
-                    explore_id: (
-                        self._looker.get_sdk()
-                        .serialize(api_model=explore_data)  # type: ignore
-                        .decode()
-                    )
+                    "dashboards_by_id": {
+                        dashboard_id: (
+                            self._looker.get_sdk()
+                            .serialize(api_model=dashboard_data)  # type: ignore
+                            .decode()
+                        )
+                        for dashboard_id, dashboard_data in looker_instance_data.dashboards_by_id.items()
+                    },
+                    "explores_by_id": {
+                        explore_id: (
+                            self._looker.get_sdk()
+                            .serialize(api_model=explore_data)  # type: ignore
+                            .decode()
+                        )
+                        for explore_id, explore_data in looker_instance_data.explores_by_id.items()
+                    },
                 }
             )
-            for explore_id, explore_data in looker_instance_data.explores_by_id.items()
         ]
 
     def build_definitions(
         self,
         data: Sequence[AssetsDefinitionCacheableData],
     ) -> Sequence[AssetsDefinition]:
+        cached_metadata_entries = [check.not_none(entry.extra_metadata) for entry in data]
         looker_instance_data = LookerInstanceData(
             explores_by_id={
                 explore_id: (
                     self._looker.get_sdk().deserialize(
-                        data=explore_data,  # type: ignore
+                        data=serialized_lookml_explore,  # type: ignore
                         structure=LookmlModelExplore,
                     )
                 )
-                for entry in data
-                for explore_id, explore_data in check.not_none(entry.extra_metadata).items()
-            }
+                for cached_metadata in cached_metadata_entries
+                for explore_id, serialized_lookml_explore in cached_metadata[
+                    "explores_by_id"
+                ].items()
+            },
+            dashboards_by_id={
+                dashboard_id: (
+                    self._looker.get_sdk().deserialize(
+                        data=serialized_looker_dashboard,  # type: ignore
+                        structure=Dashboard,
+                    )
+                )
+                for cached_metadata in cached_metadata_entries
+                for dashboard_id, serialized_looker_dashboard in cached_metadata[
+                    "dashboards_by_id"
+                ].items()
+            },
         )
 
         return [
             *external_assets_from_specs(
                 [
-                    self._dagster_looker_translator.get_asset_spec(looker_explore)
-                    for looker_explore in looker_instance_data.explores_by_id.values()
+                    *(
+                        self._dagster_looker_translator.get_asset_spec(lookml_explore)
+                        for lookml_explore in looker_instance_data.explores_by_id.values()
+                    ),
+                    *(
+                        self._dagster_looker_translator.get_asset_spec(looker_dashboard)
+                        for looker_dashboard in looker_instance_data.dashboards_by_id.values()
+                    ),
                 ]
             )
         ]

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
@@ -1,11 +1,11 @@
-from typing import Dict
+from typing import Dict, Union
 
 from dagster import (
     AssetSpec,
     _check as check,
 )
 from dagster._record import record
-from looker_sdk.sdk.api40.models import LookmlModelExplore
+from looker_sdk.sdk.api40.models import Dashboard, DashboardFilter, LookmlModelExplore
 
 
 @record
@@ -13,17 +13,44 @@ class LookerInstanceData:
     """A record representing all content in a Looker instance."""
 
     explores_by_id: Dict[str, LookmlModelExplore]
+    dashboards_by_id: Dict[str, Dashboard]
 
 
 class DagsterLookerApiTranslator:
-    def get_explore_asset_spec(self, lookml_explore: LookmlModelExplore) -> AssetSpec:
+    def get_explore_asset_spec(
+        self, lookml_explore: Union[LookmlModelExplore, DashboardFilter]
+    ) -> AssetSpec:
+        if isinstance(lookml_explore, LookmlModelExplore):
+            return AssetSpec(
+                key=check.not_none(lookml_explore.id),
+                tags={
+                    "dagster/kind/looker": "",
+                    "dagster/kind/explore": "",
+                },
+            )
+        elif isinstance(lookml_explore, DashboardFilter):
+            lookml_model_name = check.not_none(lookml_explore.model)
+            lookml_explore_name = check.not_none(lookml_explore.explore)
+
+            return AssetSpec(key=f"{lookml_model_name}::{lookml_explore_name}")
+
+    def get_dashboard_asset_spec(self, looker_dashboard: Dashboard) -> AssetSpec:
         return AssetSpec(
-            key=check.not_none(lookml_explore.id),
+            key=f"{check.not_none(looker_dashboard.title)}_{looker_dashboard.id}",
+            deps=list(
+                {
+                    self.get_explore_asset_spec(dashboard_filter).key
+                    for dashboard_filter in looker_dashboard.dashboard_filters or []
+                }
+            ),
             tags={
                 "dagster/kind/looker": "",
-                "dagster/kind/explore": "",
+                "dagster/kind/dashboard": "",
             },
         )
 
-    def get_asset_spec(self, api_model: LookmlModelExplore) -> AssetSpec:
-        return self.get_explore_asset_spec(api_model)
+    def get_asset_spec(self, api_model: Union[LookmlModelExplore, Dashboard]) -> AssetSpec:
+        if isinstance(api_model, Dashboard):
+            return self.get_dashboard_asset_spec(api_model)
+        elif isinstance(api_model, LookmlModelExplore):
+            return self.get_explore_asset_spec(api_model)

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/api/mock_looker_data.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/api/mock_looker_data.py
@@ -1,4 +1,11 @@
-from looker_sdk.sdk.api40.models import LookmlModel, LookmlModelExplore, LookmlModelNavExplore
+from looker_sdk.sdk.api40.models import (
+    Dashboard,
+    DashboardBase,
+    DashboardFilter,
+    LookmlModel,
+    LookmlModelExplore,
+    LookmlModelNavExplore,
+)
 
 mock_lookml_models = [
     LookmlModel(
@@ -10,3 +17,16 @@ mock_lookml_models = [
 ]
 
 mock_lookml_explore = LookmlModelExplore(id="my_model::my_explore")
+
+mock_looker_dashboard_bases = [
+    DashboardBase(id="1", hidden=False),
+    DashboardBase(id="2", hidden=True),
+]
+
+mock_looker_dashboard = Dashboard(
+    title="my_dashboard",
+    id="1",
+    dashboard_filters=[
+        DashboardFilter(model="my_model", explore="my_explore"),
+    ],
+)


### PR DESCRIPTION
## Summary & Motivation

Models [Looker dashboards](https://developers.looker.com/api/explorer/4.0/methods/Dashboard/all_dashboards?s=dashboard) as cacheable assets. To get a Looker dashboard's dependencies, we parse out its [dashboard filters](https://developers.looker.com/api/explorer/4.0/methods/Dashboard/dashboard?s=dashboard) for explores.

## How I Tested These Changes
pytest, local

![Screenshot 2024-09-19 at 3.16.15 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/3paPzMeByK6VgE9uQe4F/e795c7cf-9777-48e1-8fcb-453d309fcde6.png)

## Changelog
NOCHANGELOG
