### PR TITLE
Make instance name parameterizable

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
@@ -17,9 +17,10 @@ from dagster_airlift.core.dag_asset import dag_asset_metadata, dag_description
 from dagster_airlift.core.serialization.serialized_data import (
     MappedAirflowTaskData,
     SerializedAirflowDefinitionsData,
+    SerializedDagData,
     TaskInfo,
 )
-from dagster_airlift.core.utils import airflow_kind_dict
+from dagster_airlift.core.utils import airflow_kind_dict, convert_to_valid_dagster_name
 
 
 def tags_for_mapped_tasks(tasks: List[MappedAirflowTaskData]) -> Mapping[str, str]:
@@ -51,10 +52,10 @@ def enrich_spec_with_airflow_metadata(
     )
 
 
-def make_dag_external_asset(dag_data) -> AssetsDefinition:
+def make_dag_external_asset(*, instance_name: str, dag_data: SerializedDagData) -> AssetsDefinition:
     return external_asset_from_spec(
         AssetSpec(
-            key=dag_data.dag_info.dag_asset_key,
+            key=make_default_dag_asset_key(instance_name, dag_data.dag_id),
             description=dag_description(dag_data.dag_info),
             metadata=dag_asset_metadata(dag_data.dag_info, dag_data.source_code),
             tags=airflow_kind_dict(),
@@ -63,8 +64,8 @@ def make_dag_external_asset(dag_data) -> AssetsDefinition:
     )
 
 
-def key_for_automapped_task_asset(dag_id, task_id) -> AssetKey:
-    return AssetKey(["airflow_instance", "dag", dag_id, "task", task_id])
+def key_for_automapped_task_asset(instance_name: str, dag_id: str, task_id: str) -> AssetKey:
+    return AssetKey([instance_name, "dag", dag_id, "task", task_id])
 
 
 def description_for_automapped_task(task_info: TaskInfo) -> str:
@@ -84,6 +85,11 @@ def metadata_for_auto_mapped_task(task_info: TaskInfo) -> Mapping[str, Any]:
     }
 
 
+def make_default_dag_asset_key(instance_name: str, dag_id: str) -> AssetKey:
+    """Conventional asset key representing a successful run of an airfow dag."""
+    return AssetKey([instance_name, "dag", convert_to_valid_dagster_name(dag_id)])
+
+
 @whitelist_for_serdes
 @record
 class AirflowDefinitionsData:
@@ -98,7 +104,7 @@ class AirflowDefinitionsData:
     def construct_dag_assets_defs(self) -> Definitions:
         return Definitions(
             [
-                make_dag_external_asset(dag_data)
+                make_dag_external_asset(instance_name=self.instance_name, dag_data=dag_data)
                 for dag_data in self.serialized_data.dag_datas.values()
             ]
         )
@@ -117,9 +123,11 @@ class AirflowDefinitionsData:
 
             task_specs.extend(
                 AssetSpec(
-                    key=key_for_automapped_task_asset(dag_data.dag_id, task_id),
+                    key=key_for_automapped_task_asset(self.instance_name, dag_data.dag_id, task_id),
                     deps=[
-                        key_for_automapped_task_asset(dag_data.dag_id, upstream_task_id)
+                        key_for_automapped_task_asset(
+                            self.instance_name, dag_data.dag_id, upstream_task_id
+                        )
                         for upstream_task_id in upstream_task_ids
                     ],
                     description=description_for_automapped_task(dag_data.task_infos[task_id]),
@@ -131,12 +139,12 @@ class AirflowDefinitionsData:
 
             dag_specs.append(
                 AssetSpec(
-                    key=dag_data.dag_info.dag_asset_key,
+                    key=make_default_dag_asset_key(self.instance_name, dag_data.dag_id),
                     description=dag_description(dag_data.dag_info),
                     metadata=dag_asset_metadata(dag_data.dag_info, dag_data.source_code),
                     tags=airflow_kind_dict(),
                     deps=[
-                        key_for_automapped_task_asset(dag_data.dag_id, task_id)
+                        key_for_automapped_task_asset(self.instance_name, dag_data.dag_id, task_id)
                         for task_id in leaf_tasks
                     ],
                 )
@@ -149,7 +157,7 @@ class AirflowDefinitionsData:
         return set(self.serialized_data.dag_datas.keys())
 
     def asset_key_for_dag(self, dag_id: str) -> AssetKey:
-        return self.serialized_data.dag_datas[dag_id].dag_info.dag_asset_key
+        return make_default_dag_asset_key(self.instance_name, dag_id)
 
     def task_ids_in_dag(self, dag_id: str) -> AbstractSet[str]:
         return set(self.serialized_data.dag_datas[dag_id].task_handle_data.keys())

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_instance.py
@@ -5,6 +5,7 @@ from abc import ABC
 from typing import Any, Dict, List, Sequence
 
 import requests
+from dagster._core.definitions.utils import check_valid_name
 from dagster._core.errors import DagsterError
 from dagster._record import record
 from dagster._time import get_current_datetime
@@ -46,7 +47,7 @@ class AirflowInstance:
         batch_dag_runs_limit: int = DEFAULT_BATCH_DAG_RUNS_LIMIT,
     ) -> None:
         self.auth_backend = auth_backend
-        self.name = name
+        self.name = check_valid_name(name)
         self.batch_task_instance_limit = batch_task_instance_limit
         self.batch_dag_runs_limit = batch_dag_runs_limit
 

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor.py
@@ -60,7 +60,7 @@ def build_airflow_polling_sensor_defs(
     minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
 ) -> Definitions:
     @sensor(
-        name="airflow_dag_status_sensor",
+        name=f"{airflow_instance.name}__airflow_dag_status_sensor",
         minimum_interval_seconds=minimum_interval_seconds,
         default_status=DefaultSensorStatus.RUNNING,
         # This sensor will only ever execute asset checks and not asset materializations.

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
@@ -8,8 +8,6 @@ from dagster import (
 from dagster._record import record
 from dagster._serdes import whitelist_for_serdes
 
-from dagster_airlift.core.utils import convert_to_valid_dagster_name
-
 
 @whitelist_for_serdes
 @record
@@ -28,11 +26,6 @@ class TaskInfo:
         return check.is_list(self.metadata["downstream_task_ids"], str)
 
 
-def make_default_dag_asset_key(dag_id: str) -> AssetKey:
-    """Conventional asset key representing a successful run of an airfow dag."""
-    return AssetKey(["airflow_instance", "dag", convert_to_valid_dagster_name(dag_id)])
-
-
 @whitelist_for_serdes
 @record
 class DagInfo:
@@ -43,11 +36,6 @@ class DagInfo:
     @property
     def url(self) -> str:
         return f"{self.webserver_url}/dags/{self.dag_id}"
-
-    @cached_property
-    def dag_asset_key(self) -> AssetKey:
-        # Conventional asset key representing a successful run of an airfow dag.
-        return make_default_dag_asset_key(self.dag_id)
 
     @property
     def file_token(self) -> str:

--- a/examples/experimental/dagster-airlift/dagster_airlift/test/airflow_test_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/test/airflow_test_instance.py
@@ -27,6 +27,7 @@ class AirflowInstanceFake(AirflowInstance):
         task_instances: List[TaskInstance],
         dag_runs: List[DagRun],
         variables: List[Dict[str, Any]] = [],
+        instance_name: Optional[str] = None,
     ) -> None:
         self._dag_infos_by_dag_id = {dag_info.dag_id: dag_info for dag_info in dag_infos}
         self._task_infos_by_dag_and_task_id = {
@@ -46,7 +47,7 @@ class AirflowInstanceFake(AirflowInstance):
         self._variables = variables
         super().__init__(
             auth_backend=DummyAuthBackend(),
-            name="test_instance",
+            name="test_instance" if instance_name is None else instance_name,
         )
 
     def list_dags(self) -> List[DagInfo]:
@@ -196,6 +197,7 @@ def make_instance(
     dag_and_task_structure: Dict[str, List[str]],
     dag_runs: List[DagRun] = [],
     task_deps: Dict[str, List[str]] = {},
+    instance_name: Optional[str] = None,
 ) -> AirflowInstanceFake:
     """Constructs DagInfo, TaskInfo, and TaskInstance objects from provided data.
 
@@ -239,4 +241,5 @@ def make_instance(
         task_infos=task_infos,
         task_instances=task_instances,
         dag_runs=dag_runs,
+        instance_name=instance_name,
     )

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_dag_asset_keys.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_dag_asset_keys.py
@@ -1,14 +1,25 @@
 from dagster._core.definitions.utils import check_valid_name
+from dagster_airlift.core.airflow_defs_data import make_default_dag_asset_key
 from dagster_airlift.core.airflow_instance import DagInfo
+
+INSTANCE_NAME = "airflow_instance"
+
+
+def produce_valid_name(dag_info: DagInfo) -> str:
+    return (
+        make_default_dag_asset_key("airflow_instance", dag_info.dag_id)
+        .to_user_string()
+        .replace("/", "__")
+    )
 
 
 def test_dag_info_asset_key() -> None:
     # Airflow allows "exclusively alphanumeric characters, dashes, dots and underscores (all ASCII)"
     dag_info_hyphen = DagInfo(webserver_url="", dag_id="my-test-dag-id", metadata={})
-    assert check_valid_name(dag_info_hyphen.dag_asset_key.to_user_string().replace("/", "__"))
+    assert check_valid_name(produce_valid_name(dag_info_hyphen))
 
     dag_info_slash = DagInfo(webserver_url="", dag_id="my-test/dag-id", metadata={})
-    assert check_valid_name(dag_info_slash.dag_asset_key.to_user_string().replace("/", "__"))
+    assert check_valid_name(produce_valid_name(dag_info_slash))
 
     dag_info_dot = DagInfo(webserver_url="", dag_id="my-test.dag-id", metadata={})
-    assert check_valid_name(dag_info_dot.dag_asset_key.to_user_string().replace("/", "__"))
+    assert check_valid_name(produce_valid_name(dag_info_dot))

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/dbt_tests/test_dbt_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/dbt_tests/test_dbt_defs.py
@@ -46,7 +46,8 @@ def test_dbt_defs(dbt_project_path: Path, dbt_project_setup: None, init_load_con
     assert isinstance(dbt_defs_inst, Definitions)
 
     test_airflow_instance = make_instance(
-        dag_and_task_structure={"dag_one": ["task_one"], "dag_two": ["task_two"]}
+        dag_and_task_structure={"dag_one": ["task_one"], "dag_two": ["task_two"]},
+        instance_name="airflow_instance",
     )
 
     initial_defs = Definitions.merge(

--- a/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/constants.py
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/constants.py
@@ -13,7 +13,7 @@ PASSWORD = "admin"
 
 ASSETS_PATH = Path(__file__).parent / "defs"
 MIGRATION_STATE_PATH = Path(__file__).parent / "migration"
-DBT_DAG_ASSET_KEY = AssetKey(["airflow_instance", "dag", "dbt_dag"])
+DBT_DAG_ASSET_KEY = AssetKey([AIRFLOW_INSTANCE_NAME, "dag", "dbt_dag"])
 
 
 def dbt_project_path() -> Path:

--- a/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example_tests/integration_tests/test_e2e.py
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example_tests/integration_tests/test_e2e.py
@@ -85,7 +85,7 @@ def test_dagster_materializes(
         start_time = get_current_datetime()
         while get_current_datetime() - start_time < timedelta(seconds=30):
             asset_materialization = dagster_instance.get_latest_materialization_event(
-                asset_key=AssetKey(["airflow_instance", "dag", dag_id])
+                asset_key=AssetKey(["my_airflow_instance", "dag", dag_id])
             )
             if asset_materialization:
                 break

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_automapped.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_automapped.py
@@ -41,7 +41,7 @@ def test_dagster_materializes(
         start_time = get_current_datetime()
         while get_current_datetime() - start_time < timedelta(seconds=30):
             asset_materialization = dagster_instance.get_latest_materialization_event(
-                asset_key=AssetKey(["airflow_instance", "dag", dag_id])
+                asset_key=AssetKey(["my_airflow_instance", "dag", dag_id])
             )
             if asset_materialization:
                 break

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_mapped.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_mapped.py
@@ -58,7 +58,7 @@ def test_migrated_dagster_print_materializes(
         af_instance.wait_for_run_completion(dag_id=dag_id, run_id=run_id, timeout=60)
         dagster_instance = DagsterInstance.get()
 
-        dag_asset_key = AssetKey(["airflow_instance", "dag", dag_id])
+        dag_asset_key = AssetKey(["my_airflow_instance", "dag", dag_id])
         assert poll_for_materialization(dagster_instance, dag_asset_key)
 
         for expected_asset_key in expected_asset_keys:
@@ -98,7 +98,7 @@ def test_dagster_weekly_daily_materializes(
     af_instance.wait_for_run_completion(dag_id=dag_id, run_id=run_id, timeout=60)
     dagster_instance = DagsterInstance.get()
 
-    dag_asset_key = AssetKey(["airflow_instance", "dag", dag_id])
+    dag_asset_key = AssetKey(["my_airflow_instance", "dag", dag_id])
     assert poll_for_materialization(dagster_instance, dag_asset_key)
     weekly_mat_event = poll_for_materialization(dagster_instance, asset_one)
     assert weekly_mat_event.asset_materialization

--- a/examples/experimental/dagster-airlift/examples/perf-harness/perf_harness/cli.py
+++ b/examples/experimental/dagster-airlift/examples/perf-harness/perf_harness/cli.py
@@ -173,7 +173,7 @@ def run_suite_for_defs(
 
     print("Running sensor ticks with no runs...")
     for module_name, (repo_def, af_instance) in module_name_to_repo_def_and_instance.items():
-        sensor_def = repo_def.get_sensor_def("airflow_dag_status_sensor")
+        sensor_def = repo_def.get_sensor_def("my_airflow_instance__airflow_dag_status_sensor")
         print(f"Running {module_name} sensor ticks...")
         sensor_tick_no_runs_start_time = time.time()
         sensor_def(build_sensor_context(repository_def=repo_def))
@@ -189,7 +189,7 @@ def run_suite_for_defs(
     print("Dag run completed.")
     print("Running sensor ticks with single run...")
     for module_name, (repo_def, af_instance) in module_name_to_repo_def_and_instance.items():
-        sensor_def = repo_def.get_sensor_def("airflow_dag_status_sensor")
+        sensor_def = repo_def.get_sensor_def("my_airflow_instance__airflow_dag_status_sensor")
         sensor_tick_with_single_run_start_time = time.time()
         sensor_def(build_sensor_context(repository_def=repo_def))
         sensor_tick_with_single_run_end_time = time.time()
@@ -217,7 +217,7 @@ def run_suite_for_defs(
     print("All runs completed.")
     print("Running sensor ticks with all runs...")
     for module_name, (repo_def, af_instance) in module_name_to_repo_def_and_instance.items():
-        sensor_def = repo_def.get_sensor_def("airflow_dag_status_sensor")
+        sensor_def = repo_def.get_sensor_def("my_airflow_instance__airflow_dag_status_sensor")
         sensor_tick_with_all_runs_start_time = time.time()
         sensor_def(build_sensor_context(repository_def=repo_def))
         sensor_tick_with_all_runs_end_time = time.time()

--- a/examples/experimental/dagster-airlift/examples/perf-harness/perf_harness_tests/test_e2e.py
+++ b/examples/experimental/dagster-airlift/examples/perf-harness/perf_harness_tests/test_e2e.py
@@ -67,7 +67,7 @@ def test_dagster_materializes(
     start_time = get_current_datetime()
     while get_current_datetime() - start_time < timedelta(seconds=60):
         asset_materialization = dagster_instance.get_latest_materialization_event(
-            asset_key=AssetKey(["airflow_instance", "dag", "dag_0"])
+            asset_key=AssetKey(["my_airflow_instance", "dag", "dag_0"])
         )
         if asset_materialization:
             break

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/README.md
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/README.md
@@ -668,7 +668,7 @@ from dagster_airlift.core import AirflowInstance, BasicAuthBackend, build_defs_f
 
 # Attach a check to the DAG representation asset, which will be executed by Dagster
 # any time the DAG is run in Airflow
-@asset_check(asset=AssetKey(["airflow_instance", "dag", "rebuild_customers_list"]))
+@asset_check(asset=AssetKey(["airflow_instance_one", "dag", "rebuild_customers_list"]))
 def validate_exported_csv() -> AssetCheckResult:
     csv_path = Path(os.environ["TUTORIAL_EXAMPLE_DIR"]) / "customers.csv"
 

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/stages/peer_with_check.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/dagster_defs/stages/peer_with_check.py
@@ -7,7 +7,7 @@ from dagster_airlift.core import AirflowInstance, BasicAuthBackend, build_defs_f
 
 # Attach a check to the DAG representation asset, which will be executed by Dagster
 # any time the DAG is run in Airflow
-@asset_check(asset=AssetKey(["airflow_instance", "dag", "rebuild_customers_list"]))
+@asset_check(asset=AssetKey(["airflow_instance_one", "dag", "rebuild_customers_list"]))
 def validate_exported_csv() -> AssetCheckResult:
     csv_path = Path(os.environ["TUTORIAL_EXAMPLE_DIR"]) / "customers.csv"
 

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_peer_with_check_e2e.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_peer_with_check_e2e.py
@@ -24,18 +24,18 @@ def test_peer_reflects_dag_completion_status_and_runs_check(
     instance = DagsterInstance.get()
 
     mat_event = instance.get_latest_materialization_event(
-        AssetKey(["airflow_instance", "dag", "rebuild_customers_list"])
+        AssetKey(["airflow_instance_one", "dag", "rebuild_customers_list"])
     )
     assert mat_event is None
 
     start_run_and_wait_for_completion("rebuild_customers_list")
 
     poll_for_materialization(
-        instance, target=AssetKey(["airflow_instance", "dag", "rebuild_customers_list"])
+        instance, target=AssetKey(["airflow_instance_one", "dag", "rebuild_customers_list"])
     )
 
     check_key = AssetCheckKey(
-        asset_key=AssetKey(["airflow_instance", "dag", "rebuild_customers_list"]),
+        asset_key=AssetKey(["airflow_instance_one", "dag", "rebuild_customers_list"]),
         name="validate_exported_csv",
     )
     check_result = poll_for_asset_check(instance, target=check_key)

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_peering_e2e.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example_tests/integration_tests/test_peering_e2e.py
@@ -19,12 +19,12 @@ def test_peer_reflects_dag_completion_status(airflow_instance: None, dagster_dev
     instance = DagsterInstance.get()
 
     mat_event = instance.get_latest_materialization_event(
-        AssetKey(["airflow_instance", "dag", "rebuild_customers_list"])
+        AssetKey(["airflow_instance_one", "dag", "rebuild_customers_list"])
     )
     assert mat_event is None
 
     start_run_and_wait_for_completion("rebuild_customers_list")
 
     poll_for_materialization(
-        instance, target=AssetKey(["airflow_instance", "dag", "rebuild_customers_list"])
+        instance, target=AssetKey(["airflow_instance_one", "dag", "rebuild_customers_list"])
     )


### PR DESCRIPTION
## Summary & Motivation

Previously all dag and automapped asset keys were hardcoded to "airflow_instance" which was not desirable. This diff does a few things

* Defaults to `airflow_instance.name` instead of `"airflow_instance"`.
* Changes airflow instance name to be a valid dagster name so it can be incorporated in definition names.
* Changes sensor names for airflow polling sensor to include instance name.

## How I Tested These Changes

BK

Added unit test to load from two test instances.

## Changelog

NOCHANGELOG

