### PR TITLE
Add functional type mapping object to control complexity in compute_serialized_data

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
@@ -40,27 +40,21 @@ class TaskSpecMappingInfo:
     @cached_property
     # dag_id -> set of task_ids
     def task_id_map(self) -> Dict[str, Set[str]]:
-        return defaultdict(
-            set,
-            {
-                dag_id: set(task_to_asset_map.keys())
-                for dag_id, task_to_asset_map in self.asset_key_map.items()
-            },
-        )
+        task_id_map_data = {
+            dag_id: set(ta_map.keys()) for dag_id, ta_map in self.asset_key_map.items()
+        }
+        return defaultdict(set, task_id_map_data)
 
     @cached_property
+    # dag_id -> set of asset_keys
     def asset_keys_per_dag_id(self) -> Dict[str, Set[AssetKey]]:
-        return defaultdict(
-            set,
-            {
-                dag_id: {
-                    asset_key
-                    for asset_keys in task_to_asset_map.values()
-                    for asset_key in asset_keys
-                }
-                for dag_id, task_to_asset_map in self.asset_key_map.items()
-            },
-        )
+        asset_keys_per_dag_data = {
+            dag_id: {
+                asset_key for asset_keys in task_to_asset_map.values() for asset_key in asset_keys
+            }
+            for dag_id, task_to_asset_map in self.asset_key_map.items()
+        }
+        return defaultdict(set, asset_keys_per_dag_data)
 
     @cached_property
     # dag_id -> task_id -> set of asset_keys

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
@@ -38,16 +38,16 @@ class TaskSpecMappingInfo:
         return set(self.task_id_map.keys())
 
     @cached_property
-    # dag_id -> set of task_ids
     def task_id_map(self) -> Dict[str, Set[str]]:
+        """Mapping of dag_id to set of task_ids in that dag."""
         task_id_map_data = {
             dag_id: set(ta_map.keys()) for dag_id, ta_map in self.asset_key_map.items()
         }
         return defaultdict(set, task_id_map_data)
 
     @cached_property
-    # dag_id -> set of asset_keys
     def asset_keys_per_dag_id(self) -> Dict[str, Set[AssetKey]]:
+        """Mapping of dag_id to set of asset_keys in that dag. Does not include standlone dag assets."""
         asset_keys_per_dag_data = {
             dag_id: {
                 asset_key for asset_keys in task_to_asset_map.values() for asset_key in asset_keys
@@ -57,8 +57,8 @@ class TaskSpecMappingInfo:
         return defaultdict(set, asset_keys_per_dag_data)
 
     @cached_property
-    # dag_id -> task_id -> set of asset_keys
     def asset_key_map(self) -> Dict[str, Dict[str, Set[AssetKey]]]:
+        """Mapping of dag_id to task_id to set of asset_keys mapped from that task."""
         asset_key_map: Dict[str, Dict[str, Set[AssetKey]]] = defaultdict(lambda: defaultdict(set))
         for spec in self.asset_specs:
             if TASK_ID_METADATA_KEY in spec.metadata:

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
@@ -1,0 +1,56 @@
+from dagster._core.definitions.asset_key import AssetKey, CoercibleToAssetKey
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.definitions_class import Definitions
+from dagster_airlift.constants import DAG_ID_METADATA_KEY, TASK_ID_METADATA_KEY
+from dagster_airlift.core.serialization.compute import build_task_spec_mapping_info
+
+
+def ak(key: str) -> AssetKey:
+    return AssetKey(key)
+
+
+def airlift_asset_spec(key: CoercibleToAssetKey, dag_id: str, task_id: str) -> AssetSpec:
+    return AssetSpec(key=key, metadata={DAG_ID_METADATA_KEY: dag_id, TASK_ID_METADATA_KEY: task_id})
+
+
+def test_build_task_spec_mapping_info_no_mapping() -> None:
+    spec_mapping_info = build_task_spec_mapping_info(
+        defs=Definitions(assets=[AssetSpec("asset1"), AssetSpec("asset2")])
+    )
+    assert len(spec_mapping_info.asset_keys) == 2
+    assert len(spec_mapping_info.dag_ids) == 0
+    assert not (spec_mapping_info.asset_key_map)
+
+
+def test_build_single_task_spec() -> None:
+    spec_mapping_info = build_task_spec_mapping_info(
+        defs=Definitions(assets=[airlift_asset_spec("asset1", "dag1", "task1")])
+    )
+    assert spec_mapping_info.dag_ids == {"dag1"}
+    assert spec_mapping_info.task_id_map == {"dag1": {"task1"}}
+    assert spec_mapping_info.asset_keys_per_dag_id == {"dag1": {ak("asset1")}}
+    assert spec_mapping_info.asset_key_map == {"dag1": {"task1": {ak("asset1")}}}
+
+
+def test_task_with_multiple_assets() -> None:
+    spec_mapping_info = build_task_spec_mapping_info(
+        defs=Definitions(
+            assets=[
+                airlift_asset_spec("asset1", "dag1", "task1"),
+                airlift_asset_spec("asset2", "dag1", "task1"),
+                airlift_asset_spec("asset3", "dag1", "task1"),
+                airlift_asset_spec("asset4", "dag2", "task1"),
+            ]
+        )
+    )
+
+    assert spec_mapping_info.dag_ids == {"dag1", "dag2"}
+    assert spec_mapping_info.task_id_map == {"dag1": {"task1"}, "dag2": {"task1"}}
+    assert spec_mapping_info.asset_keys_per_dag_id == {
+        "dag1": {ak("asset1"), ak("asset2"), ak("asset3")},
+        "dag2": {ak("asset4")},
+    }
+    assert spec_mapping_info.asset_key_map == {
+        "dag1": {"task1": {ak("asset1"), ak("asset2"), ak("asset3")}},
+        "dag2": {"task1": {ak("asset4")}},
+    }


### PR DESCRIPTION
## Summary & Motivation

One of the big sources of complexity in airlift right now is `compute_serialized_data` which iteratively builds up a bunch of data structures in parallel. If we want to change anything about the way this works, it is complicated and error-prone.

Instead of building up these data structures imperatively in one pass, we instead will construct data structures that use functional programming to build up "views" of the data that are easier to reason about. 

In this case we introduce `TaskSpecMappingInfo` which manages all the various data that maps task_id and dag_ids to asset keys. 

It also accepts a list of asset specs, so the operations are guaranteed to be fast, and all results are memoized with `cached_property`.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG

