### PR TITLE
Add dagster/run_Id and dagster/job_name as Docker labels in the docker run launcher

### DIFF
--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
@@ -116,7 +116,8 @@ def test_launch_docker_image_on_job_config(aws_env):
         "env_vars": aws_env + ["DOCKER_LAUNCHER_NETWORK"],
         "network": {"env": "DOCKER_LAUNCHER_NETWORK"},
         "container_kwargs": {
-            "auto_remove": True,
+            "auto_remove": False,
+            "labels": {"foo": "baz", "bar": ""},
         },
     }
 
@@ -165,6 +166,12 @@ def test_launch_docker_image_on_job_config(aws_env):
                 assert run.status == DagsterRunStatus.SUCCESS
 
                 assert run.tags[DOCKER_IMAGE_TAG] == docker_image
+
+                container_obj = instance.run_launcher._get_container(run)  # noqa
+                assert container_obj.labels["foo"] == "baz"
+                assert container_obj.labels["bar"] == ""
+                assert container_obj.labels["dagster/run_id"] == run.run_id
+                assert container_obj.labels["dagster/job_name"] == run.job_name
 
 
 def check_event_log_contains(event_log, expected_type_and_message):


### PR DESCRIPTION
## Summary & Motivation
As title.

## How I Tested These Changes
BK

## Changelog
- [ ] `NEW` Run containers launched by the `DockerRunLauncher` now include `dagster/job_name` and `dagster/run_id` labels.