### PR TITLE
[docs-beta] temporarily remove `lastmod` for sitemap as `.git/` is not present on Vercel

### DIFF
--- a/docs/docs-beta/docusaurus.config.ts
+++ b/docs/docs-beta/docusaurus.config.ts
@@ -149,7 +149,7 @@ const config: Config = {
         },
         // https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-sitemap#ex-config
         sitemap: {
-          lastmod: 'date',
+          //lastmod: 'date',
           changefreq: 'weekly',
           priority: 0.5,
           ignorePatterns: ['/tags/**'],


### PR DESCRIPTION
## Summary & Motivation

- `.git` folder is present on GitHub action
- `.git` folder is lost when using `vercel deploy` as is done by Vercel GitHub action
- Sitemap plugin relies on history in `.git` to add `lastmod` attribute to site entries
- I could not figure out how to include `.git` in deployment
- Future solution might be to perform the `yarn run build` on GitHub action, and deploy static files to Vercel

## How I Tested These Changes

`yarn build`

`👀  build/sitemap.xml`

## Changelog

NOCHANGELOG
