### PR TITLE
remove unecessary conversion to subquery in run storage

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -301,7 +301,7 @@ class SqlRunStorage(RunStorage):
             runs_in_backfills = db_select([RunTagsTable.c.run_id]).where(
                 RunTagsTable.c.key == BACKFILL_ID_TAG
             )
-            query = query.where(RunsTable.c.run_id.notin_(db_subquery(runs_in_backfills)))
+            query = query.where(RunsTable.c.run_id.notin_(runs_in_backfills))
 
         return query
 


### PR DESCRIPTION
## Summary & Motivation
Was getting a warning like this
```
/Users/jamie/dev/dagster/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py:304: SAWarning: Coercing Subquery object into a select() for use in IN(); please pass a select() construct explicitly
  query = query.where(RunsTable.c.run_id.notin_(db_subquery(runs_in_backfills)))
```
This removes the unnecessary conversion to a subquery, so now the error is gone

## How I Tested These Changes
Ran the UI locally, saw that the warning was gone

## Changelog

NOCHANGELOG