### PR TITLE
[lazydefs] Default global DefinitionsLoadContext

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_loader.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_loader.py
@@ -57,12 +57,10 @@ class DefinitionsLoadContext:
 
     @classmethod
     def get(cls) -> "DefinitionsLoadContext":
-        """Get the current DefinitionsLoadContext."""
-        if not DefinitionsLoadContext._instance:
-            raise DagsterInvariantViolationError(
-                "Attempted to access the global DefinitionsLoadContext before it has been set."
-            )
-        return DefinitionsLoadContext._instance
+        """Get the current DefinitionsLoadContext. If it has not been set, the
+        context is assumed to be initialization.
+        """
+        return DefinitionsLoadContext._instance or cls(load_type=DefinitionsLoadType.INITIALIZATION)
 
     @classmethod
     def set(cls, instance: "DefinitionsLoadContext") -> None:

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_loader.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_loader.py
@@ -133,6 +133,13 @@ def test_reconstruction_metadata_with_global_context():
         mock_fetch.assert_not_called()
 
 
+def test_default_global_context():
+    instance = DefinitionsLoadContext.get()
+    DefinitionsLoadContext._instance = None  # noqa: SLF001
+    assert DefinitionsLoadContext.get().load_type == DefinitionsLoadType.INITIALIZATION
+    DefinitionsLoadContext.set(instance)
+
+
 def test_invoke_definitions_loader_with_context():
     @definitions
     def defs(context: DefinitionsLoadContext) -> Definitions:


### PR DESCRIPTION
## Summary & Motivation

Changes behavior of `DefinitionsLoadContext.get()` to default to an object with type `INITIALIZATION` and empty repository load data (instead of throwing an error).

## How I Tested These Changes

New unit test.

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
