### PR TITLE
disable run status popover for backfills in runs feed

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
@@ -16,7 +16,7 @@ import {CreatedByTagCell, CreatedByTagCellWrapper} from './CreatedByTag';
 import {QueuedRunCriteriaDialog} from './QueuedRunCriteriaDialog';
 import {RUN_ACTIONS_MENU_RUN_FRAGMENT, RunActionsMenu} from './RunActionsMenu';
 import {RunRowTags} from './RunRowTags';
-import {RunStatusTagWithStats} from './RunStatusTag';
+import {RunStatusTagWithStats, RunStatusTag} from './RunStatusTag';
 import {DagsterTag} from './RunTag';
 import {RunTargetLink} from './RunTargetLink';
 import {RunStateSummary, RunTime, titleForRun} from './RunUtils';
@@ -141,7 +141,9 @@ export const RunsFeedRow = ({
         <CreatedByTagCell tags={entry.tags || []} onAddTag={onAddTag} />
       </RowCell>
       <RowCell>
-        <RunStatusTagWithStats status={entry.runStatus} runId={entry.id} />
+      {entry.__typename === 'PartitionBackfill' ? <RunStatusTag status={entry.runStatus} />
+        : <RunStatusTagWithStats status={entry.runStatus} runId={entry.id} />
+      }
       </RowCell>
       <RowCell style={{flexDirection: 'column', gap: 4}}>
         <RunTime run={runTime} />

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
@@ -141,11 +141,13 @@ export const RunsFeedRow = ({
         <CreatedByTagCell tags={entry.tags || []} onAddTag={onAddTag} />
       </RowCell>
       <RowCell>
-        {entry.__typename === 'PartitionBackfill' ? (
-          <RunStatusTag status={entry.runStatus} />
-        ) : (
-          <RunStatusTagWithStats status={entry.runStatus} runId={entry.id} />
-        )}
+        <div>
+          {entry.__typename === 'PartitionBackfill' ? (
+            <RunStatusTag status={entry.runStatus} />
+          ) : (
+            <RunStatusTagWithStats status={entry.runStatus} runId={entry.id} />
+          )}
+        </div>
       </RowCell>
       <RowCell style={{flexDirection: 'column', gap: 4}}>
         <RunTime run={runTime} />

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
@@ -16,7 +16,7 @@ import {CreatedByTagCell, CreatedByTagCellWrapper} from './CreatedByTag';
 import {QueuedRunCriteriaDialog} from './QueuedRunCriteriaDialog';
 import {RUN_ACTIONS_MENU_RUN_FRAGMENT, RunActionsMenu} from './RunActionsMenu';
 import {RunRowTags} from './RunRowTags';
-import {RunStatusTagWithStats, RunStatusTag} from './RunStatusTag';
+import {RunStatusTag, RunStatusTagWithStats} from './RunStatusTag';
 import {DagsterTag} from './RunTag';
 import {RunTargetLink} from './RunTargetLink';
 import {RunStateSummary, RunTime, titleForRun} from './RunUtils';
@@ -141,9 +141,11 @@ export const RunsFeedRow = ({
         <CreatedByTagCell tags={entry.tags || []} onAddTag={onAddTag} />
       </RowCell>
       <RowCell>
-      {entry.__typename === 'PartitionBackfill' ? <RunStatusTag status={entry.runStatus} />
-        : <RunStatusTagWithStats status={entry.runStatus} runId={entry.id} />
-      }
+        {entry.__typename === 'PartitionBackfill' ? (
+          <RunStatusTag status={entry.runStatus} />
+        ) : (
+          <RunStatusTagWithStats status={entry.runStatus} runId={entry.id} />
+        )}
       </RowCell>
       <RowCell style={{flexDirection: 'column', gap: 4}}>
         <RunTime run={runTime} />


### PR DESCRIPTION
## Summary & Motivation
The RunStatusTagWithStats can't get stats for backfills, so instead we should show the non-stats RunStatusTag for backfills. 

I'm having an issue with the size of the tag though, the RunStatusTagWithStats is the expected size, but RunStatus tag is strangely wide 
<img width="175" alt="Screenshot 2024-09-27 at 9 44 11 AM" src="https://github.com/user-attachments/assets/6e329c59-7db6-448c-a2af-24045e7c3953">



## How I Tested These Changes
👀 

## Changelog

NOCHANGELOG