### PR TITLE
remove excludeSubruns from GrapheneRunsFilter

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -2350,7 +2350,6 @@ input RunsFilter {
   createdBefore: Float
   createdAfter: Float
   mode: String
-  excludeSubruns: Boolean
 }
 
 input PipelineSelector {

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -4790,7 +4790,6 @@ export type RunsFeedEntry = {
 export type RunsFilter = {
   createdAfter?: InputMaybe<Scalars['Float']['input']>;
   createdBefore?: InputMaybe<Scalars['Float']['input']>;
-  excludeSubruns?: InputMaybe<Scalars['Boolean']['input']>;
   mode?: InputMaybe<Scalars['String']['input']>;
   pipelineName?: InputMaybe<Scalars['String']['input']>;
   runIds?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -13649,8 +13648,6 @@ export const buildRunsFilter = (
       overrides && overrides.hasOwnProperty('createdAfter') ? overrides.createdAfter! : 2.71,
     createdBefore:
       overrides && overrides.hasOwnProperty('createdBefore') ? overrides.createdBefore! : 2.25,
-    excludeSubruns:
-      overrides && overrides.hasOwnProperty('excludeSubruns') ? overrides.excludeSubruns! : false,
     mode: overrides && overrides.hasOwnProperty('mode') ? overrides.mode! : 'voluptatem',
     pipelineName:
       overrides && overrides.hasOwnProperty('pipelineName') ? overrides.pipelineName! : 'voluptas',

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -667,9 +667,10 @@ def get_runs_feed_entries(
 
 def get_runs_feed_count(graphene_info: "ResolveInfo", filters: Optional[RunsFilter]) -> int:
     should_fetch_backfills = _filters_apply_to_backfills(filters) if filters else True
-    run_filters = (
-        copy(filters, exclude_subruns=True) if filters else RunsFilter(exclude_subruns=True)
-    )
+    with disable_dagster_warnings():
+        run_filters = (
+            copy(filters, exclude_subruns=True) if filters else RunsFilter(exclude_subruns=True)
+        )
     if should_fetch_backfills:
         backfill_filters = _bulk_action_filters_from_run_filters(run_filters)
         backfills_count = graphene_info.context.instance.get_backfills_count(backfill_filters)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -26,6 +26,7 @@ from dagster._core.storage.event_log.base import AssetRecord
 from dagster._core.storage.tags import BACKFILL_ID_TAG, TagType, get_tag_type
 from dagster._record import copy, record
 from dagster._time import datetime_from_timestamp
+from dagster._utils.warnings import disable_dagster_warnings
 
 from dagster_graphql.implementation.external import ensure_valid_config, get_external_job_or_raise
 
@@ -584,15 +585,17 @@ def get_runs_feed_entries(
             filters.exclude_subruns is None,
             "filters.exclude_subruns must be None when fetching the runs feed. Use include_runs_from_backfills instead.",
         )
-        run_filters = copy(filters, exclude_subruns=exclude_subruns)
-        run_filters = _replace_created_before_with_cursor(run_filters, created_before_cursor)
+        with disable_dagster_warnings():
+            run_filters = copy(filters, exclude_subruns=exclude_subruns)
+            run_filters = _replace_created_before_with_cursor(run_filters, created_before_cursor)
         backfill_filters = (
             _bulk_action_filters_from_run_filters(run_filters) if should_fetch_backfills else None
         )
     else:
-        run_filters = RunsFilter(
-            created_before=created_before_cursor, exclude_subruns=exclude_subruns
-        )
+        with disable_dagster_warnings():
+            run_filters = RunsFilter(
+                created_before=created_before_cursor, exclude_subruns=exclude_subruns
+            )
         backfill_filters = BulkActionsFilter(created_before=created_before_cursor)
 
     if should_fetch_backfills:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/inputs.py
@@ -48,7 +48,6 @@ class GrapheneRunsFilter(graphene.InputObjectType):
     createdBefore = graphene.InputField(graphene.Float)
     createdAfter = graphene.InputField(graphene.Float)
     mode = graphene.InputField(graphene.String)
-    excludeSubruns = graphene.InputField(graphene.Boolean)
 
     class Meta:
         description = """This type represents a filter on Dagster runs."""
@@ -81,7 +80,6 @@ class GrapheneRunsFilter(graphene.InputObjectType):
             updated_after=updated_after,
             created_before=created_before,
             created_after=created_after,
-            exclude_subruns=self.excludeSubruns,
         )
 
 


### PR DESCRIPTION
## Summary & Motivation
since we aren't using the filter to pass along whether we should show/hide the runs within backfills, we can remove it from the GQL layer.  Any users of this filter would have gotten an experimental warning when they used it, so should be fine to remove

## How I Tested These Changes

## Changelog
NOCHANGELOG
