### PR TITLE
[1.9] Promote hidden params to top-level args in AutomationConditionSensorDefinition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -94,6 +94,14 @@ class AutomationConditionSensorDefinition(SensorDefinition):
         description (Optional[str]): A human-readable description of the sensor.
         emit_backfills (bool): If set to True, will emit a backfill on any tick where more than one partition
             of any single asset is requested, rather than individual runs. Defaults to True.
+        use_user_code_server (bool): (experimental) If set to True, this sensor will be evaluated in the user
+            code server, rather than the AssetDaemon. This enables evaluating custom AutomationCondition
+            subclasses, and ensures that the condition definitions will remain in sync with your user code
+            version, eliminating version skew. Note: currently a maximum of 500 assets or checks may be
+            targeted at a time by a sensor that has this value set.
+        default_condition (Optional[AutomationCondition]): (experimental) If provided, this condition will
+            be used for any selected assets or asset checks which do not have an automation condition defined.
+            Requires `use_user_code_server` to be set to `True`.
     """
 
     def __init__(
@@ -108,16 +116,17 @@ class AutomationConditionSensorDefinition(SensorDefinition):
         description: Optional[str] = None,
         metadata: Optional[Mapping[str, object]] = None,
         emit_backfills: bool = True,
-        **kwargs,
+        use_user_code_server: bool = False,
+        default_condition: Optional[AutomationCondition] = None,
     ):
-        self._user_code = kwargs.get("user_code", False)
-        check.bool_param(emit_backfills, "emit_backfills")
+        self._use_user_code_server = use_user_code_server
+        check.bool_param(emit_backfills, "allow_backfills")
 
         self._default_condition = check.opt_inst_param(
-            kwargs.get("default_condition"), "default_condition", AutomationCondition
+            default_condition, "default_condition", AutomationCondition
         )
         check.param_invariant(
-            not (self._default_condition and not self._user_code),
+            not (self._default_condition and not self._use_user_code_server),
             "default_condition",
             "Setting a `default_condition` for a non-user-code AutomationConditionSensorDefinition is not supported.",
         )
@@ -131,7 +140,7 @@ class AutomationConditionSensorDefinition(SensorDefinition):
         super().__init__(
             name=check_valid_name(name),
             job_name=None,
-            evaluation_fn=partial(_evaluate, self) if self._user_code else not_supported,
+            evaluation_fn=partial(_evaluate, self) if self._use_user_code_server else not_supported,
             minimum_interval_seconds=minimum_interval_seconds,
             description=description,
             job=None,
@@ -161,4 +170,4 @@ class AutomationConditionSensorDefinition(SensorDefinition):
 
     @property
     def sensor_type(self) -> SensorType:
-        return SensorType.AUTOMATION if self._user_code else SensorType.AUTO_MATERIALIZE
+        return SensorType.AUTOMATION if self._use_user_code_server else SensorType.AUTO_MATERIALIZE

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/500_eager_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/500_eager_assets.py
@@ -27,7 +27,9 @@ def get_defs(n: int) -> Definitions:
     return Definitions(
         assets=assets,
         sensors=[
-            AutomationConditionSensorDefinition("the_sensor", asset_selection="*", user_code=True)
+            AutomationConditionSensorDefinition(
+                "the_sensor", asset_selection="*", use_user_code_server=True
+            )
         ],
     )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_simple_user_code.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_simple_user_code.py
@@ -46,6 +46,8 @@ def E() -> None: ...
 defs = dg.Definitions(
     assets=[A, B, C, D, E],
     sensors=[
-        dg.AutomationConditionSensorDefinition("the_sensor", asset_selection="*", user_code=True)
+        dg.AutomationConditionSensorDefinition(
+            "the_sensor", asset_selection="*", use_user_code_server=True
+        )
     ],
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_with_runs_and_checks.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_with_runs_and_checks.py
@@ -71,6 +71,8 @@ defs = dg.Definitions(
     assets=[backfillA, backfillB, backfillC, run1, run2],
     asset_checks=[outsideA, outsideB, outside1, outside2],
     sensors=[
-        dg.AutomationConditionSensorDefinition("the_sensor", asset_selection="*", user_code=True)
+        dg.AutomationConditionSensorDefinition(
+            "the_sensor", asset_selection="*", use_user_code_server=True
+        )
     ],
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/custom_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/custom_condition.py
@@ -21,6 +21,8 @@ def foo() -> None: ...
 defs = dg.Definitions(
     assets=[foo],
     sensors=[
-        dg.AutomationConditionSensorDefinition("the_sensor", asset_selection="*", user_code=True)
+        dg.AutomationConditionSensorDefinition(
+            "the_sensor", asset_selection="*", use_user_code_server=True
+        )
     ],
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/default_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/default_condition.py
@@ -16,7 +16,7 @@ defs = dg.Definitions(
             name="all_assets",
             asset_selection=dg.AssetSelection.all(),
             default_condition=dg.AutomationCondition.cron_tick_passed("*/5 * * * *"),
-            user_code=True,
+            use_user_code_server=True,
         )
     ],
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/simple_non_user_code.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/simple_non_user_code.py
@@ -8,7 +8,7 @@ def get_defs() -> dg.Definitions:
         assets=simple_defs.assets,
         sensors=[
             dg.AutomationConditionSensorDefinition(
-                name="the_sensor", asset_selection="*", user_code=False
+                name="the_sensor", asset_selection="*", use_user_code_server=False
             )
         ],
     )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/simple_user_code.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/simple_user_code.py
@@ -8,7 +8,7 @@ def get_defs() -> dg.Definitions:
         assets=simple_defs.assets,
         sensors=[
             dg.AutomationConditionSensorDefinition(
-                name="the_sensor", asset_selection="*", user_code=True
+                name="the_sensor", asset_selection="*", use_user_code_server=True
             )
         ],
     )

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_automation_condition_sensor_definition.py
@@ -26,7 +26,7 @@ def test_constructor(selection: AssetSelection, user_code: bool) -> None:
         description="fdsjkl",
         default_status=DefaultSensorStatus.RUNNING,
         minimum_interval_seconds=50,
-        user_code=user_code,
+        use_user_code_server=user_code,
     )
     assert automation_sensor.name == "foo"
     assert automation_sensor.run_tags == tags
@@ -50,13 +50,18 @@ def test_default_condition() -> None:
         )
 
     sensor = AutomationConditionSensorDefinition(
-        "foo", asset_selection="*", default_condition=AutomationCondition.eager(), user_code=True
+        "foo",
+        asset_selection="*",
+        default_condition=AutomationCondition.eager(),
+        use_user_code_server=True,
     )
     assert sensor.default_condition == AutomationCondition.eager()
 
 
 def test_limits() -> None:
-    sensor = AutomationConditionSensorDefinition("foo", asset_selection="*", user_code=True)
+    sensor = AutomationConditionSensorDefinition(
+        "foo", asset_selection="*", use_user_code_server=True
+    )
 
     defs = Definitions(
         assets=build_assets(


### PR DESCRIPTION
## Summary & Motivation

As title -- these should be documented and visible to users.

Open to suggestions on `use_user_code_server` as a name.

## How I Tested These Changes

## Changelog

Added a new `use_user_code_server` paramter to `AutomationConditionSensorDefinition`. If set, the sensor will be evaluated in the user code server (as traditional sensors are), allowing custom `AutomationCondition` subclasses to be evaluated. To learn more, view the docs [TODO].

Added a new `default_condition` parameter to `AutomationConditionSensorDefinition`. If set, this condition will be used for any assets or asset checks within the selection that do not have an automation condition defined. Requires `use_user_code_server` to be set.
