### PR TITLE
[dagster-airlift] Make proxy operator pluggable

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/__init__.py
@@ -1,3 +1,6 @@
 from .base_asset_operator import BaseDagsterAssetsOperator as BaseDagsterAssetsOperator
 from .proxying_fn import proxying_to_dagster as proxying_to_dagster
-from .task_proxy_operator import BaseProxyTaskToDagsterOperator as BaseProxyTaskToDagsterOperator
+from .task_proxy_operator import (
+    BaseProxyTaskToDagsterOperator as BaseProxyTaskToDagsterOperator,
+    DefaultProxyTaskToDagsterOperator as DefaultProxyTaskToDagsterOperator,
+)

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/task_proxy_operator.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/task_proxy_operator.py
@@ -23,6 +23,10 @@ class BaseProxyTaskToDagsterOperator(BaseDagsterAssetsOperator):
             ):
                 yield asset_node
 
+    @classmethod
+    def build_from_task(cls, task: BaseOperator) -> "BaseProxyTaskToDagsterOperator":
+        return build_dagster_task(task, cls)
+
 
 class DefaultProxyTaskToDagsterOperator(BaseProxyTaskToDagsterOperator):
     """The default task proxying operator - which opens a blank session and expects the dagster URL to be set in the environment.
@@ -37,13 +41,15 @@ class DefaultProxyTaskToDagsterOperator(BaseProxyTaskToDagsterOperator):
 
 
 def build_dagster_task(
-    original_task: BaseOperator, dagster_operator_klass: Type[BaseProxyTaskToDagsterOperator]
+    original_task: BaseOperator,
+    dagster_operator_klass: Type[BaseProxyTaskToDagsterOperator],
 ) -> BaseProxyTaskToDagsterOperator:
     return instantiate_dagster_operator(original_task, dagster_operator_klass)
 
 
 def instantiate_dagster_operator(
-    original_task: BaseOperator, dagster_operator_klass: Type[BaseProxyTaskToDagsterOperator]
+    original_task: BaseOperator,
+    dagster_operator_klass: Type[BaseProxyTaskToDagsterOperator],
 ) -> BaseProxyTaskToDagsterOperator:
     """Instantiates a DagsterOperator as a copy of the provided airflow task.
 
@@ -84,6 +90,8 @@ def instantiate_dagster_operator(
         if kwarg in ignore_args or getattr(original_task, kwarg, None) is None:
             continue
         init_kwargs[kwarg] = getattr(original_task, kwarg, default)
+
+    # Make sure that the operator overrides take precedence.
 
     return dagster_operator_klass(**init_kwargs)
 

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/custom_callback.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/custom_callback.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+from pathlib import Path
+
+from airflow import DAG
+from airflow.models import BaseOperator
+from airflow.operators.python import PythonOperator
+from dagster_airlift.in_airflow import DefaultProxyTaskToDagsterOperator, proxying_to_dagster
+from dagster_airlift.in_airflow.proxied_state import load_proxied_state_from_yaml
+from dagster_airlift.in_airflow.task_proxy_operator import (
+    BaseProxyTaskToDagsterOperator,
+    build_dagster_task,
+)
+
+
+def print_hello() -> None:
+    print("Hello")  # noqa: T201
+
+
+def build_print_task(task_id: str) -> PythonOperator:
+    return PythonOperator(task_id=task_id, python_callable=print_hello, doc_md="Original doc")
+
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2023, 1, 1),
+    "retries": 0,
+}
+
+
+with DAG(
+    "affected_dag",
+    default_args=default_args,
+    schedule_interval=None,
+    is_paused_upon_creation=False,
+) as affected_dag:
+    build_print_task("print_task") >> build_print_task("downstream_print_task")  # type: ignore
+
+with DAG(
+    "unaffected_dag",
+    default_args=default_args,
+    schedule_interval=None,
+    is_paused_upon_creation=False,
+) as unaffected_dag:
+    build_print_task("print_task") >> build_print_task("downstream_print_task")  # type: ignore
+
+
+class CustomProxyTaskToDagsterOperator(DefaultProxyTaskToDagsterOperator):
+    @classmethod
+    def build_from_task(cls, original_task: BaseOperator) -> BaseProxyTaskToDagsterOperator:
+        """A custom callback to construct a new operator for the given task. In our case, we add retries to the affected_dag."""
+        new_task = build_dagster_task(original_task, DefaultProxyTaskToDagsterOperator)
+        if original_task.dag_id == "affected_dag":
+            assert original_task.start_date
+            new_task.retries = 1
+        return new_task
+
+
+proxying_to_dagster(
+    proxied_state=load_proxied_state_from_yaml(Path(__file__).parent / "proxied_state"),
+    global_vars=globals(),
+    build_from_task_fn=CustomProxyTaskToDagsterOperator.build_from_task,
+)

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/proxied_state/affected_dag.yaml
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/proxied_state/affected_dag.yaml
@@ -1,0 +1,5 @@
+tasks:
+  - id: print_task
+    proxied: True
+  - id: downstream_print_task
+    proxied: True

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/proxied_state/unaffected_dag.yaml
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/proxied_state/unaffected_dag.yaml
@@ -1,0 +1,5 @@
+tasks:
+  - id: print_task
+    proxied: True
+  - id: downstream_print_task
+    proxied: True

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/dagster_defs/mapped_defs.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/dagster_defs/mapped_defs.py
@@ -1,4 +1,5 @@
 from dagster import Definitions, asset
+from dagster._core.definitions.assets import AssetsDefinition
 from dagster_airlift.core import (
     assets_with_dag_mappings,
     build_defs_from_airflow_instance,
@@ -10,15 +11,13 @@ from dagster_airlift.core.multiple_tasks import targeted_by_multiple_tasks
 from .airflow_instance import local_airflow_instance
 
 
-@asset
-def print_asset() -> None:
-    # ruff: noqa: T201
-    print("Hello, world!")
+def make_print_asset(key: str) -> AssetsDefinition:
+    @asset(key=key)
+    def print_asset() -> None:
+        # ruff: noqa: T201
+        print("Hello, world!")
 
-
-@asset
-def another_print_asset() -> None:
-    print("Hello, world!")
+    return print_asset
 
 
 @asset(description="Asset one is materialized by multiple airflow tasks")
@@ -38,8 +37,11 @@ def build_mapped_defs() -> Definitions:
         defs=Definitions.merge(
             dag_defs(
                 "print_dag",
-                task_defs("print_task", Definitions(assets=[print_asset])),
-                task_defs("downstream_print_task", Definitions(assets=[another_print_asset])),
+                task_defs("print_task", Definitions(assets=[make_print_asset("print_asset")])),
+                task_defs(
+                    "downstream_print_task",
+                    Definitions(assets=[make_print_asset("another_print_asset")]),
+                ),
             ),
             targeted_by_multiple_tasks(
                 Definitions([asset_one]),
@@ -49,6 +51,28 @@ def build_mapped_defs() -> Definitions:
                 ],
             ),
             Definitions(assets=assets_with_dag_mappings({"overridden_dag": [asset_two]})),
+            dag_defs(
+                "affected_dag",
+                task_defs(
+                    "print_task",
+                    Definitions(assets=[make_print_asset("affected_dag__print_asset")]),
+                ),
+                task_defs(
+                    "downstream_print_task",
+                    Definitions(assets=[make_print_asset("affected_dag__another_print_asset")]),
+                ),
+            ),
+            dag_defs(
+                "unaffected_dag",
+                task_defs(
+                    "print_task",
+                    Definitions(assets=[make_print_asset("unaffected_dag__print_asset")]),
+                ),
+                task_defs(
+                    "downstream_print_task",
+                    Definitions(assets=[make_print_asset("unaffected_dag__another_print_asset")]),
+                ),
+            ),
         ),
     )
 

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/README.md
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/README.md
@@ -340,11 +340,14 @@ from pathlib import Path
 import requests
 from airflow import DAG
 from airflow.utils.context import Context
-from dagster_airlift.in_airflow import BaseProxyToDagsterOperator, proxying_to_dagster
-from dagster_airlift.proxied_state import load_proxied_state_from_yaml
+from dagster_airlift.in_airflow import (
+    BaseProxyTaskToDagsterOperator,
+    proxying_to_dagster,
+)
+from dagster_airlift.in_airflow.proxied_state import load_proxied_state_from_yaml
 
 
-class CustomProxyToDagsterOperator(BaseProxyToDagsterOperator):
+class CustomProxyToDagsterOperator(BaseProxyTaskToDagsterOperator):
     def get_dagster_session(self, context: Context) -> requests.Session:
         if "var" not in context:
             raise ValueError("No variables found in context")
@@ -365,8 +368,9 @@ dag = DAG(
 proxying_to_dagster(
     global_vars=globals(),
     proxied_state=load_proxied_state_from_yaml(Path(__file__).parent / "proxied_state"),
-    dagster_operator_klass=CustomProxyToDagsterOperator,
+    build_from_task_fn=CustomProxyToDagsterOperator.build_from_task,
 )
+
 ```
 
 #### Dagster Plus Authorization

--- a/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/custom_operator_examples/custom_proxy.py
+++ b/examples/experimental/dagster-airlift/examples/tutorial-example/tutorial_example/custom_operator_examples/custom_proxy.py
@@ -28,5 +28,5 @@ dag = DAG(
 proxying_to_dagster(
     global_vars=globals(),
     proxied_state=load_proxied_state_from_yaml(Path(__file__).parent / "proxied_state"),
-    dagster_operator_klass=CustomProxyToDagsterOperator,
+    build_from_task_fn=CustomProxyToDagsterOperator.build_from_task,
 )


### PR DESCRIPTION
## Summary & Motivation
It's highly likely that the default magic we perform to "swizzle in" the dagster operator will fail for some cases. We need to have fallbacks for edge cases and weirdness with forked versions of airflow, weird parameters, etc.

This introduces a few different pluggability points:
- Top-level callback to the `proxying_to_dagster` fxn which allows for complete control of the creation of the new operator.
- Make the default `build_dagster_task` pluggable by allowing for parameter level overrides, and the class to be instantiated to be overridden. This should account for the common cases.

## How I Tested These Changes
Added a new kitchen sink test which invokes both layers of pluggability.
## Changelog
NOCHANGELOG
