### PR TITLE
[dagster-aws] use paginator in get_s3_keys

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
@@ -1,8 +1,11 @@
 from typing import Optional
 
 import boto3
-import botocore
 import dagster._check as check
+
+
+class ClientException(Exception):
+    pass
 
 
 def get_s3_keys(
@@ -19,9 +22,9 @@ def get_s3_keys(
         s3_session = boto3.client("s3", use_ssl=True, verify=True)
 
     if not s3_session:
-        raise botocore.exceptions.ClientError("Failed to initialize s3 client")
+        raise ClientException("Failed to initialize s3 client")
 
-    paginator = s3_session.get_paginator("list_objects_v2")
+    paginator = s3_session.get_paginator("list_objects_v2")  # type: ignore
     page_iterator = paginator.paginate(Bucket=bucket, Prefix=prefix)
 
     contents = []

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
@@ -1,18 +1,25 @@
 from typing import Optional
 
 import boto3
+import botocore
 import dagster._check as check
 
 
 def get_s3_keys(
-    bucket: str, prefix: str = "", since_key: Optional[str] = None, s3_session: boto3.Session = None
+    bucket: str,
+    prefix: str = "",
+    since_key: Optional[str] = None,
+    s3_session: Optional[boto3.Session] = None,
 ):
     check.str_param(bucket, "bucket")
     check.str_param(prefix, "prefix")
     check.opt_str_param(since_key, "since_key")
 
     if not s3_session:
-        s3_session = boto3.resource("s3", use_ssl=True, verify=True).meta.client
+        s3_session = boto3.client("s3", use_ssl=True, verify=True)
+
+    if not s3_session:
+        raise botocore.exceptions.ClientError("Failed to initialize s3 client")
 
     paginator = s3_session.get_paginator("list_objects_v2")
     page_iterator = paginator.paginate(Bucket=bucket, Prefix=prefix)


### PR DESCRIPTION
## Summary & Motivation

- Uses the `paginator` utility for improved pagination in `list_objects_v2`

https://boto3.amazonaws.com/v1/documentation/api/latest/guide/paginators.html#creating-paginators

## How I Tested These Changes

`pytest`

## Changelog

NO CHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
