### PR TITLE
[4/c] query column tags when building lineage

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -39,7 +39,7 @@
   "AssetChecksQuery": "b5e8d4663f4f77f439dc8b9424966d7298d69987c67d3033d715c13ad2856ae5",
   "AssetDaemonTicksQuery": "399ac77e660d40eba32c2ab06db2a2936a71e660d93ec108364eec1fdfc16788",
   "AssetGroupAndLocationQuery": "584b27ecda9ff883e92f2d8858520a543ea0be07d39e1b4c0fc5d802231bb602",
-  "AssetColumnLineage": "c88c38558eb5d45b3c51b125853bc0df120213c4b8f5933a264525c3689bcef1",
+  "AssetColumnLineage": "bcb70460f77b88bbbfaec90982f3e99f522d9a4e270e63832684cfde169fabc7",
   "GetAutoMaterializePausedQuery": "50f74183f54031274136ab855701d01f26642a6d958d7452ae13aa6c40ca349d",
   "SetAutoMaterializePausedMutation": "144afc0d6f43dfa6d437c0e7f621e4f19ffb48c7f75669d2e3d742c115aa7b4b",
   "AssetOverviewMetadataEventsQuery": "95837aa7d438974ed0f6f8ec9c72f59bcdb8af12091ede4e334aa24e4f6844de",

--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -39,7 +39,7 @@
   "AssetChecksQuery": "b5e8d4663f4f77f439dc8b9424966d7298d69987c67d3033d715c13ad2856ae5",
   "AssetDaemonTicksQuery": "399ac77e660d40eba32c2ab06db2a2936a71e660d93ec108364eec1fdfc16788",
   "AssetGroupAndLocationQuery": "584b27ecda9ff883e92f2d8858520a543ea0be07d39e1b4c0fc5d802231bb602",
-  "AssetColumnLineage": "bcb70460f77b88bbbfaec90982f3e99f522d9a4e270e63832684cfde169fabc7",
+  "AssetColumnLineage": "ce1683cb51cf7ac96c82f05bbf5f1cc2df57ce6c944615109e30dc6d93246dc4",
   "GetAutoMaterializePausedQuery": "50f74183f54031274136ab855701d01f26642a6d958d7452ae13aa6c40ca349d",
   "SetAutoMaterializePausedMutation": "144afc0d6f43dfa6d437c0e7f621e4f19ffb48c7f75669d2e3d742c115aa7b4b",
   "AssetOverviewMetadataEventsQuery": "95837aa7d438974ed0f6f8ec9c72f59bcdb8af12091ede4e334aa24e4f6844de",

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/buildConsolidatedColumnSchema.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/buildConsolidatedColumnSchema.tsx
@@ -26,23 +26,21 @@ export function buildConsolidatedColumnSchema({
   );
   const materializationTimestamp = materialization ? Number(materialization.timestamp) : undefined;
   const definitionTableSchema = definition?.metadataEntries?.find(isCanonicalColumnSchemaEntry);
-
   let tableSchema = materializationTableSchema ?? definitionTableSchema;
   const tableSchemaLoadTimestamp = materializationTimestamp ?? definitionLoadTimestamp;
 
   // Merge the descriptions from the definition table schema with the materialization table schema
   if (materializationTableSchema && definitionTableSchema) {
-    const definitionTableSchemaColumnDescriptionsByName = Object.fromEntries(
-      definitionTableSchema.schema.columns.map((column) => [
-        column.name.toLowerCase(),
-        column.description,
-      ]),
+    const definitionsTableColumnsByName = Object.fromEntries(
+      definitionTableSchema.schema.columns.map((column) => [column.name.toLowerCase(), column]),
     );
     const mergedColumns = materializationTableSchema.schema.columns.map((column) => {
-      const description =
-        definitionTableSchemaColumnDescriptionsByName[column.name.toLowerCase()] ||
-        column.description;
-      return {...column, name: column.name.toLowerCase(), description};
+      const definitionsCol = definitionsTableColumnsByName[column.name.toLowerCase()];
+
+      const description = definitionsCol?.description || column.description;
+      const tags = definitionsCol?.tags || column.tags;
+
+      return {...column, name: column.name.toLowerCase(), description, tags};
     });
 
     tableSchema = {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/lineage/types/useColumnLineageDataForAssets.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/lineage/types/useColumnLineageDataForAssets.types.ts
@@ -50,6 +50,7 @@ export type AssetColumnLineageQuery = {
               name: string;
               type: string;
               description: string | null;
+              tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
             }>;
           };
         }
@@ -98,6 +99,7 @@ export type AssetColumnLineageQuery = {
                 name: string;
                 type: string;
                 description: string | null;
+                tags: Array<{__typename: 'DefinitionTag'; key: string; value: string}>;
               }>;
             };
           }
@@ -109,5 +111,4 @@ export type AssetColumnLineageQuery = {
   }>;
 };
 
-export const AssetColumnLineageVersion =
-  'bcb70460f77b88bbbfaec90982f3e99f522d9a4e270e63832684cfde169fabc7';
+export const AssetColumnLineageVersion = 'ce1683cb51cf7ac96c82f05bbf5f1cc2df57ce6c944615109e30dc6d93246dc4';

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/lineage/types/useColumnLineageDataForAssets.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/lineage/types/useColumnLineageDataForAssets.types.ts
@@ -26,7 +26,19 @@ export type AssetColumnLineageQuery = {
       | {__typename: 'PathMetadataEntry'; label: string}
       | {__typename: 'PipelineRunMetadataEntry'; label: string}
       | {__typename: 'PythonArtifactMetadataEntry'; label: string}
-      | {__typename: 'TableColumnLineageMetadataEntry'; label: string}
+      | {
+          __typename: 'TableColumnLineageMetadataEntry';
+          label: string;
+          lineage: Array<{
+            __typename: 'TableColumnLineageEntry';
+            columnName: string;
+            columnDeps: Array<{
+              __typename: 'TableColumnDep';
+              columnName: string;
+              assetKey: {__typename: 'AssetKey'; path: Array<string>};
+            }>;
+          }>;
+        }
       | {__typename: 'TableMetadataEntry'; label: string}
       | {
           __typename: 'TableSchemaMetadataEntry';
@@ -97,4 +109,5 @@ export type AssetColumnLineageQuery = {
   }>;
 };
 
-export const AssetColumnLineageVersion = 'c88c38558eb5d45b3c51b125853bc0df120213c4b8f5933a264525c3689bcef1';
+export const AssetColumnLineageVersion =
+  'bcb70460f77b88bbbfaec90982f3e99f522d9a4e270e63832684cfde169fabc7';


### PR DESCRIPTION
## Summary

Return tag information when building column lineage to power the lineage view.

Also updates the lineage-data-building logic. Right now, we only return lineage data (for the lineage graph view) for assets which have lineage information. This means that assets which have schema information but no lineage information won't render a description, data type etc. This change allows for these assets to still render this extra information.

## Changelog

NOCHANGELOG