### PR TITLE
[runs feed ui] use updated gql endpoint

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -130,7 +130,7 @@
   "Delete": "3c61c79b99122910e754a8863e80dc5ed479a0c23cc1a9d9878d91e603fc0dfe",
   "Terminate": "67acf403eb320a93c9a9aa07f675a1557e0887d499cd5598f1d5ff360afc15c0",
   "LaunchPipelineReexecution": "d21e4ecaf3d1d163c4772f1d847dbdcbdaa9a40e6de0808a064ae767adf0c311",
-  "RunsFeedRootQuery": "42006dc8a4bc222d1ef7fe3275fd64769ab2645efacfb3432edc9616bb88d826",
+  "RunsFeedRootQuery": "47f5f305206b0696195bae6de586fada3d6c536cb7d84e7d9290760f8e027dde",
   "RunFeedTabsCountQuery": "5ddccded028ae94b64bda3c2b850bcc8f384de9851c0dd393f158b2a53469262",
   "RunTagKeysQuery": "833a405f7cb8f30c0901bc8a272edb51ac5281ebdf563e3017eace5d6976b2a9",
   "RunTagValuesQuery": "0c0a9998c215bb801eb0adcd5449c0ac4cf1e8efbc6d0fcc5fb6d76fcc95cb92",

--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -130,7 +130,7 @@
   "Delete": "3c61c79b99122910e754a8863e80dc5ed479a0c23cc1a9d9878d91e603fc0dfe",
   "Terminate": "67acf403eb320a93c9a9aa07f675a1557e0887d499cd5598f1d5ff360afc15c0",
   "LaunchPipelineReexecution": "d21e4ecaf3d1d163c4772f1d847dbdcbdaa9a40e6de0808a064ae767adf0c311",
-  "RunsFeedRootQuery": "47f5f305206b0696195bae6de586fada3d6c536cb7d84e7d9290760f8e027dde",
+  "RunsFeedRootQuery": "fbfc82cccaebc1698305767c04c4dc16ed15b7a272342135d5a83745ffece37e",
   "RunFeedTabsCountQuery": "5ddccded028ae94b64bda3c2b850bcc8f384de9851c0dd393f158b2a53469262",
   "RunTagKeysQuery": "833a405f7cb8f30c0901bc8a272edb51ac5281ebdf563e3017eace5d6976b2a9",
   "RunTagValuesQuery": "0c0a9998c215bb801eb0adcd5449c0ac4cf1e8efbc6d0fcc5fb6d76fcc95cb92",

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3287,7 +3287,12 @@ type Query {
   pipelineRunOrError(runId: ID!): RunOrError!
   runsOrError(filter: RunsFilter, cursor: String, limit: Int): RunsOrError!
   runOrError(runId: ID!): RunOrError!
-  runsFeedOrError(limit: Int!, cursor: String, filter: RunsFilter): RunsFeedConnectionOrError!
+  runsFeedOrError(
+    limit: Int!
+    cursor: String
+    filter: RunsFilter
+    includeRunsInBackfills: Boolean
+  ): RunsFeedConnectionOrError!
   runsFeedCountOrError(filter: RunsFilter): RunsFeedCountOrError!
   runTagKeysOrError: RunTagKeysOrError
   runTagsOrError(tagKeys: [String!], valuePrefix: String, limit: Int): RunTagsOrError

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3291,7 +3291,7 @@ type Query {
     limit: Int!
     cursor: String
     filter: RunsFilter
-    includeRunsInBackfills: Boolean
+    includeRunsFromBackfills: Boolean
   ): RunsFeedConnectionOrError!
   runsFeedCountOrError(filter: RunsFilter): RunsFeedCountOrError!
   runTagKeysOrError: RunTagKeysOrError

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -3973,7 +3973,7 @@ export type QueryRunsFeedCountOrErrorArgs = {
 export type QueryRunsFeedOrErrorArgs = {
   cursor?: InputMaybe<Scalars['String']['input']>;
   filter?: InputMaybe<RunsFilter>;
-  includeRunsInBackfills?: InputMaybe<Scalars['Boolean']['input']>;
+  includeRunsFromBackfills?: InputMaybe<Scalars['Boolean']['input']>;
   limit: Scalars['Int']['input'];
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -3973,6 +3973,7 @@ export type QueryRunsFeedCountOrErrorArgs = {
 export type QueryRunsFeedOrErrorArgs = {
   cursor?: InputMaybe<Scalars['String']['input']>;
   filter?: InputMaybe<RunsFilter>;
+  includeRunsInBackfills?: InputMaybe<Scalars['Boolean']['input']>;
   limit: Scalars['Int']['input'];
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
@@ -1,6 +1,6 @@
 import {Box, Checkbox, Colors, NonIdealState, tokenToString} from '@dagster-io/ui-components';
 import partition from 'lodash/partition';
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import {RunsQueryRefetchContext} from './RunUtils';
 import {RUNS_FEED_TABLE_ENTRY_FRAGMENT} from './RunsFeedRow';
@@ -25,6 +25,7 @@ import {
 } from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
 import {RunsFilter} from '../graphql/types';
+import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {LoadingSpinner} from '../ui/Loading';
 
 const PAGE_SIZE = 25;
@@ -118,7 +119,10 @@ export const RunsFeedRoot = () => {
     enabledFilters: filters,
   });
 
-  const [includeRunsFromBackfills, setincludeRunsFromBackfills] = useState(false);
+  const [includeRunsFromBackfills, setincludeRunsFromBackfills] = useQueryPersistedState<boolean>({
+    queryKey: 'show_runs_within_backfills',
+    defaults: {show_runs_within_backfills: false},
+  });
   const {tabs, queryResult: runQueryResult} = useRunsFeedTabs(filter);
 
   const {entries, paginationProps, queryResult} = useRunsFeedEntries(

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
@@ -40,14 +40,14 @@ const filters: RunFilterTokenType[] = [
   'status',
 ];
 
-export function useRunsFeedEntries(filter: RunsFilter, includeRunsInBackfills: boolean) {
+export function useRunsFeedEntries(filter: RunsFilter, includeRunsFromBackfills: boolean) {
   const {queryResult, paginationProps} = useCursorPaginatedQuery<
     RunsFeedRootQuery,
     RunsFeedRootQueryVariables
   >({
     query: RUNS_FEED_ROOT_QUERY,
     pageSize: PAGE_SIZE,
-    variables: {filter, includeRunsInBackfills},
+    variables: {filter, includeRunsFromBackfills},
     nextCursorForResult: (runs) => {
       if (runs.runsFeedOrError.__typename !== 'RunsFeedConnection') {
         return undefined;
@@ -118,12 +118,12 @@ export const RunsFeedRoot = () => {
     enabledFilters: filters,
   });
 
-  const [includeRunsInBackfills, setIncludeRunsInBackfills] = useState(false);
+  const [includeRunsFromBackfills, setincludeRunsFromBackfills] = useState(false);
   const {tabs, queryResult: runQueryResult} = useRunsFeedTabs(filter);
 
   const {entries, paginationProps, queryResult} = useRunsFeedEntries(
     filter,
-    includeRunsInBackfills,
+    includeRunsFromBackfills,
   );
   const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
   const countRefreshState = useQueryRefreshAtInterval(runQueryResult, FIFTEEN_SECONDS);
@@ -135,9 +135,9 @@ export const RunsFeedRoot = () => {
       {button}
       <Checkbox
         label={<span>Show runs within backfills</span>}
-        checked={includeRunsInBackfills}
+        checked={includeRunsFromBackfills}
         onChange={() => {
-          setIncludeRunsInBackfills(!includeRunsInBackfills);
+          setincludeRunsFromBackfills(!includeRunsFromBackfills);
         }}
       />
     </Box>
@@ -227,13 +227,13 @@ export const RUNS_FEED_ROOT_QUERY = gql`
     $limit: Int!
     $cursor: String
     $filter: RunsFilter
-    $includeRunsInBackfills: Boolean!
+    $includeRunsFromBackfills: Boolean!
   ) {
     runsFeedOrError(
       limit: $limit
       cursor: $cursor
       filter: $filter
-      includeRunsInBackfills: $includeRunsInBackfills
+      includeRunsFromBackfills: $includeRunsFromBackfills
     ) {
       ... on RunsFeedConnection {
         cursor

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
@@ -121,7 +121,10 @@ export const RunsFeedRoot = () => {
   const [includeRunsInBackfills, setIncludeRunsInBackfills] = useState(false);
   const {tabs, queryResult: runQueryResult} = useRunsFeedTabs(filter);
 
-  const {entries, paginationProps, queryResult} = useRunsFeedEntries(filter, includeRunsInBackfills);
+  const {entries, paginationProps, queryResult} = useRunsFeedEntries(
+    filter,
+    includeRunsInBackfills,
+  );
   const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
   const countRefreshState = useQueryRefreshAtInterval(runQueryResult, FIFTEEN_SECONDS);
   const combinedRefreshState = useMergedRefresh(countRefreshState, refreshState);
@@ -220,8 +223,18 @@ export const RunsFeedRoot = () => {
 export default RunsFeedRoot;
 
 export const RUNS_FEED_ROOT_QUERY = gql`
-  query RunsFeedRootQuery($limit: Int!, $cursor: String, $filter: RunsFilter, $includeRunsInBackfills: Boolean!) {
-    runsFeedOrError(limit: $limit, cursor: $cursor, filter: $filter, includeRunsInBackfills: $includeRunsInBackfills) {
+  query RunsFeedRootQuery(
+    $limit: Int!
+    $cursor: String
+    $filter: RunsFilter
+    $includeRunsInBackfills: Boolean!
+  ) {
+    runsFeedOrError(
+      limit: $limit
+      cursor: $cursor
+      filter: $filter
+      includeRunsInBackfills: $includeRunsInBackfills
+    ) {
       ... on RunsFeedConnection {
         cursor
         hasMore

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
@@ -123,7 +123,7 @@ export const RunsFeedRoot = () => {
     queryKey: 'show_runs_within_backfills',
     defaults: {show_runs_within_backfills: false},
   });
-  const {tabs, queryResult: runQueryResult} = useRunsFeedTabs(filter);
+  const {tabs, queryResult: runQueryResult} = useRunsFeedTabs(filter, includeRunsFromBackfills);
 
   const {entries, paginationProps, queryResult} = useRunsFeedEntries(
     filter,

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTabs.tsx
@@ -31,7 +31,7 @@ const getDocumentTitle = (selected: ReturnType<typeof useSelectedRunsFeedTab>) =
   }
 };
 
-export const useRunsFeedTabs = (filter: RunsFilter = {}) => {
+export const useRunsFeedTabs = (filter: RunsFilter = {}, includeRunsFromBackfills: boolean) => {
   const queryResult = useQuery<RunFeedTabsCountQuery, RunFeedTabsCountQueryVariables>(
     RUN_FEED_TABS_COUNT_QUERY,
     {
@@ -62,7 +62,7 @@ export const useRunsFeedTabs = (filter: RunsFilter = {}) => {
   const urlForStatus = (statuses: RunStatus[]) => {
     const tokensMinusStatus = filterTokens.filter((token) => token.token !== 'status');
     const statusTokens = statuses.map((status) => ({token: 'status' as const, value: status}));
-    return runsPathWithFilters([...statusTokens, ...tokensMinusStatus], getRunFeedPath());
+    return runsPathWithFilters([...statusTokens, ...tokensMinusStatus], getRunFeedPath(), includeRunsFromBackfills);
   };
 
   const tabs = (

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTabs.tsx
@@ -6,7 +6,7 @@ import styled, {css} from 'styled-components';
 
 import {failedStatuses, inProgressStatuses, queuedStatuses} from './RunStatuses';
 import {getRunFeedPath} from './RunsFeedUtils';
-import {runsPathWithFilters, useQueryPersistedRunFilters, RunFilterTokenType} from './RunsFilterInput';
+import {runsPathWithFilters, useQueryPersistedRunFilters} from './RunsFilterInput';
 import {RunFeedTabsCountQuery, RunFeedTabsCountQueryVariables} from './types/RunsFeedTabs.types';
 import {gql, useQuery} from '../apollo-client';
 import {RunStatus, RunsFilter} from '../graphql/types';
@@ -53,29 +53,22 @@ export const useRunsFeedTabs = (filter: RunsFilter = {}, includeRunsFromBackfill
           : null,
     };
   }, [countData]);
-  const enabledFilters: RunFilterTokenType[] = [
-    'status',
-    'tag',
-    'id',
-    'created_date_before',
-    'created_date_after',
-    'pipeline',
-    'partition',
-    'job',
-    'snapshotId',
-    'backfill'
-  ];
-  const [filterTokens] = useQueryPersistedRunFilters(enabledFilters);
+
+  const [filterTokens] = useQueryPersistedRunFilters();
   const selectedTab = useSelectedRunsFeedTab(filterTokens);
 
   useDocumentTitle(getDocumentTitle(selectedTab));
 
   const urlForStatus = (statuses: RunStatus[]) => {
-    console.log('filter tokens', filterTokens)
+    console.log('filter tokens', filterTokens);
 
     const tokensMinusStatus = filterTokens.filter((token) => token.token !== 'status');
     const statusTokens = statuses.map((status) => ({token: 'status' as const, value: status}));
-    return runsPathWithFilters([...statusTokens, ...tokensMinusStatus], getRunFeedPath(), includeRunsFromBackfills);
+    return runsPathWithFilters(
+      [...statusTokens, ...tokensMinusStatus],
+      getRunFeedPath(),
+      includeRunsFromBackfills,
+    );
   };
 
   const tabs = (
@@ -92,7 +85,13 @@ export const useRunsFeedTabs = (filter: RunsFilter = {}, includeRunsFromBackfill
         to={urlForStatus(Array.from(inProgressStatuses))}
       />
       <TabLink id="failed" title="Failed" to={urlForStatus(Array.from(failedStatuses))} />
-      <TabLink id="scheduled" title="Scheduled" to={`${getRunFeedPath()}scheduled`} />
+      <TabLink
+        id="scheduled"
+        title="Scheduled"
+        to={`${getRunFeedPath()}scheduled?${
+          includeRunsFromBackfills ? 'show_runs_within_backfills=true' : ''
+        }`}
+      />
     </Tabs>
   );
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTabs.tsx
@@ -60,8 +60,6 @@ export const useRunsFeedTabs = (filter: RunsFilter = {}, includeRunsFromBackfill
   useDocumentTitle(getDocumentTitle(selectedTab));
 
   const urlForStatus = (statuses: RunStatus[]) => {
-    console.log('filter tokens', filterTokens);
-
     const tokensMinusStatus = filterTokens.filter((token) => token.token !== 'status');
     const statusTokens = statuses.map((status) => ({token: 'status' as const, value: status}));
     return runsPathWithFilters(

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTabs.tsx
@@ -6,7 +6,7 @@ import styled, {css} from 'styled-components';
 
 import {failedStatuses, inProgressStatuses, queuedStatuses} from './RunStatuses';
 import {getRunFeedPath} from './RunsFeedUtils';
-import {runsPathWithFilters, useQueryPersistedRunFilters} from './RunsFilterInput';
+import {runsPathWithFilters, useQueryPersistedRunFilters, RunFilterTokenType} from './RunsFilterInput';
 import {RunFeedTabsCountQuery, RunFeedTabsCountQueryVariables} from './types/RunsFeedTabs.types';
 import {gql, useQuery} from '../apollo-client';
 import {RunStatus, RunsFilter} from '../graphql/types';
@@ -53,13 +53,26 @@ export const useRunsFeedTabs = (filter: RunsFilter = {}, includeRunsFromBackfill
           : null,
     };
   }, [countData]);
-
-  const [filterTokens] = useQueryPersistedRunFilters();
+  const enabledFilters: RunFilterTokenType[] = [
+    'status',
+    'tag',
+    'id',
+    'created_date_before',
+    'created_date_after',
+    'pipeline',
+    'partition',
+    'job',
+    'snapshotId',
+    'backfill'
+  ];
+  const [filterTokens] = useQueryPersistedRunFilters(enabledFilters);
   const selectedTab = useSelectedRunsFeedTab(filterTokens);
 
   useDocumentTitle(getDocumentTitle(selectedTab));
 
   const urlForStatus = (statuses: RunStatus[]) => {
+    console.log('filter tokens', filterTokens)
+
     const tokensMinusStatus = filterTokens.filter((token) => token.token !== 'status');
     const statusTokens = statuses.map((status) => ({token: 'status' as const, value: status}));
     return runsPathWithFilters([...statusTokens, ...tokensMinusStatus], getRunFeedPath(), includeRunsFromBackfills);

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -116,9 +116,13 @@ export function useQueryPersistedRunFilters(enabledFilters?: RunFilterTokenType[
   );
 }
 
-export function runsPathWithFilters(filterTokens: RunFilterToken[], basePath: string = '/runs', includeRunsFromBackfills: boolean | undefined = undefined) {
+export function runsPathWithFilters(
+  filterTokens: RunFilterToken[],
+  basePath: string = '/runs',
+  includeRunsFromBackfills: boolean | undefined = undefined,
+) {
   return `${basePath}?${qs.stringify(
-    {q: tokensAsStringArray([...filterTokens, {token: 'show_runs_within_backfills', value: includeRunsFromBackfills !== undefined ? includeRunsFromBackfills.toString() : ''}])},
+    {q: tokensAsStringArray(filterTokens), show_runs_within_backfills: includeRunsFromBackfills},
     {arrayFormat: 'brackets'},
   )}`;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -116,9 +116,9 @@ export function useQueryPersistedRunFilters(enabledFilters?: RunFilterTokenType[
   );
 }
 
-export function runsPathWithFilters(filterTokens: RunFilterToken[], basePath: string = '/runs') {
+export function runsPathWithFilters(filterTokens: RunFilterToken[], basePath: string = '/runs', includeRunsFromBackfills: boolean | undefined = undefined) {
   return `${basePath}?${qs.stringify(
-    {q: tokensAsStringArray(filterTokens)},
+    {q: tokensAsStringArray([...filterTokens, {token: 'show_runs_within_backfills', value: includeRunsFromBackfills !== undefined ? includeRunsFromBackfills.toString() : ''}])},
     {arrayFormat: 'brackets'},
   )}`;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFilterInput.tsx
@@ -50,8 +50,7 @@ export type RunFilterTokenType =
   | 'tag'
   | 'backfill'
   | 'created_date_before'
-  | 'created_date_after'
-  | 'show_runs_within_backfills';
+  | 'created_date_after';
 
 export type RunFilterToken = {
   token?: RunFilterTokenType;
@@ -89,10 +88,6 @@ const RUN_PROVIDERS_EMPTY = [
   },
   {
     token: 'created_date_after',
-    values: () => [],
-  },
-  {
-    token: 'show_runs_within_backfills',
     values: () => [],
   },
 ];
@@ -157,11 +152,6 @@ export function runsFilterForSearchTokens(search: TokenizingFieldValue[]) {
       } else {
         obj.tags = [{key: key!, value}];
       }
-    } else if (item.token === 'show_runs_within_backfills') {
-      // the Runs filter expects a boolen on whether to **exclude** runs that are within
-      // backfills. The UI checkbox is whether to **show** runs within backfills, so we
-      // negate the value when creating the filter
-      obj.excludeSubruns = item.value === 'false';
     }
   }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsFeedRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsFeedRoot.types.ts
@@ -6,7 +6,7 @@ export type RunsFeedRootQueryVariables = Types.Exact<{
   limit: Types.Scalars['Int']['input'];
   cursor?: Types.InputMaybe<Types.Scalars['String']['input']>;
   filter?: Types.InputMaybe<Types.RunsFilter>;
-  includeRunsInBackfills: Types.Scalars['Boolean']['input'];
+  includeRunsFromBackfills: Types.Scalars['Boolean']['input'];
 }>;
 
 export type RunsFeedRootQuery = {
@@ -97,4 +97,4 @@ export type RunsFeedRootQuery = {
       };
 };
 
-export const RunsFeedRootQueryVersion = '47f5f305206b0696195bae6de586fada3d6c536cb7d84e7d9290760f8e027dde';
+export const RunsFeedRootQueryVersion = 'fbfc82cccaebc1698305767c04c4dc16ed15b7a272342135d5a83745ffece37e';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsFeedRoot.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsFeedRoot.types.ts
@@ -6,6 +6,7 @@ export type RunsFeedRootQueryVariables = Types.Exact<{
   limit: Types.Scalars['Int']['input'];
   cursor?: Types.InputMaybe<Types.Scalars['String']['input']>;
   filter?: Types.InputMaybe<Types.RunsFilter>;
+  includeRunsInBackfills: Types.Scalars['Boolean']['input'];
 }>;
 
 export type RunsFeedRootQuery = {
@@ -96,4 +97,4 @@ export type RunsFeedRootQuery = {
       };
 };
 
-export const RunsFeedRootQueryVersion = '42006dc8a4bc222d1ef7fe3275fd64769ab2645efacfb3432edc9616bb88d826';
+export const RunsFeedRootQueryVersion = '47f5f305206b0696195bae6de586fada3d6c536cb7d84e7d9290760f8e027dde';

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -376,6 +376,7 @@ class GrapheneQuery(graphene.ObjectType):
         limit=graphene.NonNull(graphene.Int),
         cursor=graphene.String(),
         filter=graphene.Argument(GrapheneRunsFilter),
+        include_runs_in_backfills=graphene.Boolean(),
         description="Retrieve entries for the Runs Feed after applying a filter, cursor and limit.",
     )
     runsFeedCountOrError = graphene.Field(
@@ -852,12 +853,17 @@ class GrapheneQuery(graphene.ObjectType):
         self,
         graphene_info: ResolveInfo,
         limit: int,
+        include_runs_in_backfills,
         cursor: Optional[str] = None,
         filter: Optional[GrapheneRunsFilter] = None,  # noqa: A002
     ):
         selector = filter.to_selector() if filter is not None else None
         return get_runs_feed_entries(
-            graphene_info=graphene_info, cursor=cursor, limit=limit, filters=selector
+            graphene_info=graphene_info,
+            cursor=cursor,
+            limit=limit,
+            filters=selector,
+            include_runs_in_backfills=include_runs_in_backfills,
         )
 
     def resolve_runsFeedCountOrError(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -853,7 +853,7 @@ class GrapheneQuery(graphene.ObjectType):
         self,
         graphene_info: ResolveInfo,
         limit: int,
-        includeRunsInBackfill,
+        includeRunsInBackfills,
         cursor: Optional[str] = None,
         filter: Optional[GrapheneRunsFilter] = None,  # noqa: A002
     ):
@@ -863,7 +863,7 @@ class GrapheneQuery(graphene.ObjectType):
             cursor=cursor,
             limit=limit,
             filters=selector,
-            include_runs_in_backfills=includeRunsInBackfill,
+            include_runs_in_backfills=includeRunsInBackfills,
         )
 
     def resolve_runsFeedCountOrError(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -376,7 +376,7 @@ class GrapheneQuery(graphene.ObjectType):
         limit=graphene.NonNull(graphene.Int),
         cursor=graphene.String(),
         filter=graphene.Argument(GrapheneRunsFilter),
-        include_runs_in_backfills=graphene.Boolean(),
+        includeRunsInBackfills=graphene.Boolean(),
         description="Retrieve entries for the Runs Feed after applying a filter, cursor and limit.",
     )
     runsFeedCountOrError = graphene.Field(
@@ -853,7 +853,7 @@ class GrapheneQuery(graphene.ObjectType):
         self,
         graphene_info: ResolveInfo,
         limit: int,
-        include_runs_in_backfills,
+        includeRunsInBackfill,
         cursor: Optional[str] = None,
         filter: Optional[GrapheneRunsFilter] = None,  # noqa: A002
     ):
@@ -863,7 +863,7 @@ class GrapheneQuery(graphene.ObjectType):
             cursor=cursor,
             limit=limit,
             filters=selector,
-            include_runs_in_backfills=include_runs_in_backfills,
+            include_runs_in_backfills=includeRunsInBackfill,
         )
 
     def resolve_runsFeedCountOrError(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -376,7 +376,7 @@ class GrapheneQuery(graphene.ObjectType):
         limit=graphene.NonNull(graphene.Int),
         cursor=graphene.String(),
         filter=graphene.Argument(GrapheneRunsFilter),
-        includeRunsInBackfills=graphene.Boolean(),
+        includeRunsFromBackfills=graphene.Boolean(),
         description="Retrieve entries for the Runs Feed after applying a filter, cursor and limit.",
     )
     runsFeedCountOrError = graphene.Field(
@@ -853,7 +853,7 @@ class GrapheneQuery(graphene.ObjectType):
         self,
         graphene_info: ResolveInfo,
         limit: int,
-        includeRunsInBackfills: bool,
+        includeRunsFromBackfills: bool,
         cursor: Optional[str] = None,
         filter: Optional[GrapheneRunsFilter] = None,  # noqa: A002
     ):
@@ -863,7 +863,7 @@ class GrapheneQuery(graphene.ObjectType):
             cursor=cursor,
             limit=limit,
             filters=selector,
-            include_runs_in_backfills=includeRunsInBackfills,
+            include_runs_from_backfills=includeRunsFromBackfills,
         )
 
     def resolve_runsFeedCountOrError(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -853,7 +853,7 @@ class GrapheneQuery(graphene.ObjectType):
         self,
         graphene_info: ResolveInfo,
         limit: int,
-        includeRunsInBackfills,
+        includeRunsInBackfills: bool,
         cursor: Optional[str] = None,
         filter: Optional[GrapheneRunsFilter] = None,  # noqa: A002
     ):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
@@ -17,8 +17,8 @@ from dagster_graphql_tests.graphql.graphql_context_test_suite import (
 )
 
 GET_RUNS_FEED_QUERY = """
-query RunsFeedEntryQuery($cursor: String, $limit: Int!, $filter: RunsFilter, $include_runs_in_backfills: Boolean!) {
-    runsFeedOrError(cursor: $cursor, limit: $limit, filter: $filter, include_runs_in_backfills: $include_runs_in_backfills) {
+query RunsFeedEntryQuery($cursor: String, $limit: Int!, $filter: RunsFilter, $includeRunsInBackfills: Boolean!) {
+    runsFeedOrError(cursor: $cursor, limit: $limit, filter: $filter, includeRunsInBackfills: $includeRunsInBackfills) {
       ... on RunsFeedConnection {
           results {
             __typename
@@ -131,7 +131,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         _assert_results_match_count_match_expected(result, 20)
@@ -148,7 +148,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -174,7 +174,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": old_cursor,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -194,7 +194,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 15,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -218,7 +218,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         # limit was used, count will differ from number of results returned
@@ -239,7 +239,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -271,7 +271,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": old_cursor.to_string(),
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -297,7 +297,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
         prev_run_time = None
@@ -314,7 +314,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
 
@@ -338,7 +338,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 5,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
 
@@ -364,7 +364,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 5,
                 "cursor": old_cursor,
                 "filter": None,
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
 
@@ -401,7 +401,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -426,7 +426,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -449,7 +449,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -481,7 +481,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -512,7 +512,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -540,7 +540,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -572,7 +572,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 5,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -605,7 +605,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -643,7 +643,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -660,7 +660,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["SUCCESS"]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -674,7 +674,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["FAILURE"]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -688,7 +688,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELING"]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -702,7 +702,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELED"]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -716,7 +716,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["NOT_STARTED"]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -742,7 +742,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
 
@@ -759,7 +759,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["SUCCESS"]},
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
         assert not result.errors
@@ -773,7 +773,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["FAILURE"]},
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
         assert not result.errors
@@ -787,7 +787,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELING"]},
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
         assert not result.errors
@@ -801,7 +801,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELED"]},
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
         assert not result.errors
@@ -834,7 +834,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -851,7 +851,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": nothing_created_ts},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -866,7 +866,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": half_created_ts},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -881,7 +881,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": all_created_ts},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -898,7 +898,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 6,
                 "cursor": None,
                 "filter": {"createdBefore": half_created_ts},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -913,7 +913,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 4,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": {"createdBefore": half_created_ts},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -958,7 +958,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -975,7 +975,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"pipelineName": "foo"},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -989,7 +989,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"pipelineName": "bar"},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1020,7 +1020,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -1037,7 +1037,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "bar"}]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1052,7 +1052,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "baz", "value": "quux"}]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1066,7 +1066,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "baz"}]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1085,7 +1085,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -1102,7 +1102,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"runIds": [run.run_id]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1123,7 +1123,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
 
@@ -1140,7 +1140,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"runIds": [run.run_id]},
-                "include_runs_in_backfills": True,
+                "includeRunsInBackfills": True,
             },
         )
         assert not result.errors
@@ -1190,7 +1190,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -1207,7 +1207,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "bar"}], "statuses": ["SUCCESS"]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1224,7 +1224,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                     "tags": [{"key": "foo", "value": "bar"}],
                     "statuses": ["FAILURE", "CANCELED"],
                 },
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1238,7 +1238,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "baz"}], "statuses": ["FAILURE"]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1258,7 +1258,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
 
@@ -1274,7 +1274,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": BACKFILL_ID_TAG, "value": backfill_id}]},
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors
@@ -1296,7 +1296,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                         {"key": "not", "value": "present"},
                     ]
                 },
-                "include_runs_in_backfills": False,
+                "includeRunsInBackfills": False,
             },
         )
         assert not result.errors

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
@@ -17,8 +17,8 @@ from dagster_graphql_tests.graphql.graphql_context_test_suite import (
 )
 
 GET_RUNS_FEED_QUERY = """
-query RunsFeedEntryQuery($cursor: String, $limit: Int!, $filter: RunsFilter) {
-    runsFeedOrError(cursor: $cursor, limit: $limit, filter: $filter) {
+query RunsFeedEntryQuery($cursor: String, $limit: Int!, $filter: RunsFilter, $include_runs_in_backfills: Boolean!) {
+    runsFeedOrError(cursor: $cursor, limit: $limit, filter: $filter, include_runs_in_backfills: $include_runs_in_backfills) {
       ... on RunsFeedConnection {
           results {
             __typename
@@ -131,6 +131,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
         _assert_results_match_count_match_expected(result, 20)
@@ -147,6 +148,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -172,6 +174,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": old_cursor,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -191,6 +194,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 15,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -214,6 +218,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
         # limit was used, count will differ from number of results returned
@@ -234,6 +239,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -265,6 +271,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": old_cursor.to_string(),
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -289,7 +296,8 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 25,
                 "cursor": None,
-                "filter": {"excludeSubruns": False},
+                "filter": None,
+                "include_runs_in_backfills": True,
             },
         )
         prev_run_time = None
@@ -305,7 +313,8 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 10,
                 "cursor": None,
-                "filter": {"excludeSubruns": False},
+                "filter": None,
+                "include_runs_in_backfills": True,
             },
         )
 
@@ -328,7 +337,8 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 5,
                 "cursor": None,
-                "filter": {"excludeSubruns": False},
+                "filter": None,
+                "include_runs_in_backfills": True,
             },
         )
 
@@ -353,7 +363,8 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 5,
                 "cursor": old_cursor,
-                "filter": {"excludeSubruns": False},
+                "filter": None,
+                "include_runs_in_backfills": True,
             },
         )
 
@@ -390,6 +401,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -414,6 +426,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -436,6 +449,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -467,6 +481,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -497,6 +512,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -524,6 +540,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -555,6 +572,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 5,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -587,6 +605,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -624,6 +643,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -640,6 +660,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["SUCCESS"]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -653,6 +674,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["FAILURE"]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -666,6 +688,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELING"]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -679,6 +702,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELED"]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -692,6 +716,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["NOT_STARTED"]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -716,7 +741,8 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 10,
                 "cursor": None,
-                "filter": {"excludeSubruns": False},
+                "filter": None,
+                "include_runs_in_backfills": True,
             },
         )
 
@@ -732,7 +758,8 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 10,
                 "cursor": None,
-                "filter": {"statuses": ["SUCCESS"], "excludeSubruns": False},
+                "filter": {"statuses": ["SUCCESS"]},
+                "include_runs_in_backfills": True,
             },
         )
         assert not result.errors
@@ -745,7 +772,8 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 10,
                 "cursor": None,
-                "filter": {"statuses": ["FAILURE"], "excludeSubruns": False},
+                "filter": {"statuses": ["FAILURE"]},
+                "include_runs_in_backfills": True,
             },
         )
         assert not result.errors
@@ -758,7 +786,8 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 10,
                 "cursor": None,
-                "filter": {"statuses": ["CANCELING"], "excludeSubruns": False},
+                "filter": {"statuses": ["CANCELING"]},
+                "include_runs_in_backfills": True,
             },
         )
         assert not result.errors
@@ -771,7 +800,8 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 10,
                 "cursor": None,
-                "filter": {"statuses": ["CANCELED"], "excludeSubruns": False},
+                "filter": {"statuses": ["CANCELED"]},
+                "include_runs_in_backfills": True,
             },
         )
         assert not result.errors
@@ -804,6 +834,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -820,6 +851,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": nothing_created_ts},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -834,6 +866,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": half_created_ts},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -848,6 +881,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": all_created_ts},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -864,6 +898,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 6,
                 "cursor": None,
                 "filter": {"createdBefore": half_created_ts},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -878,6 +913,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 4,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": {"createdBefore": half_created_ts},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -922,6 +958,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -938,6 +975,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"pipelineName": "foo"},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -951,6 +989,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"pipelineName": "bar"},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -981,6 +1020,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -997,6 +1037,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "bar"}]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -1011,6 +1052,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "baz", "value": "quux"}]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -1024,6 +1066,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "baz"}]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -1042,6 +1085,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -1058,6 +1102,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"runIds": [run.run_id]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -1077,7 +1122,8 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 20,
                 "cursor": None,
-                "filter": {"excludeSubruns": False},
+                "filter": None,
+                "include_runs_in_backfills": True,
             },
         )
 
@@ -1093,7 +1139,8 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
             variables={
                 "limit": 10,
                 "cursor": None,
-                "filter": {"runIds": [run.run_id], "excludeSubruns": False},
+                "filter": {"runIds": [run.run_id]},
+                "include_runs_in_backfills": True,
             },
         )
         assert not result.errors
@@ -1143,6 +1190,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -1159,6 +1207,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "bar"}], "statuses": ["SUCCESS"]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -1175,6 +1224,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                     "tags": [{"key": "foo", "value": "bar"}],
                     "statuses": ["FAILURE", "CANCELED"],
                 },
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -1188,6 +1238,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "baz"}], "statuses": ["FAILURE"]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -1207,6 +1258,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
+                "include_runs_in_backfills": False,
             },
         )
 
@@ -1222,6 +1274,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": BACKFILL_ID_TAG, "value": backfill_id}]},
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors
@@ -1243,6 +1296,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                         {"key": "not", "value": "present"},
                     ]
                 },
+                "include_runs_in_backfills": False,
             },
         )
         assert not result.errors

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
@@ -17,8 +17,8 @@ from dagster_graphql_tests.graphql.graphql_context_test_suite import (
 )
 
 GET_RUNS_FEED_QUERY = """
-query RunsFeedEntryQuery($cursor: String, $limit: Int!, $filter: RunsFilter, $includeRunsInBackfills: Boolean!) {
-    runsFeedOrError(cursor: $cursor, limit: $limit, filter: $filter, includeRunsInBackfills: $includeRunsInBackfills) {
+query RunsFeedEntryQuery($cursor: String, $limit: Int!, $filter: RunsFilter, $includeRunsFromBackfills: Boolean!) {
+    runsFeedOrError(cursor: $cursor, limit: $limit, filter: $filter, includeRunsFromBackfills: $includeRunsFromBackfills) {
       ... on RunsFeedConnection {
           results {
             __typename
@@ -131,7 +131,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         _assert_results_match_count_match_expected(result, 20)
@@ -148,7 +148,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -174,7 +174,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": old_cursor,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -194,7 +194,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 15,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -218,7 +218,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         # limit was used, count will differ from number of results returned
@@ -239,7 +239,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -271,7 +271,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": old_cursor.to_string(),
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -297,7 +297,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
         prev_run_time = None
@@ -314,7 +314,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
 
@@ -338,7 +338,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 5,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
 
@@ -364,7 +364,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "limit": 5,
                 "cursor": old_cursor,
                 "filter": None,
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
 
@@ -401,7 +401,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -426,7 +426,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -449,7 +449,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -481,7 +481,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -512,7 +512,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -540,7 +540,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -572,7 +572,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 5,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -605,7 +605,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -643,7 +643,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -660,7 +660,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["SUCCESS"]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -674,7 +674,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["FAILURE"]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -688,7 +688,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELING"]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -702,7 +702,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELED"]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -716,7 +716,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["NOT_STARTED"]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -742,7 +742,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
 
@@ -759,7 +759,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["SUCCESS"]},
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
         assert not result.errors
@@ -773,7 +773,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["FAILURE"]},
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
         assert not result.errors
@@ -787,7 +787,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELING"]},
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
         assert not result.errors
@@ -801,7 +801,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"statuses": ["CANCELED"]},
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
         assert not result.errors
@@ -834,7 +834,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -851,7 +851,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": nothing_created_ts},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -866,7 +866,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": half_created_ts},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -881,7 +881,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 25,
                 "cursor": None,
                 "filter": {"createdBefore": all_created_ts},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -898,7 +898,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 6,
                 "cursor": None,
                 "filter": {"createdBefore": half_created_ts},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -913,7 +913,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 4,
                 "cursor": result.data["runsFeedOrError"]["cursor"],
                 "filter": {"createdBefore": half_created_ts},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -958,7 +958,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -975,7 +975,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"pipelineName": "foo"},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -989,7 +989,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"pipelineName": "bar"},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1020,7 +1020,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -1037,7 +1037,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "bar"}]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1052,7 +1052,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "baz", "value": "quux"}]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1066,7 +1066,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "baz"}]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1085,7 +1085,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -1102,7 +1102,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"runIds": [run.run_id]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1123,7 +1123,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
 
@@ -1140,7 +1140,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"runIds": [run.run_id]},
-                "includeRunsInBackfills": True,
+                "includeRunsFromBackfills": True,
             },
         )
         assert not result.errors
@@ -1190,7 +1190,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -1207,7 +1207,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "bar"}], "statuses": ["SUCCESS"]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1224,7 +1224,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                     "tags": [{"key": "foo", "value": "bar"}],
                     "statuses": ["FAILURE", "CANCELED"],
                 },
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1238,7 +1238,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": "foo", "value": "baz"}], "statuses": ["FAILURE"]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1258,7 +1258,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 20,
                 "cursor": None,
                 "filter": None,
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
 
@@ -1274,7 +1274,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                 "limit": 10,
                 "cursor": None,
                 "filter": {"tags": [{"key": BACKFILL_ID_TAG, "value": backfill_id}]},
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors
@@ -1296,7 +1296,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
                         {"key": "not", "value": "present"},
                     ]
                 },
-                "includeRunsInBackfills": False,
+                "includeRunsFromBackfills": False,
             },
         )
         assert not result.errors


### PR DESCRIPTION
## Summary & Motivation
Updates the UI to use the new `includeRunsInBackfills` param when fetching the runs feed

modifies the logic for how we generate URLs for the tabbed pages to include whether we are showing the runs within backfills

## How I Tested These Changes
<img width="961" alt="Screenshot 2024-10-03 at 3 06 21 PM" src="https://github.com/user-attachments/assets/4eb82212-c561-4590-a59f-ed75c7da9f00">
<img width="961" alt="Screenshot 2024-10-03 at 3 06 16 PM" src="https://github.com/user-attachments/assets/b5fd8be5-6718-4a4a-8056-73c1e037fa20">



## Changelog

NOCHANGELOG
