### PR TITLE
enable RunsFeed feature flag

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
@@ -42,8 +42,8 @@ export const useVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagCodeLocationPage,
   },
   // Uncomment once we're ready for this to go live
-  // {
-  //   key: 'New Runs feed',
-  //   flagType: FeatureFlag.flagRunsFeed,
-  // }
+  {
+    key: 'New Runs feed',
+    flagType: FeatureFlag.flagRunsFeed,
+  }
 ];

--- a/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
@@ -58,5 +58,5 @@ export const useVisibleFeatureFlagRows = () => [
         )
       </>
     ),
-  }
+  },
 ];

--- a/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
@@ -43,7 +43,20 @@ export const useVisibleFeatureFlagRows = () => [
   },
   // Uncomment once we're ready for this to go live
   {
-    key: 'New Runs feed',
+    key: 'New Runs page',
     flagType: FeatureFlag.flagRunsFeed,
+    label: (
+      <>
+        New Runs page (
+        <a
+          href="https://github.com/dagster-io/dagster/discussions/24898"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Learn more
+        </a>
+        )
+      </>
+    ),
   }
 ];


### PR DESCRIPTION
## Summary & Motivation
enables the Runs feed feature flag and adds a link to the github discussion i created to get feedback

## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [X] `NEW` [experimental] Backfills are incorporated into the Runs page to improve observability and provide a more simplified UI. See the [GitHub discussion](https://github.com/dagster-io/dagster/discussions/24898) for more details.
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
