### PR TITLE
Refactor airlift defintions construction logic for more elegant replacement

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
@@ -3,10 +3,12 @@ from typing import AbstractSet, List, Optional
 from dagster import AssetKey, AssetsDefinition, AssetSpec, external_asset_from_spec
 from dagster._core.definitions.asset_key import AssetCheckKey
 from dagster._record import record
+from dagster._serdes.serdes import whitelist_for_serdes
 
 from dagster_airlift.core.serialization.serialized_data import SerializedAirflowDefinitionsData
 
 
+@whitelist_for_serdes
 @record
 class AirflowDefinitionsData:
     instance_name: str

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -22,6 +22,7 @@ from dagster._core.test_utils import environ
 from dagster_airlift.core import (
     build_defs_from_airflow_instance as build_defs_from_airflow_instance,
 )
+from dagster_airlift.core.airflow_defs_data import AirflowDefinitionsData
 from dagster_airlift.core.serialization.compute import compute_serialized_data
 from dagster_airlift.test import make_instance
 from dagster_airlift.utils import DAGSTER_AIRLIFT_MIGRATION_STATE_DIR_ENV_VAR
@@ -323,6 +324,9 @@ def test_cached_loading() -> None:
     } == {a, AssetKey(["airflow_instance", "dag", "dag"])}
     assert len(defs.metadata) == 1
     assert "dagster-airlift/source/test_instance" in defs.metadata
+    assert isinstance(
+        defs.metadata["dagster-airlift/source/test_instance"].value, AirflowDefinitionsData
+    )
 
     # Create a load definitions_load_context with cache data
     context_with_cache = DefinitionsLoadContext(

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -19,6 +19,7 @@ from dagster import (
 from dagster._core.definitions.definitions_loader import DefinitionsLoadContext, DefinitionsLoadType
 from dagster._core.definitions.repository_definition.repository_definition import RepositoryLoadData
 from dagster._core.test_utils import environ
+from dagster._serdes.serdes import deserialize_value
 from dagster_airlift.core import (
     build_defs_from_airflow_instance as build_defs_from_airflow_instance,
 )
@@ -324,8 +325,10 @@ def test_cached_loading() -> None:
     } == {a, AssetKey(["airflow_instance", "dag", "dag"])}
     assert len(defs.metadata) == 1
     assert "dagster-airlift/source/test_instance" in defs.metadata
+    assert isinstance(defs.metadata["dagster-airlift/source/test_instance"].value, str)
     assert isinstance(
-        defs.metadata["dagster-airlift/source/test_instance"].value, AirflowDefinitionsData
+        deserialize_value(defs.metadata["dagster-airlift/source/test_instance"].value),
+        AirflowDefinitionsData,
     )
 
     # Create a load definitions_load_context with cache data


### PR DESCRIPTION
## Summary & Motivation

I had encountered a bug around using serdes objects in the DefinitionsLoadContext. I ended up doing this refactor and adding a test case to understand the existing behavior. This made the replacement upstack more minimal so submitting a separate PR.

Specifically `defs_with_airflow_metadata_applied` was kind of in an unexpected spot (deep in the callstack) so moved it much closer to where the state is actually fetched.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG