### PR TITLE
[docs-beta] add feedback link to github discussion

### DIFF
--- a/docs/docs-beta/docusaurus.config.ts
+++ b/docs/docs-beta/docusaurus.config.ts
@@ -102,6 +102,12 @@ const config: Config = {
         //  docId: 'changelog',
         //  position: 'right',
         //},
+        {
+          label: 'Feedback',
+          href: 'https://github.com/dagster-io/dagster/discussions/23031',
+          position: 'right',
+          className: 'feedback-nav-link',
+        },
       ],
     },
     image: 'img/docusaurus-social-card.jpg',

--- a/docs/docs-beta/src/styles/custom.scss
+++ b/docs/docs-beta/src/styles/custom.scss
@@ -663,3 +663,10 @@ div[class^='announcementBar_'] {
   padding-bottom: 0.25rem;
   background-color: var(--theme-color-background-yellow);
 }
+
+/* Feedback navigation item */
+.feedback-nav-link {
+  color: var(--theme-color-text-yellow);
+  text-decoration: underline;
+}
+


### PR DESCRIPTION
## Summary & Motivation

- Adds a "Feedback" link to a GitHub discussion

<img width="653" alt="image" src="https://github.com/user-attachments/assets/14fd7e63-4a25-4b66-ae2a-ba15a267cd99">

@PedramNavid - we will need to update this to the new discussion.

## How I Tested These Changes

`yarn start`

## Changelog

NOCHANGELOG
