### PR TITLE
[ui] Update nav flag behavior

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNav.tsx
@@ -10,7 +10,6 @@ import {
   useRepositoryLocationReload,
 } from '../../nav/useRepositoryLocationReload';
 import {SearchDialog} from '../../search/SearchDialog';
-import {useFeatureFlags} from '../Flags';
 import {LayoutContext} from '../LayoutProvider';
 import {ShortcutHandler} from '../ShortcutHandler';
 import {WebSocketStatus} from '../WebSocketProvider';
@@ -56,7 +55,6 @@ export const AppTopNav = ({children, allowGlobalReload = false}: Props) => {
 
 export const AppTopNavLogo = () => {
   const {nav} = React.useContext(LayoutContext);
-  const {flagSettingsPage} = useFeatureFlags();
   const navButton = React.useRef<null | HTMLButtonElement>(null);
 
   const onToggle = React.useCallback(() => {
@@ -75,7 +73,7 @@ export const AppTopNavLogo = () => {
 
   return (
     <LogoContainer>
-      {!flagSettingsPage && nav.canOpen ? (
+      {nav.canOpen ? (
         <ShortcutHandler
           onShortcut={() => onToggle()}
           shortcutLabel="."

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsButton.tsx
@@ -2,19 +2,12 @@ import {Icon} from '@dagster-io/ui-components';
 import {useState} from 'react';
 import {useVisibleFeatureFlagRows} from 'shared/app/useVisibleFeatureFlagRows.oss';
 
-import {useFeatureFlags} from './Flags';
 import {TopNavButton} from './TopNavButton';
 import {UserSettingsDialog} from './UserSettingsDialog/UserSettingsDialog';
 
 export const UserSettingsButton = () => {
-  const {flagSettingsPage} = useFeatureFlags();
   const [isOpen, setIsOpen] = useState(false);
-
   const visibleFlags = useVisibleFeatureFlagRows();
-
-  if (flagSettingsPage) {
-    return null;
-  }
 
   return (
     <>

--- a/js_modules/dagster-ui/packages/ui-core/src/nav/LeftNav.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/LeftNav.tsx
@@ -14,7 +14,7 @@ export const LeftNav = () => {
   }
 
   return (
-    <LeftNavContainer $open={nav.isOpen} $smallScreen={nav.isSmallScreen}>
+    <LeftNavContainer $open={nav.isOpen}>
       {wasEverOpen.current ? <LeftNavRepositorySection /> : null}
     </LeftNavContainer>
   );
@@ -22,25 +22,19 @@ export const LeftNav = () => {
 
 export const LEFT_NAV_WIDTH = 332;
 
-const LeftNavContainer = styled.div<{$open: boolean; $smallScreen: boolean}>`
+const LeftNavContainer = styled.div<{$open: boolean}>`
   position: fixed;
   z-index: 2;
   top: 64px;
   bottom: 0;
   left: 0;
   width: ${LEFT_NAV_WIDTH}px;
-  display: ${({$open, $smallScreen}) => ($open || $smallScreen ? 'flex' : 'none')};
+  display: flex;
   flex-shrink: 0;
   flex-direction: column;
   justify-content: start;
   background: ${Colors.backgroundDefault()};
   box-shadow: 1px 0px 0px ${Colors.keylineDefault()};
-
-  ${(p) =>
-    p.$smallScreen
-      ? `
-        transform: translateX(${p.$open ? '0' : `-${LEFT_NAV_WIDTH}px`});
-        transition: transform 150ms ease-in-out;
-      `
-      : ``}
+  transform: translateX(${({$open}) => ($open ? '0' : `-${LEFT_NAV_WIDTH}px`)});
+  transition: transform 150ms ease-in-out;
 `;


### PR DESCRIPTION
## Summary & Motivation

A few changes to the behavior of the new IA flag.

- Restore the left nav, and only show it by sliding over the main content, even for large screens.
- Allow immediately turning off the flag via the Alert at the top of the app.
- Restore the gear button in the top nav for users in the flag.

## How I Tested These Changes

Load the app with the flag on and off, verify that the left nav and gear button render and behave as expected. Click to turn the flag off via the Alert, verify that it works correctly.

## Changelog

NOCHANGELOG