### PR TITLE
[docs-beta] Set resolution for path-to-regexp

### DIFF
--- a/docs/docs-beta/package.json
+++ b/docs/docs-beta/package.json
@@ -73,6 +73,9 @@
       "last 5 safari version"
     ]
   },
+  "resolutions": {
+    "path-to-regexp@2.2.1": "3.3.0"
+  },
   "engines": {
     "node": ">=18.0"
   },

--- a/docs/docs-beta/yarn.lock
+++ b/docs/docs-beta/yarn.lock
@@ -11807,10 +11807,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:2.2.1":
-  version: 2.2.1
-  resolution: "path-to-regexp@npm:2.2.1"
-  checksum: 10c0/f4b51090a73dad5ce0720f13ce8528ac77914bc927d72cc4ba05ab32770ad3a8d2e431962734b688b9ed863d4098d858da6ff4746037e4e24259cbd3b2c32b79
+"path-to-regexp@npm:3.3.0":
+  version: 3.3.0
+  resolution: "path-to-regexp@npm:3.3.0"
+  checksum: 10c0/ffa0ebe7088d38d435a8d08b0fe6e8c93ceb2a81a65d4dd1d9a538f52e09d5e3474ed5f553cb3b180d894b0caa10698a68737ab599fd1e56b4663d1a64c9f77b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary & Motivation

Try to use a resolution to force `path-to-regexp` to a version that resolves the dependabot alert. I can't find a breaking changes guide for v2 to v3 so I don't actually know what might break with this. Can I ask someone from docs-infra to try this and sanity check that everything works?

## How I Tested These Changes

TBD. `yarn start` seemed to load the docs site fine.

## Changelog

NOCHANGELOG