### PR TITLE
show runs within backfill checkbox

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/TokenizingField.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/TokenizingField.tsx
@@ -85,6 +85,7 @@ export function tokenizedValueFromString(
   providers: SuggestionProvider[],
 ): TokenizingFieldValue {
   const [token, value] = tokenizeString(str);
+  console.log({token, value});
   if (findProviderByToken(token, providers)) {
     if (token && value) {
       return {token, value};

--- a/js_modules/dagster-ui/packages/ui-components/src/components/TokenizingField.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/TokenizingField.tsx
@@ -85,7 +85,6 @@ export function tokenizedValueFromString(
   providers: SuggestionProvider[],
 ): TokenizingFieldValue {
   const [token, value] = tokenizeString(str);
-  console.log({token, value});
   if (findProviderByToken(token, providers)) {
     if (token && value) {
       return {token, value};

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
@@ -126,7 +126,15 @@ export const RunsFeedRoot = () => {
   const combinedRefreshState = useMergedRefresh(countRefreshState, refreshState);
   const {error} = queryResult;
 
-  const [hideSubRuns, setHideSubRuns] = useState(false);
+  const showRunsWithinBackfills = useMemo(() => {
+    const excludeToken = filterTokens.find(
+      (token) => token?.token === 'exclude_runs_within_backfills',
+    );
+    if (!excludeToken) {
+      return false;
+    }
+    return excludeToken.value === 'false';
+  }, [filterTokens]);
 
   const actionBarComponents = (
     <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
@@ -128,24 +128,44 @@ export const RunsFeedRoot = () => {
 
   const showRunsWithinBackfills = useMemo(() => {
     const excludeToken = filterTokens.find(
-      (token) => token?.token === 'exclude_runs_within_backfills',
+      (token) => token?.token === 'show_runs_within_backfills',
     );
     if (!excludeToken) {
+      // If the token doesn't exist, the box is not checked
       return false;
     }
-    return excludeToken.value === 'false';
+    return excludeToken.value === 'true';
   }, [filterTokens]);
 
   const actionBarComponents = (
     <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
       {button}
       <Checkbox
-        label={<span>Hide sub-runs</span>}
-        checked={hideSubRuns}
-        onChange={() => {
-          setHideSubRuns(!hideSubRuns);
-        }}
-      />
+              label={<span>Show runs within backfills</span>}
+              checked={showRunsWithinBackfills}
+              onChange={() => {
+                setFilterTokens((filterTokens) => {
+                  const copy = [...filterTokens];
+                  console.log({copy});
+                  const index = copy.findIndex(
+                    (token) => token?.token === 'show_runs_within_backfills',
+                  );
+                  if (index !== -1) {
+                    const [token] = copy.splice(index, 1);
+                    if (token?.value === 'false') {
+                      copy.push({
+                        token: 'show_runs_within_backfills',
+                        value: 'true',
+                      });
+                    }
+                    // if the token value is true, removing it is enough to disable the filter
+                  } else {
+                    copy.push({token: 'show_runs_within_backfills', value: 'true'});
+                  }
+                  return copy;
+                });
+              }}
+            />
     </Box>
   );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
@@ -1,6 +1,6 @@
 import {Box, Checkbox, Colors, NonIdealState, tokenToString} from '@dagster-io/ui-components';
 import partition from 'lodash/partition';
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import {RunsQueryRefetchContext} from './RunUtils';
 import {RUNS_FEED_TABLE_ENTRY_FRAGMENT} from './RunsFeedRow';
@@ -141,30 +141,28 @@ export const RunsFeedRoot = () => {
     <Box flex={{direction: 'row', gap: 8, alignItems: 'center'}}>
       {button}
       <Checkbox
-              label={<span>Show runs within backfills</span>}
-              checked={showRunsWithinBackfills}
-              onChange={() => {
-                setFilterTokens((filterTokens) => {
-                  const copy = [...filterTokens];
-                  const index = copy.findIndex(
-                    (token) => token?.token === 'show_runs_within_backfills',
-                  );
-                  if (index !== -1) {
-                    const [token] = copy.splice(index, 1);
-                    if (token?.value === 'false') {
-                      copy.push({
-                        token: 'show_runs_within_backfills',
-                        value: 'true',
-                      });
-                    }
-                    // if the token value is true, removing it is enough to disable the filter
-                  } else {
-                    copy.push({token: 'show_runs_within_backfills', value: 'true'});
-                  }
-                  return copy;
+        label={<span>Show runs within backfills</span>}
+        checked={showRunsWithinBackfills}
+        onChange={() => {
+          setFilterTokens((filterTokens) => {
+            const copy = [...filterTokens];
+            const index = copy.findIndex((token) => token?.token === 'show_runs_within_backfills');
+            if (index !== -1) {
+              const [token] = copy.splice(index, 1);
+              if (token?.value === 'false') {
+                copy.push({
+                  token: 'show_runs_within_backfills',
+                  value: 'true',
                 });
-              }}
-            />
+              }
+              // if the token value is true, removing it is enough to disable the filter
+            } else {
+              copy.push({token: 'show_runs_within_backfills', value: 'true'});
+            }
+            return copy;
+          });
+        }}
+      />
     </Box>
   );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
@@ -146,7 +146,6 @@ export const RunsFeedRoot = () => {
               onChange={() => {
                 setFilterTokens((filterTokens) => {
                   const copy = [...filterTokens];
-                  console.log({copy});
                   const index = copy.findIndex(
                     (token) => token?.token === 'show_runs_within_backfills',
                   );

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -113,7 +113,6 @@ export function useQueryPersistedRunFilters(enabledFilters?: RunFilterTokenType[
           return {q: tokensAsStringArray(tokens), cursor: undefined};
         },
         decode: ({q = []}) => {
-
           const res = tokenizedValuesFromStringArray(q, RUN_PROVIDERS_EMPTY);
           return res.filter(
             (t) =>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -110,14 +110,11 @@ export function useQueryPersistedRunFilters(enabledFilters?: RunFilterTokenType[
     useMemo(
       () => ({
         encode: (tokens) => {
-          console.log({tokens});
           return {q: tokensAsStringArray(tokens), cursor: undefined};
         },
         decode: ({q = []}) => {
-          console.log({q});
 
           const res = tokenizedValuesFromStringArray(q, RUN_PROVIDERS_EMPTY);
-          console.log({res});
           return res.filter(
             (t) =>
               !t.token || !enabledFilters || enabledFilters.includes(t.token as RunFilterTokenType),
@@ -166,9 +163,9 @@ export function runsFilterForSearchTokens(search: TokenizingFieldValue[]) {
         obj.tags = [{key: key!, value}];
       }
     } else if (item.token === 'show_runs_within_backfills') {
-      // the Runs filter expects a boolen on whether to exclude runs that are within
-      // backfills. The UI checkbox is whether to show runs within backfills, so we
-      // negate the value when creating the filter to pass to the backend.
+      // the Runs filter expects a boolen on whether to **exclude** runs that are within
+      // backfills. The UI checkbox is whether to **show** runs within backfills, so we
+      // negate the value when creating the filter
       obj.excludeSubruns = item.value === 'false';
     }
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -109,16 +109,12 @@ export function useQueryPersistedRunFilters(enabledFilters?: RunFilterTokenType[
   return useQueryPersistedState<RunFilterToken[]>(
     useMemo(
       () => ({
-        encode: (tokens) => {
-          return {q: tokensAsStringArray(tokens), cursor: undefined};
-        },
-        decode: ({q = []}) => {
-          const res = tokenizedValuesFromStringArray(q, RUN_PROVIDERS_EMPTY);
-          return res.filter(
+        encode: (tokens) => ({q: tokensAsStringArray(tokens), cursor: undefined}),
+        decode: ({q = []}) =>
+          tokenizedValuesFromStringArray(q, RUN_PROVIDERS_EMPTY).filter(
             (t) =>
               !t.token || !enabledFilters || enabledFilters.includes(t.token as RunFilterTokenType),
-          ) as RunFilterToken[];
-        },
+          ) as RunFilterToken[],
       }),
       [enabledFilters],
     ),

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -51,7 +51,7 @@ export type RunFilterTokenType =
   | 'backfill'
   | 'created_date_before'
   | 'created_date_after'
-  | 'exclude_runs_within_backfills';
+  | 'show_runs_within_backfills';
 
 export type RunFilterToken = {
   token?: RunFilterTokenType;
@@ -92,7 +92,7 @@ const RUN_PROVIDERS_EMPTY = [
     values: () => [],
   },
   {
-    token: 'exclude_runs_within_backfills',
+    token: 'show_runs_within_backfills',
     values: () => [],
   },
 ];
@@ -165,8 +165,11 @@ export function runsFilterForSearchTokens(search: TokenizingFieldValue[]) {
       } else {
         obj.tags = [{key: key!, value}];
       }
-    } else if (item.token === 'exclude_runs_within_backfills') {
-      obj.excludeSubruns = item.value == 'true';
+    } else if (item.token === 'show_runs_within_backfills') {
+      // the Runs filter expects a boolen on whether to exclude runs that are within
+      // backfills. The UI checkbox is whether to show runs within backfills, so we
+      // negate the value when creating the filter to pass to the backend.
+      obj.excludeSubruns = item.value === 'false';
     }
   }
 


### PR DESCRIPTION
## Summary & Motivation
Hooks up the "show runs within backfills" checkbox to the backend

## How I Tested These Changes
View with runs in backfills hidden (default view)
<img width="960" alt="Screenshot 2024-09-27 at 2 17 34 PM" src="https://github.com/user-attachments/assets/5c1aff27-e1de-4d79-8a65-17b7a25e5490">

View showing runs in backfills 
<img width="960" alt="Screenshot 2024-09-27 at 2 17 25 PM" src="https://github.com/user-attachments/assets/e4f96128-3e80-4444-8da7-158d03131ce2">


## Changelog
NOCHANGELOG