### PR TITLE
[dagster-airlift] Make autopeered tasks produce synthetic materializations

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/constants.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/constants.py
@@ -1,6 +1,7 @@
-STANDALONE_DAG_ID_METADATA_KEY = "dagster-airlift/dag_id"
+STANDALONE_DAG_ID_METADATA_KEY = "dagster-airlift/dag-id"
 AIRFLOW_SOURCE_METADATA_KEY_PREFIX = "dagster-airlift/source"
-TASK_MAPPING_METADATA_KEY = "dagster-airlift/task_mapping"
+TASK_MAPPING_METADATA_KEY = "dagster-airlift/task-mapping"
+AUTOMAPPED_TASK_METADATA_KEY = "dagster-airlift/automapped-task"
 # This represents the timestamp used in ordering the materializatons.
 EFFECTIVE_TIMESTAMP_METADATA_KEY = "dagster-airlift/effective_timestamp"
 DAG_RUN_ID_TAG_KEY = "dagster-airlift/airflow-dag-run-id"

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from functools import cached_property
-from typing import AbstractSet, Mapping, cast
+from typing import AbstractSet, Mapping, Set, cast
 
 from dagster import (
     AssetKey,
@@ -12,6 +12,7 @@ from dagster._serdes.serdes import deserialize_value
 
 from dagster_airlift.constants import STANDALONE_DAG_ID_METADATA_KEY
 from dagster_airlift.core.airflow_instance import AirflowInstance
+from dagster_airlift.core.serialization.compute import AirliftMetadataMappingInfo
 from dagster_airlift.core.serialization.defs_construction import make_default_dag_asset_key
 from dagster_airlift.core.serialization.serialized_data import (
     SerializedAirflowDefinitionsData,
@@ -28,6 +29,15 @@ class AirflowDefinitionsData:
     @property
     def instance_name(self) -> str:
         return self.airflow_instance.name
+
+    @cached_property
+    def mapping_info(self) -> AirliftMetadataMappingInfo:
+        return AirliftMetadataMappingInfo(
+            asset_specs=list(self.resolved_airflow_defs.get_all_asset_specs())
+        )
+
+    def task_ids_in_dag(self, dag_id: str) -> Set[str]:
+        return self.mapping_info.task_id_map[dag_id]
 
     @cached_property
     def serialized_data(self) -> SerializedAirflowDefinitionsData:

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
@@ -33,7 +33,7 @@ class AirliftMetadataMappingInfo:
 
     @cached_property
     def task_id_map(self) -> Dict[str, Set[str]]:
-        """Mapping of dag_id to set of task_ids in that dag."""
+        """Mapping of dag_id to set of task_ids in that dag. This only contains task ids mapped to assets in this object."""
         task_id_map_data = {
             dag_id: set(ta_map.keys()) for dag_id, ta_map in self.asset_key_map.items()
         }

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
@@ -101,9 +101,6 @@ class SerializedAirflowDefinitionsData:
     def all_mapped_tasks(self) -> Dict[AssetKey, List[MappedAirflowTaskData]]:
         return {item.asset_key: item.mapped_tasks for item in self.key_scoped_data_items}
 
-    def task_ids_in_dag(self, dag_id: str) -> AbstractSet[str]:
-        return set(self.dag_datas[dag_id].task_handle_data.keys())
-
 
 # History:
 # - created

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/base_proxy_operator.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/base_proxy_operator.py
@@ -90,9 +90,12 @@ class BaseProxyToDagsterOperator(BaseOperator, ABC):
             json={"query": ASSET_NODES_QUERY},
             timeout=3,
         )
+        logger.info(f"Fetching asset nodes for {dag_id}/{task_id}")
         asset_nodes_data = self.get_valid_graphql_response(response, "assetNodes")
+        logger.info(f"Got response {asset_nodes_data}")
         for asset_node in asset_nodes_data:
-            if matched_dag_id_task_id(asset_node, dag_id, task_id):
+            # jobs can be empty if it is an external asset (e.g. an automapped task)
+            if matched_dag_id_task_id(asset_node, dag_id, task_id) and asset_node["jobs"]:
                 repo_location = asset_node["jobs"][0]["repository"]["location"]["name"]
                 repo_name = asset_node["jobs"][0]["repository"]["name"]
                 job_name = asset_node["jobs"][0]["name"]

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
@@ -1,10 +1,13 @@
+import datetime
 from typing import List
 
 from dagster._core.definitions.asset_key import AssetKey, CoercibleToAssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster_airlift.constants import TASK_MAPPING_METADATA_KEY
+from dagster_airlift.core.airflow_defs_data import AirflowDefinitionsData
 from dagster_airlift.core.airflow_instance import DagInfo
+from dagster_airlift.core.load_defs import build_full_automapped_dags_from_airflow_instance
 from dagster_airlift.core.serialization.compute import (
     FetchedAirflowData,
     TaskHandle,
@@ -14,10 +17,11 @@ from dagster_airlift.core.serialization.compute import (
 from dagster_airlift.core.serialization.serialized_data import TaskInfo
 from dagster_airlift.core.utils import metadata_for_task_mapping
 from dagster_airlift.test import AirflowInstanceFake
+from dagster_airlift.test.airflow_test_instance import make_dag_run, make_instance
 
 
 def ak(key: str) -> AssetKey:
-    return AssetKey(key)
+    return AssetKey.from_user_string(key)
 
 
 def airlift_asset_spec(key: CoercibleToAssetKey, dag_id: str, task_id: str) -> AssetSpec:
@@ -188,3 +192,37 @@ def test_produce_fetched_airflow_data() -> None:
     )
 
     assert len(fetched_airflow_data.mapping_info.mapped_asset_specs) == 1
+
+
+def test_automapped_loaded_data() -> None:
+    airflow_instance = make_instance(
+        dag_and_task_structure={"dag1": ["task1", "task2"]},
+        dag_runs=[
+            make_dag_run(
+                dag_id="dag1",
+                run_id="run1",
+                start_date=datetime.datetime.now(),
+                end_date=datetime.datetime.now(),
+            ),
+        ],
+        task_deps={"task1": ["task2"]},
+        instance_name="test_instance",
+    )
+
+    defs = build_full_automapped_dags_from_airflow_instance(
+        airflow_instance=airflow_instance,
+    )
+
+    mapping_info = build_airlift_metadata_mapping_info(defs)
+
+    fetched_airflow_data = fetch_all_airflow_data(airflow_instance, mapping_info)
+
+    airflow_data = AirflowDefinitionsData(
+        airflow_instance=airflow_instance, resolved_airflow_defs=defs
+    )
+
+    task_handle_data = fetched_airflow_data.task_handle_data_for_dag("dag1")
+    assert task_handle_data["task1"].asset_keys_in_task == {ak("test_instance/dag/dag1/task/task1")}
+    assert task_handle_data["task2"].asset_keys_in_task == {ak("test_instance/dag/dag1/task/task2")}
+
+    assert airflow_data.task_ids_in_dag("dag1") == {"task1", "task2"}

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_sensor.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_sensor.py
@@ -8,13 +8,27 @@ from dagster import (
     DagsterInstance,
     Definitions,
     SensorResult,
+    _check as check,
+    asset,
     asset_check,
     build_sensor_context,
 )
+from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.events import AssetMaterialization
+from dagster._core.definitions.materialize import materialize
+from dagster._core.execution.execute_in_process_result import ExecuteInProcessResult
 from dagster._core.test_utils import freeze_time
 from dagster._serdes import deserialize_value
+from dagster._time import get_current_datetime
+from dagster_airlift.constants import DAG_ID_TAG_KEY, DAG_RUN_ID_TAG_KEY, TASK_ID_TAG_KEY
+from dagster_airlift.core import dag_defs, task_defs
+from dagster_airlift.core.load_defs import build_full_automapped_dags_from_airflow_instance
 from dagster_airlift.core.sensor import AirflowPollingSensorCursor
+from dagster_airlift.core.serialization.defs_construction import (
+    key_for_automapped_task_asset,
+    make_default_dag_asset_key,
+)
+from dagster_airlift.test import make_dag_run, make_instance
 
 from dagster_airlift_tests.unit_tests.conftest import (
     assert_expected_key_order,
@@ -344,3 +358,226 @@ def test_no_runs(init_load_context: None, instance: DagsterInstance) -> None:
         assert new_cursor.dag_query_offset == 0
         assert not result.asset_events
         assert not result.run_requests
+
+
+def test_automapped_tasks_only(init_load_context: None, instance: DagsterInstance) -> None:
+    freeze_datetime = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    with freeze_time(freeze_datetime):
+        dag_id = "dag1"
+        dag_runs = [
+            make_dag_run(
+                dag_id=dag_id,
+                run_id=f"run-{dag_id}",
+                start_date=get_current_datetime() - timedelta(minutes=10),
+                end_date=get_current_datetime(),
+            )
+        ]
+
+        airflow_instance = make_instance(
+            dag_and_task_structure={dag_id: ["task1", "task2"]},
+            task_deps={"task1": [], "task2": ["task1"]},
+            dag_runs=dag_runs,
+            instance_name="test_instance",
+        )
+
+        automapped_defs = build_full_automapped_dags_from_airflow_instance(
+            airflow_instance=airflow_instance,
+        )
+
+        repo_def = automapped_defs.get_repository_def()
+
+        sensor = next(iter(repo_def.sensor_defs))
+        context = build_sensor_context(repository_def=repo_def, instance=instance)
+        result = sensor(context)
+        assert isinstance(result, SensorResult)
+
+        asset_mats = check.is_list(result.asset_events, of_type=AssetMaterialization)
+
+        asset_mat_dict = {mat.asset_key: mat for mat in asset_mats}
+
+        am_task1_key = key_for_automapped_task_asset("test_instance", dag_id, "task1")
+        am_task2_key = key_for_automapped_task_asset("test_instance", dag_id, "task2")
+        dag1_asset_key = make_default_dag_asset_key("test_instance", dag_id)
+
+        assert am_task1_key in asset_mat_dict
+        assert am_task2_key in asset_mat_dict
+        assert dag1_asset_key in asset_mat_dict
+
+
+def test_automapped_tasks_with_explicit_external_asset_defs(
+    init_load_context: None, instance: DagsterInstance
+) -> None:
+    freeze_datetime = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    with freeze_time(freeze_datetime):
+        dag_id = "dag1"
+        dag_runs = [
+            make_dag_run(
+                dag_id=dag_id,
+                run_id=f"run-{dag_id}",
+                start_date=get_current_datetime() - timedelta(minutes=10),
+                end_date=get_current_datetime(),
+            )
+        ]
+
+        airflow_instance = make_instance(
+            dag_and_task_structure={dag_id: ["task1", "task2"]},
+            task_deps={"task1": [], "task2": ["task1"]},
+            dag_runs=dag_runs,
+            instance_name="test_instance",
+        )
+
+        explicit_asset1 = AssetSpec(key="explicit_asset1")
+        explicit_asset2 = AssetSpec(key="explicit_asset2")
+
+        automapped_defs = build_full_automapped_dags_from_airflow_instance(
+            airflow_instance=airflow_instance,
+            defs=dag_defs(
+                "dag1",
+                task_defs("task1", Definitions(assets=[explicit_asset1])),
+                task_defs("task2", Definitions(assets=[explicit_asset2])),
+            ),
+        )
+
+        am_task1_key = key_for_automapped_task_asset("test_instance", dag_id, "task1")
+        am_task2_key = key_for_automapped_task_asset("test_instance", dag_id, "task2")
+        dag1_asset_key = make_default_dag_asset_key("test_instance", dag_id)
+
+        spec_dict = {spec.key: spec for spec in automapped_defs.get_all_asset_specs()}
+
+        assert set(spec_dict.keys()) == {
+            am_task1_key,
+            am_task2_key,
+            dag1_asset_key,
+            explicit_asset1.key,
+            explicit_asset2.key,
+        }
+
+        repo_def = automapped_defs.get_repository_def()
+
+        sensor = next(iter(repo_def.sensor_defs))
+        context = build_sensor_context(repository_def=repo_def, instance=instance)
+        result = sensor(context)
+        assert isinstance(result, SensorResult)
+
+        # there should be 5 asset materializations. 1 for dag, 2 for tasks, and 2 for explicit assets
+
+        asset_mats = check.is_list(result.asset_events, of_type=AssetMaterialization)
+
+        asset_mat_dict = {mat.asset_key: mat for mat in asset_mats}
+
+        assert set(asset_mat_dict.keys()) == {
+            am_task1_key,
+            am_task2_key,
+            dag1_asset_key,
+            explicit_asset1.key,
+            explicit_asset2.key,
+        }
+
+
+def test_automapped_tasks_with_explicit_materializable_asset_defs(
+    init_load_context: None, instance: DagsterInstance
+) -> None:
+    freeze_datetime = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    with freeze_time(freeze_datetime):
+        dag_id = "dag1"
+        dag_run_id = f"run-{dag_id}"
+        dag_runs = [
+            make_dag_run(
+                dag_id=dag_id,
+                run_id=f"run-{dag_id}",
+                start_date=get_current_datetime() - timedelta(minutes=10),
+                end_date=get_current_datetime(),
+            )
+        ]
+
+        airflow_instance = make_instance(
+            dag_and_task_structure={dag_id: ["task1", "task2"]},
+            task_deps={"task1": [], "task2": ["task1"]},
+            dag_runs=dag_runs,
+            instance_name="test_instance",
+        )
+
+        @asset
+        def explicit_asset1() -> None:
+            pass
+
+        @asset
+        def explicit_asset2() -> None:
+            pass
+
+        automapped_defs = build_full_automapped_dags_from_airflow_instance(
+            airflow_instance=airflow_instance,
+            defs=dag_defs(
+                "dag1",
+                task_defs("task1", Definitions(assets=[explicit_asset1])),
+                task_defs("task2", Definitions(assets=[explicit_asset2])),
+            ),
+        )
+
+        am_task1_key = key_for_automapped_task_asset("test_instance", dag_id, "task1")
+        am_task2_key = key_for_automapped_task_asset("test_instance", dag_id, "task2")
+        dag1_asset_key = make_default_dag_asset_key("test_instance", dag_id)
+
+        spec_dict = {spec.key: spec for spec in automapped_defs.get_all_asset_specs()}
+
+        assert set(spec_dict.keys()) == {
+            am_task1_key,
+            am_task2_key,
+            dag1_asset_key,
+            explicit_asset1.key,
+            explicit_asset2.key,
+        }
+
+        repo_def = automapped_defs.get_repository_def()
+
+        # we simulate runs from the proxy operator for both tasks
+        assert simulate_materialize_from_proxy_operator(
+            instance=instance,
+            assets_def=explicit_asset1,
+            dag_id=dag_id,
+            task_id="task1",
+            dag_run_id=dag_run_id,
+        ).success
+        assert simulate_materialize_from_proxy_operator(
+            instance=instance,
+            assets_def=explicit_asset1,
+            dag_id=dag_id,
+            task_id="task2",
+            dag_run_id=dag_run_id,
+        ).success
+
+        sensor = next(iter(repo_def.sensor_defs))
+        context = build_sensor_context(repository_def=repo_def, instance=instance)
+        result = sensor(context)
+        assert isinstance(result, SensorResult)
+
+        # there should be 3 asset materializations. 1 for dag, 2 for automapped tasks
+
+        asset_mats = check.is_list(result.asset_events, of_type=AssetMaterialization)
+
+        asset_mat_dict = {mat.asset_key: mat for mat in asset_mats}
+
+        assert set(asset_mat_dict.keys()) == {
+            am_task1_key,
+            am_task2_key,
+            dag1_asset_key,
+            # explicit_asset1.key, # no syntheic materialization for explicit asset as it was proxied
+            # explicit_asset2.key, # no syntheic materialization for explicit asset as it waws proxied
+        }
+
+
+def simulate_materialize_from_proxy_operator(
+    *,
+    instance: DagsterInstance,
+    assets_def: AssetsDefinition,
+    dag_run_id: str,
+    dag_id: str,
+    task_id: str,
+) -> ExecuteInProcessResult:
+    # TODO consolidate with code in proxy operator
+    tags = {
+        DAG_ID_TAG_KEY: dag_id,
+        DAG_RUN_ID_TAG_KEY: dag_run_id,
+        TASK_ID_TAG_KEY: task_id,
+    }
+    return materialize(assets=[assets_def], instance=instance, tags=tags)

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/in_airflow_tests/test_parse_metadata.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/in_airflow_tests/test_parse_metadata.py
@@ -7,7 +7,7 @@ def test_parse_asset_node() -> None:
         "assetKey": {"path": ["lakehouse", "iris"]},
         "metadataEntries": [
             {
-                "label": "dagster-airlift/task_mapping",
+                "label": "dagster-airlift/task-mapping",
                 "jsonString": '[{"dag_id": "rebuild_iris_models", "task_id": "load_iris"}]',
                 "__typename": "JsonMetadataEntry",
             },

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/print_dag.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/print_dag.py
@@ -25,7 +25,7 @@ with DAG(
     schedule_interval=None,
     is_paused_upon_creation=False,
 ) as dag:
-    PythonOperator(task_id="print_task", python_callable=print_hello) << PythonOperator(
+    PythonOperator(task_id="print_task", python_callable=print_hello) >> PythonOperator(
         task_id="downstream_print_task", python_callable=print_hello
     )  # type: ignore
 

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/proxied_state/print_dag.yaml
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/proxied_state/print_dag.yaml
@@ -1,3 +1,5 @@
 tasks:
   - id: print_task
     proxied: True
+  - id: downstream_print_task
+    proxied: True

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/dagster_defs/automapped_defs.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/dagster_defs/automapped_defs.py
@@ -1,13 +1,31 @@
-from dagster._core.definitions.definitions_class import Definitions
+from dagster import Definitions, asset
+from dagster_airlift.core import dag_defs, task_defs
 from dagster_airlift.core.load_defs import build_full_automapped_dags_from_airflow_instance
 
 from .airflow_instance import local_airflow_instance
 
 
-def build_automapped_defs() -> Definitions:
+@asset
+def the_print_asset() -> None:
+    # ruff: noqa: T201
+    print("Hello, world!")
+
+
+@asset(deps=[the_print_asset])
+def the_downstream_print_asset() -> None:
+    # ruff: noqa: T201
+    print("Hello, world!")
+
+
+def build_full_automapped_defs() -> Definitions:
     return build_full_automapped_dags_from_airflow_instance(
         airflow_instance=local_airflow_instance(),
+        defs=dag_defs(
+            "print_dag",
+            task_defs("print_task", Definitions(assets=[the_print_asset])),
+            task_defs("downstream_print_task", Definitions(assets=[the_downstream_print_asset])),
+        ),
     )
 
 
-defs = build_automapped_defs()
+defs = build_full_automapped_defs()

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/dagster_defs/mapped_defs.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/dagster_defs/mapped_defs.py
@@ -1,4 +1,3 @@
-# ruff: noqa: T201
 from dagster import Definitions, asset
 from dagster_airlift.core import build_defs_from_airflow_instance, dag_defs, task_defs
 from dagster_airlift.core.multiple_tasks import targeted_by_multiple_tasks
@@ -8,11 +7,13 @@ from .airflow_instance import local_airflow_instance
 
 @asset
 def print_asset() -> None:
+    # ruff: noqa: T201
     print("Hello, world!")
 
 
 @asset(description="Asset one is materialized by multiple airflow tasks")
 def asset_one() -> None:
+    # ruff: noqa: T201
     print("Materialized asset one")
 
 

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_automapped.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_automapped.py
@@ -19,8 +19,16 @@ def dagster_dev_cmd_fixture() -> List[str]:
     return ["make", "run_dagster_automapped", "-C", str(makefile_dir())]
 
 
+def ak(key: str) -> AssetKey:
+    return AssetKey.from_user_string(key)
+
+
 expected_mats_per_dag = {
-    "print_dag": [AssetKey("print_asset")],
+    "print_dag": [
+        AssetKey("the_print_asset"),
+        ak("my_airflow_instance/dag/print_dag/task/downstream_print_task"),
+        ak("my_airflow_instance/dag/print_dag/task/print_task"),
+    ],
 }
 
 
@@ -39,19 +47,23 @@ def test_dagster_materializes(
         af_instance.wait_for_run_completion(dag_id=dag_id, run_id=run_id, timeout=60)
         dagster_instance = DagsterInstance.get()
         start_time = get_current_datetime()
+        # First check to see that the dag asset materialization occured
+        dag_asset_key = AssetKey(["my_airflow_instance", "dag", dag_id])
         while get_current_datetime() - start_time < timedelta(seconds=30):
             asset_materialization = dagster_instance.get_latest_materialization_event(
-                asset_key=AssetKey(["my_airflow_instance", "dag", dag_id])
+                asset_key=dag_asset_key
             )
             if asset_materialization:
                 break
 
-        assert asset_materialization
+        assert (
+            asset_materialization
+        ), f"Timeout waiting for materialization event on {dag_id} with asset key {dag_asset_key}"
 
+        # Then check that there are materialiations for the print_asset as well as each of the
+        # automapped tasks
         for expected_asset_key in expected_asset_keys:
             asset_materialization = dagster_instance.get_latest_materialization_event(
                 asset_key=expected_asset_key
             )
-            # TODO: sensor does not pick up materialzation of automapped tasks yet
-            assert not asset_materialization
-            # assert asset_materialization
+            assert asset_materialization, f"Add did not materialize: {expected_asset_key}"


### PR DESCRIPTION
## Summary & Motivation

This PR makes it so that automapped tasks get materialization history.

The major change here is to 

1) Add the `dagster_airlift/task_mapping` metadata entry to automapped tasks AND
2) Have the sensor fetch all task_ids rather than just the ones with explicit mappings.

The second point results in more fetching in the case where the user will _not_ do automapped tasks. However I do think that is the default and I commented inline what the workaround would be.

## How I Tested These Changes

BK. Manually tested in kitchen sink.

![Screenshot 2024-10-02 at 6.22.47 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/d45f88a5-61ef-4a83-b092-11829e3d9c51.png)

Then ran an unproxied dag:

![Screenshot 2024-10-02 at 6.22.55 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wS38mdcdU6aAeJobBdry/9364d507-7496-44e8-81c0-7b13dc865390.png)

## Changelog



NOCHANGELOG