### PR TITLE
remove SerializedAssetKeyScopedAssetGraphData and SerializedAssetKeyScopedData

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
@@ -15,7 +15,7 @@ class AirflowDefinitionsData:
 
     def map_airflow_data_to_spec(self, spec: AssetSpec) -> AssetSpec:
         """If there is airflow data applicable to the asset key, transform the spec and apply the data."""
-        existing_key_data = self.serialized_data.existing_asset_data[spec.key].existing_key_data
+        existing_key_data = self.serialized_data.key_scope_data_map.get(spec.key)
         return spec if not existing_key_data else existing_key_data.apply_to_spec(spec)
 
     def construct_dag_assets_defs(self) -> List[AssetsDefinition]:

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
@@ -15,6 +15,7 @@ from dagster_airlift.constants import TASK_MAPPING_METADATA_KEY
 from dagster_airlift.core.airflow_instance import AirflowInstance, DagInfo, TaskInfo
 from dagster_airlift.core.dag_asset import dag_asset_spec_data, get_leaf_assets_for_dag
 from dagster_airlift.core.serialization.serialized_data import (
+    KeyScopedDataItem,
     SerializedAirflowDefinitionsData,
     SerializedAssetKeyScopedAirflowData,
     SerializedDagData,
@@ -211,7 +212,10 @@ def compute_serialized_data(
         )
     topology_order = toposort_flatten(upstreams_asset_dependency_graph)
     return SerializedAirflowDefinitionsData(
-        key_scoped_data_items=list(fetched_airflow_data.airflow_data_by_key.items()),
+        key_scoped_data_items=[
+            KeyScopedDataItem(asset_key=k, data=v)
+            for k, v in fetched_airflow_data.airflow_data_by_key.items()
+        ],
         dag_datas=dag_datas,
         asset_key_topological_ordering=topology_order,
     )

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
@@ -52,6 +52,8 @@ class SerializedAssetDepData:
 ###################################################################################################
 # History:
 # - created
+# - removed existing_asset_data
+# - added key_scope_data_items
 @whitelist_for_serdes
 @record
 class SerializedAirflowDefinitionsData:

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -17,13 +17,18 @@ from dagster import (
     sensor,
 )
 from dagster._core.test_utils import environ
-from dagster._serdes.serdes import deserialize_value
+from dagster._serdes.serdes import deserialize_value, serialize_value
 from dagster_airlift.constants import TASK_MAPPING_METADATA_KEY
 from dagster_airlift.core import (
     build_defs_from_airflow_instance as build_defs_from_airflow_instance,
 )
 from dagster_airlift.core.airflow_defs_data import AirflowDefinitionsData
 from dagster_airlift.core.serialization.compute import compute_serialized_data, is_mapped_asset_spec
+from dagster_airlift.core.serialization.serialized_data import (
+    KeyScopedDataItem,
+    SerializedAirflowDefinitionsData,
+    SerializedAssetKeyScopedAirflowData,
+)
 from dagster_airlift.core.state_backed_defs_loader import (
     scoped_reconstruction_metadata,
     unwrap_reconstruction_metadata,
@@ -308,6 +313,29 @@ def test_local_airflow_instance() -> None:
         assert defs.assets
         repo_def = defs.get_repository_def()
         assert len(repo_def.assets_defs_by_key) == 2
+
+
+def test_serialization_roundtrip() -> None:
+    data = AirflowDefinitionsData(
+        instance_name="test_instance",
+        serialized_data=SerializedAirflowDefinitionsData(
+            key_scoped_data_items=[
+                KeyScopedDataItem(
+                    asset_key=AssetKey("a"),
+                    data=SerializedAssetKeyScopedAirflowData(
+                        additional_metadata={"foo": "bar"}, additional_tags={"baz": "qux"}
+                    ),
+                )
+            ],
+            dag_datas={},
+            asset_key_topological_ordering=[],
+        ),
+    )
+
+    data_str = serialize_value(data)
+    assert isinstance(data_str, str)
+    deserialized_data = deserialize_value(data_str)
+    assert isinstance(deserialized_data, AirflowDefinitionsData)
 
 
 def test_cached_loading() -> None:


### PR DESCRIPTION
## Summary & Motivation

With #24728 we no longer compute check keys associated with the asset keys in the serialization process and instead compute them on demand in the sensor.

It was actually the only piece of data we accessed in the `SerializedAssetKeyScopedAssetGraphData` which allowed for a set of cascading deletes.

Also was able to eliminate the `GenericNonScalarKeyMappingSerializer` and instead just rely on serializing key-value records (I tried tuples at first which would be even less code. Not sure what is going on there.). We can very easily convert lists to dictionaries and back, which is simpler and more obvious.

e.g.

```python
@record
@whitelist_for_serdes
@record
class SerializedAirflowDefinitionsData:
    key_scoped_data_items: List[KeyScopedDataItem]

    @cached_property
    def key_scope_data_map(self) -> Mapping[AssetKey, "SerializedAssetKeyScopedAirflowData"]:
        return {item.asset_key: item.data for item in self.key_scoped_data_items}
```

and

```python
    return SerializedAirflowDefinitionsData(
        key_scoped_data_items=[
            KeyScopedDataItem(asset_key=k, data=v)
            for k, v in fetched_airflow_data.airflow_data_by_key.items()
        ],
    )
```



## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
