### PR TITLE
[external-renames] ExternalJobData -> JobDataSnap

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/dagster_types.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/dagster_types.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 import dagster._check as check
 import graphene
-from dagster._core.snap import JobSnapshot
+from dagster._core.snap import JobSnap
 from dagster._core.types.dagster_type import DagsterTypeKind
 from typing_extensions import TypeAlias
 
@@ -29,17 +29,15 @@ GrapheneDagsterTypeUnion: TypeAlias = Union[
 
 
 def config_type_for_schema(
-    pipeline_snapshot: JobSnapshot, schema_key: Optional[str]
+    pipeline_snapshot: JobSnap, schema_key: Optional[str]
 ) -> Optional[GrapheneConfigTypeUnion]:
     return (
         to_config_type(pipeline_snapshot.config_schema_snapshot, schema_key) if schema_key else None
     )
 
 
-def to_dagster_type(
-    pipeline_snapshot: JobSnapshot, dagster_type_key: str
-) -> GrapheneDagsterTypeUnion:
-    check.inst_param(pipeline_snapshot, "pipeline_snapshot", JobSnapshot)
+def to_dagster_type(pipeline_snapshot: JobSnap, dagster_type_key: str) -> GrapheneDagsterTypeUnion:
+    check.inst_param(pipeline_snapshot, "pipeline_snapshot", JobSnap)
     check.str_param(dagster_type_key, "dagster_type_key")
 
     dagster_type_meta: DagsterTypeSnap = (

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -46,7 +46,7 @@ from dagster._core.remote_representation.external_data import (
     PartitionNamesSnap,
     PartitionSetExecutionParamSnap,
 )
-from dagster._core.snap import JobSnapshot, NodeInvocationSnap
+from dagster._core.snap import JobSnap, NodeInvocationSnap
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.telemetry import log_external_repo_stats, telemetry_wrapper
 from dagster._core.utils import make_new_backfill_id
@@ -165,10 +165,10 @@ def execute_print_command(instance, verbose, cli_args, print_fn):
 
 
 def print_ops(
-    job_snapshot: JobSnapshot,
+    job_snapshot: JobSnap,
     print_fn: Callable[..., Any],
 ):
-    check.inst_param(job_snapshot, "job_snapshot", JobSnapshot)
+    check.inst_param(job_snapshot, "job_snapshot", JobSnap)
     check.callable_param(print_fn, "print_fn")
 
     printer = IndentingPrinter(indent_level=2, printer=print_fn)
@@ -181,10 +181,10 @@ def print_ops(
 
 
 def print_job(
-    job_snapshot: JobSnapshot,
+    job_snapshot: JobSnap,
     print_fn: Callable[..., Any],
 ):
-    check.inst_param(job_snapshot, "job_snapshot", JobSnapshot)
+    check.inst_param(job_snapshot, "job_snapshot", JobSnap)
     check.callable_param(print_fn, "print_fn")
     printer = IndentingPrinter(indent_level=2, printer=print_fn)
     printer.line(f"Job: {job_snapshot.name}")
@@ -216,10 +216,10 @@ def format_description(desc: str, indent: str):
 
 def print_op(
     printer: IndentingPrinter,
-    job_snapshot: JobSnapshot,
+    job_snapshot: JobSnap,
     node_invocation_snap: NodeInvocationSnap,
 ) -> None:
-    check.inst_param(job_snapshot, "job_snapshot", JobSnapshot)
+    check.inst_param(job_snapshot, "job_snapshot", JobSnap)
     check.inst_param(node_invocation_snap, "node_invocation_snap", NodeInvocationSnap)
     printer.line(f"Op: {node_invocation_snap.node_name}")
     with printer.with_indent():

--- a/python_modules/dagster/dagster/_core/debug.py
+++ b/python_modules/dagster/dagster/_core/debug.py
@@ -3,7 +3,7 @@ from typing import NamedTuple, Sequence
 import dagster._check as check
 from dagster._core.events.log import EventLogEntry
 from dagster._core.instance import DagsterInstance
-from dagster._core.snap import ExecutionPlanSnapshot, JobSnapshot
+from dagster._core.snap import ExecutionPlanSnapshot, JobSnap
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._serdes import serialize_value, whitelist_for_serdes
 
@@ -21,7 +21,7 @@ class DebugRunPayload(
             ("version", str),
             ("dagster_run", DagsterRun),
             ("event_list", Sequence[EventLogEntry]),
-            ("job_snapshot", JobSnapshot),
+            ("job_snapshot", JobSnap),
             ("execution_plan_snapshot", ExecutionPlanSnapshot),
         ],
     )
@@ -31,7 +31,7 @@ class DebugRunPayload(
         version: str,
         dagster_run: DagsterRun,
         event_list: Sequence[EventLogEntry],
-        job_snapshot: JobSnapshot,
+        job_snapshot: JobSnap,
         execution_plan_snapshot: ExecutionPlanSnapshot,
     ):
         return super(DebugRunPayload, cls).__new__(
@@ -39,7 +39,7 @@ class DebugRunPayload(
             version=check.str_param(version, "version"),
             dagster_run=check.inst_param(dagster_run, "dagster_run", DagsterRun),
             event_list=check.sequence_param(event_list, "event_list", EventLogEntry),
-            job_snapshot=check.inst_param(job_snapshot, "job_snapshot", JobSnapshot),
+            job_snapshot=check.inst_param(job_snapshot, "job_snapshot", JobSnap),
             execution_plan_snapshot=check.inst_param(
                 execution_plan_snapshot, "execution_plan_snapshot", ExecutionPlanSnapshot
             ),

--- a/python_modules/dagster/dagster/_core/definitions/job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/job_definition.py
@@ -93,7 +93,7 @@ if TYPE_CHECKING:
     from dagster._core.execution.resources_init import InitResourceContext
     from dagster._core.instance import DagsterInstance, DynamicPartitionsStore
     from dagster._core.remote_representation.job_index import JobIndex
-    from dagster._core.snap import JobSnapshot
+    from dagster._core.snap import JobSnap
 
 DEFAULT_EXECUTOR_DEF = multi_or_in_process_executor
 
@@ -1024,20 +1024,20 @@ class JobDefinition(IHasInternalInit):
     def get_config_schema_snapshot(self) -> "ConfigSchemaSnapshot":
         return self.get_job_snapshot().config_schema_snapshot
 
-    def get_job_snapshot(self) -> "JobSnapshot":
+    def get_job_snapshot(self) -> "JobSnap":
         return self.get_job_index().job_snapshot
 
     @cached_method
     def get_job_index(self) -> "JobIndex":
         from dagster._core.remote_representation import JobIndex
-        from dagster._core.snap import JobSnapshot
+        from dagster._core.snap import JobSnap
 
-        return JobIndex(JobSnapshot.from_job_def(self), self.get_parent_job_snapshot())
+        return JobIndex(JobSnap.from_job_def(self), self.get_parent_job_snapshot())
 
     def get_job_snapshot_id(self) -> str:
         return self.get_job_index().job_snapshot_id
 
-    def get_parent_job_snapshot(self) -> Optional["JobSnapshot"]:
+    def get_parent_job_snapshot(self) -> Optional["JobSnap"]:
         if self.op_selection_data:
             return self.op_selection_data.parent_job_def.get_job_snapshot()
         elif self.asset_selection_data:

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -153,7 +153,7 @@ if TYPE_CHECKING:
         ExecutionPlanSnapshot,
         ExecutionStepOutputSnap,
         ExecutionStepSnap,
-        JobSnapshot,
+        JobSnap,
     )
     from dagster._core.storage.asset_check_execution_record import (
         AssetCheckExecutionRecord,
@@ -1068,7 +1068,7 @@ class DagsterInstance(DynamicPartitionsStore):
         return records[0]
 
     @traced
-    def get_job_snapshot(self, snapshot_id: str) -> "JobSnapshot":
+    def get_job_snapshot(self, snapshot_id: str) -> "JobSnap":
         return self._run_storage.get_job_snapshot(snapshot_id)
 
     @traced
@@ -1214,9 +1214,9 @@ class DagsterInstance(DynamicPartitionsStore):
         tags: Mapping[str, str],
         root_run_id: Optional[str],
         parent_run_id: Optional[str],
-        job_snapshot: Optional["JobSnapshot"],
+        job_snapshot: Optional["JobSnap"],
         execution_plan_snapshot: Optional["ExecutionPlanSnapshot"],
-        parent_job_snapshot: Optional["JobSnapshot"],
+        parent_job_snapshot: Optional["JobSnap"],
         asset_selection: Optional[AbstractSet[AssetKey]] = None,
         asset_check_selection: Optional[AbstractSet["AssetCheckKey"]] = None,
         op_selection: Optional[Sequence[str]] = None,
@@ -1287,13 +1287,13 @@ class DagsterInstance(DynamicPartitionsStore):
 
     def _ensure_persisted_job_snapshot(
         self,
-        job_snapshot: "JobSnapshot",
-        parent_job_snapshot: "Optional[JobSnapshot]",
+        job_snapshot: "JobSnap",
+        parent_job_snapshot: "Optional[JobSnap]",
     ) -> str:
-        from dagster._core.snap import JobSnapshot, create_job_snapshot_id
+        from dagster._core.snap import JobSnap, create_job_snapshot_id
 
-        check.inst_param(job_snapshot, "job_snapshot", JobSnapshot)
-        check.opt_inst_param(parent_job_snapshot, "parent_job_snapshot", JobSnapshot)
+        check.inst_param(job_snapshot, "job_snapshot", JobSnap)
+        check.opt_inst_param(parent_job_snapshot, "parent_job_snapshot", JobSnap)
 
         if job_snapshot.lineage_snapshot:
             parent_snapshot_id = create_job_snapshot_id(check.not_none(parent_job_snapshot))
@@ -1469,8 +1469,8 @@ class DagsterInstance(DynamicPartitionsStore):
         parent_run_id: Optional[str],
         step_keys_to_execute: Optional[Sequence[str]],
         execution_plan_snapshot: Optional["ExecutionPlanSnapshot"],
-        job_snapshot: Optional["JobSnapshot"],
-        parent_job_snapshot: Optional["JobSnapshot"],
+        job_snapshot: Optional["JobSnap"],
+        parent_job_snapshot: Optional["JobSnap"],
         asset_selection: Optional[AbstractSet[AssetKey]],
         asset_check_selection: Optional[AbstractSet["AssetCheckKey"]],
         resolved_op_selection: Optional[AbstractSet[str]],
@@ -1481,7 +1481,7 @@ class DagsterInstance(DynamicPartitionsStore):
     ) -> DagsterRun:
         from dagster._core.definitions.asset_check_spec import AssetCheckKey
         from dagster._core.remote_representation.origin import RemoteJobOrigin
-        from dagster._core.snap import ExecutionPlanSnapshot, JobSnapshot
+        from dagster._core.snap import ExecutionPlanSnapshot, JobSnap
         from dagster._utils.tags import normalize_tags
 
         check.str_param(job_name, "job_name")
@@ -1521,8 +1521,8 @@ class DagsterInstance(DynamicPartitionsStore):
         # The job_snapshot should always be set in production scenarios. In tests
         # we have sometimes omitted it out of convenience.
 
-        check.opt_inst_param(job_snapshot, "job_snapshot", JobSnapshot)
-        check.opt_inst_param(parent_job_snapshot, "parent_job_snapshot", JobSnapshot)
+        check.opt_inst_param(job_snapshot, "job_snapshot", JobSnap)
+        check.opt_inst_param(parent_job_snapshot, "parent_job_snapshot", JobSnap)
 
         if parent_job_snapshot:
             check.invariant(
@@ -1718,9 +1718,9 @@ class DagsterInstance(DynamicPartitionsStore):
         tags: Mapping[str, str],
         root_run_id: Optional[str],
         parent_run_id: Optional[str],
-        job_snapshot: Optional["JobSnapshot"],
+        job_snapshot: Optional["JobSnap"],
         execution_plan_snapshot: Optional["ExecutionPlanSnapshot"],
-        parent_job_snapshot: Optional["JobSnapshot"],
+        parent_job_snapshot: Optional["JobSnap"],
         op_selection: Optional[Sequence[str]] = None,
         job_code_origin: Optional[JobPythonOrigin] = None,
     ) -> DagsterRun:
@@ -1779,7 +1779,7 @@ class DagsterInstance(DynamicPartitionsStore):
     @traced
     def add_snapshot(
         self,
-        snapshot: Union["JobSnapshot", "ExecutionPlanSnapshot"],
+        snapshot: Union["JobSnap", "ExecutionPlanSnapshot"],
         snapshot_id: Optional[str] = None,
     ) -> None:
         return self._run_storage.add_snapshot(snapshot, snapshot_id)

--- a/python_modules/dagster/dagster/_core/remote_representation/__init__.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/__init__.py
@@ -17,10 +17,10 @@ from dagster._core.remote_representation.external import (
 from dagster._core.remote_representation.external_data import (
     ExecutionParamsErrorSnap as ExecutionParamsErrorSnap,
     ExecutionParamsSnap as ExecutionParamsSnap,
-    ExternalJobData as ExternalJobData,
-    ExternalJobRef as ExternalJobRef,
     ExternalJobSubsetResult as ExternalJobSubsetResult,
     ExternalRepositoryData as ExternalRepositoryData,
+    JobDataSnap as JobDataSnap,
+    JobRefSnap as JobRefSnap,
     PartitionConfigSnap as PartitionConfigSnap,
     PartitionExecutionErrorSnap as PartitionExecutionErrorSnap,
     PartitionNamesSnap as PartitionNamesSnap,

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -893,9 +893,7 @@ class GrpcServerCodeLocation(CodeLocation):
             )
             subset = copy(
                 subset,
-                external_job_data=copy(
-                    subset.external_job_data, parent_job_snapshot=full_job.job_snapshot
-                ),
+                external_job_data=copy(subset.external_job_data, parent_job=full_job.job_snapshot),
             )
 
         return subset

--- a/python_modules/dagster/dagster/_core/remote_representation/historical.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/historical.py
@@ -3,7 +3,7 @@ from typing import Optional
 import dagster._check as check
 from dagster._core.remote_representation.job_index import JobIndex
 from dagster._core.remote_representation.represented import RepresentedJob
-from dagster._core.snap import JobSnapshot
+from dagster._core.snap import JobSnap
 
 
 class HistoricalJob(RepresentedJob):
@@ -17,13 +17,13 @@ class HistoricalJob(RepresentedJob):
 
     def __init__(
         self,
-        job_snapshot: JobSnapshot,
+        job_snapshot: JobSnap,
         identifying_job_snapshot_id: str,
-        parent_job_snapshot: Optional[JobSnapshot],
+        parent_job_snapshot: Optional[JobSnap],
     ):
-        self._snapshot = check.inst_param(job_snapshot, "job_snapshot", JobSnapshot)
+        self._snapshot = check.inst_param(job_snapshot, "job_snapshot", JobSnap)
         self._parent_snapshot = check.opt_inst_param(
-            parent_job_snapshot, "parent_job_snapshot", JobSnapshot
+            parent_job_snapshot, "parent_job_snapshot", JobSnap
         )
         self._identifying_job_snapshot_id = check.str_param(
             identifying_job_snapshot_id, "identifying_job_snapshot_id"

--- a/python_modules/dagster/dagster/_core/remote_representation/job_index.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/job_index.py
@@ -3,15 +3,15 @@ from typing import Any, Mapping, Optional, Sequence, Union
 
 import dagster._check as check
 from dagster._config import ConfigSchemaSnapshot
-from dagster._core.snap import DependencyStructureIndex, JobSnapshot, create_job_snapshot_id
+from dagster._core.snap import DependencyStructureIndex, JobSnap, create_job_snapshot_id
 from dagster._core.snap.dagster_types import DagsterTypeSnap
 from dagster._core.snap.mode import ModeDefSnap
 from dagster._core.snap.node import GraphDefSnap, OpDefSnap
 
 
 class JobIndex:
-    job_snapshot: JobSnapshot
-    parent_job_snapshot: Optional[JobSnapshot]
+    job_snapshot: JobSnap
+    parent_job_snapshot: Optional[JobSnap]
     _node_defs_snaps_index: Mapping[str, Union[OpDefSnap, GraphDefSnap]]
     _dagster_type_snaps_by_name_index: Mapping[str, DagsterTypeSnap]
     dep_structure_index: DependencyStructureIndex
@@ -20,12 +20,12 @@ class JobIndex:
 
     def __init__(
         self,
-        job_snapshot: JobSnapshot,
-        parent_job_snapshot: Optional[JobSnapshot],
+        job_snapshot: JobSnap,
+        parent_job_snapshot: Optional[JobSnap],
     ):
-        self.job_snapshot = check.inst_param(job_snapshot, "job_snapshot", JobSnapshot)
+        self.job_snapshot = check.inst_param(job_snapshot, "job_snapshot", JobSnap)
         self.parent_job_snapshot = check.opt_inst_param(
-            parent_job_snapshot, "parent_job_snapshot", JobSnapshot
+            parent_job_snapshot, "parent_job_snapshot", JobSnap
         )
 
         node_def_snaps: Sequence[Union[OpDefSnap, GraphDefSnap]] = [

--- a/python_modules/dagster/dagster/_core/remote_representation/represented.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/represented.py
@@ -6,7 +6,7 @@ from dagster._config import ConfigSchemaSnapshot
 from dagster._core.remote_representation.job_index import JobIndex
 from dagster._core.snap.dagster_types import DagsterTypeSnap
 from dagster._core.snap.dep_snapshot import DependencyStructureIndex
-from dagster._core.snap.job_snapshot import JobSnapshot
+from dagster._core.snap.job_snapshot import JobSnap
 from dagster._core.snap.mode import ModeDefSnap
 from dagster._core.snap.node import GraphDefSnap, OpDefSnap
 
@@ -44,11 +44,11 @@ class RepresentedJob(ABC):
         pass
 
     @property
-    def job_snapshot(self) -> JobSnapshot:
+    def job_snapshot(self) -> JobSnap:
         return self._job_index.job_snapshot
 
     @property
-    def parent_job_snapshot(self) -> Optional[JobSnapshot]:
+    def parent_job_snapshot(self) -> Optional[JobSnap]:
         return self._job_index.parent_job_snapshot
 
     @property

--- a/python_modules/dagster/dagster/_core/snap/__init__.py
+++ b/python_modules/dagster/dagster/_core/snap/__init__.py
@@ -55,7 +55,7 @@ from dagster._core.snap.execution_plan_snapshot import (
     snapshot_from_execution_plan as snapshot_from_execution_plan,
 )
 from dagster._core.snap.job_snapshot import (
-    JobSnapshot as JobSnapshot,
+    JobSnap as JobSnap,
     create_job_snapshot_id as create_job_snapshot_id,
 )
 from dagster._core.snap.mode import (

--- a/python_modules/dagster/dagster/_core/snap/job_snapshot.py
+++ b/python_modules/dagster/dagster/_core/snap/job_snapshot.py
@@ -52,12 +52,12 @@ from dagster._serdes import create_snapshot_id, deserialize_value, whitelist_for
 from dagster._serdes.serdes import RecordSerializer
 
 
-def create_job_snapshot_id(snapshot: "JobSnapshot") -> str:
-    check.inst_param(snapshot, "snapshot", JobSnapshot)
+def create_job_snapshot_id(snapshot: "JobSnap") -> str:
+    check.inst_param(snapshot, "snapshot", JobSnap)
     return create_snapshot_id(snapshot)
 
 
-class JobSnapshotSerializer(RecordSerializer["JobSnapshot"]):
+class JobSnapSerializer(RecordSerializer["JobSnap"]):
     # v0
     # v1:
     #     - lineage added
@@ -92,14 +92,14 @@ class JobSnapshotSerializer(RecordSerializer["JobSnapshot"]):
 # serialization.
 @whitelist_for_serdes(
     storage_name="PipelineSnapshot",
-    serializer=JobSnapshotSerializer,
+    serializer=JobSnapSerializer,
     skip_when_empty_fields={"metadata"},
     skip_when_none_fields={"run_tags"},
     field_serializers={"metadata": MetadataFieldSerializer},
     storage_field_names={"node_defs_snapshot": "solid_definitions_snapshot"},
 )
 @record_custom
-class JobSnapshot(IHaveNew):
+class JobSnap(IHaveNew):
     name: str
     description: Optional[str]
     tags: Mapping[str, Any]
@@ -114,7 +114,7 @@ class JobSnapshot(IHaveNew):
     node_defs_snapshot: NodeDefsSnapshot
     dep_structure_snapshot: DependencyStructureSnapshot
     mode_def_snaps: Sequence[ModeDefSnap]
-    lineage_snapshot: Optional["JobLineageSnapshot"]
+    lineage_snapshot: Optional["JobLineageSnap"]
     graph_def_name: str
     metadata: Mapping[str, MetadataValue]
 
@@ -129,7 +129,7 @@ class JobSnapshot(IHaveNew):
         node_defs_snapshot: NodeDefsSnapshot,
         dep_structure_snapshot: DependencyStructureSnapshot,
         mode_def_snaps: Sequence[ModeDefSnap],
-        lineage_snapshot: Optional["JobLineageSnapshot"],
+        lineage_snapshot: Optional["JobLineageSnap"],
         graph_def_name: str,
         metadata: Optional[Mapping[str, RawMetadataValue]],
     ):
@@ -152,11 +152,11 @@ class JobSnapshot(IHaveNew):
         )
 
     @classmethod
-    def from_job_def(cls, job_def: JobDefinition) -> "JobSnapshot":
+    def from_job_def(cls, job_def: JobDefinition) -> "JobSnap":
         check.inst_param(job_def, "job_def", JobDefinition)
         lineage = None
         if job_def.op_selection_data:
-            lineage = JobLineageSnapshot(
+            lineage = JobLineageSnap(
                 parent_snapshot_id=create_job_snapshot_id(
                     cls.from_job_def(job_def.op_selection_data.parent_job_def)
                 ),
@@ -164,7 +164,7 @@ class JobSnapshot(IHaveNew):
                 resolved_op_selection=job_def.op_selection_data.resolved_op_selection,
             )
         if job_def.asset_selection_data:
-            lineage = JobLineageSnapshot(
+            lineage = JobLineageSnap(
                 parent_snapshot_id=create_job_snapshot_id(
                     cls.from_job_def(job_def.asset_selection_data.parent_job_def)
                 ),
@@ -172,7 +172,7 @@ class JobSnapshot(IHaveNew):
                 asset_check_selection=job_def.asset_selection_data.asset_check_selection,
             )
 
-        return JobSnapshot(
+        return JobSnap(
             name=job_def.name,
             description=job_def.description,
             tags=job_def.tags,
@@ -398,7 +398,7 @@ def construct_config_type_from_snap(
     },
 )
 @record
-class JobLineageSnapshot:
+class JobLineageSnap:
     parent_snapshot_id: str
     op_selection: Optional[Sequence[str]] = None
     resolved_op_selection: Optional[AbstractSet[str]] = None

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
         TickStatus,
     )
     from dagster._core.snap.execution_plan_snapshot import ExecutionPlanSnapshot
-    from dagster._core.snap.job_snapshot import JobSnapshot
+    from dagster._core.snap.job_snapshot import JobSnap
     from dagster._core.storage.dagster_run import (
         DagsterRun,
         DagsterRunStatsSnapshot,
@@ -250,7 +250,7 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
 
     def add_snapshot(
         self,
-        snapshot: Union["JobSnapshot", "ExecutionPlanSnapshot"],
+        snapshot: Union["JobSnap", "ExecutionPlanSnapshot"],
         snapshot_id: Optional[str] = None,
     ) -> None:
         return self._storage.run_storage.add_snapshot(snapshot, snapshot_id)
@@ -261,12 +261,10 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     def has_job_snapshot(self, job_snapshot_id: str) -> bool:
         return self._storage.run_storage.has_job_snapshot(job_snapshot_id)
 
-    def add_job_snapshot(
-        self, job_snapshot: "JobSnapshot", snapshot_id: Optional[str] = None
-    ) -> str:
+    def add_job_snapshot(self, job_snapshot: "JobSnap", snapshot_id: Optional[str] = None) -> str:
         return self._storage.run_storage.add_job_snapshot(job_snapshot, snapshot_id)
 
-    def get_job_snapshot(self, job_snapshot_id: str) -> "JobSnapshot":
+    def get_job_snapshot(self, job_snapshot_id: str) -> "JobSnap":
         return self._storage.run_storage.get_job_snapshot(job_snapshot_id)
 
     def has_execution_plan_snapshot(self, execution_plan_snapshot_id: str) -> bool:

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -7,7 +7,7 @@ from dagster._core.events import DagsterEvent
 from dagster._core.execution.backfill import BulkActionsFilter, BulkActionStatus, PartitionBackfill
 from dagster._core.execution.telemetry import RunTelemetryData
 from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
-from dagster._core.snap import ExecutionPlanSnapshot, JobSnapshot
+from dagster._core.snap import ExecutionPlanSnapshot, JobSnap
 from dagster._core.storage.daemon_cursor import DaemonCursorStorage
 from dagster._core.storage.dagster_run import (
     DagsterRun,
@@ -204,7 +204,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
 
     def add_snapshot(
         self,
-        snapshot: Union[JobSnapshot, ExecutionPlanSnapshot],
+        snapshot: Union[JobSnap, ExecutionPlanSnapshot],
         snapshot_id: Optional[str] = None,
     ) -> None:
         """Add a snapshot to the storage.
@@ -216,7 +216,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
                 in debugging, where we might want to import a historical run whose snapshots were
                 calculated using a different hash function than the current code.
         """
-        if isinstance(snapshot, JobSnapshot):
+        if isinstance(snapshot, JobSnap):
             self.add_job_snapshot(snapshot, snapshot_id)
         else:
             self.add_execution_plan_snapshot(snapshot, snapshot_id)
@@ -236,7 +236,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         """
 
     @abstractmethod
-    def add_job_snapshot(self, job_snapshot: JobSnapshot, snapshot_id: Optional[str] = None) -> str:
+    def add_job_snapshot(self, job_snapshot: JobSnap, snapshot_id: Optional[str] = None) -> str:
         """Add a pipeline snapshot to the run store.
 
         Pipeline snapshots are content-addressable, meaning
@@ -256,7 +256,7 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
         """
 
     @abstractmethod
-    def get_job_snapshot(self, job_snapshot_id: str) -> JobSnapshot:
+    def get_job_snapshot(self, job_snapshot_id: str) -> JobSnap:
         """Fetch a snapshot by ID.
 
         Args:

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_job.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_job.py
@@ -62,7 +62,7 @@ def test_job_with_valid_subset_snapshot_api_grpc(instance):
         assert external_job_subset_result.success is True
         assert external_job_subset_result.external_job_data.name == "foo"
         assert (
-            external_job_subset_result.external_job_data.parent_job_snapshot
+            external_job_subset_result.external_job_data.parent_job
             == code_location.get_repository("bar_repo").get_full_external_job("foo").job_snapshot
         )
 
@@ -78,7 +78,7 @@ def test_job_with_valid_subset_snapshot_without_parent_snapshot(instance):
         assert isinstance(external_job_subset_result, ExternalJobSubsetResult)
         assert external_job_subset_result.success is True
         assert external_job_subset_result.external_job_data.name == "foo"
-        assert not external_job_subset_result.external_job_data.parent_job_snapshot
+        assert not external_job_subset_result.external_job_data.parent_job
 
 
 def test_job_with_invalid_subset_snapshot_api_grpc(instance):

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -15,7 +15,7 @@ from dagster._core.remote_representation import (
     ManagedGrpcPythonEnvCodeLocationOrigin,
 )
 from dagster._core.remote_representation.external import ExternalRepository
-from dagster._core.remote_representation.external_data import ExternalJobData
+from dagster._core.remote_representation.external_data import JobDataSnap
 from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.remote_representation.origin import RemoteRepositoryOrigin
 from dagster._core.test_utils import instance_for_test
@@ -141,7 +141,7 @@ def test_defer_snapshots(instance: DagsterInstance):
                 repo_origin,
                 ref.name,
             )
-            return deserialize_value(reply.serialized_job_data, ExternalJobData)
+            return deserialize_value(reply.serialized_job_data, JobDataSnap)
 
         external_repository_data = deserialize_value(ser_repo_data, ExternalRepositoryData)
         assert (

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_job_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_job_snap.py
@@ -5,7 +5,7 @@ from dagster import Field, In, Map, Nothing, Out, Permissive, Selector, Shape, j
 from dagster._config import Array, Bool, Enum, EnumValue, Float, Int, Noneable, String
 from dagster._core.snap import (
     DependencyStructureIndex,
-    JobSnapshot,
+    JobSnap,
     NodeInvocationSnap,
     create_job_snapshot_id,
     snap_from_config_type,
@@ -20,8 +20,8 @@ from dagster._serdes import serialize_pp, serialize_value
 from dagster._serdes.serdes import deserialize_value
 
 
-def serialize_rt(value: JobSnapshot) -> JobSnapshot:
-    return deserialize_value(serialize_value(value), JobSnapshot)
+def serialize_rt(value: JobSnap) -> JobSnap:
+    return deserialize_value(serialize_value(value), JobSnap)
 
 
 def get_noop_pipeline():
@@ -37,11 +37,11 @@ def get_noop_pipeline():
 
 
 def test_empty_job_snap_snapshot(snapshot):
-    snapshot.assert_match(serialize_pp(JobSnapshot.from_job_def(get_noop_pipeline())))
+    snapshot.assert_match(serialize_pp(JobSnap.from_job_def(get_noop_pipeline())))
 
 
 def test_empty_job_snap_props(snapshot):
-    job_snapshot = JobSnapshot.from_job_def(get_noop_pipeline())
+    job_snapshot = JobSnap.from_job_def(get_noop_pipeline())
 
     assert job_snapshot.name == "noop_job"
     assert job_snapshot.description is None
@@ -63,7 +63,7 @@ def test_job_snap_all_props(snapshot):
     def noop_job():
         noop_op()
 
-    job_snapshot = JobSnapshot.from_job_def(noop_job)
+    job_snapshot = JobSnap.from_job_def(noop_job)
 
     assert job_snapshot.name == "noop_job"
     assert job_snapshot.description == "desc"
@@ -103,7 +103,7 @@ def test_two_invocations_deps_snap(snapshot):
     assert index.get_invocation("one")
     assert index.get_invocation("two")
 
-    job_snapshot = JobSnapshot.from_job_def(two_op_job)
+    job_snapshot = JobSnap.from_job_def(two_op_job)
     assert job_snapshot == serialize_rt(job_snapshot)
 
     snapshot.assert_match(serialize_pp(job_snapshot))
@@ -173,7 +173,7 @@ def test_basic_dep_fan_out(snapshot):
         == dep_structure_snapshot
     )
 
-    job_snapshot = JobSnapshot.from_job_def(single_dep_job)
+    job_snapshot = JobSnap.from_job_def(single_dep_job)
     assert job_snapshot == serialize_rt(job_snapshot)
 
     snapshot.assert_match(serialize_pp(job_snapshot))
@@ -214,7 +214,7 @@ def test_basic_fan_in(snapshot):
         == dep_structure_snapshot
     )
 
-    job_snapshot = JobSnapshot.from_job_def(fan_in_test)
+    job_snapshot = JobSnap.from_job_def(fan_in_test)
     assert job_snapshot == serialize_rt(job_snapshot)
 
     snapshot.assert_match(serialize_pp(job_snapshot))
@@ -255,7 +255,7 @@ def test_deserialize_op_def_snaps_default_field():
     def noop_job():
         noop_op()
 
-    job_snapshot = JobSnapshot.from_job_def(noop_job)
+    job_snapshot = JobSnap.from_job_def(noop_job)
     node_def_snap = job_snapshot.get_node_def_snap("noop_op")
     recevied_config_type = job_snapshot.get_config_type_from_node_def_snap(node_def_snap)
     assert isinstance(recevied_config_type, Shape)
@@ -282,7 +282,7 @@ def test_deserialize_node_def_snaps_enum():
     def noop_job():
         noop_op()
 
-    job_snapshot = JobSnapshot.from_job_def(noop_job)
+    job_snapshot = JobSnap.from_job_def(noop_job)
     node_def_snap = job_snapshot.get_node_def_snap("noop_op")
     recevied_config_type = job_snapshot.get_config_type_from_node_def_snap(node_def_snap)
     assert isinstance(recevied_config_type, Enum)
@@ -302,7 +302,7 @@ def test_deserialize_node_def_snaps_strict_shape():
     def noop_job():
         noop_op()
 
-    job_snapshot = JobSnapshot.from_job_def(noop_job)
+    job_snapshot = JobSnap.from_job_def(noop_job)
     node_def_snap = job_snapshot.get_node_def_snap("noop_op")
     recevied_config_type = job_snapshot.get_config_type_from_node_def_snap(node_def_snap)
     assert isinstance(recevied_config_type, Shape)
@@ -324,7 +324,7 @@ def test_deserialize_node_def_snaps_selector():
     def noop_job():
         noop_op()
 
-    job_snapshot = JobSnapshot.from_job_def(noop_job)
+    job_snapshot = JobSnap.from_job_def(noop_job)
     node_def_snap = job_snapshot.get_node_def_snap("noop_op")
     recevied_config_type = job_snapshot.get_config_type_from_node_def_snap(node_def_snap)
     assert isinstance(recevied_config_type, Selector)
@@ -345,7 +345,7 @@ def test_deserialize_op_def_snaps_permissive():
     def noop_job():
         noop_op()
 
-    job_snapshot = JobSnapshot.from_job_def(noop_job)
+    job_snapshot = JobSnap.from_job_def(noop_job)
     node_def_snap = job_snapshot.get_node_def_snap("noop_op")
     recevied_config_type = job_snapshot.get_config_type_from_node_def_snap(node_def_snap)
     assert isinstance(recevied_config_type, Permissive)
@@ -365,7 +365,7 @@ def test_deserialize_node_def_snaps_array():
     def noop_job():
         noop_op()
 
-    job_snapshot = JobSnapshot.from_job_def(noop_job)
+    job_snapshot = JobSnap.from_job_def(noop_job)
     node_def_snap = job_snapshot.get_node_def_snap("noop_op")
     recevied_config_type = job_snapshot.get_config_type_from_node_def_snap(node_def_snap)
     assert isinstance(recevied_config_type, Array)
@@ -385,7 +385,7 @@ def test_deserialize_node_def_snaps_map():
     def noop_job():
         noop_op()
 
-    job_snapshot = JobSnapshot.from_job_def(noop_job)
+    job_snapshot = JobSnap.from_job_def(noop_job)
     node_def_snap = job_snapshot.get_node_def_snap("noop_op")
     recevied_config_type = job_snapshot.get_config_type_from_node_def_snap(node_def_snap)
     assert isinstance(recevied_config_type, Map)
@@ -406,7 +406,7 @@ def test_deserialize_node_def_snaps_map_with_name():
     def noop_job():
         noop_op()
 
-    job_snapshot = JobSnapshot.from_job_def(noop_job)
+    job_snapshot = JobSnap.from_job_def(noop_job)
     node_def_snap = job_snapshot.get_node_def_snap("noop_op")
     recevied_config_type = job_snapshot.get_config_type_from_node_def_snap(node_def_snap)
     assert isinstance(recevied_config_type, Map)
@@ -428,7 +428,7 @@ def test_deserialize_node_def_snaps_noneable():
     def noop_job():
         noop_op()
 
-    job_snapshot = JobSnapshot.from_job_def(noop_job)
+    job_snapshot = JobSnap.from_job_def(noop_job)
     node_def_snap = job_snapshot.get_node_def_snap("noop_op")
     recevied_config_type = job_snapshot.get_config_type_from_node_def_snap(node_def_snap)
     assert isinstance(recevied_config_type, Noneable)
@@ -470,7 +470,7 @@ def test_deserialize_node_def_snaps_multi_type_config(snapshot):
     def noop_job():
         fancy_op()
 
-    job_snapshot = JobSnapshot.from_job_def(noop_job)
+    job_snapshot = JobSnap.from_job_def(noop_job)
     node_def_snap = job_snapshot.get_node_def_snap("fancy_op")
     recevied_config_type = job_snapshot.get_config_type_from_node_def_snap(node_def_snap)
     snapshot.assert_match(serialize_pp(snap_from_config_type(recevied_config_type)))
@@ -490,7 +490,7 @@ def test_multi_type_config_array_dict_fields(dict_config_type, snapshot):
     def noop_job():
         fancy_op()
 
-    job_snapshot = JobSnapshot.from_job_def(noop_job)
+    job_snapshot = JobSnap.from_job_def(noop_job)
     node_def_snap = job_snapshot.get_node_def_snap("fancy_op")
     recevied_config_type = job_snapshot.get_config_type_from_node_def_snap(node_def_snap)
     snapshot.assert_match(serialize_pp(snap_from_config_type(recevied_config_type)))
@@ -509,7 +509,7 @@ def test_multi_type_config_array_map(snapshot):
     def noop_job():
         fancy_op()
 
-    job_snapshot = JobSnapshot.from_job_def(noop_job)
+    job_snapshot = JobSnap.from_job_def(noop_job)
     node_def_snap = job_snapshot.get_node_def_snap("fancy_op")
     recevied_config_type = job_snapshot.get_config_type_from_node_def_snap(node_def_snap)
     snapshot.assert_match(serialize_pp(snap_from_config_type(recevied_config_type)))
@@ -534,7 +534,7 @@ def test_multi_type_config_nested_dicts(nested_dict_types, snapshot):
     def noop_job():
         fancy_op()
 
-    job_snapshot = JobSnapshot.from_job_def(noop_job)
+    job_snapshot = JobSnap.from_job_def(noop_job)
     node_def_snap = job_snapshot.get_node_def_snap("fancy_op")
     recevied_config_type = job_snapshot.get_config_type_from_node_def_snap(node_def_snap)
     snapshot.assert_match(serialize_pp(snap_from_config_type(recevied_config_type)))

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_legacy_mode_def_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_legacy_mode_def_snap.py
@@ -1,5 +1,5 @@
 from dagster import job, logger, resource
-from dagster._core.snap import JobSnapshot
+from dagster._core.snap import JobSnap
 from dagster._core.snap.mode import ModeDefSnap
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
@@ -35,7 +35,7 @@ def test_mode_snap(snapshot):
     def a_job():
         pass
 
-    job_snapshot = JobSnapshot.from_job_def(a_job)
+    job_snapshot = JobSnap.from_job_def(a_job)
     assert len(job_snapshot.mode_def_snaps) == 1
     mode_def_snap = job_snapshot.mode_def_snaps[0]
 

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -26,14 +26,14 @@ from dagster._core.definitions.resource_annotation import ResourceParam
 from dagster._core.definitions.resource_definition import ResourceDefinition
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.execution.context.init import InitResourceContext
-from dagster._core.remote_representation import ExternalJobData, external_repository_data_from_def
+from dagster._core.remote_representation import JobDataSnap, external_repository_data_from_def
 from dagster._core.remote_representation.external_data import (
     NestedResource,
     NestedResourceType,
     ResourceJobUsageEntry,
     ResourceSnap,
 )
-from dagster._core.snap import JobSnapshot
+from dagster._core.snap import JobSnap
 
 
 def test_repository_snap_all_props():
@@ -53,10 +53,10 @@ def test_repository_snap_all_props():
 
     assert external_repo_data.name == "noop_repo"
     assert len(external_repo_data.external_job_datas) == 1
-    assert isinstance(external_repo_data.external_job_datas[0], ExternalJobData)
+    assert isinstance(external_repo_data.external_job_datas[0], JobDataSnap)
 
-    job_snapshot = external_repo_data.external_job_datas[0].job_snapshot
-    assert isinstance(job_snapshot, JobSnapshot)
+    job_snapshot = external_repo_data.external_job_datas[0].job
+    assert isinstance(job_snapshot, JobSnap)
     assert job_snapshot.name == "noop_job"
     assert job_snapshot.description is None
     assert job_snapshot.tags == {}

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
@@ -20,7 +20,7 @@ from dagster._core.origin import (
     JobPythonOrigin,
     RepositoryPythonOrigin,
 )
-from dagster._core.snap import JobSnapshot, create_job_snapshot_id
+from dagster._core.snap import JobSnap, create_job_snapshot_id
 from dagster._core.test_utils import instance_for_test
 from dagster._utils import file_relative_path
 from dagster._utils.hosted_user_process import recon_job_from_origin
@@ -52,7 +52,7 @@ lambda_version = lambda: the_job
 
 
 def pid(pipeline_def):
-    return create_job_snapshot_id(JobSnapshot.from_job_def(pipeline_def))
+    return create_job_snapshot_id(JobSnap.from_job_def(pipeline_def))
 
 
 @job

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -37,7 +37,7 @@ from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.remote_representation.external_data import StaticPartitionsSnap
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorTick
-from dagster._core.snap.job_snapshot import JobSnapshot
+from dagster._core.snap.job_snapshot import JobSnap
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.event_log.migration import migrate_event_log_data
 from dagster._core.storage.event_log.sql_event_log import SqlEventLogStorage
@@ -1317,6 +1317,6 @@ def test_legacy_compute_kind_tag_backcompat() -> None:
 
     legacy_snap_path = file_relative_path(__file__, "1_7_9_kind_op_job_snap.gz")
     legacy_snap = deserialize_value(
-        GzipFile(legacy_snap_path, mode="r").read().decode("utf-8"), JobSnapshot
+        GzipFile(legacy_snap_path, mode="r").read().decode("utf-8"), JobSnap
     )
     assert create_snapshot_id(legacy_snap) == "8db90f128b7eaa5c229bdde372e39d5cbecdc7e4"

--- a/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_dependency_structure_translation.py
+++ b/python_modules/libraries/dagster-airflow/dagster_airflow_tests/test_dagster_pipeline_factory/test_dependency_structure_translation.py
@@ -9,7 +9,7 @@ else:
     from airflow.utils.helpers import chain
 
 
-from dagster._core.snap import JobSnapshot
+from dagster._core.snap import JobSnap
 from dagster._serdes import serialize_pp
 from dagster_airflow.dagster_job_factory import make_dagster_job_from_airflow_dag
 
@@ -42,9 +42,7 @@ def test_one_task_dag(snapshot):
 
     snapshot.assert_match(
         serialize_pp(
-            JobSnapshot.from_job_def(
-                make_dagster_job_from_airflow_dag(dag=dag)
-            ).dep_structure_snapshot
+            JobSnap.from_job_def(make_dagster_job_from_airflow_dag(dag=dag)).dep_structure_snapshot
         )
     )
 
@@ -74,9 +72,7 @@ def test_two_task_dag_no_dep(snapshot):
 
     snapshot.assert_match(
         serialize_pp(
-            JobSnapshot.from_job_def(
-                make_dagster_job_from_airflow_dag(dag=dag)
-            ).dep_structure_snapshot
+            JobSnap.from_job_def(make_dagster_job_from_airflow_dag(dag=dag)).dep_structure_snapshot
         )
     )
 
@@ -108,9 +104,7 @@ def test_two_task_dag_with_dep(snapshot):
 
     snapshot.assert_match(
         serialize_pp(
-            JobSnapshot.from_job_def(
-                make_dagster_job_from_airflow_dag(dag=dag)
-            ).dep_structure_snapshot
+            JobSnap.from_job_def(make_dagster_job_from_airflow_dag(dag=dag)).dep_structure_snapshot
         )
     )
 
@@ -152,9 +146,7 @@ def test_diamond_task_dag(snapshot):
 
     snapshot.assert_match(
         serialize_pp(
-            JobSnapshot.from_job_def(
-                make_dagster_job_from_airflow_dag(dag=dag)
-            ).dep_structure_snapshot
+            JobSnap.from_job_def(make_dagster_job_from_airflow_dag(dag=dag)).dep_structure_snapshot
         )
     )
 
@@ -196,9 +188,7 @@ def test_multi_root_dag(snapshot):
 
     snapshot.assert_match(
         serialize_pp(
-            JobSnapshot.from_job_def(
-                make_dagster_job_from_airflow_dag(dag=dag)
-            ).dep_structure_snapshot
+            JobSnap.from_job_def(make_dagster_job_from_airflow_dag(dag=dag)).dep_structure_snapshot
         )
     )
 
@@ -239,9 +229,7 @@ def test_multi_leaf_dag(snapshot):
 
     snapshot.assert_match(
         serialize_pp(
-            JobSnapshot.from_job_def(
-                make_dagster_job_from_airflow_dag(dag=dag)
-            ).dep_structure_snapshot
+            JobSnap.from_job_def(make_dagster_job_from_airflow_dag(dag=dag)).dep_structure_snapshot
         )
     )
 
@@ -496,9 +484,7 @@ def test_complex_dag(snapshot):
 
     snapshot.assert_match(
         serialize_pp(
-            JobSnapshot.from_job_def(
-                make_dagster_job_from_airflow_dag(dag=dag)
-            ).dep_structure_snapshot
+            JobSnap.from_job_def(make_dagster_job_from_airflow_dag(dag=dag)).dep_structure_snapshot
         )
     )
 


### PR DESCRIPTION
Internal companion PR: https://github.com/dagster-io/internal/pull/11941

## Summary & Motivation

- `ExternalJobData` -> `JobDataSnap`
- `JobSnapshot` -> `JobSnap`
- `ExternalJobRef` -> `JobRefSnap`
- `JobLineageSnapshot` -> `JobLineageSnap`

This rename was slightly less formulaic than the others because there was _both_ an existing `ExternalJobData` and `JobSnapshot`. `ExternalJobData` is an additional layer wrapping `JobSnapshot` and a parent `JobSnapshot`

Because of this, couldn't do the usual thing of converting `ExternalJobData` -> `JobSnap`. So opted to rename `ExternalJobData` to `JobDataSnap`.

## How I Tested These Changes

Existing test suite

## Changelog

NOCHANGELOG