### PR TITLE
Do not precompute topological ordering in build airflow assets

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
@@ -42,6 +42,3 @@ class AirflowDefinitionsData:
 
     def asset_keys_in_task(self, dag_id: str, task_id: str) -> AbstractSet[AssetKey]:
         return self.serialized_data.dag_datas[dag_id].task_handle_data[task_id].asset_keys_in_task
-
-    def topo_order_index(self, asset_key: AssetKey) -> int:
-        return self.serialized_data.asset_key_topological_ordering.index(asset_key)

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
@@ -8,7 +8,6 @@ from dagster import (
     Definitions,
     _check as check,
 )
-from dagster._core.utils import toposort_flatten
 from dagster._record import record
 
 from dagster_airlift.constants import TASK_MAPPING_METADATA_KEY
@@ -210,12 +209,11 @@ def compute_serialized_data(
             task_handle_data=task_handle_data,
             all_asset_keys_in_tasks=mapping_info.asset_keys_per_dag_id[dag_id],
         )
-    topology_order = toposort_flatten(upstreams_asset_dependency_graph)
+
     return SerializedAirflowDefinitionsData(
         key_scoped_data_items=[
             KeyScopedDataItem(asset_key=k, data=v)
             for k, v in fetched_airflow_data.airflow_data_by_key.items()
         ],
         dag_datas=dag_datas,
-        asset_key_topological_ordering=topology_order,
     )

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
@@ -82,7 +82,6 @@ class KeyScopedDataItem:
 class SerializedAirflowDefinitionsData:
     key_scoped_data_items: List[KeyScopedDataItem]
     dag_datas: Mapping[str, SerializedDagData]
-    asset_key_topological_ordering: Sequence[AssetKey]
 
     @cached_property
     def key_scope_data_map(self) -> Mapping[AssetKey, "SerializedAssetKeyScopedAirflowData"]:

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -328,7 +328,6 @@ def test_serialization_roundtrip() -> None:
                 )
             ],
             dag_datas={},
-            asset_key_topological_ordering=[],
         ),
     )
 


### PR DESCRIPTION
## Summary & Motivation

This can be easily computed in the code location and it is memoized, so there is little benefit. Sets up further simplification of `compute.py`.

## How I Tested These Changes

BK

## Changelog

NOCHANGELOG

