### PR TITLE
[external-renames] external_* -> remote_* for Remote* attributes/methods

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/test_memory.py
+++ b/integration_tests/test_suites/daemon-test-suite/test_memory.py
@@ -77,8 +77,8 @@ def test_no_memory_leaks():
         },
     ) as instance:
         with get_example_repo(instance) as repo:
-            external_schedule = repo.get_external_schedule("always_run_schedule")
-            external_sensor = repo.get_external_sensor("always_on_sensor")
+            external_schedule = repo.get_schedule("always_run_schedule")
+            external_sensor = repo.get_sensor("always_on_sensor")
 
             instance.start_schedule(external_schedule)
             instance.start_sensor(external_sensor)

--- a/integration_tests/test_suites/daemon-test-suite/test_queued.py
+++ b/integration_tests/test_suites/daemon-test-suite/test_queued.py
@@ -29,9 +29,9 @@ def assert_events_in_order(logs, expected_events):
 
 
 def test_queue_from_schedule_and_sensor(instance, foo_example_workspace, foo_example_repo):
-    external_schedule = foo_example_repo.get_external_schedule("always_run_schedule")
-    external_sensor = foo_example_repo.get_external_sensor("always_on_sensor")
-    external_job = foo_example_repo.get_full_external_job("foo_job")
+    external_schedule = foo_example_repo.get_schedule("always_run_schedule")
+    external_sensor = foo_example_repo.get_sensor("always_on_sensor")
+    external_job = foo_example_repo.get_full_job("foo_job")
 
     instance.start_schedule(external_schedule)
     instance.start_sensor(external_sensor)
@@ -65,7 +65,7 @@ def test_queue_from_schedule_and_sensor(instance, foo_example_workspace, foo_exa
 
 def test_queued_runs(instance, foo_example_workspace, foo_example_repo):
     with start_daemon(workspace_file=file_relative_path(__file__, "repo.py")):
-        external_job = foo_example_repo.get_full_external_job("foo_job")
+        external_job = foo_example_repo.get_full_job("foo_job")
 
         run = create_run(instance, external_job)
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -133,7 +133,7 @@ def create_and_launch_partition_backfill(
         repository = location.get_repository(repository_selector.repository_name)
         matches = [
             partition_set
-            for partition_set in repository.get_external_partition_sets()
+            for partition_set in repository.get_partition_sets()
             if partition_set.name == partition_set_selector.get("partitionSetName")
         ]
         if not matches:

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/dynamic_partitions.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/dynamic_partitions.py
@@ -44,7 +44,7 @@ def _repository_contains_dynamic_partitions_def(
             repository = repo_loc.get_repository(repository_selector.repository_name)
             found_partitions_defs = [
                 asset_node_snap.partitions
-                for asset_node_snap in repository.external_repository_data.asset_nodes
+                for asset_node_snap in repository.repository_snap.asset_nodes
                 if asset_node_snap.partitions
             ]
             return any(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
@@ -41,15 +41,15 @@ def get_instigator_state_by_selector(
     location = graphene_info.context.get_code_location(selector.location_name)
     repository = location.get_repository(selector.repository_name)
 
-    if repository.has_external_sensor(selector.name):
-        external_sensor = repository.get_external_sensor(selector.name)
+    if repository.has_sensor(selector.name):
+        external_sensor = repository.get_sensor(selector.name)
         stored_state = graphene_info.context.instance.get_instigator_state(
             external_sensor.get_remote_origin_id(),
             external_sensor.selector_id,
         )
         current_state = external_sensor.get_current_instigator_state(stored_state)
-    elif repository.has_external_schedule(selector.name):
-        external_schedule = repository.get_external_schedule(selector.name)
+    elif repository.has_schedule(selector.name):
+        external_schedule = repository.get_schedule(selector.name)
         stored_state = graphene_info.context.instance.get_instigator_state(
             external_schedule.get_remote_origin_id(),
             external_schedule.selector_id,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -46,7 +46,7 @@ def get_partition_sets_or_error(
     repository = location.get_repository(repository_selector.repository_name)
     partition_sets = [
         partition_set
-        for partition_set in repository.get_external_partition_sets()
+        for partition_set in repository.get_partition_sets()
         if partition_set.job_name == pipeline_name
     ]
 
@@ -80,7 +80,7 @@ def get_partition_set(
     check.str_param(partition_set_name, "partition_set_name")
     location = graphene_info.context.get_code_location(repository_selector.location_name)
     repository = location.get_repository(repository_selector.repository_name)
-    partition_sets = repository.get_external_partition_sets()
+    partition_sets = repository.get_partition_sets()
     for partition_set in partition_sets:
         if partition_set.name == partition_set_name:
             return GraphenePartitionSet(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_resources.py
@@ -30,7 +30,7 @@ def get_top_level_resources_or_error(
         repository_selector.location_name
     )
     repository = location.get_repository(repository_selector.repository_name)
-    external_resources = repository.get_external_resources()
+    external_resources = repository.get_resources()
 
     results = [
         GrapheneResourceDetails(
@@ -58,12 +58,12 @@ def get_resource_or_error(
     )
     repository = location.get_repository(resource_selector.repository_name)
 
-    if not repository.has_external_resource(resource_selector.resource_name):
+    if not repository.has_resource(resource_selector.resource_name):
         raise UserFacingGraphQLError(
             GrapheneResourceNotFoundError(resource_name=resource_selector.resource_name)
         )
 
-    external_resource = repository.get_external_resource(resource_selector.resource_name)
+    external_resource = repository.get_resource(resource_selector.resource_name)
 
     return GrapheneResourceDetails(
         resource_selector.location_name, resource_selector.repository_name, external_resource

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_schedules.py
@@ -39,7 +39,7 @@ def start_schedule(
     location = graphene_info.context.get_code_location(schedule_selector.location_name)
     repository = location.get_repository(schedule_selector.repository_name)
 
-    external_schedule = repository.get_external_schedule(schedule_selector.schedule_name)
+    external_schedule = repository.get_schedule(schedule_selector.schedule_name)
     stored_state = graphene_info.context.instance.start_schedule(external_schedule)
     schedule_state = external_schedule.get_current_instigator_state(stored_state)
 
@@ -58,7 +58,7 @@ def stop_schedule(
         schedule.get_remote_origin_id(): schedule
         for repository_location in graphene_info.context.code_locations
         for repository in repository_location.get_repositories().values()
-        for schedule in repository.get_external_schedules()
+        for schedule in repository.get_schedules()
     }
 
     external_schedule = external_schedules.get(schedule_origin_id)
@@ -92,7 +92,7 @@ def reset_schedule(
     location = graphene_info.context.get_code_location(schedule_selector.location_name)
     repository = location.get_repository(schedule_selector.repository_name)
 
-    external_schedule = repository.get_external_schedule(schedule_selector.schedule_name)
+    external_schedule = repository.get_schedule(schedule_selector.schedule_name)
     stored_state = graphene_info.context.instance.reset_schedule(external_schedule)
     schedule_state = external_schedule.get_current_instigator_state(stored_state)
 
@@ -123,7 +123,7 @@ def get_schedules_or_error(
     location = graphene_info.context.get_code_location(repository_selector.location_name)
     repository = location.get_repository(repository_selector.repository_name)
     batch_loader = RepositoryScopedBatchLoader(graphene_info.context.instance, repository)
-    external_schedules = repository.get_external_schedules()
+    external_schedules = repository.get_schedules()
     schedule_states = graphene_info.context.instance.all_instigator_state(
         repository_origin_id=repository.get_remote_origin_id(),
         repository_selector_id=repository_selector.selector_id,
@@ -163,7 +163,7 @@ def get_schedules_for_pipeline(
 
     location = graphene_info.context.get_code_location(pipeline_selector.location_name)
     repository = location.get_repository(pipeline_selector.repository_name)
-    external_schedules = repository.get_external_schedules()
+    external_schedules = repository.get_schedules()
 
     results = []
     for external_schedule in external_schedules:
@@ -189,12 +189,12 @@ def get_schedule_or_error(
     location = graphene_info.context.get_code_location(schedule_selector.location_name)
     repository = location.get_repository(schedule_selector.repository_name)
 
-    if not repository.has_external_schedule(schedule_selector.schedule_name):
+    if not repository.has_schedule(schedule_selector.schedule_name):
         raise UserFacingGraphQLError(
             GrapheneScheduleNotFoundError(schedule_name=schedule_selector.schedule_name)
         )
 
-    external_schedule = repository.get_external_schedule(schedule_selector.schedule_name)
+    external_schedule = repository.get_schedule(schedule_selector.schedule_name)
 
     schedule_state = graphene_info.context.instance.get_instigator_state(
         external_schedule.get_remote_origin_id(), external_schedule.selector_id
@@ -223,10 +223,10 @@ def get_schedule_next_tick(
 
     repository = code_location.get_repository(repository_origin.repository_name)
 
-    if not repository.has_external_schedule(schedule_state.name):
+    if not repository.has_schedule(schedule_state.name):
         return None
 
-    external_schedule = repository.get_external_schedule(schedule_state.name)
+    external_schedule = repository.get_schedule(schedule_state.name)
     time_iter = external_schedule.execution_time_iterator(time.time())
 
     next_timestamp = next(time_iter).timestamp()

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_sensors.py
@@ -40,7 +40,7 @@ def get_sensors_or_error(
     location = graphene_info.context.get_code_location(repository_selector.location_name)
     repository = location.get_repository(repository_selector.repository_name)
     batch_loader = RepositoryScopedBatchLoader(graphene_info.context.instance, repository)
-    sensors = repository.get_external_sensors()
+    sensors = repository.get_sensors()
     sensor_states = graphene_info.context.instance.all_instigator_state(
         repository_origin_id=repository.get_remote_origin_id(),
         repository_selector_id=repository_selector.selector_id,
@@ -75,9 +75,9 @@ def get_sensor_or_error(graphene_info: ResolveInfo, selector: SensorSelector) ->
     location = graphene_info.context.get_code_location(selector.location_name)
     repository = location.get_repository(selector.repository_name)
 
-    if not repository.has_external_sensor(selector.sensor_name):
+    if not repository.has_sensor(selector.sensor_name):
         raise UserFacingGraphQLError(GrapheneSensorNotFoundError(selector.sensor_name))
-    external_sensor = repository.get_external_sensor(selector.sensor_name)
+    external_sensor = repository.get_sensor(selector.sensor_name)
     sensor_state = graphene_info.context.instance.get_instigator_state(
         external_sensor.get_remote_origin_id(),
         external_sensor.selector_id,
@@ -94,9 +94,9 @@ def start_sensor(graphene_info: ResolveInfo, sensor_selector: SensorSelector) ->
 
     location = graphene_info.context.get_code_location(sensor_selector.location_name)
     repository = location.get_repository(sensor_selector.repository_name)
-    if not repository.has_external_sensor(sensor_selector.sensor_name):
+    if not repository.has_sensor(sensor_selector.sensor_name):
         raise UserFacingGraphQLError(GrapheneSensorNotFoundError(sensor_selector.sensor_name))
-    external_sensor = repository.get_external_sensor(sensor_selector.sensor_name)
+    external_sensor = repository.get_sensor(sensor_selector.sensor_name)
     sensor_state = graphene_info.context.instance.start_sensor(external_sensor)
     return GrapheneSensor(external_sensor, repository, sensor_state)
 
@@ -113,7 +113,7 @@ def stop_sensor(
         sensor.get_remote_origin_id(): sensor
         for code_location in graphene_info.context.code_locations
         for repository in code_location.get_repositories().values()
-        for sensor in repository.get_external_sensors()
+        for sensor in repository.get_sensors()
     }
 
     external_sensor = external_sensors.get(instigator_origin_id)
@@ -145,10 +145,10 @@ def reset_sensor(graphene_info: ResolveInfo, sensor_selector: SensorSelector) ->
 
     location = graphene_info.context.get_code_location(sensor_selector.location_name)
     repository = location.get_repository(sensor_selector.repository_name)
-    if not repository.has_external_sensor(sensor_selector.sensor_name):
+    if not repository.has_sensor(sensor_selector.sensor_name):
         raise UserFacingGraphQLError(GrapheneSensorNotFoundError(sensor_selector.sensor_name))
 
-    external_sensor = repository.get_external_sensor(sensor_selector.sensor_name)
+    external_sensor = repository.get_sensor(sensor_selector.sensor_name)
     sensor_state = graphene_info.context.instance.reset_sensor(external_sensor)
 
     return GrapheneSensor(external_sensor, repository, sensor_state)
@@ -163,7 +163,7 @@ def get_sensors_for_pipeline(
 
     location = graphene_info.context.get_code_location(pipeline_selector.location_name)
     repository = location.get_repository(pipeline_selector.repository_name)
-    external_sensors = repository.get_external_sensors()
+    external_sensors = repository.get_sensors()
 
     results = []
     for external_sensor in external_sensors:
@@ -202,10 +202,10 @@ def get_sensor_next_tick(
 
     repository = code_location.get_repository(repository_origin.repository_name)
 
-    if not repository.has_external_sensor(sensor_state.name):
+    if not repository.has_sensor(sensor_state.name):
         return None
 
-    external_sensor = repository.get_external_sensor(sensor_state.name)
+    external_sensor = repository.get_sensor(sensor_state.name)
 
     if not sensor_state.is_running:
         return None
@@ -235,10 +235,10 @@ def set_sensor_cursor(
     location = graphene_info.context.get_code_location(selector.location_name)
     repository = location.get_repository(selector.repository_name)
 
-    if not repository.has_external_sensor(selector.sensor_name):
+    if not repository.has_sensor(selector.sensor_name):
         raise UserFacingGraphQLError(GrapheneSensorNotFoundError(selector.sensor_name))
     instance = graphene_info.context.instance
-    external_sensor = repository.get_external_sensor(selector.sensor_name)
+    external_sensor = repository.get_sensor(selector.sensor_name)
     stored_state = instance.get_instigator_state(
         external_sensor.get_remote_origin_id(),
         external_sensor.selector_id,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_solids.py
@@ -24,7 +24,7 @@ def get_used_solid_map(repo):
     inv_by_def_name = defaultdict(list)
     definitions = []
 
-    for external_pipeline in repo.get_all_external_jobs():
+    for external_pipeline in repo.get_all_jobs():
         for handle in build_solid_handles(external_pipeline).values():
             definition = handle.solid.get_solid_definition()
             if definition.name not in inv_by_def_name:
@@ -66,7 +66,7 @@ def get_graph_or_error(graphene_info, graph_selector):
 
     repository = repo_loc.get_repository(graph_selector.repository_name)
 
-    for external_pipeline in repository.get_all_external_jobs():
+    for external_pipeline in repository.get_all_jobs():
         # first check for graphs
         if external_pipeline.get_graph_name() == graph_selector.graph_name:
             return GrapheneGraph(external_pipeline)

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -77,15 +77,15 @@ class RepositoryScopedBatchLoader:
         elif data_type == RepositoryDataType.SCHEDULE_TICKS:
             if self._instance.supports_batch_tick_queries:
                 selector_ids = [
-                    schedule.selector_id for schedule in self._repository.get_external_schedules()
+                    schedule.selector_id for schedule in self._repository.get_schedules()
                 ]
                 ticks_by_selector = self._instance.get_batch_ticks(selector_ids, limit=limit)
-                for schedule in self._repository.get_external_schedules():
+                for schedule in self._repository.get_schedules():
                     fetched[schedule.get_remote_origin_id()] = list(
                         ticks_by_selector.get(schedule.selector_id, [])
                     )
             else:
-                for schedule in self._repository.get_external_schedules():
+                for schedule in self._repository.get_schedules():
                     origin_id = schedule.get_remote_origin_id()
                     fetched[origin_id] = list(
                         self._instance.get_ticks(origin_id, schedule.selector_id, limit=limit)
@@ -93,16 +93,14 @@ class RepositoryScopedBatchLoader:
 
         elif data_type == RepositoryDataType.SENSOR_TICKS:
             if self._instance.supports_batch_tick_queries:
-                selector_ids = [
-                    schedule.selector_id for schedule in self._repository.get_external_sensors()
-                ]
+                selector_ids = [schedule.selector_id for schedule in self._repository.get_sensors()]
                 ticks_by_selector = self._instance.get_batch_ticks(selector_ids, limit=limit)
-                for sensor in self._repository.get_external_sensors():
+                for sensor in self._repository.get_sensors():
                     fetched[sensor.get_remote_origin_id()] = list(
                         ticks_by_selector.get(sensor.selector_id, [])
                     )
             else:
-                for sensor in self._repository.get_external_sensors():
+                for sensor in self._repository.get_sensors():
                     origin_id = sensor.get_remote_origin_id()
                     fetched[origin_id] = list(
                         self._instance.get_ticks(origin_id, sensor.selector_id, limit=limit)
@@ -115,29 +113,25 @@ class RepositoryScopedBatchLoader:
         self._limits[data_type] = limit
 
     def get_schedule_state(self, schedule_name: str) -> Optional[InstigatorState]:
-        check.invariant(self._repository.has_external_schedule(schedule_name))
+        check.invariant(self._repository.has_schedule(schedule_name))
         states = self._get(RepositoryDataType.SCHEDULE_STATES, schedule_name, 1)
         return states[0] if states else None
 
     def get_sensor_state(self, sensor_name: str) -> Optional[InstigatorState]:
-        check.invariant(self._repository.has_external_sensor(sensor_name))
+        check.invariant(self._repository.has_sensor(sensor_name))
         states = self._get(RepositoryDataType.SENSOR_STATES, sensor_name, 1)
         return states[0] if states else None
 
     def get_sensor_ticks(self, origin_id: str, selector_id: str, limit: int) -> Sequence[Any]:
         check.invariant(
-            any(
-                selector_id == sensor.selector_id
-                for sensor in self._repository.get_external_sensors()
-            )
+            any(selector_id == sensor.selector_id for sensor in self._repository.get_sensors())
         )
         return self._get(RepositoryDataType.SENSOR_TICKS, origin_id, limit)
 
     def get_schedule_ticks(self, origin_id: str, selector_id: str, limit: int) -> Sequence[Any]:
         check.invariant(
             any(
-                selector_id == schedule.selector_id
-                for schedule in self._repository.get_external_schedules()
+                selector_id == schedule.selector_id for schedule in self._repository.get_schedules()
             )
         )
         return self._get(RepositoryDataType.SCHEDULE_TICKS, origin_id, limit)

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -868,8 +868,8 @@ class GrapheneAssetNode(graphene.ObjectType):
 
     def resolve_targetingInstigators(self, graphene_info: ResolveInfo) -> Sequence[GrapheneSensor]:
         repo = graphene_info.context.get_repository(self._repository_selector)
-        external_sensors = repo.get_external_sensors()
-        external_schedules = repo.get_external_schedules()
+        external_sensors = repo.get_sensors()
+        external_schedules = repo.get_schedules()
 
         asset_graph = repo.asset_graph
 
@@ -909,7 +909,7 @@ class GrapheneAssetNode(graphene.ObjectType):
         asset_key = self._asset_node_snap.asset_key
         matching_sensors = [
             sensor
-            for sensor in repo.get_external_sensors()
+            for sensor in repo.get_sensors()
             if sensor.sensor_type == SensorType.AUTO_MATERIALIZE
             and asset_key in check.not_none(sensor.asset_selection).resolve(asset_graph)
         ]
@@ -951,9 +951,9 @@ class GrapheneAssetNode(graphene.ObjectType):
         job_names = self._asset_node_snap.job_names or []
         repo = graphene_info.context.get_repository(self._repository_selector)
         return [
-            GraphenePipeline(repo.get_full_external_job(job_name))
+            GraphenePipeline(repo.get_full_job(job_name))
             for job_name in job_names
-            if repo.has_external_job(job_name)
+            if repo.has_job(job_name)
         ]
 
     def resolve_isPartitioned(self, _graphene_info: ResolveInfo) -> bool:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -423,7 +423,7 @@ class GraphenePartitionBackfill(graphene.ObjectType):
         repository = location.get_repository(repository_name)
         external_partition_sets = [
             partition_set
-            for partition_set in repository.get_external_partition_sets()
+            for partition_set in repository.get_partition_sets()
             if partition_set.name == origin.partition_set_name
         ]
         if not external_partition_sets:

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -315,7 +315,7 @@ class GrapheneRepository(graphene.ObjectType):
                     batch_loader.get_schedule_state(schedule.name),
                     batch_loader,
                 )
-                for schedule in repository.get_external_schedules()
+                for schedule in repository.get_schedules()
             ],
             key=lambda schedule: schedule.name,
         )
@@ -330,7 +330,7 @@ class GrapheneRepository(graphene.ObjectType):
                 batch_loader.get_sensor_state(sensor.name),
                 batch_loader,
             )
-            for sensor in sorted(repository.get_external_sensors(), key=lambda sensor: sensor.name)
+            for sensor in sorted(repository.get_sensors(), key=lambda sensor: sensor.name)
             if not sensorType or sensor.sensor_type == sensorType
         ]
 
@@ -338,7 +338,7 @@ class GrapheneRepository(graphene.ObjectType):
         return [
             GraphenePipeline(pipeline)
             for pipeline in sorted(
-                self.get_repository(graphene_info).get_all_external_jobs(),
+                self.get_repository(graphene_info).get_all_jobs(),
                 key=lambda pipeline: pipeline.name,
             )
         ]
@@ -347,7 +347,7 @@ class GrapheneRepository(graphene.ObjectType):
         return [
             GrapheneJob(pipeline)
             for pipeline in sorted(
-                self.get_repository(graphene_info).get_all_external_jobs(),
+                self.get_repository(graphene_info).get_all_jobs(),
                 key=lambda pipeline: pipeline.name,
             )
         ]
@@ -361,7 +361,7 @@ class GrapheneRepository(graphene.ObjectType):
     def resolve_partitionSets(self, graphene_info: ResolveInfo):
         return (
             GraphenePartitionSet(self._handle, partition_set)
-            for partition_set in self.get_repository(graphene_info).get_external_partition_sets()
+            for partition_set in self.get_repository(graphene_info).get_partition_sets()
         )
 
     def resolve_displayMetadata(self, graphene_info: ResolveInfo):
@@ -435,7 +435,7 @@ class GrapheneRepository(graphene.ObjectType):
                 external_resource=resource,
             )
             for resource in sorted(
-                self.get_repository(graphene_info).get_external_resources(),
+                self.get_repository(graphene_info).get_resources(),
                 key=lambda resource: resource.name,
             )
             if resource.is_top_level

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -358,7 +358,7 @@ class GrapheneDryRunInstigationTick(graphene.ObjectType):
         repository = code_location.get_repository(self._selector.repository_name)
 
         if isinstance(self._selector, SensorSelector):
-            if not repository.has_external_sensor(self._selector.sensor_name):
+            if not repository.has_sensor(self._selector.sensor_name):
                 raise UserFacingGraphQLError(
                     GrapheneSensorNotFoundError(self._selector.sensor_name)
                 )
@@ -378,7 +378,7 @@ class GrapheneDryRunInstigationTick(graphene.ObjectType):
                 sensor_data = serializable_error_info_from_exc_info(sys.exc_info())
             return GrapheneTickEvaluation(sensor_data)
         else:
-            if not repository.has_external_schedule(self._selector.schedule_name):
+            if not repository.has_schedule(self._selector.schedule_name):
                 raise UserFacingGraphQLError(
                     GrapheneScheduleNotFoundError(self._selector.schedule_name)
                 )
@@ -387,7 +387,7 @@ class GrapheneDryRunInstigationTick(graphene.ObjectType):
                     "No tick timestamp provided when attempting to dry-run schedule"
                     f" {self._selector.schedule_name}."
                 )
-            external_schedule = repository.get_external_schedule(self._selector.schedule_name)
+            external_schedule = repository.get_schedule(self._selector.schedule_name)
             timezone_str = external_schedule.execution_timezone
             if not timezone_str:
                 timezone_str = "UTC"

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -135,7 +135,7 @@ class GrapheneSchedule(graphene.ObjectType):
         repository = graphene_info.context.get_code_location(
             self._external_schedule.handle.location_name
         ).get_repository(self._external_schedule.handle.repository_name)
-        external_partition_set = repository.get_external_partition_set(
+        external_partition_set = repository.get_partition_set(
             self._external_schedule.partition_set_name
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_all_snapshot_ids.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_all_snapshot_ids.py
@@ -10,6 +10,6 @@ def test_all_snapshot_ids(snapshot):
     # schema of PipelineSnapshots you are free to rerecord
     with instance_for_test() as instance:
         with get_main_external_repo(instance) as repo:
-            for pipeline in sorted(repo.get_all_external_jobs(), key=lambda p: p.name):
+            for pipeline in sorted(repo.get_all_jobs(), key=lambda p: p.name):
                 snapshot.assert_match(serialize_pp(pipeline.job_snapshot))
                 snapshot.assert_match(pipeline.computed_job_snapshot_id)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -3041,7 +3041,7 @@ class TestPersistentInstanceAssetInProgress(ExecutingGraphQLContextTestMatrix):
         # Create two enqueued runs
         code_location = graphql_context.get_code_location("test")
         repository = code_location.get_repository("test_repo")
-        job = repository.get_full_external_job("hanging_job")
+        job = repository.get_full_job("hanging_job")
 
         queued_runs = []
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_instigation.py
@@ -71,7 +71,7 @@ class TestNextTickRepository(NonLaunchableGraphQLContextTestMatrix):
         ).get_repository(repository_selector["repositoryName"])
 
         schedule_name = "no_config_job_hourly_schedule"
-        external_schedule = external_repository.get_external_schedule(schedule_name)
+        external_schedule = external_repository.get_schedule(schedule_name)
         selector = infer_instigation_selector(graphql_context, schedule_name)
 
         # need to be running in order to generate a future tick
@@ -109,7 +109,7 @@ class TestNextTickRepository(NonLaunchableGraphQLContextTestMatrix):
         ).get_repository(repository_selector["repositoryName"])
 
         sensor_name = "always_no_config_sensor_with_tags_and_metadata"
-        external_sensor = external_repository.get_external_sensor(sensor_name)
+        external_sensor = external_repository.get_sensor(sensor_name)
         selector = infer_instigation_selector(graphql_context, sensor_name)
 
         result = execute_dagster_graphql(
@@ -167,7 +167,7 @@ class TestNextTickRepository(NonLaunchableGraphQLContextTestMatrix):
         ).get_repository(repository_selector["repositoryName"])
 
         schedule_name = "no_config_job_hourly_schedule"
-        external_schedule = external_repository.get_external_schedule(schedule_name)
+        external_schedule = external_repository.get_schedule(schedule_name)
         graphql_context.instance.start_schedule(external_schedule)
 
         result = execute_dagster_graphql(

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
@@ -71,9 +71,7 @@ class TestRetryExecutionReadonly(ReadonlyGraphQLContextTestMatrix):
 
         code_location = graphql_context.get_code_location("test")
         repository = code_location.get_repository("test_repo")
-        external_job_origin = repository.get_full_external_job(
-            "eventually_successful"
-        ).get_remote_origin()
+        external_job_origin = repository.get_full_job("eventually_successful").get_remote_origin()
 
         run_id = create_run_for_test(
             graphql_context.instance,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -540,7 +540,7 @@ def test_get_schedule_definitions_for_repository(graphql_context):
     ).get_repository(main_repo_name())
 
     results = result.data["schedulesOrError"]["results"]
-    assert len(results) == len(external_repository.get_external_schedules())
+    assert len(results) == len(external_repository.get_schedules())
 
     for schedule in results:
         if schedule["name"] == "timezone_schedule_with_tags_and_metadata":

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -1177,7 +1177,7 @@ def test_sensor_next_ticks(graphql_context: WorkspaceRequestContext):
     ).get_repository(main_repo_name())
 
     sensor_name = "always_no_config_sensor_with_tags_and_metadata"
-    external_sensor = external_repository.get_external_sensor(sensor_name)
+    external_sensor = external_repository.get_sensor(sensor_name)
     sensor_selector = infer_sensor_selector(graphql_context, sensor_name)
 
     result = execute_dagster_graphql(
@@ -1191,7 +1191,7 @@ def test_sensor_next_ticks(graphql_context: WorkspaceRequestContext):
     assert not next_tick
 
     error_sensor_name = "always_error_sensor"
-    external_error_sensor = external_repository.get_external_sensor(error_sensor_name)
+    external_error_sensor = external_repository.get_sensor(error_sensor_name)
     error_sensor_selector = infer_sensor_selector(graphql_context, error_sensor_name)
 
     # test default sensor with no tick
@@ -1262,7 +1262,7 @@ def test_sensor_tick_range(graphql_context: WorkspaceRequestContext):
     ).get_repository(main_repo_name())
 
     sensor_name = "always_no_config_sensor_with_tags_and_metadata"
-    external_sensor = external_repository.get_external_sensor(sensor_name)
+    external_sensor = external_repository.get_sensor(sensor_name)
     sensor_selector = infer_sensor_selector(graphql_context, sensor_name)
 
     # test with no job state
@@ -1402,7 +1402,7 @@ def test_sensor_ticks_filtered(graphql_context: WorkspaceRequestContext):
         "repositoryName": main_repo_name(),
     }
     sensor_name = "always_no_config_sensor_with_tags_and_metadata"
-    external_sensor = external_repository.get_external_sensor(sensor_name)
+    external_sensor = external_repository.get_sensor(sensor_name)
     sensor_selector = infer_sensor_selector(graphql_context, sensor_name)
 
     # turn the sensor on
@@ -1585,7 +1585,7 @@ def test_sensor_tick_logs(graphql_context: WorkspaceRequestContext):
     ).get_repository(main_repo_name())
 
     sensor_name = "logging_sensor"
-    external_sensor = external_repository.get_external_sensor(sensor_name)
+    external_sensor = external_repository.get_sensor(sensor_name)
     sensor_selector = infer_sensor_selector(graphql_context, sensor_name)
 
     # turn the sensor on
@@ -1619,7 +1619,7 @@ def test_sensor_dynamic_partitions_request_results(graphql_context: WorkspaceReq
     ).get_repository(main_repo_name())
 
     sensor_name = "dynamic_partition_requesting_sensor"
-    external_sensor = external_repository.get_external_sensor(sensor_name)
+    external_sensor = external_repository.get_sensor(sensor_name)
     sensor_selector = infer_sensor_selector(graphql_context, sensor_name)
 
     instance.add_dynamic_partitions("foo", ["existent_key", "old_key"])

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sync_run_launcher.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sync_run_launcher.py
@@ -32,7 +32,7 @@ def test_sync_run_launcher_run():
         with get_main_workspace(instance) as workspace:
             location = workspace.get_code_location(main_repo_location_name())
             external_repo = location.get_repository(main_repo_name())
-            external_pipeline = external_repo.get_full_external_job("noop_job")
+            external_pipeline = external_repo.get_full_job("noop_job")
 
             run = create_run_for_test(
                 instance=instance,

--- a/python_modules/dagster-test/dagster_test/test_project/__init__.py
+++ b/python_modules/dagster-test/dagster_test/test_project/__init__.py
@@ -143,7 +143,7 @@ class ReOriginatedExternalJobForTest(RemoteJob):
         self._container_context = container_context
         self._filename = filename or "repo.py"
         super(ReOriginatedExternalJobForTest, self).__init__(
-            external_job.external_job_data,
+            external_job.job_data_snap,
             external_job.repository_handle,
         )
 
@@ -198,7 +198,7 @@ class ReOriginatedExternalScheduleForTest(RemoteSchedule):
     ):
         self._container_image = container_image
         super(ReOriginatedExternalScheduleForTest, self).__init__(
-            external_schedule._external_schedule_data,  # noqa: SLF001
+            external_schedule._schedule_snap,  # noqa: SLF001
             external_schedule.handle.repository_handle,
         )
 
@@ -253,7 +253,7 @@ def get_test_project_external_job_hierarchy(
     with get_test_project_workspace(instance, container_image, filename) as workspace:
         location = workspace.get_code_location(workspace.code_location_names[0])
         repo = location.get_repository("demo_execution_repo")
-        job = repo.get_full_external_job(job_name)
+        job = repo.get_full_job(job_name)
         yield workspace, location, repo, job
 
 
@@ -284,7 +284,7 @@ def get_test_project_external_schedule(
     with get_test_project_external_repo(
         instance, container_image=container_image, filename=filename
     ) as (_, repo):
-        yield repo.get_external_schedule(schedule_name)
+        yield repo.get_schedule(schedule_name)
 
 
 def get_test_project_docker_image():

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -95,7 +95,7 @@ def execute_list_command(cli_args, print_fn):
             print_fn(title)
             print_fn("*" * len(title))
             first = True
-            for job in external_repository.get_all_external_jobs():
+            for job in external_repository.get_all_jobs():
                 job_title = f"Job: {job.name}"
 
                 if not first:
@@ -631,7 +631,7 @@ def _execute_backfill_command_at_location(
     job_partition_set = next(
         (
             external_partition_set
-            for external_partition_set in external_repo.get_external_partition_sets()
+            for external_partition_set in external_repo.get_partition_sets()
             if external_partition_set.job_name == external_job.name
         ),
         None,

--- a/python_modules/dagster/dagster/_cli/schedule.py
+++ b/python_modules/dagster/dagster/_cli/schedule.py
@@ -29,7 +29,7 @@ def schedule_cli():
 def print_changes(external_repository, instance, print_fn=print, preview=False):
     debug_info = instance.scheduler_debug_info()
     errors = debug_info.errors
-    external_schedules = external_repository.get_external_schedules()
+    external_schedules = external_repository.get_schedules()
     schedule_states = instance.all_instigator_state(
         external_repository.get_remote_origin_id(),
         external_repository.selector_id,
@@ -115,7 +115,7 @@ def check_repo_and_scheduler(repository: RemoteRepository, instance: DagsterInst
 
     repository_name = repository.name
 
-    if not repository.get_external_schedules():
+    if not repository.get_schedules():
         raise click.UsageError(f"There are no schedules defined for repository {repository_name}.")
 
     if not os.getenv("DAGSTER_HOME"):
@@ -175,7 +175,7 @@ def execute_list_command(running_filter, stopped_filter, name_filter, cli_args, 
                 print_fn(title)
                 print_fn("*" * len(title))
 
-            repo_schedules = external_repo.get_external_schedules()
+            repo_schedules = external_repo.get_schedules()
             stored_schedules_by_origin_id = {
                 stored_schedule_state.instigator_origin_id: stored_schedule_state
                 for stored_schedule_state in instance.all_instigator_state(
@@ -246,7 +246,7 @@ def execute_start_command(schedule_name, all_flag, cli_args, print_fn):
             repository_name = external_repo.name
 
             if all_flag:
-                for external_schedule in external_repo.get_external_schedules():
+                for external_schedule in external_repo.get_schedules():
                     try:
                         instance.start_schedule(external_schedule)
                     except DagsterInvariantViolationError as ex:
@@ -255,7 +255,7 @@ def execute_start_command(schedule_name, all_flag, cli_args, print_fn):
                 print_fn(f"Started all schedules for repository {repository_name}")
             else:
                 try:
-                    instance.start_schedule(external_repo.get_external_schedule(schedule_name))
+                    instance.start_schedule(external_repo.get_schedule(schedule_name))
                 except DagsterInvariantViolationError as ex:
                     raise click.UsageError(ex)
 
@@ -278,7 +278,7 @@ def execute_stop_command(schedule_name, cli_args, print_fn, instance=None):
             check_repo_and_scheduler(external_repo, instance)
 
             try:
-                external_schedule = external_repo.get_external_schedule(schedule_name)
+                external_schedule = external_repo.get_schedule(schedule_name)
                 instance.stop_schedule(
                     external_schedule.get_remote_origin_id(),
                     external_schedule.selector_id,
@@ -321,7 +321,7 @@ def execute_logs_command(schedule_name, cli_args, print_fn, instance=None):
 
             logs_path = os.path.join(
                 instance.logs_path_for_schedule(
-                    external_repo.get_external_schedule(schedule_name).get_remote_origin_id()
+                    external_repo.get_schedule(schedule_name).get_remote_origin_id()
                 )
             )
 
@@ -387,7 +387,7 @@ def execute_restart_command(schedule_name, all_running_flag, cli_args, print_fn)
                 ):
                     if schedule_state.status == InstigatorStatus.RUNNING:
                         try:
-                            external_schedule = external_repo.get_external_schedule(
+                            external_schedule = external_repo.get_schedule(
                                 schedule_state.instigator_name
                             )
                             instance.stop_schedule(
@@ -401,7 +401,7 @@ def execute_restart_command(schedule_name, all_running_flag, cli_args, print_fn)
 
                 print_fn(f"Restarted all running schedules for repository {repository_name}")
             else:
-                external_schedule = external_repo.get_external_schedule(schedule_name)
+                external_schedule = external_repo.get_schedule(schedule_name)
                 schedule_state = instance.get_instigator_state(
                     external_schedule.get_remote_origin_id(),
                     external_schedule.selector_id,

--- a/python_modules/dagster/dagster/_cli/sensor.py
+++ b/python_modules/dagster/dagster/_cli/sensor.py
@@ -36,7 +36,7 @@ def print_changes(external_repository, instance, print_fn=print, preview=False):
     sensor_states = instance.all_instigator_state(
         external_repository.get_origin_id(), external_repository.selector_id, InstigatorType.SENSOR
     )
-    external_sensors = external_repository.get_external_sensors()
+    external_sensors = external_repository.get_sensors()
     external_sensors_dict = {s.get_remote_origin_id(): s for s in external_sensors}
     sensor_states_dict = {s.instigator_origin_id: s for s in sensor_states}
 
@@ -82,7 +82,7 @@ def check_repo_and_scheduler(repository: RemoteRepository, instance: DagsterInst
 
     repository_name = repository.name
 
-    if not repository.get_external_sensors():
+    if not repository.get_sensors():
         raise click.UsageError(f"There are no sensors defined for repository {repository_name}.")
 
     if not os.getenv("DAGSTER_HOME"):
@@ -136,7 +136,7 @@ def execute_list_command(running_filter, stopped_filter, name_filter, cli_args, 
                 print_fn(title)
                 print_fn("*" * len(title))
 
-            repo_sensors = external_repo.get_external_sensors()
+            repo_sensors = external_repo.get_sensors()
             stored_sensors_by_origin_id = {
                 stored_sensor_state.instigator_origin_id: stored_sensor_state
                 for stored_sensor_state in instance.all_instigator_state(
@@ -192,14 +192,14 @@ def execute_start_command(sensor_name, all_flag, cli_args, print_fn):
 
             if all_flag:
                 try:
-                    for external_sensor in external_repo.get_external_sensors():
+                    for external_sensor in external_repo.get_sensors():
                         instance.start_sensor(external_sensor)
                     print_fn(f"Started all sensors for repository {repository_name}")
                 except DagsterInvariantViolationError as ex:
                     raise click.UsageError(ex)
             else:
                 try:
-                    external_sensor = external_repo.get_external_sensor(sensor_name)
+                    external_sensor = external_repo.get_sensor(sensor_name)
                     instance.start_sensor(external_sensor)
                 except DagsterInvariantViolationError as ex:
                     raise click.UsageError(ex)
@@ -222,7 +222,7 @@ def execute_stop_command(sensor_name, cli_args, print_fn):
         ) as external_repo:
             check_repo_and_scheduler(external_repo, instance)
             try:
-                external_sensor = external_repo.get_external_sensor(sensor_name)
+                external_sensor = external_repo.get_sensor(sensor_name)
                 instance.stop_sensor(
                     external_sensor.get_remote_origin_id(),
                     external_sensor.selector_id,
@@ -273,7 +273,7 @@ def execute_preview_command(
                     code_location, cli_args.get("repository")
                 )
                 check_repo_and_scheduler(external_repo, instance)
-                external_sensor = external_repo.get_external_sensor(sensor_name)
+                external_sensor = external_repo.get_sensor(sensor_name)
                 try:
                     sensor_runtime_data = code_location.get_external_sensor_execution_data(
                         instance,
@@ -345,7 +345,7 @@ def execute_cursor_command(sensor_name, cli_args, print_fn):
                 code_location, cli_args.get("repository")
             )
             check_repo_and_scheduler(external_repo, instance)
-            external_sensor = external_repo.get_external_sensor(sensor_name)
+            external_sensor = external_repo.get_sensor(sensor_name)
             job_state = instance.get_instigator_state(
                 external_sensor.get_remote_origin_id(), external_sensor.selector_id
             )

--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -768,7 +768,7 @@ def get_external_job_from_external_repo(
     check.inst_param(external_repo, "external_repo", RemoteRepository)
     check.opt_str_param(provided_name, "provided_name")
 
-    external_jobs = {ep.name: ep for ep in (external_repo.get_all_external_jobs())}
+    external_jobs = {ep.name: ep for ep in (external_repo.get_all_jobs())}
 
     check.invariant(external_jobs)
 

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -150,11 +150,11 @@ def _get_partition_set(
 
     partition_set_name = origin.partition_set_name
     external_repo = code_location.get_repository(repo_name)
-    if not external_repo.has_external_partition_set(partition_set_name):
+    if not external_repo.has_partition_set(partition_set_name):
         raise DagsterBackfillFailedError(
             f"Could not find partition set {partition_set_name} in repository {repo_name}. "
         )
-    return external_repo.get_external_partition_set(partition_set_name)
+    return external_repo.get_partition_set(partition_set_name)
 
 
 def _subdivide_partition_key_range(
@@ -305,7 +305,7 @@ def submit_backfill_runs(
     )
     external_repo = code_location.get_repository(repo_name)
     partition_set_name = origin.partition_set_name
-    external_partition_set = external_repo.get_external_partition_set(partition_set_name)
+    external_partition_set = external_repo.get_partition_set(partition_set_name)
 
     if backfill_job.asset_selection:
         # need to make another call to the user code location to properly subset
@@ -319,7 +319,7 @@ def submit_backfill_runs(
         )
         external_job = code_location.get_external_job(pipeline_selector)
     else:
-        external_job = external_repo.get_full_external_job(external_partition_set.job_name)
+        external_job = external_repo.get_full_job(external_partition_set.job_name)
 
     partition_data_target = check.is_list(
         [partition_names_or_ranges[0].start]

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -152,9 +152,7 @@ class CodeLocation(AbstractContextManager):
             and not selector.asset_selection
             and not selector.asset_check_selection
         ):
-            return self.get_repository(selector.repository_name).get_full_external_job(
-                selector.job_name
-            )
+            return self.get_repository(selector.repository_name).get_full_job(selector.job_name)
 
         repo_handle = self.get_repository(selector.repository_name).handle
 
@@ -246,8 +244,8 @@ class CodeLocation(AbstractContextManager):
         external_repo = self.get_repository(repository_handle.repository_name)
         partition_set_name = partition_set_snap_name_for_job_name(job_name)
 
-        if external_repo.has_external_partition_set(partition_set_name):
-            external_partition_set = external_repo.get_external_partition_set(partition_set_name)
+        if external_repo.has_partition_set(partition_set_name):
+            external_partition_set = external_repo.get_partition_set(partition_set_name)
 
             # Prefer to return the names without calling out to user code if there's a corresponding
             # partition set that allows it
@@ -888,9 +886,7 @@ class GrpcServerCodeLocation(CodeLocation):
             asset_check_selection=selector.asset_check_selection,
         )
         if subset.external_job_data:
-            full_job = self.get_repository(selector.repository_name).get_full_external_job(
-                selector.job_name
-            )
+            full_job = self.get_repository(selector.repository_name).get_full_job(selector.job_name)
             subset = copy(
                 subset,
                 external_job_data=copy(subset.external_job_data, parent_job=full_job.job_snapshot),

--- a/python_modules/dagster/dagster/_core/telemetry.py
+++ b/python_modules/dagster/dagster/_core/telemetry.py
@@ -464,16 +464,16 @@ def get_stats_from_external_repo(external_repo: "RemoteRepository") -> Mapping[s
         MultiPartitionsSnap,
     )
 
-    num_pipelines_in_repo = len(external_repo.get_all_external_jobs())
-    num_schedules_in_repo = len(external_repo.get_external_schedules())
-    num_sensors_in_repo = len(external_repo.get_external_sensors())
+    num_pipelines_in_repo = len(external_repo.get_all_jobs())
+    num_schedules_in_repo = len(external_repo.get_schedules())
+    num_sensors_in_repo = len(external_repo.get_sensors())
     asset_node_snaps = external_repo.get_asset_node_snaps()
     num_assets_in_repo = len(asset_node_snaps)
-    external_resources = external_repo.get_external_resources()
+    external_resources = external_repo.get_resources()
 
-    num_checks = len(external_repo.external_repository_data.asset_check_nodes or [])
+    num_checks = len(external_repo.repository_snap.asset_check_nodes or [])
     num_assets_with_checks = len(
-        {c.asset_key for c in external_repo.external_repository_data.asset_check_nodes or []}
+        {c.asset_key for c in external_repo.repository_snap.asset_check_nodes or []}
     )
 
     num_partitioned_assets_in_repo = 0
@@ -528,7 +528,7 @@ def get_stats_from_external_repo(external_repo: "RemoteRepository") -> Mapping[s
 
     num_asset_reconciliation_sensors_in_repo = sum(
         1
-        for external_sensor in external_repo.get_external_sensors()
+        for external_sensor in external_repo.get_sensors()
         if external_sensor.name == "asset_reconciliation_sensor"
     )
 

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -239,13 +239,13 @@ class BaseWorkspaceRequestContext(LoadingContext):
         loc = self.get_code_location(selector.location_name)
         return loc.has_repository(selector.repository_name) and loc.get_repository(
             selector.repository_name
-        ).has_external_job(selector.job_name)
+        ).has_job(selector.job_name)
 
     def get_full_external_job(self, selector: Union[JobSubsetSelector, JobSelector]) -> RemoteJob:
         return (
             self.get_code_location(selector.location_name)
             .get_repository(selector.repository_name)
-            .get_full_external_job(selector.job_name)
+            .get_full_job(selector.job_name)
         )
 
     def get_external_execution_plan(

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -483,7 +483,7 @@ class AssetDaemon(DagsterDaemon):
                 code_location = location_entry.code_location
                 if code_location:
                     for repo in code_location.get_repositories().values():
-                        for sensor in repo.get_external_sensors():
+                        for sensor in repo.get_sensors():
                             if sensor.sensor_type.is_handled_by_asset_daemon:
                                 eligible_sensors_and_repos.append((sensor, repo))
 

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -133,7 +133,7 @@ def retry_run(
 
     external_repo = code_location.get_repository(repo_name)
 
-    if not external_repo.has_external_job(failed_run.job_name):
+    if not external_repo.has_job(failed_run.job_name):
         instance.report_engine_event(
             f"Could not find job {failed_run.job_name} in repository {repo_name}, unable"
             " to retry the run. It was likely renamed or deleted.",

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -385,7 +385,7 @@ def execute_sensor_iteration(
         code_location = location_entry.code_location
         if code_location:
             for repo in code_location.get_repositories().values():
-                for sensor in repo.get_external_sensors():
+                for sensor in repo.get_sensors():
                     if sensor.sensor_type.is_handled_by_asset_daemon:
                         continue
 

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -288,7 +288,7 @@ def launch_scheduled_runs(
         code_location = location_entry.code_location
         if code_location:
             for repo in code_location.get_repositories().values():
-                for schedule in repo.get_external_schedules():
+                for schedule in repo.get_schedules():
                     selector_id = schedule.selector_id
                     if schedule.get_current_instigator_state(
                         all_schedule_states.get(selector_id)

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_job.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_job.py
@@ -63,7 +63,7 @@ def test_job_with_valid_subset_snapshot_api_grpc(instance):
         assert external_job_subset_result.external_job_data.name == "foo"
         assert (
             external_job_subset_result.external_job_data.parent_job
-            == code_location.get_repository("bar_repo").get_full_external_job("foo").job_snapshot
+            == code_location.get_repository("bar_repo").get_full_job("foo").job_snapshot
         )
 
 

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -153,7 +153,7 @@ def test_defer_snapshots(instance: DagsterInstance):
             instance=instance,
             ref_to_data_fn=_ref_to_data,
         )
-        jobs = repo.get_all_external_jobs()
+        jobs = repo.get_all_jobs()
         assert len(jobs) == 6
         assert _state.get("cnt", 0) == 0
 
@@ -177,6 +177,6 @@ def test_defer_snapshots(instance: DagsterInstance):
         assert _state.get("cnt", 0) == 1
 
         # refetching job should share fetched data
-        job = repo.get_all_external_jobs()[0]
+        job = repo.get_all_jobs()[0]
         _ = job.job_snapshot
         assert _state.get("cnt", 0) == 1

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -910,7 +910,7 @@ def create_repo_run(instance):
     ) as workspace_process_context:
         context = workspace_process_context.create_request_context()
         repo = context.code_locations[0].get_repository("my_repo")
-        external_job = repo.get_full_external_job("my_job")
+        external_job = repo.get_full_job("my_job")
         run = create_run_for_test(
             instance,
             job_name="my_job",

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_schedule_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_schedule_commands.py
@@ -191,7 +191,7 @@ def test_schedules_logs(gen_schedule_args):
 
 def test_check_repo_and_scheduler_no_external_schedules():
     repository = mock.MagicMock(spec=RemoteRepository)
-    repository.get_external_schedules.return_value = []
+    repository.get_schedules.return_value = []
     instance = mock.MagicMock(spec=DagsterInstance)
     with pytest.raises(click.UsageError, match="There are no schedules defined for repository"):
         check_repo_and_scheduler(repository, instance)
@@ -200,7 +200,7 @@ def test_check_repo_and_scheduler_no_external_schedules():
 def test_check_repo_and_scheduler_dagster_home_not_set():
     with environ({"DAGSTER_HOME": ""}):
         repository = mock.MagicMock(spec=RemoteRepository)
-        repository.get_external_schedules.return_value = [mock.MagicMock()]
+        repository.get_schedules.return_value = [mock.MagicMock()]
         instance = mock.MagicMock(spec=DagsterInstance)
 
         with pytest.raises(

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_sensor_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_sensor_commands.py
@@ -89,7 +89,7 @@ def test_sensors_start_all(gen_sensor_args):
 
 def test_check_repo_and_sensorr_no_external_sensors():
     repository = mock.MagicMock(spec=RemoteRepository)
-    repository.get_external_sensors.return_value = []
+    repository.get_sensors.return_value = []
     instance = mock.MagicMock(spec=DagsterInstance)
     with pytest.raises(click.UsageError, match="There are no sensors defined for repository"):
         check_repo_and_scheduler(repository, instance)
@@ -98,7 +98,7 @@ def test_check_repo_and_sensorr_no_external_sensors():
 def test_check_repo_and_scheduler_dagster_home_not_set():
     with environ({"DAGSTER_HOME": ""}):
         repository = mock.MagicMock(spec=RemoteRepository)
-        repository.get_external_sensors.return_value = [mock.MagicMock()]
+        repository.get_sensors.return_value = [mock.MagicMock()]
         instance = mock.MagicMock(spec=DagsterInstance)
 
         with pytest.raises(

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_custom_repository_data.py
@@ -96,10 +96,10 @@ def test_repository_data_can_reload_without_restarting(
     repo = code_location.get_repository("bar_repo")
     # get_all_jobs called on server init, then on repository load, so starts at 2
     # this is a janky test
-    assert repo.has_external_job("foo_2")
-    assert not repo.has_external_job("foo_1")
+    assert repo.has_job("foo_2")
+    assert not repo.has_job("foo_1")
 
-    external_job = repo.get_full_external_job("foo_2")
+    external_job = repo.get_full_job("foo_2")
     assert external_job.has_node_invocation("do_something_2")
 
     # Reloading the location changes the pipeline without needing
@@ -110,10 +110,10 @@ def test_repository_data_can_reload_without_restarting(
     repo = code_location.get_repository("bar_repo")
 
     # get_all_jobs is called 4 times on reload, so now at 6
-    assert repo.has_external_job("foo_6")
-    assert not repo.has_external_job("foo_5")
-    assert not repo.has_external_job("foo_4")
-    assert not repo.has_external_job("foo_3")
+    assert repo.has_job("foo_6")
+    assert not repo.has_job("foo_5")
+    assert not repo.has_job("foo_4")
+    assert not repo.has_job("foo_3")
 
-    external_job = repo.get_full_external_job("foo_6")
+    external_job = repo.get_full_job("foo_6")
     assert external_job.has_node_invocation("do_something_6")

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -298,7 +298,7 @@ def test_submit_run():
             external_job = (
                 workspace.get_code_location("bar_code_location")
                 .get_repository("bar_repo")
-                .get_full_external_job("foo")
+                .get_full_job("foo")
             )
 
             run = create_run_for_test(

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
@@ -74,7 +74,7 @@ def code_location_fixture(workspace):
 
 @pytest.fixture(name="external_job", scope="module")
 def external_job_fixture(code_location):
-    return code_location.get_repository("repo").get_full_external_job("conditional_fail_job")
+    return code_location.get_repository("repo").get_full_job("conditional_fail_job")
 
 
 @pytest.fixture(name="failed_run", scope="module")

--- a/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_default_run_coordinator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_default_run_coordinator.py
@@ -48,7 +48,7 @@ def test_submit_run(instance: DagsterInstance, coodinator: DefaultRunCoordinator
         external_job = (
             workspace.get_code_location("bar_code_location")
             .get_repository("bar_repo")
-            .get_full_external_job("foo")
+            .get_full_job("foo")
         )
 
         run = _create_run(instance, external_job)
@@ -67,7 +67,7 @@ def test_submit_run_checks_status(instance: DagsterInstance, coodinator: Default
         external_job = (
             workspace.get_code_location("bar_code_location")
             .get_repository("bar_repo")
-            .get_full_external_job("foo")
+            .get_full_job("foo")
         )
 
         run = _create_run(instance, external_job, status=DagsterRunStatus.STARTED)

--- a/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_queued_run_coordinator.py
+++ b/python_modules/dagster/dagster_tests/core_tests/run_coordinator_tests/test_queued_run_coordinator.py
@@ -54,7 +54,7 @@ class TestQueuedRunCoordinator:
     @pytest.fixture(name="external_pipeline")
     def external_job_fixture(self, workspace: WorkspaceRequestContext) -> RemoteJob:
         location = workspace.get_code_location("bar_code_location")
-        return location.get_repository("bar_repo").get_full_external_job("foo")
+        return location.get_repository("bar_repo").get_full_job("foo")
 
     def create_run_for_test(
         self, instance: DagsterInstance, external_pipeline: RemoteJob, **kwargs: object

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_active_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_active_data.py
@@ -86,7 +86,7 @@ def test_external_repo_shared_index(snapshot_mock):
             def _fetch_snap_id():
                 location = workspace.code_locations[0]
                 ex_repo = next(iter(location.get_repositories().values()))
-                return ex_repo.get_all_external_jobs()[0].identifying_job_snapshot_id
+                return ex_repo.get_all_jobs()[0].identifying_job_snapshot_id
 
             _fetch_snap_id()
             assert snapshot_mock.call_count == 1
@@ -108,7 +108,7 @@ def test_external_repo_shared_index_threaded(snapshot_mock):
             def _fetch_snap_id():
                 location = workspace.code_locations[0]
                 ex_repo = next(iter(location.get_repositories().values()))
-                return ex_repo.get_all_external_jobs()[0].identifying_job_snapshot_id
+                return ex_repo.get_all_jobs()[0].identifying_job_snapshot_id
 
             with ThreadPoolExecutor() as executor:
                 wait([executor.submit(_fetch_snap_id) for _ in range(100)])

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_snap_to_yaml.py
@@ -83,7 +83,7 @@ def test_print_root(
     instance,
 ) -> None:
     external_repository = _external_repository_for_function(instance, trivial_job_defs)
-    external_a_job: RemoteJob = external_repository.get_full_external_job("a_job")
+    external_a_job: RemoteJob = external_repository.get_full_job("a_job")
     root_config_key = external_a_job.root_config_key
     assert root_config_key
     root_type = external_a_job.config_schema_snapshot.get_config_snap(root_config_key)
@@ -114,7 +114,7 @@ def test_print_root_op_config(
     instance,
 ) -> None:
     external_repository = _external_repository_for_function(instance, job_def_with_config)
-    external_a_job: RemoteJob = external_repository.get_full_external_job("a_job")
+    external_a_job: RemoteJob = external_repository.get_full_job("a_job")
     root_config_key = external_a_job.root_config_key
     assert root_config_key
     root_type = external_a_job.config_schema_snapshot.get_config_snap(root_config_key)
@@ -149,7 +149,7 @@ def job_def_with_complex_config():
 
 def test_print_root_complex_op_config(instance) -> None:
     external_repository = _external_repository_for_function(instance, job_def_with_complex_config)
-    external_a_job: RemoteJob = external_repository.get_full_external_job("a_job")
+    external_a_job: RemoteJob = external_repository.get_full_job("a_job")
     root_config_key = external_a_job.root_config_key
     assert root_config_key
     root_type = external_a_job.config_schema_snapshot.get_config_snap(root_config_key)

--- a/python_modules/dagster/dagster_tests/core_tests/test_job_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_job_execution.py
@@ -179,7 +179,7 @@ def test_external_diamond_toposort():
             working_directory=None,
         ).create_single_location(instance) as repo_location:
             external_repo = next(iter(repo_location.get_repositories().values()))
-            external_job = next(iter(external_repo.get_all_external_jobs()))
+            external_job = next(iter(external_repo.get_all_jobs()))
             assert external_job.node_names_in_topological_order == [
                 "A_source",
                 "A",

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_asset_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_asset_sensor_run.py
@@ -26,7 +26,7 @@ def test_monitor_source_asset_sensor(executor):
     ):
         asset_sensor_repo = repos["asset_sensor_repo"]
         with freeze_time(freeze_datetime):
-            the_sensor = asset_sensor_repo.get_external_sensor("monitor_source_asset_sensor")
+            the_sensor = asset_sensor_repo.get_sensor("monitor_source_asset_sensor")
             instance.start_sensor(the_sensor)
 
             evaluate_sensors(workspace_ctx, executor)

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_pythonic_resources.py
@@ -434,7 +434,7 @@ def test_resources(
             the_job.execute_in_process(instance=instance)
             base_run_count = 1
 
-        external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
+        external_sensor = external_repo_struct_resources.get_sensor(sensor_name)
         instance.add_instigator_state(
             InstigatorState(
                 external_sensor.get_remote_origin(),
@@ -494,7 +494,7 @@ def test_resources_freshness_policy_sensor(
     original_time = freeze_datetime
 
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
+        external_sensor = external_repo_struct_resources.get_sensor(sensor_name)
         instance.add_instigator_state(
             InstigatorState(
                 external_sensor.get_remote_origin(),
@@ -566,7 +566,7 @@ def test_resources_run_status_sensor(
     original_time = freeze_datetime
 
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
+        external_sensor = external_repo_struct_resources.get_sensor(sensor_name)
         instance.add_instigator_state(
             InstigatorState(
                 external_sensor.get_remote_origin(),
@@ -644,7 +644,7 @@ def test_resources_run_failure_sensor(
     original_time = freeze_datetime
 
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo_struct_resources.get_external_sensor(sensor_name)
+        external_sensor = external_repo_struct_resources.get_sensor(sensor_name)
         instance.add_instigator_state(
             InstigatorState(
                 external_sensor.get_remote_origin(),

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -135,10 +135,10 @@ def test_run_status_sensor(
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
-        success_sensor = external_repo.get_external_sensor("my_job_success_sensor")
+        success_sensor = external_repo.get_sensor("my_job_success_sensor")
         instance.start_sensor(success_sensor)
 
-        started_sensor = external_repo.get_external_sensor("my_job_started_sensor")
+        started_sensor = external_repo.get_sensor("my_job_started_sensor")
         instance.start_sensor(started_sensor)
 
         state = instance.get_instigator_state(
@@ -166,7 +166,7 @@ def test_run_status_sensor(
         time.sleep(1)
 
     with freeze_time(freeze_datetime):
-        external_job = external_repo.get_full_external_job("failure_job")
+        external_job = external_repo.get_full_job("failure_job")
         run = instance.create_run_for_job(
             failure_job,
             external_job_origin=external_job.get_remote_origin(),
@@ -205,7 +205,7 @@ def test_run_status_sensor(
         )
 
     with freeze_time(freeze_datetime):
-        external_job = external_repo.get_full_external_job("foo_job")
+        external_job = external_repo.get_full_job("foo_job")
         run = instance.create_run_for_job(
             foo_job,
             external_job_origin=external_job.get_remote_origin(),
@@ -257,7 +257,7 @@ def test_run_failure_sensor(
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
-        failure_sensor = external_repo.get_external_sensor("my_run_failure_sensor")
+        failure_sensor = external_repo.get_sensor("my_run_failure_sensor")
         instance.start_sensor(failure_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -277,7 +277,7 @@ def test_run_failure_sensor(
         time.sleep(1)
 
     with freeze_time(freeze_datetime):
-        external_job = external_repo.get_full_external_job("failure_job")
+        external_job = external_repo.get_full_job("failure_job")
         run = instance.create_run_for_job(
             failure_job,
             external_job_origin=external_job.get_remote_origin(),
@@ -313,9 +313,7 @@ def test_run_failure_sensor_that_fails(
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
-        failure_sensor = external_repo.get_external_sensor(
-            "my_run_failure_sensor_that_itself_fails"
-        )
+        failure_sensor = external_repo.get_sensor("my_run_failure_sensor_that_itself_fails")
         instance.start_sensor(failure_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -335,7 +333,7 @@ def test_run_failure_sensor_that_fails(
         time.sleep(1)
 
     with freeze_time(freeze_datetime):
-        external_job = external_repo.get_full_external_job("failure_job")
+        external_job = external_repo.get_full_job("failure_job")
         run = instance.create_run_for_job(
             failure_job,
             external_job_origin=external_job.get_remote_origin(),
@@ -389,7 +387,7 @@ def test_run_failure_sensor_filtered(
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
-        failure_sensor = external_repo.get_external_sensor("my_run_failure_sensor_filtered")
+        failure_sensor = external_repo.get_sensor("my_run_failure_sensor_filtered")
         instance.start_sensor(failure_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -409,7 +407,7 @@ def test_run_failure_sensor_filtered(
         time.sleep(1)
 
     with freeze_time(freeze_datetime):
-        external_job = external_repo.get_full_external_job("failure_job_2")
+        external_job = external_repo.get_full_job("failure_job_2")
         run = instance.create_run_for_job(
             failure_job_2,
             external_job_origin=external_job.get_remote_origin(),
@@ -440,7 +438,7 @@ def test_run_failure_sensor_filtered(
         time.sleep(1)
 
     with freeze_time(freeze_datetime):
-        external_job = external_repo.get_full_external_job("failure_job")
+        external_job = external_repo.get_full_job("failure_job")
         run = instance.create_run_for_job(
             failure_job,
             external_job_origin=external_job.get_remote_origin(),
@@ -485,7 +483,7 @@ def test_run_failure_sensor_overfetch(
         ) as workspace_context:
             freeze_datetime = get_current_datetime()
             with freeze_time(freeze_datetime):
-                failure_sensor = external_repo.get_external_sensor("my_run_failure_sensor_filtered")
+                failure_sensor = external_repo.get_sensor("my_run_failure_sensor_filtered")
                 instance.start_sensor(failure_sensor)
 
                 evaluate_sensors(workspace_context, executor)
@@ -510,8 +508,8 @@ def test_run_failure_sensor_overfetch(
 
                 # interleave matching jobs and jobs that do not match
                 for _i in range(4):
-                    external_job = external_repo.get_full_external_job("failure_job")
-                    external_job_2 = external_repo.get_full_external_job("failure_job_2")
+                    external_job = external_repo.get_full_job("failure_job")
+                    external_job_2 = external_repo.get_full_job("failure_job_2")
 
                     run = instance.create_run_for_job(
                         failure_job_2,
@@ -654,7 +652,7 @@ def test_run_status_sensor_interleave(storage_config_fn, executor: Optional[Thre
         ):
             # start sensor
             with freeze_time(freeze_datetime):
-                failure_sensor = external_repo.get_external_sensor("my_run_failure_sensor")
+                failure_sensor = external_repo.get_sensor("my_run_failure_sensor")
                 instance.start_sensor(failure_sensor)
 
                 evaluate_sensors(workspace_context, executor)
@@ -674,7 +672,7 @@ def test_run_status_sensor_interleave(storage_config_fn, executor: Optional[Thre
                 time.sleep(1)
 
             with freeze_time(freeze_datetime):
-                external_job = external_repo.get_full_external_job("hanging_job")
+                external_job = external_repo.get_full_job("hanging_job")
                 # start run 1
                 run1 = instance.create_run_for_job(
                     hanging_job,
@@ -754,7 +752,7 @@ def test_run_failure_sensor_empty_run_records(
             external_repo,
         ):
             with freeze_time(freeze_datetime):
-                failure_sensor = external_repo.get_external_sensor("my_run_failure_sensor")
+                failure_sensor = external_repo.get_sensor("my_run_failure_sensor")
                 instance.start_sensor(failure_sensor)
 
                 evaluate_sensors(workspace_context, executor)
@@ -847,7 +845,7 @@ def test_all_code_locations_run_status_sensor(executor: Optional[ThreadPoolExecu
 
         # This remainder is largely copied from test_cross_repo_run_status_sensor
         with freeze_time(freeze_datetime):
-            my_sensor = sensor_repo.get_external_sensor("all_code_locations_run_status_sensor")
+            my_sensor = sensor_repo.get_sensor("all_code_locations_run_status_sensor")
             instance.start_sensor(my_sensor)
 
             evaluate_sensors(workspace_context, executor)
@@ -865,7 +863,7 @@ def test_all_code_locations_run_status_sensor(executor: Optional[ThreadPoolExecu
             time.sleep(1)
 
         with freeze_time(freeze_datetime):
-            external_another_job = job_repo.get_full_external_job("another_success_job")
+            external_another_job = job_repo.get_full_job("another_success_job")
 
             # this unfortunate API (create_run_for_job) requires the importation
             # of the in-memory job object even though it is dealing mostly with
@@ -934,7 +932,7 @@ def test_all_code_location_run_failure_sensor(executor: Optional[ThreadPoolExecu
 
         # This remainder is largely copied from test_cross_repo_run_status_sensor
         with freeze_time(freeze_datetime):
-            my_sensor = sensor_repo.get_external_sensor("all_code_locations_run_failure_sensor")
+            my_sensor = sensor_repo.get_sensor("all_code_locations_run_failure_sensor")
             instance.start_sensor(my_sensor)
 
             evaluate_sensors(workspace_context, executor)
@@ -952,7 +950,7 @@ def test_all_code_location_run_failure_sensor(executor: Optional[ThreadPoolExecu
             time.sleep(1)
 
         with freeze_time(freeze_datetime):
-            external_another_job = job_repo.get_full_external_job("another_failure_job")
+            external_another_job = job_repo.get_full_job("another_failure_job")
 
             # this unfortunate API (create_run_for_job) requires the importation
             # of the in-memory job object even though it is dealing mostly with
@@ -1023,7 +1021,7 @@ def test_cross_code_location_run_status_sensor(executor: Optional[ThreadPoolExec
 
         # This remainder is largely copied from test_cross_repo_run_status_sensor
         with freeze_time(freeze_datetime):
-            success_sensor = sensor_repo.get_external_sensor("success_sensor")
+            success_sensor = sensor_repo.get_sensor("success_sensor")
             instance.start_sensor(success_sensor)
 
             evaluate_sensors(workspace_context, executor)
@@ -1045,7 +1043,7 @@ def test_cross_code_location_run_status_sensor(executor: Optional[ThreadPoolExec
             time.sleep(1)
 
         with freeze_time(freeze_datetime):
-            external_success_job = job_repo.get_full_external_job("success_job")
+            external_success_job = job_repo.get_full_job("success_job")
 
             # this unfortunate API (create_run_for_job) requires the importation
             # of the in-memory job object even though it is dealing mostly with
@@ -1122,7 +1120,7 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
 
         # This remainder is largely copied from test_cross_repo_run_status_sensor
         with freeze_time(freeze_datetime):
-            success_sensor = sensor_repo.get_external_sensor("success_of_another_job_sensor")
+            success_sensor = sensor_repo.get_sensor("success_of_another_job_sensor")
             instance.start_sensor(success_sensor)
 
             evaluate_sensors(workspace_context, executor)
@@ -1144,7 +1142,7 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
             time.sleep(1)
 
         with freeze_time(freeze_datetime):
-            external_success_job = job_repo.get_full_external_job("success_job")
+            external_success_job = job_repo.get_full_job("success_job")
 
             # this unfortunate API (create_run_for_job) requires the importation
             # of the in-memory job object even though it is dealing mostly with
@@ -1193,7 +1191,7 @@ def test_cross_code_location_job_selector_on_defs_run_status_sensor(
         # now launch the run that is actually being listened to
 
         with freeze_time(freeze_datetime):
-            external_another_success_job = job_repo.get_full_external_job("another_success_job")
+            external_another_success_job = job_repo.get_full_job("another_success_job")
 
             # this unfortunate API (create_run_for_job) requires the importation
             # of the in-memory job object even though it is dealing mostly with
@@ -1269,7 +1267,7 @@ def test_code_location_scoped_run_status_sensor(executor: Optional[ThreadPoolExe
 
         # This remainder is largely copied from test_cross_repo_run_status_sensor
         with freeze_time(freeze_datetime):
-            success_sensor = sensor_repo.get_external_sensor("success_sensor")
+            success_sensor = sensor_repo.get_sensor("success_sensor")
             instance.start_sensor(success_sensor)
 
             evaluate_sensors(workspace_context, executor)
@@ -1291,7 +1289,7 @@ def test_code_location_scoped_run_status_sensor(executor: Optional[ThreadPoolExe
             time.sleep(1)
 
         with freeze_time(freeze_datetime):
-            external_success_job = sensor_repo.get_full_external_job("success_job")
+            external_success_job = sensor_repo.get_full_job("success_job")
 
             # this unfortunate API (create_run_for_job) requires the importation
             # of the in-memory job object even though it is dealing mostly with
@@ -1329,7 +1327,7 @@ def test_code_location_scoped_run_status_sensor(executor: Optional[ThreadPoolExe
             )
 
         with freeze_time(freeze_datetime):
-            external_success_job = dupe_job_repo.get_full_external_job("success_job")
+            external_success_job = dupe_job_repo.get_full_job("success_job")
 
             # this unfortunate API (create_run_for_job) requires the importation
             # of the in-memory job object even though it is dealing mostly with
@@ -1378,7 +1376,7 @@ def test_cross_repo_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
         the_other_repo = repos["the_other_repo"]
 
         with freeze_time(freeze_datetime):
-            cross_repo_sensor = the_repo.get_external_sensor("cross_repo_sensor")
+            cross_repo_sensor = the_repo.get_sensor("cross_repo_sensor")
             instance.start_sensor(cross_repo_sensor)
 
             evaluate_sensors(workspace_context, executor)
@@ -1398,7 +1396,7 @@ def test_cross_repo_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
             time.sleep(1)
 
         with freeze_time(freeze_datetime):
-            external_job = the_other_repo.get_full_external_job("the_job")
+            external_job = the_other_repo.get_full_job("the_job")
             run = instance.create_run_for_job(
                 the_job,
                 external_job_origin=external_job.get_remote_origin(),
@@ -1436,7 +1434,7 @@ def test_cross_repo_job_run_status_sensor(executor: Optional[ThreadPoolExecutor]
         the_other_repo = repos["the_other_repo"]
 
         with freeze_time(freeze_datetime):
-            cross_repo_sensor = the_repo.get_external_sensor("cross_repo_job_sensor")
+            cross_repo_sensor = the_repo.get_sensor("cross_repo_job_sensor")
             instance.start_sensor(cross_repo_sensor)
 
             assert instance.get_runs_count() == 0
@@ -1460,7 +1458,7 @@ def test_cross_repo_job_run_status_sensor(executor: Optional[ThreadPoolExecutor]
             time.sleep(1)
 
         with freeze_time(freeze_datetime):
-            external_job = the_other_repo.get_full_external_job("the_job")
+            external_job = the_other_repo.get_full_job("the_job")
             run = instance.create_run_for_job(
                 the_job,
                 external_job_origin=external_job.get_remote_origin(),
@@ -1521,7 +1519,7 @@ def test_partitioned_job_run_status_sensor(
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
-        success_sensor = external_repo.get_external_sensor("partitioned_pipeline_success_sensor")
+        success_sensor = external_repo.get_sensor("partitioned_pipeline_success_sensor")
         instance.start_sensor(success_sensor)
 
         assert instance.get_runs_count() == 0
@@ -1543,7 +1541,7 @@ def test_partitioned_job_run_status_sensor(
         time.sleep(1)
 
     with freeze_time(freeze_datetime):
-        external_job = external_repo.get_full_external_job("daily_partitioned_job")
+        external_job = external_repo.get_full_job("daily_partitioned_job")
         run = instance.create_run_for_job(
             daily_partitioned_job,
             external_job_origin=external_job.get_remote_origin(),
@@ -1592,7 +1590,7 @@ def test_different_instance_run_status_sensor(executor: Optional[ThreadPoolExecu
             the_other_repo,
         ):
             with freeze_time(freeze_datetime):
-                cross_repo_sensor = the_repo.get_external_sensor("cross_repo_sensor")
+                cross_repo_sensor = the_repo.get_sensor("cross_repo_sensor")
                 instance.start_sensor(cross_repo_sensor)
 
                 evaluate_sensors(workspace_context, executor)
@@ -1612,7 +1610,7 @@ def test_different_instance_run_status_sensor(executor: Optional[ThreadPoolExecu
                 time.sleep(1)
 
             with freeze_time(freeze_datetime):
-                external_job = the_other_repo.get_full_external_job("the_job")
+                external_job = the_other_repo.get_full_job("the_job")
                 run = the_other_instance.create_run_for_job(
                     the_job,
                     external_job_origin=external_job.get_remote_origin(),
@@ -1653,7 +1651,7 @@ def test_instance_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
         the_other_repo = repos["the_other_repo"]
 
         with freeze_time(freeze_datetime):
-            instance_sensor = the_repo.get_external_sensor("instance_sensor")
+            instance_sensor = the_repo.get_sensor("instance_sensor")
             instance.start_sensor(instance_sensor)
 
             evaluate_sensors(workspace_context, executor)
@@ -1673,7 +1671,7 @@ def test_instance_run_status_sensor(executor: Optional[ThreadPoolExecutor]):
             time.sleep(1)
 
         with freeze_time(freeze_datetime):
-            external_job = the_other_repo.get_full_external_job("the_job")
+            external_job = the_other_repo.get_full_job("the_job")
             run = instance.create_run_for_job(
                 the_job,
                 external_job_origin=external_job.get_remote_origin(),
@@ -1708,7 +1706,7 @@ def test_logging_run_status_sensor(
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
-        success_sensor = external_repo.get_external_sensor("logging_status_sensor")
+        success_sensor = external_repo.get_sensor("logging_status_sensor")
         instance.start_sensor(success_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -1727,7 +1725,7 @@ def test_logging_run_status_sensor(
         freeze_datetime = freeze_datetime + relativedelta(seconds=60)
 
     with freeze_time(freeze_datetime):
-        external_job = external_repo.get_full_external_job("foo_job")
+        external_job = external_repo.get_full_job("foo_job")
         run = instance.create_run_for_job(
             foo_job,
             external_job_origin=external_job.get_remote_origin(),

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_failure_recovery.py
@@ -62,7 +62,7 @@ def test_failure_before_run_created(crash_location, crash_signal, instance, exte
         year=2019, month=2, day=28, hour=0, minute=0, second=1
     ).astimezone(get_timezone("US/Central"))
     with freeze_time(frozen_datetime):
-        external_sensor = external_repo.get_external_sensor("simple_sensor")
+        external_sensor = external_repo.get_sensor("simple_sensor")
         instance.add_instigator_state(
             InstigatorState(
                 external_sensor.get_remote_origin(),
@@ -140,7 +140,7 @@ def test_failure_after_run_created_before_run_launched(
         year=2019, month=2, day=28, hour=0, minute=0, second=0
     ).astimezone(get_timezone("US/Central"))
     with freeze_time(frozen_datetime):
-        external_sensor = external_repo.get_external_sensor("run_key_sensor")
+        external_sensor = external_repo.get_sensor("run_key_sensor")
         instance.add_instigator_state(
             InstigatorState(
                 external_sensor.get_remote_origin(),
@@ -223,7 +223,7 @@ def test_failure_after_run_launched(crash_location, crash_signal, instance, exte
         second=0,
     ).astimezone(get_timezone("US/Central"))
     with freeze_time(frozen_datetime):
-        external_sensor = external_repo.get_external_sensor("run_key_sensor")
+        external_sensor = external_repo.get_sensor("run_key_sensor")
         instance.add_instigator_state(
             InstigatorState(
                 external_sensor.get_remote_origin(),
@@ -309,7 +309,7 @@ def test_failure_after_run_ids_reserved(
     with freeze_time(frozen_datetime), patch.object(
         DagsterInstance, "get_ticks", wraps=instance.get_ticks
     ) as mock_get_ticks:
-        external_sensor = external_repo.get_external_sensor("only_once_cursor_sensor")
+        external_sensor = external_repo.get_sensor("only_once_cursor_sensor")
         instance.add_instigator_state(
             InstigatorState(
                 external_sensor.get_remote_origin(),

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -1143,7 +1143,7 @@ def test_ignore_auto_materialize_sensor(instance, workspace_context, external_re
     freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
 
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("my_auto_materialize_sensor")
+        external_sensor = external_repo.get_sensor("my_auto_materialize_sensor")
         assert external_sensor
         instance.add_instigator_state(
             InstigatorState(
@@ -1167,7 +1167,7 @@ def test_simple_sensor(instance, workspace_context, external_repo, executor):
     freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
 
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("simple_sensor")
+        external_sensor = external_repo.get_sensor("simple_sensor")
         instance.add_instigator_state(
             InstigatorState(
                 external_sensor.get_remote_origin(),
@@ -1227,7 +1227,7 @@ def test_sensors_keyed_on_selector_not_origin(
     freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
 
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("simple_sensor")
+        external_sensor = external_repo.get_sensor("simple_sensor")
 
         existing_origin = external_sensor.get_remote_origin()
 
@@ -1272,7 +1272,7 @@ def test_bad_load_sensor_repository(
     freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
 
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("simple_sensor")
+        external_sensor = external_repo.get_sensor("simple_sensor")
 
         valid_origin = external_sensor.get_remote_origin()
 
@@ -1304,7 +1304,7 @@ def test_bad_load_sensor(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
 
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("simple_sensor")
+        external_sensor = external_repo.get_sensor("simple_sensor")
 
         valid_origin = external_sensor.get_remote_origin()
 
@@ -1332,7 +1332,7 @@ def test_bad_load_sensor(executor, instance, workspace_context, external_repo):
 def test_error_sensor(caplog, executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("error_sensor")
+        external_sensor = external_repo.get_sensor("error_sensor")
         instance.add_instigator_state(
             InstigatorState(
                 external_sensor.get_remote_origin(),
@@ -1392,7 +1392,7 @@ def test_wrong_config_sensor(caplog, executor, instance, workspace_context, exte
         second=59,
     )
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("wrong_config_sensor")
+        external_sensor = external_repo.get_sensor("wrong_config_sensor")
         instance.add_instigator_state(
             InstigatorState(
                 external_sensor.get_remote_origin(),
@@ -1460,7 +1460,7 @@ def test_launch_failure(caplog, executor, workspace_context, external_repo):
     ) as instance:
         with freeze_time(freeze_datetime):
             exploding_workspace_context = workspace_context.copy_for_test_instance(instance)
-            external_sensor = external_repo.get_external_sensor("always_on_sensor")
+            external_sensor = external_repo.get_sensor("always_on_sensor")
             instance.add_instigator_state(
                 InstigatorState(
                     external_sensor.get_remote_origin(),
@@ -1508,7 +1508,7 @@ def test_launch_once(caplog, executor, instance, workspace_context, external_rep
     with freeze_time(freeze_datetime), patch.object(
         DagsterInstance, "get_ticks", wraps=instance.get_ticks
     ) as mock_get_ticks:
-        external_sensor = external_repo.get_external_sensor("run_key_sensor")
+        external_sensor = external_repo.get_sensor("run_key_sensor")
         instance.add_instigator_state(
             InstigatorState(
                 external_sensor.get_remote_origin(),
@@ -1612,7 +1612,7 @@ def test_launch_once(caplog, executor, instance, workspace_context, external_rep
 def test_custom_interval_sensor(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=28)
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("custom_interval_sensor")
+        external_sensor = external_repo.get_sensor("custom_interval_sensor")
         instance.add_instigator_state(
             InstigatorState(
                 external_sensor.get_remote_origin(),
@@ -1694,7 +1694,7 @@ def test_custom_interval_sensor_with_offset(
         shutdown_event.wait.side_effect = fake_sleep
 
         # 60 second custom interval
-        external_sensor = external_repo.get_external_sensor("custom_interval_sensor")
+        external_sensor = external_repo.get_sensor("custom_interval_sensor")
 
         instance.add_instigator_state(
             InstigatorState(
@@ -1741,7 +1741,7 @@ def test_custom_interval_sensor_with_offset(
 def test_sensor_start_stop(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("always_on_sensor")
+        external_sensor = external_repo.get_sensor("always_on_sensor")
         remote_origin_id = external_sensor.get_remote_origin_id()
         instance.start_sensor(external_sensor)
 
@@ -1795,7 +1795,7 @@ def test_sensor_start_stop(executor, instance, workspace_context, external_repo)
 def test_large_sensor(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("large_sensor")
+        external_sensor = external_repo.get_sensor("large_sensor")
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor, timeout=300)
         ticks = instance.get_ticks(
@@ -1813,7 +1813,7 @@ def test_large_sensor(executor, instance, workspace_context, external_repo):
 def test_many_request_sensor(executor, submit_executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("many_request_sensor")
+        external_sensor = external_repo.get_sensor("many_request_sensor")
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor, submit_executor=submit_executor)
         ticks = instance.get_ticks(
@@ -1831,8 +1831,8 @@ def test_many_request_sensor(executor, submit_executor, instance, workspace_cont
 def test_cursor_sensor(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        skip_sensor = external_repo.get_external_sensor("skip_cursor_sensor")
-        run_sensor = external_repo.get_external_sensor("run_cursor_sensor")
+        skip_sensor = external_repo.get_sensor("skip_cursor_sensor")
+        run_sensor = external_repo.get_sensor("run_cursor_sensor")
         instance.start_sensor(skip_sensor)
         instance.start_sensor(run_sensor)
         evaluate_sensors(workspace_context, executor)
@@ -1885,7 +1885,7 @@ def test_cursor_sensor(executor, instance, workspace_context, external_repo):
 def test_run_request_asset_selection_sensor(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("run_request_asset_selection_sensor")
+        external_sensor = external_repo.get_sensor("run_request_asset_selection_sensor")
         remote_origin_id = external_sensor.get_remote_origin_id()
         instance.start_sensor(external_sensor)
 
@@ -1918,7 +1918,7 @@ def test_run_request_check_selection_only_sensor(
 ) -> None:
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("run_request_check_only_sensor")
+        external_sensor = external_repo.get_sensor("run_request_check_only_sensor")
         remote_origin_id = external_sensor.get_remote_origin_id()
         instance.start_sensor(external_sensor)
 
@@ -1958,7 +1958,7 @@ def test_run_request_stale_asset_selection_sensor_never_materialized(
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
 
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("run_request_stale_asset_sensor")
+        external_sensor = external_repo.get_sensor("run_request_stale_asset_sensor")
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor)
         sensor_run = next((r for r in instance.get_runs() if r.job_name == "abc"), None)
@@ -1974,7 +1974,7 @@ def test_run_request_stale_asset_selection_sensor_empty(
     materialize([a, b, c], instance=instance)
 
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("run_request_stale_asset_sensor")
+        external_sensor = external_repo.get_sensor("run_request_stale_asset_sensor")
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor)
         sensor_run = next((r for r in instance.get_runs() if r.job_name == "abc"), None)
@@ -1989,7 +1989,7 @@ def test_run_request_stale_asset_selection_sensor_subset(
     materialize([a], instance=instance)
 
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("run_request_stale_asset_sensor")
+        external_sensor = external_repo.get_sensor("run_request_stale_asset_sensor")
         instance.start_sensor(external_sensor)
         evaluate_sensors(workspace_context, executor)
         sensor_run = next((r for r in instance.get_runs() if r.job_name == "abc"), None)
@@ -2000,7 +2000,7 @@ def test_run_request_stale_asset_selection_sensor_subset(
 def test_targets_asset_selection_sensor(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("targets_asset_selection_sensor")
+        external_sensor = external_repo.get_sensor("targets_asset_selection_sensor")
         remote_origin_id = external_sensor.get_remote_origin_id()
         instance.start_sensor(external_sensor)
 
@@ -2043,7 +2043,7 @@ def test_targets_asset_selection_sensor(executor, instance, workspace_context, e
 def test_partitioned_asset_selection_sensor(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("partitioned_asset_selection_sensor")
+        external_sensor = external_repo.get_sensor("partitioned_asset_selection_sensor")
         remote_origin_id = external_sensor.get_remote_origin_id()
         instance.start_sensor(external_sensor)
 
@@ -2073,7 +2073,7 @@ def test_partitioned_asset_selection_sensor(executor, instance, workspace_contex
 def test_asset_sensor(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        foo_sensor = external_repo.get_external_sensor("asset_foo_sensor")
+        foo_sensor = external_repo.get_sensor("asset_foo_sensor")
         instance.start_sensor(foo_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -2111,7 +2111,7 @@ def test_asset_sensor(executor, instance, workspace_context, external_repo):
 def test_asset_job_sensor(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        job_sensor = external_repo.get_external_sensor("asset_job_sensor")
+        job_sensor = external_repo.get_sensor("asset_job_sensor")
         instance.start_sensor(job_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -2152,7 +2152,7 @@ def test_asset_sensor_not_triggered_on_observation(
 ):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        foo_sensor = external_repo.get_external_sensor("asset_foo_sensor")
+        foo_sensor = external_repo.get_sensor("asset_foo_sensor")
         instance.start_sensor(foo_sensor)
 
         # generates the foo asset observation
@@ -2194,7 +2194,7 @@ def test_asset_sensor_not_triggered_on_observation(
 def test_multi_asset_sensor(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        a_and_b_sensor = external_repo.get_external_sensor("asset_a_and_b_sensor")
+        a_and_b_sensor = external_repo.get_sensor("asset_a_and_b_sensor")
         instance.start_sensor(a_and_b_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -2256,7 +2256,7 @@ def test_multi_asset_sensor(executor, instance, workspace_context, external_repo
 def test_asset_selection_sensor(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        asset_selection_sensor = external_repo.get_external_sensor("asset_selection_sensor")
+        asset_selection_sensor = external_repo.get_sensor("asset_selection_sensor")
         instance.start_sensor(asset_selection_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -2278,7 +2278,7 @@ def test_multi_asset_sensor_targets_asset_selection(
 ):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        multi_asset_sensor_targets_asset_selection = external_repo.get_external_sensor(
+        multi_asset_sensor_targets_asset_selection = external_repo.get_sensor(
             "multi_asset_sensor_targets_asset_selection"
         )
         instance.start_sensor(multi_asset_sensor_targets_asset_selection)
@@ -2346,7 +2346,7 @@ def test_multi_asset_sensor_targets_asset_selection(
 def test_multi_asset_sensor_w_many_events(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        backlog_sensor = external_repo.get_external_sensor("backlog_sensor")
+        backlog_sensor = external_repo.get_sensor("backlog_sensor")
         instance.start_sensor(backlog_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -2409,7 +2409,7 @@ def test_multi_asset_sensor_w_no_cursor_update(
 ):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        cursor_sensor = external_repo.get_external_sensor("doesnt_update_cursor_sensor")
+        cursor_sensor = external_repo.get_sensor("doesnt_update_cursor_sensor")
         instance.start_sensor(cursor_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -2443,7 +2443,7 @@ def test_multi_asset_sensor_hourly_to_weekly(executor, instance, workspace_conte
     freeze_datetime = create_datetime(year=2022, month=8, day=2)
     with freeze_time(freeze_datetime):
         materialize([hourly_asset], instance=instance, partition_key="2022-08-01-00:00")
-        cursor_sensor = external_repo.get_external_sensor("multi_asset_sensor_hourly_to_weekly")
+        cursor_sensor = external_repo.get_sensor("multi_asset_sensor_hourly_to_weekly")
         instance.start_sensor(cursor_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -2467,7 +2467,7 @@ def test_multi_asset_sensor_hourly_to_hourly(executor, instance, workspace_conte
     freeze_datetime = create_datetime(year=2022, month=8, day=3)
     with freeze_time(freeze_datetime):
         materialize([hourly_asset], instance=instance, partition_key="2022-08-02-00:00")
-        cursor_sensor = external_repo.get_external_sensor("multi_asset_sensor_hourly_to_hourly")
+        cursor_sensor = external_repo.get_sensor("multi_asset_sensor_hourly_to_hourly")
         instance.start_sensor(cursor_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -2490,7 +2490,7 @@ def test_multi_asset_sensor_hourly_to_hourly(executor, instance, workspace_conte
         freeze_datetime = freeze_datetime + relativedelta(seconds=30)
 
     with freeze_time(freeze_datetime):
-        cursor_sensor = external_repo.get_external_sensor("multi_asset_sensor_hourly_to_hourly")
+        cursor_sensor = external_repo.get_sensor("multi_asset_sensor_hourly_to_hourly")
         instance.start_sensor(cursor_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -2503,7 +2503,7 @@ def test_multi_asset_sensor_hourly_to_hourly(executor, instance, workspace_conte
 def test_sensor_result_multi_asset_sensor(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2022, month=8, day=3)
     with freeze_time(freeze_datetime):
-        cursor_sensor = external_repo.get_external_sensor("sensor_result_multi_asset_sensor")
+        cursor_sensor = external_repo.get_sensor("sensor_result_multi_asset_sensor")
         instance.start_sensor(cursor_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -2523,7 +2523,7 @@ def test_cursor_update_sensor_result_multi_asset_sensor(
 ):
     freeze_datetime = create_datetime(year=2022, month=8, day=3)
     with freeze_time(freeze_datetime):
-        cursor_sensor = external_repo.get_external_sensor("cursor_sensor_result_multi_asset_sensor")
+        cursor_sensor = external_repo.get_sensor("cursor_sensor_result_multi_asset_sensor")
         instance.start_sensor(cursor_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -2542,7 +2542,7 @@ def test_cursor_update_sensor_result_multi_asset_sensor(
 def test_multi_job_sensor(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        job_sensor = external_repo.get_external_sensor("two_job_sensor")
+        job_sensor = external_repo.get_sensor("two_job_sensor")
         instance.start_sensor(job_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -2583,7 +2583,7 @@ def test_multi_job_sensor(executor, instance, workspace_context, external_repo):
 def test_bad_run_request_untargeted(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        job_sensor = external_repo.get_external_sensor("bad_request_untargeted")
+        job_sensor = external_repo.get_sensor("bad_request_untargeted")
         instance.start_sensor(job_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -2605,7 +2605,7 @@ def test_bad_run_request_untargeted(executor, instance, workspace_context, exter
 def test_bad_run_request_mismatch(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        job_sensor = external_repo.get_external_sensor("bad_request_mismatch")
+        job_sensor = external_repo.get_sensor("bad_request_mismatch")
         instance.start_sensor(job_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -2626,7 +2626,7 @@ def test_bad_run_request_mismatch(executor, instance, workspace_context, externa
 def test_bad_run_request_unspecified(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        job_sensor = external_repo.get_external_sensor("bad_request_unspecified")
+        job_sensor = external_repo.get_sensor("bad_request_unspecified")
         instance.start_sensor(job_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -2656,8 +2656,8 @@ def test_status_in_code_sensor(executor, instance):
         ).code_location.get_repository("the_status_in_code_repo")
 
         with freeze_time(freeze_datetime):
-            running_sensor = external_repo.get_external_sensor("always_running_sensor")
-            not_running_sensor = external_repo.get_external_sensor("never_running_sensor")
+            running_sensor = external_repo.get_sensor("always_running_sensor")
+            not_running_sensor = external_repo.get_sensor("never_running_sensor")
 
             always_running_origin = running_sensor.get_remote_origin()
             never_running_origin = not_running_sensor.get_remote_origin()
@@ -2730,8 +2730,8 @@ def test_status_in_code_sensor(executor, instance):
             assert reset_instigator_state.status == InstigatorStatus.DECLARED_IN_CODE
 
             running_to_not_running_sensor = RemoteSensor(
-                external_sensor_data=copy(
-                    running_sensor._external_sensor_data,  # noqa: SLF001
+                sensor_snap=copy(
+                    running_sensor._sensor_snap,  # noqa: SLF001
                     default_status=DefaultSensorStatus.STOPPED,
                 ),
                 handle=running_sensor.handle.repository_handle,
@@ -2789,7 +2789,7 @@ def test_status_in_code_sensor(executor, instance):
 def test_run_request_list_sensor(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("request_list_sensor")
+        external_sensor = external_repo.get_sensor("request_list_sensor")
         instance.add_instigator_state(
             InstigatorState(
                 external_sensor.get_remote_origin(),
@@ -2815,7 +2815,7 @@ def test_run_request_list_sensor(executor, instance, workspace_context, external
 def test_sensor_purge(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=23, minute=59, second=59)
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("simple_sensor")
+        external_sensor = external_repo.get_sensor("simple_sensor")
         instance.add_instigator_state(
             InstigatorState(
                 external_sensor.get_remote_origin(),
@@ -2866,7 +2866,7 @@ def test_sensor_custom_purge(executor, workspace_context, external_repo):
     ) as instance:
         purge_ws_ctx = workspace_context.copy_for_test_instance(instance)
         with freeze_time(freeze_datetime):
-            external_sensor = external_repo.get_external_sensor("simple_sensor")
+            external_sensor = external_repo.get_sensor("simple_sensor")
             instance.add_instigator_state(
                 InstigatorState(
                     external_sensor.get_remote_origin(),
@@ -2936,13 +2936,13 @@ def test_repository_namespacing(executor):
 
         # stop always on sensor
         status_in_code_repo = full_location.get_repository("the_status_in_code_repo")
-        running_sensor = status_in_code_repo.get_external_sensor("always_running_sensor")
+        running_sensor = status_in_code_repo.get_sensor("always_running_sensor")
         instance.stop_sensor(
             running_sensor.get_remote_origin_id(), running_sensor.selector_id, running_sensor
         )
 
-        external_sensor = external_repo.get_external_sensor("run_key_sensor")
-        other_sensor = other_repo.get_external_sensor("run_key_sensor")
+        external_sensor = external_repo.get_sensor("run_key_sensor")
+        other_sensor = other_repo.get_sensor("run_key_sensor")
 
         with freeze_time(freeze_datetime):
             instance.start_sensor(external_sensor)
@@ -2995,7 +2995,7 @@ def test_settings():
 
 @pytest.mark.parametrize("sensor_name", ["logging_sensor", "multi_asset_logging_sensor"])
 def test_sensor_logging(executor, instance, workspace_context, external_repo, sensor_name) -> None:
-    external_sensor = external_repo.get_external_sensor(sensor_name)
+    external_sensor = external_repo.get_sensor(sensor_name)
     instance.add_instigator_state(
         InstigatorState(
             external_sensor.get_remote_origin(),
@@ -3034,7 +3034,7 @@ def test_sensor_logging_on_tick_failure(
     workspace_context: WorkspaceProcessContext,
     external_repo: RemoteRepository,
 ) -> None:
-    external_sensor = external_repo.get_external_sensor("logging_fail_tick_sensor")
+    external_sensor = external_repo.get_sensor("logging_fail_tick_sensor")
     instance.add_instigator_state(
         InstigatorState(
             external_sensor.get_remote_origin(),
@@ -3078,7 +3078,7 @@ def test_add_dynamic_partitions_sensor(
     instance.add_dynamic_partitions("quux", ["foo"])
     assert set(instance.get_dynamic_partitions("quux")) == set(["foo"])
 
-    external_sensor = external_repo.get_external_sensor("add_dynamic_partitions_sensor")
+    external_sensor = external_repo.get_sensor("add_dynamic_partitions_sensor")
     instance.add_instigator_state(
         InstigatorState(
             external_sensor.get_remote_origin(),
@@ -3112,7 +3112,7 @@ def test_add_delete_skip_dynamic_partitions(
     foo_job.execute_in_process(instance=instance)  # creates event log storage tables
     instance.add_dynamic_partitions("quux", ["2"])
     assert set(instance.get_dynamic_partitions("quux")) == set(["2"])
-    external_sensor = external_repo.get_external_sensor(
+    external_sensor = external_repo.get_sensor(
         "add_delete_dynamic_partitions_and_yield_run_requests_sensor"
     )
     instance.add_instigator_state(
@@ -3201,7 +3201,7 @@ def test_error_on_deleted_dynamic_partitions_run_request(
     foo_job.execute_in_process(instance=instance)  # creates event log storage tables
     instance.add_dynamic_partitions("quux", ["2"])
     assert set(instance.get_dynamic_partitions("quux")) == set(["2"])
-    external_sensor = external_repo.get_external_sensor(
+    external_sensor = external_repo.get_sensor(
         "error_on_deleted_dynamic_partitions_run_requests_sensor"
     )
     instance.add_instigator_state(
@@ -3239,7 +3239,7 @@ def test_error_on_deleted_dynamic_partitions_run_request(
 def test_multipartitions_with_dynamic_dims_run_request_sensor(
     sensor_name, is_expected_success, executor, instance, workspace_context, external_repo
 ):
-    external_sensor = external_repo.get_external_sensor(sensor_name)
+    external_sensor = external_repo.get_sensor(sensor_name)
     instance.add_instigator_state(
         InstigatorState(
             external_sensor.get_remote_origin(),
@@ -3277,7 +3277,7 @@ def test_multipartitions_with_dynamic_dims_run_request_sensor(
 def test_multipartition_asset_with_static_time_dimensions_run_requests_sensor(
     executor, instance, workspace_context, external_repo
 ):
-    external_sensor = external_repo.get_external_sensor(
+    external_sensor = external_repo.get_sensor(
         "multipartitions_with_static_time_dimensions_run_requests_sensor"
     )
     instance.add_instigator_state(
@@ -3327,7 +3327,7 @@ def test_stale_request_context(instance, workspace_context, external_repo):
     blocking_executor = BlockingThreadPoolExecutor()
 
     with freeze_time(freeze_datetime):
-        external_sensor = external_repo.get_external_sensor("simple_sensor")
+        external_sensor = external_repo.get_sensor("simple_sensor")
         instance.add_instigator_state(
             InstigatorState(
                 external_sensor.get_remote_origin(),
@@ -3414,7 +3414,7 @@ def test_stale_request_context(instance, workspace_context, external_repo):
 def test_start_tick_sensor(executor, instance, workspace_context, external_repo):
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        start_skip_sensor = external_repo.get_external_sensor("start_skip_sensor")
+        start_skip_sensor = external_repo.get_sensor("start_skip_sensor")
         instance.start_sensor(start_skip_sensor)
         evaluate_sensors(workspace_context, executor)
         last_tick = _get_last_tick(instance, start_skip_sensor)
@@ -3465,15 +3465,15 @@ def test_sensor_run_tags(
 ) -> None:
     freeze_datetime = create_datetime(year=2019, month=2, day=27)
     with freeze_time(freeze_datetime):
-        job_with_tags_with_run_tags_sensor = external_repo.get_external_sensor(
+        job_with_tags_with_run_tags_sensor = external_repo.get_sensor(
             "job_with_tags_with_run_tags_sensor"
         )
         instance.start_sensor(job_with_tags_with_run_tags_sensor)
-        job_with_tags_no_run_tags_sensor = external_repo.get_external_sensor(
+        job_with_tags_no_run_tags_sensor = external_repo.get_sensor(
             "job_with_tags_no_run_tags_sensor"
         )
         instance.start_sensor(job_with_tags_no_run_tags_sensor)
-        job_no_tags_with_run_tags_sensor = external_repo.get_external_sensor(
+        job_no_tags_with_run_tags_sensor = external_repo.get_sensor(
             "job_no_tags_with_run_tags_sensor"
         )
         instance.start_sensor(job_no_tags_with_run_tags_sensor)

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_asset_checks.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_asset_checks.py
@@ -57,7 +57,7 @@ def test_asset_check_run_request_sensor(instance: DagsterInstance, executor):
         workspace_load_target=module_target, instance=instance
     ) as workspace_context:
         external_repo = load_external_repo(workspace_context, "__repository__")
-        external_sensor = external_repo.get_external_sensor(asset_check_run_request_sensor.name)
+        external_sensor = external_repo.get_sensor(asset_check_run_request_sensor.name)
 
         instance.add_instigator_state(
             InstigatorState(

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_daemon.py
@@ -160,7 +160,7 @@ def test_backfill_request_sensor(instance: DagsterInstance, executor, sensor_nam
         workspace_load_target=module_target, instance=instance
     ) as workspace_context:
         external_repo = load_external_repo(workspace_context, "__repository__")
-        external_sensor = external_repo.get_external_sensor(sensor_name)
+        external_sensor = external_repo.get_sensor(sensor_name)
 
         instance.add_instigator_state(
             InstigatorState(
@@ -204,7 +204,7 @@ def test_asset_selection_outside_of_range(instance, executor):
         workspace_load_target=module_target, instance=instance
     ) as workspace_context:
         external_repo = load_external_repo(workspace_context, "__repository__")
-        external_sensor = external_repo.get_external_sensor(
+        external_sensor = external_repo.get_sensor(
             asset_outside_of_selection_backfill_request_sensor.name
         )
 
@@ -235,9 +235,7 @@ def test_invalid_partition(instance, executor):
         workspace_load_target=module_target, instance=instance
     ) as workspace_context:
         external_repo = load_external_repo(workspace_context, "__repository__")
-        external_sensor = external_repo.get_external_sensor(
-            invalid_partition_backfill_request_sensor.name
-        )
+        external_sensor = external_repo.get_sensor(invalid_partition_backfill_request_sensor.name)
 
         instance.add_instigator_state(
             InstigatorState(
@@ -265,9 +263,7 @@ def test_single_partition(instance, executor):
         workspace_load_target=module_target, instance=instance
     ) as workspace_context:
         external_repo = load_external_repo(workspace_context, "__repository__")
-        external_sensor = external_repo.get_external_sensor(
-            single_partition_run_request_sensor.name
-        )
+        external_sensor = external_repo.get_sensor(single_partition_run_request_sensor.name)
 
         instance.add_instigator_state(
             InstigatorState(
@@ -299,7 +295,7 @@ def test_backfill_and_run_request(instance, executor):
         workspace_load_target=module_target, instance=instance
     ) as workspace_context:
         external_repo = load_external_repo(workspace_context, "__repository__")
-        external_sensor = external_repo.get_external_sensor(backfill_and_run_request_sensor.name)
+        external_sensor = external_repo.get_sensor(backfill_and_run_request_sensor.name)
 
         instance.add_instigator_state(
             InstigatorState(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -507,7 +507,7 @@ def test_simple_backfill(
     workspace_context: WorkspaceProcessContext,
     external_repo: RemoteRepository,
 ):
-    external_partition_set = external_repo.get_external_partition_set("the_job_partition_set")
+    external_partition_set = external_repo.get_partition_set("the_job_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
@@ -540,7 +540,7 @@ def test_canceled_backfill(
     workspace_context: WorkspaceProcessContext,
     external_repo: RemoteRepository,
 ):
-    external_partition_set = external_repo.get_external_partition_set("the_job_partition_set")
+    external_partition_set = external_repo.get_partition_set("the_job_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
@@ -576,7 +576,7 @@ def test_failure_backfill(
     external_repo: RemoteRepository,
 ):
     output_file = _failure_flag_file()
-    external_partition_set = external_repo.get_external_partition_set(
+    external_partition_set = external_repo.get_partition_set(
         "conditional_failure_job_partition_set"
     )
     instance.add_backfill(
@@ -679,7 +679,7 @@ def test_job_backfill_status(
     workspace_context: WorkspaceProcessContext,
     external_repo: RemoteRepository,
 ):
-    external_partition_set = external_repo.get_external_partition_set("the_job_partition_set")
+    external_partition_set = external_repo.get_partition_set("the_job_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
@@ -737,7 +737,7 @@ def test_partial_backfill(
     workspace_context: WorkspaceProcessContext,
     external_repo: RemoteRepository,
 ):
-    external_partition_set = external_repo.get_external_partition_set("partial_job_partition_set")
+    external_partition_set = external_repo.get_partition_set("partial_job_partition_set")
 
     # create full runs, where every step is executed
     instance.add_backfill(
@@ -829,7 +829,7 @@ def test_large_backfill(
     workspace_context: WorkspaceProcessContext,
     external_repo: RemoteRepository,
 ):
-    external_partition_set = external_repo.get_external_partition_set("config_job_partition_set")
+    external_partition_set = external_repo.get_partition_set("config_job_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
@@ -1066,9 +1066,7 @@ def test_backfill_from_partitioned_job(
     external_repo: RemoteRepository,
 ):
     partition_keys = my_config.partitions_def.get_partition_keys()
-    external_partition_set = external_repo.get_external_partition_set(
-        "comp_always_succeed_partition_set"
-    )
+    external_partition_set = external_repo.get_partition_set("comp_always_succeed_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="partition_schedule_from_job",
@@ -1103,7 +1101,7 @@ def test_backfill_with_asset_selection(
     assert job_def
     asset_job_name = job_def.name
     partition_set_name = f"{asset_job_name}_partition_set"
-    external_partition_set = external_repo.get_external_partition_set(partition_set_name)
+    external_partition_set = external_repo.get_partition_set(partition_set_name)
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="backfill_with_asset_selection",
@@ -1270,9 +1268,7 @@ def test_backfill_from_failure_for_subselection(
     run = next(iter(instance.get_runs()))
     assert run.status == DagsterRunStatus.FAILURE
 
-    external_partition_set = external_repo.get_external_partition_set(
-        "parallel_failure_job_partition_set"
-    )
+    external_partition_set = external_repo.get_partition_set("parallel_failure_job_partition_set")
 
     instance.add_backfill(
         PartitionBackfill(
@@ -1955,7 +1951,7 @@ def test_fail_backfill_when_runs_completed_but_partitions_marked_as_in_progress(
 
 # Job must have a partitions definition with a-b-c-d partitions
 def _get_abcd_job_backfill(external_repo: RemoteRepository, job_name: str) -> PartitionBackfill:
-    external_partition_set = external_repo.get_external_partition_set(f"{job_name}_partition_set")
+    external_partition_set = external_repo.get_partition_set(f"{job_name}_partition_set")
     return PartitionBackfill(
         backfill_id="simple",
         partition_set_origin=external_partition_set.get_remote_origin(),

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
@@ -48,7 +48,7 @@ def _test_backfill_in_subprocess(instance_ref, debug_crash_flags):
     IS_WINDOWS, reason="Windows keeps resources open after termination in a flaky way"
 )
 def test_simple(instance: DagsterInstance, external_repo: RemoteRepository):
-    external_partition_set = external_repo.get_external_partition_set("the_job_partition_set")
+    external_partition_set = external_repo.get_partition_set("the_job_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
@@ -79,7 +79,7 @@ def test_simple(instance: DagsterInstance, external_repo: RemoteRepository):
 def test_before_submit(
     crash_signal: Signals, instance: DagsterInstance, external_repo: RemoteRepository
 ):
-    external_partition_set = external_repo.get_external_partition_set("the_job_partition_set")
+    external_partition_set = external_repo.get_partition_set("the_job_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
@@ -126,7 +126,7 @@ def test_before_submit(
 def test_crash_after_submit(
     crash_signal: Signals, instance: DagsterInstance, external_repo: RemoteRepository
 ):
-    external_partition_set = external_repo.get_external_partition_set("the_job_partition_set")
+    external_partition_set = external_repo.get_partition_set("the_job_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -101,11 +101,11 @@ def test_default_auto_materialize_sensors(instance_with_auto_materialize_sensors
         instance=instance,
     )
 
-    sensors = external_repo.get_external_sensors()
+    sensors = external_repo.get_sensors()
 
     assert len(sensors) == 2
 
-    assert external_repo.has_external_sensor("normal_sensor")
+    assert external_repo.has_sensor("normal_sensor")
 
     auto_materialize_sensors = [
         sensor for sensor in sensors if sensor.sensor_type == SensorType.AUTO_MATERIALIZE
@@ -115,7 +115,7 @@ def test_default_auto_materialize_sensors(instance_with_auto_materialize_sensors
     auto_materialize_sensor = auto_materialize_sensors[0]
 
     assert auto_materialize_sensor.name == "default_automation_condition_sensor"
-    assert external_repo.has_external_sensor(auto_materialize_sensor.name)
+    assert external_repo.has_sensor(auto_materialize_sensor.name)
 
     assert auto_materialize_sensor.asset_selection == AssetSelection.all(include_sources=True)
 
@@ -138,14 +138,14 @@ def test_default_auto_materialize_sensors_without_observable(
         instance=instance,
     )
 
-    sensors = external_repo.get_external_sensors()
+    sensors = external_repo.get_sensors()
 
     assert len(sensors) == 1
 
     auto_materialize_sensor = sensors[0]
 
     assert auto_materialize_sensor.name == "default_automation_condition_sensor"
-    assert external_repo.has_external_sensor(auto_materialize_sensor.name)
+    assert external_repo.has_sensor(auto_materialize_sensor.name)
 
     assert auto_materialize_sensor.asset_selection == AssetSelection.all(include_sources=False)
 
@@ -164,7 +164,7 @@ def test_no_default_auto_materialize_sensors(instance_without_auto_materialize_s
         repository_handle=repo_handle,
         instance=instance_without_auto_materialize_sensors,
     )
-    sensors = external_repo.get_external_sensors()
+    sensors = external_repo.get_sensors()
     assert len(sensors) == 1
     assert sensors[0].name == "normal_sensor"
 
@@ -199,19 +199,19 @@ def test_combine_default_sensors_with_non_default_sensors(instance_with_auto_mat
         instance=instance_with_auto_materialize_sensors,
     )
 
-    sensors = external_repo.get_external_sensors()
+    sensors = external_repo.get_sensors()
 
     assert len(sensors) == 3
 
-    assert external_repo.has_external_sensor("normal_sensor")
-    assert external_repo.has_external_sensor("default_automation_condition_sensor")
-    assert external_repo.has_external_sensor("my_custom_policy_sensor")
+    assert external_repo.has_sensor("normal_sensor")
+    assert external_repo.has_sensor("default_automation_condition_sensor")
+    assert external_repo.has_sensor("my_custom_policy_sensor")
 
     asset_graph = external_repo.asset_graph
 
     # default sensor includes all assets that weren't covered by the custom one
 
-    default_sensor = external_repo.get_external_sensor("default_automation_condition_sensor")
+    default_sensor = external_repo.get_sensor("default_automation_condition_sensor")
 
     assert (
         str(default_sensor.asset_selection)
@@ -225,7 +225,7 @@ def test_combine_default_sensors_with_non_default_sensors(instance_with_auto_mat
         AssetKey(["boring_observable_asset"]),
     }
 
-    custom_sensor = external_repo.get_external_sensor("my_custom_policy_sensor")
+    custom_sensor = external_repo.get_sensor("my_custom_policy_sensor")
 
     assert custom_sensor.asset_selection.resolve(asset_graph) == {
         AssetKey(["auto_materialize_asset"]),
@@ -269,17 +269,17 @@ def test_custom_sensors_cover_all(instance_with_auto_materialize_sensors):
         instance=instance_with_auto_materialize_sensors,
     )
 
-    sensors = external_repo.get_external_sensors()
+    sensors = external_repo.get_sensors()
 
     assert len(sensors) == 2
 
-    assert external_repo.has_external_sensor("normal_sensor")
-    assert external_repo.has_external_sensor("my_custom_policy_sensor")
+    assert external_repo.has_sensor("normal_sensor")
+    assert external_repo.has_sensor("my_custom_policy_sensor")
 
     asset_graph = external_repo.asset_graph
 
     # Custom sensor covered all the valid assets
-    custom_sensor = external_repo.get_external_sensor("my_custom_policy_sensor")
+    custom_sensor = external_repo.get_sensor("my_custom_policy_sensor")
 
     assert custom_sensor.asset_selection.resolve(asset_graph) == {
         AssetKey(["auto_materialize_asset"]),

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -54,9 +54,7 @@ def _get_all_sensors(context: WorkspaceRequestContext) -> Sequence[RemoteSensor]
     external_sensors = []
     for cl_name in context.get_code_location_entries():
         external_sensors.extend(
-            next(
-                iter(context.get_code_location(cl_name).get_repositories().values())
-            ).get_external_sensors()
+            next(iter(context.get_code_location(cl_name).get_repositories().values())).get_sensors()
         )
     return external_sensors
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
@@ -192,7 +192,7 @@ class AssetDaemonScenarioState(ScenarioState):
             sensor = (
                 next(
                     iter(workspace.get_code_location("test_location").get_repositories().values())
-                ).get_external_sensor(self.sensor_name)
+                ).get_sensor(self.sensor_name)
                 if self.sensor_name
                 else None
             )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/scenario_state.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/scenario_state.py
@@ -433,7 +433,7 @@ class ScenarioState:
             workspace = workspace_context.create_request_context()
             sensor = next(
                 iter(workspace.get_code_location("test_location").get_repositories().values())
-            ).get_external_sensor(sensor_name)
+            ).get_sensor(sensor_name)
             assert sensor
             yield sensor
 

--- a/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/engine_tests/test_op_concurrency.py
@@ -208,7 +208,7 @@ def _create_run(
     external_job = (
         workspace.get_code_location("test")
         .get_repository("concurrency_repo")
-        .get_full_external_job(job_def.name)
+        .get_full_job(job_def.name)
     )
     run = instance.create_run_for_job(
         job_def=job_def,

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
@@ -204,7 +204,7 @@ def test_successful_run(
     run_config: Mapping[str, Any],
 ):
     external_job = (
-        workspace.get_code_location("test").get_repository("nope").get_full_external_job("noop_job")
+        workspace.get_code_location("test").get_repository("nope").get_full_job("noop_job")
     )
 
     dagster_run = instance.create_run_for_job(
@@ -234,9 +234,7 @@ def test_successful_run_from_pending(
 ):
     run_id = make_new_run_id()
     code_location = pending_workspace.get_code_location("test2")
-    external_job = code_location.get_repository("pending").get_full_external_job(
-        "my_cool_asset_job"
-    )
+    external_job = code_location.get_repository("pending").get_full_job("my_cool_asset_job")
     external_execution_plan = code_location.get_external_execution_plan(
         external_job=external_job,
         run_config={},
@@ -343,7 +341,7 @@ def test_invalid_instance_run():
                         external_job = (
                             workspace.get_code_location("test")
                             .get_repository("nope")
-                            .get_full_external_job("noop_job")
+                            .get_full_job("noop_job")
                         )
 
                         run = instance.create_run_for_job(
@@ -377,9 +375,7 @@ def test_crashy_run(
     run_config: Mapping[str, Any],
 ):
     external_job = (
-        workspace.get_code_location("test")
-        .get_repository("nope")
-        .get_full_external_job("crashy_job")
+        workspace.get_code_location("test").get_repository("nope").get_full_job("crashy_job")
     )
 
     run = instance.create_run_for_job(
@@ -459,9 +455,7 @@ def test_exity_run(
     run_config: Mapping[str, Any],
 ):
     external_job = (
-        workspace.get_code_location("test")
-        .get_repository("nope")
-        .get_full_external_job("exity_job")
+        workspace.get_code_location("test").get_repository("nope").get_full_job("exity_job")
     )
 
     run = instance.create_run_for_job(
@@ -520,9 +514,7 @@ def test_terminated_run(
     run_config: Mapping[str, Any],
 ):
     external_job = (
-        workspace.get_code_location("test")
-        .get_repository("nope")
-        .get_full_external_job("sleepy_job")
+        workspace.get_code_location("test").get_repository("nope").get_full_job("sleepy_job")
     )
     run = instance.create_run_for_job(
         job_def=sleepy_job,
@@ -623,9 +615,7 @@ def test_cleanup_after_force_terminate(
     run_config: Mapping[str, Any],
 ):
     external_job = (
-        workspace.get_code_location("test")
-        .get_repository("nope")
-        .get_full_external_job("sleepy_job")
+        workspace.get_code_location("test").get_repository("nope").get_full_job("sleepy_job")
     )
     run = instance.create_run_for_job(
         job_def=sleepy_job,
@@ -723,9 +713,7 @@ def test_single_op_selection_execution(
     run_config: Mapping[str, Any],
 ):
     external_job = (
-        workspace.get_code_location("test")
-        .get_repository("nope")
-        .get_full_external_job("math_diamond")
+        workspace.get_code_location("test").get_repository("nope").get_full_job("math_diamond")
     )
     run = instance.create_run_for_job(
         job_def=math_diamond,
@@ -761,9 +749,7 @@ def test_multi_op_selection_execution(
     run_config: Mapping[str, Any],
 ):
     external_job = (
-        workspace.get_code_location("test")
-        .get_repository("nope")
-        .get_full_external_job("math_diamond")
+        workspace.get_code_location("test").get_repository("nope").get_full_job("math_diamond")
     )
 
     run = instance.create_run_for_job(
@@ -804,7 +790,7 @@ def test_job_that_fails_run_worker(
     external_job = (
         workspace.get_code_location("test")
         .get_repository("nope")
-        .get_full_external_job("job_that_fails_run_worker")
+        .get_full_job("job_that_fails_run_worker")
     )
     run = instance.create_run_for_job(
         job_def=job_that_fails_run_worker,
@@ -851,9 +837,7 @@ def test_engine_events(
     run_config: Mapping[str, Any],
 ):
     external_job = (
-        workspace.get_code_location("test")
-        .get_repository("nope")
-        .get_full_external_job("math_diamond")
+        workspace.get_code_location("test").get_repository("nope").get_full_job("math_diamond")
     )
     run = instance.create_run_for_job(
         job_def=math_diamond,

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
@@ -49,7 +49,7 @@ def test_run_always_finishes():
                 external_job = (
                     workspace.get_code_location("test")
                     .get_repository("nope")
-                    .get_full_external_job("slow_job")
+                    .get_full_job("slow_job")
                 )
 
                 dagster_run = instance.create_run_for_job(
@@ -108,7 +108,7 @@ def test_run_from_pending_repository():
                 workspace = workspace_process_context.create_request_context()
 
                 code_location = workspace.get_code_location("test2")
-                external_job = code_location.get_repository("pending").get_full_external_job(
+                external_job = code_location.get_repository("pending").get_full_job(
                     "my_cool_asset_job"
                 )
                 external_execution_plan = code_location.get_external_execution_plan(
@@ -212,7 +212,7 @@ def test_terminate_after_shutdown():
             external_job = (
                 workspace.get_code_location("test")
                 .get_repository("nope")
-                .get_full_external_job("sleepy_job")
+                .get_full_job("sleepy_job")
             )
 
             dagster_run = instance.create_run_for_job(
@@ -235,7 +235,7 @@ def test_terminate_after_shutdown():
             external_job = (
                 workspace.get_code_location("test")
                 .get_repository("nope")
-                .get_full_external_job("math_diamond")
+                .get_full_job("math_diamond")
             )
 
             doomed_to_fail_dagster_run = instance.create_run_for_job(
@@ -284,7 +284,7 @@ def test_server_down():
                 external_job = (
                     workspace.get_code_location("test")
                     .get_repository("nope")
-                    .get_full_external_job("sleepy_job")
+                    .get_full_job("sleepy_job")
                 )
 
                 dagster_run = instance.create_run_for_job(

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_pythonic_resources.py
@@ -186,7 +186,7 @@ def test_resources(
     ).astimezone(get_timezone("US/Central"))
 
     with freeze_time(freeze_datetime):
-        external_schedule = external_repo_struct_resources.get_external_schedule(schedule_name)
+        external_schedule = external_repo_struct_resources.get_schedule(schedule_name)
         instance.start_schedule(external_schedule)
 
         assert instance.get_runs_count() == 0

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
@@ -89,7 +89,7 @@ def test_failure_recovery_before_run_created(
 
     freeze_datetime = initial_datetime
 
-    external_schedule = external_repo.get_external_schedule("simple_schedule")
+    external_schedule = external_repo.get_schedule("simple_schedule")
     with freeze_time(freeze_datetime):
         instance.start_schedule(external_schedule)
 
@@ -160,7 +160,7 @@ def test_failure_recovery_after_run_created(
     # it will just re-launch the already-created run when it runs again
     initial_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
     freeze_datetime = initial_datetime
-    external_schedule = external_repo.get_external_schedule("simple_schedule")
+    external_schedule = external_repo.get_schedule("simple_schedule")
     with freeze_time(freeze_datetime):
         instance.start_schedule(external_schedule)
 
@@ -247,7 +247,7 @@ def test_failure_recovery_after_tick_success(
 ):
     initial_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
     freeze_datetime = initial_datetime
-    external_schedule = external_repo.get_external_schedule("simple_schedule")
+    external_schedule = external_repo.get_schedule("simple_schedule")
     with freeze_time(freeze_datetime):
         instance.start_schedule(external_schedule)
 
@@ -330,7 +330,7 @@ def test_failure_recovery_between_multi_runs(
 ):
     initial_datetime = create_datetime(year=2019, month=2, day=28, hour=0, minute=0, second=0)
     freeze_datetime = initial_datetime
-    external_schedule = external_repo.get_external_schedule("multi_run_schedule")
+    external_schedule = external_repo.get_schedule("multi_run_schedule")
     with freeze_time(freeze_datetime):
         instance.start_schedule(external_schedule)
 

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_run.py
@@ -817,8 +817,8 @@ def test_status_in_code_schedule(instance: DagsterInstance, executor: ThreadPool
         external_repo = code_location.get_repository("the_status_in_code_repo")
 
         with freeze_time(freeze_datetime):
-            running_schedule = external_repo.get_external_schedule("always_running_schedule")
-            not_running_schedule = external_repo.get_external_schedule("never_running_schedule")
+            running_schedule = external_repo.get_schedule("always_running_schedule")
+            not_running_schedule = external_repo.get_schedule("never_running_schedule")
 
             always_running_origin = running_schedule.get_remote_origin()
             never_running_origin = not_running_schedule.get_remote_origin()
@@ -889,8 +889,8 @@ def test_status_in_code_schedule(instance: DagsterInstance, executor: ThreadPool
             assert reset_instigator_state.status == InstigatorStatus.DECLARED_IN_CODE
 
             running_to_not_running_schedule = RemoteSchedule(
-                external_schedule_data=copy(
-                    running_schedule._external_schedule_data,  # noqa: SLF001
+                schedule_snap=copy(
+                    running_schedule._schedule_snap,  # noqa: SLF001
                     default_status=DefaultScheduleStatus.STOPPED,
                 ),
                 handle=running_schedule.handle.repository_handle,
@@ -1000,7 +1000,7 @@ def test_change_default_status(instance: DagsterInstance, executor: ThreadPoolEx
         assert code_location
         external_repo = code_location.get_repository("the_status_in_code_repo")
 
-        not_running_schedule = external_repo.get_external_schedule("never_running_schedule")
+        not_running_schedule = external_repo.get_schedule("never_running_schedule")
 
         never_running_origin = not_running_schedule.get_remote_origin()
 
@@ -1081,18 +1081,18 @@ def test_repository_namespacing(instance: DagsterInstance, executor):
 
             # stop always on schedule
             status_in_code_repo = full_location.get_repository("the_status_in_code_repo")
-            running_sched = status_in_code_repo.get_external_schedule("always_running_schedule")
+            running_sched = status_in_code_repo.get_schedule("always_running_schedule")
             instance.stop_schedule(
                 running_sched.get_remote_origin_id(),
                 running_sched.selector_id,
                 running_sched,
             )
 
-            external_schedule = external_repo.get_external_schedule("multi_run_list_schedule")
+            external_schedule = external_repo.get_schedule("multi_run_list_schedule")
             schedule_origin = external_schedule.get_remote_origin()
             instance.start_schedule(external_schedule)
 
-            other_schedule = other_repo.get_external_schedule("multi_run_list_schedule")
+            other_schedule = other_repo.get_schedule("multi_run_list_schedule")
             other_origin = external_schedule.get_remote_origin()
             instance.start_schedule(other_schedule)
 
@@ -1159,7 +1159,7 @@ def test_stale_request_context(
 ):
     freeze_datetime = feb_27_2019_start_of_day()
     with freeze_time(freeze_datetime):
-        external_schedule = external_repo.get_external_schedule("many_requests_schedule")
+        external_schedule = external_repo.get_schedule("many_requests_schedule")
 
         schedule_origin = external_schedule.get_remote_origin()
 
@@ -1218,7 +1218,7 @@ def test_launch_failure(
             },
         },
     ) as scheduler_instance:
-        external_schedule = external_repo.get_external_schedule("simple_schedule")
+        external_schedule = external_repo.get_schedule("simple_schedule")
 
         schedule_origin = external_schedule.get_remote_origin()
         freeze_datetime = feb_27_2019_start_of_day()
@@ -1269,10 +1269,10 @@ def test_schedule_mutation(
     ).code_location.get_repository(  # type: ignore
         "the_repo"
     )
-    schedule_one = repo_one.get_external_schedule("simple_schedule")
+    schedule_one = repo_one.get_schedule("simple_schedule")
     origin_one = schedule_one.get_remote_origin()
     assert schedule_one.cron_schedule == "0 2 * * *"
-    schedule_two = repo_two.get_external_schedule("simple_schedule")
+    schedule_two = repo_two.get_schedule("simple_schedule")
     origin_two = schedule_two.get_remote_origin()
     assert schedule_two.cron_schedule == "0 1 * * *"
 
@@ -1328,7 +1328,7 @@ class TestSchedulerRun:
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
         with freeze_time(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("simple_schedule")
+            external_schedule = external_repo.get_schedule("simple_schedule")
 
             schedule_origin = external_schedule.get_remote_origin()
 
@@ -1494,7 +1494,7 @@ class TestSchedulerRun:
         external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
-        external_schedule = external_repo.get_external_schedule("simple_schedule")
+        external_schedule = external_repo.get_schedule("simple_schedule")
         existing_origin = external_schedule.get_remote_origin()
 
         code_location_origin = existing_origin.repository_origin.code_location_origin
@@ -1543,7 +1543,7 @@ class TestSchedulerRun:
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
         with freeze_time(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("simple_schedule")
+            external_schedule = external_repo.get_schedule("simple_schedule")
 
             # Create an old tick from several days ago
             scheduler_instance.create_tick(
@@ -1578,7 +1578,7 @@ class TestSchedulerRun:
         external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
-        external_schedule = external_repo.get_external_schedule("simple_schedule")
+        external_schedule = external_repo.get_schedule("simple_schedule")
         schedule_origin = external_schedule.get_remote_origin()
 
         evaluate_schedules(workspace_context, executor, get_current_datetime())
@@ -1601,7 +1601,7 @@ class TestSchedulerRun:
         ).code_location
         assert code_location is not None
         external_repo = code_location.get_repository("the_repo")
-        external_schedule = external_repo.get_external_schedule("simple_schedule_no_timezone")
+        external_schedule = external_repo.get_schedule("simple_schedule_no_timezone")
         schedule_origin = external_schedule.get_remote_origin()
         initial_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
 
@@ -1651,7 +1651,7 @@ class TestSchedulerRun:
         external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
-        external_schedule = external_repo.get_external_schedule("wrong_config_schedule")
+        external_schedule = external_repo.get_schedule("wrong_config_schedule")
         schedule_origin = external_schedule.get_remote_origin()
         freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
         with freeze_time(freeze_datetime):
@@ -1722,7 +1722,7 @@ class TestSchedulerRun:
         external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
-        external_schedule = external_repo.get_external_schedule("wrong_config_schedule")
+        external_schedule = external_repo.get_schedule("wrong_config_schedule")
         schedule_origin = external_schedule.get_remote_origin()
         freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
         with freeze_time(freeze_datetime):
@@ -1823,7 +1823,7 @@ class TestSchedulerRun:
             schedule_name = "passes_on_retry_schedule_sync"
         else:
             schedule_name = "passes_on_retry_schedule_async"
-        external_schedule = external_repo.get_external_schedule(schedule_name)
+        external_schedule = external_repo.get_schedule(schedule_name)
         schedule_origin = external_schedule.get_remote_origin()
         freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
         with freeze_time(freeze_datetime):
@@ -1926,7 +1926,7 @@ class TestSchedulerRun:
         external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
-        external_schedule = external_repo.get_external_schedule("bad_should_execute_schedule")
+        external_schedule = external_repo.get_schedule("bad_should_execute_schedule")
         schedule_origin = external_schedule.get_remote_origin()
         initial_datetime = create_datetime(
             year=2019,
@@ -1966,7 +1966,7 @@ class TestSchedulerRun:
         external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
-        external_schedule = external_repo.get_external_schedule("skip_schedule")
+        external_schedule = external_repo.get_schedule("skip_schedule")
         schedule_origin = external_schedule.get_remote_origin()
         freeze_datetime = feb_27_2019_start_of_day()
         with freeze_time(freeze_datetime):
@@ -1996,7 +1996,7 @@ class TestSchedulerRun:
         external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
-        external_schedule = external_repo.get_external_schedule("wrong_config_schedule")
+        external_schedule = external_repo.get_schedule("wrong_config_schedule")
         schedule_origin = external_schedule.get_remote_origin()
         freeze_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
         with freeze_time(freeze_datetime):
@@ -2028,7 +2028,7 @@ class TestSchedulerRun:
         external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
-        external_schedule = external_repo.get_external_schedule("default_config_schedule")
+        external_schedule = external_repo.get_schedule("default_config_schedule")
         schedule_origin = external_schedule.get_remote_origin()
         initial_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
         with freeze_time(initial_datetime):
@@ -2071,9 +2071,7 @@ class TestSchedulerRun:
         external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
-        external_schedule = external_repo.get_external_schedule(
-            "static_partitioned_asset1_schedule"
-        )
+        external_schedule = external_repo.get_schedule("static_partitioned_asset1_schedule")
         initial_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
         with freeze_time(initial_datetime):
             scheduler_instance.start_schedule(external_schedule)
@@ -2098,10 +2096,8 @@ class TestSchedulerRun:
         external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
-        good_schedule = external_repo.get_external_schedule("simple_schedule")
-        bad_schedule = external_repo.get_external_schedule(
-            "bad_should_execute_on_odd_days_schedule"
-        )
+        good_schedule = external_repo.get_schedule("simple_schedule")
+        bad_schedule = external_repo.get_schedule("bad_should_execute_on_odd_days_schedule")
 
         good_origin = good_schedule.get_remote_origin()
         bad_origin = bad_schedule.get_remote_origin()
@@ -2219,7 +2215,7 @@ class TestSchedulerRun:
         external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
-        external_schedule = external_repo.get_external_schedule("simple_schedule")
+        external_schedule = external_repo.get_schedule("simple_schedule")
 
         schedule_origin = external_schedule.get_remote_origin()
         freeze_datetime = feb_27_2019_start_of_day()  # 00:00:00
@@ -2246,7 +2242,7 @@ class TestSchedulerRun:
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
         with freeze_time(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("simple_schedule")
+            external_schedule = external_repo.get_schedule("simple_schedule")
             valid_schedule_origin = external_schedule.get_remote_origin()
 
             # Swap out a new repository name
@@ -2288,7 +2284,7 @@ class TestSchedulerRun:
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
         with freeze_time(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("simple_schedule")
+            external_schedule = external_repo.get_schedule("simple_schedule")
             valid_schedule_origin = external_schedule.get_remote_origin()
 
             # Swap out a new schedule name
@@ -2330,7 +2326,7 @@ class TestSchedulerRun:
         ).astimezone(get_timezone("US/Central"))
 
         with freeze_time(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("simple_schedule")
+            external_schedule = external_repo.get_schedule("simple_schedule")
             valid_schedule_origin = external_schedule.get_remote_origin()
 
             code_location_origin = valid_schedule_origin.repository_origin.code_location_origin
@@ -2373,8 +2369,8 @@ class TestSchedulerRun:
         external_repo: RemoteRepository,
         executor: ThreadPoolExecutor,
     ):
-        external_schedule = external_repo.get_external_schedule("simple_schedule")
-        external_hourly_schedule = external_repo.get_external_schedule("simple_hourly_schedule")
+        external_schedule = external_repo.get_schedule("simple_schedule")
+        external_hourly_schedule = external_repo.get_schedule("simple_hourly_schedule")
         freeze_datetime = feb_27_2019_one_second_to_midnight()
         with freeze_time(freeze_datetime):
             scheduler_instance.start_schedule(external_schedule)
@@ -2428,7 +2424,7 @@ class TestSchedulerRun:
         # This is a Wednesday.
         freeze_datetime = feb_27_2019_start_of_day()
         with freeze_time(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("union_schedule")
+            external_schedule = external_repo.get_schedule("union_schedule")
             schedule_origin = external_schedule.get_remote_origin()
             scheduler_instance.start_schedule(external_schedule)
 
@@ -2543,7 +2539,7 @@ class TestSchedulerRun:
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
         with freeze_time(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("multi_run_schedule")
+            external_schedule = external_repo.get_schedule("multi_run_schedule")
             schedule_origin = external_schedule.get_remote_origin()
             scheduler_instance.start_schedule(external_schedule)
 
@@ -2621,7 +2617,7 @@ class TestSchedulerRun:
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
         with freeze_time(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("multi_run_list_schedule")
+            external_schedule = external_repo.get_schedule("multi_run_list_schedule")
             schedule_origin = external_schedule.get_remote_origin()
             scheduler_instance.start_schedule(external_schedule)
 
@@ -2699,7 +2695,7 @@ class TestSchedulerRun:
     ):
         freeze_datetime = feb_27_2019_start_of_day()
         with freeze_time(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule(
+            external_schedule = external_repo.get_schedule(
                 "multi_run_schedule_with_missing_run_key"
             )
             schedule_origin = external_schedule.get_remote_origin()
@@ -2733,7 +2729,7 @@ class TestSchedulerRun:
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
         with freeze_time(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("large_schedule")
+            external_schedule = external_repo.get_schedule("large_schedule")
             schedule_origin = external_schedule.get_remote_origin()
             scheduler_instance.start_schedule(external_schedule)
 
@@ -2758,7 +2754,7 @@ class TestSchedulerRun:
     ):
         freeze_datetime = feb_27_2019_start_of_day()
         with freeze_time(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("empty_schedule")
+            external_schedule = external_repo.get_schedule("empty_schedule")
 
             schedule_origin = external_schedule.get_remote_origin()
 
@@ -2792,7 +2788,7 @@ class TestSchedulerRun:
     ):
         freeze_datetime = feb_27_2019_start_of_day()
         with freeze_time(freeze_datetime):
-            external_schedule = external_repo.get_external_schedule("many_requests_schedule")
+            external_schedule = external_repo.get_schedule("many_requests_schedule")
 
             schedule_origin = external_schedule.get_remote_origin()
 
@@ -2829,7 +2825,7 @@ class TestSchedulerRun:
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
-        external_schedule = external_repo.get_external_schedule("asset_selection_schedule")
+        external_schedule = external_repo.get_schedule("asset_selection_schedule")
         schedule_origin = external_schedule.get_remote_origin()
 
         with freeze_time(freeze_datetime):
@@ -2880,7 +2876,7 @@ class TestSchedulerRun:
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
-        external_schedule = external_repo.get_external_schedule("stale_asset_selection_schedule")
+        external_schedule = external_repo.get_schedule("stale_asset_selection_schedule")
 
         with freeze_time(freeze_datetime):
             scheduler_instance.start_schedule(external_schedule)
@@ -2908,7 +2904,7 @@ class TestSchedulerRun:
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
-        external_schedule = external_repo.get_external_schedule("stale_asset_selection_schedule")
+        external_schedule = external_repo.get_schedule("stale_asset_selection_schedule")
 
         with freeze_time(freeze_datetime):
             scheduler_instance.start_schedule(external_schedule)
@@ -2934,7 +2930,7 @@ class TestSchedulerRun:
         executor: ThreadPoolExecutor,
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
-        external_schedule = external_repo.get_external_schedule("stale_asset_selection_schedule")
+        external_schedule = external_repo.get_schedule("stale_asset_selection_schedule")
 
         with freeze_time(freeze_datetime):
             scheduler_instance.start_schedule(external_schedule)
@@ -2960,7 +2956,7 @@ class TestSchedulerRun:
         self, scheduler_instance: DagsterInstance, workspace_context, external_repo, executor
     ):
         freeze_datetime = feb_27_2019_one_second_to_midnight()
-        external_schedule = external_repo.get_external_schedule("source_asset_observation_schedule")
+        external_schedule = external_repo.get_schedule("source_asset_observation_schedule")
         schedule_origin = external_schedule.get_remote_origin()
 
         with freeze_time(freeze_datetime):
@@ -3013,17 +3009,17 @@ class TestSchedulerRun:
         freeze_datetime = feb_27_2019_one_second_to_midnight()
 
         with freeze_time(freeze_datetime):
-            job_with_tags_with_run_tags_schedule = external_repo.get_external_schedule(
+            job_with_tags_with_run_tags_schedule = external_repo.get_schedule(
                 "job_with_tags_with_run_tags_schedule"
             )
             scheduler_instance.start_schedule(job_with_tags_with_run_tags_schedule)
 
-            job_with_tags_no_run_tags_schedule = external_repo.get_external_schedule(
+            job_with_tags_no_run_tags_schedule = external_repo.get_schedule(
                 "job_with_tags_no_run_tags_schedule"
             )
             scheduler_instance.start_schedule(job_with_tags_no_run_tags_schedule)
 
-            job_no_tags_with_run_tags_schedule = external_repo.get_external_schedule(
+            job_no_tags_with_run_tags_schedule = external_repo.get_schedule(
                 "job_no_tags_with_run_tags_schedule"
             )
             scheduler_instance.start_schedule(job_no_tags_with_run_tags_schedule)

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_timezones.py
@@ -32,7 +32,7 @@ def test_non_utc_timezone_run(
     ).astimezone(get_timezone("US/Pacific"))
 
     with freeze_time(freeze_datetime):
-        external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
+        external_schedule = external_repo.get_schedule("daily_central_time_schedule")
 
         schedule_origin = external_schedule.get_remote_origin()
 
@@ -95,10 +95,8 @@ def test_differing_timezones(
         2019, 2, 27, 23, 59, 59, tzinfo=get_timezone("US/Eastern")
     ).astimezone(get_timezone("US/Pacific"))
     with freeze_time(freeze_datetime):
-        external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
-        external_eastern_schedule = external_repo.get_external_schedule(
-            "daily_eastern_time_schedule"
-        )
+        external_schedule = external_repo.get_schedule("daily_central_time_schedule")
+        external_eastern_schedule = external_repo.get_schedule("daily_eastern_time_schedule")
 
         schedule_origin = external_schedule.get_remote_origin()
         eastern_origin = external_eastern_schedule.get_remote_origin()
@@ -209,7 +207,7 @@ def test_different_days_in_different_timezones(
     ).astimezone(get_timezone("US/Pacific"))
     with freeze_time(freeze_datetime):
         # Runs every day at 11PM (CST)
-        external_schedule = external_repo.get_external_schedule("daily_late_schedule")
+        external_schedule = external_repo.get_schedule("daily_late_schedule")
         schedule_origin = external_schedule.get_remote_origin()
         instance.start_schedule(external_schedule)
 
@@ -270,7 +268,7 @@ def test_hourly_dst_spring_forward(
         2019, 3, 10, 1, 0, 0, tzinfo=get_timezone("US/Central")
     ).astimezone(get_timezone("US/Pacific"))
 
-    external_schedule = external_repo.get_external_schedule("hourly_central_time_schedule")
+    external_schedule = external_repo.get_schedule("hourly_central_time_schedule")
     schedule_origin = external_schedule.get_remote_origin()
     with freeze_time(freeze_datetime):
         instance.start_schedule(external_schedule)
@@ -343,7 +341,7 @@ def test_hourly_dst_fall_back(
         2019, 11, 3, 0, 30, 0, tzinfo=get_timezone("US/Central")
     ).astimezone(get_timezone("US/Pacific"))
 
-    external_schedule = external_repo.get_external_schedule("hourly_central_time_schedule")
+    external_schedule = external_repo.get_schedule("hourly_central_time_schedule")
     schedule_origin = external_schedule.get_remote_origin()
     with freeze_time(freeze_datetime):
         instance.start_schedule(external_schedule)
@@ -425,7 +423,7 @@ def test_daily_dst_spring_forward(
         2019, 3, 10, 0, 0, 0, tzinfo=get_timezone("US/Central")
     ).astimezone(get_timezone("US/Pacific"))
 
-    external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
+    external_schedule = external_repo.get_schedule("daily_central_time_schedule")
     schedule_origin = external_schedule.get_remote_origin()
     with freeze_time(freeze_datetime):
         instance.start_schedule(external_schedule)
@@ -493,7 +491,7 @@ def test_daily_dst_fall_back(
     ).astimezone(get_timezone("US/Pacific"))
 
     with freeze_time(freeze_datetime):
-        external_schedule = external_repo.get_external_schedule("daily_central_time_schedule")
+        external_schedule = external_repo.get_schedule("daily_central_time_schedule")
         schedule_origin = external_schedule.get_remote_origin()
         instance.start_schedule(external_schedule)
         evaluate_schedules(workspace_context, executor, get_current_datetime())
@@ -561,9 +559,7 @@ def test_execute_during_dst_transition_spring_forward(
     ).astimezone(get_timezone("US/Pacific"))
 
     with freeze_time(freeze_datetime):
-        external_schedule = external_repo.get_external_schedule(
-            "daily_dst_transition_schedule_skipped_time"
-        )
+        external_schedule = external_repo.get_schedule("daily_dst_transition_schedule_skipped_time")
         schedule_origin = external_schedule.get_remote_origin()
         instance.start_schedule(external_schedule)
         evaluate_schedules(workspace_context, executor, get_current_datetime())
@@ -641,9 +637,7 @@ def test_execute_during_dst_transition_fall_back(
     ).astimezone(get_timezone("US/Pacific"))
 
     with freeze_time(freeze_datetime):
-        external_schedule = external_repo.get_external_schedule(
-            "daily_dst_transition_schedule_doubled_time"
-        )
+        external_schedule = external_repo.get_schedule("daily_dst_transition_schedule_doubled_time")
         schedule_origin = external_schedule.get_remote_origin()
         instance.start_schedule(external_schedule)
         evaluate_schedules(workspace_context, executor, get_current_datetime())

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/conftest.py
@@ -269,13 +269,13 @@ def job() -> JobDefinition:
 @pytest.fixture
 def external_job(workspace: WorkspaceRequestContext) -> RemoteJob:
     location = workspace.get_code_location(workspace.code_location_names[0])
-    return location.get_repository(repo.repository.name).get_full_external_job(repo.job.name)
+    return location.get_repository(repo.repository.name).get_full_job(repo.job.name)
 
 
 @pytest.fixture
 def other_external_job(other_workspace: WorkspaceRequestContext) -> RemoteJob:
     location = other_workspace.get_code_location(other_workspace.code_location_names[0])
-    return location.get_repository(repo.repository.name).get_full_external_job(repo.job.name)
+    return location.get_repository(repo.repository.name).get_full_job(repo.job.name)
 
 
 @pytest.fixture

--- a/python_modules/libraries/dagster-celery/dagster_celery_tests/test_launcher.py
+++ b/python_modules/libraries/dagster-celery/dagster_celery_tests/test_launcher.py
@@ -85,7 +85,7 @@ def test_successful_run(
     external_job = (
         workspace.get_code_location("test")
         .get_repository("celery_test_repository")
-        .get_full_external_job("noop_job")
+        .get_full_job("noop_job")
     )
 
     dagster_run = instance.create_run_for_job(
@@ -130,7 +130,7 @@ def test_crashy_run(
     external_job = (
         workspace.get_code_location("test")
         .get_repository("celery_test_repository")
-        .get_full_external_job("crashy_job")
+        .get_full_job("crashy_job")
     )
 
     run = instance.create_run_for_job(
@@ -176,7 +176,7 @@ def test_exity_run(
     external_job = (
         workspace.get_code_location("test")
         .get_repository("celery_test_repository")
-        .get_full_external_job("exity_job")
+        .get_full_job("exity_job")
     )
 
     run = instance.create_run_for_job(
@@ -227,7 +227,7 @@ def test_terminated_run(
     external_job = (
         workspace.get_code_location("test")
         .get_repository("celery_test_repository")
-        .get_full_external_job("sleepy_job")
+        .get_full_job("sleepy_job")
     )
     run = instance.create_run_for_job(
         job_def=sleepy_job,

--- a/python_modules/libraries/dagster-shell/dagster_shell_tests/test_terminate.py
+++ b/python_modules/libraries/dagster-shell/dagster_shell_tests/test_terminate.py
@@ -66,7 +66,7 @@ def test_terminate_kills_subproc():
             external_job = (
                 workspace.get_code_location("test")
                 .get_repository("sleepy_repo")
-                .get_full_external_job("sleepy_job")
+                .get_full_job("sleepy_job")
             )
             dagster_run = instance.create_run_for_job(
                 job_def=sleepy_job,


### PR DESCRIPTION
Internal companion PR: https://github.com/dagster-io/internal/pull/12084

## Summary & Motivation

Rename methods on `RemoteRepository` that have `external` in name to unqualified version, e.g.:

- `get_external_sensor` -> `get_sensor`
- `get_all_external_jobs` -> `get_all_jobs`
- ...

This is following the convention established downstack where remote or snap objects are assumed to contain constituent elements of the same type- -when this is not the case, the accessor is qualified (e.g. `RemoteRepository.get_asset_node_snap` because `RemoteRepository` is not a snapshot object.

Also similarly rename some other private `external_*` attributes/methods on other classes. No changes to serdes layer.

## How I Tested These Changes

Existing test suite