### PR TITLE
[record] mutex record_custom and record inheritance

### DIFF
--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -9,6 +9,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Generic,
     Iterable,
     List,
     Literal,
@@ -1587,7 +1588,6 @@ def _check({name}):
     {lazy_import_str}
     return {body}
 """
-    # print(fn) # debug output
     return eval_ctx.compile_fn(fn, "_check")
 
 
@@ -1598,6 +1598,15 @@ class SubFoo(Foo): ...
 
 
 class Bar: ...
+
+
+T = TypeVar("T")
+
+
+class Gen(Generic[T]): ...
+
+
+class SubGen(Gen[str]): ...
 
 
 BUILD_CASES = [
@@ -1659,6 +1668,11 @@ BUILD_CASES = [
     (PublicAttr[Optional["Foo"]], [None], [Bar()]),  # type: ignore  # ignored for update, fix me!
     (Mapping[str, Optional["Foo"]], [{"foo": Foo()}], [{"bar": Bar()}]),
     (Mapping[str, Optional["Foo"]], [{"foo": Foo()}], [{"bar": Bar()}]),
+    (Gen, [Gen()], [Bar()]),
+    (Gen[str], [Gen()], [Bar()]),
+    (SubGen, [SubGen()], [Bar()]),
+    (Sequence[SubGen], [[SubGen()]], [[Bar()]]),
+    (Sequence[Gen[str]], [[Gen()]], [[Bar()]]),
 ]
 
 


### PR DESCRIPTION
Tidy up record inheritance fixes by enforcing different rules for `@record_custom` and `@record`, only allowing inheritance on the latter.  Doing this allows us to place the generated `__new__` on the generated class directly for regular `@record` and avoid MRO resolving to the wrong ancestral `NamedTuple`.  Additional fixes to get all tests passing on py3.8.



## How I Tested These Changes

updated test cases

on python3.8 run 
```
pytest python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py python_modules/dagster/dagster_tests/general_tests/test_record.py --sw -vvvv
```
