### PR TITLE
Add execute_k8s_job arg to delete failed k8s jobs

### DIFF
--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -163,7 +163,7 @@ def execute_k8s_job(
     job_spec_config: Optional[Dict[str, Any]] = None,
     k8s_job_name: Optional[str] = None,
     merge_behavior: K8sConfigMergeBehavior = K8sConfigMergeBehavior.DEEP,
-    delete_failed_k8s_jobs: bool = True,
+    delete_failed_k8s_jobs: Optional[bool] = True,
     _kubeconfig_file_context: Optional[str] = None,
 ):
     """This function is a utility for executing a Kubernetes job from within a Dagster op.

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -418,7 +418,7 @@ def execute_k8s_job(
     except (DagsterExecutionInterruptedError, Exception) as e:
         if delete_failed_k8s_jobs:
             context.log.info(
-                    f"Deleting Kubernetes job {job_name} in namespace {namespace} due to exception"
+                f"Deleting Kubernetes job {job_name} in namespace {namespace} due to exception"
             )
             api_client.delete_job(job_name=job_name, namespace=namespace)
         raise e

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -6,8 +6,6 @@ import kubernetes.config
 import kubernetes.watch
 from dagster import (
     Enum as DagsterEnum,
-)
-from dagster import (
     Field,
     In,
     Noneable,
@@ -21,11 +19,7 @@ from dagster._annotations import experimental
 from dagster._core.errors import DagsterExecutionInterruptedError
 from dagster._utils.merger import merge_dicts
 
-from dagster_k8s.client import (
-    DEFAULT_JOB_POD_COUNT,
-    DagsterKubernetesClient,
-    k8s_api_retry,
-)
+from dagster_k8s.client import DEFAULT_JOB_POD_COUNT, DagsterKubernetesClient, k8s_api_retry
 from dagster_k8s.container_context import K8sContainerContext
 from dagster_k8s.job import (
     DagsterK8sJobConfig,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -6,6 +6,8 @@ import kubernetes.config
 import kubernetes.watch
 from dagster import (
     Enum as DagsterEnum,
+)
+from dagster import (
     Field,
     In,
     Noneable,
@@ -19,7 +21,11 @@ from dagster._annotations import experimental
 from dagster._core.errors import DagsterExecutionInterruptedError
 from dagster._utils.merger import merge_dicts
 
-from dagster_k8s.client import DEFAULT_JOB_POD_COUNT, DagsterKubernetesClient, k8s_api_retry
+from dagster_k8s.client import (
+    DEFAULT_JOB_POD_COUNT,
+    DagsterKubernetesClient,
+    k8s_api_retry,
+)
 from dagster_k8s.container_context import K8sContainerContext
 from dagster_k8s.job import (
     DagsterK8sJobConfig,
@@ -163,6 +169,7 @@ def execute_k8s_job(
     job_spec_config: Optional[Dict[str, Any]] = None,
     k8s_job_name: Optional[str] = None,
     merge_behavior: K8sConfigMergeBehavior = K8sConfigMergeBehavior.DEEP,
+    delete_failed_k8s_jobs: bool = True,
     _kubeconfig_file_context: Optional[str] = None,
 ):
     """This function is a utility for executing a Kubernetes job from within a Dagster op.
@@ -239,6 +246,11 @@ def execute_k8s_job(
             are recursively merged, appending list fields together and merging dictionary fields.
             Setting it to SHALLOW will make the dictionaries shallowly merged - any shared values
             in the dictionaries will be replaced by the values set on this op.
+        delete_failed_k8s_jobs (bool): Whether to immediately delete failed Kubernetes jobs. If False,
+            failed jobs will remain accessible through the Kubernetes API until deleted by a user or cleaned up by the
+            .spec.ttlSecondsAfterFinished parameter of the job.
+            (https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/).
+            Defaults to True.
     """
     run_container_context = K8sContainerContext.create_for_run(
         context.dagster_run,
@@ -410,10 +422,11 @@ def execute_k8s_job(
             num_pods_to_wait_for=num_pods_to_wait_for,
         )
     except (DagsterExecutionInterruptedError, Exception) as e:
-        context.log.info(
-            f"Deleting Kubernetes job {job_name} in namespace {namespace} due to exception"
-        )
-        api_client.delete_job(job_name=job_name, namespace=namespace)
+        if delete_failed_k8s_jobs:
+            context.log.info(
+                    f"Deleting Kubernetes job {job_name} in namespace {namespace} due to exception"
+            )
+            api_client.delete_job(job_name=job_name, namespace=namespace)
         raise e
 
 


### PR DESCRIPTION
## Summary & Motivation
The current behavior of execute_k8s_job is to immediately delete a
failed Kubernetes job. This change adds a boolean parameter to control
this behavior so that users and supporting processes (such as log
ingestion tools) have time to access a failed job's pods. The new arg
defaults to True, preserving existing behavior.

## How I Tested These Changes
I created a Kubernetes job from my local dagster web server using an image I knew would fail, and observed that the job and pod were still visible using `kubectl` when `delete_failed_k8s_job` was set to `False`.

## Changelog

NOCHANGELOG

- [x ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
