### PR TITLE
[dagster-airlift] make AirflowDefinitionsData non serializable, make loader use serializable class

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
@@ -16,6 +16,7 @@ from dagster_airlift.core.airflow_instance import AirflowInstance
 from dagster_airlift.core.sensor import (
     DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
     build_airflow_polling_sensor_defs,
+    get_asset_events,
 )
 from dagster_airlift.core.serialization.compute import compute_serialized_data
 from dagster_airlift.core.state_backed_defs_loader import StateBackedDefinitionsLoader
@@ -51,6 +52,7 @@ class AirflowInstanceDefsLoader(StateBackedDefinitionsLoader[AirflowDefinitionsD
                 airflow_instance=self.airflow_instance,
                 minimum_interval_seconds=self.sensor_minimum_interval_seconds,
                 airflow_data=airflow_data,
+                event_translation_fn=get_asset_events,
             ),
         )
 
@@ -97,6 +99,7 @@ class FullAutomappedDagsLoader(StateBackedDefinitionsLoader[AirflowDefinitionsDa
                 airflow_instance=self.airflow_instance,
                 minimum_interval_seconds=self.sensor_minimum_interval_seconds,
                 airflow_data=airflow_data,
+                event_translation_fn=get_asset_events,
             ),
         )
 

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/__init__.py
@@ -3,3 +3,4 @@ from .builder import (
     AirflowPollingSensorCursor as AirflowPollingSensorCursor,
     build_airflow_polling_sensor_defs as build_airflow_polling_sensor_defs,
 )
+from .event_translation import get_asset_events as get_asset_events

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/builder.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/builder.py
@@ -26,7 +26,7 @@ from dagster._time import datetime_from_timestamp, get_current_datetime
 from dagster_airlift.core.airflow_defs_data import AirflowDefinitionsData
 from dagster_airlift.core.airflow_instance import AirflowInstance
 from dagster_airlift.core.sensor.event_translation import (
-    get_asset_events,
+    AirflowEventTranslationFn,
     get_timestamp_from_materialization,
 )
 
@@ -57,6 +57,7 @@ def check_keys_for_asset_keys(
 def build_airflow_polling_sensor_defs(
     airflow_instance: AirflowInstance,
     airflow_data: AirflowDefinitionsData,
+    event_translation_fn: AirflowEventTranslationFn,
     minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
 ) -> Definitions:
     @sensor(
@@ -90,6 +91,7 @@ def build_airflow_polling_sensor_defs(
             offset=current_dag_offset,
             airflow_instance=airflow_instance,
             airflow_data=airflow_data,
+            event_translation_fn=event_translation_fn,
         )
         all_materializations: List[Tuple[float, AssetMaterialization]] = []
         all_check_keys: Set[AssetCheckKey] = set()
@@ -158,6 +160,7 @@ def materializations_and_requests_from_batch_iter(
     offset: int,
     airflow_instance: AirflowInstance,
     airflow_data: AirflowDefinitionsData,
+    event_translation_fn: AirflowEventTranslationFn,
 ) -> Iterator[Optional[BatchResult]]:
     runs = airflow_instance.get_dag_runs_batch(
         dag_ids=list(airflow_data.all_dag_ids),
@@ -178,7 +181,7 @@ def materializations_and_requests_from_batch_iter(
             states=["success"],
         )
 
-        mats = get_asset_events(dag_run, task_instances, airflow_data)
+        mats = event_translation_fn(dag_run, task_instances, airflow_data)
         all_asset_keys_materialized = {mat.asset_key for mat in mats}
         yield (
             BatchResult(

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Mapping, Sequence
+from typing import Any, Callable, Iterable, List, Mapping, Sequence
 
 from dagster import (
     AssetMaterialization,
@@ -12,6 +12,10 @@ from dagster._time import get_current_timestamp
 from dagster_airlift.constants import EFFECTIVE_TIMESTAMP_METADATA_KEY
 from dagster_airlift.core.airflow_defs_data import AirflowDefinitionsData
 from dagster_airlift.core.airflow_instance import DagRun, TaskInstance
+
+AirflowEventTranslationFn = Callable[
+    [DagRun, Sequence[TaskInstance], AirflowDefinitionsData], Iterable[AssetMaterialization]
+]
 
 
 def get_asset_events(

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
@@ -175,6 +175,7 @@ def compute_serialized_data(
     mapping_info = build_airlift_metadata_mapping_info(defs)
     fetched_airflow_data = fetch_all_airflow_data(airflow_instance, mapping_info)
     return SerializedAirflowDefinitionsData(
+        instance_name=airflow_instance.name,
         key_scoped_data_items=[
             KeyScopedDataItem(asset_key=k, mapped_tasks=v)
             for k, v in fetched_airflow_data.all_mapped_tasks.items()

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
@@ -90,9 +90,11 @@ class KeyScopedDataItem:
 # - created
 # - removed existing_asset_data
 # - added key_scope_data_items
+# - added instance_name
 @whitelist_for_serdes
 @record
 class SerializedAirflowDefinitionsData:
+    instance_name: str
     key_scoped_data_items: List[KeyScopedDataItem]
     dag_datas: Mapping[str, SerializedDagData]
 

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -26,7 +26,6 @@ from dagster_airlift.core import (
     task_defs,
 )
 from dagster_airlift.core.airflow_defs_data import (
-    AirflowDefinitionsData,
     key_for_automapped_task_asset,
     make_default_dag_asset_key,
 )
@@ -37,7 +36,10 @@ from dagster_airlift.core.serialization.compute import (
     compute_serialized_data,
     is_mapped_asset_spec,
 )
-from dagster_airlift.core.serialization.serialized_data import TaskHandle
+from dagster_airlift.core.serialization.serialized_data import (
+    SerializedAirflowDefinitionsData,
+    TaskHandle,
+)
 from dagster_airlift.core.state_backed_defs_loader import (
     scoped_reconstruction_metadata,
     unwrap_reconstruction_metadata,
@@ -351,7 +353,7 @@ def test_cached_loading() -> None:
     assert isinstance(defs.metadata["dagster-airlift/source/test_instance"].value, str)
     assert isinstance(
         deserialize_value(defs.metadata["dagster-airlift/source/test_instance"].value),
-        AirflowDefinitionsData,
+        SerializedAirflowDefinitionsData,
     )
 
     with scoped_reconstruction_metadata(unwrap_reconstruction_metadata(defs)):


### PR DESCRIPTION
Part of my ultimate scheme to turn AirflowDefinitionsData into a user-invokable class that can be used to vend cacheable properties off of the fully resolved Definitions object. Let's make it non-serializable, and we'll eventually move all spec mapping utilities to the serializable class, so that AirflowDefinitionsData is purely an information retrieval layer and not a transformation layer.


## How I Tested These Changes
Existing tests.
## Changelog
NOCHANGELOG
