### PR TITLE
[ui] Only show “materialization failed in run” if the latest materialization is older

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
@@ -5,15 +5,7 @@ import {act, render, waitFor} from '@testing-library/react';
 import {GraphQLError} from 'graphql/error';
 
 import {buildMockedAssetGraphLiveQuery} from './util';
-import {shouldDisplayRunFailure} from '../../asset-graph/Utils';
-import {
-  AssetKey,
-  AssetKeyInput,
-  RunStatus,
-  buildAssetKey,
-  buildMaterializationEvent,
-  buildRun,
-} from '../../graphql/types';
+import {AssetKey, AssetKeyInput, buildAssetKey} from '../../graphql/types';
 import {LiveDataThreadID} from '../../live-data-provider/LiveDataThread';
 import {BATCH_SIZE, SUBSCRIPTION_IDLE_POLL_RATE} from '../../live-data-provider/util';
 import {getMockResultFn} from '../../testing/mocking';
@@ -526,41 +518,6 @@ describe('AssetLiveDataProvider', () => {
     await waitFor(() => {
       expect(resultFn3).toHaveBeenCalled();
       expect(resultFn4).toHaveBeenCalled();
-    });
-  });
-
-  describe('shouldDisplayRunFailure', () => {
-    it('should return false if the latest materialization is from the latest run', () => {
-      expect(
-        shouldDisplayRunFailure(
-          buildRun({id: '1', status: RunStatus.FAILURE, endTime: 1673301346}),
-          buildMaterializationEvent({runId: '1', timestamp: `1673300346000`}),
-        ),
-      ).toEqual(false);
-    });
-    it('should return false if the latest materialization is newer than the failure (manually reported event case)', () => {
-      expect(
-        shouldDisplayRunFailure(
-          buildRun({id: '1', status: RunStatus.FAILURE, endTime: 1673301346}),
-          buildMaterializationEvent({runId: undefined, timestamp: `1674400000000`}),
-        ),
-      ).toEqual(false);
-    });
-    it('should return false if the run succeeded', () => {
-      expect(
-        shouldDisplayRunFailure(
-          buildRun({id: '2', status: RunStatus.SUCCESS, endTime: 1673301346}),
-          buildMaterializationEvent({runId: '1', timestamp: `1673300346000`}),
-        ),
-      ).toEqual(false);
-    });
-    it('should return true if the latest run status is failed and other conditions are not met', () => {
-      expect(
-        shouldDisplayRunFailure(
-          buildRun({id: '2', status: RunStatus.FAILURE, endTime: 1673301346}),
-          buildMaterializationEvent({runId: '1', timestamp: `1673300000000`}),
-        ),
-      ).toEqual(true);
     });
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-data/__tests__/AssetLiveDataProvider.test.tsx
@@ -5,7 +5,15 @@ import {act, render, waitFor} from '@testing-library/react';
 import {GraphQLError} from 'graphql/error';
 
 import {buildMockedAssetGraphLiveQuery} from './util';
-import {AssetKey, AssetKeyInput, buildAssetKey} from '../../graphql/types';
+import {shouldDisplayRunFailure} from '../../asset-graph/Utils';
+import {
+  AssetKey,
+  AssetKeyInput,
+  RunStatus,
+  buildAssetKey,
+  buildMaterializationEvent,
+  buildRun,
+} from '../../graphql/types';
 import {LiveDataThreadID} from '../../live-data-provider/LiveDataThread';
 import {BATCH_SIZE, SUBSCRIPTION_IDLE_POLL_RATE} from '../../live-data-provider/util';
 import {getMockResultFn} from '../../testing/mocking';
@@ -518,6 +526,41 @@ describe('AssetLiveDataProvider', () => {
     await waitFor(() => {
       expect(resultFn3).toHaveBeenCalled();
       expect(resultFn4).toHaveBeenCalled();
+    });
+  });
+
+  describe('shouldDisplayRunFailure', () => {
+    it('should return false if the latest materialization is from the latest run', () => {
+      expect(
+        shouldDisplayRunFailure(
+          buildRun({id: '1', status: RunStatus.FAILURE, endTime: 1673301346}),
+          buildMaterializationEvent({runId: '1', timestamp: `1673300346000`}),
+        ),
+      ).toEqual(false);
+    });
+    it('should return false if the latest materialization is newer than the failure (manually reported event case)', () => {
+      expect(
+        shouldDisplayRunFailure(
+          buildRun({id: '1', status: RunStatus.FAILURE, endTime: 1673301346}),
+          buildMaterializationEvent({runId: undefined, timestamp: `1674400000000`}),
+        ),
+      ).toEqual(false);
+    });
+    it('should return false if the run succeeded', () => {
+      expect(
+        shouldDisplayRunFailure(
+          buildRun({id: '2', status: RunStatus.SUCCESS, endTime: 1673301346}),
+          buildMaterializationEvent({runId: '1', timestamp: `1673300346000`}),
+        ),
+      ).toEqual(false);
+    });
+    it('should return true if the latest run status is failed and other conditions are not met', () => {
+      expect(
+        shouldDisplayRunFailure(
+          buildRun({id: '2', status: RunStatus.FAILURE, endTime: 1673301346}),
+          buildMaterializationEvent({runId: '1', timestamp: `1673300000000`}),
+        ),
+      ).toEqual(true);
     });
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/Utils.tsx
@@ -218,20 +218,12 @@ export const buildLiveDataForNode = (
 ): LiveDataForNode => {
   const lastMaterialization = assetNode.assetMaterializations[0] || null;
   const lastObservation = assetNode.assetObservations[0] || null;
-  const latestRunForAsset = assetLatestInfo?.latestRun ? assetLatestInfo.latestRun : null;
-
-  const runWhichFailedToMaterialize =
-    (latestRunForAsset?.status === 'FAILURE' &&
-      (!lastMaterialization || lastMaterialization.runId !== latestRunForAsset?.id) &&
-      latestRunForAsset) ||
-    null;
+  const latestRun = assetLatestInfo?.latestRun ? assetLatestInfo.latestRun : null;
 
   return {
     lastMaterialization,
     lastMaterializationRunStatus:
-      latestRunForAsset && lastMaterialization?.runId === latestRunForAsset?.id
-        ? latestRunForAsset.status
-        : null,
+      latestRun && lastMaterialization?.runId === latestRun.id ? latestRun.status : null,
     lastObservation,
     assetChecks:
       assetNode.assetChecksOrError.__typename === 'AssetChecks'
@@ -242,10 +234,33 @@ export const buildLiveDataForNode = (
     inProgressRunIds: assetLatestInfo?.inProgressRunIds || [],
     unstartedRunIds: assetLatestInfo?.unstartedRunIds || [],
     partitionStats: assetNode.partitionStats || null,
-    runWhichFailedToMaterialize,
+    runWhichFailedToMaterialize:
+      latestRun && shouldDisplayRunFailure(latestRun, lastMaterialization) ? latestRun : null,
     opNames: assetNode.opNames,
   };
 };
+
+export function shouldDisplayRunFailure(
+  latestRun: AssetLatestInfoRunFragment,
+  lastMaterialization: AssetNodeLiveMaterializationFragment | null,
+) {
+  if (latestRun.status !== 'FAILURE') {
+    return false; // The run did not fail
+  }
+  if (lastMaterialization) {
+    if (lastMaterialization && lastMaterialization.runId === latestRun.id) {
+      // The run failed, but it successfully emitted the latest materialization event. This
+      // is caused by the run failing in a later step.
+      return false;
+    }
+    if (Number(lastMaterialization.timestamp) > Number(latestRun.endTime) * 1000) {
+      // The latest materialization is NEWER than the latest run. This is caused by the user
+      // reporting a materialization manually.
+      return false;
+    }
+  }
+  return true;
+}
 
 export function tokenForAssetKey(key: {path: string[]}) {
   return key.path.join('/');

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__fixtures__/AssetNode.fixtures.ts
@@ -142,12 +142,11 @@ export const LiveDataForNodeRunFailed: LiveDataForNodeWithStaleData = {
   lastMaterialization: null,
   lastMaterializationRunStatus: null,
   lastObservation: null,
-  runWhichFailedToMaterialize: {
-    __typename: 'Run',
+  runWhichFailedToMaterialize: buildRun({
     id: 'ABCDEF',
     status: RunStatus.FAILURE,
     endTime: 1673301346,
-  },
+  }),
   staleStatus: null,
   staleCauses: [],
   assetChecks: [],
@@ -668,12 +667,11 @@ export const LiveDataForNodePartitionedLatestRunFailed: LiveDataForNodeWithStale
   lastMaterialization: null,
   lastMaterializationRunStatus: null,
   lastObservation: null,
-  runWhichFailedToMaterialize: {
-    __typename: 'Run',
+  runWhichFailedToMaterialize: buildRun({
     id: 'ABCDEF',
     status: RunStatus.FAILURE,
     endTime: 1673301346,
-  },
+  }),
   staleStatus: null,
   staleCauses: [],
   assetChecks: [],

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/Utils.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/__tests__/Utils.test.tsx
@@ -1,0 +1,37 @@
+import {RunStatus, buildMaterializationEvent, buildRun} from '../../graphql/types';
+import {shouldDisplayRunFailure} from '../Utils';
+
+describe('shouldDisplayRunFailure', () => {
+  it('should return false if the latest materialization is from the latest run', () => {
+    expect(
+      shouldDisplayRunFailure(
+        buildRun({id: '1', status: RunStatus.FAILURE, endTime: 1673301346}),
+        buildMaterializationEvent({runId: '1', timestamp: `1673300346000`}),
+      ),
+    ).toEqual(false);
+  });
+  it('should return false if the latest materialization is newer than the failure (manually reported event case)', () => {
+    expect(
+      shouldDisplayRunFailure(
+        buildRun({id: '1', status: RunStatus.FAILURE, endTime: 1673301346}),
+        buildMaterializationEvent({runId: undefined, timestamp: `1674400000000`}),
+      ),
+    ).toEqual(false);
+  });
+  it('should return false if the run succeeded', () => {
+    expect(
+      shouldDisplayRunFailure(
+        buildRun({id: '2', status: RunStatus.SUCCESS, endTime: 1673301346}),
+        buildMaterializationEvent({runId: '1', timestamp: `1673300346000`}),
+      ),
+    ).toEqual(false);
+  });
+  it('should return true if the latest run status is failed and other conditions are not met', () => {
+    expect(
+      shouldDisplayRunFailure(
+        buildRun({id: '2', status: RunStatus.FAILURE, endTime: 1673301346}),
+        buildMaterializationEvent({runId: '1', timestamp: `1673300000000`}),
+      ),
+    ).toEqual(true);
+  });
+});


### PR DESCRIPTION
Fixes FE-535

## Summary & Motivation

Currently, If you have an asset run that fails to emit a materialization event, and you fix that failure by manually reporting a materialization event, the “Failed in Run XYZ” state is still shown everywhere in Dagster’s UI. This is undesirable especially on the asset graph, but also on the asset catalog page where the failure appears under the subheading “Latest materialization”

This PR adds a new rule: The “Failed to materialize” status, banner, and asset health alert only appear if the latest materialization is older than the run’s timestamp.

This also makes the UI consistent with what it /said/ it already did — our component for displaying the failure banner was already called  `<FailedRunSinceMaterializationBanner />`. :-)

## How I Tested These Changes

I tested this using https://elementl.dogfood.dagster.cloud/prod/assets/diamond_final_asset

Before:
<img width="1840" alt="Screenshot 2024-09-29 at 8 54 41 PM" src="https://github.com/user-attachments/assets/7645a680-bcb9-4290-8b09-c6a3ceb18c3f">

After:
<img width="1840" alt="Screenshot 2024-09-29 at 9 15 17 PM" src="https://github.com/user-attachments/assets/cba6f6db-edfb-45d8-967b-adf8b867cf10">
<img width="1840" alt="Screenshot 2024-09-29 at 9 15 07 PM" src="https://github.com/user-attachments/assets/fa14f442-96a1-4810-87e0-3ca5bb62987f">

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `BUGFIX` Reporting a materialization event now removes the asset from the asset health "Execution failures" list and returns the asset to a green / success state.