### PR TITLE
[1.9] Update default value of allow_backfills to True

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -93,7 +93,7 @@ class AutomationConditionSensorDefinition(SensorDefinition):
             the provided interval.
         description (Optional[str]): A human-readable description of the sensor.
         emit_backfills (bool): If set to True, will emit a backfill on any tick where more than one partition
-            of any single asset is requested, rather than individual runs. Defaults to False.
+            of any single asset is requested, rather than individual runs. Defaults to True.
     """
 
     def __init__(
@@ -107,7 +107,7 @@ class AutomationConditionSensorDefinition(SensorDefinition):
         minimum_interval_seconds: Optional[int] = None,
         description: Optional[str] = None,
         metadata: Optional[Mapping[str, object]] = None,
-        emit_backfills: bool = False,
+        emit_backfills: bool = True,
         **kwargs,
     ):
         self._user_code = kwargs.get("user_code", False)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
@@ -21,7 +21,6 @@ from dagster._core.definitions.declarative_automation.serialized_objects import 
     StructuredCursor,
 )
 from dagster._core.definitions.partition import PartitionsDefinition
-from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._time import get_current_datetime
 
 if TYPE_CHECKING:
@@ -68,11 +67,6 @@ class AutomationContext(Generic[T_EntityKey]):
             evaluator.asset_graph.get(key).automation_condition or evaluator.default_condition
         )
         condition_unqiue_id = condition.get_node_unique_id(parent_unique_id=None, index=None)
-
-        if condition.has_rule_condition and evaluator.emit_backfills:
-            raise DagsterInvalidDefinitionError(
-                "Cannot use AutoMaterializePolicies and request backfills. Please use AutomationCondition or set DECLARATIVE_AUTOMATION_REQUEST_BACKFILLS to False."
-            )
 
         return AutomationContext(
             condition=condition,

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_simple_non_user_code.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_simple_non_user_code.py
@@ -6,11 +6,7 @@ def get_defs() -> dg.Definitions:
 
     return dg.Definitions(
         assets=uc_defs.assets,
-        sensors=[
-            dg.AutomationConditionSensorDefinition(
-                name="the_sensor", asset_selection="*", emit_backfills=True
-            )
-        ],
+        sensors=[dg.AutomationConditionSensorDefinition(name="the_sensor", asset_selection="*")],
     )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_simple_user_code.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_simple_user_code.py
@@ -46,8 +46,6 @@ def E() -> None: ...
 defs = dg.Definitions(
     assets=[A, B, C, D, E],
     sensors=[
-        dg.AutomationConditionSensorDefinition(
-            "the_sensor", asset_selection="*", user_code=True, emit_backfills=True
-        )
+        dg.AutomationConditionSensorDefinition("the_sensor", asset_selection="*", user_code=True)
     ],
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_with_runs_and_checks.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_with_runs_and_checks.py
@@ -71,8 +71,6 @@ defs = dg.Definitions(
     assets=[backfillA, backfillB, backfillC, run1, run2],
     asset_checks=[outsideA, outsideB, outside1, outside2],
     sensors=[
-        dg.AutomationConditionSensorDefinition(
-            "the_sensor", asset_selection="*", user_code=True, emit_backfills=True
-        )
+        dg.AutomationConditionSensorDefinition("the_sensor", asset_selection="*", user_code=True)
     ],
 )


### PR DESCRIPTION
## Summary & Motivation

This updates the default value of this setting. To be merged in 1.9.

## How I Tested These Changes

## Changelog

By default, `AutomationConditionSensorDefinitions` will now emit backfills to handle cases where more than one partition of an asset is requested on a given tick. This allows that asset's BackfillPolicy to be respected. This feature can be disabled by setting `allow_backfills` to `False`.
