### PR TITLE
[external-renames] Rename `CodeLocation.get_external*` methods

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -54,7 +54,7 @@ def _get_remote_job_or_raise(
     else:
         code_location = ctx.get_code_location(selector.location_name)
         try:
-            remote_job = code_location.get_external_job(selector)
+            remote_job = code_location.get_job(selector)
         except Exception:
             error_info = serializable_error_info_from_exc_info(sys.exc_info())
             raise UserFacingGraphQLError(

--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -364,7 +364,7 @@ class GrapheneDryRunInstigationTick(graphene.ObjectType):
                 )
             sensor_data: Union[SensorExecutionData, SerializableErrorInfo]
             try:
-                sensor_data = code_location.get_external_sensor_execution_data(
+                sensor_data = code_location.get_sensor_execution_data(
                     name=self._selector.sensor_name,
                     instance=graphene_info.context.instance,
                     repository_handle=repository.handle,
@@ -395,7 +395,7 @@ class GrapheneDryRunInstigationTick(graphene.ObjectType):
             next_tick_datetime = next(schedule.execution_time_iterator(self.timestamp))
             schedule_data: Union[ScheduleExecutionData, SerializableErrorInfo]
             try:
-                schedule_data = code_location.get_external_schedule_execution_data(
+                schedule_data = code_location.get_schedule_execution_data(
                     instance=graphene_info.context.instance,
                     repository_handle=repository.handle,
                     schedule_name=schedule.name,

--- a/python_modules/dagster/dagster/_cli/job.py
+++ b/python_modules/dagster/dagster/_cli/job.py
@@ -467,9 +467,9 @@ def _create_run(
         op_selection=op_selection,
     )
 
-    remote_job = code_location.get_external_job(job_subset_selector)
+    remote_job = code_location.get_job(job_subset_selector)
 
-    execution_plan = code_location.get_external_execution_plan(
+    execution_plan = code_location.get_execution_plan(
         remote_job,
         run_config,
         step_keys_to_execute=None,
@@ -646,7 +646,7 @@ def _execute_backfill_command_at_location(
     )
 
     try:
-        partition_names_or_error = code_location.get_external_partition_names(
+        partition_names_or_error = code_location.get_partition_names(
             repository_handle=repo_handle,
             job_name=remote_job.name,
             instance=instance,
@@ -689,13 +689,11 @@ def _execute_backfill_command_at_location(
             backfill_timestamp=get_current_timestamp(),
         )
         try:
-            partition_execution_data = (
-                code_location.get_external_partition_set_execution_param_data(
-                    repository_handle=repo_handle,
-                    partition_set_name=job_partition_set.name,
-                    partition_names=partition_names,
-                    instance=instance,
-                )
+            partition_execution_data = code_location.get_partition_set_execution_params(
+                repository_handle=repo_handle,
+                partition_set_name=job_partition_set.name,
+                partition_names=partition_names,
+                instance=instance,
             )
         except Exception:
             error_info = serializable_error_info_from_exc_info(sys.exc_info())

--- a/python_modules/dagster/dagster/_cli/sensor.py
+++ b/python_modules/dagster/dagster/_cli/sensor.py
@@ -283,7 +283,7 @@ def execute_preview_command(
                 check_repo_and_scheduler(repo, instance)
                 sensor = repo.get_sensor(sensor_name)
                 try:
-                    sensor_runtime_data = code_location.get_external_sensor_execution_data(
+                    sensor_runtime_data = code_location.get_sensor_execution_data(
                         instance,
                         repo.handle,
                         sensor.name,

--- a/python_modules/dagster/dagster/_core/execution/job_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/job_backfill.py
@@ -317,7 +317,7 @@ def submit_backfill_runs(
             op_selection=None,
             asset_selection=backfill_job.asset_selection,
         )
-        remote_job = code_location.get_external_job(pipeline_selector)
+        remote_job = code_location.get_job(pipeline_selector)
     else:
         remote_job = remote_repo.get_full_job(partition_set.job_name)
 
@@ -327,7 +327,7 @@ def submit_backfill_runs(
         else partition_names_or_ranges,
         of_type=str,
     )
-    partition_set_execution_data = code_location.get_external_partition_set_execution_param_data(
+    partition_set_execution_data = code_location.get_partition_set_execution_params(
         remote_repo.handle,
         partition_set_name,
         partition_data_target,
@@ -463,7 +463,7 @@ def create_backfill_run(
             resolved_op_selection = frozenset(remote_partition_set.op_selection)
             op_selection = remote_partition_set.op_selection
 
-    remote_execution_plan = code_location.get_external_execution_plan(
+    remote_execution_plan = code_location.get_execution_plan(
         remote_job,
         run_config,
         step_keys_to_execute=step_keys_to_execute,

--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -90,9 +90,9 @@ def _get_job_execution_data_from_run_request(
 
     if pipeline_selector not in run_request_execution_data_cache:
         code_location = workspace.get_code_location(handle.location_name)
-        remote_job = code_location.get_external_job(pipeline_selector)
+        remote_job = code_location.get_job(pipeline_selector)
 
-        external_execution_plan = code_location.get_external_execution_plan(
+        external_execution_plan = code_location.get_execution_plan(
             remote_job,
             {},
             step_keys_to_execute=None,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1677,7 +1677,7 @@ class DagsterInstance(DynamicPartitionsStore):
         else:
             raise DagsterInvariantViolationError(f"Unknown reexecution strategy: {strategy}")
 
-        remote_execution_plan = code_location.get_external_execution_plan(
+        remote_execution_plan = code_location.get_execution_plan(
             remote_job,
             run_config,
             step_keys_to_execute=step_keys_to_execute,

--- a/python_modules/dagster/dagster/_core/remote_representation/code_location.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/code_location.py
@@ -131,7 +131,7 @@ class CodeLocation(AbstractContextManager):
         return self.origin.location_name
 
     @abstractmethod
-    def get_external_execution_plan(
+    def get_execution_plan(
         self,
         remote_job: RemoteJob,
         run_config: Mapping[str, object],
@@ -141,8 +141,8 @@ class CodeLocation(AbstractContextManager):
     ) -> RemoteExecutionPlan:
         pass
 
-    def get_external_job(self, selector: JobSubsetSelector) -> RemoteJob:
-        """Return the ExternalPipeline for a specific pipeline. Subclasses only
+    def get_job(self, selector: JobSubsetSelector) -> RemoteJob:
+        """Return the RemoteJob for a specific pipeline. Subclasses only
         need to implement get_subset_remote_job_result to handle the case where
         an op selection is specified, which requires access to the underlying JobDefinition
         to generate the subsetted pipeline snapshot.
@@ -172,13 +172,13 @@ class CodeLocation(AbstractContextManager):
 
     @abstractmethod
     def get_subset_remote_job_result(self, selector: JobSubsetSelector) -> ExternalJobSubsetResult:
-        """Returns a snapshot about an ExternalPipeline with an op selection, which requires
+        """Returns a snapshot about an RemoteJob with an op selection, which requires
         access to the underlying JobDefinition. Callsites should likely use
         `get_remote_job` instead.
         """
 
     @abstractmethod
-    def get_external_partition_config(
+    def get_partition_config(
         self,
         repository_handle: RepositoryHandle,
         job_name: str,
@@ -187,7 +187,7 @@ class CodeLocation(AbstractContextManager):
     ) -> Union["PartitionConfigSnap", "PartitionExecutionErrorSnap"]:
         pass
 
-    def get_external_partition_tags(
+    def get_partition_tags(
         self,
         repository_handle: RepositoryHandle,
         job_name: str,
@@ -215,7 +215,7 @@ class CodeLocation(AbstractContextManager):
                 ),
             )
         else:
-            return self.get_external_partition_tags_from_repo(
+            return self.get_partition_tags_from_repo(
                 repository_handle=repository_handle,
                 job_name=job_name,
                 partition_name=partition_name,
@@ -223,7 +223,7 @@ class CodeLocation(AbstractContextManager):
             )
 
     @abstractmethod
-    def get_external_partition_tags_from_repo(
+    def get_partition_tags_from_repo(
         self,
         repository_handle: RepositoryHandle,
         job_name: str,
@@ -232,7 +232,7 @@ class CodeLocation(AbstractContextManager):
     ) -> Union["PartitionTagsSnap", "PartitionExecutionErrorSnap"]:
         pass
 
-    def get_external_partition_names(
+    def get_partition_names(
         self,
         repository_handle: RepositoryHandle,
         job_name: str,
@@ -252,7 +252,7 @@ class CodeLocation(AbstractContextManager):
                     partition_names=partition_set.get_partition_names(instance=instance)
                 )
             else:
-                return self.get_external_partition_names_from_repo(repository_handle, job_name)
+                return self.get_partition_names_from_repo(repository_handle, job_name)
         else:
             # Asset jobs might have no corresponding partition set but still have partitioned
             # assets, so we get the partition names using the assets.
@@ -263,7 +263,7 @@ class CodeLocation(AbstractContextManager):
             )
 
     @abstractmethod
-    def get_external_partition_names_from_repo(
+    def get_partition_names_from_repo(
         self,
         repository_handle: RepositoryHandle,
         job_name: str,
@@ -271,7 +271,7 @@ class CodeLocation(AbstractContextManager):
         pass
 
     @abstractmethod
-    def get_external_partition_set_execution_param_data(
+    def get_partition_set_execution_params(
         self,
         repository_handle: RepositoryHandle,
         partition_set_name: str,
@@ -281,7 +281,7 @@ class CodeLocation(AbstractContextManager):
         pass
 
     @abstractmethod
-    def get_external_schedule_execution_data(
+    def get_schedule_execution_data(
         self,
         instance: DagsterInstance,
         repository_handle: RepositoryHandle,
@@ -292,7 +292,7 @@ class CodeLocation(AbstractContextManager):
         pass
 
     @abstractmethod
-    def get_external_sensor_execution_data(
+    def get_sensor_execution_data(
         self,
         instance: DagsterInstance,
         repository_handle: RepositoryHandle,
@@ -306,7 +306,7 @@ class CodeLocation(AbstractContextManager):
         pass
 
     @abstractmethod
-    def get_external_notebook_data(self, notebook_path: str) -> bytes:
+    def get_notebook_data(self, notebook_path: str) -> bytes:
         pass
 
     @property
@@ -463,7 +463,7 @@ class InProcessCodeLocation(CodeLocation):
             include_parent_snapshot=True,
         )
 
-    def get_external_execution_plan(
+    def get_execution_plan(
         self,
         remote_job: RemoteJob,
         run_config: Mapping[str, object],
@@ -499,7 +499,7 @@ class InProcessCodeLocation(CodeLocation):
             )
         )
 
-    def get_external_partition_config(
+    def get_partition_config(
         self,
         repository_handle: RepositoryHandle,
         job_name: str,
@@ -517,7 +517,7 @@ class InProcessCodeLocation(CodeLocation):
             instance_ref=instance.get_ref(),
         )
 
-    def get_external_partition_tags_from_repo(
+    def get_partition_tags_from_repo(
         self,
         repository_handle: RepositoryHandle,
         job_name: str,
@@ -536,7 +536,7 @@ class InProcessCodeLocation(CodeLocation):
             instance_ref=instance.get_ref(),
         )
 
-    def get_external_partition_names_from_repo(
+    def get_partition_names_from_repo(
         self,
         repository_handle: RepositoryHandle,
         job_name: str,
@@ -546,7 +546,7 @@ class InProcessCodeLocation(CodeLocation):
             job_name=job_name,
         )
 
-    def get_external_schedule_execution_data(
+    def get_schedule_execution_data(
         self,
         instance: DagsterInstance,
         repository_handle: RepositoryHandle,
@@ -579,7 +579,7 @@ class InProcessCodeLocation(CodeLocation):
 
         return result
 
-    def get_external_sensor_execution_data(
+    def get_sensor_execution_data(
         self,
         instance: DagsterInstance,
         repository_handle: RepositoryHandle,
@@ -606,7 +606,7 @@ class InProcessCodeLocation(CodeLocation):
 
         return result
 
-    def get_external_partition_set_execution_param_data(
+    def get_partition_set_execution_params(
         self,
         repository_handle: RepositoryHandle,
         partition_set_name: str,
@@ -624,7 +624,7 @@ class InProcessCodeLocation(CodeLocation):
             instance_ref=instance.get_ref(),
         )
 
-    def get_external_notebook_data(self, notebook_path: str) -> bytes:
+    def get_notebook_data(self, notebook_path: str) -> bytes:
         check.str_param(notebook_path, "notebook_path")
         return get_notebook_data(notebook_path)
 
@@ -819,7 +819,7 @@ class GrpcServerCodeLocation(CodeLocation):
     def get_repositories(self) -> Mapping[str, RemoteRepository]:
         return self.remote_repositories
 
-    def get_external_execution_plan(
+    def get_execution_plan(
         self,
         remote_job: RemoteJob,
         run_config: Mapping[str, Any],
@@ -890,7 +890,7 @@ class GrpcServerCodeLocation(CodeLocation):
 
         return subset
 
-    def get_external_partition_config(
+    def get_partition_config(
         self,
         repository_handle: RepositoryHandle,
         job_name: str,
@@ -905,7 +905,7 @@ class GrpcServerCodeLocation(CodeLocation):
             self.client, repository_handle, job_name, partition_name, instance
         )
 
-    def get_external_partition_tags_from_repo(
+    def get_partition_tags_from_repo(
         self,
         repository_handle: RepositoryHandle,
         job_name: str,
@@ -920,12 +920,12 @@ class GrpcServerCodeLocation(CodeLocation):
             self.client, repository_handle, job_name, partition_name, instance
         )
 
-    def get_external_partition_names_from_repo(
+    def get_partition_names_from_repo(
         self, repository_handle: RepositoryHandle, job_name: str
     ) -> Union[PartitionNamesSnap, "PartitionExecutionErrorSnap"]:
         return sync_get_external_partition_names_grpc(self.client, repository_handle, job_name)
 
-    def get_external_schedule_execution_data(
+    def get_schedule_execution_data(
         self,
         instance: DagsterInstance,
         repository_handle: RepositoryHandle,
@@ -950,7 +950,7 @@ class GrpcServerCodeLocation(CodeLocation):
             log_key,
         )
 
-    def get_external_sensor_execution_data(
+    def get_sensor_execution_data(
         self,
         instance: DagsterInstance,
         repository_handle: RepositoryHandle,
@@ -975,7 +975,7 @@ class GrpcServerCodeLocation(CodeLocation):
             last_sensor_start_time,
         )
 
-    def get_external_partition_set_execution_param_data(
+    def get_partition_set_execution_params(
         self,
         repository_handle: RepositoryHandle,
         partition_set_name: str,
@@ -990,7 +990,7 @@ class GrpcServerCodeLocation(CodeLocation):
             self.client, repository_handle, partition_set_name, partition_names, instance
         )
 
-    def get_external_notebook_data(self, notebook_path: str) -> bytes:
+    def get_notebook_data(self, notebook_path: str) -> bytes:
         check.str_param(notebook_path, "notebook_path")
         return sync_get_streaming_external_notebook_data_grpc(self.client, notebook_path)
 

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -255,7 +255,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
         step_keys_to_execute: Optional[Sequence[str]],
         known_state: Optional[KnownExecutionState],
     ) -> RemoteExecutionPlan:
-        return self.get_code_location(remote_job.handle.location_name).get_external_execution_plan(
+        return self.get_code_location(remote_job.handle.location_name).get_execution_plan(
             remote_job=remote_job,
             run_config=run_config,
             step_keys_to_execute=step_keys_to_execute,
@@ -270,9 +270,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
         partition_name: str,
         instance: DagsterInstance,
     ) -> Union["PartitionConfigSnap", "PartitionExecutionErrorSnap"]:
-        return self.get_code_location(
-            repository_handle.location_name
-        ).get_external_partition_config(
+        return self.get_code_location(repository_handle.location_name).get_partition_config(
             repository_handle=repository_handle,
             job_name=job_name,
             partition_name=partition_name,
@@ -287,7 +285,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
         instance: DagsterInstance,
         selected_asset_keys: Optional[AbstractSet[AssetKey]],
     ) -> Union["PartitionTagsSnap", "PartitionExecutionErrorSnap"]:
-        return self.get_code_location(repository_handle.location_name).get_external_partition_tags(
+        return self.get_code_location(repository_handle.location_name).get_partition_tags(
             repository_handle=repository_handle,
             job_name=job_name,
             partition_name=partition_name,
@@ -302,7 +300,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
         instance: DagsterInstance,
         selected_asset_keys: Optional[AbstractSet[AssetKey]],
     ) -> Union["PartitionNamesSnap", "PartitionExecutionErrorSnap"]:
-        return self.get_code_location(repository_handle.location_name).get_external_partition_names(
+        return self.get_code_location(repository_handle.location_name).get_partition_names(
             repository_handle=repository_handle,
             job_name=job_name,
             instance=instance,
@@ -318,7 +316,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
     ) -> Union["PartitionSetExecutionParamSnap", "PartitionExecutionErrorSnap"]:
         return self.get_code_location(
             repository_handle.location_name
-        ).get_external_partition_set_execution_param_data(
+        ).get_partition_set_execution_params(
             repository_handle=repository_handle,
             partition_set_name=partition_set_name,
             partition_names=partition_names,
@@ -329,7 +327,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
         check.str_param(code_location_name, "code_location_name")
         check.str_param(notebook_path, "notebook_path")
         code_location = self.get_code_location(code_location_name)
-        return code_location.get_external_notebook_data(notebook_path=notebook_path)
+        return code_location.get_notebook_data(notebook_path=notebook_path)
 
     def get_base_deployment_context(self) -> Optional["BaseWorkspaceRequestContext"]:
         return None

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -141,7 +141,7 @@ def retry_run(
         )
         return
 
-    remote_job = code_location.get_external_job(
+    remote_job = code_location.get_job(
         JobSubsetSelector(
             location_name=origin.code_location_origin.location_name,
             repository_name=repo_name,

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -702,7 +702,7 @@ def _submit_run_request(
         asset_selection=run_request.asset_selection,
         asset_check_selection=run_request.asset_check_keys,
     )
-    remote_job = code_location.get_external_job(job_subset_selector)
+    remote_job = code_location.get_job(job_subset_selector)
     run = _get_or_create_sensor_run(
         logger,
         instance,
@@ -796,7 +796,7 @@ def _evaluate_sensor(
     repository_handle = remote_sensor.handle.repository_handle
     instigator_data = _sensor_instigator_data(state)
 
-    sensor_runtime_data = code_location.get_external_sensor_execution_data(
+    sensor_runtime_data = code_location.get_sensor_execution_data(
         instance,
         repository_handle,
         remote_sensor.name,
@@ -1295,7 +1295,7 @@ def _create_sensor_run(
 ) -> DagsterRun:
     from dagster._daemon.daemon import get_telemetry_daemon_session_id
 
-    remote_execution_plan = code_location.get_external_execution_plan(
+    remote_execution_plan = code_location.get_execution_plan(
         remote_job,
         run_request.run_config,
         step_keys_to_execute=None,

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -731,7 +731,7 @@ def _submit_run_request(
         # * threaded: if thread sits pending in pool too long
         code_location = _get_code_location_for_schedule(workspace_process_context, remote_schedule)
 
-        remote_job = code_location.get_external_job(job_subset_selector)
+        remote_job = code_location.get_job(job_subset_selector)
 
         run = _create_scheduler_run(
             instance,
@@ -789,7 +789,7 @@ def _schedule_runs_at_time(
 
     code_location = _get_code_location_for_schedule(workspace_process_context, remote_schedule)
 
-    schedule_execution_data = code_location.get_external_schedule_execution_data(
+    schedule_execution_data = code_location.get_schedule_execution_data(
         instance=instance,
         repository_handle=repository_handle,
         schedule_name=remote_schedule.name,
@@ -931,7 +931,7 @@ def _create_scheduler_run(
     run_config = run_request.run_config
     schedule_tags = run_request.tags
 
-    remote_execution_plan = code_location.get_external_execution_plan(
+    remote_execution_plan = code_location.get_execution_plan(
         remote_job,
         run_config,
         step_keys_to_execute=None,

--- a/python_modules/dagster/dagster/_utils/external.py
+++ b/python_modules/dagster/dagster/_utils/external.py
@@ -31,4 +31,4 @@ def external_job_from_location(
         op_selection=op_selection,
     )
 
-    return code_location.get_external_job(pipeline_selector)
+    return code_location.get_job(pipeline_selector)

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_partition.py
@@ -60,7 +60,7 @@ def test_external_partition_names_grpc(instance: DagsterInstance):
 
 def test_external_partition_names(instance: DagsterInstance):
     with get_bar_repo_code_location(instance) as code_location:
-        data = code_location.get_external_partition_names(
+        data = code_location.get_partition_names(
             repository_handle=code_location.get_repository("bar_repo").handle,
             job_name="baz",
             instance=instance,
@@ -77,7 +77,7 @@ def test_external_partition_names_asset_selection(instance: DagsterInstance):
         location_name="something",
         instance=instance,
     ) as code_location:
-        data = code_location.get_external_partition_names(
+        data = code_location.get_partition_names(
             repository_handle=code_location.get_repository(SINGLETON_REPOSITORY_NAME).handle,
             job_name=IMPLICIT_ASSET_JOB_NAME,
             instance=instance,
@@ -118,7 +118,7 @@ def test_external_partitions_config_grpc(instance: DagsterInstance):
 
 def test_external_partition_config(instance: DagsterInstance):
     with get_bar_repo_code_location(instance) as code_location:
-        data = code_location.get_external_partition_config(
+        data = code_location.get_partition_config(
             job_name="baz",
             repository_handle=code_location.get_repository("bar_repo").handle,
             partition_name="c",
@@ -137,7 +137,7 @@ def test_external_partition_config_different_partitions_defs(instance: DagsterIn
         location_name="something",
         instance=instance,
     ) as code_location:
-        data = code_location.get_external_partition_config(
+        data = code_location.get_partition_config(
             job_name=IMPLICIT_ASSET_JOB_NAME,
             repository_handle=code_location.get_repository(SINGLETON_REPOSITORY_NAME).handle,
             partition_name="b",
@@ -195,7 +195,7 @@ def test_external_partitions_tags_grpc(instance: DagsterInstance):
 
 def test_external_partition_tags(instance: DagsterInstance):
     with get_bar_repo_code_location(instance) as code_location:
-        data = code_location.get_external_partition_tags(
+        data = code_location.get_partition_tags(
             repository_handle=code_location.get_repository("bar_repo").handle,
             job_name="baz",
             partition_name="c",
@@ -215,7 +215,7 @@ def test_external_partition_tags_different_partitions_defs(instance: DagsterInst
         location_name="something",
         instance=instance,
     ) as code_location:
-        data = code_location.get_external_partition_tags(
+        data = code_location.get_partition_tags(
             repository_handle=code_location.get_repository(SINGLETON_REPOSITORY_NAME).handle,
             job_name=IMPLICIT_ASSET_JOB_NAME,
             selected_asset_keys={AssetKey("asset2"), AssetKey("asset3")},

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -122,7 +122,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
 
     def submit_run(self, instance, external_job, workspace, **kwargs):
         location = workspace.get_code_location(external_job.handle.location_name)
-        subset_job = location.get_external_job(
+        subset_job = location.get_job(
             JobSubsetSelector(
                 location_name=location.name,
                 repository_name=external_job.handle.repository_name,
@@ -131,7 +131,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
                 asset_selection=kwargs.get("asset_selection"),
             )
         )
-        external_execution_plan = location.get_external_execution_plan(
+        external_execution_plan = location.get_execution_plan(
             subset_job,
             {},
             step_keys_to_execute=None,
@@ -155,7 +155,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     def get_run_ids(self, runs_queue):
         return [run.run_id for run in runs_queue]
 
-    def get_external_concurrency_job(self, workspace):
+    def get_concurrency_job(self, workspace):
         return workspace.get_full_job(
             JobSubsetSelector(
                 location_name="test",
@@ -856,7 +856,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     ):
         run_id_1, run_id_2, run_id_3 = [make_new_run_id() for _ in range(3)]
         workspace = concurrency_limited_workspace_context.create_request_context()
-        external_job = self.get_external_concurrency_job(workspace)
+        external_job = self.get_concurrency_job(workspace)
         foo_key = AssetKey(["prefix", "foo_limited_asset"])
 
         self.submit_run(
@@ -905,7 +905,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     ):
         run_id_1, run_id_2 = [make_new_run_id() for _ in range(2)]
         workspace = concurrency_limited_workspace_context.create_request_context()
-        external_job = self.get_external_concurrency_job(workspace)
+        external_job = self.get_concurrency_job(workspace)
         foo_key = AssetKey(["prefix", "foo_limited_asset"])
         bar_key = AssetKey(["prefix", "bar_limited_asset"])
 
@@ -969,7 +969,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         run_id_1, run_id_2 = [make_new_run_id() for _ in range(2)]
         workspace = concurrency_limited_workspace_context.create_request_context()
         foo_key = AssetKey(["prefix", "foo_limited_asset"])
-        external_job = self.get_external_concurrency_job(workspace)
+        external_job = self.get_concurrency_job(workspace)
         self.submit_run(
             instance, external_job, workspace, run_id=run_id_1, asset_selection=set([foo_key])
         )
@@ -1015,7 +1015,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         run_id_1, run_id_2, run_id_3 = [make_new_run_id() for _ in range(3)]
         workspace = concurrency_limited_workspace_context.create_request_context()
         foo_key = AssetKey(["prefix", "foo_limited_asset"])
-        external_job = self.get_external_concurrency_job(workspace)
+        external_job = self.get_concurrency_job(workspace)
         self.submit_run(
             instance, external_job, workspace, run_id=run_id_1, asset_selection=set([foo_key])
         )
@@ -1046,7 +1046,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         run_id_1, run_id_2, run_id_3 = [make_new_run_id() for _ in range(3)]
         workspace = concurrency_limited_workspace_context.create_request_context()
         foo_key = AssetKey(["prefix", "foo_limited_asset"])
-        external_job = self.get_external_concurrency_job(workspace)
+        external_job = self.get_concurrency_job(workspace)
         self.submit_run(
             instance, external_job, workspace, run_id=run_id_1, asset_selection=set([foo_key])
         )
@@ -1109,7 +1109,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     ):
         run_id_1 = make_new_run_id()
         workspace = concurrency_limited_workspace_context.create_request_context()
-        external_job = self.get_external_concurrency_job(workspace)
+        external_job = self.get_concurrency_job(workspace)
         foo_key = AssetKey(["prefix", "foo_limited_asset"])
 
         # foo is blocked, but bar is not

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
@@ -233,7 +233,7 @@ def test_successful_run_from_pending(
     run_id = make_new_run_id()
     code_location = pending_workspace.get_code_location("test2")
     remote_job = code_location.get_repository("pending").get_full_job("my_cool_asset_job")
-    external_execution_plan = code_location.get_external_execution_plan(
+    external_execution_plan = code_location.get_execution_plan(
         remote_job=remote_job,
         run_config={},
         step_keys_to_execute=None,

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
@@ -111,7 +111,7 @@ def test_run_from_pending_repository():
                 remote_job = code_location.get_repository("pending").get_full_job(
                     "my_cool_asset_job"
                 )
-                external_execution_plan = code_location.get_external_execution_plan(
+                external_execution_plan = code_location.get_execution_plan(
                     remote_job=remote_job,
                     run_config={},
                     step_keys_to_execute=None,


### PR DESCRIPTION
Internal companion PR: https://github.com/dagster-io/internal/pull/12098

## Summary & Motivation

Rename "external" accessor methods (e.g. `get_external_execution_plan`) on `CodeLocation` to remove `external` (so `get_execution_plan`), which is no longer accurate. The new qualifier is `remote` but this is left implicit.

## How I Tested These Changes

Existing test suite.