### PR TITLE
Support returning RunConfig from PartitionedConfig

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -21,7 +21,7 @@ from typing import (
     cast,
 )
 
-from typing_extensions import TypeVar
+from typing_extensions import TypeAlias, TypeVar
 
 import dagster._check as check
 from dagster._annotations import PublicAttr, deprecated, deprecated_param, public
@@ -31,6 +31,7 @@ from dagster._core.definitions.dynamic_partitions_request import (
     DeleteDynamicPartitionsRequest,
 )
 from dagster._core.definitions.partition_key_range import PartitionKeyRange
+from dagster._core.definitions.run_config import RunConfig, convert_config_input
 from dagster._core.definitions.utils import normalize_tags
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
@@ -60,6 +61,8 @@ T_PartitionsDefinition = TypeVar(
 # "..." is an invalid substring in partition keys
 # The other escape characters are characters that may not display in the Dagster UI.
 INVALID_PARTITION_SUBSTRINGS = ["...", "\a", "\b", "\f", "\n", "\r", "\t", "\v", "\0"]
+
+PartitionConfigFn: TypeAlias = Callable[[str], Union[RunConfig, Mapping[str, Any]]]
 
 
 @deprecated(breaking_version="2.0", additional_warn_text="Use string partition keys instead.")
@@ -588,9 +591,9 @@ class PartitionedConfig(Generic[T_PartitionsDefinition]):
         self,
         partitions_def: T_PartitionsDefinition,
         run_config_for_partition_fn: Optional[Callable[[Partition], Mapping[str, Any]]] = None,
-        decorated_fn: Optional[Callable[..., Mapping[str, Any]]] = None,
+        decorated_fn: Optional[Callable[..., Union[RunConfig, Mapping[str, Any]]]] = None,
         tags_for_partition_fn: Optional[Callable[[Partition[Any]], Mapping[str, str]]] = None,
-        run_config_for_partition_key_fn: Optional[Callable[[str], Mapping[str, Any]]] = None,
+        run_config_for_partition_key_fn: Optional[PartitionConfigFn] = None,
         tags_for_partition_key_fn: Optional[Callable[[str], Mapping[str, str]]] = None,
     ):
         self._partitions = check.inst_param(partitions_def, "partitions_def", PartitionsDefinition)
@@ -646,8 +649,8 @@ class PartitionedConfig(Generic[T_PartitionsDefinition]):
     @property
     def run_config_for_partition_key_fn(
         self,
-    ) -> Optional[Callable[[str], Mapping[str, Any]]]:
-        """Optional[Callable[[str], Mapping[str, Any]]]: A function that accepts a partition key
+    ) -> Optional[PartitionConfigFn]:
+        """Optional[Callable[[str], Union[RunConfig, Mapping[str, Any]]]]: A function that accepts a partition key
         and returns a dictionary representing the config to attach to runs for that partition.
         """
         return self._run_config_for_partition_key_fn
@@ -706,7 +709,10 @@ class PartitionedConfig(Generic[T_PartitionsDefinition]):
             run_config = self._run_config_for_partition_key_fn(partition_key)
         else:
             check.failed("Unreachable.")  # one of the above funcs always defined
-        return copy.deepcopy(run_config)
+        normalized_run_config = convert_config_input(
+            run_config
+        )  # convert any RunConfig to plain dict
+        return copy.deepcopy(normalized_run_config)
 
     # Assumes partition key already validated
     def get_tags_for_partition_key(
@@ -784,7 +790,7 @@ def static_partitioned_config(
     partition_keys: Sequence[str],
     tags_for_partition_fn: Optional[Callable[[str], Mapping[str, str]]] = None,
     tags_for_partition_key_fn: Optional[Callable[[str], Mapping[str, str]]] = None,
-) -> Callable[[Callable[[str], Mapping[str, Any]]], PartitionedConfig[StaticPartitionsDefinition]]:
+) -> Callable[[PartitionConfigFn], PartitionedConfig[StaticPartitionsDefinition]]:
     """Creates a static partitioned config for a job.
 
     The provided partition_keys is a static list of strings identifying the set of partitions. The
@@ -820,7 +826,7 @@ def static_partitioned_config(
     )
 
     def inner(
-        fn: Callable[[str], Mapping[str, Any]],
+        fn: PartitionConfigFn,
     ) -> PartitionedConfig[StaticPartitionsDefinition]:
         return PartitionedConfig(
             partitions_def=StaticPartitionsDefinition(partition_keys),
@@ -835,7 +841,7 @@ def static_partitioned_config(
 def partitioned_config(
     partitions_def: PartitionsDefinition,
     tags_for_partition_key_fn: Optional[Callable[[str], Mapping[str, str]]] = None,
-) -> Callable[[Callable[[str], Mapping[str, Any]]], PartitionedConfig]:
+) -> Callable[[PartitionConfigFn], PartitionedConfig]:
     """Creates a partitioned config for a job given a PartitionsDefinition.
 
     The partitions_def provides the set of partitions, which may change over time
@@ -855,7 +861,7 @@ def partitioned_config(
     """
     check.opt_callable_param(tags_for_partition_key_fn, "tags_for_partition_key_fn")
 
-    def inner(fn: Callable[[str], Mapping[str, Any]]) -> PartitionedConfig:
+    def inner(fn: PartitionConfigFn) -> PartitionedConfig:
         return PartitionedConfig(
             partitions_def=partitions_def,
             run_config_for_partition_key_fn=fn,
@@ -875,7 +881,7 @@ def dynamic_partitioned_config(
     partition_fn: Callable[[Optional[datetime]], Sequence[str]],
     tags_for_partition_fn: Optional[Callable[[str], Mapping[str, str]]] = None,
     tags_for_partition_key_fn: Optional[Callable[[str], Mapping[str, str]]] = None,
-) -> Callable[[Callable[[str], Mapping[str, Any]]], PartitionedConfig]:
+) -> Callable[[PartitionConfigFn], PartitionedConfig]:
     """Creates a dynamic partitioned config for a job.
 
     The provided partition_fn returns a list of strings identifying the set of partitions, given
@@ -905,7 +911,7 @@ def dynamic_partitioned_config(
         "tags_for_partition_fn",
     )
 
-    def inner(fn: Callable[[str], Mapping[str, Any]]) -> PartitionedConfig:
+    def inner(fn: PartitionConfigFn) -> PartitionedConfig:
         return PartitionedConfig(
             partitions_def=DynamicPartitionsDefinition(partition_fn),
             run_config_for_partition_key_fn=fn,


### PR DESCRIPTION
## Summary & Motivation

Support returning a `RunConfig` from `PartitionedConfig`. Fixes #20117.

## How I Tested These Changes

New unit test.

## Changelog

`PartitionedConfig` objects can now return a `RunConfig` without causing a crash.

- [ ] `NEW` _(added new feature or capability)_
- [x] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
