### PR TITLE
Fix asset owner links on catalog page

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/search/BuildAssetSearchResults.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/BuildAssetSearchResults.tsx
@@ -1,15 +1,16 @@
 import {COMMON_COLLATOR} from '../app/Util';
 import {AssetTableDefinitionFragment} from '../assets/types/AssetTableFragment.types';
 import {isKindTag} from '../graph/KindTags';
-import {DefinitionTag} from '../graphql/types';
+import {AssetOwner, DefinitionTag} from '../graphql/types';
 import {buildTagString} from '../ui/tagAsString';
+import {assetOwnerAsString} from '../workspace/assetOwnerAsString';
 import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 import {repoAddressAsHumanString} from '../workspace/repoAddressAsString';
 import {repoAddressFromPath} from '../workspace/repoAddressFromPath';
 import {RepoAddress} from '../workspace/types';
 
 type CountByOwner = {
-  owner: string;
+  owner: AssetOwner;
   assetCount: number;
 };
 
@@ -85,7 +86,7 @@ export function buildAssetCountBySection(assets: AssetDefinitionMetadata[]): Ass
     .forEach((asset) => {
       const assetDefinition = asset.definition!;
       assetDefinition.owners.forEach((owner) => {
-        const ownerKey = owner.__typename === 'UserAssetOwner' ? owner.email : owner.team;
+        const ownerKey = JSON.stringify(owner);
         assetCountByOwner.increment(ownerKey);
       });
 
@@ -126,10 +127,12 @@ export function buildAssetCountBySection(assets: AssetDefinitionMetadata[]): Ass
   const countsByOwner = assetCountByOwner
     .entries()
     .map(([owner, count]) => ({
-      owner,
+      owner: JSON.parse(owner),
       assetCount: count,
     }))
-    .sort(({owner: ownerA}, {owner: ownerB}) => COMMON_COLLATOR.compare(ownerA, ownerB));
+    .sort(({owner: ownerA}, {owner: ownerB}) =>
+      COMMON_COLLATOR.compare(assetOwnerAsString(ownerA), assetOwnerAsString(ownerB)),
+    );
 
   const countsByKind = assetCountByKind
     .entries()

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -21,6 +21,7 @@ import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Util
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
 import {AssetOwner, DefinitionTag} from '../graphql/types';
 import {buildTagString} from '../ui/tagAsString';
+import {assetOwnerAsString} from '../workspace/assetOwnerAsString';
 import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
 import {repoAddressAsURLString} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
@@ -39,12 +40,6 @@ export const linkToAssetTableWithKindFilter = (kind: string) => {
 export const linkToAssetTableWithTagFilter = (tag: Omit<DefinitionTag, '__typename'>) => {
   return `/assets?${qs.stringify({
     tags: JSON.stringify([tag]),
-  })}`;
-};
-
-export const linkToAssetTableWithOwnerFilter = (owner: string) => {
-  return `/assets?${qs.stringify({
-    owners: JSON.stringify([owner]),
   })}`;
 };
 
@@ -269,10 +264,10 @@ const secondaryDataToSearchResults = (
 
     const ownerResults: SearchResult[] = countsBySection.countsByOwner.map(
       ({owner, assetCount}) => ({
-        label: owner,
+        label: assetOwnerAsString(owner),
         description: '',
         type: AssetFilterSearchResultType.Owner,
-        href: linkToAssetTableWithOwnerFilter(owner),
+        href: linkToAssetTableWithAssetOwnerFilter(owner),
         numResults: assetCount,
       }),
     );

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/assetOwnerAsString.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/assetOwnerAsString.ts
@@ -1,0 +1,5 @@
+import {AssetOwner} from '../graphql/types';
+
+export const assetOwnerAsString = (owner: AssetOwner) => {
+  return owner.__typename === 'UserAssetOwner' ? owner.email : owner.team;
+};


### PR DESCRIPTION
## Summary & Motivation
Owners link in the catalog view is broken
Reported here: https://dagsterlabs.slack.com/archives/C06AWMPT3DF/p1728408026154439
https://linear.app/dagster-labs/issue/FE-602/investigate-bug-in-catalog-related-to-owners

Internal PR: https://github.com/dagster-io/internal/pull/12079/files

## How I Tested These Changes
Tested locally.

## Changelog

[dagster plus] Fixed a bug in the catalog UI where owners filters were not applied correctly.

- [ ] `NEW` _(added new feature or capability)_
- [X] `BUGFIX` _(fixed a bug)_
- [ ] `DOCS` _(added or updated documentation)_
