### PR TITLE
[external-renames] DagsterRun.external_job_origin -> remote_job_origin

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -115,7 +115,7 @@ def terminate_pipeline_execution(
     run = record.dagster_run
     graphene_run = GrapheneRun(record)
 
-    location_name = run.external_job_origin.location_name if run.external_job_origin else None
+    location_name = run.remote_job_origin.location_name if run.remote_job_origin else None
 
     if location_name:
         if not graphene_info.context.has_permission_for_location(
@@ -201,7 +201,7 @@ def delete_pipeline_run(
         assert_permission(graphene_info, Permissions.DELETE_PIPELINE_RUN)
         return GrapheneRunNotFoundError(run_id)
 
-    location_name = run.external_job_origin.location_name if run.external_job_origin else None
+    location_name = run.remote_job_origin.location_name if run.remote_job_origin else None
     if location_name:
         assert_permission_for_location(
             graphene_info, Permissions.DELETE_PIPELINE_RUN, location_name

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/launch_execution.py
@@ -86,7 +86,7 @@ def launch_reexecution_from_parent_run(
     parent_run = check.not_none(
         instance.get_run_by_id(parent_run_id), f"Could not find parent run with id: {parent_run_id}"
     )
-    origin = check.not_none(parent_run.external_job_origin)
+    origin = check.not_none(parent_run.remote_job_origin)
     selector = JobSubsetSelector(
         location_name=origin.repository_origin.code_location_origin.location_name,
         repository_name=origin.repository_origin.repository_name,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -411,8 +411,8 @@ class GrapheneRun(graphene.ObjectType):
 
     def _get_permission_value(self, permission: Permissions, graphene_info: ResolveInfo) -> bool:
         location_name = (
-            self.dagster_run.external_job_origin.location_name
-            if self.dagster_run.external_job_origin
+            self.dagster_run.remote_job_origin.location_name
+            if self.dagster_run.remote_job_origin
             else None
         )
 
@@ -440,8 +440,8 @@ class GrapheneRun(graphene.ObjectType):
 
     def resolve_repositoryOrigin(self, _graphene_info: ResolveInfo):
         return (
-            GrapheneRepositoryOrigin(self.dagster_run.external_job_origin.repository_origin)
-            if self.dagster_run.external_job_origin
+            GrapheneRepositoryOrigin(self.dagster_run.remote_job_origin.repository_origin)
+            if self.dagster_run.remote_job_origin
             else None
         )
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_retry_execution.py
@@ -71,12 +71,12 @@ class TestRetryExecutionReadonly(ReadonlyGraphQLContextTestMatrix):
 
         code_location = graphql_context.get_code_location("test")
         repository = code_location.get_repository("test_repo")
-        external_job_origin = repository.get_full_job("eventually_successful").get_remote_origin()
+        remote_job_origin = repository.get_full_job("eventually_successful").get_remote_origin()
 
         run_id = create_run_for_test(
             graphql_context.instance,
             "eventually_successful",
-            remote_job_origin=external_job_origin,
+            remote_job_origin=remote_job_origin,
         ).run_id
 
         result = execute_dagster_graphql(

--- a/python_modules/dagster/dagster/_cli/api.py
+++ b/python_modules/dagster/dagster/_cli/api.py
@@ -452,9 +452,7 @@ def _execute_step_command_body(
         )
 
         location_name = (
-            dagster_run.external_job_origin.location_name
-            if dagster_run.external_job_origin
-            else None
+            dagster_run.remote_job_origin.location_name if dagster_run.remote_job_origin else None
         )
 
         instance.inject_env_vars(location_name)

--- a/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/run_status_sensor_definition.py
@@ -828,14 +828,14 @@ class RunStatusSensorDefinition(SensorDefinition):
                     not job_match
                     and
                     # the job has a repository (not manually executed)
-                    dagster_run.external_job_origin
+                    dagster_run.remote_job_origin
                     and
                     # the job belongs to the current code location
-                    dagster_run.external_job_origin.repository_origin.code_location_origin.location_name
+                    dagster_run.remote_job_origin.repository_origin.code_location_origin.location_name
                     == code_location_name
                     and
                     # the job belongs to the current repository
-                    dagster_run.external_job_origin.repository_origin.repository_name
+                    dagster_run.remote_job_origin.repository_origin.repository_name
                     == context.repository_name
                 ):
                     if monitored_jobs:
@@ -848,11 +848,11 @@ class RunStatusSensorDefinition(SensorDefinition):
                     not job_match
                     and
                     # the job has a repository (not manually executed)
-                    dagster_run.external_job_origin
+                    dagster_run.remote_job_origin
                 ):
                     # check if the run is one of the jobs specified by JobSelector or RepositorySelector (ie in another repo)
                     # make a JobSelector for the run in question
-                    remote_repository_origin = dagster_run.external_job_origin.repository_origin
+                    remote_repository_origin = dagster_run.remote_job_origin.repository_origin
                     run_job_selector = JobSelector(
                         location_name=remote_repository_origin.code_location_origin.location_name,
                         repository_name=remote_repository_origin.repository_name,

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -1278,7 +1278,7 @@ class DagsterInstance(DynamicPartitionsStore):
             parent_run_id=parent_run_id,
             job_snapshot_id=job_snapshot_id,
             execution_plan_snapshot_id=execution_plan_snapshot_id,
-            external_job_origin=remote_job_origin,
+            remote_job_origin=remote_job_origin,
             job_code_origin=job_code_origin,
             has_repository_load_data=execution_plan_snapshot is not None
             and execution_plan_snapshot.repository_load_data is not None,
@@ -2620,7 +2620,7 @@ class DagsterInstance(DynamicPartitionsStore):
             )
 
         check.not_none(
-            run.external_job_origin,
+            run.remote_job_origin,
             "External pipeline origin must be set for submitted runs",
         )
         check.not_none(

--- a/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
+++ b/python_modules/dagster/dagster/_core/launcher/default_run_launcher.py
@@ -78,7 +78,7 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
         res = deserialize_value(
             grpc_client.start_run(
                 ExecuteExternalJobArgs(
-                    job_origin=run.external_job_origin,  # type: ignore  # (possible none)
+                    job_origin=run.remote_job_origin,  # type: ignore  # (possible none)
                     run_id=run.run_id,
                     instance_ref=instance.get_ref(),
                 )
@@ -105,9 +105,9 @@ class DefaultRunLauncher(RunLauncher, ConfigurableClass):
                 "DefaultRunLauncher requires a workspace to be included in its LaunchRunContext"
             )
 
-        external_job_origin = check.not_none(run.external_job_origin)
+        remote_job_origin = check.not_none(run.remote_job_origin)
         code_location = context.workspace.get_code_location(
-            external_job_origin.repository_origin.code_location_origin.location_name
+            remote_job_origin.repository_origin.code_location_origin.location_name
         )
 
         check.inst(

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -332,9 +332,9 @@ class PipesSession:
             "dagster/job": self.context.job_name,
         }
 
-        if self.context.dagster_run.external_job_origin:
+        if self.context.dagster_run.remote_job_origin:
             tags["dagster/code-location"] = (
-                self.context.dagster_run.external_job_origin.repository_origin.code_location_origin.location_name
+                self.context.dagster_run.remote_job_origin.repository_origin.code_location_origin.location_name
             )
 
         if user := self.context.get_tag("dagster/user"):

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -268,7 +268,7 @@ class DagsterRunSerializer(NamedTupleSerializer["DagsterRun"]):
     storage_field_names={
         "job_name": "pipeline_name",
         "job_snapshot_id": "pipeline_snapshot_id",
-        "external_job_origin": "external_pipeline_origin",
+        "remote_job_origin": "external_pipeline_origin",
         "job_code_origin": "pipeline_code_origin",
         "op_selection": "solid_selection",
         "resolved_op_selection": "solids_to_execute",
@@ -292,7 +292,7 @@ class DagsterRun(
             ("parent_run_id", Optional[str]),
             ("job_snapshot_id", Optional[str]),
             ("execution_plan_snapshot_id", Optional[str]),
-            ("external_job_origin", Optional["RemoteJobOrigin"]),
+            ("remote_job_origin", Optional["RemoteJobOrigin"]),
             ("job_code_origin", Optional[JobPythonOrigin]),
             ("has_repository_load_data", bool),
             ("run_op_concurrency", Optional[RunOpConcurrency]),
@@ -326,7 +326,7 @@ class DagsterRun(
         parent_run_id: Optional[str] = None,
         job_snapshot_id: Optional[str] = None,
         execution_plan_snapshot_id: Optional[str] = None,
-        external_job_origin: Optional["RemoteJobOrigin"] = None,
+        remote_job_origin: Optional["RemoteJobOrigin"] = None,
         job_code_origin: Optional[JobPythonOrigin] = None,
         has_repository_load_data: Optional[bool] = None,
         run_op_concurrency: Optional[RunOpConcurrency] = None,
@@ -359,10 +359,10 @@ class DagsterRun(
 
         if status == DagsterRunStatus.QUEUED:
             check.inst_param(
-                external_job_origin,
-                "external_job_origin",
+                remote_job_origin,
+                "remote_job_origin",
                 RemoteJobOrigin,
-                "external_job_origin is required for queued runs",
+                "remote_job_origin is required for queued runs",
             )
 
         if run_id is None:
@@ -388,8 +388,8 @@ class DagsterRun(
             execution_plan_snapshot_id=check.opt_str_param(
                 execution_plan_snapshot_id, "execution_plan_snapshot_id"
             ),
-            external_job_origin=check.opt_inst_param(
-                external_job_origin, "external_job_origin", RemoteJobOrigin
+            remote_job_origin=check.opt_inst_param(
+                remote_job_origin, "remote_job_origin", RemoteJobOrigin
             ),
             job_code_origin=check.opt_inst_param(
                 job_code_origin, "job_code_origin", JobPythonOrigin
@@ -408,7 +408,7 @@ class DagsterRun(
             # https://github.com/dagster-io/dagster/issues/3181
 
             check.not_none(
-                self.external_job_origin,
+                self.remote_job_origin,
                 "external_pipeline_origin is required for queued runs",
             )
 
@@ -418,7 +418,7 @@ class DagsterRun(
         from dagster._core.remote_representation.origin import RemoteJobOrigin
 
         check.inst_param(origin, "origin", RemoteJobOrigin)
-        return self._replace(external_job_origin=origin)
+        return self._replace(remote_job_origin=origin)
 
     def with_tags(self, tags: Mapping[str, str]) -> Self:
         return self._replace(tags=tags)
@@ -431,11 +431,11 @@ class DagsterRun(
 
     def tags_for_storage(self) -> Mapping[str, str]:
         repository_tags = {}
-        if self.external_job_origin:
+        if self.remote_job_origin:
             # tag the run with a label containing the repository name / location name, to allow for
             # per-repository filtering of runs from the Dagster UI.
             repository_tags[REPOSITORY_LABEL_TAG] = (
-                self.external_job_origin.repository_origin.get_label()
+                self.remote_job_origin.repository_origin.get_label()
             )
 
         if not self.tags:

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -199,11 +199,11 @@ def migrate_run_repo_tags(run_storage: RunStorage, print_fn: Optional[PrintFn] =
 
 
 def write_repo_tag(conn: Connection, run: DagsterRun) -> None:
-    if not run.external_job_origin:
+    if not run.remote_job_origin:
         # nothing to do
         return
 
-    repository_label = run.external_job_origin.repository_origin.get_label()
+    repository_label = run.remote_job_origin.repository_origin.get_label()
     try:
         conn.execute(
             RunTagsTable.insert().values(

--- a/python_modules/dagster/dagster/_core/test_utils.py
+++ b/python_modules/dagster/dagster/_core/test_utils.py
@@ -430,7 +430,7 @@ class MockedRunCoordinator(RunCoordinator, ConfigurableClass):
 
     def submit_run(self, context: SubmitRunContext):
         dagster_run = context.dagster_run
-        check.not_none(dagster_run.external_job_origin)
+        check.not_none(dagster_run.remote_job_origin)
         self._queue.append(dagster_run)
         return dagster_run
 

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -112,14 +112,14 @@ def retry_run(
     instance = workspace_context.instance
     tags = {RETRY_NUMBER_TAG: str(retry_number)}
     workspace = workspace_context.create_request_context()
-    if not failed_run.external_job_origin:
+    if not failed_run.remote_job_origin:
         instance.report_engine_event(
             "Run does not have an external job origin, unable to retry the run.",
             failed_run,
         )
         return
 
-    origin = failed_run.external_job_origin.repository_origin
+    origin = failed_run.remote_job_origin.repository_origin
     code_location = workspace.get_code_location(origin.code_location_origin.location_name)
     repo_name = origin.repository_name
 

--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -305,7 +305,7 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
                     global_concurrency_limits_counter.update_counters_with_launched_item(run)
 
                 location_name = (
-                    run.external_job_origin.location_name if run.external_job_origin else None
+                    run.remote_job_origin.location_name if run.remote_job_origin else None
                 )
                 if location_name and location_name in paused_location_names:
                     to_remove.append(run)
@@ -366,7 +366,7 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
 
         # Very old (pre 0.10.0) runs and programatically submitted runs may not have an
         # attached code location name
-        location_name = run.external_job_origin.location_name if run.external_job_origin else None
+        location_name = run.remote_job_origin.location_name if run.remote_job_origin else None
 
         if location_name and self._is_location_pausing_dequeues(location_name, now):
             self._logger.info(

--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -1232,12 +1232,12 @@ def _fetch_existing_runs(
     valid_runs: List[DagsterRun] = []
     for run in runs_with_run_keys:
         # if the run doesn't have a set origin, just match on sensor name
-        if run.external_job_origin is None and run.tags.get(SENSOR_NAME_TAG) == remote_sensor.name:
+        if run.remote_job_origin is None and run.tags.get(SENSOR_NAME_TAG) == remote_sensor.name:
             valid_runs.append(run)
         # otherwise prevent the same named sensor across repos from effecting each other
         elif (
-            run.external_job_origin is not None
-            and run.external_job_origin.repository_origin.get_selector_id()
+            run.remote_job_origin is not None
+            and run.remote_job_origin.repository_origin.get_selector_id()
             == remote_sensor.get_remote_origin().repository_origin.get_selector_id()
             and run.tags.get(SENSOR_NAME_TAG) == remote_sensor.name
         ):

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -102,8 +102,8 @@ def core_execute_run(
     if inject_env_vars:
         try:
             location_name = (
-                dagster_run.external_job_origin.location_name
-                if dagster_run.external_job_origin
+                dagster_run.remote_job_origin.location_name
+                if dagster_run.remote_job_origin
                 else None
             )
 

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -903,12 +903,12 @@ def _get_existing_run_for_request(
     matching_runs = []
     for run in existing_runs:
         # if the run doesn't have an origin consider it a match
-        if run.external_job_origin is None:
+        if run.remote_job_origin is None:
             matching_runs.append(run)
         # otherwise prevent the same named schedule (with the same execution time) across repos from effecting each other
         elif (
             remote_schedule.get_remote_origin().repository_origin.get_selector_id()
-            == run.external_job_origin.repository_origin.get_selector_id()
+            == run.remote_job_origin.repository_origin.get_selector_id()
         ):
             matching_runs.append(run)
 

--- a/python_modules/dagster/dagster/_utils/external.py
+++ b/python_modules/dagster/dagster/_utils/external.py
@@ -7,16 +7,16 @@ from dagster._core.remote_representation.external import RemoteJob
 from dagster._core.remote_representation.origin import RemoteJobOrigin
 
 
-def external_job_from_location(
+def remote_job_from_location(
     code_location: CodeLocation,
-    external_job_origin: RemoteJobOrigin,
+    remote_job_origin: RemoteJobOrigin,
     op_selection: Optional[Sequence[str]],
 ) -> RemoteJob:
     check.inst_param(code_location, "code_location", CodeLocation)
-    check.inst_param(external_job_origin, "external_pipeline_origin", RemoteJobOrigin)
+    check.inst_param(remote_job_origin, "external_pipeline_origin", RemoteJobOrigin)
 
-    repo_name = external_job_origin.repository_origin.repository_name
-    job_name = external_job_origin.job_name
+    repo_name = remote_job_origin.repository_origin.repository_name
+    job_name = remote_job_origin.job_name
 
     check.invariant(
         code_location.has_repository(repo_name),

--- a/python_modules/dagster/dagster_tests/storage_tests/test_dagster_run.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_dagster_run.py
@@ -51,7 +51,7 @@ def test_queued_job_origin_check():
     DagsterRun(
         job_name="foo",
         status=DagsterRunStatus.QUEUED,
-        external_job_origin=fake_job_origin,
+        remote_job_origin=fake_job_origin,
         job_code_origin=fake_code_origin,
     )
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_job_run.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_job_run.py
@@ -51,7 +51,7 @@ def test_queued_job_origin_check():
     DagsterRun(
         job_name="foo",
         status=DagsterRunStatus.QUEUED,
-        external_job_origin=fake_job_origin,
+        remote_job_origin=fake_job_origin,
         job_code_origin=fake_code_origin,
     )
 

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/run_storage.py
@@ -155,7 +155,7 @@ class TestRunStorage:
             root_run_id=root_run_id,
             parent_run_id=parent_run_id,
             job_snapshot_id=job_snapshot_id,
-            external_job_origin=remote_job_origin,
+            remote_job_origin=remote_job_origin,
         )
 
     def test_basic_storage(self, storage):

--- a/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/ecs/launcher.py
@@ -581,7 +581,7 @@ class EcsRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         return self._current_task
 
     def _get_run_task_definition_family(self, run: DagsterRun) -> str:
-        return get_task_definition_family("run", check.not_none(run.external_job_origin))
+        return get_task_definition_family("run", check.not_none(run.remote_job_origin))
 
     def _get_container_name(self, container_context) -> str:
         return container_context.container_name or self.container_name

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/ecs_tests/launcher_tests/test_launching.py
@@ -55,7 +55,7 @@ def test_default_launcher(
     assert instance.run_launcher.check_run_worker_health(run).status == WorkerStatus.RUNNING
 
     # It has a new family, name, and image
-    assert task_definition["family"] == get_task_definition_family("run", run.external_job_origin)
+    assert task_definition["family"] == get_task_definition_family("run", run.remote_job_origin)
     assert len(task_definition["containerDefinitions"]) == 1
     container_definition = task_definition["containerDefinitions"][0]
     assert container_definition["name"] == "run"
@@ -229,7 +229,7 @@ def test_launcher_dont_use_current_task(
     assert instance.run_launcher.check_run_worker_health(run).status == WorkerStatus.RUNNING
 
     # It has a new family, name, and image
-    assert task_definition["family"] == get_task_definition_family("run", run.external_job_origin)
+    assert task_definition["family"] == get_task_definition_family("run", run.remote_job_origin)
     assert len(task_definition["containerDefinitions"]) == 1
     container_definition = task_definition["containerDefinitions"][0]
     assert container_definition["name"] == "run"

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/executor.py
@@ -372,9 +372,9 @@ def create_k8s_job_task(celery_app, **task_kwargs):
             "dagster/op": step_key,
             "dagster/run-id": execute_step_args.run_id,
         }
-        if dagster_run.external_job_origin:
+        if dagster_run.remote_job_origin:
             labels["dagster/code-location"] = (
-                dagster_run.external_job_origin.repository_origin.code_location_origin.location_name
+                dagster_run.remote_job_origin.repository_origin.code_location_origin.location_name
             )
         per_op_override = per_step_k8s_config.get(step_key, {})
 

--- a/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
+++ b/python_modules/libraries/dagster-celery-k8s/dagster_celery_k8s/launcher.py
@@ -205,9 +205,9 @@ class CeleryK8sRunLauncher(RunLauncher, ConfigurableClass):
             "dagster/job": job_origin.job_name,
             "dagster/run-id": run.run_id,
         }
-        if run.external_job_origin:
+        if run.remote_job_origin:
             labels["dagster/code-location"] = (
-                run.external_job_origin.repository_origin.code_location_origin.location_name
+                run.remote_job_origin.repository_origin.code_location_origin.location_name
             )
 
         job = construct_dagster_k8s_job(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/executor.py
@@ -272,9 +272,9 @@ class K8sStepHandler(StepHandler):
             "dagster/op": step_key,
             "dagster/run-id": step_handler_context.execute_step_args.run_id,
         }
-        if run.external_job_origin:
+        if run.remote_job_origin:
             labels["dagster/code-location"] = (
-                run.external_job_origin.repository_origin.code_location_origin.location_name
+                run.remote_job_origin.repository_origin.code_location_origin.location_name
             )
         job = construct_dagster_k8s_job(
             job_config=job_config,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/launcher.py
@@ -230,9 +230,9 @@ class K8sRunLauncher(RunLauncher, ConfigurableClass):
             "dagster/job": job_origin.job_name,
             "dagster/run-id": run.run_id,
         }
-        if run.external_job_origin:
+        if run.remote_job_origin:
             labels["dagster/code-location"] = (
-                run.external_job_origin.repository_origin.code_location_origin.location_name
+                run.remote_job_origin.repository_origin.code_location_origin.location_name
             )
 
         job = construct_dagster_k8s_job(

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/ops/k8s_job_op.py
@@ -309,9 +309,9 @@ def execute_k8s_job(
         "dagster/op": context.op.name,
         "dagster/run-id": context.dagster_run.run_id,
     }
-    if context.dagster_run.external_job_origin:
+    if context.dagster_run.remote_job_origin:
         labels["dagster/code-location"] = (
-            context.dagster_run.external_job_origin.repository_origin.code_location_origin.location_name
+            context.dagster_run.remote_job_origin.repository_origin.code_location_origin.location_name
         )
 
     job = construct_dagster_k8s_job(


### PR DESCRIPTION
Internal companion PR: https://github.com/dagster-io/internal/pull/12106

## Summary & Motivation

Rename `DagsterRun.external_job_origin` -> `remote_job_origin`. This is separate from downstack PRs because it is a serdes-layer change.

## How I Tested These Changes

Existing test suite.