### PR TITLE
[docs] Add dbt defer and Dagster branch deployments guide

### DIFF
--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -159,6 +159,60 @@ In your CI/CD workflows for your Dagster and dbt project:
 
 ---
 
+## Leveraging dbt defer with branch deployments
+
+It is possible to leverage [dbt defer](https://docs.getdbt.com/reference/node-selection/defer) by passing a `state_path` to <PyObject object="DbtProject" module="dagster_dbt" />. This allows you to run a subset of models or tests based on the changes made since the state passed to `state_path`.
+
+In practice, this is most useful when combined with branch deployments in Dagster, to test changes made in your branches. This can be easily done by updating your Dagster code and CI/CD file for branch deployments.
+
+First, update your Dagster code to pass a `state_path` to your `DbtProject` object. Also, update the dbt command in your ``@dbt_assets` definition to pass the defer args using `get_defer_args`.
+
+```python startafter=start_use_dbt_defer_with_dbt_project endbefore=end_use_dbt_defer_with_dbt_project file=/integrations/dbt/dbt.py dedent=4
+import os
+from pathlib import Path
+
+from dagster import AssetExecutionContext
+from dagster_dbt import DbtCliResource, DbtProject, dbt_assets
+
+my_dbt_project = DbtProject(
+    project_dir=Path(__file__).joinpath("..", "..", "..").resolve(),
+    packaged_project_dir=(
+        Path(__file__)
+        .joinpath("..", "..", "dbt-project")
+        .resolve()
+    ),
+    state_path=os.getenv("DBT_STATE_PATH"),
+)
+my_dbt_project.prepare_if_dev()
+
+@dbt_assets(manifest=my_dbt_project.manifest_path)
+def my_dbt_assets(
+    context: AssetExecutionContext,
+    dbt: DbtCliResource,
+):
+    yield from dbt.cli(["build", *dbt.get_defer_args()], context=context).stream()
+```
+
+In the code above, notice that the `state_path` is set using the `DBT_STATE_PATH` environment variable. This allows to pass a value to `state_path` only when needed - in our case, the `DBT_STATE_PATH` environment variable should be set only in a branch deployment context.
+
+To do so, we need to update the `.github/workflows/branch_deployments.yml` file to set a value to the `DBT_STATE_PATH` environment variable. This will ensure that dbt uses a state path only as part of our Dagster+ branch deployments.
+
+Open the file, scroll to the environment variable section, and set an environment variable named `DBT_STATE_PATH` to the path where your state artifacts are located. This should be on or around line 12:
+
+```bash
+env:
+  DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_ORGANIZATION }}
+  DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
+  ENABLE_FAST_DEPLOYS: 'true'
+  PYTHON_VERSION: '3.8'
+  DAGSTER_CLOUD_FILE: 'dagster_cloud.yaml'
+  DBT_STATE_PATH: 'path/to/artifacts'
+```
+
+Save and commit the file to git. Don’t forget to push to remote!
+
+---
+
 ## Using config with `@dbt_assets`
 
 Like for a standard \[software-defined asset], `@dbt_assets` can use a config system to enable [run configuration](/concepts/configuration/config-schema). This allows to provide parameters to jobs at the time they're executed.

--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -165,7 +165,7 @@ It is possible to leverage [dbt defer](https://docs.getdbt.com/reference/node-se
 
 In practice, this is most useful when combined with branch deployments in Dagster, to test changes made in your branches. This can be easily done by updating your Dagster code and CI/CD file for branch deployments.
 
-First, update your Dagster code to pass a `state_path` to your `DbtProject` object. Also, update the dbt command in your `@dbt_assets` definition to pass the defer args using `get_defer_args`.
+First, update your Dagster code to pass a `state_path` to your `DbtProject` object. Also, update the dbt command in your @dbt_assets`definition to pass the defer args using`get_defer_args\`.
 
 ```python startafter=start_use_dbt_defer_with_dbt_project endbefore=end_use_dbt_defer_with_dbt_project file=/integrations/dbt/dbt.py dedent=4
 import os
@@ -176,11 +176,9 @@ from dagster_dbt import DbtCliResource, DbtProject, dbt_assets
 
 my_dbt_project = DbtProject(
     project_dir=Path(__file__).joinpath("..", "..", "..").resolve(),
-    packaged_project_dir=(
-        Path(__file__)
-        .joinpath("..", "..", "dbt-project")
-        .resolve()
-    ),
+    packaged_project_dir=Path(__file__)
+    .joinpath("..", "..", "dbt-project")
+    .resolve(),
     state_path=os.getenv("DBT_STATE_PATH"),
 )
 my_dbt_project.prepare_if_dev()

--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -163,9 +163,9 @@ In your CI/CD workflows for your Dagster and dbt project:
 
 It is possible to leverage [dbt defer](https://docs.getdbt.com/reference/node-selection/defer) by passing a `state_path` to <PyObject object="DbtProject" module="dagster_dbt" />. This allows you to run a subset of models or tests based on the changes made since the state passed to `state_path`.
 
-In practice, this is most useful when combined with branch deployments in Dagster, to test changes made in your branches. This can be easily done by updating your Dagster code and CI/CD file for branch deployments.
+In practice, this is most useful when combined with branch deployments in Dagster+, to test changes made in your branches. This can be easily done by updating your Dagster code and your CI/CD files.
 
-First, update your Dagster code to pass a `state_path` to your `DbtProject` object. Also, update the dbt command in your @dbt_assets`definition to pass the defer args using`get_defer_args\`.
+First, update your Dagster code to pass a `state_path` to your `DbtProject` object. Also, update the dbt command in your `@dbt_assets` definition to pass the defer args using `get_defer_args`.
 
 ```python startafter=start_use_dbt_defer_with_dbt_project endbefore=end_use_dbt_defer_with_dbt_project file=/integrations/dbt/dbt.py dedent=4
 import os
@@ -179,7 +179,7 @@ my_dbt_project = DbtProject(
     packaged_project_dir=Path(__file__)
     .joinpath("..", "..", "dbt-project")
     .resolve(),
-    state_path=os.getenv("DBT_STATE_PATH"),
+    state_path=Path("state"),
 )
 my_dbt_project.prepare_if_dev()
 
@@ -191,23 +191,21 @@ def my_dbt_assets(
     yield from dbt.cli(["build", *dbt.get_defer_args()], context=context).stream()
 ```
 
-In the code above, notice that the `state_path` is set using the `DBT_STATE_PATH` environment variable. This allows to pass a value to `state_path` only when needed - in our case, the `DBT_STATE_PATH` environment variable should be set only in a branch deployment context.
+Note that value passed to `state_path` must be a path, relative to the dbt project directory, to a directory of dbt artifacts. In the code above, we set the `state_path` to 'state/'.
 
-To do so, we need to update the `.github/workflows/branch_deployments.yml` file to set a value to the `DBT_STATE_PATH` environment variable. This will ensure that dbt uses a state path only as part of our Dagster+ branch deployments.
+Now that the Dagster code is updated, we need to update your CI/CD files to manage the state of your dbt project using the dagster-cloud CLI. This will ensure that dbt correctly uses your deferred artifacts as part of our Dagster+ branch deployments.
 
-Open the file, scroll to the environment variable section, and set an environment variable named `DBT_STATE_PATH` to the path where your state artifacts are located. This should be on or around line 12:
+You might have one or two CI/CD files to manage your production and branch deployments. In these files, find the steps related to your dbt project - refer to the [Deploying a Dagster project with a dbt project](#deploying-a-dagster-project-with-a-dbt-project) section for more information.
+
+Once your dbt steps are located, add the following step to manage the state of your dbt project.
 
 ```bash
-env:
-  DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_ORGANIZATION }}
-  DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
-  ENABLE_FAST_DEPLOYS: 'true'
-  PYTHON_VERSION: '3.8'
-  DAGSTER_CLOUD_FILE: 'dagster_cloud.yaml'
-  DBT_STATE_PATH: 'path/to/artifacts'
+dagster-cloud ci dagster-dbt project manage-state --file path/to/project.py
 ```
 
-Save and commit the file to git. Don’t forget to push to remote!
+The `dagster-cloud ci dagster-dbt project manage-state` CLI command above can be used to manage syncing the production manifest to branches when a `state_path` is set on your `DbtProject` object. This ensure that your branch deployments are always compared to the most recent adopted changes.
+
+In practice, this command fetches the `manifest.json` file from your production branch and add it to the state directory set to `state_path`. The production `manifest.json` file can then be used as the deferred dbt artifacts.
 
 ---
 

--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -165,7 +165,7 @@ It is possible to leverage [dbt defer](https://docs.getdbt.com/reference/node-se
 
 In practice, this is most useful when combined with branch deployments in Dagster, to test changes made in your branches. This can be easily done by updating your Dagster code and CI/CD file for branch deployments.
 
-First, update your Dagster code to pass a `state_path` to your `DbtProject` object. Also, update the dbt command in your ``@dbt_assets` definition to pass the defer args using `get_defer_args`.
+First, update your Dagster code to pass a `state_path` to your `DbtProject` object. Also, update the dbt command in your `@dbt_assets` definition to pass the defer args using `get_defer_args`.
 
 ```python startafter=start_use_dbt_defer_with_dbt_project endbefore=end_use_dbt_defer_with_dbt_project file=/integrations/dbt/dbt.py dedent=4
 import os

--- a/docs/content/integrations/dbt/reference.mdx
+++ b/docs/content/integrations/dbt/reference.mdx
@@ -161,11 +161,27 @@ In your CI/CD workflows for your Dagster and dbt project:
 
 ## Leveraging dbt defer with branch deployments
 
-It is possible to leverage [dbt defer](https://docs.getdbt.com/reference/node-selection/defer) by passing a `state_path` to <PyObject object="DbtProject" module="dagster_dbt" />. This allows you to run a subset of models or tests based on the changes made since the state passed to `state_path`.
+It is possible to leverage [dbt defer](https://docs.getdbt.com/reference/node-selection/defer) by passing a `state_path` to <PyObject object="DbtProject" module="dagster_dbt" />. This is useful for testing recent changes made in development against the state of the dbt project in production. Using `dbt defer`, you can run a subset of models or tests, those that have been changed between development and production, without having to build their upstream parents first.
 
-In practice, this is most useful when combined with branch deployments in Dagster+, to test changes made in your branches. This can be easily done by updating your Dagster code and your CI/CD files.
+In practice, this is most useful when combined with branch deployments in Dagster+, to test changes made in your branches. This can be done by updating your CI/CD files and your Dagster code.
 
-First, update your Dagster code to pass a `state_path` to your `DbtProject` object. Also, update the dbt command in your `@dbt_assets` definition to pass the defer args using `get_defer_args`.
+First, let's take a look at your CI/CD files. You might have one or two CI/CD files to manage your production and branch deployments. In these files, find the steps related to your dbt project - refer to the [Deploying a Dagster project with a dbt project](#deploying-a-dagster-project-with-a-dbt-project) section for more information.
+
+Once your dbt steps are located, add the following step to manage the state of your dbt project.
+
+```bash
+dagster-cloud ci dagster-dbt project manage-state --file path/to/project.py
+```
+
+The `dagster-cloud ci dagster-dbt project manage-state` CLI command fetches the `manifest.json` file from your production branch and saves it to a state directory, in order to power the `dbt defer` command.
+
+In practice, this command fetches the `manifest.json` file from your production branch and add it to the state directory set to the `state_path` of the DbtProject found in `path/to/project.py`. The production `manifest.json` file can then be used as the deferred dbt artifacts.
+
+Now that your CI/CD files are updated to manage the state of your dbt project using the dagster-cloud CLI, we need to update the Dagster code to pass a state directory to the DbtProject.
+
+Update your Dagster code to pass a `state_path` to your `DbtProject` object. Note that value passed to `state_path` must be a path, relative to the dbt project directory, to a state directory of dbt artifacts. In the code below, we set the `state_path` to 'state/'. If this directory does not exist in your project structure, it will be created by Dagster.
+
+Also, update the dbt command in your `@dbt_assets` definition to pass the defer args using `get_defer_args`.
 
 ```python startafter=start_use_dbt_defer_with_dbt_project endbefore=end_use_dbt_defer_with_dbt_project file=/integrations/dbt/dbt.py dedent=4
 import os
@@ -190,22 +206,6 @@ def my_dbt_assets(
 ):
     yield from dbt.cli(["build", *dbt.get_defer_args()], context=context).stream()
 ```
-
-Note that value passed to `state_path` must be a path, relative to the dbt project directory, to a directory of dbt artifacts. In the code above, we set the `state_path` to 'state/'.
-
-Now that the Dagster code is updated, we need to update your CI/CD files to manage the state of your dbt project using the dagster-cloud CLI. This will ensure that dbt correctly uses your deferred artifacts as part of our Dagster+ branch deployments.
-
-You might have one or two CI/CD files to manage your production and branch deployments. In these files, find the steps related to your dbt project - refer to the [Deploying a Dagster project with a dbt project](#deploying-a-dagster-project-with-a-dbt-project) section for more information.
-
-Once your dbt steps are located, add the following step to manage the state of your dbt project.
-
-```bash
-dagster-cloud ci dagster-dbt project manage-state --file path/to/project.py
-```
-
-The `dagster-cloud ci dagster-dbt project manage-state` CLI command above can be used to manage syncing the production manifest to branches when a `state_path` is set on your `DbtProject` object. This ensure that your branch deployments are always compared to the most recent adopted changes.
-
-In practice, this command fetches the `manifest.json` file from your production branch and add it to the state directory set to `state_path`. The production `manifest.json` file can then be used as the deferred dbt artifacts.
 
 ---
 

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -501,7 +501,7 @@ def scope_use_dbt_defer_with_dbt_project(manifest):
         packaged_project_dir=Path(__file__)
         .joinpath("..", "..", "dbt-project")
         .resolve(),
-        state_path=os.getenv("DBT_STATE_PATH"),
+        state_path=Path("state"),
     )
     my_dbt_project.prepare_if_dev()
 

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/dbt.py
@@ -486,3 +486,30 @@ def scope_build_incremental_model():
         yield from dbt.cli(dbt_build_args, context=context).stream()
 
     # end_build_incremental_model
+
+
+def scope_use_dbt_defer_with_dbt_project(manifest):
+    # start_use_dbt_defer_with_dbt_project
+    import os
+    from pathlib import Path
+
+    from dagster import AssetExecutionContext
+    from dagster_dbt import DbtCliResource, DbtProject, dbt_assets
+
+    my_dbt_project = DbtProject(
+        project_dir=Path(__file__).joinpath("..", "..", "..").resolve(),
+        packaged_project_dir=Path(__file__)
+        .joinpath("..", "..", "dbt-project")
+        .resolve(),
+        state_path=os.getenv("DBT_STATE_PATH"),
+    )
+    my_dbt_project.prepare_if_dev()
+
+    @dbt_assets(manifest=my_dbt_project.manifest_path)
+    def my_dbt_assets(
+        context: AssetExecutionContext,
+        dbt: DbtCliResource,
+    ):
+        yield from dbt.cli(["build", *dbt.get_defer_args()], context=context).stream()
+
+    # end_use_dbt_defer_with_dbt_project


### PR DESCRIPTION
## Summary & Motivation

As the title. Fixes [DS-402](https://linear.app/dagster-labs/issue/DS-402/add-dbt-and-dagster-branch-deployment-guide)

## How I Tested These Changes

Docs preview

## Changelog

[dagster-dbt] A guide on how to use dbt defer with Dagster branch deployments has been added to the dbt reference.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [x] `DOCS` _(added or updated documentation)_
