### PR TITLE
Fix `dagster-cloud serverless deploy-python-executable` references in docs

### DIFF
--- a/docs/content/dagster-plus/deployment/serverless.mdx
+++ b/docs/content/dagster-plus/deployment/serverless.mdx
@@ -194,7 +194,7 @@ To build and upload the image, use the command line:
    $ dagster-cloud serverless upload-base-image local-image:tag
 
    ...
-   To use the uploaded image run: dagster-cloud deploy-python-executable ... --base-image-tag=sha256_518ad2f92b078c63c60e89f0310f13f19d3a1c7ea9e1976d67d59fcb7040d0d6
+   To use the uploaded image run: dagster-cloud serverless deploy-python-executable ... --base-image-tag=sha256_518ad2f92b078c63c60e89f0310f13f19d3a1c7ea9e1976d67d59fcb7040d0d6
    ```
 
 3. To use a Docker image you have published to Dagster+, use the `--base-image-tag` tag printed out by the above command.

--- a/docs/docs-beta/docs/dagster-plus/deployment/serverless/runtime-environment.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/serverless/runtime-environment.md
@@ -62,7 +62,7 @@ Setting a custom base image isn't supported for GitLab CI/CD workflows out of th
     $ dagster-cloud serverless upload-base-image local-image:tag
 
     ...
-    To use the uploaded image run: dagster-cloud deploy-python-executable ... --base-image-tag=sha256_518ad2f92b078c63c60e89f0310f13f19d3a1c7ea9e1976d67d59fcb7040d0d6
+    To use the uploaded image run: dagster-cloud serverless deploy-python-executable ... --base-image-tag=sha256_518ad2f92b078c63c60e89f0310f13f19d3a1c7ea9e1976d67d59fcb7040d0d6
     ```
 
 4. Specify this base image tag in you GitHub workflow, or using the `dagster-cloud` CLI:


### PR DESCRIPTION
## Summary & Motivation

It should be `dagster-cloud serverless deploy-python-executable` and not `dagster-cloud deploy-python-executable`.

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
