### PR TITLE
[lazy-defs] Cut PendingRepositoryDefinition out of reconstruction metadata code path

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -65,7 +65,9 @@ class RepositoryLoadData(
 ):
     def __new__(
         cls,
-        cacheable_asset_data: Mapping[str, Sequence[AssetsDefinitionCacheableData]],
+        cacheable_asset_data: Optional[
+            Mapping[str, Sequence[AssetsDefinitionCacheableData]]
+        ] = None,
         reconstruction_metadata: Optional[
             Mapping[str, CodeLocationReconstructionMetadataValue]
         ] = None,
@@ -73,7 +75,7 @@ class RepositoryLoadData(
         return super(RepositoryLoadData, cls).__new__(
             cls,
             cacheable_asset_data=(
-                check.mapping_param(
+                check.opt_mapping_param(
                     cacheable_asset_data,
                     "cacheable_asset_data",
                     key_type=str,

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -1,5 +1,4 @@
 import uuid
-from typing import cast
 
 import pytest
 import responses
@@ -7,9 +6,6 @@ from dagster import materialize
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.definitions_loader import DefinitionsLoadContext, DefinitionsLoadType
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
-from dagster._core.definitions.repository_definition.repository_definition import (
-    PendingRepositoryDefinition,
-)
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.instance_for_test import instance_for_test
@@ -200,15 +196,11 @@ def test_using_reconstruction_metadata(workspace_data_api_mocks: responses.Reque
 
         from dagster_powerbi_tests.pending_repo import reconstruction_metadata_defs
 
-        pending_repo = cast(
-            PendingRepositoryDefinition,
-            reconstruction_metadata_defs(
-                DefinitionsLoadContext(load_type=DefinitionsLoadType.INITIALIZATION)
-            ).get_inner_repository(),
-        )
+        repository_def = reconstruction_metadata_defs(
+            DefinitionsLoadContext(load_type=DefinitionsLoadType.INITIALIZATION)
+        ).get_repository_def()
 
         # first, we resolve the repository to generate our cached metadata
-        repository_def = pending_repo.compute_repository_definition()
         assert len(workspace_data_api_mocks.calls) == 5
 
         # 5 PowerBI external assets, one materializable asset


### PR DESCRIPTION
## Summary & Motivation

Removes use of `PendingRepositoryDefinition` in the reconstruction metadata code path in favor of creating `RepositoryLoadData` directly in the `@repository` decorator.

Fixes https://linear.app/dagster-labs/issue/FOU-401/cut-pendingrepositorydefinition-out-of-the-loop-for-reconstruction

## How I Tested These Changes

Existing test suite.

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
