### PR TITLE
prevent TableColumn.tags from shifting job snapshot id

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/metadata/table.py
+++ b/python_modules/dagster/dagster/_core/definitions/metadata/table.py
@@ -114,7 +114,7 @@ _DEFAULT_TABLE_COLUMN_CONSTRAINTS = TableColumnConstraints()
 # ########################
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(skip_when_empty_fields={"tags"})
 class TableColumn(
     NamedTuple(
         "TableColumn",


### PR DESCRIPTION

## How I Tested These Changes

run a script on a specific snapshot to verify snapshot id is now stable
