### PR TITLE
DOCS Updated dagster-instance.mdx and example dagster.yaml to clarify UTC …

### DIFF
--- a/docs/content/deployment/dagster-instance.mdx
+++ b/docs/content/deployment/dagster-instance.mdx
@@ -276,7 +276,7 @@ To use a PostgreSQL database (<PyObject module="dagster_postgres" object="Dagste
 
 ```yaml file=/deploying/dagster_instance/dagster.yaml startafter=start_marker_storage_postgres endbefore=end_marker_storage_postgres
 # Postgres storage can be set using either credentials or a connection string.  This requires that
-# the `dagster-postgres` library be installed.
+# the `dagster-postgres` library be installed and a database configured with UTC timezone.
 
 # this config manually sets the Postgres credentials
 storage:

--- a/docs/content/deployment/dagster-instance.mdx
+++ b/docs/content/deployment/dagster-instance.mdx
@@ -378,7 +378,7 @@ storage:
 
 The `run_launcher` key allows you to configure the run launcher for your instance. Run launchers determine where runs are executed. You can use one of the Dagster-provided options or write your own custom run launcher. Refer to the [Run launcher documentation](/deployment/run-launcher) for more info.
 
-Refer to the following tabs for available options and sample configuration.
+Refer to the following tabs for available options and sample configuration. Keep in mind that databases should be configured to use UTC timezone.
 
 <TabGroup>
 <TabItem name="DefaultRunLauncher (default)">

--- a/examples/docs_snippets/docs_snippets/deploying/dagster_instance/dagster.yaml
+++ b/examples/docs_snippets/docs_snippets/deploying/dagster_instance/dagster.yaml
@@ -18,7 +18,7 @@ storage:
 # start_marker_storage_postgres
 
 # Postgres storage can be set using either credentials or a connection string.  This requires that
-# the `dagster-postgres` library be installed.
+# the `dagster-postgres` library be installed and a database configured with UTC timezone.
 
 # this config manually sets the Postgres credentials
 storage:


### PR DESCRIPTION
Just a quick add to avoid users having problems after the postgres storage configuration.

## Summary & Motivation
This update ensures users avoid potential issues related to the PostgreSQL storage configuration. The default PostgreSQL cluster is not set to the UTC timezone, which has caused problems for me and others. 

This closes #23173 

## How I Tested These Changes
Couldn't test it.

## Changelog
- [x] `DOCS` Added requirement to configure databases to use the UTC timezone.
