### PR TITLE
[dagster-sigma] add option to warn on lineage fetch failure instead of error outright

### DIFF
--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -1,8 +1,10 @@
+import contextlib
 import urllib.parse
+import warnings
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
-from typing import AbstractSet, Any, Dict, List, Mapping, Optional, Type
+from typing import AbstractSet, Any, Dict, Iterator, List, Mapping, Optional, Type
 
 import requests
 from dagster import ConfigurableResource
@@ -10,6 +12,7 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader
 from dagster._utils.cached_method import cached_method
 from pydantic import Field, PrivateAttr
+from requests import HTTPError
 from sqlglot import exp, parse_one
 
 from dagster_sigma.translator import (
@@ -51,6 +54,10 @@ class SigmaOrganization(ConfigurableResource):
     )
     client_id: str = Field(..., description="A client ID with access to the Sigma API.")
     client_secret: str = Field(..., description="A client secret with access to the Sigma API.")
+    warn_on_lineage_fetch_error: bool = Field(
+        default=False,
+        description="Whether to warn rather than raise when lineage data cannot be fetched for an element.",
+    )
 
     _api_token: Optional[str] = PrivateAttr(None)
 
@@ -125,6 +132,16 @@ class SigmaOrganization(ConfigurableResource):
     def fetch_queries_for_workbook(self, workbook_id: str) -> List[Dict[str, Any]]:
         return self.fetch_json(f"workbooks/{workbook_id}/queries")["entries"]
 
+    @contextlib.contextmanager
+    def try_except_http_warn(self, should_catch: bool, msg: str) -> Iterator[None]:
+        try:
+            yield
+        except HTTPError as e:
+            if should_catch:
+                warnings.warn(f"{msg} {e}")
+            else:
+                raise
+
     @cached_method
     def fetch_dataset_upstreams_by_inode(self) -> Mapping[str, AbstractSet[str]]:
         """Builds a mapping of dataset inodes to the upstream inputs they depend on.
@@ -151,32 +168,36 @@ class SigmaOrganization(ConfigurableResource):
                     # We extract the list of dataset dependencies from the lineage of each element
                     # If there is a single dataset dependency, we can then know the queries for that element
                     # are associated with that dataset
-                    lineage = self.fetch_lineage_for_element(
-                        workbook["workbookId"], element["elementId"]
-                    )
-                    dataset_dependencies = [
-                        dep
-                        for dep in lineage["dependencies"].values()
-                        if dep.get("type") == "dataset"
-                    ]
-                    if len(dataset_dependencies) != 1:
-                        continue
-
-                    inode = dataset_dependencies[0]["nodeId"]
-                    for query in queries_by_element_id[element["elementId"]]:
-                        # Use sqlglot to extract the tables used in each query and add them to the dataset's
-                        # list of dependencies
-                        table_deps = set(
-                            [
-                                f"{table.catalog}.{table.db}.{table.this}"
-                                for table in list(parse_one(query["sql"]).find_all(exp.Table))
-                                if table.catalog
-                            ]
+                    with self.try_except_http_warn(
+                        self.warn_on_lineage_fetch_error,
+                        f"Failed to fetch lineage for element {element['elementId']} in workbook {workbook['workbookId']}",
+                    ):
+                        lineage = self.fetch_lineage_for_element(
+                            workbook["workbookId"], element["elementId"]
                         )
+                        dataset_dependencies = [
+                            dep
+                            for dep in lineage["dependencies"].values()
+                            if dep.get("type") == "dataset"
+                        ]
+                        if len(dataset_dependencies) != 1:
+                            continue
 
-                        deps_by_dataset_inode[inode] = deps_by_dataset_inode[inode].union(
-                            table_deps
-                        )
+                        inode = dataset_dependencies[0]["nodeId"]
+                        for query in queries_by_element_id[element["elementId"]]:
+                            # Use sqlglot to extract the tables used in each query and add them to the dataset's
+                            # list of dependencies
+                            table_deps = set(
+                                [
+                                    f"{table.catalog}.{table.db}.{table.this}"
+                                    for table in list(parse_one(query["sql"]).find_all(exp.Table))
+                                    if table.catalog
+                                ]
+                            )
+
+                            deps_by_dataset_inode[inode] = deps_by_dataset_inode[inode].union(
+                                table_deps
+                            )
 
         return deps_by_dataset_inode
 
@@ -231,12 +252,16 @@ class SigmaOrganization(ConfigurableResource):
                 elements = self.fetch_elements_for_page(workbook["workbookId"], page["pageId"])
                 for element in elements:
                     # We extract the list of dataset dependencies from the lineage of each workbook.
-                    lineage = self.fetch_lineage_for_element(
-                        workbook["workbookId"], element["elementId"]
-                    )
-                    for inode, item in lineage["dependencies"].items():
-                        if item.get("type") == "dataset":
-                            workbook_deps.add(item["nodeId"])
+                    with self.try_except_http_warn(
+                        self.warn_on_lineage_fetch_error,
+                        f"Failed to fetch lineage for element {element['elementId']} in workbook {workbook['workbookId']}",
+                    ):
+                        lineage = self.fetch_lineage_for_element(
+                            workbook["workbookId"], element["elementId"]
+                        )
+                        for inode, item in lineage["dependencies"].items():
+                            if item.get("type") == "dataset":
+                                workbook_deps.add(item["nodeId"])
 
             workbooks.append(
                 SigmaWorkbook(

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/conftest.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/conftest.py
@@ -56,6 +56,15 @@ SAMPLE_DATASET_DATA = {
 }
 
 
+@pytest.fixture(name="lineage_warn")
+def lineage_warn_fixture() -> None:
+    responses.replace(
+        method_or_response=responses.GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/lineage/elements/_MuHPbskp0",
+        status=400,
+    )
+
+
 @pytest.fixture(name="sigma_sample_data")
 def sigma_sample_data_fixture() -> None:
     # Single workbook, dataset

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
@@ -1,8 +1,10 @@
 import uuid
 
+import pytest
 import responses
 from dagster_sigma import SigmaBaseUrl, SigmaOrganization
 from dagster_sigma.resource import _inode_from_url
+from requests import HTTPError
 
 
 @responses.activate
@@ -84,3 +86,36 @@ def test_model_organization_data(sigma_auth_token: str, sigma_sample_data: None)
         "Status",
     }
     assert data.datasets[0].inputs == {"TESTDB.JAFFLE_SHOP.STG_ORDERS"}
+
+
+@responses.activate
+def test_model_organization_data_warn(
+    sigma_auth_token: str, sigma_sample_data: None, lineage_warn: None
+) -> None:
+    fake_client_id = uuid.uuid4().hex
+    fake_client_secret = uuid.uuid4().hex
+
+    resource = SigmaOrganization(
+        base_url=SigmaBaseUrl.AWS_US,
+        client_id=fake_client_id,
+        client_secret=fake_client_secret,
+        warn_on_lineage_fetch_error=False,
+    )
+
+    with pytest.raises(HTTPError):
+        resource.build_organization_data()
+
+    resource_warn = SigmaOrganization(
+        base_url=SigmaBaseUrl.AWS_US,
+        client_id=fake_client_id,
+        client_secret=fake_client_secret,
+        warn_on_lineage_fetch_error=True,
+    )
+
+    data = resource_warn.build_organization_data()
+
+    assert len(data.workbooks) == 1
+    assert data.workbooks[0].properties["name"] == "Sample Workbook"
+
+    assert len(data.datasets) == 1
+    assert data.workbooks[0].datasets == {_inode_from_url(data.datasets[0].properties["url"])}


### PR DESCRIPTION
## Summary

This addresses a user issue where a lineage permissions error is raised on some workbook elements. This PR adds an option to warn on a failure to fetch a particular element's lineage rather than error.

## Test Plan

New unit test.