### PR TITLE
Add dag_id tag to base_proxy_operator.py

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/constants.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/constants.py
@@ -3,3 +3,4 @@ AIRFLOW_SOURCE_METADATA_KEY_PREFIX = "dagster-airlift/source"
 TASK_MAPPING_METADATA_KEY = "dagster-airlift/task_mapping"
 # This represents the timestamp used in ordering the materializatons.
 EFFECTIVE_TIMESTAMP_METADATA_KEY = "dagster-airlift/effective_timestamp"
+DAG_RUN_ID_TAG_KEY = "dagster-airlift/dag-run-id"

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/base_proxy_operator.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/base_proxy_operator.py
@@ -9,7 +9,7 @@ import requests
 from airflow.models.operator import BaseOperator
 from airflow.utils.context import Context
 
-from dagster_airlift.constants import TASK_MAPPING_METADATA_KEY
+from dagster_airlift.constants import DAG_RUN_ID_TAG_KEY, TASK_MAPPING_METADATA_KEY
 
 from .gql_queries import ASSET_NODES_QUERY, RUNS_QUERY, TRIGGER_ASSETS_MUTATION, VERIFICATION_QUERY
 
@@ -96,9 +96,7 @@ class BaseProxyToDagsterOperator(BaseOperator, ABC):
         for (repo_location, repo_name, job_name), asset_keys in assets_to_trigger.items():
             execution_params = {
                 "mode": "default",
-                "executionMetadata": {
-                    "tags": [{"key": "dagster-airlift/dag-run-id", "value": dag_run_id}]
-                },
+                "executionMetadata": {"tags": [{"key": DAG_RUN_ID_TAG_KEY, "value": dag_run_id}]},
                 "runConfigData": "{}",
                 "selector": {
                     "repositoryLocationName": repo_location,

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_dagster_operator.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/integration_tests/test_dagster_operator.py
@@ -6,6 +6,7 @@ import requests
 from dagster import AssetKey, DagsterInstance, DagsterRunStatus
 from dagster._core.test_utils import environ
 from dagster._time import get_current_timestamp
+from dagster_airlift.constants import DAG_RUN_ID_TAG_KEY
 
 
 @pytest.fixture(name="dags_dir")
@@ -27,6 +28,7 @@ def test_dagster_operator(airflow_instance: None, dagster_dev: None, dagster_hom
     # Wait until the run enters a terminal state
     terminal_status = None
     start_time = get_current_timestamp()
+    dag_run = None
     while get_current_timestamp() - start_time < 30:
         response = requests.get(
             "http://localhost:8080/api/v1/dags/the_dag/dagRuns", auth=("admin", "admin")
@@ -35,6 +37,7 @@ def test_dagster_operator(airflow_instance: None, dagster_dev: None, dagster_hom
         dag_runs = response.json()["dag_runs"]
         if dag_runs[0]["state"] in ["success", "failed"]:
             terminal_status = dag_runs[0]["state"]
+            dag_run = dag_runs[0]
             break
         time.sleep(1)
     assert terminal_status == "success", (
@@ -59,3 +62,8 @@ def test_dagster_operator(airflow_instance: None, dagster_dev: None, dagster_hom
         ][0]
         assert some_task_run.status == DagsterRunStatus.SUCCESS
         assert other_task_run.status == DagsterRunStatus.SUCCESS
+
+        assert isinstance(dag_run, dict)
+        assert "dag_run_id" in dag_run
+        assert some_task_run.tags[DAG_RUN_ID_TAG_KEY] == dag_run["dag_run_id"]
+        assert other_task_run.tags[DAG_RUN_ID_TAG_KEY] == dag_run["dag_run_id"]

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_mapped.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_mapped.py
@@ -74,8 +74,8 @@ def test_migrated_dagster_print_materializes(
             run_ids = dagster_instance.get_run_ids()
             assert dagster_run, f"Could not find dagster run {dagster_run_id} All run_ids {run_ids}"
             assert (
-                "dagster-airlift/dag-run_id" in dagster_run.tags
-            ), "Could not find dagster run tag"
+                "dagster-airlift/dag-run-id" in dagster_run.tags
+            ), f"Could not find dagster run tag: dagster_run.tags {dagster_run.tags}"
             assert (
                 dagster_run.tags["dagster-airlift/dag-run-id"] == airflow_run_id
             ), "dagster run tag does not match dag run id"

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_mapped.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_mapped.py
@@ -77,7 +77,9 @@ def test_migrated_dagster_print_materializes(
             assert (
                 DAG_RUN_ID_TAG_KEY in dagster_run.tags
             ), f"Could not find dagster run tag: dagster_run.tags {dagster_run.tags}"
-            assert DAG_RUN_ID_TAG_KEY == airflow_run_id, "dagster run tag does not match dag run id"
+            assert (
+                dagster_run.tags[DAG_RUN_ID_TAG_KEY] == airflow_run_id
+            ), "dagster run tag does not match dag run id"
 
 
 RAW_METADATA_KEY = "Run Metadata (raw)"

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_mapped.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_mapped.py
@@ -3,7 +3,6 @@ import time
 from datetime import timedelta
 from typing import List
 
-from dlt import run
 import pytest
 from dagster import AssetKey, DagsterInstance
 from dagster._core.definitions.metadata.metadata_value import JsonMetadataValue
@@ -74,8 +73,12 @@ def test_migrated_dagster_print_materializes(
             dagster_run = dagster_instance.get_run_by_id(dagster_run_id)
             run_ids = dagster_instance.get_run_ids()
             assert dagster_run, f"Could not find dagster run {dagster_run_id} All run_ids {run_ids}"
-            assert "dagster-airlift/dag-run_id" in dagster_run.tags, "Could not find dagster run tag"
-            assert dagster_run.tags["dagster-airlift/dag-run-id"] == airflow_run_id, "dagster run tag does not match dag run id"
+            assert (
+                "dagster-airlift/dag-run_id" in dagster_run.tags
+            ), "Could not find dagster run tag"
+            assert (
+                dagster_run.tags["dagster-airlift/dag-run-id"] == airflow_run_id
+            ), "dagster run tag does not match dag run id"
 
 
 RAW_METADATA_KEY = "Run Metadata (raw)"
@@ -115,7 +118,6 @@ def test_dagster_weekly_daily_materializes(
     assert weekly_mat_event.asset_materialization
     assert weekly_mat_event.asset_materialization.asset_key == asset_one
     assert dag_id_of_mat(weekly_mat_event) == "weekly_dag"
-
 
     dag_id = "daily_dag"
     dag_run_id = af_instance.trigger_dag(dag_id=dag_id)

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_mapped.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_mapped.py
@@ -8,6 +8,7 @@ from dagster import AssetKey, DagsterInstance
 from dagster._core.definitions.metadata.metadata_value import JsonMetadataValue
 from dagster._core.events.log import EventLogEntry
 from dagster._time import get_current_datetime
+from dagster_airlift.constants import DAG_RUN_ID_TAG_KEY
 
 from kitchen_sink_tests.integration_tests.conftest import makefile_dir
 
@@ -74,11 +75,9 @@ def test_migrated_dagster_print_materializes(
             run_ids = dagster_instance.get_run_ids()
             assert dagster_run, f"Could not find dagster run {dagster_run_id} All run_ids {run_ids}"
             assert (
-                "dagster-airlift/dag-run-id" in dagster_run.tags
+                DAG_RUN_ID_TAG_KEY in dagster_run.tags
             ), f"Could not find dagster run tag: dagster_run.tags {dagster_run.tags}"
-            assert (
-                dagster_run.tags["dagster-airlift/dag-run-id"] == airflow_run_id
-            ), "dagster run tag does not match dag run id"
+            assert DAG_RUN_ID_TAG_KEY == airflow_run_id, "dagster run tag does not match dag run id"
 
 
 RAW_METADATA_KEY = "Run Metadata (raw)"


### PR DESCRIPTION
## Summary & Motivation

Add a tag `"dagster-airlift/dag-run-id"` to every launched run in Dagster that contains the _airfllow_ dag run id that sources it.

This will allow us to query for dagster runs that are associated with a specific dag run id.

## How I Tested These Changes

Included tests. Also manually confirmed it appears in the UI


![Screenshot 2024-10-01 at 2.59.11 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/8710e8c7-1530-452f-8aad-7cb0fc036782.png)


![Screenshot 2024-10-01 at 2.59.24 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/2c8e610e-cf2d-40c7-8b5c-d69ce066b8c5.png)

## Changelog

NOCHANGELOG
