### PR TITLE
Definitions.map_asset_keys

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1297,7 +1297,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
                     new_deps.append(dep)
 
             if new_key is not spec.key or any_deps_changed:
-                new_specs.append(spec._replace(deps=new_deps))
+                new_specs.append(spec._replace(key=new_key, deps=new_deps))
             else:
                 new_specs.append(spec)
 

--- a/python_modules/dagster/dagster/_core/definitions/assets.py
+++ b/python_modules/dagster/dagster/_core/definitions/assets.py
@@ -1280,7 +1280,7 @@ class AssetsDefinition(ResourceAddable, IHasInternalInit):
         merged_attrs = merge_dicts(self.get_attributes_dict(), replaced_attributes)
         return self.__class__.dagster_internal_init(**merged_attrs)
 
-    def with_replaced_asset_keys(
+    def replace_asset_keys(
         self, new_asset_keys_by_old_asset_key: Mapping[AssetKey, AssetKey]
     ) -> "AssetsDefinition":
         new_specs = []

--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     Iterable,
     List,
@@ -9,6 +10,7 @@ from typing import (
     NamedTuple,
     Optional,
     Sequence,
+    Tuple,
     Type,
     Union,
 )
@@ -44,7 +46,7 @@ from dagster._core.definitions.schedule_definition import ScheduleDefinition
 from dagster._core.definitions.sensor_definition import SensorDefinition
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 from dagster._core.definitions.utils import dedupe_object_refs
-from dagster._core.errors import DagsterInvariantViolationError
+from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._core.execution.build_resources import wrap_resources_for_execution
 from dagster._core.execution.with_resources import with_resources
 from dagster._core.executor.base import Executor
@@ -750,3 +752,111 @@ class Definitions(IHaveNew):
                 **normalized_metadata,
             },
         )
+
+    @public
+    def map_asset_specs(self, fn: Callable[[AssetSpec], AssetSpec]) -> "Definitions":
+        """Applies the given mapping function to every asset spec within this Definitions object,
+        including both external asset specs and asset specs within AssetsDefinitions.
+
+        Returns a new Definitions object with the transformed assets; does not mutate this object.
+
+        If the mapping function produces asset specs with new asset keys, downstream assets and
+        asset checks will be updated so that they depend on the new key.
+
+        Does not support Definitions  objects that contain CacheableAssetsDefinitions.
+
+        Args:
+            fn (Callable[[AssetSpec], AssetSpec]): A function that accepts an AssetSpec and returns
+                a new AssetSpec.
+
+        Returns:
+            Definitions: A new Definitions object with the transformed assets.
+        """
+        if self.assets is None:
+            return self
+
+        new_keys_by_old_key: Dict[AssetKey, AssetKey] = {}
+
+        assets_def_new_specs: List[Tuple[AssetsDefinition, Sequence[AssetSpec]]] = []
+        new_external_asset_specs: List[AssetSpec] = []
+        new_source_assets: List[SourceAsset] = []
+
+        for el in self.assets:
+            if isinstance(el, AssetsDefinition):
+                new_specs = []
+                for spec in el.specs:
+                    new_spec = fn(spec)
+                    new_specs.append(new_spec)
+                    if new_spec.key != spec.key:
+                        new_keys_by_old_key[spec.key] = new_spec.key
+                assets_def_new_specs.append((el, new_specs))
+            elif isinstance(el, AssetSpec):
+                new_spec = fn(el)
+                if new_spec.key != el.key:
+                    new_keys_by_old_key[el.key] = new_spec.key
+                new_external_asset_specs.append(new_spec)
+            elif isinstance(el, SourceAsset):
+                new_spec = fn(el.to_asset_spec())
+                if new_spec.key != el.key:
+                    new_keys_by_old_key[el.key] = new_spec.key
+                new_source_assets.append(el.with_attributes_from_spec(new_spec))
+            elif isinstance(el, CacheableAssetsDefinition):
+                raise DagsterInvalidDefinitionError(
+                    "Can't use map_asset_specs on Definitions objects that contain "
+                    "CacheableAssetsDefinitions."
+                )
+            else:
+                check.failed(f"Unexpected asset type: {type(el)}")
+
+        # build result_assets
+        result_assets = []
+
+        for assets_def, new_specs in assets_def_new_specs:
+            new_asset_specs_replaced_deps = [
+                replace_asset_spec_dep_asset_keys(spec, new_keys_by_old_key) for spec in new_specs
+            ]
+            result_assets.append(
+                assets_def.with_replaced_asset_specs(
+                    specs=new_asset_specs_replaced_deps,
+                    new_asset_keys_by_old_asset_key=new_keys_by_old_key,
+                )
+            )
+
+        for spec in new_external_asset_specs:
+            result_assets.append(replace_asset_spec_dep_asset_keys(spec, new_keys_by_old_key))
+
+        result_assets.extend(new_source_assets)
+
+        # build result_asset_checks
+        result_asset_checks = []
+        for asset_checks_def in self.asset_checks or []:
+            result_asset_checks.append(
+                asset_checks_def.with_replaced_asset_specs(
+                    specs=[],
+                    new_asset_keys_by_old_asset_key=new_keys_by_old_key,
+                )
+            )
+
+        return copy(self, assets=result_assets, asset_checks=result_asset_checks)
+
+
+def replace_asset_spec_dep_asset_keys(
+    spec: AssetSpec, new_keys_by_old_key: Mapping[AssetKey, AssetKey]
+) -> AssetSpec:
+    if not new_keys_by_old_key:
+        return spec
+
+    new_deps = []
+    any_changed = False
+    for dep in spec.deps:
+        new_key = new_keys_by_old_key.get(dep.asset_key)
+        if new_key is not None:
+            new_deps.append(dep._replace(asset_key=new_key))
+            any_changed = True
+        else:
+            new_deps.append(dep)
+
+    if any_changed:
+        return spec._replace(deps=new_deps)
+    else:
+        return spec

--- a/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
+++ b/python_modules/dagster/dagster/_core/definitions/partitioned_schedule.py
@@ -1,6 +1,7 @@
 from typing import Callable, Mapping, NamedTuple, Optional, Union, cast
 
 import dagster._check as check
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.decorators.schedule_decorator import schedule
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.multi_dimensional_partitions import MultiPartitionsDefinition
@@ -57,6 +58,11 @@ class UnresolvedPartitionedAssetScheduleDefinition(NamedTuple):
             execution_timezone=time_partitions_def.timezone,
             description=self.description,
         )(_get_schedule_evaluation_fn(partitions_def, resolved_job, self.tags))
+
+    def replace_asset_keys(
+        self, new_keys_by_old_key: Mapping[AssetKey, AssetKey]
+    ) -> "UnresolvedPartitionedAssetScheduleDefinition":
+        return self._replace(job=self.job.replace_asset_keys(new_keys_by_old_key))
 
 
 def build_schedule_from_partitioned_job(

--- a/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/schedule_definition.py
@@ -26,6 +26,7 @@ from typing_extensions import TypeAlias
 import dagster._check as check
 from dagster._annotations import deprecated, deprecated_param, experimental_param, public
 from dagster._core.decorator_utils import has_at_least_one_parameter
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.instigation_logger import InstigationLogger
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.metadata import RawMetadataMapping, normalize_metadata
@@ -1028,3 +1029,13 @@ class ScheduleDefinition(IHasInternalInit):
     @property
     def has_anonymous_job(self) -> bool:
         return bool(self._target and self._target.job_name.startswith(ANONYMOUS_ASSET_JOB_PREFIX))
+
+    def replace_asset_keys(
+        self, new_keys_by_old_key: Mapping[AssetKey, AssetKey]
+    ) -> "ScheduleDefinition":
+        resolvable_to_job = self.target.resolvable_to_job
+
+        if isinstance(resolvable_to_job, UnresolvedAssetJobDefinition):
+            return self.with_updated_job(resolvable_to_job.replace_asset_keys(new_keys_by_old_key))
+        else:
+            return self

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -15,7 +15,7 @@ from typing_extensions import TypeAlias
 import dagster._check as check
 from dagster._annotations import PublicAttr, deprecated, experimental_param, public
 from dagster._core.decorator_utils import get_function_params
-from dagster._core.definitions.asset_spec import AssetExecutionType, AssetSpec
+from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.data_version import (
     DATA_VERSION_TAG,
     DataVersion,
@@ -485,46 +485,6 @@ class SourceAsset(ResourceAddable, IHasInternalInit):
         )
         for source_key, resource_def in self.resource_defs.items():
             yield from resource_def.get_resource_requirements(source_key=source_key)
-
-    def to_asset_spec(self) -> AssetSpec:
-        spec = AssetSpec.dagster_internal_init(
-            key=self.key,
-            deps=[],
-            description=self.description,
-            metadata=self.metadata,
-            skippable=False,
-            group_name=self.group_name,
-            code_version=None,
-            automation_condition=None,
-            freshness_policy=None,
-            owners=None,
-            tags=self.tags,
-            auto_materialize_policy=None,
-            partitions_def=self.partitions_def,
-        )
-        if self.io_manager_key is not None and self.io_manager_key != DEFAULT_IO_MANAGER_KEY:
-            return spec.with_io_manager_key(self.io_manager_key)
-        else:
-            return spec
-
-    def with_attributes_from_spec(self, spec: AssetSpec) -> "SourceAsset":
-        with disable_dagster_warnings():
-            return SourceAsset.dagster_internal_init(
-                key=spec.key,
-                metadata=spec.metadata,
-                description=spec.description,
-                partitions_def=spec.partitions_def,
-                group_name=spec.group_name,
-                tags=spec.tags,
-                freshness_policy=spec.freshness_policy,
-                resource_defs=self.resource_defs,
-                io_manager_key=self.io_manager_key,
-                io_manager_def=self.io_manager_def,
-                observe_fn=self.observe_fn,
-                auto_observe_interval_minutes=self.auto_observe_interval_minutes,
-                _required_resource_keys=self._required_resource_keys,
-                op_tags=self.op_tags,
-            )
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, SourceAsset):

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -15,7 +15,7 @@ from typing_extensions import TypeAlias
 import dagster._check as check
 from dagster._annotations import PublicAttr, deprecated, experimental_param, public
 from dagster._core.decorator_utils import get_function_params
-from dagster._core.definitions.asset_spec import AssetExecutionType
+from dagster._core.definitions.asset_spec import AssetExecutionType, AssetSpec
 from dagster._core.definitions.data_version import (
     DATA_VERSION_TAG,
     DataVersion,
@@ -485,6 +485,46 @@ class SourceAsset(ResourceAddable, IHasInternalInit):
         )
         for source_key, resource_def in self.resource_defs.items():
             yield from resource_def.get_resource_requirements(source_key=source_key)
+
+    def to_asset_spec(self) -> AssetSpec:
+        spec = AssetSpec.dagster_internal_init(
+            key=self.key,
+            deps=[],
+            description=self.description,
+            metadata=self.metadata,
+            skippable=False,
+            group_name=self.group_name,
+            code_version=None,
+            automation_condition=None,
+            freshness_policy=None,
+            owners=None,
+            tags=self.tags,
+            auto_materialize_policy=None,
+            partitions_def=self.partitions_def,
+        )
+        if self.io_manager_key is not None and self.io_manager_key != DEFAULT_IO_MANAGER_KEY:
+            return spec.with_io_manager_key(self.io_manager_key)
+        else:
+            return spec
+
+    def with_attributes_from_spec(self, spec: AssetSpec) -> "SourceAsset":
+        with disable_dagster_warnings():
+            return SourceAsset.dagster_internal_init(
+                key=spec.key,
+                metadata=spec.metadata,
+                description=spec.description,
+                partitions_def=spec.partitions_def,
+                group_name=spec.group_name,
+                tags=spec.tags,
+                freshness_policy=spec.freshness_policy,
+                resource_defs=self.resource_defs,
+                io_manager_key=self.io_manager_key,
+                io_manager_def=self.io_manager_def,
+                observe_fn=self.observe_fn,
+                auto_observe_interval_minutes=self.auto_observe_interval_minutes,
+                _required_resource_keys=self._required_resource_keys,
+                op_tags=self.op_tags,
+            )
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, SourceAsset):

--- a/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py
@@ -237,6 +237,11 @@ class UnresolvedAssetJobDefinition(
             allow_different_partitions_defs=False,
         )
 
+    def replace_asset_keys(
+        self, new_keys_by_old_key: Mapping[AssetKey, AssetKey]
+    ) -> "UnresolvedAssetJobDefinition":
+        return self._replace(selection=self.selection.replace_asset_keys(new_keys_by_old_key))
+
 
 @deprecated_param(
     param="partitions_def",

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class_map_asset_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class_map_asset_specs.py
@@ -4,7 +4,6 @@ from dagster import (
     AssetCheckSpec,
     AssetDep,
     AssetKey,
-    AssetsDefinition,
     AssetSpec,
     Definitions,
     MaterializeResult,
@@ -15,51 +14,20 @@ from dagster import (
     define_asset_job,
     materialize,
     multi_asset,
+    sensor,
 )
 from dagster._core.definitions.asset_check_result import AssetCheckResult
-from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
-from dagster._core.definitions.definitions_class import map_asset_keys, map_asset_specs
-from dagster._core.errors import DagsterInvalidDefinitionError
+from dagster._core.definitions.definitions_class import map_asset_keys
 
 
 class DefinitionsWithMapAssetMethods(Definitions):
-    map_asset_specs = map_asset_specs
     map_asset_keys = map_asset_keys
 
 
-def test_single_basic_asset() -> None:
-    @asset
-    def asset1():
-        pass
-
-    mapped_defs = DefinitionsWithMapAssetMethods(assets=[asset1]).map_asset_specs(
-        lambda spec: spec._replace(group_name="yolo")
-    )
-    all_asset_specs = mapped_defs.get_all_asset_specs()
-    assert len(all_asset_specs) == 1
-    assert all_asset_specs[0].group_name == "yolo"
-    assert all_asset_specs[0].key == asset1.key
-    assert len(mapped_defs.assets) == 1
-    assert isinstance(mapped_defs.assets[0], AssetsDefinition)
-
-
-def test_a_couple_specs() -> None:
-    mapped_defs = DefinitionsWithMapAssetMethods(
-        assets=[AssetSpec("a1"), AssetSpec("a2")]
-    ).map_asset_specs(lambda spec: spec._replace(group_name="yolo"))
-    all_asset_specs = mapped_defs.get_all_asset_specs()
-    assert len(all_asset_specs) == 2
-
-    assert all_asset_specs[0].group_name == "yolo"
-    assert all_asset_specs[0].key == AssetKey("a1")
-    assert all_asset_specs[1].group_name == "yolo"
-    assert all_asset_specs[1].key == AssetKey("a2")
-
-
-def test_two_specs_with_dep() -> None:
+def test_map_asset_keys_two_specs_with_dep() -> None:
     mapped_defs = DefinitionsWithMapAssetMethods(
         assets=[AssetSpec("a1"), AssetSpec("a2", deps=[AssetDep("a1")])]
-    ).map_asset_specs(lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"])))
+    ).map_asset_keys(lambda spec: spec.key.with_prefix(["prefix"]))
     all_asset_specs = mapped_defs.get_all_asset_specs()
     assert len(all_asset_specs) == 2
 
@@ -68,15 +36,15 @@ def test_two_specs_with_dep() -> None:
     assert all_asset_specs[1].deps == [AssetDep(["prefix", "a1"])]
 
 
-def test_two_defs_with_dep() -> None:
+def test_map_asset_keys_two_defs_with_dep() -> None:
     @asset
     def a1(): ...
 
     @asset(deps=[a1])
     def a2(): ...
 
-    mapped_defs = DefinitionsWithMapAssetMethods(assets=[a1, a2]).map_asset_specs(
-        lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"]))
+    mapped_defs = DefinitionsWithMapAssetMethods(assets=[a1, a2]).map_asset_keys(
+        lambda spec: spec.key.with_prefix(["prefix"])
     )
     all_asset_specs = mapped_defs.get_all_asset_specs()
     assert len(all_asset_specs) == 2
@@ -93,33 +61,32 @@ def test_two_defs_with_dep() -> None:
     } == {AssetKey(["prefix", "a1"]), AssetKey(["prefix", "a2"])}
 
 
-def test_independent_asset_check() -> None:
+def test_map_asset_keys_independent_asset_check() -> None:
     @asset_check(asset="a1")
     def asset_check1():
         return AssetCheckResult(passed=True)
 
     mapped_defs = DefinitionsWithMapAssetMethods(
         assets=[AssetSpec("a1")], asset_checks=[asset_check1]
-    ).map_asset_specs(lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"])))
+    ).map_asset_keys(lambda spec: spec.key.with_prefix(["prefix"]))
     all_asset_specs = mapped_defs.get_all_asset_specs()
     assert len(all_asset_specs) == 1
-
     assert all_asset_specs[0].key == AssetKey(["prefix", "a1"])
-    assert len(mapped_defs.asset_checks) == 1
-    assert len(mapped_defs.asset_checks[0].check_specs) == 1
-    assert next(iter(mapped_defs.asset_checks[0].check_specs)).asset_key == AssetKey(
-        ["prefix", "a1"]
-    )
+
+    asset_graph = mapped_defs.get_asset_graph()
+    with pytest.raises(KeyError):
+        asset_graph.get(AssetCheckKey(AssetKey(["a1"]), "asset_check1"))
+    assert asset_graph.get(AssetCheckKey(AssetKey(["prefix", "a1"]), "asset_check1"))
 
 
-def test_internal_dep():
+def test_map_asset_keys_internal_dep():
     @multi_asset(specs=[AssetSpec("a1"), AssetSpec("a2", deps=[AssetDep("a1")])])
     def assets(context):
         yield MaterializeResult(asset_key=AssetKey(["prefix", "a1"]))
         yield MaterializeResult(asset_key=AssetKey(["prefix", "a2"]))
 
-    mapped_defs = DefinitionsWithMapAssetMethods(assets=[assets]).map_asset_specs(
-        lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"]))
+    mapped_defs = DefinitionsWithMapAssetMethods(assets=[assets]).map_asset_keys(
+        lambda spec: spec.key.with_prefix(["prefix"])
     )
     all_asset_specs = mapped_defs.get_all_asset_specs()
     assert len(all_asset_specs) == 2
@@ -136,7 +103,7 @@ def test_internal_dep():
     } == {AssetKey(["prefix", "a1"]), AssetKey(["prefix", "a2"])}
 
 
-def test_asset_and_check_same_op():
+def test_map_asset_keys_asset_and_check_same_op():
     @asset(check_specs=[AssetCheckSpec(asset="a1", name="c1")])
     def a1(context):
         for ak in context.selected_asset_keys:
@@ -144,8 +111,8 @@ def test_asset_and_check_same_op():
         for ck in context.selected_asset_check_keys:
             yield AssetCheckResult(asset_key=ck.asset_key, check_name=ck.name, passed=True)
 
-    mapped_defs = DefinitionsWithMapAssetMethods(assets=[a1]).map_asset_specs(
-        lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"]))
+    mapped_defs = DefinitionsWithMapAssetMethods(assets=[a1]).map_asset_keys(
+        lambda spec: spec.key.with_prefix(["prefix"])
     )
     all_asset_specs = mapped_defs.get_all_asset_specs()
     assert len(all_asset_specs) == 1
@@ -164,10 +131,10 @@ def test_asset_and_check_same_op():
     assert {e.asset_check_key for e in result.get_asset_check_evaluations()} == {check_key}
 
 
-def test_source_asset():
+def test_map_asset_keys_source_asset():
     mapped_defs = DefinitionsWithMapAssetMethods(
         assets=[SourceAsset("a1", group_name="abc"), AssetSpec("a2", deps=["a1"])]
-    ).map_asset_specs(lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"])))
+    ).map_asset_keys(lambda spec: spec.key.with_prefix(["prefix"]))
     all_asset_specs = mapped_defs.get_all_asset_specs()
     assert len(all_asset_specs) == 2
 
@@ -177,24 +144,18 @@ def test_source_asset():
     assert mapped_specs_by_key[AssetKey(["prefix", "a1"])].group_name == "abc"
 
 
-def test_cacheable_assets_definition():
-    class FooCacheableAssetsDefinition(CacheableAssetsDefinition):
-        def compute_cacheable_data(self):
-            return []
+def test_map_asset_keys_job_def():
+    @asset
+    def asset1(): ...
 
-        def build_definitions(self, *_args, **_kwargs):
-            return []
-
-    defs = DefinitionsWithMapAssetMethods(assets=[FooCacheableAssetsDefinition("abc")])
-
-    with pytest.raises(
-        DagsterInvalidDefinitionError,
-        match="Can't use map_asset_specs on Definitions objects that contain CacheableAssetsDefinitions.",
-    ):
-        defs.map_asset_specs(lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"])))
+    job1 = define_asset_job("job1", selection=["asset1"])
+    defs = DefinitionsWithMapAssetMethods(assets=[asset1], jobs=[job1])
+    mapped_defs = defs.map_asset_keys(lambda x: AssetKey("asset2"))
+    result = mapped_defs.get_job_def("job1").execute_in_process()
+    assert len(result.get_asset_materialization_events()) == 1
 
 
-def test_job_def_and_schedule():
+def test_map_asset_keys_job_def_and_schedule():
     @asset
     def asset1(): ...
 
@@ -202,6 +163,49 @@ def test_job_def_and_schedule():
     schedule1 = ScheduleDefinition(job=job1, cron_schedule="@daily")
     defs = DefinitionsWithMapAssetMethods(assets=[asset1], jobs=[job1], schedules=[schedule1])
     mapped_defs = defs.map_asset_keys(lambda x: AssetKey("asset2"))
-    breakpoint()
     result = mapped_defs.get_job_def("job1").execute_in_process()
-    assert len(result.get_asset_materialization_events())
+    assert len(result.get_asset_materialization_events()) == 1
+
+
+def test_map_asset_keys_job_def_inside_schedule():
+    @asset
+    def asset1(): ...
+
+    job1 = define_asset_job("job1", selection=["asset1"])
+    schedule1 = ScheduleDefinition(job=job1, cron_schedule="@daily")
+    defs = DefinitionsWithMapAssetMethods(assets=[asset1], schedules=[schedule1])
+    mapped_defs = defs.map_asset_keys(lambda x: AssetKey("asset2"))
+    result = mapped_defs.get_job_def("job1").execute_in_process()
+    assert len(result.get_asset_materialization_events()) == 1
+
+
+def test_map_asset_keys_job_def_and_sensor():
+    @asset
+    def asset1(): ...
+
+    job1 = define_asset_job("job1", selection=["asset1"])
+
+    @sensor(job=job1)
+    def sensor1():
+        return True
+
+    defs = DefinitionsWithMapAssetMethods(assets=[asset1], jobs=[job1], sensors=[sensor1])
+    mapped_defs = defs.map_asset_keys(lambda x: AssetKey("asset2"))
+    result = mapped_defs.get_job_def("job1").execute_in_process()
+    assert len(result.get_asset_materialization_events()) == 1
+
+
+def test_map_asset_keys_job_def_inside_sensor():
+    @asset
+    def asset1(): ...
+
+    job1 = define_asset_job("job1", selection=["asset1"])
+
+    @sensor(job=job1)
+    def sensor1():
+        return True
+
+    defs = DefinitionsWithMapAssetMethods(assets=[asset1], sensors=[sensor1])
+    mapped_defs = defs.map_asset_keys(lambda x: AssetKey("asset2"))
+    result = mapped_defs.get_job_def("job1").execute_in_process()
+    assert len(result.get_asset_materialization_events()) == 1

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class_map_asset_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class_map_asset_specs.py
@@ -16,7 +16,12 @@ from dagster import (
 )
 from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
+from dagster._core.definitions.definitions_class import map_asset_specs
 from dagster._core.errors import DagsterInvalidDefinitionError
+
+
+class DefinitionsWithMapAssetSpecs(Definitions):
+    map_asset_specs = map_asset_specs
 
 
 def test_single_basic_asset() -> None:
@@ -24,7 +29,7 @@ def test_single_basic_asset() -> None:
     def asset1():
         pass
 
-    mapped_defs = Definitions(assets=[asset1]).map_asset_specs(
+    mapped_defs = DefinitionsWithMapAssetSpecs(assets=[asset1]).map_asset_specs(
         lambda spec: spec._replace(group_name="yolo")
     )
     all_asset_specs = mapped_defs.get_all_asset_specs()
@@ -36,9 +41,9 @@ def test_single_basic_asset() -> None:
 
 
 def test_a_couple_specs() -> None:
-    mapped_defs = Definitions(assets=[AssetSpec("a1"), AssetSpec("a2")]).map_asset_specs(
-        lambda spec: spec._replace(group_name="yolo")
-    )
+    mapped_defs = DefinitionsWithMapAssetSpecs(
+        assets=[AssetSpec("a1"), AssetSpec("a2")]
+    ).map_asset_specs(lambda spec: spec._replace(group_name="yolo"))
     all_asset_specs = mapped_defs.get_all_asset_specs()
     assert len(all_asset_specs) == 2
 
@@ -47,11 +52,9 @@ def test_a_couple_specs() -> None:
     assert all_asset_specs[1].group_name == "yolo"
     assert all_asset_specs[1].key == AssetKey("a2")
 
-    assert len(mapped_defs.assets) == 2
-
 
 def test_two_specs_with_dep() -> None:
-    mapped_defs = Definitions(
+    mapped_defs = DefinitionsWithMapAssetSpecs(
         assets=[AssetSpec("a1"), AssetSpec("a2", deps=[AssetDep("a1")])]
     ).map_asset_specs(lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"])))
     all_asset_specs = mapped_defs.get_all_asset_specs()
@@ -61,8 +64,6 @@ def test_two_specs_with_dep() -> None:
     assert all_asset_specs[1].key == AssetKey(["prefix", "a2"])
     assert all_asset_specs[1].deps == [AssetDep(["prefix", "a1"])]
 
-    assert len(mapped_defs.assets) == 2
-
 
 def test_two_defs_with_dep() -> None:
     @asset
@@ -71,7 +72,7 @@ def test_two_defs_with_dep() -> None:
     @asset(deps=[a1])
     def a2(): ...
 
-    mapped_defs = Definitions(assets=[a1, a2]).map_asset_specs(
+    mapped_defs = DefinitionsWithMapAssetSpecs(assets=[a1, a2]).map_asset_specs(
         lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"]))
     )
     all_asset_specs = mapped_defs.get_all_asset_specs()
@@ -81,7 +82,6 @@ def test_two_defs_with_dep() -> None:
     assert mapped_specs_by_key.keys() == {AssetKey(["prefix", "a1"]), AssetKey(["prefix", "a2"])}
     assert mapped_specs_by_key[AssetKey(["prefix", "a2"])].deps == [AssetDep(["prefix", "a1"])]
 
-    assert len(mapped_defs.assets) == 2
     result = materialize(mapped_defs.assets)
     assert result.success
     assert {
@@ -95,14 +95,13 @@ def test_independent_asset_check() -> None:
     def asset_check1():
         return AssetCheckResult(passed=True)
 
-    mapped_defs = Definitions(
+    mapped_defs = DefinitionsWithMapAssetSpecs(
         assets=[AssetSpec("a1")], asset_checks=[asset_check1]
     ).map_asset_specs(lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"])))
     all_asset_specs = mapped_defs.get_all_asset_specs()
     assert len(all_asset_specs) == 1
 
     assert all_asset_specs[0].key == AssetKey(["prefix", "a1"])
-    assert len(mapped_defs.assets) == 1
     assert len(mapped_defs.asset_checks) == 1
     assert len(mapped_defs.asset_checks[0].check_specs) == 1
     assert next(iter(mapped_defs.asset_checks[0].check_specs)).asset_key == AssetKey(
@@ -116,7 +115,7 @@ def test_internal_dep():
         yield MaterializeResult(asset_key=AssetKey(["prefix", "a1"]))
         yield MaterializeResult(asset_key=AssetKey(["prefix", "a2"]))
 
-    mapped_defs = Definitions(assets=[assets]).map_asset_specs(
+    mapped_defs = DefinitionsWithMapAssetSpecs(assets=[assets]).map_asset_specs(
         lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"]))
     )
     all_asset_specs = mapped_defs.get_all_asset_specs()
@@ -126,7 +125,6 @@ def test_internal_dep():
     assert mapped_specs_by_key.keys() == {AssetKey(["prefix", "a1"]), AssetKey(["prefix", "a2"])}
     assert mapped_specs_by_key[AssetKey(["prefix", "a2"])].deps == [AssetDep(["prefix", "a1"])]
 
-    assert len(mapped_defs.assets) == 1
     result = materialize(mapped_defs.assets)
     assert result.success
     assert {
@@ -143,7 +141,7 @@ def test_asset_and_check_same_op():
         for ck in context.selected_asset_check_keys:
             yield AssetCheckResult(asset_key=ck.asset_key, check_name=ck.name, passed=True)
 
-    mapped_defs = Definitions(assets=[a1]).map_asset_specs(
+    mapped_defs = DefinitionsWithMapAssetSpecs(assets=[a1]).map_asset_specs(
         lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"]))
     )
     all_asset_specs = mapped_defs.get_all_asset_specs()
@@ -153,7 +151,6 @@ def test_asset_and_check_same_op():
     check_key = AssetCheckKey(asset_key=AssetKey(["prefix", "a1"]), name="c1")
     assert asset_graph.get(check_key) is not None
 
-    assert len(mapped_defs.assets) == 1
     result = materialize(mapped_defs.assets)
     assert result.success
     assert {
@@ -165,7 +162,7 @@ def test_asset_and_check_same_op():
 
 
 def test_source_asset():
-    mapped_defs = Definitions(
+    mapped_defs = DefinitionsWithMapAssetSpecs(
         assets=[SourceAsset("a1", group_name="abc"), AssetSpec("a2", deps=["a1"])]
     ).map_asset_specs(lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"])))
     all_asset_specs = mapped_defs.get_all_asset_specs()
@@ -176,12 +173,6 @@ def test_source_asset():
     assert mapped_specs_by_key[AssetKey(["prefix", "a2"])].deps == [AssetDep(["prefix", "a1"])]
     assert mapped_specs_by_key[AssetKey(["prefix", "a1"])].group_name == "abc"
 
-    assert len(mapped_defs.assets) == 2
-    assert any(
-        isinstance(el, SourceAsset) and el.key == AssetKey(["prefix", "a1"])
-        for el in mapped_defs.assets
-    )
-
 
 def test_cacheable_assets_definition():
     class FooCacheableAssetsDefinition(CacheableAssetsDefinition):
@@ -191,7 +182,7 @@ def test_cacheable_assets_definition():
         def build_definitions(self, *_args, **_kwargs):
             return []
 
-    defs = Definitions(assets=[FooCacheableAssetsDefinition("abc")])
+    defs = DefinitionsWithMapAssetSpecs(assets=[FooCacheableAssetsDefinition("abc")])
 
     with pytest.raises(
         DagsterInvalidDefinitionError,

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class_map_asset_specs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_class_map_asset_specs.py
@@ -1,0 +1,200 @@
+import pytest
+from dagster import (
+    AssetCheckKey,
+    AssetCheckSpec,
+    AssetDep,
+    AssetKey,
+    AssetsDefinition,
+    AssetSpec,
+    Definitions,
+    MaterializeResult,
+    SourceAsset,
+    asset,
+    asset_check,
+    materialize,
+    multi_asset,
+)
+from dagster._core.definitions.asset_check_result import AssetCheckResult
+from dagster._core.definitions.cacheable_assets import CacheableAssetsDefinition
+from dagster._core.errors import DagsterInvalidDefinitionError
+
+
+def test_single_basic_asset() -> None:
+    @asset
+    def asset1():
+        pass
+
+    mapped_defs = Definitions(assets=[asset1]).map_asset_specs(
+        lambda spec: spec._replace(group_name="yolo")
+    )
+    all_asset_specs = mapped_defs.get_all_asset_specs()
+    assert len(all_asset_specs) == 1
+    assert all_asset_specs[0].group_name == "yolo"
+    assert all_asset_specs[0].key == asset1.key
+    assert len(mapped_defs.assets) == 1
+    assert isinstance(mapped_defs.assets[0], AssetsDefinition)
+
+
+def test_a_couple_specs() -> None:
+    mapped_defs = Definitions(assets=[AssetSpec("a1"), AssetSpec("a2")]).map_asset_specs(
+        lambda spec: spec._replace(group_name="yolo")
+    )
+    all_asset_specs = mapped_defs.get_all_asset_specs()
+    assert len(all_asset_specs) == 2
+
+    assert all_asset_specs[0].group_name == "yolo"
+    assert all_asset_specs[0].key == AssetKey("a1")
+    assert all_asset_specs[1].group_name == "yolo"
+    assert all_asset_specs[1].key == AssetKey("a2")
+
+    assert len(mapped_defs.assets) == 2
+
+
+def test_two_specs_with_dep() -> None:
+    mapped_defs = Definitions(
+        assets=[AssetSpec("a1"), AssetSpec("a2", deps=[AssetDep("a1")])]
+    ).map_asset_specs(lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"])))
+    all_asset_specs = mapped_defs.get_all_asset_specs()
+    assert len(all_asset_specs) == 2
+
+    assert all_asset_specs[0].key == AssetKey(["prefix", "a1"])
+    assert all_asset_specs[1].key == AssetKey(["prefix", "a2"])
+    assert all_asset_specs[1].deps == [AssetDep(["prefix", "a1"])]
+
+    assert len(mapped_defs.assets) == 2
+
+
+def test_two_defs_with_dep() -> None:
+    @asset
+    def a1(): ...
+
+    @asset(deps=[a1])
+    def a2(): ...
+
+    mapped_defs = Definitions(assets=[a1, a2]).map_asset_specs(
+        lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"]))
+    )
+    all_asset_specs = mapped_defs.get_all_asset_specs()
+    assert len(all_asset_specs) == 2
+
+    mapped_specs_by_key = {spec.key: spec for spec in all_asset_specs}
+    assert mapped_specs_by_key.keys() == {AssetKey(["prefix", "a1"]), AssetKey(["prefix", "a2"])}
+    assert mapped_specs_by_key[AssetKey(["prefix", "a2"])].deps == [AssetDep(["prefix", "a1"])]
+
+    assert len(mapped_defs.assets) == 2
+    result = materialize(mapped_defs.assets)
+    assert result.success
+    assert {
+        e.event_specific_data.materialization.asset_key
+        for e in result.get_asset_materialization_events()
+    } == {AssetKey(["prefix", "a1"]), AssetKey(["prefix", "a2"])}
+
+
+def test_independent_asset_check() -> None:
+    @asset_check(asset="a1")
+    def asset_check1():
+        return AssetCheckResult(passed=True)
+
+    mapped_defs = Definitions(
+        assets=[AssetSpec("a1")], asset_checks=[asset_check1]
+    ).map_asset_specs(lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"])))
+    all_asset_specs = mapped_defs.get_all_asset_specs()
+    assert len(all_asset_specs) == 1
+
+    assert all_asset_specs[0].key == AssetKey(["prefix", "a1"])
+    assert len(mapped_defs.assets) == 1
+    assert len(mapped_defs.asset_checks) == 1
+    assert len(mapped_defs.asset_checks[0].check_specs) == 1
+    assert next(iter(mapped_defs.asset_checks[0].check_specs)).asset_key == AssetKey(
+        ["prefix", "a1"]
+    )
+
+
+def test_internal_dep():
+    @multi_asset(specs=[AssetSpec("a1"), AssetSpec("a2", deps=[AssetDep("a1")])])
+    def assets(context):
+        yield MaterializeResult(asset_key=AssetKey(["prefix", "a1"]))
+        yield MaterializeResult(asset_key=AssetKey(["prefix", "a2"]))
+
+    mapped_defs = Definitions(assets=[assets]).map_asset_specs(
+        lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"]))
+    )
+    all_asset_specs = mapped_defs.get_all_asset_specs()
+    assert len(all_asset_specs) == 2
+
+    mapped_specs_by_key = {spec.key: spec for spec in all_asset_specs}
+    assert mapped_specs_by_key.keys() == {AssetKey(["prefix", "a1"]), AssetKey(["prefix", "a2"])}
+    assert mapped_specs_by_key[AssetKey(["prefix", "a2"])].deps == [AssetDep(["prefix", "a1"])]
+
+    assert len(mapped_defs.assets) == 1
+    result = materialize(mapped_defs.assets)
+    assert result.success
+    assert {
+        e.event_specific_data.materialization.asset_key
+        for e in result.get_asset_materialization_events()
+    } == {AssetKey(["prefix", "a1"]), AssetKey(["prefix", "a2"])}
+
+
+def test_asset_and_check_same_op():
+    @asset(check_specs=[AssetCheckSpec(asset="a1", name="c1")])
+    def a1(context):
+        for ak in context.selected_asset_keys:
+            yield MaterializeResult(asset_key=ak)
+        for ck in context.selected_asset_check_keys:
+            yield AssetCheckResult(asset_key=ck.asset_key, check_name=ck.name, passed=True)
+
+    mapped_defs = Definitions(assets=[a1]).map_asset_specs(
+        lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"]))
+    )
+    all_asset_specs = mapped_defs.get_all_asset_specs()
+    assert len(all_asset_specs) == 1
+    assert all_asset_specs[0].key == AssetKey(["prefix", "a1"])
+    asset_graph = mapped_defs.get_asset_graph()
+    check_key = AssetCheckKey(asset_key=AssetKey(["prefix", "a1"]), name="c1")
+    assert asset_graph.get(check_key) is not None
+
+    assert len(mapped_defs.assets) == 1
+    result = materialize(mapped_defs.assets)
+    assert result.success
+    assert {
+        e.event_specific_data.materialization.asset_key
+        for e in result.get_asset_materialization_events()
+    } == {AssetKey(["prefix", "a1"])}
+
+    assert {e.asset_check_key for e in result.get_asset_check_evaluations()} == {check_key}
+
+
+def test_source_asset():
+    mapped_defs = Definitions(
+        assets=[SourceAsset("a1", group_name="abc"), AssetSpec("a2", deps=["a1"])]
+    ).map_asset_specs(lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"])))
+    all_asset_specs = mapped_defs.get_all_asset_specs()
+    assert len(all_asset_specs) == 2
+
+    mapped_specs_by_key = {spec.key: spec for spec in all_asset_specs}
+    assert mapped_specs_by_key.keys() == {AssetKey(["prefix", "a1"]), AssetKey(["prefix", "a2"])}
+    assert mapped_specs_by_key[AssetKey(["prefix", "a2"])].deps == [AssetDep(["prefix", "a1"])]
+    assert mapped_specs_by_key[AssetKey(["prefix", "a1"])].group_name == "abc"
+
+    assert len(mapped_defs.assets) == 2
+    assert any(
+        isinstance(el, SourceAsset) and el.key == AssetKey(["prefix", "a1"])
+        for el in mapped_defs.assets
+    )
+
+
+def test_cacheable_assets_definition():
+    class FooCacheableAssetsDefinition(CacheableAssetsDefinition):
+        def compute_cacheable_data(self):
+            return []
+
+        def build_definitions(self, *_args, **_kwargs):
+            return []
+
+    defs = Definitions(assets=[FooCacheableAssetsDefinition("abc")])
+
+    with pytest.raises(
+        DagsterInvalidDefinitionError,
+        match="Can't use map_asset_specs on Definitions objects that contain CacheableAssetsDefinitions.",
+    ):
+        defs.map_asset_specs(lambda spec: spec._replace(key=spec.key.with_prefix(["prefix"])))


### PR DESCRIPTION
## Summary & Motivation

Introduces a `map_assets_keys` function for `Definitions`. It accepts a function that can be applied per asset spec and returns a new `Definitions` object. The function is applied to both external asset specs and asset specs within AssetsDefinitions.

One of the uses for this is to be able to supplant the DagsterXTranslator pattern. E.g. it enables the following:

```python
from dagster import Definitions, AssetSpec
from dagster_powerbi import PowerBIWorkspace

power_bi_workspace = PowerBIWorkspace(...)

def power_bi_asset_key_from_display_name(spec: AssetSpec) -> AssetSpec:
    power_bi_display_name = spec.metadata["dagster_powerbi/display_name"]
    return AssetKey(power_bi_display_name.split("/"))

power_bi_defs = power_bi_workspace.build_defs(...).map_asset_keys(power_bi_asset_key_from_display_name)
```
instead of

```python
from dagster import Definitions, AssetSpec
from dagster_powerbi import PowerBIWorkspace, DagsterPowerBITranslator

power_bi_workspace = PowerBIWorkspace(...)

class MyDagsterPowerBITranslator(DagsterPowerBITranslator):
    def get_asset_spec(self, power_bi_blob) -> AssetSpec:
        power_bi_display_name = power_bi_blob.display_name
        return AssetSpec(key=AssetKey(power_bi_display_name.split("/")))

power_bi_defs = power_bi_workspace.build_defs(..., translator=MyDagsterPowerBITranslator())
```

Keeps jobs, downstream assets, and downstream asset checks in sync.

Sits atop `AssetSelection.replace_asset_keys`: https://github.com/dagster-io/dagster/pull/24998.

## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

