### PR TITLE
[RemoteAssetNode] move back to RepositoryHandle

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -197,11 +197,11 @@ def _graphene_asset_node(
 ):
     from dagster_graphql.schema.asset_graph import GrapheneAssetNode
 
-    selector = remote_node.priority_repository_selector
+    handle = remote_node.priority_repository_handle
     base_deployment_context = graphene_info.context.get_base_deployment_context()
 
     return GrapheneAssetNode(
-        repository_selector=selector,
+        repository_handle=handle,
         asset_node_snap=remote_node.priority_node_snap,
         asset_checks_loader=asset_checks_loader,
         depended_by_loader=depended_by_loader,
@@ -209,8 +209,8 @@ def _graphene_asset_node(
         dynamic_partitions_loader=dynamic_partitions_loader,
         # base_deployment_context will be None if we are not in a branch deployment
         asset_graph_differ=AssetGraphDiffer.from_external_repositories(
-            code_location_name=selector.location_name,
-            repository_name=selector.repository_name,
+            code_location_name=handle.location_name,
+            repository_name=handle.repository_name,
             branch_workspace=graphene_info.context,
             base_workspace=base_deployment_context,
         )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -258,8 +258,8 @@ def get_assets_latest_info(
         if asset_node:
             node_id = get_unique_asset_id(
                 asset_key,
-                asset_node.priority_repository_selector.repository_name,
-                asset_node.priority_repository_selector.location_name,
+                asset_node.priority_repository_handle.repository_name,
+                asset_node.priority_repository_handle.location_name,
             )
         else:
             node_id = get_unique_asset_id(asset_key)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/utils.py
@@ -100,13 +100,13 @@ def has_permission_for_asset_graph(
 
     # If any of the asset keys don't map to a location (e.g. because they are no longer in the
     # graph) need deployment-wide permissions - no valid code location to check
-    if asset_keys.difference(asset_graph.repository_selectors_by_key.keys()):
+    if asset_keys.difference(asset_graph.repository_handles_by_key.keys()):
         return context.has_permission(permission)
 
     if asset_keys:
-        selectors = [asset_graph.get_repository_selector(asset_key) for asset_key in asset_keys]
+        selectors = [asset_graph.get_repository_handle(asset_key) for asset_key in asset_keys]
     else:
-        selectors = asset_graph.repository_selectors_by_key.values()
+        selectors = asset_graph.repository_handles_by_key.values()
 
     location_names = set(s.location_name for s in selectors)
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -391,7 +391,7 @@ class GrapheneRepository(graphene.ObjectType):
         )
         return [
             GrapheneAssetNode(
-                repository_selector=self._repository.selector,
+                repository_handle=self._repository.handle,
                 asset_node_snap=asset_node_snap,
                 asset_checks_loader=asset_checks_loader,
                 stale_status_loader=self._stale_status_loader,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -1035,7 +1035,7 @@ class GrapheneQuery(graphene.ObjectType):
             results = []
             for remote_node in remote_nodes:
                 if remote_node:
-                    repo_handle = remote_node.priority_repository_selector
+                    repo_handle = remote_node.priority_repository_handle
                     code_loc = graphene_info.context.get_code_location(repo_handle.location_name)
                     results.append(
                         (
@@ -1082,7 +1082,7 @@ class GrapheneQuery(graphene.ObjectType):
 
         nodes = [
             GrapheneAssetNode(
-                repository_selector=repo.selector,
+                repository_handle=repo.handle,
                 asset_node_snap=asset_node_snap,
                 asset_checks_loader=asset_checks_loader,
                 depended_by_loader=depended_by_loader,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -455,7 +455,7 @@ class ISolidDefinitionMixin:
 
             return [
                 GrapheneAssetNode(
-                    repository_selector=ext_repo.selector,
+                    repository_handle=ext_repo.handle,
                     asset_node_snap=node,
                     asset_checks_loader=asset_checks_loader,
                     # base_deployment_context will be None if we are not in a branch deployment

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -357,8 +357,8 @@ def executable_in_same_run(
 
     # if operating on a RemoteAssetGraph, must share a repository handle
     if isinstance(asset_graph, RemoteAssetGraph):
-        child_handle = asset_graph.get_repository_selector(child_key)
-        parent_handle = asset_graph.get_repository_selector(parent_key)
+        child_handle = asset_graph.get_repository_handle(child_key)
+        parent_handle = asset_graph.get_repository_handle(parent_key)
         if child_handle != parent_handle:
             return False
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -146,7 +146,7 @@ class AssetGraphDiffer:
 
         We cannot make RemoteAssetGraphs directly from the workspaces because if multiple code locations
         use the same asset key, those asset keys will override each other in the dictionaries the RemoteAssetGraph
-        creates (see from_repository_selectors_and_asset_node_snaps in RemoteAssetGraph). We need to ensure
+        creates (see from_repository_handles_and_asset_node_snaps in RemoteAssetGraph). We need to ensure
         that we are comparing assets in the same code location and repository, so we need to make the
         RemoteAssetGraph from an ExternalRepository to ensure that there are no duplicate asset keys
         that could override each other.

--- a/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_based_auto_materialize.py
@@ -142,8 +142,8 @@ def get_expected_data_time_for_asset_key(
             if isinstance(asset_graph, RemoteAssetGraph) and context.will_update_asset_partition(
                 AssetKeyPartitionKey(parent_key)
             ):
-                parent_repo = asset_graph.get_repository_selector(parent_key)
-                if parent_repo != asset_graph.get_repository_selector(asset_key):
+                parent_repo = asset_graph.get_repository_handle(parent_key)
+                if parent_repo != asset_graph.get_repository_handle(asset_key):
                     return context.data_time_resolver.get_current_data_time(asset_key, current_time)
             # find the minimum non-None data time of your parents
             parent_expected_data_time = context.expected_data_time_mapping.get(

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -36,9 +36,9 @@ from dagster._core.definitions.freshness_policy import FreshnessPolicy
 from dagster._core.definitions.metadata import ArbitraryMetadataMapping
 from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.definitions.partition_mapping import PartitionMapping
-from dagster._core.definitions.selector import RepositorySelector
 from dagster._core.definitions.utils import DEFAULT_GROUP_NAME
 from dagster._core.remote_representation.external import ExternalRepository
+from dagster._core.remote_representation.handle import RepositoryHandle
 
 if TYPE_CHECKING:
     from dagster._core.remote_representation.external_data import AssetCheckNodeSnap, AssetNodeSnap
@@ -52,7 +52,7 @@ class RemoteAssetNode(BaseAssetNode):
         parent_keys: AbstractSet[AssetKey],
         child_keys: AbstractSet[AssetKey],
         execution_set_keys: AbstractSet[EntityKey],
-        repo_node_pairs: Sequence[Tuple[RepositorySelector, "AssetNodeSnap"]],
+        repo_node_pairs: Sequence[Tuple[RepositoryHandle, "AssetNodeSnap"]],
         check_keys: AbstractSet[AssetCheckKey],
     ):
         self.key = key
@@ -181,7 +181,7 @@ class RemoteAssetNode(BaseAssetNode):
         return self.priority_node_snap.job_names if self.is_executable else []
 
     @property
-    def priority_repository_selector(self) -> RepositorySelector:
+    def priority_repository_handle(self) -> RepositoryHandle:
         # This property supports existing behavior but it should be phased out, because it relies on
         # materialization nodes shadowing observation nodes that would otherwise be exposed.
         return next(
@@ -193,11 +193,11 @@ class RemoteAssetNode(BaseAssetNode):
         )
 
     @property
-    def repository_selectors(self) -> Sequence[RepositorySelector]:
-        return [repo_selector for repo_selector, _ in self._repo_node_pairs]
+    def repository_handles(self) -> Sequence[RepositoryHandle]:
+        return [repo_handle for repo_handle, _ in self._repo_node_pairs]
 
     @property
-    def repo_node_pairs(self) -> Sequence[Tuple[RepositorySelector, "AssetNodeSnap"]]:
+    def repo_node_pairs(self) -> Sequence[Tuple[RepositoryHandle, "AssetNodeSnap"]]:
         return self._repo_node_pairs
 
     @cached_property
@@ -238,7 +238,7 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
         asset_nodes_by_key: Mapping[AssetKey, RemoteAssetNode],
         asset_checks_by_key: Mapping[AssetCheckKey, "AssetCheckNodeSnap"],
         asset_check_execution_sets_by_key: Mapping[AssetCheckKey, AbstractSet[EntityKey]],
-        repository_selectors_by_asset_check_key: Mapping[AssetCheckKey, RepositorySelector],
+        repository_handles_by_asset_check_key: Mapping[AssetCheckKey, RepositoryHandle],
     ):
         self._asset_nodes_by_key = asset_nodes_by_key
         self._asset_checks_by_key = asset_checks_by_key
@@ -247,28 +247,28 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
             for k, v in asset_checks_by_key.items()
         }
         self._asset_check_execution_sets_by_key = asset_check_execution_sets_by_key
-        self._repository_selectors_by_asset_check_key = repository_selectors_by_asset_check_key
+        self._repository_handles_by_asset_check_key = repository_handles_by_asset_check_key
 
     @classmethod
-    def from_repository_selectors_and_asset_node_snaps(
+    def from_repository_handles_and_asset_node_snaps(
         cls,
-        repo_selector_assets: Sequence[Tuple[RepositorySelector, "AssetNodeSnap"]],
-        repo_selector_asset_checks: Sequence[Tuple[RepositorySelector, "AssetCheckNodeSnap"]],
+        repo_handle_assets: Sequence[Tuple[RepositoryHandle, "AssetNodeSnap"]],
+        repo_handle_asset_checks: Sequence[Tuple[RepositoryHandle, "AssetCheckNodeSnap"]],
     ) -> "RemoteAssetGraph":
-        _warn_on_duplicate_nodes(repo_selector_assets)
+        _warn_on_duplicate_nodes(repo_handle_assets)
 
         # Build an index of execution sets by key. An execution set is a set of assets and checks
         # that must be executed together. AssetNodeSnaps and AssetCheckNodeSnaps already have an
         # optional execution_set_identifier set. A null execution_set_identifier indicates that the
         # node or check can be executed independently.
-        assets = [asset for _, asset in repo_selector_assets]
-        asset_checks = [asset_check for _, asset_check in repo_selector_asset_checks]
+        assets = [asset for _, asset in repo_handle_assets]
+        asset_checks = [asset_check for _, asset_check in repo_handle_asset_checks]
         execution_sets_by_key = _build_execution_set_index(assets, asset_checks)
 
-        # Index all (RepositorySelector, AssetNodeSnap) pairs by their asset key, then use this to
+        # Index all (RepositoryHandle, AssetNodeSnap) pairs by their asset key, then use this to
         # build the set of RemoteAssetNodes (indexed by key). Each RemoteAssetNode wraps the set of
         # pairs for an asset key.
-        repo_node_pairs_by_key: Dict[AssetKey, List[Tuple[RepositorySelector, "AssetNodeSnap"]]] = (
+        repo_node_pairs_by_key: Dict[AssetKey, List[Tuple[RepositoryHandle, "AssetNodeSnap"]]] = (
             defaultdict(list)
         )
 
@@ -277,8 +277,8 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
         upstream: Dict[AssetKey, Set[AssetKey]] = {key: set() for key in all_keys}
         downstream: Dict[AssetKey, Set[AssetKey]] = {key: set() for key in all_keys}
 
-        for repo_selector, node in repo_selector_assets:
-            repo_node_pairs_by_key[node.asset_key].append((repo_selector, node))
+        for repo_handle, node in repo_handle_assets:
+            repo_node_pairs_by_key[node.asset_key].append((repo_handle, node))
             for dep in node.parent_edges:
                 upstream[node.asset_key].add(dep.parent_asset_key)
                 downstream[dep.parent_asset_key].add(node.asset_key)
@@ -289,11 +289,11 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
         # each asset check key.
         check_keys_by_asset_key: Dict[AssetKey, Set[AssetCheckKey]] = defaultdict(set)
         asset_checks_by_key: Dict[AssetCheckKey, "AssetCheckNodeSnap"] = {}
-        repository_selectors_by_asset_check_key: Dict[AssetCheckKey, RepositorySelector] = {}
-        for repo_selector, asset_check in repo_selector_asset_checks:
+        repository_handles_by_asset_check_key: Dict[AssetCheckKey, RepositoryHandle] = {}
+        for repo_handle, asset_check in repo_handle_asset_checks:
             asset_checks_by_key[asset_check.key] = asset_check
             check_keys_by_asset_key[asset_check.asset_key].add(asset_check.key)
-            repository_selectors_by_asset_check_key[asset_check.key] = repo_selector
+            repository_handles_by_asset_check_key[asset_check.key] = repo_handle
 
         asset_check_execution_sets_by_key = {
             k: v for k, v in execution_sets_by_key.items() if isinstance(k, AssetCheckKey)
@@ -316,7 +316,7 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
             asset_nodes_by_key,
             asset_checks_by_key,
             asset_check_execution_sets_by_key,
-            repository_selectors_by_asset_check_key,
+            repository_handles_by_asset_check_key,
         )
 
     ##### COMMON ASSET GRAPH INTERFACE
@@ -354,16 +354,14 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
         return {job_name for node in self.asset_nodes for job_name in node.job_names}
 
     @cached_property
-    def repository_selectors_by_key(self) -> Mapping[EntityKey, RepositorySelector]:
+    def repository_handles_by_key(self) -> Mapping[EntityKey, RepositoryHandle]:
         return {
-            **{
-                k: node.priority_repository_selector for k, node in self._asset_nodes_by_key.items()
-            },
-            **self._repository_selectors_by_asset_check_key,
+            **{k: node.priority_repository_handle for k, node in self._asset_nodes_by_key.items()},
+            **self._repository_handles_by_asset_check_key,
         }
 
-    def get_repository_selector(self, key: EntityKey) -> RepositorySelector:
-        return self.repository_selectors_by_key[key]
+    def get_repository_handle(self, key: EntityKey) -> RepositoryHandle:
+        return self.repository_handles_by_key[key]
 
     def get_materialization_job_names(self, asset_key: AssetKey) -> Sequence[str]:
         """Returns the names of jobs that materialize this asset."""
@@ -396,28 +394,28 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
     ) -> Sequence[AbstractSet[EntityKey]]:
         keys_by_repo = defaultdict(set)
         for key in keys:
-            repo_selector = self.get_repository_selector(key)
-            keys_by_repo[(repo_selector.location_name, repo_selector.repository_name)].add(key)
+            repo_handle = self.get_repository_handle(key)
+            keys_by_repo[(repo_handle.location_name, repo_handle.repository_name)].add(key)
         return list(keys_by_repo.values())
 
 
 def _warn_on_duplicate_nodes(
-    repo_selector_asset_node_snaps: Sequence[Tuple[RepositorySelector, "AssetNodeSnap"]],
+    repo_handle_asset_node_snaps: Sequence[Tuple[RepositoryHandle, "AssetNodeSnap"]],
 ) -> None:
     # Split the nodes into materializable, observable, and unexecutable nodes. Observable and
     # unexecutable `AssetNodeSnap` represent both source and external assets-- the
     # "External" in "AssetNodeSnap" is unrelated to the "external" in "external asset", this
     # is just an unfortunate naming collision. `AssetNodeSnap` will be renamed eventually.
-    materializable_node_pairs: List[Tuple[RepositorySelector, "AssetNodeSnap"]] = []
-    observable_node_pairs: List[Tuple[RepositorySelector, "AssetNodeSnap"]] = []
-    unexecutable_node_pairs: List[Tuple[RepositorySelector, "AssetNodeSnap"]] = []
-    for repo_selector, node in repo_selector_asset_node_snaps:
+    materializable_node_pairs: List[Tuple[RepositoryHandle, "AssetNodeSnap"]] = []
+    observable_node_pairs: List[Tuple[RepositoryHandle, "AssetNodeSnap"]] = []
+    unexecutable_node_pairs: List[Tuple[RepositoryHandle, "AssetNodeSnap"]] = []
+    for repo_handle, node in repo_handle_asset_node_snaps:
         if node.is_source and node.is_observable:
-            observable_node_pairs.append((repo_selector, node))
+            observable_node_pairs.append((repo_handle, node))
         elif node.is_source:
-            unexecutable_node_pairs.append((repo_selector, node))
+            unexecutable_node_pairs.append((repo_handle, node))
         else:
-            materializable_node_pairs.append((repo_selector, node))
+            materializable_node_pairs.append((repo_handle, node))
 
     # It is possible for multiple nodes to exist that share the same key. This is invalid if
     # more than one node is materializable or if more than one node is observable. It is valid
@@ -428,17 +426,17 @@ def _warn_on_duplicate_nodes(
 
 
 def _warn_on_duplicates_within_subset(
-    node_pairs: Sequence[Tuple[RepositorySelector, "AssetNodeSnap"]],
+    node_pairs: Sequence[Tuple[RepositoryHandle, "AssetNodeSnap"]],
     execution_type: AssetExecutionType,
 ) -> None:
-    repo_selectors_by_asset_key: DefaultDict[AssetKey, List[RepositorySelector]] = defaultdict(list)
-    for repo_selector, node in node_pairs:
-        repo_selectors_by_asset_key[node.asset_key].append(repo_selector)
+    repo_handles_by_asset_key: DefaultDict[AssetKey, List[RepositoryHandle]] = defaultdict(list)
+    for repo_handle, node in node_pairs:
+        repo_handles_by_asset_key[node.asset_key].append(repo_handle)
 
-    duplicates = {k: v for k, v in repo_selectors_by_asset_key.items() if len(v) > 1}
+    duplicates = {k: v for k, v in repo_handles_by_asset_key.items() if len(v) > 1}
     duplicate_lines = []
-    for asset_key, repo_selectors in duplicates.items():
-        locations = [repo_selector.location_name for repo_selector in repo_selectors]
+    for asset_key, repo_handles in duplicates.items():
+        locations = [repo_handle.code_location_origin.location_name for repo_handle in repo_handles]
         duplicate_lines.append(f"  {asset_key.to_string()}: {locations}")
     duplicate_str = "\n".join(duplicate_lines)
     if duplicates:

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -1564,7 +1564,7 @@ def can_run_with_parent(
             False,
             f"parent {parent_node.key.to_user_string()} and {candidate_node.key.to_user_string()} have different backfill policies so they cannot be materialized in the same run. {candidate_node.key.to_user_string()} can be materialized once {parent_node.key} is materialized.",
         )
-    if parent_node.priority_repository_selector != candidate_node.priority_repository_selector:
+    if parent_node.priority_repository_handle != candidate_node.priority_repository_handle:
         return (
             False,
             f"parent {parent_node.key.to_user_string()} and {candidate_node.key.to_user_string()} are in different code locations so they cannot be materialized in the same run. {candidate_node.key.to_user_string()} can be materialized once {parent_node.key.to_user_string()} is materialized.",

--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -64,8 +64,8 @@ def _get_job_execution_data_from_run_request(
         len(run_request.entity_keys) > 0,
         "Expected RunRequest to have an asset selection or asset check keys",
     )
-    selector = asset_graph.get_repository_selector(run_request.entity_keys[0])
-    location_name = selector.location_name
+    handle = asset_graph.get_repository_handle(run_request.entity_keys[0])
+    location_name = handle.location_name
     job_name = (
         _get_implicit_job_name_for_assets(asset_graph, run_request.asset_selection)
         if run_request.asset_selection
@@ -81,7 +81,7 @@ def _get_job_execution_data_from_run_request(
 
     pipeline_selector = JobSubsetSelector(
         location_name=location_name,
-        repository_name=selector.repository_name,
+        repository_name=handle.repository_name,
         job_name=job_name,
         asset_selection=run_request.asset_selection,
         asset_check_selection=run_request.asset_check_keys,
@@ -89,7 +89,7 @@ def _get_job_execution_data_from_run_request(
     )
 
     if pipeline_selector not in run_request_execution_data_cache:
-        code_location = workspace.get_code_location(selector.location_name)
+        code_location = workspace.get_code_location(handle.location_name)
         external_job = code_location.get_external_job(pipeline_selector)
 
         external_execution_plan = code_location.get_external_execution_plan(

--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -434,12 +434,12 @@ class ExternalRepository:
         """Returns a repository scoped RemoteAssetGraph."""
         from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
 
-        return RemoteAssetGraph.from_repository_selectors_and_asset_node_snaps(
-            repo_selector_assets=[
-                (self.selector, node_snap) for node_snap in self.get_asset_node_snaps()
+        return RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
+            repo_handle_assets=[
+                (self.handle, node_snap) for node_snap in self.get_asset_node_snaps()
             ],
-            repo_selector_asset_checks=[
-                (self.selector, asset_check_node)
+            repo_handle_asset_checks=[
+                (self.handle, asset_check_node)
                 for asset_check_node in self.get_asset_check_node_snaps()
             ],
         )

--- a/python_modules/dagster/dagster/_core/workspace/workspace.py
+++ b/python_modules/dagster/dagster/_core/workspace/workspace.py
@@ -9,9 +9,9 @@ from dagster._utils.error import SerializableErrorInfo
 
 if TYPE_CHECKING:
     from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
-    from dagster._core.definitions.selector import RepositorySelector
     from dagster._core.remote_representation import CodeLocation, CodeLocationOrigin
     from dagster._core.remote_representation.external_data import AssetCheckNodeSnap, AssetNodeSnap
+    from dagster._core.remote_representation.handle import RepositoryHandle
 
 
 # For locations that are loaded asynchronously
@@ -63,19 +63,18 @@ class WorkspaceSnapshot:
             for code_location in code_locations
             for repo in code_location.get_repositories().values()
         )
-
-        repo_handle_assets: Sequence[Tuple["RepositorySelector", "AssetNodeSnap"]] = []
-        repo_handle_asset_checks: Sequence[Tuple["RepositorySelector", "AssetCheckNodeSnap"]] = []
+        repo_handle_assets: Sequence[Tuple["RepositoryHandle", "AssetNodeSnap"]] = []
+        repo_handle_asset_checks: Sequence[Tuple["RepositoryHandle", "AssetCheckNodeSnap"]] = []
 
         for repo in repos:
             for asset_node_snap in repo.get_asset_node_snaps():
-                repo_handle_assets.append((repo.selector, asset_node_snap))
+                repo_handle_assets.append((repo.handle, asset_node_snap))
             for asset_check_node_snap in repo.get_asset_check_node_snaps():
-                repo_handle_asset_checks.append((repo.selector, asset_check_node_snap))
+                repo_handle_asset_checks.append((repo.handle, asset_check_node_snap))
 
-        return RemoteAssetGraph.from_repository_selectors_and_asset_node_snaps(
-            repo_selector_assets=repo_handle_assets,
-            repo_selector_asset_checks=repo_handle_asset_checks,
+        return RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
+            repo_handle_assets=repo_handle_assets,
+            repo_handle_asset_checks=repo_handle_asset_checks,
         )
 
     def with_code_location(self, name: str, entry: CodeLocationEntry) -> "WorkspaceSnapshot":

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -34,7 +34,6 @@ from dagster._core.definitions.partition import PartitionsDefinition, Partitions
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
 from dagster._core.definitions.partition_mapping import UpstreamPartitionsResult
 from dagster._core.definitions.remote_asset_graph import RemoteAssetGraph
-from dagster._core.definitions.selector import RepositorySelector
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.errors import DagsterDefinitionChangedDeserializationError
 from dagster._core.instance import DynamicPartitionsStore
@@ -42,6 +41,7 @@ from dagster._core.remote_representation.external_data import (
     asset_check_node_snaps_from_repo,
     asset_node_snaps_from_repo,
 )
+from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.test_utils import freeze_time, instance_for_test
 from dagster._time import create_datetime, get_current_datetime
 
@@ -52,10 +52,10 @@ def to_remote_asset_graph(assets, asset_checks=None) -> RemoteAssetGraph:
         return assets + (asset_checks or [])
 
     asset_node_snaps = asset_node_snaps_from_repo(repo)
-    selector = RepositorySelector(location_name="fake", repository_name="repo")
-    return RemoteAssetGraph.from_repository_selectors_and_asset_node_snaps(
-        [(selector, asset_node) for asset_node in asset_node_snaps],
-        [(selector, asset_check) for asset_check in asset_check_node_snaps_from_repo(repo)],
+    handle = RepositoryHandle.for_test(location_name="fake", repository_name="repo")
+    return RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
+        [(handle, asset_node) for asset_node in asset_node_snaps],
+        [(handle, asset_check) for asset_check in asset_check_node_snaps_from_repo(repo)],
     )
 
 
@@ -891,9 +891,9 @@ def test_cross_code_location_partition_mapping() -> None:
 
     a_nodes = asset_node_snaps_from_repo(repo_a)
     b_nodes = asset_node_snaps_from_repo(repo_b)
-    selector = RepositorySelector(location_name="foo", repository_name="bar")
-    asset_graph = RemoteAssetGraph.from_repository_selectors_and_asset_node_snaps(
-        [(selector, asset_node) for asset_node in [*a_nodes, *b_nodes]], []
+    handle = RepositoryHandle.for_test(location_name="foo", repository_name="bar")
+    asset_graph = RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
+        [(handle, asset_node) for asset_node in [*a_nodes, *b_nodes]], []
     )
 
     assert isinstance(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -177,11 +177,11 @@ def test_get_repository_selector(instance) -> None:
     asset_graph = _make_context(instance, ["defs1", "defs2"]).asset_graph
 
     assert asset_graph.get_materialization_job_names(asset1.key) == ["__ASSET_JOB"]
-    repo_handle1 = asset_graph.get_repository_selector(asset1.key)
+    repo_handle1 = asset_graph.get_repository_handle(asset1.key)
     assert repo_handle1.repository_name == "__repository__"
 
     assert asset_graph.get_materialization_job_names(asset1.key) == ["__ASSET_JOB"]
-    repo_handle2 = asset_graph.get_repository_selector(asset2.key)
+    repo_handle2 = asset_graph.get_repository_handle(asset2.key)
     assert repo_handle2.repository_name == "__repository__"
 
 

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_backfill.py
@@ -47,7 +47,6 @@ from dagster._core.definitions.selector import (
     PartitionRangeSelector,
     PartitionsByAssetSelector,
     PartitionsSelector,
-    RepositorySelector,
 )
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.asset_backfill import (
@@ -58,6 +57,7 @@ from dagster._core.execution.asset_backfill import (
     get_canceling_asset_backfill_iteration_data,
 )
 from dagster._core.remote_representation.external_data import asset_node_snaps_from_repo
+from dagster._core.remote_representation.handle import RepositoryHandle
 from dagster._core.storage.dagster_run import RunsFilter
 from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
@@ -251,7 +251,11 @@ def _get_instance_queryer(
 
 
 def _single_backfill_iteration(
-    backfill_id, backfill_data, asset_graph, instance, assets_by_repo_name
+    backfill_id,
+    backfill_data,
+    asset_graph: RemoteAssetGraph,
+    instance,
+    assets_by_repo_name,
 ) -> AssetBackfillData:
     result = execute_asset_backfill_iteration_consume_generator(
         backfill_id, backfill_data, asset_graph, instance
@@ -264,7 +268,7 @@ def _single_backfill_iteration(
         assert asset_keys is not None
 
         assets = assets_by_repo_name[
-            asset_graph.get_repository_selector(asset_keys[0]).repository_name
+            asset_graph.get_repository_handle(asset_keys[0]).repository_name
         ]
 
         do_run(
@@ -668,12 +672,12 @@ def run_backfill_to_completion(
             )
 
             assert all(
-                asset_graph.get_repository_selector(asset_keys[0])
-                == asset_graph.get_repository_selector(asset_key)
+                asset_graph.get_repository_handle(asset_keys[0])
+                == asset_graph.get_repository_handle(asset_key)
                 for asset_key in asset_keys
             )
             assets = assets_by_repo_name[
-                asset_graph.get_repository_selector(asset_keys[0]).repository_name
+                asset_graph.get_repository_handle(asset_keys[0]).repository_name
             ]
 
             do_run(
@@ -737,18 +741,18 @@ def _requested_asset_partitions_in_run_request(
 def remote_asset_graph_from_assets_by_repo_name(
     assets_by_repo_name: Mapping[str, Sequence[AssetsDefinition]],
 ) -> RemoteAssetGraph:
-    from_repository_selectors_and_asset_node_snaps = []
+    from_repository_handles_and_asset_node_snaps = []
 
     for repo_name, assets in assets_by_repo_name.items():
         repo = Definitions(assets=assets).get_repository_def()
         asset_node_snaps = asset_node_snaps_from_repo(repo)
-        selector = RepositorySelector(location_name="test", repository_name=repo_name)
-        from_repository_selectors_and_asset_node_snaps.extend(
-            [(selector, asset_node) for asset_node in asset_node_snaps]
+        handle = RepositoryHandle.for_test(location_name="test", repository_name=repo_name)
+        from_repository_handles_and_asset_node_snaps.extend(
+            [(handle, asset_node) for asset_node in asset_node_snaps]
         )
 
-    return RemoteAssetGraph.from_repository_selectors_and_asset_node_snaps(
-        from_repository_selectors_and_asset_node_snaps, []
+    return RemoteAssetGraph.from_repository_handles_and_asset_node_snaps(
+        from_repository_handles_and_asset_node_snaps, []
     )
 
 


### PR DESCRIPTION
partial revert of https://github.com/dagster-io/dagster/pull/24824

in the process of solving other issues in that PR I figured out how to make `RepositoryHandle` serializable, and it turns out that theres some information in there its best to keep available to support things like https://github.com/dagster-io/dagster/pull/25122


## How I Tested These Changes

existing tests

