### PR TITLE
add AssetSpec.with_io_manager_key and update SourceAsset deprecation warning

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -3,7 +3,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, NamedTuple, Optional, Sequence, Set
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, experimental_param
+from dagster._annotations import PublicAttr, experimental_param, public
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
@@ -238,3 +238,9 @@ class AssetSpec(
     @cached_property
     def kinds(self) -> Set[str]:
         return {tag[len(KIND_PREFIX) :] for tag in self.tags if tag.startswith(KIND_PREFIX)}
+
+    @public
+    def with_io_manager_key(self, io_manager_key: str) -> "AssetSpec":
+        return self._replace(
+            metadata={**self.metadata, SYSTEM_METADATA_KEY_IO_MANAGER_KEY: io_manager_key}
+        )

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -167,7 +167,11 @@ def wrap_source_asset_observe_fn_in_op_compute_fn(
 @experimental_param(param="io_manager_def")
 @experimental_param(param="freshness_policy")
 @experimental_param(param="tags")
-@deprecated(breaking_version="2.0.0", additional_warn_text="Use AssetSpec instead.")
+@deprecated(
+    breaking_version="2.0.0",
+    additional_warn_text="Use AssetSpec instead. If using the SourceAsset io_manager_key property, "
+    "use AssetSpec(...).with_io_manager_key(...).",
+)
 class SourceAsset(ResourceAddable):
     """A SourceAsset represents an asset that will be loaded by (but not updated by) Dagster.
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_materialize.py
@@ -162,9 +162,7 @@ def test_materialize_asset_specs():
         def load_input(self, context):
             return 5
 
-    the_source = AssetSpec(
-        key=AssetKey(["the_source"]), metadata={"dagster/io_manager_key": "my_io_manager"}
-    )
+    the_source = AssetSpec(key=AssetKey(["the_source"])).with_io_manager_key("my_io_manager")
 
     @asset
     def the_asset(the_source):


### PR DESCRIPTION
## Motivation

`SourceAsset` has been deprecated in favor of `AssetSpec`. Unlike `SourceAsset`, `AssetSpec` has no `io_manager_key` attribute, but an IO manager key can be provided via metadata to dictate how the asset is loaded in downstream assets.

This metadata-based IO management has up until this point not been very discoverable (you need to read the migration guide or https://docs.dagster.io/concepts/io-management/io-managers#using-io-managers-to-load-source-data to find it).

## How I Tested These Changes

## Changelog

`AssetSpec` now has a `with_io_manager_key` method that returns an `AssetSpec` with the appropriate metadata entry to dictate the key for the IO manager used to load it. The deprecation warning for `SourceAsset` now references this method.

- [x] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
