### PR TITLE
Make automation condition evaluator async

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -303,7 +303,7 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
         ]
 
     @cached_property
-    def toposorted_entity_keys(self) -> Sequence[Sequence[EntityKey]]:
+    def toposorted_entity_keys_by_level(self) -> Sequence[Sequence[EntityKey]]:
         """Return topologically sorted levels for entity keys in graph. Keys with the same topological level are
         sorted alphabetically to provide stability.
         """

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -303,16 +303,12 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
         ]
 
     @cached_property
-    def toposorted_entity_keys(self) -> Sequence[EntityKey]:
-        """Return topologically sorted entity keys in graph. Keys with the same topological level are
+    def toposorted_entity_keys(self) -> Sequence[Sequence[EntityKey]]:
+        """Return topologically sorted levels for entity keys in graph. Keys with the same topological level are
         sorted alphabetically to provide stability.
         """
         sort_key = lambda e: (e, None) if isinstance(e, AssetKey) else (e.asset_key, e.name)
-        return [
-            item
-            for items_in_level in toposort(self.entity_dep_graph["upstream"], sort_key=sort_key)
-            for item in sorted(items_in_level, key=sort_key)
-        ]
+        return toposort(self.entity_dep_graph["upstream"], sort_key=sort_key)
 
     @cached_property
     def toposorted_asset_keys_by_level(self) -> Sequence[AbstractSet[AssetKey]]:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -140,7 +140,7 @@ class AutomationConditionEvaluator:
             )
             num_evaluated += 1
 
-        for topo_level in self.asset_graph.toposorted_entity_keys:
+        for topo_level in self.asset_graph.toposorted_entity_keys_by_level:
             coroutines = [
                 _evaluate_entity_async(entity_key)
                 for entity_key in topo_level

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -139,8 +139,8 @@ class AutomationConditionEvaluator:
 
         for topo_level in self.asset_graph.toposorted_entity_keys_by_level:
             coroutines = [
-                _evaluate_entity_async(entity_key, num_evaluated)
-                for entity_key in topo_level
+                _evaluate_entity_async(entity_key, offset)
+                for offset, entity_key in enumerate(topo_level)
                 if entity_key in self.entity_keys
             ]
             await asyncio.gather(*coroutines)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -757,7 +757,11 @@ def test_toposort(
     asset_graph = asset_graph_from_assets([A, B, Ac, Bc])
 
     assert asset_graph.toposorted_asset_keys == [A.key, B.key]
-    assert asset_graph.toposorted_entity_keys == [A.key, Ac.check_key, B.key, Bc.check_key]
+    assert asset_graph.toposorted_entity_keys_by_level == [
+        [A.key],
+        [Ac.check_key, B.key],
+        [Bc.check_key],
+    ]
 
 
 def test_required_assets_and_checks_by_key_asset_decorator(


### PR DESCRIPTION
## Summary & Motivation
Start to making the automation condition evaluator evaluate asynchronously. This won't reduce any latency yet, but will be useful once we can actually batch database queries instead of doing `AssetRecord.blocking_get`.

## How I Tested These Changes
Existing tests should pass