### PR TITLE
incorporate runsfilter.exclude_subruns value when fetching runs feed

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2339,6 +2339,7 @@ input RunsFilter {
   createdBefore: Float
   createdAfter: Float
   mode: String
+  excludeSubruns: Boolean
 }
 
 input PipelineSelector {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -4766,6 +4766,7 @@ export type RunsFeedEntry = {
 export type RunsFilter = {
   createdAfter?: InputMaybe<Scalars['Float']['input']>;
   createdBefore?: InputMaybe<Scalars['Float']['input']>;
+  excludeSubruns?: InputMaybe<Scalars['Boolean']['input']>;
   mode?: InputMaybe<Scalars['String']['input']>;
   pipelineName?: InputMaybe<Scalars['String']['input']>;
   runIds?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -13540,6 +13541,8 @@ export const buildRunsFilter = (
       overrides && overrides.hasOwnProperty('createdAfter') ? overrides.createdAfter! : 2.71,
     createdBefore:
       overrides && overrides.hasOwnProperty('createdBefore') ? overrides.createdBefore! : 2.25,
+    excludeSubruns:
+      overrides && overrides.hasOwnProperty('excludeSubruns') ? overrides.excludeSubruns! : false,
     mode: overrides && overrides.hasOwnProperty('mode') ? overrides.mode! : 'voluptatem',
     pipelineName:
       overrides && overrides.hasOwnProperty('pipelineName') ? overrides.pipelineName! : 'voluptas',

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -48,6 +48,7 @@ class GrapheneRunsFilter(graphene.InputObjectType):
     createdBefore = graphene.InputField(graphene.Float)
     createdAfter = graphene.InputField(graphene.Float)
     mode = graphene.InputField(graphene.String)
+    excludeBackfillRuns = graphene.InputField(graphene.Boolean)
 
     class Meta:
         description = """This type represents a filter on Dagster runs."""
@@ -80,6 +81,7 @@ class GrapheneRunsFilter(graphene.InputObjectType):
             updated_after=updated_after,
             created_before=created_before,
             created_after=created_after,
+            exclude_backfill_runs=self.excludeBackfillRuns,
         )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -48,7 +48,7 @@ class GrapheneRunsFilter(graphene.InputObjectType):
     createdBefore = graphene.InputField(graphene.Float)
     createdAfter = graphene.InputField(graphene.Float)
     mode = graphene.InputField(graphene.String)
-    excludeBackfillRuns = graphene.InputField(graphene.Boolean)
+    excludeSubruns = graphene.InputField(graphene.Boolean)
 
     class Meta:
         description = """This type represents a filter on Dagster runs."""
@@ -81,7 +81,7 @@ class GrapheneRunsFilter(graphene.InputObjectType):
             updated_after=updated_after,
             created_before=created_before,
             created_after=created_after,
-            exclude_backfill_runs=self.excludeBackfillRuns,
+            exclude_subruns=self.excludeSubruns,
         )
 
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
@@ -268,6 +268,90 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
 
         assert not result.data["runsFeedOrError"]["hasMore"]
 
+    def test_get_runs_feed_with_subruns(self, gql_context_with_runs_and_backfills):
+        result = execute_dagster_graphql(
+            gql_context_with_runs_and_backfills.create_request_context(),
+            GET_RUNS_FEED_QUERY,
+            variables={
+                "limit": 25,
+                "cursor": None,
+                "filter": {"excludeSubruns": False},
+            },
+        )
+        prev_run_time = None
+        for res in result.data["runsFeedOrError"]["results"]:
+            assert res["__typename"] == "Run"
+            if prev_run_time:
+                assert res["creationTime"] <= prev_run_time
+            prev_run_time = res["creationTime"]
+
+        result = execute_dagster_graphql(
+            gql_context_with_runs_and_backfills.create_request_context(),
+            GET_RUNS_FEED_QUERY,
+            variables={
+                "limit": 10,
+                "cursor": None,
+                "filter": {"excludeSubruns": False},
+            },
+        )
+
+        assert not result.errors
+        assert result.data
+
+        assert len(result.data["runsFeedOrError"]["results"]) == 10
+        prev_run_time = None
+        for res in result.data["runsFeedOrError"]["results"]:
+            assert res["__typename"] == "Run"
+            if prev_run_time:
+                assert res["creationTime"] <= prev_run_time
+            prev_run_time = res["creationTime"]
+
+        assert not result.data["runsFeedOrError"]["hasMore"]
+
+        result = execute_dagster_graphql(
+            gql_context_with_runs_and_backfills.create_request_context(),
+            GET_RUNS_FEED_QUERY,
+            variables={
+                "limit": 5,
+                "cursor": None,
+                "filter": {"excludeSubruns": False},
+            },
+        )
+
+        assert not result.errors
+        assert result.data
+
+        assert len(result.data["runsFeedOrError"]["results"]) == 5
+        prev_run_time = None
+        for res in result.data["runsFeedOrError"]["results"]:
+            assert res["__typename"] == "Run"
+            if prev_run_time:
+                assert res["creationTime"] <= prev_run_time
+            prev_run_time = res["creationTime"]
+
+        assert result.data["runsFeedOrError"]["hasMore"]
+        old_cursor = result.data["runsFeedOrError"]["cursor"]
+        assert old_cursor is not None
+
+        result = execute_dagster_graphql(
+            gql_context_with_runs_and_backfills.create_request_context(),
+            GET_RUNS_FEED_QUERY,
+            variables={
+                "limit": 5,
+                "cursor": old_cursor,
+                "filter": {"excludeSubruns": False},
+            },
+        )
+
+        assert len(result.data["runsFeedOrError"]["results"]) == 5
+        for res in result.data["runsFeedOrError"]["results"]:
+            assert res["__typename"] == "Run"
+            if prev_run_time:
+                assert res["creationTime"] <= prev_run_time
+            prev_run_time = res["creationTime"]
+
+        assert not result.data["runsFeedOrError"]["hasMore"]
+
 
 class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
     """Tests for the runs feed that need special ordering of runs and backfills. Split these
@@ -600,6 +684,86 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
         assert result.data
         assert len(result.data["runsFeedOrError"]["results"]) == 1
 
+    def test_get_runs_feed_filter_status_and_show_subruns(self, graphql_context):
+        _create_run(graphql_context, status=DagsterRunStatus.SUCCESS)
+        _create_run(graphql_context, status=DagsterRunStatus.CANCELING)
+        _create_run(graphql_context, status=DagsterRunStatus.FAILURE)
+        _create_run(graphql_context, status=DagsterRunStatus.NOT_STARTED)
+        time.sleep(CREATE_DELAY)
+        _create_backfill(graphql_context, status=BulkActionStatus.COMPLETED_SUCCESS)
+        _create_backfill(graphql_context, status=BulkActionStatus.COMPLETED_FAILED)
+        _create_backfill(graphql_context, status=BulkActionStatus.COMPLETED)
+        _create_backfill(graphql_context, status=BulkActionStatus.CANCELING)
+        _create_backfill(graphql_context, status=BulkActionStatus.CANCELED)
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_RUNS_FEED_QUERY,
+            variables={
+                "limit": 10,
+                "cursor": None,
+                "filter": {"excludeSubruns": False},
+            },
+        )
+
+        assert not result.errors
+        assert result.data
+
+        assert len(result.data["runsFeedOrError"]["results"]) == 4
+        assert not result.data["runsFeedOrError"]["hasMore"]
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_RUNS_FEED_QUERY,
+            variables={
+                "limit": 10,
+                "cursor": None,
+                "filter": {"statuses": ["SUCCESS"], "excludeSubruns": False},
+            },
+        )
+        assert not result.errors
+        assert result.data
+        assert len(result.data["runsFeedOrError"]["results"]) == 1
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_RUNS_FEED_QUERY,
+            variables={
+                "limit": 10,
+                "cursor": None,
+                "filter": {"statuses": ["FAILURE"], "excludeSubruns": False},
+            },
+        )
+        assert not result.errors
+        assert result.data
+        assert len(result.data["runsFeedOrError"]["results"]) == 1
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_RUNS_FEED_QUERY,
+            variables={
+                "limit": 10,
+                "cursor": None,
+                "filter": {"statuses": ["CANCELING"], "excludeSubruns": False},
+            },
+        )
+        assert not result.errors
+        assert result.data
+        assert len(result.data["runsFeedOrError"]["results"]) == 1
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_RUNS_FEED_QUERY,
+            variables={
+                "limit": 10,
+                "cursor": None,
+                "filter": {"statuses": ["CANCELED"], "excludeSubruns": False},
+            },
+        )
+        assert not result.errors
+        assert result.data
+        assert len(result.data["runsFeedOrError"]["results"]) == 0
+
     def test_get_runs_feed_filter_create_time(self, graphql_context):
         nothing_created_ts = get_current_timestamp()
         time.sleep(CREATE_DELAY)
@@ -880,6 +1044,42 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"runIds": [run.run_id]},
+            },
+        )
+        assert not result.errors
+        assert result.data
+        assert len(result.data["runsFeedOrError"]["results"]) == 1
+
+    def test_get_runs_feed_filters_that_dont_apply_to_backfills_and_show_subruns(
+        self, graphql_context
+    ):
+        run = _create_run(graphql_context)
+        time.sleep(CREATE_DELAY)
+        _create_backfill(graphql_context)
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_RUNS_FEED_QUERY,
+            variables={
+                "limit": 20,
+                "cursor": None,
+                "filter": {"excludeSubruns": False},
+            },
+        )
+
+        assert not result.errors
+        assert result.data
+
+        assert len(result.data["runsFeedOrError"]["results"]) == 1
+        assert not result.data["runsFeedOrError"]["hasMore"]
+
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_RUNS_FEED_QUERY,
+            variables={
+                "limit": 10,
+                "cursor": None,
+                "filter": {"runIds": [run.run_id], "excludeSubruns": False},
             },
         )
         assert not result.errors


### PR DESCRIPTION
## Summary & Motivation
Updates the `runsFeedOrError` query to incorporate the `exclude_subruns` filter if provided. 

## How I Tested These Changes

## Changelog

NOCHANGELOG
