### PR TITLE
[dagster-airlift] Add python 3.8 support

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -361,7 +361,6 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     PackageSpec(
         "examples/experimental/dagster-airlift",
         unsupported_python_versions=[
-            AvailablePythonVersion.V3_8,
             AvailablePythonVersion.V3_12,
         ],
     ),

--- a/examples/experimental/dagster-airlift/setup.py
+++ b/examples/experimental/dagster-airlift/setup.py
@@ -54,7 +54,9 @@ setup(
             f"dagster{pin}",
         ],
         "in-airflow": airflow_dep_list,
-        "mwaa": ["boto3"],
+        "mwaa": [
+            "boto3>=1.18.0"
+        ],  # confirms that mwaa is available in the environment (can't find exactly which version adds mwaa support, but I can confirm that 1.18.0 and greater have it.)
         "dbt": ["dagster-dbt"],
         "k8s": ["dagster-k8s"],
         "test": ["pytest", "dagster-dbt", "dbt-duckdb", "boto3", "dagster-webserver"],


### PR DESCRIPTION
## Summary & Motivation
In order to support 3.8, we need to place a lower bound on boto3 (older versions don't have access to mwaa).
The version I chose is quite old, I don't anticipate this causing a problem. I guess with some resolvers it chooses a version pre-mwaa though, as that's why the tests were failing.
## How I Tested These Changes
Tests now run on 3.8
## Changelog
NOCHANGELOG
