### PR TITLE
Add metadata to sensors

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3033,6 +3033,7 @@ type Sensor {
   sensorType: SensorType!
   assetSelection: AssetSelection
   tags: [DefinitionTag!]!
+  metadataEntries: [MetadataEntry!]!
 }
 
 type Target {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -4983,6 +4983,27 @@ export type Sensor = {
   id: Scalars['ID']['output'];
   jobOriginId: Scalars['String']['output'];
   metadata: SensorMetadata;
+  metadataEntries: Array<
+    | AssetMetadataEntry
+    | BoolMetadataEntry
+    | CodeReferencesMetadataEntry
+    | FloatMetadataEntry
+    | IntMetadataEntry
+    | JobMetadataEntry
+    | JsonMetadataEntry
+    | MarkdownMetadataEntry
+    | NotebookMetadataEntry
+    | NullMetadataEntry
+    | PathMetadataEntry
+    | PipelineRunMetadataEntry
+    | PythonArtifactMetadataEntry
+    | TableColumnLineageMetadataEntry
+    | TableMetadataEntry
+    | TableSchemaMetadataEntry
+    | TextMetadataEntry
+    | TimestampMetadataEntry
+    | UrlMetadataEntry
+  >;
   minIntervalSeconds: Scalars['Int']['output'];
   name: Scalars['String']['output'];
   nextTick: Maybe<DryRunInstigationTick>;
@@ -13998,6 +14019,8 @@ export const buildSensor = (
         : relationshipsToOmit.has('SensorMetadata')
         ? ({} as SensorMetadata)
         : buildSensorMetadata({}, relationshipsToOmit),
+    metadataEntries:
+      overrides && overrides.hasOwnProperty('metadataEntries') ? overrides.metadataEntries! : [],
     minIntervalSeconds:
       overrides && overrides.hasOwnProperty('minIntervalSeconds')
         ? overrides.minIntervalSeconds!

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_sensors.ambr
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/__snapshots__/test_sensors.ambr
@@ -3,8 +3,14 @@
   dict({
     '__typename': 'Sensor',
     'assetSelection': None,
+    'metadataEntries': list([
+      dict({
+        'label': 'foo',
+        'text': 'bar',
+      }),
+    ]),
     'minIntervalSeconds': 30,
-    'name': 'always_no_config_sensor_with_tags',
+    'name': 'always_no_config_sensor_with_tags_and_metadata',
     'nextTick': None,
     'sensorState': dict({
       'runs': list([
@@ -55,7 +61,7 @@
     dict({
       'description': None,
       'minIntervalSeconds': 30,
-      'name': 'always_no_config_sensor_with_tags',
+      'name': 'always_no_config_sensor_with_tags_and_metadata',
       'sensorState': dict({
         'runs': list([
         ]),

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1132,8 +1132,8 @@ def define_schedules():
 
 
 def define_sensors():
-    @sensor(job_name="no_config_job", tags={"foo": "bar"})
-    def always_no_config_sensor_with_tags(_):
+    @sensor(job_name="no_config_job", tags={"foo": "bar"}, metadata={"foo": "bar"})
+    def always_no_config_sensor_with_tags_and_metadata(_):
         return RunRequest(
             run_key=None,
             tags={"test": "1234"},
@@ -1254,7 +1254,7 @@ def define_sensors():
     )
 
     return [
-        always_no_config_sensor_with_tags,
+        always_no_config_sensor_with_tags_and_metadata,
         always_error_sensor,
         once_no_config_sensor,
         never_no_config_sensor,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
@@ -108,7 +108,7 @@ class TestNextTickRepository(NonLaunchableGraphQLContextTestMatrix):
             repository_selector["repositoryLocationName"]
         ).get_repository(repository_selector["repositoryName"])
 
-        sensor_name = "always_no_config_sensor_with_tags"
+        sensor_name = "always_no_config_sensor_with_tags_and_metadata"
         external_sensor = external_repository.get_external_sensor(sensor_name)
         selector = infer_instigation_selector(graphql_context, sensor_name)
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -173,6 +173,12 @@ query SensorQuery($sensorSelector: SensorSelector!) {
         key
         value
       }
+      metadataEntries {
+        label
+        ... on TextMetadataEntry {
+          text
+        }
+      }
       assetSelection {
         assetSelectionString
         assetKeys {
@@ -553,7 +559,7 @@ class TestSensors(NonLaunchableGraphQLContextTestMatrix):
     @pytest.mark.parametrize(
         "sensor_name, expected_type",
         [
-            ("always_no_config_sensor_with_tags", "STANDARD"),
+            ("always_no_config_sensor_with_tags_and_metadata", "STANDARD"),
             ("run_status", "RUN_STATUS"),
             ("single_asset_sensor", "ASSET"),
             ("many_asset_sensor", "MULTI_ASSET"),
@@ -579,7 +585,7 @@ class TestSensors(NonLaunchableGraphQLContextTestMatrix):
 
     def test_dry_run(self, graphql_context: WorkspaceRequestContext):
         instigator_selector = infer_sensor_selector(
-            graphql_context, "always_no_config_sensor_with_tags"
+            graphql_context, "always_no_config_sensor_with_tags_and_metadata"
         )
         result = execute_dagster_graphql(
             graphql_context,
@@ -768,7 +774,7 @@ class TestSensors(NonLaunchableGraphQLContextTestMatrix):
 
     def test_get_sensor(self, graphql_context: WorkspaceRequestContext, snapshot):
         sensor_selector = infer_sensor_selector(
-            graphql_context, "always_no_config_sensor_with_tags"
+            graphql_context, "always_no_config_sensor_with_tags_and_metadata"
         )
         result = execute_dagster_graphql(
             graphql_context,
@@ -783,12 +789,13 @@ class TestSensors(NonLaunchableGraphQLContextTestMatrix):
         snapshot.assert_match(sensor)
         assert sensor["sensorType"] == "STANDARD"
         assert sensor["tags"] == [{"key": "foo", "value": "bar"}]
+        assert sensor["metadataEntries"] == [{"label": "foo", "text": "bar"}]
 
 
 class TestReadonlySensorPermissions(ReadonlyGraphQLContextTestMatrix):
     def test_start_sensor_failure(self, graphql_context: WorkspaceRequestContext):
         sensor_selector = infer_sensor_selector(
-            graphql_context, "always_no_config_sensor_with_tags"
+            graphql_context, "always_no_config_sensor_with_tags_and_metadata"
         )
         result = execute_dagster_graphql(
             graphql_context,
@@ -801,7 +808,7 @@ class TestReadonlySensorPermissions(ReadonlyGraphQLContextTestMatrix):
 
     def test_stop_sensor_failure(self, graphql_context: WorkspaceRequestContext):
         sensor_selector = infer_sensor_selector(
-            graphql_context, "always_no_config_sensor_with_tags"
+            graphql_context, "always_no_config_sensor_with_tags_and_metadata"
         )
 
         result = execute_dagster_graphql(
@@ -826,7 +833,9 @@ class TestReadonlySensorPermissions(ReadonlyGraphQLContextTestMatrix):
         assert stop_result.data["stopSensor"]["__typename"] == "UnauthorizedError"
 
     def test_set_cursor_failure(self, graphql_context: WorkspaceRequestContext):
-        selector = infer_sensor_selector(graphql_context, "always_no_config_sensor_with_tags")
+        selector = infer_sensor_selector(
+            graphql_context, "always_no_config_sensor_with_tags_and_metadata"
+        )
 
         result = execute_dagster_graphql(
             graphql_context,
@@ -840,7 +849,7 @@ class TestReadonlySensorPermissions(ReadonlyGraphQLContextTestMatrix):
 class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
     def test_start_sensor(self, graphql_context: WorkspaceRequestContext):
         sensor_selector = infer_sensor_selector(
-            graphql_context, "always_no_config_sensor_with_tags"
+            graphql_context, "always_no_config_sensor_with_tags_and_metadata"
         )
         result = execute_dagster_graphql(
             graphql_context,
@@ -853,7 +862,7 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
 
     def test_stop_sensor(self, graphql_context: WorkspaceRequestContext):
         sensor_selector = infer_sensor_selector(
-            graphql_context, "always_no_config_sensor_with_tags"
+            graphql_context, "always_no_config_sensor_with_tags_and_metadata"
         )
 
         # start sensor
@@ -904,7 +913,7 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
             return sensor["sensorState"]["typeSpecificData"]["lastCursor"]
 
         sensor_selector = infer_sensor_selector(
-            graphql_context, "always_no_config_sensor_with_tags"
+            graphql_context, "always_no_config_sensor_with_tags_and_metadata"
         )
         assert get_cursor(sensor_selector) is None
         set_cursor(sensor_selector, "new cursor value")
@@ -971,7 +980,7 @@ class TestSensorMutations(ExecutingGraphQLContextTestMatrix):
 
     def test_reset_sensor(self, graphql_context: WorkspaceRequestContext):
         sensor_selector = infer_sensor_selector(
-            graphql_context, "always_no_config_sensor_with_tags"
+            graphql_context, "always_no_config_sensor_with_tags_and_metadata"
         )
         result = execute_dagster_graphql(
             graphql_context,
@@ -1167,7 +1176,7 @@ def test_sensor_next_ticks(graphql_context: WorkspaceRequestContext):
         main_repo_location_name()
     ).get_repository(main_repo_name())
 
-    sensor_name = "always_no_config_sensor_with_tags"
+    sensor_name = "always_no_config_sensor_with_tags_and_metadata"
     external_sensor = external_repository.get_external_sensor(sensor_name)
     sensor_selector = infer_sensor_selector(graphql_context, sensor_name)
 
@@ -1252,7 +1261,7 @@ def test_sensor_tick_range(graphql_context: WorkspaceRequestContext):
         main_repo_location_name()
     ).get_repository(main_repo_name())
 
-    sensor_name = "always_no_config_sensor_with_tags"
+    sensor_name = "always_no_config_sensor_with_tags_and_metadata"
     external_sensor = external_repository.get_external_sensor(sensor_name)
     sensor_selector = infer_sensor_selector(graphql_context, sensor_name)
 
@@ -1392,7 +1401,7 @@ def test_sensor_ticks_filtered(graphql_context: WorkspaceRequestContext):
         "repositoryLocationName": main_repo_location_name(),
         "repositoryName": main_repo_name(),
     }
-    sensor_name = "always_no_config_sensor_with_tags"
+    sensor_name = "always_no_config_sensor_with_tags_and_metadata"
     external_sensor = external_repository.get_external_sensor(sensor_name)
     sensor_selector = infer_sensor_selector(graphql_context, sensor_name)
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_sensor_definition.py
@@ -67,6 +67,8 @@ class AssetSensorDefinition(SensorDefinition):
             (experimental) A list of jobs to be executed when the sensor fires.
         tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
             be used for searching and filtering in the UI.
+        metadata (Optional[Mapping[str, object]]): A set of metadata entries that annotate the
+            sensor. Values will be normalized to typed `MetadataValue` objects.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
             status can be overridden from the Dagster UI or via the GraphQL API.
     """
@@ -87,6 +89,7 @@ class AssetSensorDefinition(SensorDefinition):
         default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
         required_resource_keys: Optional[Set[str]] = None,
         tags: Optional[Mapping[str, str]] = None,
+        metadata: Optional[Mapping[str, object]] = None,
     ):
         self._asset_key = check.inst_param(asset_key, "asset_key", AssetKey)
 
@@ -167,6 +170,7 @@ class AssetSensorDefinition(SensorDefinition):
             default_status=default_status,
             required_resource_keys=combined_required_resource_keys,
             tags=tags,
+            metadata=metadata,
         )
 
     @public

--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -69,6 +69,8 @@ class AutomationConditionSensorDefinition(SensorDefinition):
         tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
             be used for searching and filtering in the UI.
         run_tags (Optional[Mapping[str, Any]]): Tags that will be automatically attached to runs launched by this sensor.
+        metadata (Optional[Mapping[str, object]]): A set of metadata entries that annotate the
+            sensor. Values will be normalized to typed `MetadataValue` objects.
         default_status (DefaultSensorStatus): Whether the sensor starts as running or not. The default
             status can be overridden from the Dagster UI or via the GraphQL API.
         minimum_interval_seconds (Optional[int]): The frequency at which to try to evaluate the
@@ -87,6 +89,7 @@ class AutomationConditionSensorDefinition(SensorDefinition):
         default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
         minimum_interval_seconds: Optional[int] = None,
         description: Optional[str] = None,
+        metadata: Optional[Mapping[str, object]] = None,
         **kwargs,
     ):
         self._user_code = kwargs.get("user_code", False)
@@ -113,6 +116,7 @@ class AutomationConditionSensorDefinition(SensorDefinition):
             required_resource_keys=None,
             asset_selection=asset_selection,
             tags=tags,
+            metadata=metadata,
         )
 
     @property

--- a/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/sensor_decorator.py
@@ -45,6 +45,7 @@ def sensor(
     asset_selection: Optional[CoercibleToAssetSelection] = None,
     required_resource_keys: Optional[Set[str]] = None,
     tags: Optional[Mapping[str, str]] = None,
+    metadata: Optional[Mapping[str, object]] = None,
     target: Optional[
         Union[
             "CoercibleToAssetSelection",
@@ -83,6 +84,8 @@ def sensor(
             This can be provided instead of specifying a job.
         tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
             be used for searching and filtering in the UI.
+        metadata (Optional[Mapping[str, object]]): A set of metadata entries that annotate the
+            sensor. Values will be normalized to typed `MetadataValue` objects.
         target (Optional[Union[CoercibleToAssetSelection, AssetsDefinition, JobDefinition, UnresolvedAssetJobDefinition]]):
             The target that the sensor will execute.
             It can take :py:class:`~dagster.AssetSelection` objects and anything coercible to it (e.g. `str`, `Sequence[str]`, `AssetKey`, `AssetsDefinition`).
@@ -106,6 +109,7 @@ def sensor(
             asset_selection=asset_selection,
             required_resource_keys=required_resource_keys,
             tags=tags,
+            metadata=metadata,
             target=target,
         )
 
@@ -128,6 +132,7 @@ def asset_sensor(
     default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
     required_resource_keys: Optional[Set[str]] = None,
     tags: Optional[Mapping[str, str]] = None,
+    metadata: Optional[Mapping[str, object]] = None,
 ) -> Callable[
     [
         AssetMaterializationFunction,
@@ -166,6 +171,8 @@ def asset_sensor(
             status can be overridden from the Dagster UI or via the GraphQL API.
         tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
             be used for searching and filtering in the UI. Values that are not already strings will be serialized as JSON.
+        metadata (Optional[Mapping[str, object]]): A set of metadata entries that annotate the
+            sensor. Values will be normalized to typed `MetadataValue` objects.
 
 
     Example:
@@ -236,6 +243,7 @@ def asset_sensor(
             default_status=default_status,
             required_resource_keys=required_resource_keys,
             tags=tags,
+            metadata=metadata,
         )
 
     return inner
@@ -255,6 +263,7 @@ def multi_asset_sensor(
     request_assets: Optional[AssetSelection] = None,
     required_resource_keys: Optional[Set[str]] = None,
     tags: Optional[Mapping[str, str]] = None,
+    metadata: Optional[Mapping[str, object]] = None,
 ) -> Callable[
     [
         MultiAssetMaterializationFunction,
@@ -293,6 +302,9 @@ def multi_asset_sensor(
             for if the sensor condition is met. This can be provided instead of specifying a job.
         tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
             be used for searching and filtering in the UI.
+        metadata (Optional[Mapping[str, object]]): A set of metadata entries that annotate the
+            sensor. Values will be normalized to typed `MetadataValue` objects.
+
     """
     check.opt_str_param(name, "name")
 
@@ -322,6 +334,7 @@ def multi_asset_sensor(
             request_assets=request_assets,
             required_resource_keys=required_resource_keys,
             tags=tags,
+            metadata=metadata,
         )
         update_wrapper(sensor_def, wrapped=fn)
         return sensor_def

--- a/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/multi_asset_sensor_definition.py
@@ -1135,6 +1135,9 @@ class MultiAssetSensorDefinition(SensorDefinition):
             for if the sensor condition is met. This can be provided instead of specifying a job.
         tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
             be used for searching and filtering in the UI.
+        metadata (Optional[Mapping[str, object]]): A set of metadata entries that annotate the
+            sensor. Values will be normalized to typed `MetadataValue` objects.
+
     """
 
     def __init__(
@@ -1151,6 +1154,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
         request_assets: Optional[AssetSelection] = None,
         required_resource_keys: Optional[Set[str]] = None,
         tags: Optional[Mapping[str, str]] = None,
+        metadata: Optional[Mapping[str, object]] = None,
     ):
         resource_arg_names: Set[str] = {
             arg.name for arg in get_resource_args(asset_materialization_fn)
@@ -1258,6 +1262,7 @@ class MultiAssetSensorDefinition(SensorDefinition):
             asset_selection=request_assets,
             required_resource_keys=combined_required_resource_keys,
             tags=tags,
+            metadata=metadata,
         )
 
     def __call__(self, *args, **kwargs) -> AssetMaterializationFunctionReturn:

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -442,6 +442,7 @@ def run_failure_sensor(
     request_jobs: Optional[Sequence[ExecutableDefinition]] = None,
     monitor_all_repositories: bool = False,
     tags: Optional[Mapping[str, str]] = None,
+    metadata: Optional[Mapping[str, object]] = None,
 ) -> Callable[
     [RunFailureSensorEvaluationFn],
     SensorDefinition,
@@ -492,6 +493,7 @@ def run_failure_sensor(
     request_jobs: Optional[Sequence[ExecutableDefinition]] = None,
     monitor_all_repositories: Optional[bool] = None,
     tags: Optional[Mapping[str, str]] = None,
+    metadata: Optional[Mapping[str, object]] = None,
 ) -> Union[
     SensorDefinition,
     Callable[
@@ -532,6 +534,8 @@ def run_failure_sensor(
             monitored_jobs or job_selection. Defaults to False.
         tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
             be used for searching and filtering in the UI.
+        metadata (Optional[Mapping[str, object]]): A set of metadata entries that annotate the
+            sensor. Values will be normalized to typed `MetadataValue` objects.
     """
 
     def inner(
@@ -562,6 +566,7 @@ def run_failure_sensor(
             request_job=request_job,
             request_jobs=request_jobs,
             tags=tags,
+            metadata=metadata,
         )
         @functools.wraps(fn)
         def _run_failure_sensor(*args, **kwargs) -> Any:
@@ -609,6 +614,8 @@ class RunStatusSensorDefinition(SensorDefinition):
             execute if yielded from the sensor.
         tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
             be used for searching and filtering in the UI.
+        metadata (Optional[Mapping[str, object]]): A set of metadata entries that annotate the
+            sensor. Values will be normalized to typed `MetadataValue` objects.
         request_jobs (Optional[Sequence[Union[GraphDefinition, JobDefinition]]]): (experimental)
             A list of jobs to be executed if RunRequests are yielded from the sensor.
     """
@@ -637,6 +644,7 @@ class RunStatusSensorDefinition(SensorDefinition):
         request_job: Optional[ExecutableDefinition] = None,
         request_jobs: Optional[Sequence[ExecutableDefinition]] = None,
         tags: Optional[Mapping[str, str]] = None,
+        metadata: Optional[Mapping[str, object]] = None,
         required_resource_keys: Optional[Set[str]] = None,
     ):
         from dagster._core.definitions.selector import (
@@ -963,6 +971,7 @@ class RunStatusSensorDefinition(SensorDefinition):
             jobs=request_jobs,
             required_resource_keys=combined_required_resource_keys,
             tags=tags,
+            metadata=metadata,
         )
 
     def __call__(self, *args, **kwargs) -> RawSensorEvaluationFunctionReturn:
@@ -1032,6 +1041,7 @@ def run_status_sensor(
     request_jobs: Optional[Sequence[ExecutableDefinition]] = None,
     monitor_all_repositories: Optional[bool] = None,
     tags: Optional[Mapping[str, str]] = None,
+    metadata: Optional[Mapping[str, object]] = None,
 ) -> Callable[
     [RunStatusSensorEvaluationFunction],
     RunStatusSensorDefinition,
@@ -1070,6 +1080,8 @@ def run_status_sensor(
             Defaults to False.
         tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
             be used for searching and filtering in the UI.
+        metadata (Optional[Mapping[str, object]]): A set of metadata entries that annotate the
+            sensor. Values will be normalized to typed `MetadataValue` objects.
     """
 
     def inner(
@@ -1104,6 +1116,7 @@ def run_status_sensor(
             request_job=request_job,
             request_jobs=request_jobs,
             tags=tags,
+            metadata=metadata,
         )
 
     return inner

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -439,9 +439,16 @@ class TargetSnap:
 @whitelist_for_serdes(storage_name="ExternalSensorMetadata")
 @record
 class SensorMetadataSnap:
-    """Stores additional sensor metadata which is available in the Dagster UI."""
+    """Stores sensor metadata which is available in the Dagster UI.
+
+    This is an unfortunate legacy class that is out of line with our preferred pattern of storing
+    standard `Mapping[str, MetadataValue]` under the metadata field. Because this class already
+    existed when adding this standard metadata to sensors, we stash it on here as a field under
+    `standard_metadata`.
+    """
 
     asset_keys: Optional[Sequence[AssetKey]]
+    standard_metadata: Optional[Mapping[str, MetadataValue]] = None
 
 
 @whitelist_for_serdes(
@@ -573,7 +580,9 @@ class SensorSnap(IHaveNew):
             target_dict=target_dict,
             min_interval=sensor_def.minimum_interval_seconds,
             description=sensor_def.description,
-            metadata=SensorMetadataSnap(asset_keys=asset_keys),
+            metadata=SensorMetadataSnap(
+                asset_keys=asset_keys, standard_metadata=sensor_def.metadata
+            ),
             default_status=sensor_def.default_status,
             sensor_type=sensor_def.sensor_type,
             asset_selection=serializable_asset_selection,

--- a/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_sensor_decorator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/definitions_tests/decorators_tests/test_sensor_decorator.py
@@ -1,4 +1,5 @@
 from dagster import AssetKey, asset, sensor
+from dagster._core.definitions.metadata.metadata_value import MetadataValue
 
 
 def test_coerce_to_asset_selection():
@@ -42,3 +43,12 @@ def test_sensor_tags():
 
     # auto-serialized to JSON
     assert my_sensor.tags == {"foo": "bar"}
+
+
+def test_sensor_metadata():
+    @sensor(metadata={"foo": "bar"})
+    def my_sensor():
+        pass
+
+    # auto-serialized to JSON
+    assert my_sensor.metadata["foo"] == MetadataValue.text("bar")


### PR DESCRIPTION
## Summary & Motivation

Add standard `metadata` to `@sensor`, `SensorDefinition`, and all sensor subclasses.

Threading metadata through the serdes layer was slightly complicated by the presence of an existing `ExternalSensorMetadata` object with a single field `asset_keys` that is already passed as `SensorSnap.metadata`. This was added three years ago before we had the standard of using a `Mapping[str, MetadataValue]` on all definitions.

I attached the standard metadata as `standard_metadata` on this object rather than placing it directly on `SensorSnap`, since `SensorSnap.metadata` was already taken.

## How I Tested These Changes

New unit tests.

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
