### PR TITLE
[dagster-airlift][mapped-defs] make explicit our reliance on the serialized data within sensor

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from functools import cached_property
-from typing import AbstractSet, Mapping, Optional, cast
+from typing import AbstractSet, Mapping, cast
 
 from dagster import AssetKey, Definitions
 from dagster._record import record
@@ -54,12 +54,6 @@ class AirflowDefinitionsData:
 
     def asset_key_for_dag(self, dag_id: str) -> AssetKey:
         return make_default_dag_asset_key(self.serialized_data.instance_name, dag_id)
-
-    def task_ids_in_dag(self, dag_id: str) -> AbstractSet[str]:
-        return set(self.serialized_data.dag_datas[dag_id].task_handle_data.keys())
-
-    def proxied_state_for_task(self, dag_id: str, task_id: str) -> Optional[bool]:
-        return self.serialized_data.dag_datas[dag_id].task_handle_data[task_id].proxied_state
 
     def asset_keys_in_task(self, dag_id: str, task_id: str) -> AbstractSet[AssetKey]:
         return self.asset_keys_per_task_handle[TaskHandle(dag_id=dag_id, task_id=task_id)]

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/builder.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/builder.py
@@ -175,8 +175,8 @@ def materializations_and_requests_from_batch_iter(
             # We need to make sure to ignore tasks that have already been proxied.
             task_ids=[
                 task_id
-                for task_id in airflow_data.task_ids_in_dag(dag_run.dag_id)
-                if not airflow_data.proxied_state_for_task(dag_run.dag_id, task_id)
+                for task_id in airflow_data.serialized_data.task_ids_in_dag(dag_run.dag_id)
+                if not airflow_data.serialized_data.proxied_state_for_task(dag_run.dag_id, task_id)
             ],
             states=["success"],
         )

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
@@ -102,6 +102,12 @@ class SerializedAirflowDefinitionsData:
     def all_mapped_tasks(self) -> Dict[AssetKey, List[MappedAirflowTaskData]]:
         return {item.asset_key: item.mapped_tasks for item in self.key_scoped_data_items}
 
+    def task_ids_in_dag(self, dag_id: str) -> AbstractSet[str]:
+        return set(self.dag_datas[dag_id].task_handle_data.keys())
+
+    def proxied_state_for_task(self, dag_id: str, task_id: str) -> Optional[bool]:
+        return self.dag_datas[dag_id].task_handle_data[task_id].proxied_state
+
 
 # History:
 # - created


### PR DESCRIPTION
## Summary & Motivation
This makes our reliance on the serialized data within the sensor explicit. These callsites should both eventually be eliminated in favor of approaches which don't require the serialized data.

## How I Tested These Changes
Existing tests
## Changelog
NOCHANGELOG
