### PR TITLE
add `exclude_subruns` option to GrapheneRunsFilter

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2339,6 +2339,7 @@ input RunsFilter {
   createdBefore: Float
   createdAfter: Float
   mode: String
+  excludeSubruns: Boolean
 }
 
 input PipelineSelector {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -4766,6 +4766,7 @@ export type RunsFeedEntry = {
 export type RunsFilter = {
   createdAfter?: InputMaybe<Scalars['Float']['input']>;
   createdBefore?: InputMaybe<Scalars['Float']['input']>;
+  excludeSubruns?: InputMaybe<Scalars['Boolean']['input']>;
   mode?: InputMaybe<Scalars['String']['input']>;
   pipelineName?: InputMaybe<Scalars['String']['input']>;
   runIds?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -13540,6 +13541,8 @@ export const buildRunsFilter = (
       overrides && overrides.hasOwnProperty('createdAfter') ? overrides.createdAfter! : 2.71,
     createdBefore:
       overrides && overrides.hasOwnProperty('createdBefore') ? overrides.createdBefore! : 2.25,
+    excludeSubruns:
+      overrides && overrides.hasOwnProperty('excludeSubruns') ? overrides.excludeSubruns! : false,
     mode: overrides && overrides.hasOwnProperty('mode') ? overrides.mode! : 'voluptatem',
     pipelineName:
       overrides && overrides.hasOwnProperty('pipelineName') ? overrides.pipelineName! : 'voluptas',

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -48,6 +48,7 @@ class GrapheneRunsFilter(graphene.InputObjectType):
     createdBefore = graphene.InputField(graphene.Float)
     createdAfter = graphene.InputField(graphene.Float)
     mode = graphene.InputField(graphene.String)
+    excludeBackfillRuns = graphene.InputField(graphene.Boolean)
 
     class Meta:
         description = """This type represents a filter on Dagster runs."""
@@ -80,6 +81,7 @@ class GrapheneRunsFilter(graphene.InputObjectType):
             updated_after=updated_after,
             created_before=created_before,
             created_after=created_after,
+            exclude_backfill_runs=self.excludeBackfillRuns,
         )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -48,7 +48,7 @@ class GrapheneRunsFilter(graphene.InputObjectType):
     createdBefore = graphene.InputField(graphene.Float)
     createdAfter = graphene.InputField(graphene.Float)
     mode = graphene.InputField(graphene.String)
-    excludeBackfillRuns = graphene.InputField(graphene.Boolean)
+    excludeSubruns = graphene.InputField(graphene.Boolean)
 
     class Meta:
         description = """This type represents a filter on Dagster runs."""
@@ -81,7 +81,7 @@ class GrapheneRunsFilter(graphene.InputObjectType):
             updated_after=updated_after,
             created_before=created_before,
             created_after=created_after,
-            exclude_backfill_runs=self.excludeBackfillRuns,
+            exclude_subruns=self.excludeSubruns,
         )
 
 


### PR DESCRIPTION
## Summary & Motivation
Adds `excludeSubruns` to  `GrapheneRunsFilter` so that the UI can power the "Show runs within backfills" checkbox

An alternate implementation would be to have a separate parameter for the `runsFeedOrError` query that determines whether we exclude subruns. I tried that [here](https://github.com/dagster-io/dagster/pull/24710) but ran into some confusing gql errors. Marco had a slight preference for implementing the UI as passing the option to the RunsFilter, so i switched to that approach. I can go back to the parameter version though if we want to be more cautious about adding this filter to more APIs

Corresponding internal PR https://github.com/dagster-io/internal/pull/11793

## How I Tested These Changes

## Changelog

NOCHANGELOG
