### PR TITLE
[ui] Fix Asset column schema tags

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/metadata/TableSchema.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/metadata/TableSchema.tsx
@@ -122,12 +122,14 @@ export const TableSchema = ({
                 <Mono>{column.name}</Mono>
               </td>
               <td>
-                <TypeTag type={column.type} />
-                {!column.constraints.nullable && NonNullableTag}
-                {column.constraints.unique && UniqueTag}
-                {column.constraints.other.map((constraint, i) => (
-                  <ArbitraryConstraintTag key={i} constraint={constraint} />
-                ))}
+                <Box flex={{wrap: 'wrap', gap: 4, alignItems: 'center'}}>
+                  <TypeTag type={column.type} />
+                  {!column.constraints.nullable && NonNullableTag}
+                  {column.constraints.unique && UniqueTag}
+                  {column.constraints.other.map((constraint, i) => (
+                    <ArbitraryConstraintTag key={i} constraint={constraint} />
+                  ))}
+                </Box>
               </td>
               <td>
                 <Description description={column.description} />


### PR DESCRIPTION
## Summary & Motivation

Column schema tags are a little misaligned, fix them by putting them in a wrapping flexbox.

Before:

<img width="482" alt="Screenshot 2024-09-27 at 13 53 23" src="https://github.com/user-attachments/assets/7cfa4947-f373-43a8-a7d7-c5e93018dd58">

After:

<img width="489" alt="Screenshot 2024-09-27 at 13 52 43" src="https://github.com/user-attachments/assets/b3602daa-3652-4955-b16d-1b3dbba8dc80">


## How I Tested These Changes

Add a column schema to an asset, verify that tags render and wrap nicely.

## Changelog

- [ ] `BUGFIX` [ui] Fixed tag wrapping on asset column schema table.
