### PR TITLE
[dagster-embedded-elt] fix `KeyError` when fetching Sling `row_count`

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -291,7 +291,9 @@ class SlingResource(ConfigurableResource):
             ["conns", "exec", target_name, select_stmt],
             force_json=True,
         )
-        return int(self._parse_json_table_output(json.loads(output.strip()))[0]["ct"])
+        return int(
+            next(iter(self._parse_json_table_output(json.loads(output.strip()))[0].values()))
+        )
 
     def run_sling_cli(self, args: Sequence[str], force_json: bool = False) -> str:
         """Runs the Sling CLI with the given arguments and returns the output.


### PR DESCRIPTION
## Summary & Motivation
The current implementation explicitly tries to access the returned value through the `"ct"` key. This has led to a `KeyError` for us.

Whether the column name alias `"ct"` is upper or lowercase depends on the backend system. While DuckDB returns lowercase, which makes the tests pass, the Snowflake connection returns `"CT"`. By instead iterating once over the `dict_values`, we do not need to use a key to access the row count.

## How I Tested These Changes
Ran all unit tests for Sling.
## Changelog

Sling's `fetch_row_count()` method now works for databases returning uppercase column names.

- [ ] `NEW` _(added new feature or capability)_
- [X] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
