### PR TITLE
[dagster-airlift] add changelog tooling + changelog section for 0.0.26

### DIFF
--- a/examples/experimental/dagster-airlift/CHANGES.md
+++ b/examples/experimental/dagster-airlift/CHANGES.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.0.26
+
+### New
+
+- Add python 3.8 support
+- `BaseMaterializeAssetsOperator` for kicking off execution of a discrete set of Dagster assets from Airflow.
+
+## 0.0.25
+
+### Breaking Changes
+
+- `dagster-airlift[core,mwaa,dbt]` is now pinned on Dagster >= 1.8.10.
+
 ## 0.0.24
 
 ### New

--- a/examples/experimental/dagster-airlift/Makefile
+++ b/examples/experimental/dagster-airlift/Makefile
@@ -33,3 +33,8 @@ adhoc_release:
 	echo "Airlift release branch created. Please create a PR and merge it to master."
 	@echo "Returning to master branch..."
 	@git checkout master
+
+find_airlift_commits:
+	@echo "Finding commits for dagster-airlift..."
+	@chmod +x scripts/find_airlift_commits.sh
+	@./scripts/find_airlift_commits.sh

--- a/examples/experimental/dagster-airlift/scripts/find_airlift_commits.sh
+++ b/examples/experimental/dagster-airlift/scripts/find_airlift_commits.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Function to decrement version number
+decrement_version() {
+    echo "$1" | awk -F. '{
+        if ($3 > 0) $3--;
+        else if ($2 > 0) {$2--; $3=99;}
+        else if ($1 > 0) {$1--; $2=99; $3=99;}
+        print $1"."$2"."$3
+    }'
+}
+
+# Get the current version
+current_version=$(./scripts/extract_pypi_version.sh)
+
+# Decrement the version
+previous_version=$(decrement_version "$current_version")
+
+# Get the upper hash
+upper_hash=$(git log --format="%h" --grep="\[dagster-airlift\] $current_version" | head -n 1)
+
+# Get the lower hash
+lower_hash=$(git log --format="%h" --grep="\[dagster-airlift\] $previous_version" | head -n 1)
+
+# If either hash is empty, exit with an error
+if [ -z "$upper_hash" ] || [ -z "$lower_hash" ]; then
+    echo "Error: Could not find one or both version commits."
+    exit 1
+fi
+
+# Find commits, format them, print to stdout, and copy to clipboard
+git log --format="- %s" ${lower_hash}..${upper_hash}^ | 
+    grep -E "\[dagster-airlift\]" | 
+    sed -E 's/\[(dagster-airlift)\]//g' | 
+    sed -E 's/ \(#[0-9]+\)//g' |
+    sed -E 's/^- ([a-f0-9]+) /- \1 /' |
+    tee >(pbcopy)
+
+# Inform the user that the list has been copied to the clipboard
+echo -e "\nCommit list has been copied to the clipboard."


### PR DESCRIPTION
## Summary & Motivation
Adds tooling to pull all [dagster-airlift] prefixed commits between the last two changelog versions, pastes it to the clipboard.
## How I Tested These Changes
Tested the new fxnality to write the 0.0.26 entry 😄 
## Changelog
NOCHANGELOG (ironic)