### PR TITLE
Create backfill_in_progress AutomationCondition

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -676,7 +676,7 @@ class TestAssetConditionEvaluations(ExecutingGraphQLContextTestMatrix):
         assert record["numRequested"] == 0
 
         # all nodes in the tree
-        assert len(record["evaluationNodes"]) == 28
+        assert len(record["evaluationNodes"]) == 32
 
         rootNode = record["evaluationNodes"][0]
         assert rootNode["uniqueId"] == record["rootUniqueId"]

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/__init__.py
@@ -1,11 +1,12 @@
 from dagster._core.definitions.declarative_automation.operands import (
+    BackfillInProgressAutomationCondition as BackfillInProgressAutomationCondition,
     CronTickPassedCondition as CronTickPassedCondition,
     ExecutionFailedAutomationCondition as ExecutionFailedAutomationCondition,
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,
-    InProgressAutomationCondition as InProgressAutomationCondition,
     MissingAutomationCondition as MissingAutomationCondition,
     NewlyRequestedCondition as NewlyRequestedCondition,
     NewlyUpdatedCondition as NewlyUpdatedCondition,
+    RunInProgressAutomationCondition as RunInProgressAutomationCondition,
     WillBeRequestedCondition as WillBeRequestedCondition,
 )
 from dagster._core.definitions.declarative_automation.operands.operands import (

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -325,13 +325,24 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
     @public
     @experimental
     @staticmethod
-    def in_progress() -> "BuiltinAutomationCondition":
+    def run_in_progress() -> "BuiltinAutomationCondition":
         """Returns an AutomationCondition that is true if the target is part of an in-progress run."""
         from dagster._core.definitions.declarative_automation.operands import (
-            InProgressAutomationCondition,
+            RunInProgressAutomationCondition,
         )
 
-        return InProgressAutomationCondition()
+        return RunInProgressAutomationCondition()
+
+    @public
+    @experimental
+    @staticmethod
+    def backfill_in_progress() -> "BuiltinAutomationCondition":
+        """Returns an AutomationCondition that is true if the target is part of an in-progress backfill."""
+        from dagster._core.definitions.declarative_automation.operands import (
+            BackfillInProgressAutomationCondition,
+        )
+
+        return BackfillInProgressAutomationCondition()
 
     @public
     @experimental
@@ -343,6 +354,17 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
         )
 
         return ExecutionFailedAutomationCondition()
+
+    @public
+    @experimental
+    @staticmethod
+    def in_progress() -> "BuiltinAutomationCondition":
+        """Returns an AutomationCondition that is true for an asset partition if it is part of an
+        in-progress run or backfill.
+        """
+        return (
+            AutomationCondition.run_in_progress() | AutomationCondition.backfill_in_progress()
+        ).with_label("in_progress")
 
     @public
     @experimental

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/__init__.py
@@ -1,13 +1,14 @@
 from dagster._core.definitions.declarative_automation.operands.operands import (
+    BackfillInProgressAutomationCondition as BackfillInProgressAutomationCondition,
     CheckResultCondition as CheckResultCondition,
     CodeVersionChangedCondition as CodeVersionChangedCondition,
     CronTickPassedCondition as CronTickPassedCondition,
     ExecutionFailedAutomationCondition as ExecutionFailedAutomationCondition,
     InitialEvaluationCondition as InitialEvaluationCondition,
     InLatestTimeWindowCondition as InLatestTimeWindowCondition,
-    InProgressAutomationCondition as InProgressAutomationCondition,
     MissingAutomationCondition as MissingAutomationCondition,
     NewlyRequestedCondition as NewlyRequestedCondition,
     NewlyUpdatedCondition as NewlyUpdatedCondition,
+    RunInProgressAutomationCondition as RunInProgressAutomationCondition,
     WillBeRequestedCondition as WillBeRequestedCondition,
 )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/operands.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/operands.py
@@ -66,15 +66,26 @@ class MissingAutomationCondition(SubsetAutomationCondition):
         )
 
 
-@whitelist_for_serdes
+@whitelist_for_serdes(storage_name="InProgressAutomationCondition")
 @record
-class InProgressAutomationCondition(SubsetAutomationCondition):
+class RunInProgressAutomationCondition(SubsetAutomationCondition):
     @property
     def name(self) -> str:
-        return "in_progress"
+        return "execution_in_progress"
 
     def compute_subset(self, context: AutomationContext) -> EntitySubset:
-        return context.asset_graph_view.compute_in_progress_subset(key=context.key)
+        return context.asset_graph_view.compute_run_in_progress_subset(key=context.key)
+
+
+@whitelist_for_serdes
+@record
+class BackfillInProgressAutomationCondition(SubsetAutomationCondition):
+    @property
+    def name(self) -> str:
+        return "backfill_in_progress"
+
+    def compute_subset(self, context: AutomationContext) -> EntitySubset:
+        return context.asset_graph_view.compute_backfill_in_progress_subset(key=context.key)
 
 
 @whitelist_for_serdes(storage_name="FailedAutomationCondition")

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_result_value_hash.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_result_value_hash.py
@@ -38,11 +38,11 @@ two_parents_daily = two_parents.with_asset_properties(partitions_def=daily_parti
         ("dd74c7cfe19d869931ea4aad9ee10127", SC.on_cron("0 * * * *"), two_parents, False),
         ("861f8e40d4624d49c4ebdd034c8e1e84", SC.on_cron("0 * * * *"), two_parents_daily, False),
         # same as above
-        ("b5cb0d7a1c627bd2c9e7c6da3313ab71", SC.eager(), one_parent, False),
-        ("7802a65024d04bbe44a3e0e541c0a577", SC.eager(), one_parent, True),
-        ("5d9c70da7ecca9e40f32c1ad99956b5d", SC.eager(), one_parent_daily, False),
-        ("904bac575906542d28b9e069129dad37", SC.eager(), two_parents, False),
-        ("3ef1d373a2b38752ad8e23fe9c053d9f", SC.eager(), two_parents_daily, False),
+        ("dfb268e321e2e7aa7b0e2e71fa674e06", SC.eager(), one_parent, False),
+        ("781252e1a53db1ecd5938b0da61dba0b", SC.eager(), one_parent, True),
+        ("293186887409aac2fe99b09bd633c64b", SC.eager(), one_parent_daily, False),
+        ("c92d9d5181b4d0a6c7ab5d1c6e26962a", SC.eager(), two_parents, False),
+        ("911bcc4f8904ec6dae85f6aaf78f5ee5", SC.eager(), two_parents_daily, False),
         # missing condition is invariant to changes other than partitions def changes
         ("6d7809c4949e3d812d7eddfb1b60d529", SC.missing(), one_parent, False),
         ("6d7809c4949e3d812d7eddfb1b60d529", SC.missing(), one_parent, True),

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 from typing import AbstractSet, Mapping, Sequence, cast
 
 import dagster._check as check
-import pytest
 from dagster import AssetMaterialization, RunsFilter, instance_for_test
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
@@ -419,7 +418,6 @@ def _get_subsets_by_key(
     return {s.key: s for s in target_subset.iterate_asset_subsets(asset_graph)}
 
 
-@pytest.mark.skip("Pending change to in_progress() behavior")
 def test_backfill_creation_simple() -> None:
     with get_workspace_request_context(
         ["backfill_simple"]
@@ -462,7 +460,6 @@ def test_backfill_creation_simple() -> None:
             assert len(runs) == 0
 
 
-@pytest.mark.skip("Pending change to in_progress() behavior")
 def test_backfill_with_runs_and_checks() -> None:
     with get_workspace_request_context(
         ["backfill_with_runs_and_checks"]


### PR DESCRIPTION
## Summary & Motivation

As title. This converts the existing `in_progress` AutomationCondition to capture both in progress runs and in progress backfills. It keeps these as separate conditions to maximize flexibility (and also increases explainability in the UI, as you can tell if an asset is part of a backfill but not an active run, or vice-versa).

## How I Tested These Changes

## Changelog

`AutomationCondition.in_progress()` now will be true if an asset partition is part of an in-progress backfill that has not yet executed it. The prior behavior, which only considered runs, is encapsulated in `AutomationCondition.execution_in_progress()`.
