### PR TITLE
[ui] Fix asset group outlines not rendering properly in Safari

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -509,7 +509,7 @@ const AssetGraphExplorerWithData = ({
                   e.stopPropagation();
                 }}
               >
-                <GroupOutline $minimal={scale < MINIMAL_SCALE} />
+                <GroupOutline minimal={scale < MINIMAL_SCALE} />
               </foreignObject>
             ))}
 

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ExpandedGroupNode.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/ExpandedGroupNode.tsx
@@ -6,6 +6,7 @@ import {GroupNodeNameAndRepo, useGroupNodeContextMenu} from './CollapsedGroupNod
 import {ContextMenuWrapper} from './ContextMenuWrapper';
 import {GraphNode} from './Utils';
 import {GroupLayout} from './layout';
+import {SVGRelativeContainerForSafari} from '../graph/SVGComponents';
 
 export const ExpandedGroupNode = ({
   group,
@@ -30,7 +31,7 @@ export const ExpandedGroupNode = ({
     preferredJobName,
   });
   return (
-    <div style={{position: 'relative', width: '100%', height: '100%'}}>
+    <SVGRelativeContainerForSafari>
       <ContextMenuWrapper menu={menu} stopPropagation>
         <GroupNodeHeaderBox
           $minimal={minimal}
@@ -54,11 +55,17 @@ export const ExpandedGroupNode = ({
         </GroupNodeHeaderBox>
       </ContextMenuWrapper>
       {dialog}
-    </div>
+    </SVGRelativeContainerForSafari>
   );
 };
 
-export const GroupOutline = styled.div<{$minimal: boolean}>`
+export const GroupOutline = ({minimal}: {minimal: boolean}) => (
+  <SVGRelativeContainerForSafari>
+    <GroupOutlineBox $minimal={minimal} />
+  </SVGRelativeContainerForSafari>
+);
+
+const GroupOutlineBox = styled.div<{$minimal: boolean}>`
   inset: 0;
   top: 60px;
   position: absolute;

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeLineageGraph.tsx
@@ -115,7 +115,7 @@ export const AssetNodeLineageGraph = ({
                     e.stopPropagation();
                   }}
                 >
-                  <GroupOutline $minimal={scale < MINIMAL_SCALE} />
+                  <GroupOutline minimal={scale < MINIMAL_SCALE} />
                 </foreignObject>
               ))}
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/SVGComponents.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/SVGComponents.tsx
@@ -1,5 +1,6 @@
 import {FontFamily} from '@dagster-io/ui-components';
 import * as React from 'react';
+import styled from 'styled-components';
 
 const PX_TO_UNITS = 0.53;
 
@@ -89,3 +90,12 @@ export class SVGMonospaceText extends React.PureComponent<
     );
   }
 }
+
+// In Safari 17.5, applying margin, relative or absolute offsets to the "root" DOM node within
+// a <foreignObject /> doesn't seem to work. For `top`, `marginTop`, etc., to work, we need to
+// place them inside a DOM node that starts at 0,0.
+export const SVGRelativeContainerForSafari = styled.div`
+  width: 100%;
+  height: 100%;
+  position: relative;
+`;


### PR DESCRIPTION
## Summary & Motivation

Fixes FE-570

I'd seen this happen a couple other times -- Safari seems to have an annoying bug where you can't "position" the first DOM node inside a foreignObject. To use things like marginTop / top / inset, etc. we have to have at least one div above the positioned one in the foreignObject.

I created a named wrapper for this case because I think I'm likely to drive-by and remove this wrap layer otherwise :-) 

## How I Tested These Changes

Tested in Firefox, Chrome and Safari

Before:
![image](https://github.com/user-attachments/assets/580cce4c-3a53-447a-8769-d824521fe117)

After:
![image](https://github.com/user-attachments/assets/1fc88e9c-9a5e-453a-9b8b-33094decf45a)


## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `BUGFIX` Fixed asset group outlines not rendering properly in Safari
