### PR TITLE
Change underlying metadata representation to handle multiple task mappings

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/constants.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/constants.py
@@ -1,3 +1,3 @@
-DAG_ID_METADATA_KEY = "airlift/dag_id"
-TASK_ID_METADATA_KEY = "airlift/task_id"
+STANDALONE_DAG_ID_METADATA_KEY = "airlift/dag_id"
 AIRFLOW_SOURCE_METADATA_KEY_PREFIX = "dagster-airlift/source"
+TASK_MAPPING_METADATA_KEY = "airlift/task_mapping"

--- a/examples/experimental/dagster-airlift/dagster_airlift/constants.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/constants.py
@@ -1,3 +1,3 @@
 STANDALONE_DAG_ID_METADATA_KEY = "airlift/dag_id"
 AIRFLOW_SOURCE_METADATA_KEY_PREFIX = "dagster-airlift/source"
-TASK_MAPPING_METADATA_KEY = "airlift/task_mapping"
+TASK_MAPPING_METADATA_KEY = "dagster-airlift/task_mapping"

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/dag_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/dag_asset.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Mapping, Sequence, Set
 from dagster import AssetKey, JsonMetadataValue, MarkdownMetadataValue
 from dagster._core.definitions.metadata.metadata_value import UrlMetadataValue
 
-from dagster_airlift.constants import DAG_ID_METADATA_KEY
+from dagster_airlift.constants import STANDALONE_DAG_ID_METADATA_KEY
 from dagster_airlift.core.airflow_instance import AirflowInstance, DagInfo
 from dagster_airlift.core.serialization.serialized_data import (
     SerializedAssetDepData,
@@ -40,7 +40,7 @@ def dag_asset_metadata(airflow_instance: AirflowInstance, dag_info: DagInfo) -> 
         "Dag Info (raw)": JsonMetadataValue(dag_info.metadata),
         "Dag ID": dag_info.dag_id,
         "Link to DAG": UrlMetadataValue(dag_info.url),
-        DAG_ID_METADATA_KEY: dag_info.dag_id,
+        STANDALONE_DAG_ID_METADATA_KEY: dag_info.dag_id,
     }
     source_code = airflow_instance.get_dag_source_code(dag_info.metadata["file_token"])
     # Attempt to retrieve source code from the DAG.

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/dag_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/dag_defs.py
@@ -7,7 +7,7 @@ from dagster import (
     _check as check,
 )
 
-from dagster_airlift.constants import DAG_ID_METADATA_KEY, TASK_ID_METADATA_KEY
+from dagster_airlift.core.utils import metadata_for_task_mapping
 
 
 class TaskDefs:
@@ -61,8 +61,9 @@ def dag_defs(dag_id: str, *defs: TaskDefs) -> Definitions:
     associated with a particular Dag in Airflow that is being tracked by Airlift tooling.
 
     Concretely this adds metadata to all asset specs in the provided definitions
-    with the provided dag_id and task_id. Dag id is tagged with the
-    "airlift/dag_id" key and task id is tagged with the "airlift/task_id" key.
+    with the provided dag_id and task_id. There is a single metadata key
+    "airlift/task_mapping" that is used to store this information. It is a list of
+    dictionaries with keys "dag_id" and "task_id".
 
     Used in concert with :py:func:`task_defs`.
 
@@ -79,7 +80,7 @@ def dag_defs(dag_id: str, *defs: TaskDefs) -> Definitions:
         defs_to_merge.append(
             apply_metadata_to_all_specs(
                 defs=task_def.defs,
-                metadata={DAG_ID_METADATA_KEY: dag_id, TASK_ID_METADATA_KEY: task_def.task_id},
+                metadata=metadata_for_task_mapping(task_id=task_def.task_id, dag_id=dag_id),
             )
         )
     return Definitions.merge(*defs_to_merge)

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/defs_builders.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/defs_builders.py
@@ -4,7 +4,7 @@ from dagster import AssetSpec
 from dagster._core.definitions.asset_key import CoercibleToAssetKey
 from typing_extensions import TypeAlias
 
-from dagster_airlift.constants import DAG_ID_METADATA_KEY, TASK_ID_METADATA_KEY
+from .utils import metadata_for_task_mapping
 
 CoercibleToAssetSpec: TypeAlias = Union[AssetSpec, CoercibleToAssetKey]
 
@@ -19,7 +19,7 @@ def specs_from_task(
         asset
         if isinstance(asset, AssetSpec)
         else AssetSpec(
-            key=asset, metadata={DAG_ID_METADATA_KEY: dag_id, TASK_ID_METADATA_KEY: task_id}
+            key=asset, metadata=metadata_for_task_mapping(task_id=task_id, dag_id=dag_id)
         )
         for asset in assets
     ]

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
@@ -6,6 +6,8 @@ from dagster._core.definitions.utils import VALID_NAME_REGEX
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.storage.tags import KIND_PREFIX
 
+from dagster_airlift.constants import TASK_MAPPING_METADATA_KEY
+
 
 def convert_to_valid_dagster_name(name: str) -> str:
     """Converts a name to a valid dagster name by replacing invalid characters with underscores. / is converted to a double underscore."""
@@ -30,3 +32,7 @@ def spec_iterator(
             raise DagsterInvariantViolationError(
                 "Expected orchestrated defs to all be AssetsDefinitions or AssetSpecs."
             )
+
+
+def metadata_for_task_mapping(*, task_id: str, dag_id: str) -> dict:
+    return {TASK_MAPPING_METADATA_KEY: [{"dag_id": dag_id, "task_id": task_id}]}

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/gql_queries.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/gql_queries.py
@@ -16,6 +16,10 @@ query AssetNodeQuery {
                 label
                 text
             }
+            ... on JsonMetadataEntry {
+                label
+                jsonString
+            }
             __typename
         }
         jobs {

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/operator_test_project/dagster_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/operator_test_project/dagster_defs.py
@@ -1,8 +1,8 @@
 from dagster import Definitions, asset
-from dagster_airlift.constants import DAG_ID_METADATA_KEY, TASK_ID_METADATA_KEY
+from dagster_airlift.core.utils import metadata_for_task_mapping
 
 
-@asset(metadata={DAG_ID_METADATA_KEY: "the_dag", TASK_ID_METADATA_KEY: "some_task"})
+@asset(metadata=metadata_for_task_mapping(dag_id="the_dag", task_id="some_task"))
 def the_dag__some_task():
     return "asset_value"
 
@@ -12,7 +12,7 @@ def unrelated():
     return "unrelated_value"
 
 
-@asset(metadata={DAG_ID_METADATA_KEY: "the_dag", TASK_ID_METADATA_KEY: "other_task"})
+@asset(metadata=metadata_for_task_mapping(dag_id="the_dag", task_id="other_task"))
 def the_dag__other_task():
     return "other_task_value"
 

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
@@ -25,6 +25,7 @@ from dagster._time import get_current_datetime
 from dagster_airlift.core import (
     build_defs_from_airflow_instance as build_defs_from_airflow_instance,
 )
+from dagster_airlift.core.utils import metadata_for_task_mapping
 from dagster_airlift.test import make_dag_run, make_instance
 
 
@@ -60,7 +61,7 @@ def load_definitions_airflow_asset_graph(
                 spec = AssetSpec(
                     asset_key,
                     deps=deps,
-                    metadata={"airlift/dag_id": dag_id, "airlift/task_id": task_id},
+                    metadata=metadata_for_task_mapping(dag_id=dag_id, task_id=task_id),
                 )
                 if create_assets_defs:
 

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/in_airflow_tests/test_parse_metadata.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/in_airflow_tests/test_parse_metadata.py
@@ -1,0 +1,43 @@
+from dagster_airlift.in_airflow.base_proxy_operator import matched_dag_id_task_id
+
+
+def test_parse_asset_node() -> None:
+    asset_node = {
+        "id": 'dbt_example.dagster_defs.migrate.__repository__.["lakehouse", "iris"]',
+        "assetKey": {"path": ["lakehouse", "iris"]},
+        "metadataEntries": [
+            {
+                "label": "dagster-airlift/task_mapping",
+                "jsonString": '[{"dag_id": "rebuild_iris_models", "task_id": "load_iris"}]',
+                "__typename": "JsonMetadataEntry",
+            },
+            {
+                "label": "Task Info (raw)",
+                "jsonString": '{"class_ref": {"class_name": "DefaultProxyToDagsterOperator", "module_path": "dagster_airlift.in_airflow.base_proxy_operator"}, "depends_on_past": false, "downstream_task_ids": ["build_dbt_models"], "end_date": null, "execution_timeout": null, "extra_links": [], "is_mapped": false, "operator_name": "DefaultProxyToDagsterOperator", "owner": "airflow", "params": {}, "pool": "default_pool", "pool_slots": 1.0, "priority_weight": 1.0, "queue": "default", "retries": 0.0, "retry_delay": {"__type": "TimeDelta", "days": 0, "microseconds": 0, "seconds": 300}, "retry_exponential_backoff": false, "start_date": "2024-09-24T18:48:05.148806+00:00", "task_id": "load_iris", "template_fields": [], "trigger_rule": "all_success", "ui_color": "#fff", "ui_fgcolor": "#000", "wait_for_downstream": false, "weight_rule": "downstream"}',
+                "__typename": "JsonMetadataEntry",
+            },
+            {"label": "Dag ID", "text": "rebuild_iris_models", "__typename": "TextMetadataEntry"},
+            {"__typename": "UrlMetadataEntry"},
+            {
+                "label": "Triggered by Task ID",
+                "text": "load_iris",
+                "__typename": "TextMetadataEntry",
+            },
+        ],
+        "jobs": [
+            {
+                "id": "50b0b23cdb52e8f68e39bce56dd28e30ef221a53",
+                "name": "__ASSET_JOB",
+                "repository": {
+                    "id": "0abb753321e78ef093132df5e05aa2046ce7bca9::7170e8bbd3d71e16435c1fbdad3185ab83074660",
+                    "name": "__repository__",
+                    "location": {
+                        "id": "dbt_example.dagster_defs.migrate",
+                        "name": "dbt_example.dagster_defs.migrate",
+                    },
+                },
+            }
+        ],
+    }
+    assert matched_dag_id_task_id(asset_node, "rebuild_iris_models", "load_iris")
+    assert not matched_dag_id_task_id(asset_node, "other_dag", "other_task")


### PR DESCRIPTION
## Summary & Motivation

This changes the actual underlying metadata representation 

Note that this still preserves us the option to display additional (purely for display) metadata in the common case where there is only a single airflow task at play.

Instead of separate `task_id` and `dag_id` metadata entries, we just have a single `dagster-airlift/task_mapping` key which expects a list of dictionaries with keys task_id and dag_id. This ends up getting coerce to a JsonMetadataValue, a slight regression in our display. 

## How I Tested These Changes

BK

Additionally ran through dbt-example (and debugged issue)

## Changelog

NOCHANGELOG

