### PR TITLE
Rename AssetDefinitionDiff serdes class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -65,7 +65,7 @@ class DictDiff(Generic[T]):
 
 @whitelist_for_serdes
 @record
-class AssetDefinitionDiff:
+class AssetDefinitionDiffDetails:
     """Represents the diff information for changes between assets.
 
     Change types in change_types should have diff info for their corresponding fields
@@ -171,20 +171,20 @@ class AssetGraphDiffer:
 
     def _compare_base_and_branch_assets(
         self, asset_key: "AssetKey", include_diff: bool = False
-    ) -> AssetDefinitionDiff:
+    ) -> AssetDefinitionDiffDetails:
         """Computes the diff between a branch deployment asset and the
         corresponding base deployment asset.
         """
         if self.base_asset_graph is None:
             # if the base asset graph is None, it is because the asset graph in the branch deployment
             # is new and doesn't exist in the base deployment. Thus all assets are new.
-            return AssetDefinitionDiff(change_types={AssetDefinitionChangeType.NEW})
+            return AssetDefinitionDiffDetails(change_types={AssetDefinitionChangeType.NEW})
 
         if asset_key not in self.base_asset_graph.all_asset_keys:
-            return AssetDefinitionDiff(change_types={AssetDefinitionChangeType.NEW})
+            return AssetDefinitionDiffDetails(change_types={AssetDefinitionChangeType.NEW})
 
         if asset_key not in self.branch_asset_graph.all_asset_keys:
-            return AssetDefinitionDiff(change_types={AssetDefinitionChangeType.REMOVED})
+            return AssetDefinitionDiffDetails(change_types={AssetDefinitionChangeType.REMOVED})
 
         branch_asset = self.branch_asset_graph.get(asset_key)
         base_asset = self.base_asset_graph.get(asset_key)
@@ -258,7 +258,7 @@ class AssetGraphDiffer:
                     added_keys=added, changed_keys=changed, removed_keys=removed
                 )
 
-        return AssetDefinitionDiff(
+        return AssetDefinitionDiffDetails(
             change_types=change_types,
             code_version=code_version_diff,
             dependencies=dependencies_diff,
@@ -280,7 +280,7 @@ class AssetGraphDiffer:
         """Returns list of AssetDefinitionChangeType for asset_key as compared to the base deployment."""
         return list(self._compare_base_and_branch_assets(asset_key).change_types)
 
-    def get_changes_for_asset_with_diff(self, asset_key: "AssetKey") -> AssetDefinitionDiff:
+    def get_changes_for_asset_with_diff(self, asset_key: "AssetKey") -> AssetDefinitionDiffDetails:
         """Returns list of AssetDefinitionDiff for asset_key as compared to the base deployment."""
         return self._compare_base_and_branch_assets(asset_key, include_diff=True)
 

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -8,7 +8,7 @@ import pytest
 from dagster import DagsterInstance, instance_for_test
 from dagster._core.definitions.asset_graph_differ import (
     AssetDefinitionChangeType,
-    AssetDefinitionDiff,
+    AssetDefinitionDiffDetails,
     AssetGraphDiffer,
     DictDiff,
     ValueDiff,
@@ -127,12 +127,12 @@ def test_new_asset(instance):
 
     assert differ.get_changes_for_asset(AssetKey("new_asset")) == [AssetDefinitionChangeType.NEW]
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
-    assert differ.get_changes_for_asset_with_diff(AssetKey("new_asset")) == AssetDefinitionDiff(
-        change_types={AssetDefinitionChangeType.NEW}
-    )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
-        change_types=set()
-    )
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("new_asset")
+    ) == AssetDefinitionDiffDetails(change_types={AssetDefinitionChangeType.NEW})
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("upstream")
+    ) == AssetDefinitionDiffDetails(change_types=set())
 
 
 def test_removed_asset(instance) -> None:
@@ -149,12 +149,12 @@ def test_removed_asset(instance) -> None:
         AssetDefinitionChangeType.REMOVED
     ]
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
-    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
-        change_types={AssetDefinitionChangeType.REMOVED}
-    )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
-        change_types=set()
-    )
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("downstream")
+    ) == AssetDefinitionDiffDetails(change_types={AssetDefinitionChangeType.REMOVED})
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("upstream")
+    ) == AssetDefinitionDiffDetails(change_types=set())
 
 
 def test_new_asset_connected(instance):
@@ -172,18 +172,22 @@ def test_new_asset_connected(instance):
         AssetDefinitionChangeType.DEPENDENCIES
     ]
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
-    assert differ.get_changes_for_asset_with_diff(AssetKey("new_asset")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("new_asset")
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.NEW},
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("downstream")
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.DEPENDENCIES},
         dependencies=DictDiff(
             added_keys={AssetKey("new_asset")}, changed_keys=set(), removed_keys=set()
         ),
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
-        change_types=set()
-    )
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("upstream")
+    ) == AssetDefinitionDiffDetails(change_types=set())
 
 
 def test_update_code_version(instance):
@@ -200,13 +204,15 @@ def test_update_code_version(instance):
         AssetDefinitionChangeType.CODE_VERSION
     ]
     assert len(differ.get_changes_for_asset(AssetKey("downstream"))) == 0
-    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("upstream")
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.CODE_VERSION},
         code_version=ValueDiff(old="1", new="2"),
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
-        change_types=set()
-    )
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("downstream")
+    ) == AssetDefinitionDiffDetails(change_types=set())
 
 
 def test_change_inputs(instance):
@@ -223,15 +229,17 @@ def test_change_inputs(instance):
         AssetDefinitionChangeType.DEPENDENCIES
     ]
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
-    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("downstream")
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.DEPENDENCIES},
         dependencies=DictDiff(
             added_keys=set(), changed_keys=set(), removed_keys={AssetKey("upstream")}
         ),
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
-        change_types=set()
-    )
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("upstream")
+    ) == AssetDefinitionDiffDetails(change_types=set())
 
 
 def test_multiple_changes_for_one_asset(instance):
@@ -249,7 +257,9 @@ def test_multiple_changes_for_one_asset(instance):
         AssetDefinitionChangeType.DEPENDENCIES,
     }
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
-    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("downstream")
+    ) == AssetDefinitionDiffDetails(
         change_types={
             AssetDefinitionChangeType.DEPENDENCIES,
             AssetDefinitionChangeType.CODE_VERSION,
@@ -259,9 +269,9 @@ def test_multiple_changes_for_one_asset(instance):
             added_keys=set(), changed_keys=set(), removed_keys={AssetKey("upstream")}
         ),
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
-        change_types=set()
-    )
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("upstream")
+    ) == AssetDefinitionDiffDetails(change_types=set())
 
 
 def test_change_then_revert(instance):
@@ -278,13 +288,15 @@ def test_change_then_revert(instance):
         AssetDefinitionChangeType.CODE_VERSION
     ]
     assert len(differ.get_changes_for_asset(AssetKey("downstream"))) == 0
-    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("upstream")
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.CODE_VERSION},
         code_version=ValueDiff(old="1", new="2"),
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
-        change_types=set()
-    )
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("downstream")
+    ) == AssetDefinitionDiffDetails(change_types=set())
 
     differ = get_asset_graph_differ(
         instance=instance,
@@ -295,12 +307,12 @@ def test_change_then_revert(instance):
 
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
     assert len(differ.get_changes_for_asset(AssetKey("downstream"))) == 0
-    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
-        change_types=set()
-    )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
-        change_types=set()
-    )
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("upstream")
+    ) == AssetDefinitionDiffDetails(change_types=set())
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("downstream")
+    ) == AssetDefinitionDiffDetails(change_types=set())
 
 
 def test_large_asset_graph(instance):
@@ -323,7 +335,7 @@ def test_large_asset_graph(instance):
     for i in range(6):
         key = AssetKey(f"asset_{i}")
         assert len(differ.get_changes_for_asset(key)) == 0
-        assert differ.get_changes_for_asset_with_diff(key) == AssetDefinitionDiff(
+        assert differ.get_changes_for_asset_with_diff(key) == AssetDefinitionDiffDetails(
             change_types=set()
         )
 
@@ -347,18 +359,22 @@ def test_multiple_code_locations(instance):
         AssetDefinitionChangeType.DEPENDENCIES
     ]
     assert len(differ.get_changes_for_asset(AssetKey("upstream"))) == 0
-    assert differ.get_changes_for_asset_with_diff(AssetKey("new_asset")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("new_asset")
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.NEW},
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("downstream")
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.DEPENDENCIES},
         dependencies=DictDiff(
             added_keys={AssetKey("new_asset")}, changed_keys=set(), removed_keys=set()
         ),
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
-        change_types=set()
-    )
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("upstream")
+    ) == AssetDefinitionDiffDetails(change_types=set())
 
 
 def test_new_code_location(instance):
@@ -371,13 +387,19 @@ def test_new_code_location(instance):
     assert differ.get_changes_for_asset(AssetKey("new_asset")) == [AssetDefinitionChangeType.NEW]
     assert differ.get_changes_for_asset(AssetKey("upstream")) == [AssetDefinitionChangeType.NEW]
     assert differ.get_changes_for_asset(AssetKey("downstream")) == [AssetDefinitionChangeType.NEW]
-    assert differ.get_changes_for_asset_with_diff(AssetKey("new_asset")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("new_asset")
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.NEW},
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("upstream")
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.NEW},
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("downstream")
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.NEW},
     )
 
@@ -411,7 +433,7 @@ def test_change_partitions_definitions(instance):
     ]
     assert differ.get_changes_for_asset_with_diff(
         AssetKey("daily_upstream")
-    ) == AssetDefinitionDiff(
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.PARTITIONS_DEFINITION},
         partitions_definition=ValueDiff(
             old="TimeWindowPartitionsDefinition", new="TimeWindowPartitionsDefinition"
@@ -419,7 +441,7 @@ def test_change_partitions_definitions(instance):
     )
     assert differ.get_changes_for_asset_with_diff(
         AssetKey("daily_downstream")
-    ) == AssetDefinitionDiff(
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.PARTITIONS_DEFINITION},
         partitions_definition=ValueDiff(
             old="TimeWindowPartitionsDefinition", new="TimeWindowPartitionsDefinition"
@@ -427,7 +449,7 @@ def test_change_partitions_definitions(instance):
     )
     assert differ.get_changes_for_asset_with_diff(
         AssetKey("static_upstream")
-    ) == AssetDefinitionDiff(
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.PARTITIONS_DEFINITION},
         partitions_definition=ValueDiff(
             old="StaticPartitionsDefinition", new="StaticPartitionsDefinition"
@@ -435,7 +457,7 @@ def test_change_partitions_definitions(instance):
     )
     assert differ.get_changes_for_asset_with_diff(
         AssetKey("static_downstream")
-    ) == AssetDefinitionDiff(
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.PARTITIONS_DEFINITION},
         partitions_definition=ValueDiff(
             old="StaticPartitionsDefinition", new="StaticPartitionsDefinition"
@@ -443,7 +465,7 @@ def test_change_partitions_definitions(instance):
     )
     assert differ.get_changes_for_asset_with_diff(
         AssetKey("multi_partitioned_upstream")
-    ) == AssetDefinitionDiff(
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.PARTITIONS_DEFINITION},
         partitions_definition=ValueDiff(
             old="MultiPartitionsDefinition", new="MultiPartitionsDefinition"
@@ -451,7 +473,7 @@ def test_change_partitions_definitions(instance):
     )
     assert differ.get_changes_for_asset_with_diff(
         AssetKey("multi_partitioned_downstream")
-    ) == AssetDefinitionDiff(
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.PARTITIONS_DEFINITION},
         partitions_definition=ValueDiff(
             old="MultiPartitionsDefinition", new="MultiPartitionsDefinition"
@@ -482,10 +504,10 @@ def test_change_partition_mapping(instance):
     ]
     assert differ.get_changes_for_asset_with_diff(
         AssetKey("daily_upstream")
-    ) == AssetDefinitionDiff(change_types=set())
+    ) == AssetDefinitionDiffDetails(change_types=set())
     assert differ.get_changes_for_asset_with_diff(
         AssetKey("daily_downstream")
-    ) == AssetDefinitionDiff(
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.DEPENDENCIES},
         dependencies=DictDiff(
             added_keys=set(), changed_keys={AssetKey("daily_upstream")}, removed_keys=set()
@@ -493,10 +515,10 @@ def test_change_partition_mapping(instance):
     )
     assert differ.get_changes_for_asset_with_diff(
         AssetKey("static_upstream")
-    ) == AssetDefinitionDiff(change_types=set())
+    ) == AssetDefinitionDiffDetails(change_types=set())
     assert differ.get_changes_for_asset_with_diff(
         AssetKey("static_downstream")
-    ) == AssetDefinitionDiff(
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.DEPENDENCIES},
         dependencies=DictDiff(
             added_keys=set(), changed_keys={AssetKey("static_upstream")}, removed_keys=set()
@@ -504,10 +526,10 @@ def test_change_partition_mapping(instance):
     )
     assert differ.get_changes_for_asset_with_diff(
         AssetKey("multi_partitioned_upstream")
-    ) == AssetDefinitionDiff(change_types=set())
+    ) == AssetDefinitionDiffDetails(change_types=set())
     assert differ.get_changes_for_asset_with_diff(
         AssetKey("multi_partitioned_downstream")
-    ) == AssetDefinitionDiff(
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.DEPENDENCIES},
         dependencies=DictDiff(
             added_keys=set(),
@@ -529,25 +551,31 @@ def test_change_tags(instance):
     assert differ.get_changes_for_asset(AssetKey("fruits")) == [AssetDefinitionChangeType.TAGS]
     assert differ.get_changes_for_asset(AssetKey("letters")) == [AssetDefinitionChangeType.TAGS]
     assert len(differ.get_changes_for_asset(AssetKey("numbers"))) == 0
-    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("upstream")
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.TAGS},
         tags=DictDiff(added_keys=set(), changed_keys=set(), removed_keys={"one"}),
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("downstream")
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.TAGS},
         tags=DictDiff(added_keys=set(), changed_keys={"baz"}, removed_keys=set()),
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("fruits")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("fruits")) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.TAGS},
         tags=DictDiff(added_keys={"green"}, changed_keys=set(), removed_keys={"red"}),
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("letters")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("letters")
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.TAGS},
         tags=DictDiff(added_keys={"c"}, changed_keys=set(), removed_keys=set()),
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("numbers")) == AssetDefinitionDiff(
-        change_types=set()
-    )
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("numbers")
+    ) == AssetDefinitionDiffDetails(change_types=set())
 
 
 def test_change_metadata(instance):
@@ -568,7 +596,9 @@ def test_change_metadata(instance):
     assert differ.get_changes_for_asset(AssetKey("fruits")) == [AssetDefinitionChangeType.METADATA]
     assert differ.get_changes_for_asset(AssetKey("letters")) == [AssetDefinitionChangeType.METADATA]
     assert len(differ.get_changes_for_asset(AssetKey("numbers"))) == 0
-    assert differ.get_changes_for_asset_with_diff(AssetKey("upstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("upstream")
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.METADATA},
         metadata=DictDiff(
             added_keys=set(),
@@ -576,7 +606,9 @@ def test_change_metadata(instance):
             removed_keys={"one"},
         ),
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("downstream")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("downstream")
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.METADATA},
         metadata=DictDiff(
             added_keys=set(),
@@ -584,7 +616,7 @@ def test_change_metadata(instance):
             removed_keys=set(),
         ),
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("fruits")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(AssetKey("fruits")) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.METADATA},
         metadata=DictDiff(
             added_keys={"green"},
@@ -592,7 +624,9 @@ def test_change_metadata(instance):
             removed_keys={"red"},
         ),
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("letters")) == AssetDefinitionDiff(
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("letters")
+    ) == AssetDefinitionDiffDetails(
         change_types={AssetDefinitionChangeType.METADATA},
         metadata=DictDiff(
             added_keys={"c"},
@@ -600,6 +634,6 @@ def test_change_metadata(instance):
             removed_keys=set(),
         ),
     )
-    assert differ.get_changes_for_asset_with_diff(AssetKey("numbers")) == AssetDefinitionDiff(
-        change_types=set()
-    )
+    assert differ.get_changes_for_asset_with_diff(
+        AssetKey("numbers")
+    ) == AssetDefinitionDiffDetails(change_types=set())


### PR DESCRIPTION
## Summary & Motivation
An `AssetDefinitionDiff` serdes class already exists in internal, causing a `SerdesUsageError`. Renaming it to `AssetDefinitionDiffDetails`

## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [x] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
