### PR TITLE
[dagster-airlift][rfc] support time-window partitioned assets

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/dag_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/dag_asset.py
@@ -9,7 +9,7 @@ from dagster_airlift.core.serialization.serialized_data import (
     SerializedAssetDepData,
     SerializedAssetSpecData,
 )
-from dagster_airlift.core.utils import airflow_kind_dict
+from dagster_airlift.core.utils import airflow_dag_kind_dict
 
 
 def dag_asset_spec_data(
@@ -21,7 +21,7 @@ def dag_asset_spec_data(
         asset_key=dag_info.dag_asset_key,
         description=dag_description(dag_info),
         metadata=dag_asset_metadata(airflow_instance, dag_info),
-        tags=airflow_kind_dict(),
+        tags=airflow_dag_kind_dict(),
         deps=[
             SerializedAssetDepData(asset_key=leaf_asset_key)
             for leaf_asset_key in asset_keys_for_leaf_tasks

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/partition_utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/partition_utils.py
@@ -1,0 +1,53 @@
+from dagster import (
+    AssetKey,
+    PartitionsDefinition,
+    TimeWindowPartitionsDefinition,
+    _check as check,
+)
+from dagster._time import get_timezone
+
+from dagster_airlift.core.airflow_instance import TaskInstance
+
+
+def get_partition_key_from_task_instance(
+    partitions_def: PartitionsDefinition, task_instance: TaskInstance, asset_key: AssetKey
+) -> str:
+    partitions_def = check.inst(
+        partitions_def,
+        TimeWindowPartitionsDefinition,
+        "Only time window-partitioned assets are supported.",
+    )
+    logical_date = task_instance.logical_datetime
+    logical_date_timezone = logical_date.tzinfo
+    partitions_def_timezone = get_timezone(partitions_def.timezone)
+    check.invariant(
+        logical_date_timezone == partitions_def_timezone,
+        (
+            f"The timezone of the retrieved logical date from the airflow run ({logical_date_timezone}) does not "
+            f"match that of the partitions definition ({partitions_def_timezone}) for asset key {asset_key.to_user_string()}."
+            "To ensure consistent behavior, the timezone of the logical date must match the timezone of the partitions definition."
+        ),
+    )
+    # Assuming that "logical_date" lies on a partition, the previous partition window
+    # (where upper bound can be the passed-in date, which is why we set respect_bounds=False)
+    # will end on the logical date. This would indicate that there is a partition for the logical date.
+    partition_window = check.not_none(
+        partitions_def.get_prev_partition_window(logical_date, respect_bounds=False),
+        f"Could not find partition for logical date {logical_date.isoformat()}. This likely means that your partition range is too small to cover the logical date.",
+    )
+    check.invariant(
+        logical_date.timestamp() == partition_window.end.timestamp(),
+        (
+            "Expected logical date to match a partition in the partitions definition. This likely means that "
+            "The partition range is not aligned with the scheduling interval in airflow."
+        ),
+    )
+    check.invariant(
+        logical_date.timestamp() >= partitions_def.start.timestamp(),
+        (
+            f"For run {task_instance.run_id} in dag {task_instance.dag_id}, "
+            f"Logical date is before the start of the partitions definition in asset key {asset_key.to_user_string()}. "
+            "Ensure that the start date of your PartitionsDefinition is early enough to capture current runs coming from airflow."
+        ),
+    )
+    return partitions_def.get_partition_key_for_timestamp(logical_date.timestamp())

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
@@ -5,6 +5,7 @@ from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 from dagster._core.definitions.utils import VALID_NAME_REGEX
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.storage.tags import KIND_PREFIX
+from dagster._utils.merger import merge_dicts
 
 from dagster_airlift.constants import TASK_MAPPING_METADATA_KEY
 
@@ -16,6 +17,10 @@ def convert_to_valid_dagster_name(name: str) -> str:
 
 def airflow_kind_dict() -> dict:
     return {f"{KIND_PREFIX}airflow": ""}
+
+
+def airflow_dag_kind_dict() -> dict:
+    return merge_dicts(airflow_kind_dict(), {f"{KIND_PREFIX}dag": ""})
 
 
 def spec_iterator(

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_airflow_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_airflow_instance.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 from dagster._core.errors import DagsterError
 from dagster_airlift.core import AirflowInstance, BasicAuthBackend
@@ -71,6 +73,6 @@ def test_airflow_instance(airflow_instance: None) -> None:
     assert_link_exists("Task instance", task_instance.details_url)
     assert_link_exists("Task logs", task_instance.log_url)
 
-    assert isinstance(task_instance.start_date, float)
-    assert isinstance(task_instance.end_date, float)
+    assert isinstance(task_instance.start_datetime, datetime)
+    assert isinstance(task_instance.end_datetime, datetime)
     assert isinstance(task_instance.note, str)

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
@@ -79,6 +79,7 @@ def load_definitions_airflow_asset_graph(
                 run_id=f"run-{dag_id}",
                 start_date=get_current_datetime() - timedelta(minutes=10),
                 end_date=get_current_datetime(),
+                logical_date=get_current_datetime() - timedelta(minutes=10),
             )
             for dag_id in dag_and_task_structure.keys()
         ]

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -425,3 +425,21 @@ def test_multiple_tasks_to_single_asset() -> None:
         {"dag_id": "dag1", "task_id": "task1"},
         {"dag_id": "dag2", "task_id": "task2"},
     ]
+
+
+def test_kind_tags_peered_dag() -> None:
+    defs = load_definitions_airflow_asset_graph(
+        assets_per_task={
+            "dag": {"task": []},
+        },
+    )
+    assert defs.assets
+    repo_def = defs.get_repository_def()
+    repo_def.load_all_definitions()
+    assert len(repo_def.assets_defs_by_key) == 1
+    dag_asset = repo_def.assets_defs_by_key[AssetKey(["airflow_instance", "dag", "dag"])]
+    dag_spec = next(iter(dag_asset.specs))
+    assert dag_spec.tags == {
+        "dagster/kind/airflow": "",
+        "dagster/kind/dag": "",
+    }

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_sensor.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_sensor.py
@@ -1,19 +1,26 @@
 from datetime import datetime, timedelta, timezone
 
 import mock
+import pytest
+import pytz
 from dagster import (
     AssetCheckKey,
     AssetKey,
     AssetSpec,
+    DailyPartitionsDefinition,
     Definitions,
     SensorResult,
     asset_check,
     build_sensor_context,
 )
+from dagster._check.functions import CheckError
 from dagster._core.definitions.events import AssetMaterialization
 from dagster._core.test_utils import freeze_time
 from dagster._serdes import deserialize_value
+from dagster_airlift.core import dag_defs, task_defs
+from dagster_airlift.core.load_defs import build_defs_from_airflow_instance
 from dagster_airlift.core.sensor import AirflowPollingSensorCursor
+from dagster_airlift.test.airflow_test_instance import make_dag_run, make_instance
 
 from dagster_airlift_tests.unit_tests.conftest import (
     assert_expected_key_order,
@@ -57,6 +64,7 @@ def test_dag_and_task_metadata(init_load_context: None) -> None:
             "Task Logs",
             "Airflow Config",
             "Run Type",
+            "Logical Date",
         }
         assert set(task_mat.metadata.keys()) == expected_task_metadata_keys
 
@@ -328,3 +336,265 @@ def test_no_runs(init_load_context: None) -> None:
         assert new_cursor.dag_query_offset == 0
         assert not result.asset_events
         assert not result.run_requests
+
+
+def test_default_time_partitioned_asset(init_load_context: None) -> None:
+    """Test that a task instance for a time-partitioned asset is correctly ingested."""
+    defs = build_defs_from_airflow_instance(
+        airflow_instance=make_instance(
+            dag_and_task_structure={
+                "dag": ["task"],
+            },
+            dag_runs=[
+                make_dag_run(
+                    dag_id="dag",
+                    run_id="run-dag",
+                    start_date=datetime(2021, 1, 2, 5, tzinfo=timezone.utc),
+                    end_date=datetime(2021, 1, 2, 6, tzinfo=timezone.utc),
+                    logical_date=datetime(2021, 1, 1, tzinfo=timezone.utc),
+                )
+            ],
+        ),
+        defs=dag_defs(
+            "dag",
+            task_defs(
+                "task",
+                Definitions(
+                    assets=[
+                        AssetSpec(
+                            key="a",
+                            partitions_def=DailyPartitionsDefinition(
+                                start_date=datetime(2021, 1, 1, tzinfo=timezone.utc)
+                            ),
+                        )
+                    ],
+                ),
+            ),
+        ),
+    )
+    assert defs.sensors
+    sensor = next(iter(defs.sensors))
+    with freeze_time(datetime(2021, 1, 2, 6, tzinfo=timezone.utc)):
+        sensor_context = build_sensor_context(repository_def=defs.get_repository_def())
+        result = sensor(sensor_context)
+        assert isinstance(result, SensorResult)
+        assert len(result.asset_events) == 2
+        assert_expected_key_order(result.asset_events, ["a", "airflow_instance/dag/dag"])
+        a_asset_mat = result.asset_events[0]
+        assert isinstance(a_asset_mat, AssetMaterialization)
+        # We expect the partition to match the logical date.
+        assert a_asset_mat.partition == "2021-01-01"
+
+
+def test_timezones_mismatch_partitioned_asset(init_load_context: None) -> None:
+    """We expect that timezones should match for the logical date and the passed-in partitions definition."""
+    instance_with_pacific_run = make_instance(
+        dag_and_task_structure={
+            "dag": ["task"],
+        },
+        dag_runs=[
+            make_dag_run(
+                dag_id="dag",
+                run_id="run-dag",
+                start_date=datetime(2021, 1, 2, 5, tzinfo=pytz.timezone("US/Pacific")),
+                end_date=datetime(2021, 1, 2, 6, tzinfo=pytz.timezone("US/Pacific")),
+                logical_date=datetime(2021, 1, 1, tzinfo=pytz.timezone("US/Pacific")),
+            )
+        ],
+    )
+    # We have a dag run whose logical date aligns with the partition definition, except for the timezone.
+    # As a result, we should expect an error, since there is no partition window bounded at this exact timestamp.
+    defs = build_defs_from_airflow_instance(
+        airflow_instance=instance_with_pacific_run,
+        defs=dag_defs(
+            "dag",
+            task_defs(
+                "task",
+                Definitions(
+                    assets=[
+                        AssetSpec(
+                            key="a",
+                            partitions_def=DailyPartitionsDefinition(
+                                start_date=datetime(2021, 1, 1, tzinfo=pytz.timezone("US/Eastern")),
+                                timezone="US/Eastern",
+                            ),
+                        )
+                    ],
+                ),
+            ),
+        ),
+    )
+    assert defs.sensors
+    sensor = next(iter(defs.sensors))
+    # Freeze at a time s.t. the run will be processed.
+    with freeze_time(datetime(2021, 1, 2, 6, tzinfo=pytz.timezone("US/Pacific"))):
+        sensor_context = build_sensor_context(repository_def=defs.get_repository_def())
+        with pytest.raises(CheckError, match="does not match"):
+            sensor(sensor_context)
+
+
+def test_before_start_of_partitioned_asset(init_load_context: None) -> None:
+    """We expect to throw an error if there is no matching partition after the start date."""
+    defs = build_defs_from_airflow_instance(
+        airflow_instance=make_instance(
+            dag_and_task_structure={
+                "dag": ["task"],
+            },
+            dag_runs=[
+                make_dag_run(
+                    dag_id="dag",
+                    run_id="run-dag",
+                    start_date=datetime(2021, 1, 1, 5, tzinfo=timezone.utc),
+                    end_date=datetime(2021, 1, 1, 6, tzinfo=timezone.utc),
+                    logical_date=datetime(2021, 1, 1, tzinfo=timezone.utc),
+                )
+            ],
+        ),
+        defs=dag_defs(
+            "dag",
+            task_defs(
+                "task",
+                Definitions(
+                    assets=[
+                        AssetSpec(
+                            key="a",
+                            partitions_def=DailyPartitionsDefinition(
+                                # Partitions definition starts after the logical date.
+                                start_date=datetime(2021, 1, 2, tzinfo=timezone.utc)
+                            ),
+                        )
+                    ],
+                ),
+            ),
+        ),
+    )
+    assert defs.sensors
+    sensor = next(iter(defs.sensors))
+    with freeze_time(datetime(2021, 1, 1, 6, tzinfo=timezone.utc)):
+        sensor_context = build_sensor_context(repository_def=defs.get_repository_def())
+        with pytest.raises(CheckError, match="before the start of the partitions definition"):
+            sensor(sensor_context)
+
+
+def test_logical_date_mismatch(init_load_context: None) -> None:
+    """Test a logical date which does not align with the partition definition due to date mismatch."""
+    defs = build_defs_from_airflow_instance(
+        airflow_instance=make_instance(
+            dag_and_task_structure={
+                "dag": ["task"],
+            },
+            dag_runs=[
+                make_dag_run(
+                    dag_id="dag",
+                    run_id="run-dag",
+                    start_date=datetime(2021, 1, 1, 5, tzinfo=timezone.utc),
+                    end_date=datetime(2021, 1, 1, 6, tzinfo=timezone.utc),
+                    # Logical date isn't aligned with midnight.
+                    logical_date=datetime(2021, 1, 1, 3, tzinfo=timezone.utc),
+                )
+            ],
+        ),
+        defs=dag_defs(
+            "dag",
+            task_defs(
+                "task",
+                Definitions(
+                    assets=[
+                        AssetSpec(
+                            key="a",
+                            partitions_def=DailyPartitionsDefinition(
+                                start_date=datetime(2021, 1, 1, tzinfo=timezone.utc)
+                            ),
+                        )
+                    ],
+                ),
+            ),
+        ),
+    )
+    assert defs.sensors
+    sensor = next(iter(defs.sensors))
+    with freeze_time(datetime(2021, 1, 1, 6, tzinfo=timezone.utc)):
+        sensor_context = build_sensor_context(repository_def=defs.get_repository_def())
+        with pytest.raises(CheckError, match="match a partition"):
+            sensor(sensor_context)
+
+
+def test_partition_offset_mismatch(init_load_context: None) -> None:
+    """Test that partition offsets are respected when determining the partition corresponding to a logical date."""
+    instance = make_instance(
+        dag_and_task_structure={
+            "dag": ["task"],
+        },
+        dag_runs=[
+            make_dag_run(
+                dag_id="dag",
+                run_id="run-dag",
+                start_date=datetime(2021, 1, 1, 5, tzinfo=timezone.utc),
+                end_date=datetime(2021, 1, 1, 6, tzinfo=timezone.utc),
+                # Logical date is 3 AM.
+                logical_date=datetime(2021, 1, 1, 3, tzinfo=timezone.utc),
+            )
+        ],
+    )
+
+    defs = build_defs_from_airflow_instance(
+        airflow_instance=instance,
+        defs=dag_defs(
+            "dag",
+            task_defs(
+                "task",
+                Definitions(
+                    assets=[
+                        AssetSpec(
+                            key="a",
+                            partitions_def=DailyPartitionsDefinition(
+                                start_date=datetime(2021, 1, 1, tzinfo=timezone.utc),
+                                hour_offset=6,
+                            ),
+                        )
+                    ],
+                ),
+            ),
+        ),
+    )
+    # Due to differing hours offset, we expect an error to throw.
+    assert defs.sensors
+    sensor = next(iter(defs.sensors))
+    with freeze_time(datetime(2021, 1, 1, 6, tzinfo=timezone.utc)):
+        sensor_context = build_sensor_context(repository_def=defs.get_repository_def())
+        with pytest.raises(CheckError, match="match a partition"):
+            sensor(sensor_context)
+
+    # now, align the offset and expect success.
+    defs = build_defs_from_airflow_instance(
+        airflow_instance=instance,
+        defs=dag_defs(
+            "dag",
+            task_defs(
+                "task",
+                Definitions(
+                    assets=[
+                        AssetSpec(
+                            key="a",
+                            partitions_def=DailyPartitionsDefinition(
+                                start_date=datetime(2021, 1, 1, tzinfo=timezone.utc),
+                                hour_offset=3,
+                            ),
+                        )
+                    ],
+                ),
+            ),
+        ),
+    )
+    assert defs.sensors
+    sensor = next(iter(defs.sensors))
+    with freeze_time(datetime(2021, 1, 1, 6, tzinfo=timezone.utc)):
+        sensor_context = build_sensor_context(repository_def=defs.get_repository_def())
+        result = sensor(sensor_context)
+        assert isinstance(result, SensorResult)
+        assert len(result.asset_events) == 2
+        assert_expected_key_order(result.asset_events, ["a", "airflow_instance/dag/dag"])
+        a_asset_mat = result.asset_events[0]
+        assert isinstance(a_asset_mat, AssetMaterialization)
+        # We expect the partition to match the logical date.
+        assert a_asset_mat.partition == "2021-01-01"

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_test_utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_test_utils.py
@@ -20,12 +20,14 @@ def test_test_instance() -> None:
         run_id="test_run_id",
         start_date=datetime(2022, 1, 1),
         end_date=datetime(2022, 1, 2),
+        logical_date=datetime(2022, 1, 1),
     )
     dag_run = make_dag_run(
         dag_id="test_dag",
         run_id="test_run_id",
         start_date=datetime(2022, 1, 1),
         end_date=datetime(2022, 1, 2),
+        logical_date=datetime(2022, 1, 1),
     )
     test_instance = AirflowInstanceFake(
         dag_infos=[dag_info],


### PR DESCRIPTION
## Summary & Motivation
Support automatically munging time window partitioned assets into partitioned materializations via the sensor.

I've placed the main implementation in its own function, the signature of which I'm thinking is what we'll be exposing to users as a pluggability point.
## How I Tested These Changes
Added a bunch of new unit tests.

## Changelog
NOCHANGELOG