### PR TITLE
[dagster-airlift][dag] in-airflow dag proxying behavior

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/dag_proxy_operator.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/dag_proxy_operator.py
@@ -1,0 +1,53 @@
+import json
+import os
+from typing import Any, Iterable, Mapping, Sequence
+
+import requests
+from airflow import DAG
+from airflow.utils.context import Context
+
+from dagster_airlift.constants import DAG_MAPPING_METADATA_KEY
+from dagster_airlift.in_airflow.base_asset_operator import BaseDagsterAssetsOperator
+
+
+class BaseProxyDAGToDagsterOperator(BaseDagsterAssetsOperator):
+    """An operator that proxies task execution to Dagster assets with metadata that map to this task's dag ID and task ID."""
+
+    def filter_asset_nodes(
+        self, context: Context, asset_nodes: Sequence[Mapping[str, Any]]
+    ) -> Iterable[Mapping[str, Any]]:
+        for asset_node in asset_nodes:
+            if matched_dag_id(asset_node, self.get_airflow_dag_id(context)):
+                yield asset_node
+
+
+class DefaultProxyDAGToDagsterOperator(BaseProxyDAGToDagsterOperator):
+    """The default task proxying operator - which opens a blank session and expects the dagster URL to be set in the environment.
+    The dagster url is expected to be set in the environment as DAGSTER_URL.
+    """
+
+    def get_dagster_session(self, context: Context) -> requests.Session:
+        return requests.Session()
+
+    def get_dagster_url(self, context: Context) -> str:
+        return os.environ["DAGSTER_URL"]
+
+
+def build_dag_level_proxied_task(dag: DAG) -> DefaultProxyDAGToDagsterOperator:
+    return DefaultProxyDAGToDagsterOperator(
+        task_id=f"DAGSTER_OVERRIDE_DAG_{dag.dag_id}",
+        dag=dag,
+    )
+
+
+def matched_dag_id(asset_node: Mapping[str, Any], dag_id: str) -> bool:
+    json_metadata_entries = {
+        entry["label"]: entry["jsonString"]
+        for entry in asset_node["metadataEntries"]
+        if entry["__typename"] == "JsonMetadataEntry"
+    }
+
+    if mapping_entry := json_metadata_entries.get(DAG_MAPPING_METADATA_KEY):
+        mappings = json.loads(mapping_entry)
+        return any(mapping["dag_id"] == dag_id for mapping in mappings)
+    return False

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/proxied_state.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/proxied_state.py
@@ -55,6 +55,24 @@ class DagProxiedState(NamedTuple):
             return False
         return self.tasks[task_id].proxied
 
+    @property
+    def dag_proxies_at_task_level(self) -> bool:
+        """Dags can proxy on either a task-by-task basis, or for the entire dag at once.
+        We use the proxied state to determine which is the case for a given dag. If the dag's proxied state
+        is None, then we assume the dag proxies at the task level. If the dag's proxied state is a boolean,
+        then we assume the dag proxies at the dag level.
+        """
+        return self.proxied is None
+
+    @property
+    def dag_proxies_at_dag_level(self) -> bool:
+        """Dags can proxy on either a task-by-task basis, or for the entire dag at once.
+        We use the proxied state to determine which is the case for a given dag. If the dag's proxied state
+        is None, then we assume the dag proxies at the task level. If the dag's proxied state is a boolean,
+        then we assume the dag proxies at the dag level.
+        """
+        return self.proxied is not None
+
 
 class AirflowProxiedState(NamedTuple):
     dags: Dict[str, DagProxiedState]
@@ -68,6 +86,22 @@ class AirflowProxiedState(NamedTuple):
 
     def dag_has_proxied_state(self, dag_id: str) -> bool:
         return self.get_proxied_dict_for_dag(dag_id) is not None
+
+    def dag_proxies_at_task_level(self, dag_id: str) -> bool:
+        """Dags can proxy on either a task-by-task basis, or for the entire dag at once.
+        We use the proxied state to determine which is the case for a given dag. If the dag's proxied state
+        is None, then we assume the dag proxies at the task level. If the dag's proxied state is a boolean,
+        then we assume the dag proxies at the dag level.
+        """
+        return self.dags[dag_id].dag_proxies_at_task_level
+
+    def dag_proxies_at_dag_level(self, dag_id: str) -> bool:
+        """Dags can proxy on either a task-by-task basis, or for the entire dag at once.
+        We use the proxied state to determine which is the case for a given dag. If the dag's proxied state
+        is None, then we assume the dag proxies at the task level. If the dag's proxied state is a boolean,
+        then we assume the dag proxies at the dag level.
+        """
+        return self.dags[dag_id].dag_proxies_at_dag_level
 
     def get_proxied_dict_for_dag(
         self, dag_id: str

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/proxied_state.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/proxied_state.py
@@ -23,20 +23,29 @@ class TaskProxiedState(NamedTuple):
 
 
 class DagProxiedState(NamedTuple):
+    proxied: Optional[bool]
     tasks: Dict[str, TaskProxiedState]
 
     @staticmethod
-    def from_dict(dag_dict: Dict[str, Sequence[Dict[str, Any]]]) -> "DagProxiedState":
-        if "tasks" not in dag_dict:
+    def from_dict(dag_dict: Dict[str, Any]) -> "DagProxiedState":
+        if "tasks" not in dag_dict and "proxied" not in dag_dict:
             raise Exception(
-                f"Expected a 'tasks' key in the dag dictionary. Instead; got: {dag_dict}"
+                f"Expected a 'tasks' or 'proxied' top-level key in the dag dictionary. Instead; got: {dag_dict}"
             )
-        task_list = dag_dict["tasks"]
+        if "tasks" in dag_dict and "proxied" in dag_dict:
+            raise Exception(
+                f"Expected only one of 'tasks' or 'proxied' top-level keys in the dag dictionary. Instead; got: {dag_dict}"
+            )
         task_proxied_states = {}
-        for task_dict in task_list:
-            task_state = TaskProxiedState.from_dict(task_dict)
-            task_proxied_states[task_state.task_id] = task_state
-        return DagProxiedState(tasks=task_proxied_states)
+        if "tasks" in dag_dict:
+            task_list: Sequence[Dict[str, Any]] = dag_dict["tasks"]
+            for task_dict in task_list:
+                task_state = TaskProxiedState.from_dict(task_dict)
+                task_proxied_states[task_state.task_id] = task_state
+        dag_proxied_state: Optional[bool] = dag_dict.get("proxied")
+        if dag_proxied_state not in [True, False, None]:
+            raise Exception("Expected 'proxied' key to be a boolean or None")
+        return DagProxiedState(tasks=task_proxied_states, proxied=dag_proxied_state)
 
     def to_dict(self) -> Dict[str, Sequence[Dict[str, Any]]]:
         return {"tasks": [task_state.to_dict() for task_state in self.tasks.values()]}

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_proxied_state.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/test_proxied_state.py
@@ -24,13 +24,15 @@ def test_proxied_state() -> None:
                     "first_task": TaskProxiedState(task_id="first_task", proxied=True),
                     "second_task": TaskProxiedState(task_id="second_task", proxied=False),
                     "third_task": TaskProxiedState(task_id="third_task", proxied=True),
-                }
+                },
+                proxied=None,
             ),
             "second": DagProxiedState(
                 tasks={
                     "some_task": TaskProxiedState("some_task", proxied=True),
                     "other_task": TaskProxiedState("other_task", proxied=False),
-                }
+                },
+                proxied=None,
             ),
         }
     )
@@ -58,3 +60,23 @@ tasks:
     assert dag_proxied_state.is_task_proxied("load_raw_customers") is False
     assert dag_proxied_state.is_task_proxied("build_dbt_models") is False
     assert dag_proxied_state.is_task_proxied("export_customers") is True
+
+
+def test_dag_level_proxied_state_from_yaml() -> None:
+    proxied_state_dict = yaml.safe_load("""
+proxied: True
+""")
+    dag_proxied_state = DagProxiedState.from_dict(proxied_state_dict)
+    assert dag_proxied_state.proxied is True
+
+    proxied_state_dict = yaml.safe_load("""
+proxied: False
+""")
+    dag_proxied_state = DagProxiedState.from_dict(proxied_state_dict)
+    assert dag_proxied_state.proxied is False
+
+    proxied_state_dict = yaml.safe_load("""
+proxied: Fish
+""")
+    with pytest.raises(Exception, match="Expected 'proxied' key to be a boolean or None"):
+        DagProxiedState.from_dict(proxied_state_dict)

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/dag_level_proxied.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/dag_level_proxied.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from pathlib import Path
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from dagster_airlift.in_airflow import proxying_to_dagster
+from dagster_airlift.in_airflow.proxied_state import load_proxied_state_from_yaml
+
+
+def print_hello() -> None:
+    print("Hello")  # noqa: T201
+
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2023, 1, 1),
+    "retries": 1,
+}
+
+
+with DAG(
+    "overridden_dag",
+    default_args=default_args,
+    schedule_interval=None,
+    is_paused_upon_creation=False,
+) as dag:
+    PythonOperator(task_id="print_task", python_callable=print_hello) << PythonOperator(
+        task_id="downstream_print_task", python_callable=print_hello
+    )  # type: ignore
+
+
+proxying_to_dagster(
+    proxied_state=load_proxied_state_from_yaml(Path(__file__).parent / "proxied_state"),
+    global_vars=globals(),
+)

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/proxied_state/overridden_dag.yaml
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/proxied_state/overridden_dag.yaml
@@ -1,0 +1,1 @@
+proxied: True

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/dagster_defs/mapped_defs.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/dagster_defs/mapped_defs.py
@@ -1,5 +1,10 @@
 from dagster import Definitions, asset
-from dagster_airlift.core import build_defs_from_airflow_instance, dag_defs, task_defs
+from dagster_airlift.core import (
+    assets_with_dag_mappings,
+    build_defs_from_airflow_instance,
+    dag_defs,
+    task_defs,
+)
 from dagster_airlift.core.multiple_tasks import targeted_by_multiple_tasks
 
 from .airflow_instance import local_airflow_instance
@@ -22,6 +27,11 @@ def asset_one() -> None:
     print("Materialized asset one")
 
 
+@asset(description="Asset two is materialized by an overridden dag")
+def asset_two() -> None:
+    print("Materialized asset two")
+
+
 def build_mapped_defs() -> Definitions:
     return build_defs_from_airflow_instance(
         airflow_instance=local_airflow_instance(),
@@ -38,6 +48,7 @@ def build_mapped_defs() -> Definitions:
                     {"dag_id": "daily_dag", "task_id": "asset_one_daily"},
                 ],
             ),
+            Definitions(assets=assets_with_dag_mappings({"overridden_dag": [asset_two]})),
         ),
     )
 


### PR DESCRIPTION
## Summary & Motivation
Adds everything we need to get dag-level proxying working airflow side. Namely a new operator type and handling within `proxying_to_dagster`
Implementation here more or less matches what was in https://github.com/dagster-io/dagster/pull/25013.
## How I Tested These Changes
Added a kitchen sink test for the behavior.
## Changelog
NOCHANGELOG
