### PR TITLE
[dagster-airlift][dag] remove MappedAirflowTaskData

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/compute.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from functools import cached_property
-from typing import Dict, List, Set
+from typing import AbstractSet, Dict, List, Set
 
 from dagster import AssetKey, AssetSpec, Definitions
 from dagster._record import record
@@ -9,7 +9,6 @@ from dagster_airlift.core.airflow_instance import AirflowInstance, DagInfo
 from dagster_airlift.core.dag_asset import get_leaf_assets_for_dag
 from dagster_airlift.core.serialization.serialized_data import (
     KeyScopedDataItem,
-    MappedAirflowTaskData,
     SerializedAirflowDefinitionsData,
     SerializedDagData,
     SerializedTaskHandleData,
@@ -90,16 +89,9 @@ class FetchedAirflowData:
     mapping_info: AirliftMetadataMappingInfo
 
     @cached_property
-    def all_mapped_tasks(self) -> Dict[AssetKey, List[MappedAirflowTaskData]]:
+    def all_mapped_tasks(self) -> Dict[AssetKey, AbstractSet[TaskHandle]]:
         return {
-            spec.key: [
-                MappedAirflowTaskData(
-                    task_handle=task_handle,
-                    task_info=self.task_info_map[task_handle.dag_id][task_handle.task_id],
-                )
-                for task_handle in task_handles_for_spec(spec)
-            ]
-            for spec in self.mapping_info.mapped_asset_specs
+            spec.key: task_handles_for_spec(spec) for spec in self.mapping_info.mapped_asset_specs
         }
 
     def task_handle_data_for_dag(self, dag_id: str) -> Dict[str, SerializedTaskHandleData]:

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/serialized_data.py
@@ -48,14 +48,6 @@ class TaskHandle(NamedTuple):
     task_id: str
 
 
-@whitelist_for_serdes
-@record
-class MappedAirflowTaskData:
-    # remove if we keep it in SerializedDataData
-    task_info: TaskInfo
-    task_handle: TaskHandle
-
-
 ###################################################################################################
 # Serialized data that scopes to airflow DAGs and tasks.
 ###################################################################################################
@@ -78,7 +70,7 @@ class SerializedDagData:
 @record
 class KeyScopedDataItem:
     asset_key: AssetKey
-    mapped_tasks: List[MappedAirflowTaskData]
+    mapped_tasks: AbstractSet[TaskHandle]
 
 
 ###################################################################################################
@@ -98,7 +90,7 @@ class SerializedAirflowDefinitionsData:
     dag_datas: Mapping[str, SerializedDagData]
 
     @cached_property
-    def all_mapped_tasks(self) -> Dict[AssetKey, List[MappedAirflowTaskData]]:
+    def all_mapped_tasks(self) -> Dict[AssetKey, AbstractSet[TaskHandle]]:
         return {item.asset_key: item.mapped_tasks for item in self.key_scoped_data_items}
 
 

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
@@ -156,9 +156,7 @@ def test_fetched_airflow_data() -> None:
 
     all_mapped_tasks = fetched_airflow_data.all_mapped_tasks
     assert all_mapped_tasks.keys() == {ak("asset1"), ak("asset2")}
-    assert all_mapped_tasks[ak("asset1")][0].task_handle == TaskHandle(
-        dag_id="dag1", task_id="task1"
-    )
+    assert all_mapped_tasks[ak("asset1")] == {TaskHandle(dag_id="dag1", task_id="task1")}
 
 
 def test_produce_fetched_airflow_data() -> None:


### PR DESCRIPTION
## Summary & Motivation
Trying to simplify implementation patterns in advance of dag-level overrides to tease out a shared implementation.
In this case, MappedAirflowTaskData was giving us information that is better inferred from the airflow mapping info. So get rid of it.
## How I Tested These Changes
Existing tests
## Changelog
NOCHANGELOG
