### PR TITLE
Add error for user code sensors with too many entities targeted

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_tick_evaluation_context.py
@@ -72,6 +72,7 @@ class AutomationTickEvaluationContext:
             )
             if default_condition or asset_graph.get(entity_key).automation_condition is not None
         }
+        self._total_keys = len(resolved_entity_keys)
         self._evaluation_id = evaluation_id
         self._evaluator = AutomationConditionEvaluator(
             entity_keys=resolved_entity_keys,
@@ -94,6 +95,10 @@ class AutomationTickEvaluationContext:
     @property
     def asset_graph(self) -> BaseAssetGraph:
         return self._evaluator.asset_graph
+
+    @property
+    def total_keys(self) -> int:
+        return self._total_keys
 
     def _legacy_build_auto_observe_run_requests(self) -> Sequence[RunRequest]:
         current_timestamp = self._evaluator.evaluation_time.timestamp()

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition.py
@@ -161,7 +161,8 @@ class AutomationCondition(ABC, Generic[T_EntityKey]):
         """Returns an AutoMaterializePolicy which contains this condition."""
         from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 
-        return AutoMaterializePolicy.from_automation_condition(self)
+        with disable_dagster_warnings():
+            return AutoMaterializePolicy.from_automation_condition(self)
 
     @abstractmethod
     def evaluate(


### PR DESCRIPTION
## Summary & Motivation

Building off of the previous PR, now we emit a helpful error message rather than just letting users run into the RESOURCE_EXHAUSTED error.

## How I Tested These Changes

