### PR TITLE
[external-renames] External* -> Remote*

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/test_queued.py
+++ b/integration_tests/test_suites/daemon-test-suite/test_queued.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.external import ExternalJob
+from dagster._core.remote_representation.external import RemoteJob
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.test_utils import create_run_for_test, poll_for_finished_run
 from dagster._utils import file_relative_path
@@ -9,7 +9,7 @@ from dagster._utils.merger import merge_dicts
 from utils import start_daemon
 
 
-def create_run(instance: DagsterInstance, external_job: ExternalJob, **kwargs: Any) -> DagsterRun:
+def create_run(instance: DagsterInstance, external_job: RemoteJob, **kwargs: Any) -> DagsterRun:
     job_args = merge_dicts(
         {
             "job_name": "foo_job",

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/asset_checks_loader.py
@@ -4,7 +4,7 @@ from dagster import _check as check
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.selector import RepositorySelector
 from dagster._core.remote_representation.code_location import CodeLocation
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.remote_representation.external_data import AssetCheckNodeSnap
 from dagster._core.storage.asset_check_execution_record import (
     AssetCheckExecutionRecord,
@@ -39,7 +39,7 @@ class AssetChecksLoader:
 
     def _get_external_checks(
         self, pipeline: Optional[GraphenePipelineSelector]
-    ) -> Iterator[Tuple[CodeLocation, ExternalRepository, AssetCheckNodeSnap]]:
+    ) -> Iterator[Tuple[CodeLocation, RemoteRepository, AssetCheckNodeSnap]]:
         if pipeline is None:
             entries = self._context.get_code_location_entries().values()
             for entry in entries:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/run_lifecycle.py
@@ -5,7 +5,7 @@ from dagster._core.errors import DagsterRunNotFoundError
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation import CodeLocation
-from dagster._core.remote_representation.external import ExternalJob
+from dagster._core.remote_representation.external import RemoteJob
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._core.storage.tags import RESUME_RETRY_TAG
 from dagster._core.utils import make_new_run_id
@@ -60,7 +60,7 @@ def is_resume_retry(execution_params: ExecutionParams) -> bool:
 
 def create_valid_pipeline_run(
     graphql_context: BaseWorkspaceRequestContext,
-    external_pipeline: ExternalJob,
+    external_pipeline: RemoteJob,
     execution_params: ExecutionParams,
     code_location: CodeLocation,
 ) -> DagsterRun:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -5,8 +5,8 @@ import dagster._check as check
 from dagster._config import validate_config_from_snap
 from dagster._core.definitions.selector import JobSubsetSelector, RepositorySelector
 from dagster._core.execution.plan.state import KnownExecutionState
-from dagster._core.remote_representation import ExternalJob
-from dagster._core.remote_representation.external import ExternalExecutionPlan
+from dagster._core.remote_representation import RemoteJob
+from dagster._core.remote_representation.external import RemoteExecutionPlan
 from dagster._core.workspace.context import BaseWorkspaceRequestContext, WorkspaceRequestContext
 from dagster._utils.error import serializable_error_info_from_exc_info
 
@@ -27,21 +27,21 @@ if TYPE_CHECKING:
 def get_full_external_job_or_raise(
     graphene_info: "ResolveInfo",
     selector: JobSubsetSelector,
-) -> ExternalJob:
+) -> RemoteJob:
     check.inst_param(selector, "selector", JobSubsetSelector)
     return _get_external_job_or_raise(graphene_info, selector, ignore_subset=True)
 
 
 def get_external_job_or_raise(
     graphene_info: "ResolveInfo", selector: JobSubsetSelector
-) -> ExternalJob:
+) -> RemoteJob:
     check.inst_param(selector, "selector", JobSubsetSelector)
     return _get_external_job_or_raise(graphene_info, selector)
 
 
 def _get_external_job_or_raise(
     graphene_info: "ResolveInfo", selector: JobSubsetSelector, ignore_subset: bool = False
-) -> ExternalJob:
+) -> RemoteJob:
     from dagster_graphql.schema.errors import (
         GrapheneInvalidSubsetError,
         GraphenePipelineNotFoundError,
@@ -72,10 +72,10 @@ def _get_external_job_or_raise(
     return external_job
 
 
-def ensure_valid_config(external_job: ExternalJob, run_config: object) -> object:
+def ensure_valid_config(external_job: RemoteJob, run_config: object) -> object:
     from dagster_graphql.schema.pipelines.config import GrapheneRunConfigValidationInvalid
 
-    check.inst_param(external_job, "external_job", ExternalJob)
+    check.inst_param(external_job, "external_job", RemoteJob)
     # do not type check run_config so that validate_config_from_snap throws
 
     validated_config = validate_config_from_snap(
@@ -96,11 +96,11 @@ def ensure_valid_config(external_job: ExternalJob, run_config: object) -> object
 
 def get_external_execution_plan_or_raise(
     graphql_context: BaseWorkspaceRequestContext,
-    external_pipeline: ExternalJob,
+    external_pipeline: RemoteJob,
     run_config: Mapping[str, object],
     step_keys_to_execute: Optional[Sequence[str]],
     known_state: Optional[KnownExecutionState],
-) -> ExternalExecutionPlan:
+) -> RemoteExecutionPlan:
     return graphql_context.get_external_execution_plan(
         external_job=external_pipeline,
         run_config=run_config,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -41,7 +41,7 @@ from dagster._core.event_api import AssetRecordsFilter
 from dagster._core.events.log import EventLogEntry
 from dagster._core.instance import DynamicPartitionsStore
 from dagster._core.loader import LoadingContext
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.storage.event_log.base import AssetRecord
 from dagster._core.storage.event_log.sql_event_log import get_max_event_records_limit
 from dagster._core.storage.partition_status_cache import (
@@ -755,8 +755,8 @@ def get_freshness_info(
 
 
 def unique_repos(
-    external_repositories: Sequence[ExternalRepository],
-) -> Sequence[ExternalRepository]:
+    external_repositories: Sequence[RemoteRepository],
+) -> Sequence[RemoteRepository]:
     repos = []
     used = set()
     for external_repository in external_repositories:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -5,7 +5,7 @@ import dagster._check as check
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.selector import RepositorySelector
 from dagster._core.errors import DagsterUserCodeProcessError
-from dagster._core.remote_representation import ExternalPartitionSet, RepositoryHandle
+from dagster._core.remote_representation import RemotePartitionSet, RepositoryHandle
 from dagster._core.remote_representation.external_data import PartitionExecutionErrorSnap
 from dagster._core.storage.dagster_run import DagsterRunStatus, RunPartitionData, RunsFilter
 from dagster._core.storage.tags import (
@@ -94,13 +94,13 @@ def get_partition_set(
 def get_partition_by_name(
     graphene_info: ResolveInfo,
     repository_handle: RepositoryHandle,
-    partition_set: ExternalPartitionSet,
+    partition_set: RemotePartitionSet,
     partition_name: str,
 ) -> "GraphenePartition":
     from dagster_graphql.schema.partition_sets import GraphenePartition
 
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
-    check.inst_param(partition_set, "partition_set", ExternalPartitionSet)
+    check.inst_param(partition_set, "partition_set", RemotePartitionSet)
     check.str_param(partition_name, "partition_name")
     return GraphenePartition(
         external_repository_handle=repository_handle,
@@ -168,7 +168,7 @@ def get_partition_tags(
 
 def get_partitions(
     repository_handle: RepositoryHandle,
-    partition_set: ExternalPartitionSet,
+    partition_set: RemotePartitionSet,
     partition_names: Sequence[str],
     cursor: Optional[str] = None,
     limit: Optional[int] = None,
@@ -177,7 +177,7 @@ def get_partitions(
     from dagster_graphql.schema.partition_sets import GraphenePartition, GraphenePartitions
 
     check.inst_param(repository_handle, "repository_handle", RepositoryHandle)
-    check.inst_param(partition_set, "partition_set", ExternalPartitionSet)
+    check.inst_param(partition_set, "partition_set", RemotePartitionSet)
 
     partition_names = apply_cursor_limit_reverse(partition_names, cursor, limit, reverse)
 
@@ -195,10 +195,10 @@ def get_partitions(
 
 def get_partition_set_partition_statuses(
     graphene_info: ResolveInfo,
-    external_partition_set: ExternalPartitionSet,
+    external_partition_set: RemotePartitionSet,
     partition_names: Sequence[str],
 ) -> Sequence["GraphenePartitionStatus"]:
-    check.inst_param(external_partition_set, "external_partition_set", ExternalPartitionSet)
+    check.inst_param(external_partition_set, "external_partition_set", RemotePartitionSet)
 
     repository_handle = external_partition_set.repository_handle
     partition_set_name = external_partition_set.name
@@ -288,7 +288,7 @@ def partition_status_counts_from_run_partition_data(
 
 def get_partition_set_partition_runs(
     graphene_info: ResolveInfo,
-    partition_set: ExternalPartitionSet,
+    partition_set: RemotePartitionSet,
     partition_names: Sequence[str],
 ) -> Sequence["GraphenePartitionRun"]:
     from dagster_graphql.schema.partition_sets import GraphenePartitionRun

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_solids.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict, defaultdict
 
 import dagster._check as check
-from dagster._core.remote_representation import ExternalRepository
+from dagster._core.remote_representation import RemoteRepository
 
 from dagster_graphql.implementation.utils import GraphSelector
 
@@ -19,7 +19,7 @@ def get_used_solid_map(repo):
     from dagster_graphql.schema.solids import build_solid_handles
     from dagster_graphql.schema.used_solid import GrapheneNodeInvocationSite, GrapheneUsedSolid
 
-    check.inst_param(repo, "repo", ExternalRepository)
+    check.inst_param(repo, "repo", RemoteRepository)
 
     inv_by_def_name = defaultdict(list)
     definitions = []

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -10,7 +10,7 @@ from dagster import (
 from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.data_version import CachingStaleStatusResolver
 from dagster._core.definitions.events import AssetKey
-from dagster._core.remote_representation import ExternalRepository
+from dagster._core.remote_representation import RemoteRepository
 from dagster._core.remote_representation.external_data import (
     AssetChildEdgeSnap,
     AssetNodeSnap,
@@ -45,7 +45,7 @@ class RepositoryScopedBatchLoader:
     cache.
     """
 
-    def __init__(self, instance: DagsterInstance, external_repository: ExternalRepository):
+    def __init__(self, instance: DagsterInstance, external_repository: RemoteRepository):
         self._instance = instance
         self._repository = external_repository
         self._data: Dict[RepositoryDataType, Dict[str, List[Any]]] = {}

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -21,7 +21,7 @@ from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.event_api import AssetRecordsFilter
 from dagster._core.events import DagsterEventType
-from dagster._core.remote_representation.external import ExternalJob, ExternalSensor
+from dagster._core.remote_representation.external import RemoteJob, RemoteSensor
 from dagster._core.remote_representation.external_data import (
     AssetNodeSnap,
     DynamicPartitionsSnap,
@@ -411,7 +411,7 @@ class GrapheneAssetNode(graphene.ObjectType):
     def asset_graph_differ(self) -> Optional[AssetGraphDiffer]:
         return self._asset_graph_differ
 
-    def get_external_job(self, graphene_info: ResolveInfo) -> ExternalJob:
+    def get_external_job(self, graphene_info: ResolveInfo) -> RemoteJob:
         if self._external_job is None:
             check.invariant(
                 len(self._asset_node_snap.job_names) >= 1,
@@ -908,7 +908,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         return None
 
     def _sensor_targets_asset(
-        self, sensor: ExternalSensor, asset_graph: RemoteAssetGraph, job_names: Set[str]
+        self, sensor: RemoteSensor, asset_graph: RemoteAssetGraph, job_names: Set[str]
     ) -> bool:
         asset_key = self._asset_node_snap.asset_key
 
@@ -959,7 +959,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     def _get_auto_materialize_external_sensor(
         self, graphene_info: ResolveInfo
-    ) -> Optional[ExternalSensor]:
+    ) -> Optional[RemoteSensor]:
         repo = graphene_info.context.get_repository(self._repository_selector)
         asset_graph = repo.asset_graph
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_selections.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_selections.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Sequence
 import graphene
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_selection import AssetSelection
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.external import RemoteRepository
 
 from dagster_graphql.implementation.fetch_assets import get_asset_nodes_by_asset_key
 from dagster_graphql.implementation.utils import capture_error
@@ -21,7 +21,7 @@ class GrapheneAssetSelection(graphene.ObjectType):
     assets = non_null_list("dagster_graphql.schema.pipelines.pipeline.GrapheneAsset")
     assetsOrError = graphene.NonNull("dagster_graphql.schema.roots.assets.GrapheneAssetsOrError")
 
-    def __init__(self, asset_selection: AssetSelection, external_repository: ExternalRepository):
+    def __init__(self, asset_selection: AssetSelection, external_repository: RemoteRepository):
         self._asset_selection = asset_selection
         self._external_repository = external_repository
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -17,7 +17,7 @@ from dagster._core.execution.asset_backfill import (
 )
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.external import ExternalPartitionSet
+from dagster._core.remote_representation.external import RemotePartitionSet
 from dagster._core.storage.compute_log_manager import ComputeIOType
 from dagster._core.storage.dagster_run import DagsterRun, RunPartitionData, RunRecord, RunsFilter
 from dagster._core.storage.tags import (
@@ -406,7 +406,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             assetCheckSelection=[],
         )
 
-    def _get_partition_set(self, graphene_info: ResolveInfo) -> Optional[ExternalPartitionSet]:
+    def _get_partition_set(self, graphene_info: ResolveInfo) -> Optional[RemotePartitionSet]:
         if self._backfill_job.partition_set_origin is None:
             return None
 
@@ -465,7 +465,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         return self._partition_run_data
 
     def _get_partition_run_data_for_ranged_job_backfill(
-        self, instance: DagsterInstance, partition_set: ExternalPartitionSet
+        self, instance: DagsterInstance, partition_set: RemotePartitionSet
     ) -> Sequence[RunPartitionData]:
         partitions_def = partition_set.get_partitions_definition()
         records = instance.get_run_records(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/execution.py
@@ -1,6 +1,6 @@
 import dagster._check as check
 import graphene
-from dagster._core.remote_representation import ExternalExecutionPlan
+from dagster._core.remote_representation import RemoteExecutionPlan
 from dagster._core.snap import ExecutionStepInputSnap, ExecutionStepOutputSnap, ExecutionStepSnap
 
 from dagster_graphql.schema.metadata import GrapheneMetadataItemDefinition
@@ -36,7 +36,7 @@ class GrapheneExecutionStepInput(graphene.ObjectType):
             step_input_snap, "step_input_snap", ExecutionStepInputSnap
         )
         self._external_execution_plan = check.inst_param(
-            external_execution_plan, "external_execution_plan", ExternalExecutionPlan
+            external_execution_plan, "external_execution_plan", RemoteExecutionPlan
         )
 
     def resolve_name(self, _graphene_info: ResolveInfo):
@@ -91,7 +91,7 @@ class GrapheneExecutionStep(graphene.ObjectType):
     def __init__(self, external_execution_plan, execution_step_snap):
         super().__init__()
         self._external_execution_plan = check.inst_param(
-            external_execution_plan, "external_execution_plan", ExternalExecutionPlan
+            external_execution_plan, "external_execution_plan", RemoteExecutionPlan
         )
         self._plan_snapshot = external_execution_plan.execution_plan_snapshot
         self._step_snap = check.inst_param(
@@ -133,7 +133,7 @@ class GrapheneExecutionPlan(graphene.ObjectType):
     def __init__(self, external_execution_plan):
         super().__init__()
         self._external_execution_plan = check.inst_param(
-            external_execution_plan, external_execution_plan, ExternalExecutionPlan
+            external_execution_plan, external_execution_plan, RemoteExecutionPlan
         )
 
     def resolve_steps(self, _graphene_info: ResolveInfo):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -10,8 +10,8 @@ from dagster._core.remote_representation import (
     CodeLocation,
     GrpcServerCodeLocation,
     ManagedGrpcPythonEnvCodeLocationOrigin,
+    RemoteRepository,
 )
-from dagster._core.remote_representation.external import ExternalRepository
 from dagster._core.remote_representation.feature_flags import get_feature_flags_for_location
 from dagster._core.remote_representation.grpc_server_state_subscriber import (
     LocationStateChangeEvent,
@@ -282,7 +282,7 @@ class GrapheneRepository(graphene.ObjectType):
 
         super().__init__(name=handle.repository_name)
 
-    def get_repository(self, graphene_info: ResolveInfo) -> ExternalRepository:
+    def get_repository(self, graphene_info: ResolveInfo) -> RemoteRepository:
         return graphene_info.context.get_repository(self._handle.to_selector())
 
     def get_batch_loader(self, graphene_info: ResolveInfo):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -5,7 +5,7 @@ import graphene
 from dagster import MultiPartitionsDefinition
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.errors import DagsterUserCodeProcessError
-from dagster._core.remote_representation import ExternalJob, ExternalPartitionSet, RepositoryHandle
+from dagster._core.remote_representation import RemoteJob, RemotePartitionSet, RepositoryHandle
 from dagster._core.remote_representation.external_data import (
     DynamicPartitionsSnap,
     MultiPartitionsSnap,
@@ -195,7 +195,7 @@ class GrapheneJobSelectionPartition(graphene.ObjectType):
 
     def __init__(
         self,
-        external_job: ExternalJob,
+        external_job: RemoteJob,
         partition_name: str,
         selected_asset_keys: Optional[AbstractSet[AssetKey]],
     ):
@@ -247,14 +247,14 @@ class GraphenePartition(graphene.ObjectType):
     def __init__(
         self,
         external_repository_handle: RepositoryHandle,
-        external_partition_set: ExternalPartitionSet,
+        external_partition_set: RemotePartitionSet,
         partition_name: str,
     ):
         self._external_repository_handle = check.inst_param(
             external_repository_handle, "external_respository_handle", RepositoryHandle
         )
         self._external_partition_set = check.inst_param(
-            external_partition_set, "external_partition_set", ExternalPartitionSet
+            external_partition_set, "external_partition_set", RemotePartitionSet
         )
         self._partition_name = check.str_param(partition_name, "partition_name")
 
@@ -351,13 +351,13 @@ class GraphenePartitionSet(graphene.ObjectType):
     def __init__(
         self,
         external_repository_handle: RepositoryHandle,
-        external_partition_set: ExternalPartitionSet,
+        external_partition_set: RemotePartitionSet,
     ):
         self._external_repository_handle = check.inst_param(
             external_repository_handle, "external_respository_handle", RepositoryHandle
         )
         self._external_partition_set = check.inst_param(
-            external_partition_set, "external_partition_set", ExternalPartitionSet
+            external_partition_set, "external_partition_set", RemotePartitionSet
         )
         self._partition_names = None
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/resources.py
@@ -3,7 +3,7 @@ from typing import List
 import dagster._check as check
 import graphene
 from dagster._core.definitions.selector import ResourceSelector
-from dagster._core.remote_representation.external import ExternalResource
+from dagster._core.remote_representation.external import RemoteResource
 from dagster._core.remote_representation.external_data import (
     NestedResourceType,
     ResourceConfigEnvVarSnap,
@@ -120,9 +120,7 @@ class GrapheneResourceDetails(graphene.ObjectType):
     class Meta:
         name = "ResourceDetails"
 
-    def __init__(
-        self, location_name: str, repository_name: str, external_resource: ExternalResource
-    ):
+    def __init__(self, location_name: str, repository_name: str, external_resource: RemoteResource):
         super().__init__()
 
         self.id = f"{location_name}-{repository_name}-{external_resource.name}"
@@ -131,7 +129,7 @@ class GrapheneResourceDetails(graphene.ObjectType):
         self._repository_name = check.str_param(repository_name, "repository_name")
 
         self._external_resource = check.inst_param(
-            external_resource, "external_resource", ExternalResource
+            external_resource, "external_resource", RemoteResource
         )
         self.name = external_resource.name
         self.description = external_resource.description

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -4,8 +4,8 @@ from typing import List, Optional, Sequence
 import dagster._check as check
 import graphene
 from dagster import DefaultScheduleStatus
-from dagster._core.remote_representation import ExternalSchedule
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation import RemoteSchedule
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus
 from dagster._time import get_current_timestamp
 
@@ -65,13 +65,13 @@ class GrapheneSchedule(graphene.ObjectType):
 
     def __init__(
         self,
-        external_schedule: ExternalSchedule,
-        external_repository: ExternalRepository,
+        external_schedule: RemoteSchedule,
+        external_repository: RemoteRepository,
         schedule_state: Optional[InstigatorState],
         batch_loader: Optional[RepositoryScopedBatchLoader] = None,
     ):
         self._external_schedule = check.inst_param(
-            external_schedule, "external_schedule", ExternalSchedule
+            external_schedule, "external_schedule", RemoteSchedule
         )
         self._external_repository = external_repository
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/sensors.py
@@ -6,8 +6,8 @@ from dagster import DefaultSensorStatus
 from dagster._core.definitions.selector import SensorSelector
 from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster._core.remote_representation import ExternalSensor, TargetSnap
-from dagster._core.remote_representation.external import CompoundID, ExternalRepository
+from dagster._core.remote_representation import RemoteSensor, TargetSnap
+from dagster._core.remote_representation.external import CompoundID, RemoteRepository
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus
 from dagster._core.workspace.permissions import Permissions
 
@@ -93,12 +93,12 @@ class GrapheneSensor(graphene.ObjectType):
 
     def __init__(
         self,
-        external_sensor: ExternalSensor,
-        external_repository: ExternalRepository,
+        external_sensor: RemoteSensor,
+        external_repository: RemoteRepository,
         sensor_state: Optional[InstigatorState],
         batch_loader: Optional[RepositoryScopedBatchLoader] = None,
     ):
-        self._external_sensor = check.inst_param(external_sensor, "external_sensor", ExternalSensor)
+        self._external_sensor = check.inst_param(external_sensor, "external_sensor", RemoteSensor)
         self._external_repository = external_repository
 
         # optional run loader, provided by a parent GrapheneRepository object that instantiates

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -6,7 +6,7 @@ import graphene
 from dagster._core.definitions import NodeHandle
 from dagster._core.definitions.asset_graph_differ import AssetGraphDiffer
 from dagster._core.remote_representation import RepresentedJob
-from dagster._core.remote_representation.external import ExternalJob
+from dagster._core.remote_representation.external import RemoteJob
 from dagster._core.remote_representation.historical import HistoricalJob
 from dagster._core.snap import DependencyStructureIndex, GraphDefSnap, OpDefSnap
 from dagster._core.snap.node import InputMappingSnap, OutputMappingSnap
@@ -434,7 +434,7 @@ class ISolidDefinitionMixin:
         if isinstance(self._represented_pipeline, HistoricalJob):
             return []
         else:
-            assert isinstance(self._represented_pipeline, ExternalJob)
+            assert isinstance(self._represented_pipeline, RemoteJob)
             repo_handle = self._represented_pipeline.repository_handle
             origin = repo_handle.code_location_origin
             location = graphene_info.context.get_code_location(origin.location_name)

--- a/python_modules/dagster-graphql/dagster_graphql/test/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/test/utils.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Iterator, Mapping, Optional, Sequence
 import dagster._check as check
 import graphene
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.test_utils import wait_for_runs_to_finish
 from dagster._core.workspace.context import WorkspaceProcessContext, WorkspaceRequestContext
 from dagster._core.workspace.load_target import PythonFileTarget
@@ -157,7 +157,7 @@ def define_out_of_process_workspace(
     )
 
 
-def infer_repository(graphql_context: WorkspaceRequestContext) -> ExternalRepository:
+def infer_repository(graphql_context: WorkspaceRequestContext) -> RemoteRepository:
     if len(graphql_context.code_locations) == 1:
         # This is to account for having a single in process repository
         code_location = graphql_context.code_locations[0]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -105,7 +105,7 @@ from dagster._core.definitions.sensor_definition import RunRequest, SensorDefini
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.log_manager import coerce_valid_log_level
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.storage.tags import RESUME_RETRY_TAG
 from dagster._core.workspace.context import WorkspaceProcessContext, WorkspaceRequestContext
@@ -180,7 +180,7 @@ def get_main_workspace(instance: DagsterInstance) -> Iterator[WorkspaceRequestCo
 
 
 @contextmanager
-def get_main_external_repo(instance: DagsterInstance) -> Iterator[ExternalRepository]:
+def get_main_external_repo(instance: DagsterInstance) -> Iterator[RemoteRepository]:
     with get_main_workspace(instance) as workspace:
         location = workspace.get_code_location(main_repo_location_name())
         yield location.get_repository(main_repo_name())

--- a/python_modules/dagster-test/dagster_test/test_project/__init__.py
+++ b/python_modules/dagster-test/dagster_test/test_project/__init__.py
@@ -15,10 +15,10 @@ from dagster._core.origin import (
     RepositoryPythonOrigin,
 )
 from dagster._core.remote_representation import (
-    ExternalJob,
-    ExternalSchedule,
     GrpcServerCodeLocationOrigin,
     InProcessCodeLocationOrigin,
+    RemoteJob,
+    RemoteSchedule,
 )
 from dagster._core.remote_representation.origin import (
     RemoteInstigatorOrigin,
@@ -135,9 +135,9 @@ class ReOriginatedReconstructableJobForTest(ReconstructableJob):
         )
 
 
-class ReOriginatedExternalJobForTest(ExternalJob):
+class ReOriginatedExternalJobForTest(RemoteJob):
     def __init__(
-        self, external_job: ExternalJob, container_image=None, container_context=None, filename=None
+        self, external_job: RemoteJob, container_image=None, container_context=None, filename=None
     ):
         self._container_image = container_image
         self._container_context = container_context
@@ -190,10 +190,10 @@ class ReOriginatedExternalJobForTest(ExternalJob):
         )
 
 
-class ReOriginatedExternalScheduleForTest(ExternalSchedule):
+class ReOriginatedExternalScheduleForTest(RemoteSchedule):
     def __init__(
         self,
-        external_schedule: ExternalSchedule,
+        external_schedule: RemoteSchedule,
         container_image=None,
     ):
         self._container_image = container_image

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -38,8 +38,8 @@ from dagster._core.execution.job_backfill import create_backfill_run
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation import (
     CodeLocation,
-    ExternalJob,
-    ExternalRepository,
+    RemoteJob,
+    RemoteRepository,
     RepositoryHandle,
 )
 from dagster._core.remote_representation.external_data import (
@@ -435,8 +435,8 @@ def execute_launch_command(
 def _create_external_run(
     instance: DagsterInstance,
     code_location: CodeLocation,
-    external_repo: ExternalRepository,
-    external_job: ExternalJob,
+    external_repo: RemoteRepository,
+    external_job: RemoteJob,
     run_config: Mapping[str, object],
     tags: Optional[Mapping[str, str]],
     op_selection: Optional[Sequence[str]],
@@ -444,8 +444,8 @@ def _create_external_run(
 ) -> DagsterRun:
     check.inst_param(instance, "instance", DagsterInstance)
     check.inst_param(code_location, "code_location", CodeLocation)
-    check.inst_param(external_repo, "external_repo", ExternalRepository)
-    check.inst_param(external_job, "external_job", ExternalJob)
+    check.inst_param(external_repo, "external_repo", RemoteRepository)
+    check.inst_param(external_job, "external_job", RemoteJob)
     check.opt_mapping_param(run_config, "run_config", key_type=str)
 
     check.opt_mapping_param(tags, "tags", key_type=str)
@@ -501,12 +501,12 @@ def _create_external_run(
 
 
 def _check_execute_external_job_args(
-    external_job: ExternalJob,
+    external_job: RemoteJob,
     run_config: Mapping[str, object],
     tags: Optional[Mapping[str, str]],
     op_selection: Optional[Sequence[str]],
 ) -> Tuple[Mapping[str, object], Mapping[str, str], Optional[Sequence[str]]]:
-    check.inst_param(external_job, "external_job", ExternalJob)
+    check.inst_param(external_job, "external_job", RemoteJob)
     run_config = check.opt_mapping_param(run_config, "run_config")
 
     tags = check.opt_mapping_param(tags, "tags", key_type=str)

--- a/python_modules/dagster/dagster/_cli/schedule.py
+++ b/python_modules/dagster/dagster/_cli/schedule.py
@@ -16,7 +16,7 @@ from dagster._cli.workspace.cli_target import (
 )
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation import ExternalRepository
+from dagster._core.remote_representation import RemoteRepository
 from dagster._core.scheduler.instigation import InstigatorStatus
 from dagster._core.scheduler.scheduler import DagsterDaemonScheduler
 
@@ -109,8 +109,8 @@ def print_changes(external_repository, instance, print_fn=print, preview=False):
         )
 
 
-def check_repo_and_scheduler(repository: ExternalRepository, instance: DagsterInstance) -> None:
-    check.inst_param(repository, "repository", ExternalRepository)
+def check_repo_and_scheduler(repository: RemoteRepository, instance: DagsterInstance) -> None:
+    check.inst_param(repository, "repository", RemoteRepository)
     check.inst_param(instance, "instance", DagsterInstance)
 
     repository_name = repository.name

--- a/python_modules/dagster/dagster/_cli/sensor.py
+++ b/python_modules/dagster/dagster/_cli/sensor.py
@@ -17,7 +17,7 @@ from dagster._cli.workspace.cli_target import (
 )
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation import ExternalRepository
+from dagster._core.remote_representation import RemoteRepository
 from dagster._core.scheduler.instigation import (
     InstigatorState,
     InstigatorStatus,
@@ -76,8 +76,8 @@ def print_changes(external_repository, instance, print_fn=print, preview=False):
         )
 
 
-def check_repo_and_scheduler(repository: ExternalRepository, instance: DagsterInstance) -> None:
-    check.inst_param(repository, "repository", ExternalRepository)
+def check_repo_and_scheduler(repository: RemoteRepository, instance: DagsterInstance) -> None:
+    check.inst_param(repository, "repository", RemoteRepository)
     check.inst_param(instance, "instance", DagsterInstance)
 
     repository_name = repository.name

--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -34,7 +34,7 @@ from dagster._core.origin import (
     RepositoryPythonOrigin,
 )
 from dagster._core.remote_representation.code_location import CodeLocation
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.workspace.context import WorkspaceRequestContext
 from dagster._core.workspace.load_target import (
     CompositeTarget,
@@ -53,7 +53,7 @@ from dagster._utils.hosted_user_process import recon_repository_from_origin
 if TYPE_CHECKING:
     from dagster._core.workspace.context import WorkspaceProcessContext
 
-from dagster._core.remote_representation.external import ExternalJob
+from dagster._core.remote_representation.external import RemoteJob
 
 WORKSPACE_TARGET_WARNING = (
     "Can only use ONE of --workspace/-w, --python-file/-f, --module-name/-m, --grpc-port,"
@@ -724,7 +724,7 @@ def get_code_location_from_workspace(
 
 def get_external_repository_from_code_location(
     code_location: CodeLocation, provided_repo_name: Optional[str]
-) -> ExternalRepository:
+) -> RemoteRepository:
     check.inst_param(code_location, "code_location", CodeLocation)
     check.opt_str_param(provided_repo_name, "provided_repo_name")
 
@@ -753,7 +753,7 @@ def get_external_repository_from_code_location(
 @contextmanager
 def get_external_repository_from_kwargs(
     instance: DagsterInstance, version: str, kwargs: ClickArgMapping
-) -> Iterator[ExternalRepository]:
+) -> Iterator[RemoteRepository]:
     # Instance isn't strictly required to load an ExternalRepository, but is included
     # to satisfy the WorkspaceProcessContext / WorkspaceRequestContext requirements
     with get_code_location_from_kwargs(instance, version, kwargs) as code_location:
@@ -762,10 +762,10 @@ def get_external_repository_from_kwargs(
 
 
 def get_external_job_from_external_repo(
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
     provided_name: Optional[str],
-) -> ExternalJob:
-    check.inst_param(external_repo, "external_repo", ExternalRepository)
+) -> RemoteJob:
+    check.inst_param(external_repo, "external_repo", RemoteRepository)
     check.opt_str_param(provided_name, "provided_name")
 
     external_jobs = {ep.name: ep for ep in (external_repo.get_all_external_jobs())}

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -17,7 +17,7 @@ import dagster._check as check
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster._core.remote_representation import ExternalRepository
+from dagster._core.remote_representation import RemoteRepository
 from dagster._core.workspace.context import BaseWorkspaceRequestContext
 from dagster._record import record
 from dagster._serdes import whitelist_for_serdes
@@ -84,7 +84,7 @@ class AssetDefinitionDiffDetails:
 
 def _get_external_repo_from_context(
     context: BaseWorkspaceRequestContext, code_location_name: str, repository_name: str
-) -> Optional[ExternalRepository]:
+) -> Optional[RemoteRepository]:
     """Returns the ExternalRepository specified by the code location name and repository name
     for the provided workspace context. If the repository doesn't exist, return None.
     """

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -37,7 +37,7 @@ from dagster._core.definitions.metadata import ArbitraryMetadataMapping
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
 from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.remote_representation.handle import RepositoryHandle
 
 if TYPE_CHECKING:
@@ -380,7 +380,7 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
     def get_implicit_job_name_for_assets(
         self,
         asset_keys: Iterable[AssetKey],
-        external_repo: Optional[ExternalRepository],
+        external_repo: Optional[RemoteRepository],
     ) -> Optional[str]:
         """Returns the name of the asset base job that contains all the given assets, or None if there is no such
         job.

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -11,7 +11,7 @@ from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation import CodeLocation, ExternalJob, ExternalPartitionSet
+from dagster._core.remote_representation import CodeLocation, RemoteJob, RemotePartitionSet
 from dagster._core.remote_representation.external_data import PartitionSetExecutionParamSnap
 from dagster._core.remote_representation.origin import RemotePartitionSetOrigin
 from dagster._core.storage.dagster_run import (
@@ -133,7 +133,7 @@ def execute_job_backfill_iteration(
 
 def _get_partition_set(
     workspace_process_context: IWorkspaceProcessContext, backfill_job: PartitionBackfill
-) -> ExternalPartitionSet:
+) -> RemotePartitionSet:
     origin = cast(RemotePartitionSetOrigin, backfill_job.partition_set_origin)
 
     location_name = origin.repository_origin.code_location_origin.location_name
@@ -182,7 +182,7 @@ def _get_partitions_chunk(
     logger: logging.Logger,
     backfill_job: PartitionBackfill,
     chunk_size: int,
-    partition_set: ExternalPartitionSet,
+    partition_set: RemotePartitionSet,
 ) -> Tuple[Sequence[Union[str, PartitionKeyRange]], str, bool]:
     partition_names = cast(Sequence[str], backfill_job.partition_names)
     checkpoint = backfill_job.last_submitted_partition_name
@@ -391,8 +391,8 @@ def submit_backfill_runs(
 def create_backfill_run(
     instance: DagsterInstance,
     code_location: CodeLocation,
-    external_pipeline: ExternalJob,
-    external_partition_set: ExternalPartitionSet,
+    external_pipeline: RemoteJob,
+    external_partition_set: RemotePartitionSet,
     backfill_job: PartitionBackfill,
     partition_key_or_range: Union[str, PartitionKeyRange],
     run_tags: Mapping[str, str],
@@ -499,11 +499,11 @@ def create_backfill_run(
 
 def _fetch_last_run(
     instance: DagsterInstance,
-    external_partition_set: ExternalPartitionSet,
+    external_partition_set: RemotePartitionSet,
     partition_key_or_range: Union[str, PartitionKeyRange],
 ) -> Optional[DagsterRun]:
     check.inst_param(instance, "instance", DagsterInstance)
-    check.inst_param(external_partition_set, "external_partition_set", ExternalPartitionSet)
+    check.inst_param(external_partition_set, "external_partition_set", RemotePartitionSet)
     check.str_param(partition_key_or_range, "partition_name")
 
     tags = (

--- a/python_modules/dagster/dagster/_core/execution/plan/state.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/state.py
@@ -240,7 +240,7 @@ def _derive_state_of_past_run(
 ) -> Tuple[
     Sequence[str], Mapping[str, Mapping[str, Optional[Sequence[str]]]], Set[StepOutputHandle]
 ]:
-    from dagster._core.remote_representation import ExternalExecutionPlan
+    from dagster._core.remote_representation import RemoteExecutionPlan
 
     check.inst_param(instance, "instance", DagsterInstance)
     check.opt_inst_param(parent_run, "parent_run", DagsterRun)
@@ -267,7 +267,7 @@ def _derive_state_of_past_run(
             f"Could not load execution plan snapshot for run {parent_run_id}"
         )
 
-    execution_plan = ExternalExecutionPlan(execution_plan_snapshot=execution_plan_snapshot)
+    execution_plan = RemoteExecutionPlan(execution_plan_snapshot=execution_plan_snapshot)
 
     output_set: Set[StepOutputHandle] = set()
     observed_dynamic_outputs: Dict[str, Dict[str, List[str]]] = defaultdict(

--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -12,7 +12,7 @@ from dagster._core.definitions.run_request import RunRequest
 from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.errors import DagsterInvalidSubsetError, DagsterUserCodeProcessError
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation import ExternalExecutionPlan, ExternalJob
+from dagster._core.remote_representation import RemoteExecutionPlan, RemoteJob
 from dagster._core.snap import ExecutionPlanSnapshot
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
 from dagster._core.workspace.context import BaseWorkspaceRequestContext, IWorkspaceProcessContext
@@ -22,8 +22,8 @@ EXECUTION_PLAN_CREATION_RETRIES = 1
 
 
 class RunRequestExecutionData(NamedTuple):
-    external_job: ExternalJob
-    external_execution_plan: ExternalExecutionPlan
+    external_job: RemoteJob
+    external_execution_plan: RemoteExecutionPlan
 
 
 def _get_implicit_job_name_for_assets(

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -133,12 +133,12 @@ if TYPE_CHECKING:
     from dagster._core.launcher import RunLauncher
     from dagster._core.remote_representation import (
         CodeLocation,
-        ExternalJob,
-        ExternalSensor,
         HistoricalJob,
+        RemoteJob,
         RemoteJobOrigin,
+        RemoteSensor,
     )
-    from dagster._core.remote_representation.external import ExternalSchedule
+    from dagster._core.remote_representation.external import RemoteSchedule
     from dagster._core.run_coordinator import RunCoordinator
     from dagster._core.scheduler import Scheduler, SchedulerDebugInfo
     from dagster._core.scheduler.instigation import (
@@ -1621,7 +1621,7 @@ class DagsterInstance(DynamicPartitionsStore):
         *,
         parent_run: DagsterRun,
         code_location: "CodeLocation",
-        external_job: "ExternalJob",
+        external_job: "RemoteJob",
         strategy: "ReexecutionStrategy",
         extra_tags: Optional[Mapping[str, Any]] = None,
         run_config: Optional[Mapping[str, Any]] = None,
@@ -1629,11 +1629,11 @@ class DagsterInstance(DynamicPartitionsStore):
     ) -> DagsterRun:
         from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
         from dagster._core.execution.plan.state import KnownExecutionState
-        from dagster._core.remote_representation import CodeLocation, ExternalJob
+        from dagster._core.remote_representation import CodeLocation, RemoteJob
 
         check.inst_param(parent_run, "parent_run", DagsterRun)
         check.inst_param(code_location, "code_location", CodeLocation)
-        check.inst_param(external_job, "external_job", ExternalJob)
+        check.inst_param(external_job, "external_job", RemoteJob)
         check.inst_param(strategy, "strategy", ReexecutionStrategy)
         check.opt_mapping_param(extra_tags, "extra_tags", key_type=str)
         check.opt_mapping_param(run_config, "run_config", key_type=str)
@@ -2756,20 +2756,20 @@ class DagsterInstance(DynamicPartitionsStore):
 
     # Scheduler
 
-    def start_schedule(self, external_schedule: "ExternalSchedule") -> "InstigatorState":
+    def start_schedule(self, external_schedule: "RemoteSchedule") -> "InstigatorState":
         return self._scheduler.start_schedule(self, external_schedule)  # type: ignore
 
     def stop_schedule(
         self,
         schedule_origin_id: str,
         schedule_selector_id: str,
-        external_schedule: Optional["ExternalSchedule"],
+        external_schedule: Optional["RemoteSchedule"],
     ) -> "InstigatorState":
         return self._scheduler.stop_schedule(  # type: ignore
             self, schedule_origin_id, schedule_selector_id, external_schedule
         )
 
-    def reset_schedule(self, external_schedule: "ExternalSchedule") -> "InstigatorState":
+    def reset_schedule(self, external_schedule: "RemoteSchedule") -> "InstigatorState":
         return self._scheduler.reset_schedule(self, external_schedule)  # type: ignore
 
     def scheduler_debug_info(self) -> "SchedulerDebugInfo":
@@ -2800,7 +2800,7 @@ class DagsterInstance(DynamicPartitionsStore):
 
     # Schedule / Sensor Storage
 
-    def start_sensor(self, external_sensor: "ExternalSensor") -> "InstigatorState":
+    def start_sensor(self, external_sensor: "RemoteSensor") -> "InstigatorState":
         from dagster._core.definitions.run_request import InstigatorType
         from dagster._core.scheduler.instigation import (
             InstigatorState,
@@ -2841,7 +2841,7 @@ class DagsterInstance(DynamicPartitionsStore):
         self,
         instigator_origin_id: str,
         selector_id: str,
-        external_sensor: Optional["ExternalSensor"],
+        external_sensor: Optional["RemoteSensor"],
     ) -> "InstigatorState":
         from dagster._core.definitions.run_request import InstigatorType
         from dagster._core.scheduler.instigation import (
@@ -2876,7 +2876,7 @@ class DagsterInstance(DynamicPartitionsStore):
         else:
             return self.update_instigator_state(stored_state.with_status(InstigatorStatus.STOPPED))
 
-    def reset_sensor(self, external_sensor: "ExternalSensor") -> "InstigatorState":
+    def reset_sensor(self, external_sensor: "RemoteSensor") -> "InstigatorState":
         """If the given sensor has a default sensor status, then update the status to
         `InstigatorStatus.DECLARED_IN_CODE` in instigator storage.
 

--- a/python_modules/dagster/dagster/_core/remote_representation/__init__.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/__init__.py
@@ -7,12 +7,12 @@ that have been persisted. e.g. HistoricalPipeline
 """
 
 from dagster._core.remote_representation.external import (
-    ExternalExecutionPlan as ExternalExecutionPlan,
-    ExternalJob as ExternalJob,
-    ExternalPartitionSet as ExternalPartitionSet,
-    ExternalRepository as ExternalRepository,
-    ExternalSchedule as ExternalSchedule,
-    ExternalSensor as ExternalSensor,
+    RemoteExecutionPlan as RemoteExecutionPlan,
+    RemoteJob as RemoteJob,
+    RemotePartitionSet as RemotePartitionSet,
+    RemoteRepository as RemoteRepository,
+    RemoteSchedule as RemoteSchedule,
+    RemoteSensor as RemoteSensor,
 )
 from dagster._core.remote_representation.external_data import (
     ExecutionParamsErrorSnap as ExecutionParamsErrorSnap,

--- a/python_modules/dagster/dagster/_core/scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_core/scheduler/scheduler.py
@@ -9,7 +9,7 @@ from dagster._config import Field, IntSource
 from dagster._core.definitions.run_request import InstigatorType
 from dagster._core.errors import DagsterError
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation import ExternalSchedule
+from dagster._core.remote_representation import RemoteSchedule
 from dagster._core.scheduler.instigation import (
     InstigatorState,
     InstigatorStatus,
@@ -64,7 +64,7 @@ class Scheduler(abc.ABC):
     """
 
     def start_schedule(
-        self, instance: DagsterInstance, external_schedule: ExternalSchedule
+        self, instance: DagsterInstance, external_schedule: RemoteSchedule
     ) -> InstigatorState:
         """Updates the status of the given schedule to `InstigatorStatus.RUNNING` in schedule storage,.
 
@@ -76,7 +76,7 @@ class Scheduler(abc.ABC):
 
         """
         check.inst_param(instance, "instance", DagsterInstance)
-        check.inst_param(external_schedule, "external_schedule", ExternalSchedule)
+        check.inst_param(external_schedule, "external_schedule", RemoteSchedule)
 
         stored_state = instance.get_instigator_state(
             external_schedule.get_remote_origin_id(), external_schedule.selector_id
@@ -110,7 +110,7 @@ class Scheduler(abc.ABC):
         instance: DagsterInstance,
         schedule_origin_id: str,
         schedule_selector_id: str,
-        external_schedule: Optional[ExternalSchedule],
+        external_schedule: Optional[RemoteSchedule],
     ) -> InstigatorState:
         """Updates the status of the given schedule to `InstigatorStatus.STOPPED` in schedule storage,.
 
@@ -120,7 +120,7 @@ class Scheduler(abc.ABC):
             schedule_origin_id (string): The id of the schedule target to stop running.
         """
         check.str_param(schedule_origin_id, "schedule_origin_id")
-        check.opt_inst_param(external_schedule, "external_schedule", ExternalSchedule)
+        check.opt_inst_param(external_schedule, "external_schedule", RemoteSchedule)
 
         stored_state = instance.get_instigator_state(schedule_origin_id, schedule_selector_id)
 
@@ -154,7 +154,7 @@ class Scheduler(abc.ABC):
         return stopped_state
 
     def reset_schedule(
-        self, instance: DagsterInstance, external_schedule: ExternalSchedule
+        self, instance: DagsterInstance, external_schedule: RemoteSchedule
     ) -> InstigatorState:
         """If the given schedule has a default schedule status, then update the status to
         `InstigatorStatus.DECLARED_IN_CODE` in schedule storage.
@@ -166,7 +166,7 @@ class Scheduler(abc.ABC):
             external_schedule (ExternalSchedule): The schedule to reset.
         """
         check.inst_param(instance, "instance", DagsterInstance)
-        check.inst_param(external_schedule, "external_schedule", ExternalSchedule)
+        check.inst_param(external_schedule, "external_schedule", RemoteSchedule)
 
         stored_state = instance.get_instigator_state(
             external_schedule.get_remote_origin_id(), external_schedule.selector_id

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from dagster._core.definitions.schedule_definition import ScheduleDefinition
     from dagster._core.definitions.sensor_definition import SensorDefinition
     from dagster._core.instance import DagsterInstance
-    from dagster._core.remote_representation.external import ExternalSchedule, ExternalSensor
+    from dagster._core.remote_representation.external import RemoteSchedule, RemoteSensor
     from dagster._core.remote_representation.origin import RemoteJobOrigin
     from dagster._core.scheduler.instigation import InstigatorState
 
@@ -486,13 +486,13 @@ class DagsterRun(
 
     @staticmethod
     def tags_for_schedule(
-        schedule: Union["InstigatorState", "ExternalSchedule", "ScheduleDefinition"],
+        schedule: Union["InstigatorState", "RemoteSchedule", "ScheduleDefinition"],
     ) -> Mapping[str, str]:
         return {SCHEDULE_NAME_TAG: schedule.name}
 
     @staticmethod
     def tags_for_sensor(
-        sensor: Union["InstigatorState", "ExternalSensor", "SensorDefinition"],
+        sensor: Union["InstigatorState", "RemoteSensor", "SensorDefinition"],
     ) -> Mapping[str, str]:
         return {SENSOR_NAME_TAG: sensor.name}
 
@@ -575,13 +575,13 @@ class RunsFilter(IHaveNew):
 
     @staticmethod
     def for_schedule(
-        schedule: Union["ExternalSchedule", "InstigatorState", "ScheduleDefinition"],
+        schedule: Union["RemoteSchedule", "InstigatorState", "ScheduleDefinition"],
     ) -> "RunsFilter":
         return RunsFilter(tags=DagsterRun.tags_for_schedule(schedule))
 
     @staticmethod
     def for_sensor(
-        sensor: Union["ExternalSensor", "InstigatorState", "SensorDefinition"],
+        sensor: Union["RemoteSensor", "InstigatorState", "SensorDefinition"],
     ) -> "RunsFilter":
         return RunsFilter(tags=DagsterRun.tags_for_sensor(sensor))
 

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -57,9 +57,9 @@ from dagster.version import __version__ as dagster_module_version
 
 if TYPE_CHECKING:
     from dagster._core.remote_representation.external import (
-        ExternalJob,
-        ExternalRepository,
-        ExternalResource,
+        RemoteJob,
+        RemoteRepository,
+        RemoteResource,
     )
     from dagster._core.workspace.context import IWorkspaceProcessContext
 
@@ -458,7 +458,7 @@ def hash_name(name: str) -> str:
     return hashlib.sha256(name.encode("utf-8")).hexdigest()
 
 
-def get_stats_from_external_repo(external_repo: "ExternalRepository") -> Mapping[str, str]:
+def get_stats_from_external_repo(external_repo: "RemoteRepository") -> Mapping[str, str]:
     from dagster._core.remote_representation.external_data import (
         DynamicPartitionsSnap,
         MultiPartitionsSnap,
@@ -566,7 +566,7 @@ def get_stats_from_external_repo(external_repo: "ExternalRepository") -> Mapping
     }
 
 
-def get_resource_stats(external_resources: Sequence["ExternalResource"]) -> Mapping[str, Any]:
+def get_resource_stats(external_resources: Sequence["RemoteResource"]) -> Mapping[str, Any]:
     used_dagster_resources = []
     used_custom_resources = False
 
@@ -590,15 +590,15 @@ def get_resource_stats(external_resources: Sequence["ExternalResource"]) -> Mapp
 def log_external_repo_stats(
     instance: DagsterInstance,
     source: str,
-    external_repo: "ExternalRepository",
-    external_job: Optional["ExternalJob"] = None,
+    external_repo: "RemoteRepository",
+    external_job: Optional["RemoteJob"] = None,
 ):
-    from dagster._core.remote_representation.external import ExternalJob, ExternalRepository
+    from dagster._core.remote_representation.external import RemoteJob, RemoteRepository
 
     check.inst_param(instance, "instance", DagsterInstance)
     check.str_param(source, "source")
-    check.inst_param(external_repo, "external_repo", ExternalRepository)
-    check.opt_inst_param(external_job, "external_job", ExternalJob)
+    check.inst_param(external_repo, "external_repo", RemoteRepository)
+    check.opt_inst_param(external_job, "external_job", RemoteJob)
 
     if _get_instance_telemetry_enabled(instance):
         instance_id = get_or_set_instance_id()

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -60,7 +60,7 @@ from dagster._core.instance_for_test import (
     instance_for_test as instance_for_test,
 )
 from dagster._core.launcher import RunLauncher
-from dagster._core.remote_representation import ExternalRepository
+from dagster._core.remote_representation import RemoteRepository
 from dagster._core.remote_representation.origin import InProcessCodeLocationOrigin
 from dagster._core.run_coordinator import RunCoordinator, SubmitRunContext
 from dagster._core.secrets import SecretsLoader
@@ -527,7 +527,7 @@ def create_test_daemon_workspace_context(
 
 def load_external_repo(
     workspace_context: WorkspaceProcessContext, repo_name: str
-) -> ExternalRepository:
+) -> RemoteRepository:
     code_location_entry = next(
         iter(workspace_context.create_request_context().get_code_location_entries().values())
     )

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -31,12 +31,12 @@ from dagster._core.loader import LoadingContext
 from dagster._core.remote_representation import (
     CodeLocation,
     CodeLocationOrigin,
-    ExternalExecutionPlan,
-    ExternalJob,
     GrpcServerCodeLocation,
+    RemoteExecutionPlan,
+    RemoteJob,
     RepositoryHandle,
 )
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.remote_representation.grpc_server_registry import GrpcServerRegistry
 from dagster._core.remote_representation.grpc_server_state_subscriber import (
     LocationStateChangeEvent,
@@ -241,7 +241,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
             selector.repository_name
         ).has_external_job(selector.job_name)
 
-    def get_full_external_job(self, selector: JobSubsetSelector) -> ExternalJob:
+    def get_full_external_job(self, selector: JobSubsetSelector) -> RemoteJob:
         return (
             self.get_code_location(selector.location_name)
             .get_repository(selector.repository_name)
@@ -250,11 +250,11 @@ class BaseWorkspaceRequestContext(LoadingContext):
 
     def get_external_execution_plan(
         self,
-        external_job: ExternalJob,
+        external_job: RemoteJob,
         run_config: Mapping[str, object],
         step_keys_to_execute: Optional[Sequence[str]],
         known_state: Optional[KnownExecutionState],
-    ) -> ExternalExecutionPlan:
+    ) -> RemoteExecutionPlan:
         return self.get_code_location(
             external_job.handle.location_name
         ).get_external_execution_plan(
@@ -342,7 +342,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
 
         return self.get_workspace_snapshot().asset_graph.get(asset_key)
 
-    def get_repository(self, selector: RepositorySelector) -> ExternalRepository:
+    def get_repository(self, selector: RepositorySelector) -> RemoteRepository:
         return self.get_code_location(selector.location_name).get_repository(
             selector.repository_name
         )

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -34,8 +34,8 @@ from dagster._core.errors import DagsterCodeLocationLoadError, DagsterUserCodeUn
 from dagster._core.execution.backfill import PartitionBackfill
 from dagster._core.execution.submit_asset_runs import submit_asset_run
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation import ExternalSensor
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation import RemoteSensor
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.remote_representation.origin import RemoteInstigatorOrigin
 from dagster._core.scheduler.instigation import (
     InstigatorState,
@@ -219,7 +219,7 @@ class AutoMaterializeLaunchContext:
     def __init__(
         self,
         tick: InstigatorTick,
-        external_sensor: Optional[ExternalSensor],
+        external_sensor: Optional[RemoteSensor],
         instance: DagsterInstance,
         logger: logging.Logger,
         tick_retention_settings,
@@ -344,7 +344,7 @@ class AssetDaemon(DagsterDaemon):
     def daemon_type(cls) -> str:
         return "ASSET"
 
-    def _get_print_sensor_name(self, sensor: Optional[ExternalSensor]) -> str:
+    def _get_print_sensor_name(self, sensor: Optional[RemoteSensor]) -> str:
         if not sensor:
             return ""
         repo_origin = sensor.get_remote_origin().repository_origin
@@ -470,9 +470,7 @@ class AssetDaemon(DagsterDaemon):
 
         if not self._initialized_evaluation_id:
             self._initialize_evaluation_id(instance)
-        sensors_and_repos: Sequence[
-            Tuple[Optional[ExternalSensor], Optional[ExternalRepository]]
-        ] = []
+        sensors_and_repos: Sequence[Tuple[Optional[RemoteSensor], Optional[RemoteRepository]]] = []
 
         if use_auto_materialize_sensors:
             workspace_snapshot = {
@@ -615,7 +613,7 @@ class AssetDaemon(DagsterDaemon):
     def _create_initial_sensor_cursors_from_raw_cursor(
         self,
         instance: DagsterInstance,
-        sensors_and_repos: Sequence[Tuple[ExternalSensor, ExternalRepository]],
+        sensors_and_repos: Sequence[Tuple[RemoteSensor, RemoteRepository]],
         all_auto_materialize_states: Mapping[str, InstigatorState],
         pre_sensor_cursor: AssetDaemonCursor,
     ) -> Mapping[str, InstigatorState]:
@@ -688,8 +686,8 @@ class AssetDaemon(DagsterDaemon):
     def _process_auto_materialize_tick(
         self,
         workspace_process_context: IWorkspaceProcessContext,
-        repository: Optional[ExternalRepository],
-        sensor: Optional[ExternalSensor],
+        repository: Optional[RemoteRepository],
+        sensor: Optional[RemoteSensor],
         debug_crash_flags: SingleInstigatorDebugCrashFlags,
     ):
         return list(
@@ -704,8 +702,8 @@ class AssetDaemon(DagsterDaemon):
     def _process_auto_materialize_tick_generator(
         self,
         workspace_process_context: IWorkspaceProcessContext,
-        repository: Optional[ExternalRepository],
-        sensor: Optional[ExternalSensor],
+        repository: Optional[RemoteRepository],
+        sensor: Optional[RemoteSensor],
         debug_crash_flags: SingleInstigatorDebugCrashFlags,  # TODO No longer single instigator
     ):
         evaluation_time = get_current_datetime()
@@ -899,7 +897,7 @@ class AssetDaemon(DagsterDaemon):
         self,
         tick_context: AutoMaterializeLaunchContext,
         tick: InstigatorTick,
-        sensor: Optional[ExternalSensor],
+        sensor: Optional[RemoteSensor],
         workspace_process_context: IWorkspaceProcessContext,
         asset_graph: RemoteAssetGraph,
         auto_materialize_entity_keys: Set[EntityKey],

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -46,7 +46,7 @@ from dagster._core.errors import (
 from dagster._core.execution.backfill import PartitionBackfill
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.code_location import CodeLocation
-from dagster._core.remote_representation.external import ExternalJob, ExternalSensor
+from dagster._core.remote_representation.external import RemoteJob, RemoteSensor
 from dagster._core.remote_representation.external_data import TargetSnap
 from dagster._core.scheduler.instigation import (
     DynamicPartitionsRequestResult,
@@ -107,7 +107,7 @@ class BackfillSubmission(NamedTuple):
 class SensorLaunchContext(AbstractContextManager):
     def __init__(
         self,
-        external_sensor: ExternalSensor,
+        external_sensor: RemoteSensor,
         tick: InstigatorTick,
         instance: DagsterInstance,
         logger: logging.Logger,
@@ -380,7 +380,7 @@ def execute_sensor_iteration(
 
     tick_retention_settings = instance.get_tick_retention_settings(InstigatorType.SENSOR)
 
-    sensors: Dict[str, ExternalSensor] = {}
+    sensors: Dict[str, RemoteSensor] = {}
     for location_entry in workspace_snapshot.values():
         code_location = location_entry.code_location
         if code_location:
@@ -460,7 +460,7 @@ def execute_sensor_iteration(
 def _process_tick(
     workspace_process_context: IWorkspaceProcessContext,
     logger: logging.Logger,
-    external_sensor: ExternalSensor,
+    external_sensor: RemoteSensor,
     sensor_state: InstigatorState,
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags],
     tick_retention_settings,
@@ -483,7 +483,7 @@ def _process_tick(
 
 def _get_evaluation_tick(
     instance: DagsterInstance,
-    sensor: ExternalSensor,
+    sensor: RemoteSensor,
     instigator_data: Optional[SensorInstigatorData],
     evaluation_timestamp: float,
     logger: logging.Logger,
@@ -562,7 +562,7 @@ def _get_evaluation_tick(
 def _process_tick_generator(
     workspace_process_context: IWorkspaceProcessContext,
     logger: logging.Logger,
-    external_sensor: ExternalSensor,
+    external_sensor: RemoteSensor,
     sensor_state: InstigatorState,
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags],
     tick_retention_settings,
@@ -644,7 +644,7 @@ def _sensor_instigator_data(state: InstigatorState) -> Optional[SensorInstigator
 
 def mark_sensor_state_for_tick(
     instance: DagsterInstance,
-    external_sensor: ExternalSensor,
+    external_sensor: RemoteSensor,
     sensor_state: InstigatorState,
     now: datetime.datetime,
 ) -> None:
@@ -679,7 +679,7 @@ def _submit_run_request(
     run_id: str,
     run_request: RunRequest,
     workspace_process_context: IWorkspaceProcessContext,
-    external_sensor: ExternalSensor,
+    external_sensor: RemoteSensor,
     existing_runs_by_key,
     logger,
     sensor_debug_crash_flags,
@@ -740,7 +740,7 @@ def _resume_tick(
     workspace_process_context: IWorkspaceProcessContext,
     context: SensorLaunchContext,
     tick: InstigatorTick,
-    external_sensor: ExternalSensor,
+    external_sensor: RemoteSensor,
     submit_threadpool_executor: Optional[ThreadPoolExecutor],
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags] = None,
 ):
@@ -774,7 +774,7 @@ def _resume_tick(
 
 def _get_code_location_for_sensor(
     workspace_process_context: IWorkspaceProcessContext,
-    external_sensor: ExternalSensor,
+    external_sensor: RemoteSensor,
 ) -> CodeLocation:
     sensor_origin = external_sensor.get_remote_origin()
     return workspace_process_context.create_request_context().get_code_location(
@@ -785,7 +785,7 @@ def _get_code_location_for_sensor(
 def _evaluate_sensor(
     workspace_process_context: IWorkspaceProcessContext,
     context: SensorLaunchContext,
-    external_sensor: ExternalSensor,
+    external_sensor: RemoteSensor,
     state: InstigatorState,
     submit_threadpool_executor: Optional[ThreadPoolExecutor],
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags] = None,
@@ -945,7 +945,7 @@ def _handle_run_reactions(
     instance: DagsterInstance,
     context: SensorLaunchContext,
     cursor: Optional[str],
-    external_sensor: ExternalSensor,
+    external_sensor: RemoteSensor,
 ) -> None:
     for run_reaction in dagster_run_reactions:
         origin_run_id = check.not_none(run_reaction.dagster_run).run_id
@@ -988,7 +988,7 @@ def _handle_run_reactions(
 def _resolve_run_requests(
     workspace_process_context: IWorkspaceProcessContext,
     context: SensorLaunchContext,
-    external_sensor: ExternalSensor,
+    external_sensor: RemoteSensor,
     run_ids_with_requests: Sequence[Tuple[str, RunRequest]],
     has_evaluations: bool,
 ) -> Sequence[Tuple[str, RunRequest]]:
@@ -1026,7 +1026,7 @@ def _handle_run_requests_and_automation_condition_evaluations(
     cursor: Optional[str],
     instance: DagsterInstance,
     context: SensorLaunchContext,
-    external_sensor: ExternalSensor,
+    external_sensor: RemoteSensor,
     workspace_process_context: IWorkspaceProcessContext,
     submit_threadpool_executor: Optional[ThreadPoolExecutor],
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags] = None,
@@ -1079,7 +1079,7 @@ def _submit_run_requests(
     automation_condition_evaluations: Sequence[AutomationConditionEvaluationWithRunIds],
     instance: DagsterInstance,
     context: SensorLaunchContext,
-    external_sensor: ExternalSensor,
+    external_sensor: RemoteSensor,
     workspace_process_context: IWorkspaceProcessContext,
     submit_threadpool_executor: Optional[ThreadPoolExecutor],
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags] = None,
@@ -1189,7 +1189,7 @@ def _submit_backfill_request(
     )
 
 
-def is_under_min_interval(state: InstigatorState, external_sensor: ExternalSensor) -> bool:
+def is_under_min_interval(state: InstigatorState, external_sensor: RemoteSensor) -> bool:
     instigator_data = _sensor_instigator_data(state)
     if not instigator_data:
         return False
@@ -1209,7 +1209,7 @@ def is_under_min_interval(state: InstigatorState, external_sensor: ExternalSenso
 
 def _fetch_existing_runs(
     instance: DagsterInstance,
-    external_sensor: ExternalSensor,
+    external_sensor: RemoteSensor,
     run_requests: Sequence[RunRequest],
 ):
     run_keys = [run_request.run_key for run_request in run_requests if run_request.run_key]
@@ -1259,8 +1259,8 @@ def _get_or_create_sensor_run(
     logger: logging.Logger,
     instance: DagsterInstance,
     code_location: CodeLocation,
-    external_sensor: ExternalSensor,
-    external_job: ExternalJob,
+    external_sensor: RemoteSensor,
+    external_job: RemoteJob,
     run_id: str,
     run_request: RunRequest,
     target_data: TargetSnap,
@@ -1290,8 +1290,8 @@ def _get_or_create_sensor_run(
 def _create_sensor_run(
     instance: DagsterInstance,
     code_location: CodeLocation,
-    external_sensor: ExternalSensor,
-    external_job: ExternalJob,
+    external_sensor: RemoteSensor,
+    external_job: RemoteJob,
     run_id: str,
     run_request: RunRequest,
     target_data: TargetSnap,

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -29,9 +29,9 @@ from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.definitions.timestamp import TimestampWithTimezone
 from dagster._core.errors import DagsterCodeLocationLoadError, DagsterUserCodeUnreachableError
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation import ExternalSchedule
+from dagster._core.remote_representation import RemoteSchedule
 from dagster._core.remote_representation.code_location import CodeLocation
-from dagster._core.remote_representation.external import ExternalJob
+from dagster._core.remote_representation.external import RemoteJob
 from dagster._core.scheduler.instigation import (
     InstigatorState,
     InstigatorStatus,
@@ -77,7 +77,7 @@ ERROR_INTERVAL_TIME = 5
 class _ScheduleLaunchContext(AbstractContextManager):
     def __init__(
         self,
-        external_schedule: ExternalSchedule,
+        external_schedule: RemoteSchedule,
         tick: InstigatorTick,
         instance: DagsterInstance,
         logger: logging.Logger,
@@ -174,7 +174,7 @@ class ScheduleIterationTimes(NamedTuple):
     next_iteration_timestamp: float
     last_iteration_timestamp: float
 
-    def should_run_next_iteration(self, schedule: ExternalSchedule, now_timestamp: float):
+    def should_run_next_iteration(self, schedule: RemoteSchedule, now_timestamp: float):
         if schedule.cron_schedule != self.cron_schedule:
             # cron schedule has changed - always run next iteration to check
             return True
@@ -281,7 +281,7 @@ def launch_scheduled_runs(
 
     tick_retention_settings = instance.get_tick_retention_settings(InstigatorType.SCHEDULE)
 
-    schedules: Dict[str, ExternalSchedule] = {}
+    schedules: Dict[str, RemoteSchedule] = {}
     error_locations = set()
 
     for location_entry in workspace_snapshot.values():
@@ -446,7 +446,7 @@ def launch_scheduled_runs(
 def launch_scheduled_runs_for_schedule(
     workspace_process_context: IWorkspaceProcessContext,
     logger: logging.Logger,
-    external_schedule: ExternalSchedule,
+    external_schedule: RemoteSchedule,
     schedule_state: InstigatorState,
     end_datetime_utc: datetime.datetime,
     max_catchup_runs: int,
@@ -481,7 +481,7 @@ def launch_scheduled_runs_for_schedule(
 def launch_scheduled_runs_for_schedule_iterator(
     workspace_process_context: IWorkspaceProcessContext,
     logger: logging.Logger,
-    external_schedule: ExternalSchedule,
+    external_schedule: RemoteSchedule,
     schedule_state: InstigatorState,
     end_datetime_utc: datetime.datetime,
     max_catchup_runs: int,
@@ -693,7 +693,7 @@ class SubmitRunRequestResult(NamedTuple):
 def _submit_run_request(
     run_request: RunRequest,
     workspace_process_context: IWorkspaceProcessContext,
-    external_schedule: ExternalSchedule,
+    external_schedule: RemoteSchedule,
     schedule_time: datetime.datetime,
     logger,
     debug_crash_flags,
@@ -768,7 +768,7 @@ def _submit_run_request(
 
 def _get_code_location_for_schedule(
     workspace_process_context: IWorkspaceProcessContext,
-    external_schedule: ExternalSchedule,
+    external_schedule: RemoteSchedule,
 ) -> CodeLocation:
     schedule_origin = external_schedule.get_remote_origin()
     return workspace_process_context.create_request_context().get_code_location(
@@ -779,7 +779,7 @@ def _get_code_location_for_schedule(
 def _schedule_runs_at_time(
     workspace_process_context: IWorkspaceProcessContext,
     logger: logging.Logger,
-    external_schedule: ExternalSchedule,
+    external_schedule: RemoteSchedule,
     schedule_time: datetime.datetime,
     timezone_str: str,
     tick_context: _ScheduleLaunchContext,
@@ -884,7 +884,7 @@ def _schedule_runs_at_time(
 
 def _get_existing_run_for_request(
     instance: DagsterInstance,
-    external_schedule: ExternalSchedule,
+    external_schedule: RemoteSchedule,
     schedule_time: datetime.datetime,
     run_request: RunRequest,
 ) -> Optional[DagsterRun]:
@@ -924,8 +924,8 @@ def _create_scheduler_run(
     instance: DagsterInstance,
     schedule_time: datetime.datetime,
     code_location: CodeLocation,
-    external_schedule: ExternalSchedule,
-    external_job: ExternalJob,
+    external_schedule: RemoteSchedule,
+    external_job: RemoteJob,
     run_request: RunRequest,
 ) -> DagsterRun:
     from dagster._daemon.daemon import get_telemetry_daemon_session_id

--- a/python_modules/dagster/dagster/_scheduler/stale.py
+++ b/python_modules/dagster/dagster/_scheduler/stale.py
@@ -4,14 +4,14 @@ import dagster._check as check
 from dagster._core.definitions.data_version import CachingStaleStatusResolver, StaleStatus
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.run_request import RunRequest
-from dagster._core.remote_representation.external import ExternalSchedule, ExternalSensor
+from dagster._core.remote_representation.external import RemoteSchedule, RemoteSensor
 from dagster._core.workspace.context import WorkspaceProcessContext
 
 
 def resolve_stale_or_missing_assets(
     context: WorkspaceProcessContext,
     run_request: RunRequest,
-    instigator: Union[ExternalSensor, ExternalSchedule],
+    instigator: Union[RemoteSensor, RemoteSchedule],
 ) -> Sequence[AssetKey]:
     request_context = context.create_request_context()
     asset_graph = request_context.asset_graph

--- a/python_modules/dagster/dagster/_utils/external.py
+++ b/python_modules/dagster/dagster/_utils/external.py
@@ -3,7 +3,7 @@ from typing import Optional, Sequence
 import dagster._check as check
 from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.remote_representation import CodeLocation
-from dagster._core.remote_representation.external import ExternalJob
+from dagster._core.remote_representation.external import RemoteJob
 from dagster._core.remote_representation.origin import RemoteJobOrigin
 
 
@@ -11,7 +11,7 @@ def external_job_from_location(
     code_location: CodeLocation,
     external_job_origin: RemoteJobOrigin,
     op_selection: Optional[Sequence[str]],
-) -> ExternalJob:
+) -> RemoteJob:
     check.inst_param(code_location, "code_location", CodeLocation)
     check.inst_param(external_job_origin, "external_pipeline_origin", RemoteJobOrigin)
 

--- a/python_modules/dagster/dagster/_utils/hosted_user_process.py
+++ b/python_modules/dagster/dagster/_utils/hosted_user_process.py
@@ -14,7 +14,7 @@ import dagster._check as check
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
 from dagster._core.origin import JobPythonOrigin, RepositoryPythonOrigin
-from dagster._core.remote_representation import ExternalJob
+from dagster._core.remote_representation import RemoteJob
 from dagster._core.remote_representation.external_data import external_job_data_from_def
 from dagster._core.remote_representation.handle import RepositoryHandle
 
@@ -41,7 +41,7 @@ def external_job_from_recon_job(
     op_selection: Optional[Iterable[str]],
     repository_handle: RepositoryHandle,
     asset_selection: Optional[AbstractSet[AssetKey]] = None,
-) -> ExternalJob:
+) -> RemoteJob:
     if op_selection or asset_selection:
         sub_recon_job = recon_job.get_subset(
             op_selection=op_selection, asset_selection=asset_selection
@@ -50,7 +50,7 @@ def external_job_from_recon_job(
     else:
         job_def = recon_job.get_definition()
 
-    return ExternalJob(
+    return RemoteJob(
         external_job_data_from_def(job_def, include_parent_snapshot=True),
         repository_handle=repository_handle,
     )

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -14,7 +14,7 @@ from dagster._core.remote_representation import (
     ManagedGrpcPythonEnvCodeLocationOrigin,
     RepositorySnap,
 )
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.remote_representation.external_data import JobDataSnap
 from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.remote_representation.origin import RemoteRepositoryOrigin
@@ -147,7 +147,7 @@ def test_defer_snapshots(instance: DagsterInstance):
         assert external_repository_data.job_refs and len(external_repository_data.job_refs) == 6
         assert external_repository_data.job_datas is None
 
-        repo = ExternalRepository(
+        repo = RemoteRepository(
             external_repository_data,
             RepositoryHandle.from_location(repository_name="bar_repo", code_location=code_location),
             instance=instance,

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_schedule_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_schedule_commands.py
@@ -14,7 +14,7 @@ from dagster._cli.schedule import (
     schedule_wipe_command,
 )
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation import ExternalRepository
+from dagster._core.remote_representation import RemoteRepository
 from dagster._core.test_utils import environ
 
 from dagster_tests.cli_tests.command_tests.test_cli_commands import (
@@ -190,7 +190,7 @@ def test_schedules_logs(gen_schedule_args):
 
 
 def test_check_repo_and_scheduler_no_external_schedules():
-    repository = mock.MagicMock(spec=ExternalRepository)
+    repository = mock.MagicMock(spec=RemoteRepository)
     repository.get_external_schedules.return_value = []
     instance = mock.MagicMock(spec=DagsterInstance)
     with pytest.raises(click.UsageError, match="There are no schedules defined for repository"):
@@ -199,7 +199,7 @@ def test_check_repo_and_scheduler_no_external_schedules():
 
 def test_check_repo_and_scheduler_dagster_home_not_set():
     with environ({"DAGSTER_HOME": ""}):
-        repository = mock.MagicMock(spec=ExternalRepository)
+        repository = mock.MagicMock(spec=RemoteRepository)
         repository.get_external_schedules.return_value = [mock.MagicMock()]
         instance = mock.MagicMock(spec=DagsterInstance)
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_sensor_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_sensor_commands.py
@@ -13,7 +13,7 @@ from dagster._cli.sensor import (
     sensor_stop_command,
 )
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation import ExternalRepository
+from dagster._core.remote_representation import RemoteRepository
 from dagster._core.test_utils import environ
 
 from dagster_tests.cli_tests.command_tests.test_cli_commands import sensor_command_contexts
@@ -88,7 +88,7 @@ def test_sensors_start_all(gen_sensor_args):
 
 
 def test_check_repo_and_sensorr_no_external_sensors():
-    repository = mock.MagicMock(spec=ExternalRepository)
+    repository = mock.MagicMock(spec=RemoteRepository)
     repository.get_external_sensors.return_value = []
     instance = mock.MagicMock(spec=DagsterInstance)
     with pytest.raises(click.UsageError, match="There are no sensors defined for repository"):
@@ -97,7 +97,7 @@ def test_check_repo_and_sensorr_no_external_sensors():
 
 def test_check_repo_and_scheduler_dagster_home_not_set():
     with environ({"DAGSTER_HOME": ""}):
-        repository = mock.MagicMock(spec=ExternalRepository)
+        repository = mock.MagicMock(spec=RemoteRepository)
         repository.get_external_sensors.return_value = [mock.MagicMock()]
         instance = mock.MagicMock(spec=DagsterInstance)
 

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -31,7 +31,7 @@ from dagster._core.definitions.reconstruct import get_ephemeral_repository_name
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.input import InputContext
 from dagster._core.execution.context.output import OutputContext
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.remote_representation.external_data import RepositorySnap
 from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.storage.io_manager import dagster_maintained_io_manager
@@ -218,7 +218,7 @@ def test_get_stats_from_external_repo_partitions(instance):
     @asset
     def asset3(): ...
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(Definitions(assets=[asset1, asset2, asset3]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
@@ -238,7 +238,7 @@ def test_get_stats_from_external_repo_multi_partitions(instance):
     )
     def multi_partitioned_asset(): ...
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(Definitions(assets=[multi_partitioned_asset]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
@@ -254,7 +254,7 @@ def test_get_stats_from_external_repo_source_assets(instance):
     @asset
     def asset1(): ...
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(Definitions(assets=[source_asset1, asset1]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
@@ -272,7 +272,7 @@ def test_get_stats_from_external_repo_observable_source_assets(instance):
     @asset
     def asset1(): ...
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(
             Definitions(assets=[source_asset1, source_asset2, asset1]).get_repository_def()
         ),
@@ -291,7 +291,7 @@ def test_get_stats_from_external_repo_freshness_policies(instance):
     @asset
     def asset2(): ...
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(Definitions(assets=[asset1, asset2]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
@@ -312,7 +312,7 @@ def test_get_status_from_external_repo_auto_materialize_policy(instance):
     @asset(auto_materialize_policy=AutoMaterializePolicy.eager())
     def asset3(): ...
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(Definitions(assets=[asset1, asset2, asset3]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
@@ -329,7 +329,7 @@ def test_get_stats_from_external_repo_code_versions(instance):
     @asset
     def asset2(): ...
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(Definitions(assets=[asset1, asset2]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
@@ -351,7 +351,7 @@ def test_get_stats_from_external_repo_code_checks(instance):
     @asset
     def my_other_asset(): ...
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(
             Definitions(
                 assets=[my_asset, my_other_asset], asset_checks=[my_check, my_check_2]
@@ -372,7 +372,7 @@ def test_get_stats_from_external_repo_dbt(instance):
     @asset
     def asset2(): ...
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(Definitions(assets=[asset1, asset2]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
@@ -395,7 +395,7 @@ def test_get_stats_from_external_repo_resources(instance):
     @asset
     def asset1(my_resource: MyResource, custom_resource: CustomResource): ...
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(
             Definitions(
                 assets=[asset1],
@@ -441,7 +441,7 @@ def test_get_stats_from_external_repo_io_managers(instance):
     @asset
     def asset1(): ...
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(
             Definitions(
                 assets=[asset1],
@@ -474,7 +474,7 @@ def test_get_stats_from_external_repo_functional_resources(instance):
     @asset(required_resource_keys={"my_resource", "custom_resource"})
     def asset1(): ...
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(
             Definitions(
                 assets=[asset1],
@@ -507,7 +507,7 @@ def test_get_stats_from_external_repo_functional_io_managers(instance):
     @asset
     def asset1(): ...
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(
             Definitions(
                 assets=[asset1],
@@ -528,7 +528,7 @@ def test_get_stats_from_external_repo_functional_io_managers(instance):
 
 
 def test_get_stats_from_external_repo_pipes_client(instance):
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(
             Definitions(
                 resources={
@@ -583,7 +583,7 @@ def test_get_stats_from_external_repo_delayed_resource_configuration(instance):
     @asset(required_resource_keys={"my_other_resource"})
     def asset2(): ...
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(
             Definitions(
                 assets=[asset1, asset2],

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_job_load.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_job_load.py
@@ -3,7 +3,7 @@ import pytest
 from click.testing import CliRunner
 from dagster._cli.workspace.cli_target import get_external_job_from_kwargs, job_target_argument
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation import ExternalJob
+from dagster._core.remote_representation import RemoteJob
 from dagster._core.test_utils import instance_for_test
 from dagster._utils import file_relative_path
 
@@ -28,7 +28,7 @@ def load_pipeline_via_cli_runner(cli_args):
 def successfully_load_pipeline_via_cli(cli_args):
     result, external_job = load_pipeline_via_cli_runner(cli_args)
     assert result.exit_code == 0, result
-    assert isinstance(external_job, ExternalJob)
+    assert isinstance(external_job, RemoteJob)
     return external_job
 
 
@@ -62,7 +62,7 @@ def get_all_loading_combos():
 @pytest.mark.parametrize("cli_args", get_all_loading_combos())
 def test_valid_loading_combos_single_job_code_location(cli_args):
     external_job = successfully_load_pipeline_via_cli(cli_args)
-    assert isinstance(external_job, ExternalJob)
+    assert isinstance(external_job, RemoteJob)
     assert external_job.name == "hello_world_job"
 
 

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_repository_load.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/test_repository_load.py
@@ -7,7 +7,7 @@ from dagster._cli.workspace.cli_target import (
     repository_target_argument,
 )
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation import ExternalRepository
+from dagster._core.remote_representation import RemoteRepository
 from dagster._core.test_utils import instance_for_test
 from dagster._core.workspace.context import WorkspaceRequestContext
 from dagster._utils import file_relative_path
@@ -54,7 +54,7 @@ def load_workspace_via_cli_runner(cli_args, workspace_assert_fn=None):
 
 def successfully_load_repository_via_cli(cli_args, repo_assert_fn=None):
     def wrapped_repo_assert(external_repo):
-        assert isinstance(external_repo, ExternalRepository)
+        assert isinstance(external_repo, RemoteRepository)
         if repo_assert_fn:
             repo_assert_fn(external_repo)
 
@@ -303,7 +303,7 @@ def test_dagster_definitions():
 
     executed = {}
 
-    def the_assert(external_repo: ExternalRepository):
+    def the_assert(external_repo: RemoteRepository):
         assert external_repo.name == "__repository__"
         assert len(external_repo.get_asset_node_snaps()) == 1
         executed["yes"] = True

--- a/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_default_run_coordinator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_default_run_coordinator.py
@@ -2,7 +2,7 @@ from typing import Iterator
 
 import pytest
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.external import ExternalJob
+from dagster._core.remote_representation.external import RemoteJob
 from dagster._core.run_coordinator import SubmitRunContext
 from dagster._core.run_coordinator.base import RunCoordinator
 from dagster._core.run_coordinator.default_run_coordinator import DefaultRunCoordinator
@@ -30,7 +30,7 @@ def coodinator(instance: DagsterInstance) -> Iterator[RunCoordinator]:
 
 
 def _create_run(
-    instance: DagsterInstance, external_pipeline: ExternalJob, **kwargs: object
+    instance: DagsterInstance, external_pipeline: RemoteJob, **kwargs: object
 ) -> DagsterRun:
     job_args = merge_dicts(
         {

--- a/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_queued_run_coordinator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_queued_run_coordinator.py
@@ -4,7 +4,7 @@ import pytest
 from dagster._core.errors import DagsterInvalidConfigError
 from dagster._core.events import DagsterEventType
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.external import ExternalJob
+from dagster._core.remote_representation.external import RemoteJob
 from dagster._core.run_coordinator import SubmitRunContext
 from dagster._core.run_coordinator.queued_run_coordinator import QueuedRunCoordinator
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
@@ -52,12 +52,12 @@ class TestQueuedRunCoordinator:
             yield workspace
 
     @pytest.fixture(name="external_pipeline")
-    def external_job_fixture(self, workspace: WorkspaceRequestContext) -> ExternalJob:
+    def external_job_fixture(self, workspace: WorkspaceRequestContext) -> RemoteJob:
         location = workspace.get_code_location("bar_code_location")
         return location.get_repository("bar_repo").get_full_external_job("foo")
 
     def create_run_for_test(
-        self, instance: DagsterInstance, external_pipeline: ExternalJob, **kwargs: object
+        self, instance: DagsterInstance, external_pipeline: RemoteJob, **kwargs: object
     ) -> DagsterRun:
         job_args = merge_dicts(
             {

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
@@ -13,7 +13,7 @@ from dagster._core.test_utils import instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 
 if TYPE_CHECKING:
-    from dagster._core.remote_representation.external import ExternalJob
+    from dagster._core.remote_representation.external import RemoteJob
 
 
 @pytest.fixture
@@ -83,7 +83,7 @@ def test_print_root(
     instance,
 ) -> None:
     external_repository = _external_repository_for_function(instance, trivial_job_defs)
-    external_a_job: ExternalJob = external_repository.get_full_external_job("a_job")
+    external_a_job: RemoteJob = external_repository.get_full_external_job("a_job")
     root_config_key = external_a_job.root_config_key
     assert root_config_key
     root_type = external_a_job.config_schema_snapshot.get_config_snap(root_config_key)
@@ -114,7 +114,7 @@ def test_print_root_op_config(
     instance,
 ) -> None:
     external_repository = _external_repository_for_function(instance, job_def_with_config)
-    external_a_job: ExternalJob = external_repository.get_full_external_job("a_job")
+    external_a_job: RemoteJob = external_repository.get_full_external_job("a_job")
     root_config_key = external_a_job.root_config_key
     assert root_config_key
     root_type = external_a_job.config_schema_snapshot.get_config_snap(root_config_key)
@@ -149,7 +149,7 @@ def job_def_with_complex_config():
 
 def test_print_root_complex_op_config(instance) -> None:
     external_repository = _external_repository_for_function(instance, job_def_with_complex_config)
-    external_a_job: ExternalJob = external_repository.get_full_external_job("a_job")
+    external_a_job: RemoteJob = external_repository.get_full_external_job("a_job")
     root_config_key = external_a_job.root_config_key
     assert root_config_key
     root_type = external_a_job.config_schema_snapshot.get_config_snap(root_config_key)

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
@@ -4,7 +4,7 @@ from typing import Iterator, Optional
 
 import pytest
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.test_utils import (
     SingleThreadPoolExecutor,
     create_test_daemon_workspace_context,
@@ -70,7 +70,7 @@ def workspace_fixture(instance_module_scoped: DagsterInstance) -> Iterator[Works
 
 
 @pytest.fixture(name="external_repo", scope="module")
-def external_repo_fixture(workspace_context: WorkspaceProcessContext) -> ExternalRepository:
+def external_repo_fixture(workspace_context: WorkspaceProcessContext) -> RemoteRepository:
     return load_external_repo(workspace_context, "the_repo")
 
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -17,7 +17,7 @@ from dagster._core.events import DagsterEvent, DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._core.instance import DagsterInstance
 from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR
-from dagster._core.remote_representation import CodeLocation, ExternalRepository
+from dagster._core.remote_representation import CodeLocation, RemoteRepository
 from dagster._core.scheduler.instigation import SensorInstigatorData, TickStatus
 from dagster._core.test_utils import (
     create_test_daemon_workspace_context,
@@ -79,10 +79,10 @@ def instance_with_sensors(overrides=None, attribute="the_repo"):
 class CodeLocationInfoForSensorTest(NamedTuple):
     instance: DagsterInstance
     context: WorkspaceProcessContext
-    repositories: Dict[str, ExternalRepository]
+    repositories: Dict[str, RemoteRepository]
     code_location: CodeLocation
 
-    def get_single_repository(self) -> ExternalRepository:
+    def get_single_repository(self) -> RemoteRepository:
         assert len(self.repositories) == 1
         return next(iter(self.repositories.values()))
 
@@ -91,7 +91,7 @@ class CodeLocationInfoForSensorTest(NamedTuple):
 def instance_with_single_code_location_multiple_repos_with_sensors(
     overrides: Optional[Mapping[str, Any]] = None,
     workspace_load_target: Optional[WorkspaceLoadTarget] = None,
-) -> Iterator[Tuple[DagsterInstance, WorkspaceProcessContext, Dict[str, ExternalRepository]]]:
+) -> Iterator[Tuple[DagsterInstance, WorkspaceProcessContext, Dict[str, RemoteRepository]]]:
     with instance_with_multiple_code_locations(overrides, workspace_load_target) as many_tuples:
         assert len(many_tuples) == 1
         location_info = next(iter(many_tuples.values()))
@@ -131,7 +131,7 @@ def test_run_status_sensor(
     executor: Optional[ThreadPoolExecutor],
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
@@ -253,7 +253,7 @@ def test_run_failure_sensor(
     executor: Optional[ThreadPoolExecutor],
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
@@ -309,7 +309,7 @@ def test_run_failure_sensor_that_fails(
     executor: Optional[ThreadPoolExecutor],
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
@@ -385,7 +385,7 @@ def test_run_failure_sensor_filtered(
     executor: Optional[ThreadPoolExecutor],
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
@@ -472,7 +472,7 @@ def test_run_failure_sensor_filtered(
 def test_run_failure_sensor_overfetch(
     executor: Optional[ThreadPoolExecutor],
     instance: DagsterInstance,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     with environ(
         {
@@ -1517,7 +1517,7 @@ def test_partitioned_job_run_status_sensor(
     executor: Optional[ThreadPoolExecutor],
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
@@ -1704,7 +1704,7 @@ def test_logging_run_status_sensor(
     executor: Optional[ThreadPoolExecutor],
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -67,11 +67,11 @@ from dagster._core.definitions.sensor_definition import (
 from dagster._core.events import DagsterEventType
 from dagster._core.log_manager import LOG_RECORD_METADATA_ATTR
 from dagster._core.remote_representation import (
-    ExternalSensor,
     RemoteInstigatorOrigin,
     RemoteRepositoryOrigin,
+    RemoteSensor,
 )
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.remote_representation.origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.scheduler.instigation import (
     DynamicPartitionsRequestResult,
@@ -1221,7 +1221,7 @@ def test_simple_sensor(instance, workspace_context, external_repo, executor):
 def test_sensors_keyed_on_selector_not_origin(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
     executor: ThreadPoolExecutor,
 ):
     freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
@@ -1267,7 +1267,7 @@ def test_bad_load_sensor_repository(
     executor: ThreadPoolExecutor,
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
 
@@ -2729,7 +2729,7 @@ def test_status_in_code_sensor(executor, instance):
             assert reset_instigator_state
             assert reset_instigator_state.status == InstigatorStatus.DECLARED_IN_CODE
 
-            running_to_not_running_sensor = ExternalSensor(
+            running_to_not_running_sensor = RemoteSensor(
                 external_sensor_data=copy(
                     running_sensor._external_sensor_data,  # noqa: SLF001
                     default_status=DefaultSensorStatus.STOPPED,
@@ -3032,7 +3032,7 @@ def test_sensor_logging_on_tick_failure(
     executor: ThreadPoolExecutor,
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ) -> None:
     external_sensor = external_repo.get_external_sensor("logging_fail_tick_sensor")
     instance.add_instigator_state(
@@ -3461,7 +3461,7 @@ def test_sensor_run_tags(
     executor: ThreadPoolExecutor,
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ) -> None:
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):

--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -6,8 +6,8 @@ import pytest
 from dagster import DagsterInstance
 from dagster._core.remote_representation import (
     CodeLocation,
-    ExternalRepository,
     InProcessCodeLocationOrigin,
+    RemoteRepository,
 )
 from dagster._core.remote_representation.origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.test_utils import (
@@ -59,7 +59,7 @@ def workspace_fixture(instance_module_scoped) -> Iterator[WorkspaceProcessContex
 @pytest.fixture(name="external_repo", scope="module")
 def external_repo_fixture(
     workspace_context: WorkspaceProcessContext,
-) -> Iterator[ExternalRepository]:
+) -> Iterator[RemoteRepository]:
     yield cast(
         CodeLocation,
         next(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -52,8 +52,8 @@ from dagster._core.execution.asset_backfill import (
 )
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.remote_representation import (
-    ExternalRepository,
     InProcessCodeLocationOrigin,
+    RemoteRepository,
     RemoteRepositoryOrigin,
 )
 from dagster._core.storage.compute_log_manager import ComputeIOType
@@ -505,7 +505,7 @@ def wait_for_all_runs_to_finish(instance, timeout=10):
 def test_simple_backfill(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     external_partition_set = external_repo.get_external_partition_set("the_job_partition_set")
     instance.add_backfill(
@@ -538,7 +538,7 @@ def test_simple_backfill(
 def test_canceled_backfill(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     external_partition_set = external_repo.get_external_partition_set("the_job_partition_set")
     instance.add_backfill(
@@ -573,7 +573,7 @@ def test_canceled_backfill(
 def test_failure_backfill(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     output_file = _failure_flag_file()
     external_partition_set = external_repo.get_external_partition_set(
@@ -677,7 +677,7 @@ def test_failure_backfill(
 def test_job_backfill_status(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     external_partition_set = external_repo.get_external_partition_set("the_job_partition_set")
     instance.add_backfill(
@@ -735,7 +735,7 @@ def test_job_backfill_status(
 def test_partial_backfill(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     external_partition_set = external_repo.get_external_partition_set("partial_job_partition_set")
 
@@ -827,7 +827,7 @@ def test_partial_backfill(
 def test_large_backfill(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     external_partition_set = external_repo.get_external_partition_set("config_job_partition_set")
     instance.add_backfill(
@@ -1063,7 +1063,7 @@ def test_unloadable_backfill_retry(
 def test_backfill_from_partitioned_job(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     partition_keys = my_config.partitions_def.get_partition_keys()
     external_partition_set = external_repo.get_external_partition_set(
@@ -1095,7 +1095,7 @@ def test_backfill_from_partitioned_job(
 def test_backfill_with_asset_selection(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     partition_keys = static_partitions.get_partition_keys()
     asset_selection = [AssetKey("foo"), AssetKey("a1"), AssetKey("bar")]
@@ -1137,7 +1137,7 @@ def test_backfill_with_asset_selection(
 def test_pure_asset_backfill_with_multiple_assets_selected(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     asset_selection = [
         AssetKey("asset_a"),
@@ -1207,7 +1207,7 @@ def test_pure_asset_backfill_with_multiple_assets_selected(
 def test_pure_asset_backfill(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     del external_repo
 
@@ -1256,7 +1256,7 @@ def test_pure_asset_backfill(
 def test_backfill_from_failure_for_subselection(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     parallel_failure_job.execute_in_process(
         partition_key="one",
@@ -1954,7 +1954,7 @@ def test_fail_backfill_when_runs_completed_but_partitions_marked_as_in_progress(
 
 
 # Job must have a partitions definition with a-b-c-d partitions
-def _get_abcd_job_backfill(external_repo: ExternalRepository, job_name: str) -> PartitionBackfill:
+def _get_abcd_job_backfill(external_repo: RemoteRepository, job_name: str) -> PartitionBackfill:
     external_partition_set = external_repo.get_external_partition_set(f"{job_name}_partition_set")
     return PartitionBackfill(
         backfill_id="simple",
@@ -1971,7 +1971,7 @@ def _get_abcd_job_backfill(external_repo: ExternalRepository, job_name: str) -> 
 def test_asset_job_backfill_single_run(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     backfill = _get_abcd_job_backfill(external_repo, "bp_single_run_asset_job")
     assert instance.get_runs_count() == 0
@@ -1989,7 +1989,7 @@ def test_asset_job_backfill_single_run(
 def test_asset_job_backfill_single_run_multiple_iterations(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     """Tests that job backfills correctly find existing runs for partitions in the backfill and don't
     relaunch those partitions. This is a regression test for a bug where the backfill would relaunch
@@ -2050,7 +2050,7 @@ def test_asset_job_backfill_single_run_multiple_iterations(
 def test_asset_job_backfill_multi_run(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     backfill = _get_abcd_job_backfill(external_repo, "bp_multi_run_asset_job")
     assert instance.get_runs_count() == 0
@@ -2072,7 +2072,7 @@ def test_asset_job_backfill_multi_run(
 def test_asset_job_backfill_default(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     backfill = _get_abcd_job_backfill(external_repo, "bp_none_asset_job")
     assert instance.get_runs_count() == 0
@@ -2520,7 +2520,7 @@ def test_asset_backfill_logging(caplog, instance, workspace_context):
 def test_backfill_with_title_and_description(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     asset_selection = [
         AssetKey("asset_a"),
@@ -2586,7 +2586,7 @@ def test_backfill_with_title_and_description(
 def test_old_dynamic_partitions_job_backfill(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     backfill = _get_abcd_job_backfill(external_repo, "old_dynamic_partitions_job")
     assert instance.get_runs_count() == 0
@@ -2599,7 +2599,7 @@ def test_old_dynamic_partitions_job_backfill(
 def test_asset_backfill_logs(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     # need to override this method on the instance since it defaults ot False in OSS. When we enable this
     # feature in OSS we can remove this override
@@ -2681,7 +2681,7 @@ def test_asset_backfill_logs(
 def test_asset_backfill_from_asset_graph_subset(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     del external_repo
 
@@ -2734,7 +2734,7 @@ def test_asset_backfill_from_asset_graph_subset(
 def test_asset_backfill_from_asset_graph_subset_with_static_and_time_partitions(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     del external_repo
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
@@ -5,7 +5,7 @@ from signal import Signals
 import pytest
 from dagster import DagsterInstance
 from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
-from dagster._core.remote_representation import ExternalRepository
+from dagster._core.remote_representation import RemoteRepository
 from dagster._core.test_utils import (
     cleanup_test_instance,
     create_test_daemon_workspace_context,
@@ -47,7 +47,7 @@ def _test_backfill_in_subprocess(instance_ref, debug_crash_flags):
 @pytest.mark.skipif(
     IS_WINDOWS, reason="Windows keeps resources open after termination in a flaky way"
 )
-def test_simple(instance: DagsterInstance, external_repo: ExternalRepository):
+def test_simple(instance: DagsterInstance, external_repo: RemoteRepository):
     external_partition_set = external_repo.get_external_partition_set("the_job_partition_set")
     instance.add_backfill(
         PartitionBackfill(
@@ -77,7 +77,7 @@ def test_simple(instance: DagsterInstance, external_repo: ExternalRepository):
 )
 @pytest.mark.parametrize("crash_signal", get_crash_signals())
 def test_before_submit(
-    crash_signal: Signals, instance: DagsterInstance, external_repo: ExternalRepository
+    crash_signal: Signals, instance: DagsterInstance, external_repo: RemoteRepository
 ):
     external_partition_set = external_repo.get_external_partition_set("the_job_partition_set")
     instance.add_backfill(
@@ -124,7 +124,7 @@ def test_before_submit(
 )
 @pytest.mark.parametrize("crash_signal", get_crash_signals())
 def test_crash_after_submit(
-    crash_signal: Signals, instance: DagsterInstance, external_repo: ExternalRepository
+    crash_signal: Signals, instance: DagsterInstance, external_repo: RemoteRepository
 ):
     external_partition_set = external_repo.get_external_partition_set("the_job_partition_set")
     instance.add_backfill(

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -13,7 +13,7 @@ from dagster._core.definitions.automation_condition_sensor_definition import (
     AutomationConditionSensorDefinition,
 )
 from dagster._core.definitions.sensor_definition import SensorType
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.remote_representation.external_data import RepositorySnap
 from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.test_utils import instance_for_test
@@ -93,7 +93,7 @@ def test_default_auto_materialize_sensors(instance_with_auto_materialize_sensors
         location_name="foo_location",
         repository_name="bar_repo",
     )
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(
             defs.get_repository_def(),
         ),
@@ -130,7 +130,7 @@ def test_default_auto_materialize_sensors_without_observable(
         repository_name="bar_repo",
     )
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(
             defs_without_observables.get_repository_def(),
         ),
@@ -157,7 +157,7 @@ def test_no_default_auto_materialize_sensors(instance_without_auto_materialize_s
     )
 
     # If not opted in, no default sensors are created
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(
             defs.get_repository_def(),
         ),
@@ -191,7 +191,7 @@ def test_combine_default_sensors_with_non_default_sensors(instance_with_auto_mat
         repository_name="bar_repo",
     )
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(
             defs_with_auto_materialize_sensor.get_repository_def(),
         ),
@@ -261,7 +261,7 @@ def test_custom_sensors_cover_all(instance_with_auto_materialize_sensors):
         repository_name="bar_repo",
     )
 
-    external_repo = ExternalRepository(
+    external_repo = RemoteRepository(
         RepositorySnap.from_def(
             defs_with_auto_materialize_sensor.get_repository_def(),
         ),

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -13,7 +13,7 @@ from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.sensor_definition import SensorType
 from dagster._core.execution.backfill import PartitionBackfill
-from dagster._core.remote_representation.external import ExternalSensor
+from dagster._core.remote_representation.external import RemoteSensor
 from dagster._core.remote_representation.origin import InProcessCodeLocationOrigin
 from dagster._core.scheduler.instigation import InstigatorState, SensorInstigatorData
 from dagster._core.storage.dagster_run import DagsterRun
@@ -50,7 +50,7 @@ def get_code_location_origin(filename: str) -> InProcessCodeLocationOrigin:
     )
 
 
-def _get_all_sensors(context: WorkspaceRequestContext) -> Sequence[ExternalSensor]:
+def _get_all_sensors(context: WorkspaceRequestContext) -> Sequence[RemoteSensor]:
     external_sensors = []
     for cl_name in context.get_code_location_entries():
         external_sensors.extend(
@@ -61,7 +61,7 @@ def _get_all_sensors(context: WorkspaceRequestContext) -> Sequence[ExternalSenso
     return external_sensors
 
 
-def _get_automation_sensors(context: WorkspaceRequestContext) -> Sequence[ExternalSensor]:
+def _get_automation_sensors(context: WorkspaceRequestContext) -> Sequence[RemoteSensor]:
     return [
         sensor
         for sensor in _get_all_sensors(context)

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_change_snapshot_structure.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_change_snapshot_structure.py
@@ -1,5 +1,5 @@
 from dagster._core.instance import DagsterInstance, InstanceRef
-from dagster._core.remote_representation import ExternalExecutionPlan
+from dagster._core.remote_representation import RemoteExecutionPlan
 from dagster._core.snap import create_execution_plan_snapshot_id, create_job_snapshot_id
 from dagster._utils import file_relative_path
 from dagster._utils.test import copy_directory
@@ -33,7 +33,7 @@ def test_run_created_in_0_7_9_snapshot_id_change():
         assert create_execution_plan_snapshot_id(ep_snapshot) != old_execution_plan_snapshot_id
 
         # This previously failed with a check error
-        assert ExternalExecutionPlan(ep_snapshot)
+        assert RemoteExecutionPlan(ep_snapshot)
 
 
 # Scripts to create this (run against 0.7.9)

--- a/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
@@ -4,7 +4,7 @@ from typing import Iterator, Optional
 
 import pytest
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.test_utils import (
     SingleThreadPoolExecutor,
     create_test_daemon_workspace_context,
@@ -72,7 +72,7 @@ def workspace_fixture(
 
 
 @pytest.fixture(name="external_repo", scope="session")
-def external_repo_fixture(workspace_context: WorkspaceProcessContext) -> ExternalRepository:
+def external_repo_fixture(workspace_context: WorkspaceProcessContext) -> RemoteRepository:
     return next(
         iter(workspace_context.create_request_context().get_code_location_entries().values())
     ).code_location.get_repository(  # type: ignore  # (possible none)

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
@@ -6,7 +6,7 @@ from signal import Signals
 import pytest
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance.ref import InstanceRef
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.scheduler.instigation import TickStatus
 from dagster._core.storage.dagster_run import DagsterRunStatus
 from dagster._core.storage.tags import SCHEDULED_EXECUTION_TIME_TAG
@@ -78,7 +78,7 @@ def _test_launch_scheduled_runs_in_subprocess(
 @pytest.mark.parametrize("executor", get_schedule_executor_names())
 def test_failure_recovery_before_run_created(
     instance: DagsterInstance,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
     crash_location: str,
     crash_signal: Signals,
     executor: ThreadPoolExecutor,
@@ -151,7 +151,7 @@ def test_failure_recovery_before_run_created(
 @pytest.mark.parametrize("executor", get_schedule_executor_names())
 def test_failure_recovery_after_run_created(
     instance: DagsterInstance,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
     crash_location: str,
     crash_signal: Signals,
     executor: ThreadPoolExecutor,
@@ -240,7 +240,7 @@ def test_failure_recovery_after_run_created(
 @pytest.mark.parametrize("executor", get_schedule_executor_names())
 def test_failure_recovery_after_tick_success(
     instance: DagsterInstance,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
     crash_location: str,
     crash_signal: Signals,
     executor: ThreadPoolExecutor,
@@ -323,7 +323,7 @@ def test_failure_recovery_after_tick_success(
 @pytest.mark.parametrize("executor", get_schedule_executor_names())
 def test_failure_recovery_between_multi_runs(
     instance: DagsterInstance,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
     crash_location: str,
     crash_signal: Signals,
     executor: ThreadPoolExecutor,

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -36,7 +36,7 @@ from dagster._core.remote_representation import (
     RemoteInstigatorOrigin,
     RemoteRepositoryOrigin,
 )
-from dagster._core.remote_representation.external import ExternalRepository, ExternalSchedule
+from dagster._core.remote_representation.external import RemoteRepository, RemoteSchedule
 from dagster._core.remote_representation.origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.scheduler.instigation import (
     InstigatorState,
@@ -641,7 +641,7 @@ def logger():
 
 def validate_tick(
     tick: InstigatorTick,
-    external_schedule: ExternalSchedule,
+    external_schedule: RemoteSchedule,
     expected_datetime: datetime.datetime,
     expected_status: TickStatus,
     expected_run_ids: Sequence[str],
@@ -888,7 +888,7 @@ def test_status_in_code_schedule(instance: DagsterInstance, executor: ThreadPool
             assert reset_instigator_state
             assert reset_instigator_state.status == InstigatorStatus.DECLARED_IN_CODE
 
-            running_to_not_running_schedule = ExternalSchedule(
+            running_to_not_running_schedule = RemoteSchedule(
                 external_schedule_data=copy(
                     running_schedule._external_schedule_data,  # noqa: SLF001
                     default_status=DefaultScheduleStatus.STOPPED,
@@ -1155,7 +1155,7 @@ def test_repository_namespacing(instance: DagsterInstance, executor):
 def test_stale_request_context(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
 ):
     freeze_datetime = feb_27_2019_start_of_day()
     with freeze_time(freeze_datetime):
@@ -1207,7 +1207,7 @@ def test_stale_request_context(
 @pytest.mark.parametrize("executor", get_schedule_executors())
 def test_launch_failure(
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
     executor: ThreadPoolExecutor,
 ):
     with instance_for_test(
@@ -1323,7 +1323,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
@@ -1491,7 +1491,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("simple_schedule")
@@ -1538,7 +1538,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
@@ -1575,7 +1575,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("simple_schedule")
@@ -1648,7 +1648,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("wrong_config_schedule")
@@ -1719,7 +1719,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("wrong_config_schedule")
@@ -1815,7 +1815,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         # We need to use different keys across sync and async executors, as the dictionary is persisted across processes.
@@ -1923,7 +1923,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("bad_should_execute_schedule")
@@ -1963,7 +1963,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("skip_schedule")
@@ -1993,7 +1993,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("wrong_config_schedule")
@@ -2025,7 +2025,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("default_config_schedule")
@@ -2068,7 +2068,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule(
@@ -2095,7 +2095,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         good_schedule = external_repo.get_external_schedule("simple_schedule")
@@ -2216,7 +2216,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("simple_schedule")
@@ -2241,7 +2241,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
@@ -2283,7 +2283,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
@@ -2322,7 +2322,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = create_datetime(
@@ -2370,7 +2370,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         external_schedule = external_repo.get_external_schedule("simple_schedule")
@@ -2422,7 +2422,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         # This is a Wednesday.
@@ -2538,7 +2538,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
@@ -2616,7 +2616,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
@@ -2694,7 +2694,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_start_of_day()
@@ -2728,7 +2728,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
@@ -2753,7 +2753,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_start_of_day()
@@ -2786,7 +2786,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
         submit_executor: Optional[ThreadPoolExecutor],
     ):
@@ -2825,7 +2825,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
@@ -2876,7 +2876,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
@@ -2904,7 +2904,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
@@ -2930,7 +2930,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
@@ -3007,7 +3007,7 @@ class TestSchedulerRun:
         self,
         scheduler_instance: DagsterInstance,
         workspace_context: WorkspaceProcessContext,
-        external_repo: ExternalRepository,
+        external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ) -> None:
         freeze_datetime = feb_27_2019_one_second_to_midnight()

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
@@ -3,7 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.external import RemoteRepository
 from dagster._core.scheduler.instigation import TickStatus
 from dagster._core.test_utils import freeze_time
 from dagster._core.workspace.context import WorkspaceProcessContext
@@ -23,7 +23,7 @@ from dagster_tests.scheduler_tests.test_scheduler_run import (
 def test_non_utc_timezone_run(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
     executor: ThreadPoolExecutor,
 ):
     # Verify that schedule runs at the expected time in a non-UTC timezone
@@ -87,7 +87,7 @@ def test_non_utc_timezone_run(
 def test_differing_timezones(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
     executor: ThreadPoolExecutor,
 ):
     # Two schedules, one using US/Central, the other on US/Eastern
@@ -201,7 +201,7 @@ def test_differing_timezones(
 def test_different_days_in_different_timezones(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
     executor: ThreadPoolExecutor,
 ):
     freeze_datetime = datetime.datetime(
@@ -261,7 +261,7 @@ def test_different_days_in_different_timezones(
 def test_hourly_dst_spring_forward(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
     executor: ThreadPoolExecutor,
 ):
     # Verify that an hourly schedule still runs hourly during the spring DST transition
@@ -334,7 +334,7 @@ def test_hourly_dst_spring_forward(
 def test_hourly_dst_fall_back(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
     executor: ThreadPoolExecutor,
 ):
     # Verify that an hourly schedule still runs hourly during the fall DST transition
@@ -416,7 +416,7 @@ def test_hourly_dst_fall_back(
 def test_daily_dst_spring_forward(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
     executor: ThreadPoolExecutor,
 ):
     # Verify that a daily schedule still runs once per day during the spring DST transition
@@ -483,7 +483,7 @@ def test_daily_dst_spring_forward(
 def test_daily_dst_fall_back(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
     executor: ThreadPoolExecutor,
 ):
     # Verify that a daily schedule still runs once per day during the fall DST transition
@@ -550,7 +550,7 @@ def test_daily_dst_fall_back(
 def test_execute_during_dst_transition_spring_forward(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
     executor: ThreadPoolExecutor,
 ):
     # Verify that a daily schedule that is supposed to execute at a time that is skipped
@@ -631,7 +631,7 @@ def test_execute_during_dst_transition_spring_forward(
 def test_execute_during_dst_transition_fall_back(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: ExternalRepository,
+    external_repo: RemoteRepository,
     executor: ThreadPoolExecutor,
 ):
     # A schedule that runs daily during a time that occurs twice during a fall DST transition

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -8,7 +8,7 @@ import moto
 import pytest
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.instance import DagsterInstance
-from dagster._core.remote_representation.external import ExternalJob
+from dagster._core.remote_representation.external import RemoteJob
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._core.test_utils import in_process_test_workspace, instance_for_test
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
@@ -267,19 +267,19 @@ def job() -> JobDefinition:
 
 
 @pytest.fixture
-def external_job(workspace: WorkspaceRequestContext) -> ExternalJob:
+def external_job(workspace: WorkspaceRequestContext) -> RemoteJob:
     location = workspace.get_code_location(workspace.code_location_names[0])
     return location.get_repository(repo.repository.name).get_full_external_job(repo.job.name)
 
 
 @pytest.fixture
-def other_external_job(other_workspace: WorkspaceRequestContext) -> ExternalJob:
+def other_external_job(other_workspace: WorkspaceRequestContext) -> RemoteJob:
     location = other_workspace.get_code_location(other_workspace.code_location_names[0])
     return location.get_repository(repo.repository.name).get_full_external_job(repo.job.name)
 
 
 @pytest.fixture
-def run(instance: DagsterInstance, job: JobDefinition, external_job: ExternalJob) -> DagsterRun:
+def run(instance: DagsterInstance, job: JobDefinition, external_job: RemoteJob) -> DagsterRun:
     return instance.create_run_for_job(
         job,
         external_job_origin=external_job.get_remote_origin(),
@@ -289,7 +289,7 @@ def run(instance: DagsterInstance, job: JobDefinition, external_job: ExternalJob
 
 @pytest.fixture
 def other_run(
-    instance: DagsterInstance, job: JobDefinition, other_external_job: ExternalJob
+    instance: DagsterInstance, job: JobDefinition, other_external_job: RemoteJob
 ) -> DagsterRun:
     return instance.create_run_for_job(
         job,
@@ -300,7 +300,7 @@ def other_run(
 
 @pytest.fixture
 def launch_run(
-    workspace: WorkspaceRequestContext, job: JobDefinition, external_job: ExternalJob
+    workspace: WorkspaceRequestContext, job: JobDefinition, external_job: RemoteJob
 ) -> Callable[[DagsterInstance], None]:
     def _launch_run(instance: DagsterInstance) -> None:
         run = instance.create_run_for_job(
@@ -355,7 +355,7 @@ def custom_workspace(
 
 @pytest.fixture
 def custom_run(
-    custom_instance: DagsterInstance, job: JobDefinition, external_job: ExternalJob
+    custom_instance: DagsterInstance, job: JobDefinition, external_job: RemoteJob
 ) -> DagsterRun:
     return custom_instance.create_run_for_job(
         job,
@@ -558,7 +558,7 @@ def other_container_context_config(other_configured_secret):
 @pytest.fixture
 def launch_run_with_container_context(
     job: JobDefinition,
-    external_job: ExternalJob,
+    external_job: RemoteJob,
     workspace: WorkspaceRequestContext,
     container_context_config,
 ):


### PR DESCRIPTION
Internal companion PR: https://github.com/dagster-io/internal/pull/11943

## Summary & Motivation

- `ExternalJob` -> `RemoteJob`
- `ExternalRepository` -> `RemoteRepository`
- `ExternalExecutionPlan` -> `RemoteExecutionPlan`
- `ExternalPartitionSet` -> `RemotePartitionSet`
- `ExternalSensor` -> `RemoteSensor`
- `ExternalSchedule` -> `RemoteSchedule`
- `ExternalResource` -> `RemoteResource`

## How I Tested These Changes

Existing test suite

## Changelog

NOCHANGELOG