### PR TITLE
RFC: targeted_by_multiple_tasks

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/dag_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/dag_defs.py
@@ -42,7 +42,7 @@ def apply_metadata_to_all_specs(defs: Definitions, metadata: Dict[str, Any]) -> 
     )
 
 
-def spec_with_metadata(spec: AssetSpec, metadata: Mapping[str, str]) -> "AssetSpec":
+def spec_with_metadata(spec: AssetSpec, metadata: Mapping[str, Any]) -> "AssetSpec":
     return spec._replace(metadata={**spec.metadata, **metadata})
 
 


### PR DESCRIPTION
## Summary & Motivation

Labeling this as an RFC as it is still in a test case, but wanted to put up code to demonstrate the approach. Rather than be overly clever, the proposal is to make this case possible, but a slightly ugly. Effectively if there are assets targeted by multple tasks you adopt out of `dag_defs` and `task_defs` completely, and instead annotated individual assets with metadata in a separate definition object and merge them at the top-level. I think this strikes a reasonable balance of making this complex use case possible while keeping the simple case simple, especially in terms of implementation complexity.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG
