### PR TITLE
[dagster-airlift][partitions] add support for time-windowed partitions

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
@@ -1,13 +1,16 @@
 from typing import Any, Callable, Iterable, List, Mapping, Sequence
 
 from dagster import (
+    AssetKey,
     AssetMaterialization,
     JsonMetadataValue,
     MarkdownMetadataValue,
+    PartitionsDefinition,
     TimestampMetadataValue,
+    TimeWindowPartitionsDefinition,
     _check as check,
 )
-from dagster._time import get_current_timestamp
+from dagster._time import get_current_timestamp, get_timezone
 
 from dagster_airlift.constants import EFFECTIVE_TIMESTAMP_METADATA_KEY
 from dagster_airlift.core.airflow_defs_data import AirflowDefinitionsData
@@ -91,11 +94,62 @@ def materializations_for_task_instance(
     mats = []
     asset_keys = airflow_data.asset_keys_in_task(dag_run.dag_id, task_instance.task_id)
     for asset_key in asset_keys:
+        spec = airflow_data.resolved_airflow_defs.get_asset_graph().get_asset_spec(asset_key)
+        partition = (
+            get_partition_key_from_task_instance(spec.partitions_def, task_instance, asset_key)
+            if spec.partitions_def
+            else None
+        )
         mats.append(
             AssetMaterialization(
                 asset_key=asset_key,
                 description=task_instance.note,
                 metadata=get_task_instance_metadata(dag_run, task_instance),
+                partition=partition,
             )
         )
     return mats
+
+
+def get_partition_key_from_task_instance(
+    partitions_def: PartitionsDefinition, task_instance: TaskInstance, asset_key: AssetKey
+) -> str:
+    partitions_def = check.inst(
+        partitions_def,
+        TimeWindowPartitionsDefinition,
+        "Only time window-partitioned assets are supported.",
+    )
+    airflow_logical_date = task_instance.logical_date
+    airflow_logical_date_timezone = airflow_logical_date.tzinfo
+    partitions_def_timezone = get_timezone(partitions_def.timezone)
+    check.invariant(
+        airflow_logical_date_timezone == partitions_def_timezone,
+        (
+            f"The timezone of the retrieved logical date from the airflow run ({airflow_logical_date_timezone}) does not "
+            f"match that of the partitions definition ({partitions_def_timezone}) for asset key {asset_key.to_user_string()}."
+            "To ensure consistent behavior, the timezone of the logical date must match the timezone of the partitions definition."
+        ),
+    )
+    # Assuming that "logical_date" lies on a partition, the previous partition window
+    # (where upper bound can be the passed-in date, which is why we set respect_bounds=False)
+    # will end on the logical date. This would indicate that there is a partition for the logical date.
+    partition_window = check.not_none(
+        partitions_def.get_prev_partition_window(airflow_logical_date, respect_bounds=False),
+        f"Could not find partition for airflow logical date {airflow_logical_date.isoformat()}. This likely means that your partition range is too small to cover the logical date.",
+    )
+    check.invariant(
+        airflow_logical_date.timestamp() == partition_window.end.timestamp(),
+        (
+            "Expected logical date to match a partition in the partitions definition. This likely means that "
+            "The partition range is not aligned with the scheduling interval in airflow."
+        ),
+    )
+    check.invariant(
+        airflow_logical_date.timestamp() >= partitions_def.start.timestamp(),
+        (
+            f"For run {task_instance.run_id} in dag {task_instance.dag_id}, "
+            f"Logical date is before the start of the partitions definition in asset key {asset_key.to_user_string()}. "
+            "Ensure that the start date of your PartitionsDefinition is early enough to capture current runs coming from airflow."
+        ),
+    )
+    return partitions_def.get_partition_key_for_timestamp(airflow_logical_date.timestamp())

--- a/examples/experimental/dagster-airlift/dagster_airlift/test/airflow_test_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/test/airflow_test_instance.py
@@ -245,6 +245,7 @@ def make_instance(
                     - timedelta(
                         seconds=1
                     ),  # Ensure that the task ends before the full "dag" completes.
+                    logical_date=dag_run.logical_date,
                 )
                 for task_id in dag_and_task_structure[dag_run.dag_id]
             ]

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -343,6 +343,9 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
     def get_check_spec(self, key: AssetCheckKey) -> AssetCheckSpec:
         return self._assets_defs_by_check_key[key].get_spec_for_check_key(key)
 
+    def get_asset_spec(self, key: AssetKey) -> AssetSpec:
+        return self.assets_def_for_key(key).get_asset_spec(key)
+
 
 def executable_in_same_run(
     asset_graph: BaseAssetGraph, child_key: EntityKey, parent_key: EntityKey


### PR DESCRIPTION
## Summary & Motivation
Take two on supporting time-window partitions in the sensor. We use airflow's "logical date", which every dag run should have and roughly maps to a time window partition start, to figure out which partition to attach to a run of a partitioned asset.

## How I Tested These Changes
A bunch of new tests for timezone mangling and default cases.

## Changelog
NOCHANGELOG
