### PR TITLE
[quick] align backfill and sub-run job name for job name filtering test

### DIFF
--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -1666,7 +1666,7 @@ class TestRunStorage:
         storage.add_run(
             TestRunStorage.build_run(
                 run_id=run_id,
-                job_name="some_pipeline",
+                job_name="fake",
                 status=DagsterRunStatus.SUCCESS,
                 tags={BACKFILL_ID_TAG: backfill.backfill_id},
             )
@@ -1681,9 +1681,7 @@ class TestRunStorage:
             )
         )
 
-        backfills_for_job = storage.get_backfills(
-            filters=BulkActionsFilter(job_name="some_pipeline")
-        )
+        backfills_for_job = storage.get_backfills(filters=BulkActionsFilter(job_name="fake"))
         assert len(backfills_for_job) == 1
         assert backfills_for_job[0].backfill_id == backfill.backfill_id
 


### PR DESCRIPTION
## Summary & Motivation
fixes a test where the job_name for a backfill and it's subrun were different because the backfill and run were manually created. This was fine for OSS because filtering by job name for backfills in OSS just looks at the run, but didn't work for plus because we actually store the job name of the backfill in plus

## How I Tested These Changes

## Changelog

NOCHANGELOG
