### PR TITLE
[docs-beta] add algolia search when deployed

### DIFF
--- a/docs/docs-beta/README.md
+++ b/docs/docs-beta/README.md
@@ -131,3 +131,15 @@ yarn sync-api-docs && yarn build
 ```
 
 This runs the `scripts/vercel-sync-api-docs.sh` script which builds the MDX files using the custom `sphinx-mdx-builder`, and copies the resulting MDX files to `docs/api`.
+
+## Search
+
+Algolia search is used for search results on the website, as configured in `docusaurus.config.ts`.
+
+The following environment variables must be configured in Vercel:
+
+- `ALGOLIA_APP_ID`
+- `ALGOLIA_API_KEY`
+- `ALGOLIA_INDEX_NAME`
+
+These variables are not loaded when `process.env.ENV === 'development'`.

--- a/docs/docs-beta/docusaurus.config.ts
+++ b/docs/docs-beta/docusaurus.config.ts
@@ -23,6 +23,16 @@ const config: Config = {
     require.resolve('docusaurus-plugin-image-zoom'),
   ],
   themeConfig: {
+    // Algolia environment variables are not required during development
+    algolia:
+      process.env.NODE_ENV === 'development'
+        ? null
+        : {
+            appId: process.env.ALGOLIA_APP_ID,
+            apiKey: process.env.ALGOLIA_API_KEY,
+            indexName: process.env.ALGOLIA_INDEX_NAME,
+            contextualSearch: false,
+          },
     announcementBar: {
       id: 'announcementBar',
       // TODO - once discussion has been created update link


### PR DESCRIPTION
## Summary & Motivation

- Adds Algolia search when _not_ `process.env.ENV === 'development'

## How I Tested These Changes

- Reviewed the deployed preview

## Changelog

NOCHANGELOG
