### PR TITLE
Wrap IndexeddbDB usage with try/catch and degrade gracefully.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Util.tsx
@@ -152,10 +152,13 @@ export function indexedDBAsyncMemoize<T, R, U extends (arg: T, ...rest: any[]) =
 ): U & {
   isCached: (arg: T, ...rest: any[]) => Promise<boolean>;
 } {
-  const lru = cache<string, R>({
-    dbName: 'indexDBAsyncMemoizeDB',
-    maxCount: 50,
-  });
+  let lru: ReturnType<typeof cache<string, R>> | undefined;
+  try {
+    lru = cache<string, R>({
+      dbName: 'indexDBAsyncMemoizeDB',
+      maxCount: 50,
+    });
+  } catch (e) {}
 
   async function genHashKey(arg: T, ...rest: any[]) {
     const hash = hashFn ? hashFn(arg, ...rest) : arg;
@@ -175,7 +178,7 @@ export function indexedDBAsyncMemoize<T, R, U extends (arg: T, ...rest: any[]) =
   const ret = (async (arg: T, ...rest: any[]) => {
     return new Promise<R>(async (resolve) => {
       const hashKey = await genHashKey(arg, ...rest);
-      if (await lru.has(hashKey)) {
+      if (lru && (await lru.has(hashKey))) {
         const {value} = await lru.get(hashKey);
         resolve(value);
         return;
@@ -184,14 +187,19 @@ export function indexedDBAsyncMemoize<T, R, U extends (arg: T, ...rest: any[]) =
       const result = await fn(arg, ...rest);
       // Resolve the promise before storing the result in IndexedDB
       resolve(result);
-      await lru.set(hashKey, result, {
-        // Some day in the year 2050...
-        expiry: new Date(9 ** 13),
-      });
+      if (lru) {
+        await lru.set(hashKey, result, {
+          // Some day in the year 2050...
+          expiry: new Date(9 ** 13),
+        });
+      }
     });
   }) as any;
   ret.isCached = async (arg: T, ...rest: any) => {
     const hashKey = await genHashKey(arg, ...rest);
+    if (!lru) {
+      return false;
+    }
     return await lru.has(hashKey);
   };
   return ret;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/HourlyDataCache.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/HourlyDataCache/HourlyDataCache.tsx
@@ -41,12 +41,14 @@ export class HourlyDataCache<T> {
     this.indexedDBKey = keyPrefix ? `${keyPrefix}-hourlyData` : 'hourlyData';
 
     if (id) {
-      this.indexedDBCache = cache<string, CacheType<T>>({
-        dbName: `HourlyDataCache:${id}`,
-        maxCount: keyMaxCount,
-      });
-      this.loadCacheFromIndexedDB();
-      this.clearOldEntries();
+      try {
+        this.indexedDBCache = cache<string, CacheType<T>>({
+          dbName: `HourlyDataCache:${id}`,
+          maxCount: keyMaxCount,
+        });
+        this.loadCacheFromIndexedDB();
+        this.clearOldEntries();
+      } catch (e) {}
     }
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/search/__tests__/useIndexedDBCachedQuery.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/__tests__/useIndexedDBCachedQuery.test.tsx
@@ -12,11 +12,13 @@ import {
 } from '../../assets/types/AssetsCatalogTable.types';
 import {buildAssetConnection} from '../../graphql/types';
 import {buildQueryMock} from '../../testing/mocking';
-import {useIndexedDBCachedQuery} from '../useIndexedDBCachedQuery';
+import {__resetForJest, useIndexedDBCachedQuery} from '../useIndexedDBCachedQuery';
 
 const mockCache = _cache as any;
 
 jest.useFakeTimers();
+
+let mockShouldThrowError = false;
 
 // Mock idb-lru-cache
 jest.mock('idb-lru-cache', () => {
@@ -27,7 +29,14 @@ jest.mock('idb-lru-cache', () => {
     delete: jest.fn(),
   };
   return {
-    cache: jest.fn(() => mockedCache),
+    cache: jest.fn(() => {
+      if (mockShouldThrowError) {
+        console.log('throwing');
+        throw new Error('Internal error opening backing store for indexedDB.open.');
+      }
+      console.log('not throwing');
+      return mockedCache;
+    }),
   };
 });
 
@@ -68,84 +77,107 @@ describe('useIndexedDBCachedQuery', () => {
     jest.clearAllMocks();
   });
 
-  it('should use cached data if available and version matches', async () => {
-    mockCache().has.mockResolvedValue(true);
-    mockCache().get.mockResolvedValue({value: {data: 'test', version: 1}});
-
-    const {result, waitForNextUpdate} = renderHook(
-      () =>
-        useIndexedDBCachedQuery({
-          key: 'testKey',
-          query: ASSET_CATALOG_TABLE_QUERY,
-          version: 1,
-        }),
-      {
-        wrapper: ({children}: {children: ReactNode}) => (
-          <Wrapper mocks={[mock({delay: Infinity})]}>{children}</Wrapper>
-        ),
-      },
-    );
-    expect(result.current.data).toBeUndefined();
-
-    await act(async () => {
-      await waitForNextUpdate();
-    });
-
-    expect(result.current.data).toBe('test');
-  });
-
-  it('should not return cached data if version does not match', async () => {
-    mockCache().has.mockResolvedValue(true);
-    mockCache().get.mockResolvedValue({value: {data: 'test', version: 1}});
-
-    const {result} = renderHook(
-      () =>
-        useIndexedDBCachedQuery({
-          key: 'testKey',
-          query: ASSET_CATALOG_TABLE_QUERY,
-          version: 2,
-        }),
-      {
-        wrapper: ({children}: {children: ReactNode}) => <Wrapper mocks={[]}>{children}</Wrapper>,
-      },
-    );
-    expect(result.current.data).toBeUndefined();
-    jest.runAllTimers();
-    expect(result.current.data).toBeUndefined();
-  });
-
-  it('Ensures that concurrent fetch requests consolidate correctly, not triggering multiple network requests for the same key', async () => {
-    mockCache().has.mockResolvedValue(false);
-    const mock1 = mock();
-    const mock2 = mock();
-    let result1;
-    let result2;
-    renderHook(
+  [true, false].forEach((shouldThrowError) => {
+    const throwingError = shouldThrowError;
+    describe(
+      // eslint-disable-next-line jest/valid-title
+      throwingError ? 'with crashing indexeddb cache' : 'with working indexeddb cache',
       () => {
-        result1 = useIndexedDBCachedQuery({
-          key: 'testKey',
-          query: ASSET_CATALOG_TABLE_QUERY,
-          version: 2,
+        beforeEach(() => {
+          __resetForJest();
+          mockShouldThrowError = throwingError;
         });
-        const {fetch} = result1;
-        useMemo(() => fetch(), [fetch]);
-        result2 = useIndexedDBCachedQuery({
-          key: 'testKey',
-          query: ASSET_CATALOG_TABLE_QUERY,
-          version: 2,
+
+        it('should use cached data if available and version matches', async () => {
+          console.log('in test', {throwingError});
+          if (!throwingError) {
+            mockCache().has.mockResolvedValue(true);
+            mockCache().get.mockResolvedValue({value: {data: 'test', version: 1}});
+          }
+
+          const {result, waitForNextUpdate} = renderHook(
+            () =>
+              useIndexedDBCachedQuery({
+                key: 'testKey',
+                query: ASSET_CATALOG_TABLE_QUERY,
+                version: 1,
+              }),
+            {
+              wrapper: ({children}: {children: ReactNode}) => (
+                <Wrapper mocks={[mock({delay: Infinity})]}>{children}</Wrapper>
+              ),
+            },
+          );
+          expect(result.current.data).toBeUndefined();
+
+          await act(async () => {
+            await waitForNextUpdate();
+          });
+
+          expect(result.current.data).toBe(throwingError ? undefined : 'test');
         });
-        const {fetch: fetch2} = result2;
-        useMemo(() => fetch2(), [fetch2]);
-        return result2;
-      },
-      {
-        wrapper: ({children}: {children: ReactNode}) => (
-          <Wrapper mocks={[mock1, mock2]}>{children}</Wrapper>
-        ),
+
+        it('should not return cached data if version does not match', async () => {
+          if (!throwingError) {
+            mockCache().has.mockResolvedValue(true);
+            mockCache().get.mockResolvedValue({value: {data: 'test', version: 1}});
+          }
+
+          const {result} = renderHook(
+            () =>
+              useIndexedDBCachedQuery({
+                key: 'testKey',
+                query: ASSET_CATALOG_TABLE_QUERY,
+                version: 2,
+              }),
+            {
+              wrapper: ({children}: {children: ReactNode}) => (
+                <Wrapper mocks={[]}>{children}</Wrapper>
+              ),
+            },
+          );
+          expect(result.current.data).toBeUndefined();
+          jest.runAllTimers();
+          expect(result.current.data).toBeUndefined();
+        });
+
+        it('Ensures that concurrent fetch requests consolidate correctly, not triggering multiple network requests for the same key', async () => {
+          if (!throwingError) {
+            mockCache().has.mockResolvedValue(false);
+          }
+          const mock1 = mock();
+          const mock2 = mock();
+          let result1;
+          let result2;
+          renderHook(
+            () => {
+              result1 = useIndexedDBCachedQuery({
+                key: 'testKey',
+                query: ASSET_CATALOG_TABLE_QUERY,
+                version: 2,
+              });
+              const {fetch} = result1;
+              useMemo(() => fetch(), [fetch]);
+              result2 = useIndexedDBCachedQuery({
+                key: 'testKey',
+                query: ASSET_CATALOG_TABLE_QUERY,
+                version: 2,
+              });
+              const {fetch: fetch2} = result2;
+              useMemo(() => fetch2(), [fetch2]);
+              return result2;
+            },
+            {
+              wrapper: ({children}: {children: ReactNode}) => (
+                <Wrapper mocks={[mock1, mock2]}>{children}</Wrapper>
+              ),
+            },
+          );
+          expect(useApolloClient().query).toHaveBeenCalledTimes(1);
+          expect(result1!.data).toEqual(result2!.data);
+          expect(result1!.loading).toEqual(result2!.loading);
+        });
       },
     );
-    expect(useApolloClient().query).toHaveBeenCalledTimes(1);
-    expect(result1!.data).toEqual(result2!.data);
-    expect(result1!.loading).toEqual(result2!.loading);
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/search/__tests__/useIndexedDBCachedQuery.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/__tests__/useIndexedDBCachedQuery.test.tsx
@@ -31,10 +31,8 @@ jest.mock('idb-lru-cache', () => {
   return {
     cache: jest.fn(() => {
       if (mockShouldThrowError) {
-        console.log('throwing');
         throw new Error('Internal error opening backing store for indexedDB.open.');
       }
-      console.log('not throwing');
       return mockedCache;
     }),
   };
@@ -89,7 +87,6 @@ describe('useIndexedDBCachedQuery', () => {
         });
 
         it('should use cached data if available and version matches', async () => {
-          console.log('in test', {throwingError});
           if (!throwingError) {
             mockCache().has.mockResolvedValue(true);
             mockCache().get.mockResolvedValue({value: {data: 'test', version: 1}});


### PR DESCRIPTION
## Summary & Motivation

Some users are hitting [this issue](https://issues.chromium.org/issues/369636250) so lets degrade gracefully incase we can't rely on indexeddb.

I'm banking on this line https://github.com/make-github-pseudonymous-again/idb-lru-cache/blob/main/src/mod.ts#L322 being the problematic line that throws the error since it leads to this line https://github.com/jakearchibald/idb/blob/main/src/entry.ts#L70

## How I Tested These Changes

I forced an error and loaded the app and saw that we could still load code locations.
Also added jest tests

## Changelog

- [x] `BUGFIX` _([ui] Added work-around for "Internal error opening backing store for indexedDB.open" error)_
