### PR TITLE
[ui][ez] Add definition metadata to TableSchemaAssetContext

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -175,7 +175,11 @@ export const SidebarAssetInfo = ({graphNode}: {graphNode: GraphNode}) => {
       {assetMetadata.length > 0 && (
         <SidebarSection title="Metadata">
           <TableSchemaAssetContext.Provider
-            value={{assetKey, materializationMetadataEntries: latestEvent?.metadataEntries}}
+            value={{
+              assetKey,
+              materializationMetadataEntries: latestEvent?.metadataEntries,
+              definitionMetadataEntries: assetMetadata,
+            }}
           >
             <AssetMetadataTable
               assetMetadata={assetMetadata}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -610,6 +610,7 @@ export const AssetNodeOverview = ({
                 value={{
                   assetKey: cachedOrLiveAssetNode.assetKey,
                   materializationMetadataEntries: materialization?.metadataEntries,
+                  definitionMetadataEntries: assetNode?.metadataEntries,
                 }}
               >
                 <TableSchema

--- a/js_modules/dagster-ui/packages/ui-core/src/metadata/TableSchema.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/metadata/TableSchema.tsx
@@ -63,9 +63,11 @@ export const isCanonicalUriEntry = (
 export const TableSchemaAssetContext = createContext<{
   assetKey: AssetKeyInput | undefined;
   materializationMetadataEntries: MetadataEntryLabelOnly[] | undefined;
+  definitionMetadataEntries: MetadataEntryLabelOnly[] | undefined;
 }>({
   assetKey: undefined,
   materializationMetadataEntries: undefined,
+  definitionMetadataEntries: undefined,
 });
 
 export const TableSchema = ({


### PR DESCRIPTION
## Summary

Adds definition metadata to the `TableSchemaAssetContext` so we can use definition-level column lineage.

## How I Tested These Changes

Tested locally.


