### PR TITLE
[dagster-embedded-elt] Include entire error message when failing to fetch Sling metadata

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
@@ -90,9 +90,9 @@ def fetch_row_count_metadata(
         try:
             row_count = sling_cli.get_row_count_for_table(target_name, target_table_name)
             return dict(TableMetadataSet(row_count=row_count))
-        except Exception:
+        except Exception as e:
             context.log.warning(
-                "Failed to fetch row count for stream %s\nException: {e}",
+                f"Failed to fetch row count for stream %s\nException: {e}",
                 stream_name,
                 exc_info=True,
             )
@@ -158,9 +158,9 @@ def fetch_column_metadata(
                     column_lineage=column_lineage,
                 )
             )
-        except Exception:
+        except Exception as e:
             context.log.warning(
-                "Failed to fetch column metadata for stream %s\nException: {e}",
+                f"Failed to fetch column metadata for stream %s\nException: {e}",
                 stream_name,
                 exc_info=True,
             )

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/sling_event_iterator.py
@@ -92,7 +92,9 @@ def fetch_row_count_metadata(
             return dict(TableMetadataSet(row_count=row_count))
         except Exception:
             context.log.warning(
-                "Failed to fetch row count for stream %s", stream_name, exc_info=True
+                "Failed to fetch row count for stream %s\nException: {e}",
+                stream_name,
+                exc_info=True,
             )
 
     return {}
@@ -158,7 +160,9 @@ def fetch_column_metadata(
             )
         except Exception:
             context.log.warning(
-                "Failed to fetch column metadata for stream %s", stream_name, exc_info=True
+                "Failed to fetch column metadata for stream %s\nException: {e}",
+                stream_name,
+                exc_info=True,
             )
 
     return {}


### PR DESCRIPTION
## Summary

Right now, we don't include the actual error message text in the warning log. We should emit it so it's easier for users to track down what went wrong.
