### PR TITLE
[dagster-airlift] pluggability readme

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/__init__.py
@@ -1,3 +1,8 @@
+from dagster_airlift.core.airflow_instance import (
+    DagRun as DagRun,
+    TaskInstance as TaskInstance,
+)
+
 from ..proxied_state import load_proxied_state_from_yaml as load_proxied_state_from_yaml
 from .basic_auth import BasicAuthBackend as BasicAuthBackend
 from .dag_defs import (
@@ -9,3 +14,5 @@ from .load_defs import (
     AirflowInstance as AirflowInstance,
     build_defs_from_airflow_instance as build_defs_from_airflow_instance,
 )
+from .sensor import build_airflow_polling_sensor_defs as build_airflow_polling_sensor_defs
+from .utils import maps_to_dag as maps_to_dag

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/utils.py
@@ -11,7 +11,11 @@ from dagster._core.definitions.utils import VALID_NAME_REGEX
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.storage.tags import KIND_PREFIX
 
-from dagster_airlift.constants import AIRFLOW_SOURCE_METADATA_KEY_PREFIX, TASK_MAPPING_METADATA_KEY
+from dagster_airlift.constants import (
+    AIRFLOW_SOURCE_METADATA_KEY_PREFIX,
+    STANDALONE_DAG_ID_METADATA_KEY,
+    TASK_MAPPING_METADATA_KEY,
+)
 
 if TYPE_CHECKING:
     from dagster_airlift.core.serialization.serialized_data import TaskHandle
@@ -64,3 +68,10 @@ def task_handles_for_spec(spec: AssetSpec) -> Set["TaskHandle"]:
             TaskHandle(dag_id=task_handle_dict["dag_id"], task_id=task_handle_dict["task_id"])
         )
     return set(task_handles)
+
+
+def maps_to_dag(asset_spec: AssetSpec, dag_id: str) -> bool:
+    return (
+        STANDALONE_DAG_ID_METADATA_KEY in asset_spec.metadata
+        and asset_spec.metadata[STANDALONE_DAG_ID_METADATA_KEY] == dag_id
+    )

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/additional_dagster_examples/customizing_dagster.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/additional_dagster_examples/customizing_dagster.py
@@ -1,0 +1,39 @@
+from dagster import AssetSpec, Definitions
+from dagster_airlift.core import (
+    AirflowDefinitionsData,
+    AirflowInstance,
+    BasicAuthBackend,
+    build_airflow_polling_sensor_defs,
+    get_resolved_airflow_defs,
+    maps_to_dag,
+)
+
+airflow_instance = AirflowInstance(
+    auth_backend=BasicAuthBackend(
+        webserver_url="http://localhost:8080", username="admin", password="admin"
+    ),
+    name="airflow_instance_one",
+)
+
+
+def get_resolved_defs() -> Definitions:
+    """Get resolved definitions with additional metadata for a particular dag."""
+    defs = get_resolved_airflow_defs(airflow_instance=airflow_instance)
+
+    def _add_metadata(spec: AssetSpec) -> AssetSpec:
+        if maps_to_dag(spec, "my_dag"):
+            return spec._replace(metadata={"team": "my_team", **spec.metadata})
+        return spec
+
+    return defs.map_asset_specs(_add_metadata)  # type: ignore
+
+
+defs_data = AirflowDefinitionsData(
+    resolved_airflow_defs=get_resolved_defs(),
+    airflow_instance=airflow_instance,
+)
+
+defs = Definitions.merge(
+    defs_data.resolved_airflow_defs,
+    build_airflow_polling_sensor_defs(defs_data),
+)

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/additional_dagster_examples/sensor_callback.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/additional_dagster_examples/sensor_callback.py
@@ -1,0 +1,52 @@
+from typing import List, Sequence
+
+from dagster import AssetMaterialization, Definitions
+from dagster_airlift.core import (
+    AirflowDefinitionsData,
+    AirflowInstance,
+    BasicAuthBackend,
+    DagRun,
+    TaskInstance,
+    build_airflow_polling_sensor_defs,
+    get_resolved_airflow_defs,
+)
+
+airflow_instance = AirflowInstance(
+    auth_backend=BasicAuthBackend(
+        webserver_url="http://localhost:8080", username="admin", password="admin"
+    ),
+    name="airflow_instance_one",
+)
+
+
+def get_resolved_defs() -> Definitions:
+    """Get resolved definitions with additional metadata for a particular dag."""
+    return get_resolved_airflow_defs(airflow_instance=airflow_instance)
+
+
+defs_data = AirflowDefinitionsData(
+    resolved_airflow_defs=get_resolved_defs(),
+    airflow_instance=airflow_instance,
+)
+
+
+def alter_materializations(
+    dag_run: DagRun, task_instances: Sequence[TaskInstance]
+) -> List[AssetMaterialization]:
+    def _transform_materialization(materialization: AssetMaterialization) -> AssetMaterialization:
+        if defs_data.asset_key_for_dag("my_dag_id") == materialization.asset_key:
+            return materialization._replace(
+                metadata={"team": "my_team", **materialization.metadata}
+            )
+        return materialization
+
+    return [
+        _transform_materialization(mat)
+        for mat in defs_data.default_event_translation_fn(dag_run, task_instances)
+    ]
+
+
+defs = Definitions.merge(
+    defs_data.resolved_airflow_defs,
+    build_airflow_polling_sensor_defs(defs_data, event_translation_fn=alter_materializations),
+)


### PR DESCRIPTION
Add a section to the readme on pluggability points. This PR references the currently non-existent `Definitions.map_asset_specs`, and adds some new utility methods for retrieving the asset for a dag (useful for readability in example)

- [] add docs snippet handling
- [] add tests
## How I Tested These Changes
Need to add unit tests

## Changelog
NOCHANGELOG
