### PR TITLE
[dagster-aws] add `since_last_modified` parameter to get_s3_keys

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/_stubs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/_stubs.py
@@ -1,0 +1,50 @@
+# Stubs have been sourced from
+#
+#    https://youtype.github.io/boto3_stubs_docs/mypy_boto3_s3/type_defs/#objecttypedef
+#
+# as to not require any additional dependencies
+
+from datetime import datetime
+from typing import List, Literal, Optional, TypedDict
+
+ChecksumAlgorithmType = Literal[
+    "CRC32",
+    "CRC32C",
+    "SHA1",
+    "SHA256",
+]
+
+ObjectStorageClassType = Literal[
+    "DEEP_ARCHIVE",
+    "EXPRESS_ONEZONE",
+    "GLACIER",
+    "GLACIER_IR",
+    "INTELLIGENT_TIERING",
+    "ONEZONE_IA",
+    "OUTPOSTS",
+    "REDUCED_REDUNDANCY",
+    "SNOW",
+    "STANDARD",
+    "STANDARD_IA",
+]
+
+
+class OwnerTypeDef(TypedDict):
+    DisplayName: Optional[str]
+    ID: Optional[str]
+
+
+class RestoreStatusTypeDef(TypedDict):
+    IsRestoreInProgress: Optional[bool]
+    RestoreExpiryDate: Optional[datetime]
+
+
+class ObjectTypeDef(TypedDict):
+    Key: str
+    LastModified: datetime
+    ETag: Optional[str]
+    ChecksumAlgorithm: Optional[List[ChecksumAlgorithmType]]
+    Size: Optional[int]
+    StorageClass: Optional[ObjectStorageClassType]
+    Owner: Optional[OwnerTypeDef]
+    RestoreStatus: Optional[RestoreStatusTypeDef]

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
@@ -1,43 +1,98 @@
-from typing import Optional
+from collections import namedtuple
+from datetime import datetime
+from typing import List, Optional
 
 import boto3
 import dagster._check as check
+from dagster._annotations import deprecated
+
+Object = namedtuple("Object", ["key", "last_modified"])
 
 
 class ClientException(Exception):
     pass
 
 
+def get_objects(
+    bucket: str,
+    prefix: str = "",
+    since_key: Optional[str] = None,
+    since_last_modified: Optional[str] = None,
+    client=None,
+) -> List[Object]:
+    """Retrieves a list of object keys in S3 for a given `bucket`, `prefix`, and filter option.
+
+    Args:
+        bucket (str): s3 bucket
+        prefix (str): s3 object prefix
+        since_key (Optional[str]): retrieve objects after the modified date of this key
+        since_last_modified (Optional[str]): retrieve objects after this timestamp
+        client (Optional[boto3.Client]): s3 client
+
+    Returns:
+        List of object keys in S3.
+
+    """
+    check.str_param(bucket, "bucket")
+    check.str_param(prefix, "prefix")
+    check.opt_str_param(since_key, "since_key")
+    check.opt_str_param(since_last_modified, "since_last_modified")
+
+    if not client:
+        raise ClientException("Failed to initialize s3 client")
+
+    paginator = client.get_paginator("list_objects_v2")
+    page_iterator = paginator.paginate(Bucket=bucket, Prefix=prefix, Delimiter="")
+
+    objects = []
+    for page in page_iterator:
+        contents = page.get("Contents", [])
+        objects.extend([Object(obj.get("Key"), obj.get("LastModified")) for obj in contents])
+
+    if since_key and not any(obj.key == since_key for obj in objects):
+        raise Exception("Provided `since_key` is not present in list of objects")
+
+    sorted_objects = [obj for obj in sorted(objects, key=lambda x: x.last_modified)]
+
+    if since_key and since_key:
+        for idx, obj in enumerate(sorted_objects):
+            if obj.key == since_key:
+                return sorted_objects[idx + 1 :]
+
+    if since_last_modified:
+        since_last_modified_dt = datetime.fromisoformat(since_last_modified)
+        for idx, obj in enumerate(sorted_objects):
+            if obj.last_modified >= since_last_modified_dt:
+                return sorted_objects[idx + 1 :]
+
+    return sorted_objects
+
+
+@deprecated(breaking_version="2.0", additional_warn_text="Use get_objects instead.")
 def get_s3_keys(
     bucket: str,
     prefix: str = "",
     since_key: Optional[str] = None,
     s3_session: Optional[boto3.Session] = None,
-):
-    check.str_param(bucket, "bucket")
-    check.str_param(prefix, "prefix")
-    check.opt_str_param(since_key, "since_key")
+) -> List[str]:
+    """Retrieves a list of object keys in S3 for a given `bucket`, `prefix`, and filter option.
 
-    if not s3_session:
-        s3_session = boto3.client("s3", use_ssl=True, verify=True)
+    Note: when using the `since_key` it is possible to miss records if that key has been modified,
+    as sorting is done by the `LastModified` property of the S3 object. For more information, see
+    the following GitHub issue:
 
-    if not s3_session:
-        raise ClientException("Failed to initialize s3 client")
+        https://github.com/dagster-io/dagster/issues/22892
 
-    paginator = s3_session.get_paginator("list_objects_v2")  # type: ignore
-    page_iterator = paginator.paginate(Bucket=bucket, Prefix=prefix)
+    Args:
+        bucket (str): s3 bucket
+        prefix (str): s3 object prefix
+        since_key (Optional[str]): retrieve objects after the modified date of this key
+        since_last_modified (Optional[str]): retrieve objects after this timestamp
+        s3_session (Optional[boto3.Session]): s3 client
 
-    contents = []
-    for page in page_iterator:
-        contents.extend(page.get("Contents", []))
+    Returns:
+        List of object keys in S3.
 
-    sorted_keys = [obj["Key"] for obj in sorted(contents, key=lambda x: x["LastModified"])]
-
-    if not since_key or since_key not in sorted_keys:
-        return sorted_keys
-
-    for idx, key in enumerate(sorted_keys):
-        if key == since_key:
-            return sorted_keys[idx + 1 :]
-
-    return []
+    """
+    objects = get_objects(bucket=bucket, prefix=prefix, since_key=since_key, client=s3_session)
+    return [obj.key for obj in objects]

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import Any, List, Optional, cast
 
 import boto3
 import dagster._check as check
@@ -49,7 +49,7 @@ def get_objects(
     objects: List[ObjectTypeDef] = []
     for page in page_iterator:
         contents = page.get("Contents", [])
-        objects.extend([ObjectTypeDef(obj) for obj in contents])
+        objects.extend([cast(ObjectTypeDef, obj) for obj in contents])
 
     if since_key and not any(obj.get("Key") == since_key for obj in objects):
         raise Exception("Provided `since_key` is not present in list of objects")

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_sensor.py
@@ -1,5 +1,8 @@
+import time
+
 import boto3
 import moto
+import pytest
 
 from dagster_aws.s3.sensor import get_s3_keys
 
@@ -59,6 +62,69 @@ def test_get_s3_keys():
         # The test would be flaky if sorted was not guaranteed to be stable, which it is
         # according to: https://wiki.python.org/moin/HowTo/Sorting/.
         keys = get_s3_keys(
-            bucket=bucket_name, prefix=prefix, since_key=thousand_and_one_hundred_keys[1090]
+            bucket=bucket_name,
+            prefix=prefix,
+            since_key=thousand_and_one_hundred_keys[1090],
         )
         assert len(keys) == 9, "9 keys should be returned"
+
+
+def test_get_s3_keys_missing_since_key():
+    bucket_name = "test-bucket"
+    prefix = "content"
+
+    with moto.mock_s3():
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        response = s3_client.create_bucket(Bucket=bucket_name)
+        if not response:
+            raise Exception("Failed to create bucket")
+
+        def put_key_in_bucket(key, body):
+            r = s3_client.put_object(Bucket=bucket_name, Key=f"{prefix}/{key}", Body=body)
+            if not r:
+                raise Exception("Failed to create object")
+
+        no_key = get_s3_keys(bucket=bucket_name, prefix=prefix)
+        assert len(no_key) == 0  # no keys in bucket
+
+        put_key_in_bucket(key="foo-1", body="test")
+        put_key_in_bucket(key="foo-2", body="test")
+        two_keys = get_s3_keys(bucket=bucket_name, prefix=prefix)
+        assert len(two_keys) == 2
+
+        # if `since_key` is not present in the list of objects, then an exception is thrown
+        with pytest.raises(Exception):
+            _ = get_s3_keys(bucket=bucket_name, prefix=prefix, since_key="content/foo-z")
+
+
+def test_get_s3_keys_with_modified_files():
+    bucket_name = "test-bucket"
+    prefix = "content"
+
+    with moto.mock_s3():
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        s3_client.create_bucket(Bucket=bucket_name)
+
+        def put_key_in_bucket(key, body):
+            s3_client.put_object(Bucket=bucket_name, Key=f"{prefix}/{key}", Body=body)
+            time.sleep(1)  # Ensure each file has a unique timestamp
+
+        # Create file "A" at timestamp 1
+        put_key_in_bucket(key="A", body="initial content")
+
+        # Simulate first sensor run
+        initial_keys = get_s3_keys(bucket=bucket_name, prefix=prefix)
+        assert len(initial_keys) == 1
+        assert initial_keys[0].endswith("A")
+
+        # Create files "B" and "C", and modify "A" between sensor runs
+        put_key_in_bucket(key="B", body="content B")
+        put_key_in_bucket(key="C", body="content C")
+        put_key_in_bucket(key="A", body="modified content")
+
+        # Simulate second sensor run
+        new_keys = get_s3_keys(bucket=bucket_name, prefix=prefix, since_key=initial_keys[0])
+
+        # Because `since_key` has been modified, and our files are sorted by last modified date, we
+        # will _not_ get keys for objecfts B and C
+        assert len(new_keys) == 0


### PR DESCRIPTION
## Summary & Motivation

- Adds `since_last_modified` parameter to `get_s3_keys` to support shortcoming of `since_key` as `since_key` can result in missing records if that key has been modified (keys are sorted by last modified date)

## How I Tested These Changes

- `pytest`

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [x] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
