### PR TITLE
[dagster-airbyte] Add relation identifier metadata to Airbyte assets

### DIFF
--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -127,7 +127,7 @@ def _build_airbyte_asset_defn_metadata(
                     destination_raw_table_names_by_table[table],
                 ]
             )
-            if normalization_tables:
+            if normalization_tables and normalization_raw_table_names_by_table:
                 for normalization_table in normalization_tables.get(table, set()):
                     relation_identifiers[normalization_table] = ".".join(
                         [

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/asset_defs.py
@@ -40,7 +40,7 @@ from dagster._core.definitions.cacheable_assets import (
     CacheableAssetsDefinition,
 )
 from dagster._core.definitions.events import CoercibleToAssetKey, CoercibleToAssetKeyPrefix
-from dagster._core.definitions.metadata import MetadataValue, TableSchemaMetadataValue
+from dagster._core.definitions.metadata.metadata_set import TableMetadataSet
 from dagster._core.definitions.metadata.table import TableSchema
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvalidInvocationError
 from dagster._core.execution.context.init import build_init_resource_context
@@ -62,9 +62,13 @@ def _table_to_output_name_fn(table: str) -> str:
 def _build_airbyte_asset_defn_metadata(
     connection_id: str,
     destination_tables: Sequence[str],
+    destination_raw_table_names_by_table: Mapping[str, str],
+    destination_database: Optional[str],
+    destination_schema: Optional[str],
     table_to_asset_key_fn: Callable[[str], AssetKey],
     asset_key_prefix: Optional[Sequence[str]] = None,
     normalization_tables: Optional[Mapping[str, Set[str]]] = None,
+    normalization_raw_table_names_by_table: Optional[Mapping[str, str]] = None,
     upstream_assets: Optional[Iterable[AssetKey]] = None,
     group_name: Optional[str] = None,
     io_manager_key: Optional[str] = None,
@@ -112,6 +116,30 @@ def _build_airbyte_asset_defn_metadata(
     for table in destination_tables:
         internal_deps[table] = set(upstream_assets or [])
 
+    relation_identifiers: Dict[str, str] = {}
+    for table in destination_tables:
+        if destination_database and destination_schema and table:
+            # Use the destination raw table name to create the relation identifier
+            relation_identifiers[table] = ".".join(
+                [
+                    destination_database,
+                    destination_schema,
+                    destination_raw_table_names_by_table[table],
+                ]
+            )
+            if normalization_tables:
+                for normalization_table in normalization_tables.get(table, set()):
+                    relation_identifiers[normalization_table] = ".".join(
+                        [
+                            destination_database,
+                            destination_schema,
+                            destination_raw_table_names_by_table[table],
+                            normalization_raw_table_names_by_table[normalization_table],
+                        ]
+                    )
+
+    schema_by_table_name = schema_by_table_name if schema_by_table_name else {}
+
     return AssetsDefinitionCacheableData(
         keys_by_input_name=(
             {asset_key.path[-1]: asset_key for asset_key in upstream_assets}
@@ -125,11 +153,14 @@ def _build_airbyte_asset_defn_metadata(
         can_subset=False,
         metadata_by_output_name=(
             {
-                table: {"table_schema": MetadataValue.table_schema(schema_by_table_name[table])}
+                table: {
+                    **TableMetadataSet(
+                        column_schema=schema_by_table_name.get(table),
+                        relation_identifier=relation_identifiers.get(table),
+                    ),
+                }
                 for table in tables
             }
-            if schema_by_table_name
-            else None
         ),
         freshness_policies_by_output_name=(
             {output: freshness_policy for output in outputs} if freshness_policy else None
@@ -167,10 +198,7 @@ def _build_airbyte_assets_from_metadata(
             k: AssetOut(
                 key=v,
                 metadata=(
-                    {
-                        k: cast(TableSchemaMetadataValue, v)
-                        for k, v in assets_defn_meta.metadata_by_output_name.get(k, {}).items()
-                    }
+                    assets_defn_meta.metadata_by_output_name.get(k)
                     if assets_defn_meta.metadata_by_output_name
                     else None
                 ),
@@ -225,6 +253,8 @@ def _build_airbyte_assets_from_metadata(
 def build_airbyte_assets(
     connection_id: str,
     destination_tables: Sequence[str],
+    destination_database: Optional[str] = None,
+    destination_schema: Optional[str] = None,
     asset_key_prefix: Optional[Sequence[str]] = None,
     group_name: Optional[str] = None,
     normalization_tables: Optional[Mapping[str, Set[str]]] = None,
@@ -243,6 +273,8 @@ def build_airbyte_assets(
         destination_tables (List[str]): The names of the tables that you want to be represented
             in the Dagster asset graph for this sync. This will generally map to the name of the
             stream in Airbyte, unless a stream prefix has been specified in Airbyte.
+        destination_database (Optional[str]): The name of the destination database.
+        destination_schema (Optional[str]): The name of the destination schema.
         normalization_tables (Optional[Mapping[str, List[str]]]): If you are using Airbyte's
             normalization feature, you may specify a mapping of destination table to a list of
             derived tables that will be created by the normalization process.
@@ -269,13 +301,36 @@ def build_airbyte_assets(
     tables = chain.from_iterable(
         chain([destination_tables], normalization_tables.values() if normalization_tables else [])
     )
+
+    relation_identifiers: Dict[str, str] = {}
+    for table in destination_tables:
+        if destination_database and destination_schema and table:
+            relation_identifiers[table] = ".".join(
+                [destination_database, destination_schema, table]
+            )
+            if normalization_tables:
+                for normalization_table in normalization_tables.get(table, set()):
+                    relation_identifiers[normalization_table] = ".".join(
+                        [
+                            destination_database,
+                            destination_schema,
+                            table,
+                            normalization_table,
+                        ]
+                    )
+
+    schema_by_table_name = schema_by_table_name if schema_by_table_name else {}
+
     outputs = {
         table: AssetOut(
             key=AssetKey([*asset_key_prefix, table]),
             metadata=(
-                {"table_schema": MetadataValue.table_schema(schema_by_table_name[table])}
-                if schema_by_table_name
-                else None
+                {
+                    **TableMetadataSet(
+                        column_schema=schema_by_table_name.get(table),
+                        relation_identifier=relation_identifiers.get(table),
+                    ),
+                }
             ),
             freshness_policy=freshness_policy,
             auto_materialize_policy=auto_materialize_policy,
@@ -389,7 +444,7 @@ def _get_normalization_tables_for_schema(
 
         if "object" in schema_types and len(sub_schema.get("properties", {})) > 0:
             out[prefix + key] = AirbyteTableMetadata(
-                schema=generate_table_schema(sub_schema.get("properties", {}))
+                raw_table_name=key, schema=generate_table_schema(sub_schema.get("properties", {}))
             )
             for k, v in sub_schema["properties"].items():
                 out = merge_dicts(
@@ -398,7 +453,8 @@ def _get_normalization_tables_for_schema(
         # Array types are also broken into a new table
         elif "array" in schema_types:
             out[prefix + key] = AirbyteTableMetadata(
-                schema=generate_table_schema(sub_schema.get("items", {}).get("properties", {}))
+                raw_table_name=key,
+                schema=generate_table_schema(sub_schema.get("items", {}).get("properties", {})),
             )
             if sub_schema.get("items", {}).get("properties"):
                 for k, v in sub_schema["items"]["properties"].items():
@@ -422,6 +478,7 @@ class AirbyteConnectionMetadata(
             ("stream_prefix", str),
             ("has_basic_normalization", bool),
             ("stream_data", List[Mapping[str, Any]]),
+            ("destination", Mapping[str, Any]),
         ],
     )
 ):
@@ -436,7 +493,10 @@ class AirbyteConnectionMetadata(
 
     @classmethod
     def from_api_json(
-        cls, contents: Mapping[str, Any], operations: Mapping[str, Any]
+        cls,
+        contents: Mapping[str, Any],
+        operations: Mapping[str, Any],
+        destination: Mapping[str, Any],
     ) -> "AirbyteConnectionMetadata":
         return cls(
             name=contents["name"],
@@ -446,10 +506,13 @@ class AirbyteConnectionMetadata(
                 for op in operations.get("operations", [])
             ),
             stream_data=contents.get("syncCatalog", {}).get("streams", []),
+            destination=destination,
         )
 
     @classmethod
-    def from_config(cls, contents: Mapping[str, Any]) -> "AirbyteConnectionMetadata":
+    def from_config(
+        cls, contents: Mapping[str, Any], destination: Mapping[str, Any]
+    ) -> "AirbyteConnectionMetadata":
         config_contents = cast(Mapping[str, Any], contents.get("configuration"))
         check.invariant(
             config_contents is not None, "Airbyte connection config is missing 'configuration' key"
@@ -463,6 +526,7 @@ class AirbyteConnectionMetadata(
                 for op in config_contents.get("operations", [])
             ),
             stream_data=config_contents.get("sync_catalog", {}).get("streams", []),
+            destination=destination,
         )
 
     def parse_stream_tables(
@@ -497,6 +561,7 @@ class AirbyteConnectionMetadata(
                         prefixed_norm_table_name = f"{self.stream_prefix}{normalization_table_name}"
                         normalization_tables[prefixed_norm_table_name] = meta
             tables[prefixed_name] = AirbyteTableMetadata(
+                raw_table_name=name,
                 schema=generate_table_schema(schema_props),
                 normalization_tables=normalization_tables,
             )
@@ -576,14 +641,35 @@ class AirbyteCoreCacheableAssetsDefinition(CacheableAssetsDefinition):
             )
             schema_by_table_name = _get_schema_by_table_name(stream_table_metadata)
 
+            destination_database = connection.destination.get("configuration", {}).get("database")
+            destination_schema = connection.destination.get("configuration", {}).get("schema")
+
             table_to_asset_key = partial(self._connection_to_asset_key_fn, connection)
+
+            destination_tables = list(stream_table_metadata.keys())
+            destination_raw_table_names_by_table = {
+                table: metadata.raw_table_name for table, metadata in stream_table_metadata.items()
+            }
+            normalization_tables = {
+                table: set(metadata.normalization_tables.keys())
+                for table, metadata in stream_table_metadata.items()
+            }
+            normalization_raw_table_names_by_table = {
+                normalization_table: metadata.normalization_tables[
+                    normalization_table
+                ].raw_table_name
+                for table, metadata in stream_table_metadata.items()
+                for normalization_table in normalization_tables[table]
+            }
+
             asset_data_for_conn = _build_airbyte_asset_defn_metadata(
                 connection_id=connection_id,
-                destination_tables=list(stream_table_metadata.keys()),
-                normalization_tables={
-                    table: set(metadata.normalization_tables.keys())
-                    for table, metadata in stream_table_metadata.items()
-                },
+                destination_tables=destination_tables,
+                destination_raw_table_names_by_table=destination_raw_table_names_by_table,
+                destination_database=destination_database,
+                destination_schema=destination_schema,
+                normalization_tables=normalization_tables,
+                normalization_raw_table_names_by_table=normalization_raw_table_names_by_table,
                 asset_key_prefix=self._key_prefix,
                 group_name=(
                     self._connection_meta_to_group_fn(connection)
@@ -699,7 +785,21 @@ class AirbyteInstanceCacheableAssetsDefinition(AirbyteCoreCacheableAssetsDefinit
                     )
                 ),
             )
-            connection = AirbyteConnectionMetadata.from_api_json(connection_json, operations_json)
+
+            destination_id = cast(str, connection_json.get("destinationId"))
+            destination_json = cast(
+                Dict[str, Any],
+                check.not_none(
+                    self._airbyte_instance.make_request(
+                        endpoint="/destinations/get",
+                        data={"destinationId": destination_id},
+                    )
+                ),
+            )
+
+            connection = AirbyteConnectionMetadata.from_api_json(
+                connection_json, operations_json, destination_json
+            )
 
             # Filter out connections that don't match the filter function
             if self._connection_filter and not self._connection_filter(connection):
@@ -759,7 +859,17 @@ class AirbyteYAMLCacheableAssetsDefinition(AirbyteCoreCacheableAssetsDefinition)
         for connection_name in connection_directories:
             connection_dir = os.path.join(connections_dir, connection_name)
             with open(os.path.join(connection_dir, "configuration.yaml"), encoding="utf-8") as f:
-                connection = AirbyteConnectionMetadata.from_config(yaml.safe_load(f.read()))
+                connection_data = yaml.safe_load(f.read())
+
+            destination_configuration_path = cast(
+                str, connection_data.get("destination_configuration_path")
+            )
+            with open(
+                os.path.join(self._project_dir, destination_configuration_path), encoding="utf-8"
+            ) as f:
+                destination_data = yaml.safe_load(f.read())
+
+            connection = AirbyteConnectionMetadata.from_config(connection_data, destination_data)
 
             # Filter out connections that don't match the filter function
             if self._connection_filter and not self._connection_filter(connection):

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte/types.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte/types.py
@@ -6,10 +6,14 @@ from dagster._core.definitions.metadata.table import TableSchema
 class AirbyteTableMetadata:
     def __init__(
         self,
+        raw_table_name: str,
         schema: TableSchema,
         normalization_tables: Optional[Mapping[str, "AirbyteTableMetadata"]] = None,
     ):
-        """Contains metadata about an Airbyte table, including its schema and any created normalization tables."""
+        """Contains metadata about an Airbyte table, including its destination raw table name,
+        schema and any created normalization tables.
+        """
+        self.raw_table_name = raw_table_name
         self.schema = schema
         self.normalization_tables = normalization_tables or dict()
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -338,8 +338,8 @@ def test_built_airbyte_asset_relation_identifier():
     for key, metadata in assets_def.metadata_by_key.items():
         # Extract the table name from the asset key
         table_name = key.path[-1]
-        assert metadata.get("dagster/relation_identifier") in relation_identifiers
-        assert table_name in metadata.get("dagster/relation_identifier")
+        assert metadata["dagster/relation_identifier"] in relation_identifiers
+        assert table_name in metadata["dagster/relation_identifier"]
 
     ab_assets = build_airbyte_assets(
         "12345",
@@ -356,5 +356,5 @@ def test_built_airbyte_asset_relation_identifier():
     for key, metadata in assets_def.metadata_by_key.items():
         # Extract the table name from the asset key
         table_name = key.path[-1]
-        assert metadata.get("dagster/relation_identifier") in relation_identifiers
-        assert table_name in metadata.get("dagster/relation_identifier")
+        assert metadata["dagster/relation_identifier"] in relation_identifiers
+        assert table_name in metadata["dagster/relation_identifier"]

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_asset_defs.py
@@ -308,3 +308,53 @@ def test_built_airbyte_asset_with_downstream_asset():
     assert len(downstream_of_ab.input_names) == 2
     assert downstream_of_ab.op.ins["some_prefix_foo"].dagster_type.is_nothing
     assert downstream_of_ab.op.ins["some_prefix_bar"].dagster_type.is_nothing
+
+
+def test_built_airbyte_asset_relation_identifier():
+    destination_tables = ["foo", "bar"]
+
+    ab_assets = build_airbyte_assets(
+        "12345",
+        destination_tables=destination_tables,
+        normalization_tables={"foo": {"baz"}},
+    )
+
+    # Check relation identifier metadata is added correctly to asset def
+    assets_def = ab_assets[0]
+    for metadata in assets_def.metadata_by_key.values():
+        assert metadata.get("dagster/relation_identifier") is None
+
+    ab_assets = build_airbyte_assets(
+        "12345",
+        destination_tables=destination_tables,
+        destination_database="test_database",
+        destination_schema="test_schema",
+    )
+
+    relation_identifiers = {"test_database.test_schema.foo", "test_database.test_schema.bar"}
+
+    # Check relation identifier metadata is added correctly to asset def
+    assets_def = ab_assets[0]
+    for key, metadata in assets_def.metadata_by_key.items():
+        # Extract the table name from the asset key
+        table_name = key.path[-1]
+        assert metadata.get("dagster/relation_identifier") in relation_identifiers
+        assert table_name in metadata.get("dagster/relation_identifier")
+
+    ab_assets = build_airbyte_assets(
+        "12345",
+        destination_tables=destination_tables,
+        destination_database="test_database",
+        destination_schema="test_schema",
+        normalization_tables={"foo": {"baz"}},
+    )
+
+    relation_identifiers.add("test_database.test_schema.foo.baz")
+
+    # Check relation identifier metadata is added correctly to asset def
+    assets_def = ab_assets[0]
+    for key, metadata in assets_def.metadata_by_key.items():
+        # Extract the table name from the asset key
+        table_name = key.path[-1]
+        assert metadata.get("dagster/relation_identifier") in relation_identifiers
+        assert table_name in metadata.get("dagster/relation_identifier")

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -16,7 +16,6 @@ from dagster import (
 )
 from dagster._check import ParameterCheckError
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
-from dagster._core.definitions.metadata import MetadataValue
 from dagster._core.definitions.metadata.table import TableColumn, TableSchema
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.execution.context.init import build_init_resource_context
@@ -26,6 +25,8 @@ from dagster_airbyte import AirbyteCloudResource, AirbyteResource, airbyte_resou
 from dagster_airbyte.asset_defs import AirbyteConnectionMetadata, load_assets_from_airbyte_instance
 
 from dagster_airbyte_tests.utils import (
+    get_destination_with_database_and_schema_json,
+    get_destination_without_database_and_schema_json,
     get_instance_connections_json,
     get_instance_operations_json,
     get_instance_workspaces_json,
@@ -51,6 +52,7 @@ def airbyte_instance_fixture(request):
 
 @pytest.mark.skipif(sys.version_info >= (3, 12), reason="something with py3.12 and sqlite")
 @responses.activate
+@pytest.mark.parametrize("with_destination_database_and_schema", [True, False])
 @pytest.mark.parametrize("use_normalization_tables", [True, False])
 @pytest.mark.parametrize(
     "connection_to_group_fn, connection_meta_to_group_fn",
@@ -67,6 +69,7 @@ def airbyte_instance_fixture(request):
     "connection_to_auto_materialize_policy_fn", [None, lambda _: AutoMaterializePolicy.lazy()]
 )
 def test_load_from_instance(
+    with_destination_database_and_schema,
     use_normalization_tables,
     connection_to_group_fn,
     connection_meta_to_group_fn,
@@ -108,6 +111,14 @@ def test_load_from_instance(
         method=responses.POST,
         url=base_url + "/operations/list",
         json=get_instance_operations_json(),
+        status=200,
+    )
+    responses.add(
+        method=responses.POST,
+        url=base_url + "/destinations/get",
+        json=get_destination_with_database_and_schema_json()
+        if with_destination_database_and_schema
+        else get_destination_without_database_and_schema_json(),
         status=200,
     )
     if connection_to_group_fn:
@@ -154,6 +165,9 @@ def test_load_from_instance(
         assert len(ab_assets) == 0
         return
 
+    # Check metadata is added correctly to asset def
+    assets_def = ab_assets[0]
+
     tables = {
         "dagster_releases",
         "dagster_tags",
@@ -176,18 +190,22 @@ def test_load_from_instance(
         tables = {
             connection_to_asset_key_fn(
                 AirbyteConnectionMetadata(
-                    "Github <> snowflake-ben", "", use_normalization_tables, []
+                    "Github <> snowflake-ben",
+                    "",
+                    use_normalization_tables,
+                    [],
+                    get_destination_with_database_and_schema_json()
+                    if with_destination_database_and_schema
+                    else get_destination_without_database_and_schema_json(),
                 ),
                 t,
             ).path[0]
             for t in tables
         }
 
-    # Check schema metadata is added correctly to asset def
-
     assert any(
-        out.metadata.get("table_schema")
-        == MetadataValue.table_schema(
+        metadata.get("dagster/column_schema")
+        == (
             TableSchema(
                 columns=[
                     TableColumn(name="commit", type="['null', 'object']"),
@@ -199,13 +217,13 @@ def test_load_from_instance(
                 ]
             )
         )
-        for out in ab_assets[0].node_def.output_defs
+        for key, metadata in assets_def.metadata_by_key.items()
     )
     # Check schema metadata works for normalization tables too
     if use_normalization_tables:
         assert any(
-            out.metadata.get("table_schema")
-            == MetadataValue.table_schema(
+            metadata.get("dagster/column_schema")
+            == (
                 TableSchema(
                     columns=[
                         TableColumn(name="sha", type="['null', 'string']"),
@@ -213,16 +231,57 @@ def test_load_from_instance(
                     ]
                 )
             )
-            for out in ab_assets[0].node_def.output_defs
+            for key, metadata in assets_def.metadata_by_key.items()
         )
 
-    assert ab_assets[0].keys == {AssetKey(t) for t in tables}
+    relation_identifiers = {
+        "test_database.test_schema.releases",
+        "test_database.test_schema.tags",
+        "test_database.test_schema.teams",
+        "test_database.test_schema.array_test",
+        "test_database.test_schema.unknown_test",
+    } | (
+        {
+            "test_database.test_schema.releases.assets",
+            "test_database.test_schema.releases.author",
+            "test_database.test_schema.tags.commit",
+            "test_database.test_schema.releases.foo",
+            "test_database.test_schema.array_test.author",
+        }
+        if use_normalization_tables
+        else set()
+    )
+
+    for key, metadata in assets_def.metadata_by_key.items():
+        if with_destination_database_and_schema:
+            # Extract the table name from the asset key
+            table_name = (
+                key.path[-1]
+                .replace("dagster_", "")
+                .replace("G_", "")
+                .replace("_test", "")
+                .split("_")[-1]
+            )
+            assert metadata.get("dagster/relation_identifier") in relation_identifiers
+            assert table_name in metadata.get("dagster/relation_identifier")
+        else:
+            assert not metadata.get("dagster/relation_identifier")
+
+    assert assets_def.keys == {AssetKey(t) for t in tables}
     assert all(
         [
-            ab_assets[0].specs_by_key[AssetKey(t)].group_name
+            assets_def.specs_by_key[AssetKey(t)].group_name
             == (
                 connection_meta_to_group_fn(
-                    AirbyteConnectionMetadata("GitHub <> snowflake-ben", "", False, [])
+                    AirbyteConnectionMetadata(
+                        "GitHub <> snowflake-ben",
+                        "",
+                        False,
+                        [],
+                        get_destination_with_database_and_schema_json()
+                        if with_destination_database_and_schema
+                        else get_destination_without_database_and_schema_json(),
+                    )
                 )
                 if connection_meta_to_group_fn
                 else (
@@ -234,17 +293,17 @@ def test_load_from_instance(
             for t in tables
         ]
     )
-    assert len(ab_assets[0].op.output_defs) == len(tables)
+    assert len(assets_def.op.output_defs) == len(tables)
 
     expected_freshness_policy = TEST_FRESHNESS_POLICY if connection_to_freshness_policy_fn else None
-    freshness_policies = {spec.key: spec.freshness_policy for spec in ab_assets[0].specs}
+    freshness_policies = {spec.key: spec.freshness_policy for spec in assets_def.specs}
     assert all(freshness_policies[key] == expected_freshness_policy for key in freshness_policies)
 
     expected_auto_materialize_policy = (
         AutoMaterializePolicy.lazy() if connection_to_auto_materialize_policy_fn else None
     )
     auto_materialize_policies_by_key = {
-        spec.key: spec.auto_materialize_policy for spec in ab_assets[0].specs
+        spec.key: spec.auto_materialize_policy for spec in assets_def.specs
     }
     if expected_auto_materialize_policy:
         assert auto_materialize_policies_by_key

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_instance.py
@@ -262,8 +262,8 @@ def test_load_from_instance(
                 .replace("_test", "")
                 .split("_")[-1]
             )
-            assert metadata.get("dagster/relation_identifier") in relation_identifiers
-            assert table_name in metadata.get("dagster/relation_identifier")
+            assert metadata["dagster/relation_identifier"] in relation_identifiers
+            assert table_name in metadata["dagster/relation_identifier"]
         else:
             assert not metadata.get("dagster/relation_identifier")
 

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_project.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_project.py
@@ -1,5 +1,6 @@
 import pytest
 import responses
+import yaml
 from dagster import AssetKey, build_init_resource_context, materialize, with_resources
 from dagster._utils import file_relative_path
 from dagster_airbyte import AirbyteResource, airbyte_resource, load_assets_from_airbyte_project
@@ -83,25 +84,70 @@ def test_load_from_project(
         else set()
     )
 
+    with open(
+        file_relative_path(
+            __file__, "./test_airbyte_project/destinations/snowflake_ben/configuration.yaml"
+        ),
+        encoding="utf-8",
+    ) as f:
+        destination_data = yaml.safe_load(f.read())
+
     if connection_to_asset_key_fn:
         tables = {
             connection_to_asset_key_fn(
                 AirbyteConnectionMetadata(
-                    "Github <> snowflake-ben", "", use_normalization_tables, []
+                    "Github <> snowflake-ben", "", use_normalization_tables, [], destination_data
                 ),
                 t,
             ).path[0]
             for t in tables
         }
 
-    assert ab_assets[0].keys == {AssetKey(t) for t in tables}
+    # Check metadata is added correctly to asset def
+    assets_def = ab_assets[0]
+
+    relation_identifiers = {
+        "AIRBYTE.BEN_DEMO.releases",
+        "AIRBYTE.BEN_DEMO.tags",
+        "AIRBYTE.BEN_DEMO.teams",
+        "AIRBYTE.BEN_DEMO.array_test",
+        "AIRBYTE.BEN_DEMO.unknown_test",
+    } | (
+        {
+            "AIRBYTE.BEN_DEMO.releases.assets",
+            "AIRBYTE.BEN_DEMO.releases.author",
+            "AIRBYTE.BEN_DEMO.tags.commit",
+            "AIRBYTE.BEN_DEMO.releases.foo",
+            "AIRBYTE.BEN_DEMO.array_test.author",
+        }
+        if use_normalization_tables
+        else set()
+    )
+
+    for key, metadata in assets_def.metadata_by_key.items():
+        # Extract the table name from the asset key
+        table_name = (
+            key.path[-1]
+            .replace("dagster_", "")
+            .replace("G_", "")
+            .replace("_test", "")
+            .split("_")[-1]
+        )
+        assert metadata.get("dagster/relation_identifier") in relation_identifiers
+        assert table_name in metadata.get("dagster/relation_identifier")
+
+    assert assets_def.keys == {AssetKey(t) for t in tables}
     assert all(
         [
-            ab_assets[0].group_names_by_key.get(AssetKey(t))
+            assets_def.group_names_by_key.get(AssetKey(t))
             == (
                 connection_meta_to_group_fn(
                     AirbyteConnectionMetadata(
-                        "GitHub <> snowflake-ben", "", use_normalization_tables, []
+                        "GitHub <> snowflake-ben",
+                        "",
+                        use_normalization_tables,
+                        [],
+                        destination_data,
                     )
                 )
                 if connection_meta_to_group_fn
@@ -114,7 +160,7 @@ def test_load_from_project(
             for t in tables
         ]
     )
-    assert len(ab_assets[0].op.output_defs) == len(tables)
+    assert len(assets_def.op.output_defs) == len(tables)
 
     responses.add(
         method=responses.POST,

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_project.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/test_load_from_project.py
@@ -133,8 +133,8 @@ def test_load_from_project(
             .replace("_test", "")
             .split("_")[-1]
         )
-        assert metadata.get("dagster/relation_identifier") in relation_identifiers
-        assert table_name in metadata.get("dagster/relation_identifier")
+        assert metadata["dagster/relation_identifier"] in relation_identifiers
+        assert table_name in metadata["dagster/relation_identifier"]
 
     assert assets_def.keys == {AssetKey(t) for t in tables}
     assert all(

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/utils.py
@@ -700,3 +700,17 @@ def get_instance_operations_json():
             }
         ]
     }
+
+
+def get_destination_with_database_and_schema_json():
+    return {
+        "destinationId": "028fc82d-3a27-4fef-94a6-a22fbd45bac4",
+        "configuration": {
+            "database": "test_database",
+            "schema": "test_schema",
+        },
+    }
+
+
+def get_destination_without_database_and_schema_json():
+    return {"destinationId": "028fc82d-3a27-4fef-94a6-a22fbd45bac4", "configuration": {}}


### PR DESCRIPTION
## Summary & Motivation

Pull `configuration.database` and `configuration.schema` from Airbyte destinations when loading assets Airbyte. Works for a project and an instance.

Also, `destination_table` and `destination_schema` can now be passed to `build_airbyte_assets()` when creating assets for Airbyte Cloud. Currently, we don't fetch connection details for Airbyte Cloud, and users can only create Airbyte assets using `build_airbyte_assets()`, so destination details must be manually provided to create the relation identifier metadata in this use case.

Join this with known schema and table info to produce a full `dagster/relation_identifier`.

<img width="528" alt="Screenshot 2024-10-01 at 5 49 22 PM" src="https://github.com/user-attachments/assets/819afbda-d599-4521-8954-a9113bda8d5a">

## How I Tested These Changes

BK with new and updated tests + tested with an instance and a project.

## Changelog

[dagster-airbyte] relation identifier metadata is now attached to Airbyte assets.

- [x] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
