### PR TITLE
Refactor compute.py to think in terms of multiple task handles per asset key

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from functools import cached_property
-from typing import Dict, List, NamedTuple, Optional, Set
+from typing import Dict, List, Optional, Set
 
 from dagster import (
     AssetKey,
@@ -22,14 +22,14 @@ from dagster_airlift.core.serialization.serialized_data import (
     SerializedDagData,
     SerializedTaskHandleData,
 )
-from dagster_airlift.core.task_asset import get_airflow_data_for_task_mapped_spec
+from dagster_airlift.core.task_asset import (
+    FetchedAirflowTask,
+    TaskHandle,
+    TasksToAssetMapping,
+    get_airflow_data_for_task_mapped_spec,
+)
 from dagster_airlift.core.utils import spec_iterator
 from dagster_airlift.migration_state import AirflowMigrationState
-
-
-class TaskHandle(NamedTuple):
-    dag_id: str
-    task_id: str
 
 
 @record
@@ -73,17 +73,17 @@ class TaskSpecMappingInfo:
         asset_key_map: Dict[str, Dict[str, Set[AssetKey]]] = defaultdict(lambda: defaultdict(set))
         for spec in self.asset_specs:
             if is_mapped_asset_spec(spec):
-                dag_id, task_id = task_handle_for_spec(spec)
-                asset_key_map[dag_id][task_id].add(spec.key)
+                for task_handle in task_handles_for_spec(spec):
+                    asset_key_map[task_handle.dag_id][task_handle.task_id].add(spec.key)
         return asset_key_map
 
     @cached_property
-    def task_handle_map(self) -> Dict[AssetKey, TaskHandle]:
+    def task_handle_map(self) -> Dict[AssetKey, Set[TaskHandle]]:
         task_handle_map = {}
         for dag_id, asset_key_by_task_id in self.asset_key_map.items():
             for task_id, asset_keys in asset_key_by_task_id.items():
                 for asset_key in asset_keys:
-                    task_handle_map[asset_key] = TaskHandle(dag_id=dag_id, task_id=task_id)
+                    task_handle_map[asset_key] = set([TaskHandle(dag_id=dag_id, task_id=task_id)])
         return task_handle_map
 
 
@@ -91,10 +91,15 @@ def is_mapped_asset_spec(spec: AssetSpec) -> bool:
     return DAG_ID_METADATA_KEY in spec.metadata and TASK_ID_METADATA_KEY in spec.metadata
 
 
-def task_handle_for_spec(spec: AssetSpec) -> TaskHandle:
+def task_handles_for_spec(spec: AssetSpec) -> Set[TaskHandle]:
     check.param_invariant(is_mapped_asset_spec(spec), "spec", "Must be mappped spec")
-    return TaskHandle(
-        dag_id=spec.metadata[DAG_ID_METADATA_KEY], task_id=spec.metadata[TASK_ID_METADATA_KEY]
+    return set(
+        [
+            TaskHandle(
+                dag_id=spec.metadata[DAG_ID_METADATA_KEY],
+                task_id=spec.metadata[TASK_ID_METADATA_KEY],
+            )
+        ]
     )
 
 
@@ -114,22 +119,32 @@ class FetchedAirflowData:
     def migration_state_map(self) -> Dict[str, Dict[str, Optional[bool]]]:
         migration_state_map: Dict[str, Dict[str, Optional[bool]]] = defaultdict(dict)
         for spec in self.spec_mapping_info.mapped_asset_specs:
-            dag_id, task_id = task_handle_for_spec(spec)
-            migration_state_for_task = self.migration_state.get_migration_state_for_task(
-                dag_id=dag_id, task_id=task_id
-            )
-            migration_state_map[dag_id][task_id] = migration_state_for_task
+            for task_handle in task_handles_for_spec(spec):
+                dag_id, task_id = task_handle
+                migration_state_map[task_handle.dag_id][task_handle.task_id] = None
+                migration_state_for_task = self.migration_state.get_migration_state_for_task(
+                    dag_id=dag_id, task_id=task_id
+                )
+                migration_state_map[dag_id][task_id] = migration_state_for_task
         return migration_state_map
 
     @cached_property
     def airflow_data_by_key(self) -> Dict[AssetKey, SerializedAssetKeyScopedAirflowData]:
         airflow_data_by_key = {}
         for spec in self.spec_mapping_info.mapped_asset_specs:
-            dag_id, task_id = task_handle_for_spec(spec)
-            airflow_data_by_key[spec.key] = get_airflow_data_for_task_mapped_spec(
-                task_info=self.task_info_map[dag_id][task_id],
-                migration_state=self.migration_state_map[dag_id][task_id],
+            mapping = TasksToAssetMapping(
+                asset=spec,
+                mapped_tasks=[
+                    FetchedAirflowTask(
+                        task_handle=task_handle,
+                        task_info=self.task_info_map[task_handle.dag_id][task_handle.task_id],
+                        migrated=self.migration_state_map[task_handle.dag_id][task_handle.task_id],
+                    )
+                    for task_handle in task_handles_for_spec(spec)
+                ],
             )
+
+            airflow_data_by_key[spec.key] = get_airflow_data_for_task_mapped_spec(mapping)
 
         return airflow_data_by_key
 

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/task_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/task_asset.py
@@ -1,7 +1,12 @@
-from typing import Any, Mapping, Optional
+from typing import Any, List, Mapping, NamedTuple, Optional
 
-from dagster import JsonMetadataValue
+from dagster import (
+    JsonMetadataValue,
+    _check as check,
+)
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.metadata.metadata_value import UrlMetadataValue
+from dagster._record import record
 
 from dagster_airlift.constants import MIGRATED_TAG
 from dagster_airlift.core.airflow_instance import TaskInfo
@@ -9,13 +14,45 @@ from dagster_airlift.core.serialization.serialized_data import SerializedAssetKe
 from dagster_airlift.core.utils import airflow_kind_dict
 
 
+class TaskHandle(NamedTuple):
+    dag_id: str
+    task_id: str
+
+
+@record
+class FetchedAirflowTask:
+    task_info: TaskInfo
+    task_handle: TaskHandle
+    migrated: Optional[bool]
+
+
+@record
+class TasksToAssetMapping:
+    """Represents a mapping between a Dagster asset and the tasks in Airflow
+    that orchestrate. We support multiple tasks mapping to a single asset. (e.g. a daily and weekly DAG)
+    So there can multiple tasks for single asset key.
+    """
+
+    asset: AssetSpec
+    mapped_tasks: List[FetchedAirflowTask]
+
+
 def get_airflow_data_for_task_mapped_spec(
-    task_info: TaskInfo,
-    migration_state: Optional[bool],
+    mapping: TasksToAssetMapping,
 ) -> SerializedAssetKeyScopedAirflowData:
+    check.param_invariant(
+        len(mapping.mapped_tasks) == 1,
+        "edges",
+        "For now we constrain to 1:1 relationship between asset and task until we support multiple tasks in asset metadata",
+    )
+    mapped_task = mapping.mapped_tasks[0]
+    migration_state = mapped_task.migrated
+    task_info = mapped_task.task_info
+
     tags = airflow_kind_dict() if not migration_state else {}
     if migration_state is not None:
         tags[MIGRATED_TAG] = str(bool(migration_state))
+
     return SerializedAssetKeyScopedAirflowData(
         additional_metadata=task_asset_metadata(task_info, migration_state),
         additional_tags=tags,

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
@@ -42,7 +42,7 @@ def test_build_single_task_spec() -> None:
     assert spec_mapping_info.asset_keys_per_dag_id == {"dag1": {ak("asset1")}}
     assert spec_mapping_info.asset_key_map == {"dag1": {"task1": {ak("asset1")}}}
     assert spec_mapping_info.task_handle_map == {
-        ak("asset1"): TaskHandle(dag_id="dag1", task_id="task1")
+        ak("asset1"): set([TaskHandle(dag_id="dag1", task_id="task1")])
     }
 
 
@@ -70,10 +70,10 @@ def test_task_with_multiple_assets() -> None:
     }
 
     assert spec_mapping_info.task_handle_map == {
-        ak("asset1"): TaskHandle(dag_id="dag1", task_id="task1"),
-        ak("asset2"): TaskHandle(dag_id="dag1", task_id="task1"),
-        ak("asset3"): TaskHandle(dag_id="dag1", task_id="task1"),
-        ak("asset4"): TaskHandle(dag_id="dag2", task_id="task1"),
+        ak("asset1"): set([TaskHandle(dag_id="dag1", task_id="task1")]),
+        ak("asset2"): set([TaskHandle(dag_id="dag1", task_id="task1")]),
+        ak("asset3"): set([TaskHandle(dag_id="dag1", task_id="task1")]),
+        ak("asset4"): set([TaskHandle(dag_id="dag2", task_id="task1")]),
     }
 
 


### PR DESCRIPTION
## Summary & Motivation

To split up the work of converting to allowing multiple tasks to map to single asset, we first refactor the internals to handle this without changing the actual metadata format. We write everything in terms of lists but asset that those lists only contain one element.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG