### PR TITLE
remove papermill-origami dependency

### DIFF
--- a/examples/tutorial_notebook_assets/setup.py
+++ b/examples/tutorial_notebook_assets/setup.py
@@ -6,7 +6,6 @@ setup(
     install_requires=[
         "dagster",
         "dagstermill",
-        "papermill-origami>=0.0.8",
         "pandas",
         "matplotlib",
         "seaborn",

--- a/pyright/alt-1/requirements-pinned.txt
+++ b/pyright/alt-1/requirements-pinned.txt
@@ -25,9 +25,9 @@ backports-tarfile==1.2.0
 beautifulsoup4==4.12.3
 bleach==6.1.0
 boto3==1.35.23
-boto3-stubs-lite==1.35.28
+boto3-stubs-lite==1.35.29
 botocore==1.35.23
-botocore-stubs==1.35.28
+botocore-stubs==1.35.29
 buildkite-test-collector==0.1.9
 cachetools==5.5.0
 caio==0.9.17
@@ -78,7 +78,7 @@ decopatch==1.4.10
 decorator==5.1.1
 deepdiff==8.0.1
 defusedxml==0.7.1
-deltalake==0.20.0
+deltalake==0.20.1
 dill==0.3.8
 distlib==0.3.8
 docker==7.1.0
@@ -129,7 +129,7 @@ isoduration==20.11.0
 isort==5.13.2
 jaraco-classes==3.4.0
 jaraco-context==6.0.1
-jaraco-functools==4.0.2
+jaraco-functools==4.1.0
 jedi==0.19.1
 jinja2==3.1.4
 jmespath==1.0.1
@@ -320,10 +320,10 @@ universal-pathlib==0.2.5
 uri-template==1.3.0
 uritemplate==4.1.1
 urllib3==2.2.3
-uvicorn==0.30.6
+uvicorn==0.31.0
 uvloop==0.20.0
-virtualenv==20.26.5
-watchdog==5.0.2
+virtualenv==20.26.6
+watchdog==5.0.3
 watchfiles==0.24.0
 wcwidth==0.2.13
 webcolors==24.8.0
@@ -332,5 +332,5 @@ websocket-client==1.8.0
 websockets==13.1
 wheel==0.44.0
 wrapt==1.16.0
-yarl==1.13.0
+yarl==1.13.1
 zipp==3.20.2

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -54,14 +54,13 @@ backoff==2.2.1
 bcrypt==4.2.0
 beautifulsoup4==4.12.3
 billiard==4.2.1
-bitmath==1.3.3.1
 bleach==6.1.0
 blinker==1.8.2
 bokeh==3.6.0
-boto3==1.35.28
-boto3-stubs-lite==1.35.28
-botocore==1.35.28
-botocore-stubs==1.35.28
+boto3==1.35.29
+boto3-stubs-lite==1.35.29
+botocore==1.35.29
+botocore-stubs==1.35.29
 buildkite-test-collector==0.1.9
 cachecontrol==0.14.0
 cached-property==1.5.2
@@ -83,7 +82,7 @@ click-plugins==1.1.1
 click-repl==0.3.0
 click-spinner==0.1.10
 clickclick==20.10.2
-cloudpickle==2.2.1
+cloudpickle==3.0.0
 colorama==0.4.6
 coloredlogs==14.0
 colorlog==4.8.0
@@ -168,8 +167,8 @@ daff==1.3.46
 -e python_modules/libraries/dagster-wandb
 -e python_modules/dagster-webserver
 -e python_modules/libraries/dagstermill
-dask==2024.8.0
-dask-expr==1.1.10
+dask==2024.9.0
+dask-expr==1.1.14
 dask-jobqueue==0.9.0
 dask-kubernetes==2022.9.0
 dask-yarn==0.9
@@ -195,10 +194,9 @@ deltalake==0.17.4
 deprecated==1.2.14
 -e examples/development_to_production
 dict2css==0.3.0.post1
-diff-match-patch==20200713
 dill==0.3.8
 distlib==0.3.8
-distributed==2024.8.0
+distributed==2024.9.0
 distro==1.9.0
 dlt==1.1.0
 dnspython==2.6.1
@@ -312,7 +310,6 @@ jupyterlab==4.2.5
 jupyterlab-pygments==0.3.0
 jupyterlab-server==2.27.3
 jupyterlab-widgets==3.0.13
-jwt==1.3.1
 -e examples/experimental/dagster-airlift/examples/kitchen-sink
 kiwisolver==1.4.7
 kombu==5.4.2
@@ -376,7 +373,6 @@ nest-asyncio==1.6.0
 networkx==3.3
 nh3==0.2.18
 nodeenv==1.9.1
-noteable-origami==1.1.5
 notebook==7.2.2
 notebook-shim==0.2.4
 numpy==1.26.4
@@ -386,7 +382,7 @@ objgraph==3.6.1
 onnx==1.16.2
 onnxconverter-common==1.13.0
 onnxruntime==1.19.2
-openai==1.50.0
+openai==1.50.1
 openapi-schema-validator==0.6.2
 openapi-spec-validator==0.7.1
 opentelemetry-api==1.27.0
@@ -409,7 +405,6 @@ pandas-stubs==2.2.2.240909
 pandera==0.20.4
 pandocfilters==1.5.1
 papermill==2.6.0
-papermill-origami==0.0.29
 paramiko==3.5.0
 parsedatetime==2.6
 parso==0.8.4
@@ -453,7 +448,7 @@ pydata-google-auth==1.8.2
 pyflakes==3.2.0
 pygments==2.18.0
 pyjwt==2.9.0
-pymdown-extensions==10.10.2
+pymdown-extensions==10.11
 pynacl==1.5.0
 pyopenssl==24.2.1
 pyparsing==3.1.4
@@ -514,7 +509,6 @@ seaborn==0.13.2
 selenium==4.25.0
 semver==3.0.2
 send2trash==1.8.3
-sending==0.3.0
 sentry-sdk==2.14.0
 setproctitle==1.3.3
 setuptools==70.3.0
@@ -525,7 +519,7 @@ skein==0.8.2
 skl2onnx==1.17.0
 slack-sdk==3.33.1
 sling==1.2.20
-sling-linux-amd64==1.2.20
+sling-mac-arm64==1.2.20
 smmap==5.0.1
 sniffio==1.3.1
 snowballstemmer==2.2.0
@@ -623,12 +617,12 @@ uri-template==1.3.0
 uritemplate==4.1.1
 urllib3==1.26.20
 -e examples/use_case_repository
-uvicorn==0.30.6
+uvicorn==0.31.0
 uvloop==0.20.0
 vine==5.1.0
 virtualenv==20.25.0
-wandb==0.18.1
-watchdog==5.0.2
+wandb==0.18.2
+watchdog==5.0.3
 watchfiles==0.24.0
 wcwidth==0.2.13
 webcolors==24.8.0
@@ -650,6 +644,6 @@ wtforms==3.0.1
 xgboost==2.1.1
 xmltodict==0.12.0
 xyzservices==2024.9.0
-yarl==1.13.0
+yarl==1.13.1
 zict==3.0.0
 zipp==3.20.2


### PR DESCRIPTION
This install the `jwt` package which conflicts with `pyjwt` and screws up our pyright env.

@jamiedemaria confirms we no longer need this anyawy.

## How I Tested These Changes

pyright, existing test suite

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
