### PR TITLE
Add `output_metadata` to `build_output_context`

### DIFF
--- a/python_modules/dagster/dagster/_core/execution/context/output.py
+++ b/python_modules/dagster/dagster/_core/execution/context/output.py
@@ -843,6 +843,7 @@ def build_output_context(
     op_def: Optional["OpDefinition"] = None,
     asset_key: Optional[CoercibleToAssetKey] = None,
     partition_key: Optional[str] = None,
+    output_metadata: Optional[Mapping[str, RawMetadataValue]] = None,
     # deprecated
     metadata: Optional[Mapping[str, RawMetadataValue]] = None,
 ) -> "OutputContext":
@@ -871,6 +872,8 @@ def build_output_context(
         asset_key: Optional[Union[AssetKey, Sequence[str], str]]: The asset key corresponding to the
             output.
         partition_key: Optional[str]: String value representing partition key to execute with.
+        output_metadata: (Optional[str, RawMetadataValue]): A dict of the metadata that is assigned
+            to the output at execution time.
         metadata (Optional[Mapping[str, Any]]): Deprecated. Use definition_metadata instead.
 
     Examples:
@@ -905,6 +908,7 @@ def build_output_context(
     op_def = check.opt_inst_param(op_def, "op_def", OpDefinition)
     asset_key = AssetKey.from_coercible(asset_key) if asset_key else None
     partition_key = check.opt_str_param(partition_key, "partition_key")
+    output_metadata = check.opt_mapping_param(output_metadata, "output_metadata")
 
     return OutputContext(
         step_key=step_key,
@@ -923,4 +927,5 @@ def build_output_context(
         op_def=op_def,
         asset_key=asset_key,
         partition_key=partition_key,
+        output_metadata=output_metadata
     )


### PR DESCRIPTION
## Summary & Motivation

When developing an IO Manager that relies on some `output_metadata` to exist, we may want to write a test around this, using the `build_output_context` function. 

Currently, `build_output_context` does not support adding `output_metadata`, and the `add_output_metadata` method on the `OutputContext` returned by it does not work as it does when called within an op or asset. It adds this metadata to `OutputContext._user_generated_metadata`, which I'm assuming Dagster is injecting in `OutputContext.output_metadata` when in the context of a real run.

## How I Tested These Changes

I did not find any existing tests for `build_output_context`, so I'm assuming this isn't required since this is a relatively simple constructor function for `OutputContext`.

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
