### PR TITLE
[runs feed ui] display correct number of selected backfills in actions menu

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTable.tsx
@@ -62,10 +62,12 @@ export const RunsFeedTable = ({
   const totalHeight = rowVirtualizer.getTotalSize();
   const items = rowVirtualizer.getVirtualItems();
 
-  const selectedRuns = entries.filter(
-    (e): e is RunsFeedTableEntryFragment_Run => checkedIds.has(e.id) && e.__typename === 'Run',
+  const selectedEntries = entries.filter((e): e is RunsFeedTableEntryFragment_Run => checkedIds.has(e.id));
+
+  const selectedRuns = selectedEntries.filter(
+    (e): e is RunsFeedTableEntryFragment_Run => e.__typename === 'Run',
   );
-  const backfillsExcluded = entries.length - selectedRuns.length;
+  const backfillsExcluded = selectedEntries.length - selectedRuns.length;
 
   const actionBar = (
     <Box flex={{direction: 'column', gap: 8}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTable.tsx
@@ -62,7 +62,9 @@ export const RunsFeedTable = ({
   const totalHeight = rowVirtualizer.getTotalSize();
   const items = rowVirtualizer.getVirtualItems();
 
-  const selectedEntries = entries.filter((e): e is RunsFeedTableEntryFragment_Run => checkedIds.has(e.id));
+  const selectedEntries = entries.filter((e): e is RunsFeedTableEntryFragment_Run =>
+    checkedIds.has(e.id),
+  );
 
   const selectedRuns = selectedEntries.filter(
     (e): e is RunsFeedTableEntryFragment_Run => e.__typename === 'Run',


### PR DESCRIPTION
## Summary & Motivation
When using the bulk action menu, the number of backfills being excluded was determined based on the total number of entries in the page, not on the number of selected entries

## How I Tested These Changes
before - one run selected, but warning says 25 backfills will be ignored
<img width="961" alt="Screenshot 2024-10-03 at 5 04 57 PM" src="https://github.com/user-attachments/assets/eb3dac3d-54b4-49e1-adfc-dc3f35d97b78">

after
one run selected, no warning
<img width="961" alt="Screenshot 2024-10-03 at 5 06 32 PM" src="https://github.com/user-attachments/assets/5dcdfb80-7f4b-437a-82d7-340b17a33919">

one backfill and one run selected, warning says 1 backfill will be ignored 
<img width="961" alt="Screenshot 2024-10-03 at 5 06 26 PM" src="https://github.com/user-attachments/assets/5d923a91-efcf-465e-8047-4298a9c59786">


## Changelog

- [ ] `NEW` _(added new feature or capability)_
- [X] `BUGFIX` [ui] Fixed a bug in the experimental Runs page where an incorrect number of backfills was reported in the bulk actions menu.
- [ ] `DOCS` _(added or updated documentation)_
