### PR TITLE
[dagster-airlift][rfc] move sensor out of initial builder

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/__init__.py
@@ -1,4 +1,5 @@
 from ..proxied_state import load_proxied_state_from_yaml as load_proxied_state_from_yaml
+from .airflow_defs_data import AirflowDefinitionsData as AirflowDefinitionsData
 from .basic_auth import BasicAuthBackend as BasicAuthBackend
 from .dag_defs import (
     dag_defs as dag_defs,
@@ -8,4 +9,6 @@ from .defs_builders import specs_from_task as specs_from_task
 from .load_defs import (
     AirflowInstance as AirflowInstance,
     build_defs_from_airflow_instance as build_defs_from_airflow_instance,
+    get_resolved_airflow_defs as get_resolved_airflow_defs,
 )
+from .sensor import build_airflow_polling_sensor_defs as build_airflow_polling_sensor_defs

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from functools import cached_property
-from typing import AbstractSet, Mapping, Optional, cast
+from typing import AbstractSet, Mapping, cast
 
 from dagster import AssetKey, Definitions
 from dagster._record import record
@@ -54,12 +54,6 @@ class AirflowDefinitionsData:
 
     def asset_key_for_dag(self, dag_id: str) -> AssetKey:
         return make_default_dag_asset_key(self.serialized_data.instance_name, dag_id)
-
-    def task_ids_in_dag(self, dag_id: str) -> AbstractSet[str]:
-        return set(self.serialized_data.dag_datas[dag_id].task_handle_data.keys())
-
-    def proxied_state_for_task(self, dag_id: str, task_id: str) -> Optional[bool]:
-        return self.serialized_data.dag_datas[dag_id].task_handle_data[task_id].proxied_state
 
     def asset_keys_in_task(self, dag_id: str, task_id: str) -> AbstractSet[AssetKey]:
         return self.asset_keys_per_task_handle[TaskHandle(dag_id=dag_id, task_id=task_id)]

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
@@ -1,13 +1,18 @@
+from collections import defaultdict
 from functools import cached_property
-from typing import AbstractSet, Optional, cast
+from typing import AbstractSet, Mapping, Optional, cast
 
 from dagster import AssetKey, Definitions
 from dagster._record import record
 from dagster._serdes.serdes import deserialize_value
 
+from dagster_airlift.constants import STANDALONE_DAG_ID_METADATA_KEY
 from dagster_airlift.core.serialization.defs_construction import make_default_dag_asset_key
-from dagster_airlift.core.serialization.serialized_data import SerializedAirflowDefinitionsData
-from dagster_airlift.core.utils import get_metadata_key
+from dagster_airlift.core.serialization.serialized_data import (
+    SerializedAirflowDefinitionsData,
+    TaskHandle,
+)
+from dagster_airlift.core.utils import get_metadata_key, is_mapped_asset_spec, task_handles_for_spec
 
 
 @record
@@ -28,6 +33,25 @@ class AirflowDefinitionsData:
     def all_dag_ids(self) -> AbstractSet[str]:
         return set(self.serialized_data.dag_datas.keys())
 
+    @cached_property
+    def asset_keys_per_task_handle(self) -> Mapping[TaskHandle, AbstractSet[AssetKey]]:
+        asset_keys_per_handle = defaultdict(set)
+        for spec in self.resolved_airflow_defs.get_all_asset_specs():
+            if is_mapped_asset_spec(spec):
+                task_handles = task_handles_for_spec(spec)
+                for task_handle in task_handles:
+                    asset_keys_per_handle[task_handle].add(spec.key)
+        return asset_keys_per_handle
+
+    @cached_property
+    def asset_key_per_dag(self) -> Mapping[str, AssetKey]:
+        dag_id_to_asset_key = {}
+        for spec in self.resolved_airflow_defs.get_all_asset_specs():
+            if STANDALONE_DAG_ID_METADATA_KEY in spec.metadata:
+                dag_id = spec.metadata[STANDALONE_DAG_ID_METADATA_KEY]
+                dag_id_to_asset_key[dag_id] = spec.key
+        return dag_id_to_asset_key
+
     def asset_key_for_dag(self, dag_id: str) -> AssetKey:
         return make_default_dag_asset_key(self.serialized_data.instance_name, dag_id)
 
@@ -38,4 +62,4 @@ class AirflowDefinitionsData:
         return self.serialized_data.dag_datas[dag_id].task_handle_data[task_id].proxied_state
 
     def asset_keys_in_task(self, dag_id: str, task_id: str) -> AbstractSet[AssetKey]:
-        return self.serialized_data.dag_datas[dag_id].task_handle_data[task_id].asset_keys_in_task
+        return self.asset_keys_per_task_handle[TaskHandle(dag_id=dag_id, task_id=task_id)]

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
@@ -10,7 +10,6 @@ from dagster import (
 )
 from dagster._utils.warnings import suppress_dagster_warnings
 
-from dagster_airlift.constants import AIRFLOW_SOURCE_METADATA_KEY_PREFIX
 from dagster_airlift.core.airflow_defs_data import AirflowDefinitionsData
 from dagster_airlift.core.airflow_instance import AirflowInstance
 from dagster_airlift.core.sensor import (
@@ -26,10 +25,7 @@ from dagster_airlift.core.serialization.defs_construction import (
 )
 from dagster_airlift.core.serialization.serialized_data import SerializedAirflowDefinitionsData
 from dagster_airlift.core.state_backed_defs_loader import StateBackedDefinitionsLoader
-
-
-def _metadata_key(instance_name: str) -> str:
-    return f"{AIRFLOW_SOURCE_METADATA_KEY_PREFIX}/{instance_name}"
+from dagster_airlift.core.utils import get_metadata_key
 
 
 @dataclass
@@ -40,7 +36,7 @@ class AirflowInstanceDefsLoader(StateBackedDefinitionsLoader[SerializedAirflowDe
 
     @property
     def defs_key(self) -> str:
-        return _metadata_key(self.airflow_instance.name)
+        return get_metadata_key(self.airflow_instance.name)
 
     def fetch_state(self) -> SerializedAirflowDefinitionsData:
         return compute_serialized_data(
@@ -53,12 +49,6 @@ class AirflowInstanceDefsLoader(StateBackedDefinitionsLoader[SerializedAirflowDe
         return Definitions.merge(
             enrich_explicit_defs_with_airflow_metadata(self.explicit_defs, serialized_airflow_data),
             construct_dag_assets_defs(serialized_airflow_data),
-            build_airflow_polling_sensor_defs(
-                airflow_instance=self.airflow_instance,
-                minimum_interval_seconds=self.sensor_minimum_interval_seconds,
-                airflow_data=AirflowDefinitionsData(serialized_data=serialized_airflow_data),
-                event_translation_fn=get_asset_events,
-            ),
         )
 
 
@@ -69,11 +59,22 @@ def build_defs_from_airflow_instance(
     defs: Optional[Definitions] = None,
     sensor_minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
 ) -> Definitions:
-    return AirflowInstanceDefsLoader(
+    resolved_defs = AirflowInstanceDefsLoader(
         airflow_instance=airflow_instance,
         explicit_defs=defs or Definitions(),
         sensor_minimum_interval_seconds=sensor_minimum_interval_seconds,
     ).build_defs()
+    return Definitions.merge(
+        resolved_defs,
+        build_airflow_polling_sensor_defs(
+            airflow_instance=airflow_instance,
+            airflow_data=AirflowDefinitionsData(
+                instance_name=airflow_instance.name, resolved_airflow_defs=resolved_defs
+            ),
+            event_translation_fn=get_asset_events,
+            minimum_interval_seconds=sensor_minimum_interval_seconds,
+        ),
+    )
 
 
 class FullAutomappedDagsLoader(StateBackedDefinitionsLoader[SerializedAirflowDefinitionsData]):
@@ -87,7 +88,7 @@ class FullAutomappedDagsLoader(StateBackedDefinitionsLoader[SerializedAirflowDef
 
     @property
     def defs_key(self) -> str:
-        return _metadata_key(self.airflow_instance.name) + "/full_automapped_dags"
+        return get_metadata_key(self.airflow_instance.name) + "/full_automapped_dags"
 
     def fetch_state(self) -> SerializedAirflowDefinitionsData:
         return compute_serialized_data(airflow_instance=self.airflow_instance, defs=Definitions())
@@ -95,16 +96,16 @@ class FullAutomappedDagsLoader(StateBackedDefinitionsLoader[SerializedAirflowDef
     def defs_from_state(
         self, serialized_airflow_data: SerializedAirflowDefinitionsData
     ) -> Definitions:
-        airflow_data = AirflowDefinitionsData(serialized_data=serialized_airflow_data)
-        return Definitions.merge(
-            construct_automapped_dag_assets_defs(serialized_airflow_data),
-            build_airflow_polling_sensor_defs(
-                airflow_instance=self.airflow_instance,
-                minimum_interval_seconds=self.sensor_minimum_interval_seconds,
-                airflow_data=airflow_data,
-                event_translation_fn=get_asset_events,
+        resolved_defs = construct_automapped_dag_assets_defs(serialized_airflow_data)
+        airflow_polling_sensor_defs = build_airflow_polling_sensor_defs(
+            airflow_instance=self.airflow_instance,
+            minimum_interval_seconds=self.sensor_minimum_interval_seconds,
+            airflow_data=AirflowDefinitionsData(
+                resolved_airflow_defs=resolved_defs, instance_name=self.airflow_instance.name
             ),
+            event_translation_fn=get_asset_events,
         )
+        return Definitions.merge(resolved_defs, airflow_polling_sensor_defs)
 
 
 def build_full_automapped_dags_from_airflow_instance(
@@ -130,6 +131,7 @@ def enrich_explicit_defs_with_airflow_metadata(
         executor=explicit_defs.executor,
         loggers=explicit_defs.loggers,
         resources=explicit_defs.resources,
+        metadata=explicit_defs.metadata,
     )
 
 

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/builder.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/builder.py
@@ -175,8 +175,8 @@ def materializations_and_requests_from_batch_iter(
             # We need to make sure to ignore tasks that have already been proxied.
             task_ids=[
                 task_id
-                for task_id in airflow_data.task_ids_in_dag(dag_run.dag_id)
-                if not airflow_data.proxied_state_for_task(dag_run.dag_id, task_id)
+                for task_id in airflow_data.serialized_data.task_ids_in_dag(dag_run.dag_id)
+                if not airflow_data.serialized_data.proxied_state_for_task(dag_run.dag_id, task_id)
             ],
             states=["success"],
         )

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/builder.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/builder.py
@@ -27,6 +27,7 @@ from dagster_airlift.core.airflow_defs_data import AirflowDefinitionsData
 from dagster_airlift.core.airflow_instance import AirflowInstance
 from dagster_airlift.core.sensor.event_translation import (
     AirflowEventTranslationFn,
+    get_asset_events,
     get_timestamp_from_materialization,
 )
 
@@ -57,9 +58,11 @@ def check_keys_for_asset_keys(
 def build_airflow_polling_sensor_defs(
     airflow_instance: AirflowInstance,
     airflow_data: AirflowDefinitionsData,
-    event_translation_fn: AirflowEventTranslationFn,
-    minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
+    event_translation_fn: AirflowEventTranslationFn = get_asset_events,
+    minimum_interval_seconds: Optional[int] = None,
 ) -> Definitions:
+    minimum_interval_seconds = minimum_interval_seconds or DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS
+
     @sensor(
         name=f"{airflow_instance.name}__airflow_dag_status_sensor",
         minimum_interval_seconds=minimum_interval_seconds,

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
@@ -102,6 +102,12 @@ class SerializedAirflowDefinitionsData:
     def all_mapped_tasks(self) -> Dict[AssetKey, List[MappedAirflowTaskData]]:
         return {item.asset_key: item.mapped_tasks for item in self.key_scoped_data_items}
 
+    def task_ids_in_dag(self, dag_id: str) -> AbstractSet[str]:
+        return set(self.dag_datas[dag_id].task_handle_data.keys())
+
+    def proxied_state_for_task(self, dag_id: str, task_id: str) -> Optional[bool]:
+        return self.dag_datas[dag_id].task_handle_data[task_id].migration_state
+
 
 # History:
 # - created

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
@@ -6,7 +6,7 @@ from dagster._core.definitions.utils import VALID_NAME_REGEX
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.storage.tags import KIND_PREFIX
 
-from dagster_airlift.constants import TASK_MAPPING_METADATA_KEY
+from dagster_airlift.constants import AIRFLOW_SOURCE_METADATA_KEY_PREFIX, TASK_MAPPING_METADATA_KEY
 
 
 def convert_to_valid_dagster_name(name: str) -> str:
@@ -36,3 +36,7 @@ def spec_iterator(
 
 def metadata_for_task_mapping(*, task_id: str, dag_id: str) -> dict:
     return {TASK_MAPPING_METADATA_KEY: [{"dag_id": dag_id, "task_id": task_id}]}
+
+
+def get_metadata_key(instance_name: str) -> str:
+    return f"{AIRFLOW_SOURCE_METADATA_KEY_PREFIX}/{instance_name}"

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
@@ -1,12 +1,20 @@
-from typing import Iterable, Iterator, Optional, Union
+from typing import TYPE_CHECKING, Iterable, Iterator, Optional, Set, Union
 
-from dagster import AssetsDefinition, AssetSpec, SourceAsset
+from dagster import (
+    AssetsDefinition,
+    AssetSpec,
+    SourceAsset,
+    _check as check,
+)
 from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
 from dagster._core.definitions.utils import VALID_NAME_REGEX
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.storage.tags import KIND_PREFIX
 
 from dagster_airlift.constants import AIRFLOW_SOURCE_METADATA_KEY_PREFIX, TASK_MAPPING_METADATA_KEY
+
+if TYPE_CHECKING:
+    from dagster_airlift.core.serialization.serialized_data import TaskHandle
 
 
 def convert_to_valid_dagster_name(name: str) -> str:
@@ -40,3 +48,19 @@ def metadata_for_task_mapping(*, task_id: str, dag_id: str) -> dict:
 
 def get_metadata_key(instance_name: str) -> str:
     return f"{AIRFLOW_SOURCE_METADATA_KEY_PREFIX}/{instance_name}"
+
+
+def is_mapped_asset_spec(spec: AssetSpec) -> bool:
+    return TASK_MAPPING_METADATA_KEY in spec.metadata
+
+
+def task_handles_for_spec(spec: AssetSpec) -> Set["TaskHandle"]:
+    from dagster_airlift.core.serialization.serialized_data import TaskHandle
+
+    check.param_invariant(is_mapped_asset_spec(spec), "spec", "Must be mappped spec")
+    task_handles = []
+    for task_handle_dict in spec.metadata[TASK_MAPPING_METADATA_KEY]:
+        task_handles.append(
+            TaskHandle(dag_id=task_handle_dict["dag_id"], task_id=task_handle_dict["task_id"])
+        )
+    return set(task_handles)

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -30,7 +30,6 @@ from dagster_airlift.core.multiple_tasks import targeted_by_multiple_tasks
 from dagster_airlift.core.serialization.compute import (
     build_airlift_metadata_mapping_info,
     compute_serialized_data,
-    is_mapped_asset_spec,
 )
 from dagster_airlift.core.serialization.defs_construction import (
     key_for_automapped_task_asset,
@@ -44,7 +43,7 @@ from dagster_airlift.core.state_backed_defs_loader import (
     scoped_reconstruction_metadata,
     unwrap_reconstruction_metadata,
 )
-from dagster_airlift.core.utils import metadata_for_task_mapping
+from dagster_airlift.core.utils import is_mapped_asset_spec, metadata_for_task_mapping
 from dagster_airlift.test import make_instance
 from dagster_airlift.utils import DAGSTER_AIRLIFT_PROXIED_STATE_DIR_ENV_VAR
 


### PR DESCRIPTION
## Summary & Motivation
This PR moves the sensor out of the initial builder and starts to make the necessary example code changes.
This complicates the examples quite a bit, and I think some API changes are in order to help out here.
The main problems are this:
- The same parameters are being passed all over the place. IE airflow_instance is kinda passed around everywhere
- It's very easy to have two top level definitions objects. IE resolved_defs = ..., then calling Definitions.merge on that.
- It's way more code for the simple case.
- Should the sensor builder return a Definitions object? Or just a sensor? Sensor is more explicit, Definitions object is nicer for merge behavior.

Some possible API changes:
- Include a top-level function which will still construct the sensor and definitions. Also provide two underlying APIs which handle the explicit construction at each step. So have the top level build_airflow_definitions..., and then also have build_resolved_defs and build_sensor.
- AirflowDefinitionsData takes in an instance and Definitions object so that we're not passing it in everywhere.
- The function which constructs the resolved defs can return a function which constructs definitions, to avoid the semi-gross need for a top level definitions caller (this may not be necessary, as @definitions decorator can solve things here as well I think.

## How I Tested These Changes
Existing tests
## Changelog
NOCHANGELOG
