### PR TITLE
Delete upstream deps and simplify compute_serialized_data 

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
@@ -40,7 +40,6 @@ def test_build_task_mapping_info_no_mapping() -> None:
     spec_mapping_info = build_airlift_metadata_mapping_info(
         defs=Definitions(assets=[AssetSpec("asset1"), AssetSpec("asset2")])
     )
-    assert len(spec_mapping_info.asset_keys) == 2
     assert len(spec_mapping_info.dag_ids) == 0
     assert not (spec_mapping_info.asset_key_map)
     assert not (spec_mapping_info.task_handle_map)


### PR DESCRIPTION
## Summary & Motivation

With the need to serialize the topological order, we can simplify our favorite `compute_serialized_data`. The downstream dependencies dictionary is immutable, `all_asset_keys` is totally eliminated, as well  computing upstream deps.

## How I Tested These Changes

## Changelog

NOCHANGELOG
