### PR TITLE
[dagster-airlift][dag-asset][rfc] full dag override working

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/constants.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/constants.py
@@ -1,4 +1,4 @@
-STANDALONE_DAG_ID_METADATA_KEY = "airlift/dag_id"
+STANDALONE_DAG_ID_METADATA_KEY = "dagster-airlift/dag_id"
 AIRFLOW_SOURCE_METADATA_KEY_PREFIX = "dagster-airlift/source"
 TASK_MAPPING_METADATA_KEY = "dagster-airlift/task_mapping"
 # This represents the timestamp used in ordering the materializatons.

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/__init__.py
@@ -2,6 +2,7 @@ from ..proxied_state import load_proxied_state_from_yaml as load_proxied_state_f
 from .basic_auth import BasicAuthBackend as BasicAuthBackend
 from .dag_defs import (
     dag_defs as dag_defs,
+    standalone_dag_defs as standalone_dag_defs,
     task_defs as task_defs,
 )
 from .defs_builders import specs_from_task as specs_from_task

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
@@ -10,14 +10,18 @@ from dagster import (
 from dagster._record import record
 from dagster._serdes.serdes import deserialize_value
 
-from dagster_airlift.constants import STANDALONE_DAG_ID_METADATA_KEY
 from dagster_airlift.core.airflow_instance import AirflowInstance
-from dagster_airlift.core.serialization.defs_construction import make_default_dag_asset_key
 from dagster_airlift.core.serialization.serialized_data import (
     SerializedAirflowDefinitionsData,
     TaskHandle,
 )
-from dagster_airlift.core.utils import get_metadata_key, is_mapped_asset_spec, task_handles_for_spec
+from dagster_airlift.core.utils import (
+    dag_ids_for_spec,
+    get_metadata_key,
+    is_dag_mapped_asset_spec,
+    is_task_mapped_asset_spec,
+    task_handles_for_spec,
+)
 
 
 @record
@@ -57,23 +61,24 @@ class AirflowDefinitionsData:
     def asset_keys_per_task_handle(self) -> Mapping[TaskHandle, AbstractSet[AssetKey]]:
         asset_keys_per_handle = defaultdict(set)
         for spec in self.resolved_airflow_defs.get_all_asset_specs():
-            if is_mapped_asset_spec(spec):
+            if is_task_mapped_asset_spec(spec):
                 task_handles = task_handles_for_spec(spec)
                 for task_handle in task_handles:
                     asset_keys_per_handle[task_handle].add(spec.key)
         return asset_keys_per_handle
 
     @cached_property
-    def asset_key_per_dag(self) -> Mapping[str, AssetKey]:
-        dag_id_to_asset_key = {}
+    def asset_keys_per_dag(self) -> Mapping[str, AbstractSet[AssetKey]]:
+        dag_id_to_asset_key = defaultdict(set)
         for spec in self.resolved_airflow_defs.get_all_asset_specs():
-            if STANDALONE_DAG_ID_METADATA_KEY in spec.metadata:
-                dag_id = spec.metadata[STANDALONE_DAG_ID_METADATA_KEY]
-                dag_id_to_asset_key[dag_id] = spec.key
+            if is_dag_mapped_asset_spec(spec):
+                dag_ids = dag_ids_for_spec(spec)
+                for dag_id in dag_ids:
+                    dag_id_to_asset_key[dag_id].add(spec.key)
         return dag_id_to_asset_key
 
-    def asset_key_for_dag(self, dag_id: str) -> AssetKey:
-        return make_default_dag_asset_key(self.serialized_data.instance_name, dag_id)
+    def asset_keys_for_dag(self, dag_id: str) -> AbstractSet[AssetKey]:
+        return self.asset_keys_per_dag[dag_id]
 
     def asset_keys_in_task(self, dag_id: str, task_id: str) -> AbstractSet[AssetKey]:
         return self.asset_keys_per_task_handle[TaskHandle(dag_id=dag_id, task_id=task_id)]

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/dag_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/dag_defs.py
@@ -7,7 +7,7 @@ from dagster import (
     _check as check,
 )
 
-from dagster_airlift.core.utils import metadata_for_task_mapping
+from dagster_airlift.core.utils import metadata_for_dag_mapping, metadata_for_task_mapping
 
 
 class TaskDefs:
@@ -91,3 +91,30 @@ def task_defs(task_id, defs: Definitions) -> TaskDefs:
     by Airlift tooling.
     """
     return TaskDefs(task_id, defs)
+
+
+def standalone_dag_defs(
+    dag_id: str,
+    defs: Definitions,
+) -> Definitions:
+    """Construct a Dagster :py:class:`Definitions` object with definitions
+    associated with a particular Dag in Airflow that is being tracked by Airlift tooling.
+
+    Concretely this adds metadata to all asset specs in the provided definitions
+    with the provided dag_id. There is a single metadata key
+    "dagster-airlift/dag_id" that is used to store this information. It is a simple string listing the dag_id.
+    This should be used in an either-or manner with :py:func:`dag_defs`. Whereas dag_defs is used to associate
+    each task with a specific set of Definitions, this function is used to associate a single set of Definitions
+    with an entire Dag.
+
+    Example:
+    .. code-block:: python
+        defs = standalone_dag_defs(
+            "dag_one",
+            Definitions(assets=[AssetSpec(key="asset_one")]),
+        )
+    """
+    return apply_metadata_to_all_specs(
+        defs=defs,
+        metadata=metadata_for_dag_mapping(dag_id=dag_id),
+    )

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
@@ -43,10 +43,11 @@ def materializations_for_dag_run(
 ) -> Sequence[AssetMaterialization]:
     return [
         AssetMaterialization(
-            asset_key=airflow_data.asset_key_for_dag(dag_run.dag_id),
+            asset_key=key,
             description=dag_run.note,
             metadata=get_dag_run_metadata(dag_run),
         )
+        for key in airflow_data.asset_keys_for_dag(dag_run.dag_id)
     ]
 
 

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/gql_queries.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/gql_queries.py
@@ -20,6 +20,10 @@ query AssetNodeQuery {
                 label
                 jsonString
             }
+            ... on TextMetadataEntry {
+                label
+                text
+            }
             __typename
         }
         jobs {

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/proxying_fn.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/proxying_fn.py
@@ -10,6 +10,7 @@ from dagster_airlift.in_airflow.base_proxy_operator import (
     BaseProxyToDagsterOperator,
     DefaultProxyToDagsterOperator,
     build_dagster_task,
+    build_override_task,
 )
 from dagster_airlift.proxied_state import AirflowProxiedState, DagProxiedState
 from dagster_airlift.utils import get_local_proxied_state_dir
@@ -38,7 +39,8 @@ def proxying_to_dagster(
     if not logger:
         logger = logging.getLogger("dagster_airlift")
     logger.debug(f"Searching for dags proxied to dagster{suffix}...")
-    proxying_dags: List[DAG] = []
+    task_proxying_dags: List[DAG] = []
+    override_dags: List[DAG] = []
     all_dag_ids: Set[str] = set()
     # Do a pass to collect dags and ensure that proxied information is set correctly.
     for obj in global_vars.values():
@@ -46,28 +48,43 @@ def proxying_to_dagster(
             continue
         dag: DAG = obj
         all_dag_ids.add(dag.dag_id)
-        if not proxied_state.dag_has_proxied_state(dag.dag_id):
+        if not proxied_state.dag_proxies_dag(dag.dag_id) and not proxied_state.dag_proxies_tasks(
+            dag.dag_id
+        ):
             logger.debug(f"Dag with id `{dag.dag_id}` has no proxied state. Skipping...")
             continue
         logger.debug(f"Dag with id `{dag.dag_id}` has proxied state.")
         proxied_state_for_dag = proxied_state.dags[dag.dag_id]
-        for task_id in proxied_state_for_dag.tasks.keys():
-            if task_id not in dag.task_dict:
-                raise Exception(
-                    f"Task with id `{task_id}` not found in dag `{dag.dag_id}`. Found tasks: {list(dag.task_dict.keys())}"
-                )
-            if not isinstance(dag.task_dict[task_id], BaseOperator):
-                raise Exception(
-                    f"Task with id `{task_id}` in dag `{dag.dag_id}` is not an instance of BaseOperator. This likely means a MappedOperator was attempted, which is not yet supported by airlift."
-                )
-        proxying_dags.append(dag)
+        if proxied_state_for_dag.proxied:
+            logger.debug("Full dag-level override detected.")
+            override_dags.append(dag)
+        else:
+            logger.debug("Task-level overrides detected.")
+            for task_id in proxied_state_for_dag.tasks.keys():
+                if task_id not in dag.task_dict:
+                    raise Exception(
+                        f"Task with id `{task_id}` not found in dag `{dag.dag_id}`. Found tasks: {list(dag.task_dict.keys())}"
+                    )
+                if not isinstance(dag.task_dict[task_id], BaseOperator):
+                    raise Exception(
+                        f"Task with id `{task_id}` in dag `{dag.dag_id}` is not an instance of BaseOperator. This likely means a MappedOperator was attempted, which is not yet supported by airlift."
+                    )
+        task_proxying_dags.append(dag)
 
     if len(all_dag_ids) == 0:
         raise Exception(
             "No dags found in globals dictionary. Ensure that your dags are available from global context, and that the call to `proxying_to_dagster` is the last line in your dag file."
         )
 
-    for dag in proxying_dags:
+    for dag in override_dags:
+        logger.debug(f"Tagging dag {dag.dag_id} as override proxied.")
+        dag.tags = [*dag.tags, "Dag overriden to Dagster"]
+        dag.task_dict = {}
+        dag.task_group.children = {}
+        override_task = build_override_task(dag)
+        dag.task_dict[override_task.task_id] = override_task
+
+    for dag in task_proxying_dags:
         logger.debug(f"Tagging dag {dag.dag_id} as proxied.")
         set_proxied_state_for_dag_if_changed(dag.dag_id, proxied_state.dags[dag.dag_id], logger)
         proxied_state_for_dag = proxied_state.dags[dag.dag_id]
@@ -108,7 +125,7 @@ def proxying_to_dagster(
             original_op.dag = None
             proxied_tasks.add(task_id)
         logger.debug(f"Proxied tasks {proxied_tasks} in dag {dag.dag_id}.")
-    logging.debug(f"Proxied {len(proxying_dags)}.")
+    logging.debug(f"Proxied {len(task_proxying_dags)}.")
     logging.debug(f"Completed switching proxied tasks to dagster{suffix}.")
 
 

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
@@ -200,4 +200,4 @@ def test_produce_fetched_airflow_data() -> None:
         mapping_info=mapping_info,
     )
 
-    assert len(fetched_airflow_data.mapping_info.mapped_asset_specs) == 1
+    assert len(fetched_airflow_data.mapping_info.mapped_to_task_asset_specs) == 1

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_dag_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_dag_defs.py
@@ -1,7 +1,7 @@
 from dagster import AssetKey, AssetSpec, Definitions, multi_asset
 from dagster._core.definitions.asset_key import CoercibleToAssetKey
 from dagster_airlift.constants import TASK_MAPPING_METADATA_KEY
-from dagster_airlift.core import dag_defs, task_defs
+from dagster_airlift.core import dag_defs, standalone_dag_defs, task_defs
 
 
 def from_specs(*specs: AssetSpec) -> Definitions:
@@ -58,3 +58,11 @@ def test_dag_def_defs() -> None:
         task_defs("task_one", Definitions(assets=[an_asset])),
     )
     assert has_single_task_handle(asset_spec(defs, "asset_one"), "dag_one", "task_one")
+
+
+def test_standlone_dag_defs() -> None:
+    @multi_asset(specs=[AssetSpec(key="asset_one")])
+    def an_asset() -> None: ...
+
+    defs = standalone_dag_defs("dag_one", Definitions(assets=[an_asset]))
+    assert asset_spec(defs, "asset_one").metadata == {"dagster-airlift/dag_id": "dag_one"}

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_sensor.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_sensor.py
@@ -344,3 +344,20 @@ def test_no_runs(init_load_context: None, instance: DagsterInstance) -> None:
         assert new_cursor.dag_query_offset == 0
         assert not result.asset_events
         assert not result.run_requests
+
+
+def test_standalone_dag_materializations(init_load_context: None) -> None:
+    """Test that assets provided in the standalone dag are materialized."""
+    freeze_datetime = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    with freeze_time(freeze_datetime):
+        result, context = build_and_invoke_sensor(
+            assets_per_dag={
+                "dag": [
+                    ("a", []),
+                    ("b", ["a"]),
+                ]
+            },
+        )
+        assert isinstance(result, SensorResult)
+        assert len(result.asset_events) == 2
+        assert_expected_key_order(result.asset_events, ["a", "b"])

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/full_proxied_dag.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/full_proxied_dag.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from pathlib import Path
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from dagster_airlift.in_airflow import proxying_to_dagster
+from dagster_airlift.proxied_state import load_proxied_state_from_yaml
+
+
+def print_hello() -> None:
+    print("Hello")  # noqa: T201
+
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2023, 1, 1),
+    "retries": 1,
+}
+
+
+with DAG(
+    "overridden_dag",
+    default_args=default_args,
+    schedule_interval=None,
+    is_paused_upon_creation=False,
+) as dag:
+    PythonOperator(task_id="print_task", python_callable=print_hello) << PythonOperator(
+        task_id="downstream_print_task", python_callable=print_hello
+    )  # type: ignore
+
+
+proxying_to_dagster(
+    proxied_state=load_proxied_state_from_yaml(Path(__file__).parent / "proxied_state"),
+    global_vars=globals(),
+)

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/proxied_state/overridden_dag.yaml
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/proxied_state/overridden_dag.yaml
@@ -1,0 +1,1 @@
+proxied: True

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/dagster_defs/mapped_defs.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/dagster_defs/mapped_defs.py
@@ -1,6 +1,11 @@
 # ruff: noqa: T201
 from dagster import Definitions, asset
-from dagster_airlift.core import build_defs_from_airflow_instance, dag_defs, task_defs
+from dagster_airlift.core import (
+    build_defs_from_airflow_instance,
+    dag_defs,
+    standalone_dag_defs,
+    task_defs,
+)
 from dagster_airlift.core.multiple_tasks import targeted_by_multiple_tasks
 
 from .airflow_instance import local_airflow_instance
@@ -14,6 +19,11 @@ def print_asset() -> None:
 @asset(description="Asset one is materialized by multiple airflow tasks")
 def asset_one() -> None:
     print("Materialized asset one")
+
+
+@asset(description="Asset two is materialized by an overridden dag")
+def asset_two() -> None:
+    print("Materialized asset two")
 
 
 def build_mapped_defs() -> Definitions:
@@ -30,6 +40,10 @@ def build_mapped_defs() -> Definitions:
                     {"dag_id": "weekly_dag", "task_id": "asset_one_weekly"},
                     {"dag_id": "daily_dag", "task_id": "asset_one_daily"},
                 ],
+            ),
+            standalone_dag_defs(
+                "overridden_dag",
+                Definitions([asset_two]),
             ),
         ),
     )

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_mapped.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_mapped.py
@@ -40,6 +40,44 @@ def dagster_dev_cmd_fixture() -> List[str]:
     return ["make", "run_dagster_mapped", "-C", str(makefile_dir())]
 
 
+def test_migrated_overridden_dag_materializes(
+    airflow_instance: None,
+    dagster_dev: None,
+    dagster_home: str,
+) -> None:
+    """Test that assets are properly materialized from an overridden dag."""
+    from kitchen_sink.dagster_defs.airflow_instance import local_airflow_instance
+
+    af_instance = local_airflow_instance()
+
+    expected_mats_per_dag = {
+        "overridden_dag": [AssetKey("asset_two")],
+    }
+    for dag_id, expected_asset_keys in expected_mats_per_dag.items():
+        airflow_run_id = af_instance.trigger_dag(dag_id=dag_id)
+        af_instance.wait_for_run_completion(dag_id=dag_id, run_id=airflow_run_id, timeout=60)
+        dagster_instance = DagsterInstance.get()
+
+        for expected_asset_key in expected_asset_keys:
+            mat_event_log_entry = poll_for_materialization(dagster_instance, expected_asset_key)
+            assert mat_event_log_entry.asset_materialization
+            assert mat_event_log_entry.asset_materialization.asset_key == expected_asset_key
+
+            assert mat_event_log_entry.asset_materialization
+            dagster_run_id = mat_event_log_entry.run_id
+
+            # test for dag run-tag-id
+            dagster_run = dagster_instance.get_run_by_id(dagster_run_id)
+            run_ids = dagster_instance.get_run_ids()
+            assert dagster_run, f"Could not find dagster run {dagster_run_id} All run_ids {run_ids}"
+            assert (
+                DAG_RUN_ID_TAG_KEY in dagster_run.tags
+            ), f"Could not find dagster run tag: dagster_run.tags {dagster_run.tags}"
+            assert (
+                dagster_run.tags[DAG_RUN_ID_TAG_KEY] == airflow_run_id
+            ), "dagster run tag does not match dag run id"
+
+
 def test_migrated_dagster_print_materializes(
     airflow_instance: None,
     dagster_dev: None,


### PR DESCRIPTION
## Summary & Motivation
Full working dag override. This PR is mostly to get alignment on direction and bulldoze through implementation details.
A few things that come out of this:
- Proxied state stuff should use TypedDicts. Makes everything feel way better.
- We should preempt actually doing full dag overrides with changing the standalone dag id key to accept a list of dags. Starting with pluralization will make everything less painful.
- In this PR I did a ton of code duplication, but I think there's a lot of opportunities for consolidation. For example, I think that we could consolidate a lot of the "spec metadata enrichment" utilities to operate on a union of types, which vend out their metadata and thus don't require duplicating dag id/task id across everything. Comments should point out what I mean.
- I think the BaseProxyOperator needs a shared surface area of "what asset keys should I be targeting". This will three-birds-one-stone serve to also share implementation with a "specified asset key operator".

## How I Tested These Changes
Added new unit tests for defs loader and sensor, and a kitchen sink test for the whole thing.
Also tested kitchen sink example manually.
