### PR TITLE
[dagster-airlift][dag] Support dag-level overrides in builder

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/dag_asset.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/dag_asset.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, Mapping, Set
 
-from dagster import AssetKey, JsonMetadataValue, MarkdownMetadataValue
-from dagster._core.definitions.metadata.metadata_value import UrlMetadataValue
+from dagster import AssetKey, MarkdownMetadataValue
 
 from dagster_airlift.constants import DAG_MAPPING_METADATA_KEY
 from dagster_airlift.core.airflow_instance import DagInfo
@@ -15,12 +14,9 @@ def dag_description(dag_info: DagInfo) -> str:
 
 def dag_asset_metadata(dag_info: DagInfo, source_code: str) -> Mapping[str, Any]:
     metadata = {
-        "Dag Info (raw)": JsonMetadataValue(dag_info.metadata),
-        "Dag ID": dag_info.dag_id,
-        "Link to DAG": UrlMetadataValue(dag_info.url),
+        **dag_info.dagster_metadata,
         DAG_MAPPING_METADATA_KEY: [{"dag_id": dag_info.dag_id}],
     }
-    # Attempt to retrieve source code from the DAG.
     metadata["Source Code"] = MarkdownMetadataValue(
         f"""
 ```python

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_airflow_asset_mapping.py
@@ -41,8 +41,8 @@ def test_build_task_mapping_info_no_mapping() -> None:
         defs=Definitions(assets=[AssetSpec("asset1"), AssetSpec("asset2")])
     )
     assert len(spec_mapping_info.dag_ids) == 0
-    assert not (spec_mapping_info.asset_key_map)
-    assert not (spec_mapping_info.task_handle_map)
+    assert not (spec_mapping_info.handle_to_asset_keys)
+    assert not (spec_mapping_info.asset_key_to_handles)
 
 
 def test_build_single_task_spec() -> None:
@@ -52,8 +52,8 @@ def test_build_single_task_spec() -> None:
     assert spec_mapping_info.dag_ids == {"dag1"}
     assert spec_mapping_info.task_id_map == {"dag1": {"task1"}}
     assert spec_mapping_info.asset_keys_per_dag_id == {"dag1": {ak("asset1")}}
-    assert spec_mapping_info.asset_key_map == {"dag1": {"task1": {ak("asset1")}}}
-    assert spec_mapping_info.task_handle_map == {
+    assert spec_mapping_info.handle_to_asset_keys == {TaskHandle("dag1", "task1"): {ak("asset1")}}
+    assert spec_mapping_info.asset_key_to_handles == {
         ak("asset1"): set([TaskHandle(dag_id="dag1", task_id="task1")])
     }
 
@@ -76,12 +76,12 @@ def test_task_with_multiple_assets() -> None:
         "dag1": {ak("asset1"), ak("asset2"), ak("asset3")},
         "dag2": {ak("asset4")},
     }
-    assert spec_mapping_info.asset_key_map == {
-        "dag1": {"task1": {ak("asset1"), ak("asset2"), ak("asset3")}},
-        "dag2": {"task1": {ak("asset4")}},
+    assert spec_mapping_info.handle_to_asset_keys == {
+        TaskHandle("dag1", "task1"): {ak("asset1"), ak("asset2"), ak("asset3")},
+        TaskHandle("dag2", "task1"): {ak("asset4")},
     }
 
-    assert spec_mapping_info.task_handle_map == {
+    assert spec_mapping_info.asset_key_to_handles == {
         ak("asset1"): set([TaskHandle(dag_id="dag1", task_id="task1")]),
         ak("asset2"): set([TaskHandle(dag_id="dag1", task_id="task1")]),
         ak("asset3"): set([TaskHandle(dag_id="dag1", task_id="task1")]),
@@ -111,12 +111,12 @@ def test_map_multiple_tasks_to_single_asset() -> None:
         "dag2": {ak("asset1")},
     }
 
-    assert spec_mapping_info.asset_key_map == {
-        "dag1": {"task1": {ak("asset1")}},
-        "dag2": {"task1": {ak("asset1")}},
+    assert spec_mapping_info.handle_to_asset_keys == {
+        TaskHandle("dag1", "task1"): {ak("asset1")},
+        TaskHandle("dag2", "task1"): {ak("asset1")},
     }
 
-    assert spec_mapping_info.task_handle_map == {
+    assert spec_mapping_info.asset_key_to_handles == {
         ak("asset1"): set(
             [TaskHandle(dag_id="dag1", task_id="task1"), TaskHandle(dag_id="dag2", task_id="task1")]
         )
@@ -154,7 +154,7 @@ def test_fetched_airflow_data() -> None:
         ),
     )
 
-    all_mapped_tasks = fetched_airflow_data.all_mapped_tasks
+    all_mapped_tasks = fetched_airflow_data.all_mapped_handles
     assert all_mapped_tasks.keys() == {ak("asset1"), ak("asset2")}
     assert all_mapped_tasks[ak("asset1")] == {TaskHandle(dag_id="dag1", task_id="task1")}
 


### PR DESCRIPTION
## Summary & Motivation
Allows dag-level overrides to be set in the builder function.
In practice, we change the serialized data construction to be scoped agnostically to dag handle or task handle, and bubble that change through to the "spec enrichment" step.
This refactor was somewhat limited by the differing way in which peered dags and tasks were handled. I think there's room for _significant_ code simplification if we change how task automapping works, but we can discuss that in future prs.
## How I Tested These Changes
Added a new test for dag-level override behavior.

## Changelog
NOCHANGELOG
