### PR TITLE
Add functools.wrap to graphql decorators

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -1,3 +1,4 @@
+import functools
 import sys
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -53,6 +54,7 @@ def assert_permission_for_location(
 
 def require_permission_check(permission: str) -> Callable[[GrapheneResolverFn], GrapheneResolverFn]:
     def decorator(fn: GrapheneResolverFn) -> GrapheneResolverFn:
+        @functools.wraps(fn)
         def _fn(self, graphene_info, *args: P.args, **kwargs: P.kwargs):
             result = fn(self, graphene_info, *args, **kwargs)
 
@@ -68,6 +70,7 @@ def require_permission_check(permission: str) -> Callable[[GrapheneResolverFn], 
 
 def check_permission(permission: str) -> Callable[[GrapheneResolverFn], GrapheneResolverFn]:
     def decorator(fn: GrapheneResolverFn) -> GrapheneResolverFn:
+        @functools.wraps(fn)
         def _fn(self, graphene_info, *args: P.args, **kwargs: P.kwargs):
             assert_permission(graphene_info, permission)
 
@@ -163,6 +166,7 @@ class ErrorCapture:
 def capture_error(
     fn: Callable[P, T],
 ) -> Callable[P, Union[T, "GrapheneError", "GraphenePythonError"]]:
+    @functools.wraps(fn)
     def _fn(*args: P.args, **kwargs: P.kwargs) -> T:
         try:
             return fn(*args, **kwargs)


### PR DESCRIPTION
Summary:
This ensures that if the inner resolver sets attributes or other metadata on the resolver, that it is still accessible by determined middleware.

Test Plan: BK

Changelog:
NOCHANGELOG

## Summary & Motivation

## How I Tested These Changes

## Changelog

Insert changelog entry or "NOCHANGELOG" here.

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
