### PR TITLE
[record] opt-in defensive checks

### DIFF
--- a/python_modules/dagster/dagster_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/conftest.py
@@ -3,6 +3,8 @@ import subprocess
 import sys
 
 import dagster._seven as seven
+import pytest
+from dagster._utils.env import environ
 
 IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 
@@ -11,3 +13,9 @@ IS_BUILDKITE = os.getenv("BUILDKITE") is not None
 # Fixed in later versions of Python but never back-ported, see the bug for details.
 if seven.IS_WINDOWS and sys.version_info[0] == 3 and sys.version_info[1] == 6:
     subprocess._cleanup = lambda: None  # type: ignore # noqa: SLF001
+
+
+@pytest.fixture(scope="session", autouse=True)
+def enable_defensive_checks():
+    with environ({"DAGSTER_RECORD_DEFENSIVE_CHECKS": "true"}):
+        yield

--- a/python_modules/dagster/dagster_tests/general_tests/test_record.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_record.py
@@ -1,3 +1,4 @@
+import os
 import pickle
 from abc import ABC, abstractmethod
 from functools import cached_property
@@ -824,3 +825,8 @@ def test_replace() -> None:
     assert replaced == obj
     replaced.boop()
     assert replaced.__class__ is obj.__class__
+
+
+def test_defensive_checks_running():
+    # make sure we have enabled defensive checks in test, ideally as broadly as possible
+    assert os.getenv("DAGSTER_RECORD_DEFENSIVE_CHECKS") == "true"


### PR DESCRIPTION
Caught a one-off error here in the wild, so thinking its a threading race condition. Disable the check in produciton but gating it to only be done in test.

## How I Tested These Changes

add a print line and ensure it only fires in test
