### PR TITLE
[dagster-airlift][dag-asset] make dag assets plural

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
@@ -43,10 +43,11 @@ def materializations_for_dag_run(
 ) -> Sequence[AssetMaterialization]:
     return [
         AssetMaterialization(
-            asset_key=airflow_data.asset_key_for_dag(dag_run.dag_id),
+            asset_key=asset_key,
             description=dag_run.note,
             metadata=get_dag_run_metadata(dag_run),
         )
+        for asset_key in airflow_data.asset_keys_for_dag(dag_run.dag_id)
     ]
 
 


### PR DESCRIPTION
## Summary & Motivation
In preparation for allowing arbitrary dag-level overrides on assets, make the utilities which retrieve dag assets from the mapped Definitions operate over a set instead of a single asset key.

## How I Tested These Changes
Existing tests
## Changelog
NOCHANGELOG
