### PR TITLE
serializable RemoteAssetNodes

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -144,7 +144,10 @@ def get_schedules_or_error(
 
     results = [
         GrapheneSchedule(
-            schedule, repository, schedule_states_by_name.get(schedule.name), batch_loader
+            schedule,
+            repository.handle,
+            schedule_states_by_name.get(schedule.name),
+            batch_loader,
         )
         for schedule in filtered
     ]
@@ -172,7 +175,8 @@ def get_schedules_for_pipeline(
             schedule.get_remote_origin_id(),
             schedule.selector_id,
         )
-        results.append(GrapheneSchedule(schedule, repository, schedule_state))
+
+        results.append(GrapheneSchedule(schedule, repository.handle, schedule_state))
 
     return results
 
@@ -197,7 +201,7 @@ def get_schedule_or_error(
     schedule_state = graphene_info.context.instance.get_instigator_state(
         schedule.get_remote_origin_id(), schedule.selector_id
     )
-    return GrapheneSchedule(schedule, repository, schedule_state)
+    return GrapheneSchedule(schedule, repository.handle, schedule_state)
 
 
 def get_schedule_next_tick(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -61,7 +61,12 @@ def get_sensors_or_error(
 
     return GrapheneSensors(
         results=[
-            GrapheneSensor(sensor, repository, sensor_states_by_name.get(sensor.name), batch_loader)
+            GrapheneSensor(
+                sensor,
+                repository.handle,
+                sensor_states_by_name.get(sensor.name),
+                batch_loader,
+            )
             for sensor in filtered
         ]
     )
@@ -83,7 +88,7 @@ def get_sensor_or_error(graphene_info: ResolveInfo, selector: SensorSelector) ->
         sensor.selector_id,
     )
 
-    return GrapheneSensor(sensor, repository, sensor_state)
+    return GrapheneSensor(sensor, repository.handle, sensor_state)
 
 
 def start_sensor(graphene_info: ResolveInfo, sensor_selector: SensorSelector) -> "GrapheneSensor":
@@ -98,7 +103,7 @@ def start_sensor(graphene_info: ResolveInfo, sensor_selector: SensorSelector) ->
         raise UserFacingGraphQLError(GrapheneSensorNotFoundError(sensor_selector.sensor_name))
     sensor = repository.get_sensor(sensor_selector.sensor_name)
     sensor_state = graphene_info.context.instance.start_sensor(sensor)
-    return GrapheneSensor(sensor, repository, sensor_state)
+    return GrapheneSensor(sensor, repository.handle, sensor_state)
 
 
 def stop_sensor(
@@ -151,7 +156,7 @@ def reset_sensor(graphene_info: ResolveInfo, sensor_selector: SensorSelector) ->
     sensor = repository.get_sensor(sensor_selector.sensor_name)
     sensor_state = graphene_info.context.instance.reset_sensor(sensor)
 
-    return GrapheneSensor(sensor, repository, sensor_state)
+    return GrapheneSensor(sensor, repository.handle, sensor_state)
 
 
 def get_sensors_for_pipeline(
@@ -174,7 +179,7 @@ def get_sensors_for_pipeline(
             sensor.get_remote_origin_id(),
             sensor.selector_id,
         )
-        results.append(GrapheneSensor(sensor, repository, sensor_state))
+        results.append(GrapheneSensor(sensor, repository.handle, sensor_state))
 
     return results
 
@@ -259,4 +264,4 @@ def set_sensor_cursor(
     else:
         instance.update_instigator_state(updated_state)
 
-    return GrapheneSensor(sensor, repository, updated_state)
+    return GrapheneSensor(sensor, repository.handle, updated_state)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -1,13 +1,11 @@
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Set, Union, cast
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Union, cast
 
 import graphene
 from dagster import (
     AssetKey,
-    DagsterError,
     _check as check,
 )
 from dagster._core.definitions.asset_graph_differ import AssetDefinitionChangeType, AssetGraphDiffer
-from dagster._core.definitions.asset_job import IMPLICIT_ASSET_JOB_NAME
 from dagster._core.definitions.data_time import CachingDataTimeResolver
 from dagster._core.definitions.data_version import (
     NULL_DATA_VERSION,
@@ -16,7 +14,7 @@ from dagster._core.definitions.data_version import (
 )
 from dagster._core.definitions.partition import CachingDynamicPartitionsLoader, PartitionsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
-from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph, RemoteAssetNode
+from dagster._core.definitions.remote_asset_graph import RemoteAssetNode, RemoteWorkspaceAssetNode
 from dagster._core.definitions.selector import JobSelector
 from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.errors import DagsterInvariantViolationError
@@ -847,53 +845,49 @@ class GrapheneAssetNode(graphene.ObjectType):
             return GrapheneAutomationCondition(self._asset_node_snap.automation_condition)
         return None
 
-    def _sensor_targets_asset(
-        self, sensor: RemoteSensor, asset_graph: RemoteAssetGraph, job_names: Set[str]
-    ) -> bool:
-        asset_key = self._asset_node_snap.asset_key
-
-        if sensor.asset_selection is not None:
-            try:
-                asset_selection = sensor.asset_selection.resolve(asset_graph)
-            except DagsterError:
-                return False
-
-            if asset_key in asset_selection:
-                return True
-
-        return any(target.job_name in job_names for target in sensor.get_targets())
-
     def resolve_targetingInstigators(self, graphene_info: ResolveInfo) -> Sequence[GrapheneSensor]:
-        repo = graphene_info.context.get_repository(self._repository_selector)
-        sensors = repo.get_sensors()
-        schedules = repo.get_schedules()
-
-        asset_graph = repo.asset_graph
-
-        job_names = {
-            job_name
-            for job_name in self._asset_node_snap.job_names
-            if not job_name == IMPLICIT_ASSET_JOB_NAME
-        }
+        if isinstance(self._remote_node, RemoteWorkspaceAssetNode):
+            # global nodes have saved references to their targeting instigators
+            schedules = [
+                graphene_info.context.get_schedule(schedule_handle)
+                for schedule_handle in self._remote_node.get_targeting_schedule_handles()
+            ]
+            sensors = [
+                graphene_info.context.get_sensor(sensor_handle)
+                for sensor_handle in self._remote_node.get_targeting_sensor_handles()
+            ]
+        else:
+            # fallback to using the repository
+            repo = graphene_info.context.get_repository(self._repository_selector)
+            schedules = repo.get_schedules_targeting(self._asset_node_snap.asset_key)
+            sensors = repo.get_sensors_targeting(self._asset_node_snap.asset_key)
 
         results = []
         for sensor in sensors:
-            if not self._sensor_targets_asset(sensor, asset_graph, job_names):
-                continue
-
             sensor_state = graphene_info.context.instance.get_instigator_state(
                 sensor.get_remote_origin_id(),
                 sensor.selector_id,
             )
-            results.append(GrapheneSensor(sensor, repo, sensor_state))
+            results.append(
+                GrapheneSensor(
+                    sensor,
+                    sensor.handle.repository_handle,
+                    sensor_state,
+                )
+            )
 
         for schedule in schedules:
-            if schedule.job_name in job_names:
-                schedule_state = graphene_info.context.instance.get_instigator_state(
-                    schedule.get_remote_origin_id(),
-                    schedule.selector_id,
+            schedule_state = graphene_info.context.instance.get_instigator_state(
+                schedule.get_remote_origin_id(),
+                schedule.selector_id,
+            )
+            results.append(
+                GrapheneSchedule(
+                    schedule,
+                    schedule.handle.repository_handle,
+                    schedule_state,
                 )
-                results.append(GrapheneSchedule(schedule, repo, schedule_state))
+            )
 
         return results
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -311,7 +311,7 @@ class GrapheneRepository(graphene.ObjectType):
             [
                 GrapheneSchedule(
                     schedule,
-                    repository,
+                    repository.handle,
                     batch_loader.get_schedule_state(schedule.name),
                     batch_loader,
                 )
@@ -326,7 +326,7 @@ class GrapheneRepository(graphene.ObjectType):
         return [
             GrapheneSensor(
                 sensor,
-                repository,
+                repository.handle,
                 batch_loader.get_sensor_state(sensor.name),
                 batch_loader,
             )

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -5,7 +5,7 @@ import dagster._check as check
 import graphene
 from dagster import DefaultScheduleStatus
 from dagster._core.remote_representation import RemoteSchedule
-from dagster._core.remote_representation.external import RemoteRepository
+from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus
 from dagster._time import get_current_timestamp
 
@@ -66,12 +66,11 @@ class GrapheneSchedule(graphene.ObjectType):
     def __init__(
         self,
         remote_schedule: RemoteSchedule,
-        remote_repository: RemoteRepository,
+        repository_handle: RepositoryHandle,
         schedule_state: Optional[InstigatorState],
         batch_loader: Optional[RepositoryScopedBatchLoader] = None,
     ):
         self._remote_schedule = check.inst_param(remote_schedule, "remote_schedule", RemoteSchedule)
-        self._remote_repository = remote_repository
 
         # optional run loader, provided by a parent graphene object (e.g. GrapheneRepository)
         # that instantiates multiple schedules
@@ -98,7 +97,7 @@ class GrapheneSchedule(graphene.ObjectType):
             description=remote_schedule.description,
             assetSelection=GrapheneAssetSelection(
                 asset_selection=remote_schedule.asset_selection,
-                remote_repository=self._remote_repository,
+                repository_handle=repository_handle,
             )
             if remote_schedule.asset_selection
             else None,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -7,7 +7,8 @@ from dagster._core.definitions.selector import SensorSelector
 from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.remote_representation import RemoteSensor, TargetSnap
-from dagster._core.remote_representation.external import CompoundID, RemoteRepository
+from dagster._core.remote_representation.external import CompoundID
+from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus
 from dagster._core.workspace.permissions import Permissions
 
@@ -94,12 +95,11 @@ class GrapheneSensor(graphene.ObjectType):
     def __init__(
         self,
         remote_sensor: RemoteSensor,
-        remote_repo: RemoteRepository,
+        repository_handle: RepositoryHandle,
         sensor_state: Optional[InstigatorState],
         batch_loader: Optional[RepositoryScopedBatchLoader] = None,
     ):
         self._remote_sensor = check.inst_param(remote_sensor, "remote_sensor", RemoteSensor)
-        self._remote_repository = remote_repo
 
         # optional run loader, provided by a parent GrapheneRepository object that instantiates
         # multiple sensors
@@ -122,7 +122,7 @@ class GrapheneSensor(graphene.ObjectType):
             sensorType=remote_sensor.sensor_type.value,
             assetSelection=GrapheneAssetSelection(
                 asset_selection=remote_sensor.asset_selection,
-                remote_repository=self._remote_repository,
+                repository_handle=repository_handle,
             )
             if remote_sensor.asset_selection
             else None,

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -265,29 +265,29 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
             "downstream": {node.key: node.child_entity_keys for node in self.nodes},
         }
 
-    @cached_property
+    @property
     def all_asset_keys(self) -> AbstractSet[AssetKey]:
-        return {node.key for node in self.asset_nodes}
+        return set(self._asset_nodes_by_key)
 
     @cached_property
     def materializable_asset_keys(self) -> AbstractSet[AssetKey]:
-        return {node.key for node in self.asset_nodes if node.is_materializable}
+        return {key for key, node in self._asset_nodes_by_key.items() if node.is_materializable}
 
     @cached_property
     def observable_asset_keys(self) -> AbstractSet[AssetKey]:
-        return {node.key for node in self.asset_nodes if node.is_observable}
+        return {key for key, node in self._asset_nodes_by_key.items() if node.is_observable}
 
     @cached_property
     def external_asset_keys(self) -> AbstractSet[AssetKey]:
-        return {node.key for node in self.asset_nodes if node.is_external}
+        return {key for key, node in self._asset_nodes_by_key.items() if node.is_external}
 
     @cached_property
     def executable_asset_keys(self) -> AbstractSet[AssetKey]:
-        return {node.key for node in self.asset_nodes if node.is_executable}
+        return {key for key, node in self._asset_nodes_by_key.items() if node.is_executable}
 
     @cached_property
     def unexecutable_asset_keys(self) -> AbstractSet[AssetKey]:
-        return {node.key for node in self.asset_nodes if not node.is_executable}
+        return {key for key, node in self._asset_nodes_by_key.items() if not node.is_executable}
 
     @cached_property
     def toposorted_asset_keys(self) -> Sequence[AssetKey]:

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -42,7 +42,7 @@ from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster._core.remote_representation.external import RemoteRepository
-from dagster._core.remote_representation.handle import RepositoryHandle
+from dagster._core.remote_representation.handle import InstigatorHandle, RepositoryHandle
 from dagster._core.workspace.workspace import WorkspaceSnapshot
 from dagster._record import ImportFrom, record
 from dagster._utils.cached_method import cached_method
@@ -199,6 +199,8 @@ class RepositoryScopedAssetInfo:
     """
 
     asset_node: RemoteRepositoryAssetNode
+    targeting_sensor_names: Sequence[str]
+    targeting_schedule_names: Sequence[str]
 
     @property
     def handle(self) -> RepositoryHandle:
@@ -331,6 +333,35 @@ class RemoteWorkspaceAssetNode(RemoteAssetNode):
                 (info.asset_node for info in self.repo_scoped_asset_infos),
             )
         )
+
+    def get_targeting_schedule_handles(
+        self,
+    ) -> Sequence[InstigatorHandle]:
+        selectors = []
+        for node in self.repo_scoped_asset_infos:
+            for schedule_name in node.targeting_schedule_names:
+                selectors.append(
+                    InstigatorHandle(
+                        repository_handle=node.handle,
+                        instigator_name=schedule_name,
+                    )
+                )
+
+        return selectors
+
+    def get_targeting_sensor_handles(
+        self,
+    ) -> Sequence[InstigatorHandle]:
+        selectors = []
+        for node in self.repo_scoped_asset_infos:
+            for sensor_name in node.targeting_sensor_names:
+                selectors.append(
+                    InstigatorHandle(
+                        repository_handle=node.handle,
+                        instigator_name=sensor_name,
+                    )
+                )
+        return selectors
 
     ##### HELPERS
 
@@ -573,6 +604,12 @@ class RemoteWorkspaceAssetGraph(RemoteAssetGraph[RemoteWorkspaceAssetNode]):
                 asset_infos_by_key[key].append(
                     RepositoryScopedAssetInfo(
                         asset_node=asset_node,
+                        targeting_sensor_names=[
+                            s.name for s in repo.get_sensors_targeting(asset_node.key)
+                        ],
+                        targeting_schedule_names=[
+                            s.name for s in repo.get_schedules_targeting(asset_node.key)
+                        ],
                     )
                 )
             # NOTE: matches previous behavior of completely ignoring asset check collisions

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -45,6 +45,7 @@ from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.remote_representation.handle import InstigatorHandle, RepositoryHandle
 from dagster._core.workspace.workspace import WorkspaceSnapshot
 from dagster._record import ImportFrom, record
+from dagster._serdes.serdes import whitelist_for_serdes
 from dagster._utils.cached_method import cached_method
 
 if TYPE_CHECKING:
@@ -124,6 +125,7 @@ class RemoteAssetNode(BaseAssetNode, ABC):
         )
 
 
+@whitelist_for_serdes
 @record
 class RemoteRepositoryAssetNode(RemoteAssetNode):
     """Asset nodes from a single RemoteRepository."""
@@ -191,6 +193,7 @@ class RemoteRepositoryAssetNode(RemoteAssetNode):
         return self.asset_node_snap.auto_observe_interval_minutes
 
 
+@whitelist_for_serdes
 @record
 class RepositoryScopedAssetInfo:
     """RemoteRepositoryAssetNode paired with additional information from that repository.
@@ -207,6 +210,7 @@ class RepositoryScopedAssetInfo:
         return self.asset_node.repository_handle
 
 
+@whitelist_for_serdes
 @record
 class RemoteWorkspaceAssetNode(RemoteAssetNode):
     """Asset nodes constructed from a WorkspaceSnapshot, containing nodes from potentially several RemoteRepositories."""
@@ -315,7 +319,6 @@ class RemoteWorkspaceAssetNode(RemoteAssetNode):
         # materialization node was previously preferred over the observable node. This is a
         # temporary measure until we can appropriately scope the accessors that could apply to
         # either a materialization or observation node.
-
         # This property supports existing behavior but it should be phased out, because it relies on
         # materialization nodes shadowing observation nodes that would otherwise be exposed.
         return next(

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import datetime
 from functools import cached_property
 from threading import RLock
@@ -13,6 +14,7 @@ from typing import (
     Optional,
     Sequence,
     Set,
+    Tuple,
     Union,
 )
 
@@ -20,6 +22,7 @@ import dagster._check as check
 from dagster import AssetSelection
 from dagster._config.snap import ConfigFieldSnap, ConfigSchemaSnapshot
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
+from dagster._core.definitions.asset_job import IMPLICIT_ASSET_JOB_NAME
 from dagster._core.definitions.backfill_policy import BackfillPolicy
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.metadata import MetadataValue
@@ -37,6 +40,7 @@ from dagster._core.definitions.sensor_definition import (
     DefaultSensorStatus,
     SensorType,
 )
+from dagster._core.errors import DagsterError
 from dagster._core.execution.plan.handle import ResolvedFromDynamicStepHandle, StepHandle
 from dagster._core.instance import DagsterInstance
 from dagster._core.origin import JobPythonOrigin, RepositoryPythonOrigin
@@ -86,6 +90,8 @@ if TYPE_CHECKING:
     from dagster._core.definitions.remote_asset_graph import RemoteRepositoryAssetGraph
     from dagster._core.scheduler.instigation import InstigatorState
     from dagster._core.snap.execution_plan_snapshot import ExecutionStepSnap
+
+_empty_set = frozenset()
 
 
 class RemoteRepository:
@@ -372,13 +378,15 @@ class RemoteRepository:
             else self._asset_jobs.get(job_name, [])
         )
 
+    @cached_property
+    def _asset_snaps_by_key(self) -> Mapping[AssetKey, AssetNodeSnap]:
+        mapping = {}
+        for asset_snap in self.repository_snap.asset_nodes:
+            mapping[asset_snap.asset_key] = asset_snap
+        return mapping
+
     def get_asset_node_snap(self, asset_key: AssetKey) -> Optional[AssetNodeSnap]:
-        matching = [
-            asset_node
-            for asset_node in self.repository_snap.asset_nodes
-            if asset_node.asset_key == asset_key
-        ]
-        return matching[0] if matching else None
+        return self._asset_snaps_by_key.get(asset_key)
 
     def get_asset_check_node_snaps(
         self, job_name: Optional[str] = None
@@ -440,6 +448,72 @@ class RemoteRepository:
                 "There is no PartitionsDefinition shared by all the provided assets."
                 f" {len(unique_partitions_defs)} unique PartitionsDefinitions."
             )
+
+    @cached_property
+    def _sensor_mappings(
+        self,
+    ) -> Tuple[
+        Mapping[str, Sequence["RemoteSensor"]],
+        Mapping[AssetKey, Sequence["RemoteSensor"]],
+    ]:
+        asset_key_mapping = defaultdict(list)
+        job_name_mapping = defaultdict(list)
+        for sensor in self.get_sensors():
+            for target in sensor.get_targets():
+                job_name_mapping[target.job_name].append(sensor)
+
+            if sensor and sensor.asset_selection:
+                try:
+                    keys = sensor.asset_selection.resolve(self.asset_graph)
+                    for key in keys:
+                        asset_key_mapping[key].append(sensor)
+                except DagsterError:
+                    pass
+
+        return job_name_mapping, asset_key_mapping
+
+    @property
+    def _sensors_by_job_name(self) -> Mapping[str, Sequence["RemoteSensor"]]:
+        return self._sensor_mappings[0]
+
+    @property
+    def _sensors_by_asset_key(self) -> Mapping[AssetKey, Sequence["RemoteSensor"]]:
+        return self._sensor_mappings[1]
+
+    @cached_property
+    def _schedules_by_job_name(self) -> Mapping[str, Sequence["RemoteSchedule"]]:
+        mapping = defaultdict(list)
+        for schedule in self.get_schedules():
+            mapping[schedule.job_name].append(schedule)
+
+        return mapping
+
+    def get_sensors_targeting(self, asset_key: AssetKey) -> AbstractSet["RemoteSensor"]:
+        asset_snap = self.get_asset_node_snap(asset_key)
+        if not asset_snap:
+            return _empty_set
+
+        sensors = set()
+        if asset_key in self._sensors_by_asset_key:
+            sensors.update(self._sensors_by_asset_key[asset_key])
+
+        for job_name in asset_snap.job_names:
+            if job_name != IMPLICIT_ASSET_JOB_NAME and job_name in self._sensors_by_job_name:
+                sensors.update(self._sensors_by_job_name[job_name])
+
+        return sensors
+
+    def get_schedules_targeting(self, asset_key: AssetKey) -> AbstractSet["RemoteSchedule"]:
+        asset_snap = self.get_asset_node_snap(asset_key)
+        if not asset_snap:
+            return _empty_set
+
+        schedules = set()
+        for job_name in asset_snap.job_names:
+            if job_name != IMPLICIT_ASSET_JOB_NAME and job_name in self._schedules_by_job_name:
+                schedules.update(self._schedules_by_job_name[job_name])
+
+        return schedules
 
 
 class RemoteJob(RepresentedJob):

--- a/python_modules/dagster/dagster/_core/remote_representation/handle.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/handle.py
@@ -12,11 +12,13 @@ from dagster._core.remote_representation.origin import (
     RemoteRepositoryOrigin,
 )
 from dagster._record import IHaveNew, record, record_custom
+from dagster._serdes.serdes import whitelist_for_serdes
 
 if TYPE_CHECKING:
     from dagster._core.remote_representation.code_location import CodeLocation
 
 
+@whitelist_for_serdes
 @record
 class RepositoryHandle:
     repository_name: str

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -36,13 +36,18 @@ from dagster._core.remote_representation import (
     RemoteJob,
     RepositoryHandle,
 )
-from dagster._core.remote_representation.external import RemoteRepository
+from dagster._core.remote_representation.external import (
+    RemoteRepository,
+    RemoteSchedule,
+    RemoteSensor,
+)
 from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
 from dagster._core.remote_representation.grpc_server_state_subscriber import (
     LocationStateChangeEvent,
     LocationStateChangeEventType,
     LocationStateSubscriber,
 )
+from dagster._core.remote_representation.handle import InstigatorHandle
 from dagster._core.remote_representation.origin import (
     GrpcServerCodeLocationOrigin,
     ManagedGrpcPythonEnvCodeLocationOrigin,
@@ -341,9 +346,25 @@ class BaseWorkspaceRequestContext(LoadingContext):
 
         return self.get_workspace_snapshot().asset_graph.get(asset_key)
 
-    def get_repository(self, selector: RepositorySelector) -> RemoteRepository:
+    def get_repository(
+        self, selector: Union[RepositorySelector, RepositoryHandle]
+    ) -> RemoteRepository:
         return self.get_code_location(selector.location_name).get_repository(
             selector.repository_name
+        )
+
+    def get_sensor(self, selector: InstigatorHandle) -> RemoteSensor:
+        return (
+            self.get_code_location(selector.location_name)
+            .get_repository(selector.repository_name)
+            .get_sensor(selector.instigator_name)
+        )
+
+    def get_schedule(self, selector: InstigatorHandle) -> RemoteSchedule:
+        return (
+            self.get_code_location(selector.location_name)
+            .get_repository(selector.repository_name)
+            .get_schedule(selector.instigator_name)
         )
 
 

--- a/python_modules/dagster/dagster/_serdes/serdes.py
+++ b/python_modules/dagster/dagster/_serdes/serdes.py
@@ -871,6 +871,14 @@ def pack_value(
 ) -> Sequence[JsonSerializableValue]: ...
 
 
+@overload
+def pack_value(
+    val: PackableValue,
+    whitelist_map: WhitelistMap = ...,
+    descent_path: Optional[str] = ...,
+) -> JsonSerializableValue: ...
+
+
 def pack_value(
     val: PackableValue,
     whitelist_map: WhitelistMap = _WHITELIST_MAP,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -42,6 +42,7 @@ from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.remote_representation.external_data import RepositorySnap
 from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.test_utils import freeze_time, instance_for_test, mock_workspace_from_repos
+from dagster._serdes.serdes import deserialize_value, serialize_value
 from dagster._time import create_datetime, get_current_datetime
 
 
@@ -894,3 +895,16 @@ def test_cross_code_location_partition_mapping() -> None:
         asset_graph.get_partition_mapping(key=b.key, parent_asset_key=a.key),
         TimeWindowPartitionMapping,
     )
+
+
+def test_serdes() -> None:
+    @asset
+    def a(): ...
+
+    @repository
+    def repo():
+        return [a]
+
+    asset_graph = mock_workspace_from_repos([repo]).asset_graph
+    for node in asset_graph.asset_nodes:
+        assert node == deserialize_value(serialize_value(node))


### PR DESCRIPTION
Make the global and repository scoped `RemoteAssetNode` serializable so we can persist/cache the resolved global asset node of a workspace.

## How I Tested These Changes

added test
