### PR TITLE
Raise a clearer exception when a concurrency slot is tried to claim with a priority outside of the valid range

### DIFF
--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_instance_concurrency_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_instance_concurrency_context.py
@@ -292,3 +292,19 @@ def test_run_step_priority(concurrency_instance):
         time.sleep(0.1)
 
         assert low_context.claim("foo", "low_run_low_step", step_priority=-1)  # -1001
+
+        with pytest.raises(
+            Exception,
+            match="Tried to claim a concurrency slot with a priority -2147483648 that was not in the allowed range of a 32-bit signed integer.",
+        ):
+            low_context.claim("foo", "too_low_step", step_priority=-(2**31 - 1) + 1000 - 1)
+
+        low_context.claim("foo", "too_low_step", step_priority=-(2**31 - 1) + 1000)
+
+        with pytest.raises(
+            Exception,
+            match="Tried to claim a concurrency slot with a priority 2147483648 that was not in the allowed range of a 32-bit signed integer.",
+        ):
+            regular_context.claim("foo", "too_high_step", step_priority=(2**31 - 1) + 1)
+
+        regular_context.claim("foo", "too_high_step", step_priority=-(2**31 - 1))


### PR DESCRIPTION
## Summary & Motivation
the column is stored as a postgres Integer, so trying to set a priority that is too high will fail.

## How I Tested These Changes
BK

## Changelog
- [x] `NEW` Raise a clearer error message when a concurrency slot is claimed with a priority that is too large.

