### PR TITLE
[freshness] override materialization timestamp

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/last_update.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/last_update.py
@@ -17,8 +17,8 @@ from dagster._core.definitions.asset_check_factories.utils import (
     assets_to_keys,
     ensure_no_duplicate_assets,
     freshness_multi_asset_check,
-    get_last_updated_timestamp,
     retrieve_last_update_record,
+    retrieve_timestamp_from_record,
     seconds_in_words,
 )
 from dagster._core.definitions.asset_check_result import AssetCheckResult
@@ -189,7 +189,9 @@ def _build_freshness_multi_check(
             latest_record = retrieve_last_update_record(
                 instance=context.instance, asset_key=asset_key, partition_key=None
             )
-            update_timestamp = get_last_updated_timestamp(latest_record, context)
+            update_timestamp = (
+                retrieve_timestamp_from_record(latest_record) if latest_record else None
+            )
             passed = (
                 update_timestamp is not None
                 and update_timestamp >= last_update_time_lower_bound.timestamp()

--- a/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/time_partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_factories/freshness_checks/time_partition.py
@@ -14,8 +14,8 @@ from dagster._core.definitions.asset_check_factories.utils import (
     assets_to_keys,
     ensure_no_duplicate_assets,
     freshness_multi_asset_check,
-    get_last_updated_timestamp,
     retrieve_last_update_record,
+    retrieve_timestamp_from_record,
 )
 from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.asset_check_spec import AssetCheckSeverity
@@ -180,7 +180,7 @@ def _build_freshness_multi_check(
                 # If this asset has been updated at all before, provide the time at which that
                 # happened as additional metadata.
                 metadata[LAST_UPDATED_TIMESTAMP_METADATA_KEY] = TimestampMetadataValue(
-                    check.not_none(get_last_updated_timestamp(latest_record_any_partition, context))
+                    check.not_none(retrieve_timestamp_from_record(latest_record_any_partition))
                 )
             elif passed:
                 metadata[FRESH_UNTIL_METADATA_KEY] = TimestampMetadataValue(

--- a/python_modules/dagster/dagster/_core/event_api.py
+++ b/python_modules/dagster/dagster/_core/event_api.py
@@ -134,6 +134,10 @@ class EventLogRecord(NamedTuple):
         return self.event_log_entry.asset_observation
 
     @property
+    def asset_event(self) -> Optional[Union[AssetMaterialization, AssetObservation]]:
+        return self.asset_materialization or self.asset_observation
+
+    @property
     def event_type(self) -> DagsterEventType:
         return check.not_none(
             self.event_log_entry.dagster_event,

--- a/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/freshness_checks_tests/conftest.py
@@ -74,19 +74,21 @@ def add_new_event(
     include_metadata: bool = True,
 ):
     klass = AssetMaterialization if is_materialization else AssetObservation
-    metadata = (
-        {
-            "dagster/last_updated_timestamp": TimestampMetadataValue(
-                get_current_timestamp() if not override_timestamp else override_timestamp
-            )
-        }
+    last_updated_timestamp = (
+        override_timestamp
+        if override_timestamp is not None
+        else get_current_timestamp()
         if not is_materialization
         else None
     )
     instance.report_runless_asset_event(
         klass(
             asset_key=asset_key,
-            metadata=metadata if include_metadata else None,
+            metadata={
+                "dagster/last_updated_timestamp": TimestampMetadataValue(last_updated_timestamp)
+            }
+            if last_updated_timestamp and include_metadata
+            else None,
             partition=partition_key,
         )
     )


### PR DESCRIPTION
## Summary & Motivation
This PR makes it possible to override materialization timestamp for freshness checks.
I also discovered a bug where we weren't rendering "0 seconds" properly in the description, so I fixed that.
## How I Tested These Changes
New test for this behavior.
## Changelog
NOCHANGELOG
