### PR TITLE
Add get asset status cache values to EventLogStorage

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -637,7 +637,7 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
     def default_run_scoped_event_tailer_offset(self) -> int:
         return 0
 
-    def get_updated_asset_status_cache_values(
+    def get_asset_status_cache_values(
         self,
         asset_keys: Sequence[AssetKey],
         partitions_defs: Sequence[Optional[PartitionsDefinition]],

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -639,14 +639,11 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
 
     def get_asset_status_cache_values(
         self,
-        asset_keys: Sequence[AssetKey],
-        partitions_defs: Sequence[Optional[PartitionsDefinition]],
+        partitions_defs_by_key: Mapping[AssetKey, Optional[PartitionsDefinition]],
     ) -> Sequence[Optional["AssetStatusCacheValue"]]:
         """Get the cached status information for each asset."""
-        check.param_invariant(len(asset_keys) == len(partitions_defs), "asset_keys")
-
         values = []
-        for asset_key, partitions_def in zip(asset_keys, partitions_defs):
+        for asset_key, partitions_def in partitions_defs_by_key.items():
             values.append(
                 get_and_update_asset_status_cache_value(self._instance, asset_key, partitions_def)
             )

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -643,6 +643,8 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
         partitions_defs: Sequence[Optional[PartitionsDefinition]],
     ) -> Sequence[Optional["AssetStatusCacheValue"]]:
         """Get the cached status information for each asset."""
+        check.param_invariant(len(asset_keys) == len(partitions_defs), "asset_keys")
+
         values = []
         for asset_key, partitions_def in zip(asset_keys, partitions_defs):
             values.append(

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -16,6 +16,7 @@ from dagster._core.assets import AssetDetails
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.definitions.events import AssetKey
+from dagster._core.definitions.partition import PartitionsDefinition
 from dagster._core.event_api import (
     AssetRecordsFilter,
     EventHandlerFn,
@@ -35,6 +36,7 @@ from dagster._core.instance import DagsterInstance, MayHaveInstanceWeakref, T_Da
 from dagster._core.loader import InstanceLoadableBy
 from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecord
 from dagster._core.storage.dagster_run import DagsterRunStatsSnapshot
+from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 from dagster._core.storage.sql import AlembicVersion
 from dagster._core.storage.tags import MULTIDIMENSIONAL_PARTITION_PREFIX
 from dagster._utils import PrintFn
@@ -43,7 +45,6 @@ from dagster._utils.warnings import deprecation_warning
 
 if TYPE_CHECKING:
     from dagster._core.events.log import EventLogEntry
-    from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
 
 
 class EventLogConnection(NamedTuple):
@@ -634,3 +635,12 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
 
     def default_run_scoped_event_tailer_offset(self) -> int:
         return 0
+
+    @abstractmethod
+    def get_updated_asset_status_cache_values(
+        self,
+        asset_keys: Sequence[AssetKey],
+        partitions_def: Sequence[Optional[PartitionsDefinition]],
+    ) -> Mapping[AssetKey, Optional[AssetStatusCacheValue]]:
+        """Get the cached status information for each asset."""
+        raise NotImplementedError()

--- a/python_modules/dagster/dagster/_core/storage/sqlite_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/sqlite_storage.py
@@ -86,6 +86,7 @@ class DagsterSqliteStorage(DagsterStorage, ConfigurableClass):
         return cls(base_dir, inst_data=inst_data)
 
     def register_instance(self, instance: "DagsterInstance") -> None:
+        super().register_instance(instance)
         if not self._run_storage.has_instance:
             self._run_storage.register_instance(instance)
         if not self._event_log_storage.has_instance:

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -6017,14 +6017,13 @@ class TestEventLogStorage:
     def test_get_updated_asset_status_cache_values(
         self, instance: DagsterInstance, storage: EventLogStorage
     ):
-        asset_keys = [AssetKey("hourly"), AssetKey("daily"), AssetKey("static")]
-        partition_defs = [
-            HourlyPartitionsDefinition("2020-01-01-00:00"),
-            DailyPartitionsDefinition("2020-01-01"),
-            StaticPartitionsDefinition(["a", "b", "c"]),
-        ]
+        partition_defs_by_key = {
+            AssetKey("hourly"): HourlyPartitionsDefinition("2020-01-01-00:00"),
+            AssetKey("daily"): DailyPartitionsDefinition("2020-01-01"),
+            AssetKey("static"): StaticPartitionsDefinition(["a", "b", "c"]),
+        }
 
-        assert storage.get_asset_status_cache_values(asset_keys, partition_defs) == [
+        assert storage.get_asset_status_cache_values(partition_defs_by_key) == [
             None,
             None,
             None,
@@ -6038,8 +6037,7 @@ class TestEventLogStorage:
         )
         instance.report_runless_asset_event(AssetMaterialization(asset_key="static", partition="a"))
 
-        for i, value in enumerate(
-            storage.get_asset_status_cache_values(asset_keys, partition_defs)
-        ):
+        partition_defs = list(partition_defs_by_key.values())
+        for i, value in enumerate(storage.get_asset_status_cache_values(partition_defs_by_key)):
             assert value is not None
             assert len(value.deserialize_materialized_partition_subsets(partition_defs[i])) == 1


### PR DESCRIPTION
## Summary & Motivation
We want to turn `get_and_update_asset_status_cache_value` into a GraphQL query to improve performance for declarative automation. Thus, we need to add `get_updated_asset_status_cache_values` to `EventLogStorage` which will call `get_and_update_asset_status_cache_value`.

## How I Tested These Changes
```pytest -vv /Users/briantu/repos/dagster/python_modules/dagster/dagster_tests/storage_tests/test_event_log.py -k test_get_updated_asset_status_cache_values```
