### PR TITLE
[docs-beta] Add workspace.yaml [DOC-437]

### DIFF
--- a/docs/docs-beta/.cursorrules
+++ b/docs/docs-beta/.cursorrules
@@ -1,27 +1,29 @@
+You are an expert in Python, Dagster, and data engineering.
+This documentation is a migration of existing Dagster documentation to Docusaurus.
+Documentation is in the `/docs` directory.
+Components are in the `/src/components` directory.
 
-  You are an expert in Python, Dagster, and data engineering.
-  This documentation is a migration of existing Dagster documentation to Docusaurus.
-  Documentation is in the `/docs` directory.
-  Components are in the `/src/components` directory.
-  
-  Key Principles
-  - Follow the Diataxis Principle for documentation.
-  - Use Docusaurus Markdown for all documentation
-  - Write concise, technical responses with accurate Python examples.
-  - Prefer iteration and modularization over code duplication.
-  - Use descriptive variable names with auxiliary verbs (e.g., is_active, has_permission).
-  
-  Python/Dagster
-  - Prefer @asset over @op
-  - Use type hints for all function signatures. Prefer Pydantic models over raw dictionaries for input validation.
+Key Principles
+- Follow the Diataxis Principle for documentation.
+- Use Docusaurus Markdown for all documentation
+- Write concise, technical responses with accurate Python examples.
+- Prefer iteration and modularization over code duplication.
+- Use descriptive variable names with auxiliary verbs (e.g., is_active, has_permission).
 
-  Guides
-  - Guides should include the following
-    - A details tag with a summary of prerequisites
-        <details>
-        <summary>Prerequisites</summary>
-          - **Organization**, **Admin**, or **Editor** permissions on Dagster+
-        </details>
-  - Code examples should be in the following format
-    <CodeExample filePath="getting-started/hello-world.py" language="python" />
-    
+Python/Dagster
+- Prefer @asset over @op
+- Use type hints for all function signatures. Prefer Pydantic models over raw dictionaries for input validation.
+
+Guides
+- Guides should include the following
+  - A details tag with a summary of prerequisites
+      <details>
+      <summary>Prerequisites</summary>
+        - **Organization**, **Admin**, or **Editor** permissions on Dagster+
+      </details>
+- Code examples should be in the following format
+  <CodeExample filePath="getting-started/hello-world.py" language="python" />
+  
+
+Output Formatting
+When writing markdown, use ``` for the main documentation block, and ~~~ for embedded code within the main block. Only output the main block, do not add any extra text. 

--- a/docs/docs-beta/docs/reference/workspace-yaml.md
+++ b/docs/docs-beta/docs/reference/workspace-yaml.md
@@ -1,0 +1,116 @@
+# Workspace File Reference
+
+:::info
+    This reference is only applicable to Dagster OSS, for Dagster Cloud see [the Dagster Cloud Code Locations guide](/dagster-plus/deployment/code-locations)
+:::
+
+The `workspace.yaml` file is used to configure code locations in Dagster. It tells Dagster where to find your code and how to load it.
+
+## Location of workspace.yaml
+
+Dagster command-line tools (like dagster dev, dagster-webserver, or dagster-daemon run) look for workspace files in the current directory when invoked. This allows you to launch from that directory without the need for command line arguments
+
+To load the workspace.yaml file from a different folder, use the -w argument:
+
+```bash
+dagster dev -w path/to/workspace.yaml
+```
+
+## File Structure
+
+The `workspace.yaml` file uses the following structure:
+
+```yaml
+load_from:
+  - <loading_method>:
+      <configuration_options>
+```
+
+Where `<loading_method>` can be one of:
+- `python_file`
+- `python_module`
+- `grpc_server`
+
+
+
+## Loading Methods
+
+We recommend using `python_module` for most use cases.
+
+### Python module
+
+Loads a code location from a Python module.
+
+**Options:**
+- `module_name`: Name of the Python module to load.
+- Other options are the same as `python_file`.
+
+**Example:**
+```yaml
+load_from:
+  - python_module:
+      module_name: hello_world_module.definitions
+```
+
+
+### Python file
+
+Loads a code location from a Python file.
+
+**Options:**
+- `relative_path`: Path to the Python file, relative to the `workspace.yaml` location.
+- `attribute` (optional): Name of a specific repository or function returning a `RepositoryDefinition`.
+- `working_directory` (optional): Custom working directory for relative imports.
+- `executable_path` (optional): Path to a specific Python executable.
+- `location_name` (optional): Custom name for the code location.
+
+**Example:**
+```yaml
+load_from:
+  - python_file:
+      relative_path: hello_world_repository.py
+      attribute: hello_world_repository
+      working_directory: my_working_directory/
+      executable_path: venvs/path/to/python
+      location_name: my_location
+```
+
+### gRPC server
+
+Configures a gRPC server as a code location.
+
+**Options:**
+- `host`: The host address of the gRPC server.
+- `port`: The port number of the gRPC server.
+- `location_name`: Custom name for the code location.
+
+**Example:**
+```yaml
+load_from:
+  - grpc_server:
+      host: localhost
+      port: 4266
+      location_name: "my_grpc_server"
+```
+
+## Multiple Code Locations
+
+You can define multiple code locations in a single `workspace.yaml` file:
+
+```yaml
+load_from:
+  - python_file:
+      relative_path: path/to/dataengineering_spark_team.py
+      location_name: dataengineering_spark_team_py_38_virtual_env
+      executable_path: venvs/path/to/dataengineering_spark_team/bin/python
+  - python_file:
+      relative_path: path/to/team_code_location.py
+      location_name: ml_team_py_36_virtual_env
+      executable_path: venvs/path/to/ml_tensorflow/bin/python
+```
+
+## Notes
+
+- Each code location is loaded in its own process.
+- Code locations can mix and match between `Definitions` objects and `@repository` decorators.
+- If a code location is renamed or its configuration is modified, running schedules and sensors in that location need to be stopped and restarted.

--- a/docs/vale/styles/config/vocabularies/Dagster/accept.txt
+++ b/docs/vale/styles/config/vocabularies/Dagster/accept.txt
@@ -151,3 +151,5 @@ AWS
 backfills
 anonymized
 boolean
+python_file
+dev


### PR DESCRIPTION
## Summary & Motivation

Adds a reference doc for workspace.yaml.

I used the following as references:

https://docs.dagster.io/concepts/code-locations/workspace-files
https://github.com/dagster-io/cloud-examples/blob/main/multi-location-project/workspace.yaml 
https://github.com/dagster-io/dagster/blob/618731246cf220c0257f5d030e8c4eaf68b5d8b1/docs/content/concepts/code-locations.mdx#L121 

## How I Tested These Changes

I read them

## Changelog

NOCHANGELOG
