### PR TITLE
Add kinds parameter to @asset

### DIFF
--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2290,6 +2290,29 @@ def test_asset_spec_with_tags():
         def assets(): ...
 
 
+def test_asset_decorator_with_kinds() -> None:
+    @asset(kinds={"python"})
+    def asset1():
+        pass
+
+    assert asset1.specs_by_key[AssetKey("asset1")].kinds == {"python"}
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError, match="Assets can have at most three kinds currently."
+    ):
+
+        @asset(kinds={"python", "snowflake", "bigquery", "airflow"})
+        def asset2(): ...
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="Cannot specify compute_kind and kinds on the @asset decorator.",
+    ):
+
+        @asset(compute_kind="my_compute_kind", kinds={"python"})
+        def asset3(): ...
+
+
 def test_asset_spec_with_kinds() -> None:
     @multi_asset(specs=[AssetSpec("asset1", kinds={"python"})])
     def assets(): ...


### PR DESCRIPTION
## Summary

Adds an experimental `kinds` parameter to `@asset`, following from the pattern introduced in #24154.

```python
@asset(kinds={"python", "snowflake"}) 
def my_asset():
  pass
```
## How I Tested These Changes

New unit tests.

## Changelog

Added the ability to experimentally specify multiple kinds for an asset with the `kinds` parameter.