### PR TITLE
[dagster-sigma] Extract defs loading context implicitly

### DIFF
--- a/docs/content/integrations/sigma.mdx
+++ b/docs/content/integrations/sigma.mdx
@@ -45,9 +45,7 @@ resource = SigmaOrganization(
 )
 
 
-@definitions
-def defs(context: DefinitionsLoadContext) -> Definitions:
-    return resource.build_defs(context)
+defs = resource.build_defs()
 ```
 
 ### Customize asset definition metadata for Sigma assets
@@ -81,11 +79,7 @@ class MyCustomSigmaTranslator(DagsterSigmaTranslator):
         return super().get_workbook_spec(data)._replace(owners=["my_team"])
 
 
-@definitions
-def defs(context: DefinitionsLoadContext) -> Definitions:
-    return resource.build_defs(
-        context, dagster_sigma_translator=MyCustomSigmaTranslator
-    )
+defs = resource.build_defs(dagster_sigma_translator=MyCustomSigmaTranslator)
 ```
 
 ### Load Sigma assets from multiple organizations
@@ -110,14 +104,8 @@ marketing_team_organization = SigmaOrganization(
     client_id=EnvVar("MARKETING_SIGMA_CLIENT_ID"),
     client_secret=EnvVar("MARKETING_SIGMA_CLIENT_SECRET"),
 )
-
-
-@definitions
-def defs(context: DefinitionsLoadContext) -> Definitions:
-    # We use Definitions.merge to combine the definitions from both organizations
-    # into a single set of definitions to load
-    return Definitions.merge(
-        sales_team_organization.build_defs(context),
-        marketing_team_organization.build_defs(context),
-    )
+defs = Definitions.merge(
+    sales_team_organization.build_defs(),
+    marketing_team_organization.build_defs(),
+)
 ```

--- a/examples/docs_snippets/docs_snippets/integrations/sigma/customize-sigma-asset-defs.py
+++ b/examples/docs_snippets/docs_snippets/integrations/sigma/customize-sigma-asset-defs.py
@@ -24,8 +24,4 @@ class MyCustomSigmaTranslator(DagsterSigmaTranslator):
         return super().get_workbook_spec(data)._replace(owners=["my_team"])
 
 
-@definitions
-def defs(context: DefinitionsLoadContext) -> Definitions:
-    return resource.build_defs(
-        context, dagster_sigma_translator=MyCustomSigmaTranslator
-    )
+defs = resource.build_defs(dagster_sigma_translator=MyCustomSigmaTranslator)

--- a/examples/docs_snippets/docs_snippets/integrations/sigma/multiple-sigma-organizations.py
+++ b/examples/docs_snippets/docs_snippets/integrations/sigma/multiple-sigma-organizations.py
@@ -15,13 +15,7 @@ marketing_team_organization = SigmaOrganization(
     client_id=EnvVar("MARKETING_SIGMA_CLIENT_ID"),
     client_secret=EnvVar("MARKETING_SIGMA_CLIENT_SECRET"),
 )
-
-
-@definitions
-def defs(context: DefinitionsLoadContext) -> Definitions:
-    # We use Definitions.merge to combine the definitions from both organizations
-    # into a single set of definitions to load
-    return Definitions.merge(
-        sales_team_organization.build_defs(context),
-        marketing_team_organization.build_defs(context),
-    )
+defs = Definitions.merge(
+    sales_team_organization.build_defs(),
+    marketing_team_organization.build_defs(),
+)

--- a/examples/docs_snippets/docs_snippets/integrations/sigma/representing-sigma-assets.py
+++ b/examples/docs_snippets/docs_snippets/integrations/sigma/representing-sigma-assets.py
@@ -11,6 +11,4 @@ resource = SigmaOrganization(
 )
 
 
-@definitions
-def defs(context: DefinitionsLoadContext) -> Definitions:
-    return resource.build_defs(context)
+defs = resource.build_defs()

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -245,21 +245,18 @@ class SigmaOrganization(ConfigurableResource):
 
     def build_defs(
         self,
-        context: Optional[DefinitionsLoadContext] = None,
         dagster_sigma_translator: Type[DagsterSigmaTranslator] = DagsterSigmaTranslator,
     ) -> Definitions:
         """Returns a Definitions object representing the Sigma content in the organization.
 
         Args:
-            context (Optional[DefinitionsLoadContext]): The context in which the definitions are being loaded. If not
-                provided, inferred from the current context.
             dagster_sigma_translator (Type[DagsterSigmaTranslator]): The translator to use
                 to convert Sigma content into AssetSpecs. Defaults to DagsterSigmaTranslator.
 
         Returns:
             Definitions: The set of assets representing the Sigma content in the organization.
         """
-        context = context or DefinitionsLoadContext.get()
+        context = DefinitionsLoadContext.get()
 
         # Attempt to load cached data from the context.
         if (

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -245,19 +245,22 @@ class SigmaOrganization(ConfigurableResource):
 
     def build_defs(
         self,
-        context: DefinitionsLoadContext,
+        context: Optional[DefinitionsLoadContext] = None,
         dagster_sigma_translator: Type[DagsterSigmaTranslator] = DagsterSigmaTranslator,
     ) -> Definitions:
         """Returns a Definitions object representing the Sigma content in the organization.
 
         Args:
-            context (DefinitionsLoadContext): The context in which the definitions are being loaded.
+            context (Optional[DefinitionsLoadContext]): The context in which the definitions are being loaded. If not
+                provided, inferred from the current context.
             dagster_sigma_translator (Type[DagsterSigmaTranslator]): The translator to use
                 to convert Sigma content into AssetSpecs. Defaults to DagsterSigmaTranslator.
 
         Returns:
             Definitions: The set of assets representing the Sigma content in the organization.
         """
+        context = context or DefinitionsLoadContext.get()
+
         # Attempt to load cached data from the context.
         if (
             context.load_type == DefinitionsLoadType.RECONSTRUCTION

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/pending_repo.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/pending_repo.py
@@ -1,7 +1,5 @@
 from dagster import asset, define_asset_job
-from dagster._core.definitions.decorators.definitions_decorator import definitions
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.definitions_loader import DefinitionsLoadContext
 from dagster_sigma import SigmaBaseUrl, SigmaOrganization
 
 fake_client_id = "fake_client_id"
@@ -20,10 +18,8 @@ def my_materializable_asset():
     pass
 
 
-@definitions
-def defs(context: DefinitionsLoadContext) -> Definitions:
-    sigma_defs = resource.build_defs(context)
-    return Definitions.merge(
-        Definitions(assets=[my_materializable_asset], jobs=[define_asset_job("all_asset_job")]),
-        sigma_defs,
-    )
+sigma_defs = resource.build_defs()
+defs = Definitions.merge(
+    Definitions(assets=[my_materializable_asset], jobs=[define_asset_job("all_asset_job")]),
+    sigma_defs,
+)


### PR DESCRIPTION
## Summary & Motivation

Now that we can obtain the definitions load context contextually, add a default `None` input for `sigma_organization.build_defs()` so that it can be called outside the context of a definitions-building function. This simplifies the user-facing code:

```python
resource = SigmaOrganization(
    base_url=SigmaBaseUrl.AWS_US,
    client_id=fake_client_id,
    client_secret=fake_client_secret,
)


@asset
def my_materializable_asset():
    pass

defs = Definitions.merge(
    Definitions(assets=[my_materializable_asset], jobs=[define_asset_job("all_asset_job")]),
    resource.build_defs(),
)

```

## Test Plan

Existing unit tests, with new approach.

## Changelog

NOCHANGELOG