### PR TITLE
[lazy-defs] [dagster-sigma] Refactor dagster-sigma to use the StateBackedDefinitionsLoader

### DIFF
--- a/python_modules/libraries/dagster-sigma/dagster_sigma/translator.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/translator.py
@@ -49,6 +49,7 @@ class SigmaDataset:
     inputs: AbstractSet[str]
 
 
+@whitelist_for_serdes
 @record
 class SigmaOrganizationData:
     workbooks: List[SigmaWorkbook]


### PR DESCRIPTION
## Summary & Motivation

Define a `SigmaOrganizationDefsLoader` class inheriting from the new `StateBackedDefinitionsLoader` and make SigmaOrganization.build_defs() use this class.

## How I Tested These Changes

Existing test suite.

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
