### PR TITLE
[dagster-tableau][fix] Update workbooks and view endpoint

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/resources.py
@@ -101,7 +101,7 @@ class BaseTableauClient:
         self,
         job_id: str,
     ) -> requests.Response:
-        """Fetches information for a given job."""
+        """Cancels a given job."""
         return self._server.jobs.cancel(job_id)
 
     def refresh_workbook(self, workbook_id) -> TSC.JobItem:

--- a/python_modules/libraries/dagster-tableau/setup.py
+++ b/python_modules/libraries/dagster-tableau/setup.py
@@ -39,7 +39,6 @@ setup(
         f"dagster{pin}",
         "pyjwt[crypto]",
         "tableauserverclient",
-        "xmltodict",
     ],
     include_package_data=True,
     python_requires=">=3.8,<3.13",


### PR DESCRIPTION
## Summary & Motivation

Previous implementation worked well when multiple workbooks exist in a workspace, but could not be loaded in Dagster when only one workbook exists. Parsing a XML response with only one workbook would create a JSON object like

`{"workbooks": {"workbook": {"id": "my_id"}}}`

but one with many workbooks would be 

`{"workbooks": {"workbook": [{"id": "my_id_1"}, ..., {"id": "my_id_n"}]}}`

Updates the code to use `tableauserverclient.WorkbookItem` and `tableauserverclient.ViewItem` instead of XML and JSON objects - Tableau handles parsing their API response in these classes.

## How I Tested These Changes

BK with updated tests.

## Changelog

NOCHANGELOG

- [ ] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
