### PR TITLE
Allow DA to selectively emit backfills

### DIFF
--- a/integration_tests/test_suites/auto_materialize_perf_tests/test_asset_daemon_perf.py
+++ b/integration_tests/test_suites/auto_materialize_perf_tests/test_asset_daemon_perf.py
@@ -92,6 +92,7 @@ def test_auto_materialize_perf(scenario: PerfScenario):
             entity_keys=AssetSelection.all().resolve(asset_graph),
             instance=instance,
             asset_graph=asset_graph,
+            allow_backfills=False,
             cursor=AssetDaemonCursor.empty(),
         ).evaluate()
 

--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -40,6 +40,7 @@ def _evaluate(sensor_def: "AutomationConditionSensorDefinition", context: Sensor
         observe_run_tags={},
         auto_observe_asset_keys=set(),
         asset_selection=sensor_def.asset_selection,
+        allow_backfills=sensor_def.allow_backfills,
         default_condition=sensor_def.default_condition,
         logger=context.log,
     ).evaluate()
@@ -93,6 +94,14 @@ class AutomationConditionSensorDefinition(SensorDefinition):
         **kwargs,
     ):
         self._user_code = kwargs.get("user_code", False)
+        self._allow_backfills = check.opt_bool_param(
+            kwargs.get("allow_backfills"), "allow_backfills", default=False
+        )
+        check.param_invariant(
+            not (self._allow_backfills and not self._user_code),
+            "allow_backfills",
+            "Setting `allow_backfills` for a non-user-code AutomationConditionSensorDefinition is not supported.",
+        )
         self._default_condition = check.opt_inst_param(
             kwargs.get("default_condition"), "default_condition", AutomationCondition
         )
@@ -126,6 +135,10 @@ class AutomationConditionSensorDefinition(SensorDefinition):
     @property
     def asset_selection(self) -> AssetSelection:
         return cast(AssetSelection, super().asset_selection)
+
+    @property
+    def allow_backfills(self) -> bool:
+        return self._allow_backfills
 
     @property
     def default_condition(self) -> Optional[AutomationCondition]:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -324,7 +324,9 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
     @experimental
     @staticmethod
     def in_progress() -> "InProgressAutomationCondition":
-        """Returns an AutomationCondition that is true for an asset partition if it is part of an in-progress run."""
+        """Returns an AutomationCondition that is true for an asset partition if it is part of an
+        in-progress run or backfill.
+        """
         from dagster._core.definitions.declarative_automation.operands import (
             InProgressAutomationCondition,
         )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -40,6 +40,7 @@ class AutomationConditionEvaluator:
         instance: DagsterInstance,
         asset_graph: BaseAssetGraph,
         cursor: AssetDaemonCursor,
+        allow_backfills: bool,
         default_condition: Optional[AutomationCondition] = None,
         evaluation_time: Optional[datetime.datetime] = None,
         logger: logging.Logger = logging.getLogger("dagster.automation"),
@@ -68,7 +69,7 @@ class AutomationConditionEvaluator:
         self.legacy_respect_materialization_data_versions = (
             _instance.auto_materialize_respect_materialization_data_versions
         )
-        self.request_backfills = _instance.da_request_backfills()
+        self.allow_backfills = allow_backfills or _instance.da_request_backfills()
 
         self.legacy_expected_data_time_by_key: Dict[AssetKey, Optional[datetime.datetime]] = {}
         self.legacy_data_time_resolver = CachingDataTimeResolver(self.instance_queryer)
@@ -112,7 +113,7 @@ class AutomationConditionEvaluator:
         self.instance_queryer.prefetch_asset_records(self.asset_records_to_prefetch)
         self.logger.info("Done prefetching asset records.")
 
-    def evaluate(self) -> Tuple[Iterable[AutomationResult], Iterable[EntitySubset[EntityKey]]]:
+    def evaluate(self) -> Tuple[Sequence[AutomationResult], Sequence[EntitySubset[EntityKey]]]:
         self.prefetch()
         num_conditions = len(self.entity_keys)
         num_evaluated = 0
@@ -144,7 +145,7 @@ class AutomationConditionEvaluator:
                 f"({format(result.end_timestamp - result.start_timestamp, '.3f')} seconds)"
             )
             num_evaluated += 1
-        return self.current_results_by_key.values(), self._get_entity_subsets()
+        return list(self.current_results_by_key.values()), list(self._get_entity_subsets())
 
     def evaluate_entity(self, key: EntityKey) -> None:
         # evaluate the condition of this asset

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
@@ -124,6 +124,7 @@ def evaluate_automation_conditions(
             if asset_graph.get(key).automation_condition is not None
         },
         evaluation_time=evaluation_time,
+        allow_backfills=False,
         logger=logging.getLogger("dagster.automation_condition_tester"),
         cursor=cursor or AssetDaemonCursor.empty(),
     )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
@@ -70,7 +70,7 @@ class AutomationContext(Generic[T_EntityKey]):
         )
         condition_unqiue_id = condition.get_unique_id(parent_unique_id=None, index=None)
 
-        if condition.has_rule_condition and evaluator.request_backfills:
+        if condition.has_rule_condition and evaluator.allow_backfills:
             raise DagsterInvalidDefinitionError(
                 "Cannot use AutoMaterializePolicies and request backfills. Please use AutomationCondition or set DECLARATIVE_AUTOMATION_REQUEST_BACKFILLS to False."
             )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/slice_conditions.py
@@ -60,7 +60,7 @@ class MissingAutomationCondition(SubsetAutomationCondition[AssetKey]):
 class InProgressAutomationCondition(SubsetAutomationCondition[AssetKey]):
     @property
     def description(self) -> str:
-        return "Part of an in-progress run"
+        return "Part of an in-progress run or backfill"
 
     @property
     def name(self) -> str:

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_result_value_hash.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_result_value_hash.py
@@ -38,11 +38,11 @@ two_parents_daily = two_parents.with_asset_properties(partitions_def=daily_parti
         ("c0e6323656d8208666e8c74d9af93a64", SC.on_cron("0 * * * *"), two_parents, False),
         ("3545889e64a11959400cb116ba2320ec", SC.on_cron("0 * * * *"), two_parents_daily, False),
         # same as above
-        ("8d1dc13e39337b2cc43c711930893a36", SC.eager(), one_parent, False),
-        ("a111331589fc2766a34bacab88639ff5", SC.eager(), one_parent, True),
-        ("a41576711e61908a321bf8fc4f7d1261", SC.eager(), one_parent_daily, False),
-        ("a4dbf8969ab764eb07fb666688dafe1b", SC.eager(), two_parents, False),
-        ("ceff99f39c4db7381d8da4622421fde2", SC.eager(), two_parents_daily, False),
+        ("65f04b97a21501e043b8f3468dbe1b0d", SC.eager(), one_parent, False),
+        ("f05bc0e375b310db37e7440b7a19c5b0", SC.eager(), one_parent, True),
+        ("9ac1d99f9f0ce0e75a4de15f56791aea", SC.eager(), one_parent_daily, False),
+        ("16c84b631ff46a4cd1c44b8772f015d7", SC.eager(), two_parents, False),
+        ("bbfa1e36a49aad4c955f9d2536529093", SC.eager(), two_parents_daily, False),
         # missing condition is invariant to changes other than partitions def changes
         ("5c24ffc21af9983a4917b91290de8f5d", SC.missing(), one_parent, False),
         ("5c24ffc21af9983a4917b91290de8f5d", SC.missing(), one_parent, True),

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_simple.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_simple.py
@@ -1,0 +1,53 @@
+import dagster as dg
+
+static_partitions1 = dg.StaticPartitionsDefinition(["x", "y", "z"])
+static_partitions2 = dg.StaticPartitionsDefinition(["t", "u", "v"])
+
+condition = dg.AutomationCondition.missing() & ~dg.AutomationCondition.in_progress()
+
+
+@dg.asset(
+    automation_condition=condition,
+)
+def A() -> None: ...
+
+
+@dg.asset(
+    deps=[A],
+    automation_condition=condition,
+    partitions_def=static_partitions2,
+)
+def B() -> None: ...
+
+
+@dg.asset(
+    deps=[A],
+    automation_condition=condition,
+    partitions_def=static_partitions1,
+)
+def C() -> None: ...
+
+
+@dg.asset(
+    deps=[C],
+    automation_condition=condition,
+    partitions_def=static_partitions1,
+)
+def D() -> None: ...
+
+
+@dg.asset(
+    deps=[D],
+    automation_condition=condition,
+)
+def E() -> None: ...
+
+
+defs = dg.Definitions(
+    assets=[A, B, C, D, E],
+    sensors=[
+        dg.AutomationConditionSensorDefinition(
+            "the_sensor", asset_selection="*", user_code=True, allow_backfills=True
+        )
+    ],
+)

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_with_runs_and_checks.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_with_runs_and_checks.py
@@ -1,0 +1,78 @@
+import dagster as dg
+
+static_partitions1 = dg.StaticPartitionsDefinition(["x", "y", "z"])
+static_partitions2 = dg.StaticPartitionsDefinition(["t", "u", "v"])
+
+condition = dg.AutomationCondition.missing() & ~dg.AutomationCondition.in_progress()
+
+
+@dg.asset(
+    automation_condition=condition,
+    check_specs=[dg.AssetCheckSpec(name="inside", asset="backfillA")],
+)
+def backfillA() -> dg.MaterializeResult:
+    return dg.MaterializeResult(check_results=[dg.AssetCheckResult(passed=True)])
+
+
+@dg.asset(
+    deps=[backfillA],
+    automation_condition=condition,
+    partitions_def=static_partitions2,
+    check_specs=[dg.AssetCheckSpec(name="inside", asset="backfillB")],
+)
+def backfillB() -> dg.MaterializeResult:
+    return dg.MaterializeResult(check_results=[dg.AssetCheckResult(passed=True)])
+
+
+@dg.asset(
+    deps=[backfillA],
+    automation_condition=condition,
+    partitions_def=static_partitions1,
+)
+def backfillC() -> None: ...
+
+
+@dg.asset(
+    automation_condition=condition,
+    check_specs=[dg.AssetCheckSpec(name="inside", asset="run1")],
+)
+def run1() -> dg.MaterializeResult:
+    return dg.MaterializeResult(check_results=[dg.AssetCheckResult(passed=True)])
+
+
+@dg.asset(
+    automation_condition=condition,
+    partitions_def=static_partitions1,
+    check_specs=[dg.AssetCheckSpec(name="inside", asset="run2")],
+)
+def run2() -> dg.MaterializeResult:
+    return dg.MaterializeResult(check_results=[dg.AssetCheckResult(passed=True)])
+
+
+# these checks should never be executed as they are not required
+# and do not have an automation condition
+@dg.asset_check(name="outside", asset="backfillA")
+def outsideA() -> dg.AssetCheckResult: ...
+
+
+@dg.asset_check(name="outside", asset="backfillB")
+def outsideB() -> dg.AssetCheckResult: ...
+
+
+@dg.asset_check(name="outside", asset="run1")
+def outside1() -> dg.AssetCheckResult: ...
+
+
+@dg.asset_check(name="outside", asset="run2")
+def outside2() -> dg.AssetCheckResult: ...
+
+
+defs = dg.Definitions(
+    assets=[backfillA, backfillB, backfillC, run1, run2],
+    asset_checks=[outsideA, outsideB, outside1, outside2],
+    sensors=[
+        dg.AutomationConditionSensorDefinition(
+            "the_sensor", asset_selection="*", user_code=True, allow_backfills=True
+        )
+    ],
+)

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_backfills_requested.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_backfills_requested.py
@@ -1,9 +1,7 @@
-from datetime import datetime, timezone
 from unittest import mock
 
 from dagster import AutomationCondition
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.time_window_partitions import TimeWindow
 
 from dagster_tests.definitions_tests.declarative_automation_tests.daemon_tests.test_asset_daemon import (
     get_daemon_instance,
@@ -17,7 +15,6 @@ from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils
 from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils.scenario_specs import (
     daily_partitions_def,
     hourly_partitions_def,
-    two_assets_depend_on_one,
     two_assets_in_sequence,
     two_disconnected_graphs,
     two_partitions_def,
@@ -53,6 +50,7 @@ def test_simple_conditions_with_backfills(mock_da_request_backfills) -> None:
 
         # update A with an old partition, should cause B to materialize
         state = state.with_runs(run_request("A", "2019-07-05-00:00"))
+        state = state.with_runs(run_request("A", "2019-07-05-01:00"))
         state, new_run_requests = state.evaluate_tick_daemon()
         assert len(new_run_requests) == 1
         assert new_run_requests[0].requires_backfill_daemon()
@@ -61,77 +59,8 @@ def test_simple_conditions_with_backfills(mock_da_request_backfills) -> None:
         state = state.with_runs(run_request("A", "2020-02-02-00:00"))
         state, new_run_requests = state.evaluate_tick_daemon()
         assert len(new_run_requests) == 1
-        assert new_run_requests[0].requires_backfill_daemon()
-        assert new_run_requests[0].asset_graph_subset
-        state = state.with_runs(
-            *(
-                run_request(ak, pk)
-                for ak, pk in new_run_requests[0].asset_graph_subset.iterate_asset_partitions()
-            )
-        )
-
-        # now B has been materialized, so don't execute again
-        state, new_run_requests = state.evaluate_tick_daemon()
-        assert len(new_run_requests) == 0
-
-        # new partition comes into being, parent hasn't been materialized yet
-        state = state.with_current_time_advanced(hours=1)
-        state, new_run_requests = state.evaluate_tick_daemon()
-        assert len(new_run_requests) == 0
-
-        # parent gets materialized, B requested
-        state = state.with_runs(run_request("A", "2020-02-02-01:00"))
-        state, new_run_requests = state.evaluate_tick_daemon()
-        assert len(new_run_requests) == 1
-        # but it fails
-        state = state.with_failed_run_for_asset("B", "2020-02-02-01:00")
-
-        # B does not get immediately requested again
-        state, new_run_requests = state.evaluate_tick_daemon()
-        assert len(new_run_requests) == 0
-
-
-@mock.patch(
-    "dagster_tests.definitions_tests.declarative_automation_tests.daemon_tests.test_asset_daemon.DagsterInstance.da_request_backfills",
-    return_value=True,
-)
-def test_eager_conditions_with_backfills(mock_da_request_backfills) -> None:
-    with get_daemon_instance(
-        extra_overrides={"auto_materialize": {"use_sensors": False}}
-    ) as instance:
-        state = (
-            AssetDaemonScenarioState(
-                two_assets_in_sequence.with_asset_properties(
-                    keys=["B"], automation_condition=AutomationCondition.eager()
-                ),
-                request_backfills=True,
-                instance=instance,
-            )
-            .with_asset_properties(partitions_def=hourly_partitions_def)
-            .with_current_time("2020-02-02T01:05:00")
-        )
-
-        # parent hasn't updated yet
-        state, new_run_requests = state.evaluate_tick_daemon()
-        assert len(new_run_requests) == 0
-
-        # historical parent updated, doesn't matter
-        state = state.with_runs(run_request("A", "2019-07-05-00:00"))
-        state, new_run_requests = state.evaluate_tick_daemon()
-        assert len(new_run_requests) == 0
-
-        # latest parent updated, now can execute
-        state = state.with_runs(run_request("A", "2020-02-02-00:00"))
-        state, new_run_requests = state.evaluate_tick_daemon()
-        assert len(new_run_requests) == 1
-        assert new_run_requests[0].requires_backfill_daemon()
-        assert new_run_requests[0].asset_graph_subset
-        state = state.with_runs(
-            *(
-                run_request(ak, pk)
-                for ak, pk in new_run_requests[0].asset_graph_subset.iterate_asset_partitions()
-            )
-        )
+        # backfill daemon not required
+        assert not new_run_requests[0].requires_backfill_daemon()
 
         # now B has been materialized, so don't execute again
         state, new_run_requests = state.evaluate_tick_daemon()
@@ -184,6 +113,7 @@ def test_disconnected_graphs_backfill(mock_da_request_backfills) -> None:
 
         # A updated, now can execute B, but not D
         state = state.with_runs(run_request("A", "2020-02-01"))
+        state = state.with_runs(run_request("A", "2020-01-30"))
         state, new_run_requests = state.evaluate_tick_daemon()
         assert len(new_run_requests) == 1
         assert new_run_requests[0].requires_backfill_daemon()
@@ -206,90 +136,15 @@ def test_disconnected_graphs_backfill(mock_da_request_backfills) -> None:
         assert len(new_run_requests) == 0
 
         # both A and C get materialized, B and D requested in the same backfill
-        state = state.with_runs(*(run_request("A", "2020-02-02"), run_request("C", "2")))
+        state = state.with_runs(
+            run_request("A", "2020-01-30"),
+            run_request("A", "2020-02-02"),
+            run_request("C", "1"),
+            run_request("C", "2"),
+        )
         state, new_run_requests = state.evaluate_tick_daemon()
         assert len(new_run_requests) == 1
         assert new_run_requests[0].requires_backfill_daemon()
         assert new_run_requests[0].asset_graph_subset and new_run_requests[
             0
         ].asset_graph_subset.asset_keys == {AssetKey("B"), AssetKey("D")}
-
-
-@mock.patch(
-    "dagster_tests.definitions_tests.declarative_automation_tests.daemon_tests.test_asset_daemon.DagsterInstance.da_request_backfills",
-    return_value=True,
-)
-def test_multiple_partitions_defs_backfill(mock_da_request_backfills) -> None:
-    with get_daemon_instance(
-        extra_overrides={"auto_materialize": {"use_sensors": False}}
-    ) as instance:
-        state = (
-            AssetDaemonScenarioState(
-                two_assets_depend_on_one.with_asset_properties(
-                    keys=["B", "C"],
-                    automation_condition=AutomationCondition.eager(),
-                ),
-                request_backfills=True,
-                instance=instance,
-            )
-            .with_asset_properties(keys=["A"], partitions_def=hourly_partitions_def)
-            .with_asset_properties(keys=["B", "C"], partitions_def=daily_partitions_def)
-            .with_current_time("2020-02-02T01:05:00")
-        )
-
-        # parent hasn't updated yet
-        state, new_run_requests = state.evaluate_tick_daemon()
-        assert len(new_run_requests) == 0
-
-        # historical parent updated, doesn't matter
-        state = state.with_runs(run_request("A", "2019-07-05-00:00"))
-        state, new_run_requests = state.evaluate_tick_daemon()
-        assert len(new_run_requests) == 0
-
-        # latest parent updated, now can execute
-        state = state.with_runs(
-            *(
-                run_request("A", pk)
-                for pk in hourly_partitions_def.get_partition_keys_in_time_window(
-                    TimeWindow(
-                        start=datetime(2020, 2, 1, 0, 0, tzinfo=timezone.utc),
-                        end=datetime(2020, 2, 2, 1, 0, tzinfo=timezone.utc),
-                    )
-                )
-            )
-        )
-        state, new_run_requests = state.evaluate_tick_daemon()
-        assert len(new_run_requests) == 1
-        assert new_run_requests[0].requires_backfill_daemon()
-        assert new_run_requests[0].asset_graph_subset
-        state = state.with_runs(
-            *(
-                run_request(ak, pk)
-                for ak, pk in new_run_requests[0].asset_graph_subset.iterate_asset_partitions()
-            )
-        )
-
-        # now B has been materialized, so don't execute again
-        state, new_run_requests = state.evaluate_tick_daemon()
-        assert len(new_run_requests) == 0
-
-        # new partition comes into being, parent hasn't been materialized yet
-        state = state.with_current_time_advanced(days=1)
-        state, new_run_requests = state.evaluate_tick_daemon()
-        assert len(new_run_requests) == 0
-
-        # parent gets materialized, B and C requested
-        state = state.with_runs(
-            *(
-                run_request("A", pk)
-                for pk in hourly_partitions_def.get_partition_keys_in_time_window(
-                    TimeWindow(
-                        start=datetime(2020, 2, 2, 0, 0, tzinfo=timezone.utc),
-                        end=datetime(2020, 2, 3, 1, 0, tzinfo=timezone.utc),
-                    )
-                )
-            )
-        )
-        state, new_run_requests = state.evaluate_tick_daemon()
-        assert len(new_run_requests) == 1
-        assert new_run_requests[0].requires_backfill_daemon()

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/legacy_tests/test_auto_observe.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/legacy_tests/test_auto_observe.py
@@ -32,6 +32,7 @@ def get_auto_observe_run_requests(
         auto_observe_asset_keys,
         AssetSelection.all(),
         logging.getLogger(),
+        False,
         None,
         datetime.datetime.fromtimestamp(current_timestamp),
     ).evaluate()[0]
@@ -142,6 +143,7 @@ def test_reconcile() -> None:
         instance=instance,
         cursor=AssetDaemonCursor.empty(),
         materialize_run_tags={},
+        allow_backfills=False,
         observe_run_tags={"tag1": "tag_value"},
         logger=logging.getLogger("dagster.amp"),
     ).evaluate()

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
@@ -159,6 +159,7 @@ class AssetDaemonScenarioState(ScenarioState):
                 if self.asset_graph.get(key).auto_observe_interval_minutes is not None
             },
             logger=self.logger,
+            allow_backfills=False,
         ).evaluate()
         check.is_list(new_run_requests, of_type=RunRequest)
         check.inst(new_cursor, AssetDaemonCursor)

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
@@ -97,6 +97,7 @@ class AutomationConditionScenarioState(ScenarioState):
                     0, 0, [], [self.condition_cursor] if self.condition_cursor else []
                 ),
                 logger=self.logger,
+                allow_backfills=False,
             )
             evaluator.current_results_by_key = self._get_current_results_by_key(
                 evaluator.asset_graph_view

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/base_scenario.py
@@ -405,6 +405,7 @@ class AssetReconciliationScenario(
                     materialize_run_tags={},
                     observe_run_tags={},
                     cursor=cursor,
+                    allow_backfills=False,
                     auto_observe_asset_keys={
                         key
                         for key in asset_graph.observable_asset_keys


### PR DESCRIPTION
## Summary & Motivation

The previous behavior when enabling DA to emit backfills was to *always* emit a backfill regardless of it was required or not.

This updates the behavior to only emit a backfill when more than one partition is requested for a given asset at one time.

If a backfill is required, the system will group together all "touching" assets into a single backfill to ensure that execution order is respected.

This means that it is possible for the system to request multiple backfills and multiple runs on the same tick.

## How I Tested These Change

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
