### PR TITLE
[ui] Fix Automations page when only schedules present

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/automation/MergedAutomationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/MergedAutomationRoot.tsx
@@ -353,7 +353,7 @@ const buildBuckets = (
       const {name, schedules, sensors} = repo;
       const repoAddress = buildRepoAddress(name, entry.name);
 
-      if (sensors.length > 0) {
+      if (sensors.length > 0 || schedules.length > 0) {
         buckets.push({
           repoAddress,
           schedules,


### PR DESCRIPTION
## Summary & Motivation

When determining whether to show a code location bucket in the Automations page, repos with 1+ schedules and zero sensors were being incorrectly ignored. The result was an empty Automations page even though there were schedules that should have appeared.

## How I Tested These Changes

View an org with a single code location that has schedules but not sensors. Verify that the Automations page now shows them correctly.

## Changelog

- [ ] `BUGFIX` In new navigation experimental flag, fix automations page for code locations that have schedules but no sensors.