### PR TITLE
Add get_task_infos on AirflowInstance

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/test/airflow_test_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/test/airflow_test_instance.py
@@ -121,6 +121,15 @@ class AirflowInstanceFake(AirflowInstance):
             raise ValueError(f"Task info not found for dag_id {dag_id} and task_id {task_id}")
         return self._task_infos_by_dag_and_task_id[(dag_id, task_id)]
 
+    def get_task_infos(self, *, dag_id: str) -> List[TaskInfo]:
+        if dag_id not in self._dag_infos_by_dag_id:
+            raise ValueError(f"Dag info not found for dag_id {dag_id}")
+        task_infos = []
+        for dag_id, task_id in self._task_infos_by_dag_and_task_id:
+            if dag_id == dag_id:
+                task_infos.append(self._task_infos_by_dag_and_task_id[(dag_id, task_id)])
+        return task_infos
+
     def get_dag_info(self, dag_id) -> DagInfo:
         if dag_id not in self._dag_infos_by_dag_id:
             raise ValueError(f"Dag info not found for dag_id {dag_id}")

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_airflow_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_airflow_instance.py
@@ -32,6 +32,16 @@ def test_airflow_instance(airflow_instance: None) -> None:
     assert task_info.task_id == "print_task"
     assert_link_exists("Dag url from task info object", task_info.dag_url)
 
+    task_infos = instance.get_task_infos(dag_id="print_dag")
+    assert len(task_infos) == 2
+
+    task_dict = {task_info.task_id: task_info for task_info in task_infos}
+    assert set(task_dict.keys()) == {"print_task", "downstream_print_task"}
+    assert task_dict["print_task"].dag_id == "print_dag"
+    assert task_dict["print_task"].task_id == "print_task"
+    assert task_dict["downstream_print_task"].dag_id == "print_dag"
+    assert task_dict["downstream_print_task"].task_id == "downstream_print_task"
+
     task_info = instance.get_task_info(dag_id="print_dag", task_id="downstream_print_task")
     assert task_info.dag_id == "print_dag"
     assert task_info.task_id == "downstream_print_task"

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_test_utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_test_utils.py
@@ -44,6 +44,10 @@ def test_test_instance() -> None:
     with pytest.raises(ValueError):
         test_instance.get_task_info(dag_id="test_dag", task_id="nonexistent_task")
 
+    # Dag not in instance
+    with pytest.raises(ValueError):
+        test_instance.get_task_infos(dag_id="nonexistent_dag")
+
     # Task instance doesn't exist in instance (task id is wrong)
     with pytest.raises(ValueError):
         test_instance.get_task_instance(
@@ -90,6 +94,10 @@ def test_test_instance() -> None:
 
     # Can retrieve task info
     assert test_instance.get_task_info(dag_id="test_dag", task_id="test_task") == task_info
+
+    # Can retrieve task infos
+    assert test_instance.get_task_infos(dag_id="test_dag") == [task_info]
+
     # Can retrieve task instance
     assert (
         test_instance.get_task_instance(


### PR DESCRIPTION
## Summary & Motivation

Add `get_task_infos` to AirlfowInstance and its associated test class

We will use this to improve performance of our definitions fetching code.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG
