### PR TITLE
Simplify return types of static constructors for AutomationCondition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/check_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/check_operators.py
@@ -16,9 +16,8 @@ from dagster._record import record
 from dagster._serdes.serdes import whitelist_for_serdes
 
 
-@whitelist_for_serdes
 @record
-class ChecksCondition(BuiltinAutomationCondition[AssetKey]):
+class ChecksAutomationCondition(BuiltinAutomationCondition[AssetKey]):
     operand: AutomationCondition[AssetCheckKey]
 
     blocking_only: bool = False
@@ -52,7 +51,7 @@ class ChecksCondition(BuiltinAutomationCondition[AssetKey]):
 
 @whitelist_for_serdes
 @record
-class AnyChecksCondition(ChecksCondition):
+class AnyChecksCondition(ChecksAutomationCondition):
     @property
     def base_description(self) -> str:
         return "Any"
@@ -85,7 +84,7 @@ class AnyChecksCondition(ChecksCondition):
 
 @whitelist_for_serdes
 @record
-class AllChecksCondition(ChecksCondition):
+class AllChecksCondition(ChecksAutomationCondition):
     @property
     def base_description(self) -> str:
         return "All"

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -57,7 +57,7 @@ class EntityMatchesCondition(
 
 
 @record
-class DepCondition(BuiltinAutomationCondition[T_EntityKey]):
+class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     operand: AutomationCondition
 
     # Should be AssetSelection, but this causes circular reference issues
@@ -81,7 +81,7 @@ class DepCondition(BuiltinAutomationCondition[T_EntityKey]):
     def requires_cursor(self) -> bool:
         return False
 
-    def allow(self, selection: "AssetSelection") -> "DepCondition":
+    def allow(self, selection: "AssetSelection") -> "DepsAutomationCondition":
         """Returns a copy of this condition that will only consider dependencies within the provided
         AssetSelection.
         """
@@ -93,7 +93,7 @@ class DepCondition(BuiltinAutomationCondition[T_EntityKey]):
         )
         return copy(self, allow_selection=allow_selection)
 
-    def ignore(self, selection: "AssetSelection") -> "DepCondition":
+    def ignore(self, selection: "AssetSelection") -> "DepsAutomationCondition":
         """Returns a copy of this condition that will ignore dependencies within the provided
         AssetSelection.
         """
@@ -117,7 +117,7 @@ class DepCondition(BuiltinAutomationCondition[T_EntityKey]):
 
 
 @whitelist_for_serdes
-class AnyDepsCondition(DepCondition[T_EntityKey]):
+class AnyDepsCondition(DepsAutomationCondition[T_EntityKey]):
     @property
     def base_description(self) -> str:
         return "Any"
@@ -147,7 +147,7 @@ class AnyDepsCondition(DepCondition[T_EntityKey]):
 
 
 @whitelist_for_serdes
-class AllDepsCondition(DepCondition[T_EntityKey]):
+class AllDepsCondition(DepsAutomationCondition[T_EntityKey]):
     @property
     def base_description(self) -> str:
         return "All"


### PR DESCRIPTION
## Summary & Motivation

As title. These return types were overly-specific. We have some subclasses that support additional methods, but most do not. To keep things more comprehensible for users that are seeing these types, use the least specific type possible in these cases.


## How I Tested These Changes

## Changelog

NOCHANGELOG
