### PR TITLE
[FOU-402] Add AutomationCondition.asset_matches() capability

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, AbstractSet, Dict, NamedTuple, Optional, Type, TypeVar
+from typing import TYPE_CHECKING, AbstractSet, Dict, NamedTuple, Optional, Type, TypeVar, cast
 
 from dagster import _check as check
 from dagster._core.asset_graph_view.entity_subset import EntitySubset, _ValidatedEntitySubsetValue
@@ -269,6 +269,48 @@ class AssetGraphView(LoadingContext):
                 key=child_key,
                 value=_ValidatedEntitySubsetValue(child_partitions_subset),
             )
+
+    def compute_map_subset(
+        self, to_key: T_EntityKey, subset: EntitySubset[T_EntityKey]
+    ) -> EntitySubset[T_EntityKey]:
+        from_key = subset.key
+        from_partitions_def = self.asset_graph.get(from_key).partitions_def
+        to_partitions_def = self.asset_graph.get(to_key).partitions_def
+
+        if isinstance(to_key, AssetKey):
+            to_subset = self.compute_parent_subset(to_key, subset)
+            if not to_subset.is_empty:
+                return cast(EntitySubset[T_EntityKey], to_subset)
+
+        if isinstance(from_key, AssetKey):
+            to_subset = self.compute_child_subset(to_key, cast(EntitySubset[AssetKey], subset))
+            if not to_subset.is_empty:
+                return to_subset
+
+        partition_mapping = self.asset_graph.get_partition_mapping(from_key, to_key)
+
+        if from_partitions_def is None or to_partitions_def is None:
+            return (
+                self.get_empty_subset(key=to_key)
+                if subset.is_empty
+                else self.get_full_subset(key=to_key)
+            )
+
+        to_partitions_subset = (
+            partition_mapping.get_upstream_mapped_partitions_result_for_partitions(
+                downstream_partitions_subset=None,
+                downstream_partitions_def=None,
+                upstream_partitions_def=to_partitions_def,
+                dynamic_partitions_store=self._queryer,
+                current_time=self.effective_dt,
+            )
+        ).partitions_subset
+
+        return EntitySubset(
+            self,
+            key=to_key,
+            value=_ValidatedEntitySubsetValue(to_partitions_subset),
+        )
 
     def compute_intersection_with_partition_keys(
         self, partition_keys: AbstractSet[str], asset_subset: EntitySubset[AssetKey]

--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -271,7 +271,7 @@ class AssetGraphView(LoadingContext):
             )
 
     def compute_mapped_subset(
-        self, to_key: T_EntityKey, from_subset: EntitySubset[AssetKey]
+        self, to_key: T_EntityKey, from_subset: EntitySubset
     ) -> EntitySubset[T_EntityKey]:
         from_key = from_subset.key
         from_partitions_def = self.asset_graph.get(from_key).partitions_def
@@ -294,7 +294,7 @@ class AssetGraphView(LoadingContext):
                 dynamic_partitions_store=self._queryer,
                 current_time=self.effective_dt,
             )
-        elif from_key in self.asset_graph.get(to_key).child_entity_keys:
+        else:
             to_partitions_subset = (
                 partition_mapping.get_upstream_mapped_partitions_result_for_partitions(
                     downstream_partitions_subset=from_subset.get_internal_subset_value(),
@@ -304,16 +304,6 @@ class AssetGraphView(LoadingContext):
                     current_time=self.effective_dt,
                 ).partitions_subset
             )
-        else:
-            to_partitions_subset = (
-                partition_mapping.get_upstream_mapped_partitions_result_for_partitions(
-                    downstream_partitions_subset=None,
-                    downstream_partitions_def=None,
-                    upstream_partitions_def=to_partitions_def,
-                    dynamic_partitions_store=self._queryer,
-                    current_time=self.effective_dt,
-                )
-            ).partitions_subset
 
         return EntitySubset(
             self,

--- a/python_modules/dagster/dagster/_core/asset_graph_view/entity_subset.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/entity_subset.py
@@ -104,6 +104,10 @@ class EntitySubset(Generic[T_EntityKey]):
     def compute_child_subset(self, child_key: U_EntityKey) -> "EntitySubset[U_EntityKey]":
         return self._asset_graph_view.compute_child_subset(child_key, self)
 
+    @cached_method
+    def compute_map_subset(self, to_key: U_EntityKey) -> "EntitySubset[U_EntityKey]":
+        return self._asset_graph_view.compute_map_subset(to_key, self)  # type: ignore
+
     @property
     def size(self) -> int:
         if isinstance(self._value, bool):

--- a/python_modules/dagster/dagster/_core/asset_graph_view/entity_subset.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/entity_subset.py
@@ -105,8 +105,10 @@ class EntitySubset(Generic[T_EntityKey]):
         return self._asset_graph_view.compute_child_subset(child_key, self)
 
     @cached_method
-    def compute_map_subset(self, to_key: U_EntityKey) -> "EntitySubset[U_EntityKey]":
-        return self._asset_graph_view.compute_map_subset(to_key, self)  # type: ignore
+    def compute_mapped_subset(
+        self: "EntitySubset[AssetKey]", to_key: U_EntityKey
+    ) -> "EntitySubset[U_EntityKey]":
+        return self._asset_graph_view.compute_mapped_subset(to_key, self)
 
     @property
     def size(self) -> int:

--- a/python_modules/dagster/dagster/_core/asset_graph_view/entity_subset.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/entity_subset.py
@@ -105,9 +105,7 @@ class EntitySubset(Generic[T_EntityKey]):
         return self._asset_graph_view.compute_child_subset(child_key, self)
 
     @cached_method
-    def compute_mapped_subset(
-        self: "EntitySubset[AssetKey]", to_key: U_EntityKey
-    ) -> "EntitySubset[U_EntityKey]":
+    def compute_mapped_subset(self, to_key: U_EntityKey) -> "EntitySubset[U_EntityKey]":
         return self._asset_graph_view.compute_mapped_subset(to_key, self)
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
         AnyChecksCondition,
         AnyDepsCondition,
         AnyDownstreamConditionsCondition,
+        AssetMatchesCondition,
         NewlyTrueCondition,
         NotAutomationCondition,
         OrAutomationCondition,
@@ -238,6 +239,17 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
                     | AutomationCondition[AssetKey].newly_updated()
                 ).with_label("handled")
             )
+
+    @public
+    @experimental
+    @staticmethod
+    def asset_matches(
+        to_key: T_EntityKey, condition: "AutomationCondition"
+    ) -> "AssetMatchesCondition":
+        """Returns an AutomationCondition that is true if this condition is true for the given entity key."""
+        from dagster._core.definitions.declarative_automation.operators import AssetMatchesCondition
+
+        return AssetMatchesCondition(to_key=to_key, operand=condition)
 
     @public
     @experimental

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -9,7 +9,12 @@ import dagster._check as check
 from dagster._annotations import experimental, public
 from dagster._core.asset_graph_view.entity_subset import EntitySubset
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
-from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey, T_EntityKey
+from dagster._core.definitions.asset_key import (
+    AssetCheckKey,
+    AssetKey,
+    CoercibleToAssetKey,
+    T_EntityKey,
+)
 from dagster._core.definitions.declarative_automation.serialized_objects import (
     AssetSubsetWithMetadata,
     AutomationConditionCursor,
@@ -50,7 +55,7 @@ if TYPE_CHECKING:
         AnyChecksCondition,
         AnyDepsCondition,
         AnyDownstreamConditionsCondition,
-        AssetMatchesCondition,
+        EntityMatchesCondition,
         NewlyTrueCondition,
         NotAutomationCondition,
         OrAutomationCondition,
@@ -244,12 +249,15 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
     @experimental
     @staticmethod
     def asset_matches(
-        to_key: T_EntityKey, condition: "AutomationCondition"
-    ) -> "AssetMatchesCondition":
+        key: "CoercibleToAssetKey", condition: "AutomationCondition[AssetKey]"
+    ) -> "EntityMatchesCondition":
         """Returns an AutomationCondition that is true if this condition is true for the given entity key."""
-        from dagster._core.definitions.declarative_automation.operators import AssetMatchesCondition
+        from dagster._core.definitions.declarative_automation.operators import (
+            EntityMatchesCondition,
+        )
 
-        return AssetMatchesCondition(to_key=to_key, operand=condition)
+        asset_key = AssetKey.from_coercible(key)
+        return EntityMatchesCondition(key=asset_key, operand=condition)
 
     @public
     @experimental

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/__init__.py
@@ -13,6 +13,7 @@ from dagster._core.definitions.declarative_automation.operators.check_operators 
 from dagster._core.definitions.declarative_automation.operators.dep_operators import (
     AllDepsCondition as AllDepsCondition,
     AnyDepsCondition as AnyDepsCondition,
+    AssetMatchesCondition as AssetMatchesCondition,
 )
 from dagster._core.definitions.declarative_automation.operators.newly_true_operator import (
     NewlyTrueCondition as NewlyTrueCondition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/__init__.py
@@ -13,7 +13,7 @@ from dagster._core.definitions.declarative_automation.operators.check_operators 
 from dagster._core.definitions.declarative_automation.operators.dep_operators import (
     AllDepsCondition as AllDepsCondition,
     AnyDepsCondition as AnyDepsCondition,
-    AssetMatchesCondition as AssetMatchesCondition,
+    EntityMatchesCondition as EntityMatchesCondition,
 )
 from dagster._core.definitions.declarative_automation.operators.newly_true_operator import (
     NewlyTrueCondition as NewlyTrueCondition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -53,6 +53,23 @@ class DepConditionWrapperCondition(BuiltinAutomationCondition[T_EntityKey]):
         )
 
 
+@whitelist_for_serdes
+class AssetMatchesCondition(BuiltinAutomationCondition[T_EntityKey]):
+    to_key: T_EntityKey
+    operand: AutomationCondition
+
+    def evaluate(self, context: AutomationContext[T_EntityKey]) -> AutomationResult[T_EntityKey]:
+        to_candidate_subset = context.candidate_subset.compute_map_subset(self.to_key)
+        to_context = context.for_child_condition(
+            child_condition=self.operand, child_index=0, candidate_subset=to_candidate_subset
+        )
+
+        to_result = self.operand.evaluate(to_context)
+
+        true_subset = to_result.true_subset.compute_map_subset(context.key)
+        return AutomationResult(context=context, true_subset=true_subset, child_results=[to_result])
+
+
 @record
 class DepCondition(BuiltinAutomationCondition[T_EntityKey]):
     operand: AutomationCondition

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -54,12 +54,13 @@ class DepConditionWrapperCondition(BuiltinAutomationCondition[T_EntityKey]):
 
 
 @whitelist_for_serdes
-class AssetMatchesCondition(BuiltinAutomationCondition[T_EntityKey]):
-    to_key: T_EntityKey
+@record
+class EntityMatchesCondition(BuiltinAutomationCondition[T_EntityKey]):
+    key: T_EntityKey
     operand: AutomationCondition
 
     def evaluate(self, context: AutomationContext[T_EntityKey]) -> AutomationResult[T_EntityKey]:
-        to_candidate_subset = context.candidate_subset.compute_mapped_subset(self.to_key)
+        to_candidate_subset = context.candidate_subset.compute_mapped_subset(self.key)
         to_context = context.for_child_condition(
             child_condition=self.operand, child_index=0, candidate_subset=to_candidate_subset
         )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -59,14 +59,14 @@ class AssetMatchesCondition(BuiltinAutomationCondition[T_EntityKey]):
     operand: AutomationCondition
 
     def evaluate(self, context: AutomationContext[T_EntityKey]) -> AutomationResult[T_EntityKey]:
-        to_candidate_subset = context.candidate_subset.compute_map_subset(self.to_key)
+        to_candidate_subset = context.candidate_subset.compute_mapped_subset(self.to_key)
         to_context = context.for_child_condition(
             child_condition=self.operand, child_index=0, candidate_subset=to_candidate_subset
         )
 
         to_result = self.operand.evaluate(to_context)
 
-        true_subset = to_result.true_subset.compute_map_subset(context.key)
+        true_subset = to_result.true_subset.compute_mapped_subset(context.key)
         return AutomationResult(context=context, true_subset=true_subset, child_results=[to_result])
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition_tester.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition_tester.py
@@ -1,5 +1,6 @@
 import datetime
 
+import pytest
 from dagster import (
     AssetsDefinition,
     AssetSelection,
@@ -14,6 +15,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetExecutionType
+from dagster._core.definitions.events import AssetMaterialization
 from dagster._core.instance import DagsterInstance
 
 
@@ -126,3 +128,84 @@ def test_observable_asset_defs() -> None:
         evaluation_time=evaluation_time,
     )
     assert result.total_requested == 3
+
+
+@pytest.mark.parametrize(
+    ("a_partitions_def", "b_partitions_def", "expected_requested"),
+    [
+        (None, None, 1),
+        (None, HourlyPartitionsDefinition("2020-01-01-00:00"), 24),
+        (HourlyPartitionsDefinition("2020-01-01-00:00"), None, 1),
+        (
+            HourlyPartitionsDefinition("2020-01-01-00:00"),
+            HourlyPartitionsDefinition("2020-01-01-00:00"),
+            24,
+        ),
+        (
+            HourlyPartitionsDefinition("2020-01-01-00:00"),
+            StaticPartitionsDefinition(["a", "b", "c"]),
+            0,
+        ),
+        (
+            StaticPartitionsDefinition(["a", "b", "c"]),
+            StaticPartitionsDefinition(["a", "b", "c"]),
+            3,
+        ),
+    ],
+)
+def test_asset_matches(a_partitions_def, b_partitions_def, expected_requested) -> None:
+    # default: a -> b
+    def _get_asset_defs(b_upstream: bool = False, no_deps: bool = False) -> Definitions:
+        if no_deps:
+            a_deps = None
+            b_deps = None
+        elif b_upstream:
+            a_deps = ["b"]
+            b_deps = None
+        else:
+            a_deps = None
+            b_deps = ["a"]
+
+        @asset(
+            deps=a_deps,
+            partitions_def=a_partitions_def,
+        )
+        def a() -> None: ...
+
+        @asset(
+            deps=b_deps,
+            partitions_def=b_partitions_def,
+            auto_materialize_policy=AutomationCondition.asset_matches(
+                AssetKey("a"), AutomationCondition.missing()
+            ).as_auto_materialize_policy(),
+        )
+        def b() -> None: ...
+
+        return Definitions(assets=[a, b])
+
+    evaluation_time = datetime.datetime(2020, 1, 2)
+
+    for asset_defs in [
+        _get_asset_defs(),
+        _get_asset_defs(b_upstream=True),
+        _get_asset_defs(no_deps=True),
+    ]:
+        instance = DagsterInstance.ephemeral()
+
+        result = evaluate_automation_conditions(
+            defs=asset_defs,
+            instance=instance,
+            evaluation_time=evaluation_time,
+        )
+        assert result.total_requested == expected_requested
+
+        # if a is unpartitioned, test when a is materialized
+        if a_partitions_def is None:
+            instance.report_runless_asset_event(AssetMaterialization("a"))
+            result = evaluate_automation_conditions(
+                defs=asset_defs,
+                instance=instance,
+                cursor=result.cursor,
+                evaluation_time=evaluation_time,
+            )
+            assert result.total_requested == 0


### PR DESCRIPTION
## Summary & Motivation
Right now, we allow users to apply an arbitrary AutomationCondition against all of its dependencies.
However, there is no way for a user to apply an arbitrary AutomationCondition against an arbitrary non-dependency.

## How I Tested These Changes
```
pytest python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition_tester.py::test_asset_matches
```

## Changelog
Add AutomationCondition.asset_matches() capability

- [x] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
