### PR TITLE
update AssetIn dagster_type type

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_in.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_in.py
@@ -53,7 +53,7 @@ class AssetIn(
         key_prefix: Optional[CoercibleToAssetKeyPrefix] = None,
         input_manager_key: Optional[str] = None,
         partition_mapping: Optional[PartitionMapping] = None,
-        dagster_type: Union[DagsterType, Type[NoValueSentinel]] = NoValueSentinel,
+        dagster_type: Union[DagsterType, Type] = NoValueSentinel,
     ):
         if isinstance(key_prefix, str):
             key_prefix = [key_prefix]

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -861,7 +861,7 @@ def test_invalid_self_dep_no_time_dimension():
             del b
 
 
-def test_asset_in_nothing():
+def test_asset_in_nothing() -> None:
     @asset(ins={"upstream": AssetIn(dagster_type=Nothing)})
     def asset1(): ...
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/base_scenario.py
@@ -622,7 +622,7 @@ def asset_def(
     else:
         non_argument_deps = None
         ins = {
-            dep: AssetIn(partition_mapping=partition_mapping, dagster_type=Nothing)  # type: ignore
+            dep: AssetIn(partition_mapping=partition_mapping, dagster_type=Nothing)
             for dep, partition_mapping in deps.items()
         }
 


### PR DESCRIPTION
match `AssetOut`s typing
since we coerce to `DagsterType` in the construcotr it actually accepts any `Type`

## How I Tested These Changes

added -> None to existing test to have type checker run on it

## Changelog

Corrected the AssetIn.__new__ typing for the dagster_type argument

- [x] `BUGFIX` _(fixed a bug)_
