### PR TITLE
set mode tag for runs feed entries to 'default' so that it doesn't get displayed in runs feed

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
@@ -101,7 +101,7 @@ export const RunsFeedRow = ({
             style={{gap: '4px 8px', lineHeight: 0}}
           >
             <RunRowTags
-              run={{...entry, mode: ''}}
+              run={{...entry, mode: 'default'}}
               isJob={true}
               isHovered={isHovered}
               onAddTag={onAddTag}


### PR DESCRIPTION
## Summary & Motivation
Planned to include this in https://github.com/dagster-io/dagster/pull/24915 but it got dropped (idk). 

The mode tag is relic from when there were PipelineModes (solid, pipeline days) but some of the UI still thinks they should be around. This sets the mode to 'default' so that the UI doesn't display it as a tag

## How I Tested These Changes
👀 

before - tags has a "view all tags" and the pop up has a mode tag
<img width="527" alt="Screenshot 2024-10-01 at 5 16 47 PM" src="https://github.com/user-attachments/assets/497d84a8-75b5-4a03-8d5b-7032ffae3697">
<img width="527" alt="Screenshot 2024-10-01 at 5 16 39 PM" src="https://github.com/user-attachments/assets/96d08462-81c7-470e-925f-f018dee269e2">


after 
<img width="409" alt="Screenshot 2024-10-01 at 5 14 52 PM" src="https://github.com/user-attachments/assets/8d5e96b2-2b36-41be-bfa3-025e11ba2cda">


## Changelog

NOCHANGELOG
