### PR TITLE
[external-renames] Rename private `external_{repository,sensor,schedule,partition_set}` params/args/vars to `remote` variants

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/test_memory.py
+++ b/integration_tests/test_suites/daemon-test-suite/test_memory.py
@@ -77,11 +77,11 @@ def test_no_memory_leaks():
         },
     ) as instance:
         with get_example_repo(instance) as repo:
-            external_schedule = repo.get_schedule("always_run_schedule")
-            external_sensor = repo.get_sensor("always_on_sensor")
+            schedule = repo.get_schedule("always_run_schedule")
+            sensor = repo.get_sensor("always_on_sensor")
 
-            instance.start_schedule(external_schedule)
-            instance.start_sensor(external_sensor)
+            instance.start_schedule(schedule)
+            instance.start_sensor(sensor)
 
             with daemon_controller_from_instance(
                 instance,

--- a/integration_tests/test_suites/daemon-test-suite/test_queued.py
+++ b/integration_tests/test_suites/daemon-test-suite/test_queued.py
@@ -29,12 +29,12 @@ def assert_events_in_order(logs, expected_events):
 
 
 def test_queue_from_schedule_and_sensor(instance, foo_example_workspace, foo_example_repo):
-    external_schedule = foo_example_repo.get_schedule("always_run_schedule")
-    external_sensor = foo_example_repo.get_sensor("always_on_sensor")
+    remote_schedule = foo_example_repo.get_schedule("always_run_schedule")
+    remote_sensor = foo_example_repo.get_sensor("always_on_sensor")
     remote_job = foo_example_repo.get_full_job("foo_job")
 
-    instance.start_schedule(external_schedule)
-    instance.start_sensor(external_sensor)
+    instance.start_schedule(remote_schedule)
+    instance.start_sensor(remote_sensor)
 
     with start_daemon(timeout=180, workspace_file=file_relative_path(__file__, "repo.py")):
         run = create_run(instance, remote_job)
@@ -42,10 +42,10 @@ def test_queue_from_schedule_and_sensor(instance, foo_example_workspace, foo_exa
 
         runs = [
             poll_for_finished_run(instance, run.run_id),
-            poll_for_finished_run(instance, run_tags=DagsterRun.tags_for_sensor(external_sensor)),
+            poll_for_finished_run(instance, run_tags=DagsterRun.tags_for_sensor(remote_sensor)),
             poll_for_finished_run(
                 instance,
-                run_tags=DagsterRun.tags_for_schedule(external_schedule),
+                run_tags=DagsterRun.tags_for_schedule(remote_schedule),
                 timeout=90,
             ),
         ]

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -143,12 +143,12 @@ def create_and_launch_partition_backfill(
             raise DagsterInvariantViolationError(
                 f"Partition set names must be unique: found {len(matches)} matches for {partition_set_name}"
             )
-        external_partition_set = next(iter(matches))
+        remote_partition_set = next(iter(matches))
 
         if backfill_params.get("allPartitions"):
             result = graphene_info.context.get_external_partition_names(
                 repository_handle=repository.handle,
-                job_name=external_partition_set.job_name,
+                job_name=remote_partition_set.job_name,
                 instance=graphene_info.context.instance,
                 selected_asset_keys=None,
             )
@@ -169,7 +169,7 @@ def create_and_launch_partition_backfill(
 
         backfill = PartitionBackfill(
             backfill_id=backfill_id,
-            partition_set_origin=external_partition_set.get_remote_origin(),
+            partition_set_origin=remote_partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=partition_names,
             from_failure=bool(backfill_params.get("fromFailure")),
@@ -183,7 +183,7 @@ def create_and_launch_partition_backfill(
         assert_valid_job_partition_backfill(
             graphene_info,
             backfill,
-            external_partition_set.get_partitions_definition(),
+            remote_partition_set.get_partitions_definition(),
             dynamic_partitions_store,
             backfill_datetime,
         )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -198,7 +198,7 @@ def _graphene_asset_node(
         stale_status_loader=stale_status_loader,
         dynamic_partitions_loader=dynamic_partitions_loader,
         # base_deployment_context will be None if we are not in a branch deployment
-        asset_graph_differ=AssetGraphDiffer.from_external_repositories(
+        asset_graph_differ=AssetGraphDiffer.from_remote_repositories(
             code_location_name=handle.location_name,
             repository_name=handle.repository_name,
             branch_workspace=graphene_info.context,
@@ -747,17 +747,17 @@ def get_freshness_info(
 
 
 def unique_repos(
-    external_repositories: Sequence[RemoteRepository],
+    remote_repositories: Sequence[RemoteRepository],
 ) -> Sequence[RemoteRepository]:
     repos = []
     used = set()
-    for external_repository in external_repositories:
+    for remote_repository in remote_repositories:
         repo_id = (
-            external_repository.handle.location_name,
-            external_repository.name,
+            remote_repository.handle.location_name,
+            remote_repository.name,
         )
         if repo_id not in used:
             used.add(repo_id)
-            repos.append(external_repository)
+            repos.append(remote_repository)
 
     return repos

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_instigators.py
@@ -42,19 +42,19 @@ def get_instigator_state_by_selector(
     repository = location.get_repository(selector.repository_name)
 
     if repository.has_sensor(selector.name):
-        external_sensor = repository.get_sensor(selector.name)
+        sensor = repository.get_sensor(selector.name)
         stored_state = graphene_info.context.instance.get_instigator_state(
-            external_sensor.get_remote_origin_id(),
-            external_sensor.selector_id,
+            sensor.get_remote_origin_id(),
+            sensor.selector_id,
         )
-        current_state = external_sensor.get_current_instigator_state(stored_state)
+        current_state = sensor.get_current_instigator_state(stored_state)
     elif repository.has_schedule(selector.name):
-        external_schedule = repository.get_schedule(selector.name)
+        schedule = repository.get_schedule(selector.name)
         stored_state = graphene_info.context.instance.get_instigator_state(
-            external_schedule.get_remote_origin_id(),
-            external_schedule.selector_id,
+            schedule.get_remote_origin_id(),
+            schedule.selector_id,
         )
-        current_state = external_schedule.get_current_instigator_state(stored_state)
+        current_state = schedule.get_current_instigator_state(stored_state)
     else:
         return GrapheneInstigationStateNotFoundError(selector.name)
 

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -53,8 +53,8 @@ def get_partition_sets_or_error(
     return GraphenePartitionSets(
         results=[
             GraphenePartitionSet(
-                external_repository_handle=repository.handle,
-                external_partition_set=partition_set,
+                repository_handle=repository.handle,
+                remote_partition_set=partition_set,
             )
             for partition_set in sorted(
                 partition_sets,
@@ -84,8 +84,8 @@ def get_partition_set(
     for partition_set in partition_sets:
         if partition_set.name == partition_set_name:
             return GraphenePartitionSet(
-                external_repository_handle=repository.handle,
-                external_partition_set=partition_set,
+                repository_handle=repository.handle,
+                remote_partition_set=partition_set,
             )
 
     return GraphenePartitionSetNotFoundError(partition_set_name)
@@ -103,8 +103,8 @@ def get_partition_by_name(
     check.inst_param(partition_set, "partition_set", RemotePartitionSet)
     check.str_param(partition_name, "partition_name")
     return GraphenePartition(
-        external_repository_handle=repository_handle,
-        external_partition_set=partition_set,
+        repository_handle=repository_handle,
+        remote_partition_set=partition_set,
         partition_name=partition_name,
     )
 
@@ -184,8 +184,8 @@ def get_partitions(
     return GraphenePartitions(
         results=[
             GraphenePartition(
-                external_partition_set=partition_set,
-                external_repository_handle=repository_handle,
+                remote_partition_set=partition_set,
+                repository_handle=repository_handle,
                 partition_name=partition_name,
             )
             for partition_name in partition_names
@@ -195,13 +195,13 @@ def get_partitions(
 
 def get_partition_set_partition_statuses(
     graphene_info: ResolveInfo,
-    external_partition_set: RemotePartitionSet,
+    remote_partition_set: RemotePartitionSet,
     partition_names: Sequence[str],
 ) -> Sequence["GraphenePartitionStatus"]:
-    check.inst_param(external_partition_set, "external_partition_set", RemotePartitionSet)
+    check.inst_param(remote_partition_set, "remote_partition_set", RemotePartitionSet)
 
-    repository_handle = external_partition_set.repository_handle
-    partition_set_name = external_partition_set.name
+    repository_handle = remote_partition_set.repository_handle
+    partition_set_name = remote_partition_set.name
 
     run_partition_data = graphene_info.context.instance.run_storage.get_run_partition_data(
         runs_filter=RunsFilter(

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_resources.py
@@ -30,16 +30,16 @@ def get_top_level_resources_or_error(
         repository_selector.location_name
     )
     repository = location.get_repository(repository_selector.repository_name)
-    external_resources = repository.get_resources()
+    remote_resources = repository.get_resources()
 
     results = [
         GrapheneResourceDetails(
             repository_selector.location_name,
             repository_selector.repository_name,
-            external_resource,
+            remote_resource,
         )
-        for external_resource in external_resources
-        if external_resource.is_top_level
+        for remote_resource in remote_resources
+        if remote_resource.is_top_level
     ]
 
     return GrapheneResourceDetailsList(results=results)
@@ -63,8 +63,8 @@ def get_resource_or_error(
             GrapheneResourceNotFoundError(resource_name=resource_selector.resource_name)
         )
 
-    external_resource = repository.get_resource(resource_selector.resource_name)
+    remote_resource = repository.get_resource(resource_selector.resource_name)
 
     return GrapheneResourceDetails(
-        resource_selector.location_name, resource_selector.repository_name, external_resource
+        resource_selector.location_name, resource_selector.repository_name, remote_resource
     )

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/loader.py
@@ -36,9 +36,9 @@ class RepositoryScopedBatchLoader:
     cache.
     """
 
-    def __init__(self, instance: DagsterInstance, external_repository: RemoteRepository):
+    def __init__(self, instance: DagsterInstance, remote_repository: RemoteRepository):
         self._instance = instance
-        self._repository = external_repository
+        self._repository = remote_repository
         self._data: Dict[RepositoryDataType, Dict[str, List[Any]]] = {}
         self._limits: Dict[RepositoryDataType, int] = {}
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_selections.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_selections.py
@@ -21,9 +21,9 @@ class GrapheneAssetSelection(graphene.ObjectType):
     assets = non_null_list("dagster_graphql.schema.pipelines.pipeline.GrapheneAsset")
     assetsOrError = graphene.NonNull("dagster_graphql.schema.roots.assets.GrapheneAssetsOrError")
 
-    def __init__(self, asset_selection: AssetSelection, external_repository: RemoteRepository):
+    def __init__(self, asset_selection: AssetSelection, remote_repository: RemoteRepository):
         self._asset_selection = asset_selection
-        self._external_repository = external_repository
+        self._remote_repository = remote_repository
 
     def resolve_assetSelectionString(self, _graphene_info):
         return str(self._asset_selection)
@@ -48,7 +48,7 @@ class GrapheneAssetSelection(graphene.ObjectType):
     @cached_property
     def _resolved_and_sorted_keys(self) -> Sequence[AssetKey]:
         """Use this to maintain stability in ordering."""
-        return sorted(self._asset_selection.resolve(self._external_repository.asset_graph), key=str)
+        return sorted(self._asset_selection.resolve(self._remote_repository.asset_graph), key=str)
 
     @capture_error
     def resolve_assetsOrError(self, graphene_info) -> "GrapheneAssetConnection":

--- a/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/backfill.py
@@ -421,15 +421,15 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             return None
 
         repository = location.get_repository(repository_name)
-        external_partition_sets = [
+        partition_sets = [
             partition_set
             for partition_set in repository.get_partition_sets()
             if partition_set.name == origin.partition_set_name
         ]
-        if not external_partition_sets:
+        if not partition_sets:
             return None
 
-        return external_partition_sets[0]
+        return partition_sets[0]
 
     def _get_records(self, graphene_info: ResolveInfo) -> Sequence[RunRecord]:
         if self._records is None:
@@ -557,8 +557,8 @@ class GraphenePartitionBackfill(graphene.ObjectType):
             return None
 
         return GraphenePartitionSet(
-            external_repository_handle=partition_set.repository_handle,
-            external_partition_set=partition_set,
+            repository_handle=partition_set.repository_handle,
+            remote_partition_set=partition_set,
         )
 
     def resolve_partitionStatuses(self, graphene_info: ResolveInfo):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/external.py
@@ -383,7 +383,7 @@ class GrapheneRepository(graphene.ObjectType):
         base_deployment_context = graphene_info.context.get_base_deployment_context()
         if base_deployment_context is not None:
             # then we are in a branch deployment
-            asset_graph_differ = AssetGraphDiffer.from_external_repositories(
+            asset_graph_differ = AssetGraphDiffer.from_remote_repositories(
                 code_location_name=self._handle.location_name,
                 repository_name=self._handle.repository_name,
                 branch_workspace=graphene_info.context,
@@ -415,16 +415,16 @@ class GrapheneRepository(graphene.ObjectType):
         for asset_node_snap in self.get_repository(graphene_info).get_asset_node_snaps():
             if not asset_node_snap.group_name:
                 continue
-            external_assets = groups.setdefault(asset_node_snap.group_name, [])
-            external_assets.append(asset_node_snap)
+            asset_node_snaps = groups.setdefault(asset_node_snap.group_name, [])
+            asset_node_snaps.append(asset_node_snap)
 
         return [
             GrapheneAssetGroup(
                 f"{self._handle.location_name}-{self._handle.repository_name}-{group_name}",
                 group_name,
-                [external_node.asset_key for external_node in external_nodes],
+                [external_node.asset_key for external_node in asset_node_snaps],
             )
-            for group_name, external_nodes in groups.items()
+            for group_name, asset_node_snaps in groups.items()
         ]
 
     def resolve_allTopLevelResourceDetails(self, graphene_info) -> List[GrapheneResourceDetails]:
@@ -432,7 +432,7 @@ class GrapheneRepository(graphene.ObjectType):
             GrapheneResourceDetails(
                 location_name=self._handle.location_name,
                 repository_name=self._handle.repository_name,
-                external_resource=resource,
+                remote_resource=resource,
             )
             for resource in sorted(
                 self.get_repository(graphene_info).get_resources(),

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -387,18 +387,18 @@ class GrapheneDryRunInstigationTick(graphene.ObjectType):
                     "No tick timestamp provided when attempting to dry-run schedule"
                     f" {self._selector.schedule_name}."
                 )
-            external_schedule = repository.get_schedule(self._selector.schedule_name)
-            timezone_str = external_schedule.execution_timezone
+            schedule = repository.get_schedule(self._selector.schedule_name)
+            timezone_str = schedule.execution_timezone
             if not timezone_str:
                 timezone_str = "UTC"
 
-            next_tick_datetime = next(external_schedule.execution_time_iterator(self.timestamp))
+            next_tick_datetime = next(schedule.execution_time_iterator(self.timestamp))
             schedule_data: Union[ScheduleExecutionData, SerializableErrorInfo]
             try:
                 schedule_data = code_location.get_external_schedule_execution_data(
                     instance=graphene_info.context.instance,
                     repository_handle=repository.handle,
-                    schedule_name=external_schedule.name,
+                    schedule_name=schedule.name,
                     scheduled_execution_time=TimestampWithTimezone(
                         next_tick_datetime.timestamp(),
                         timezone_str,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/resources.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/resources.py
@@ -37,16 +37,16 @@ class GrapheneConfiguredValue(graphene.ObjectType):
     class Meta:
         name = "ConfiguredValue"
 
-    def __init__(self, key: str, external_resource_value: ResourceValueSnap):
+    def __init__(self, key: str, resource_value_snap: ResourceValueSnap):
         super().__init__()
 
         self.key = key
-        if isinstance(external_resource_value, ResourceConfigEnvVarSnap):
+        if isinstance(resource_value_snap, ResourceConfigEnvVarSnap):
             self.type = GrapheneConfiguredValueType.ENV_VAR
-            self.value = external_resource_value.name
+            self.value = resource_value_snap.name
         else:
             self.type = GrapheneConfiguredValueType.VALUE
-            self.value = external_resource_value
+            self.value = resource_value_snap
 
 
 GrapheneNestedResourceType = graphene.Enum.from_enum(NestedResourceType)
@@ -120,31 +120,29 @@ class GrapheneResourceDetails(graphene.ObjectType):
     class Meta:
         name = "ResourceDetails"
 
-    def __init__(self, location_name: str, repository_name: str, external_resource: RemoteResource):
+    def __init__(self, location_name: str, repository_name: str, remote_resource: RemoteResource):
         super().__init__()
 
-        self.id = f"{location_name}-{repository_name}-{external_resource.name}"
+        self.id = f"{location_name}-{repository_name}-{remote_resource.name}"
 
         self._location_name = check.str_param(location_name, "location_name")
         self._repository_name = check.str_param(repository_name, "repository_name")
 
-        self._external_resource = check.inst_param(
-            external_resource, "external_resource", RemoteResource
-        )
-        self.name = external_resource.name
-        self.description = external_resource.description
-        self._config_field_snaps = external_resource.config_field_snaps
-        self._configured_values = external_resource.configured_values
+        self._remote_resource = check.inst_param(remote_resource, "remote_resource", RemoteResource)
+        self.name = remote_resource.name
+        self.description = remote_resource.description
+        self._config_field_snaps = remote_resource.config_field_snaps
+        self._configured_values = remote_resource.configured_values
 
-        self._config_schema_snap = external_resource.config_schema_snap
-        self.isTopLevel = external_resource.is_top_level
-        self._nested_resources = external_resource.nested_resources
-        self._parent_resources = external_resource.parent_resources
-        self.resourceType = external_resource.resource_type
-        self._asset_keys_using = external_resource.asset_keys_using
-        self._job_ops_using = external_resource.job_ops_using
-        self._schedules_using = external_resource.schedules_using
-        self._sensors_using = external_resource.sensors_using
+        self._config_schema_snap = remote_resource.config_schema_snap
+        self.isTopLevel = remote_resource.is_top_level
+        self._nested_resources = remote_resource.nested_resources
+        self._parent_resources = remote_resource.parent_resources
+        self.resourceType = remote_resource.resource_type
+        self._asset_keys_using = remote_resource.asset_keys_using
+        self._job_ops_using = remote_resource.job_ops_using
+        self._schedules_using = remote_resource.schedules_using
+        self._sensors_using = remote_resource.sensors_using
 
     def resolve_configFields(self, _graphene_info):
         return [
@@ -157,7 +155,7 @@ class GrapheneResourceDetails(graphene.ObjectType):
 
     def resolve_configuredValues(self, _graphene_info):
         return [
-            GrapheneConfiguredValue(key=key, external_resource_value=value)
+            GrapheneConfiguredValue(key=key, resource_value_snap=value)
             for key, value in self._configured_values.items()
         ]
 

--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -1065,7 +1065,7 @@ class GrapheneQuery(graphene.ObjectType):
                 stale_status_loader=stale_status_loader,
                 dynamic_partitions_loader=dynamic_partitions_loader,
                 # base_deployment_context will be None if we are not in a branch deployment
-                asset_graph_differ=AssetGraphDiffer.from_external_repositories(
+                asset_graph_differ=AssetGraphDiffer.from_remote_repositories(
                     code_location_name=remote_node.priority_repository_handle.location_name,
                     repository_name=remote_node.priority_repository_handle.repository_name,
                     branch_workspace=graphene_info.context,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/schedules/schedules.py
@@ -65,15 +65,13 @@ class GrapheneSchedule(graphene.ObjectType):
 
     def __init__(
         self,
-        external_schedule: RemoteSchedule,
-        external_repository: RemoteRepository,
+        remote_schedule: RemoteSchedule,
+        remote_repository: RemoteRepository,
         schedule_state: Optional[InstigatorState],
         batch_loader: Optional[RepositoryScopedBatchLoader] = None,
     ):
-        self._external_schedule = check.inst_param(
-            external_schedule, "external_schedule", RemoteSchedule
-        )
-        self._external_repository = external_repository
+        self._remote_schedule = check.inst_param(remote_schedule, "remote_schedule", RemoteSchedule)
+        self._remote_repository = remote_repository
 
         # optional run loader, provided by a parent graphene object (e.g. GrapheneRepository)
         # that instantiates multiple schedules
@@ -82,35 +80,35 @@ class GrapheneSchedule(graphene.ObjectType):
         )
 
         self._stored_state = schedule_state
-        self._schedule_state = self._external_schedule.get_current_instigator_state(schedule_state)
+        self._schedule_state = self._remote_schedule.get_current_instigator_state(schedule_state)
 
         super().__init__(
-            name=external_schedule.name,
+            name=remote_schedule.name,
             cron_schedule=str(
-                external_schedule.cron_schedule
+                remote_schedule.cron_schedule
             ),  # can be sequence, coercing to str for now
-            pipeline_name=external_schedule.job_name,
-            solid_selection=external_schedule.op_selection,
-            mode=external_schedule.mode,
+            pipeline_name=remote_schedule.job_name,
+            solid_selection=remote_schedule.op_selection,
+            mode=remote_schedule.mode,
             execution_timezone=(
-                self._external_schedule.execution_timezone
-                if self._external_schedule.execution_timezone
+                self._remote_schedule.execution_timezone
+                if self._remote_schedule.execution_timezone
                 else "UTC"
             ),
-            description=external_schedule.description,
+            description=remote_schedule.description,
             assetSelection=GrapheneAssetSelection(
-                asset_selection=external_schedule.asset_selection,
-                external_repository=self._external_repository,
+                asset_selection=remote_schedule.asset_selection,
+                remote_repository=self._remote_repository,
             )
-            if external_schedule.asset_selection
+            if remote_schedule.asset_selection
             else None,
         )
 
     def resolve_id(self, _graphene_info: ResolveInfo) -> str:
-        return self._external_schedule.get_compound_id().to_string()
+        return self._remote_schedule.get_compound_id().to_string()
 
     def resolve_defaultStatus(self, _graphene_info: ResolveInfo):
-        default_schedule_status = self._external_schedule.default_status
+        default_schedule_status = self._remote_schedule.default_status
 
         if default_schedule_status == DefaultScheduleStatus.RUNNING:
             return GrapheneInstigationStatus.RUNNING
@@ -129,19 +127,17 @@ class GrapheneSchedule(graphene.ObjectType):
     def resolve_partition_set(self, graphene_info: ResolveInfo):
         from dagster_graphql.schema.partition_sets import GraphenePartitionSet
 
-        if self._external_schedule.partition_set_name is None:
+        if self._remote_schedule.partition_set_name is None:
             return None
 
         repository = graphene_info.context.get_code_location(
-            self._external_schedule.handle.location_name
-        ).get_repository(self._external_schedule.handle.repository_name)
-        external_partition_set = repository.get_partition_set(
-            self._external_schedule.partition_set_name
-        )
+            self._remote_schedule.handle.location_name
+        ).get_repository(self._remote_schedule.handle.repository_name)
+        partition_set = repository.get_partition_set(self._remote_schedule.partition_set_name)
 
         return GraphenePartitionSet(
-            external_repository_handle=repository.handle,
-            external_partition_set=external_partition_set,
+            repository_handle=repository.handle,
+            remote_partition_set=partition_set,
         )
 
     def resolve_futureTicks(
@@ -154,7 +150,7 @@ class GrapheneSchedule(graphene.ObjectType):
         cursor = cursor or time.time()
 
         tick_times: List[float] = []
-        time_iter = self._external_schedule.execution_time_iterator(cursor)
+        time_iter = self._remote_schedule.execution_time_iterator(cursor)
 
         if until:
             currentTime = None
@@ -172,7 +168,7 @@ class GrapheneSchedule(graphene.ObjectType):
             for _ in range(limit):
                 tick_times.append(next(time_iter).timestamp())
 
-        schedule_selector = self._external_schedule.schedule_selector
+        schedule_selector = self._remote_schedule.schedule_selector
         future_ticks = [
             GrapheneDryRunInstigationTick(schedule_selector, tick_time) for tick_time in tick_times
         ]
@@ -182,7 +178,7 @@ class GrapheneSchedule(graphene.ObjectType):
 
     def resolve_futureTick(self, _graphene_info: ResolveInfo, tick_timestamp: int):
         return GrapheneDryRunInstigationTick(
-            self._external_schedule.schedule_selector, float(tick_timestamp)
+            self._remote_schedule.schedule_selector, float(tick_timestamp)
         )
 
     def resolve_potentialTickTimestamps(
@@ -201,8 +197,8 @@ class GrapheneSchedule(graphene.ObjectType):
         lower_limit = lower_limit or 10
 
         tick_times: List[float] = []
-        ascending_tick_iterator = self._external_schedule.execution_time_iterator(start_timestamp)
-        descending_tick_iterator = self._external_schedule.execution_time_iterator(
+        ascending_tick_iterator = self._remote_schedule.execution_time_iterator(start_timestamp)
+        descending_tick_iterator = self._remote_schedule.execution_time_iterator(
             start_timestamp, ascending=False
         )
 
@@ -230,11 +226,11 @@ class GrapheneSchedule(graphene.ObjectType):
     def resolve_tags(self, _graphene_info: ResolveInfo) -> Sequence[GrapheneDefinitionTag]:
         return [
             GrapheneDefinitionTag(key, value)
-            for key, value in (self._external_schedule.tags or {}).items()
+            for key, value in (self._remote_schedule.tags or {}).items()
         ]
 
     def resolve_metadataEntries(self, _graphene_info: ResolveInfo) -> List[GrapheneMetadataEntry]:
-        return list(iterate_metadata_entries(self._external_schedule.metadata))
+        return list(iterate_metadata_entries(self._remote_schedule.metadata))
 
 
 class GrapheneScheduleOrError(graphene.Union):

--- a/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/solids.py
@@ -461,7 +461,7 @@ class ISolidDefinitionMixin:
                     remote_node=remote_node,
                     asset_checks_loader=asset_checks_loader,
                     # base_deployment_context will be None if we are not in a branch deployment
-                    asset_graph_differ=AssetGraphDiffer.from_external_repositories(
+                    asset_graph_differ=AssetGraphDiffer.from_remote_repositories(
                         code_location_name=location.name,
                         repository_name=ext_repo.name,
                         branch_workspace=graphene_info.context,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_context.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_context.py
@@ -31,7 +31,7 @@ def get_repo():
     return my_repo
 
 
-def test_can_reload_on_external_repository_error():
+def test_can_reload_on_remote_repository_error():
     with instance_for_test() as instance:
         with ExitStack() as exit_stack:
             with mock.patch(
@@ -39,10 +39,10 @@ def test_can_reload_on_external_repository_error():
                 # where it is defined.
                 # see https://docs.python.org/3/library/unittest.mock.html#where-to-patch
                 "dagster._core.remote_representation.code_location.sync_get_streaming_external_repositories_data_grpc"
-            ) as external_repository_mock:
-                external_repository_mock.side_effect = Exception("get_external_repo_failure")
+            ) as remote_repository_mock:
+                remote_repository_mock.side_effect = Exception("get_remote_repo_failure")
 
-                with pytest.warns(UserWarning, match=re.escape("get_external_repo_failure")):
+                with pytest.warns(UserWarning, match=re.escape("get_remote_repo_failure")):
                     workspace = exit_stack.enter_context(
                         define_out_of_process_workspace(__file__, "get_repo", instance)
                     )

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reload_repository_location.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_reload_repository_location.py
@@ -294,7 +294,7 @@ class TestReloadRepositoriesOutOfProcess(OutOfProcessTestSuite):
                 # where it is defined.
                 # see https://docs.python.org/3/library/unittest.mock.html#where-to-patch
                 "dagster._core.remote_representation.code_location.sync_get_streaming_external_repositories_data_grpc"
-            ) as external_repository_mock:
+            ) as remote_repository_mock:
 
                 @repository
                 def new_repo():
@@ -302,7 +302,7 @@ class TestReloadRepositoriesOutOfProcess(OutOfProcessTestSuite):
 
                 new_repo_data = RepositorySnap.from_def(new_repo)
 
-                external_repository_mock.return_value = {"new_repo": new_repo_data}
+                remote_repository_mock.return_value = {"new_repo": new_repo_data}
 
                 cli_command_mock.return_value = ListRepositoriesResponse(
                     repository_symbols=[],
@@ -319,7 +319,7 @@ class TestReloadRepositoriesOutOfProcess(OutOfProcessTestSuite):
                 )
 
                 assert cli_command_mock.call_count == 1
-                assert external_repository_mock.call_count == 1
+                assert remote_repository_mock.call_count == 1
 
                 repositories = result.data["reloadRepositoryLocation"]["locationOrLoadError"][
                     "repositories"

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -535,12 +535,12 @@ def test_get_schedule_definitions_for_repository(graphql_context):
     assert result.data["schedulesOrError"]
     assert result.data["schedulesOrError"]["__typename"] == "Schedules"
 
-    external_repository = graphql_context.get_code_location(
-        main_repo_location_name()
-    ).get_repository(main_repo_name())
+    remote_repository = graphql_context.get_code_location(main_repo_location_name()).get_repository(
+        main_repo_name()
+    )
 
     results = result.data["schedulesOrError"]["results"]
-    assert len(results) == len(external_repository.get_schedules())
+    assert len(results) == len(remote_repository.get_schedules())
 
     for schedule in results:
         if schedule["name"] == "timezone_schedule_with_tags_and_metadata":

--- a/python_modules/dagster-test/dagster_test/test_project/__init__.py
+++ b/python_modules/dagster-test/dagster_test/test_project/__init__.py
@@ -193,13 +193,13 @@ class ReOriginatedExternalJobForTest(RemoteJob):
 class ReOriginatedExternalScheduleForTest(RemoteSchedule):
     def __init__(
         self,
-        external_schedule: RemoteSchedule,
+        remote_schedule: RemoteSchedule,
         container_image=None,
     ):
         self._container_image = container_image
         super(ReOriginatedExternalScheduleForTest, self).__init__(
-            external_schedule._schedule_snap,  # noqa: SLF001
-            external_schedule.handle.repository_handle,
+            remote_schedule._schedule_snap,  # noqa: SLF001
+            remote_schedule.handle.repository_handle,
         )
 
     def get_remote_origin(self):
@@ -256,7 +256,7 @@ def get_test_project_remote_job_hierarchy(instance, job_name, container_image=No
 
 
 @contextmanager
-def get_test_project_external_repo(instance, container_image=None, filename=None):
+def get_test_project_remote_repo(instance, container_image=None, filename=None):
     with get_test_project_workspace(instance, container_image, filename) as workspace:
         location = workspace.get_code_location(workspace.code_location_names[0])
         yield location, location.get_repository("demo_execution_repo")
@@ -276,10 +276,8 @@ def get_test_project_workspace_and_remote_job(
 
 
 @contextmanager
-def get_test_project_external_schedule(
-    instance, schedule_name, container_image=None, filename=None
-):
-    with get_test_project_external_repo(
+def get_test_project_remote_schedule(instance, schedule_name, container_image=None, filename=None):
+    with get_test_project_remote_repo(
         instance, container_image=container_image, filename=filename
     ) as (_, repo):
         yield repo.get_schedule(schedule_name)

--- a/python_modules/dagster/dagster/_cli/sensor.py
+++ b/python_modules/dagster/dagster/_cli/sensor.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from typing import Callable
 
 import click
 
@@ -11,8 +12,8 @@ from dagster import (
 from dagster._cli.utils import get_instance_for_cli
 from dagster._cli.workspace.cli_target import (
     get_code_location_from_kwargs,
-    get_external_repository_from_code_location,
-    get_external_repository_from_kwargs,
+    get_remote_repository_from_code_location,
+    get_remote_repository_from_kwargs,
     repository_target_argument,
 )
 from dagster._core.definitions.run_request import InstigatorType
@@ -32,27 +33,34 @@ def sensor_cli():
     """Commands for working with Dagster sensors."""
 
 
-def print_changes(external_repository, instance, print_fn=print, preview=False):
+def print_changes(
+    remote_repository: RemoteRepository,
+    instance: DagsterInstance,
+    print_fn: Callable[[object], None] = print,
+    preview: bool = False,
+) -> None:
     sensor_states = instance.all_instigator_state(
-        external_repository.get_origin_id(), external_repository.selector_id, InstigatorType.SENSOR
+        remote_repository.get_remote_origin_id(),
+        remote_repository.selector_id,
+        InstigatorType.SENSOR,
     )
-    external_sensors = external_repository.get_sensors()
-    external_sensors_dict = {s.get_remote_origin_id(): s for s in external_sensors}
+    sensors = remote_repository.get_sensors()
+    sensors_dict = {s.get_remote_origin_id(): s for s in sensors}
     sensor_states_dict = {s.instigator_origin_id: s for s in sensor_states}
 
-    external_sensor_origin_ids = set(external_sensors_dict.keys())
+    sensor_origin_ids = set(sensors_dict.keys())
     sensor_state_ids = set(sensor_states_dict.keys())
 
-    added_sensors = external_sensor_origin_ids - sensor_state_ids
-    removed_sensors = sensor_state_ids - external_sensor_origin_ids
+    added_sensors = sensor_origin_ids - sensor_state_ids
+    removed_sensors = sensor_state_ids - sensor_origin_ids
 
     if not added_sensors and not removed_sensors:
         if preview:
             print_fn(click.style("No planned changes to sensors.", fg="magenta", bold=True))
-            print_fn(f"{len(external_sensors)} sensors will remain unchanged")
+            print_fn(f"{len(sensors)} sensors will remain unchanged")
         else:
             print_fn(click.style("No changes to sensors.", fg="magenta", bold=True))
-            print_fn(f"{len(external_sensors)} sensors unchanged")
+            print_fn(f"{len(sensors)} sensors unchanged")
         return
 
     print_fn(
@@ -62,7 +70,7 @@ def print_changes(external_repository, instance, print_fn=print, preview=False):
     for sensor_origin_id in added_sensors:
         print_fn(
             click.style(
-                f"  + {external_sensors_dict[sensor_origin_id].name} (add) [{sensor_origin_id}]",
+                f"  + {sensors_dict[sensor_origin_id].name} (add) [{sensor_origin_id}]",
                 fg="green",
             )
         )
@@ -70,7 +78,7 @@ def print_changes(external_repository, instance, print_fn=print, preview=False):
     for sensor_origin_id in removed_sensors:
         print_fn(
             click.style(
-                f"  + {external_sensors_dict[sensor_origin_id].name} (delete) [{sensor_origin_id}]",
+                f"  + {sensors_dict[sensor_origin_id].name} (delete) [{sensor_origin_id}]",
                 fg="red",
             )
         )
@@ -125,32 +133,32 @@ def sensor_list_command(running, stopped, name, **kwargs):
 
 def execute_list_command(running_filter, stopped_filter, name_filter, cli_args, print_fn):
     with get_instance_for_cli() as instance:
-        with get_external_repository_from_kwargs(
+        with get_remote_repository_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
-        ) as external_repo:
-            check_repo_and_scheduler(external_repo, instance)
-            repository_name = external_repo.name
+        ) as repo:
+            check_repo_and_scheduler(repo, instance)
+            repository_name = repo.name
 
             if not name_filter:
                 title = f"Repository {repository_name}"
                 print_fn(title)
                 print_fn("*" * len(title))
 
-            repo_sensors = external_repo.get_sensors()
+            repo_sensors = repo.get_sensors()
             stored_sensors_by_origin_id = {
                 stored_sensor_state.instigator_origin_id: stored_sensor_state
                 for stored_sensor_state in instance.all_instigator_state(
-                    external_repo.get_remote_origin_id(),
-                    external_repo.selector_id,
+                    repo.get_remote_origin_id(),
+                    repo.selector_id,
                     instigator_type=InstigatorType.SENSOR,
                 )
             }
 
             first = True
 
-            for external_sensor in repo_sensors:
-                sensor_state = external_sensor.get_current_instigator_state(
-                    stored_sensors_by_origin_id.get(external_sensor.get_remote_origin_id())
+            for sensor in repo_sensors:
+                sensor_state = sensor.get_current_instigator_state(
+                    stored_sensors_by_origin_id.get(sensor.get_remote_origin_id())
                 )
 
                 if running_filter and not sensor_state.is_running:
@@ -159,11 +167,11 @@ def execute_list_command(running_filter, stopped_filter, name_filter, cli_args, 
                     continue
 
                 if name_filter:
-                    print_fn(external_sensor.name)
+                    print_fn(sensor.name)
                     continue
 
                 status = "RUNNING" if sensor_state.is_running else "STOPPED"
-                sensor_title = f"Sensor: {external_sensor.name} [{status}]"
+                sensor_title = f"Sensor: {sensor.name} [{status}]"
                 if not first:
                     print_fn("*" * len(sensor_title))
 
@@ -184,23 +192,23 @@ def sensor_start_command(sensor_name, start_all, **kwargs):
 
 def execute_start_command(sensor_name, all_flag, cli_args, print_fn):
     with get_instance_for_cli() as instance:
-        with get_external_repository_from_kwargs(
+        with get_remote_repository_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
-        ) as external_repo:
-            check_repo_and_scheduler(external_repo, instance)
-            repository_name = external_repo.name
+        ) as repo:
+            check_repo_and_scheduler(repo, instance)
+            repository_name = repo.name
 
             if all_flag:
                 try:
-                    for external_sensor in external_repo.get_sensors():
-                        instance.start_sensor(external_sensor)
+                    for sensor in repo.get_sensors():
+                        instance.start_sensor(sensor)
                     print_fn(f"Started all sensors for repository {repository_name}")
                 except DagsterInvariantViolationError as ex:
                     raise click.UsageError(ex)
             else:
                 try:
-                    external_sensor = external_repo.get_sensor(sensor_name)
-                    instance.start_sensor(external_sensor)
+                    sensor = repo.get_sensor(sensor_name)
+                    instance.start_sensor(sensor)
                 except DagsterInvariantViolationError as ex:
                     raise click.UsageError(ex)
 
@@ -217,16 +225,16 @@ def sensor_stop_command(sensor_name, **kwargs):
 
 def execute_stop_command(sensor_name, cli_args, print_fn):
     with get_instance_for_cli() as instance:
-        with get_external_repository_from_kwargs(
+        with get_remote_repository_from_kwargs(
             instance, version=dagster_version, kwargs=cli_args
-        ) as external_repo:
-            check_repo_and_scheduler(external_repo, instance)
+        ) as repo:
+            check_repo_and_scheduler(repo, instance)
             try:
-                external_sensor = external_repo.get_sensor(sensor_name)
+                sensor = repo.get_sensor(sensor_name)
                 instance.stop_sensor(
-                    external_sensor.get_remote_origin_id(),
-                    external_sensor.selector_id,
-                    external_sensor,
+                    sensor.get_remote_origin_id(),
+                    sensor.selector_id,
+                    sensor,
                 )
             except DagsterInvariantViolationError as ex:
                 raise click.UsageError(ex)
@@ -269,16 +277,16 @@ def execute_preview_command(
             kwargs=cli_args,
         ) as code_location:
             try:
-                external_repo = get_external_repository_from_code_location(
+                repo = get_remote_repository_from_code_location(
                     code_location, cli_args.get("repository")
                 )
-                check_repo_and_scheduler(external_repo, instance)
-                external_sensor = external_repo.get_sensor(sensor_name)
+                check_repo_and_scheduler(repo, instance)
+                sensor = repo.get_sensor(sensor_name)
                 try:
                     sensor_runtime_data = code_location.get_external_sensor_execution_data(
                         instance,
-                        external_repo.handle,
-                        external_sensor.name,
+                        repo.handle,
+                        sensor.name,
                         since,
                         last_run_key,
                         cursor,
@@ -288,17 +296,17 @@ def execute_preview_command(
                 except Exception:
                     error_info = serializable_error_info_from_exc_info(sys.exc_info())
                     print_fn(
-                        f"Failed to resolve sensor for {external_sensor.name} : {error_info.to_string()}"
+                        f"Failed to resolve sensor for {sensor.name} : {error_info.to_string()}"
                     )
                     return
 
                 if not sensor_runtime_data.run_requests:
                     if sensor_runtime_data.skip_message:
                         print_fn(
-                            f"Sensor returned false for {external_sensor.name}, skipping: {sensor_runtime_data.skip_message}"
+                            f"Sensor returned false for {sensor.name}, skipping: {sensor_runtime_data.skip_message}"
                         )
                     else:
-                        print_fn(f"Sensor returned false for {external_sensor.name}, skipping")
+                        print_fn(f"Sensor returned false for {sensor.name}, skipping")
                 else:
                     print_fn(
                         "Sensor returning run requests for {num} run(s):\n\n{run_requests}".format(
@@ -341,24 +349,24 @@ def execute_cursor_command(sensor_name, cli_args, print_fn):
 
             cursor_value = cli_args.get("set")
 
-            external_repo = get_external_repository_from_code_location(
+            repo = get_remote_repository_from_code_location(
                 code_location, cli_args.get("repository")
             )
-            check_repo_and_scheduler(external_repo, instance)
-            external_sensor = external_repo.get_sensor(sensor_name)
+            check_repo_and_scheduler(repo, instance)
+            sensor = repo.get_sensor(sensor_name)
             job_state = instance.get_instigator_state(
-                external_sensor.get_remote_origin_id(), external_sensor.selector_id
+                sensor.get_remote_origin_id(), sensor.selector_id
             )
             if not job_state:
                 instance.add_instigator_state(
                     InstigatorState(
-                        external_sensor.get_remote_origin(),
+                        sensor.get_remote_origin(),
                         InstigatorType.SENSOR,
                         InstigatorStatus.STOPPED,
                         SensorInstigatorData(
-                            min_interval=external_sensor.min_interval_seconds,
+                            min_interval=sensor.min_interval_seconds,
                             cursor=cursor_value,
-                            sensor_type=external_sensor.sensor_type,
+                            sensor_type=sensor.sensor_type,
                         ),
                     )
                 )
@@ -368,15 +376,15 @@ def execute_cursor_command(sensor_name, cli_args, print_fn):
                         SensorInstigatorData(
                             last_tick_timestamp=job_state.instigator_data.last_tick_timestamp,
                             last_run_key=job_state.instigator_data.last_run_key,
-                            min_interval=external_sensor.min_interval_seconds,
+                            min_interval=sensor.min_interval_seconds,
                             cursor=cursor_value,
                             last_tick_start_timestamp=job_state.instigator_data.last_tick_start_timestamp,
                             last_sensor_start_timestamp=job_state.instigator_data.last_sensor_start_timestamp,
-                            sensor_type=external_sensor.sensor_type,
+                            sensor_type=sensor.sensor_type,
                         ),
                     )
                 )
             if cursor_value:
-                print_fn(f'Set cursor state for sensor {external_sensor.name} to "{cursor_value}"')
+                print_fn(f'Set cursor state for sensor {sensor.name} to "{cursor_value}"')
             else:
-                print_fn(f"Cleared cursor state for sensor {external_sensor.name}")
+                print_fn(f"Cleared cursor state for sensor {sensor.name}")

--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -722,7 +722,7 @@ def get_code_location_from_workspace(
     return workspace.get_code_location(provided_location_name)
 
 
-def get_external_repository_from_code_location(
+def get_remote_repository_from_code_location(
     code_location: CodeLocation, provided_repo_name: Optional[str]
 ) -> RemoteRepository:
     check.inst_param(code_location, "code_location", CodeLocation)
@@ -751,24 +751,24 @@ def get_external_repository_from_code_location(
 
 
 @contextmanager
-def get_external_repository_from_kwargs(
+def get_remote_repository_from_kwargs(
     instance: DagsterInstance, version: str, kwargs: ClickArgMapping
 ) -> Iterator[RemoteRepository]:
     # Instance isn't strictly required to load an ExternalRepository, but is included
     # to satisfy the WorkspaceProcessContext / WorkspaceRequestContext requirements
     with get_code_location_from_kwargs(instance, version, kwargs) as code_location:
         provided_repo_name = check.opt_str_elem(kwargs, "repository")
-        yield get_external_repository_from_code_location(code_location, provided_repo_name)
+        yield get_remote_repository_from_code_location(code_location, provided_repo_name)
 
 
 def get_remote_job_from_remote_repo(
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
     provided_name: Optional[str],
 ) -> RemoteJob:
-    check.inst_param(external_repo, "external_repo", RemoteRepository)
+    check.inst_param(remote_repo, "remote_repo", RemoteRepository)
     check.opt_str_param(provided_name, "provided_name")
 
-    remote_jobs = {ep.name: ep for ep in (external_repo.get_all_jobs())}
+    remote_jobs = {ep.name: ep for ep in (remote_repo.get_all_jobs())}
 
     check.invariant(remote_jobs)
 
@@ -778,12 +778,12 @@ def get_remote_job_from_remote_repo(
     if provided_name is None:
         raise click.UsageError(
             "Must provide --job as there is more than one job "
-            f"in {external_repo.name}. Options are: {_sorted_quoted(remote_jobs.keys())}."
+            f"in {remote_repo.name}. Options are: {_sorted_quoted(remote_jobs.keys())}."
         )
 
     if provided_name not in remote_jobs:
         raise click.UsageError(
-            f'Job "{provided_name}" not found in repository "{external_repo.name}". '
+            f'Job "{provided_name}" not found in repository "{remote_repo.name}". '
             f"Found {_sorted_quoted(remote_jobs.keys())} instead."
         )
 
@@ -794,9 +794,9 @@ def get_remote_job_from_remote_repo(
 def get_remote_job_from_kwargs(instance: DagsterInstance, version: str, kwargs: ClickArgMapping):
     # Instance isn't strictly required to load an ExternalJob, but is included
     # to satisfy the WorkspaceProcessContext / WorkspaceRequestContext requirements
-    with get_external_repository_from_kwargs(instance, version, kwargs) as external_repo:
+    with get_remote_repository_from_kwargs(instance, version, kwargs) as repo:
         provided_name = check.opt_str_elem(kwargs, "job_name")
-        yield get_remote_job_from_remote_repo(external_repo, provided_name)
+        yield get_remote_job_from_remote_repo(repo, provided_name)
 
 
 def _sorted_quoted(strings: Iterable[str]) -> str:

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -82,7 +82,7 @@ class AssetDefinitionDiffDetails:
     metadata: Optional[DictDiff[str]] = None
 
 
-def _get_external_repo_from_context(
+def _get_remote_repo_from_context(
     context: BaseWorkspaceRequestContext, code_location_name: str, repository_name: str
 ) -> Optional[RemoteRepository]:
     """Returns the ExternalRepository specified by the code location name and repository name
@@ -134,7 +134,7 @@ class AssetGraphDiffer:
             self._branch_asset_graph_load_fn = branch_asset_graph
 
     @classmethod
-    def from_external_repositories(
+    def from_remote_repositories(
         cls,
         code_location_name: str,
         repository_name: str,
@@ -154,14 +154,14 @@ class AssetGraphDiffer:
         check.inst_param(branch_workspace, "branch_workspace", BaseWorkspaceRequestContext)
         check.inst_param(base_workspace, "base_workspace", BaseWorkspaceRequestContext)
 
-        branch_repo = _get_external_repo_from_context(
+        branch_repo = _get_remote_repo_from_context(
             branch_workspace, code_location_name, repository_name
         )
         if branch_repo is None:
             raise DagsterInvariantViolationError(
                 f"Repository {repository_name} does not exist in code location {code_location_name} for the branch deployment."
             )
-        base_repo = _get_external_repo_from_context(
+        base_repo = _get_remote_repo_from_context(
             base_workspace, code_location_name, repository_name
         )
         return AssetGraphDiffer(

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -852,10 +852,10 @@ class RunStatusSensorDefinition(SensorDefinition):
                 ):
                     # check if the run is one of the jobs specified by JobSelector or RepositorySelector (ie in another repo)
                     # make a JobSelector for the run in question
-                    external_repository_origin = dagster_run.external_job_origin.repository_origin
+                    remote_repository_origin = dagster_run.external_job_origin.repository_origin
                     run_job_selector = JobSelector(
-                        location_name=external_repository_origin.code_location_origin.location_name,
-                        repository_name=external_repository_origin.repository_name,
+                        location_name=remote_repository_origin.code_location_origin.location_name,
+                        repository_name=remote_repository_origin.repository_name,
                         job_name=dagster_run.job_name,
                     )
                     if run_job_selector in other_repo_jobs:
@@ -863,8 +863,8 @@ class RunStatusSensorDefinition(SensorDefinition):
 
                     # make a RepositorySelector for the run in question
                     run_repo_selector = RepositorySelector(
-                        location_name=external_repository_origin.code_location_origin.location_name,
-                        repository_name=external_repository_origin.repository_name,
+                        location_name=remote_repository_origin.code_location_origin.location_name,
+                        repository_name=remote_repository_origin.repository_name,
                     )
                     if run_repo_selector in other_repos:
                         job_match = True

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -149,12 +149,12 @@ def _get_partition_set(
         )
 
     partition_set_name = origin.partition_set_name
-    external_repo = code_location.get_repository(repo_name)
-    if not external_repo.has_partition_set(partition_set_name):
+    remote_repo = code_location.get_repository(repo_name)
+    if not remote_repo.has_partition_set(partition_set_name):
         raise DagsterBackfillFailedError(
             f"Could not find partition set {partition_set_name} in repository {repo_name}. "
         )
-    return external_repo.get_partition_set(partition_set_name)
+    return remote_repo.get_partition_set(partition_set_name)
 
 
 def _subdivide_partition_key_range(
@@ -303,9 +303,9 @@ def submit_backfill_runs(
         code_location.has_repository(repo_name),
         f"Could not find repository {repo_name} in location {code_location.name}",
     )
-    external_repo = code_location.get_repository(repo_name)
+    remote_repo = code_location.get_repository(repo_name)
     partition_set_name = origin.partition_set_name
-    external_partition_set = external_repo.get_partition_set(partition_set_name)
+    partition_set = remote_repo.get_partition_set(partition_set_name)
 
     if backfill_job.asset_selection:
         # need to make another call to the user code location to properly subset
@@ -313,13 +313,13 @@ def submit_backfill_runs(
         pipeline_selector = JobSubsetSelector(
             location_name=code_location.name,
             repository_name=repo_name,
-            job_name=external_partition_set.job_name,
+            job_name=partition_set.job_name,
             op_selection=None,
             asset_selection=backfill_job.asset_selection,
         )
         remote_job = code_location.get_external_job(pipeline_selector)
     else:
-        remote_job = external_repo.get_full_job(external_partition_set.job_name)
+        remote_job = remote_repo.get_full_job(partition_set.job_name)
 
     partition_data_target = check.is_list(
         [partition_names_or_ranges[0].start]
@@ -328,7 +328,7 @@ def submit_backfill_runs(
         of_type=str,
     )
     partition_set_execution_data = code_location.get_external_partition_set_execution_param_data(
-        external_repo.handle,
+        remote_repo.handle,
         partition_set_name,
         partition_data_target,
         instance,
@@ -373,7 +373,7 @@ def submit_backfill_runs(
             instance,
             code_location,
             remote_job,
-            external_partition_set,
+            partition_set,
             backfill_job,
             key_or_range,
             run_tags=tags_by_key_or_range[key_or_range],
@@ -391,8 +391,8 @@ def submit_backfill_runs(
 def create_backfill_run(
     instance: DagsterInstance,
     code_location: CodeLocation,
-    external_pipeline: RemoteJob,
-    external_partition_set: RemotePartitionSet,
+    remote_job: RemoteJob,
+    remote_partition_set: RemotePartitionSet,
     backfill_job: PartitionBackfill,
     partition_key_or_range: Union[str, PartitionKeyRange],
     run_tags: Mapping[str, str],
@@ -406,12 +406,12 @@ def create_backfill_run(
         metadata={
             "DAEMON_SESSION_ID": get_telemetry_daemon_session_id(),
             "repo_hash": hash_name(code_location.name),
-            "pipeline_name_hash": hash_name(external_pipeline.name),
+            "pipeline_name_hash": hash_name(remote_job.name),
         },
     )
 
     tags = merge_dicts(
-        external_pipeline.tags,
+        remote_job.tags,
         run_tags,
         DagsterRun.tags_for_backfill_id(backfill_job.backfill_id),
         backfill_job.tags,
@@ -424,18 +424,18 @@ def create_backfill_run(
         parent_run_id = None
         root_run_id = None
         known_state = None
-        if external_partition_set.op_selection:
-            resolved_op_selection = frozenset(external_partition_set.op_selection)
-            op_selection = external_partition_set.op_selection
+        if remote_partition_set.op_selection:
+            resolved_op_selection = frozenset(remote_partition_set.op_selection)
+            op_selection = remote_partition_set.op_selection
 
     elif backfill_job.from_failure:
-        last_run = _fetch_last_run(instance, external_partition_set, partition_key_or_range)
+        last_run = _fetch_last_run(instance, remote_partition_set, partition_key_or_range)
         if not last_run or last_run.status != DagsterRunStatus.FAILURE:
             return None
         return instance.create_reexecuted_run(
             parent_run=last_run,
             code_location=code_location,
-            remote_job=external_pipeline,
+            remote_job=remote_job,
             strategy=ReexecutionStrategy.FROM_FAILURE,
             extra_tags=tags,
             run_config=run_config,
@@ -443,7 +443,7 @@ def create_backfill_run(
         )
 
     else:  # backfill_job.reexecution_steps
-        last_run = _fetch_last_run(instance, external_partition_set, partition_key_or_range)
+        last_run = _fetch_last_run(instance, remote_partition_set, partition_key_or_range)
         parent_run_id = last_run.run_id if last_run else None
         root_run_id = (last_run.root_run_id or last_run.run_id) if last_run else None
         if parent_run_id and root_run_id:
@@ -459,12 +459,12 @@ def create_backfill_run(
         else:
             known_state = None
 
-        if external_partition_set.op_selection:
-            resolved_op_selection = frozenset(external_partition_set.op_selection)
-            op_selection = external_partition_set.op_selection
+        if remote_partition_set.op_selection:
+            resolved_op_selection = frozenset(remote_partition_set.op_selection)
+            op_selection = remote_partition_set.op_selection
 
-    external_execution_plan = code_location.get_external_execution_plan(
-        external_pipeline,
+    remote_execution_plan = code_location.get_external_execution_plan(
+        remote_job,
         run_config,
         step_keys_to_execute=step_keys_to_execute,
         known_state=known_state,
@@ -472,10 +472,10 @@ def create_backfill_run(
     )
 
     return instance.create_run(
-        job_snapshot=external_pipeline.job_snapshot,
-        execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,
-        parent_job_snapshot=external_pipeline.parent_job_snapshot,
-        job_name=external_pipeline.name,
+        job_snapshot=remote_job.job_snapshot,
+        execution_plan_snapshot=remote_execution_plan.execution_plan_snapshot,
+        parent_job_snapshot=remote_job.parent_job_snapshot,
+        job_name=remote_job.name,
         run_id=make_new_run_id(),
         resolved_op_selection=resolved_op_selection,
         run_config=run_config,
@@ -484,26 +484,26 @@ def create_backfill_run(
         root_run_id=root_run_id,
         parent_run_id=parent_run_id,
         status=DagsterRunStatus.NOT_STARTED,
-        remote_job_origin=external_pipeline.get_remote_origin(),
-        job_code_origin=external_pipeline.get_python_origin(),
+        remote_job_origin=remote_job.get_remote_origin(),
+        job_code_origin=remote_job.get_python_origin(),
         op_selection=op_selection,
         asset_selection=(
             frozenset(backfill_job.asset_selection) if backfill_job.asset_selection else None
         ),
         asset_check_selection=None,
         asset_graph=code_location.get_repository(
-            external_pipeline.repository_handle.repository_name
+            remote_job.repository_handle.repository_name
         ).asset_graph,
     )
 
 
 def _fetch_last_run(
     instance: DagsterInstance,
-    external_partition_set: RemotePartitionSet,
+    remote_partition_set: RemotePartitionSet,
     partition_key_or_range: Union[str, PartitionKeyRange],
 ) -> Optional[DagsterRun]:
     check.inst_param(instance, "instance", DagsterInstance)
-    check.inst_param(external_partition_set, "external_partition_set", RemotePartitionSet)
+    check.inst_param(remote_partition_set, "remote_partition_set", RemotePartitionSet)
     check.str_param(partition_key_or_range, "partition_name")
 
     tags = (
@@ -519,8 +519,8 @@ def _fetch_last_run(
 
     runs = instance.get_runs(
         RunsFilter(
-            job_name=external_partition_set.job_name,
-            tags={PARTITION_SET_TAG: external_partition_set.name, **tags},
+            job_name=remote_partition_set.job_name,
+            tags={PARTITION_SET_TAG: remote_partition_set.name, **tags},
         ),
         limit=1,
     )

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -1213,7 +1213,7 @@ class ResourceSnap(IHaveNew):
         # we parse the JSON and break it out into defaults for each individual nested Field
         # for display in the UI
         configured_values = {
-            k: external_resource_value_from_raw(v) for k, v in config_schema_default.items()
+            k: resource_value_snap_from_raw(v) for k, v in config_schema_default.items()
         }
 
         resource_type_def = resource_def
@@ -1736,7 +1736,7 @@ def external_job_ref_from_def(job_def: JobDefinition) -> JobRefSnap:
     )
 
 
-def external_resource_value_from_raw(v: Any) -> ResourceValueSnap:
+def resource_value_snap_from_raw(v: Any) -> ResourceValueSnap:
     if isinstance(v, dict) and set(v.keys()) == {"env"}:
         return ResourceConfigEnvVarSnap(name=v["env"])
     return json.dumps(v)

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -532,7 +532,7 @@ def create_test_daemon_workspace_context(
             yield workspace_process_context
 
 
-def load_external_repo(
+def load_remote_repo(
     workspace_context: WorkspaceProcessContext, repo_name: str
 ) -> RemoteRepository:
     code_location_entry = next(

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -219,7 +219,7 @@ class AutoMaterializeLaunchContext:
     def __init__(
         self,
         tick: InstigatorTick,
-        external_sensor: Optional[RemoteSensor],
+        remote_sensor: Optional[RemoteSensor],
         instance: DagsterInstance,
         logger: logging.Logger,
         tick_retention_settings,
@@ -227,7 +227,7 @@ class AutoMaterializeLaunchContext:
         self._tick = tick
         self._logger = logger
         self._instance = instance
-        self._external_sensor = external_sensor
+        self._remote_sensor = remote_sensor
 
         self._purge_settings = defaultdict(set)
         for status, day_offset in tick_retention_settings.items():
@@ -308,13 +308,13 @@ class AutoMaterializeLaunchContext:
                 continue
             self._instance.purge_ticks(
                 (
-                    self._external_sensor.get_remote_origin().get_id()
-                    if self._external_sensor
+                    self._remote_sensor.get_remote_origin().get_id()
+                    if self._remote_sensor
                     else _PRE_SENSOR_AUTO_MATERIALIZE_ORIGIN_ID
                 ),
                 (
-                    self._external_sensor.selector.get_id()
-                    if self._external_sensor
+                    self._remote_sensor.selector.get_id()
+                    if self._remote_sensor
                     else _PRE_SENSOR_AUTO_MATERIALIZE_SELECTOR_ID
                 ),
                 before=(get_current_datetime() - datetime.timedelta(days=day_offset)).timestamp(),

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -107,13 +107,13 @@ class BackfillSubmission(NamedTuple):
 class SensorLaunchContext(AbstractContextManager):
     def __init__(
         self,
-        external_sensor: RemoteSensor,
+        remote_sensor: RemoteSensor,
         tick: InstigatorTick,
         instance: DagsterInstance,
         logger: logging.Logger,
         tick_retention_settings,
     ):
-        self._external_sensor = external_sensor
+        self._remote_sensor = remote_sensor
         self._instance = instance
         self._logger = logger
         self._tick = tick
@@ -141,8 +141,8 @@ class SensorLaunchContext(AbstractContextManager):
     @property
     def log_key(self) -> Sequence[str]:
         return [
-            self._external_sensor.handle.repository_handle.repository_name,
-            self._external_sensor.name,
+            self._remote_sensor.handle.repository_handle.repository_name,
+            self._remote_sensor.name,
             self.tick_id,
         ]
 
@@ -216,7 +216,7 @@ class SensorLaunchContext(AbstractContextManager):
         # because we want to minimize the window of clobbering the sensor state upon updating the
         # sensor state data.
         state = self._instance.get_instigator_state(
-            self._external_sensor.get_remote_origin_id(), self._external_sensor.selector_id
+            self._remote_sensor.get_remote_origin_id(), self._remote_sensor.selector_id
         )
         last_run_key = state.instigator_data.last_run_key if state.instigator_data else None  # type: ignore  # (possible none)
         last_sensor_start_timestamp = (
@@ -238,11 +238,11 @@ class SensorLaunchContext(AbstractContextManager):
                 SensorInstigatorData(
                     last_tick_timestamp=self._tick.timestamp,
                     last_run_key=last_run_key,
-                    min_interval=self._external_sensor.min_interval_seconds,
+                    min_interval=self._remote_sensor.min_interval_seconds,
                     cursor=cursor,
                     last_tick_start_timestamp=marked_timestamp,
                     last_sensor_start_timestamp=last_sensor_start_timestamp,
-                    sensor_type=self._external_sensor.sensor_type,
+                    sensor_type=self._remote_sensor.sensor_type,
                     last_tick_success_timestamp=None
                     if self._tick.status == TickStatus.FAILURE
                     else get_current_datetime().timestamp(),
@@ -269,7 +269,7 @@ class SensorLaunchContext(AbstractContextManager):
             ):
                 try:
                     raise DagsterSensorDaemonError(
-                        f"Unable to reach the user code server for sensor {self._external_sensor.name}."
+                        f"Unable to reach the user code server for sensor {self._remote_sensor.name}."
                         " Sensor will resume execution once the server is available."
                     ) from exception_value
                 except:
@@ -292,8 +292,8 @@ class SensorLaunchContext(AbstractContextManager):
             if day_offset <= 0:
                 continue
             self._instance.purge_ticks(
-                self._external_sensor.get_remote_origin_id(),
-                selector_id=self._external_sensor.selector_id,
+                self._remote_sensor.get_remote_origin_id(),
+                selector_id=self._remote_sensor.selector_id,
                 before=(get_current_datetime() - datetime.timedelta(days=day_offset)).timestamp(),
                 tick_statuses=list(statuses),
             )
@@ -399,24 +399,24 @@ def execute_sensor_iteration(
         yield
         return
 
-    for external_sensor in sensors.values():
-        sensor_name = external_sensor.name
+    for sensor in sensors.values():
+        sensor_name = sensor.name
         sensor_debug_crash_flags = debug_crash_flags.get(sensor_name) if debug_crash_flags else None
-        sensor_state = all_sensor_states.get(external_sensor.selector_id)
+        sensor_state = all_sensor_states.get(sensor.selector_id)
         if not sensor_state:
-            assert external_sensor.default_status == DefaultSensorStatus.RUNNING
+            assert sensor.default_status == DefaultSensorStatus.RUNNING
             sensor_state = InstigatorState(
-                external_sensor.get_remote_origin(),
+                sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.DECLARED_IN_CODE,
                 SensorInstigatorData(
-                    min_interval=external_sensor.min_interval_seconds,
+                    min_interval=sensor.min_interval_seconds,
                     last_sensor_start_timestamp=get_current_timestamp(),
-                    sensor_type=external_sensor.sensor_type,
+                    sensor_type=sensor.sensor_type,
                 ),
             )
             instance.add_instigator_state(sensor_state)
-        elif is_under_min_interval(sensor_state, external_sensor):
+        elif is_under_min_interval(sensor_state, sensor):
             continue
 
         if threadpool_executor:
@@ -425,8 +425,8 @@ def execute_sensor_iteration(
 
             # only allow one tick per sensor to be in flight
             if (
-                external_sensor.selector_id in sensor_tick_futures
-                and not sensor_tick_futures[external_sensor.selector_id].done()
+                sensor.selector_id in sensor_tick_futures
+                and not sensor_tick_futures[sensor.selector_id].done()
             ):
                 continue
 
@@ -434,13 +434,13 @@ def execute_sensor_iteration(
                 _process_tick,
                 workspace_process_context,
                 logger,
-                external_sensor,
+                sensor,
                 sensor_state,
                 sensor_debug_crash_flags,
                 tick_retention_settings,
                 submit_threadpool_executor,
             )
-            sensor_tick_futures[external_sensor.selector_id] = future
+            sensor_tick_futures[sensor.selector_id] = future
             yield
 
         else:
@@ -449,7 +449,7 @@ def execute_sensor_iteration(
             yield from _process_tick_generator(
                 workspace_process_context,
                 logger,
-                external_sensor,
+                sensor,
                 sensor_state,
                 sensor_debug_crash_flags,
                 tick_retention_settings,
@@ -460,7 +460,7 @@ def execute_sensor_iteration(
 def _process_tick(
     workspace_process_context: IWorkspaceProcessContext,
     logger: logging.Logger,
-    external_sensor: RemoteSensor,
+    remote_sensor: RemoteSensor,
     sensor_state: InstigatorState,
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags],
     tick_retention_settings,
@@ -472,7 +472,7 @@ def _process_tick(
         _process_tick_generator(
             workspace_process_context,
             logger,
-            external_sensor,
+            remote_sensor,
             sensor_state,
             sensor_debug_crash_flags,
             tick_retention_settings,
@@ -562,7 +562,7 @@ def _get_evaluation_tick(
 def _process_tick_generator(
     workspace_process_context: IWorkspaceProcessContext,
     logger: logging.Logger,
-    external_sensor: RemoteSensor,
+    remote_sensor: RemoteSensor,
     sensor_state: InstigatorState,
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags],
     tick_retention_settings,
@@ -573,20 +573,20 @@ def _process_tick_generator(
     now = get_current_datetime()
     sensor_state = check.not_none(
         instance.get_instigator_state(
-            external_sensor.get_remote_origin_id(), external_sensor.selector_id
+            remote_sensor.get_remote_origin_id(), remote_sensor.selector_id
         )
     )
-    if is_under_min_interval(sensor_state, external_sensor):
+    if is_under_min_interval(sensor_state, remote_sensor):
         # check the since we might have been queued before processing
         return
     else:
-        mark_sensor_state_for_tick(instance, external_sensor, sensor_state, now)
+        mark_sensor_state_for_tick(instance, remote_sensor, sensor_state, now)
 
     try:
         # get the tick that we should be evaluating for
         tick = _get_evaluation_tick(
             instance,
-            external_sensor,
+            remote_sensor,
             _sensor_instigator_data(sensor_state),
             now.timestamp(),
             logger,
@@ -595,7 +595,7 @@ def _process_tick_generator(
         check_for_debug_crash(sensor_debug_crash_flags, "TICK_CREATED")
 
         with SensorLaunchContext(
-            external_sensor,
+            remote_sensor,
             tick,
             instance,
             logger,
@@ -610,7 +610,7 @@ def _process_tick_generator(
                     workspace_process_context,
                     tick_context,
                     tick,
-                    external_sensor,
+                    remote_sensor,
                     submit_threadpool_executor,
                     sensor_debug_crash_flags,
                 )
@@ -618,7 +618,7 @@ def _process_tick_generator(
                 yield from _evaluate_sensor(
                     workspace_process_context,
                     tick_context,
-                    external_sensor,
+                    remote_sensor,
                     sensor_state,
                     submit_threadpool_executor,
                     sensor_debug_crash_flags,
@@ -628,7 +628,7 @@ def _process_tick_generator(
         error_info = DaemonErrorCapture.on_exception(
             exc_info=sys.exc_info(),
             logger=logger,
-            log_message=f"Sensor daemon caught an error for sensor {external_sensor.name}",
+            log_message=f"Sensor daemon caught an error for sensor {remote_sensor.name}",
         )
 
     yield error_info
@@ -644,7 +644,7 @@ def _sensor_instigator_data(state: InstigatorState) -> Optional[SensorInstigator
 
 def mark_sensor_state_for_tick(
     instance: DagsterInstance,
-    external_sensor: RemoteSensor,
+    remote_sensor: RemoteSensor,
     sensor_state: InstigatorState,
     now: datetime.datetime,
 ) -> None:
@@ -656,10 +656,10 @@ def mark_sensor_state_for_tick(
                     instigator_data.last_tick_timestamp if instigator_data else None
                 ),
                 last_run_key=instigator_data.last_run_key if instigator_data else None,
-                min_interval=external_sensor.min_interval_seconds,
+                min_interval=remote_sensor.min_interval_seconds,
                 cursor=instigator_data.cursor if instigator_data else None,
                 last_tick_start_timestamp=now.timestamp(),
-                sensor_type=external_sensor.sensor_type,
+                sensor_type=remote_sensor.sensor_type,
                 last_sensor_start_timestamp=instigator_data.last_sensor_start_timestamp
                 if instigator_data
                 else None,
@@ -679,21 +679,21 @@ def _submit_run_request(
     run_id: str,
     run_request: RunRequest,
     workspace_process_context: IWorkspaceProcessContext,
-    external_sensor: RemoteSensor,
+    remote_sensor: RemoteSensor,
     existing_runs_by_key,
     logger,
     sensor_debug_crash_flags,
 ) -> SubmitRunRequestResult:
     instance = workspace_process_context.instance
 
-    sensor_origin = external_sensor.get_remote_origin()
+    sensor_origin = remote_sensor.get_remote_origin()
 
-    target_data: TargetSnap = check.not_none(external_sensor.get_target(run_request.job_name))
+    target_data: TargetSnap = check.not_none(remote_sensor.get_target(run_request.job_name))
 
     # reload the code_location on each submission, request_context derived data can become out date
     # * non-threaded: if number of serial submissions is too many
     # * threaded: if thread sits pending in pool too long
-    code_location = _get_code_location_for_sensor(workspace_process_context, external_sensor)
+    code_location = _get_code_location_for_sensor(workspace_process_context, remote_sensor)
     job_subset_selector = JobSubsetSelector(
         location_name=code_location.name,
         repository_name=sensor_origin.repository_origin.repository_name,
@@ -707,7 +707,7 @@ def _submit_run_request(
         logger,
         instance,
         code_location,
-        external_sensor,
+        remote_sensor,
         remote_job,
         run_id,
         run_request,
@@ -722,9 +722,9 @@ def _submit_run_request(
 
     error_info = None
     try:
-        logger.info(f"Launching run for {external_sensor.name}")
+        logger.info(f"Launching run for {remote_sensor.name}")
         instance.submit_run(run.run_id, workspace_process_context.create_request_context())
-        logger.info(f"Completed launch of run {run.run_id} for {external_sensor.name}")
+        logger.info(f"Completed launch of run {run.run_id} for {remote_sensor.name}")
     except Exception:
         error_info = DaemonErrorCapture.on_exception(
             exc_info=sys.exc_info(),
@@ -740,7 +740,7 @@ def _resume_tick(
     workspace_process_context: IWorkspaceProcessContext,
     context: SensorLaunchContext,
     tick: InstigatorTick,
-    external_sensor: RemoteSensor,
+    remote_sensor: RemoteSensor,
     submit_threadpool_executor: Optional[ThreadPoolExecutor],
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags] = None,
 ):
@@ -764,7 +764,7 @@ def _resume_tick(
         evaluations,
         instance=instance,
         context=context,
-        external_sensor=external_sensor,
+        remote_sensor=remote_sensor,
         workspace_process_context=workspace_process_context,
         submit_threadpool_executor=submit_threadpool_executor,
         sensor_debug_crash_flags=sensor_debug_crash_flags,
@@ -774,9 +774,9 @@ def _resume_tick(
 
 def _get_code_location_for_sensor(
     workspace_process_context: IWorkspaceProcessContext,
-    external_sensor: RemoteSensor,
+    remote_sensor: RemoteSensor,
 ) -> CodeLocation:
-    sensor_origin = external_sensor.get_remote_origin()
+    sensor_origin = remote_sensor.get_remote_origin()
     return workspace_process_context.create_request_context().get_code_location(
         sensor_origin.repository_origin.code_location_origin.location_name
     )
@@ -785,21 +785,21 @@ def _get_code_location_for_sensor(
 def _evaluate_sensor(
     workspace_process_context: IWorkspaceProcessContext,
     context: SensorLaunchContext,
-    external_sensor: RemoteSensor,
+    remote_sensor: RemoteSensor,
     state: InstigatorState,
     submit_threadpool_executor: Optional[ThreadPoolExecutor],
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags] = None,
 ):
     instance = workspace_process_context.instance
-    context.logger.info(f"Checking for new runs for sensor: {external_sensor.name}")
-    code_location = _get_code_location_for_sensor(workspace_process_context, external_sensor)
-    repository_handle = external_sensor.handle.repository_handle
+    context.logger.info(f"Checking for new runs for sensor: {remote_sensor.name}")
+    code_location = _get_code_location_for_sensor(workspace_process_context, remote_sensor)
+    repository_handle = remote_sensor.handle.repository_handle
     instigator_data = _sensor_instigator_data(state)
 
     sensor_runtime_data = code_location.get_external_sensor_execution_data(
         instance,
         repository_handle,
-        external_sensor.name,
+        remote_sensor.name,
         instigator_data.last_tick_timestamp if instigator_data else None,
         instigator_data.last_run_key if instigator_data else None,
         instigator_data.cursor if instigator_data else None,
@@ -833,11 +833,11 @@ def _evaluate_sensor(
                 instance,
                 context,
                 sensor_runtime_data.cursor,
-                external_sensor,
+                remote_sensor,
             )
         elif sensor_runtime_data.skip_message:
             context.logger.info(
-                f"Sensor {external_sensor.name} skipped: {sensor_runtime_data.skip_message}"
+                f"Sensor {remote_sensor.name} skipped: {sensor_runtime_data.skip_message}"
             )
             context.update_state(
                 TickStatus.SKIPPED,
@@ -845,7 +845,7 @@ def _evaluate_sensor(
                 cursor=sensor_runtime_data.cursor,
             )
         else:
-            context.logger.info(f"No run requests returned for {external_sensor.name}, skipping")
+            context.logger.info(f"No run requests returned for {remote_sensor.name}, skipping")
             context.update_state(TickStatus.SKIPPED, cursor=sensor_runtime_data.cursor)
 
         yield
@@ -856,7 +856,7 @@ def _evaluate_sensor(
             cursor=sensor_runtime_data.cursor,
             context=context,
             instance=instance,
-            external_sensor=external_sensor,
+            remote_sensor=remote_sensor,
             workspace_process_context=workspace_process_context,
             submit_threadpool_executor=submit_threadpool_executor,
             sensor_debug_crash_flags=sensor_debug_crash_flags,
@@ -945,7 +945,7 @@ def _handle_run_reactions(
     instance: DagsterInstance,
     context: SensorLaunchContext,
     cursor: Optional[str],
-    external_sensor: RemoteSensor,
+    remote_sensor: RemoteSensor,
 ) -> None:
     for run_reaction in dagster_run_reactions:
         origin_run_id = check.not_none(run_reaction.dagster_run).run_id
@@ -973,7 +973,7 @@ def _handle_run_reactions(
             )
             # log to the original dagster run
             message = (
-                f'Sensor "{external_sensor.name}" acted on run status '
+                f'Sensor "{remote_sensor.name}" acted on run status '
                 f"{status} of run {origin_run_id}."
             )
             instance.report_engine_event(message=message, dagster_run=run_reaction.dagster_run)
@@ -988,7 +988,7 @@ def _handle_run_reactions(
 def _resolve_run_requests(
     workspace_process_context: IWorkspaceProcessContext,
     context: SensorLaunchContext,
-    external_sensor: RemoteSensor,
+    remote_sensor: RemoteSensor,
     run_ids_with_requests: Sequence[Tuple[str, RunRequest]],
     has_evaluations: bool,
 ) -> Sequence[Tuple[str, RunRequest]]:
@@ -1006,7 +1006,7 @@ def _resolve_run_requests(
             stale_assets = resolve_stale_or_missing_assets(
                 workspace_process_context,  # type: ignore
                 run_request,
-                external_sensor,
+                remote_sensor,
             )
             # asset selection is empty set after filtering for stale
             if len(stale_assets) == 0:
@@ -1026,7 +1026,7 @@ def _handle_run_requests_and_automation_condition_evaluations(
     cursor: Optional[str],
     instance: DagsterInstance,
     context: SensorLaunchContext,
-    external_sensor: RemoteSensor,
+    remote_sensor: RemoteSensor,
     workspace_process_context: IWorkspaceProcessContext,
     submit_threadpool_executor: Optional[ThreadPoolExecutor],
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags] = None,
@@ -1067,7 +1067,7 @@ def _handle_run_requests_and_automation_condition_evaluations(
         evaluations,
         instance,
         context,
-        external_sensor,
+        remote_sensor,
         workspace_process_context,
         submit_threadpool_executor,
         sensor_debug_crash_flags,
@@ -1079,7 +1079,7 @@ def _submit_run_requests(
     automation_condition_evaluations: Sequence[AutomationConditionEvaluationWithRunIds],
     instance: DagsterInstance,
     context: SensorLaunchContext,
-    external_sensor: RemoteSensor,
+    remote_sensor: RemoteSensor,
     workspace_process_context: IWorkspaceProcessContext,
     submit_threadpool_executor: Optional[ThreadPoolExecutor],
     sensor_debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags] = None,
@@ -1087,12 +1087,12 @@ def _submit_run_requests(
     resolved_run_ids_with_requests = _resolve_run_requests(
         workspace_process_context,
         context,
-        external_sensor,
+        remote_sensor,
         raw_run_ids_with_requests,
         has_evaluations=len(automation_condition_evaluations) > 0,
     )
     existing_runs_by_key = _fetch_existing_runs(
-        instance, external_sensor, [request for _, request in resolved_run_ids_with_requests]
+        instance, remote_sensor, [request for _, request in resolved_run_ids_with_requests]
     )
 
     def submit_run_request(
@@ -1106,7 +1106,7 @@ def _submit_run_requests(
                 run_id,
                 run_request,
                 workspace_process_context,
-                external_sensor,
+                remote_sensor,
                 existing_runs_by_key,
                 context.logger,
                 sensor_debug_crash_flags,
@@ -1162,7 +1162,7 @@ def _submit_run_requests(
         skipped_count = len(skipped_runs)
         context.logger.info(
             f"Skipping {skipped_count} {'run' if skipped_count == 1 else 'runs'} for sensor "
-            f"{external_sensor.name} already completed with run keys: {seven.json.dumps(run_keys)}"
+            f"{remote_sensor.name} already completed with run keys: {seven.json.dumps(run_keys)}"
         )
     yield
 
@@ -1189,7 +1189,7 @@ def _submit_backfill_request(
     )
 
 
-def is_under_min_interval(state: InstigatorState, external_sensor: RemoteSensor) -> bool:
+def is_under_min_interval(state: InstigatorState, remote_sensor: RemoteSensor) -> bool:
     instigator_data = _sensor_instigator_data(state)
     if not instigator_data:
         return False
@@ -1197,19 +1197,19 @@ def is_under_min_interval(state: InstigatorState, external_sensor: RemoteSensor)
     if not instigator_data.last_tick_start_timestamp and not instigator_data.last_tick_timestamp:
         return False
 
-    if not external_sensor.min_interval_seconds:
+    if not remote_sensor.min_interval_seconds:
         return False
 
     elapsed = get_current_timestamp() - max(
         instigator_data.last_tick_timestamp or 0,
         instigator_data.last_tick_start_timestamp or 0,
     )
-    return elapsed < external_sensor.min_interval_seconds
+    return elapsed < remote_sensor.min_interval_seconds
 
 
 def _fetch_existing_runs(
     instance: DagsterInstance,
-    external_sensor: RemoteSensor,
+    remote_sensor: RemoteSensor,
     run_requests: Sequence[RunRequest],
 ):
     run_keys = [run_request.run_key for run_request in run_requests if run_request.run_key]
@@ -1232,17 +1232,14 @@ def _fetch_existing_runs(
     valid_runs: List[DagsterRun] = []
     for run in runs_with_run_keys:
         # if the run doesn't have a set origin, just match on sensor name
-        if (
-            run.external_job_origin is None
-            and run.tags.get(SENSOR_NAME_TAG) == external_sensor.name
-        ):
+        if run.external_job_origin is None and run.tags.get(SENSOR_NAME_TAG) == remote_sensor.name:
             valid_runs.append(run)
         # otherwise prevent the same named sensor across repos from effecting each other
         elif (
             run.external_job_origin is not None
             and run.external_job_origin.repository_origin.get_selector_id()
-            == external_sensor.get_remote_origin().repository_origin.get_selector_id()
-            and run.tags.get(SENSOR_NAME_TAG) == external_sensor.name
+            == remote_sensor.get_remote_origin().repository_origin.get_selector_id()
+            and run.tags.get(SENSOR_NAME_TAG) == remote_sensor.name
         ):
             valid_runs.append(run)
 
@@ -1259,7 +1256,7 @@ def _get_or_create_sensor_run(
     logger: logging.Logger,
     instance: DagsterInstance,
     code_location: CodeLocation,
-    external_sensor: RemoteSensor,
+    remote_sensor: RemoteSensor,
     remote_job: RemoteJob,
     run_id: str,
     run_request: RunRequest,
@@ -1276,21 +1273,21 @@ def _get_or_create_sensor_run(
         else:
             logger.info(
                 f"Run {run.run_id} already created with the run key "
-                f"`{run_request.run_key}` for {external_sensor.name}"
+                f"`{run_request.run_key}` for {remote_sensor.name}"
             )
             return run
 
-    logger.info(f"Creating new run for {external_sensor.name}")
+    logger.info(f"Creating new run for {remote_sensor.name}")
 
     return _create_sensor_run(
-        instance, code_location, external_sensor, remote_job, run_id, run_request, target_data
+        instance, code_location, remote_sensor, remote_job, run_id, run_request, target_data
     )
 
 
 def _create_sensor_run(
     instance: DagsterInstance,
     code_location: CodeLocation,
-    external_sensor: RemoteSensor,
+    remote_sensor: RemoteSensor,
     remote_job: RemoteJob,
     run_id: str,
     run_request: RunRequest,
@@ -1298,21 +1295,21 @@ def _create_sensor_run(
 ) -> DagsterRun:
     from dagster._daemon.daemon import get_telemetry_daemon_session_id
 
-    external_execution_plan = code_location.get_external_execution_plan(
+    remote_execution_plan = code_location.get_external_execution_plan(
         remote_job,
         run_request.run_config,
         step_keys_to_execute=None,
         known_state=None,
         instance=instance,
     )
-    execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
+    execution_plan_snapshot = remote_execution_plan.execution_plan_snapshot
 
     tags = {
         **(remote_job.run_tags or {}),
         **run_request.tags,
         # this gets applied in the sensor definition too, but we apply it here for backcompat
         # with sensors before the tag was added to the sensor definition
-        **DagsterRun.tags_for_sensor(external_sensor),
+        **DagsterRun.tags_for_sensor(remote_sensor),
     }
     if run_request.run_key:
         tags[RUN_KEY_TAG] = run_request.run_key
@@ -1322,7 +1319,7 @@ def _create_sensor_run(
         SENSOR_RUN_CREATED,
         metadata={
             "DAEMON_SESSION_ID": get_telemetry_daemon_session_id(),
-            "SENSOR_NAME_HASH": hash_name(external_sensor.name),
+            "SENSOR_NAME_HASH": hash_name(remote_sensor.name),
             "pipeline_name_hash": hash_name(remote_job.name),
             "repo_hash": hash_name(code_location.name),
         },

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -77,13 +77,13 @@ ERROR_INTERVAL_TIME = 5
 class _ScheduleLaunchContext(AbstractContextManager):
     def __init__(
         self,
-        external_schedule: RemoteSchedule,
+        remote_schedule: RemoteSchedule,
         tick: InstigatorTick,
         instance: DagsterInstance,
         logger: logging.Logger,
         tick_retention_settings,
     ):
-        self._external_schedule = external_schedule
+        self._remote_schedule = remote_schedule
         self._instance = instance
         self._logger = logger
         self._tick = tick
@@ -102,8 +102,8 @@ class _ScheduleLaunchContext(AbstractContextManager):
     @property
     def log_key(self) -> Sequence[str]:
         return [
-            self._external_schedule.handle.repository_name,
-            self._external_schedule.name,
+            self._remote_schedule.handle.repository_name,
+            self._remote_schedule.name,
             self.tick_id,
         ]
 
@@ -135,8 +135,8 @@ class _ScheduleLaunchContext(AbstractContextManager):
             if day_offset <= 0:
                 continue
             self._instance.purge_ticks(
-                self._external_schedule.get_remote_origin_id(),
-                selector_id=self._external_schedule.selector_id,
+                self._remote_schedule.get_remote_origin_id(),
+                selector_id=self._remote_schedule.selector_id,
                 before=(get_current_datetime() - datetime.timedelta(days=day_offset)).timestamp(),
                 tick_statuses=list(statuses),
             )
@@ -320,18 +320,18 @@ def launch_scheduled_runs(
         yield
         return
 
-    for external_schedule in schedules.values():
+    for schedule in schedules.values():
         error_info = None
         try:
-            schedule_state = all_schedule_states.get(external_schedule.selector_id)
+            schedule_state = all_schedule_states.get(schedule.selector_id)
             if not schedule_state:
-                assert external_schedule.default_status == DefaultScheduleStatus.RUNNING
+                assert schedule.default_status == DefaultScheduleStatus.RUNNING
                 schedule_state = InstigatorState(
-                    external_schedule.get_remote_origin(),
+                    schedule.get_remote_origin(),
                     InstigatorType.SCHEDULE,
                     InstigatorStatus.DECLARED_IN_CODE,
                     ScheduleInstigatorData(
-                        external_schedule.cron_schedule,
+                        schedule.cron_schedule,
                         end_datetime_utc.timestamp(),
                     ),
                 )
@@ -347,26 +347,26 @@ def launch_scheduled_runs(
                         "scheduler_run_futures dict must be passed with threadpool_executor"
                     )
 
-                if external_schedule.selector_id in scheduler_run_futures:
-                    if scheduler_run_futures[external_schedule.selector_id].done():
+                if schedule.selector_id in scheduler_run_futures:
+                    if scheduler_run_futures[schedule.selector_id].done():
                         try:
-                            result = scheduler_run_futures[external_schedule.selector_id].result()
-                            iteration_times[external_schedule.selector_id] = result
+                            result = scheduler_run_futures[schedule.selector_id].result()
+                            iteration_times[schedule.selector_id] = result
                         except Exception:
                             # Log exception and continue on rather than erroring the whole scheduler loop
                             logger.exception(
-                                f"Error getting tick result for schedule {external_schedule.name}"
+                                f"Error getting tick result for schedule {schedule.name}"
                             )
-                        del scheduler_run_futures[external_schedule.selector_id]
+                        del scheduler_run_futures[schedule.selector_id]
                     else:
                         # only allow one tick per schedule to be in flight
                         continue
 
-                previous_iteration_times = iteration_times.get(external_schedule.selector_id)
+                previous_iteration_times = iteration_times.get(schedule.selector_id)
                 if (
                     previous_iteration_times
                     and not previous_iteration_times.should_run_next_iteration(
-                        external_schedule, end_datetime_utc.timestamp()
+                        schedule, end_datetime_utc.timestamp()
                     )
                 ):
                     # Not enough time has passed for this schedule, don't bother creating a thread
@@ -376,7 +376,7 @@ def launch_scheduled_runs(
                     launch_scheduled_runs_for_schedule,
                     workspace_process_context,
                     logger,
-                    external_schedule,
+                    schedule,
                     schedule_state,
                     end_datetime_utc,
                     max_catchup_runs,
@@ -390,15 +390,15 @@ def launch_scheduled_runs(
                         else None
                     ),
                 )
-                scheduler_run_futures[external_schedule.selector_id] = future
+                scheduler_run_futures[schedule.selector_id] = future
                 yield
 
             else:
-                previous_iteration_times = iteration_times.get(external_schedule.selector_id)
+                previous_iteration_times = iteration_times.get(schedule.selector_id)
                 if (
                     previous_iteration_times
                     and not previous_iteration_times.should_run_next_iteration(
-                        external_schedule, end_datetime_utc.timestamp()
+                        schedule, end_datetime_utc.timestamp()
                     )
                 ):
                     # Not enough time has passed for this schedule, don't bother executing
@@ -410,7 +410,7 @@ def launch_scheduled_runs(
                 for yielded_value in launch_scheduled_runs_for_schedule_iterator(
                     workspace_process_context,
                     logger,
-                    external_schedule,
+                    schedule,
                     schedule_state,
                     end_datetime_utc,
                     max_catchup_runs,
@@ -430,7 +430,7 @@ def launch_scheduled_runs(
                             "launch_scheduled_runs_for_schedule_iterator yielded more than one ScheduleIterationTimes",
                         )
                         found_iteration_times = True
-                        iteration_times[external_schedule.selector_id] = yielded_value
+                        iteration_times[schedule.selector_id] = yielded_value
                     else:
                         yield yielded_value
                 check.invariant(
@@ -439,14 +439,14 @@ def launch_scheduled_runs(
                 )
         except Exception:
             error_info = serializable_error_info_from_exc_info(sys.exc_info())
-            logger.exception(f"Scheduler caught an error for schedule {external_schedule.name}")
+            logger.exception(f"Scheduler caught an error for schedule {schedule.name}")
         yield error_info
 
 
 def launch_scheduled_runs_for_schedule(
     workspace_process_context: IWorkspaceProcessContext,
     logger: logging.Logger,
-    external_schedule: RemoteSchedule,
+    remote_schedule: RemoteSchedule,
     schedule_state: InstigatorState,
     end_datetime_utc: datetime.datetime,
     max_catchup_runs: int,
@@ -462,7 +462,7 @@ def launch_scheduled_runs_for_schedule(
     for yielded_value in launch_scheduled_runs_for_schedule_iterator(
         workspace_process_context,
         logger,
-        external_schedule,
+        remote_schedule,
         schedule_state,
         end_datetime_utc,
         max_catchup_runs,
@@ -481,7 +481,7 @@ def launch_scheduled_runs_for_schedule(
 def launch_scheduled_runs_for_schedule_iterator(
     workspace_process_context: IWorkspaceProcessContext,
     logger: logging.Logger,
-    external_schedule: RemoteSchedule,
+    remote_schedule: RemoteSchedule,
     schedule_state: InstigatorState,
     end_datetime_utc: datetime.datetime,
     max_catchup_runs: int,
@@ -495,8 +495,8 @@ def launch_scheduled_runs_for_schedule_iterator(
     end_datetime_utc = check.inst_param(end_datetime_utc, "end_datetime_utc", datetime.datetime)
     instance = workspace_process_context.instance
 
-    instigator_origin_id = external_schedule.get_remote_origin_id()
-    ticks = instance.get_ticks(instigator_origin_id, external_schedule.selector_id, limit=1)
+    instigator_origin_id = remote_schedule.get_remote_origin_id()
+    ticks = instance.get_ticks(instigator_origin_id, remote_schedule.selector_id, limit=1)
     latest_tick: Optional[InstigatorTick] = ticks[0] if ticks else None
 
     instigator_data = cast(ScheduleInstigatorData, schedule_state.instigator_data)
@@ -528,9 +528,9 @@ def launch_scheduled_runs_for_schedule_iterator(
             in_memory_last_iteration_timestamp or 0.0,
         )
 
-    schedule_name = external_schedule.name
+    schedule_name = remote_schedule.name
 
-    timezone_str = external_schedule.execution_timezone
+    timezone_str = remote_schedule.execution_timezone
     if not timezone_str:
         timezone_str = "UTC"
 
@@ -540,7 +540,7 @@ def launch_scheduled_runs_for_schedule_iterator(
 
     next_iteration_timestamp = None
 
-    for next_time in external_schedule.execution_time_iterator(start_timestamp_utc):
+    for next_time in remote_schedule.execution_time_iterator(start_timestamp_utc):
         next_tick_timestamp = next_time.timestamp()
         if next_tick_timestamp > now_timestamp:
             next_iteration_timestamp = next_tick_timestamp
@@ -561,13 +561,13 @@ def launch_scheduled_runs_for_schedule_iterator(
         )
 
         yield ScheduleIterationTimes(
-            cron_schedule=external_schedule.cron_schedule,
+            cron_schedule=remote_schedule.cron_schedule,
             next_iteration_timestamp=next_iteration_timestamp,
             last_iteration_timestamp=now_timestamp,
         )
         return
 
-    if not external_schedule.partition_set_name and len(tick_times) > 1:
+    if not remote_schedule.partition_set_name and len(tick_times) > 1:
         logger.warning(f"{schedule_name} has no partition set, so not trying to catch up")
         tick_times = tick_times[-1:]
     elif len(tick_times) > max_catchup_runs:
@@ -600,14 +600,14 @@ def launch_scheduled_runs_for_schedule_iterator(
                     instigator_type=InstigatorType.SCHEDULE,
                     status=TickStatus.STARTED,
                     timestamp=schedule_timestamp,
-                    selector_id=external_schedule.selector_id,
+                    selector_id=remote_schedule.selector_id,
                 )
             )
 
             check_for_debug_crash(schedule_debug_crash_flags, "TICK_CREATED")
 
         with _ScheduleLaunchContext(
-            external_schedule, tick, instance, logger, tick_retention_settings
+            remote_schedule, tick, instance, logger, tick_retention_settings
         ) as tick_context:
             try:
                 check_for_debug_crash(schedule_debug_crash_flags, "TICK_HELD")
@@ -616,7 +616,7 @@ def launch_scheduled_runs_for_schedule_iterator(
                 yield from _schedule_runs_at_time(
                     workspace_process_context,
                     logger,
-                    external_schedule,
+                    remote_schedule,
                     schedule_time,
                     timezone_str,
                     tick_context,
@@ -635,7 +635,7 @@ def launch_scheduled_runs_for_schedule_iterator(
 
                         logger.exception(
                             "Scheduler daemon caught an error for schedule "
-                            f"{external_schedule.name}"
+                            f"{remote_schedule.name}"
                         )
 
                         tick_context.update_state(
@@ -659,7 +659,7 @@ def launch_scheduled_runs_for_schedule_iterator(
                 # as both the next_iteration_timestamp and the last_iteration_timestmap
                 # (to ensure that the scheduler doesn't accidentally skip past it)
                 yield ScheduleIterationTimes(
-                    cron_schedule=external_schedule.cron_schedule,
+                    cron_schedule=remote_schedule.cron_schedule,
                     next_iteration_timestamp=schedule_time.timestamp(),
                     last_iteration_timestamp=schedule_time.timestamp(),
                 )
@@ -676,7 +676,7 @@ def launch_scheduled_runs_for_schedule_iterator(
         check.not_none(next_iteration_timestamp), next_checkpoint_timestamp
     )
     yield ScheduleIterationTimes(
-        cron_schedule=external_schedule.cron_schedule,
+        cron_schedule=remote_schedule.cron_schedule,
         next_iteration_timestamp=next_iteration_timestamp,
         last_iteration_timestamp=now_timestamp,
     )
@@ -693,45 +693,43 @@ class SubmitRunRequestResult(NamedTuple):
 def _submit_run_request(
     run_request: RunRequest,
     workspace_process_context: IWorkspaceProcessContext,
-    external_schedule: RemoteSchedule,
+    remote_schedule: RemoteSchedule,
     schedule_time: datetime.datetime,
     logger,
     debug_crash_flags,
 ) -> SubmitRunRequestResult:
     instance = workspace_process_context.instance
-    schedule_origin = external_schedule.get_remote_origin()
+    schedule_origin = remote_schedule.get_remote_origin()
 
-    run = _get_existing_run_for_request(instance, external_schedule, schedule_time, run_request)
+    run = _get_existing_run_for_request(instance, remote_schedule, schedule_time, run_request)
     if run:
         if run.status != DagsterRunStatus.NOT_STARTED:
             # A run already exists and was launched for this time period,
             # but the scheduler must have crashed or errored before the tick could be put
             # into a SUCCESS state
             logger.info(
-                f"Run {run.run_id} already completed for this execution of {external_schedule.name}"
+                f"Run {run.run_id} already completed for this execution of {remote_schedule.name}"
             )
             return SubmitRunRequestResult(
                 run_key=run_request.run_key, error_info=None, existing_run=run, submitted_run=None
             )
         else:
             logger.info(
-                f"Run {run.run_id} already created for this execution of {external_schedule.name}"
+                f"Run {run.run_id} already created for this execution of {remote_schedule.name}"
             )
     else:
         job_subset_selector = JobSubsetSelector(
             location_name=schedule_origin.repository_origin.code_location_origin.location_name,
             repository_name=schedule_origin.repository_origin.repository_name,
-            job_name=external_schedule.job_name,
-            op_selection=external_schedule.op_selection,
+            job_name=remote_schedule.job_name,
+            op_selection=remote_schedule.op_selection,
             asset_selection=run_request.asset_selection,
         )
 
         # reload the code_location on each submission, request_context derived data can become out date
         # * non-threaded: if number of serial submissions is too many
         # * threaded: if thread sits pending in pool too long
-        code_location = _get_code_location_for_schedule(
-            workspace_process_context, external_schedule
-        )
+        code_location = _get_code_location_for_schedule(workspace_process_context, remote_schedule)
 
         remote_job = code_location.get_external_job(job_subset_selector)
 
@@ -739,7 +737,7 @@ def _submit_run_request(
             instance,
             schedule_time,
             code_location,
-            external_schedule,
+            remote_schedule,
             remote_job,
             run_request,
         )
@@ -752,7 +750,7 @@ def _submit_run_request(
         try:
             instance.submit_run(run.run_id, workspace_process_context.create_request_context())
             logger.info(
-                f"Completed scheduled launch of run {run.run_id} for {external_schedule.name}"
+                f"Completed scheduled launch of run {run.run_id} for {remote_schedule.name}"
             )
         except Exception:
             error_info = serializable_error_info_from_exc_info(sys.exc_info())
@@ -768,9 +766,9 @@ def _submit_run_request(
 
 def _get_code_location_for_schedule(
     workspace_process_context: IWorkspaceProcessContext,
-    external_schedule: RemoteSchedule,
+    remote_schedule: RemoteSchedule,
 ) -> CodeLocation:
-    schedule_origin = external_schedule.get_remote_origin()
+    schedule_origin = remote_schedule.get_remote_origin()
     return workspace_process_context.create_request_context().get_code_location(
         schedule_origin.repository_origin.code_location_origin.location_name
     )
@@ -779,7 +777,7 @@ def _get_code_location_for_schedule(
 def _schedule_runs_at_time(
     workspace_process_context: IWorkspaceProcessContext,
     logger: logging.Logger,
-    external_schedule: RemoteSchedule,
+    remote_schedule: RemoteSchedule,
     schedule_time: datetime.datetime,
     timezone_str: str,
     tick_context: _ScheduleLaunchContext,
@@ -787,14 +785,14 @@ def _schedule_runs_at_time(
     debug_crash_flags: Optional[SingleInstigatorDebugCrashFlags] = None,
 ) -> Generator[Union[None, SerializableErrorInfo, ScheduleIterationTimes], None, None]:
     instance = workspace_process_context.instance
-    repository_handle = external_schedule.handle.repository_handle
+    repository_handle = remote_schedule.handle.repository_handle
 
-    code_location = _get_code_location_for_schedule(workspace_process_context, external_schedule)
+    code_location = _get_code_location_for_schedule(workspace_process_context, remote_schedule)
 
     schedule_execution_data = code_location.get_external_schedule_execution_data(
         instance=instance,
         repository_handle=repository_handle,
-        schedule_name=external_schedule.name,
+        schedule_name=remote_schedule.name,
         scheduled_execution_time=TimestampWithTimezone(
             schedule_time.timestamp(),
             timezone_str,
@@ -814,10 +812,10 @@ def _schedule_runs_at_time(
     if not schedule_execution_data.run_requests:
         if schedule_execution_data.skip_message:
             logger.info(
-                f"Schedule {external_schedule.name} skipped: {schedule_execution_data.skip_message}"
+                f"Schedule {remote_schedule.name} skipped: {schedule_execution_data.skip_message}"
             )
         else:
-            logger.info(f"No run requests returned for {external_schedule.name}, skipping")
+            logger.info(f"No run requests returned for {remote_schedule.name}, skipping")
 
         # Update tick to skipped state and return
         tick_context.update_state(
@@ -839,7 +837,7 @@ def _schedule_runs_at_time(
             stale_assets = resolve_stale_or_missing_assets(
                 workspace_process_context,  # type: ignore
                 run_request,
-                external_schedule,
+                remote_schedule,
             )
             # asset selection is empty set after filtering for stale
             if len(stale_assets) == 0:
@@ -854,7 +852,7 @@ def _schedule_runs_at_time(
     submit_run_request = lambda run_request: _submit_run_request(
         run_request,
         workspace_process_context,
-        external_schedule,
+        remote_schedule,
         schedule_time,
         logger,
         debug_crash_flags,
@@ -884,12 +882,12 @@ def _schedule_runs_at_time(
 
 def _get_existing_run_for_request(
     instance: DagsterInstance,
-    external_schedule: RemoteSchedule,
+    remote_schedule: RemoteSchedule,
     schedule_time: datetime.datetime,
     run_request: RunRequest,
 ) -> Optional[DagsterRun]:
     tags = merge_dicts(
-        DagsterRun.tags_for_schedule(external_schedule),
+        DagsterRun.tags_for_schedule(remote_schedule),
         {
             SCHEDULED_EXECUTION_TIME_TAG: schedule_time.astimezone(
                 datetime.timezone.utc
@@ -909,7 +907,7 @@ def _get_existing_run_for_request(
             matching_runs.append(run)
         # otherwise prevent the same named schedule (with the same execution time) across repos from effecting each other
         elif (
-            external_schedule.get_remote_origin().repository_origin.get_selector_id()
+            remote_schedule.get_remote_origin().repository_origin.get_selector_id()
             == run.external_job_origin.repository_origin.get_selector_id()
         ):
             matching_runs.append(run)
@@ -924,7 +922,7 @@ def _create_scheduler_run(
     instance: DagsterInstance,
     schedule_time: datetime.datetime,
     code_location: CodeLocation,
-    external_schedule: RemoteSchedule,
+    remote_schedule: RemoteSchedule,
     remote_job: RemoteJob,
     run_request: RunRequest,
 ) -> DagsterRun:
@@ -933,13 +931,13 @@ def _create_scheduler_run(
     run_config = run_request.run_config
     schedule_tags = run_request.tags
 
-    external_execution_plan = code_location.get_external_execution_plan(
+    remote_execution_plan = code_location.get_external_execution_plan(
         remote_job,
         run_config,
         step_keys_to_execute=None,
         known_state=None,
     )
-    execution_plan_snapshot = external_execution_plan.execution_plan_snapshot
+    execution_plan_snapshot = remote_execution_plan.execution_plan_snapshot
 
     tags = {
         **remote_job.run_tags,
@@ -955,14 +953,14 @@ def _create_scheduler_run(
         SCHEDULED_RUN_CREATED,
         metadata={
             "DAEMON_SESSION_ID": get_telemetry_daemon_session_id(),
-            "SCHEDULE_NAME_HASH": hash_name(external_schedule.name),
+            "SCHEDULE_NAME_HASH": hash_name(remote_schedule.name),
             "repo_hash": hash_name(code_location.name),
             "pipeline_name_hash": hash_name(remote_job.name),
         },
     )
 
     return instance.create_run(
-        job_name=external_schedule.job_name,
+        job_name=remote_schedule.job_name,
         run_id=None,
         run_config=run_config,
         resolved_op_selection=remote_job.resolved_op_selection,

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_repository.py
@@ -27,26 +27,26 @@ from dagster_tests.api_tests.utils import get_bar_repo_code_location
 
 def test_streaming_external_repositories_api_grpc(instance):
     with get_bar_repo_code_location(instance) as code_location:
-        external_repo_datas = sync_get_streaming_external_repositories_data_grpc(
+        repository_snaps = sync_get_streaming_external_repositories_data_grpc(
             code_location.client, code_location
         )
 
-        assert len(external_repo_datas) == 1
+        assert len(repository_snaps) == 1
 
-        external_repository_data = external_repo_datas["bar_repo"]
+        repository_snap = repository_snaps["bar_repo"]
 
-        assert isinstance(external_repository_data, RepositorySnap)
-        assert external_repository_data.name == "bar_repo"
-        assert external_repository_data.metadata == {
+        assert isinstance(repository_snap, RepositorySnap)
+        assert repository_snap.name == "bar_repo"
+        assert repository_snap.metadata == {
             "string": TextMetadataValue("foo"),
             "integer": IntMetadataValue(123),
         }
 
-        async_external_repo_datas = asyncio.run(
+        async_repository_snaps = asyncio.run(
             gen_streaming_external_repositories_data_grpc(code_location.client, code_location)
         )
 
-        assert async_external_repo_datas == external_repo_datas
+        assert async_repository_snaps == repository_snaps
 
 
 def test_streaming_external_repositories_error(instance):
@@ -109,16 +109,16 @@ def test_giant_external_repository_streaming_grpc():
     with instance_for_test() as instance:
         with get_giant_repo_grpc_code_location(instance) as code_location:
             # Using streaming allows the giant repo to load
-            external_repos_data = sync_get_streaming_external_repositories_data_grpc(
+            repository_snaps = sync_get_streaming_external_repositories_data_grpc(
                 code_location.client, code_location
             )
 
-            assert len(external_repos_data) == 1
+            assert len(repository_snaps) == 1
 
-            external_repository_data = external_repos_data["giant_repo"]
+            repository_snap = repository_snaps["giant_repo"]
 
-            assert isinstance(external_repository_data, RepositorySnap)
-            assert external_repository_data.name == "giant_repo"
+            assert isinstance(repository_snap, RepositorySnap)
+            assert repository_snap.name == "giant_repo"
 
 
 def test_defer_snapshots(instance: DagsterInstance):
@@ -143,12 +143,12 @@ def test_defer_snapshots(instance: DagsterInstance):
             )
             return deserialize_value(reply.serialized_job_data, JobDataSnap)
 
-        external_repository_data = deserialize_value(ser_repo_data, RepositorySnap)
-        assert external_repository_data.job_refs and len(external_repository_data.job_refs) == 6
-        assert external_repository_data.job_datas is None
+        repository_snap = deserialize_value(ser_repo_data, RepositorySnap)
+        assert repository_snap.job_refs and len(repository_snap.job_refs) == 6
+        assert repository_snap.job_datas is None
 
         repo = RemoteRepository(
-            external_repository_data,
+            repository_snap,
             RepositoryHandle.from_location(repository_name="bar_repo", code_location=code_location),
             instance=instance,
             ref_to_data_fn=_ref_to_data,

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_sensor_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_sensor_commands.py
@@ -87,7 +87,7 @@ def test_sensors_start_all(gen_sensor_args):
             assert result.output == "Started all sensors for repository bar\n"
 
 
-def test_check_repo_and_sensorr_no_external_sensors():
+def test_check_repo_and_sensorr_no_remote_sensors():
     repository = mock.MagicMock(spec=RemoteRepository)
     repository.get_sensors.return_value = []
     instance = mock.MagicMock(spec=DagsterInstance)

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -41,7 +41,7 @@ from dagster._core.telemetry import (
     cleanup_telemetry_logger,
     get_or_create_dir_from_dagster_home,
     get_or_set_instance_id,
-    get_stats_from_external_repo,
+    get_stats_from_remote_repo,
     hash_name,
     log_workspace_stats,
     write_telemetry_log_line,
@@ -223,7 +223,7 @@ def test_get_stats_from_external_repo_partitions(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_external_repo(external_repo)
+    stats = get_stats_from_remote_repo(external_repo)
     assert stats["num_partitioned_assets_in_repo"] == "2"
 
 
@@ -243,7 +243,7 @@ def test_get_stats_from_external_repo_multi_partitions(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_external_repo(external_repo)
+    stats = get_stats_from_remote_repo(external_repo)
     assert stats["num_multi_partitioned_assets_in_repo"] == "1"
     assert stats["num_partitioned_assets_in_repo"] == "1"
 
@@ -259,7 +259,7 @@ def test_get_stats_from_external_repo_source_assets(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_external_repo(external_repo)
+    stats = get_stats_from_remote_repo(external_repo)
     assert stats["num_source_assets_in_repo"] == "1"
 
 
@@ -279,7 +279,7 @@ def test_get_stats_from_external_repo_observable_source_assets(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_external_repo(external_repo)
+    stats = get_stats_from_remote_repo(external_repo)
     assert stats["num_source_assets_in_repo"] == "2"
     assert stats["num_observable_source_assets_in_repo"] == "1"
 
@@ -296,7 +296,7 @@ def test_get_stats_from_external_repo_freshness_policies(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_external_repo(external_repo)
+    stats = get_stats_from_remote_repo(external_repo)
     assert stats["num_assets_with_freshness_policies_in_repo"] == "1"
 
 
@@ -317,7 +317,7 @@ def test_get_status_from_external_repo_auto_materialize_policy(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_external_repo(external_repo)
+    stats = get_stats_from_remote_repo(external_repo)
     assert stats["num_assets_with_eager_auto_materialize_policies_in_repo"] == "1"
     assert stats["num_assets_with_lazy_auto_materialize_policies_in_repo"] == "1"
 
@@ -334,7 +334,7 @@ def test_get_stats_from_external_repo_code_versions(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_external_repo(external_repo)
+    stats = get_stats_from_remote_repo(external_repo)
     assert stats["num_assets_with_code_versions_in_repo"] == "1"
 
 
@@ -360,7 +360,7 @@ def test_get_stats_from_external_repo_code_checks(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_external_repo(external_repo)
+    stats = get_stats_from_remote_repo(external_repo)
     assert stats["num_asset_checks"] == "2"
     assert stats["num_assets_with_checks"] == "1"
 
@@ -377,7 +377,7 @@ def test_get_stats_from_external_repo_dbt(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_external_repo(external_repo)
+    stats = get_stats_from_remote_repo(external_repo)
     assert stats["num_dbt_assets_in_repo"] == "1"
 
 
@@ -408,7 +408,7 @@ def test_get_stats_from_external_repo_resources(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_external_repo(external_repo)
+    stats = get_stats_from_remote_repo(external_repo)
     assert stats["dagster_resources"] == [
         {"module_name": "dagster_tests", "class_name": "MyResource"}
     ]
@@ -454,7 +454,7 @@ def test_get_stats_from_external_repo_io_managers(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_external_repo(external_repo)
+    stats = get_stats_from_remote_repo(external_repo)
     assert stats["dagster_resources"] == [
         {"module_name": "dagster_tests", "class_name": "MyIOManager"}
     ]
@@ -487,7 +487,7 @@ def test_get_stats_from_external_repo_functional_resources(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_external_repo(external_repo)
+    stats = get_stats_from_remote_repo(external_repo)
     assert stats["dagster_resources"] == [
         {"module_name": "dagster_tests", "class_name": "my_resource"}
     ]
@@ -520,7 +520,7 @@ def test_get_stats_from_external_repo_functional_io_managers(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_external_repo(external_repo)
+    stats = get_stats_from_remote_repo(external_repo)
     assert stats["dagster_resources"] == [
         {"module_name": "dagster_tests", "class_name": "my_io_manager"}
     ]
@@ -539,7 +539,7 @@ def test_get_stats_from_external_repo_pipes_client(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_external_repo(external_repo)
+    stats = get_stats_from_remote_repo(external_repo)
     assert stats["dagster_resources"] == [
         {"module_name": "dagster", "class_name": "PipesSubprocessClient"}
     ]
@@ -598,7 +598,7 @@ def test_get_stats_from_external_repo_delayed_resource_configuration(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_external_repo(external_repo)
+    stats = get_stats_from_remote_repo(external_repo)
     assert stats["dagster_resources"] == [
         {"module_name": "dagster_tests", "class_name": "MyIOManager"},
         {"module_name": "dagster_tests", "class_name": "my_io_manager"},

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -1097,16 +1097,16 @@ def test_deps_resolve_group():
     ]
 
 
-def test_back_compat_external_sensor():
+def test_back_compat_remote_sensor():
     SERIALIZED_0_12_10_SENSOR = (
         '{"__class__": "ExternalSensorData", "description": null, "min_interval": null, "mode":'
         ' "default", "name": "my_sensor", "pipeline_name": "my_pipeline", "solid_selection": null}'
     )
-    external_sensor_data = deserialize_value(SERIALIZED_0_12_10_SENSOR, SensorSnap)
-    assert isinstance(external_sensor_data, SensorSnap)
-    assert len(external_sensor_data.target_dict) == 1
-    assert "my_pipeline" in external_sensor_data.target_dict
-    target = external_sensor_data.target_dict["my_pipeline"]
+    sensor_snap = deserialize_value(SERIALIZED_0_12_10_SENSOR, SensorSnap)
+    assert isinstance(sensor_snap, SensorSnap)
+    assert len(sensor_snap.target_dict) == 1
+    assert "my_pipeline" in sensor_snap.target_dict
+    target = sensor_snap.target_dict["my_pipeline"]
     assert isinstance(target, TargetSnap)
     assert target.job_name == "my_pipeline"
 
@@ -1121,7 +1121,7 @@ def _check_partitions_def_equal(
     assert p1.cron_schedule == p2.cron_schedule
 
 
-def test_back_compat_external_time_window_partitions_def():
+def test_back_compat_remote_time_window_partitions_def():
     start = datetime(year=2022, month=5, day=5)
 
     external = TimeWindowPartitionsSnap(
@@ -1148,7 +1148,7 @@ def test_back_compat_external_time_window_partitions_def():
     )
 
 
-def test_external_time_window_partitions_def_cron_schedule():
+def test_remote_time_window_partitions_def_cron_schedule():
     start = datetime(year=2022, month=5, day=5)
 
     partitions_def = TimeWindowPartitionsDefinition(
@@ -1164,7 +1164,7 @@ def test_external_time_window_partitions_def_cron_schedule():
     _check_partitions_def_equal(external, partitions_def)
 
 
-def test_external_multi_partitions_def():
+def test_remote_multi_partitions_def():
     partitions_def = MultiPartitionsDefinition(
         {
             "date": DailyPartitionsDefinition("2022-01-01"),
@@ -1221,21 +1221,18 @@ def test_graph_multi_asset_description():
     assert asset_node_snaps[AssetKey("asset2")].description == "baz"
 
 
-def test_external_time_window_valid_partition_key():
+def test_remote_time_window_valid_partition_key():
     hourly_partition = HourlyPartitionsDefinition(start_date="2023-03-11-15:00")
 
-    external_partitions_def = TimeWindowPartitionsSnap.from_def(hourly_partition)
+    partitions_snap = TimeWindowPartitionsSnap.from_def(hourly_partition)
+    assert partitions_snap.get_partitions_definition().has_partition_key("2023-03-11-15:00") is True
     assert (
-        external_partitions_def.get_partitions_definition().has_partition_key("2023-03-11-15:00")
-        is True
-    )
-    assert (
-        external_partitions_def.get_partitions_definition().start.timestamp()
+        partitions_snap.get_partitions_definition().start.timestamp()
         == create_datetime(2023, 3, 11, 15).timestamp()
     )
 
 
-def test_external_assets_def_to_external_asset_graph():
+def test_external_assets_def_to_asset_node_snaps():
     asset1, asset2 = external_assets_from_specs(
         [AssetSpec("asset1"), AssetSpec("asset2", deps=["asset1"])]
     )
@@ -1262,7 +1259,7 @@ def test_external_assets_def_to_external_asset_graph():
     ]
 
 
-def test_historical_external_asset_node_that_models_underlying_external_assets_def() -> None:
+def test_historical_asset_node_snap_that_models_underlying_external_assets_def() -> None:
     assert not AssetNodeSnap(
         asset_key=AssetKey("asset_one"),
         parent_edges=[],
@@ -1315,5 +1312,5 @@ def test_back_compat_team_owners():
         "owners": ["foo", "hi@me.com"],
     }
 
-    external_asset_node = unpack_value(packed_1_7_7_external_asset)
-    assert external_asset_node.owners == ["team:foo", "hi@me.com"]
+    asset_node_snap = unpack_value(packed_1_7_7_external_asset)
+    assert asset_node_snap.owners == ["team:foo", "hi@me.com"]

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_sensor_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_sensor_data.py
@@ -5,7 +5,7 @@ from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.remote_representation.external_data import SensorSnap
 
 
-def test_external_sensor_has_asset_selection():
+def test_remote_sensor_has_asset_selection():
     @sensor(asset_selection=["asset1", "asset2"])
     def sensor1(): ...
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/conftest.py
@@ -9,7 +9,7 @@ from dagster._core.test_utils import (
     SingleThreadPoolExecutor,
     create_test_daemon_workspace_context,
     instance_for_test,
-    load_external_repo,
+    load_remote_repo,
 )
 from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
 from dagster._core.workspace.context import WorkspaceProcessContext
@@ -69,9 +69,9 @@ def workspace_fixture(instance_module_scoped: DagsterInstance) -> Iterator[Works
         yield workspace
 
 
-@pytest.fixture(name="external_repo", scope="module")
+@pytest.fixture(name="remote_repo", scope="module")
 def external_repo_fixture(workspace_context: WorkspaceProcessContext) -> RemoteRepository:
-    return load_external_repo(workspace_context, "the_repo")
+    return load_remote_repo(workspace_context, "the_repo")
 
 
 def loadable_target_origin() -> LoadableTargetOrigin:

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -131,14 +131,14 @@ def test_run_status_sensor(
     executor: Optional[ThreadPoolExecutor],
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
-        success_sensor = external_repo.get_sensor("my_job_success_sensor")
+        success_sensor = remote_repo.get_sensor("my_job_success_sensor")
         instance.start_sensor(success_sensor)
 
-        started_sensor = external_repo.get_sensor("my_job_started_sensor")
+        started_sensor = remote_repo.get_sensor("my_job_started_sensor")
         instance.start_sensor(started_sensor)
 
         state = instance.get_instigator_state(
@@ -166,7 +166,7 @@ def test_run_status_sensor(
         time.sleep(1)
 
     with freeze_time(freeze_datetime):
-        remote_job = external_repo.get_full_job("failure_job")
+        remote_job = remote_repo.get_full_job("failure_job")
         run = instance.create_run_for_job(
             failure_job,
             remote_job_origin=remote_job.get_remote_origin(),
@@ -205,7 +205,7 @@ def test_run_status_sensor(
         )
 
     with freeze_time(freeze_datetime):
-        remote_job = external_repo.get_full_job("foo_job")
+        remote_job = remote_repo.get_full_job("foo_job")
         run = instance.create_run_for_job(
             foo_job,
             remote_job_origin=remote_job.get_remote_origin(),
@@ -253,11 +253,11 @@ def test_run_failure_sensor(
     executor: Optional[ThreadPoolExecutor],
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
-        failure_sensor = external_repo.get_sensor("my_run_failure_sensor")
+        failure_sensor = remote_repo.get_sensor("my_run_failure_sensor")
         instance.start_sensor(failure_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -277,7 +277,7 @@ def test_run_failure_sensor(
         time.sleep(1)
 
     with freeze_time(freeze_datetime):
-        remote_job = external_repo.get_full_job("failure_job")
+        remote_job = remote_repo.get_full_job("failure_job")
         run = instance.create_run_for_job(
             failure_job,
             remote_job_origin=remote_job.get_remote_origin(),
@@ -309,11 +309,11 @@ def test_run_failure_sensor_that_fails(
     executor: Optional[ThreadPoolExecutor],
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
-        failure_sensor = external_repo.get_sensor("my_run_failure_sensor_that_itself_fails")
+        failure_sensor = remote_repo.get_sensor("my_run_failure_sensor_that_itself_fails")
         instance.start_sensor(failure_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -333,7 +333,7 @@ def test_run_failure_sensor_that_fails(
         time.sleep(1)
 
     with freeze_time(freeze_datetime):
-        remote_job = external_repo.get_full_job("failure_job")
+        remote_job = remote_repo.get_full_job("failure_job")
         run = instance.create_run_for_job(
             failure_job,
             remote_job_origin=remote_job.get_remote_origin(),
@@ -383,11 +383,11 @@ def test_run_failure_sensor_filtered(
     executor: Optional[ThreadPoolExecutor],
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
-        failure_sensor = external_repo.get_sensor("my_run_failure_sensor_filtered")
+        failure_sensor = remote_repo.get_sensor("my_run_failure_sensor_filtered")
         instance.start_sensor(failure_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -407,7 +407,7 @@ def test_run_failure_sensor_filtered(
         time.sleep(1)
 
     with freeze_time(freeze_datetime):
-        remote_job = external_repo.get_full_job("failure_job_2")
+        remote_job = remote_repo.get_full_job("failure_job_2")
         run = instance.create_run_for_job(
             failure_job_2,
             remote_job_origin=remote_job.get_remote_origin(),
@@ -438,7 +438,7 @@ def test_run_failure_sensor_filtered(
         time.sleep(1)
 
     with freeze_time(freeze_datetime):
-        remote_job = external_repo.get_full_job("failure_job")
+        remote_job = remote_repo.get_full_job("failure_job")
         run = instance.create_run_for_job(
             failure_job,
             remote_job_origin=remote_job.get_remote_origin(),
@@ -470,7 +470,7 @@ def test_run_failure_sensor_filtered(
 def test_run_failure_sensor_overfetch(
     executor: Optional[ThreadPoolExecutor],
     instance: DagsterInstance,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
     with environ(
         {
@@ -483,7 +483,7 @@ def test_run_failure_sensor_overfetch(
         ) as workspace_context:
             freeze_datetime = get_current_datetime()
             with freeze_time(freeze_datetime):
-                failure_sensor = external_repo.get_sensor("my_run_failure_sensor_filtered")
+                failure_sensor = remote_repo.get_sensor("my_run_failure_sensor_filtered")
                 instance.start_sensor(failure_sensor)
 
                 evaluate_sensors(workspace_context, executor)
@@ -508,8 +508,8 @@ def test_run_failure_sensor_overfetch(
 
                 # interleave matching jobs and jobs that do not match
                 for _i in range(4):
-                    remote_job = external_repo.get_full_job("failure_job")
-                    remote_job_2 = external_repo.get_full_job("failure_job_2")
+                    remote_job = remote_repo.get_full_job("failure_job")
+                    remote_job_2 = remote_repo.get_full_job("failure_job_2")
 
                     run = instance.create_run_for_job(
                         failure_job_2,
@@ -1515,11 +1515,11 @@ def test_partitioned_job_run_status_sensor(
     executor: Optional[ThreadPoolExecutor],
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
-        success_sensor = external_repo.get_sensor("partitioned_pipeline_success_sensor")
+        success_sensor = remote_repo.get_sensor("partitioned_pipeline_success_sensor")
         instance.start_sensor(success_sensor)
 
         assert instance.get_runs_count() == 0
@@ -1541,7 +1541,7 @@ def test_partitioned_job_run_status_sensor(
         time.sleep(1)
 
     with freeze_time(freeze_datetime):
-        remote_job = external_repo.get_full_job("daily_partitioned_job")
+        remote_job = remote_repo.get_full_job("daily_partitioned_job")
         run = instance.create_run_for_job(
             daily_partitioned_job,
             remote_job_origin=remote_job.get_remote_origin(),
@@ -1702,11 +1702,11 @@ def test_logging_run_status_sensor(
     executor: Optional[ThreadPoolExecutor],
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
     freeze_datetime = get_current_datetime()
     with freeze_time(freeze_datetime):
-        success_sensor = external_repo.get_sensor("logging_status_sensor")
+        success_sensor = remote_repo.get_sensor("logging_status_sensor")
         instance.start_sensor(success_sensor)
 
         evaluate_sensors(workspace_context, executor)
@@ -1725,7 +1725,7 @@ def test_logging_run_status_sensor(
         freeze_datetime = freeze_datetime + relativedelta(seconds=60)
 
     with freeze_time(freeze_datetime):
-        remote_job = external_repo.get_full_job("foo_job")
+        remote_job = remote_repo.get_full_job("foo_job")
         run = instance.create_run_for_job(
             foo_job,
             remote_job_origin=remote_job.get_remote_origin(),

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run_backfill_daemon.py
@@ -15,7 +15,7 @@ from dagster._core.definitions.asset_graph_subset import AssetGraphSubset
 from dagster._core.definitions.events import AssetKeyPartitionKey
 from dagster._core.definitions.run_request import InstigatorType, RunRequest
 from dagster._core.scheduler.instigation import InstigatorState, InstigatorStatus, TickStatus
-from dagster._core.test_utils import create_test_daemon_workspace_context, load_external_repo
+from dagster._core.test_utils import create_test_daemon_workspace_context, load_remote_repo
 from dagster._core.workspace.load_target import ModuleTarget
 
 from dagster_tests.daemon_sensor_tests.test_sensor_run import evaluate_sensors, validate_tick
@@ -159,12 +159,12 @@ def test_backfill_request_sensor(instance: DagsterInstance, executor, sensor_nam
     with create_test_daemon_workspace_context(
         workspace_load_target=module_target, instance=instance
     ) as workspace_context:
-        external_repo = load_external_repo(workspace_context, "__repository__")
-        external_sensor = external_repo.get_sensor(sensor_name)
+        repo = load_remote_repo(workspace_context, "__repository__")
+        sensor = repo.get_sensor(sensor_name)
 
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_remote_origin(),
+                sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
@@ -172,9 +172,7 @@ def test_backfill_request_sensor(instance: DagsterInstance, executor, sensor_nam
         evaluate_sensors(workspace_context, executor)
 
         assert instance.get_runs_count() == 0
-        ticks = instance.get_ticks(
-            external_sensor.get_remote_origin_id(), external_sensor.selector_id
-        )
+        ticks = instance.get_ticks(sensor.get_remote_origin_id(), sensor.selector_id)
         assert len(ticks) == 1
 
         backfills = instance.get_backfills()
@@ -192,7 +190,7 @@ def test_backfill_request_sensor(instance: DagsterInstance, executor, sensor_nam
 
         validate_tick(
             ticks[0],
-            external_sensor,
+            sensor,
             None,
             TickStatus.SUCCESS,
             expected_run_ids=[backfill.backfill_id],
@@ -203,26 +201,22 @@ def test_asset_selection_outside_of_range(instance, executor):
     with create_test_daemon_workspace_context(
         workspace_load_target=module_target, instance=instance
     ) as workspace_context:
-        external_repo = load_external_repo(workspace_context, "__repository__")
-        external_sensor = external_repo.get_sensor(
-            asset_outside_of_selection_backfill_request_sensor.name
-        )
+        repo = load_remote_repo(workspace_context, "__repository__")
+        sensor = repo.get_sensor(asset_outside_of_selection_backfill_request_sensor.name)
 
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_remote_origin(),
+                sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         evaluate_sensors(workspace_context, executor)
-        ticks = instance.get_ticks(
-            external_sensor.get_remote_origin_id(), external_sensor.selector_id
-        )
+        ticks = instance.get_ticks(sensor.get_remote_origin_id(), sensor.selector_id)
 
         validate_tick(
             ticks[0],
-            external_sensor=external_sensor,
+            remote_sensor=sensor,
             expected_status=TickStatus.FAILURE,
             expected_datetime=None,
             expected_error="RunRequest includes asset keys that are not part of sensor's "
@@ -234,24 +228,22 @@ def test_invalid_partition(instance, executor):
     with create_test_daemon_workspace_context(
         workspace_load_target=module_target, instance=instance
     ) as workspace_context:
-        external_repo = load_external_repo(workspace_context, "__repository__")
-        external_sensor = external_repo.get_sensor(invalid_partition_backfill_request_sensor.name)
+        repo = load_remote_repo(workspace_context, "__repository__")
+        sensor = repo.get_sensor(invalid_partition_backfill_request_sensor.name)
 
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_remote_origin(),
+                sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         evaluate_sensors(workspace_context, executor)
-        ticks = instance.get_ticks(
-            external_sensor.get_remote_origin_id(), external_sensor.selector_id
-        )
+        ticks = instance.get_ticks(sensor.get_remote_origin_id(), sensor.selector_id)
 
         # allow creating a backfill with an invalid partition. it will get caught in the daemon
         # and show up as an error there.
-        validate_tick(ticks[0], external_sensor, None, TickStatus.SUCCESS)
+        validate_tick(ticks[0], sensor, None, TickStatus.SUCCESS)
 
 
 def test_single_partition(instance, executor):
@@ -262,20 +254,18 @@ def test_single_partition(instance, executor):
     with create_test_daemon_workspace_context(
         workspace_load_target=module_target, instance=instance
     ) as workspace_context:
-        external_repo = load_external_repo(workspace_context, "__repository__")
-        external_sensor = external_repo.get_sensor(single_partition_run_request_sensor.name)
+        repo = load_remote_repo(workspace_context, "__repository__")
+        sensor = repo.get_sensor(single_partition_run_request_sensor.name)
 
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_remote_origin(),
+                sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         evaluate_sensors(workspace_context, executor)
-        ticks = instance.get_ticks(
-            external_sensor.get_remote_origin_id(), external_sensor.selector_id
-        )
+        ticks = instance.get_ticks(sensor.get_remote_origin_id(), sensor.selector_id)
 
         backfills = instance.get_backfills()
         assert len(backfills) == 1
@@ -283,7 +273,7 @@ def test_single_partition(instance, executor):
 
         validate_tick(
             ticks[0],
-            external_sensor,
+            sensor,
             None,
             TickStatus.SUCCESS,
             expected_run_ids=[backfill.backfill_id],
@@ -294,20 +284,18 @@ def test_backfill_and_run_request(instance, executor):
     with create_test_daemon_workspace_context(
         workspace_load_target=module_target, instance=instance
     ) as workspace_context:
-        external_repo = load_external_repo(workspace_context, "__repository__")
-        external_sensor = external_repo.get_sensor(backfill_and_run_request_sensor.name)
+        repo = load_remote_repo(workspace_context, "__repository__")
+        sensor = repo.get_sensor(backfill_and_run_request_sensor.name)
 
         instance.add_instigator_state(
             InstigatorState(
-                external_sensor.get_remote_origin(),
+                sensor.get_remote_origin(),
                 InstigatorType.SENSOR,
                 InstigatorStatus.RUNNING,
             )
         )
         evaluate_sensors(workspace_context, executor)
-        ticks = instance.get_ticks(
-            external_sensor.get_remote_origin_id(), external_sensor.selector_id
-        )
+        ticks = instance.get_ticks(sensor.get_remote_origin_id(), sensor.selector_id)
 
         backfills = instance.get_backfills()
         assert len(backfills) == 1
@@ -319,7 +307,7 @@ def test_backfill_and_run_request(instance, executor):
 
         validate_tick(
             ticks[0],
-            external_sensor,
+            sensor,
             None,
             TickStatus.SUCCESS,
             expected_run_ids=[backfill.backfill_id, run.run_id],

--- a/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/conftest.py
@@ -56,8 +56,8 @@ def workspace_fixture(instance_module_scoped) -> Iterator[WorkspaceProcessContex
         yield workspace_context
 
 
-@pytest.fixture(name="external_repo", scope="module")
-def external_repo_fixture(
+@pytest.fixture(name="remote_repo", scope="module")
+def remote_repo_fixture(
     workspace_context: WorkspaceProcessContext,
 ) -> Iterator[RemoteRepository]:
     yield cast(

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -505,13 +505,13 @@ def wait_for_all_runs_to_finish(instance, timeout=10):
 def test_simple_backfill(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
-    external_partition_set = external_repo.get_partition_set("the_job_partition_set")
+    partition_set = remote_repo.get_partition_set("the_job_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
-            partition_set_origin=external_partition_set.get_remote_origin(),
+            partition_set_origin=partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -538,13 +538,13 @@ def test_simple_backfill(
 def test_canceled_backfill(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
-    external_partition_set = external_repo.get_partition_set("the_job_partition_set")
+    partition_set = remote_repo.get_partition_set("the_job_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
-            partition_set_origin=external_partition_set.get_remote_origin(),
+            partition_set_origin=partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -573,16 +573,14 @@ def test_canceled_backfill(
 def test_failure_backfill(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
     output_file = _failure_flag_file()
-    external_partition_set = external_repo.get_partition_set(
-        "conditional_failure_job_partition_set"
-    )
+    partition_set = remote_repo.get_partition_set("conditional_failure_job_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="shouldfail",
-            partition_set_origin=external_partition_set.get_remote_origin(),
+            partition_set_origin=partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -631,7 +629,7 @@ def test_failure_backfill(
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="fromfailure",
-            partition_set_origin=external_partition_set.get_remote_origin(),
+            partition_set_origin=partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=True,
@@ -677,13 +675,13 @@ def test_failure_backfill(
 def test_job_backfill_status(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
-    external_partition_set = external_repo.get_partition_set("the_job_partition_set")
+    partition_set = remote_repo.get_partition_set("the_job_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
-            partition_set_origin=external_partition_set.get_remote_origin(),
+            partition_set_origin=partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -735,15 +733,15 @@ def test_job_backfill_status(
 def test_partial_backfill(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
-    external_partition_set = external_repo.get_partition_set("partial_job_partition_set")
+    partition_set = remote_repo.get_partition_set("partial_job_partition_set")
 
     # create full runs, where every step is executed
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="full",
-            partition_set_origin=external_partition_set.get_remote_origin(),
+            partition_set_origin=partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -790,7 +788,7 @@ def test_partial_backfill(
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="partial",
-            partition_set_origin=external_partition_set.get_remote_origin(),
+            partition_set_origin=partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -827,13 +825,13 @@ def test_partial_backfill(
 def test_large_backfill(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
-    external_partition_set = external_repo.get_partition_set("config_job_partition_set")
+    partition_set = remote_repo.get_partition_set("config_job_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
-            partition_set_origin=external_partition_set.get_remote_origin(),
+            partition_set_origin=partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -1063,14 +1061,14 @@ def test_unloadable_backfill_retry(
 def test_backfill_from_partitioned_job(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
     partition_keys = my_config.partitions_def.get_partition_keys()
-    external_partition_set = external_repo.get_partition_set("comp_always_succeed_partition_set")
+    partition_set = remote_repo.get_partition_set("comp_always_succeed_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="partition_schedule_from_job",
-            partition_set_origin=external_partition_set.get_remote_origin(),
+            partition_set_origin=partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=partition_keys[:3],
             from_failure=False,
@@ -1093,7 +1091,7 @@ def test_backfill_from_partitioned_job(
 def test_backfill_with_asset_selection(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
     partition_keys = static_partitions.get_partition_keys()
     asset_selection = [AssetKey("foo"), AssetKey("a1"), AssetKey("bar")]
@@ -1101,11 +1099,11 @@ def test_backfill_with_asset_selection(
     assert job_def
     asset_job_name = job_def.name
     partition_set_name = f"{asset_job_name}_partition_set"
-    external_partition_set = external_repo.get_partition_set(partition_set_name)
+    partition_set = remote_repo.get_partition_set(partition_set_name)
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="backfill_with_asset_selection",
-            partition_set_origin=external_partition_set.get_remote_origin(),
+            partition_set_origin=partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=partition_keys,
             from_failure=False,
@@ -1135,7 +1133,7 @@ def test_backfill_with_asset_selection(
 def test_pure_asset_backfill_with_multiple_assets_selected(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
     asset_selection = [
         AssetKey("asset_a"),
@@ -1205,9 +1203,9 @@ def test_pure_asset_backfill_with_multiple_assets_selected(
 def test_pure_asset_backfill(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
-    del external_repo
+    del remote_repo
 
     partition_keys = static_partitions.get_partition_keys()
     asset_selection = [AssetKey("foo"), AssetKey("a1"), AssetKey("bar")]
@@ -1254,7 +1252,7 @@ def test_pure_asset_backfill(
 def test_backfill_from_failure_for_subselection(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
     parallel_failure_job.execute_in_process(
         partition_key="one",
@@ -1268,12 +1266,12 @@ def test_backfill_from_failure_for_subselection(
     run = next(iter(instance.get_runs()))
     assert run.status == DagsterRunStatus.FAILURE
 
-    external_partition_set = external_repo.get_partition_set("parallel_failure_job_partition_set")
+    partition_set = remote_repo.get_partition_set("parallel_failure_job_partition_set")
 
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="fromfailure",
-            partition_set_origin=external_partition_set.get_remote_origin(),
+            partition_set_origin=partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one"],
             from_failure=True,
@@ -1950,11 +1948,11 @@ def test_fail_backfill_when_runs_completed_but_partitions_marked_as_in_progress(
 
 
 # Job must have a partitions definition with a-b-c-d partitions
-def _get_abcd_job_backfill(external_repo: RemoteRepository, job_name: str) -> PartitionBackfill:
-    external_partition_set = external_repo.get_partition_set(f"{job_name}_partition_set")
+def _get_abcd_job_backfill(remote_repo: RemoteRepository, job_name: str) -> PartitionBackfill:
+    partition_set = remote_repo.get_partition_set(f"{job_name}_partition_set")
     return PartitionBackfill(
         backfill_id="simple",
-        partition_set_origin=external_partition_set.get_remote_origin(),
+        partition_set_origin=partition_set.get_remote_origin(),
         status=BulkActionStatus.REQUESTED,
         partition_names=["a", "b", "c", "d"],
         from_failure=False,
@@ -1967,9 +1965,9 @@ def _get_abcd_job_backfill(external_repo: RemoteRepository, job_name: str) -> Pa
 def test_asset_job_backfill_single_run(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
-    backfill = _get_abcd_job_backfill(external_repo, "bp_single_run_asset_job")
+    backfill = _get_abcd_job_backfill(remote_repo, "bp_single_run_asset_job")
     assert instance.get_runs_count() == 0
     instance.add_backfill(backfill)
     list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
@@ -1985,14 +1983,14 @@ def test_asset_job_backfill_single_run(
 def test_asset_job_backfill_single_run_multiple_iterations(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
     """Tests that job backfills correctly find existing runs for partitions in the backfill and don't
     relaunch those partitions. This is a regression test for a bug where the backfill would relaunch
     runs for BackfillPolicy.single_run asset jobs since we were incorrectly determining which partitions
     had already been launched.
     """
-    backfill = _get_abcd_job_backfill(external_repo, "bp_single_run_asset_job")
+    backfill = _get_abcd_job_backfill(remote_repo, "bp_single_run_asset_job")
     assert instance.get_runs_count() == 0
     instance.add_backfill(backfill)
 
@@ -2046,9 +2044,9 @@ def test_asset_job_backfill_single_run_multiple_iterations(
 def test_asset_job_backfill_multi_run(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
-    backfill = _get_abcd_job_backfill(external_repo, "bp_multi_run_asset_job")
+    backfill = _get_abcd_job_backfill(remote_repo, "bp_multi_run_asset_job")
     assert instance.get_runs_count() == 0
     instance.add_backfill(backfill)
     list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
@@ -2068,9 +2066,9 @@ def test_asset_job_backfill_multi_run(
 def test_asset_job_backfill_default(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
-    backfill = _get_abcd_job_backfill(external_repo, "bp_none_asset_job")
+    backfill = _get_abcd_job_backfill(remote_repo, "bp_none_asset_job")
     assert instance.get_runs_count() == 0
     instance.add_backfill(backfill)
     list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
@@ -2516,7 +2514,7 @@ def test_asset_backfill_logging(caplog, instance, workspace_context):
 def test_backfill_with_title_and_description(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
     asset_selection = [
         AssetKey("asset_a"),
@@ -2582,9 +2580,9 @@ def test_backfill_with_title_and_description(
 def test_old_dynamic_partitions_job_backfill(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
-    backfill = _get_abcd_job_backfill(external_repo, "old_dynamic_partitions_job")
+    backfill = _get_abcd_job_backfill(remote_repo, "old_dynamic_partitions_job")
     assert instance.get_runs_count() == 0
     instance.add_backfill(backfill)
     list(execute_backfill_iteration(workspace_context, get_default_daemon_logger("BackfillDaemon")))
@@ -2595,7 +2593,7 @@ def test_old_dynamic_partitions_job_backfill(
 def test_asset_backfill_logs(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
     # need to override this method on the instance since it defaults ot False in OSS. When we enable this
     # feature in OSS we can remove this override
@@ -2677,9 +2675,9 @@ def test_asset_backfill_logs(
 def test_asset_backfill_from_asset_graph_subset(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
-    del external_repo
+    del remote_repo
 
     partition_keys = static_partitions.get_partition_keys()
     asset_selection = [AssetKey("foo"), AssetKey("a1"), AssetKey("bar")]
@@ -2730,9 +2728,9 @@ def test_asset_backfill_from_asset_graph_subset(
 def test_asset_backfill_from_asset_graph_subset_with_static_and_time_partitions(
     instance: DagsterInstance,
     workspace_context: WorkspaceProcessContext,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
 ):
-    del external_repo
+    del remote_repo
 
     static_partition_keys = static_partitions.get_partition_keys()
     static_asset_selection = [AssetKey("foo"), AssetKey("a1"), AssetKey("bar")]

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill_failure_recovery.py
@@ -47,12 +47,12 @@ def _test_backfill_in_subprocess(instance_ref, debug_crash_flags):
 @pytest.mark.skipif(
     IS_WINDOWS, reason="Windows keeps resources open after termination in a flaky way"
 )
-def test_simple(instance: DagsterInstance, external_repo: RemoteRepository):
-    external_partition_set = external_repo.get_partition_set("the_job_partition_set")
+def test_simple(instance: DagsterInstance, remote_repo: RemoteRepository):
+    partition_set = remote_repo.get_partition_set("the_job_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
-            partition_set_origin=external_partition_set.get_remote_origin(),
+            partition_set_origin=partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -77,13 +77,13 @@ def test_simple(instance: DagsterInstance, external_repo: RemoteRepository):
 )
 @pytest.mark.parametrize("crash_signal", get_crash_signals())
 def test_before_submit(
-    crash_signal: Signals, instance: DagsterInstance, external_repo: RemoteRepository
+    crash_signal: Signals, instance: DagsterInstance, remote_repo: RemoteRepository
 ):
-    external_partition_set = external_repo.get_partition_set("the_job_partition_set")
+    partition_set = remote_repo.get_partition_set("the_job_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
-            partition_set_origin=external_partition_set.get_remote_origin(),
+            partition_set_origin=partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,
@@ -124,13 +124,13 @@ def test_before_submit(
 )
 @pytest.mark.parametrize("crash_signal", get_crash_signals())
 def test_crash_after_submit(
-    crash_signal: Signals, instance: DagsterInstance, external_repo: RemoteRepository
+    crash_signal: Signals, instance: DagsterInstance, remote_repo: RemoteRepository
 ):
-    external_partition_set = external_repo.get_partition_set("the_job_partition_set")
+    partition_set = remote_repo.get_partition_set("the_job_partition_set")
     instance.add_backfill(
         PartitionBackfill(
             backfill_id="simple",
-            partition_set_origin=external_partition_set.get_remote_origin(),
+            partition_set_origin=partition_set.get_remote_origin(),
             status=BulkActionStatus.REQUESTED,
             partition_names=["one", "two", "three"],
             from_failure=False,

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -51,12 +51,12 @@ def get_code_location_origin(filename: str) -> InProcessCodeLocationOrigin:
 
 
 def _get_all_sensors(context: WorkspaceRequestContext) -> Sequence[RemoteSensor]:
-    external_sensors = []
+    sensors = []
     for cl_name in context.get_code_location_entries():
-        external_sensors.extend(
+        sensors.extend(
             next(iter(context.get_code_location(cl_name).get_repositories().values())).get_sensors()
         )
-    return external_sensors
+    return sensors
 
 
 def _get_automation_sensors(context: WorkspaceRequestContext) -> Sequence[RemoteSensor]:

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/scenario_state.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/scenario_state.py
@@ -418,17 +418,17 @@ class ScenarioState:
         return self
 
     def start_sensor(self, sensor_name: str) -> Self:
-        with self._get_external_sensor(sensor_name) as sensor:
+        with self._get_remote_sensor(sensor_name) as sensor:
             self.instance.start_sensor(sensor)
         return self
 
     def stop_sensor(self, sensor_name: str) -> Self:
-        with self._get_external_sensor(sensor_name) as sensor:
+        with self._get_remote_sensor(sensor_name) as sensor:
             self.instance.stop_sensor(sensor.get_remote_origin_id(), sensor.selector_id, sensor)
         return self
 
     @contextmanager
-    def _get_external_sensor(self, sensor_name):
+    def _get_remote_sensor(self, sensor_name):
         with self._create_workspace_context() as workspace_context:
             workspace = workspace_context.create_request_context()
             sensor = next(

--- a/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
+++ b/python_modules/dagster/dagster_tests/general_tests/asset_graph_differ_tests/test_asset_graph_differ.py
@@ -109,7 +109,7 @@ def get_asset_graph_differ(
         instance, {code_location: "base_asset_graph" for code_location in base_code_locations}
     )
 
-    return AssetGraphDiffer.from_external_repositories(
+    return AssetGraphDiffer.from_remote_repositories(
         code_location_name=code_location_to_diff,
         repository_name=SINGLETON_REPOSITORY_NAME,
         branch_workspace=branch_workspace_ctx,

--- a/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
@@ -71,7 +71,7 @@ def workspace_fixture(
         yield workspace
 
 
-@pytest.fixture(name="external_repo", scope="session")
+@pytest.fixture(name="remote_repo", scope="session")
 def external_repo_fixture(workspace_context: WorkspaceProcessContext) -> RemoteRepository:
     return next(
         iter(workspace_context.create_request_context().get_code_location_entries().values())

--- a/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/test_scheduler_failure_recovery.py
@@ -78,7 +78,7 @@ def _test_launch_scheduled_runs_in_subprocess(
 @pytest.mark.parametrize("executor", get_schedule_executor_names())
 def test_failure_recovery_before_run_created(
     instance: DagsterInstance,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
     crash_location: str,
     crash_signal: Signals,
     executor: ThreadPoolExecutor,
@@ -89,11 +89,11 @@ def test_failure_recovery_before_run_created(
 
     freeze_datetime = initial_datetime
 
-    external_schedule = external_repo.get_schedule("simple_schedule")
+    schedule = remote_repo.get_schedule("simple_schedule")
     with freeze_time(freeze_datetime):
-        instance.start_schedule(external_schedule)
+        instance.start_schedule(schedule)
 
-        debug_crash_flags = {external_schedule.name: {crash_location: crash_signal}}
+        debug_crash_flags = {schedule.name: {crash_location: crash_signal}}
 
         scheduler_process = spawn_ctx.Process(
             target=_test_launch_scheduled_runs_in_subprocess,
@@ -104,9 +104,7 @@ def test_failure_recovery_before_run_created(
 
         assert scheduler_process.exitcode != 0
 
-        ticks = instance.get_ticks(
-            external_schedule.get_remote_origin_id(), external_schedule.selector_id
-        )
+        ticks = instance.get_ticks(schedule.get_remote_origin_id(), schedule.selector_id)
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.STARTED
 
@@ -130,13 +128,11 @@ def test_failure_recovery_before_run_created(
             execution_time=initial_datetime,
         )
 
-        ticks = instance.get_ticks(
-            external_schedule.get_remote_origin_id(), external_schedule.selector_id
-        )
+        ticks = instance.get_ticks(schedule.get_remote_origin_id(), schedule.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
-            external_schedule,
+            schedule,
             initial_datetime,
             TickStatus.SUCCESS,
             [instance.get_runs()[0].run_id],
@@ -151,7 +147,7 @@ def test_failure_recovery_before_run_created(
 @pytest.mark.parametrize("executor", get_schedule_executor_names())
 def test_failure_recovery_after_run_created(
     instance: DagsterInstance,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
     crash_location: str,
     crash_signal: Signals,
     executor: ThreadPoolExecutor,
@@ -160,11 +156,11 @@ def test_failure_recovery_after_run_created(
     # it will just re-launch the already-created run when it runs again
     initial_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
     freeze_datetime = initial_datetime
-    external_schedule = external_repo.get_schedule("simple_schedule")
+    schedule = remote_repo.get_schedule("simple_schedule")
     with freeze_time(freeze_datetime):
-        instance.start_schedule(external_schedule)
+        instance.start_schedule(schedule)
 
-        debug_crash_flags = {external_schedule.name: {crash_location: crash_signal}}
+        debug_crash_flags = {schedule.name: {crash_location: crash_signal}}
 
         scheduler_process = spawn_ctx.Process(
             target=_test_launch_scheduled_runs_in_subprocess,
@@ -175,9 +171,7 @@ def test_failure_recovery_after_run_created(
 
         assert scheduler_process.exitcode != 0
 
-        ticks = instance.get_ticks(
-            external_schedule.get_remote_origin_id(), external_schedule.selector_id
-        )
+        ticks = instance.get_ticks(schedule.get_remote_origin_id(), schedule.selector_id)
         assert len(ticks) == 1
         assert ticks[0].status == TickStatus.STARTED
 
@@ -219,13 +213,11 @@ def test_failure_recovery_after_run_created(
         wait_for_all_runs_to_start(instance)
         validate_run_exists(instance.get_runs()[0], initial_datetime)
 
-        ticks = instance.get_ticks(
-            external_schedule.get_remote_origin_id(), external_schedule.selector_id
-        )
+        ticks = instance.get_ticks(schedule.get_remote_origin_id(), schedule.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
-            external_schedule,
+            schedule,
             initial_datetime,
             TickStatus.SUCCESS,
             [instance.get_runs()[0].run_id],
@@ -240,18 +232,18 @@ def test_failure_recovery_after_run_created(
 @pytest.mark.parametrize("executor", get_schedule_executor_names())
 def test_failure_recovery_after_tick_success(
     instance: DagsterInstance,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
     crash_location: str,
     crash_signal: Signals,
     executor: ThreadPoolExecutor,
 ):
     initial_datetime = create_datetime(year=2019, month=2, day=27, hour=0, minute=0, second=0)
     freeze_datetime = initial_datetime
-    external_schedule = external_repo.get_schedule("simple_schedule")
+    schedule = remote_repo.get_schedule("simple_schedule")
     with freeze_time(freeze_datetime):
-        instance.start_schedule(external_schedule)
+        instance.start_schedule(schedule)
 
-        debug_crash_flags = {external_schedule.name: {crash_location: crash_signal}}
+        debug_crash_flags = {schedule.name: {crash_location: crash_signal}}
 
         scheduler_process = spawn_ctx.Process(
             target=_test_launch_scheduled_runs_in_subprocess,
@@ -270,9 +262,7 @@ def test_failure_recovery_after_tick_success(
         assert instance.get_runs_count() == 1
         validate_run_exists(instance.get_runs()[0], initial_datetime)
 
-        ticks = instance.get_ticks(
-            external_schedule.get_remote_origin_id(), external_schedule.selector_id
-        )
+        ticks = instance.get_ticks(schedule.get_remote_origin_id(), schedule.selector_id)
         assert len(ticks) == 1
 
         if crash_signal == get_terminate_signal():
@@ -282,7 +272,7 @@ def test_failure_recovery_after_tick_success(
 
         validate_tick(
             ticks[0],
-            external_schedule,
+            schedule,
             initial_datetime,
             TickStatus.STARTED,
             run_ids,
@@ -302,13 +292,11 @@ def test_failure_recovery_after_tick_success(
         assert instance.get_runs_count() == 1
         validate_run_exists(instance.get_runs()[0], initial_datetime)
 
-        ticks = instance.get_ticks(
-            external_schedule.get_remote_origin_id(), external_schedule.selector_id
-        )
+        ticks = instance.get_ticks(schedule.get_remote_origin_id(), schedule.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
-            external_schedule,
+            schedule,
             initial_datetime,
             TickStatus.SUCCESS,
             [instance.get_runs()[0].run_id],
@@ -323,18 +311,18 @@ def test_failure_recovery_after_tick_success(
 @pytest.mark.parametrize("executor", get_schedule_executor_names())
 def test_failure_recovery_between_multi_runs(
     instance: DagsterInstance,
-    external_repo: RemoteRepository,
+    remote_repo: RemoteRepository,
     crash_location: str,
     crash_signal: Signals,
     executor: ThreadPoolExecutor,
 ):
     initial_datetime = create_datetime(year=2019, month=2, day=28, hour=0, minute=0, second=0)
     freeze_datetime = initial_datetime
-    external_schedule = external_repo.get_schedule("multi_run_schedule")
+    schedule = remote_repo.get_schedule("multi_run_schedule")
     with freeze_time(freeze_datetime):
-        instance.start_schedule(external_schedule)
+        instance.start_schedule(schedule)
 
-        debug_crash_flags = {external_schedule.name: {crash_location: crash_signal}}
+        debug_crash_flags = {schedule.name: {crash_location: crash_signal}}
 
         scheduler_process = spawn_ctx.Process(
             target=_test_launch_scheduled_runs_in_subprocess,
@@ -349,9 +337,7 @@ def test_failure_recovery_between_multi_runs(
         assert instance.get_runs_count() == 1
         validate_run_exists(instance.get_runs()[0], initial_datetime)
 
-        ticks = instance.get_ticks(
-            external_schedule.get_remote_origin_id(), external_schedule.selector_id
-        )
+        ticks = instance.get_ticks(schedule.get_remote_origin_id(), schedule.selector_id)
         assert len(ticks) == 1
 
     freeze_datetime = freeze_datetime + relativedelta(minutes=1)
@@ -365,13 +351,11 @@ def test_failure_recovery_between_multi_runs(
         assert scheduler_process.exitcode == 0
         assert instance.get_runs_count() == 2
         validate_run_exists(instance.get_runs()[0], initial_datetime)
-        ticks = instance.get_ticks(
-            external_schedule.get_remote_origin_id(), external_schedule.selector_id
-        )
+        ticks = instance.get_ticks(schedule.get_remote_origin_id(), schedule.selector_id)
         assert len(ticks) == 1
         validate_tick(
             ticks[0],
-            external_schedule,
+            schedule,
             initial_datetime,
             TickStatus.SUCCESS,
             [run.run_id for run in instance.get_runs()],


### PR DESCRIPTION
Internal companion PR: https://github.com/dagster-io/internal/pull/12095

## Summary & Motivation

Rename private variables/params/methods matching `external_{repository,sensor,schedule,partition_set}*` to either `remote_{repository,sensor,schedule,partition_set}*` or just `{repository,sensor,schedule,partition_set}*`  depending on context. No serdes changes.

This is a large volume of changes. It was done by grepping the codebase for `external_*` and then using language server "rename symbol" on all instances that could be appropriately renamed.

## How I Tested These Changes

Existing test suite.