### PR TITLE
[dagster-dbt][rfc] automatically pull row count, lineage

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -29,7 +29,7 @@ pytestmark: pytest.MarkDecorator = pytest.mark.derived_metadata
 def test_no_column_schema(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
     @dbt_assets(manifest=test_jaffle_shop_manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        yield from dbt.cli(["build"], context=context).stream()
+        yield from dbt.cli(["build"], context=context).stream(fetch_additional_metadata=False)
 
     result = materialize(
         [my_dbt_assets],
@@ -58,7 +58,7 @@ def test_column_schema(
 
     @dbt_assets(manifest=test_metadata_manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        cli_invocation = dbt.cli(["build"], context=context).stream()
+        cli_invocation = dbt.cli(["build"], context=context).stream(fetch_additional_metadata=False)
         if use_experimental_fetch_column_schema:
             cli_invocation = cli_invocation.fetch_column_metadata(with_column_lineage=False)
         yield from cli_invocation
@@ -110,7 +110,7 @@ def test_exception_fetch_column_schema_with_adapter(
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
         yield from (
             dbt.cli(["build"], context=context)
-            .stream()
+            .stream(fetch_additional_metadata=False)
             .fetch_column_metadata(with_column_lineage=False)
         )
 
@@ -150,7 +150,7 @@ def test_exception_column_schema(
 
     @dbt_assets(manifest=test_metadata_manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        cli_invocation = dbt.cli(["build"], context=context).stream()
+        cli_invocation = dbt.cli(["build"], context=context).stream(fetch_additional_metadata=False)
         if use_experimental_fetch_column_schema:
             cli_invocation = cli_invocation.fetch_column_metadata(with_column_lineage=False)
         yield from cli_invocation
@@ -177,7 +177,7 @@ def test_no_column_lineage(test_metadata_manifest: Dict[str, Any]) -> None:
                 json.dumps({"dagster_enable_parent_relation_metadata_collection": False}),
             ],
             context=context,
-        ).stream()
+        ).stream(fetch_additional_metadata=False)
 
     result = materialize(
         [my_dbt_assets],
@@ -211,7 +211,7 @@ def test_exception_column_lineage(
 
     @dbt_assets(manifest=test_metadata_manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        cli_invocation = dbt.cli(["build"], context=context).stream()
+        cli_invocation = dbt.cli(["build"], context=context).stream(fetch_additional_metadata=False)
         if use_experimental_fetch_column_schema:
             cli_invocation = cli_invocation.fetch_column_metadata(with_column_lineage=False)
         yield from cli_invocation
@@ -460,7 +460,7 @@ def test_column_lineage_real_warehouse(
         seed_cli_invocation = dbt.cli(
             ["seed"],
             context=context,
-        ).stream()
+        ).stream(fetch_additional_metadata=False)
         if fetch_row_counts:
             seed_cli_invocation = seed_cli_invocation.fetch_row_counts()
         seed_cli_invocation = seed_cli_invocation.fetch_column_metadata()
@@ -469,7 +469,7 @@ def test_column_lineage_real_warehouse(
         cli_invocation = dbt.cli(
             ["build", "--exclude", "resource_type:seed", *excluded_models],
             context=context,
-        ).stream()
+        ).stream(fetch_additional_metadata=False)
         if fetch_row_counts:
             cli_invocation = cli_invocation.fetch_row_counts()
         cli_invocation = cli_invocation.fetch_column_metadata()
@@ -558,7 +558,7 @@ def test_column_lineage(
 
     @dbt_assets(manifest=manifest)
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
-        cli_invocation = dbt.cli(["build"], context=context).stream()
+        cli_invocation = dbt.cli(["build"], context=context).stream(fetch_additional_metadata=False)
         if use_async_fetch_column_schema:
             cli_invocation = cli_invocation.fetch_column_metadata()
         yield from cli_invocation


### PR DESCRIPTION
## Summary

Automatically calls `fetch_row_count` and `fetch_column_metadata` on DBT stream calls. This prevents users from needing to request this information explicitly. They may still opt out by passing `stream(fetch_extra_metadata=False)`.

Adds a thin layer of tracking which post-processing steps have already been run to avoid re-running these operations, for existing users who are calling these fns themselves.

This PR is a bit of an RFC as to whether we should be doing this automatically.

## Test Plan

Update existing unit tests; new unit test for auto-opt-in behavior.

## Changelog

- [dagster-dbt] DBT assets now automatically pull in row count and column lineage.