### PR TITLE
explicitly set kwargs_fields to fix bk

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -55,7 +55,7 @@ class ValueDiff(Generic[T]):
     new: T
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(kwargs_fields={"added_keys", "changed_keys", "removed_keys"})
 @record
 class DictDiff(Generic[T]):
     added_keys: AbstractSet[T]


### PR DESCRIPTION
## Summary

Without explicitly specifying this here, we were hitting this error on the backcompat tests:

```python
...
2024-09-25 08:51:16   File "/tmp/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py", line 34, in <module>
2024-09-25 08:51:16     from dagster_graphql.implementation.fetch_assets import get_external_asset_node
2024-09-25 08:51:16   File "/tmp/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py", line 25, in <module>
2024-09-25 08:51:16     from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
2024-09-25 08:51:16   File "/tmp/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py", line 60, in <module>
2024-09-25 08:51:16     class DictDiff(Generic[T]):
2024-09-25 08:51:16   File "/tmp/python_modules/dagster/dagster/_serdes/serdes.py", line 344, in whitelist_for_serdes
2024-09-25 08:51:16     return _whitelist_for_serdes(
2024-09-25 08:51:16   File "/tmp/python_modules/dagster/dagster/_serdes/serdes.py", line 391, in __whitelist_for_serdes
2024-09-25 08:51:16     _check_serdes_tuple_class_invariants(
2024-09-25 08:51:16   File "/tmp/python_modules/dagster/dagster/_serdes/serdes.py", line 1338, in _check_serdes_tuple_class_invariants
2024-09-25 08:51:16     raise SerdesUsageError(
2024-09-25 08:51:16 dagster._serdes.errors.SerdesUsageError: For DictDiff: kwargs capture used in __new__ but kwargs_fields was not specified. Declare the set of fields processed via kwargs as kwargs_fields Expecting: ['removed_keys']

```

My guess is this is some weird interaction between generics/abstractset, `@record` and serdes