### PR TITLE
Make existing conditions work with Asset Checks

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/__init__.py
@@ -1,7 +1,7 @@
 from dagster._core.definitions.declarative_automation.operands import (
     CodeVersionChangedCondition as CodeVersionChangedCondition,
     CronTickPassedCondition as CronTickPassedCondition,
-    FailedAutomationCondition as FailedAutomationCondition,
+    ExecutionFailedAutomationCondition as ExecutionFailedAutomationCondition,
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,
     InProgressAutomationCondition as InProgressAutomationCondition,
     MissingAutomationCondition as MissingAutomationCondition,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
@@ -46,7 +46,7 @@ class EvaluateAutomationConditionsResult:
     @property
     def total_requested(self) -> int:
         """Returns the total number of asset partitions requested during this evaluation."""
-        return len(self._requested_asset_partitions)
+        return sum(r.true_subset.size for r in self.results)
 
     def get_requested_partitions(self, asset_key: AssetKey) -> AbstractSet[Optional[str]]:
         """Returns the specific partition keys requested for the given asset during this evaluation."""
@@ -113,7 +113,9 @@ def evaluate_automation_conditions(
         defs = Definitions(assets=defs)
 
     if asset_selection is None:
-        asset_selection = AssetSelection.all(include_sources=True)
+        asset_selection = (
+            AssetSelection.all(include_sources=True) | AssetSelection.all_asset_checks()
+        )
 
     asset_graph = defs.get_asset_graph()
     evaluator = AutomationConditionEvaluator(
@@ -122,6 +124,7 @@ def evaluate_automation_conditions(
         entity_keys={
             key
             for key in asset_selection.resolve(asset_graph)
+            | asset_selection.resolve_checks(asset_graph)
             if asset_graph.get(key).automation_condition is not None
         },
         evaluation_time=evaluation_time,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generic, Mapping, Optional, Type, TypeVar
 
 import dagster._check as check
-from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView
+from dagster._core.asset_graph_view.asset_graph_view import AssetGraphView, TemporalContext
 from dagster._core.asset_graph_view.entity_subset import EntitySubset
 from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey, EntityKey, T_EntityKey
 from dagster._core.definitions.declarative_automation.automation_condition import (
@@ -200,6 +200,11 @@ class AutomationContext(Generic[T_EntityKey]):
     def previous_evaluation_time(self) -> Optional[datetime.datetime]:
         """The `evaluation_time` value used on the previous tick's evaluation."""
         return self._cursor.temporal_context.effective_dt if self._cursor else None
+
+    @property
+    def previous_temporal_context(self) -> Optional[TemporalContext]:
+        """The `temporal_context` value used on the previous tick's evaluation."""
+        return self._cursor.temporal_context if self._cursor else None
 
     @property
     def legacy_context(self) -> LegacyRuleEvaluationContext:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/__init__.py
@@ -2,8 +2,9 @@ from dagster._core.definitions.declarative_automation.operands.code_version_chan
     CodeVersionChangedCondition as CodeVersionChangedCondition,
 )
 from dagster._core.definitions.declarative_automation.operands.slice_conditions import (
+    CheckResultCondition as CheckResultCondition,
     CronTickPassedCondition as CronTickPassedCondition,
-    FailedAutomationCondition as FailedAutomationCondition,
+    ExecutionFailedAutomationCondition as ExecutionFailedAutomationCondition,
     InitialEvaluationCondition as InitialEvaluationCondition,
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,
     InProgressAutomationCondition as InProgressAutomationCondition,

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_check_passed_failed_conditions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_check_passed_failed_conditions.py
@@ -1,0 +1,56 @@
+import pytest
+from dagster import (
+    AssetCheckResult,
+    AssetMaterialization,
+    AutomationCondition,
+    DagsterInstance,
+    Definitions,
+    asset,
+    asset_check,
+    evaluate_automation_conditions,
+)
+
+
+@pytest.mark.parametrize("passed", [True, False])
+def test_check_result_conditions(passed: bool) -> None:
+    condition = AutomationCondition.check_passed() if passed else AutomationCondition.check_failed()
+
+    @asset
+    def A() -> None: ...
+
+    @asset_check(asset=A, automation_condition=condition)
+    def foo_check() -> AssetCheckResult:
+        return AssetCheckResult(passed=passed)
+
+    defs = Definitions(assets=[A], asset_checks=[foo_check])
+    instance = DagsterInstance.ephemeral()
+    check_job = defs.get_implicit_global_asset_job_def().get_subset(
+        asset_check_selection={foo_check.check_key}
+    )
+
+    # hasn't been executed
+    result = evaluate_automation_conditions(defs=defs, instance=instance)
+    assert result.total_requested == 0
+
+    # now gets executed, so the status matches
+    check_job.execute_in_process(instance=instance)
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 1
+
+    # stays true
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 1
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 1
+
+    # now the parent asset gets materialized, which means that the status goes to "missing"
+    instance.report_runless_asset_event(AssetMaterialization("A"))
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 0
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 0
+
+    # now gets executed again, so the status matches
+    check_job.execute_in_process(instance=instance)
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 1

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_eager_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_eager_condition.py
@@ -3,6 +3,7 @@ from dagster import (
     AssetKey,
     AssetMaterialization,
     AutomationCondition,
+    DagsterInstance,
     DailyPartitionsDefinition,
     Definitions,
     DimensionPartitionMapping,
@@ -11,6 +12,7 @@ from dagster import (
     StaticPartitionsDefinition,
     TimeWindowPartitionMapping,
     asset,
+    asset_check,
     evaluate_automation_conditions,
 )
 from dagster._core.instance_for_test import instance_for_test
@@ -204,3 +206,37 @@ def test_eager_multi_partitioned_self_dependency() -> None:
         result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
         # can't materialize downstream yet because previous partition of child is still missing
         assert result.total_requested == 0
+
+
+def test_eager_on_asset_check() -> None:
+    @asset
+    def A() -> None: ...
+
+    @asset_check(asset=A, automation_condition=AutomationCondition.eager())
+    def foo_check() -> ...: ...
+
+    defs = Definitions(assets=[A], asset_checks=[foo_check])
+
+    instance = DagsterInstance.ephemeral()
+
+    # parent hasn't been updated yet
+    result = evaluate_automation_conditions(defs=defs, instance=instance)
+    assert result.total_requested == 0
+
+    # now A is updated, so request
+    instance.report_runless_asset_event(AssetMaterialization("A"))
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 1
+
+    # don't keep requesting
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 0
+
+    # A updated again, re-request
+    instance.report_runless_asset_event(AssetMaterialization("A"))
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 1
+
+    # don't keep requesting
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_failed_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_failed_condition.py
@@ -16,7 +16,7 @@ from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils
 
 def test_failed_unpartitioned() -> None:
     state = AutomationConditionScenarioState(
-        one_asset, automation_condition=AutomationCondition.failed()
+        one_asset, automation_condition=AutomationCondition.execution_failed()
     )
 
     # no failed partitions
@@ -36,7 +36,7 @@ def test_failed_unpartitioned() -> None:
 
 def test_in_progress_static_partitioned() -> None:
     state = AutomationConditionScenarioState(
-        one_asset, automation_condition=AutomationCondition.failed()
+        one_asset, automation_condition=AutomationCondition.execution_failed()
     ).with_asset_properties(partitions_def=two_partitions_def)
 
     # no failed_runs


### PR DESCRIPTION
## Summary & Motivation

This updates our suite of built-in automation conditions to work natively with asset checks (previously, they only worked with assets).

This means you can do things like use the `on_cron` or `eager` conditions with checks.

This requires a unified set of statuses that apply to both assets and asset checks, as each has different ways of describing their status.

## How I Tested These Changes

## Changelog

- The `AutomationCondition.eager()`, `AutomationCondition.missing()`, and `AutomationCondition.on_cron` conditions are now compatible with asset checks.
