### PR TITLE
change backfill view runs button to view

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillActionsMenu.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillActionsMenu.tsx
@@ -163,7 +163,7 @@ export const BackfillActionsMenu = ({
       {anchorLabel ? (
         <JoinedButtons>
           <AnchorButton to={getBackfillPath(backfill.id, backfill.isAssetBackfill)}>
-            View run
+            View
           </AnchorButton>
           {popover}
         </JoinedButtons>


### PR DESCRIPTION
## Summary & Motivation
We renamed the view button for runs, but missed it for backfills - this make the button "View" instead of "view runs" 

## How I Tested These Changes
before 
<img width="1434" alt="Screenshot 2024-10-02 at 10 36 01 AM" src="https://github.com/user-attachments/assets/d89b256c-1f64-4dba-976e-0dabe2464d92">

after
<img width="1434" alt="Screenshot 2024-10-02 at 10 36 34 AM" src="https://github.com/user-attachments/assets/0a7c158a-18d7-4acf-8343-33231af0149b">
 


## Changelog

NOCHANGELOG
