### PR TITLE
[dagster-airlift] Add python 3.12 support

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -360,36 +360,21 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     ),
     PackageSpec(
         "examples/experimental/dagster-airlift",
-        unsupported_python_versions=[
-            AvailablePythonVersion.V3_12,
-        ],
     ),
     PackageSpec(
         "examples/experimental/dagster-airlift/examples/dbt-example",
-        unsupported_python_versions=[
-            AvailablePythonVersion.V3_12,
-        ],
         always_run_if=has_dagster_airlift_changes,
     ),
     PackageSpec(
         "examples/experimental/dagster-airlift/examples/perf-harness",
-        unsupported_python_versions=[
-            AvailablePythonVersion.V3_12,
-        ],
         always_run_if=has_dagster_airlift_changes,
     ),
     PackageSpec(
         "examples/experimental/dagster-airlift/examples/tutorial-example",
-        unsupported_python_versions=[
-            AvailablePythonVersion.V3_12,
-        ],
         always_run_if=has_dagster_airlift_changes,
     ),
     PackageSpec(
         "examples/experimental/dagster-airlift/examples/kitchen-sink",
-        unsupported_python_versions=[
-            AvailablePythonVersion.V3_12,
-        ],
         always_run_if=has_dagster_airlift_changes,
     ),
 ]

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/Makefile
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/Makefile
@@ -24,7 +24,7 @@ wipe: ## Wipe out all the files created by the Makefile
 
 airflow_install:
 	pip install uv && \
-	uv pip install dagster-airlift[in-airflow] && \
+	uv pip install dagster-airlift[in-airflow,dbt,tutorial] && \
 	uv pip install -e $(MAKEFILE_DIR)
 
 airflow_setup:

--- a/examples/experimental/dagster-airlift/setup.py
+++ b/examples/experimental/dagster-airlift/setup.py
@@ -17,14 +17,20 @@ def get_version() -> str:
 ver = get_version()
 pin = "" if ver == "1!0+dev" else NON_EDITABLE_INSTALL_DAGSTER_PIN
 
-airflow_dep_list = [
-    "apache-airflow>=2.0.0,<2.8",
+AIRFLOW_REQUIREMENTS = [
+    # Requirements for python versions under 3.12.
+    "apache-airflow>=2.0.0; python_version < '3.12'",
+    "pendulum>=2.0.0,<3.0.0; python_version < '3.12'",
+    # Requirements for python versions 3.12 and above.
+    "apache-airflow>=2.9.0; python_version >= '3.12'",
+    "pendulum >= 3.0.0; python_version >= '3.12'",
     # Flask-session 0.6 is incompatible with certain airflow-provided test
     # utilities.
     "flask-session<0.6.0",
-    "connexion<3.0.0",  # https://github.com/apache/airflow/issues/35234
-    "pendulum>=2.0.0,<3.0.0",
+    # https://github.com/apache/airflow/issues/35234
+    "connexion<3.0.0",
 ]
+
 
 setup(
     name="dagster-airlift",
@@ -53,13 +59,27 @@ setup(
         "core": [
             f"dagster{pin}",
         ],
-        "in-airflow": airflow_dep_list,
+        # [in-airflow] doesn't directly have a dependency on airflow because Airflow cannot be installed via setup.py reliably. Instead, users need to install from a constraints
+        # file as recommended by the Airflow project.
+        "in-airflow": [],
+        # [tutorial] includes additional dependencies needed to run the tutorial. Namely, the dagster-webserver and the constrained airflow packages.
+        "tutorial": [
+            "dagster-webserver",
+            *AIRFLOW_REQUIREMENTS,
+        ],
         "mwaa": [
             "boto3>=1.18.0"
         ],  # confirms that mwaa is available in the environment (can't find exactly which version adds mwaa support, but I can confirm that 1.18.0 and greater have it.)
         "dbt": ["dagster-dbt"],
         "k8s": ["dagster-k8s"],
-        "test": ["pytest", "dagster-dbt", "dbt-duckdb", "boto3", "dagster-webserver"],
+        "test": [
+            "pytest",
+            "dagster-dbt",
+            "dbt-duckdb",
+            "boto3",
+            "dagster-webserver",
+            *AIRFLOW_REQUIREMENTS,
+        ],
     },
     zip_safe=False,
 )


### PR DESCRIPTION
## Summary & Motivation
A few things preventing 3.12 support and additional fixes.
- Different airflow requirements for 3.12 above and below, as Airflow 2.9 officially added python 3.12 support.
- When performing automagical task creation with parameter swapping (I suspect we'll need to either get rid of this or at least have an argument to disable it), the weight_rule parameter causes problems because it's attribute form is transformed into something we can't interpret in 2.9 or above. So ignore it.
- Remove airflow as a setup.py dependency from the [in-airflow] package. This is because Airflow recommends installation via a constraints file, and installations can be wonky if this is not done. Instead, expect the user to roll their own airflow and have the tests + tutorial install airflow directly.
## How I Tested These Changes
Existing tests + a few modifications. Test suite now runs on 3.12
## Changelog
NOCHANGELOG
