### PR TITLE
[docs-beta] fix mobile view of announcement bar

### DIFF
--- a/docs/docs-beta/src/styles/custom.scss
+++ b/docs/docs-beta/src/styles/custom.scss
@@ -658,7 +658,8 @@ span {
 
 /* Announcement bar */
 div[class^='announcementBar_'] {
-  height: 40px;
   color: var(--theme-color-text);
-  background-color: var(--theme-color-background-red);
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  background-color: var(--theme-color-background-yellow);
 }


### PR DESCRIPTION
## Summary & Motivation

- Fixes mobile view of announcement bar
    * Removes hard-coded height limit
    * Adds padding to top and bottom
    * Changes color from red to yellow

**Before**

<img width="445" alt="image" src="https://github.com/user-attachments/assets/3263c08c-b86a-4890-af1b-016f04d4dae7">


**After**

<img width="425" alt="image" src="https://github.com/user-attachments/assets/e33c1641-cbf7-45bc-97d0-4014777e1e78">

## How I Tested These Changes

`yarn start`

## Changelog

NOCHANGELOG
