### PR TITLE
Make invariant that canceling runs must have a canceling event fail open

### DIFF
--- a/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
+++ b/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
@@ -71,7 +71,8 @@ def monitor_canceling_run(
     )
 
     if not canceling_events:
-        raise Exception("Run in status CANCELING doesn't have a RUN_CANCELING event")
+        logger.warning("Run in status CANCELING doesn't have a RUN_CANCELING event")
+        return
 
     event = canceling_events[0]
 


### PR DESCRIPTION
## Summary & Motivation
This is typically the case, but on runs launched from much older versions of dagster can be un-true. Make it a warning instead of stopping the daemon in its tracks.


## How I Tested These Changes
BK

## Changelog
NOCHANGELOG
