### PR TITLE
feat: graphql add Run.hasRunMetricsEnabled field

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -1440,6 +1440,7 @@ type Run implements PipelineRun & RunsFeedEntry {
   hasConcurrencyKeySlots: Boolean!
   rootConcurrencyKeys: [String!]
   hasUnconstrainedRootNodes: Boolean!
+  hasRunMetricsEnabled: Boolean!
 }
 
 interface RunsFeedEntry {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -4435,6 +4435,7 @@ export type Run = PipelineRun &
     hasConcurrencyKeySlots: Scalars['Boolean']['output'];
     hasDeletePermission: Scalars['Boolean']['output'];
     hasReExecutePermission: Scalars['Boolean']['output'];
+    hasRunMetricsEnabled: Scalars['Boolean']['output'];
     hasTerminatePermission: Scalars['Boolean']['output'];
     hasUnconstrainedRootNodes: Scalars['Boolean']['output'];
     id: Scalars['ID']['output'];
@@ -12981,6 +12982,10 @@ export const buildRun = (
       overrides && overrides.hasOwnProperty('hasReExecutePermission')
         ? overrides.hasReExecutePermission!
         : true,
+    hasRunMetricsEnabled:
+      overrides && overrides.hasOwnProperty('hasRunMetricsEnabled')
+        ? overrides.hasRunMetricsEnabled!
+        : false,
     hasTerminatePermission:
       overrides && overrides.hasOwnProperty('hasTerminatePermission')
         ? overrides.hasTerminatePermission!

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -90,6 +90,12 @@ USER_EDITABLE_SYSTEM_TAGS = [
     RETRY_ON_ASSET_OR_OP_FAILURE_TAG,
 ]
 
+# Supports for the public tag is deprecated
+RUN_METRIC_TAGS = [
+    f"{HIDDEN_TAG_PREFIX}run_metrics",
+    f"{SYSTEM_TAG_PREFIX}run_metrics",
+]
+
 
 class TagType(Enum):
     # Custom tag provided by a user


### PR DESCRIPTION
## Summary & Motivation

This change introduces a new field `hasRunMetricsEnabled` to the GrapheneRun type in the GraphQL schema. It allows clients to query whether run metrics are enabled for a specific run. The implementation checks for the presence of run metric tags and their boolean values.

This enables hiding the run metrics tag to declutter the frontend of this implementation detail.

## How I Tested These Changes

- BK w/ added test

## Changelog

NOCHANGELOG
