### PR TITLE
[1.9] Update deprecation warnings for automation_condition, auto_materialize_policy, and freshness_policy

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_spec.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_spec.py
@@ -13,7 +13,7 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster._annotations import PublicAttr, experimental_param, public
+from dagster._annotations import PublicAttr, deprecated_param, experimental_param, public
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
@@ -88,6 +88,11 @@ def validate_kind_tags(kinds: Optional[AbstractSet[str]]) -> None:
 @experimental_param(param="owners")
 @experimental_param(param="tags")
 @experimental_param(param="kinds")
+@deprecated_param(
+    param="freshness_policy",
+    breaking_version="1.10.0",
+    additional_warn_text="use freshness checks instead.",
+)
 class AssetSpec(
     NamedTuple(
         "_AssetSpec",

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_policy.py
@@ -196,7 +196,7 @@ class AutoMaterializePolicy(
     @public
     @staticmethod
     @deprecated(
-        breaking_version="1.9",
+        breaking_version="1.10.0",
         additional_warn_text="Use `AutomationCondition.eager()` instead.",
     )
     def eager(max_materializations_per_minute: Optional[int] = 1) -> "AutoMaterializePolicy":
@@ -228,7 +228,7 @@ class AutoMaterializePolicy(
     @public
     @staticmethod
     @deprecated(
-        breaking_version="1.9",
+        breaking_version="1.10.0",
         additional_warn_text="Use `AutomationCondition.any_downstream_conditions()` instead.",
     )
     def lazy(max_materializations_per_minute: Optional[int] = 1) -> "AutoMaterializePolicy":

--- a/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
+++ b/python_modules/dagster/dagster/_core/definitions/auto_materialize_rule_impls.py
@@ -14,7 +14,7 @@ from typing import (
     Set,
 )
 
-from dagster._annotations import deprecated, experimental
+from dagster._annotations import experimental
 from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
 from dagster._core.definitions.auto_materialize_rule import AutoMaterializeRule
 from dagster._core.definitions.auto_materialize_rule_evaluation import (
@@ -52,7 +52,6 @@ if TYPE_CHECKING:
     )
 
 
-@deprecated(breaking_version="1.9")
 @whitelist_for_serdes
 class MaterializeOnRequiredForFreshnessRule(
     AutoMaterializeRule, NamedTuple("_MaterializeOnRequiredForFreshnessRule", [])

--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -134,7 +134,6 @@ def _validate_hidden_non_argument_dep_param(
 
 @experimental_param(param="resource_defs")
 @experimental_param(param="io_manager_def")
-@experimental_param(param="automation_condition")
 @experimental_param(param="backfill_policy")
 @experimental_param(param="owners")
 @experimental_param(param="tags")
@@ -146,8 +145,13 @@ def _validate_hidden_non_argument_dep_param(
 )
 @deprecated_param(
     param="auto_materialize_policy",
-    breaking_version="1.9.0",
+    breaking_version="1.10.0",
     additional_warn_text="use `automation_condition` instead.",
+)
+@deprecated_param(
+    param="freshness_policy",
+    breaking_version="1.10.0",
+    additional_warn_text="use freshness checks instead.",
 )
 def asset(
     compute_fn: Optional[Callable[..., Any]] = None,

--- a/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
+++ b/python_modules/dagster/dagster/_core/definitions/freshness_policy.py
@@ -22,7 +22,7 @@ class FreshnessMinutes(NamedTuple):
 
 
 @deprecated(
-    breaking_version="1.9",
+    breaking_version="1.10.0",
     additional_warn_text="For monitoring freshness, use freshness checks instead. If using lazy "
     "auto-materialize, use AutomationCondition.cron() and AutomationCondition.any_downstream_conditions().",
 )


### PR DESCRIPTION
## Summary & Motivation

As title. We're bumping back one more release on these deprecations to give a full release worth of non-experimental AutomationConditions before forcing a migration.

As a note, the FreshnessPolicy object was always marked as deprecated, so it was not possible to use the freshness_policy params without getting a deprecation warning. However, I added those warnings to be extra explicit.

## How I Tested These Changes

## Changelog

NOCHANGELOG
