### PR TITLE
[RemoteAssetNode] move from RepositoryHandle to RepositorySelector

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -196,23 +196,20 @@ def _graphene_asset_node(
 ):
     from dagster_graphql.schema.asset_graph import GrapheneAssetNode
 
-    repo_handle = remote_node.priority_repository_handle
-    code_location = graphene_info.context.get_code_location(repo_handle.location_name)
-    repo = code_location.get_repository(repo_handle.repository_name)
+    selector = remote_node.priority_repository_selector
     base_deployment_context = graphene_info.context.get_base_deployment_context()
 
     return GrapheneAssetNode(
-        code_location,
-        repo,
-        remote_node.priority_node_snap,
+        repository_selector=selector,
+        asset_node_snap=remote_node.priority_node_snap,
         asset_checks_loader=asset_checks_loader,
         depended_by_loader=depended_by_loader,
         stale_status_loader=stale_status_loader,
         dynamic_partitions_loader=dynamic_partitions_loader,
         # base_deployment_context will be None if we are not in a branch deployment
         asset_graph_differ=AssetGraphDiffer.from_external_repositories(
-            code_location_name=code_location.name,
-            repository_name=repo.name,
+            code_location_name=selector.location_name,
+            repository_name=selector.repository_name,
             branch_workspace=graphene_info.context,
             base_workspace=base_deployment_context,
         )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -257,8 +257,8 @@ def get_assets_latest_info(
         if asset_node:
             node_id = get_unique_asset_id(
                 asset_key,
-                asset_node.priority_repository_handle.repository_name,
-                asset_node.priority_repository_handle.location_name,
+                asset_node.priority_repository_selector.repository_name,
+                asset_node.priority_repository_selector.location_name,
             )
         else:
             node_id = get_unique_asset_id(asset_key)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -97,17 +97,15 @@ def has_permission_for_asset_graph(
 
     # If any of the asset keys don't map to a location (e.g. because they are no longer in the
     # graph) need deployment-wide permissions - no valid code location to check
-    if asset_keys.difference(asset_graph.repository_handles_by_key.keys()):
+    if asset_keys.difference(asset_graph.repository_selectors_by_key.keys()):
         return context.has_permission(permission)
 
     if asset_keys:
-        repo_handles = [asset_graph.get_repository_handle(asset_key) for asset_key in asset_keys]
+        selectors = [asset_graph.get_repository_selector(asset_key) for asset_key in asset_keys]
     else:
-        repo_handles = asset_graph.repository_handles_by_key.values()
+        selectors = asset_graph.repository_selectors_by_key.values()
 
-    location_names = set(
-        repo_handle.code_location_origin.location_name for repo_handle in repo_handles
-    )
+    location_names = set(s.location_name for s in selectors)
 
     if not location_names:
         return context.has_permission(permission)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -391,9 +391,8 @@ class GrapheneRepository(graphene.ObjectType):
         )
         return [
             GrapheneAssetNode(
-                self._repository_location,
-                self._repository,
-                asset_node_snap,
+                repository_selector=self._repository.selector,
+                asset_node_snap=asset_node_snap,
                 asset_checks_loader=asset_checks_loader,
                 stale_status_loader=self._stale_status_loader,
                 dynamic_partitions_loader=self._dynamic_partitions_loader,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -79,6 +79,7 @@ from dagster_graphql.schema.tags import GraphenePipelineTag
 from dagster_graphql.schema.util import ResolveInfo, get_compute_log_manager, non_null_list
 
 if TYPE_CHECKING:
+    from dagster_graphql.schema.asset_graph import GrapheneAssetNode
     from dagster_graphql.schema.partition_sets import GrapheneJobSelectionPartition
 
 
@@ -214,19 +215,15 @@ class GrapheneAsset(graphene.ObjectType):
     class Meta:
         name = "Asset"
 
-    def __init__(self, key, definition=None):
+    def __init__(self, key, definition: Optional["GrapheneAssetNode"] = None):
         super().__init__(key=key, definition=definition)
         self._definition = definition
 
-    def resolve_id(self, _):
+    def resolve_id(self, _) -> str:
         # If the asset is not a SDA asset (has no definition), the id is the asset key
-        # Else, return a unique idenitifer containing the repository location and name
+        # Else, return a unique identifier containing the repository location and name
         if self._definition:
-            return get_unique_asset_id(
-                self.key,
-                self._definition.repository_location.name,
-                self._definition.external_repository.name,
-            )
+            return self._definition.id
         return get_unique_asset_id(self.key)
 
     def resolve_assetMaterializations(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -1023,7 +1023,7 @@ class GrapheneQuery(graphene.ObjectType):
             results = []
             for remote_node in remote_nodes:
                 if remote_node:
-                    repo_handle = remote_node.priority_repository_handle
+                    repo_handle = remote_node.priority_repository_selector
                     code_loc = graphene_info.context.get_code_location(repo_handle.location_name)
                     results.append(
                         (
@@ -1070,9 +1070,8 @@ class GrapheneQuery(graphene.ObjectType):
 
         nodes = [
             GrapheneAssetNode(
-                code_loc,
-                repo,
-                asset_node_snap,
+                repository_selector=repo.selector,
+                asset_node_snap=asset_node_snap,
                 asset_checks_loader=asset_checks_loader,
                 depended_by_loader=depended_by_loader,
                 stale_status_loader=stale_status_loader,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -455,9 +455,8 @@ class ISolidDefinitionMixin:
 
             return [
                 GrapheneAssetNode(
-                    location,
-                    ext_repo,
-                    node,
+                    repository_selector=ext_repo.selector,
+                    asset_node_snap=node,
                     asset_checks_loader=asset_checks_loader,
                     # base_deployment_context will be None if we are not in a branch deployment
                     asset_graph_differ=AssetGraphDiffer.from_external_repositories(

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -642,7 +642,7 @@ def _execute_backfill_command_at_location(
 
     run_tags = get_tags_from_args(cli_args)
 
-    repo_handle = RepositoryHandle(
+    repo_handle = RepositoryHandle.from_location(
         repository_name=external_repo.name,
         code_location=code_location,
     )

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -357,8 +357,8 @@ def executable_in_same_run(
 
     # if operating on a RemoteAssetGraph, must share a repository handle
     if isinstance(asset_graph, RemoteAssetGraph):
-        child_handle = asset_graph.get_repository_handle(child_key)
-        parent_handle = asset_graph.get_repository_handle(parent_key)
+        child_handle = asset_graph.get_repository_selector(child_key)
+        parent_handle = asset_graph.get_repository_selector(parent_key)
         if child_handle != parent_handle:
             return False
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -146,7 +146,7 @@ class AssetGraphDiffer:
 
         We cannot make RemoteAssetGraphs directly from the workspaces because if multiple code locations
         use the same asset key, those asset keys will override each other in the dictionaries the RemoteAssetGraph
-        creates (see from_repository_handles_and_asset_node_snaps in RemoteAssetGraph). We need to ensure
+        creates (see from_repository_selectors_and_asset_node_snaps in RemoteAssetGraph). We need to ensure
         that we are comparing assets in the same code location and repository, so we need to make the
         RemoteAssetGraph from an ExternalRepository to ensure that there are no duplicate asset keys
         that could override each other.

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -142,8 +142,8 @@ def get_expected_data_time_for_asset_key(
             if isinstance(asset_graph, RemoteAssetGraph) and context.will_update_asset_partition(
                 AssetKeyPartitionKey(parent_key)
             ):
-                parent_repo = asset_graph.get_repository_handle(parent_key)
-                if parent_repo != asset_graph.get_repository_handle(asset_key):
+                parent_repo = asset_graph.get_repository_selector(parent_key)
+                if parent_repo != asset_graph.get_repository_selector(asset_key):
                     return context.data_time_resolver.get_current_data_time(asset_key, current_time)
             # find the minimum non-None data time of your parents
             parent_expected_data_time = context.expected_data_time_mapping.get(

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1564,7 +1564,7 @@ def can_run_with_parent(
             False,
             f"parent {parent_node.key.to_user_string()} and {candidate_node.key.to_user_string()} have different backfill policies so they cannot be materialized in the same run. {candidate_node.key.to_user_string()} can be materialized once {parent_node.key} is materialized.",
         )
-    if parent_node.priority_repository_handle is not candidate_node.priority_repository_handle:
+    if parent_node.priority_repository_selector != candidate_node.priority_repository_selector:
         return (
             False,
             f"parent {parent_node.key.to_user_string()} and {candidate_node.key.to_user_string()} are in different code locations so they cannot be materialized in the same run. {candidate_node.key.to_user_string()} can be materialized once {parent_node.key.to_user_string()} is materialized.",

--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -64,8 +64,8 @@ def _get_job_execution_data_from_run_request(
         len(run_request.entity_keys) > 0,
         "Expected RunRequest to have an asset selection or asset check keys",
     )
-    repo_handle = asset_graph.get_repository_handle(run_request.entity_keys[0])
-    location_name = repo_handle.code_location_origin.location_name
+    selector = asset_graph.get_repository_selector(run_request.entity_keys[0])
+    location_name = selector.location_name
     job_name = (
         _get_implicit_job_name_for_assets(asset_graph, run_request.asset_selection)
         if run_request.asset_selection
@@ -81,7 +81,7 @@ def _get_job_execution_data_from_run_request(
 
     pipeline_selector = JobSubsetSelector(
         location_name=location_name,
-        repository_name=repo_handle.repository_name,
+        repository_name=selector.repository_name,
         job_name=job_name,
         asset_selection=run_request.asset_selection,
         asset_check_selection=run_request.asset_check_keys,
@@ -89,7 +89,7 @@ def _get_job_execution_data_from_run_request(
     )
 
     if pipeline_selector not in run_request_execution_data_cache:
-        code_location = workspace.get_code_location(repo_handle.code_location_origin.location_name)
+        code_location = workspace.get_code_location(selector.location_name)
         external_job = code_location.get_external_job(pipeline_selector)
 
         external_execution_plan = code_location.get_external_execution_plan(

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -399,7 +399,7 @@ class InProcessCodeLocation(CodeLocation):
         for repo_name, repo_def in self._loaded_repositories.definitions_by_name.items():
             self._repositories[repo_name] = ExternalRepository(
                 external_repository_data_from_def(repo_def),
-                RepositoryHandle(repository_name=repo_name, code_location=self),
+                RepositoryHandle.from_location(repository_name=repo_name, code_location=self),
                 instance=instance,
             )
 
@@ -737,7 +737,7 @@ class GrpcServerCodeLocation(CodeLocation):
             self.external_repositories = {
                 repo_name: ExternalRepository(
                     repo_data,
-                    RepositoryHandle(
+                    RepositoryHandle.from_location(
                         repository_name=repo_name,
                         code_location=self,
                     ),

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -375,13 +375,15 @@ class ExternalRepository:
         return self._handle
 
     @property
-    def selector_id(self) -> str:
-        return create_snapshot_id(
-            RepositorySelector(
-                location_name=self._handle.location_name,
-                repository_name=self._handle.repository_name,
-            ),
+    def selector(self) -> RepositorySelector:
+        return RepositorySelector(
+            location_name=self._handle.location_name,
+            repository_name=self._handle.repository_name,
         )
+
+    @property
+    def selector_id(self) -> str:
+        return create_snapshot_id(self.selector)
 
     def get_compound_id(self) -> CompoundID:
         return CompoundID(
@@ -432,12 +434,12 @@ class ExternalRepository:
         """Returns a repository scoped RemoteAssetGraph."""
         from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 
-        return RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
-            repo_handle_assets=[
-                (self.handle, node_snap) for node_snap in self.get_asset_node_snaps()
+        return RemoteAssetGraph.from_repository_selectors_and_asset_node_snaps(
+            repo_selector_assets=[
+                (self.selector, node_snap) for node_snap in self.get_asset_node_snaps()
             ],
-            repo_handle_asset_checks=[
-                (self.handle, asset_check_node)
+            repo_selector_asset_checks=[
+                (self.selector, asset_check_node)
                 for asset_check_node in self.get_asset_check_node_snaps()
             ],
         )

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -23,7 +23,7 @@ from typing_extensions import Self
 
 import dagster._check as check
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.selector import JobSubsetSelector
+from dagster._core.definitions.selector import JobSubsetSelector, RepositorySelector
 from dagster._core.errors import DagsterCodeLocationLoadError, DagsterCodeLocationNotFoundError
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.instance import DagsterInstance
@@ -36,6 +36,7 @@ from dagster._core.remote_representation import (
     GrpcServerCodeLocation,
     RepositoryHandle,
 )
+from dagster._core.remote_representation.external import ExternalRepository
 from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
 from dagster._core.remote_representation.grpc_server_state_subscriber import (
     LocationStateChangeEvent,
@@ -340,6 +341,11 @@ class BaseWorkspaceRequestContext(LoadingContext):
             return None
 
         return self.get_workspace_snapshot().asset_graph.get(asset_key)
+
+    def get_repository(self, selector: RepositorySelector) -> ExternalRepository:
+        return self.get_code_location(selector.location_name).get_repository(
+            selector.repository_name
+        )
 
 
 class WorkspaceRequestContext(BaseWorkspaceRequestContext):

--- a/python_modules/dagster/dagster/_core/workspace/workspace.py
+++ b/python_modules/dagster/dagster/_core/workspace/workspace.py
@@ -9,9 +9,9 @@ from dagster._utils.error import SerializableErrorInfo
 
 if TYPE_CHECKING:
     from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
+    from dagster._core.definitions.selector import RepositorySelector
     from dagster._core.remote_representation import CodeLocation, CodeLocationOrigin
     from dagster._core.remote_representation.external_data import AssetCheckNodeSnap, AssetNodeSnap
-    from dagster._core.remote_representation.handle import RepositoryHandle
 
 
 # For locations that are loaded asynchronously
@@ -63,18 +63,19 @@ class WorkspaceSnapshot:
             for code_location in code_locations
             for repo in code_location.get_repositories().values()
         )
-        repo_handle_assets: Sequence[Tuple["RepositoryHandle", "AssetNodeSnap"]] = []
-        repo_handle_asset_checks: Sequence[Tuple["RepositoryHandle", "AssetCheckNodeSnap"]] = []
+
+        repo_handle_assets: Sequence[Tuple["RepositorySelector", "AssetNodeSnap"]] = []
+        repo_handle_asset_checks: Sequence[Tuple["RepositorySelector", "AssetCheckNodeSnap"]] = []
 
         for repo in repos:
             for asset_node_snap in repo.get_asset_node_snaps():
-                repo_handle_assets.append((repo.handle, asset_node_snap))
+                repo_handle_assets.append((repo.selector, asset_node_snap))
             for asset_check_node_snap in repo.get_asset_check_node_snaps():
-                repo_handle_asset_checks.append((repo.handle, asset_check_node_snap))
+                repo_handle_asset_checks.append((repo.selector, asset_check_node_snap))
 
-        return RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
-            repo_handle_assets=repo_handle_assets,
-            repo_handle_asset_checks=repo_handle_asset_checks,
+        return RemoteAssetGraph.from_repository_selectors_and_asset_node_snaps(
+            repo_selector_assets=repo_handle_assets,
+            repo_selector_asset_checks=repo_handle_asset_checks,
         )
 
     def with_code_location(self, name: str, entry: CodeLocationEntry) -> "WorkspaceSnapshot":

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -152,7 +152,7 @@ def test_defer_snapshots(instance: DagsterInstance):
 
         repo = ExternalRepository(
             external_repository_data,
-            RepositoryHandle(repository_name="bar_repo", code_location=code_location),
+            RepositoryHandle.from_location(repository_name="bar_repo", code_location=code_location),
             instance=instance,
             ref_to_data_fn=_ref_to_data,
         )

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -34,6 +34,7 @@ from dagster._core.definitions.partition import PartitionsDefinition, Partitions
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import UpstreamPartitionsResult
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
+from dagster._core.definitions.selector import RepositorySelector
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterDefinitionChangedDeserializationError
 from dagster._core.instance import DynamicPartitionsStore
@@ -51,9 +52,10 @@ def to_remote_asset_graph(assets, asset_checks=None) -> RemoteAssetGraph:
         return assets + (asset_checks or [])
 
     asset_node_snaps = asset_node_snaps_from_repo(repo)
-    return RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
-        [(MagicMock(), asset_node) for asset_node in asset_node_snaps],
-        [(MagicMock(), asset_check) for asset_check in asset_check_node_snaps_from_repo(repo)],
+    selector = RepositorySelector(location_name="fake", repository_name="repo")
+    return RemoteAssetGraph.from_repository_selectors_and_asset_node_snaps(
+        [(selector, asset_node) for asset_node in asset_node_snaps],
+        [(selector, asset_check) for asset_check in asset_check_node_snaps_from_repo(repo)],
     )
 
 
@@ -889,9 +891,9 @@ def test_cross_code_location_partition_mapping() -> None:
 
     a_nodes = asset_node_snaps_from_repo(repo_a)
     b_nodes = asset_node_snaps_from_repo(repo_b)
-
-    asset_graph = RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
-        [(MagicMock(), asset_node) for asset_node in [*a_nodes, *b_nodes]], []
+    selector = RepositorySelector(location_name="foo", repository_name="bar")
+    asset_graph = RemoteAssetGraph.from_repository_selectors_and_asset_node_snaps(
+        [(selector, asset_node) for asset_node in [*a_nodes, *b_nodes]], []
     )
 
     assert isinstance(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -173,73 +173,50 @@ def _make_context(instance: DagsterInstance, defs_attrs):
     )
 
 
-def test_get_repository_handle(instance):
+def test_get_repository_selector(instance) -> None:
     asset_graph = _make_context(instance, ["defs1", "defs2"]).asset_graph
 
     assert asset_graph.get_materialization_job_names(asset1.key) == ["__ASSET_JOB"]
-    repo_handle1 = asset_graph.get_repository_handle(asset1.key)
+    repo_handle1 = asset_graph.get_repository_selector(asset1.key)
     assert repo_handle1.repository_name == "__repository__"
-    assert repo_handle1.repository_python_origin.code_pointer.fn_name == "defs1"
 
     assert asset_graph.get_materialization_job_names(asset1.key) == ["__ASSET_JOB"]
-    repo_handle2 = asset_graph.get_repository_handle(asset2.key)
+    repo_handle2 = asset_graph.get_repository_selector(asset2.key)
     assert repo_handle2.repository_name == "__repository__"
-    assert repo_handle2.repository_python_origin.code_pointer.fn_name == "defs2"
 
 
-def test_cross_repo_dep_with_source_asset(instance):
+def test_cross_repo_dep_with_source_asset(instance) -> None:
     asset_graph = _make_context(instance, ["defs1", "downstream_defs"]).asset_graph
 
     assert len(asset_graph.external_asset_keys) == 0
     assert asset_graph.get(AssetKey("downstream")).parent_keys == {AssetKey("asset1")}
     assert asset_graph.get(AssetKey("asset1")).child_keys == {AssetKey("downstream")}
-    assert (
-        asset_graph.get_repository_handle(
-            AssetKey("asset1")
-        ).repository_python_origin.code_pointer.fn_name
-        == "defs1"
-    )
+
     assert asset_graph.get_materialization_job_names(AssetKey("asset1")) == ["__ASSET_JOB"]
-    assert (
-        asset_graph.get_repository_handle(
-            AssetKey("downstream")
-        ).repository_python_origin.code_pointer.fn_name
-        == "downstream_defs"
-    )
+
     assert asset_graph.get_materialization_job_names(AssetKey("downstream")) == ["__ASSET_JOB"]
 
 
-def test_cross_repo_dep_no_source_asset(instance):
+def test_cross_repo_dep_no_source_asset(instance) -> None:
     asset_graph = _make_context(instance, ["defs1", "downstream_defs_no_source"]).asset_graph
     assert len(asset_graph.external_asset_keys) == 0
     assert asset_graph.get(AssetKey("downstream_non_arg_dep")).parent_keys == {AssetKey("asset1")}
     assert asset_graph.get(AssetKey("asset1")).child_keys == {AssetKey("downstream_non_arg_dep")}
-    assert (
-        asset_graph.get_repository_handle(
-            AssetKey("asset1")
-        ).repository_python_origin.code_pointer.fn_name
-        == "defs1"
-    )
+
     assert asset_graph.get_materialization_job_names(AssetKey("asset1")) == ["__ASSET_JOB"]
-    assert (
-        asset_graph.get_repository_handle(
-            AssetKey("downstream_non_arg_dep")
-        ).repository_python_origin.code_pointer.fn_name
-        == "downstream_defs_no_source"
-    )
     assert asset_graph.get_materialization_job_names(AssetKey("downstream_non_arg_dep")) == [
         "__ASSET_JOB"
     ]
 
 
-def test_partitioned_source_asset(instance):
+def test_partitioned_source_asset(instance) -> None:
     asset_graph = _make_context(instance, ["partitioned_defs"]).asset_graph
 
     assert asset_graph.get(AssetKey("partitioned_source")).is_partitioned
     assert asset_graph.get(AssetKey("downstream_of_partitioned_source")).is_partitioned
 
 
-def test_auto_materialize_policy(instance):
+def test_auto_materialize_policy(instance) -> None:
     asset_graph = _make_context(instance, ["partitioned_defs"]).asset_graph
 
     assert asset_graph.get(
@@ -264,7 +241,7 @@ def partition_mapping_asset(static_partitioned_asset):
 partition_mapping_defs = Definitions(assets=[static_partitioned_asset, partition_mapping_asset])
 
 
-def test_partition_mapping(instance):
+def test_partition_mapping(instance) -> None:
     asset_graph = _make_context(instance, ["partition_mapping_defs"]).asset_graph
 
     assert isinstance(

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -3,7 +3,6 @@ import os
 import tempfile
 from difflib import SequenceMatcher
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 from click.testing import CliRunner
@@ -223,7 +222,7 @@ def test_get_stats_from_external_repo_partitions(instance):
         external_repository_data_from_def(
             Definitions(assets=[asset1, asset2, asset3]).get_repository_def()
         ),
-        repository_handle=MagicMock(spec=RepositoryHandle),
+        repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
     stats = get_stats_from_external_repo(external_repo)
@@ -245,7 +244,7 @@ def test_get_stats_from_external_repo_multi_partitions(instance):
         external_repository_data_from_def(
             Definitions(assets=[multi_partitioned_asset]).get_repository_def()
         ),
-        repository_handle=MagicMock(spec=RepositoryHandle),
+        repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
     stats = get_stats_from_external_repo(external_repo)
@@ -263,7 +262,7 @@ def test_get_stats_from_external_repo_source_assets(instance):
         external_repository_data_from_def(
             Definitions(assets=[source_asset1, asset1]).get_repository_def()
         ),
-        repository_handle=MagicMock(spec=RepositoryHandle),
+        repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
     stats = get_stats_from_external_repo(external_repo)
@@ -283,7 +282,7 @@ def test_get_stats_from_external_repo_observable_source_assets(instance):
         external_repository_data_from_def(
             Definitions(assets=[source_asset1, source_asset2, asset1]).get_repository_def()
         ),
-        repository_handle=MagicMock(spec=RepositoryHandle),
+        repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
     stats = get_stats_from_external_repo(external_repo)
@@ -302,7 +301,7 @@ def test_get_stats_from_external_repo_freshness_policies(instance):
         external_repository_data_from_def(
             Definitions(assets=[asset1, asset2]).get_repository_def()
         ),
-        repository_handle=MagicMock(spec=RepositoryHandle),
+        repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
     stats = get_stats_from_external_repo(external_repo)
@@ -325,7 +324,7 @@ def test_get_status_from_external_repo_auto_materialize_policy(instance):
         external_repository_data_from_def(
             Definitions(assets=[asset1, asset2, asset3]).get_repository_def()
         ),
-        repository_handle=MagicMock(spec=RepositoryHandle),
+        repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
     stats = get_stats_from_external_repo(external_repo)
@@ -344,7 +343,7 @@ def test_get_stats_from_external_repo_code_versions(instance):
         external_repository_data_from_def(
             Definitions(assets=[asset1, asset2]).get_repository_def()
         ),
-        repository_handle=MagicMock(spec=RepositoryHandle),
+        repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
     stats = get_stats_from_external_repo(external_repo)
@@ -370,7 +369,7 @@ def test_get_stats_from_external_repo_code_checks(instance):
                 assets=[my_asset, my_other_asset], asset_checks=[my_check, my_check_2]
             ).get_repository_def()
         ),
-        repository_handle=MagicMock(spec=RepositoryHandle),
+        repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
     stats = get_stats_from_external_repo(external_repo)
@@ -389,7 +388,7 @@ def test_get_stats_from_external_repo_dbt(instance):
         external_repository_data_from_def(
             Definitions(assets=[asset1, asset2]).get_repository_def()
         ),
-        repository_handle=MagicMock(spec=RepositoryHandle),
+        repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
     stats = get_stats_from_external_repo(external_repo)
@@ -420,7 +419,7 @@ def test_get_stats_from_external_repo_resources(instance):
                 },
             ).get_repository_def()
         ),
-        repository_handle=MagicMock(spec=RepositoryHandle),
+        repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
     stats = get_stats_from_external_repo(external_repo)
@@ -466,7 +465,7 @@ def test_get_stats_from_external_repo_io_managers(instance):
                 },
             ).get_repository_def()
         ),
-        repository_handle=MagicMock(spec=RepositoryHandle),
+        repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
     stats = get_stats_from_external_repo(external_repo)
@@ -499,7 +498,7 @@ def test_get_stats_from_external_repo_functional_resources(instance):
                 },
             ).get_repository_def()
         ),
-        repository_handle=MagicMock(spec=RepositoryHandle),
+        repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
     stats = get_stats_from_external_repo(external_repo)
@@ -532,7 +531,7 @@ def test_get_stats_from_external_repo_functional_io_managers(instance):
                 },
             ).get_repository_def()
         ),
-        repository_handle=MagicMock(spec=RepositoryHandle),
+        repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
     stats = get_stats_from_external_repo(external_repo)
@@ -551,7 +550,7 @@ def test_get_stats_from_external_repo_pipes_client(instance):
                 },
             ).get_repository_def()
         ),
-        repository_handle=MagicMock(spec=RepositoryHandle),
+        repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
     stats = get_stats_from_external_repo(external_repo)
@@ -610,7 +609,7 @@ def test_get_stats_from_external_repo_delayed_resource_configuration(instance):
                 },
             ).get_repository_def()
         ),
-        repository_handle=MagicMock(spec=RepositoryHandle),
+        repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
     stats = get_stats_from_external_repo(external_repo)

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -47,6 +47,7 @@ from dagster._core.definitions.selector import (
     PartitionRangeSelector,
     PartitionsByAssetSelector,
     PartitionsSelector,
+    RepositorySelector,
 )
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.asset_backfill import (
@@ -263,7 +264,7 @@ def _single_backfill_iteration(
         assert asset_keys is not None
 
         assets = assets_by_repo_name[
-            asset_graph.get_repository_handle(asset_keys[0]).repository_name
+            asset_graph.get_repository_selector(asset_keys[0]).repository_name
         ]
 
         do_run(
@@ -667,12 +668,12 @@ def run_backfill_to_completion(
             )
 
             assert all(
-                asset_graph.get_repository_handle(asset_keys[0])
-                == asset_graph.get_repository_handle(asset_key)
+                asset_graph.get_repository_selector(asset_keys[0])
+                == asset_graph.get_repository_selector(asset_key)
                 for asset_key in asset_keys
             )
             assets = assets_by_repo_name[
-                asset_graph.get_repository_handle(asset_keys[0]).repository_name
+                asset_graph.get_repository_selector(asset_keys[0]).repository_name
             ]
 
             do_run(
@@ -736,19 +737,18 @@ def _requested_asset_partitions_in_run_request(
 def remote_asset_graph_from_assets_by_repo_name(
     assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
 ) -> RemoteAssetGraph:
-    from_repository_handles_and_asset_node_snaps = []
+    from_repository_selectors_and_asset_node_snaps = []
 
     for repo_name, assets in assets_by_repo_name.items():
         repo = Definitions(assets=assets).get_repository_def()
-
         asset_node_snaps = asset_node_snaps_from_repo(repo)
-        repo_handle = MagicMock(repository_name=repo_name)
-        from_repository_handles_and_asset_node_snaps.extend(
-            [(repo_handle, asset_node) for asset_node in asset_node_snaps]
+        selector = RepositorySelector(location_name="test", repository_name=repo_name)
+        from_repository_selectors_and_asset_node_snaps.extend(
+            [(selector, asset_node) for asset_node in asset_node_snaps]
         )
 
-    return RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
-        from_repository_handles_and_asset_node_snaps, repo_handle_asset_checks=[]
+    return RemoteAssetGraph.from_repository_selectors_and_asset_node_snaps(
+        from_repository_selectors_and_asset_node_snaps, []
     )
 
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -85,7 +85,9 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         new_origin = code_location_origin._replace(location_name="other_location_name")
         with instance_for_test() as temp_instance:
             with new_origin.create_single_location(temp_instance) as location:
-                new_repo_handle = RepositoryHandle(job_handle.repository_name, location)
+                new_repo_handle = RepositoryHandle.from_location(
+                    job_handle.repository_name, location
+                )
 
         return copy(
             job_handle,

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 import pytest
 from dagster import (
     AssetKey,
@@ -18,10 +16,6 @@ from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.remote_representation.external import ExternalRepository
 from dagster._core.remote_representation.external_data import external_repository_data_from_def
 from dagster._core.remote_representation.handle import RepositoryHandle
-from dagster._core.remote_representation.origin import (
-    RegisteredCodeLocationOrigin,
-    RemoteRepositoryOrigin,
-)
 from dagster._core.test_utils import instance_for_test
 
 
@@ -95,13 +89,10 @@ def instance_without_auto_materialize_sensors():
 
 def test_default_auto_materialize_sensors(instance_with_auto_materialize_sensors):
     instance = instance_with_auto_materialize_sensors
-
-    repo_handle = MagicMock(spec=RepositoryHandle)
-    repo_handle.get_remote_origin.return_value = RemoteRepositoryOrigin(
-        code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
+    repo_handle = RepositoryHandle.for_test(
+        location_name="foo_location",
         repository_name="bar_repo",
     )
-
     external_repo = ExternalRepository(
         external_repository_data_from_def(
             defs.get_repository_def(),
@@ -134,9 +125,8 @@ def test_default_auto_materialize_sensors_without_observable(
 ):
     instance = instance_with_auto_materialize_sensors
 
-    repo_handle = MagicMock(spec=RepositoryHandle)
-    repo_handle.get_remote_origin.return_value = RemoteRepositoryOrigin(
-        code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
+    repo_handle = RepositoryHandle.for_test(
+        location_name="foo_location",
         repository_name="bar_repo",
     )
 
@@ -161,9 +151,8 @@ def test_default_auto_materialize_sensors_without_observable(
 
 
 def test_no_default_auto_materialize_sensors(instance_without_auto_materialize_sensors):
-    repo_handle = MagicMock(spec=RepositoryHandle)
-    repo_handle.get_remote_origin.return_value = RemoteRepositoryOrigin(
-        code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
+    repo_handle = RepositoryHandle.for_test(
+        location_name="foo_location",
         repository_name="bar_repo",
     )
 
@@ -197,10 +186,8 @@ def test_combine_default_sensors_with_non_default_sensors(instance_with_auto_mat
         ],
         sensors=[normal_sensor, auto_materialize_sensor],
     )
-
-    repo_handle = MagicMock(spec=RepositoryHandle)
-    repo_handle.get_remote_origin.return_value = RemoteRepositoryOrigin(
-        code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
+    repo_handle = RepositoryHandle.for_test(
+        location_name="foo_location",
         repository_name="bar_repo",
     )
 
@@ -269,9 +256,8 @@ def test_custom_sensors_cover_all(instance_with_auto_materialize_sensors):
         sensors=[normal_sensor, auto_materialize_sensor],
     )
 
-    repo_handle = MagicMock(spec=RepositoryHandle)
-    repo_handle.get_remote_origin.return_value = RemoteRepositoryOrigin(
-        code_location_origin=RegisteredCodeLocationOrigin(location_name="foo_location"),
+    repo_handle = RepositoryHandle.for_test(
+        location_name="foo_location",
         repository_name="bar_repo",
     )
 

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
@@ -344,7 +344,7 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
             location = workspace.get_code_location(workspace.code_location_names[0])
 
             repo_def = recon_repo.get_definition()
-            repo_handle = RepositoryHandle(
+            repo_handle = RepositoryHandle.from_location(
                 repository_name=repo_def.name,
                 code_location=location,
             )
@@ -423,7 +423,7 @@ def test_raise_on_error(kubeconfig_file):
             location = workspace.get_code_location(workspace.code_location_names[0])
 
             repo_def = recon_repo.get_definition()
-            repo_handle = RepositoryHandle(
+            repo_handle = RepositoryHandle.from_location(
                 repository_name=repo_def.name,
                 code_location=location,
             )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
@@ -447,7 +447,7 @@ def test_step_handler(kubeconfig_file, k8s_instance):
     with instance_for_test() as instance:
         with in_process_test_workspace(instance, loadable_target_origin) as workspace:
             location = workspace.get_code_location(workspace.code_location_names[0])
-            repo_handle = RepositoryHandle(
+            repo_handle = RepositoryHandle.from_location(
                 repository_name="bar_repo",
                 code_location=location,
             )

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
@@ -177,7 +177,7 @@ def test_launcher_with_container_context(kubeconfig_file):
     with instance_for_test() as instance:
         with in_process_test_workspace(instance, loadable_target_origin) as workspace:
             location = workspace.get_code_location(workspace.code_location_names[0])
-            repo_handle = RepositoryHandle(
+            repo_handle = RepositoryHandle.from_location(
                 repository_name=repo_def.name,
                 code_location=location,
             )
@@ -346,7 +346,7 @@ def test_launcher_with_k8s_config(kubeconfig_file):
     with instance_for_test() as instance:
         with in_process_test_workspace(instance, loadable_target_origin) as workspace:
             location = workspace.get_code_location(workspace.code_location_names[0])
-            repo_handle = RepositoryHandle(
+            repo_handle = RepositoryHandle.from_location(
                 repository_name=repo_def.name,
                 code_location=location,
             )
@@ -440,7 +440,7 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
     with instance_for_test() as instance:
         with in_process_test_workspace(instance, loadable_target_origin) as workspace:
             location = workspace.get_code_location(workspace.code_location_names[0])
-            repo_handle = RepositoryHandle(
+            repo_handle = RepositoryHandle.from_location(
                 repository_name=repo_def.name,
                 code_location=location,
             )
@@ -521,7 +521,7 @@ def test_raise_on_error(kubeconfig_file):
     with instance_for_test() as instance:
         with in_process_test_workspace(instance, loadable_target_origin) as workspace:
             location = workspace.get_code_location(workspace.code_location_names[0])
-            repo_handle = RepositoryHandle(
+            repo_handle = RepositoryHandle.from_location(
                 repository_name=repo_def.name,
                 code_location=location,
             )
@@ -582,7 +582,7 @@ def test_no_postgres(kubeconfig_file):
     with instance_for_test() as instance:
         with in_process_test_workspace(instance, loadable_target_origin) as workspace:
             location = workspace.get_code_location(workspace.code_location_names[0])
-            repo_handle = RepositoryHandle(
+            repo_handle = RepositoryHandle.from_location(
                 repository_name=repo_def.name,
                 code_location=location,
             )
@@ -648,7 +648,7 @@ def test_check_run_health(kubeconfig_file):
     with instance_for_test() as instance:
         with in_process_test_workspace(instance, loadable_target_origin) as workspace:
             location = workspace.get_code_location(workspace.code_location_names[0])
-            repo_handle = RepositoryHandle(
+            repo_handle = RepositoryHandle.from_location(
                 repository_name=repo_def.name,
                 code_location=location,
             )
@@ -785,7 +785,7 @@ def test_get_run_worker_debug_info(kubeconfig_file):
 
         with in_process_test_workspace(instance, loadable_target_origin) as workspace:
             location = workspace.get_code_location(workspace.code_location_names[0])
-            repo_handle = RepositoryHandle(
+            repo_handle = RepositoryHandle.from_location(
                 repository_name=repo_def.name,
                 code_location=location,
             )


### PR DESCRIPTION
In an effort to make `RemoteAssetNode` serializable, have it use a simple pointer to know which code location / repo it came from. 

## How I Tested These Changes

existing coverage