### PR TITLE
[dagster-github] add create_ref method on GithubClient

### DIFF
--- a/python_modules/libraries/dagster-github/dagster_github/resources.py
+++ b/python_modules/libraries/dagster-github/dagster_github/resources.py
@@ -159,6 +159,65 @@ class GithubClient:
             installation_id=installation_id,
         )
 
+    def create_ref(
+        self,
+        repo_name: str,
+        repo_owner: str,
+        source: str,
+        target: str,
+        installation_id=None,
+    ):
+        if installation_id is None:
+            installation_id = self.default_installation_id
+        res = self.execute(
+            query="""
+            query get_repo_and_source_ref($repo_name: String!, $repo_owner: String!, $source: String!) {
+                repository(name: $repo_name, owner: $repo_owner) {
+                    id
+                    ref(qualifiedName: $source) {
+                        target {
+                            oid
+                        }
+                    }
+                }
+            }
+            """,
+            variables={
+                "repo_name": repo_name,
+                "repo_owner": repo_owner,
+                "source": source,
+            },
+            installation_id=installation_id,
+        )
+
+        branch = self.execute(
+            query="""
+                mutation CreateRef($id: ID!, $name: String!, $oid: GitObjectID!) {
+                createRef(input: {
+                    repositoryId: $id,
+                    name: $name,
+                    oid: $oid
+                }) {
+                    clientMutationId,
+                    ref {
+                        id
+                        name
+                        target {
+                            oid
+                        }
+                    }
+                }
+                }
+            """,
+            variables={
+                "id": res["data"]["repository"]["id"],
+                "name": target,
+                "oid": res["data"]["repository"]["ref"]["target"]["oid"],
+            },
+            installation_id=installation_id,
+        )
+        return branch
+
 
 class GithubResource(ConfigurableResource):
     github_app_id: int = Field(

--- a/python_modules/libraries/dagster-github/dagster_github_tests/test_resources.py
+++ b/python_modules/libraries/dagster-github/dagster_github_tests/test_resources.py
@@ -129,6 +129,58 @@ def test_github_resource_create_issue():
 
 
 @responses.activate
+def test_github_resource_create_ref():
+    @op
+    def github_op(github_client_resource: GithubResource):
+        github = github_client_resource.get_client()
+        assert github
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                rsps.POST,
+                "https://api.github.com/app/installations/123/access_tokens",
+                status=201,
+                json={
+                    "token": "fake_token",
+                    "expires_at": "2016-07-11T22:14:10Z",
+                },
+            )
+            rsps.add(
+                rsps.POST,
+                "https://api.github.com/graphql",
+                status=200,
+                json={
+                    "data": {
+                        "repository": {"id": 123, "ref": {"target": {"oid": "refs/heads/master"}}}
+                    },
+                },
+            )
+            rsps.add(
+                rsps.POST,
+                "https://api.github.com/graphql",
+                status=200,
+                json={},
+            )
+            github.create_ref(
+                repo_name="dagster",
+                repo_owner="dagster-io",
+                source="refs/heads/master",
+                target="refs/heads/test-branch",
+            )
+
+    result = wrap_op_in_graph_and_execute(
+        github_op,
+        resources={
+            "github_client_resource": GithubResource(
+                github_app_id=123,
+                github_app_private_rsa_key=FAKE_PRIVATE_RSA_KEY,
+                github_installation_id=123,
+            )
+        },
+    )
+    assert result.success
+
+
+@responses.activate
 def test_github_resource_execute():
     @op
     def github_op(github_client_resource: GithubResource):


### PR DESCRIPTION
## Summary & Motivation

Contributes to https://github.com/dagster-io/dagster/issues/24967

## How I Tested These Changes

Tested on my fork with the snippet below:

```python
from dagster import Definitions, asset
from dagster_github import GithubResource

@asset
def github_branch(github_resource: GithubResource):
    client = github_resource.get_client()
    return client.create_ref("dagster", "marijncv", "refs/heads/master", "refs/heads/test-branch")


defs = Definitions(
    assets=[github_branch],
    resources={
        "github_resource": GithubResource(
            github_app_id=<your_app_id>,
            github_app_private_rsa_key=<your_rsa_key>,
            github_installation_id=<your_installation_id>,
        )
    },
)
```

& added unit test

## Changelog

[dagster-github] Added `create_ref` method on `GithubClient` that enables creating a new branch

- [x] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
