### PR TITLE
Remove AssetMaterializationUpstreamData view from materialization views

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetEventDetail.tsx
@@ -4,7 +4,6 @@ import {Link} from 'react-router-dom';
 import {AssetEventMetadataEntriesTable} from './AssetEventMetadataEntriesTable';
 import {AssetEventSystemTags} from './AssetEventSystemTags';
 import {AssetLineageElements} from './AssetLineageElements';
-import {AssetMaterializationUpstreamData} from './AssetMaterializationUpstreamData';
 import {RunlessEventTag} from './RunlessEventTag';
 import {assetDetailsPathForKey} from './assetDetailsPathForKey';
 import {isRunlessEvent} from './isRunlessEvent';
@@ -147,13 +146,6 @@ export const AssetEventDetail = ({
           showDescriptions
         />
       </Box>
-
-      {event.__typename === 'MaterializationEvent' && (
-        <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
-          <Subheading>Source data</Subheading>
-          <AssetMaterializationUpstreamData timestamp={event.timestamp} assetKey={assetKey} />
-        </Box>
-      )}
 
       <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
         <Subheading>Tags</Subheading>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
@@ -17,7 +17,6 @@ import {Link} from 'react-router-dom';
 import {AllIndividualEventsButton} from './AllIndividualEventsButton';
 import {AssetEventMetadataEntriesTable} from './AssetEventMetadataEntriesTable';
 import {AssetEventSystemTags} from './AssetEventSystemTags';
-import {AssetMaterializationUpstreamData} from './AssetMaterializationUpstreamData';
 import {ChangedReasonsTag} from './ChangedReasons';
 import {FailedRunSinceMaterializationBanner} from './FailedRunSinceMaterializationBanner';
 import {StaleReasonsTag} from './Stale';
@@ -372,10 +371,6 @@ export const AssetPartitionDetail = ({
           repoAddress={repoAddress}
           showDescriptions
         />
-      </Box>
-      <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
-        <Subheading>Source data</Subheading>
-        <AssetMaterializationUpstreamData timestamp={latest?.timestamp} assetKey={assetKey} />
       </Box>
       <Box padding={{top: 24}} flex={{direction: 'column', gap: 8}}>
         <Subheading>Tags</Subheading>


### PR DESCRIPTION
## Summary & Motivation

As title -- keeps this view around for the overdue tag (which is hidden behind a popover).

This mostly useful to give information relevant to the now-deprecated FreshnessPolicy abstraction, and these queries can be very expensive.

## How I Tested These Changes

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
