### PR TITLE
add get_backfills_count

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -3095,6 +3095,9 @@ class DagsterInstance(DynamicPartitionsStore):
             status=status, cursor=cursor, limit=limit, filters=filters
         )
 
+    def get_backfills_count(self, filters: Optional["BulkActionsFilter"] = None) -> int:
+        return self._run_storage.get_backfills_count(filters=filters)
+
     def get_backfill(self, backfill_id: str) -> Optional["PartitionBackfill"]:
         return self._run_storage.get_backfill(backfill_id)
 

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -322,6 +322,9 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
             cursor=cursor, limit=limit, filters=filters, status=status
         )
 
+    def get_backfills_count(self, filters: Optional["BulkActionsFilter"] = None) -> int:
+        return self._run_storage.get_backfills_count(filters=filters)
+
     def get_backfill(self, backfill_id: str) -> Optional["PartitionBackfill"]:
         return self._storage.run_storage.get_backfill(backfill_id)
 

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -323,7 +323,7 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
         )
 
     def get_backfills_count(self, filters: Optional["BulkActionsFilter"] = None) -> int:
-        return self._run_storage.get_backfills_count(filters=filters)
+        return self._storage.run_storage.get_backfills_count(filters=filters)
 
     def get_backfill(self, backfill_id: str) -> Optional["PartitionBackfill"]:
         return self._storage.run_storage.get_backfill(backfill_id)

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -377,6 +377,17 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         """Get a list of partition backfills."""
 
     @abstractmethod
+    def get_backfills_count(self, filters: Optional[BulkActionsFilter] = None) -> int:
+        """Return the number of backfills present in the storage that match the given filters.
+
+        Args:
+            filters (Optional[BulkActionsFilter]) -- The filter by which to filter backfills
+
+        Returns:
+            int: The number of backfills that match the given filters.
+        """
+
+    @abstractmethod
     def get_backfill(self, backfill_id: str) -> Optional[PartitionBackfill]:
         """Get the partition backfill of the given backfill id."""
 

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -958,7 +958,6 @@ class SqlRunStorage(RunStorage):
         return backfill_candidates
 
     def get_backfills_count(self, filters: Optional[BulkActionsFilter] = None) -> int:
-
         if filters.tags:
             # runs can have more tags than the backfill that launched them. Since we filtered tags by
             # querying for runs with those tags, we need to do an additional check that the backfills

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -957,7 +957,7 @@ class SqlRunStorage(RunStorage):
             )
         return backfill_candidates
 
-    def get_backfills_count(self, filters: Optional[RunsFilter] = None) -> int:
+    def get_backfills_count(self, filters: Optional[BulkActionsFilter] = None) -> int:
 
         if filters.tags:
             # runs can have more tags than the backfill that launched them. Since we filtered tags by

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -957,6 +957,30 @@ class SqlRunStorage(RunStorage):
             )
         return backfill_candidates
 
+    def get_backfills_count(self, filters: Optional[RunsFilter] = None) -> int:
+
+        if filters.tags:
+            # runs can have more tags than the backfill that launched them. Since we filtered tags by
+            # querying for runs with those tags, we need to do an additional check that the backfills
+            # also have the requested tags. This requires fetching the backfills from the db and filtering them
+            query = self._backfills_query(filters=filters)
+            rows = self.fetchall(query)
+            backfill_candidates = deserialize_values(
+                (row["body"] for row in rows), PartitionBackfill
+            )
+            backfill_candidates = [
+                backfill
+                for backfill in backfill_candidates
+                if self._backfill_matches_tags(backfill, filters.tags)
+            ]
+            return len(backfill_candidates)
+
+        subquery = db_subquery(self._backfills_query(filters=filters))
+        query = db_select([db.func.count().label("count")]).select_from(subquery)
+        row = self.fetchone(query)
+        count = row["count"] if row else 0
+        return count
+
     def get_backfill(self, backfill_id: str) -> Optional[PartitionBackfill]:
         check.str_param(backfill_id, "backfill_id")
         query = db_select([BulkActionsTable.c.body]).where(BulkActionsTable.c.key == backfill_id)

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -958,6 +958,7 @@ class SqlRunStorage(RunStorage):
         return backfill_candidates
 
     def get_backfills_count(self, filters: Optional[BulkActionsFilter] = None) -> int:
+        check.opt_inst_param(filters, "filters", BulkActionsFilter)
         if filters.tags:
             # runs can have more tags than the backfill that launched them. Since we filtered tags by
             # querying for runs with those tags, we need to do an additional check that the backfills

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -959,7 +959,7 @@ class SqlRunStorage(RunStorage):
 
     def get_backfills_count(self, filters: Optional[BulkActionsFilter] = None) -> int:
         check.opt_inst_param(filters, "filters", BulkActionsFilter)
-        if filters.tags:
+        if filters and filters.tags:
             # runs can have more tags than the backfill that launched them. Since we filtered tags by
             # querying for runs with those tags, we need to do an additional check that the backfills
             # also have the requested tags. This requires fetching the backfills from the db and filtering them
@@ -968,12 +968,9 @@ class SqlRunStorage(RunStorage):
             backfill_candidates = deserialize_values(
                 (row["body"] for row in rows), PartitionBackfill
             )
-            backfill_candidates = [
-                backfill
-                for backfill in backfill_candidates
-                if self._backfill_matches_tags(backfill, filters.tags)
-            ]
-            return len(backfill_candidates)
+            return len(
+                self._apply_backfill_tags_filter_to_results(backfill_candidates, filters.tags)
+            )
 
         subquery = db_subquery(self._backfills_query(filters=filters))
         query = db_select([db.func.count().label("count")]).select_from(subquery)

--- a/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_run_storage.py
@@ -52,6 +52,9 @@ class TestSqliteRunStorage(TestRunStorage):
     def supports_backfill_id_filtering_queries(self):
         return True
 
+    def supports_backfills_count(self):
+        return True
+
     @pytest.fixture(name="instance", scope="function")
     def instance(self):
         with tempfile.TemporaryDirectory(dir=os.getcwd()) as tmpdir_path:
@@ -77,6 +80,9 @@ class TestInMemoryRunStorage(TestRunStorage):
     def supports_backfill_id_filtering_queries(self):
         return True
 
+    def supports_backfills_count(self):
+        return True
+
     @pytest.fixture(name="instance", scope="function")
     def instance(self):
         with DagsterInstance.ephemeral() as the_instance:
@@ -100,6 +106,9 @@ class TestLegacyRunStorage(TestRunStorage):
         return True
 
     def supports_backfill_id_filtering_queries(self):
+        return True
+
+    def supports_backfills_count(self):
         return True
 
     @pytest.fixture(name="instance", scope="function")

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -101,9 +101,6 @@ class TestRunStorage:
     # Override for storages that support filtering backfills by backfill id
     def supports_backfill_id_filtering_queries(self):
         return False
-    def assert_results_match_count_match_expected(results, count, expected):
-        assert len(results) == count
-        assert count == expected
 
     def get_backfills_and_assert_expected_count(self, storage, filters, expected_count):
         backfills = storage.get_backfills(filters)

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -101,6 +101,7 @@ class TestRunStorage:
     # Override for storages that support filtering backfills by backfill id
     def supports_backfill_id_filtering_queries(self):
         return False
+
     # Override for storages that support getting backfill counts
     def supports_backfills_count(self):
         return False
@@ -1728,10 +1729,9 @@ class TestRunStorage:
             )
         )
 
-        backfills_for_id = storage.get_backfills(
-            filters=BulkActionsFilter(backfill_ids=[backfill.backfill_id])
+        backfills_for_id = self.get_backfills_and_assert_expected_count(
+            storage, BulkActionsFilter(backfill_ids=[backfill.backfill_id]), 1
         )
-        assert len(backfills_for_id) == 1
         assert backfills_for_id[0].backfill_id == backfill.backfill_id
 
     def test_secondary_index(self, storage):

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -101,6 +101,16 @@ class TestRunStorage:
     # Override for storages that support filtering backfills by backfill id
     def supports_backfill_id_filtering_queries(self):
         return False
+    def assert_results_match_count_match_expected(results, count, expected):
+        assert len(results) == count
+        assert count == expected
+
+    def get_backfills_and_assert_expected_count(self, storage, filters, expected_count):
+        backfills = storage.get_backfills(filters)
+        count = storage.get_backfills_count(filters)
+        assert len(backfills) == count
+        assert count == expected_count
+        return backfills
 
     @staticmethod
     def fake_repo_target(repo_name=None):
@@ -1431,54 +1441,31 @@ class TestRunStorage:
             backfill_timestamp=time.time(),
         )
         storage.add_backfill(one)
-        assert (
-            len(
-                storage.get_backfills(
-                    filters=BulkActionsFilter(statuses=[BulkActionStatus.REQUESTED])
-                )
-            )
-            == 1
+        requested_filters = BulkActionsFilter(statuses=[BulkActionStatus.REQUESTED])
+        requested_backfills = self.get_backfills_and_assert_expected_count(
+            storage, requested_filters, 1
         )
-        assert (
-            len(
-                storage.get_backfills(
-                    filters=BulkActionsFilter(statuses=[BulkActionStatus.COMPLETED_SUCCESS])
-                )
-            )
-            == 0
+
+        assert requested_backfills[0] == one
+
+        success_filters = BulkActionsFilter(statuses=[BulkActionStatus.COMPLETED_SUCCESS])
+        self.get_backfills_and_assert_expected_count(storage, success_filters, 0)
+
+        multi_filters = BulkActionsFilter(
+            statuses=[BulkActionStatus.COMPLETED_SUCCESS, BulkActionStatus.REQUESTED]
         )
-        assert (
-            len(
-                storage.get_backfills(
-                    filters=BulkActionsFilter(
-                        statuses=[BulkActionStatus.COMPLETED_SUCCESS, BulkActionStatus.REQUESTED]
-                    )
-                )
-            )
-            == 1
-        )
-        backfills = storage.get_backfills(
-            filters=BulkActionsFilter(statuses=[BulkActionStatus.REQUESTED])
-        )
-        assert backfills[0] == one
+        self.get_backfills_and_assert_expected_count(storage, multi_filters, 1)
 
         storage.update_backfill(one.with_status(status=BulkActionStatus.COMPLETED_SUCCESS))
-        assert (
-            len(
-                storage.get_backfills(
-                    filters=BulkActionsFilter(statuses=[BulkActionStatus.REQUESTED])
-                )
-            )
-            == 0
+
+        self.get_backfills_and_assert_expected_count(storage, requested_filters, 0)
+
+        success_backfills = self.get_backfills_and_assert_expected_count(
+            storage, success_filters, 1
         )
-        assert (
-            len(
-                storage.get_backfills(
-                    filters=BulkActionsFilter(statuses=[BulkActionStatus.COMPLETED_SUCCESS])
-                )
-            )
-            == 1
-        )
+        assert success_backfills[0] == one
+
+        self.get_backfills_and_assert_expected_count(storage, multi_filters, 1)
 
         two = PartitionBackfill(
             "two",
@@ -1490,16 +1477,7 @@ class TestRunStorage:
             backfill_timestamp=time.time(),
         )
         storage.add_backfill(two)
-        assert (
-            len(
-                storage.get_backfills(
-                    filters=BulkActionsFilter(
-                        statuses=[BulkActionStatus.COMPLETED_SUCCESS, BulkActionStatus.REQUESTED]
-                    )
-                )
-            )
-            == 2
-        )
+        self.get_backfills_and_assert_expected_count(storage, multi_filters, 1)
 
     def test_backfill_created_time_filtering(self, storage: RunStorage):
         origin = self.fake_partition_set_origin("fake_partition_set")
@@ -1520,21 +1498,21 @@ class TestRunStorage:
             storage.add_backfill(backfill)
             all_backfills.append(backfill)
 
-        created_before = storage.get_backfills(
-            filters=BulkActionsFilter(
-                created_before=datetime_from_timestamp(all_backfills[2].backfill_timestamp)
-            )
+        created_before_filter = BulkActionsFilter(
+            created_before=datetime_from_timestamp(all_backfills[2].backfill_timestamp)
         )
-        assert len(created_before) == 2
+        created_before = self.get_backfills_and_assert_expected_count(
+            storage, created_before_filter, 2
+        )
         for backfill in created_before:
             assert backfill.backfill_timestamp < all_backfills[2].backfill_timestamp
 
-        created_after = storage.get_backfills(
-            filters=BulkActionsFilter(
-                created_after=datetime_from_timestamp(all_backfills[2].backfill_timestamp)
-            )
+        created_after_filter = BulkActionsFilter(
+            created_after=datetime_from_timestamp(all_backfills[2].backfill_timestamp)
         )
-        assert len(created_after) == 2
+        created_after = self.get_backfills_and_assert_expected_count(
+            storage, created_after_filter, 2
+        )
         for backfill in created_after:
             assert backfill.backfill_timestamp > all_backfills[2].backfill_timestamp
 
@@ -1566,27 +1544,24 @@ class TestRunStorage:
             )
         )
 
-        backfill_with_tags = storage.get_backfills(filters=BulkActionsFilter(tags={"foo": "bar"}))
-        assert len(backfill_with_tags) == 1
+        foo_bar_filter = BulkActionsFilter(tags={"foo": "bar"})
+        backfill_with_tags = self.get_backfills_and_assert_expected_count(
+            storage, foo_bar_filter, 1
+        )
         assert backfill_with_tags[0].backfill_id == backfill.backfill_id
         assert backfill_with_tags[0].tags == backfill.tags
 
-        backfill_with_tags = storage.get_backfills(
-            filters=BulkActionsFilter(tags={"letter": ["x", "y", "z"]})
-        )
-        assert len(backfill_with_tags) == 1
+        letter_filter = BulkActionsFilter(tags={"letter": ["x", "y", "z"]})
+        backfill_with_tags = self.get_backfills_and_assert_expected_count(storage, letter_filter, 1)
         assert backfill_with_tags[0].backfill_id == backfill.backfill_id
         assert backfill_with_tags[0].tags == backfill.tags
 
         # test for a tag that doesn't exist
+        not_present_filter = BulkActionsFilter(tags={"not": "present"})
+        self.get_backfills_and_assert_expected_count(storage, not_present_filter, 0)
 
-        backfill_with_tags = storage.get_backfills(
-            filters=BulkActionsFilter(tags={"not": "present"})
-        )
-        assert len(backfill_with_tags) == 0
-
-        backfill_with_tags = storage.get_backfills(filters=BulkActionsFilter(tags={"foo": "no"}))
-        assert len(backfill_with_tags) == 0
+        wrong_value_filter = BulkActionsFilter(tags={"foo": "no"})
+        self.get_backfills_and_assert_expected_count(storage, wrong_value_filter, 0)
 
     def test_backfill_tags_on_runs_not_backfills_filtering(self, storage: RunStorage):
         if not self.supports_backfill_tags_filtering_queries():
@@ -1621,13 +1596,11 @@ class TestRunStorage:
             )
         )
 
-        backfill_with_tags = storage.get_backfills(filters=BulkActionsFilter(tags={"baz": "qux"}))
-        assert len(backfill_with_tags) == 0
+        baz_filter = BulkActionsFilter(tags={"baz": "qux"})
+        self.get_backfills_and_assert_expected_count(storage, baz_filter, 0)
 
-        backfill_with_tags = storage.get_backfills(
-            filters=BulkActionsFilter(tags={"letter": ["x", "y", "z"]})
-        )
-        assert len(backfill_with_tags) == 0
+        letter_filter = BulkActionsFilter(tags={"letter": ["x", "y", "z"]})
+        self.get_backfills_and_assert_expected_count(storage, letter_filter, 0)
 
     def test_backfill_tags_filtering_multiple_results(self, storage: RunStorage):
         if not self.supports_backfill_tags_filtering_queries():
@@ -1660,31 +1633,23 @@ class TestRunStorage:
                 )
             )
 
-        backfill_with_tags = storage.get_backfills(filters=BulkActionsFilter(tags={"foo": "bar"}))
-        assert len(backfill_with_tags) == 3
+        foo_filter = BulkActionsFilter(tags={"foo": "bar"})
+        self.get_backfills_and_assert_expected_count(storage, foo_filter, 3)
 
-        backfill_with_tags = storage.get_backfills(
-            filters=BulkActionsFilter(tags={"letter": ["x", "y", "z"]})
-        )
-        assert len(backfill_with_tags) == 0
+        letter_filter = BulkActionsFilter(tags={"letter": ["x", "y", "z"]})
+        self.get_backfills_and_assert_expected_count(storage, letter_filter, 0)
 
-        backfill_with_tags = storage.get_backfills(filters=BulkActionsFilter(tags={"even": "True"}))
-        assert len(backfill_with_tags) == 2
+        even_filter = BulkActionsFilter(tags={"even": "True"})
+        self.get_backfills_and_assert_expected_count(storage, even_filter, 2)
 
-        backfill_with_tags = storage.get_backfills(
-            filters=BulkActionsFilter(tags={"iter": ["1", "2"]})
-        )
-        assert len(backfill_with_tags) == 2
+        iter_filter = BulkActionsFilter(tags={"iter": ["1", "2"]})
+        self.get_backfills_and_assert_expected_count(storage, iter_filter, 2)
 
-        backfill_with_tags = storage.get_backfills(
-            filters=BulkActionsFilter(tags={"iter": ["1", "2"], "even": "True"})
-        )
-        assert len(backfill_with_tags) == 1
+        iter_even_filter = BulkActionsFilter(tags={"iter": ["1", "2"], "even": "True"})
+        self.get_backfills_and_assert_expected_count(storage, iter_even_filter, 1)
 
-        backfill_with_tags = storage.get_backfills(
-            filters=BulkActionsFilter(tags={"not": "present"})
-        )
-        assert len(backfill_with_tags) == 0
+        not_present_filter = BulkActionsFilter(tags={"not": "present"})
+        self.get_backfills_and_assert_expected_count(storage, not_present_filter, 0)
 
     def test_backfill_simple_job_name_filtering(self, storage: RunStorage):
         if not self.supports_backfill_job_name_filtering_queries():
@@ -1723,16 +1688,15 @@ class TestRunStorage:
             )
         )
 
-        backfills_for_job = storage.get_backfills(filters=BulkActionsFilter(job_name="fake"))
-        assert len(backfills_for_job) == 1
+        backfills_for_job = self.get_backfills_and_assert_expected_count(
+            storage, BulkActionsFilter(job_name="fake"), 1
+        )
         assert backfills_for_job[0].backfill_id == backfill.backfill_id
 
         # test for a job_name that doesn't match
-
-        backfills_for_job = storage.get_backfills(
-            filters=BulkActionsFilter(job_name="a_different_pipeline")
+        self.get_backfills_and_assert_expected_count(
+            storage, BulkActionsFilter(job_name="a_different_pipeline"), 0
         )
-        assert len(backfills_for_job) == 0
 
     def test_backfill_id_filtering(self, storage: RunStorage):
         if not self.supports_backfill_id_filtering_queries():

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -1457,6 +1457,7 @@ class TestRunStorage:
         self.get_backfills_and_assert_expected_count(storage, multi_filters, 1)
 
         storage.update_backfill(one.with_status(status=BulkActionStatus.COMPLETED_SUCCESS))
+        one = storage.get_backfill(one.backfill_id)
 
         self.get_backfills_and_assert_expected_count(storage, requested_filters, 0)
 
@@ -1477,7 +1478,7 @@ class TestRunStorage:
             backfill_timestamp=time.time(),
         )
         storage.add_backfill(two)
-        self.get_backfills_and_assert_expected_count(storage, multi_filters, 1)
+        self.get_backfills_and_assert_expected_count(storage, multi_filters, 2)
 
     def test_backfill_created_time_filtering(self, storage: RunStorage):
         origin = self.fake_partition_set_origin("fake_partition_set")

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -101,12 +101,16 @@ class TestRunStorage:
     # Override for storages that support filtering backfills by backfill id
     def supports_backfill_id_filtering_queries(self):
         return False
+    # Override for storages that support getting backfill counts
+    def supports_backfills_count(self):
+        return False
 
     def get_backfills_and_assert_expected_count(self, storage, filters, expected_count):
         backfills = storage.get_backfills(filters)
-        count = storage.get_backfills_count(filters)
-        assert len(backfills) == count
-        assert count == expected_count
+        assert len(backfills) == expected_count
+        if self.supports_backfills_count():
+            count = storage.get_backfills_count(filters)
+            assert len(backfills) == count
         return backfills
 
     @staticmethod

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_run_storage.py
@@ -23,6 +23,9 @@ class TestMySQLRunStorage(TestRunStorage):
     def supports_backfill_id_filtering_queries(self):
         return True
 
+    def supports_backfills_count(self):
+        return True
+
     @pytest.fixture(name="instance", scope="function")
     def instance(self, conn_string):
         MySQLRunStorage.create_clean_storage(conn_string)

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_run_storage.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/test_run_storage.py
@@ -19,6 +19,9 @@ class TestPostgresRunStorage(TestRunStorage):
     def supports_backfill_id_filtering_queries(self):
         return True
 
+    def supports_backfills_count(self):
+        return True
+
     @pytest.fixture(name="instance", scope="function")
     def instance(self, conn_string):
         PostgresRunStorage.create_clean_storage(conn_string)


### PR DESCRIPTION
## Summary & Motivation
Adds `get_backfills_count` method to return the number of backfills that match a given filter

corresponding internal pr https://github.com/dagster-io/internal/pull/11795

## How I Tested These Changes

## Changelog

NOCHANGELOG
