### PR TITLE
Generic pattern for serializing dictionaries in serdes

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
@@ -15,7 +15,6 @@ from dagster_airlift.constants import TASK_MAPPING_METADATA_KEY
 from dagster_airlift.core.airflow_instance import AirflowInstance, DagInfo, TaskInfo
 from dagster_airlift.core.dag_asset import dag_asset_spec_data, get_leaf_assets_for_dag
 from dagster_airlift.core.serialization.serialized_data import (
-    KeyScopedDataItem,
     SerializedAirflowDefinitionsData,
     SerializedAssetKeyScopedAirflowData,
     SerializedDagData,
@@ -29,6 +28,7 @@ from dagster_airlift.core.task_asset import (
 )
 from dagster_airlift.core.utils import spec_iterator
 from dagster_airlift.migration_state import AirflowMigrationState
+from dagster_airlift.utils import items_from_dict
 
 
 @record
@@ -212,10 +212,7 @@ def compute_serialized_data(
         )
     topology_order = toposort_flatten(upstreams_asset_dependency_graph)
     return SerializedAirflowDefinitionsData(
-        key_scoped_data_items=[
-            KeyScopedDataItem(asset_key=k, data=v)
-            for k, v in fetched_airflow_data.airflow_data_by_key.items()
-        ],
+        key_scoped_data_items=items_from_dict(fetched_airflow_data.airflow_data_by_key),
         dag_datas=dag_datas,
         asset_key_topological_ordering=topology_order,
     )

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
@@ -64,13 +64,6 @@ class SerializedDagData:
     all_asset_keys_in_tasks: AbstractSet[AssetKey]
 
 
-@whitelist_for_serdes
-@record
-class KeyScopedDataItem:
-    asset_key: AssetKey
-    data: "SerializedAssetKeyScopedAirflowData"
-
-
 ###################################################################################################
 # Serializable data that will be cached to avoid repeated calls to the Airflow API, and to avoid
 # repeated scans of passed-in Definitions objects.

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
@@ -6,6 +6,8 @@ from dagster._record import record
 from dagster._serdes import whitelist_for_serdes
 from dagster._utils.merger import merge_dicts
 
+from dagster_airlift.utils import DictItem, dict_from_items
+
 
 ###################################################################################################
 # Data for reconstructing AssetSpecs from serialized data.
@@ -80,13 +82,13 @@ class KeyScopedDataItem:
 @whitelist_for_serdes
 @record
 class SerializedAirflowDefinitionsData:
-    key_scoped_data_items: List[KeyScopedDataItem]
+    key_scoped_data_items: List[DictItem[AssetKey, "SerializedAssetKeyScopedAirflowData"]]
     dag_datas: Mapping[str, SerializedDagData]
     asset_key_topological_ordering: Sequence[AssetKey]
 
     @cached_property
     def key_scope_data_map(self) -> Mapping[AssetKey, "SerializedAssetKeyScopedAirflowData"]:
-        return {item.asset_key: item.data for item in self.key_scoped_data_items}
+        return dict_from_items(self.key_scoped_data_items)
 
 
 # History:

--- a/examples/experimental/dagster-airlift/dagster_airlift/utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/utils.py
@@ -3,8 +3,31 @@ from pathlib import Path
 from typing import Optional
 
 DAGSTER_AIRLIFT_MIGRATION_STATE_DIR_ENV_VAR = "DAGSTER_AIRLIFT_MIGRATION_STATE_DIR"
+from typing import Generic, List, Mapping, TypeVar
+
+from dagster._record import record
+from dagster._serdes import whitelist_for_serdes
 
 
 def get_local_migration_state_dir() -> Optional[Path]:
     migration_dir = os.getenv(DAGSTER_AIRLIFT_MIGRATION_STATE_DIR_ENV_VAR)
     return Path(migration_dir) if migration_dir else None
+
+
+TKey = TypeVar("TKey")
+TValue = TypeVar("TValue")
+
+
+@whitelist_for_serdes
+@record
+class DictItem(Generic[TKey, TValue]):
+    key: TKey
+    value: TValue
+
+
+def items_from_dict(d: Mapping[TKey, TValue]) -> List[DictItem[TKey, TValue]]:
+    return [DictItem(key=k, value=v) for k, v in d.items()]
+
+
+def dict_from_items(items: List[DictItem[TKey, TValue]]) -> Mapping[TKey, TValue]:
+    return {item.key: item.value for item in items}

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -25,7 +25,6 @@ from dagster_airlift.core import (
 from dagster_airlift.core.airflow_defs_data import AirflowDefinitionsData
 from dagster_airlift.core.serialization.compute import compute_serialized_data, is_mapped_asset_spec
 from dagster_airlift.core.serialization.serialized_data import (
-    KeyScopedDataItem,
     SerializedAirflowDefinitionsData,
     SerializedAssetKeyScopedAirflowData,
 )
@@ -35,7 +34,7 @@ from dagster_airlift.core.state_backed_defs_loader import (
 )
 from dagster_airlift.core.utils import metadata_for_task_mapping
 from dagster_airlift.test import make_instance
-from dagster_airlift.utils import DAGSTER_AIRLIFT_MIGRATION_STATE_DIR_ENV_VAR
+from dagster_airlift.utils import DAGSTER_AIRLIFT_MIGRATION_STATE_DIR_ENV_VAR, DictItem
 
 from dagster_airlift_tests.unit_tests.conftest import (
     assert_dependency_structure_in_assets,
@@ -320,9 +319,9 @@ def test_serialization_roundtrip() -> None:
         instance_name="test_instance",
         serialized_data=SerializedAirflowDefinitionsData(
             key_scoped_data_items=[
-                KeyScopedDataItem(
-                    asset_key=AssetKey("a"),
-                    data=SerializedAssetKeyScopedAirflowData(
+                DictItem(
+                    key=AssetKey("a"),
+                    value=SerializedAssetKeyScopedAirflowData(
                         additional_metadata={"foo": "bar"}, additional_tags={"baz": "qux"}
                     ),
                 )


### PR DESCRIPTION
## Summary & Motivation

Serdes does not handle cases where there are non-scalar, but serializable keys. @dpeng817's previous solution involved implementing a custom serializing, which seemed complicated and magical. 

This was removed in #24729 in lieu of encoded key value pairs as a record itself, which was much more obvious and involved less code.

This PR makes that more generic, so we could do it for any dictionary.

If we like this we can move it into serdes proper.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG

