### PR TITLE
Fix toposorted_entity_keys sorting

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -305,10 +305,11 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
         """Return topologically sorted entity keys in graph. Keys with the same topological level are
         sorted alphabetically to provide stability.
         """
+        sort_key = lambda e: (e, None) if isinstance(e, AssetKey) else (e.asset_key, e.name)
         return [
             item
-            for items_in_level in toposort(self.entity_dep_graph["upstream"])
-            for item in sorted(items_in_level)
+            for items_in_level in toposort(self.entity_dep_graph["upstream"], sort_key=sort_key)
+            for item in sorted(items_in_level, key=sort_key)
         ]
 
     @cached_property

--- a/python_modules/dagster/dagster/_core/utils.py
+++ b/python_modules/dagster/dagster/_core/utils.py
@@ -70,10 +70,12 @@ def coerce_valid_log_level(log_level: Union[str, int]) -> int:
     return PYTHON_LOGGING_LEVELS_MAPPING[str_log_level]
 
 
-def toposort(data: Mapping[T, AbstractSet[T]]) -> Sequence[Sequence[T]]:
+def toposort(
+    data: Mapping[T, AbstractSet[T]], sort_key: Optional[Callable[[T], Any]] = None
+) -> Sequence[Sequence[T]]:
     # Workaround a bug in older versions of toposort that choke on frozenset
     data = {k: set(v) if isinstance(v, frozenset) else v for k, v in data.items()}
-    return [sorted(list(level)) for level in toposort_.toposort(data)]
+    return [sorted(list(level), key=sort_key) for level in toposort_.toposort(data)]
 
 
 def toposort_flatten(data: Mapping[T, AbstractSet[T]]) -> Sequence[T]:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -739,6 +739,27 @@ def test_required_assets_and_checks_by_key_check_decorator(
     assert check_node.automation_condition == AutomationCondition.cron_tick_passed("*/15 * * * *")
 
 
+def test_toposort(
+    asset_graph_from_assets: Callable[..., BaseAssetGraph],
+) -> None:
+    @asset
+    def A(): ...
+
+    @asset(deps=[A])
+    def B(): ...
+
+    @asset_check(asset=A)
+    def Ac(): ...
+
+    @asset_check(asset=B)
+    def Bc(): ...
+
+    asset_graph = asset_graph_from_assets([A, B, Ac, Bc])
+
+    assert asset_graph.toposorted_asset_keys == [A.key, B.key]
+    assert asset_graph.toposorted_entity_keys == [A.key, Ac.check_key, B.key, Bc.check_key]
+
+
 def test_required_assets_and_checks_by_key_asset_decorator(
     asset_graph_from_assets: Callable[..., BaseAssetGraph],
 ):


### PR DESCRIPTION
## Summary & Motivation

This would cause an error if both an asset key and an asset check key existed in the same "level", as there was no way to sort a list of asset key or asset check key.

## How I Tested These Changes


## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
