### PR TITLE
update UI Runs filter to use created_after rather than updated_after

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -134,7 +134,7 @@ export function runsFilterForSearchTokens(search: TokenizingFieldValue[]) {
     if (item.token === 'created_date_before') {
       obj.createdBefore = parseInt(item.value);
     } else if (item.token === 'created_date_after') {
-      obj.updatedAfter = parseInt(item.value);
+      obj.createdAfter = parseInt(item.value);
     } else if (item.token === 'pipeline' || item.token === 'job') {
       obj.pipelineName = item.value;
     } else if (item.token === 'id') {


### PR DESCRIPTION
## Summary & Motivation
I noticed that the "created date" filter in the UI uses the `createdBefore` and `updatedAfter` filters rather than the `createdBefore` and `createdAfter` filters. I think this is because the `createdAfter` filter was not added to the GrapheneLayer until recently ([pr](https://github.com/dagster-io/dagster/pull/21945)), but want to ensure that it's not intentional that the `updatedAfter` filter is being used.

## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [X] `BUGFIX` [ui] Previously, filtering runs by `Created date` would include runs that had been updated after the lower bound of the requested time range. This has been updated so that only runs created after the lower bound will be included.
- [ ] `DOCS` _(added or updated documentation)_
