### PR TITLE
[definition-tags] Remove `warn_on_deprecated_tags` flag from `normalize_tags`

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -161,7 +161,6 @@ def struct_to_string(name: str, **kwargs: object) -> str:
 def normalize_tags(
     tags: Optional[Mapping[str, Any]],
     allow_reserved_tags: bool = True,
-    warn_on_deprecated_tags: bool = True,
     warning_stacklevel: int = 4,
 ) -> Mapping[str, str]:
     """Normalizes JSON-object tags into string tags and warns on deprecated tags.
@@ -199,12 +198,11 @@ def normalize_tags(
 
     if invalid_tag_keys:
         invalid_tag_keys_sample = invalid_tag_keys[: min(5, len(invalid_tag_keys))]
-        if warn_on_deprecated_tags:
-            warnings.warn(
-                f"Non-compliant tag keys like {invalid_tag_keys_sample} are deprecated. {VALID_DEFINITION_TAG_KEY_EXPLANATION}",
-                category=DeprecationWarning,
-                stacklevel=warning_stacklevel,
-            )
+        warnings.warn(
+            f"Non-compliant tag keys like {invalid_tag_keys_sample} are deprecated. {VALID_DEFINITION_TAG_KEY_EXPLANATION}",
+            category=DeprecationWarning,
+            stacklevel=warning_stacklevel,
+        )
 
     if not allow_reserved_tags:
         check_reserved_tags(valid_tags)

--- a/python_modules/dagster/dagster/_core/execution/plan/step.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/step.py
@@ -16,7 +16,6 @@ from typing import (
 from typing_extensions import TypeGuard
 
 import dagster._check as check
-from dagster._core.definitions.utils import normalize_tags
 from dagster._core.execution.plan.handle import (
     ResolvedFromDynamicStepHandle,
     StepHandle,
@@ -161,7 +160,7 @@ class ExecutionStep(
                 so.name: so
                 for so in check.sequence_param(step_outputs, "step_outputs", of_type=StepOutput)
             },
-            tags=normalize_tags(tags, warn_on_deprecated_tags=False),
+            tags=tags or {},
             logging_tags=merge_dicts(
                 {
                     "step_key": handle.to_key(),

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -81,7 +81,7 @@ from dagster._time import get_current_datetime, get_current_timestamp
 from dagster._utils import PrintFn, is_uuid, traced
 from dagster._utils.error import serializable_error_info_from_exc_info
 from dagster._utils.merger import merge_dicts
-from dagster._utils.warnings import experimental_warning
+from dagster._utils.warnings import disable_dagster_warnings, experimental_warning
 
 # 'airflow_execution_date' and 'is_airflow_ingest_pipeline' are hardcoded tags used in the
 # airflow ingestion logic (see: dagster_pipeline_factory.py). 'airflow_execution_date' stores the
@@ -1493,7 +1493,8 @@ class DagsterInstance(DynamicPartitionsStore):
         check.opt_inst_param(status, "status", DagsterRunStatus)
         check.opt_mapping_param(tags, "tags", key_type=str)
 
-        validated_tags = normalize_tags(tags, warn_on_deprecated_tags=False)
+        with disable_dagster_warnings():
+            validated_tags = normalize_tags(tags)
 
         check.opt_str_param(root_run_id, "root_run_id")
         check.opt_str_param(parent_run_id, "parent_run_id")

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -38,7 +38,6 @@ from dagster._core.definitions.dynamic_partitions_request import (
 from dagster._core.definitions.run_request import DagsterRunReaction, InstigatorType, RunRequest
 from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.definitions.sensor_definition import DefaultSensorStatus
-from dagster._core.definitions.utils import normalize_tags
 from dagster._core.errors import (
     DagsterCodeLocationLoadError,
     DagsterError,
@@ -1308,15 +1307,13 @@ def _create_sensor_run(
     )
     execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
 
-    job_tags = normalize_tags(
-        external_job.run_tags or {}, allow_reserved_tags=False, warn_on_deprecated_tags=False
-    )
-    tags = merge_dicts(
-        merge_dicts(job_tags, run_request.tags),
+    tags = {
+        **(external_job.run_tags or {}),
+        **run_request.tags,
         # this gets applied in the sensor definition too, but we apply it here for backcompat
         # with sensors before the tag was added to the sensor definition
-        DagsterRun.tags_for_sensor(external_sensor),
-    )
+        **DagsterRun.tags_for_sensor(external_sensor),
+    }
     if run_request.run_key:
         tags[RUN_KEY_TAG] = run_request.run_key
 

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -27,7 +27,6 @@ from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.schedule_definition import DefaultScheduleStatus
 from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.definitions.timestamp import TimestampWithTimezone
-from dagster._core.definitions.utils import normalize_tags
 from dagster._core.errors import DagsterCodeLocationLoadError, DagsterUserCodeUnreachableError
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation import ExternalSchedule
@@ -942,13 +941,10 @@ def _create_scheduler_run(
     )
     execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
 
-    tags = merge_dicts(
-        normalize_tags(
-            external_job.run_tags, allow_reserved_tags=False, warn_on_deprecated_tags=False
-        )
-        or {},
-        schedule_tags,
-    )
+    tags = {
+        **external_job.run_tags,
+        **schedule_tags,
+    }
 
     tags[SCHEDULED_EXECUTION_TIME_TAG] = schedule_time.astimezone(datetime.timezone.utc).isoformat()
     if run_request.run_key:


### PR DESCRIPTION
## Summary & Motivation

Makes it so that `normalize_tags` always warns on deprecated tags.

This flag was only being used in places where (a) we don't need to normalize because tags are already normalized/will be normalized again; or (b) we can just use `disable_dagster_warnings`, which is the standard approach in the codebase to suppressing unwanted warnings.

This is part of a stack that aims to consolidate and simplify tags normalization logic.

## How I Tested These Changes

Existing test suite.

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
