### PR TITLE
Document API rate limits

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -771,6 +771,10 @@
           {
             "title": "dagster_cloud.yaml",
             "path": "/dagster-plus/managing-deployments/dagster-cloud-yaml"
+          },
+          {
+            "title": "API Limits",
+            "path": "/dagster-plus/references/limits"
           }
         ]
       }

--- a/docs/content/dagster-plus/references/limits.mdx
+++ b/docs/content/dagster-plus/references/limits.mdx
@@ -1,0 +1,15 @@
+---
+title: "Dagster+ API Limits | Dagster Docs"
+description: "Dagster+ Rate Limiting and API Limits"
+---
+
+# Dagster+ API Limits
+
+Dagster+ enforces several API rate limits to smoothly distribute load. Deployments are limited to:
+
+- 40,000 custom events per minute. This limit only applies to custom events; system events like the ones that drive orchestration or materialize assets are not subject to this limit.
+- 35MB of events per minute. This limit applies to both custom events and system events.
+
+Rate limited requests return a "429 - Too Many Requests" response. Dagster+ agents automatically retry these requests.
+
+Switching from [Structured event logs](/concepts/logging#structured-event-logs) to [Raw compute logs](/concepts/logging#raw-event-logs) or reducing your custom log volume can help you stay within these limits.


### PR DESCRIPTION
These have always existed but we've never been very good about documenting them.