### PR TITLE
[ui] Clean up dynamic row sizing in virtualized tables

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/AutomationsTable.tsx
@@ -1,4 +1,4 @@
-import {Box, Tag, Tooltip} from '@dagster-io/ui-components';
+import {Box, Row, Tag, Tooltip} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import * as React from 'react';
 
@@ -8,7 +8,7 @@ import {VirtualizedAutomationSensorRow} from './VirtualizedAutomationSensorRow';
 import {COMMON_COLLATOR} from '../app/Util';
 import {OVERVIEW_COLLAPSED_KEY} from '../overview/OverviewExpansionKey';
 import {makeAutomationKey} from '../sensors/makeSensorKey';
-import {Container, DynamicRowContainer, Inner} from '../ui/VirtualizedTable';
+import {Container, Inner} from '../ui/VirtualizedTable';
 import {findDuplicateRepoNames} from '../ui/findDuplicateRepoNames';
 import {useRepoExpansionState} from '../ui/useRepoExpansionState';
 import {DynamicRepoRow} from '../workspace/VirtualizedWorkspaceTable';
@@ -99,12 +99,12 @@ export const AutomationsTable = ({
       <Container ref={parentRef}>
         <VirtualizedAutomationHeader checkbox={headerCheckbox} />
         <Inner $totalHeight={totalHeight}>
-          <DynamicRowContainer $start={items[0]?.start ?? 0}>
-            {items.map(({index, key}) => {
-              const row: RowType = flattened[index]!;
-              const type = row!.type;
-              if (type === 'header') {
-                return (
+          {items.map(({index, key, size, start}) => {
+            const row: RowType = flattened[index]!;
+            const type = row!.type;
+            if (type === 'header') {
+              return (
+                <Row $height={size} $start={start} key={key}>
                   <DynamicRepoRow
                     repoAddress={row.repoAddress}
                     key={key}
@@ -137,12 +137,14 @@ export const AutomationsTable = ({
                       </Box>
                     }
                   />
-                );
-              }
+                </Row>
+              );
+            }
 
-              if (type === 'sensor') {
-                const sensorKey = makeAutomationKey(row.repoAddress, row.sensor);
-                return (
+            if (type === 'sensor') {
+              const sensorKey = makeAutomationKey(row.repoAddress, row.sensor);
+              return (
+                <Row $height={size} $start={start} key={key}>
                   <VirtualizedAutomationSensorRow
                     key={key}
                     index={index}
@@ -152,12 +154,14 @@ export const AutomationsTable = ({
                     onToggleChecked={onToggleCheckFactory(sensorKey)}
                     repoAddress={row.repoAddress}
                   />
-                );
-              }
+                </Row>
+              );
+            }
 
-              if (type === 'schedule') {
-                const scheduleKey = makeAutomationKey(row.repoAddress, row.schedule);
-                return (
+            if (type === 'schedule') {
+              const scheduleKey = makeAutomationKey(row.repoAddress, row.schedule);
+              return (
+                <Row $height={size} $start={start} key={key}>
                   <VirtualizedAutomationScheduleRow
                     key={key}
                     index={index}
@@ -167,12 +171,12 @@ export const AutomationsTable = ({
                     onToggleChecked={onToggleCheckFactory(scheduleKey)}
                     repoAddress={row.repoAddress}
                   />
-                );
-              }
+                </Row>
+              );
+            }
 
-              return <div key={key} />;
-            })}
-          </DynamicRowContainer>
+            return <div key={key} />;
+          })}
         </Inner>
       </Container>
     </div>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsScrollingTable.tsx
@@ -1,4 +1,4 @@
-import {Box, Colors, NonIdealState} from '@dagster-io/ui-components';
+import {Box, Colors, NonIdealState, Row} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import {useEffect, useRef} from 'react';
 import styled from 'styled-components';
@@ -8,7 +8,7 @@ import {Structured, Unstructured} from './LogsRow';
 import {ColumnWidthsProvider, Headers} from './LogsScrollingTableHeader';
 import {IRunMetadataDict} from './RunMetadataProvider';
 import {filterLogs} from './filterLogs';
-import {Container, DynamicRowContainer, Inner} from '../ui/VirtualizedTable';
+import {Container, Inner} from '../ui/VirtualizedTable';
 
 const BOTTOM_SCROLL_THRESHOLD_PX = 60;
 
@@ -101,32 +101,31 @@ export const LogsScrollingTable = (props: Props) => {
 
     return (
       <Inner $totalHeight={totalHeight}>
-        <DynamicRowContainer $start={items[0]?.start ?? 0}>
-          {items.map(({index, key}) => {
-            const node = filteredNodes[index]!;
-            const textMatch = textMatchNodes.includes(node);
-            const focusedTimeMatch = Number(node.timestamp) === filter.focusedTime;
-            const highlighted = textMatch || focusedTimeMatch;
+        {items.map(({index, key, size, start}) => {
+          const node = filteredNodes[index]!;
+          const textMatch = textMatchNodes.includes(node);
+          const focusedTimeMatch = Number(node.timestamp) === filter.focusedTime;
+          const highlighted = textMatch || focusedTimeMatch;
 
-            const row =
-              node.__typename === 'LogMessageEvent' ? (
-                <Unstructured node={node} metadata={metadata} highlighted={highlighted} />
-              ) : (
-                <Structured node={node} metadata={metadata} highlighted={highlighted} />
-              );
+          const row =
+            node.__typename === 'LogMessageEvent' ? (
+              <Unstructured node={node} metadata={metadata} highlighted={highlighted} />
+            ) : (
+              <Structured node={node} metadata={metadata} highlighted={highlighted} />
+            );
 
-            return (
+          return (
+            <Row $height={size} $start={start} key={key}>
               <div
                 ref={virtualizer.measureElement}
-                key={key}
                 data-index={index}
                 style={{position: 'relative'}}
               >
                 {row}
               </div>
-            );
-          })}
-        </DynamicRowContainer>
+            </Row>
+          );
+        })}
       </Inner>
     );
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/VirtualizedTable.tsx
@@ -124,16 +124,3 @@ export const Row = styled.div.attrs<RowProps>(({$height, $start}) => ({
   top: 0;
   overflow: hidden;
 `;
-
-type DynamicRowContainerProps = {$start: number};
-
-export const DynamicRowContainer = styled.div.attrs<DynamicRowContainerProps>(({$start}) => ({
-  style: {
-    transform: `translateY(${$start}px)`,
-  },
-}))<DynamicRowContainerProps>`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-`;

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryLocationsList.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/RepositoryLocationsList.tsx
@@ -1,4 +1,4 @@
-import {Box, NonIdealState, Spinner} from '@dagster-io/ui-components';
+import {Box, NonIdealState, Row, Spinner} from '@dagster-io/ui-components';
 import {useVirtualizer} from '@tanstack/react-virtual';
 import {useRef} from 'react';
 
@@ -8,7 +8,7 @@ import {
   VirtualizedCodeLocationRepositoryRow,
   VirtualizedCodeLocationRow,
 } from './VirtualizedCodeLocationRow';
-import {Container, DynamicRowContainer, Inner} from '../ui/VirtualizedTable';
+import {Container, Inner} from '../ui/VirtualizedTable';
 
 interface Props {
   loading: boolean;
@@ -88,32 +88,32 @@ export const RepositoryLocationsList = ({
     <Container ref={parentRef}>
       <VirtualizedCodeLocationHeader />
       <Inner $totalHeight={totalHeight}>
-        <DynamicRowContainer $start={items[0]?.start ?? 0}>
-          {items.map(({index, key}) => {
-            const row: CodeLocationRowType = codeLocations[index]!;
-            if (row.type === 'location') {
-              return (
+        {items.map(({index, key, size, start}) => {
+          const row: CodeLocationRowType = codeLocations[index]!;
+          if (row.type === 'location') {
+            return (
+              <Row $height={size} $start={start} key={key}>
                 <VirtualizedCodeLocationRow
-                  key={key}
                   index={index}
                   locationEntry={row.locationEntry}
                   locationStatus={row.locationStatus}
                   ref={virtualizer.measureElement}
                 />
-              );
-            }
-            return (
+              </Row>
+            );
+          }
+          return (
+            <Row $height={size} $start={start} key={key}>
               <VirtualizedCodeLocationRepositoryRow
-                key={key}
                 index={index}
                 locationStatus={row.locationStatus}
                 locationEntry={row.locationEntry}
                 repository={row.repository}
                 ref={virtualizer.measureElement}
               />
-            );
-          })}
-        </DynamicRowContainer>
+            </Row>
+          );
+        })}
       </Inner>
     </Container>
   );


### PR DESCRIPTION
## Summary & Motivation

Remove `DynamicRowContainer`, as it's not actually necessary for our dynamic row sizing in virtualized tables.

## How I Tested These Changes

View affected list views, verify that they render and scroll correctly.

## Changelog

NOCHANGELOG