### PR TITLE
[dagster-embedded-elt] Add relation identifier metadata to sling assets

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/resources.py
@@ -402,10 +402,10 @@ class SlingResource(ConfigurableResource):
                 asset_key = dagster_sling_translator.get_asset_key(stream)
 
                 object_key = stream.get("config", {}).get("object")
-                stream_name = object_key or stream["name"]
+                destination_stream_name = object_key or stream["name"]
                 relation_identifier = None
-                if destination_name and stream_name:
-                    relation_identifier = ".".join([destination_name, stream_name])
+                if destination_name and destination_stream_name:
+                    relation_identifier = ".".join([destination_name, destination_stream_name])
 
                 metadata = {
                     "elapsed_time": end_time - start_time,

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_asset_decorator.py
@@ -13,6 +13,7 @@ from dagster import (
     file_relative_path,
 )
 from dagster._core.definitions.materialize import materialize
+from dagster._core.definitions.metadata.metadata_value import TextMetadataValue
 from dagster._core.definitions.tags import build_kind_tag
 from dagster_embedded_elt.sling import SlingReplicationParam, sling_assets
 from dagster_embedded_elt.sling.dagster_sling_translator import DagsterSlingTranslator
@@ -466,3 +467,35 @@ def test_subset_with_run_config(
     assert found_asset_keys == {
         AssetKey(["target", "main", "orders"]),
     }
+
+
+def test_relation_identifier(
+    csv_to_sqlite_dataworks_replication: SlingReplicationParam,
+    path_to_temp_sqlite_db: str,
+):
+    @sling_assets(replication_config=csv_to_sqlite_dataworks_replication)
+    def my_sling_assets(context: AssetExecutionContext, sling: SlingResource):
+        yield from sling.replicate(context=context)
+
+    sling_resource = SlingResource(
+        connections=[
+            SlingConnectionResource(type="file", name="SLING_FILE"),
+            SlingConnectionResource(
+                type="sqlite",
+                name="SLING_SQLITE",
+                connection_string=f"sqlite://{path_to_temp_sqlite_db}",
+            ),
+        ]
+    )
+    res = materialize(
+        [my_sling_assets],
+        resources={"sling": sling_resource},
+        selection=[AssetKey(["target", "main", "orders"])],
+    )
+
+    assert res.success
+    asset_materializations = res.get_asset_materialization_events()
+    assert len(asset_materializations) == 1
+    assert asset_materializations[0].materialization.metadata[
+        "dagster/relation_identifier"
+    ] == TextMetadataValue(text="SLING_SQLITE.main.orders")


### PR DESCRIPTION
## Summary & Motivation

Pull `target` from a sling replication config and use it as a destination name create a relation identifier when a sling asset is materialized.

<img width="1367" alt="Screenshot 2024-10-02 at 5 51 22 PM" src="https://github.com/user-attachments/assets/110266c0-b1d6-4a3c-8425-9fa642cc575f">

## How I Tested These Changes

BK with new test + tested with a test pipeline.

## Changelog

[dagster-embedded-elt] relation identifier metadata is now attached to sling assets.

- [x] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
