### PR TITLE
[dagster-airlift][rfc] simplify pluggable function

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
@@ -7,6 +7,7 @@ from dagster._record import record
 from dagster._serdes.serdes import deserialize_value
 
 from dagster_airlift.constants import STANDALONE_DAG_ID_METADATA_KEY
+from dagster_airlift.core.airflow_instance import AirflowInstance
 from dagster_airlift.core.serialization.defs_construction import make_default_dag_asset_key
 from dagster_airlift.core.serialization.serialized_data import (
     SerializedAirflowDefinitionsData,
@@ -17,13 +18,13 @@ from dagster_airlift.core.utils import get_metadata_key, is_mapped_asset_spec, t
 
 @record
 class AirflowDefinitionsData:
-    instance_name: str
+    airflow_instance: AirflowInstance
     resolved_airflow_defs: Definitions
 
     @cached_property
     def serialized_data(self) -> SerializedAirflowDefinitionsData:
         serialized_data_str = self.resolved_airflow_defs.metadata[
-            get_metadata_key(self.instance_name)
+            get_metadata_key(self.airflow_instance.name)
         ].value
         return deserialize_value(
             cast(str, serialized_data_str), as_type=SerializedAirflowDefinitionsData

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
@@ -67,9 +67,8 @@ def build_defs_from_airflow_instance(
     return Definitions.merge(
         resolved_defs,
         build_airflow_polling_sensor_defs(
-            airflow_instance=airflow_instance,
             airflow_data=AirflowDefinitionsData(
-                instance_name=airflow_instance.name, resolved_airflow_defs=resolved_defs
+                airflow_instance=airflow_instance, resolved_airflow_defs=resolved_defs
             ),
             event_translation_fn=get_asset_events,
             minimum_interval_seconds=sensor_minimum_interval_seconds,

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/builder.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/builder.py
@@ -156,7 +156,7 @@ def materializations_and_requests_from_batch_iter(
     end_date_lte: float,
     offset: int,
     airflow_data: AirflowDefinitionsData,
-    event_translation_fn: AirflowEventTranslationFn,
+    event_translation_fn: Optional[AirflowEventTranslationFn],
 ) -> Iterator[Optional[BatchResult]]:
     runs = airflow_data.airflow_instance.get_dag_runs_batch(
         dag_ids=list(airflow_data.all_dag_ids),
@@ -176,8 +176,8 @@ def materializations_and_requests_from_batch_iter(
             ],
             states=["success"],
         )
-
-        mats = event_translation_fn(dag_run, task_instances, airflow_data)
+        event_translation_fn = event_translation_fn or airflow_data.default_event_translation_fn
+        mats = event_translation_fn(dag_run, task_instances)
         all_asset_keys_materialized = {mat.asset_key for mat in mats}
         yield (
             BatchResult(

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
@@ -14,7 +14,7 @@ from dagster_airlift.core.airflow_defs_data import AirflowDefinitionsData
 from dagster_airlift.core.airflow_instance import DagRun, TaskInstance
 
 AirflowEventTranslationFn = Callable[
-    [DagRun, Sequence[TaskInstance], AirflowDefinitionsData], Iterable[AssetMaterialization]
+    [DagRun, Sequence[TaskInstance]], Iterable[AssetMaterialization]
 ]
 
 


### PR DESCRIPTION
## Summary & Motivation
Pluggability function shouldn't take AirflowDefinitionsData as a parameter, since the usage of that object will likely be specific to the callsite. I think this streamlines the readme examples added in the downstream

## How I Tested These Changes
Existing tests.
## Changelog
NOCHANGELOG
