### PR TITLE
[dagster-github] add create_pull_request method on GithubClient

### DIFF
--- a/python_modules/libraries/dagster-github/dagster_github_tests/test_resources.py
+++ b/python_modules/libraries/dagster-github/dagster_github_tests/test_resources.py
@@ -182,6 +182,76 @@ def test_github_resource_create_ref():
 
 
 @responses.activate
+def test_github_resource_create_pull_request():
+    @op
+    def github_op(github_client_resource: GithubResource):
+        github = github_client_resource.get_client()
+        assert github
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                rsps.POST,
+                "https://api.github.com/app/installations/123/access_tokens",
+                status=201,
+                json={
+                    "token": "fake_token",
+                    "expires_at": "2016-07-11T22:14:10Z",
+                },
+            )
+            rsps.add(
+                rsps.POST,
+                "https://api.github.com/graphql",
+                status=200,
+                json={
+                    "data": {
+                        "repository": {"id": 123, "ref": {"target": {"oid": "refs/heads/master"}}}
+                    },
+                },
+            )
+            rsps.add(
+                rsps.POST,
+                "https://api.github.com/graphql",
+                status=200,
+                json={
+                    "data": {
+                        "repository": {"id": 456, "ref": {"target": {"oid": "refs/heads/master"}}}
+                    },
+                },
+            )
+            rsps.add(
+                rsps.POST,
+                "https://api.github.com/graphql",
+                status=200,
+                json={
+                    "data": {
+                        "clientMutationId": "1",
+                        "pullRequest": {"id": "2", "url": ""},
+                    },
+                },
+            )
+            github.create_pull_request(
+                base_repo_name="dagster",
+                base_repo_owner="dagster-io",
+                base_ref_name="refs/heads/master",
+                head_repo_name="dagster",
+                head_repo_owner="some-user",
+                head_ref_name="refs/heads/test-branch",
+                title="pr-title",
+            )
+
+    result = wrap_op_in_graph_and_execute(
+        github_op,
+        resources={
+            "github_client_resource": GithubResource(
+                github_app_id=123,
+                github_app_private_rsa_key=FAKE_PRIVATE_RSA_KEY,
+                github_installation_id=123,
+            )
+        },
+    )
+    assert result.success
+
+
+@responses.activate
 def test_github_resource_execute():
     @op
     def github_op(github_client_resource: GithubResource):


### PR DESCRIPTION
## Summary & Motivation

Adds a method to `GithubClient` that enables creating a pull request. Contributes to https://github.com/dagster-io/dagster/issues/24967

## How I Tested These Changes

Unit test & running snippet below:

```python
from dagster import Definitions, asset
from dagster_github import GithubResource

@asset
def github_pull_request(github_resource: GithubResource):
    client = github_resource.get_client()
    return client.create_pull_request(
        "dagster",
        "marijncv",
        "refs/heads/master",
        "dagster",
        "marijncv",
        "refs/heads/test-branch",
        "test-pull-request",
        "test-content",
    )


defs = Definitions(
    assets=[github_pull_request],
    resources={
        "github_resource": GithubResource(
            github_app_id=<app_id>,
            github_app_private_rsa_key=<rsa_key>,
            github_installation_id=<installation_id>,
        )
    },
)
```

## Changelog

[dagster-github] Added create_pull_request method on GithubClient that enables creating a pull request

- [x] `NEW` _(added new feature or capability)_
- [ ] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
