### PR TITLE
feat(looker): implement pdts as assets

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker/__init__.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/__init__.py
@@ -2,6 +2,7 @@ from dagster._core.libraries import DagsterLibraryRegistry
 
 from dagster_looker.api.dagster_looker_api_translator import (
     DagsterLookerApiTranslator as DagsterLookerApiTranslator,
+    RequestStartPdtBuild as RequestStartPdtBuild,
 )
 from dagster_looker.api.resource import LookerResource as LookerResource
 from dagster_looker.lkml.asset_specs import build_looker_asset_specs as build_looker_asset_specs

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/cacheable_assets.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/cacheable_assets.py
@@ -1,9 +1,12 @@
 from typing import TYPE_CHECKING, Sequence
 
 from dagster import (
+    AssetExecutionContext,
     AssetsDefinition,
+    Failure,
     _check as check,
     external_assets_from_specs,
+    multi_asset,
 )
 from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
@@ -15,6 +18,8 @@ from dagster_looker.api.dagster_looker_api_translator import (
     LookerInstanceData,
     LookerStructureData,
     LookerStructureType,
+    LookmlView,
+    RequestStartPdtBuild,
 )
 
 if TYPE_CHECKING:
@@ -25,9 +30,11 @@ class LookerCacheableAssetsDefinition(CacheableAssetsDefinition):
     def __init__(
         self,
         looker: "LookerResource",
+        request_start_pdt_builds: Sequence[RequestStartPdtBuild],
         dagster_looker_translator: DagsterLookerApiTranslator,
     ):
         self._looker = looker
+        self._request_start_pdt_builds = request_start_pdt_builds
         self._dagster_looker_translator = dagster_looker_translator
         super().__init__(unique_id=self._looker.client_id)
 
@@ -49,6 +56,54 @@ class LookerCacheableAssetsDefinition(CacheableAssetsDefinition):
             cacheable_metadata=[check.not_none(cached_data.extra_metadata) for cached_data in data],
         )
 
+        executable_pdt_assets = []
+        for request_start_pdt_build in self._request_start_pdt_builds:
+
+            @multi_asset(
+                specs=[
+                    self._dagster_looker_translator.get_asset_spec(
+                        LookerStructureData(
+                            structure_type=LookerStructureType.VIEW,
+                            data=LookmlView(
+                                view_name=request_start_pdt_build.view_name,
+                                sql_table_name=None,
+                            ),
+                        )
+                    )
+                ],
+                name=f"{request_start_pdt_build.model_name}_{request_start_pdt_build.view_name}",
+                resource_defs={"looker": self._looker.get_resource_definition()},
+            )
+            def asset_fn(context: AssetExecutionContext):
+                looker: "LookerResource" = context.resources.looker
+
+                context.log.info(
+                    f"Starting pdt build for Looker view `{request_start_pdt_build.view_name}` in Looker model `{request_start_pdt_build.model_name}`."
+                )
+
+                materialize_pdt = looker.get_sdk().start_pdt_build(
+                    model_name=request_start_pdt_build.model_name,
+                    view_name=request_start_pdt_build.view_name,
+                    force_rebuild=request_start_pdt_build.force_rebuild,
+                    force_full_incremental=request_start_pdt_build.force_full_incremental,
+                    workspace=request_start_pdt_build.workspace,
+                    source=f"Dagster run {context.run_id}" or request_start_pdt_build.source,
+                )
+
+                if not materialize_pdt.materialization_id:
+                    raise Failure("No materialization id was returned from Looker API.")
+
+                check_pdt = looker.get_sdk().check_pdt_build(
+                    materialization_id=materialize_pdt.materialization_id
+                )
+
+                context.log.info(
+                    f"Materialization id: {check_pdt.materialization_id}, "
+                    f"response text: {check_pdt.resp_text}"
+                )
+
+            executable_pdt_assets.append(asset_fn)
+
         return [
             *external_assets_from_specs(
                 [
@@ -69,5 +124,6 @@ class LookerCacheableAssetsDefinition(CacheableAssetsDefinition):
                         for looker_dashboard in looker_instance_data.dashboards_by_id.values()
                     ),
                 ]
-            )
+            ),
+            *executable_pdt_assets,
         ]

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
@@ -70,7 +70,18 @@ class LookerInstanceData:
         )
 
 
+@record
+class RequestStartPdtBuild:
+    model_name: str
+    view_name: str
+    force_rebuild: Optional[str] = None
+    force_full_incremental: Optional[str] = None
+    workspace: Optional[str] = None
+    source: Optional[str] = None
+
+
 class LookerStructureType(Enum):
+    VIEW = "view"
     EXPLORE = "explore"
     DASHBOARD = "dashboard"
 
@@ -145,6 +156,10 @@ class DagsterLookerApiTranslator:
         )
 
     def get_asset_spec(self, looker_structure: LookerStructureData) -> AssetSpec:
+        if looker_structure.structure_type == LookerStructureType.VIEW:
+            data = check.inst(looker_structure.data, LookmlView)
+
+            return self.get_view_asset_spec(data)
         if looker_structure.structure_type == LookerStructureType.EXPLORE:
             data = check.inst(looker_structure.data, (LookmlModelExplore, DashboardFilter))
 

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/api/mock_looker_data.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/api/mock_looker_data.py
@@ -1,3 +1,5 @@
+import json
+
 from looker_sdk.sdk.api40.models import (
     Dashboard,
     DashboardBase,
@@ -5,6 +7,7 @@ from looker_sdk.sdk.api40.models import (
     LookmlModel,
     LookmlModelExplore,
     LookmlModelNavExplore,
+    MaterializePDT,
 )
 
 mock_lookml_models = [
@@ -31,4 +34,12 @@ mock_looker_dashboard = Dashboard(
     dashboard_filters=[
         DashboardFilter(model="my_model", explore="my_explore"),
     ],
+)
+
+mock_start_pdt_build = MaterializePDT(
+    materialization_id="100",
+)
+mock_check_pdt_build = MaterializePDT(
+    materialization_id="100",
+    resp_text=json.dumps({"status": "running"}),
 )


### PR DESCRIPTION
## Summary & Motivation

Uses https://cloud.google.com/looker/docs/reference/looker-api/latest/methods/DerivedTable/start_pdt_build to materialize a PDT.

Unfortunately, there's no API to fetch these PDTs in the first place, so they have to be manually specified. Here are all the APIs related to PDT's, just as a sanity check: https://cloud.google.com/looker/docs/reference/looker-api/latest/methods/DerivedTable.

## How I Tested These Changes
pytest, local

## Changelog
NOCHANGELOG
