### PR TITLE
[docs-beta] fix announcement bar colors for dark theme

### DIFF
--- a/docs/docs-beta/src/styles/custom.scss
+++ b/docs/docs-beta/src/styles/custom.scss
@@ -659,5 +659,6 @@ span {
 /* Announcement bar */
 div[class^='announcementBar_'] {
   height: 40px;
+  color: var(--theme-color-text);
   background-color: var(--theme-color-background-red);
 }


### PR DESCRIPTION
## Summary & Motivation

- Text color was incorrectly black on dark background for announcement bar with dark theme

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/13e7ee4d-f80e-4a96-a7f6-273c10d84361">
<img width="917" alt="image" src="https://github.com/user-attachments/assets/8c479ee5-83bd-44dd-a745-ee27dd8d1a68">

## How I Tested These Changes

`yarn start`

## Changelog

NOCHANGELOG
