### PR TITLE
accept asset key coercibles in AssetSelection.checks_for_assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_key.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_key.py
@@ -1,5 +1,5 @@
 import re
-from typing import TYPE_CHECKING, Any, Mapping, NamedTuple, Optional, Sequence, TypeVar, Union
+from typing import TYPE_CHECKING, Any, List, Mapping, NamedTuple, Optional, Sequence, TypeVar, Union
 
 import dagster._check as check
 import dagster._seven as seven
@@ -224,3 +224,21 @@ T_EntityKey = TypeVar("T_EntityKey", AssetKey, AssetCheckKey, EntityKey)
 def entity_key_from_db_string(db_string: str) -> EntityKey:
     check_key = AssetCheckKey.from_db_string(db_string)
     return check_key if check_key else check.not_none(AssetKey.from_db_string(db_string))
+
+
+def asset_keys_from_defs_and_coercibles(
+    assets: Sequence[Union["AssetsDefinition", CoercibleToAssetKey]],
+) -> Sequence[AssetKey]:
+    from dagster._core.definitions.assets import AssetsDefinition
+
+    result: List[AssetKey] = []
+    for el in assets:
+        if isinstance(el, AssetsDefinition):
+            result.extend(el.keys)
+        else:
+            result.append(
+                AssetKey.from_user_string(el)
+                if isinstance(el, str)
+                else AssetKey.from_coercible(el)
+            )
+    return result

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_selection.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_asset_check_selection.py
@@ -72,6 +72,35 @@ def test_job_with_all_checks_for_asset():
     }
 
 
+def test_checks_for_assets_asset_key_coercibles():
+    @asset
+    def asset1(): ...
+
+    @asset_check(asset=asset1)
+    def asset1_check():
+        return AssetCheckResult(passed=True)
+
+    @asset
+    def asset2(): ...
+
+    @asset_check(asset=asset2)
+    def asset2_check():
+        return AssetCheckResult(passed=True)
+
+    defs = Definitions(assets=[asset1, asset2], asset_checks=[asset1_check, asset2_check])
+    asset_graph = defs.get_asset_graph()
+
+    assert AssetSelection.checks_for_assets(asset1).resolve_checks(asset_graph) == {
+        AssetCheckKey(asset1.key, "asset1_check")
+    }
+    assert AssetSelection.checks_for_assets(asset1.key).resolve_checks(asset_graph) == {
+        AssetCheckKey(asset1.key, "asset1_check")
+    }
+    assert AssetSelection.checks_for_assets("asset1").resolve_checks(asset_graph) == {
+        AssetCheckKey(asset1.key, "asset1_check")
+    }
+
+
 def test_job_with_asset_and_all_its_checks():
     job_def = define_asset_job("job1", selection=AssetSelection.assets(asset1))
     result = execute_asset_job_in_process(job_def)


### PR DESCRIPTION
## Summary & Motivation

## How I Tested These Changes

## Changelog

`AssetSelection.checks_for_assets` now accepts `AssetKey`s and string asset keys, in addition to `AssetsDefinition`s.
