### PR TITLE
feat(looker): implement views as dependencies of explores

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker/api/cacheable_assets.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/cacheable_assets.py
@@ -13,6 +13,8 @@ from dagster._core.definitions.cacheable_assets import (
 from dagster_looker.api.dagster_looker_api_translator import (
     DagsterLookerApiTranslator,
     LookerInstanceData,
+    LookerStructureData,
+    LookerStructureType,
 )
 
 if TYPE_CHECKING:
@@ -51,11 +53,19 @@ class LookerCacheableAssetsDefinition(CacheableAssetsDefinition):
             *external_assets_from_specs(
                 [
                     *(
-                        self._dagster_looker_translator.get_asset_spec(lookml_explore)
+                        self._dagster_looker_translator.get_asset_spec(
+                            LookerStructureData(
+                                structure_type=LookerStructureType.EXPLORE, data=lookml_explore
+                            )
+                        )
                         for lookml_explore in looker_instance_data.explores_by_id.values()
                     ),
                     *(
-                        self._dagster_looker_translator.get_asset_spec(looker_dashboard)
+                        self._dagster_looker_translator.get_asset_spec(
+                            LookerStructureData(
+                                structure_type=LookerStructureType.DASHBOARD, data=looker_dashboard
+                            )
+                        )
                         for looker_dashboard in looker_instance_data.dashboards_by_id.values()
                     ),
                 ]

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/api/mock_looker_data.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/api/mock_looker_data.py
@@ -16,7 +16,9 @@ mock_lookml_models = [
     )
 ]
 
-mock_lookml_explore = LookmlModelExplore(id="my_model::my_explore")
+mock_lookml_explore = LookmlModelExplore(
+    id="my_model::my_explore", view_name="my_view", sql_table_name="my_table"
+)
 
 mock_looker_dashboard_bases = [
     DashboardBase(id="1", hidden=False),


### PR DESCRIPTION
## Summary & Motivation
Slowly paves the way for modeling the materialized tables upstream of the views. First, we model the views upstream of an explore as dependencies.

## How I Tested These Changes
pytest, local

## Changelog
NOCHANGELOG
