### PR TITLE
[dagster-airlift][dag] make dag mapping utilities plural

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/constants.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/constants.py
@@ -1,4 +1,4 @@
-STANDALONE_DAG_ID_METADATA_KEY = "dagster-airlift/dag-id"
+DAG_MAPPING_METADATA_KEY = "dagster-airlift/dag-mapping"
 AIRFLOW_SOURCE_METADATA_KEY_PREFIX = "dagster-airlift/source"
 TASK_MAPPING_METADATA_KEY = "dagster-airlift/task-mapping"
 AUTOMAPPED_TASK_METADATA_KEY = "dagster-airlift/automapped-task"

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_defs_data.py
@@ -10,10 +10,9 @@ from dagster import (
 from dagster._record import record
 from dagster._serdes.serdes import deserialize_value
 
-from dagster_airlift.constants import STANDALONE_DAG_ID_METADATA_KEY
+from dagster_airlift.constants import DAG_MAPPING_METADATA_KEY
 from dagster_airlift.core.airflow_instance import AirflowInstance
 from dagster_airlift.core.serialization.compute import AirliftMetadataMappingInfo
-from dagster_airlift.core.serialization.defs_construction import make_default_dag_asset_key
 from dagster_airlift.core.serialization.serialized_data import (
     SerializedAirflowDefinitionsData,
     TaskHandle,
@@ -72,16 +71,13 @@ class AirflowDefinitionsData:
         return asset_keys_per_handle
 
     @cached_property
-    def asset_key_per_dag(self) -> Mapping[str, AssetKey]:
-        dag_id_to_asset_key = {}
+    def asset_keys_per_dag(self) -> Mapping[str, AbstractSet[AssetKey]]:
+        dag_id_to_asset_key = defaultdict(set)
         for spec in self.mapped_defs.get_all_asset_specs():
-            if STANDALONE_DAG_ID_METADATA_KEY in spec.metadata:
-                dag_id = spec.metadata[STANDALONE_DAG_ID_METADATA_KEY]
-                dag_id_to_asset_key[dag_id] = spec.key
+            if DAG_MAPPING_METADATA_KEY in spec.metadata:
+                for mapping in spec.metadata[DAG_MAPPING_METADATA_KEY]:
+                    dag_id_to_asset_key[mapping["dag_id"]].add(spec.key)
         return dag_id_to_asset_key
-
-    def asset_key_for_dag(self, dag_id: str) -> AssetKey:
-        return make_default_dag_asset_key(self.serialized_data.instance_name, dag_id)
 
     def asset_keys_in_task(self, dag_id: str, task_id: str) -> AbstractSet[AssetKey]:
         return self.asset_keys_per_task_handle[TaskHandle(dag_id=dag_id, task_id=task_id)]

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/dag_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/dag_asset.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Mapping, Set
 from dagster import AssetKey, JsonMetadataValue, MarkdownMetadataValue
 from dagster._core.definitions.metadata.metadata_value import UrlMetadataValue
 
-from dagster_airlift.constants import STANDALONE_DAG_ID_METADATA_KEY
+from dagster_airlift.constants import DAG_MAPPING_METADATA_KEY
 from dagster_airlift.core.airflow_instance import DagInfo
 
 
@@ -18,7 +18,7 @@ def dag_asset_metadata(dag_info: DagInfo, source_code: str) -> Mapping[str, Any]
         "Dag Info (raw)": JsonMetadataValue(dag_info.metadata),
         "Dag ID": dag_info.dag_id,
         "Link to DAG": UrlMetadataValue(dag_info.url),
-        STANDALONE_DAG_ID_METADATA_KEY: dag_info.dag_id,
+        DAG_MAPPING_METADATA_KEY: [{"dag_id": dag_info.dag_id}],
     }
     # Attempt to retrieve source code from the DAG.
     metadata["Source Code"] = MarkdownMetadataValue(

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/event_translation.py
@@ -36,10 +36,9 @@ def materializations_for_dag_run(
 ) -> Sequence[AssetMaterialization]:
     return [
         AssetMaterialization(
-            asset_key=airflow_data.asset_key_for_dag(dag_run.dag_id),
-            description=dag_run.note,
-            metadata=get_dag_run_metadata(dag_run),
+            asset_key=asset_key, description=dag_run.note, metadata=get_dag_run_metadata(dag_run)
         )
+        for asset_key in airflow_data.asset_keys_per_dag[dag_run.dag_id]
     ]
 
 


### PR DESCRIPTION
## Summary & Motivation
Make dag mapping utilities plural. This allows us to map a single asset to multiple dags eventually.

## How I Tested These Changes
Existing changes.
## Changelog

Insert changelog entry or "NOCHANGELOG" here.
NOCHANGELOG
