### PR TITLE
Add AssetSelection.materializable selection type

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -17,7 +17,7 @@ from dagster._core.definitions.asset_key import (
     key_prefix_from_coercible,
 )
 from dagster._core.definitions.assets import AssetsDefinition
-from dagster._core.definitions.base_asset_graph import BaseAssetGraph
+from dagster._core.definitions.base_asset_graph import BaseAssetGraph, BaseAssetNode
 from dagster._core.definitions.resolved_asset_deps import resolve_similar_asset_names
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterInvalidSubsetError
@@ -355,6 +355,13 @@ class AssetSelection(ABC, DagsterModel):
         use the `upstream_source_assets` method.
         """
         return RootsAssetSelection(child=self)
+
+    @public
+    def executable(self) -> "ExecutableAssetSelection":
+        """Given an asset selection, returns a new asset selection that contains all of the assets
+        that are executable. Removes any external assets which are not executable.
+        """
+        return ExecutableAssetSelection(child=self)
 
     @public
     @deprecated(breaking_version="2.0", additional_warn_text="Use AssetSelection.roots instead.")
@@ -781,6 +788,18 @@ class RootsAssetSelection(ChainedAssetSelection):
         return fetch_sources(asset_graph.asset_dep_graph, selection)
 
 
+@whitelist_for_serdes
+class ExecutableAssetSelection(ChainedAssetSelection):
+    def resolve_inner(
+        self, asset_graph: BaseAssetGraph, allow_missing: bool
+    ) -> AbstractSet[AssetKey]:
+        selection = self.child.resolve_inner(asset_graph, allow_missing=allow_missing)
+        output = {
+            asset_key
+            for asset_key in selection
+            if cast(BaseAssetNode, asset_graph.get(asset_key)).is_executable
+        }
+        return output
 @whitelist_for_serdes
 class DownstreamAssetSelection(ChainedAssetSelection):
     depth: Optional[int]

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -357,11 +357,11 @@ class AssetSelection(ABC, DagsterModel):
         return RootsAssetSelection(child=self)
 
     @public
-    def executable(self) -> "ExecutableAssetSelection":
+    def materializable(self) -> "MaterializableAssetSelection":
         """Given an asset selection, returns a new asset selection that contains all of the assets
-        that are executable. Removes any external assets which are not executable.
+        that are materializable. Removes any assets which are not materializable.
         """
-        return ExecutableAssetSelection(child=self)
+        return MaterializableAssetSelection(child=self)
 
     @public
     @deprecated(breaking_version="2.0", additional_warn_text="Use AssetSelection.roots instead.")
@@ -789,17 +789,17 @@ class RootsAssetSelection(ChainedAssetSelection):
 
 
 @whitelist_for_serdes
-class ExecutableAssetSelection(ChainedAssetSelection):
+class MaterializableAssetSelection(ChainedAssetSelection):
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
-        selection = self.child.resolve_inner(asset_graph, allow_missing=allow_missing)
-        output = {
+        return {
             asset_key
-            for asset_key in selection
-            if cast(BaseAssetNode, asset_graph.get(asset_key)).is_executable
+            for asset_key in self.child.resolve_inner(asset_graph, allow_missing=allow_missing)
+            if cast(BaseAssetNode, asset_graph.get(asset_key)).is_materializable
         }
-        return output
+
+
 @whitelist_for_serdes
 class DownstreamAssetSelection(ChainedAssetSelection):
     depth: Optional[int]


### PR DESCRIPTION
## Summary

Adds a way to drop all non-materializable assets from a selection, in case a user has downstream non-materializable, external assets within a selection they'd like to ignore

## Test Plan

Unit test

## Changelog

- Added AssetSelection.materializable(), which returns only assets that are materializable in an existing selection