### PR TITLE
Put dags downstream of automapped tasks

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -460,3 +460,8 @@ def test_automapped_build() -> None:
 
     assert "dagster/kind/airflow" in specs[dag1_task1].tags
     assert "dagster/kind/task" in specs[dag1_task1].tags
+
+    assert set(specs[make_default_dag_asset_key("dag1")].deps) == {
+        AssetDep(dag1_standalone),
+        AssetDep(dag1_task2),
+    }


### PR DESCRIPTION
## Summary & Motivation

This PR puts the dag downstream of the automapped tasks.

![Screenshot 2024-09-27 at 4.33.25 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/1bdf9239-93ea-4f42-bea6-00ab2dfe971d.png)

## How I Tested These Changes

BK. Viewed in kitchen sink.

## Changelog

NOCHANGELOG

