### PR TITLE
[ui] Fix logs toolbar step selector width

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/LogsToolbar.tsx
@@ -167,30 +167,32 @@ export const ComputeLogToolbar = ({
     >
       <Box flex={{direction: 'row', alignItems: 'center', gap: 12}}>
         {steps ? (
-          <Suggest
-            resetOnClose
-            inputProps={{placeholder: 'Select a step…'}}
-            activeItem={computeLogFileKey}
-            selectedItem={computeLogFileKey}
-            disabled={!steps.length}
-            items={Object.keys(logCaptureSteps)}
-            noResults="No matching steps"
-            inputValueRenderer={(item) => fileKeyText(item)}
-            itemPredicate={(query, item) =>
-              fileKeyText(item).toLocaleLowerCase().includes(query.toLocaleLowerCase())
-            }
-            itemRenderer={(item, itemProps) => (
-              <MenuItem
-                active={itemProps.modifiers.active}
-                onClick={(e) => itemProps.handleClick(e)}
-                text={fileKeyText(item)}
-                key={item}
-              />
-            )}
-            onItemSelect={(fileKey) => {
-              onSetComputeLogKey(fileKey);
-            }}
-          />
+          <div style={{width: 200}}>
+            <Suggest
+              resetOnClose
+              inputProps={{placeholder: 'Select a step…'}}
+              activeItem={computeLogFileKey}
+              selectedItem={computeLogFileKey}
+              disabled={!steps.length}
+              items={Object.keys(logCaptureSteps)}
+              noResults="No matching steps"
+              inputValueRenderer={(item) => fileKeyText(item)}
+              itemPredicate={(query, item) =>
+                fileKeyText(item).toLocaleLowerCase().includes(query.toLocaleLowerCase())
+              }
+              itemRenderer={(item, itemProps) => (
+                <MenuItem
+                  active={itemProps.modifiers.active}
+                  onClick={(e) => itemProps.handleClick(e)}
+                  text={fileKeyText(item)}
+                  key={item}
+                />
+              )}
+              onItemSelect={(fileKey) => {
+                onSetComputeLogKey(fileKey);
+              }}
+            />
+          </div>
         ) : undefined}
 
         {!steps ? <Box>Step: {(logCaptureInfo?.stepKeys || []).join(', ')}</Box> : undefined}


### PR DESCRIPTION
## Summary & Motivation

The Blueprint upgrade broke the step selector in the Run logs toolbar. Fix it by giving it a container with some width.

It would probably make sense to try to clean up the `GlobalSuggestStyle` styles to see if they can be simplified altogether, but I'm hesitant to risk breaking other `Suggest` right this second.

<img width="401" alt="Screenshot 2024-10-03 at 16 55 02" src="https://github.com/user-attachments/assets/d1c1e895-b8cd-41d5-b891-56c4f8768d8c">

## How I Tested These Changes

View Run, switch to stdout logs. Verify that the suggest component input has width.

## Changelog

- [ ] `BUGFIX` [ui] Fixed width of step selector component in Run logs toolbar.