### PR TITLE
Skip fetching partition information for unpartitioned assets

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphData.tsx
@@ -80,7 +80,7 @@ export function useAssetGraphData(opsQuery: string, options: AssetGraphFetchScop
       [options.pipelineSelector, options.groupSelector],
     ),
     key: usePrefixedCacheKey(
-      `/AssetGraphQuery/${JSON.stringify({
+      `AssetGraphQuery/${JSON.stringify({
         pipelineSelector: options.pipelineSelector,
         groupSelector: options.groupSelector,
       })}`,

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/usePartitionHealthData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/usePartitionHealthData.tsx
@@ -569,11 +569,15 @@ export function usePartitionHealthData(
     });
   }, [assetKeyJSON, cacheClearStrategy, client.cache]);
 
+  const [loading, setLoading] = useState(true);
+  useBlockTraceUntilTrue('usePartitionHealthData', !loading);
+
   // Refresh state health ranges, one asset key at a time. This kicks off one
   // request and then missingKeyJSON updates when that is complete, kicking
   // off the next query.
   useMemo(() => {
     if (!missingKeyJSON) {
+      setLoading(false);
       return;
     }
     const loadKey: AssetKey = JSON.parse(missingKeyJSON);

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/AssetJobPartitionsView.tsx
@@ -50,7 +50,13 @@ export const AssetJobPartitionsView = ({
     });
   }, [assetGraph]);
 
-  const assetHealth = usePartitionHealthData(assetKeysWithPartitions);
+  const assetHealth = usePartitionHealthData(
+    assetKeysWithPartitions.length
+      ? assetKeysWithPartitions
+      : assetGraph.graphAssetKeys[0]
+      ? [assetGraph.graphAssetKeys[0]]
+      : [],
+  );
 
   const {total, missing, merged} = useMemo(() => {
     const merged = mergedAssetHealth(assetHealth.filter((h) => h.dimensions.length > 0));

--- a/js_modules/dagster-ui/packages/ui-core/src/partitions/AssetJobPartitionsView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/partitions/AssetJobPartitionsView.tsx
@@ -9,6 +9,7 @@ import {PartitionPerAssetStatus, getVisibleItemCount} from './PartitionStepStatu
 import {GRID_FLOATING_CONTAINER_WIDTH} from './RunMatrixUtils';
 import {allPartitionsRange} from './SpanRepresentation';
 import {usePartitionStepQuery} from './usePartitionStepQuery';
+import {toGraphId} from '../asset-graph/Utils';
 import {useAssetGraphData} from '../asset-graph/useAssetGraphData';
 import {AssetPartitionStatus} from '../assets/AssetPartitionStatus';
 import {LaunchAssetExecutionButton} from '../assets/LaunchAssetExecutionButton';
@@ -43,7 +44,13 @@ export const AssetJobPartitionsView = ({
     },
   });
 
-  const assetHealth = usePartitionHealthData(assetGraph.graphAssetKeys);
+  const assetKeysWithPartitions = useMemo(() => {
+    return assetGraph.graphAssetKeys.filter((key) => {
+      return assetGraph.assetGraphData?.nodes[toGraphId(key)]?.definition.isPartitioned;
+    });
+  }, [assetGraph]);
+
+  const assetHealth = usePartitionHealthData(assetKeysWithPartitions);
 
   const {total, missing, merged} = useMemo(() => {
     const merged = mergedAssetHealth(assetHealth.filter((h) => h.dimensions.length > 0));


### PR DESCRIPTION
## Summary & Motivation

Currently AssetJobPartitionsView ends up fetching partition information for every asset in the job. This PR updates it to only do it for partitioned assets because those are the assets that would have any partition information...

## How I Tested These Changes

app-proxy

Saw that a job with a hundred asset keys only fetched partition information for the 6 assets that have partititons.

## Changelog

- [x] `NEW` _([UI] Improved performance for loading partition statuses of an asset job)_

