### PR TITLE
publicize and privatize PowerBIWorkspace methods

### DIFF
--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -27,7 +27,7 @@ def test_fetch_powerbi_workspace_data(workspace_data_api_mocks: None, workspace_
         workspace_id=workspace_id,
     )
 
-    actual_workspace_data = resource.fetch_powerbi_workspace_data()
+    actual_workspace_data = resource._fetch_powerbi_workspace_data()  # noqa: SLF001
     assert len(actual_workspace_data.dashboards_by_id) == 1
     assert len(actual_workspace_data.reports_by_id) == 1
     assert len(actual_workspace_data.semantic_models_by_id) == 1

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_resource.py
@@ -26,7 +26,7 @@ def test_basic_resource_request() -> None:
         status=200,
     )
 
-    resource.get_reports()
+    resource._get_reports()  # noqa: SLF001
 
     assert len(responses.calls) == 1
     assert responses.calls[0].request.headers["Authorization"] == f"Bearer {fake_token}"
@@ -63,7 +63,7 @@ def test_service_principal_auth() -> None:
         status=200,
     )
 
-    resource.get_reports()
+    resource._get_reports()  # noqa: SLF001
 
     assert len(responses.calls) == 2
     assert fake_client_id in responses.calls[0].request.body


### PR DESCRIPTION
## Summary & Motivation

On `PowerBIWorkspace`:
- Mark public methods with `@public`
- Make other methods private, so they won't so up in auto-complete

Also change some `Dict`s to `Mapping`s.

## How I Tested These Changes

## Changelog

NOCHANGELOG