### PR TITLE
[AssetPageHeader] Add keys to breadcrumb elements to fix crazy flashing

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetPageHeader.oss.tsx
@@ -76,17 +76,21 @@ export const AssetPageHeader = ({
           <Title>
             <BreadcrumbsWithSlashes
               items={breadcrumbs}
-              currentBreadcrumbRenderer={({text}) => (
-                <TruncatedHeading>
-                  {typeof text === 'string' ? <MiddleTruncate text={text} /> : text}
-                </TruncatedHeading>
+              currentBreadcrumbRenderer={({text, href}) => (
+                <span key={href}>
+                  <TruncatedHeading>
+                    {typeof text === 'string' ? <MiddleTruncate text={text} /> : text}
+                  </TruncatedHeading>
+                </span>
               )}
               breadcrumbRenderer={({text, href}) => (
-                <TruncatedHeading>
-                  <BreadcrumbLink to={href || '#'}>
-                    {typeof text === 'string' ? <MiddleTruncate text={text} /> : text}
-                  </BreadcrumbLink>
-                </TruncatedHeading>
+                <span key={href}>
+                  <TruncatedHeading>
+                    <BreadcrumbLink to={href || '#'}>
+                      {typeof text === 'string' ? <MiddleTruncate text={text} /> : text}
+                    </BreadcrumbLink>
+                  </TruncatedHeading>
+                </span>
               )}
               $numHeaderBreadcrumbs={headerBreadcrumbs.length}
               popoverProps={{


### PR DESCRIPTION
## Summary & Motivation

I'm honestly not entirely sure what is happening here but while debugging I noticed that the internal React fiber nodes were being improperly reused for different instances of the breadcrumb. In one render the instance would be rendering "SEO", and in the next it was rendering "Mart". I'm assuming this is due to our recent Blueprint upgrade. Adding keys onto the breadcrumb elements fixes the issue.

https://app.usepylon.com/issues?conversationID=6713c615-56be-43b1-9559-18d76f2f5c32

## How I Tested These Changes

Successfully Loaded an asset page that was previously flickering like crazy.


## Changelog

[Bugfix][ui] Fixed an issue where the breadcumb on asset pages would flicker nonstop.