### PR TITLE
Eliminating direct use of Definitions and Definitions.merge from an airlift example

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/top_level_dag_def_api.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/top_level_dag_def_api.py
@@ -62,14 +62,14 @@ def assets_def_with_af_metadata(
     )
 
 
-class TaskMapping:
+class ProxyableTaskMapping:
     def __init__(self, task_id: str, assets: Sequence[Union[AssetsDefinition, AssetSpec]]):
         self.task_id = task_id
         self.assets = assets
 
 
 def proxying_dag_assets(
-    dag_id: str, *task_mapping: TaskMapping
+    dag_id: str, *task_mapping: ProxyableTaskMapping
 ) -> Sequence[Union[AssetsDefinition, AssetSpec]]:
     assets_list = []
     for single_task_mapping in task_mapping:
@@ -84,8 +84,8 @@ def proxying_dag_assets(
 
 def proxying_task_assets(
     task_id: str, assets: Sequence[Union[AssetsDefinition, AssetSpec]]
-) -> TaskMapping:
-    return TaskMapping(task_id, assets)
+) -> ProxyableTaskMapping:
+    return ProxyableTaskMapping(task_id, assets)
 
 
 def dag_defs(dag_id: str, *defs: TaskDefs) -> Definitions:

--- a/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/jaffle_shop.py
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/jaffle_shop.py
@@ -1,0 +1,26 @@
+from dagster import AssetExecutionContext
+from dagster_dbt import (
+    DagsterDbtTranslator,
+    DagsterDbtTranslatorSettings,
+    DbtCliResource,
+    DbtProject,
+    dbt_assets,
+)
+
+from dbt_example.dagster_defs.constants import dbt_manifest_path, dbt_project_path
+
+
+@dbt_assets(
+    manifest=dbt_manifest_path(),
+    project=DbtProject(dbt_project_path()),
+    dagster_dbt_translator=DagsterDbtTranslator(
+        settings=DagsterDbtTranslatorSettings(enable_asset_checks=False)
+    ),
+)
+def jaffle_shop_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+    context.log.info(f"project_dir {dbt.project_dir}")
+    yield from dbt.cli(["build"], context=context).stream()
+
+
+def jaffle_shop_resource() -> DbtCliResource:
+    return DbtCliResource(project_dir=dbt_project_path())

--- a/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/lakehouse.py
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/lakehouse.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import List, Optional, Sequence
 
 from dagster import AssetKey, AssetSpec, Definitions, multi_asset
+from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
 )
@@ -36,6 +37,15 @@ def defs_from_lakehouse(
         )
 
     return Definitions(assets=[_multi_asset])
+
+
+def lakehouse_existence_check(csv_path: Path, duckdb_path: Path) -> AssetChecksDefinition:
+    return build_table_existence_check(
+        target_key=lakehouse_asset_key(csv_path=csv_path),
+        duckdb_path=duckdb_path,
+        table_name=id_from_path(csv_path),
+        schema="lakehouse",
+    )
 
 
 def lakehouse_existence_check_defs(csv_path: Path, duckdb_path: Path) -> Definitions:


### PR DESCRIPTION
## Summary & Motivation

Per the discussion about not pushing the `Definitions`-centric integration pattern and instead focusing more on continuity, this is how that would apply to the current airlift examples.

In order for it to make sense, I felt like I needed need top-level APIs. If nothing else it made it cleaner to implement, but the old names made it make much less sense in this case.

Sadly we can no longer bundle up the resource alongside the dbt definitions in a single composable pattern. However the dbt integration is immediately customizable per all our existing docs and examples.

## How I Tested These Changes

Local integration tests

NOCHANGELOG
