### PR TITLE
[lazy-defs] Restrict reconstruction metadata to string values

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -723,20 +723,30 @@ class Definitions(IHaveNew):
         return [asset_node.to_asset_spec() for asset_node in asset_graph.asset_nodes]
 
     @experimental
-    def with_reconstruction_metadata(self, state_metadata: Mapping[str, Any]) -> Self:
-        """Add metadata to the Definitions object. This is typically used to cache data
+    def with_reconstruction_metadata(self, reconstruction_metadata: Mapping[str, str]) -> Self:
+        """Add reconstruction metadata to the Definitions object. This is typically used to cache data
         loaded from some external API that is computed during initialization of a code server.
         The cached data is then made available on the DefinitionsLoadContext during
         reconstruction of the same code location context (such as a run worker), allowing use of the
-        cached data to avoid additional external API queries. Values must be JSON-serializable.
+        cached data to avoid additional external API queries. Values are expected to be serialized
+        in advance and must be strings.
         """
-        state_metadata = {
-            k: CodeLocationReconstructionMetadataValue(v) for k, v in state_metadata.items()
+        check.mapping_param(reconstruction_metadata, "reconstruction_metadata", key_type=str)
+        for k, v in reconstruction_metadata.items():
+            if not isinstance(v, str):
+                raise DagsterInvariantViolationError(
+                    f"Reconstruction metadata values must be strings. State-representing values are"
+                    f" expected to be serialized before being passed as reconstruction metadata."
+                    f" Got for key {k}:\n\n{v}"
+                )
+        normalized_metadata = {
+            k: CodeLocationReconstructionMetadataValue(v)
+            for k, v in reconstruction_metadata.items()
         }
         return copy(
             self,
             metadata={
                 **(self.metadata or {}),
-                **state_metadata,
+                **normalized_metadata,
             },
         )

--- a/python_modules/dagster/dagster/_core/definitions/metadata/metadata_value.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/metadata_value.py
@@ -20,8 +20,7 @@ from dagster._core.definitions.metadata.table import (
 )
 from dagster._core.errors import DagsterInvalidMetadata
 from dagster._serdes import whitelist_for_serdes
-from dagster._serdes.errors import SerializationError
-from dagster._serdes.serdes import PackableValue, serialize_value
+from dagster._serdes.serdes import PackableValue
 
 T_Packable = TypeVar("T_Packable", bound=PackableValue, default=PackableValue, covariant=True)
 from dagster._serdes import pack_value
@@ -492,13 +491,13 @@ class MetadataValue(ABC, Generic[T_Packable]):
 
     # not public because rest of code location metadata API is not public
     @staticmethod
-    def code_location_reconstruction(data: Any) -> "CodeLocationReconstructionMetadataValue":
+    def code_location_reconstruction(data: str) -> "CodeLocationReconstructionMetadataValue":
         """Static constructor for a metadata value wrapping arbitrary code location data useful during reconstruction as
         :py:class:`CodeLocationReconstructionMetadataValue`. Can be used as the value type for the `metadata`
         parameter for supported events.
 
         Args:
-            data (Any): The code location state for a metadata entry.
+            data (str): The serialized code location state for a metadata entry.
         """
         return CodeLocationReconstructionMetadataValue(data)
 
@@ -1034,26 +1033,24 @@ class NullMetadataValue(NamedTuple("_NullMetadataValue", []), MetadataValue[None
 
 @whitelist_for_serdes
 class CodeLocationReconstructionMetadataValue(
-    NamedTuple("_CodeLocationReconstructionMetadataValue", [("data", PublicAttr[Any])]),
-    MetadataValue[Any],
+    NamedTuple("_CodeLocationReconstructionMetadataValue", [("data", PublicAttr[str])]),
+    MetadataValue[str],
 ):
-    """Representation of some state data used to define the Definitions in a code location.
+    """Representation of some state data used to define the Definitions in a code location. Users
+    are expected to serialize data before passing it to this class.
 
     Args:
-        data (Any): Arbitrary JSON-serializable data used to define the Definitions in a
+        data (str): A string representing data used to define the Definitions in a
             code location.
     """
 
-    def __new__(cls, data: Any):
-        try:
-            serialize_value(data)
-        except SerializationError:
-            raise DagsterInvalidMetadata("Value is not JSON-serializable.")
-
-        return super(CodeLocationReconstructionMetadataValue, cls).__new__(cls, data)
+    def __new__(cls, data: str):
+        return super(CodeLocationReconstructionMetadataValue, cls).__new__(
+            cls, check.str_param(data, "data")
+        )
 
     @public
     @property
-    def value(self) -> Any:
-        """None: The wrapped code location state data."""
+    def value(self) -> str:
+        """str: The wrapped code location state data."""
         return self.data

--- a/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_metadata.py
@@ -16,10 +16,10 @@ from dagster import (
     UrlMetadataValue,
     op,
 )
+from dagster._check.functions import CheckError
 from dagster._core.definitions.metadata.metadata_value import (
     CodeLocationReconstructionMetadataValue,
 )
-from dagster._core.errors import DagsterInvalidMetadata
 from dagster._serdes.serdes import deserialize_value, serialize_value
 
 
@@ -113,13 +113,11 @@ def test_json_metadata_value():
 
 
 def test_code_location_reconstruction_metadata_value():
-    assert CodeLocationReconstructionMetadataValue({"a": "b"}).data == {"a": "b"}
-    assert CodeLocationReconstructionMetadataValue({"a": "b"}).value == {"a": "b"}
-    assert CodeLocationReconstructionMetadataValue("abc").data == "abc"
-    assert CodeLocationReconstructionMetadataValue(1).data == 1
+    assert CodeLocationReconstructionMetadataValue("foo").data == "foo"
+    assert CodeLocationReconstructionMetadataValue("foo").value == "foo"
 
-    with pytest.raises(DagsterInvalidMetadata, match="not JSON-serializable"):
-        CodeLocationReconstructionMetadataValue(object())
+    with pytest.raises(CheckError, match="not a str"):
+        CodeLocationReconstructionMetadataValue({"foo": "bar"})
 
 
 def test_serdes_json_metadata():


### PR DESCRIPTION
## Summary & Motivation

Make reconstruction metadata only accept string values. Add error message about need to pre-serialize when string is not passed.

## How I Tested These Changes

New unit tests.

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
