### PR TITLE
Avoid annoying pydantic warnings

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -93,8 +93,6 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
 
     """
 
-    label: Optional[str] = None
-
     @property
     def requires_cursor(self) -> bool:
         return True
@@ -113,13 +111,16 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
         """Formal name of this specific condition, generally aligning with its static constructor."""
         return self.__class__.__name__
 
+    def get_label(self) -> Optional[str]:
+        return None
+
     def get_node_snapshot(self, unique_id: str) -> AutomationConditionNodeSnapshot:
         """Returns a snapshot of this condition that can be used for serialization."""
         return AutomationConditionNodeSnapshot(
             class_name=self.__class__.__name__,
             description=self.description,
             unique_id=unique_id,
-            label=self.label,
+            label=self.get_label(),
             name=self.name,
         )
 
@@ -559,6 +560,9 @@ class BuiltinAutomationCondition(DagsterModel, AutomationCondition[T_EntityKey])
     """Base class for AutomationConditions provided by the core dagster framework."""
 
     label: Optional[str] = None
+
+    def get_label(self) -> Optional[str]:
+        return self.label
 
     @public
     def with_label(self, label: Optional[str]) -> Self:

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_check_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_check_condition.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pytest
 from dagster import AutomationCondition
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
@@ -40,10 +38,6 @@ def get_hardcoded_condition():
     true_set = set()
 
     class HardcodedCondition(AutomationCondition):
-        @property
-        def label(self) -> Optional[str]:
-            return None
-
         @property
         def description(self) -> str:
             return "..."

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_dep_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_dep_condition.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from typing import Sequence
 
 import pytest
 from dagster import AutomationCondition
@@ -28,10 +28,6 @@ def get_hardcoded_condition():
     true_set = set()
 
     class HardcodedCondition(AutomationCondition):
-        @property
-        def label(self) -> Optional[str]:
-            return None
-
         @property
         def description(self) -> str:
             return "..."

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
@@ -139,8 +139,8 @@ def test_label_automation_condition() -> None:
     not_missing_and_not_in_progress = (not_missing & not_in_progress).with_label("Blah")
     assert not_missing_and_not_in_progress.label == "Blah"
     assert not_missing_and_not_in_progress.get_node_snapshot("").label == "Blah"
-    assert not_missing_and_not_in_progress.children[0].label == "Not missing"
-    assert not_missing_and_not_in_progress.children[1].label == "Not in progress"
+    assert not_missing_and_not_in_progress.children[0].get_label() == "Not missing"
+    assert not_missing_and_not_in_progress.children[1].get_label() == "Not in progress"
 
 
 def test_without_automation_condition() -> None:


### PR DESCRIPTION
## Summary & Motivation

Avoids warning in pydantic 2, and is just better architecturally. It's kinda weird to have a class that users subclass have a built-in property.

## How I Tested These Changes

Existing tests

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
