### PR TITLE
[dagster-airlift][partitions] standardize on datetime properties

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_instance.py
@@ -338,12 +338,12 @@ class TaskInstance:
         return f"{self.details_url}&tab=logs"
 
     @property
-    def start_date(self) -> float:
-        return datetime.datetime.fromisoformat(self.metadata["start_date"]).timestamp()
+    def start_date(self) -> datetime.datetime:
+        return datetime.datetime.fromisoformat(self.metadata["start_date"])
 
     @property
-    def end_date(self) -> float:
-        return datetime.datetime.fromisoformat(self.metadata["end_date"]).timestamp()
+    def end_date(self) -> datetime.datetime:
+        return datetime.datetime.fromisoformat(self.metadata["end_date"])
 
 
 @record
@@ -382,17 +382,9 @@ class DagRun:
         return self.metadata["conf"]
 
     @property
-    def start_date(self) -> float:
-        return datetime.datetime.fromisoformat(self.metadata["start_date"]).timestamp()
-
-    @property
-    def start_datetime(self) -> datetime.datetime:
+    def start_date(self) -> datetime.datetime:
         return datetime.datetime.fromisoformat(self.metadata["start_date"])
 
     @property
-    def end_date(self) -> float:
-        return datetime.datetime.fromisoformat(self.metadata["end_date"]).timestamp()
-
-    @property
-    def end_datetime(self) -> datetime.datetime:
+    def end_date(self) -> datetime.datetime:
         return datetime.datetime.fromisoformat(self.metadata["end_date"])

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
@@ -54,9 +54,9 @@ def get_dag_run_metadata(dag_run: DagRun) -> Mapping[str, Any]:
     return {
         **get_common_metadata(dag_run),
         "Run Details": MarkdownMetadataValue(f"[View Run]({dag_run.url})"),
-        "Start Date": TimestampMetadataValue(dag_run.start_date),
-        "End Date": TimestampMetadataValue(dag_run.end_date),
-        EFFECTIVE_TIMESTAMP_METADATA_KEY: TimestampMetadataValue(dag_run.end_date),
+        "Start Date": TimestampMetadataValue(dag_run.start_date.timestamp()),
+        "End Date": TimestampMetadataValue(dag_run.end_date.timestamp()),
+        EFFECTIVE_TIMESTAMP_METADATA_KEY: TimestampMetadataValue(dag_run.end_date.timestamp()),
     }
 
 
@@ -75,9 +75,11 @@ def get_task_instance_metadata(dag_run: DagRun, task_instance: TaskInstance) -> 
         **get_common_metadata(dag_run),
         "Run Details": MarkdownMetadataValue(f"[View Run]({task_instance.details_url})"),
         "Task Logs": MarkdownMetadataValue(f"[View Logs]({task_instance.log_url})"),
-        "Start Date": TimestampMetadataValue(task_instance.start_date),
-        "End Date": TimestampMetadataValue(task_instance.end_date),
-        EFFECTIVE_TIMESTAMP_METADATA_KEY: TimestampMetadataValue(task_instance.end_date),
+        "Start Date": TimestampMetadataValue(task_instance.start_date.timestamp()),
+        "End Date": TimestampMetadataValue(task_instance.end_date.timestamp()),
+        EFFECTIVE_TIMESTAMP_METADATA_KEY: TimestampMetadataValue(
+            task_instance.end_date.timestamp()
+        ),
     }
 
 

--- a/examples/experimental/dagster-airlift/dagster_airlift/test/airflow_test_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/test/airflow_test_instance.py
@@ -62,8 +62,8 @@ class AirflowInstanceFake(AirflowInstance):
         return [
             run
             for run in self._dag_runs_by_dag_id[dag_id]
-            if start_date.timestamp() <= run.start_date <= end_date.timestamp()
-            and start_date.timestamp() <= run.end_date <= end_date.timestamp()
+            if start_date.timestamp() <= run.start_date.timestamp() <= end_date.timestamp()
+            and start_date.timestamp() <= run.end_date.timestamp() <= end_date.timestamp()
         ]
 
     def get_dag_runs_batch(
@@ -77,7 +77,7 @@ class AirflowInstanceFake(AirflowInstance):
             (run.end_date, run)
             for runs in self._dag_runs_by_dag_id.values()
             for run in runs
-            if end_date_gte.timestamp() <= run.end_date <= end_date_lte.timestamp()
+            if end_date_gte.timestamp() <= run.end_date.timestamp() <= end_date_lte.timestamp()
             and run.dag_id in dag_ids
         ]
         sorted_by_end_date = [run for _, run in sorted(runs, key=lambda x: x[0])]
@@ -227,8 +227,8 @@ def make_instance(
                     dag_id=dag_run.dag_id,
                     task_id=task_id,
                     run_id=dag_run.run_id,
-                    start_date=dag_run.start_datetime,
-                    end_date=dag_run.end_datetime
+                    start_date=dag_run.start_date,
+                    end_date=dag_run.end_date
                     - timedelta(
                         seconds=1
                     ),  # Ensure that the task ends before the full "dag" completes.

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_airflow_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_airflow_instance.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from dagster._core.errors import DagsterError
 from dagster_airlift.core import AirflowInstance, BasicAuthBackend
@@ -64,6 +66,8 @@ def test_airflow_instance(airflow_instance: None) -> None:
 
     assert run.finished
     assert run.success
+    assert isinstance(run.start_date, datetime.datetime)
+    assert isinstance(run.end_date, datetime.datetime)
 
     # Fetch task instance
     task_instance = instance.get_task_instance(
@@ -72,6 +76,6 @@ def test_airflow_instance(airflow_instance: None) -> None:
     assert_link_exists("Task instance", task_instance.details_url)
     assert_link_exists("Task logs", task_instance.log_url)
 
-    assert isinstance(task_instance.start_date, float)
-    assert isinstance(task_instance.end_date, float)
+    assert isinstance(task_instance.start_date, datetime.datetime)
+    assert isinstance(task_instance.end_date, datetime.datetime)
     assert isinstance(task_instance.note, str)


### PR DESCRIPTION
## Summary & Motivation
DagRun.start_date,end_date is confusingly a float (same for TaskInstance). Instead, make it a fully-fledged datetime and call `.timestamp()` when needed

## How I Tested These Changes
Existing tests
## Changelog
NOCHANGELOG
