### PR TITLE
[dagster-airlift][sensor] Move sorting to end of loop

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
@@ -16,7 +16,6 @@ from dagster_airlift.core.airflow_instance import AirflowInstance
 from dagster_airlift.core.sensor import (
     DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
     build_airflow_polling_sensor_defs,
-    get_asset_events,
 )
 from dagster_airlift.core.serialization.compute import compute_serialized_data
 from dagster_airlift.core.serialization.defs_construction import (
@@ -70,8 +69,8 @@ def build_defs_from_airflow_instance(
             airflow_data=AirflowDefinitionsData(
                 airflow_instance=airflow_instance, resolved_airflow_defs=resolved_defs
             ),
-            event_translation_fn=get_asset_events,
             minimum_interval_seconds=sensor_minimum_interval_seconds,
+            event_translation_fn=None,
         ),
     )
 
@@ -118,7 +117,7 @@ def build_full_automapped_dags_from_airflow_instance(
             airflow_data=AirflowDefinitionsData(
                 resolved_airflow_defs=resolved_defs, airflow_instance=airflow_instance
             ),
-            event_translation_fn=get_asset_events,
+            event_translation_fn=None,
         ),
     )
 

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/__init__.py
@@ -3,4 +3,3 @@ from .builder import (
     AirflowPollingSensorCursor as AirflowPollingSensorCursor,
     build_airflow_polling_sensor_defs as build_airflow_polling_sensor_defs,
 )
-from .event_translation import get_asset_events as get_asset_events

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/builder.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/builder.py
@@ -65,7 +65,7 @@ def check_keys_for_asset_keys(
 
 def build_airflow_polling_sensor_defs(
     airflow_data: AirflowDefinitionsData,
-    event_translation_fn: AirflowEventTranslationFn,
+    event_translation_fn: Optional[AirflowEventTranslationFn],
     minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
 ) -> Definitions:
     @sensor(
@@ -174,7 +174,7 @@ def materializations_and_requests_from_batch_iter(
     end_date_lte: float,
     offset: int,
     airflow_data: AirflowDefinitionsData,
-    event_translation_fn: AirflowEventTranslationFn,
+    event_translation_fn: Optional[AirflowEventTranslationFn],
 ) -> Iterator[Optional[BatchResult]]:
     runs = airflow_data.airflow_instance.get_dag_runs_batch(
         dag_ids=list(airflow_data.all_dag_ids),

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
@@ -1,4 +1,4 @@
-from typing import AbstractSet, Any, Callable, Iterable, List, Mapping, Sequence
+from typing import AbstractSet, Any, Callable, Iterable, Mapping, Sequence
 
 from dagster import (
     AssetMaterialization,
@@ -17,20 +17,6 @@ from dagster_airlift.core.airflow_instance import DagRun, TaskInstance
 AirflowEventTranslationFn = Callable[
     [DagRun, Sequence[TaskInstance], AirflowDefinitionsData], Iterable[AssetMaterialization]
 ]
-
-
-def get_asset_events(
-    dag_run: DagRun, task_instances: Sequence[TaskInstance], airflow_data: AirflowDefinitionsData
-) -> List[AssetMaterialization]:
-    mats: List[AssetMaterialization] = []
-    mats.extend(materializations_for_dag_run(dag_run, airflow_data))
-    for task_run in task_instances:
-        mats.extend(
-            synthetic_mats_for_task_instance(
-                airflow_data=airflow_data, dag_run=dag_run, task_instance=task_run
-            )
-        )
-    return mats
 
 
 def get_timestamp_from_materialization(mat: AssetMaterialization) -> float:


### PR DESCRIPTION
## Summary & Motivation
Moves sorting of events to the end of the sensor's iteration loop. This provides a clearer pluggability point where we have access to all the events, but they haven't been sorted yet.

## How I Tested These Changes
Existing tests
## Changelog
NOCHANGELOG