### PR TITLE
Introduce individual package publish Buildkite script

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/cli.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from dagster_buildkite.git import GitInfo
 from dagster_buildkite.pipelines.dagster_oss_main import build_dagster_oss_main_steps
 from dagster_buildkite.pipelines.dagster_oss_nightly_pipeline import build_dagster_oss_nightly_steps
+from dagster_buildkite.pipelines.prerelease_package import build_prerelease_package_steps
 from dagster_buildkite.python_packages import PythonPackages
 from dagster_buildkite.utils import buildkite_yaml_for_steps
 
@@ -23,4 +24,11 @@ def dagster_nightly() -> None:
     PythonPackages.load_from_git(GitInfo(directory=Path(".")))
     steps = build_dagster_oss_nightly_steps()
     buildkite_yaml = buildkite_yaml_for_steps(steps, custom_slack_channel="eng-buildkite-nightly")
+    print(buildkite_yaml)  # noqa: T201
+
+
+def prerelease_package() -> None:
+    PythonPackages.load_from_git(GitInfo(directory=Path(".")))
+    steps = build_prerelease_package_steps()
+    buildkite_yaml = buildkite_yaml_for_steps(steps)
     print(buildkite_yaml)  # noqa: T201

--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/prerelease_package.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/prerelease_package.py
@@ -1,0 +1,70 @@
+import re
+from pathlib import Path
+from typing import List
+
+from dagster_buildkite.python_version import AvailablePythonVersion
+from dagster_buildkite.step_builder import CommandStepBuilder
+from dagster_buildkite.steps.packages import _get_uncustomized_pkg_roots
+from dagster_buildkite.utils import BlockStep, BuildkiteStep
+
+
+def build_prerelease_package_steps() -> List[BuildkiteStep]:
+    steps: List[BuildkiteStep] = []
+
+    packages = (
+        _get_uncustomized_pkg_roots("python_modules", [])
+        + _get_uncustomized_pkg_roots("python_modules/libraries", [])
+        + _get_uncustomized_pkg_roots("examples/experimental", [])
+    )
+
+    # Get only packages that have a fixed version in setup.py
+    filtered_packages = []
+    for package in packages:
+        setup_file = Path(package) / "setup.py"
+        contents = setup_file.read_text()
+        if re.findall(r"version=\"[\d\.]+\"", contents):
+            filtered_packages.append(package)
+
+    input_step: BlockStep = {
+        "block": ":question: Choose package",
+        "prompt": None,
+        "fields": [
+            {
+                "select": "Select a package to publish",
+                "key": "package-to-release-path",
+                "options": [
+                    {
+                        "label": package[len("python_modules/") :]
+                        if package.startswith("python_modules/")
+                        else package,
+                        "value": package,
+                    }
+                    for package in filtered_packages
+                ],
+                "hint": None,
+                "default": None,
+                "required": True,
+                "multiple": None,
+            },
+            {
+                "text": "Enter the version to publish",
+                "required": False,
+                "key": "version-to-release",
+                "default": None,
+                "hint": "Leave blank to auto-increment the minor version",
+            },
+        ],
+    }
+    steps.append(input_step)
+
+    steps.append(
+        CommandStepBuilder(":package: Build and publish package")
+        .run(
+            "pip install build",
+            "sh ./scripts/build_and_publish.sh",
+        )
+        .on_test_image(AvailablePythonVersion.get_default(), env=["PYPI_TOKEN"])
+        .build()
+    )
+
+    return steps

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -74,7 +74,7 @@ _PACKAGE_TYPE_ORDER = ["core", "extension", "example", "infrastructure", "unknow
 
 
 # Find packages under a root subdirectory that are not configured above.
-def _get_uncustomized_pkg_roots(root, custom_pkg_roots) -> List[str]:
+def _get_uncustomized_pkg_roots(root: str, custom_pkg_roots: List[str]) -> List[str]:
     all_files_in_root = [
         os.path.relpath(p, GIT_REPO_ROOT) for p in glob(os.path.join(GIT_REPO_ROOT, root, "*"))
     ]

--- a/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/utils.py
@@ -63,7 +63,40 @@ TriggerStep = TypedDict(
 
 WaitStep: TypeAlias = Literal["wait"]
 
-BuildkiteStep: TypeAlias = Union[CommandStep, GroupStep, TriggerStep, WaitStep]
+InputSelectOption = TypedDict("InputSelectOption", {"label": str, "value": str})
+InputSelectField = TypedDict(
+    "InputSelectField",
+    {
+        "select": str,
+        "key": str,
+        "options": List[InputSelectOption],
+        "hint": Optional[str],
+        "default": Optional[str],
+        "required": Optional[bool],
+        "multiple": Optional[bool],
+    },
+)
+InputTextField = TypedDict(
+    "InputTextField",
+    {
+        "text": str,
+        "key": str,
+        "hint": Optional[str],
+        "default": Optional[str],
+        "required": Optional[bool],
+    },
+)
+
+BlockStep = TypedDict(
+    "BlockStep",
+    {
+        "block": str,
+        "prompt": Optional[str],
+        "fields": List[Union[InputSelectField, InputTextField]],
+    },
+)
+
+BuildkiteStep: TypeAlias = Union[CommandStep, GroupStep, TriggerStep, WaitStep, BlockStep]
 BuildkiteLeafStep = Union[CommandStep, TriggerStep, WaitStep]
 BuildkiteTopLevelStep = Union[CommandStep, GroupStep]
 
@@ -84,7 +117,9 @@ def safe_getenv(env_var: str) -> str:
     return os.environ[env_var]
 
 
-def buildkite_yaml_for_steps(steps, custom_slack_channel: Optional[str] = None) -> str:
+def buildkite_yaml_for_steps(
+    steps: Sequence[BuildkiteStep], custom_slack_channel: Optional[str] = None
+) -> str:
     return yaml.dump(
         {
             "env": {

--- a/.buildkite/dagster-buildkite/setup.py
+++ b/.buildkite/dagster-buildkite/setup.py
@@ -30,6 +30,7 @@ setup(
         "console_scripts": [
             "dagster-buildkite = dagster_buildkite.cli:dagster",
             "dagster-buildkite-nightly = dagster_buildkite.cli:dagster_nightly",
+            "dagster-buildkite-prerelease-package = dagster_buildkite.cli:prerelease_package",
         ]
     },
 )

--- a/python_modules/libraries/dagster-powerbi/setup.py
+++ b/python_modules/libraries/dagster-powerbi/setup.py
@@ -1,22 +1,10 @@
 from setuptools import find_packages, setup
 
-
-def get_version() -> str:
-    return "1!0+dev"
-    # Uncomment when ready to publish
-    # version: Dict[str, str] = {}
-    # with open(Path(__file__).parent / "dagster_powerbi/version.py", encoding="utf8") as fp:
-    #     exec(fp.read(), version)
-
-    # return version["__version__"]
-
-
-ver = get_version()
 # dont pin dev installs to avoid pip dep resolver issues
 pin = ""
 setup(
     name="dagster_powerbi",
-    version=get_version(),
+    version="0.0.3",
     author="Dagster Labs",
     author_email="hello@dagsterlabs.com",
     license="Apache-2.0",

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/__init__.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/__init__.py
@@ -11,6 +11,6 @@ from dagster_sigma.translator import (
 )
 
 # Move back to version.py and edit setup.py once we are ready to publish.
-__version__ = "1!0+dev"
+__version__ = "0.0.10"
 
 DagsterLibraryRegistry.register("dagster-sigma", __version__)

--- a/python_modules/libraries/dagster-sigma/setup.py
+++ b/python_modules/libraries/dagster-sigma/setup.py
@@ -1,22 +1,9 @@
 from setuptools import find_packages, setup
 
-
-def get_version() -> str:
-    return "1!0+dev"
-    # Uncomment when ready to publish
-    # version: Dict[str, str] = {}
-    # with open(Path(__file__).parent / "dagster_sigma/version.py", encoding="utf8") as fp:
-    #     exec(fp.read(), version)
-
-    # return version["__version__"]
-
-
-ver = get_version()
-# dont pin dev installs to avoid pip dep resolver issues
 pin = ""
 setup(
     name="dagster_sigma",
-    version=get_version(),
+    version="0.0.10",
     author="Dagster Labs",
     author_email="hello@dagsterlabs.com",
     license="Apache-2.0",


### PR DESCRIPTION
## Summary & Motivation

Introduces a new BK pipeline which we can manually trigger to publish a package outside of the typical release process.
Right now, pulls a list of possible packages that do not have dynamic versions in `setup.py`:

![Screenshot 2024-09-19 at 4 08 03 PM](https://github.com/user-attachments/assets/4469c97c-d2c4-49ae-b9eb-d5887bb9a097)

The main use-case is for new integrations and experimental packages that we may want to iterate on rapidly, e.g. release more than once a week, separate from our stable package release process.

The pipeline:
1. Updates the version tag in code
2. Builds and publishes the package to pypi
3. Commits the new version tag
4. Pushes to a git tag `{package_name}/v{version}` and the selected branch on GitHub

## How I Tested These Changes

Tested manually in BK

## Changelog

NOCHANGELOG