### PR TITLE
Fix a typo in dlt.mdx

### DIFF
--- a/docs/content/integrations/embedded-elt/dlt.mdx
+++ b/docs/content/integrations/embedded-elt/dlt.mdx
@@ -53,7 +53,7 @@ pipeline = dlt.pipeline(
 )
 ```
 
-A dlt source and pipelinea are the two components required to load data using dlt. These will be the parameters of our multi-asset, which will integrate dlt and Dagster.
+A dlt source and pipeline are the two components required to load data using dlt. These will be the parameters of our multi-asset, which will integrate dlt and Dagster.
 
 ---
 


### PR DESCRIPTION
## Summary & Motivation

This PR fixes a typo in docs on the `dlt.mdx` page.

## How I Tested These Changes

Didn't test it.

## Changelog

NOCHANGELOG