### PR TITLE
[dagster-powerbi] Fix refreshing semantic models on non-personal workspaces

### DIFF
--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
@@ -158,7 +158,7 @@ class PowerBIWorkspace(ConfigurableResource):
             method="POST",
             endpoint=f"datasets/{dataset_id}/refreshes",
             json={"notifyOption": "NoNotification"},
-            group_scoped=False,
+            group_scoped=True,
         )
         if response.status_code != 202:
             raise Failure(f"Refresh failed to start: {response.content}")
@@ -175,7 +175,7 @@ class PowerBIWorkspace(ConfigurableResource):
 
             last_refresh = self._fetch_json(
                 f"datasets/{dataset_id}/refreshes",
-                group_scoped=False,
+                group_scoped=True,
             )["value"][0]
             status = last_refresh["status"]
 

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -129,20 +129,20 @@ def test_refreshable_semantic_model(
 
     workspace_data_api_mocks.add(
         method=responses.POST,
-        url=f"{BASE_API_URL}/datasets/{SAMPLE_SEMANTIC_MODEL['id']}/refreshes",
+        url=f"{BASE_API_URL}/groups/{workspace_id}/datasets/{SAMPLE_SEMANTIC_MODEL['id']}/refreshes",
         json={"notifyOption": "NoNotification"},
         status=202,
     )
 
     workspace_data_api_mocks.add(
         method=responses.GET,
-        url=f"{BASE_API_URL}/datasets/{SAMPLE_SEMANTIC_MODEL['id']}/refreshes",
+        url=f"{BASE_API_URL}/groups/{workspace_id}/datasets/{SAMPLE_SEMANTIC_MODEL['id']}/refreshes",
         json={"value": [{"status": "Unknown"}]},
         status=200,
     )
     workspace_data_api_mocks.add(
         method=responses.GET,
-        url=f"{BASE_API_URL}/datasets/{SAMPLE_SEMANTIC_MODEL['id']}/refreshes",
+        url=f"{BASE_API_URL}/groups/{workspace_id}/datasets/{SAMPLE_SEMANTIC_MODEL['id']}/refreshes",
         json={
             "value": [{"status": "Completed" if success else "Failed", "serviceExceptionJson": {}}]
         },


### PR DESCRIPTION
## Summary

When testing this feature locally against a live PowerBI instance, I ended up using a non-group scoped URL for my personal workspace. These URLs do not work for group-scoped objects.

## How I Tested These Changes

Update unit test, test against live instance.


