### PR TITLE
[graphql] back GrapheneAssetNode with RemoteAssetNode

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -714,7 +714,6 @@ enum ChangeReason {
 
 type AssetDependency {
   asset: AssetNode!
-  inputName: String!
   partitionMapping: PartitionMapping
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -338,7 +338,6 @@ export type AssetConnection = {
 export type AssetDependency = {
   __typename: 'AssetDependency';
   asset: AssetNode;
-  inputName: Scalars['String']['output'];
   partitionMapping: Maybe<PartitionMapping>;
 };
 
@@ -6288,8 +6287,6 @@ export const buildAssetDependency = (
         : relationshipsToOmit.has('AssetNode')
         ? ({} as AssetNode)
         : buildAssetNode({}, relationshipsToOmit),
-    inputName:
-      overrides && overrides.hasOwnProperty('inputName') ? overrides.inputName! : 'aspernatur',
     partitionMapping:
       overrides && overrides.hasOwnProperty('partitionMapping')
         ? overrides.partitionMapping!

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -53,7 +53,7 @@ from dagster._core.storage.partition_status_cache import (
     is_cacheable_partition_type,
 )
 
-from dagster_graphql.implementation.loader import CrossRepoAssetDependedByLoader, StaleStatusLoader
+from dagster_graphql.implementation.loader import StaleStatusLoader
 
 if TYPE_CHECKING:
     from dagster_graphql.implementation.asset_checks_loader import AssetChecksLoader
@@ -184,7 +184,6 @@ def _graphene_asset_node(
     graphene_info: "ResolveInfo",
     remote_node: RemoteAssetNode,
     asset_checks_loader: "AssetChecksLoader",
-    depended_by_loader: Optional[CrossRepoAssetDependedByLoader],
     stale_status_loader: Optional[StaleStatusLoader],
     dynamic_partitions_loader: CachingDynamicPartitionsLoader,
 ):
@@ -194,10 +193,8 @@ def _graphene_asset_node(
     base_deployment_context = graphene_info.context.get_base_deployment_context()
 
     return GrapheneAssetNode(
-        repository_handle=handle,
-        asset_node_snap=remote_node.priority_node_snap,
+        remote_node=remote_node,
         asset_checks_loader=asset_checks_loader,
-        depended_by_loader=depended_by_loader,
         stale_status_loader=stale_status_loader,
         dynamic_partitions_loader=dynamic_partitions_loader,
         # base_deployment_context will be None if we are not in a branch deployment
@@ -220,8 +217,6 @@ def get_asset_nodes_by_asset_key(
     """
     from dagster_graphql.implementation.asset_checks_loader import AssetChecksLoader
 
-    depended_by_loader = CrossRepoAssetDependedByLoader(context=graphene_info.context)
-
     stale_status_loader = StaleStatusLoader(
         instance=graphene_info.context.instance,
         asset_graph=lambda: graphene_info.context.asset_graph,
@@ -240,7 +235,6 @@ def get_asset_nodes_by_asset_key(
             graphene_info,
             remote_node,
             asset_checks_loader=asset_checks_loader,
-            depended_by_loader=depended_by_loader,
             stale_status_loader=stale_status_loader,
             dynamic_partitions_loader=dynamic_partitions_loader,
         )
@@ -268,7 +262,6 @@ def get_asset_node(
             asset_graph=lambda: graphene_info.context.asset_graph,
             loading_context=graphene_info.context,
         ),
-        depended_by_loader=None,
         asset_checks_loader=AssetChecksLoader(
             context=graphene_info.context,
             asset_keys=[asset_key],
@@ -297,7 +290,6 @@ def get_asset(
             graphene_info,
             remote_node,
             stale_status_loader=None,
-            depended_by_loader=None,
             asset_checks_loader=AssetChecksLoader(
                 context=graphene_info.context,
                 asset_keys=[asset_key],

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -373,10 +373,10 @@ class GrapheneRepository(graphene.ObjectType):
         ]
 
     def resolve_assetNodes(self, graphene_info: ResolveInfo):
-        asset_node_snaps = self.get_repository(graphene_info).get_asset_node_snaps()
+        remote_nodes = self.get_repository(graphene_info).asset_graph.asset_nodes
         asset_checks_loader = AssetChecksLoader(
             context=graphene_info.context,
-            asset_keys=[node.asset_key for node in asset_node_snaps],
+            asset_keys=[node.key for node in remote_nodes],
         )
 
         asset_graph_differ = None
@@ -401,14 +401,13 @@ class GrapheneRepository(graphene.ObjectType):
 
         return [
             GrapheneAssetNode(
-                repository_handle=self._handle,
-                asset_node_snap=asset_node_snap,
+                remote_node=remote_node,
                 asset_checks_loader=asset_checks_loader,
                 stale_status_loader=stale_status_loader,
                 dynamic_partitions_loader=dynamic_partitions_loader,
                 asset_graph_differ=asset_graph_differ,
             )
-            for asset_node_snap in self.get_repository(graphene_info).get_asset_node_snaps()
+            for remote_node in remote_nodes
         ]
 
     def resolve_assetGroups(self, graphene_info: ResolveInfo):


### PR DESCRIPTION
complete the migration to backing `GrapheneAssetNode` with `RemoteAssetNode`, which allowed me to delete the entire cross dependency loader class 

## How I Tested These Changes

existing coverage