### PR TITLE
Retry certain kinds of run task failures

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -12,11 +12,9 @@ from dagster import (
     Array,
     DagsterRunStatus,
     Field,
-    IntSource,
     Noneable,
     Permissive,
     ScalarUnion,
-    Shape,
     StringSource,
     _check as check,
 )
@@ -91,7 +89,6 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         run_task_kwargs: Optional[Mapping[str, Any]] = None,
         run_resources: Optional[Dict[str, Any]] = None,
         run_ecs_tags: Optional[List[Dict[str, Optional[str]]]] = None,
-        retries: Optional[Dict[str, int]] = None,
     ):
         self._inst_data = inst_data
         self.ecs = boto3.client("ecs")
@@ -182,8 +179,6 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         self.run_resources = check.opt_mapping_param(run_resources, "run_resources")
 
         self.run_ecs_tags = check.opt_sequence_param(run_ecs_tags, "run_ecs_tags")
-
-        self._retry_config = check.opt_dict_param(retries, "retries")
 
         self._current_task_metadata = None
         self._current_task = None
@@ -340,24 +335,6 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
                     " always be set by the run launcher."
                 ),
             ),
-            "retries": Field(
-                Shape(
-                    fields={
-                        "register_task_definition": Field(
-                            IntSource,
-                            is_required=False,
-                            default_value=DEFAULT_REGISTER_TASK_DEFINITION_RETRIES,
-                            description="How many times to retry transient ECS register_task_definition failures (for example, concurrent registrations of the same task defintion)",
-                        ),
-                        "run_task": Field(
-                            IntSource,
-                            is_required=False,
-                            default_value=DEFAULT_RUN_TASK_RETRIES,
-                            description="How many times to retry transient ECS run_task failures (for example, AZ capacity failures)",
-                        ),
-                    }
-                )
-            ),
             **SHARED_ECS_SCHEMA,
         }
 
@@ -498,7 +475,9 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
             self._run_task,
             retry_on=(RetryableEcsException,),
             kwargs=run_task_kwargs,
-            max_retries=self._retry_config.get("run_task", DEFAULT_RUN_TASK_RETRIES),
+            max_retries=int(
+                os.getenv("RUN_TASK_RETRIES", DEFAULT_RUN_TASK_RETRIES),
+            ),
         )
 
         arn = task["taskArn"]
@@ -704,8 +683,10 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
                     "container_name": container_name,
                     "task_definition_dict": task_definition_dict,
                 },
-                max_retries=self._retry_config.get(
-                    "register_task_definition", DEFAULT_REGISTER_TASK_DEFINITION_RETRIES
+                max_retries=int(
+                    os.getenv(
+                        "REGISTER_TASK_DEFINITION_RETRIES", DEFAULT_REGISTER_TASK_DEFINITION_RETRIES
+                    ),
                 ),
             )
 

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -67,6 +67,9 @@ DEFAULT_WINDOWS_RESOURCES = {"cpu": "1024", "memory": "2048"}
 DEFAULT_LINUX_RESOURCES = {"cpu": "256", "memory": "512"}
 
 
+class RetryableEcsException(Exception): ...
+
+
 class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
     """RunLauncher that starts a task in ECS for each Dagster job run."""
 
@@ -373,6 +376,36 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         job_origin = check.not_none(context.job_code_origin)
         return job_origin.repository_origin.container_image
 
+    def _run_task(self, **run_task_kwargs):
+        response = self.ecs.run_task(**run_task_kwargs)
+
+        tasks = response["tasks"]
+
+        if not tasks:
+            failures = response["failures"]
+            failure_messages = []
+            for failure in failures:
+                arn = failure.get("arn")
+                reason = failure.get("reason")
+                detail = failure.get("detail")
+
+                failure_message = (
+                    "Task"
+                    + (f" {arn}" if arn else "")
+                    + " failed."
+                    + (f" Failure reason: {reason}" if reason else "")
+                    + (f" Failure details: {detail}" if detail else "")
+                )
+                failure_messages.append(failure_message)
+
+            failure_message = "\n".join(failure_messages) if failure_messages else "Task failed."
+
+            if "Capacity is unavailable at this time" in failure_message:
+                raise RetryableEcsException(failure_message)
+
+            raise Exception(failure_message)
+        return tasks[0]
+
     def launch_run(self, context: LaunchRunContext) -> None:
         """Launch a run in an ECS task."""
         run = context.dagster_run
@@ -435,31 +468,15 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
             del run_task_kwargs["launchType"]
 
         # Run a task using the same network configuration as this processes's task.
-        response = self.ecs.run_task(**run_task_kwargs)
+        task = backoff(
+            self._run_task,
+            retry_on=(RetryableEcsException,),
+            kwargs=run_task_kwargs,
+            max_retries=5,
+        )
 
-        tasks = response["tasks"]
-
-        if not tasks:
-            failures = response["failures"]
-            failure_messages = []
-            for failure in failures:
-                arn = failure.get("arn")
-                reason = failure.get("reason")
-                detail = failure.get("detail")
-
-                failure_message = (
-                    "Task"
-                    + (f" {arn}" if arn else "")
-                    + " failed."
-                    + (f" Failure reason: {reason}" if reason else "")
-                    + (f" Failure details: {detail}" if detail else "")
-                )
-                failure_messages.append(failure_message)
-
-            raise Exception("\n".join(failure_messages) if failure_messages else "Task failed.")
-
-        arn = tasks[0]["taskArn"]
-        cluster_arn = tasks[0]["clusterArn"]
+        arn = task["taskArn"]
+        cluster_arn = task["clusterArn"]
         self._set_run_tags(run.run_id, cluster=cluster_arn, task_arn=arn)
         self.report_launch_events(run, arn, cluster_arn)
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_failures.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_failures.py
@@ -30,3 +30,30 @@ def test_run_task_failure(ecs, instance, workspace, run):
     )
     assert ex.match("\nTask missing-detail failed. Failure reason: too succinct\n")
     assert ex.match("Task failed. Failure reason: ran out of arns")
+
+
+def test_run_task_retryrable_failure(ecs, instance, workspace, run):
+    original = ecs.run_task
+
+    out_of_capacity_response = {
+        "tasks": [],
+        "failures": [
+            {
+                "arn": "missing-capacity",
+                "reason": "Capacity is unavailable at this time. Please try again later or in a different availability zone",
+                "detail": "boom",
+            },
+        ],
+    }
+
+    retryable_failures = iter([out_of_capacity_response])
+
+    def run_task(*args, **kwargs):
+        try:
+            return next(retryable_failures)
+        except StopIteration:
+            return original(*args, **kwargs)
+
+    instance.run_launcher.ecs.run_task = run_task
+
+    instance.launch_run(run.run_id, workspace)


### PR DESCRIPTION
For example, task placement failures.

## Changelog

[dagster-aws] The ECS launcher now automatically retries transient ECS RunTask failures (like capacity placement failures).

- [x] `NEW` 
