### PR TITLE
storage endpoint for deleting backfills

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3735,7 +3735,7 @@ type Mutation {
   ): ReportRunlessAssetEventsResult!
   launchPartitionBackfill(backfillParams: LaunchBackfillParams!): LaunchBackfillResult!
   resumePartitionBackfill(backfillId: String!): ResumeBackfillResult!
-  retryPartitionBackfill(backfillId: String!): LaunchBackfillResult!
+  reexecutePartitionBackfill(reexecutionParams: ReexecutionParams): LaunchBackfillResult!
   cancelPartitionBackfill(backfillId: String!): CancelBackfillResult!
   logTelemetry(
     action: String!

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3735,7 +3735,7 @@ type Mutation {
   ): ReportRunlessAssetEventsResult!
   launchPartitionBackfill(backfillParams: LaunchBackfillParams!): LaunchBackfillResult!
   resumePartitionBackfill(backfillId: String!): ResumeBackfillResult!
-  retryPartitionBackfill(backfillId: String!): RetryBackfillResult!
+  retryPartitionBackfill(backfillId: String!): LaunchBackfillResult!
   cancelPartitionBackfill(backfillId: String!): CancelBackfillResult!
   logTelemetry(
     action: String!
@@ -3814,12 +3814,6 @@ type ReportRunlessAssetEventsSuccess {
 union ResumeBackfillResult = ResumeBackfillSuccess | UnauthorizedError | PythonError
 
 type ResumeBackfillSuccess {
-  backfillId: String!
-}
-
-union RetryBackfillResult = RetryBackfillSuccess | UnauthorizedError | PythonError
-
-type RetryBackfillSuccess {
   backfillId: String!
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/schema.graphql
@@ -3735,6 +3735,7 @@ type Mutation {
   ): ReportRunlessAssetEventsResult!
   launchPartitionBackfill(backfillParams: LaunchBackfillParams!): LaunchBackfillResult!
   resumePartitionBackfill(backfillId: String!): ResumeBackfillResult!
+  retryPartitionBackfill(backfillId: String!): RetryBackfillResult!
   cancelPartitionBackfill(backfillId: String!): CancelBackfillResult!
   logTelemetry(
     action: String!
@@ -3813,6 +3814,12 @@ type ReportRunlessAssetEventsSuccess {
 union ResumeBackfillResult = ResumeBackfillSuccess | UnauthorizedError | PythonError
 
 type ResumeBackfillSuccess {
+  backfillId: String!
+}
+
+union RetryBackfillResult = RetryBackfillSuccess | UnauthorizedError | PythonError
+
+type RetryBackfillSuccess {
   backfillId: String!
 }
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2627,6 +2627,7 @@ export type Mutation = {
   resetSchedule: ScheduleMutationResult;
   resetSensor: SensorOrError;
   resumePartitionBackfill: ResumeBackfillResult;
+  retryPartitionBackfill: RetryBackfillResult;
   scheduleDryRun: ScheduleDryRunResult;
   sensorDryRun: SensorDryRunResult;
   setAutoMaterializePaused: Scalars['Boolean']['output'];
@@ -2727,6 +2728,10 @@ export type MutationResetSensorArgs = {
 };
 
 export type MutationResumePartitionBackfillArgs = {
+  backfillId: Scalars['String']['input'];
+};
+
+export type MutationRetryPartitionBackfillArgs = {
   backfillId: Scalars['String']['input'];
 };
 
@@ -4421,6 +4426,13 @@ export type ResumeBackfillResult = PythonError | ResumeBackfillSuccess | Unautho
 
 export type ResumeBackfillSuccess = {
   __typename: 'ResumeBackfillSuccess';
+  backfillId: Scalars['String']['output'];
+};
+
+export type RetryBackfillResult = PythonError | RetryBackfillSuccess | UnauthorizedError;
+
+export type RetryBackfillSuccess = {
+  __typename: 'RetryBackfillSuccess';
   backfillId: Scalars['String']['output'];
 };
 
@@ -10254,6 +10266,12 @@ export const buildMutation = (
         : relationshipsToOmit.has('PythonError')
         ? ({} as PythonError)
         : buildPythonError({}, relationshipsToOmit),
+    retryPartitionBackfill:
+      overrides && overrides.hasOwnProperty('retryPartitionBackfill')
+        ? overrides.retryPartitionBackfill!
+        : relationshipsToOmit.has('PythonError')
+        ? ({} as PythonError)
+        : buildPythonError({}, relationshipsToOmit),
     scheduleDryRun:
       overrides && overrides.hasOwnProperty('scheduleDryRun')
         ? overrides.scheduleDryRun!
@@ -12943,6 +12961,18 @@ export const buildResumeBackfillSuccess = (
     __typename: 'ResumeBackfillSuccess',
     backfillId:
       overrides && overrides.hasOwnProperty('backfillId') ? overrides.backfillId! : 'sint',
+  };
+};
+
+export const buildRetryBackfillSuccess = (
+  overrides?: Partial<RetryBackfillSuccess>,
+  _relationshipsToOmit: Set<string> = new Set(),
+): {__typename: 'RetryBackfillSuccess'} & RetryBackfillSuccess => {
+  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+  relationshipsToOmit.add('RetryBackfillSuccess');
+  return {
+    __typename: 'RetryBackfillSuccess',
+    backfillId: overrides && overrides.hasOwnProperty('backfillId') ? overrides.backfillId! : 'at',
   };
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2627,7 +2627,7 @@ export type Mutation = {
   resetSchedule: ScheduleMutationResult;
   resetSensor: SensorOrError;
   resumePartitionBackfill: ResumeBackfillResult;
-  retryPartitionBackfill: RetryBackfillResult;
+  retryPartitionBackfill: LaunchBackfillResult;
   scheduleDryRun: ScheduleDryRunResult;
   sensorDryRun: SensorDryRunResult;
   setAutoMaterializePaused: Scalars['Boolean']['output'];
@@ -4426,13 +4426,6 @@ export type ResumeBackfillResult = PythonError | ResumeBackfillSuccess | Unautho
 
 export type ResumeBackfillSuccess = {
   __typename: 'ResumeBackfillSuccess';
-  backfillId: Scalars['String']['output'];
-};
-
-export type RetryBackfillResult = PythonError | RetryBackfillSuccess | UnauthorizedError;
-
-export type RetryBackfillSuccess = {
-  __typename: 'RetryBackfillSuccess';
   backfillId: Scalars['String']['output'];
 };
 
@@ -10269,9 +10262,9 @@ export const buildMutation = (
     retryPartitionBackfill:
       overrides && overrides.hasOwnProperty('retryPartitionBackfill')
         ? overrides.retryPartitionBackfill!
-        : relationshipsToOmit.has('PythonError')
-        ? ({} as PythonError)
-        : buildPythonError({}, relationshipsToOmit),
+        : relationshipsToOmit.has('ConflictingExecutionParamsError')
+        ? ({} as ConflictingExecutionParamsError)
+        : buildConflictingExecutionParamsError({}, relationshipsToOmit),
     scheduleDryRun:
       overrides && overrides.hasOwnProperty('scheduleDryRun')
         ? overrides.scheduleDryRun!
@@ -12961,18 +12954,6 @@ export const buildResumeBackfillSuccess = (
     __typename: 'ResumeBackfillSuccess',
     backfillId:
       overrides && overrides.hasOwnProperty('backfillId') ? overrides.backfillId! : 'sint',
-  };
-};
-
-export const buildRetryBackfillSuccess = (
-  overrides?: Partial<RetryBackfillSuccess>,
-  _relationshipsToOmit: Set<string> = new Set(),
-): {__typename: 'RetryBackfillSuccess'} & RetryBackfillSuccess => {
-  const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
-  relationshipsToOmit.add('RetryBackfillSuccess');
-  return {
-    __typename: 'RetryBackfillSuccess',
-    backfillId: overrides && overrides.hasOwnProperty('backfillId') ? overrides.backfillId! : 'at',
   };
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/graphql/types.ts
@@ -2621,13 +2621,13 @@ export type Mutation = {
   launchRun: LaunchRunResult;
   launchRunReexecution: LaunchRunReexecutionResult;
   logTelemetry: LogTelemetryMutationResult;
+  reexecutePartitionBackfill: LaunchBackfillResult;
   reloadRepositoryLocation: ReloadRepositoryLocationMutationResult;
   reloadWorkspace: ReloadWorkspaceMutationResult;
   reportRunlessAssetEvents: ReportRunlessAssetEventsResult;
   resetSchedule: ScheduleMutationResult;
   resetSensor: SensorOrError;
   resumePartitionBackfill: ResumeBackfillResult;
-  retryPartitionBackfill: LaunchBackfillResult;
   scheduleDryRun: ScheduleDryRunResult;
   sensorDryRun: SensorDryRunResult;
   setAutoMaterializePaused: Scalars['Boolean']['output'];
@@ -2711,6 +2711,10 @@ export type MutationLogTelemetryArgs = {
   metadata: Scalars['String']['input'];
 };
 
+export type MutationReexecutePartitionBackfillArgs = {
+  reexecutionParams?: InputMaybe<ReexecutionParams>;
+};
+
 export type MutationReloadRepositoryLocationArgs = {
   repositoryLocationName: Scalars['String']['input'];
 };
@@ -2728,10 +2732,6 @@ export type MutationResetSensorArgs = {
 };
 
 export type MutationResumePartitionBackfillArgs = {
-  backfillId: Scalars['String']['input'];
-};
-
-export type MutationRetryPartitionBackfillArgs = {
   backfillId: Scalars['String']['input'];
 };
 
@@ -10223,6 +10223,12 @@ export const buildMutation = (
         : relationshipsToOmit.has('LogTelemetrySuccess')
         ? ({} as LogTelemetrySuccess)
         : buildLogTelemetrySuccess({}, relationshipsToOmit),
+    reexecutePartitionBackfill:
+      overrides && overrides.hasOwnProperty('reexecutePartitionBackfill')
+        ? overrides.reexecutePartitionBackfill!
+        : relationshipsToOmit.has('ConflictingExecutionParamsError')
+        ? ({} as ConflictingExecutionParamsError)
+        : buildConflictingExecutionParamsError({}, relationshipsToOmit),
     reloadRepositoryLocation:
       overrides && overrides.hasOwnProperty('reloadRepositoryLocation')
         ? overrides.reloadRepositoryLocation!
@@ -10259,12 +10265,6 @@ export const buildMutation = (
         : relationshipsToOmit.has('PythonError')
         ? ({} as PythonError)
         : buildPythonError({}, relationshipsToOmit),
-    retryPartitionBackfill:
-      overrides && overrides.hasOwnProperty('retryPartitionBackfill')
-        ? overrides.retryPartitionBackfill!
-        : relationshipsToOmit.has('ConflictingExecutionParamsError')
-        ? ({} as ConflictingExecutionParamsError)
-        : buildConflictingExecutionParamsError({}, relationshipsToOmit),
     scheduleDryRun:
       overrides && overrides.hasOwnProperty('scheduleDryRun')
         ? overrides.scheduleDryRun!

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -43,6 +43,7 @@ from dagster_graphql.implementation.execution.backfill import (
     cancel_partition_backfill as cancel_partition_backfill,
     create_and_launch_partition_backfill as create_and_launch_partition_backfill,
     resume_partition_backfill as resume_partition_backfill,
+    retry_partition_backfill as retry_partition_backfill,
 )
 from dagster_graphql.implementation.utils import assert_permission, assert_permission_for_location
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -391,9 +391,7 @@ def retry_partition_backfill(
             tags={
                 **backfill.tags,
                 PARENT_BACKFILL_ID_TAG: backfill.backfill_id,
-                ROOT_BACKFILL_ID_TAG: backfill.tags.get(
-                    PARENT_BACKFILL_ID_TAG, backfill.backfill_id
-                ),
+                ROOT_BACKFILL_ID_TAG: backfill.tags.get(ROOT_BACKFILL_ID_TAG, backfill.backfill_id),
             },
             backfill_timestamp=get_current_timestamp(),
             title=f"Retry of {backfill.title}" if backfill.title else None,
@@ -416,9 +414,7 @@ def retry_partition_backfill(
             tags={
                 **backfill.tags,
                 PARENT_BACKFILL_ID_TAG: backfill.backfill_id,
-                ROOT_BACKFILL_ID_TAG: backfill.tags.get(
-                    PARENT_BACKFILL_ID_TAG, backfill.backfill_id
-                ),
+                ROOT_BACKFILL_ID_TAG: backfill.tags.get(ROOT_BACKFILL_ID_TAG, backfill.backfill_id),
             },
             backfill_timestamp=get_current_timestamp(),
             asset_selection=backfill.asset_selection,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -363,8 +363,9 @@ def retry_partition_backfill(
         )
 
     if backfill.is_asset_backfill:
+        asset_backfill_data = backfill.get_asset_backfill_data()
         if (
-            backfill.asset_backfill_data.failed_and_downstream_subset.num_partitions_and_non_partitioned_assets
+            asset_backfill_data.failed_and_downstream_subset.num_partitions_and_non_partitioned_assets
             == 0
         ):
             raise DagsterInvariantViolationError(
@@ -374,13 +375,13 @@ def retry_partition_backfill(
         assert_permission_for_asset_graph(
             graphene_info,
             asset_graph,
-            backfill.asset_backfill_data.failed_and_downstream_subset.asset_keys,
+            list(asset_backfill_data.failed_and_downstream_subset.asset_keys),
             Permissions.LAUNCH_PARTITION_BACKFILL,
         )
 
         new_backfill = PartitionBackfill.from_asset_graph_subset(
             backfill_id=make_new_backfill_id(),
-            asset_graph_subset=backfill.asset_backfill_data.failed_and_downstream_subset,
+            asset_graph_subset=asset_backfill_data.failed_and_downstream_subset,
             dynamic_partitions_store=graphene_info.context.instance,
             tags={
                 **backfill.tags,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -351,7 +351,7 @@ def resume_partition_backfill(
 def retry_partition_backfill(
     graphene_info: "ResolveInfo", backfill_id: str
 ) -> "GrapheneRetryBackfillSuccess":
-    from ...schema.backfill import GrapheneRetryBackfillSuccess
+    from dagster_graphql.schema.backfill import GrapheneRetryBackfillSuccess
 
     backfill = graphene_info.context.instance.get_backfill(backfill_id)
     if not backfill:
@@ -391,7 +391,9 @@ def retry_partition_backfill(
             tags={
                 **backfill.tags,
                 PARENT_BACKFILL_ID_TAG: backfill.backfill_id,
-                ROOT_BACKFILL_ID_TAG: backfill.tags.get(PARENT_BACKFILL_ID_TAG, backfill.backfill_id),
+                ROOT_BACKFILL_ID_TAG: backfill.tags.get(
+                    PARENT_BACKFILL_ID_TAG, backfill.backfill_id
+                ),
             },
             backfill_timestamp=get_current_timestamp(),
             title=f"Retry of {backfill.title}" if backfill.title else None,
@@ -414,7 +416,9 @@ def retry_partition_backfill(
             tags={
                 **backfill.tags,
                 PARENT_BACKFILL_ID_TAG: backfill.backfill_id,
-                ROOT_BACKFILL_ID_TAG: backfill.tags.get(PARENT_BACKFILL_ID_TAG, backfill.backfill_id),
+                ROOT_BACKFILL_ID_TAG: backfill.tags.get(
+                    PARENT_BACKFILL_ID_TAG, backfill.backfill_id
+                ),
             },
             backfill_timestamp=get_current_timestamp(),
             asset_selection=backfill.asset_selection,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -11,7 +11,7 @@ from dagster._core.errors import (
 from dagster._core.events import AssetKey
 from dagster._core.execution.asset_backfill import create_asset_backfill_data_from_asset_partitions
 from dagster._core.execution.backfill import (
-    BULK_ACTION_COMPLETED_STATUSES,
+    BULK_ACTION_TERMINAL_STATUSES,
     BulkActionStatus,
     PartitionBackfill,
 )
@@ -357,7 +357,7 @@ def retry_partition_backfill(
     if not backfill:
         check.failed(f"No backfill found for id: {backfill_id}")
 
-    if backfill.status not in BULK_ACTION_COMPLETED_STATUSES:
+    if backfill.status not in BULK_ACTION_TERMINAL_STATUSES:
         raise DagsterInvariantViolationError(
             f"Cannot retry backfill {backfill_id} because it is still in progress."
         )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -363,7 +363,7 @@ def retry_partition_backfill(
         )
 
     if backfill.is_asset_backfill:
-        asset_backfill_data = backfill.get_asset_backfill_data()
+        asset_backfill_data = backfill.get_asset_backfill_data(graphene_info.context.asset_graph)
         if (
             asset_backfill_data.failed_and_downstream_subset.num_partitions_and_non_partitioned_assets
             == 0

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -109,10 +109,23 @@ class GrapheneResumeBackfillSuccess(graphene.ObjectType):
         name = "ResumeBackfillSuccess"
 
 
+class GrapheneRetryBackfillSuccess(graphene.ObjectType):
+    backfill_id = graphene.NonNull(graphene.String)
+
+    class Meta:
+        name = "RetryBackfillSuccess"
+
+
 class GrapheneResumeBackfillResult(graphene.Union):
     class Meta:
         types = (GrapheneResumeBackfillSuccess, GrapheneUnauthorizedError, GraphenePythonError)
         name = "ResumeBackfillResult"
+
+
+class GrapheneRetryBackfillResult(graphene.Union):
+    class Meta:
+        types = (GrapheneRetryBackfillSuccess, GrapheneUnauthorizedError, GraphenePythonError)
+        name = "RetryBackfillResult"
 
 
 class GrapheneBulkActionStatus(graphene.Enum):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -109,23 +109,10 @@ class GrapheneResumeBackfillSuccess(graphene.ObjectType):
         name = "ResumeBackfillSuccess"
 
 
-class GrapheneRetryBackfillSuccess(graphene.ObjectType):
-    backfill_id = graphene.NonNull(graphene.String)
-
-    class Meta:
-        name = "RetryBackfillSuccess"
-
-
 class GrapheneResumeBackfillResult(graphene.Union):
     class Meta:
         types = (GrapheneResumeBackfillSuccess, GrapheneUnauthorizedError, GraphenePythonError)
         name = "ResumeBackfillResult"
-
-
-class GrapheneRetryBackfillResult(graphene.Union):
-    class Meta:
-        types = (GrapheneRetryBackfillSuccess, GrapheneUnauthorizedError, GraphenePythonError)
-        name = "RetryBackfillResult"
 
 
 class GrapheneBulkActionStatus(graphene.Enum):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -373,7 +373,6 @@ class GrapheneReexecuteBackfillMutation(graphene.Mutation):
     Output = graphene.NonNull(GrapheneLaunchBackfillResult)
 
     class Arguments:
-        # backfillId = graphene.NonNull(graphene.String)
         reexecutionParams = graphene.Argument(GrapheneReexecutionParams)
 
     class Meta:
@@ -384,7 +383,7 @@ class GrapheneReexecuteBackfillMutation(graphene.Mutation):
     def mutate(
         self,
         graphene_info: ResolveInfo,
-        reexecutionParams: Optional[GrapheneReexecutionParams] = None,
+        reexecutionParams: GrapheneReexecutionParams,
     ):
         return retry_partition_backfill(
             graphene_info,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -367,21 +367,30 @@ class GrapheneResumeBackfillMutation(graphene.Mutation):
         return resume_partition_backfill(graphene_info, backfillId)
 
 
-class GrapheneRetryBackfillMutation(graphene.Mutation):
+class GrapheneReexecuteBackfillMutation(graphene.Mutation):
     """Retries a set of partition backfill runs. Retrying a backfill will create a new backfill to retry any failed partitions."""
 
     Output = graphene.NonNull(GrapheneLaunchBackfillResult)
 
     class Arguments:
-        backfillId = graphene.NonNull(graphene.String)
+        # backfillId = graphene.NonNull(graphene.String)
+        reexecutionParams = graphene.Argument(GrapheneReexecutionParams)
 
     class Meta:
         name = "RetryBackfillMutation"
 
     @capture_error
     @require_permission_check(Permissions.LAUNCH_PARTITION_BACKFILL)
-    def mutate(self, graphene_info: ResolveInfo, backfillId: str):
-        return retry_partition_backfill(graphene_info, backfillId)
+    def mutate(
+        self,
+        graphene_info: ResolveInfo,
+        reexecutionParams: Optional[GrapheneReexecutionParams] = None,
+    ):
+        return retry_partition_backfill(
+            graphene_info,
+            backfill_id=reexecutionParams["parentRunId"],
+            strategy=reexecutionParams["strategy"],
+        )
 
 
 class GrapheneAddDynamicPartitionMutation(graphene.Mutation):
@@ -999,7 +1008,7 @@ class GrapheneMutation(graphene.ObjectType):
     reportRunlessAssetEvents = GrapheneReportRunlessAssetEventsMutation.Field()
     launchPartitionBackfill = GrapheneLaunchBackfillMutation.Field()
     resumePartitionBackfill = GrapheneResumeBackfillMutation.Field()
-    retryPartitionBackfill = GrapheneRetryBackfillMutation.Field()
+    reexecutePartitionBackfill = GrapheneReexecuteBackfillMutation.Field()
     cancelPartitionBackfill = GrapheneCancelBackfillMutation.Field()
     logTelemetry = GrapheneLogTelemetryMutation.Field()
     setNuxSeen = GrapheneSetNuxSeenMutation.Field()

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/mutation.py
@@ -50,7 +50,6 @@ from dagster_graphql.schema.backfill import (
     GrapheneCancelBackfillResult,
     GrapheneLaunchBackfillResult,
     GrapheneResumeBackfillResult,
-    GrapheneRetryBackfillResult,
 )
 from dagster_graphql.schema.errors import (
     GrapheneAssetNotFoundError,
@@ -371,7 +370,7 @@ class GrapheneResumeBackfillMutation(graphene.Mutation):
 class GrapheneRetryBackfillMutation(graphene.Mutation):
     """Retries a set of partition backfill runs. Retrying a backfill will create a new backfill to retry any failed partitions."""
 
-    Output = graphene.NonNull(GrapheneRetryBackfillResult)
+    Output = graphene.NonNull(GrapheneLaunchBackfillResult)
 
     class Arguments:
         backfillId = graphene.NonNull(graphene.String)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -1714,7 +1714,7 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert result.data
         assert result.data["reexecutePartitionBackfill"]["__typename"] == "PythonError"
         assert (
-            "Cannot re-execute an asset backfill that has no missing materializations"
+            "Cannot re-execute from failure an asset backfill that has no missing materializations"
             in result.data["reexecutePartitionBackfill"]["message"]
         )
 
@@ -1858,7 +1858,7 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         retried_backfill = graphql_context.instance.get_backfill(retry_backfill_id)
 
         assert (
-            first_backfill.asset_backfill_data.failed_and_downstream_subset
+            first_backfill.asset_backfill_data.target_subset
             == retried_backfill.asset_backfill_data.target_subset
         )
         assert retried_backfill.tags.get(PARENT_BACKFILL_ID_TAG) == backfill_id
@@ -1964,7 +1964,7 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
             graphql_context,
             RETRY_BACKFILL_MUTATION,
             variables={
-                "reexecutionParams": {"parentRunId": backfill_id, "strategy": "FROM_FAILURE"},
+                "reexecutionParams": {"parentRunId": retry_backfill_id, "strategy": "FROM_FAILURE"},
             },
         )
 
@@ -2078,7 +2078,7 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert result.data["partitionBackfillOrError"]["status"] == "REQUESTED"
         assert result.data["partitionBackfillOrError"]["numCancelable"] == 2
         assert len(result.data["partitionBackfillOrError"]["partitionNames"]) == 2
-        assert result.data["partitionBackfillOrError"]["fromFailure"]
+        assert not result.data["partitionBackfillOrError"]["fromFailure"]
 
     def test_retry_in_progress_job_backfill(self, graphql_context):
         repository_selector = infer_repository_selector(graphql_context)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -25,9 +25,9 @@ from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
     ASSET_PARTITION_RANGE_START_TAG,
     BACKFILL_ID_TAG,
-    PARENT_RUN_ID_TAG,
+    PARENT_BACKFILL_ID_TAG,
     PARTITION_NAME_TAG,
-    ROOT_RUN_ID_TAG,
+    ROOT_BACKFILL_ID_TAG,
 )
 from dagster._core.test_utils import create_run_for_test, environ
 from dagster._core.utils import make_new_backfill_id
@@ -619,8 +619,8 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
         retried_backfill_id = result.data["retryPartitionBackfill"]["backfillId"]
         retried_backfill = graphql_context.instance.get_backfill(retried_backfill_id)
 
-        assert retried_backfill.tags.get(PARENT_RUN_ID_TAG) == backfill_id
-        assert retried_backfill.tags.get(ROOT_RUN_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(PARENT_BACKFILL_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
         result = execute_dagster_graphql(
             graphql_context,
@@ -809,8 +809,8 @@ class TestDaemonPartitionBackfill(ExecutingGraphQLContextTestMatrix):
             first_backfill.asset_backfill_data.target_subset
             == retried_backfill.asset_backfill_data.target_subset
         )
-        assert retried_backfill.tags.get(PARENT_RUN_ID_TAG) == backfill_id
-        assert retried_backfill.tags.get(ROOT_RUN_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(PARENT_BACKFILL_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
     def test_resume_backfill(self, graphql_context):
         repository_selector = infer_repository_selector(graphql_context)
@@ -1628,8 +1628,8 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
             first_backfill.asset_backfill_data.failed_and_downstream_subset
             == retried_backfill.asset_backfill_data.target_subset
         )
-        assert retried_backfill.tags.get(PARENT_RUN_ID_TAG) == backfill_id
-        assert retried_backfill.tags.get(ROOT_RUN_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(PARENT_BACKFILL_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
     def test_retry_successful_asset_backfill(self, graphql_context):
         # TestLaunchDaemonBackfillFromFailure::test_retry_successful_asset_backfill[sqlite_with_default_run_launcher_managed_grpc_env]
@@ -1784,8 +1784,8 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
             first_backfill.asset_backfill_data.failed_and_downstream_subset
             == retried_backfill.asset_backfill_data.target_subset
         )
-        assert retried_backfill.tags.get(PARENT_RUN_ID_TAG) == backfill_id
-        assert retried_backfill.tags.get(ROOT_RUN_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(PARENT_BACKFILL_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
     def test_retry_asset_backfill_twice(self, graphql_context):
         # TestLaunchDaemonBackfillFromFailure::test_retry_asset_backfill_twice[sqlite_with_default_run_launcher_managed_grpc_env]
@@ -1859,8 +1859,8 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
             first_backfill.asset_backfill_data.failed_and_downstream_subset
             == retried_backfill.asset_backfill_data.target_subset
         )
-        assert retried_backfill.tags.get(PARENT_RUN_ID_TAG) == backfill_id
-        assert retried_backfill.tags.get(ROOT_RUN_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(PARENT_BACKFILL_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
         _execute_asset_backfill_iteration_no_side_effects(
             graphql_context, retried_backfill.backfill_id, asset_graph
@@ -1904,8 +1904,8 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
             retried_backfill.asset_backfill_data.failed_and_downstream_subset
             == second_retried_backfill.asset_backfill_data.target_subset
         )
-        assert second_retried_backfill.tags.get(PARENT_RUN_ID_TAG) == retry_backfill_id
-        assert second_retried_backfill.tags.get(ROOT_RUN_ID_TAG) == backfill_id
+        assert second_retried_backfill.tags.get(PARENT_BACKFILL_ID_TAG) == retry_backfill_id
+        assert second_retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
     def test_retry_job_backfill(self, graphql_context):
         # TestLaunchDaemonBackfillFromFailure::test_retry_job_backfill[sqlite_with_default_run_launcher_managed_grpc_env]
@@ -1956,8 +1956,8 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         retried_backfill_id = result.data["retryPartitionBackfill"]["backfillId"]
         retried_backfill = graphql_context.instance.get_backfill(retried_backfill_id)
 
-        assert retried_backfill.tags.get(PARENT_RUN_ID_TAG) == backfill_id
-        assert retried_backfill.tags.get(ROOT_RUN_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(PARENT_BACKFILL_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
         result = execute_dagster_graphql(
             graphql_context,
@@ -2033,8 +2033,8 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         retried_backfill_id = result.data["retryPartitionBackfill"]["backfillId"]
         retried_backfill = graphql_context.instance.get_backfill(retried_backfill_id)
 
-        assert retried_backfill.tags.get(PARENT_RUN_ID_TAG) == backfill_id
-        assert retried_backfill.tags.get(ROOT_RUN_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(PARENT_BACKFILL_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
     def test_retry_job_backfill_twice(self, graphql_context):
         # TestLaunchDaemonBackfillFromFailure::test_retry_in_progress_job_backfill[sqlite_with_default_run_launcher_managed_grpc_env]
@@ -2086,8 +2086,8 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         retried_backfill_id = result.data["retryPartitionBackfill"]["backfillId"]
         retried_backfill = graphql_context.instance.get_backfill(retried_backfill_id)
 
-        assert retried_backfill.tags.get(PARENT_RUN_ID_TAG) == backfill_id
-        assert retried_backfill.tags.get(ROOT_RUN_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(PARENT_BACKFILL_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
         graphql_context.instance.update_backfill(
             retried_backfill.with_status(BulkActionStatus.COMPLETED)
@@ -2106,8 +2106,8 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         second_retried_backfill_id = result.data["retryPartitionBackfill"]["backfillId"]
         second_retried_backfill = graphql_context.instance.get_backfill(second_retried_backfill_id)
 
-        assert second_retried_backfill.tags.get(PARENT_RUN_ID_TAG) == retried_backfill_id
-        assert second_retried_backfill.tags.get(ROOT_RUN_ID_TAG) == backfill_id
+        assert second_retried_backfill.tags.get(PARENT_BACKFILL_ID_TAG) == retried_backfill_id
+        assert second_retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
     def test_retry_successful_job_backfill(self, graphql_context):
         # TestLaunchDaemonBackfillFromFailure::test_retry_successful_job_backfill[sqlite_with_default_run_launcher_managed_grpc_env]
@@ -2150,5 +2150,5 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         retried_backfill_id = result.data["retryPartitionBackfill"]["backfillId"]
         retried_backfill = graphql_context.instance.get_backfill(retried_backfill_id)
 
-        assert retried_backfill.tags.get(PARENT_RUN_ID_TAG) == backfill_id
-        assert retried_backfill.tags.get(ROOT_RUN_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(PARENT_BACKFILL_ID_TAG) == backfill_id
+        assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_partition_backfill.py
@@ -1557,7 +1557,6 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert len(result.data["partitionBackfillOrError"]["partitionNames"]) == 10
 
     def test_retry_asset_backfill(self, graphql_context):
-        # TestLaunchDaemonBackfillFromFailure::test_retry_asset_backfill[sqlite_with_default_run_launcher_managed_grpc_env]
         code_location = graphql_context.get_code_location("test")
         repository = code_location.get_repository("test_repo")
         asset_graph = repository.asset_graph
@@ -1632,7 +1631,6 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
     def test_retry_successful_asset_backfill(self, graphql_context):
-        # TestLaunchDaemonBackfillFromFailure::test_retry_successful_asset_backfill[sqlite_with_default_run_launcher_managed_grpc_env]
         code_location = graphql_context.get_code_location("test")
         repository = code_location.get_repository("test_repo")
         asset_graph = repository.asset_graph
@@ -1689,7 +1687,6 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
                 "backfillId": backfill_id,
             },
         )
-        # TestLaunchDaemonBackfillFromFailure::test_retry_successful_asset_backfill[sqlite_with_default_run_launcher_managed_grpc_env]
         assert not result.errors
         assert result.data
         assert result.data["retryPartitionBackfill"]["__typename"] == "PythonError"
@@ -1699,7 +1696,6 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         )
 
     def test_retry_asset_backfill_still_in_progress(self, graphql_context):
-        # TestLaunchDaemonBackfillFromFailure::test_retry_asset_backfill_still_in_progress[sqlite_with_default_run_launcher_managed_grpc_env]
         code_location = graphql_context.get_code_location("test")
         repository = code_location.get_repository("test_repo")
         asset_graph = repository.asset_graph
@@ -1788,7 +1784,6 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
     def test_retry_asset_backfill_twice(self, graphql_context):
-        # TestLaunchDaemonBackfillFromFailure::test_retry_asset_backfill_twice[sqlite_with_default_run_launcher_managed_grpc_env]
         code_location = graphql_context.get_code_location("test")
         repository = code_location.get_repository("test_repo")
         asset_graph = repository.asset_graph
@@ -1908,7 +1903,6 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert second_retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
     def test_retry_job_backfill(self, graphql_context):
-        # TestLaunchDaemonBackfillFromFailure::test_retry_job_backfill[sqlite_with_default_run_launcher_managed_grpc_env]
         repository_selector = infer_repository_selector(graphql_context)
         partition_set_selector = {
             "repositorySelector": repository_selector,
@@ -1973,7 +1967,6 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert result.data["partitionBackfillOrError"]["fromFailure"]
 
     def test_retry_in_progress_job_backfill(self, graphql_context):
-        # TestLaunchDaemonBackfillFromFailure::test_retry_in_progress_job_backfill[sqlite_with_default_run_launcher_managed_grpc_env]
         repository_selector = infer_repository_selector(graphql_context)
         partition_set_selector = {
             "repositorySelector": repository_selector,
@@ -2037,7 +2030,6 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
     def test_retry_job_backfill_twice(self, graphql_context):
-        # TestLaunchDaemonBackfillFromFailure::test_retry_in_progress_job_backfill[sqlite_with_default_run_launcher_managed_grpc_env]
         repository_selector = infer_repository_selector(graphql_context)
         partition_set_selector = {
             "repositorySelector": repository_selector,
@@ -2110,7 +2102,6 @@ class TestLaunchDaemonBackfillFromFailure(ExecutingGraphQLContextTestMatrix):
         assert second_retried_backfill.tags.get(ROOT_BACKFILL_ID_TAG) == backfill_id
 
     def test_retry_successful_job_backfill(self, graphql_context):
-        # TestLaunchDaemonBackfillFromFailure::test_retry_successful_job_backfill[sqlite_with_default_run_launcher_managed_grpc_env]
         repository_selector = infer_repository_selector(graphql_context)
         partition_set_selector = {
             "repositorySelector": repository_selector,

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -41,6 +41,11 @@ class BulkActionStatus(Enum):
     def from_graphql_input(graphql_str):
         return BulkActionStatus(graphql_str)
 
+BULK_ACTION_COMPLETED_STATUSES = [
+    BulkActionStatus.COMPLETED,
+    BulkActionStatus.FAILED,
+    BulkActionStatus.CANCELED,
+]
 
 @record
 class BulkActionsFilter:

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -41,11 +41,13 @@ class BulkActionStatus(Enum):
     def from_graphql_input(graphql_str):
         return BulkActionStatus(graphql_str)
 
+
 BULK_ACTION_COMPLETED_STATUSES = [
     BulkActionStatus.COMPLETED,
     BulkActionStatus.FAILED,
     BulkActionStatus.CANCELED,
 ]
+
 
 @record
 class BulkActionsFilter:

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -42,7 +42,7 @@ class BulkActionStatus(Enum):
         return BulkActionStatus(graphql_str)
 
 
-BULK_ACTION_COMPLETED_STATUSES = [
+BULK_ACTION_TERMINAL_STATUSES = [
     BulkActionStatus.COMPLETED,
     BulkActionStatus.FAILED,
     BulkActionStatus.CANCELED,

--- a/python_modules/dagster/dagster/_core/execution/backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/backfill.py
@@ -46,6 +46,9 @@ BULK_ACTION_COMPLETED_STATUSES = [
     BulkActionStatus.COMPLETED,
     BulkActionStatus.FAILED,
     BulkActionStatus.CANCELED,
+    BulkActionStatus.COMPLETED_SUCCESS,
+    BulkActionStatus.COMPLETED_SUCCESS,
+    BulkActionStatus.COMPLETED_FAILED,
 ]
 
 

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -3108,6 +3108,9 @@ class DagsterInstance(DynamicPartitionsStore):
     def update_backfill(self, partition_backfill: "PartitionBackfill") -> None:
         self._run_storage.update_backfill(partition_backfill)
 
+    def delete_backfill(self, backfill_id: str) -> None:
+        self._run_storage.delete_backfill(backfill_id)
+
     @property
     def should_start_background_run_thread(self) -> bool:
         """Gate on an experimental feature to start a thread that monitors for if the run should be canceled."""

--- a/python_modules/dagster/dagster/_core/storage/legacy_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/legacy_storage.py
@@ -332,6 +332,9 @@ class LegacyRunStorage(RunStorage, ConfigurableClass):
     def update_backfill(self, partition_backfill: "PartitionBackfill") -> None:
         return self._storage.run_storage.update_backfill(partition_backfill)
 
+    def delete_backfill(self, backfill_id: str) -> None:
+        return self._storage.run_storage.delete_backfill(backfill_id)
+
     def get_run_partition_data(self, runs_filter: "RunsFilter") -> Sequence["RunPartitionData"]:
         return self._storage.run_storage.get_run_partition_data(runs_filter)
 

--- a/python_modules/dagster/dagster/_core/storage/runs/base.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/base.py
@@ -403,6 +403,10 @@ class RunStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance], DaemonCursorSto
     def update_backfill(self, partition_backfill: PartitionBackfill):
         """Update a partition backfill in run storage."""
 
+    @abstractmethod
+    def delete_backfill(self, backfill_id: str) -> None:
+        """Delete a backfill from run storage."""
+
     def alembic_version(self) -> Optional[AlembicVersion]:
         return None
 

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -1017,6 +1017,12 @@ class SqlRunStorage(RunStorage):
                 )
             )
 
+    def delete_backfill(self, backfill_id: str) -> None:
+        check.str_param(backfill_id, "backfill_id")
+        query = db.delete(BulkActionsTable).where(BulkActionsTable.c.key == backfill_id)
+        with self.connect() as conn:
+            conn.execute(query)
+
     def get_cursor_values(self, keys: Set[str]) -> Mapping[str, str]:
         check.set_param(keys, "keys", of_type=str)
 

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -31,7 +31,11 @@ PARTITION_SET_TAG = f"{SYSTEM_TAG_PREFIX}partition_set"
 
 PARENT_RUN_ID_TAG = f"{SYSTEM_TAG_PREFIX}parent_run_id"
 
+PARENT_BACKFILL_ID_TAG = f"{SYSTEM_TAG_PREFIX}parent_backfill_id"
+
 ROOT_RUN_ID_TAG = f"{SYSTEM_TAG_PREFIX}root_run_id"
+
+ROOT_BACKFILL_ID_TAG = f"{SYSTEM_TAG_PREFIX}root_backfill_id"
 
 RESUME_RETRY_TAG = f"{SYSTEM_TAG_PREFIX}is_resume_retry"
 


### PR DESCRIPTION
## Summary & Motivation
adds storage endpoint for deleting backfills. This will NOT delete any runs that the backfill launched, just deletes the row for the backfill from the BulkActionsTable

associated internal pr https://github.com/dagster-io/internal/pull/12090

## How I Tested These Changes
new unit tests
