### PR TITLE
[dagster-airlift][mapped-defs] asset properties on AirflowDefinitionsData use resolved defs

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
@@ -1,13 +1,18 @@
+from collections import defaultdict
 from functools import cached_property
-from typing import AbstractSet, Optional, cast
+from typing import AbstractSet, Mapping, Optional, cast
 
 from dagster import AssetKey, Definitions
 from dagster._record import record
 from dagster._serdes.serdes import deserialize_value
 
+from dagster_airlift.constants import STANDALONE_DAG_ID_METADATA_KEY
 from dagster_airlift.core.serialization.defs_construction import make_default_dag_asset_key
-from dagster_airlift.core.serialization.serialized_data import SerializedAirflowDefinitionsData
-from dagster_airlift.core.utils import get_metadata_key
+from dagster_airlift.core.serialization.serialized_data import (
+    SerializedAirflowDefinitionsData,
+    TaskHandle,
+)
+from dagster_airlift.core.utils import get_metadata_key, is_mapped_asset_spec, task_handles_for_spec
 
 
 @record
@@ -28,6 +33,25 @@ class AirflowDefinitionsData:
     def all_dag_ids(self) -> AbstractSet[str]:
         return set(self.serialized_data.dag_datas.keys())
 
+    @cached_property
+    def asset_keys_per_task_handle(self) -> Mapping[TaskHandle, AbstractSet[AssetKey]]:
+        asset_keys_per_handle = defaultdict(set)
+        for spec in self.resolved_airflow_defs.get_all_asset_specs():
+            if is_mapped_asset_spec(spec):
+                task_handles = task_handles_for_spec(spec)
+                for task_handle in task_handles:
+                    asset_keys_per_handle[task_handle].add(spec.key)
+        return asset_keys_per_handle
+
+    @cached_property
+    def asset_key_per_dag(self) -> Mapping[str, AssetKey]:
+        dag_id_to_asset_key = {}
+        for spec in self.resolved_airflow_defs.get_all_asset_specs():
+            if STANDALONE_DAG_ID_METADATA_KEY in spec.metadata:
+                dag_id = spec.metadata[STANDALONE_DAG_ID_METADATA_KEY]
+                dag_id_to_asset_key[dag_id] = spec.key
+        return dag_id_to_asset_key
+
     def asset_key_for_dag(self, dag_id: str) -> AssetKey:
         return make_default_dag_asset_key(self.serialized_data.instance_name, dag_id)
 
@@ -38,4 +62,4 @@ class AirflowDefinitionsData:
         return self.serialized_data.dag_datas[dag_id].task_handle_data[task_id].proxied_state
 
     def asset_keys_in_task(self, dag_id: str, task_id: str) -> AbstractSet[AssetKey]:
-        return self.serialized_data.dag_datas[dag_id].task_handle_data[task_id].asset_keys_in_task
+        return self.asset_keys_per_task_handle[TaskHandle(dag_id=dag_id, task_id=task_id)]

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
@@ -1,12 +1,20 @@
-from typing import Iterable, Iterator, Optional, Union
+from typing import TYPE_CHECKING, Iterable, Iterator, Optional, Set, Union
 
-from dagster import AssetsDefinition, AssetSpec, SourceAsset
+from dagster import (
+    AssetsDefinition,
+    AssetSpec,
+    SourceAsset,
+    _check as check,
+)
 from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 from dagster._core.definitions.utils import VALID_NAME_REGEX
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.storage.tags import KIND_PREFIX
 
 from dagster_airlift.constants import AIRFLOW_SOURCE_METADATA_KEY_PREFIX, TASK_MAPPING_METADATA_KEY
+
+if TYPE_CHECKING:
+    from dagster_airlift.core.serialization.serialized_data import TaskHandle
 
 
 def convert_to_valid_dagster_name(name: str) -> str:
@@ -40,3 +48,19 @@ def metadata_for_task_mapping(*, task_id: str, dag_id: str) -> dict:
 
 def get_metadata_key(instance_name: str) -> str:
     return f"{AIRFLOW_SOURCE_METADATA_KEY_PREFIX}/{instance_name}"
+
+
+def is_mapped_asset_spec(spec: AssetSpec) -> bool:
+    return TASK_MAPPING_METADATA_KEY in spec.metadata
+
+
+def task_handles_for_spec(spec: AssetSpec) -> Set["TaskHandle"]:
+    from dagster_airlift.core.serialization.serialized_data import TaskHandle
+
+    check.param_invariant(is_mapped_asset_spec(spec), "spec", "Must be mappped spec")
+    task_handles = []
+    for task_handle_dict in spec.metadata[TASK_MAPPING_METADATA_KEY]:
+        task_handles.append(
+            TaskHandle(dag_id=task_handle_dict["dag_id"], task_id=task_handle_dict["task_id"])
+        )
+    return set(task_handles)

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -30,7 +30,6 @@ from dagster_airlift.core.multiple_tasks import targeted_by_multiple_tasks
 from dagster_airlift.core.serialization.compute import (
     build_airlift_metadata_mapping_info,
     compute_serialized_data,
-    is_mapped_asset_spec,
 )
 from dagster_airlift.core.serialization.defs_construction import (
     key_for_automapped_task_asset,
@@ -44,7 +43,7 @@ from dagster_airlift.core.state_backed_defs_loader import (
     scoped_reconstruction_metadata,
     unwrap_reconstruction_metadata,
 )
-from dagster_airlift.core.utils import metadata_for_task_mapping
+from dagster_airlift.core.utils import is_mapped_asset_spec, metadata_for_task_mapping
 from dagster_airlift.test import make_instance
 from dagster_airlift.utils import DAGSTER_AIRLIFT_PROXIED_STATE_DIR_ENV_VAR
 


### PR DESCRIPTION
## Summary & Motivation
Previously, the properties on AirflowDefinitionsData which retrieved information about asset keys did so from the information gathered during the serialization compute step. In a world where the sensor can be built separately from the mapped definitions, we need to be able to handle any additional mapping steps that the user might perform.
## How I Tested These Changes
Existing tests.

## Changelog
NOCHANGELOG
