### PR TITLE
Fix an issue where build_op_context could sometimes raise an exception during process shutdown

### DIFF
--- a/python_modules/dagster/dagster/_utils/interrupts.py
+++ b/python_modules/dagster/dagster/_utils/interrupts.py
@@ -94,5 +94,6 @@ def raise_interrupts_as(error_cls: Type[BaseException]) -> Iterator[None]:
 
         yield
     finally:
-        if signal_replaced:
+        # during process cleanup, the original signal handler may no longer exist
+        if signal_replaced and original_signal_handler:
             _replace_interrupt_signal(original_signal_handler)


### PR DESCRIPTION
## Summary & Motivation

Fix an issue where this code could result in a spurious exception during process shutdown. Resolves https://github.com/dagster-io/dagster/issues/15100.

## How I Tested These Changes

Writing an automated test is tricky because it only happens during proess shutdown, but the following script no longer raises an exception during __del__ in process shutdown:

```
from dagster import build_op_context

x = build_op_context(resources={"foo": "bar"})
```

## Changelog

- [x] `BUGFIX` Fixed an issue where calling `build_op_context` in a unit test would sometimes raise a `TypeError: signal handler must be signal.SIG_IGN, signal.SIG_DFL, or a callable object` Exception on process shutdonw.

