### PR TITLE
More performant way of going from a run to its asset keys in graphql

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -25,7 +25,7 @@ from dagster._utils.yaml_utils import dump_run_config_yaml
 
 from dagster_graphql.implementation.events import from_event_record, iterate_metadata_entries
 from dagster_graphql.implementation.fetch_asset_checks import get_asset_checks_for_run_id
-from dagster_graphql.implementation.fetch_assets import get_assets_for_run_id, get_unique_asset_id
+from dagster_graphql.implementation.fetch_assets import get_assets_for_run, get_unique_asset_id
 from dagster_graphql.implementation.fetch_pipelines import get_job_reference_or_raise
 from dagster_graphql.implementation.fetch_runs import get_runs, get_stats, get_step_stats
 from dagster_graphql.implementation.fetch_schedules import get_schedules_for_pipeline
@@ -545,7 +545,7 @@ class GrapheneRun(graphene.ObjectType):
         )
 
     def resolve_assets(self, graphene_info: ResolveInfo):
-        return get_assets_for_run_id(graphene_info, self.run_id)
+        return get_assets_for_run(graphene_info, self.dagster_run)
 
     def resolve_assetChecks(self, graphene_info: ResolveInfo):
         return get_asset_checks_for_run_id(graphene_info, self.run_id)


### PR DESCRIPTION
## Summary & Motivation
This currently does an event log fetch, which can be slow. Instead, get the materializations and observations separately (which is faster) and get the planned asset materializations from the execution plan snapshot (which is also fast)

## How I Tested These Changes
BK

## Changelog
NOCHANGELOG
