### PR TITLE
Updated dagster-instance.mdx Add requirement for UTC timezone in PostgreSQL configuration

### DIFF
--- a/docs/content/deployment/dagster-instance.mdx
+++ b/docs/content/deployment/dagster-instance.mdx
@@ -276,7 +276,7 @@ To use a PostgreSQL database (<PyObject module="dagster_postgres" object="Dagste
 
 ```yaml file=/deploying/dagster_instance/dagster.yaml startafter=start_marker_storage_postgres endbefore=end_marker_storage_postgres
 # Postgres storage can be set using either credentials or a connection string.  This requires that
-# the `dagster-postgres` library be installed.
+# the `dagster-postgres` library be installed and a database configured to use the UTC timezone.
 
 # this config manually sets the Postgres credentials
 storage:
@@ -285,7 +285,7 @@ storage:
       username: { DAGSTER_PG_USERNAME }
       password: { DAGSTER_PG_PASSWORD }
       hostname: { DAGSTER_PG_HOSTNAME }
-      db_name: { DAGSTER_PG_DB }
+      db_name: { DAGSTER_PG_DB } # UTC timezone
       port: 5432
 
 # and this config grabs the database credentials from environment variables


### PR DESCRIPTION
Just a quick add to avoid users having problems after the postgres storage configuration.

## Summary & Motivation
This update ensures users avoid potential issues related to the PostgreSQL storage configuration. The default PostgreSQL cluster is not set to the UTC timezone, which has caused problems for me and others. 

This closes #23173 

## How I Tested These Changes
No testing needed.

## Changelog
- [ ] `DOCS` Added requirement to configure PostgreSQL database to use the UTC timezone.
