### PR TITLE
Remove condition wrapper conditions

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -238,14 +238,13 @@ class AssetGraphView(LoadingContext):
 
         partition_mapping = self.asset_graph.get_partition_mapping(from_key, to_key)
 
-        if from_partitions_def is None or to_partitions_def is None:
-            return (
-                self.get_empty_subset(key=to_key)
-                if from_subset.is_empty
-                else self.get_full_subset(key=to_key)
-            )
-
         if from_key in self.asset_graph.get(to_key).parent_entity_keys:
+            if from_partitions_def is None or to_partitions_def is None:
+                return (
+                    self.get_empty_subset(key=to_key)
+                    if from_subset.is_empty
+                    else self.get_full_subset(key=to_key)
+                )
             to_partitions_subset = partition_mapping.get_downstream_partitions_for_partitions(
                 upstream_partitions_subset=from_subset.get_internal_subset_value(),
                 upstream_partitions_def=from_partitions_def,
@@ -254,9 +253,17 @@ class AssetGraphView(LoadingContext):
                 current_time=self.effective_dt,
             )
         else:
+            if to_partitions_def is None or from_subset.is_empty:
+                return (
+                    self.get_empty_subset(key=to_key)
+                    if from_subset.is_empty
+                    else self.get_full_subset(key=to_key)
+                )
             to_partitions_subset = (
                 partition_mapping.get_upstream_mapped_partitions_result_for_partitions(
-                    downstream_partitions_subset=from_subset.get_internal_subset_value(),
+                    downstream_partitions_subset=from_subset.get_internal_subset_value()
+                    if from_partitions_def is not None
+                    else None,
                     downstream_partitions_def=from_partitions_def,
                     upstream_partitions_def=to_partitions_def,
                     dynamic_partitions_store=self._queryer,

--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -216,59 +216,18 @@ class AssetGraphView(LoadingContext):
     def compute_parent_subset(
         self, parent_key: AssetKey, subset: EntitySubset[T_EntityKey]
     ) -> EntitySubset[AssetKey]:
-        child_key = subset.key
-        child_partitions_def = self.asset_graph.get(child_key).partitions_def
-        parent_partitions_def = self.asset_graph.get(parent_key).partitions_def
-
-        if parent_partitions_def is None or subset.is_empty:
-            return (
-                self.get_empty_subset(key=parent_key)
-                if subset.is_empty
-                else self.get_full_subset(key=parent_key)
-            )
-
-        partition_mapping = self.asset_graph.get_partition_mapping(child_key, parent_key)
-        parent_partitions_subset = (
-            partition_mapping.get_upstream_mapped_partitions_result_for_partitions(
-                subset.get_internal_subset_value() if child_partitions_def is not None else None,
-                downstream_partitions_def=child_partitions_def,
-                upstream_partitions_def=parent_partitions_def,
-                dynamic_partitions_store=self._queryer,
-                current_time=self.effective_dt,
-            )
-        ).partitions_subset
-
-        return EntitySubset(
-            self, key=parent_key, value=_ValidatedEntitySubsetValue(parent_partitions_subset)
+        check.invariant(
+            parent_key in self.asset_graph.get(subset.key).parent_entity_keys,
         )
+        return self.compute_mapped_subset(parent_key, subset)
 
     def compute_child_subset(
         self, child_key: T_EntityKey, subset: EntitySubset[U_EntityKey]
     ) -> EntitySubset[T_EntityKey]:
-        parent_key = subset.key
-        parent_partitions_def = self.asset_graph.get(parent_key).partitions_def
-        child_partitions_def = self.asset_graph.get(child_key).partitions_def
-
-        if parent_partitions_def is None or child_partitions_def is None:
-            return (
-                self.get_empty_subset(key=child_key)
-                if subset.is_empty
-                else self.get_full_subset(key=child_key)
-            )
-        else:
-            partition_mapping = self.asset_graph.get_partition_mapping(child_key, parent_key)
-            child_partitions_subset = partition_mapping.get_downstream_partitions_for_partitions(
-                subset.get_internal_subset_value(),
-                parent_partitions_def,
-                downstream_partitions_def=child_partitions_def,
-                dynamic_partitions_store=self._queryer,
-                current_time=self.effective_dt,
-            )
-            return EntitySubset(
-                self,
-                key=child_key,
-                value=_ValidatedEntitySubsetValue(child_partitions_subset),
-            )
+        check.invariant(
+            child_key in self.asset_graph.get(subset.key).child_entity_keys,
+        )
+        return self.compute_mapped_subset(child_key, subset)
 
     def compute_mapped_subset(
         self, to_key: T_EntityKey, from_subset: EntitySubset

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -104,7 +104,7 @@ class BaseAssetNode(BaseEntityNode[AssetKey]):
 
     @property
     def child_entity_keys(self) -> AbstractSet[EntityKey]:
-        return self.parent_keys | self.check_keys
+        return self.child_keys | self.check_keys
 
     @property
     def has_self_dependency(self) -> bool:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -177,8 +177,7 @@ class AutomationConditionEvaluator:
                 # evaluated it may have had a different requested subset. however, because
                 # all these neighbors must be executed as a unit, we need to union together
                 # the subset of all required neighbors
-                # TODO: replace with result.true_subset.map_to(neighbor_key)
-                neighbor_true_subset = result.true_subset.compute_child_subset(neighbor_key)
+                neighbor_true_subset = result.true_subset.compute_mapped_subset(neighbor_key)
                 if neighbor_key in self.current_results_by_key:
                     self.current_results_by_key[
                         neighbor_key

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/check_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/check_operators.py
@@ -9,35 +9,11 @@ from dagster._core.definitions.declarative_automation.automation_condition impor
     BuiltinAutomationCondition,
 )
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
+from dagster._core.definitions.declarative_automation.operators.dep_operators import (
+    EntityMatchesCondition,
+)
 from dagster._record import record
 from dagster._serdes.serdes import whitelist_for_serdes
-
-
-@record
-class CheckConditionWrapperCondition(BuiltinAutomationCondition[AssetKey]):
-    check_key: AssetCheckKey
-    operand: AutomationCondition[AssetCheckKey]
-
-    @property
-    def description(self) -> str:
-        return f"{self.check_key.to_user_string()}"
-
-    def evaluate(self, context: AutomationContext[AssetKey]) -> AutomationResult[AssetKey]:
-        # only evaluate parents of the current candidates
-
-        check_candidate_subset = context.candidate_subset.compute_child_subset(self.check_key)
-        check_context = context.for_child_condition(
-            child_condition=self.operand, child_index=0, candidate_subset=check_candidate_subset
-        )
-
-        # evaluate condition against the check
-        check_result = self.operand.evaluate(check_context)
-
-        # find all parents of the check subset
-        true_subset = check_result.true_subset.compute_parent_subset(context.key)
-        return AutomationResult(
-            context=context, true_subset=true_subset, child_results=[check_result]
-        )
 
 
 @whitelist_for_serdes
@@ -92,9 +68,7 @@ class AnyChecksCondition(ChecksCondition):
         for i, check_key in enumerate(
             sorted(self._get_check_keys(context.key, context.asset_graph))
         ):
-            check_condition = CheckConditionWrapperCondition(
-                check_key=check_key, operand=self.operand
-            )
+            check_condition = EntityMatchesCondition(key=check_key, operand=self.operand)
             check_result = check_condition.evaluate(
                 context.for_child_condition(
                     child_condition=check_condition,
@@ -127,9 +101,7 @@ class AllChecksCondition(ChecksCondition):
         for i, check_key in enumerate(
             sorted(self._get_check_keys(context.key, context.asset_graph))
         ):
-            check_condition = CheckConditionWrapperCondition(
-                check_key=check_key, operand=self.operand
-            )
+            check_condition = EntityMatchesCondition(key=check_key, operand=self.operand)
             check_result = check_condition.evaluate(
                 context.for_child_condition(
                     child_condition=check_condition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -1,7 +1,8 @@
 from abc import abstractmethod
-from typing import TYPE_CHECKING, AbstractSet, Any, Optional
+from typing import TYPE_CHECKING, AbstractSet, Any, Generic, Optional
 
 import dagster._check as check
+from dagster._core.asset_graph_view.asset_graph_view import U_EntityKey
 from dagster._core.definitions.asset_key import AssetKey, T_EntityKey
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph, BaseAssetNode
 from dagster._core.definitions.declarative_automation.automation_condition import (
@@ -17,47 +18,13 @@ if TYPE_CHECKING:
     from dagster._core.definitions.asset_selection import AssetSelection
 
 
-@record
-class DepConditionWrapperCondition(BuiltinAutomationCondition[T_EntityKey]):
-    """Wrapper object which evaluates a condition against a dependency and returns a subset
-    representing the subset of downstream asset which has at least one parent which evaluated to
-    True.
-    """
-
-    dep_key: AssetKey
-    operand: AutomationCondition[AssetKey]
-
-    @property
-    def name(self) -> str:
-        return self.dep_key.to_user_string()
-
-    @property
-    def description(self) -> str:
-        return self.dep_key.to_user_string()
-
-    def evaluate(self, context: AutomationContext[T_EntityKey]) -> AutomationResult[T_EntityKey]:
-        # only evaluate parents of the current candidates
-
-        dep_candidate_subset = context.candidate_subset.compute_parent_subset(self.dep_key)
-        dep_context = context.for_child_condition(
-            child_condition=self.operand, child_index=0, candidate_subset=dep_candidate_subset
-        )
-
-        # evaluate condition against the dependency
-        dep_result = self.operand.evaluate(dep_context)
-
-        # find all children of the true dep subset
-        true_subset = dep_result.true_subset.compute_child_subset(context.key)
-        return AutomationResult(
-            context=context, true_subset=true_subset, child_results=[dep_result]
-        )
-
-
 @whitelist_for_serdes
 @record
-class EntityMatchesCondition(BuiltinAutomationCondition[T_EntityKey]):
-    key: T_EntityKey
-    operand: AutomationCondition
+class EntityMatchesCondition(
+    BuiltinAutomationCondition[T_EntityKey], Generic[T_EntityKey, U_EntityKey]
+):
+    key: U_EntityKey
+    operand: AutomationCondition[U_EntityKey]
 
     def evaluate(self, context: AutomationContext[T_EntityKey]) -> AutomationResult[T_EntityKey]:
         to_candidate_subset = context.candidate_subset.compute_mapped_subset(self.key)
@@ -146,7 +113,7 @@ class AnyDepsCondition(DepCondition[T_EntityKey]):
         true_subset = context.get_empty_subset()
 
         for i, dep_key in enumerate(sorted(self._get_dep_keys(context.key, context.asset_graph))):
-            dep_condition = DepConditionWrapperCondition(dep_key=dep_key, operand=self.operand)
+            dep_condition = EntityMatchesCondition(key=dep_key, operand=self.operand)
             dep_result = dep_condition.evaluate(
                 context.for_child_condition(
                     child_condition=dep_condition,
@@ -176,7 +143,7 @@ class AllDepsCondition(DepCondition[T_EntityKey]):
         true_subset = context.candidate_subset
 
         for i, dep_key in enumerate(sorted(self._get_dep_keys(context.key, context.asset_graph))):
-            dep_condition = DepConditionWrapperCondition(dep_key=dep_key, operand=self.operand)
+            dep_condition = EntityMatchesCondition(key=dep_key, operand=self.operand)
             dep_result = dep_condition.evaluate(
                 context.for_child_condition(
                     child_condition=dep_condition,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
@@ -1,8 +1,9 @@
 from dagster import AssetDep, Definitions, asset
 from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
+from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.partition import StaticPartitionsDefinition
-from dagster._core.definitions.partition_mapping import StaticPartitionMapping
+from dagster._core.definitions.partition_mapping import LastPartitionMapping, StaticPartitionMapping
 from dagster._core.instance import DagsterInstance
 from dagster._time import create_datetime
 
@@ -134,3 +135,37 @@ def test_only_partition_keys() -> None:
     ).compute_intersection_with_partition_keys({"3"}).expensively_compute_partition_keys() == set(
         ["3"]
     )
+
+
+def test_upstream_of_unpartitioned_partition_mapping() -> None:
+    @asset(partitions_def=StaticPartitionsDefinition(["a", "b", "c"]))
+    def upstream() -> None: ...
+
+    @asset(
+        deps=[AssetDep(upstream, partition_mapping=LastPartitionMapping())],
+    )
+    def unpartitioned() -> None: ...
+
+    defs = Definitions([upstream, unpartitioned])
+    instance = DagsterInstance.ephemeral()
+    asset_graph_view = AssetGraphView.for_test(defs, instance)
+
+    unpartitioned_full = asset_graph_view.get_full_subset(key=unpartitioned.key)
+    unpartitioned_empty = asset_graph_view.get_empty_subset(key=unpartitioned.key)
+
+    upstream_full = asset_graph_view.get_full_subset(key=upstream.key)
+    upstream_empty = asset_graph_view.get_empty_subset(key=upstream.key)
+    upstream_last = asset_graph_view.get_asset_subset_from_asset_partitions(
+        key=upstream.key, asset_partitions={AssetKeyPartitionKey(upstream.key, "c")}
+    )
+
+    assert upstream_full.compute_child_subset(child_key=unpartitioned.key) == unpartitioned_full
+    assert upstream_last.compute_child_subset(child_key=unpartitioned.key) == unpartitioned_full
+
+    assert (
+        unpartitioned_full.compute_parent_subset(
+            parent_key=upstream.key
+        ).expensively_compute_asset_partitions()
+        == upstream_last.expensively_compute_asset_partitions()
+    )
+    assert unpartitioned_empty.compute_parent_subset(parent_key=upstream.key) == upstream_empty

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
@@ -61,13 +61,10 @@ def test_subset_traversal_static_partitions() -> None:
     # from full up to down
     up_subset = asset_graph_view_t0.get_full_subset(key=up_numbers.key)
     assert up_subset.expensively_compute_partition_keys() == {"1", "2", "3"}
-    assert up_subset.compute_child_subset(
-        down_letters.key
-    ).expensively_compute_partition_keys() == {
-        "a",
-        "b",
-        "c",
-    }
+    assert (
+        up_subset.compute_child_subset(down_letters.key).expensively_compute_partition_keys()
+        == set()
+    )
 
     # from full up to down
     down_subset = asset_graph_view_t0.get_full_subset(key=down_letters.key)
@@ -100,9 +97,12 @@ def test_subset_traversal_static_partitions() -> None:
     )
 
     # subset of up to subset of down
-    assert up_subset.compute_intersection_with_partition_keys({"2"}).compute_child_subset(
-        down_letters.key
-    ).expensively_compute_partition_keys() == {"b"}
+    assert (
+        up_subset.compute_intersection_with_partition_keys({"2"})
+        .compute_child_subset(down_letters.key)
+        .expensively_compute_partition_keys()
+        == set()
+    )
 
     # subset of down to subset of up
     assert down_subset.compute_intersection_with_partition_keys({"b"}).compute_parent_subset(

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_result_value_hash.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_result_value_hash.py
@@ -31,18 +31,18 @@ two_parents_daily = two_parents.with_asset_properties(partitions_def=daily_parti
     [
         # cron condition returns a unique value hash if parents change, if schedule changes, if the
         # partitions def changes, or if an asset is materialized
-        ("0696dcb07b82fd8f4934c828bbc8365f", SC.on_cron("0 * * * *"), one_parent, False),
-        ("7fb8a01606b51f6306e85769533fd5b9", SC.on_cron("0 * * * *"), one_parent, True),
-        ("38ba78431e6c22552840e7177918a880", SC.on_cron("0 0 * * *"), one_parent, False),
-        ("98e74cd660564cb881d889ec9ae75ce0", SC.on_cron("0 * * * *"), one_parent_daily, False),
-        ("c0e6323656d8208666e8c74d9af93a64", SC.on_cron("0 * * * *"), two_parents, False),
-        ("3545889e64a11959400cb116ba2320ec", SC.on_cron("0 * * * *"), two_parents_daily, False),
+        ("9a5947c1196f3311a1039aecb90e04f5", SC.on_cron("0 * * * *"), one_parent, False),
+        ("bdf32a2d014be85c68843f55776bd70c", SC.on_cron("0 * * * *"), one_parent, True),
+        ("be9c8c64a822d0dbc49e462a3aabf4d8", SC.on_cron("0 0 * * *"), one_parent, False),
+        ("dfed65a9a20ff1f10e60ff7f0397ffb1", SC.on_cron("0 * * * *"), one_parent_daily, False),
+        ("44305b43d3719344819f9bda178f4588", SC.on_cron("0 * * * *"), two_parents, False),
+        ("1d902e0c59648e5022ae84bd6a1b1c49", SC.on_cron("0 * * * *"), two_parents_daily, False),
         # same as above
-        ("8d1dc13e39337b2cc43c711930893a36", SC.eager(), one_parent, False),
-        ("a111331589fc2766a34bacab88639ff5", SC.eager(), one_parent, True),
-        ("a41576711e61908a321bf8fc4f7d1261", SC.eager(), one_parent_daily, False),
-        ("a4dbf8969ab764eb07fb666688dafe1b", SC.eager(), two_parents, False),
-        ("ceff99f39c4db7381d8da4622421fde2", SC.eager(), two_parents_daily, False),
+        ("0e5ef287a89ed9e6c08a25e4920ee4f3", SC.eager(), one_parent, False),
+        ("42a1a04bf1fa76fd723fb60294bff6ae", SC.eager(), one_parent, True),
+        ("bfb3170339eea63e425d375d2c187c34", SC.eager(), one_parent_daily, False),
+        ("0e9b7774d09132a19b8d8674fdca500d", SC.eager(), two_parents, False),
+        ("3cf82286c216f9535842fb2852b88838", SC.eager(), two_parents_daily, False),
         # missing condition is invariant to changes other than partitions def changes
         ("5c24ffc21af9983a4917b91290de8f5d", SC.missing(), one_parent, False),
         ("5c24ffc21af9983a4917b91290de8f5d", SC.missing(), one_parent, True),


### PR DESCRIPTION
## Summary & Motivation
Now that we have `EntityMatchesCondition`, we can replace `DepConditionWrapperCondition` and `CheckConditionWrapperCondition`. Can also clean up the implementation of `compute_parent_subset` and `compute_child_subset` using the new `compute_mapped_subset`.

## How I Tested These Changes
Existing tests should pass
