### PR TITLE
[ui] Render column tags in the metadata table

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -175,7 +175,11 @@ export const SidebarAssetInfo = ({graphNode}: {graphNode: GraphNode}) => {
       {assetMetadata.length > 0 && (
         <SidebarSection title="Metadata">
           <TableSchemaAssetContext.Provider
-            value={{assetKey, materializationMetadataEntries: latestEvent?.metadataEntries}}
+            value={{
+              assetKey,
+              materializationMetadataEntries: latestEvent?.metadataEntries,
+              definitionMetadataEntries: assetMetadata,
+            }}
           >
             <AssetMetadataTable
               assetMetadata={assetMetadata}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -610,6 +610,7 @@ export const AssetNodeOverview = ({
                 value={{
                   assetKey: cachedOrLiveAssetNode.assetKey,
                   materializationMetadataEntries: materialization?.metadataEntries,
+                  definitionMetadataEntries: assetNode?.metadataEntries,
                 }}
               >
                 <TableSchema

--- a/js_modules/dagster-ui/packages/ui-core/src/metadata/OverflowingTagCollection.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/metadata/OverflowingTagCollection.tsx
@@ -1,0 +1,137 @@
+import {
+  Button,
+  ButtonLink,
+  Colors,
+  Dialog,
+  DialogBody,
+  DialogFooter,
+  Tag,
+} from '@dagster-io/ui-components';
+import {useEffect, useRef, useState} from 'react';
+import styled from 'styled-components';
+
+import {DefinitionTag} from '../graphql/types';
+import {RunTags} from '../runs/RunTags';
+import {buildTagString} from '../ui/tagAsString';
+
+const SHOW_EXTRA_TAGS_WIDTH = 20;
+
+const getOverflowingTag = (target: HTMLDivElement | null) => {
+  if (!target || target.offsetWidth >= target.scrollWidth) {
+    return false;
+  }
+  // find the first tag that is overflowing
+  for (let i = 0; i < target.children.length; i++) {
+    const child = target.children[i];
+    if (
+      child &&
+      child?.getBoundingClientRect()?.right >
+        target.getBoundingClientRect().right - SHOW_EXTRA_TAGS_WIDTH
+    ) {
+      console.log(
+        child,
+        child?.getBoundingClientRect()?.right,
+        target.getBoundingClientRect().right,
+      );
+      return i;
+    }
+  }
+  return target.children.length;
+};
+
+type OverflowingTagCollectionProps = {
+  tags: DefinitionTag[];
+};
+
+export const OverflowingTagCollection = ({tags}: OverflowingTagCollectionProps) => {
+  const [showColumnTags, setShowColumnTags] = useState(false);
+  const [overflowing, setOverflowing] = useState<number | false>(false);
+  const container = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const tag = getOverflowingTag(container.current);
+    if (tag) {
+      setOverflowing(tag);
+    }
+  }, [overflowing]);
+
+  const tagsToRender = overflowing !== false ? tags.slice(0, overflowing) : tags;
+  const hiddenTagNumber = tags.length - tagsToRender.length;
+
+  const openColumnTagDialog = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setShowColumnTags(true);
+  };
+
+  return (
+    <div
+      ref={container}
+      style={{
+        display: 'flex',
+        gap: 4,
+        flexWrap: 'nowrap',
+        overflow: overflowing !== false ? 'visible' : 'hidden',
+        // backgroundColor: overflowing ? 'red' : 'blue',
+      }}
+      className="columnTags"
+    >
+      {tagsToRender.map((tag) => (
+        <Tag key={tag.key}>
+          <TagCollectionLabel
+            style={{
+              textOverflow: 'ellipsis',
+              overflowX: 'hidden',
+              maxWidth: overflowing !== false ? '70px' : undefined,
+              paddingRight: '20',
+              verticalAlign: 'top',
+              cursor: overflowing ? 'pointer' : 'default',
+            }}
+            onClick={overflowing ? openColumnTagDialog : undefined}
+          >
+            {buildTagString(tag)}
+          </TagCollectionLabel>
+        </Tag>
+      ))}
+      {overflowing !== false && (
+        <ButtonLink
+          color={Colors.textLight()}
+          style={{margin: '-4px', padding: '4px', cursor: 'pointer'}}
+          onClick={openColumnTagDialog}
+        >
+          <TagCollectionLabel className="hiddenTagNumber">+{hiddenTagNumber}</TagCollectionLabel>
+        </ButtonLink>
+      )}
+      <Dialog
+        isOpen={showColumnTags}
+        title="Tags"
+        canOutsideClickClose
+        canEscapeKeyClose
+        onClose={() => {
+          setShowColumnTags(false);
+        }}
+      >
+        <DialogBody>
+          <RunTags tags={tags} />
+        </DialogBody>
+        <DialogFooter topBorder>
+          <Button
+            intent="primary"
+            onClick={() => {
+              setShowColumnTags(false);
+            }}
+          >
+            Close
+          </Button>
+        </DialogFooter>
+      </Dialog>
+    </div>
+  );
+};
+
+// This is a p so that we can use it in the lineage view & have it nested in an anchor tag but not
+// have it underlined - only certain tag types can do this
+const TagCollectionLabel = styled.p`
+  margin: 0;
+  padding: 0;
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/metadata/TableSchema.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/metadata/TableSchema.tsx
@@ -63,9 +63,11 @@ export const isCanonicalUriEntry = (
 export const TableSchemaAssetContext = createContext<{
   assetKey: AssetKeyInput | undefined;
   materializationMetadataEntries: MetadataEntryLabelOnly[] | undefined;
+  definitionMetadataEntries: MetadataEntryLabelOnly[] | undefined;
 }>({
   assetKey: undefined,
   materializationMetadataEntries: undefined,
+  definitionMetadataEntries: undefined,
 });
 
 export const TableSchema = ({

--- a/js_modules/dagster-ui/packages/ui-core/src/metadata/TableSchema.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/metadata/TableSchema.tsx
@@ -13,6 +13,7 @@ import {Spacing} from '@dagster-io/ui-components/src/components/types';
 import {createContext, useContext, useState} from 'react';
 
 import {MetadataEntryLabelOnly} from './MetadataEntry';
+import {OverflowingTagCollection} from './OverflowingTagCollection';
 import {TableSchemaFragment} from './types/TableSchemaFragment.types';
 import {Timestamp} from '../app/time/Timestamp';
 import {StyledTableWithHeader} from '../assets/AssetEventMetadataEntriesTable';
@@ -121,7 +122,21 @@ export const TableSchema = ({
           {rows.map((column) => (
             <tr key={column.name}>
               <td>
-                <Mono>{column.name}</Mono>
+                <Box
+                  flex={{
+                    direction: 'row',
+                    gap: 8,
+                    alignItems: 'center',
+                    display: 'flex',
+                    wrap: 'wrap',
+                  }}
+                  style={{
+                    overflow: 'hidden',
+                  }}
+                >
+                  <Mono>{column.name}</Mono>
+                  <OverflowingTagCollection tags={column.tags} />
+                </Box>
               </td>
               <td>
                 <Box flex={{wrap: 'wrap', gap: 4, alignItems: 'center'}}>


### PR DESCRIPTION
## Summary

Renders column tags in the column info metadata table. Right now, sticks them next to the column name. If there are many tags, most will be hidden and can be expanded into a dialog.

<img width="995" alt="Screenshot 2024-10-10 at 11 27 14 AM" src="https://github.com/user-attachments/assets/ee550a0c-1b1b-4420-a960-1b76736b9b16">


## Test Plan

Tested locally.
