### PR TITLE
[dagster-airlift][misc][rfc] proxy operator revamp

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/base_proxy_operator.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/base_proxy_operator.py
@@ -3,10 +3,27 @@ import json
 import logging
 import os
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, Set, Tuple, Type
+from collections import defaultdict
+from functools import lru_cache
+from typing import (
+    AbstractSet,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    TypedDict,
+    cast,
+)
 
 import requests
+from airflow.models.dagrun import DagRun
 from airflow.models.operator import BaseOperator
+from airflow.operators.python import get_current_context
 from airflow.utils.context import Context
 from requests import Response
 
@@ -20,6 +37,16 @@ from dagster_airlift.constants import (
 from .gql_queries import ASSET_NODES_QUERY, RUNS_QUERY, TRIGGER_ASSETS_MUTATION, VERIFICATION_QUERY
 
 logger = logging.getLogger(__name__)
+
+
+class ExecutableAssetIdentifier(TypedDict):
+    location_name: str
+    repository_name: str
+    asset_key_path: Sequence[str]
+    job_name: str
+
+
+JobIdentifier = Tuple[str, str, str]
 
 
 def matched_dag_id_task_id(asset_node: dict, dag_id: str, task_id: str) -> bool:
@@ -45,12 +72,20 @@ class BaseProxyToDagsterOperator(BaseOperator, ABC):
     """
 
     @abstractmethod
-    def get_dagster_session(self, context: Context) -> requests.Session:
+    def get_dagster_session(self) -> requests.Session:
         """Returns a requests session that can be used to make requests to the Dagster API."""
 
-    def _get_validated_session(self, context: Context) -> requests.Session:
-        session = self.get_dagster_session(context)
-        dagster_url = self.get_dagster_url(context)
+    @abstractmethod
+    def get_dagster_url(self) -> str:
+        """Returns the URL for the Dagster instance."""
+
+    @abstractmethod
+    def get_assets_to_trigger(self) -> Sequence[ExecutableAssetIdentifier]:
+        """Returns the assets to trigger for the given task."""
+
+    def _get_validated_session(self) -> requests.Session:
+        session = self.get_dagster_session()
+        dagster_url = self.get_dagster_url()
         response = session.post(
             # Timeout in seconds
             f"{dagster_url}/graphql",
@@ -63,9 +98,128 @@ class BaseProxyToDagsterOperator(BaseOperator, ABC):
             )
         return session
 
-    @abstractmethod
-    def get_dagster_url(self, context: Context) -> str:
-        """Returns the URL for the Dagster instance."""
+    def get_dag_run(self) -> DagRun:
+        context = get_current_context()
+        if "dag_run" not in context:
+            raise Exception("Dag run not found in context. Expected to find dag_run.")
+        return context["dag_run"]
+
+    def get_dag_id(self) -> str:
+        return self.get_dag_run().dag_id  # type: ignore # thinks it's a column due to django syntax
+
+    def get_dag_run_id(self) -> str:
+        return self.get_dag_run().run_id  # type: ignore # thinks it's a column due to django syntax
+
+    def get_task_id(self) -> str:
+        context = get_current_context()
+        if "task" not in context:
+            raise Exception("Task not found in context. Expected to find task.")
+        return context["task"].task_id
+
+    def get_dagster_run_tags(self) -> Mapping[str, str]:
+        dag_run = self.get_dag_run()
+        return {
+            DAG_ID_TAG_KEY: cast(str, dag_run.dag_id),
+            DAG_RUN_ID_TAG_KEY: cast(str, dag_run.run_id),
+            TASK_ID_TAG_KEY: self.get_task_id(),
+        }
+
+    @lru_cache(maxsize=1)
+    def get_all_asset_nodes(self) -> Sequence[Dict[str, Any]]:
+        """Returns all asset nodes retrieved from the Dagster graphql API.
+        We cache the result after the first call.
+        """
+        dagster_url = self.get_dagster_url()
+        response = self.get_dagster_session().post(
+            # Timeout in seconds
+            f"{dagster_url}/graphql",
+            json={"query": ASSET_NODES_QUERY},
+            timeout=3,
+        )
+        return self.get_valid_graphql_response(response, "assetNodes")
+
+    def _build_asset_identifier_from_asset_node(
+        self, asset_node: Dict[str, Any]
+    ) -> ExecutableAssetIdentifier:
+        return {
+            "location_name": asset_node["jobs"][0]["repository"]["location"]["name"],
+            "repository_name": asset_node["jobs"][0]["repository"]["name"],
+            "asset_key_path": asset_node["assetKey"]["path"],
+            "job_name": asset_node["jobs"][0]["name"],
+        }
+
+    def trigger_run(self, execution_params: Dict[str, Any]) -> str:
+        """Triggers a run in Dagster."""
+        session = self.get_dagster_session()
+        dagster_url = self.get_dagster_url()
+        response = session.post(
+            f"{dagster_url}/graphql",
+            json={
+                "query": TRIGGER_ASSETS_MUTATION,
+                "variables": {"executionParams": execution_params},
+            },
+            # Timeout in seconds
+            timeout=10,
+        )
+        launch_data = self.get_valid_graphql_response(response, "launchPipelineExecution")
+        return launch_data["run"]["id"]
+
+    def trigger_runs_for_assets(
+        self, executable_assets: Sequence[ExecutableAssetIdentifier]
+    ) -> AbstractSet[str]:
+        """Triggers runs for the given assets in Dagster."""
+        assets_grouped_by_job_identifier = _group_assets_by_job_identifier(executable_assets)
+        triggered_runs = set()
+        for (
+            location_name,
+            repository_name,
+            job_name,
+        ), asset_key_paths in assets_grouped_by_job_identifier.items():
+            user_friendly_asset_paths = [
+                "/".join(asset_key_path) for asset_key_path in asset_key_paths
+            ]
+            logger.debug(
+                f"Triggering run for {location_name}/{repository_name}/{job_name} with assets {user_friendly_asset_paths}"
+            )
+            run_id = self.trigger_run(
+                _build_execution_params(
+                    self.get_dagster_run_tags(),
+                    asset_key_paths,
+                    location_name,
+                    repository_name,
+                    job_name,
+                )
+            )
+            logger.debug(f"Launched run {run_id}...")
+            triggered_runs.add(run_id)
+        return triggered_runs
+
+    def _get_dagster_run_status(self, run_id: str) -> str:
+        session = self._get_validated_session()
+        response = session.post(
+            f"{self.get_dagster_url()}/graphql",
+            json={"query": RUNS_QUERY, "variables": {"runId": run_id}},
+            # Timeout in seconds
+            timeout=3,
+        )
+        return self.get_valid_graphql_response(response, "runOrError")["status"]
+
+    def wait_for_runs_to_complete(self, run_ids: AbstractSet[str]) -> None:
+        completed_runs = {}  # key is run_id, value is status
+        while len(completed_runs) < len(run_ids):
+            for run_id in run_ids:
+                if run_id in completed_runs:
+                    continue
+                run_status = self._get_dagster_run_status(run_id)
+                if run_status in ["SUCCESS", "FAILURE", "CANCELED"]:
+                    logger.debug(f"Run {run_id} completed with status {run_status}")
+                    completed_runs[run_id] = run_status
+        non_successful_runs = [
+            run_id for run_id, status in completed_runs.items() if status != "SUCCESS"
+        ]
+        if len(non_successful_runs) > 0:
+            raise Exception(f"Runs {non_successful_runs} did not complete successfully.")
+        logger.debug("All runs completed successfully.")
 
     def get_valid_graphql_response(self, response: Response, key: str) -> Any:
         response_json = response.json()
@@ -77,111 +231,90 @@ class BaseProxyToDagsterOperator(BaseOperator, ABC):
 
         return response_json["data"][key]
 
-    def launch_runs_for_task(self, context: Context, dag_id: str, task_id: str) -> None:
-        """Launches runs for the given task in Dagster."""
-        session = self._get_validated_session(context)
-
-        dagster_url = self.get_dagster_url(context)
-        assets_to_trigger = {}  # key is (repo_location, repo_name, job_name), value is list of asset keys
-        # create graphql client
-        response = session.post(
-            # Timeout in seconds
-            f"{dagster_url}/graphql",
-            json={"query": ASSET_NODES_QUERY},
-            timeout=3,
-        )
-        asset_nodes_data = self.get_valid_graphql_response(response, "assetNodes")
-        for asset_node in asset_nodes_data:
-            if matched_dag_id_task_id(asset_node, dag_id, task_id):
-                repo_location = asset_node["jobs"][0]["repository"]["location"]["name"]
-                repo_name = asset_node["jobs"][0]["repository"]["name"]
-                job_name = asset_node["jobs"][0]["name"]
-                if (repo_location, repo_name, job_name) not in assets_to_trigger:
-                    assets_to_trigger[(repo_location, repo_name, job_name)] = []
-                assets_to_trigger[(repo_location, repo_name, job_name)].append(
-                    asset_node["assetKey"]["path"]
-                )
-        logger.debug(f"Found assets to trigger: {assets_to_trigger}")
-
-        dag_run = context.get("dag_run")
-        assert dag_run, "dag_run not found in context"
-        # Get the dag_run_id
-        dag_run_id = dag_run.run_id
-
-        triggered_runs = []
-        tags = {
-            DAG_ID_TAG_KEY: dag_id,
-            DAG_RUN_ID_TAG_KEY: dag_run_id,
-            TASK_ID_TAG_KEY: task_id,
-        }
-        for (repo_location, repo_name, job_name), asset_keys in assets_to_trigger.items():
-            execution_params = {
-                "mode": "default",
-                "executionMetadata": {
-                    "tags": [{"key": key, "value": value} for key, value in tags.items()]
-                },
-                "runConfigData": "{}",
-                "selector": {
-                    "repositoryLocationName": repo_location,
-                    "repositoryName": repo_name,
-                    "pipelineName": job_name,
-                    "assetSelection": [{"path": asset_key} for asset_key in asset_keys],
-                    "assetCheckSelection": [],
-                },
-            }
-            logger.debug(
-                f"Triggering run for {repo_location}/{repo_name}/{job_name} with assets {asset_keys}"
-            )
-            response = session.post(
-                f"{dagster_url}/graphql",
-                json={
-                    "query": TRIGGER_ASSETS_MUTATION,
-                    "variables": {"executionParams": execution_params},
-                },
-                # Timeout in seconds
-                timeout=10,
-            )
-            launch_data = self.get_valid_graphql_response(response, "launchPipelineExecution")
-            run_id = launch_data["run"]["id"]
-            logger.debug(f"Launched run {run_id}...")
-            triggered_runs.append(run_id)
-        completed_runs = {}  # key is run_id, value is status
-        while len(completed_runs) < len(triggered_runs):
-            for run_id in triggered_runs:
-                if run_id in completed_runs:
-                    continue
-                response = session.post(
-                    f"{dagster_url}/graphql",
-                    json={"query": RUNS_QUERY, "variables": {"runId": run_id}},
-                    # Timeout in seconds
-                    timeout=3,
-                )
-                run_status = self.get_valid_graphql_response(response, "runOrError")["status"]
-                if run_status in ["SUCCESS", "FAILURE", "CANCELED"]:
-                    logger.debug(f"Run {run_id} completed with status {run_status}")
-                    completed_runs[run_id] = run_status
-        non_successful_runs = [
-            run_id for run_id, status in completed_runs.items() if status != "SUCCESS"
-        ]
-        if non_successful_runs:
-            raise Exception(f"Runs {non_successful_runs} did not complete successfully.")
-        logger.debug("All runs completed successfully.")
-        return None
+    def _execute_proxied_dagster_runs(self, context: Context) -> None:
+        assets = self.get_assets_to_trigger()
+        triggered_runs = self.trigger_runs_for_assets(assets)
+        self.wait_for_runs_to_complete(triggered_runs)
 
     def execute(self, context: Context) -> Any:
         # https://github.com/apache/airflow/discussions/24463
         os.environ["NO_PROXY"] = "*"
-        dag_id = os.environ["AIRFLOW_CTX_DAG_ID"]
-        task_id = os.environ["AIRFLOW_CTX_TASK_ID"]
-        return self.launch_runs_for_task(context, dag_id, task_id)
+        self._execute_proxied_dagster_runs(context)
 
 
-class DefaultProxyToDagsterOperator(BaseProxyToDagsterOperator):
-    def get_dagster_session(self, context: Context) -> requests.Session:
+def _group_assets_by_job_identifier(
+    assets: Sequence[ExecutableAssetIdentifier],
+) -> Mapping[JobIdentifier, Sequence[Sequence[str]]]:
+    assets_by_job_identifier: Dict[JobIdentifier, List[Sequence[str]]] = defaultdict(list)
+    for asset in assets:
+        assets_by_job_identifier[
+            (asset["location_name"], asset["repository_name"], asset["job_name"])
+        ].append(asset["asset_key_path"])
+    return assets_by_job_identifier
+
+
+def _build_execution_params(
+    tags: Mapping[str, str],
+    asset_key_paths: Sequence[Sequence[str]],
+    location_name: str,
+    repository_name: str,
+    job_name: str,
+) -> Dict[str, Any]:
+    return {
+        "mode": "default",
+        "executionMetadata": {
+            "tags": [{"key": key, "value": value} for key, value in tags.items()]
+        },
+        "runConfigData": "{}",
+        "selector": {
+            "repositoryLocationName": location_name,
+            "repositoryName": repository_name,
+            "pipelineName": job_name,
+            "assetSelection": [{"path": asset_key_path} for asset_key_path in asset_key_paths],
+            "assetCheckSelection": [],
+        },
+    }
+
+
+class DefaulProxyToDagsterOperator(BaseProxyToDagsterOperator):
+    """Underlying implementation of a DagsterOperator. This one uses the DAGSTER_URL environment variable to connect to the Dagster instance."""
+
+    @lru_cache(maxsize=1)
+    def get_dagster_session(self) -> requests.Session:
         return requests.Session()
 
-    def get_dagster_url(self, context: Context) -> str:
+    def get_dagster_url(self) -> str:
         return os.environ["DAGSTER_URL"]
+
+
+class ProxiedTaskDagsterOperator(DefaulProxyToDagsterOperator):
+    """Operator that executes tasks that have been proxied to Dagster.
+    This operator will find all assets that are mapped to this task and trigger runs for them.
+    """
+
+    def get_assets_to_trigger(self, context: Context) -> Sequence[ExecutableAssetIdentifier]:
+        dag_id = self.get_dag_id()
+        task_id = self.get_task_id()
+        executable_assets = []
+        for asset_node in self.get_all_asset_nodes(self.get_dagster_session()):
+            if matched_dag_id_task_id(asset_node, dag_id, task_id):
+                executable_assets.append(self._build_asset_identifier_from_asset_node(asset_node))
+        return executable_assets
+
+
+class StandaloneAssetsDagsterOperator(DefaulProxyToDagsterOperator):
+    """Operator that triggers runs for a set of provided assets."""
+
+    def __init__(self, asset_key_paths: Sequence[Sequence[str]], **kwargs):
+        super().__init__(**kwargs)
+        self.asset_key_paths = asset_key_paths
+
+    def get_assets_to_trigger(self) -> Sequence[ExecutableAssetIdentifier]:
+        executable_assets = []
+        for node in self.get_all_asset_nodes(self.get_dagster_session()):
+            if node["assetKey"]["path"] in self.asset_key_paths:
+                executable_assets.append(self._build_asset_identifier_from_asset_node(node))
+        return executable_assets
 
 
 def build_dagster_task(


### PR DESCRIPTION
## Summary & Motivation
Revamp of proxy operator functionality to be more composable.
- Hide dagster graphql API calls behind methods.
- Use get_current_context() to retrieve context out of thin air. This allows us to use lru_cache on expensive methods.
- Use lru_cache on potentially expensive methods
- Add ProxiedToTaskOperator and StaticProxiedAssetsOperator. ProxiedToTaskOperator is the operator that `proxy_to_dagster` uses by default, and `StaticProxiedAssetsOperator` is a new operator for executing standalone assets.

Questions:
- Top level API for specifying a standalone asset. Should we vendor out an API for specifying an AssetKey?
- Do we want to give users any control over which job executes their asset?
- There's some shenanigans regarding the airflow `context` object. I've changed methods to retrieve the context object from `get_current_context`, which has been around since airflow 2.0. However, can we be sure that for the duration of a given python process that the airflow context object won't change under our feet? The caching behavior kind of makes that assumption.

## How I Tested These Changes
No tests right now, I'll go back and add as I make more surgical changes.
## Changelog
NOCHANGELOG
