### PR TITLE
[dagster-airlift] Introduce asset_with_task_mapping and use the to divorce from Definitions-centric construction in airlift examples

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/__init__.py
@@ -13,6 +13,7 @@ from .sensor.sensor_builder import (
     build_airflow_polling_sensor_defs as build_airflow_polling_sensor_defs,
 )
 from .top_level_dag_def_api import (
+    assets_with_task_mappings as assets_with_task_mappings,
     dag_defs as dag_defs,
     task_defs as task_defs,
 )

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/top_level_dag_def_api.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/top_level_dag_def_api.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Mapping, Union
+from typing import Any, Dict, Iterable, Mapping, Sequence, Union
 
 from dagster import (
     AssetsDefinition,
@@ -14,6 +14,12 @@ class TaskDefs:
     def __init__(self, task_id: str, defs: Definitions):
         self.task_id = task_id
         self.defs = defs
+
+
+def apply_metadata_to_assets(
+    assets: Iterable[Union[AssetsDefinition, AssetSpec]], metadata: Dict[str, Any]
+) -> Sequence[Union[AssetsDefinition, AssetSpec]]:
+    return [assets_def_with_af_metadata(asset, metadata) for asset in assets]
 
 
 def apply_metadata_to_all_specs(defs: Definitions, metadata: Dict[str, Any]) -> Definitions:
@@ -54,6 +60,50 @@ def assets_def_with_af_metadata(
         if isinstance(assets_def, AssetsDefinition)
         else spec_with_metadata(assets_def, metadata)
     )
+
+
+def assets_with_task_mappings(
+    dag_id: str, task_mappings: Mapping[str, Iterable[Union[AssetsDefinition, AssetSpec]]]
+) -> Sequence[Union[AssetsDefinition, AssetSpec]]:
+    """Modify assets to be associated with a particular task in Airlift tooling.
+
+    Used in concert with `build_defs_from_airflow_instance` to observe an airflow
+    instance to monitor the tasks that are associated with the assets and
+    keep their materialization histories up to date.
+
+    Concretely this adds metadata to all asset specs in the provided definitions
+    with the provided dag_id and task_id. The dag_id comes from the dag_id argument;
+    the task_id comes from the key of the provided task_mappings dictionary.
+    There is a single metadata key "airlift/task_mapping" that is used to store
+    this information. It is a list of dictionaries with keys "dag_id" and "task_id".
+
+    Example:
+    .. code-block:: python
+        from dagster import AssetSpec, Definitions, asset
+        from dagster_airlift.core import assets_with_task_mappings
+
+        @asset
+        def asset_one() -> None: ...
+
+        defs = Definitions(
+            assets=assets_with_task_mappings(
+                dag_id="dag_one",
+                task_mappings={
+                    "task_one": [asset_one],
+                    "task_two": [AssetSpec(key="asset_two"), AssetSpec(key="asset_three")],
+                },
+            )
+        )
+    """
+    assets_list = []
+    for task_id, assets in task_mappings.items():
+        assets_list.extend(
+            apply_metadata_to_assets(
+                assets,
+                metadata_for_task_mapping(task_id=task_id, dag_id=dag_id),
+            )
+        )
+    return assets_list
 
 
 def dag_defs(dag_id: str, *defs: TaskDefs) -> Definitions:

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -43,6 +43,7 @@ from dagster_airlift.core.serialization.serialized_data import (
     SerializedAirflowDefinitionsData,
     TaskHandle,
 )
+from dagster_airlift.core.top_level_dag_def_api import assets_with_task_mappings
 from dagster_airlift.core.utils import is_mapped_asset_spec, metadata_for_task_mapping
 from dagster_airlift.test import make_instance
 from dagster_airlift.utils import DAGSTER_AIRLIFT_PROXIED_STATE_DIR_ENV_VAR
@@ -711,8 +712,13 @@ def test_automapped_dag_with_two_tasks_plus_explicit_defs() -> None:
     explicit_asset_1 = AssetKey("explicit_asset1")
     full_defs = build_full_automapped_dags_from_airflow_instance(
         airflow_instance=airflow_instance,
-        defs=dag_defs(
-            "dag1", task_defs("task1", Definitions(assets=[AssetSpec(explicit_asset_1)]))
+        defs=Definitions(
+            assets=assets_with_task_mappings(
+                dag_id="dag1",
+                task_mappings={
+                    "task1": [AssetSpec(explicit_asset_1)],
+                },
+            )
         ),
     )
 

--- a/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/jaffle_shop.py
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/jaffle_shop.py
@@ -1,0 +1,26 @@
+from dagster import AssetExecutionContext
+from dagster_dbt import (
+    DagsterDbtTranslator,
+    DagsterDbtTranslatorSettings,
+    DbtCliResource,
+    DbtProject,
+    dbt_assets,
+)
+
+from dbt_example.dagster_defs.constants import dbt_manifest_path, dbt_project_path
+
+
+@dbt_assets(
+    manifest=dbt_manifest_path(),
+    project=DbtProject(dbt_project_path()),
+    dagster_dbt_translator=DagsterDbtTranslator(
+        settings=DagsterDbtTranslatorSettings(enable_asset_checks=False)
+    ),
+)
+def jaffle_shop_assets(context: AssetExecutionContext, dbt: DbtCliResource):
+    context.log.info(f"project_dir {dbt.project_dir}")
+    yield from dbt.cli(["build"], context=context).stream()
+
+
+def jaffle_shop_resource() -> DbtCliResource:
+    return DbtCliResource(project_dir=dbt_project_path())

--- a/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/lakehouse.py
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/lakehouse.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import List, Optional, Sequence
 
 from dagster import AssetKey, AssetSpec, Definitions, multi_asset
+from dagster._core.definitions.asset_checks import AssetChecksDefinition
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
 )
@@ -36,6 +37,15 @@ def defs_from_lakehouse(
         )
 
     return Definitions(assets=[_multi_asset])
+
+
+def lakehouse_existence_check(csv_path: Path, duckdb_path: Path) -> AssetChecksDefinition:
+    return build_table_existence_check(
+        target_key=lakehouse_asset_key(csv_path=csv_path),
+        duckdb_path=duckdb_path,
+        table_name=id_from_path(csv_path),
+        schema="lakehouse",
+    )
 
 
 def lakehouse_existence_check_defs(csv_path: Path, duckdb_path: Path) -> Definitions:

--- a/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/observe.py
+++ b/examples/experimental/dagster-airlift/examples/dbt-example/dbt_example/dagster_defs/observe.py
@@ -2,22 +2,15 @@ from dagster._core.definitions.definitions_class import Definitions
 from dagster_airlift.core import (
     AirflowInstance,
     BasicAuthBackend,
+    assets_with_task_mappings,
     build_defs_from_airflow_instance,
-    dag_defs,
-    task_defs,
 )
-from dagster_dbt.asset_specs import build_dbt_asset_specs
 
-from dbt_example.dagster_defs.lakehouse import lakehouse_existence_check_defs, specs_from_lakehouse
+from dbt_example.dagster_defs.lakehouse import lakehouse_existence_check, specs_from_lakehouse
 from dbt_example.shared.load_iris import CSV_PATH, DB_PATH
 
-from .constants import (
-    AIRFLOW_BASE_URL,
-    AIRFLOW_INSTANCE_NAME,
-    PASSWORD,
-    USERNAME,
-    dbt_manifest_path,
-)
+from .constants import AIRFLOW_BASE_URL, AIRFLOW_INSTANCE_NAME, PASSWORD, USERNAME
+from .jaffle_shop import jaffle_shop_assets, jaffle_shop_resource
 
 airflow_instance = AirflowInstance(
     auth_backend=BasicAuthBackend(
@@ -29,18 +22,20 @@ airflow_instance = AirflowInstance(
 
 defs = build_defs_from_airflow_instance(
     airflow_instance=airflow_instance,
-    defs=Definitions.merge(
-        dag_defs(
-            "rebuild_iris_models",
-            task_defs("load_iris", Definitions(assets=specs_from_lakehouse(csv_path=CSV_PATH))),
-            task_defs(
-                "build_dbt_models",
-                Definitions(assets=build_dbt_asset_specs(manifest=dbt_manifest_path())),
-            ),
+    defs=Definitions(
+        assets=assets_with_task_mappings(
+            dag_id="rebuild_iris_models",
+            task_mappings={
+                "load_iris": specs_from_lakehouse(csv_path=CSV_PATH),
+                "build_dbt_models": [jaffle_shop_assets],
+            },
         ),
-        lakehouse_existence_check_defs(
-            csv_path=CSV_PATH,
-            duckdb_path=DB_PATH,
-        ),
+        asset_checks=[
+            lakehouse_existence_check(
+                csv_path=CSV_PATH,
+                duckdb_path=DB_PATH,
+            )
+        ],
+        resources={"dbt": jaffle_shop_resource()},
     ),
 )


### PR DESCRIPTION
## Summary & Motivation

Per the discussion about not pushing the `Definitions`-centric integration pattern and instead focusing more on continuity, this is how that would apply to the current airlift examples.

This means that the airlift mapping APIs need to be changed to "think" in terms of `AssetsDefinitions` and friends rather than `Definitions`.

We need new top-level APIs to do this, as the current ones return `Definitions` objects.

Sadly we can no longer bundle up the resource alongside the dbt definitions in a single composable pattern. However the dbt integration is immediately customizable per all our existing docs and examples.

The new API for mapping assets to tasks is a single function: `assets_with_task_mappings`.

Docblock:

```python
def assets_with_task_mappings(
    dag_id: str, task_mappings: Mapping[str, Iterable[Union[AssetsDefinition, AssetSpec]]]
) -> Sequence[Union[AssetsDefinition, AssetSpec]]:
    """Modify assets to be associated with a particular task in Airlift tooling. Used
    in concert with `proxying_to_dagster` in dagster_airlift.in_airflow.

    Concretely this adds metadata to all asset specs in the provided definitions
    with the provided dag_id and task_id. The dag_id comes from the dag_id argument;
    the task_id comes from the key of the provided task_mappings dictionary..
    There is a single metadata key "airlift/task_mapping" that is used to store
    this information. It is a list of dictionaries with keys "dag_id" and "task_id".

    Example:
    .. code-block:: python
        from dagster import AssetSpec, Definitions, asset
        from dagster_airlift.core import assets_with_task_mappings

        @asset
        def asset_one() -> None: ...

        defs = Definitions(
            assets=assets_with_task_mappings(
                dag_id="dag_one",
                task_mappings={
                    "task_one": [asset_one],
                    "task_two": [AssetSpec(key="asset_two"), AssetSpec(key="asset_three")],
                },
            )
        )
    """
```



## How I Tested These Changes

Local integration tests

## Changelog

NOCHANGELOG