### PR TITLE
[dagster-airlift][sensor] make sensor implementation pluggable at top level

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
@@ -17,6 +17,7 @@ from dagster_airlift.core.sensor import (
     DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
     build_airflow_polling_sensor_defs,
 )
+from dagster_airlift.core.sensor.event_translation import DagsterEventTransformerFn
 from dagster_airlift.core.serialization.compute import compute_serialized_data
 from dagster_airlift.core.serialization.defs_construction import (
     construct_automapped_dag_assets_defs,
@@ -57,6 +58,7 @@ def build_defs_from_airflow_instance(
     airflow_instance: AirflowInstance,
     defs: Optional[Definitions] = None,
     sensor_minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
+    event_transformer_fn: Optional[DagsterEventTransformerFn] = None,
 ) -> Definitions:
     resolved_defs = AirflowInstanceDefsLoader(
         airflow_instance=airflow_instance,
@@ -70,7 +72,7 @@ def build_defs_from_airflow_instance(
                 airflow_instance=airflow_instance, resolved_airflow_defs=resolved_defs
             ),
             minimum_interval_seconds=sensor_minimum_interval_seconds,
-            event_translation_fn=None,
+            event_transformer_fn=event_transformer_fn,
         ),
     )
 
@@ -117,7 +119,7 @@ def build_full_automapped_dags_from_airflow_instance(
             airflow_data=AirflowDefinitionsData(
                 resolved_airflow_defs=resolved_defs, airflow_instance=airflow_instance
             ),
-            event_translation_fn=None,
+            event_transformer_fn=None,
         ),
     )
 

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/conftest.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Dict, Generator, List, Sequence, Tuple, Union
+from typing import Dict, Generator, List, Optional, Sequence, Tuple, Union
 
 import pytest
 from dagster import (
@@ -28,6 +28,7 @@ from dagster._time import get_current_datetime
 from dagster_airlift.core import (
     build_defs_from_airflow_instance as build_defs_from_airflow_instance,
 )
+from dagster_airlift.core.sensor.event_translation import DagsterEventTransformerFn
 from dagster_airlift.core.utils import metadata_for_task_mapping
 from dagster_airlift.test import make_dag_run, make_instance
 
@@ -40,9 +41,13 @@ def fully_loaded_repo_from_airflow_asset_graph(
     assets_per_task: Dict[str, Dict[str, List[Tuple[str, List[str]]]]],
     additional_defs: Definitions = Definitions(),
     create_runs: bool = True,
+    event_transformer_fn: Optional[DagsterEventTransformerFn] = None,
 ) -> RepositoryDefinition:
     defs = load_definitions_airflow_asset_graph(
-        assets_per_task, additional_defs=additional_defs, create_runs=create_runs
+        assets_per_task,
+        additional_defs=additional_defs,
+        create_runs=create_runs,
+        event_transformer_fn=event_transformer_fn,
     )
     repo_def = defs.get_repository_def()
     repo_def.load_all_definitions()
@@ -54,6 +59,7 @@ def load_definitions_airflow_asset_graph(
     additional_defs: Definitions = Definitions(),
     create_runs: bool = True,
     create_assets_defs: bool = True,
+    event_transformer_fn: Optional[DagsterEventTransformerFn] = None,
 ) -> Definitions:
     assets = []
     dag_and_task_structure = defaultdict(list)
@@ -96,7 +102,9 @@ def load_definitions_airflow_asset_graph(
         additional_defs,
         Definitions(assets=assets),
     )
-    return build_defs_from_airflow_instance(airflow_instance=instance, defs=defs)
+    return build_defs_from_airflow_instance(
+        airflow_instance=instance, defs=defs, event_transformer_fn=event_transformer_fn
+    )
 
 
 def build_and_invoke_sensor(
@@ -104,9 +112,10 @@ def build_and_invoke_sensor(
     assets_per_task: Dict[str, Dict[str, List[Tuple[str, List[str]]]]],
     instance: DagsterInstance,
     additional_defs: Definitions = Definitions(),
+    event_transformer_fn: Optional[DagsterEventTransformerFn] = None,
 ) -> Tuple[SensorResult, SensorEvaluationContext]:
     repo_def = fully_loaded_repo_from_airflow_asset_graph(
-        assets_per_task, additional_defs=additional_defs
+        assets_per_task, additional_defs=additional_defs, event_transformer_fn=event_transformer_fn
     )
     sensor = next(iter(repo_def.sensor_defs))
     sensor_context = build_sensor_context(repository_def=repo_def, instance=instance)


### PR DESCRIPTION
## Summary & Motivation
Introduce a pluggability point for the sensor. Only bit that has changed from offline discussion is that I added a context argument so that users can perform their own logging.

## How I Tested These Changes
Added a new test for pluggable implementation.
Additional testing I would like to do:
- ensure that an error in pluggable fxn doesn't advance the cursor
- ensure that we handle errors in the pluggable function well.
- ensure that we gracefully error when effective timestamp metadata is missing.

## Changelog
NOCHANGELOG
