### PR TITLE
[documentation] Fix incorrect example of TableColumnConstraints

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/table.py
@@ -207,7 +207,7 @@ class TableSchema(
                         type = "string",
                         description = "Foo description",
                         constraints = TableColumnConstraints(
-                            required = True,
+                            nullable = False,
                             other = [
                                 "starts with the letter 'a'",
                             ],


### PR DESCRIPTION
## Summary & Motivation

This docblock uses `required = True` in `TableColumnConstraints`, but the API appears to be `nullable = False` based on the definition elsewhere in the file. This updates the doc accordingly.

## How I Tested These Changes

I didn't, but this is a doc only change.

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [X] `DOCS` _(added or updated documentation)_
