### PR TITLE
Move useAugmentSearchResults to a shared component

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/CloudOSSContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/CloudOSSContext.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import {SearchResult} from '../search/types';
-
 type FeatureContext = {
   canSeeMaterializeAction: boolean;
   canSeeWipeMaterializationAction: boolean;
@@ -14,10 +12,6 @@ type FeatureContext = {
 export const CloudOSSContext = React.createContext<{
   isBranchDeployment: boolean;
   featureContext: FeatureContext;
-  useAugmentSearchResults: () => (
-    results: SearchResult[],
-    searchContext: 'catalog' | 'global',
-  ) => SearchResult[];
 }>({
   isBranchDeployment: false,
   featureContext: {
@@ -28,5 +22,4 @@ export const CloudOSSContext = React.createContext<{
     canSeeExecuteChecksAction: true,
     canSeeBackfillCoordinatorLogs: false,
   },
-  useAugmentSearchResults: () => (results) => results,
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useAugmentSearchResults.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useAugmentSearchResults.oss.tsx
@@ -1,0 +1,4 @@
+export const useAugmentSearchResults =
+  () =>
+  <T,>(results: T, _searchContext: any) =>
+    results;

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -1,5 +1,6 @@
 import qs from 'qs';
 import {useCallback, useContext, useEffect, useRef} from 'react';
+import {useAugmentSearchResults} from 'shared/search/useAugmentSearchResults.oss';
 
 import {GroupMetadata, buildAssetCountBySection} from './BuildAssetSearchResults';
 import {QueryResponse, WorkerSearchResult, createSearchWorker} from './createSearchWorker';
@@ -15,7 +16,6 @@ import {
 import {useIndexedDBCachedQuery} from './useIndexedDBCachedQuery';
 import {gql} from '../apollo-client';
 import {AppContext} from '../app/AppContext';
-import {CloudOSSContext} from '../app/CloudOSSContext';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
@@ -323,7 +323,6 @@ export const useGlobalSearch = ({searchContext}: {searchContext: 'global' | 'cat
   const primarySearch = useRef<WorkerSearchResult | null>(null);
   const secondarySearch = useRef<WorkerSearchResult | null>(null);
 
-  const {useAugmentSearchResults} = useContext(CloudOSSContext);
   const augmentSearchResults = useAugmentSearchResults();
 
   const {localCacheIdPrefix} = useContext(AppContext);


### PR DESCRIPTION
Injecting this via context introduces a run time circular dependency when combined with https://github.com/dagster-io/dagster/pull/24685 and https://github.com/dagster-io/internal/pull/11739.

Instead lets use our new shared component approach which will make circular dependencies harder to miss.

## How I Tested These Changes

build and load the app with the above PRs included, observe no white screen.

## Changelog

NOCHANGELOG