### PR TITLE
Use AirflowInstance.get_task_infos to improve performance.

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
@@ -144,11 +144,10 @@ def fetch_all_airflow_data(
     dag_infos = {dag.dag_id: dag for dag in airflow_instance.list_dags()}
     task_info_map = defaultdict(dict)
     for dag_id in mapping_info.dag_ids:
-        # TODO replace with single get_task_infos call
-        for task_id in mapping_info.task_id_map[dag_id]:
-            task_info_map[dag_id][task_id] = airflow_instance.get_task_info(
-                dag_id=dag_id, task_id=task_id
-            )
+        task_info_map[dag_id] = {
+            task_info.task_id: task_info
+            for task_info in airflow_instance.get_task_infos(dag_id=dag_id)
+        }
 
     migration_state = airflow_instance.get_migration_state()
 


### PR DESCRIPTION
## Summary & Motivation

Using bulk fetching of task infos on a per-dag basis. Things are much faster now.

## How I Tested These Changes

`sudo py-spy record --format speedscope -- python perf_harness/cli.py 1 100 1`

Before:

![Screenshot 2024-09-23 at 11.30.14 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/7b70c2b6-c13f-4280-b5dd-1e11bf1c240f.png)

After:

![Screenshot 2024-09-23 at 11.29.57 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/7f7f6cfc-1a8f-4128-a03b-58622a023914.png)

Suspect that at a certain number of dags and task we will need to either throttle down fetching or move this process to a CI/CD step in the Airflow repo. 

`make run_perf_1_100_1`

Before:

```
Total airflow dags load time: 0.2467 seconds
Airflow defs import time: 0.2093 seconds
Mark as dagster migrating time: 0.0311 seconds
Airflow setup time: 3.2898 seconds
Airflow standup time: 5.0973 seconds
Peered defs import time: 0.2268 seconds
Observed defs import time: 9.2317 seconds
Migrate defs import time: 8.4607 seconds
peer defs initial load time: 0.0017 seconds
observe defs initial load time: 0.0068 seconds
migrate defs initial load time: 0.0085 seconds
peer sensor tick with no runs time: 0.0868 seconds
observe sensor tick with no runs time: 0.0814 seconds
migrate sensor tick with no runs time: 0.0815 seconds
```

After:

```
Total airflow dags load time: 0.2248 seconds
Airflow defs import time: 0.1894 seconds
Mark as dagster migrating time: 0.0296 seconds
Airflow setup time: 3.0729 seconds
Airflow standup time: 5.0507 seconds
Peered defs import time: 0.1834 seconds
Observed defs import time: 0.3321 seconds
Migrate defs import time: 0.4488 seconds
peer defs initial load time: 0.0013 seconds
observe defs initial load time: 0.0039 seconds
migrate defs initial load time: 0.0051 seconds
peer sensor tick with no runs time: 0.0857 seconds
observe sensor tick with no runs time: 0.0847 seconds
migrate sensor tick with no runs time: 0.0859 seconds
```

So unscientifically 30x speed up or so on observe/migrate scenarios.

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
