### PR TITLE
[dagster-dbt] add profiles_dir to DbtProject

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -223,6 +223,9 @@ class DbtCliResource(ConfigurableResource):
             if not target and project_dir.target:
                 target = project_dir.target
 
+            if not profiles_dir and project_dir.profiles_dir:
+                profiles_dir = project_dir.profiles_dir
+
             project_dir = project_dir.project_dir
 
         project_dir = os.fspath(project_dir)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_project.py
@@ -148,6 +148,8 @@ class DbtProject(IHaveNew):
     Args:
         project_dir (Union[str, Path]):
             The directory of the dbt project.
+        profiles_dir (Optional[Union[str, Path]):
+            The directory of the dbt profiles.yml file.
         target_path (Union[str, Path]):
             The path, relative to the project directory, to output artifacts.
             It corresponds to the target path in dbt.
@@ -174,7 +176,7 @@ class DbtProject(IHaveNew):
 
             my_project = DbtProject(project_dir=Path("path/to/dbt_project"))
 
-        Creating a DbtProject that changes target based on environment variables and uses manged state artifacts:
+        Creating a DbtProject that changes target based on environment variables and uses managed state artifacts:
 
         .. code-block:: python
 
@@ -200,6 +202,7 @@ class DbtProject(IHaveNew):
     """
 
     project_dir: Path
+    profiles_dir: Optional[Path]
     target_path: Path
     target: Optional[str]
     manifest_path: Path
@@ -212,6 +215,7 @@ class DbtProject(IHaveNew):
         cls,
         project_dir: Union[Path, str],
         *,
+        profiles_dir: Optional[Union[Path, str]] = None,
         target_path: Union[Path, str] = Path("target"),
         target: Optional[str] = None,
         packaged_project_dir: Optional[Union[Path, str]] = None,
@@ -251,6 +255,7 @@ class DbtProject(IHaveNew):
         return super().__new__(
             cls,
             project_dir=project_dir,
+            profiles_dir=profiles_dir,
             target_path=target_path,
             target=target,
             manifest_path=manifest_path,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_resource.py
@@ -27,6 +27,7 @@ from dagster_dbt_tests.dbt_projects import (
     test_exceptions_path,
     test_jaffle_shop_path,
     test_jaffle_with_profile_vars_path,
+    test_profiles_dir,
 )
 
 
@@ -234,12 +235,23 @@ def test_dbt_profile_configuration() -> None:
 
 
 @pytest.mark.parametrize(
-    "profiles_dir", [None, test_jaffle_shop_path, os.fspath(test_jaffle_shop_path)]
+    "project_dir",
+    [
+        test_jaffle_shop_path,
+        os.fspath(test_jaffle_shop_path),
+        DbtProject(project_dir=os.fspath(test_jaffle_shop_path), profiles_dir=test_profiles_dir),
+    ],
 )
-def test_dbt_profiles_dir_configuration(profiles_dir: Union[str, Path]) -> None:
+@pytest.mark.parametrize(
+    "profiles_dir",
+    [None, test_jaffle_shop_path, os.fspath(test_jaffle_shop_path), test_profiles_dir],
+)
+def test_dbt_profiles_dir_configuration(
+    project_dir: Union[str, Path, DbtProject], profiles_dir: Union[str, Path, None]
+) -> None:
     assert (
         DbtCliResource(
-            project_dir=os.fspath(test_jaffle_shop_path),
+            project_dir=project_dir,
             profiles_dir=profiles_dir,
         )
         .cli(["parse"])
@@ -248,12 +260,12 @@ def test_dbt_profiles_dir_configuration(profiles_dir: Union[str, Path]) -> None:
 
     # profiles directory must exist
     with pytest.raises(ValidationError, match="does not exist"):
-        DbtCliResource(project_dir=os.fspath(test_jaffle_shop_path), profiles_dir="nonexistent")
+        DbtCliResource(project_dir=project_dir, profiles_dir="nonexistent")
 
     # profiles directory must contain profile configuration
     with pytest.raises(ValidationError, match="specify a valid path to a dbt profile directory"):
         DbtCliResource(
-            project_dir=os.fspath(test_jaffle_shop_path),
+            project_dir=project_dir,
             profiles_dir=f"{os.fspath(test_jaffle_shop_path)}/models",
         )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/__init__.py
@@ -27,3 +27,4 @@ test_time_partition_freshness_multiple_assets_defs_path = projects_path.joinpath
 )
 test_dagster_dbt_mixed_freshness_path = projects_path.joinpath("test_dagster_dbt_mixed_freshness")
 test_jaffle_with_profile_vars_path = projects_path.joinpath("test_jaffle_with_profile_vars")
+test_profiles_dir = projects_path.joinpath("test_profiles_dir")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_profiles_dir/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_profiles_dir/profiles.yml
@@ -1,0 +1,8 @@
+jaffle_shop:
+  target: dev
+  outputs:
+    dev:
+      type: duckdb
+      path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH', 'target/local.duckdb') }}"
+      schema: "{{ env_var('DAGSTER_DBT_JAFFLE_SCHEMA', 'dev') }}"
+      threads: 24


### PR DESCRIPTION
## Summary & Motivation

Contributes to https://github.com/dagster-io/dagster/issues/23543. This enables the use of `.prepare_if_dev()` on a `DbtProject` when the `profiles_dir` is different from the `project_dir`.

One slight hesitation about the approach here is that you could argue that the `profiles_dir` is not actually a part of a specific dbt project (since it can be reused for different projects), and therefore should not be a part of the `DbtProject` class. But then again, it is needed to be able to parse and generate the project manifest.

## How I Tested These Changes
Added to the test suite:
- A test that confirms that the dbt manifest can be created by `.prepare_if_dev()` when the `profiles.yml` file is not in the dbt project root but somewhere else
- Tests with different combinations of project_dir & profiles_dir in `DbtCliResource` and confirm they work together

## Changelog

Added the option to configure the `profiles_dir` on `DbtProject`. This enables generating the manifest on-the-fly during local development when the profiles_dir is in a custom location.

- [ ] `NEW` _(added new feature or capability)_
- [x] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
