### PR TITLE
handle pyproject.toml that doesn't specify dependencies

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/python_packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/python_packages.py
@@ -52,7 +52,7 @@ class PythonPackage:
                 self._extras_require = {}
             else:
                 self.name = project["name"]
-                self._install_requires = project["dependencies"]
+                self._install_requires = project.get("dependencies", [])
                 self._extras_require = project.get("optional-dependencies", {})
 
     @property
@@ -157,7 +157,11 @@ class PythonPackages:
             processed |= {str(path_dir)}
             assert path_dir.is_dir()
             if (path_dir / "setup.py").exists() or (path_dir / "pyproject.toml").exists():
-                packages.append(PythonPackage(path_dir))
+                try:
+                    packages.append(PythonPackage(path_dir))
+                except:
+                    logging.exception(f"Failed processing python package at {path_dir}")
+                    raise
 
         for package in sorted(packages):
             logging.info("  - " + package.name)


### PR DESCRIPTION
## Summary & Motivation

not all pyproject.toml files will have dependencies, so gracefully handle that, and log a better error when python package processing fails

## How I Tested These Changes

https://github.com/dagster-io/internal/pull/11948 failed build with https://buildkite.com/dagster/internal/builds/83302#01926879-ff03-4440-839e-4ae0be6528e6, but I can now run `make pipeline` locally and it succeeds
