### PR TITLE
[external-renames] external_repository_data_from_def -> RepositorySnap.from_def

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reload_repository_location.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reload_repository_location.py
@@ -4,10 +4,8 @@ from unittest import mock
 
 from dagster import file_relative_path, repository
 from dagster._core.code_pointer import CodePointer
-from dagster._core.remote_representation import (
-    ManagedGrpcPythonEnvCodeLocationOrigin,
-    external_repository_data_from_def,
-)
+from dagster._core.remote_representation import ManagedGrpcPythonEnvCodeLocationOrigin
+from dagster._core.remote_representation.external_data import RepositorySnap
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.load import location_origins_from_yaml_paths
 from dagster._grpc.types import ListRepositoriesResponse
@@ -302,7 +300,7 @@ class TestReloadRepositoriesOutOfProcess(OutOfProcessTestSuite):
                 def new_repo():
                     return []
 
-                new_repo_data = external_repository_data_from_def(new_repo)
+                new_repo_data = RepositorySnap.from_def(new_repo)
 
                 external_repository_mock.return_value = {"new_repo": new_repo_data}
 

--- a/python_modules/dagster/dagster/_core/remote_representation/__init__.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/__init__.py
@@ -35,7 +35,6 @@ from dagster._core.remote_representation.external_data import (
     SensorSnap as SensorSnap,
     TargetSnap as TargetSnap,
     external_job_data_from_def as external_job_data_from_def,
-    external_repository_data_from_def as external_repository_data_from_def,
 )
 from dagster._core.remote_representation.handle import (
     JobHandle as JobHandle,

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -54,9 +54,9 @@ from dagster._core.remote_representation.external import (
 )
 from dagster._core.remote_representation.external_data import (
     PartitionNamesSnap,
+    RepositorySnap,
     ScheduleExecutionErrorSnap,
     SensorExecutionErrorSnap,
-    external_repository_data_from_def,
     partition_set_snap_name_for_job_name,
 )
 from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
@@ -398,7 +398,7 @@ class InProcessCodeLocation(CodeLocation):
         self._repositories: Dict[str, ExternalRepository] = {}
         for repo_name, repo_def in self._loaded_repositories.definitions_by_name.items():
             self._repositories[repo_name] = ExternalRepository(
-                external_repository_data_from_def(repo_def),
+                RepositorySnap.from_def(repo_def),
                 RepositoryHandle.from_location(repository_name=repo_name, code_location=self),
                 instance=instance,
             )

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -49,10 +49,10 @@ from dagster._core.remote_representation.external_data import (
     ExternalJobSubsetResult,
     PartitionExecutionErrorSnap,
     RepositoryErrorSnap,
+    RepositorySnap,
     ScheduleExecutionErrorSnap,
     SensorExecutionErrorSnap,
     external_job_data_from_def,
-    external_repository_data_from_def,
 )
 from dagster._core.remote_representation.origin import RemoteRepositoryOrigin
 from dagster._core.snap.execution_plan_snapshot import ExecutionPlanSnapshotErrorData
@@ -789,7 +789,7 @@ class DagsterApiServer(DagsterApiServicer):
             )
 
             return serialize_value(
-                external_repository_data_from_def(
+                RepositorySnap.from_def(
                     self._get_repo_for_origin(repository_origin),
                     defer_snapshots=request.defer_snapshots,
                 )

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -32,7 +32,7 @@ from dagster._core.definitions.resource_definition import dagster_maintained_res
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
 from dagster._core.remote_representation.external import ExternalRepository
-from dagster._core.remote_representation.external_data import external_repository_data_from_def
+from dagster._core.remote_representation.external_data import RepositorySnap
 from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.storage.io_manager import dagster_maintained_io_manager
 from dagster._core.telemetry import (
@@ -219,9 +219,7 @@ def test_get_stats_from_external_repo_partitions(instance):
     def asset3(): ...
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
-            Definitions(assets=[asset1, asset2, asset3]).get_repository_def()
-        ),
+        RepositorySnap.from_def(Definitions(assets=[asset1, asset2, asset3]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
@@ -241,9 +239,7 @@ def test_get_stats_from_external_repo_multi_partitions(instance):
     def multi_partitioned_asset(): ...
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
-            Definitions(assets=[multi_partitioned_asset]).get_repository_def()
-        ),
+        RepositorySnap.from_def(Definitions(assets=[multi_partitioned_asset]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
@@ -259,9 +255,7 @@ def test_get_stats_from_external_repo_source_assets(instance):
     def asset1(): ...
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
-            Definitions(assets=[source_asset1, asset1]).get_repository_def()
-        ),
+        RepositorySnap.from_def(Definitions(assets=[source_asset1, asset1]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
@@ -279,7 +273,7 @@ def test_get_stats_from_external_repo_observable_source_assets(instance):
     def asset1(): ...
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
+        RepositorySnap.from_def(
             Definitions(assets=[source_asset1, source_asset2, asset1]).get_repository_def()
         ),
         repository_handle=RepositoryHandle.for_test(),
@@ -298,9 +292,7 @@ def test_get_stats_from_external_repo_freshness_policies(instance):
     def asset2(): ...
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
-            Definitions(assets=[asset1, asset2]).get_repository_def()
-        ),
+        RepositorySnap.from_def(Definitions(assets=[asset1, asset2]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
@@ -321,9 +313,7 @@ def test_get_status_from_external_repo_auto_materialize_policy(instance):
     def asset3(): ...
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
-            Definitions(assets=[asset1, asset2, asset3]).get_repository_def()
-        ),
+        RepositorySnap.from_def(Definitions(assets=[asset1, asset2, asset3]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
@@ -340,9 +330,7 @@ def test_get_stats_from_external_repo_code_versions(instance):
     def asset2(): ...
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
-            Definitions(assets=[asset1, asset2]).get_repository_def()
-        ),
+        RepositorySnap.from_def(Definitions(assets=[asset1, asset2]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
@@ -364,7 +352,7 @@ def test_get_stats_from_external_repo_code_checks(instance):
     def my_other_asset(): ...
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
+        RepositorySnap.from_def(
             Definitions(
                 assets=[my_asset, my_other_asset], asset_checks=[my_check, my_check_2]
             ).get_repository_def()
@@ -385,9 +373,7 @@ def test_get_stats_from_external_repo_dbt(instance):
     def asset2(): ...
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
-            Definitions(assets=[asset1, asset2]).get_repository_def()
-        ),
+        RepositorySnap.from_def(Definitions(assets=[asset1, asset2]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
@@ -410,7 +396,7 @@ def test_get_stats_from_external_repo_resources(instance):
     def asset1(my_resource: MyResource, custom_resource: CustomResource): ...
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
+        RepositorySnap.from_def(
             Definitions(
                 assets=[asset1],
                 resources={
@@ -456,7 +442,7 @@ def test_get_stats_from_external_repo_io_managers(instance):
     def asset1(): ...
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
+        RepositorySnap.from_def(
             Definitions(
                 assets=[asset1],
                 resources={
@@ -489,7 +475,7 @@ def test_get_stats_from_external_repo_functional_resources(instance):
     def asset1(): ...
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
+        RepositorySnap.from_def(
             Definitions(
                 assets=[asset1],
                 resources={
@@ -522,7 +508,7 @@ def test_get_stats_from_external_repo_functional_io_managers(instance):
     def asset1(): ...
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
+        RepositorySnap.from_def(
             Definitions(
                 assets=[asset1],
                 resources={
@@ -543,7 +529,7 @@ def test_get_stats_from_external_repo_functional_io_managers(instance):
 
 def test_get_stats_from_external_repo_pipes_client(instance):
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
+        RepositorySnap.from_def(
             Definitions(
                 resources={
                     "pipes_subprocess_client": PipesSubprocessClient(),
@@ -598,7 +584,7 @@ def test_get_stats_from_external_repo_delayed_resource_configuration(instance):
     def asset2(): ...
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
+        RepositorySnap.from_def(
             Definitions(
                 assets=[asset1, asset2],
                 resources={

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_active_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_active_data.py
@@ -4,11 +4,11 @@ from unittest import mock
 
 from dagster import daily_partitioned_config, job, op, repository
 from dagster._core.definitions.decorators.schedule_decorator import schedule
-from dagster._core.remote_representation import (
-    external_job_data_from_def,
-    external_repository_data_from_def,
+from dagster._core.remote_representation import external_job_data_from_def
+from dagster._core.remote_representation.external_data import (
+    RepositorySnap,
+    TimeWindowPartitionsSnap,
 )
-from dagster._core.remote_representation.external_data import TimeWindowPartitionsSnap
 from dagster._core.snap.job_snapshot import create_job_snapshot_id
 from dagster._core.test_utils import in_process_test_workspace, instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
@@ -50,7 +50,7 @@ def test_external_repository_data(snapshot):
     def repo():
         return [foo_job, foo_schedule]
 
-    external_repo_data = external_repository_data_from_def(repo)
+    external_repo_data = RepositorySnap.from_def(repo)
     assert external_repo_data.get_job_data("foo_job")
     assert external_repo_data.get_schedule("foo_schedule")
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -14,7 +14,7 @@ from dagster._core.definitions.automation_condition_sensor_definition import (
 )
 from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.remote_representation.external import ExternalRepository
-from dagster._core.remote_representation.external_data import external_repository_data_from_def
+from dagster._core.remote_representation.external_data import RepositorySnap
 from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.test_utils import instance_for_test
 
@@ -94,7 +94,7 @@ def test_default_auto_materialize_sensors(instance_with_auto_materialize_sensors
         repository_name="bar_repo",
     )
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
+        RepositorySnap.from_def(
             defs.get_repository_def(),
         ),
         repository_handle=repo_handle,
@@ -131,7 +131,7 @@ def test_default_auto_materialize_sensors_without_observable(
     )
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
+        RepositorySnap.from_def(
             defs_without_observables.get_repository_def(),
         ),
         repository_handle=repo_handle,
@@ -158,7 +158,7 @@ def test_no_default_auto_materialize_sensors(instance_without_auto_materialize_s
 
     # If not opted in, no default sensors are created
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
+        RepositorySnap.from_def(
             defs.get_repository_def(),
         ),
         repository_handle=repo_handle,
@@ -192,7 +192,7 @@ def test_combine_default_sensors_with_non_default_sensors(instance_with_auto_mat
     )
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
+        RepositorySnap.from_def(
             defs_with_auto_materialize_sensor.get_repository_def(),
         ),
         repository_handle=repo_handle,
@@ -262,7 +262,7 @@ def test_custom_sensors_cover_all(instance_with_auto_materialize_sensors):
     )
 
     external_repo = ExternalRepository(
-        external_repository_data_from_def(
+        RepositorySnap.from_def(
             defs_with_auto_materialize_sensor.get_repository_def(),
         ),
         repository_handle=repo_handle,

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition.py
@@ -5,10 +5,7 @@ from dagster import AutoMaterializePolicy, AutomationCondition, Definitions, ass
 from dagster._check.functions import CheckError
 from dagster._core.definitions.declarative_automation.automation_condition import AutomationResult
 from dagster._core.definitions.declarative_automation.automation_context import AutomationContext
-from dagster._core.remote_representation.external_data import (
-    RepositorySnap,
-    external_repository_data_from_def,
-)
+from dagster._core.remote_representation.external_data import RepositorySnap
 from dagster._serdes import serialize_value
 from dagster._serdes.serdes import deserialize_value
 
@@ -95,7 +92,7 @@ def test_serialize_definitions_with_asset_condition() -> None:
     assert isinstance(serialized, str)
 
     serialized = serialize_value(
-        external_repository_data_from_def(Definitions(assets=[my_asset]).get_repository_def())
+        RepositorySnap.from_def(Definitions(assets=[my_asset]).get_repository_def())
     )
     assert isinstance(serialized, str)
 
@@ -114,7 +111,7 @@ def test_serialize_definitions_with_user_code_asset_condition() -> None:
         return 0
 
     serialized = serialize_value(
-        external_repository_data_from_def(Definitions(assets=[my_asset]).get_repository_def())
+        RepositorySnap.from_def(Definitions(assets=[my_asset]).get_repository_def())
     )
     assert isinstance(serialized, str)
     deserialized = deserialize_value(serialized)

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/scenario_state.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/scenario_state.py
@@ -49,7 +49,7 @@ from dagster._core.definitions.repository_definition.valid_definitions import (
 )
 from dagster._core.execution.api import create_execution_plan
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.external_data import external_repository_data_from_def
+from dagster._core.remote_representation.external_data import RepositorySnap
 from dagster._core.remote_representation.origin import InProcessCodeLocationOrigin
 from dagster._core.storage.tags import PARTITION_NAME_TAG
 from dagster._core.test_utils import (
@@ -92,7 +92,7 @@ def get_code_location_origin(
 
 def _get_code_location_origin_from_repository(repository: RepositoryDefinition, location_name: str):
     attribute_name = (
-        f"_asset_daemon_target_{create_snapshot_id(external_repository_data_from_def(repository))}"
+        f"_asset_daemon_target_{create_snapshot_id(RepositorySnap.from_def(repository))}"
     )
 
     if attribute_name not in globals():


### PR DESCRIPTION
Internal companion PR: https://github.com/dagster-io/internal/pull/11942

## Summary & Motivation

`external_repository_data_from_def` -> `RepositorySnap.from_def`

This change follows the pattern used throughout the rest of the external rename stack.

## How I Tested These Changes

Existing test suite

## Changelog

NOCHANGELOG