### PR TITLE
feat: Make Dagster scaffold pyproject compatible with uv

### DIFF
--- a/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/CODE_LOCATION_NAME_PLACEHOLDER/definitions.py
+++ b/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/CODE_LOCATION_NAME_PLACEHOLDER/definitions.py
@@ -1,6 +1,6 @@
 from dagster import Definitions, load_assets_from_modules
 
-from CODE_LOCATION_NAME_PLACEHOLDER import assets  # type: ignore
+from . import assets
 
 all_assets = load_assets_from_modules([assets])
 

--- a/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/pyproject.toml.tmpl
+++ b/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/pyproject.toml.tmpl
@@ -1,5 +1,5 @@
 [project]
-name = "dagster_quickstart"
+name = "{{ code_location_name }}"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
@@ -7,10 +7,9 @@ requires-python = ">=3.8,<3.12"
 dependencies = [
     "dagster",
     "dagster-cloud",
-    "pandas",
 ]
 
-[tool.uv]
+[pyproject.optional-dependencies]
 dev-dependencies = [
     "dagster-webserver", 
     "pytest",

--- a/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/pyproject.toml.tmpl
+++ b/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/pyproject.toml.tmpl
@@ -1,3 +1,21 @@
+[project]
+name = "dagster_quickstart"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.8,<3.12"
+dependencies = [
+    "dagster",
+    "dagster-cloud",
+    "pandas",
+]
+
+[tool.uv]
+dev-dependencies = [
+    "dagster-webserver", 
+    "pytest",
+]
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/pyproject.toml.tmpl
+++ b/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/pyproject.toml.tmpl
@@ -9,7 +9,7 @@ dependencies = [
     "dagster-cloud",
 ]
 
-[pyproject.optional-dependencies]
+[project.optional-dependencies]
 dev-dependencies = [
     "dagster-webserver", 
     "pytest",

--- a/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/pyproject.toml.tmpl
+++ b/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/pyproject.toml.tmpl
@@ -10,7 +10,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev-dependencies = [
+dev = [
     "dagster-webserver", 
     "pytest",
 ]


### PR DESCRIPTION
## Summary & Motivation

In this [issue](https://github.com/dagster-io/dagster/issues/24878) Daniel Bartley demonstrates that we can make Dagster compatible with uv by updating the `pyproject.toml` template. This is an opt-in feature that gives users the benefit of being able to have uv manage virutal environments.

Assuming a user has `uv` installed, one can install and run Dagster as follows:

```bash
uvx dagster project scaffold --name dagster-quickstart
cd dagster-quickstart
uv run dagster dev
```

This also fixes a bug in the project scaffold template introduced during a refactor.

The documentation for this will be in a follow-up PR in our docs-beta repo.

## How I Tested These Changes

Updated the template, installed Dagster as a local editable installed, and confirmed the scaffolding works.

## Changelog

- [x] `NEW` Update Dagster scaffold template to be compatible with `uv`
