### PR TITLE
[dagster-dbt] Fix generating column metadata for models installed through dbt dependencies

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -120,9 +120,10 @@ def _build_column_lineage_metadata(
             dialect=sql_dialect,
         )
 
+    package_name = dbt_resource_props["package_name"]
     node_sql_path = target_path.joinpath(
         "compiled",
-        manifest["metadata"]["project_name"],
+        package_name,
         dbt_resource_props["original_file_path"],
     )
     optimized_node_ast = cast(

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
@@ -16,6 +16,7 @@ from dagster_dbt_tests.dbt_projects import (
     test_dbt_semantic_models_path,
     test_dbt_source_freshness_path,
     test_dbt_unit_tests_path,
+    test_dependencies_path,
     test_duplicate_source_asset_key_path,
     test_jaffle_shop_path,
     test_last_update_freshness_multiple_assets_defs_path,
@@ -185,5 +186,13 @@ def test_metadata_manifest_fixture() -> Dict[str, Any]:
     # Prepopulate duckdb with jaffle shop data to support testing individual column metadata.
     return _create_dbt_invocation(
         test_metadata_path,
+        build_project=True,
+    ).get_artifact("manifest.json")
+
+
+@pytest.fixture(name="test_dependencies_manifest", scope="session")
+def test_dependencies_manifest_fixture() -> Dict[str, Any]:
+    return _create_dbt_invocation(
+        test_dependencies_path,
         build_project=True,
     ).get_artifact("manifest.json")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/__init__.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/__init__.py
@@ -27,3 +27,4 @@ test_time_partition_freshness_multiple_assets_defs_path = projects_path.joinpath
 )
 test_dagster_dbt_mixed_freshness_path = projects_path.joinpath("test_dagster_dbt_mixed_freshness")
 test_jaffle_with_profile_vars_path = projects_path.joinpath("test_jaffle_with_profile_vars")
+test_dependencies_path = projects_path.joinpath("test_dagster_dbt_dependencies")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_dependencies/.gitignore
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_dependencies/.gitignore
@@ -1,0 +1,11 @@
+
+target/
+dbt_packages/
+dbt_modules/
+logs/
+**/.DS_Store
+.user.yml
+venv/
+env/
+**/*.duckdb
+**/*.duckdb.wal

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_dependencies/dbt_project.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_dependencies/dbt_project.yml
@@ -1,0 +1,26 @@
+name: "test_dagster_dbt_dependencies"
+
+config-version: 2
+version: "0.1"
+
+profile: "jaffle_shop"
+
+model-paths: ["models"]
+seed-paths: ["seeds"]
+test-paths: ["tests"]
+analysis-paths: ["analysis"]
+macro-paths: ["macros"]
+
+target-path: "target"
+clean-targets:
+  - "target"
+  - "dbt_modules"
+  - "logs"
+
+require-dbt-version: [">=1.0.0", "<2.0.0"]
+
+models:
+  test_dagster_dbt_alias:
+    materialized: table
+    staging:
+      materialized: view

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_dependencies/models/customers_refined.sql
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_dependencies/models/customers_refined.sql
@@ -1,0 +1,7 @@
+with customers as (
+
+    select * from {{ ref('jaffle_shop', 'customers') }}
+
+)
+
+select * from customers

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_dependencies/models/schema.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_dependencies/models/schema.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: customers_refined
+    description: This table references the jaffle shop customers table

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_dependencies/package-lock.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_dependencies/package-lock.yml
@@ -1,0 +1,3 @@
+packages:
+  - local: ../jaffle_shop
+sha1_hash: d3c6b8add4fdc078f8ec5f965c7a976f447e5852

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_dependencies/packages.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_dependencies/packages.yml
@@ -1,0 +1,2 @@
+packages:
+  - local: ../jaffle_shop

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_dependencies/profiles.yml
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/dbt_projects/test_dagster_dbt_dependencies/profiles.yml
@@ -1,0 +1,7 @@
+jaffle_shop:
+  target: dev
+  outputs:
+    dev:
+      type: duckdb
+      path: "{{ env_var('DAGSTER_DBT_PYTEST_XDIST_DUCKDB_DBFILE_PATH') }}"
+      threads: 24


### PR DESCRIPTION
## Summary

Addresses #23116. Right now, when building column metadata, we attempt to read a dbt .sql source file from a path including the current dbt project name, but this incorrectly generates a path for models that are pulled in from other projects via dependencies. This PR updates the logic to pull the package name for each individual node.


## Test Plan

New unit test with dependencies.

## Changelog

> [dagster-dbt] Fixed an issue where column metadata generated with `fetch_column_metadata` did not work properly for models imported through dbt dependencies
