### PR TITLE
[external-renames] `ExternalJobSubsetResult` -> `RemoteJobSubsetResult`

### DIFF
--- a/python_modules/dagster/dagster/_api/snapshot_job.py
+++ b/python_modules/dagster/dagster/_api/snapshot_job.py
@@ -4,7 +4,7 @@ import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
 from dagster._core.errors import DagsterUserCodeProcessError
-from dagster._core.remote_representation.external_data import ExternalJobSubsetResult
+from dagster._core.remote_representation.external_data import RemoteJobSubsetResult
 from dagster._core.remote_representation.origin import RemoteJobOrigin
 from dagster._grpc.types import JobSubsetSnapshotArgs
 from dagster._serdes import deserialize_value
@@ -20,7 +20,7 @@ def sync_get_external_job_subset_grpc(
     op_selection: Optional[Sequence[str]] = None,
     asset_selection: Optional[AbstractSet[AssetKey]] = None,
     asset_check_selection: Optional[AbstractSet[AssetCheckKey]] = None,
-) -> ExternalJobSubsetResult:
+) -> RemoteJobSubsetResult:
     from dagster._grpc.client import DagsterGrpcClient
 
     check.inst_param(api_client, "api_client", DagsterGrpcClient)
@@ -40,7 +40,7 @@ def sync_get_external_job_subset_grpc(
                 include_parent_snapshot=include_parent_snapshot,
             ),
         ),
-        ExternalJobSubsetResult,
+        RemoteJobSubsetResult,
     )
 
     if result.error:

--- a/python_modules/dagster/dagster/_core/remote_representation/__init__.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/__init__.py
@@ -17,7 +17,6 @@ from dagster._core.remote_representation.external import (
 from dagster._core.remote_representation.external_data import (
     ExecutionParamsErrorSnap as ExecutionParamsErrorSnap,
     ExecutionParamsSnap as ExecutionParamsSnap,
-    ExternalJobSubsetResult as ExternalJobSubsetResult,
     JobDataSnap as JobDataSnap,
     JobRefSnap as JobRefSnap,
     PartitionConfigSnap as PartitionConfigSnap,
@@ -27,6 +26,7 @@ from dagster._core.remote_representation.external_data import (
     PartitionSetSnap as PartitionSetSnap,
     PartitionTagsSnap as PartitionTagsSnap,
     PresetSnap as PresetSnap,
+    RemoteJobSubsetResult as RemoteJobSubsetResult,
     RepositoryErrorSnap as RepositoryErrorSnap,
     RepositorySnap as RepositorySnap,
     ScheduleExecutionErrorSnap as ScheduleExecutionErrorSnap,

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -409,13 +409,13 @@ class JobDataSnap:
 
 @whitelist_for_serdes(
     storage_name="ExternalPipelineSubsetResult",
-    storage_field_names={"external_job_data": "external_pipeline_data"},
+    storage_field_names={"job_data_snap": "external_pipeline_data"},
 )
 @record
-class ExternalJobSubsetResult:
+class RemoteJobSubsetResult:
     success: bool
     error: Optional[SerializableErrorInfo] = None
-    external_job_data: Optional[JobDataSnap] = None
+    job_data_snap: Optional[JobDataSnap] = None
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -42,17 +42,17 @@ from dagster._core.events import DagsterEvent, EngineEventData
 from dagster._core.execution.api import create_execution_plan, execute_run_iterator
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance.ref import InstanceRef
-from dagster._core.remote_representation import external_job_data_from_def
 from dagster._core.remote_representation.external_data import (
-    ExternalJobSubsetResult,
     PartitionConfigSnap,
     PartitionExecutionErrorSnap,
     PartitionExecutionParamSnap,
     PartitionNamesSnap,
     PartitionSetExecutionParamSnap,
     PartitionTagsSnap,
+    RemoteJobSubsetResult,
     ScheduleExecutionErrorSnap,
     SensorExecutionErrorSnap,
+    external_job_data_from_def,
     job_name_for_partition_set_snap_name,
 )
 from dagster._core.remote_representation.origin import CodeLocationOrigin
@@ -290,9 +290,9 @@ def get_external_pipeline_subset_result(
         job_data_snap = external_job_data_from_def(
             definition, include_parent_snapshot=include_parent_snapshot
         )
-        return ExternalJobSubsetResult(success=True, external_job_data=job_data_snap)
+        return RemoteJobSubsetResult(success=True, job_data_snap=job_data_snap)
     except Exception:
-        return ExternalJobSubsetResult(
+        return RemoteJobSubsetResult(
             success=False, error=serializable_error_info_from_exc_info(sys.exc_info())
         )
 

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -46,8 +46,8 @@ from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.libraries import DagsterLibraryRegistry
 from dagster._core.origin import DEFAULT_DAGSTER_ENTRY_POINT, get_python_environment_entry_point
 from dagster._core.remote_representation.external_data import (
-    ExternalJobSubsetResult,
     PartitionExecutionErrorSnap,
+    RemoteJobSubsetResult,
     RepositoryErrorSnap,
     RepositorySnap,
     ScheduleExecutionErrorSnap,
@@ -770,7 +770,7 @@ class DagsterApiServer(DagsterApiServicer):
         except Exception:
             _maybe_log_exception(self._logger, "JobSubset")
             serialized_external_pipeline_subset_result = serialize_value(
-                ExternalJobSubsetResult(
+                RemoteJobSubsetResult(
                     success=False, error=serializable_error_info_from_exc_info(sys.exc_info())
                 )
             )

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_job.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_job.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 from dagster._api.snapshot_job import sync_get_external_job_subset_grpc
 from dagster._core.errors import DagsterUserCodeProcessError
-from dagster._core.remote_representation.external_data import ExternalJobSubsetResult
+from dagster._core.remote_representation.external_data import RemoteJobSubsetResult
 from dagster._core.remote_representation.handle import JobHandle
 from dagster._grpc.types import JobSubsetSnapshotArgs
 from dagster._serdes import deserialize_value
@@ -27,9 +27,9 @@ def test_job_snapshot_api_grpc(instance):
         api_client = code_location.client
 
         external_job_subset_result = _test_job_subset_grpc(job_handle, api_client)
-        assert isinstance(external_job_subset_result, ExternalJobSubsetResult)
+        assert isinstance(external_job_subset_result, RemoteJobSubsetResult)
         assert external_job_subset_result.success is True
-        assert external_job_subset_result.external_job_data.name == "foo"
+        assert external_job_subset_result.job_data_snap.name == "foo"
 
 
 def test_job_snapshot_deserialize_error(instance):
@@ -47,7 +47,7 @@ def test_job_snapshot_deserialize_error(instance):
                 )._replace(job_origin="INVALID"),
             )
         )
-        assert isinstance(external_pipeline_subset_result, ExternalJobSubsetResult)
+        assert isinstance(external_pipeline_subset_result, RemoteJobSubsetResult)
         assert external_pipeline_subset_result.success is False
         assert external_pipeline_subset_result.error
 
@@ -58,11 +58,11 @@ def test_job_with_valid_subset_snapshot_api_grpc(instance):
         api_client = code_location.client
 
         external_job_subset_result = _test_job_subset_grpc(job_handle, api_client, ["do_something"])
-        assert isinstance(external_job_subset_result, ExternalJobSubsetResult)
+        assert isinstance(external_job_subset_result, RemoteJobSubsetResult)
         assert external_job_subset_result.success is True
-        assert external_job_subset_result.external_job_data.name == "foo"
+        assert external_job_subset_result.job_data_snap.name == "foo"
         assert (
-            external_job_subset_result.external_job_data.parent_job
+            external_job_subset_result.job_data_snap.parent_job
             == code_location.get_repository("bar_repo").get_full_job("foo").job_snapshot
         )
 
@@ -75,10 +75,10 @@ def test_job_with_valid_subset_snapshot_without_parent_snapshot(instance):
         external_job_subset_result = _test_job_subset_grpc(
             job_handle, api_client, ["do_something"], include_parent_snapshot=False
         )
-        assert isinstance(external_job_subset_result, ExternalJobSubsetResult)
+        assert isinstance(external_job_subset_result, RemoteJobSubsetResult)
         assert external_job_subset_result.success is True
-        assert external_job_subset_result.external_job_data.name == "foo"
-        assert not external_job_subset_result.external_job_data.parent_job
+        assert external_job_subset_result.job_data_snap.name == "foo"
+        assert not external_job_subset_result.job_data_snap.parent_job
 
 
 def test_job_with_invalid_subset_snapshot_api_grpc(instance):


### PR DESCRIPTION
Internal companion PR: https://github.com/dagster-io/internal/pull/12109

## Summary & Motivation

Serdes layer renames:

- `ExternalJobSubsetResult` -> `RemoteJobSubsetResult`
- `RemoteJobSubsetResult.external_job_data` -> `.job_data_snap`

## How I Tested These Changes

Existing test suite.