### PR TITLE
[1/c] add column tag field to TableColumn

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/table.py
@@ -123,7 +123,7 @@ class TableColumn(
             ("type", PublicAttr[str]),
             ("description", PublicAttr[Optional[str]]),
             ("constraints", PublicAttr[TableColumnConstraints]),
-            ("tags", PublicAttr[Mapping[str, str]])
+            ("tags", PublicAttr[Mapping[str, str]]),
         ],
     )
 ):

--- a/python_modules/dagster/dagster/_core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/table.py
@@ -161,7 +161,7 @@ class TableColumn(
                 TableColumnConstraints,
                 default=_DEFAULT_TABLE_COLUMN_CONSTRAINTS,
             ),
-            tags=check.opt_dict_param(tags, "tags", key_type=str, value_type=str),
+            tags=check.opt_mapping_param(tags, "tags", key_type=str, value_type=str),
         )
 
 

--- a/python_modules/dagster/dagster/_core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/table.py
@@ -123,6 +123,7 @@ class TableColumn(
             ("type", PublicAttr[str]),
             ("description", PublicAttr[Optional[str]]),
             ("constraints", PublicAttr[TableColumnConstraints]),
+            ("tags", PublicAttr[Mapping[str, str]])
         ],
     )
 ):
@@ -138,6 +139,7 @@ class TableColumn(
         description (Optional[str]): Description of this column. Defaults to `None`.
         constraints (Optional[TableColumnConstraints]): Column-level constraints.
             If unspecified, column is nullable with no constraints.
+        tags (Optional[Mapping[str, str]]): Tags for filtering or organizing columns.
     """
 
     def __new__(
@@ -146,6 +148,7 @@ class TableColumn(
         type: str = "string",  # noqa: A002
         description: Optional[str] = None,
         constraints: Optional[TableColumnConstraints] = None,
+        tags: Optional[Mapping[str, str]] = None,
     ):
         return super(TableColumn, cls).__new__(
             cls,
@@ -158,6 +161,7 @@ class TableColumn(
                 TableColumnConstraints,
                 default=_DEFAULT_TABLE_COLUMN_CONSTRAINTS,
             ),
+            tags=check.opt_dict_param(tags, "tags", key_type=str, value_type=str),
         )
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
@@ -102,7 +102,7 @@ def test_table_metadata_value():
 
 def test_table_schema_metadata_value():
     schema = TableSchema(
-        columns=[TableColumn(name="foo", type="int"), TableColumn(name="bar", type="int")]
+        columns=[TableColumn(name="foo", type="int", tags={"introduced": "v3"}), TableColumn(name="bar", type="int")]
     )
     assert TableSchemaMetadataValue(schema).schema == schema
 

--- a/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
@@ -102,7 +102,10 @@ def test_table_metadata_value():
 
 def test_table_schema_metadata_value():
     schema = TableSchema(
-        columns=[TableColumn(name="foo", type="int", tags={"introduced": "v3"}), TableColumn(name="bar", type="int")]
+        columns=[
+            TableColumn(name="foo", type="int", tags={"introduced": "v3"}),
+            TableColumn(name="bar", type="int"),
+        ]
     )
     assert TableSchemaMetadataValue(schema).schema == schema
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/metadata_tests/test_table_metadata_set.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/metadata_tests/test_table_metadata_set.py
@@ -12,7 +12,9 @@ def error_on_warning():
 
 
 def test_table_metadata_set() -> None:
-    column_schema = TableSchema(columns=[TableColumn("foo", "str", tags={"pii": "", "introduced": "v2"})])
+    column_schema = TableSchema(
+        columns=[TableColumn("foo", "str", tags={"pii": "", "introduced": "v2"})]
+    )
     table_metadata = TableMetadataSet(column_schema=column_schema)
 
     dict_table_metadata = dict(table_metadata)

--- a/python_modules/dagster/dagster_tests/definitions_tests/metadata_tests/test_table_metadata_set.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/metadata_tests/test_table_metadata_set.py
@@ -12,7 +12,7 @@ def error_on_warning():
 
 
 def test_table_metadata_set() -> None:
-    column_schema = TableSchema(columns=[TableColumn("foo", "str")])
+    column_schema = TableSchema(columns=[TableColumn("foo", "str", tags={"pii": "", "introduced": "v2"})])
     table_metadata = TableMetadataSet(column_schema=column_schema)
 
     dict_table_metadata = dict(table_metadata)


### PR DESCRIPTION
## Summary

Introduces a new `tags` field to `TableColumn` which can be used to encode additional tag-style information to tabular assets' columns.

Use-cases include:
- Carrying over tags from dbt #24718
- Marking PII information
- Marking primary keys in databases or keys used in ETL syncs 

Eventually, these tags should be made searchable in Cloud.

## Changelog

NOCHANGELOG