### PR TITLE
Apply a limit to the events fetched in AssetPartitionDetailQuery

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -11,7 +11,7 @@
   "AssetDefinitionCollisionQuery": "84027ea05480797a69eb150ce07ac7dfd40d6007a8107f90a6c558cf3a2662f5",
   "AssetGroupMetadataQuery": "260d747ab8d454c1fe55a5a5fa6e11a548a301ea44740566c0c43756cca363eb",
   "AssetMaterializationUpstreamQuery": "754bab88738acc8d310c71f577ac3cf06dc57950bb1f98a18844e6e00bae756d",
-  "AssetPartitionDetailQuery": "b49c58aafc8743640c067d5897b931ad98adcc3584193afad7fb96424a1ee010",
+  "AssetPartitionDetailQuery": "080db74be8d44bd691f61a36925c983a4682962b9f9df5eecf6ce76b31b85ab4",
   "AssetPartitionStaleQuery": "4215f4014e9d7592142e1775c4b07377703e913389396f9ca14dc6bb779ce764",
   "AssetViewDefinitionQuery": "932aa7a5c3d285d2a938c89f24eb6cab960123277a2abaab3027d80f944d0ddd",
   "AssetCatalogTableQuery": "24337025321725613b86a82d1733d75dde2cfd750be0a0cee0b4b75ac5b14d64",

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPartitionDetail.tsx
@@ -46,7 +46,7 @@ import {buildRepoAddress} from '../workspace/buildRepoAddress';
 export const AssetPartitionDetailLoader = (props: {assetKey: AssetKey; partitionKey: string}) => {
   const result = useQuery<AssetPartitionDetailQuery, AssetPartitionDetailQueryVariables>(
     ASSET_PARTITION_DETAIL_QUERY,
-    {variables: {assetKey: props.assetKey, partitionKey: props.partitionKey}},
+    {variables: {assetKey: props.assetKey, partitionKey: props.partitionKey, eventLimit: 10}},
   );
 
   const stale = useQuery<AssetPartitionStaleQuery, AssetPartitionStaleQueryVariables>(
@@ -119,7 +119,11 @@ export const AssetPartitionDetailLoader = (props: {assetKey: AssetKey; partition
 };
 
 export const ASSET_PARTITION_DETAIL_QUERY = gql`
-  query AssetPartitionDetailQuery($assetKey: AssetKeyInput!, $partitionKey: String!) {
+  query AssetPartitionDetailQuery(
+    $assetKey: AssetKeyInput!
+    $partitionKey: String!
+    $eventLimit: Int!
+  ) {
     assetNodeOrError(assetKey: $assetKey) {
       ... on AssetNode {
         id
@@ -128,13 +132,13 @@ export const ASSET_PARTITION_DETAIL_QUERY = gql`
           id
           ...AssetPartitionLatestRunFragment
         }
-        assetMaterializations(partitions: [$partitionKey]) {
+        assetMaterializations(partitions: [$partitionKey], limit: $eventLimit) {
           ... on MaterializationEvent {
             runId
             ...AssetMaterializationFragment
           }
         }
-        assetObservations(partitions: [$partitionKey]) {
+        assetObservations(partitions: [$partitionKey], limit: $eventLimit) {
           ... on ObservationEvent {
             runId
             ...AssetObservationFragment

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetEventDetail.fixtures.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__fixtures__/AssetEventDetail.fixtures.ts
@@ -283,7 +283,7 @@ export const buildAssetPartitionDetailMock = (
 ): MockedResponse<AssetPartitionDetailQuery> => ({
   request: {
     operationName: 'AssetPartitionDetailQuery',
-    variables: {assetKey: {path: ['asset_1']}, partitionKey: Partition},
+    variables: {assetKey: {path: ['asset_1']}, partitionKey: Partition, eventLimit: 10},
     query: ASSET_PARTITION_DETAIL_QUERY,
   },
   result: {

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetPartitionDetail.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/types/AssetPartitionDetail.types.ts
@@ -5,6 +5,7 @@ import * as Types from '../../graphql/types';
 export type AssetPartitionDetailQueryVariables = Types.Exact<{
   assetKey: Types.AssetKeyInput;
   partitionKey: Types.Scalars['String']['input'];
+  eventLimit: Types.Scalars['Int']['input'];
 }>;
 
 export type AssetPartitionDetailQuery = {
@@ -443,6 +444,6 @@ export type AssetPartitionStaleQuery = {
     | {__typename: 'AssetNotFoundError'};
 };
 
-export const AssetPartitionDetailQueryVersion = 'b49c58aafc8743640c067d5897b931ad98adcc3584193afad7fb96424a1ee010';
+export const AssetPartitionDetailQueryVersion = '080db74be8d44bd691f61a36925c983a4682962b9f9df5eecf6ce76b31b85ab4';
 
 export const AssetPartitionStaleQueryVersion = '4215f4014e9d7592142e1775c4b07377703e913389396f9ca14dc6bb779ce764';


### PR DESCRIPTION
Summary:
Right now this query passes down no limit - instead, return the most recent 10 materializations and 10 observations for the given asset+partition.

(The dream would be to only include the most recent single materialization or observation, since that can be fetched much more efficiently - appreciate that that would make this view less useful though)

Load an asset + partition page in dagit

NOCHANGELOG

## Summary & Motivation

## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
