### PR TITLE
[dagster-dbt] populate column tags for dbt

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -447,6 +447,7 @@ def default_metadata_from_dbt_resource_props(
                     name=column_name,
                     type=column_info.get("data_type") or "?",
                     description=column_info.get("description"),
+                    tags={tag_name: "" for tag_name in column_info.get("tags", [])},
                 )
                 for column_name, column_info in columns.items()
             ]

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/schema.yml
@@ -6,15 +6,18 @@ models:
 
     columns:
       - name: customer_id
+        tags: ['primary_key']
         description: This is a unique identifier for a customer
         tests:
           - unique
           - not_null
 
       - name: first_name
+        tags: ['pii']
         description: Customer's first name. PII.
 
       - name: last_name
+        tags: ['pii']
         description: Customer's last name. PII.
 
       - name: first_order

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_metadata/models/schema.yml
@@ -6,18 +6,18 @@ models:
 
     columns:
       - name: customer_id
-        tags: ['primary_key']
+        tags: ["primary_key"]
         description: This is a unique identifier for a customer
         tests:
           - unique
           - not_null
 
       - name: first_name
-        tags: ['pii']
+        tags: ["pii"]
         description: Customer's first name. PII.
 
       - name: last_name
-        tags: ['pii']
+        tags: ["pii"]
         description: Customer's last name. PII.
 
       - name: first_order


### PR DESCRIPTION
## Summary

Surfaces dbt column tags in the new `TableColumn` tags field introduced in #24717. These will flow into table column search and UI, once built.

## Test Plan

New unit test.

## Changelog

NOCHANGELOG