### PR TITLE
incorporate checkbox value when querying for status counts

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -131,7 +131,7 @@
   "Terminate": "67acf403eb320a93c9a9aa07f675a1557e0887d499cd5598f1d5ff360afc15c0",
   "LaunchPipelineReexecution": "d21e4ecaf3d1d163c4772f1d847dbdcbdaa9a40e6de0808a064ae767adf0c311",
   "RunsFeedRootQuery": "fbfc82cccaebc1698305767c04c4dc16ed15b7a272342135d5a83745ffece37e",
-  "RunFeedTabsCountQuery": "5ddccded028ae94b64bda3c2b850bcc8f384de9851c0dd393f158b2a53469262",
+  "RunFeedTabsCountQuery": "fe1a07dfc152faddc4fd8936aee1f856b8d8308edf8078bdaa4e5cd111e044cc",
   "RunTagKeysQuery": "833a405f7cb8f30c0901bc8a272edb51ac5281ebdf563e3017eace5d6976b2a9",
   "RunTagValuesQuery": "0c0a9998c215bb801eb0adcd5449c0ac4cf1e8efbc6d0fcc5fb6d76fcc95cb92",
   "ScheduledRunsListQuery": "2650d8ebdfc444fe76fcf8acd9ff54f9ecacdb680b1d83e3f487cb71dd0c7eae",

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3292,7 +3292,7 @@ type Query {
     filter: RunsFilter
     includeRunsFromBackfills: Boolean
   ): RunsFeedConnectionOrError!
-  runsFeedCountOrError(filter: RunsFilter): RunsFeedCountOrError!
+  runsFeedCountOrError(filter: RunsFilter, includeRunsFromBackfills: Boolean): RunsFeedCountOrError!
   runTagKeysOrError: RunTagKeysOrError
   runTagsOrError(tagKeys: [String!], valuePrefix: String, limit: Int): RunTagsOrError
   runIdsOrError(filter: RunsFilter, cursor: String, limit: Int): RunIdsOrError!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -3968,6 +3968,7 @@ export type QueryRunTagsOrErrorArgs = {
 
 export type QueryRunsFeedCountOrErrorArgs = {
   filter?: InputMaybe<RunsFilter>;
+  includeRunsFromBackfills?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type QueryRunsFeedOrErrorArgs = {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTabs.tsx
@@ -38,6 +38,7 @@ export const useRunsFeedTabs = (filter: RunsFilter = {}, includeRunsFromBackfill
       variables: {
         queuedFilter: {...filter, statuses: Array.from(queuedStatuses)},
         inProgressFilter: {...filter, statuses: Array.from(inProgressStatuses)},
+        includeRunsFromBackfills,
       },
     },
   );
@@ -140,13 +141,23 @@ export const useSelectedRunsFeedTab = (filterTokens: TokenizingFieldValue[]) => 
 };
 
 export const RUN_FEED_TABS_COUNT_QUERY = gql`
-  query RunFeedTabsCountQuery($queuedFilter: RunsFilter!, $inProgressFilter: RunsFilter!) {
-    queuedCount: runsFeedCountOrError(filter: $queuedFilter) {
+  query RunFeedTabsCountQuery(
+    $queuedFilter: RunsFilter!
+    $inProgressFilter: RunsFilter!
+    $includeRunsFromBackfills: Boolean!
+  ) {
+    queuedCount: runsFeedCountOrError(
+      filter: $queuedFilter
+      includeRunsFromBackfills: $includeRunsFromBackfills
+    ) {
       ... on RunsFeedCount {
         count
       }
     }
-    inProgressCount: runsFeedCountOrError(filter: $inProgressFilter) {
+    inProgressCount: runsFeedCountOrError(
+      filter: $inProgressFilter
+      includeRunsFromBackfills: $includeRunsFromBackfills
+    ) {
       ... on RunsFeedCount {
         count
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsFeedTabs.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunsFeedTabs.types.ts
@@ -5,6 +5,7 @@ import * as Types from '../../graphql/types';
 export type RunFeedTabsCountQueryVariables = Types.Exact<{
   queuedFilter: Types.RunsFilter;
   inProgressFilter: Types.RunsFilter;
+  includeRunsFromBackfills: Types.Scalars['Boolean']['input'];
 }>;
 
 export type RunFeedTabsCountQuery = {
@@ -13,4 +14,4 @@ export type RunFeedTabsCountQuery = {
   inProgressCount: {__typename: 'PythonError'} | {__typename: 'RunsFeedCount'; count: number};
 };
 
-export const RunFeedTabsCountQueryVersion = '5ddccded028ae94b64bda3c2b850bcc8f384de9851c0dd393f158b2a53469262';
+export const RunFeedTabsCountQueryVersion = 'fe1a07dfc152faddc4fd8936aee1f856b8d8308edf8078bdaa4e5cd111e044cc';

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -666,12 +666,12 @@ def get_runs_feed_entries(
 
 
 def get_runs_feed_count(
-    graphene_info: "ResolveInfo", filters: Optional[RunsFilter], include_runs_in_backfills: bool
+    graphene_info: "ResolveInfo", filters: Optional[RunsFilter], include_runs_from_backfills: bool
 ) -> int:
     # the UI is oriented toward showing runs that are part of a backfill, but the backend
     # is oriented toward excluding runs that are part of a backfill, so negate include_runs_in_backfills
     # to get the value to pass to the backend
-    exclude_subruns = not include_runs_in_backfills
+    exclude_subruns = not include_runs_from_backfills
     should_fetch_backfills = exclude_subruns and (
         _filters_apply_to_backfills(filters) if filters else True
     )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -665,11 +665,21 @@ def get_runs_feed_entries(
     )
 
 
-def get_runs_feed_count(graphene_info: "ResolveInfo", filters: Optional[RunsFilter]) -> int:
-    should_fetch_backfills = _filters_apply_to_backfills(filters) if filters else True
+def get_runs_feed_count(
+    graphene_info: "ResolveInfo", filters: Optional[RunsFilter], include_runs_in_backfills: bool
+) -> int:
+    # the UI is oriented toward showing runs that are part of a backfill, but the backend
+    # is oriented toward excluding runs that are part of a backfill, so negate include_runs_in_backfills
+    # to get the value to pass to the backend
+    exclude_subruns = not include_runs_in_backfills
+    should_fetch_backfills = exclude_subruns and (
+        _filters_apply_to_backfills(filters) if filters else True
+    )
     with disable_dagster_warnings():
         run_filters = (
-            copy(filters, exclude_subruns=True) if filters else RunsFilter(exclude_subruns=True)
+            copy(filters, exclude_subruns=exclude_subruns)
+            if filters
+            else RunsFilter(exclude_subruns=exclude_subruns)
         )
     if should_fetch_backfills:
         backfill_filters = _bulk_action_filters_from_run_filters(run_filters)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -382,7 +382,7 @@ class GrapheneQuery(graphene.ObjectType):
     runsFeedCountOrError = graphene.Field(
         graphene.NonNull(GrapheneRunsFeedCountOrError),
         filter=graphene.Argument(GrapheneRunsFilter),
-        includeRunsInBackfills=graphene.Boolean(),
+        includeRunsFromBackfills=graphene.Boolean(),
         description="Retrieve the number of entries for the Runs Feed after applying a filter.",
     )
     runTagKeysOrError = graphene.Field(
@@ -870,13 +870,13 @@ class GrapheneQuery(graphene.ObjectType):
     def resolve_runsFeedCountOrError(
         self,
         graphene_info: ResolveInfo,
-        includeRunsInBackfills: bool,
+        includeRunsFromBackfills: bool,
         filter: Optional[GrapheneRunsFilter] = None,  # noqa: A002
     ):
         selector = filter.to_selector() if filter is not None else None
         return GrapheneRunsFeedCount(
             get_runs_feed_count(
-                graphene_info, selector, include_runs_in_backfills=includeRunsInBackfills
+                graphene_info, selector, include_runs_from_backfills=includeRunsFromBackfills
             )
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -382,6 +382,7 @@ class GrapheneQuery(graphene.ObjectType):
     runsFeedCountOrError = graphene.Field(
         graphene.NonNull(GrapheneRunsFeedCountOrError),
         filter=graphene.Argument(GrapheneRunsFilter),
+        includeRunsInBackfills=graphene.Boolean(),
         description="Retrieve the number of entries for the Runs Feed after applying a filter.",
     )
     runTagKeysOrError = graphene.Field(
@@ -869,10 +870,15 @@ class GrapheneQuery(graphene.ObjectType):
     def resolve_runsFeedCountOrError(
         self,
         graphene_info: ResolveInfo,
+        includeRunsInBackfills: bool,
         filter: Optional[GrapheneRunsFilter] = None,  # noqa: A002
     ):
         selector = filter.to_selector() if filter is not None else None
-        return GrapheneRunsFeedCount(get_runs_feed_count(graphene_info, selector))
+        return GrapheneRunsFeedCount(
+            get_runs_feed_count(
+                graphene_info, selector, include_runs_in_backfills=includeRunsInBackfills
+            )
+        )
 
     @capture_error
     def resolve_partitionSetsOrError(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
@@ -47,7 +47,7 @@ query RunsFeedEntryQuery($cursor: String, $limit: Int!, $filter: RunsFilter, $in
         message
       }
     }
-    runsFeedCountOrError(filter: $filter) {
+    runsFeedCountOrError(filter: $filter, includeRunsInBackfills: $includeRunsInBackfills) {
         ... on RunsFeedCount {
             count
         }

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
@@ -47,7 +47,7 @@ query RunsFeedEntryQuery($cursor: String, $limit: Int!, $filter: RunsFilter, $in
         message
       }
     }
-    runsFeedCountOrError(filter: $filter, includeRunsInBackfills: $includeRunsInBackfills) {
+    runsFeedCountOrError(filter: $filter, includeRunsFromBackfills: $includeRunsFromBackfills) {
         ... on RunsFeedCount {
             count
         }

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs_feed.py
@@ -300,6 +300,7 @@ class TestRunsFeedWithSharedSetup(ExecutingGraphQLContextTestMatrix):
                 "includeRunsFromBackfills": True,
             },
         )
+        _assert_results_match_count_match_expected(result, 10)
         prev_run_time = None
         for res in result.data["runsFeedOrError"]["results"]:
             assert res["__typename"] == "Run"
@@ -749,7 +750,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
         assert not result.errors
         assert result.data
 
-        assert len(result.data["runsFeedOrError"]["results"]) == 4
+        _assert_results_match_count_match_expected(result, 4)
         assert not result.data["runsFeedOrError"]["hasMore"]
 
         result = execute_dagster_graphql(
@@ -764,7 +765,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
         )
         assert not result.errors
         assert result.data
-        assert len(result.data["runsFeedOrError"]["results"]) == 1
+        _assert_results_match_count_match_expected(result, 1)
 
         result = execute_dagster_graphql(
             graphql_context,
@@ -778,7 +779,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
         )
         assert not result.errors
         assert result.data
-        assert len(result.data["runsFeedOrError"]["results"]) == 1
+        _assert_results_match_count_match_expected(result, 1)
 
         result = execute_dagster_graphql(
             graphql_context,
@@ -792,7 +793,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
         )
         assert not result.errors
         assert result.data
-        assert len(result.data["runsFeedOrError"]["results"]) == 1
+        _assert_results_match_count_match_expected(result, 1)
 
         result = execute_dagster_graphql(
             graphql_context,
@@ -806,7 +807,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
         )
         assert not result.errors
         assert result.data
-        assert len(result.data["runsFeedOrError"]["results"]) == 0
+        _assert_results_match_count_match_expected(result, 0)
 
     def test_get_runs_feed_filter_create_time(self, graphql_context):
         nothing_created_ts = get_current_timestamp()
@@ -1130,7 +1131,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
         assert not result.errors
         assert result.data
 
-        assert len(result.data["runsFeedOrError"]["results"]) == 1
+        _assert_results_match_count_match_expected(result, 1)
         assert not result.data["runsFeedOrError"]["hasMore"]
 
         result = execute_dagster_graphql(
@@ -1145,7 +1146,7 @@ class TestRunsFeedUniqueSetups(ExecutingGraphQLContextTestMatrix):
         )
         assert not result.errors
         assert result.data
-        assert len(result.data["runsFeedOrError"]["results"]) == 1
+        _assert_results_match_count_match_expected(result, 1)
 
     def test_get_runs_feed_filter_tags_and_status(self, graphql_context):
         if not self.supports_filtering():


### PR DESCRIPTION
## Summary & Motivation
Updates the runs feed UI to pass the value of the `show runs within backfills` checkbox to the counts query so that we display the correct number of results in the status tabs

## How I Tested These Changes
<img width="1440" alt="Screenshot 2024-10-04 at 4 16 34 PM" src="https://github.com/user-attachments/assets/a0ac653e-10a8-4579-84aa-1ec8fa858f36">
<img width="1440" alt="Screenshot 2024-10-04 at 4 16 47 PM" src="https://github.com/user-attachments/assets/140e6f03-9ecd-4ea9-9fb0-79dc1e6bb0fe">

## Changelog


- [ ] `NEW` _(added new feature or capability)_
- [X] `BUGFIX` [ui] The experimental Runs page now correctly shows the number of Queued and In Progress runs and backfills based on whether the "Show runs within backfills" box is checked. 
- [ ] `DOCS` _(added or updated documentation)_
