### PR TITLE
[ui] Flip navigation feature flag

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/App.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/App.tsx
@@ -18,7 +18,7 @@ export const App = ({banner, children}: Props) => {
   const {nav} = React.useContext(LayoutContext);
 
   // todo dish: Remove flag and alert once this change has shipped.
-  const {flagSettingsPage} = useFeatureFlags();
+  const {flagLegacyNav} = useFeatureFlags();
   const [didDismissNavAlert, setDidDismissNavAlert] = useStateWithStorage<boolean>(
     'new_navigation_alert',
     (json) => !!json,
@@ -33,7 +33,7 @@ export const App = ({banner, children}: Props) => {
       <LeftNav />
       <Main $navOpen={nav.isOpen} onClick={onClickMain}>
         <div>{banner}</div>
-        {flagSettingsPage && !didDismissNavAlert ? (
+        {!flagLegacyNav && !didDismissNavAlert ? (
           <ExperimentalNavAlert setDidDismissNavAlert={setDidDismissNavAlert} />
         ) : null}
         <ChildContainer>{children}</ChildContainer>
@@ -52,7 +52,7 @@ const ExperimentalNavAlert = (props: AlertProps) => {
 
   const revertToLegacyNavigation = () => {
     const copy = new Set(flags);
-    copy.delete(FeatureFlag.flagSettingsPage);
+    copy.add(FeatureFlag.flagLegacyNav);
     setFeatureFlags(Array.from(copy));
     setDidDismissNavAlert(true);
     window.location.reload();

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavLinks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavLinks.tsx
@@ -94,7 +94,7 @@ export const navLinks = (config: Config): AppNavLinkType[] => {
     ),
   };
 
-  if (featureEnabled(FeatureFlag.flagSettingsPage)) {
+  if (!featureEnabled(FeatureFlag.flagLegacyNav)) {
     const jobs =
       jobState === 'has-jobs'
         ? {

--- a/js_modules/dagster-ui/packages/ui-core/src/app/FeatureFlags.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/FeatureFlags.oss.tsx
@@ -3,7 +3,7 @@ export enum FeatureFlag {
   flagDisableWebsockets = 'flagDisableWebsockets',
   flagSidebarResources = 'flagSidebarResources',
   flagDisableAutoLoadDefaults = 'flagDisableAutoLoadDefaults',
-  flagSettingsPage = 'flagSettingsPage',
+  flagLegacyNav = 'flagLegacyNav',
   flagCodeLocationPage = 'flagCodeLocationPage',
   flagRunsFeed = 'flagRunsFeed',
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/AppTopNav.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/AppTopNav.test.tsx
@@ -28,6 +28,6 @@ describe('AppTopNav', () => {
     expect(screen.getByText('Overview').closest('a')).toHaveAttribute('href', '/overview');
     expect(screen.getByText('Runs').closest('a')).toHaveAttribute('href', '/runs');
     expect(screen.getByText('Assets').closest('a')).toHaveAttribute('href', '/assets');
-    expect(screen.getByText('Deployment').closest('a')).toHaveAttribute('href', '/locations');
+    expect(screen.getByText('Deployment').closest('a')).toHaveAttribute('href', '/deployment');
   });
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
@@ -21,10 +21,10 @@ export const useVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagDebugConsoleLogging,
   },
   {
-    key: 'New navigation',
+    key: 'Revert to legacy navigation',
     label: (
       <>
-        Experimental navigation (
+        Revert to legacy navigation (
         <a
           href="https://github.com/dagster-io/dagster/discussions/21370"
           target="_blank"
@@ -35,7 +35,7 @@ export const useVisibleFeatureFlagRows = () => [
         )
       </>
     ),
-    flagType: FeatureFlag.flagSettingsPage,
+    flagType: FeatureFlag.flagLegacyNav,
   },
   {
     key: 'New code location page',

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -14,14 +14,14 @@ import {useAutoMaterializeSensorFlag} from '../AutoMaterializeSensorFlag';
 // depending on their nav flag state.
 export const AutomaterializationRoot = () => {
   const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
-  const {flagSettingsPage} = useFeatureFlags();
+  const {flagLegacyNav} = useFeatureFlags();
   switch (automaterializeSensorsFlagState) {
     case 'unknown':
       return <div />; // Waiting for result
     case 'has-global-amp':
       return <GlobalAutomaterializationRoot />;
     case 'has-sensor-amp':
-      return <Redirect to={flagSettingsPage ? '/automation' : '/overview/sensors'} />;
+      return <Redirect to={flagLegacyNav ? '/overview/sensors' : '/automation'} />;
     default:
       assertUnreachable(automaterializeSensorsFlagState);
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
@@ -14,7 +14,7 @@ import {InstanceBackfillsRoot} from '../instance/InstanceBackfillsRoot';
 import {BackfillPage} from '../instance/backfill/BackfillPage';
 
 export const OverviewRoot = () => {
-  const {flagSettingsPage} = useFeatureFlags();
+  const {flagLegacyNav} = useFeatureFlags();
   const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
   return (
     <Switch>
@@ -23,22 +23,20 @@ export const OverviewRoot = () => {
       </Route>
       <Route
         path="/overview/jobs"
-        render={() => (flagSettingsPage ? <Redirect to="/jobs" /> : <OverviewJobsRoot />)}
+        render={() => (flagLegacyNav ? <OverviewJobsRoot /> : <Redirect to="/jobs" />)}
       />
       <Route
         path="/overview/schedules"
-        render={() =>
-          flagSettingsPage ? <Redirect to="/automation" /> : <OverviewSchedulesRoot />
-        }
+        render={() => (flagLegacyNav ? <OverviewSchedulesRoot /> : <Redirect to="/automation" />)}
       />
       <Route
         path="/overview/sensors"
-        render={() => (flagSettingsPage ? <Redirect to="/automation" /> : <OverviewSensorsRoot />)}
+        render={() => (flagLegacyNav ? <OverviewSensorsRoot /> : <Redirect to="/automation" />)}
       />
       <Route
         path="/overview/automation"
         render={() =>
-          flagSettingsPage && automaterializeSensorsFlagState !== 'has-global-amp' ? (
+          !flagLegacyNav && automaterializeSensorsFlagState !== 'has-global-amp' ? (
             <Redirect to="/automation" />
           ) : (
             <AutomaterializationRoot />

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
@@ -18,7 +18,7 @@ interface Props<TData> {
 export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TData>) => {
   const {refreshState, tab} = props;
 
-  const {flagSettingsPage, flagRunsFeed} = useFeatureFlags();
+  const {flagLegacyNav, flagRunsFeed} = useFeatureFlags();
 
   const automaterialize = useAutomaterializeDaemonStatus();
   const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
@@ -32,11 +32,11 @@ export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TDa
           <TabLink id="asset-health" title="Asset health" to="/overview/asset-health" />
         )}
         {/* These are flagged individually because the links must be children of `Tabs`: */}
-        {flagSettingsPage ? null : <TabLink id="jobs" title="Jobs" to="/overview/jobs" />}
-        {flagSettingsPage ? null : (
+        {flagLegacyNav ? <TabLink id="jobs" title="Jobs" to="/overview/jobs" /> : null}
+        {flagLegacyNav ? (
           <TabLink id="schedules" title="Schedules" to="/overview/schedules" />
-        )}
-        {flagSettingsPage ? null : <TabLink id="sensors" title="Sensors" to="/overview/sensors" />}
+        ) : null}
+        {flagLegacyNav ? <TabLink id="sensors" title="Sensors" to="/overview/sensors" /> : null}
         {automaterializeSensorsFlagState === 'has-global-amp' ? (
           <TabLink
             id="amp"

--- a/js_modules/dagster-ui/packages/ui-core/src/settings/SettingsMainPane.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/settings/SettingsMainPane.tsx
@@ -9,8 +9,8 @@ import {InstanceConfigContent} from '../instance/InstanceConfig';
 import {InstanceHealthPageContent} from '../instance/InstanceHealthPage';
 
 export const SettingsMainPane = () => {
-  const {flagSettingsPage} = useFeatureFlags();
-  if (!flagSettingsPage) {
+  const {flagLegacyNav} = useFeatureFlags();
+  if (flagLegacyNav) {
     return <Redirect to="/locations" />;
   }
 


### PR DESCRIPTION
## Summary & Motivation

Enable the new navigation UI by flipping the feature flag to be a "revert to legacy nav" flag, turned off by default.

- Replace all `flagSettingsPage` with `flagLegacyNav`, flip the logic at each callsite.
- Add a `trackEvent` call to start observing feature flag change events (Plus only)

## How I Tested These Changes

Load app. Verify that the app has the updated nav without my changing any flags. Verify behavior of new flag to revert to old nav.

## Changelog

- [ ] `NEW` [ui] The updated navigation is now enabled for all users. You can revert to the legacy navigation via a feature flag. See [GitHub discussion](https://github.com/dagster-io/dagster/discussions/21370) for more.