### PR TITLE
Explicitly error if auto_materialize: use_sensors is set to False, but AutomationConditionSensorDefinitions are found

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/simple_non_user_space.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/simple_non_user_space.py
@@ -1,0 +1,21 @@
+import dagster as dg
+
+
+@dg.asset(automation_condition=dg.AutomationCondition.eager())
+def thing() -> None: ...
+
+
+@dg.asset()
+def other_thing() -> None: ...
+
+
+defs = dg.Definitions(
+    assets=[thing, other_thing],
+    sensors=[
+        dg.AutomationConditionSensorDefinition(
+            name="all_assets_non_user_space",
+            asset_selection=dg.AssetSelection.all(),
+            user_code=False,
+        )
+    ],
+)


### PR DESCRIPTION
## Summary & Motivation

As title. This is an invalid state, and the previous behavior would be to ignore this sensor and continue using the daemon, which is very confusing.

Updated this so that we will error if we find ourselves in this state, informing users of the cause and the way to fix it (which should always just be to remove that instance configuration).

## How I Tested These Changes

Unit tests, confirmed that no existing organizations are in this state.

## Changelog

If the legacy `auto_materialize: use_sensors` instance configuration value is overridden to be `False`, and any `AutomationConditionSensorDefinitions` are defined, this will now raise an error rather than silently ignoring the sensor.

- [ ] `NEW` _(added new feature or capability)_
- [x] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
