### PR TITLE
stop ignoring AssetsDefinitions with only checks passed to Definitions

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -21,7 +21,6 @@ from dagster._config.pythonic_config import (
     ConfigurableIOManagerFactoryResourceDefinition,
     ConfigurableResourceFactoryResourceDefinition,
 )
-from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_job import (
     IMPLICIT_ASSET_JOB_NAME,
@@ -186,7 +185,7 @@ def build_caching_repository_data_from_list(
     asset_keys: Set[AssetKey] = set()
     asset_check_keys: Set["AssetCheckKey"] = set()
     source_assets: List[SourceAsset] = []
-    asset_checks_defs: List[AssetChecksDefinition] = []
+    asset_checks_defs: List[AssetsDefinition] = []
     partitions_defs: Set[PartitionsDefinition] = set()
     for definition in repository_definitions:
         if isinstance(definition, JobDefinition):
@@ -245,7 +244,11 @@ def build_caching_repository_data_from_list(
             if definition.partitions_def is not None:
                 partitions_defs.add(definition.partitions_def)
             unresolved_jobs[definition.name] = definition
-        elif isinstance(definition, AssetChecksDefinition):
+        elif (
+            isinstance(definition, AssetsDefinition)
+            and definition.has_check_keys
+            and not definition.has_keys
+        ):
             for key in definition.check_keys:
                 if key in asset_check_keys:
                     raise DagsterInvalidDefinitionError(f"Duplicate asset check key: {key}")

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, Sequence
 
 import pytest
 from dagster import (
+    AssetCheckKey,
     AssetDep,
     AssetExecutionContext,
     AssetKey,
@@ -1095,3 +1096,15 @@ def test_definitions_class_metadata():
     defs = Definitions(metadata={"foo": "bar"})
     assert defs.metadata == {"foo": MetadataValue.text("bar")}
     assert defs.get_repository_def().metadata == {"foo": MetadataValue.text("bar")}
+
+
+def test_assets_def_with_only_checks():
+    @asset_check(asset="asset1")
+    def check1():
+        pass
+
+    assets_def = AssetsDefinition(**check1.get_attributes_dict())
+    defs = Definitions(assets=[assets_def])
+    check_key = AssetCheckKey(AssetKey("asset1"), "check1")
+    assert defs.get_asset_graph().asset_check_keys == {check_key}
+    assert check_key in defs.get_repository_def().asset_checks_defs_by_key


### PR DESCRIPTION
## Summary & Motivation

In the course of implementing `map_asset_specs`, I noticed an oddity / gap in how we handle canonicalized asset check definitions.

During construction of `Definitions`, we canonicalize `AssetChecksDefinition` objects to `AssetsDefinition` objects. However, if these are then passed in to construct a new `Definitions` object, then they are ignored. This PR addresses that.

## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
