### PR TITLE
 Allow @records to have optional, generic @records as fields

### DIFF
--- a/python_modules/dagster/dagster/_check/builder.py
+++ b/python_modules/dagster/dagster/_check/builder.py
@@ -260,6 +260,8 @@ def build_check_call_str(
     name: str,
     eval_ctx: EvalContext,
 ) -> str:
+    from dagster._record import _RECORD_MARKER_FIELD
+
     # assumes this module is in global/local scope as check
     origin = get_origin(ttype)
     args = get_args(ttype)
@@ -313,6 +315,12 @@ def build_check_call_str(
             return f'check.mapping_param({name}, "{name}", {_name(pair_left)}, {_name(pair_right)})'
         elif origin is collections.abc.Set:
             return f'check.set_param({name}, "{name}", {_name(single)})'
+        # If the type is a Generic record, we just use an inst check
+        elif hasattr(origin, _RECORD_MARKER_FIELD):
+            it = _name(ttype)
+            return (
+                f'{name} if isinstance({name}, {it}) else check.inst_param({name}, "{name}", {it})'
+            )
         elif origin in (UnionType, Union):
             # optional
             if pair_right is type(None):
@@ -359,6 +367,10 @@ def build_check_call_str(
                         return (
                             f'check.opt_nullable_set_param({name}, "{name}", {_name(inner_single)})'
                         )
+                    # If the type is a Generic record, we just use an inst check
+                    elif hasattr(inner_origin, _RECORD_MARKER_FIELD):
+                        it = _name(inner_origin)
+                        return f'{name} if isinstance({name}, {it}) else check.opt_inst_param({name}, "{name}", {it})'
 
             # union
             else:


### PR DESCRIPTION
## Summary

Updated the `@record` check generating code to support optional, generic type annotations where the base type is also a `@record`. #24629 fixed this for non-optional generic records. Previously, this hit the unhandled case and raised an exception, e.g.

```python
@record
class Things(Generic[T]):
    things: Sequence[T]

@record
class HolderOfThings(Generic[T]):
    things: Optional[Things[T]]

```

## Test Plan

New unit test which previously failed