### PR TITLE
Revert "explicitly set kwargs_fields to fix bk (#24750)"

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -55,7 +55,7 @@ class ValueDiff(Generic[T]):
     new: T
 
 
-@whitelist_for_serdes(kwargs_fields={"added_keys", "changed_keys", "removed_keys"})
+@whitelist_for_serdes
 @record
 class DictDiff(Generic[T]):
     added_keys: AbstractSet[T]


### PR DESCRIPTION
## Summary

Now that records and generics are fixed, revert this change as it's no longer necessary.

## Test Plan

See if backcompat test works on bk.

## Changelog

NOCHANGELOG