### PR TITLE
[dagster-airlift][dag] fix downstreams in airflow mapping data

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
@@ -72,7 +72,7 @@ class AirliftMetadataMappingInfo:
     @cached_property
     def downstream_deps(self) -> Dict[AssetKey, Set[AssetKey]]:
         downstreams = defaultdict(set)
-        for spec in self.mapped_asset_specs:
+        for spec in self.asset_specs:
             for dep in spec.deps:
                 downstreams[dep.asset_key].add(spec.key)
         return downstreams

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
@@ -163,7 +163,12 @@ def test_fetched_airflow_data() -> None:
 
 def test_produce_fetched_airflow_data() -> None:
     mapping_info = build_airlift_metadata_mapping_info(
-        defs=Definitions(assets=[airlift_asset_spec("asset1", "dag1", "task1")])
+        defs=Definitions(
+            assets=[
+                airlift_asset_spec("asset1", "dag1", "task1"),
+                AssetSpec("asset2", deps=[ak("asset1")]),
+            ]
+        )
     )
 
     instance = AirflowInstanceFake(
@@ -192,6 +197,8 @@ def test_produce_fetched_airflow_data() -> None:
     )
 
     assert len(fetched_airflow_data.mapping_info.mapped_asset_specs) == 1
+    assert len(fetched_airflow_data.mapping_info.asset_specs) == 2
+    assert fetched_airflow_data.mapping_info.downstream_deps == {ak("asset1"): {ak("asset2")}}
 
 
 def test_automapped_loaded_data() -> None:


### PR DESCRIPTION
## Summary & Motivation
Found this while working on dag-level overrides.
Downstreams in airflow mapping data were operating on an incomplete set of asset specs (only the mapped ones). But it's in fact possible for the definitions object to have unmapped asset specs which affect the asset graph dependency structure.

## How I Tested These Changes
Existing tests (could probably add better testing here)
## Changelog
NOCHANGELOG
