### PR TITLE
Add service_metadata and deployment_metadata to UserDefinedDagsterK8sConfig

### DIFF
--- a/docs/content/dagster-plus/deployment/agents/kubernetes/configuration-reference.mdx
+++ b/docs/content/dagster-plus/deployment/agents/kubernetes/configuration-reference.mdx
@@ -73,23 +73,40 @@ locations:
             config_map:
               name: test-volume-configmap
         server_k8s_config: # Raw kubernetes config for code servers launched by the agent
-          pod_spec_config:
+          pod_spec_config: # Config for the code server pod spec
             node_selector:
               disktype: standard
-          container_config:
+          pod_template_spec_metadata: # Metadata for the code server pod
+            annotations:
+              mykey: myvalue
+          deployment_metadata: # Metadata for the code server deployment
+            annotations:
+              mykey: myvalue
+          service_metadata: # Metadata for the code server service
+            annotations:
+              mykey: myvalue
+          container_config: # Config for the main dagster container in the code server pod
             resources:
               limits:
                 cpu: 100m
                 memory: 128Mi
         run_k8s_config: # Raw kubernetes config for runs launched by the agent
-          pod_spec_config:
+          pod_spec_config: # Config for the run's PodSpec
             node_selector:
               disktype: ssd
-          container_config:
+          container_config: # Config for the main dagster container in the run pod
             resources:
               limits:
                 cpu: 500m
                 memory: 1024Mi
+          pod_template_spec_metadata: # Metadata for the run pod
+            annotations:
+              mykey: myvalue
+          job_spec_config: # Config for the Kubernetes job for the run
+            ttl_seconds_after_finished: 7200
+          job_metadata: # Metadata for the Kubernetes job for the run
+            annotations:
+              mykey: myvalue
 ```
 
 ### Environment variables and secrets

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/config.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/config.py
@@ -4,7 +4,7 @@ from dagster._utils.merger import merge_dicts
 from dagster_celery.executor import CELERY_CONFIG
 from dagster_k8s import DagsterK8sJobConfig
 from dagster_k8s.client import DEFAULT_WAIT_TIMEOUT
-from dagster_k8s.job import USER_DEFINED_K8S_CONFIG_SCHEMA
+from dagster_k8s.job import USER_DEFINED_K8S_JOB_CONFIG_SCHEMA
 
 CELERY_K8S_CONFIG_KEY = "celery-k8s"
 
@@ -54,7 +54,7 @@ def celery_k8s_executor_config():
             ),
         ),
         "per_step_k8s_config": Field(
-            Map(str, USER_DEFINED_K8S_CONFIG_SCHEMA, key_label_name="step_name"),
+            Map(str, USER_DEFINED_K8S_JOB_CONFIG_SCHEMA, key_label_name="step_name"),
             is_required=False,
             default_value={},
             description="Per op k8s configuration overrides.",

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s_tests/test_launcher.py
@@ -1,4 +1,3 @@
-import json
 from unittest import mock
 
 import pytest
@@ -25,7 +24,6 @@ from dagster_celery_k8s.launcher import (
     _get_validated_celery_k8s_executor_config,
 )
 from dagster_k8s.client import DEFAULT_WAIT_TIMEOUT
-from dagster_k8s.job import UserDefinedDagsterK8sConfig
 from dagster_test.test_project import get_test_project_workspace_and_external_job
 
 
@@ -328,12 +326,12 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
         "requests": {"cpu": "250m", "memory": "64Mi"},
         "limits": {"cpu": "500m", "memory": "2560Mi"},
     }
-    user_defined_k8s_config = UserDefinedDagsterK8sConfig(
-        container_config={"image": expected_image, "resources": expected_resources},
-    )
-    user_defined_k8s_config_json = json.dumps(user_defined_k8s_config.to_dict())
-    tags = {"dagster-k8s/config": user_defined_k8s_config_json}
-
+    tags = {
+        "dagster-k8s/config": {
+            "container_config": {"image": expected_image, "resources": expected_resources},
+            "pod_spec_config": {"scheduler_name": "test-scheduler-2"},
+        }
+    }
     # Create fake external job.
     recon_job = reconstructable(fake_job)
     recon_repo = recon_job.repository

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -27,7 +27,7 @@ from dagster._utils.merger import merge_dicts
 from dagster_k8s.client import DagsterKubernetesClient
 from dagster_k8s.container_context import K8sContainerContext
 from dagster_k8s.job import (
-    USER_DEFINED_K8S_CONFIG_SCHEMA,
+    USER_DEFINED_K8S_JOB_CONFIG_SCHEMA,
     DagsterK8sJobConfig,
     UserDefinedDagsterK8sConfig,
     construct_dagster_k8s_job,
@@ -69,7 +69,7 @@ _K8S_EXECUTOR_CONFIG_SCHEMA = merge_dicts(
         ),
         "tag_concurrency_limits": get_tag_concurrency_limits_config(),
         "step_k8s_config": Field(
-            USER_DEFINED_K8S_CONFIG_SCHEMA,
+            USER_DEFINED_K8S_JOB_CONFIG_SCHEMA,
             is_required=False,
             description="Raw Kubernetes configuration for each step launched by the executor.",
         ),

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_executor.py
@@ -65,15 +65,7 @@ THIRD_RESOURCES_TAGS = {
     resource_defs={"io_manager": fs_io_manager},
 )
 def bar_with_resources():
-    expected_resources = RESOURCE_TAGS
-    user_defined_k8s_config_with_resources = UserDefinedDagsterK8sConfig(
-        container_config={"resources": expected_resources},
-    )
-    user_defined_k8s_config_with_resources_json = json.dumps(
-        user_defined_k8s_config_with_resources.to_dict()
-    )
-
-    @op(tags={"dagster-k8s/config": user_defined_k8s_config_with_resources_json})
+    @op(tags={"dagster-k8s/config": {"container_config": {"resources": RESOURCE_TAGS}}})
     def foo():
         return 1
 
@@ -111,15 +103,7 @@ def bar_with_tags_in_job_and_op():
     resource_defs={"io_manager": fs_io_manager},
 )
 def bar_with_images():
-    # Construct Dagster op tags with user defined k8s config.
-    user_defined_k8s_config_with_image = UserDefinedDagsterK8sConfig(
-        container_config={"image": "new-image"},
-    )
-    user_defined_k8s_config_with_image_json = json.dumps(
-        user_defined_k8s_config_with_image.to_dict()
-    )
-
-    @op(tags={"dagster-k8s/config": user_defined_k8s_config_with_image_json})
+    @op(tags={"dagster-k8s/config": {"container_config": {"image": "new-image"}}})
     def foo():
         return 1
 

--- a/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s_tests/unit_tests/test_launcher.py
@@ -1,4 +1,3 @@
-import json
 from datetime import datetime
 from unittest import mock
 
@@ -19,11 +18,7 @@ from dagster._grpc.types import ExecuteRunArgs
 from dagster._utils.hosted_user_process import external_job_from_recon_job
 from dagster._utils.merger import merge_dicts
 from dagster_k8s import K8sRunLauncher
-from dagster_k8s.job import (
-    DAGSTER_PG_PASSWORD_ENV_VAR,
-    UserDefinedDagsterK8sConfig,
-    get_job_name_from_run_id,
-)
+from dagster_k8s.job import DAGSTER_PG_PASSWORD_ENV_VAR, get_job_name_from_run_id
 from kubernetes import __version__ as kubernetes_version
 from kubernetes.client.models.v1_job import V1Job
 from kubernetes.client.models.v1_job_status import V1JobStatus
@@ -324,11 +319,7 @@ def test_launcher_with_k8s_config(kubeconfig_file):
         }
     }
 
-    run_tags_k8s_config = UserDefinedDagsterK8sConfig(
-        container_config={"working_dir": "my_working_dir"},
-    )
-    user_defined_k8s_config_json = json.dumps(run_tags_k8s_config.to_dict())
-    run_tags = {"dagster-k8s/config": user_defined_k8s_config_json}
+    run_tags = {"dagster-k8s/config": {"container_config": {"working_dir": "my_working_dir"}}}
 
     # Create fake external job.
     recon_job = reconstructable(fake_job)
@@ -424,12 +415,13 @@ def test_user_defined_k8s_config_in_run_tags(kubeconfig_file):
         "requests": {"cpu": "250m", "memory": "64Mi"},
         "limits": {"cpu": "500m", "memory": "2560Mi"},
     }
-    user_defined_k8s_config = UserDefinedDagsterK8sConfig(
-        container_config={"image": expected_image, "resources": expected_resources},
-        pod_spec_config={"scheduler_name": "test-scheduler-2"},
-    )
-    user_defined_k8s_config_json = json.dumps(user_defined_k8s_config.to_dict())
-    tags = {"dagster-k8s/config": user_defined_k8s_config_json}
+
+    tags = {
+        "dagster-k8s/config": {
+            "container_config": {"image": expected_image, "resources": expected_resources},
+            "pod_spec_config": {"scheduler_name": "test-scheduler-2"},
+        }
+    }
 
     # Create fake external job.
     recon_job = reconstructable(fake_job)


### PR DESCRIPTION
## Summary & Motivation
Provides a hook to add additional metadata configuration (e.g. annotations) when using this class to spin up code servers. Allows us to remove the "labels" argument from K8sContainerContext since it is now redundant.

Requires some changes to the "only_allow_user_defined_k8s_config_fields" config option since there are now explicitly fields that only make sense in a code server context - so use two different paths, one of which considers the run specific config fields, and the other considers the code server fields. Similarly, make "namespace" a top-level thing that you can allowlist instead of asking people to set pod_template_spec_metadata.namespace to allow it - that didn't really make sense anyway since you set the namespace in many different places, not just no the pod.

## How I Tested These Changes
New / modified test cases

## Changelog
NOCHANGELOG
