### PR TITLE
StateBackedDefinitionsLoader

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/state_backed_defs_loader.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/state_backed_defs_loader.py
@@ -1,0 +1,135 @@
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from typing import Any, Generator, Generic, TypeVar, cast
+
+from dagster import Definitions
+from dagster._core.definitions.definitions_loader import DefinitionsLoadContext, DefinitionsLoadType
+from dagster._core.definitions.metadata.metadata_value import (
+    CodeLocationReconstructionMetadataValue,
+)
+from dagster._core.definitions.repository_definition.repository_definition import RepositoryLoadData
+from dagster._serdes.serdes import PackableValue, deserialize_value, serialize_value
+
+TState = TypeVar("TState", bound=PackableValue)
+
+
+class StateBackedDefinitionsLoader(ABC, Generic[TState]):
+    """A class for building state-backed definitions. In a structured way. It
+    handles manipulation of the DefinitionsLoadContext on the user's behalf.
+
+    The goal here is so that an unreliable backing source is fetched only
+    at code server load time, which defines the code location. When, for example,
+    a run worker is launched, the backing source is not queryed again, and
+    only `defs_from_state` is called.
+
+    Current meant for internal usage only hence TState must be a marked as whitelist_for_serdes.
+
+    Args:
+        defs_key (str): The unique key for the definitions. Must be unique per code location.
+
+    Examples:
+
+    .. code-block:: python
+
+        @whitelist_for_serdes
+        @record
+        class ExampleDefState:
+            a_string: str
+
+        class ExampleStateBackedDefinitionsLoader(StateBackedDefinitionsLoader[ExampleDefState]):
+            def fetch_state(self) -> ExampleDefState:
+                # Fetch from potentially unreliable API (e.g. Rest API)
+                return ExampleDefState(a_string="foo")
+
+            def defs_from_state(self, state: ExampleDefState) -> Definitions:
+                # Construct or reconstruct the Definitions from the previously
+                # fetched state.
+                return Definitions([AssetSpec(key=state.a_string)])
+    """
+
+    @property
+    @abstractmethod
+    def defs_key(self) -> str:
+        """The unique key for the definitions. Must be unique per code location."""
+        ...
+
+    @abstractmethod
+    def fetch_state(self) -> TState:
+        """Subclasses must implement this method. This is where the integration runs
+        code that fetches the backing state from the source of truth for the definitions.
+        This is only called when the code location is initializing, for example on
+        code server load, or when loading via dagster dev.
+        """
+        ...
+
+    @abstractmethod
+    def defs_from_state(self, state: TState) -> Definitions:
+        """Subclasses must implement this method. It is invoked whenever the code location
+        is loading, whether it be initializaton or reconstruction. In the case of
+        intialization, it takes the result of fetch_backing state that just happened.
+        When reconstructing, it takes the state that was previously fetched and attached
+        as metadata.
+
+        This method also takes responsibility for attaching the state to the definitions
+        on its metadata, with the key passed in as defs_key.
+        """
+        ...
+
+    def build_defs(self) -> Definitions:
+        context = DefinitionsLoadContext.get()
+
+        state = (
+            cast(TState, deserialize_value(context.reconstruction_metadata[self.defs_key]))
+            if (
+                context.load_type == DefinitionsLoadType.RECONSTRUCTION
+                and self.defs_key in context.reconstruction_metadata
+            )
+            else self.fetch_state()
+        )
+
+        return self.defs_from_state(state).with_reconstruction_metadata(
+            {self.defs_key: serialize_value(state)}
+        )
+
+
+@contextmanager
+def scoped_reconstruction_metadata(**state_objects: Any) -> Generator:
+    """For test cases that involved state-backed definition objects. This context manager
+    allows one to see backing state for a definitions object and test reconstruction
+    logic.
+
+    Examples:
+
+    .. code-block:: python
+
+        with scoped_reconstruction_metadata(test_key=ExampleDefState(a_string="bar")):
+            loader_cached = ExampleStateBackedDefinitionsLoader("test_key")
+            defs = loader_cached.build_defs()
+            assert len(defs.get_all_asset_specs()) == 1
+            assert defs.get_assets_def("bar")
+    """
+    prev_context = DefinitionsLoadContext.get()
+
+    try:
+        prev_load_data = prev_context._repository_load_data  # noqa
+        new_metadata = {
+            k: CodeLocationReconstructionMetadataValue(serialize_value(v))
+            for k, v in state_objects.items()
+        }
+        DefinitionsLoadContext.set(
+            DefinitionsLoadContext(
+                load_type=DefinitionsLoadType.RECONSTRUCTION,
+                repository_load_data=RepositoryLoadData(
+                    cacheable_asset_data=prev_load_data.cacheable_asset_data
+                    if prev_load_data
+                    else {},
+                    reconstruction_metadata={
+                        **new_metadata,
+                        **(prev_load_data.reconstruction_metadata if prev_load_data else {}),
+                    },
+                ),
+            )
+        )
+        yield
+    finally:
+        DefinitionsLoadContext.set(prev_context)

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_state_backed_defs_loader.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_state_backed_defs_loader.py
@@ -1,0 +1,39 @@
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.definitions_class import Definitions
+from dagster._record import record
+from dagster._serdes.serdes import whitelist_for_serdes
+from dagster_airlift.core.state_backed_defs_loader import (
+    StateBackedDefinitionsLoader,
+    scoped_reconstruction_metadata,
+)
+
+
+def test_state_backed_defs_loader() -> None:
+    @whitelist_for_serdes
+    @record
+    class ExampleDefState:
+        a_string: str
+
+    class ExampleStateBackedDefinitionsLoader(StateBackedDefinitionsLoader[ExampleDefState]):
+        @property
+        def defs_key(self) -> str:
+            return "test_key"
+
+        def fetch_state(self) -> ExampleDefState:
+            return ExampleDefState(a_string="foo")
+
+        def defs_from_state(self, state: ExampleDefState) -> Definitions:
+            return Definitions([AssetSpec(key=state.a_string)])
+
+    loader = ExampleStateBackedDefinitionsLoader()
+
+    defs = loader.build_defs()
+
+    assert len(defs.get_all_asset_specs()) == 1
+    assert defs.get_assets_def("foo")
+
+    with scoped_reconstruction_metadata(test_key=ExampleDefState(a_string="bar")):
+        loader_cached = ExampleStateBackedDefinitionsLoader()
+        defs = loader_cached.build_defs()
+        assert len(defs.get_all_asset_specs()) == 1
+        assert defs.get_assets_def("bar")


### PR DESCRIPTION
## Summary & Motivation

This class captures the common pattern of how an integration will interact with `DefinitionsLoadContext` to do state-backed loading.

Note: I am doing this in airlift only to make adding this lower stakes for now. If it proves useful, we can move it into dagster-core.

This also adds `scoped_metadata_for_reconstruction` which will be useful for test cases.

Docblock for usage:

```python
class StateBackedDefinitionsLoader(ABC, Generic[TState]):
    """A class for building state-backed definitions. In a structured way. It
    handles manipulation of the DefinitionsLoadContext on the user's behalf.

    The goal here is so that an unreliable backing source is fetched only
    at code server load time, which defines the code location. When, for example,
    a run worker is launched, the backing source is not queryed again, and
    only `defs_from_state` is called.

    Current meant for internal usage only hence TState must be a marked as whitelist_for_serdes.

    Args:
        defs_key (str): The unique key for the definitions. Must be unique per code location.

    Examples:

    .. code-block:: python

        @whitelist_for_serdes
        @record
        class ExampleDefState:
            a_string: str

        class ExampleStateBackedDefinitionsLoader(StateBackedDefinitionsLoader[ExampleDefState]):
            def fetch_backing_state(self) -> ExampleDefState:
                # Fetch from potentially unreliable API (e.g. Rest API)
                return ExampleDefState(a_string="foo")

            def defs_from_state(self, state: ExampleDefState) -> Definitions:
                # Construct or reconstruct the Definitions from the previously
                # fetched state.
                return Definitions([AssetSpec(key=state.a_string)])
    """

    def __init__(self, defs_key: str):
        self.defs_key = defs_key

    @abstractmethod
    def fetch_backing_state(self) -> TState:
        """Subclasses must implement this method. This is where the integration runs
        code that fetches the backing state from the source of truth for the definitions.
        This is only called when the code location is initializing, for example on
        code server load, or when loading via dagster dev.
        """
        ...

    @abstractmethod
    def defs_from_state(self, state: TState) -> Definitions:
        """Subclasses must implement this method. It is invoked whenever the code location
        is loading, whether it be initializaton or reconstruction. In the case of
        intialization, it takes the result of fetch_backing state that just happened.
        When reconstructing, it takes the state that was previously fetched and attached
        as metadata.

        This method also takes responsibility for attaching the state to the definitions
        on its metadata, with the key passed in as defs_key.
        """
        ...
```

## How I Tested These Changes

BK

Practical application in upstack #24647  

## Changelog

NOCHANGELOG
