### PR TITLE
Allow name to be assigned independently of key in the @asset / @graph_asset decorators

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -172,7 +172,7 @@ class _ObservableSourceAsset:
         self.tags = tags
 
     def __call__(self, observe_fn: SourceAssetObserveFunction) -> SourceAsset:
-        source_asset_key, source_asset_name = resolve_asset_key_and_name_for_decorator(
+        source_asset_key, _node_name = resolve_asset_key_and_name_for_decorator(
             key=self.key,
             key_prefix=self.key_prefix,
             name=self.name,


### PR DESCRIPTION
## Summary & Motivation

Currently it's not possible to create an asset like the following:

```python
@asset(key=AssetKey("test.test"))
```

This is because we convert the asset key into the op name when generating the definition, and the op name cannot have a "." in it. If you try to set the `name` arg to something valid, then this will also result in an error.

## How I Tested These Changes

## Changelog

Fixed an issue which made it impossible to generate assets using the `@asset` decorator if the key had certain special characters in it.

- [ ] `NEW` _(added new feature or capability)_
- [x] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
