### PR TITLE
[docs-beta-snippets] fix broken unit test in `module_from_spec`

### DIFF
--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/tutorials/etl_tutorial/etl_tutorial/definitions.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/tutorials/etl_tutorial/etl_tutorial/definitions.py
@@ -341,12 +341,16 @@ def adhoc_request_sensor(context: dg.SensorEvaluationContext):
     )
 
 
-all_assets = dg.load_assets_from_current_module()
-all_asset_checks = dg.load_asset_checks_from_current_module()
-
 defs = dg.Definitions(
-    assets=all_assets,
-    asset_checks=all_asset_checks,
+    assets=[
+        products,
+        sales_reps,
+        sales_data,
+        joined_data,
+        monthly_sales_performance,
+        product_performance,
+    ],
+    asset_checks=[missing_dimension_check],
     schedules=[weekly_update_schedule],
     jobs=[analysis_update_job, adhoc_request_job],
     sensors=[adhoc_request_sensor],


### PR DESCRIPTION
## Summary & Motivation

The unit test that validates that our `docs_beta_snippets` example load uses the following:

```
    spec = importlib.util.spec_from_file_location("module", file_path)
    assert spec is not None and spec.loader is not None
    module = importlib.util.module_from_spec(spec)
    try:
        spec.loader.exec_module(module)
    except Exception as e:
        pytest.fail(f"Failed to load {file_path}: {e!s}")
```

It appears that this doesn't play well with our loader functions:

```
all_assets = dg.load_assets_from_current_module()
all_asset_checks = dg.load_asset_checks_from_current_module()
```

This pull request replaces these with hard-coded asset names--though admittedly this is less elegant.

## How I Tested These Changes

`tox -e all`

## Changelog

NOCHANGELOG
