### PR TITLE
[dagster-tableau] Implement data quality warning endpoint for data sources

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -166,15 +166,28 @@ class BaseTableauClient:
 
     def add_data_quality_warning_to_data_source(
         self,
-        datasource_id: str,
+        data_source_id: str,
         warning_type: Optional[TSC.DQWItem.WarningType] = None,
         message: Optional[str] = None,
         active: Optional[bool] = None,
         severe: Optional[bool] = None,
-    ) -> List[TSC.DQWItem]:
-        """Add a data quality warning to a data source."""
-        datasource: TSC.DatasourceItem = self._server.datasources.get_by_id(
-            datasource_id=datasource_id
+    ) -> Sequence[TSC.DQWItem]:
+        """Add a data quality warning to a data source.
+
+        Args:
+            data_source_id (str): The ID of the data source for which a data quality warning is to be added.
+            warning_type (Optional[tableauserverclient.DQWItem.WarningType]): The warning type
+                for the data quality warning. Defaults to `TSC.DQWItem.WarningType.WARNING`.
+            message (Optional[str]): The message for the data quality warning. Defaults to `None`.
+            active (Optional[bool]): Whether the data quality warning is active or not. Defaults to `True`.
+            severe (Optional[bool]): Whether the data quality warning is sever or not. Defaults to `False`.
+
+        Returns:
+            Sequence[tableauserverclient.DQWItem]: The list of tableauserverclient.DQWItems which
+                exist for the data source.
+        """
+        data_source: TSC.DatasourceItem = self._server.datasources.get_by_id(
+            datasource_id=data_source_id
         )
         warning: TSC.DQWItem = TSC.DQWItem(
             warning_type=str(warning_type) or TSC.DQWItem.WarningType.WARNING,
@@ -182,7 +195,7 @@ class BaseTableauClient:
             active=active or True,
             severe=severe or False,
         )
-        return self._server.datasources.add_dqw(item=datasource, warning=warning)
+        return self._server.datasources.add_dqw(item=data_source, warning=warning)
 
     def sign_in(self) -> Auth.contextmgr:
         """Sign in to the site in Tableau."""

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -164,7 +164,7 @@ class BaseTableauClient:
 
         return job.workbook_id
 
-    def add_data_quality_warning_to_datasource(
+    def add_data_quality_warning_to_data_source(
         self,
         datasource_id: str,
         warning_type: Optional[TSC.DQWItem.WarningType] = None,

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -164,6 +164,26 @@ class BaseTableauClient:
 
         return job.workbook_id
 
+    def add_data_quality_warning_to_datasource(
+        self,
+        datasource_id: str,
+        warning_type: Optional[TSC.DQWItem.WarningType] = None,
+        message: Optional[str] = None,
+        active: Optional[bool] = None,
+        severe: Optional[bool] = None,
+    ) -> List[TSC.DQWItem]:
+        """Add a data quality warning to a data source."""
+        datasource: TSC.DatasourceItem = self._server.datasources.get_by_id(
+            datasource_id=datasource_id
+        )
+        warning: TSC.DQWItem = TSC.DQWItem(
+            warning_type=warning_type or TSC.DQWItem.WarningType.WARNING,
+            message=message,
+            active=active or True,
+            severe=severe or False,
+        )
+        return self._server.datasources.add_dqw(item=datasource, warning=warning)
+
     def sign_in(self) -> Auth.contextmgr:
         """Sign in to the site in Tableau."""
         jwt_token = jwt.encode(

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -177,7 +177,7 @@ class BaseTableauClient:
             datasource_id=datasource_id
         )
         warning: TSC.DQWItem = TSC.DQWItem(
-            warning_type=warning_type or TSC.DQWItem.WarningType.WARNING,
+            warning_type=str(warning_type) or TSC.DQWItem.WarningType.WARNING,
             message=message,
             active=active or True,
             severe=severe or False,

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/conftest.py
@@ -185,6 +185,28 @@ def cancel_job_fixture():
         yield mocked_function
 
 
+@pytest.fixture(name="get_data_source_by_id", autouse=True)
+def get_data_source_by_id_fixture():
+    with patch(
+        "dagster_tableau.resources.TSC.server.endpoint.datasources_endpoint.Datasources.get_by_id"
+    ) as mocked_function:
+        yield mocked_function
+
+
+@pytest.fixture(name="build_data_quality_warning_item", autouse=True)
+def build_data_quality_warning_item_fixture():
+    with patch("dagster_tableau.resources.TSC.DQWItem") as mocked_class:
+        yield mocked_class
+
+
+@pytest.fixture(name="add_data_quality_warning", autouse=True)
+def add_data_quality_warning_fixture():
+    with patch(
+        "dagster_tableau.resources.TSC.server.endpoint.datasources_endpoint.Datasources.add_dqw"
+    ) as mocked_function:
+        yield mocked_function
+
+
 @pytest.fixture(
     name="workspace_data",
 )

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
@@ -96,7 +96,7 @@ def test_add_data_quality_warning(
     resource = clazz(**resource_args)  # type: ignore
 
     with resource.get_client() as client:
-        client.add_data_quality_warning_to_data_source(datasource_id="fake_datasource_id")
+        client.add_data_quality_warning_to_data_source(data_source_id="fake_datasource_id")
 
     assert get_data_source_by_id.call_count == 1
     assert build_data_quality_warning_item.call_count == 1

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
@@ -58,3 +58,49 @@ def test_basic_resource_request(
     assert get_workbooks.call_count == 1
     assert get_workbook.call_count == 1
     get_workbook.assert_called_with(workbook_id=workbook_id)
+
+
+@pytest.mark.parametrize(
+    "clazz,host_key,host_value",
+    [
+        (TableauServerWorkspace, "server_name", "fake_server_name"),
+        (TableauCloudWorkspace, "pod_name", "fake_pod_name"),
+    ],
+)
+def test_add_data_quality_warning(
+    clazz: Union[Type[TableauCloudWorkspace], Type[TableauServerWorkspace]],
+    host_key: str,
+    host_value: str,
+    site_name: str,
+    api_token: str,
+    workbook_id: str,
+    sign_in: MagicMock,
+    get_data_source_by_id: MagicMock,
+    build_data_quality_warning_item: MagicMock,
+    add_data_quality_warning: MagicMock,
+) -> None:
+    connected_app_client_id = uuid.uuid4().hex
+    connected_app_secret_id = uuid.uuid4().hex
+    connected_app_secret_value = uuid.uuid4().hex
+    username = "fake_username"
+
+    resource_args = {
+        "connected_app_client_id": connected_app_client_id,
+        "connected_app_secret_id": connected_app_secret_id,
+        "connected_app_secret_value": connected_app_secret_value,
+        "username": username,
+        "site_name": site_name,
+        host_key: host_value,
+    }
+
+    resource = clazz(**resource_args)  # type: ignore
+
+    with resource.get_client() as client:
+        client.add_data_quality_warning_to_datasource(datasource_id="fake_datasource_id")
+
+    assert get_data_source_by_id.call_count == 1
+    assert build_data_quality_warning_item.call_count == 1
+    add_data_quality_warning.assert_called_with(
+        item=get_data_source_by_id.return_value,
+        warning=build_data_quality_warning_item.return_value,
+    )

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_resources.py
@@ -96,7 +96,7 @@ def test_add_data_quality_warning(
     resource = clazz(**resource_args)  # type: ignore
 
     with resource.get_client() as client:
-        client.add_data_quality_warning_to_datasource(datasource_id="fake_datasource_id")
+        client.add_data_quality_warning_to_data_source(datasource_id="fake_datasource_id")
 
     assert get_data_source_by_id.call_count == 1
     assert build_data_quality_warning_item.call_count == 1


### PR DESCRIPTION
## Summary & Motivation

Add `add_data_quality_warning_to_data_source` so that users can add a data quality warning to a Tableau data source with upstream assets are failing asset checks or materialization.

## How I Tested These Changes

BK with additional unit test

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
