### PR TITLE
Store allow_backfills in the sensor metadata

### DIFF
--- a/integration_tests/test_suites/auto_materialize_perf_tests/test_asset_daemon_perf.py
+++ b/integration_tests/test_suites/auto_materialize_perf_tests/test_asset_daemon_perf.py
@@ -92,7 +92,7 @@ def test_auto_materialize_perf(scenario: PerfScenario):
             entity_keys=AssetSelection.all().resolve(asset_graph),
             instance=instance,
             asset_graph=asset_graph,
-            allow_backfills=False,
+            emit_backfills=False,
             cursor=AssetDaemonCursor.empty(),
         ).evaluate()
 

--- a/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
@@ -61,7 +61,7 @@ class AutomationTickEvaluationContext:
         auto_observe_asset_keys: AbstractSet[AssetKey],
         asset_selection: AssetSelection,
         logger: logging.Logger,
-        allow_backfills: bool,
+        emit_backfills: bool,
         default_condition: Optional[AutomationCondition] = None,
         evaluation_time: Optional[datetime.datetime] = None,
     ):
@@ -78,7 +78,7 @@ class AutomationTickEvaluationContext:
             default_condition=default_condition,
             instance=instance,
             asset_graph=asset_graph,
-            allow_backfills=allow_backfills,
+            emit_backfills=emit_backfills,
             cursor=cursor,
             evaluation_time=evaluation_time,
             logger=logger,
@@ -137,7 +137,7 @@ class AutomationTickEvaluationContext:
             entity_subsets=entity_subsets,
             asset_graph=self.asset_graph,
             run_tags=self._materialize_run_tags,
-            allow_backfills=self._evaluator.allow_backfills,
+            emit_backfills=self._evaluator.emit_backfills,
         )
 
     def _get_updated_cursor(
@@ -304,9 +304,9 @@ def build_run_requests(
     entity_subsets: Sequence[EntitySubset],
     asset_graph: BaseAssetGraph,
     run_tags: Optional[Mapping[str, str]],
-    allow_backfills: bool,
+    emit_backfills: bool,
 ) -> Sequence[RunRequest]:
-    if allow_backfills:
+    if emit_backfills:
         backfill_run_request, entity_subsets = _build_backfill_request(
             entity_subsets, asset_graph, run_tags
         )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -30,7 +30,7 @@ class AutomationConditionEvaluator:
         instance: DagsterInstance,
         asset_graph: BaseAssetGraph,
         cursor: AssetDaemonCursor,
-        allow_backfills: bool,
+        emit_backfills: bool,
         default_condition: Optional[AutomationCondition] = None,
         evaluation_time: Optional[datetime.datetime] = None,
         logger: logging.Logger = logging.getLogger("dagster.automation"),
@@ -59,7 +59,7 @@ class AutomationConditionEvaluator:
         self.legacy_respect_materialization_data_versions = (
             _instance.auto_materialize_respect_materialization_data_versions
         )
-        self.allow_backfills = allow_backfills or _instance.da_request_backfills()
+        self.emit_backfills = emit_backfills or _instance.da_request_backfills()
 
         self.legacy_expected_data_time_by_key: Dict[AssetKey, Optional[datetime.datetime]] = {}
         self.legacy_data_time_resolver = CachingDataTimeResolver(self.instance_queryer)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_tester.py
@@ -128,7 +128,7 @@ def evaluate_automation_conditions(
             if asset_graph.get(key).automation_condition is not None
         },
         evaluation_time=evaluation_time,
-        allow_backfills=False,
+        emit_backfills=False,
         logger=logging.getLogger("dagster.automation_condition_tester"),
         # round-trip the provided cursor to simulate actual usage
         cursor=deserialize_value(serialize_value(cursor), AssetDaemonCursor)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
@@ -69,7 +69,7 @@ class AutomationContext(Generic[T_EntityKey]):
         )
         condition_unqiue_id = condition.get_node_unique_id(parent_unique_id=None, index=None)
 
-        if condition.has_rule_condition and evaluator.allow_backfills:
+        if condition.has_rule_condition and evaluator.emit_backfills:
             raise DagsterInvalidDefinitionError(
                 "Cannot use AutoMaterializePolicies and request backfills. Please use AutomationCondition or set DECLARATIVE_AUTOMATION_REQUEST_BACKFILLS to False."
             )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_simple_non_user_code.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_simple_non_user_code.py
@@ -1,0 +1,17 @@
+import dagster as dg
+
+
+def get_defs() -> dg.Definitions:
+    from .backfill_simple_user_code import defs as uc_defs  # noqa
+
+    return dg.Definitions(
+        assets=uc_defs.assets,
+        sensors=[
+            dg.AutomationConditionSensorDefinition(
+                name="the_sensor", asset_selection="*", emit_backfills=True
+            )
+        ],
+    )
+
+
+defs = get_defs()

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_simple_user_code.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_simple_user_code.py
@@ -47,7 +47,7 @@ defs = dg.Definitions(
     assets=[A, B, C, D, E],
     sensors=[
         dg.AutomationConditionSensorDefinition(
-            "the_sensor", asset_selection="*", user_code=True, allow_backfills=True
+            "the_sensor", asset_selection="*", user_code=True, emit_backfills=True
         )
     ],
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_with_runs_and_checks.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_with_runs_and_checks.py
@@ -72,7 +72,7 @@ defs = dg.Definitions(
     asset_checks=[outsideA, outsideB, outside1, outside2],
     sensors=[
         dg.AutomationConditionSensorDefinition(
-            "the_sensor", asset_selection="*", user_code=True, allow_backfills=True
+            "the_sensor", asset_selection="*", user_code=True, emit_backfills=True
         )
     ],
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_e2e.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_e2e.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from typing import AbstractSet, Mapping, Sequence, cast
 
 import dagster._check as check
+import pytest
 from dagster import AssetMaterialization, RunsFilter, instance_for_test
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
@@ -418,9 +419,10 @@ def _get_subsets_by_key(
     return {s.key: s for s in target_subset.iterate_asset_subsets(asset_graph)}
 
 
-def test_backfill_creation_simple() -> None:
+@pytest.mark.parametrize("location", ["backfill_simple_user_code", "backfill_simple_non_user_code"])
+def test_backfill_creation_simple(location: str) -> None:
     with get_workspace_request_context(
-        ["backfill_simple"]
+        [location]
     ) as context, get_threadpool_executor() as executor:
         asset_graph = context.create_request_context().asset_graph
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/legacy_tests/test_auto_observe.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/legacy_tests/test_auto_observe.py
@@ -143,7 +143,7 @@ def test_reconcile() -> None:
         instance=instance,
         cursor=AssetDaemonCursor.empty(),
         materialize_run_tags={},
-        allow_backfills=False,
+        emit_backfills=False,
         observe_run_tags={"tag1": "tag_value"},
         logger=logging.getLogger("dagster.amp"),
     ).evaluate()

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
@@ -159,7 +159,7 @@ class AssetDaemonScenarioState(ScenarioState):
                 if self.asset_graph.get(key).auto_observe_interval_minutes is not None
             },
             logger=self.logger,
-            allow_backfills=False,
+            emit_backfills=False,
         ).evaluate()
         check.is_list(new_run_requests, of_type=RunRequest)
         check.inst(new_cursor, AssetDaemonCursor)

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
@@ -94,7 +94,7 @@ class AutomationConditionScenarioState(ScenarioState):
                     0, 0, [], [self.condition_cursor] if self.condition_cursor else []
                 ),
                 logger=self.logger,
-                allow_backfills=False,
+                emit_backfills=False,
             )
             evaluator.request_subsets_by_key = self._get_request_subsets_by_key(
                 evaluator.asset_graph_view

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/base_scenario.py
@@ -405,7 +405,7 @@ class AssetReconciliationScenario(
                     materialize_run_tags={},
                     observe_run_tags={},
                     cursor=cursor,
-                    allow_backfills=False,
+                    emit_backfills=False,
                     auto_observe_asset_keys={
                         key
                         for key in asset_graph.observable_asset_keys


### PR DESCRIPTION
## Summary & Motivation

This allows it to be transferred across the serdes boundary, enabling it for non-user code automation conditions

## How I Tested These Changes

## Changelog

NOCHANGELOG
