### PR TITLE
update runs feed resolver to have runs within backfill exclusion as a separate param

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3287,7 +3287,12 @@ type Query {
   pipelineRunOrError(runId: ID!): RunOrError!
   runsOrError(filter: RunsFilter, cursor: String, limit: Int): RunsOrError!
   runOrError(runId: ID!): RunOrError!
-  runsFeedOrError(limit: Int!, cursor: String, filter: RunsFilter): RunsFeedConnectionOrError!
+  runsFeedOrError(
+    limit: Int!
+    cursor: String
+    filter: RunsFilter
+    includeRunsInBackfills: Boolean
+  ): RunsFeedConnectionOrError!
   runsFeedCountOrError(filter: RunsFilter): RunsFeedCountOrError!
   runTagKeysOrError: RunTagKeysOrError
   runTagsOrError(tagKeys: [String!], valuePrefix: String, limit: Int): RunTagsOrError

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3291,7 +3291,7 @@ type Query {
     limit: Int!
     cursor: String
     filter: RunsFilter
-    includeRunsInBackfills: Boolean
+    includeRunsFromBackfills: Boolean
   ): RunsFeedConnectionOrError!
   runsFeedCountOrError(filter: RunsFilter): RunsFeedCountOrError!
   runTagKeysOrError: RunTagKeysOrError

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -3973,7 +3973,7 @@ export type QueryRunsFeedCountOrErrorArgs = {
 export type QueryRunsFeedOrErrorArgs = {
   cursor?: InputMaybe<Scalars['String']['input']>;
   filter?: InputMaybe<RunsFilter>;
-  includeRunsInBackfills?: InputMaybe<Scalars['Boolean']['input']>;
+  includeRunsFromBackfills?: InputMaybe<Scalars['Boolean']['input']>;
   limit: Scalars['Int']['input'];
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -3973,6 +3973,7 @@ export type QueryRunsFeedCountOrErrorArgs = {
 export type QueryRunsFeedOrErrorArgs = {
   cursor?: InputMaybe<Scalars['String']['input']>;
   filter?: InputMaybe<RunsFilter>;
+  includeRunsInBackfills?: InputMaybe<Scalars['Boolean']['input']>;
   limit: Scalars['Int']['input'];
 };
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -376,6 +376,7 @@ class GrapheneQuery(graphene.ObjectType):
         limit=graphene.NonNull(graphene.Int),
         cursor=graphene.String(),
         filter=graphene.Argument(GrapheneRunsFilter),
+        include_runs_in_backfills=graphene.Boolean(),
         description="Retrieve entries for the Runs Feed after applying a filter, cursor and limit.",
     )
     runsFeedCountOrError = graphene.Field(
@@ -852,12 +853,17 @@ class GrapheneQuery(graphene.ObjectType):
         self,
         graphene_info: ResolveInfo,
         limit: int,
+        include_runs_in_backfills,
         cursor: Optional[str] = None,
         filter: Optional[GrapheneRunsFilter] = None,  # noqa: A002
     ):
         selector = filter.to_selector() if filter is not None else None
         return get_runs_feed_entries(
-            graphene_info=graphene_info, cursor=cursor, limit=limit, filters=selector
+            graphene_info=graphene_info,
+            cursor=cursor,
+            limit=limit,
+            filters=selector,
+            include_runs_in_backfills=include_runs_in_backfills,
         )
 
     def resolve_runsFeedCountOrError(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -853,7 +853,7 @@ class GrapheneQuery(graphene.ObjectType):
         self,
         graphene_info: ResolveInfo,
         limit: int,
-        includeRunsInBackfill,
+        includeRunsInBackfills,
         cursor: Optional[str] = None,
         filter: Optional[GrapheneRunsFilter] = None,  # noqa: A002
     ):
@@ -863,7 +863,7 @@ class GrapheneQuery(graphene.ObjectType):
             cursor=cursor,
             limit=limit,
             filters=selector,
-            include_runs_in_backfills=includeRunsInBackfill,
+            include_runs_in_backfills=includeRunsInBackfills,
         )
 
     def resolve_runsFeedCountOrError(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -376,7 +376,7 @@ class GrapheneQuery(graphene.ObjectType):
         limit=graphene.NonNull(graphene.Int),
         cursor=graphene.String(),
         filter=graphene.Argument(GrapheneRunsFilter),
-        include_runs_in_backfills=graphene.Boolean(),
+        includeRunsInBackfills=graphene.Boolean(),
         description="Retrieve entries for the Runs Feed after applying a filter, cursor and limit.",
     )
     runsFeedCountOrError = graphene.Field(
@@ -853,7 +853,7 @@ class GrapheneQuery(graphene.ObjectType):
         self,
         graphene_info: ResolveInfo,
         limit: int,
-        include_runs_in_backfills,
+        includeRunsInBackfill,
         cursor: Optional[str] = None,
         filter: Optional[GrapheneRunsFilter] = None,  # noqa: A002
     ):
@@ -863,7 +863,7 @@ class GrapheneQuery(graphene.ObjectType):
             cursor=cursor,
             limit=limit,
             filters=selector,
-            include_runs_in_backfills=include_runs_in_backfills,
+            include_runs_in_backfills=includeRunsInBackfill,
         )
 
     def resolve_runsFeedCountOrError(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -376,7 +376,7 @@ class GrapheneQuery(graphene.ObjectType):
         limit=graphene.NonNull(graphene.Int),
         cursor=graphene.String(),
         filter=graphene.Argument(GrapheneRunsFilter),
-        includeRunsInBackfills=graphene.Boolean(),
+        includeRunsFromBackfills=graphene.Boolean(),
         description="Retrieve entries for the Runs Feed after applying a filter, cursor and limit.",
     )
     runsFeedCountOrError = graphene.Field(
@@ -853,7 +853,7 @@ class GrapheneQuery(graphene.ObjectType):
         self,
         graphene_info: ResolveInfo,
         limit: int,
-        includeRunsInBackfills: bool,
+        includeRunsFromBackfills: bool,
         cursor: Optional[str] = None,
         filter: Optional[GrapheneRunsFilter] = None,  # noqa: A002
     ):
@@ -863,7 +863,7 @@ class GrapheneQuery(graphene.ObjectType):
             cursor=cursor,
             limit=limit,
             filters=selector,
-            include_runs_in_backfills=includeRunsInBackfills,
+            include_runs_from_backfills=includeRunsFromBackfills,
         )
 
     def resolve_runsFeedCountOrError(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -853,7 +853,7 @@ class GrapheneQuery(graphene.ObjectType):
         self,
         graphene_info: ResolveInfo,
         limit: int,
-        includeRunsInBackfills,
+        includeRunsInBackfills: bool,
         cursor: Optional[str] = None,
         filter: Optional[GrapheneRunsFilter] = None,  # noqa: A002
     ):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
@@ -17,8 +17,8 @@ from dagster_graphql_tests.graphql.graphql_context_test_suite import (
 )
 
 GET_RUNS_FEED_QUERY = """
-query RunsFeedEntryQuery($cursor: String, $limit: Int!, $filter: RunsFilter, $include_runs_in_backfills: Boolean!) {
-    runsFeedOrError(cursor: $cursor, limit: $limit, filter: $filter, include_runs_in_backfills: $include_runs_in_backfills) {
+query RunsFeedEntryQuery($cursor: String, $limit: Int!, $filter: RunsFilter, $includeRunsInBackfills: Boolean!) {
+    runsFeedOrError(cursor: $cursor, limit: $limit, filter: $filter, includeRunsInBackfills: $includeRunsInBackfills) {
       ... on RunsFeedConnection {
           results {
             __typename
@@ -131,7 +131,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         _assert_results_match_count_match_expected(result, 20)
@@ -148,7 +148,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -174,7 +174,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": old_cursor,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -194,7 +194,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 15,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -218,7 +218,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         # limit was used, count will differ from number of results returned
@@ -239,7 +239,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -271,7 +271,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": old_cursor.to_string(),
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -297,7 +297,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
         prev_run_time = None
@@ -314,7 +314,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
 
@@ -338,7 +338,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 5,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
 
@@ -364,7 +364,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 5,
                 "cursor": old_cursor,
                 "filter": None,
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
 
@@ -401,7 +401,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -426,7 +426,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -449,7 +449,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -481,7 +481,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -512,7 +512,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -540,7 +540,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -572,7 +572,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 5,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -605,7 +605,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -643,7 +643,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -660,7 +660,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["SUCCESS"]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -674,7 +674,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["FAILURE"]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -688,7 +688,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELING"]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -702,7 +702,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELED"]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -716,7 +716,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["NOT_STARTED"]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -742,7 +742,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
 
@@ -759,7 +759,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["SUCCESS"]},
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
         assert not result.errors
@@ -773,7 +773,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["FAILURE"]},
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
         assert not result.errors
@@ -787,7 +787,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELING"]},
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
         assert not result.errors
@@ -801,7 +801,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELED"]},
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
         assert not result.errors
@@ -834,7 +834,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -851,7 +851,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": nothing_created_ts},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -866,7 +866,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": half_created_ts},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -881,7 +881,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": all_created_ts},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -898,7 +898,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 6,
                 "cursor": None,
                 "filter": {"createdBefore": half_created_ts},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -913,7 +913,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 4,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": {"createdBefore": half_created_ts},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -958,7 +958,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -975,7 +975,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"pipelineName": "foo"},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -989,7 +989,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"pipelineName": "bar"},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1020,7 +1020,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -1037,7 +1037,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "bar"}]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1052,7 +1052,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "baz", "value": "quux"}]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1066,7 +1066,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "baz"}]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1085,7 +1085,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -1102,7 +1102,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"runIds": [run.run_id]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1123,7 +1123,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
 
@@ -1140,7 +1140,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"runIds": [run.run_id]},
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
         assert not result.errors
@@ -1190,7 +1190,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -1207,7 +1207,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "bar"}], "statuses": ["SUCCESS"]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1224,7 +1224,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                     "tags": [{"key": "foo", "value": "bar"}],
                     "statuses": ["FAILURE", "CANCELED"],
                 },
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1238,7 +1238,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "baz"}], "statuses": ["FAILURE"]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1258,7 +1258,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -1274,7 +1274,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": BACKFILL_ID_TAG, "value": backfill_id}]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1296,7 +1296,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                         {"key": "not", "value": "present"},
                     ]
                 },
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
@@ -17,8 +17,8 @@ from dagster_graphql_tests.graphql.graphql_context_test_suite import (
 )
 
 GET_RUNS_FEED_QUERY = """
-query RunsFeedEntryQuery($cursor: String, $limit: Int!, $filter: RunsFilter) {
-    runsFeedOrError(cursor: $cursor, limit: $limit, filter: $filter) {
+query RunsFeedEntryQuery($cursor: String, $limit: Int!, $filter: RunsFilter, $include_runs_in_backfills: Boolean!) {
+    runsFeedOrError(cursor: $cursor, limit: $limit, filter: $filter, include_runs_in_backfills: $include_runs_in_backfills) {
       ... on RunsFeedConnection {
           results {
             __typename
@@ -131,6 +131,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
         _assert_results_match_count_match_expected(result, 20)
@@ -147,6 +148,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -172,6 +174,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": old_cursor,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -191,6 +194,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 15,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -214,6 +218,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
         # limit was used, count will differ from number of results returned
@@ -234,6 +239,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -265,6 +271,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": old_cursor.to_string(),
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -289,7 +296,8 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 25,
                 "cursor": None,
-                "filter": {"excludeSubruns": False},
+                "filter": None,
+                "include_runs_in_backfills": True,
             },
         )
         prev_run_time = None
@@ -305,7 +313,8 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 10,
                 "cursor": None,
-                "filter": {"excludeSubruns": False},
+                "filter": None,
+                "include_runs_in_backfills": True,
             },
         )
 
@@ -328,7 +337,8 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 5,
                 "cursor": None,
-                "filter": {"excludeSubruns": False},
+                "filter": None,
+                "include_runs_in_backfills": True,
             },
         )
 
@@ -353,7 +363,8 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 5,
                 "cursor": old_cursor,
-                "filter": {"excludeSubruns": False},
+                "filter": None,
+                "include_runs_in_backfills": True,
             },
         )
 
@@ -390,6 +401,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -414,6 +426,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -436,6 +449,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -467,6 +481,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -497,6 +512,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -524,6 +540,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -555,6 +572,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 5,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -587,6 +605,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -624,6 +643,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -640,6 +660,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["SUCCESS"]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -653,6 +674,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["FAILURE"]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -666,6 +688,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELING"]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -679,6 +702,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELED"]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -692,6 +716,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["NOT_STARTED"]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -716,7 +741,8 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 10,
                 "cursor": None,
-                "filter": {"excludeSubruns": False},
+                "filter": None,
+                "include_runs_in_backfills": True,
             },
         )
 
@@ -732,7 +758,8 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 10,
                 "cursor": None,
-                "filter": {"statuses": ["SUCCESS"], "excludeSubruns": False},
+                "filter": {"statuses": ["SUCCESS"]},
+                "include_runs_in_backfills": True,
             },
         )
         assert not result.errors
@@ -745,7 +772,8 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 10,
                 "cursor": None,
-                "filter": {"statuses": ["FAILURE"], "excludeSubruns": False},
+                "filter": {"statuses": ["FAILURE"]},
+                "include_runs_in_backfills": True,
             },
         )
         assert not result.errors
@@ -758,7 +786,8 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 10,
                 "cursor": None,
-                "filter": {"statuses": ["CANCELING"], "excludeSubruns": False},
+                "filter": {"statuses": ["CANCELING"]},
+                "include_runs_in_backfills": True,
             },
         )
         assert not result.errors
@@ -771,7 +800,8 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 10,
                 "cursor": None,
-                "filter": {"statuses": ["CANCELED"], "excludeSubruns": False},
+                "filter": {"statuses": ["CANCELED"]},
+                "include_runs_in_backfills": True,
             },
         )
         assert not result.errors
@@ -804,6 +834,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -820,6 +851,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": nothing_created_ts},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -834,6 +866,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": half_created_ts},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -848,6 +881,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": all_created_ts},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -864,6 +898,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 6,
                 "cursor": None,
                 "filter": {"createdBefore": half_created_ts},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -878,6 +913,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 4,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": {"createdBefore": half_created_ts},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -922,6 +958,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -938,6 +975,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"pipelineName": "foo"},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -951,6 +989,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"pipelineName": "bar"},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -981,6 +1020,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -997,6 +1037,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "bar"}]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -1011,6 +1052,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "baz", "value": "quux"}]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -1024,6 +1066,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "baz"}]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -1042,6 +1085,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -1058,6 +1102,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"runIds": [run.run_id]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -1077,7 +1122,8 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 20,
                 "cursor": None,
-                "filter": {"excludeSubruns": False},
+                "filter": None,
+                "include_runs_in_backfills": True,
             },
         )
 
@@ -1093,7 +1139,8 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 10,
                 "cursor": None,
-                "filter": {"runIds": [run.run_id], "excludeSubruns": False},
+                "filter": {"runIds": [run.run_id]},
+                "include_runs_in_backfills": True,
             },
         )
         assert not result.errors
@@ -1143,6 +1190,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -1159,6 +1207,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "bar"}], "statuses": ["SUCCESS"]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -1175,6 +1224,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                     "tags": [{"key": "foo", "value": "bar"}],
                     "statuses": ["FAILURE", "CANCELED"],
                 },
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -1188,6 +1238,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "baz"}], "statuses": ["FAILURE"]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -1207,6 +1258,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -1222,6 +1274,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": BACKFILL_ID_TAG, "value": backfill_id}]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -1243,6 +1296,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                         {"key": "not", "value": "present"},
                     ]
                 },
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
@@ -17,8 +17,8 @@ from dagster_graphql_tests.graphql.graphql_context_test_suite import (
 )
 
 GET_RUNS_FEED_QUERY = """
-query RunsFeedEntryQuery($cursor: String, $limit: Int!, $filter: RunsFilter, $includeRunsInBackfills: Boolean!) {
-    runsFeedOrError(cursor: $cursor, limit: $limit, filter: $filter, includeRunsInBackfills: $includeRunsInBackfills) {
+query RunsFeedEntryQuery($cursor: String, $limit: Int!, $filter: RunsFilter, $includeRunsFromBackfills: Boolean!) {
+    runsFeedOrError(cursor: $cursor, limit: $limit, filter: $filter, includeRunsFromBackfills: $includeRunsFromBackfills) {
       ... on RunsFeedConnection {
           results {
             __typename
@@ -131,7 +131,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         _assert_results_match_count_match_expected(result, 20)
@@ -148,7 +148,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -174,7 +174,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": old_cursor,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -194,7 +194,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 15,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -218,7 +218,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         # limit was used, count will differ from number of results returned
@@ -239,7 +239,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -271,7 +271,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": old_cursor.to_string(),
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -297,7 +297,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
         prev_run_time = None
@@ -314,7 +314,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
 
@@ -338,7 +338,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 5,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
 
@@ -364,7 +364,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 5,
                 "cursor": old_cursor,
                 "filter": None,
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
 
@@ -401,7 +401,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -426,7 +426,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -449,7 +449,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -481,7 +481,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -512,7 +512,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -540,7 +540,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -572,7 +572,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 5,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -605,7 +605,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -643,7 +643,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -660,7 +660,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["SUCCESS"]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -674,7 +674,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["FAILURE"]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -688,7 +688,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELING"]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -702,7 +702,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELED"]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -716,7 +716,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["NOT_STARTED"]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -742,7 +742,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
 
@@ -759,7 +759,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["SUCCESS"]},
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
         assert not result.errors
@@ -773,7 +773,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["FAILURE"]},
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
         assert not result.errors
@@ -787,7 +787,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELING"]},
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
         assert not result.errors
@@ -801,7 +801,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELED"]},
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
         assert not result.errors
@@ -834,7 +834,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -851,7 +851,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": nothing_created_ts},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -866,7 +866,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": half_created_ts},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -881,7 +881,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": all_created_ts},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -898,7 +898,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 6,
                 "cursor": None,
                 "filter": {"createdBefore": half_created_ts},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -913,7 +913,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 4,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": {"createdBefore": half_created_ts},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -958,7 +958,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -975,7 +975,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"pipelineName": "foo"},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -989,7 +989,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"pipelineName": "bar"},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1020,7 +1020,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -1037,7 +1037,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "bar"}]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1052,7 +1052,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "baz", "value": "quux"}]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1066,7 +1066,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "baz"}]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1085,7 +1085,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -1102,7 +1102,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"runIds": [run.run_id]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1123,7 +1123,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
 
@@ -1140,7 +1140,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"runIds": [run.run_id]},
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
         assert not result.errors
@@ -1190,7 +1190,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -1207,7 +1207,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "bar"}], "statuses": ["SUCCESS"]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1224,7 +1224,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                     "tags": [{"key": "foo", "value": "bar"}],
                     "statuses": ["FAILURE", "CANCELED"],
                 },
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1238,7 +1238,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "baz"}], "statuses": ["FAILURE"]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1258,7 +1258,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -1274,7 +1274,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": BACKFILL_ID_TAG, "value": backfill_id}]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1296,7 +1296,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                         {"key": "not", "value": "present"},
                     ]
                 },
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors


### PR DESCRIPTION
## Summary & Motivation

Originally we were showing/hiding subruns by setting `exclude_subruns` on `GrapheneRunsFilter`. This caused an issue with the default behavior for the filter

The existing Runs page and the Runs feed share code for how to create the filters that are applied to the page. 
On the existing runs page, we want all runs shown, but on the runs feed we want to hide runs that are part of backfills by default. Since the two pages use the same code to generate the filters that are sent to the backend, both have `show_runs_within_backfill` as None in the default case. That means the backend needs to determine what to do in this default case. For the existing runs page it's fine, because the filter is always ignored (and there's no way to set in the UI). For the runs feed, we need to convert the `None` to `True` so that we exclude subruns from the results we fetch from the db. This becomes more confusing because the behavior for `exclude_subruns` on `RunsFilter` is to be `False` when  `None` is passed (i think this should also change to be non-optional, but will do that later). So we have different behavior for the default None value based on whether you set it on the front end or the backend. 

This behavior is too complicated, even explaining it here is difficult, and will definitely cause a headache in the future so i'm changing it so that the GQL endpoint for fetching the runs feed take an additional parameter on whether to hide or show. makes the whole thing a lot easier to keep track of and understand the intended behavior.

internal pr https://github.com/dagster-io/internal/pull/11998

## How I Tested These Changes

## Changelog

NOCHANGELOG
