### PR TITLE
[graphql] shuffle execution methods

### DIFF
--- a/python_modules/dagster-webserver/dagster_webserver/graphql.py
+++ b/python_modules/dagster-webserver/dagster_webserver/graphql.py
@@ -1,17 +1,17 @@
-import time
 from abc import ABC, abstractmethod
 from asyncio import Task, get_event_loop, run
-from contextlib import contextmanager
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
     AsyncGenerator,
     Dict,
+    Generic,
     List,
     Optional,
     Sequence,
     Tuple,
+    TypeVar,
     Union,
     cast,
 )
@@ -55,7 +55,10 @@ class GraphQLWS(str, Enum):
     STOP = "stop"
 
 
-class GraphQLServer(ABC):
+TRequestContext = TypeVar("TRequestContext")
+
+
+class GraphQLServer(ABC, Generic[TRequestContext]):
     def __init__(self, app_path_prefix: str = ""):
         self._app_path_prefix = app_path_prefix
 
@@ -75,16 +78,7 @@ class GraphQLServer(ABC):
     def build_routes(self) -> List[BaseRoute]: ...
 
     @abstractmethod
-    def make_request_context(self, conn: HTTPConnection): ...
-
-    def monitor_threadqueue_latency(self, latency: float) -> None:
-        """This method is called with the latency incurred by handing
-        graphql requests off to a thread pool, ie the time between invocation
-        of `execute_graphql_request` and the time `graphql_schema.execute_async`
-        gets invoked in a thread. By default this method does nothing, but it
-        can be overriden to provide instrumentation.
-        """
-        pass
+    def make_request_context(self, conn: HTTPConnection) -> TRequestContext: ...
 
     def handle_graphql_errors(self, errors: Sequence[GraphQLError]):
         results = []
@@ -166,7 +160,12 @@ class GraphQLServer(ABC):
 
         captured_errors: List[Exception] = []
         with ErrorCapture.watch(captured_errors.append):
-            result = await self.execute_graphql_request(request, query, variables, operation_name)
+            result = await self.execute_graphql_request(
+                request=request,
+                query=query,
+                variables=variables,
+                operation_name=operation_name,
+            )
 
         response_data: Dict[str, Any] = {"data": result.data}
 
@@ -248,29 +247,45 @@ class GraphQLServer(ABC):
     ) -> ExecutionResult:
         # run each query in a separate thread, as much of the schema is sync/blocking
         # use execute_async to allow async resolvers to facilitate dataloader pattern
+        return await run_in_threadpool(
+            self.graphql_execution_thread,
+            request=request,
+            query=query,
+            variables=variables,
+            operation_name=operation_name,
+        )
 
+    def graphql_execution_thread(
+        self,
+        request: Request,
+        query: str,
+        variables: Optional[Dict[str, Any]],
+        operation_name: Optional[str],
+    ) -> ExecutionResult:
         request_context = self.make_request_context(request)
-        start_time = time.monotonic()
+        return run(
+            self.gen_graphql_response(
+                request_context=request_context,
+                query=query,
+                variables=variables,
+                operation_name=operation_name,
+            )
+        )
 
-        def _graphql_request():
-            self.monitor_threadqueue_latency(time.monotonic() - start_time)
-            with self.graphql_request_context(request):
-                return run(
-                    self._graphql_schema.execute_async(
-                        query,
-                        variables=variables,
-                        operation_name=operation_name,
-                        context=request_context,
-                        middleware=self._graphql_middleware,
-                    )
-                )
-
-        return await run_in_threadpool(_graphql_request)
-
-    @contextmanager
-    def graphql_request_context(self, request: Request):
-        """This context manager executes within the threadpool and can be used to wrap logic around a single graphql request."""
-        yield
+    async def gen_graphql_response(
+        self,
+        request_context: TRequestContext,
+        query: str,
+        variables: Optional[Dict[str, Any]],
+        operation_name: Optional[str],
+    ) -> ExecutionResult:
+        return await self._graphql_schema.execute_async(
+            query,
+            variables=variables,
+            operation_name=operation_name,
+            context=request_context,
+            middleware=self._graphql_middleware,
+        )
 
     async def execute_graphql_subscription(
         self,

--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -47,7 +47,10 @@ mimetypes.init()
 T_IWorkspaceProcessContext = TypeVar("T_IWorkspaceProcessContext", bound=IWorkspaceProcessContext)
 
 
-class DagsterWebserver(GraphQLServer, Generic[T_IWorkspaceProcessContext]):
+class DagsterWebserver(
+    GraphQLServer[BaseWorkspaceRequestContext],
+    Generic[T_IWorkspaceProcessContext],
+):
     _process_context: T_IWorkspaceProcessContext
     _uses_app_path_prefix: bool
 


### PR DESCRIPTION
Break up the methods for graphql execution to when it is handed off to a thread and when it is handed off to an asyncio event loop.

## How I Tested These Changes

bk
