### PR TITLE
[dagster-github] add docstrings to dagster-github public methods

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-github.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-github.rst
@@ -39,7 +39,7 @@ Sharing your App ID and Installation ID is fine, but make sure that the Private 
 stored securily.
 
 Posting Issues
---------------
+==============
 
 Now, you can create issues in GitHub from Dagster with the GitHub resource:
 
@@ -91,7 +91,7 @@ By provisioning ``GithubResource`` as a Dagster resource, you can post to GitHub
 within any asset or op execution.
 
 Executing GraphQL queries
--------------------------
+=========================
 
 .. code-block:: python
 
@@ -125,11 +125,16 @@ Executing GraphQL queries
 
    github_job.execute_in_process()
 
-.. currentmodule:: dagster_github
+
+Resources
+=========
+
+.. currentmodule:: dagster_github.resources
+
+.. autoclass:: GithubClient
 
 .. autoconfigurable:: GithubResource
   :annotation: ResourceDefinition
-
 
 Legacy
 =======


### PR DESCRIPTION
## Summary & Motivation

This adds docstrings to the public methods of `GithubClient` & `GithubResource`, and the classes themselves. Also updates the `.rst` file to start rendering the `GithubClient`.

## How I Tested These Changes
Built the docs locally and inspected the result with:
```
cd docs
make apidoc-build
make next-watch-build
```
