### PR TITLE
Add `code_version` parameter to `@graph_asset` decorator

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -221,7 +221,7 @@ def asset(
         backfill_policy (BackfillPolicy): (Experimental) Configure Dagster to backfill this asset according to its
             BackfillPolicy.
         retry_policy (Optional[RetryPolicy]): The retry policy for the op that computes the asset.
-        code_version (Optional[str]): (Experimental) Version of the code that generates this asset. In
+        code_version (Optional[str]): Version of the code that generates this asset. In
             general, versions should be set only for code that deterministically produces the same
             output when given the same inputs.
         check_specs (Optional[Sequence[AssetCheckSpec]]): (Experimental) Specs for asset checks that
@@ -574,7 +574,7 @@ def multi_asset(
         group_name (Optional[str]): A string name used to organize multiple assets into groups. This
             group name will be applied to all assets produced by this multi_asset.
         retry_policy (Optional[RetryPolicy]): The retry policy for the op that computes the asset.
-        code_version (Optional[str]): (Experimental) Version of the code encapsulated by the multi-asset. If set,
+        code_version (Optional[str]): Version of the code encapsulated by the multi-asset. If set,
             this is used as a default code version for all defined assets.
         specs (Optional[Sequence[AssetSpec]]): (Experimental) The specifications for the assets materialized
             by this function.
@@ -691,6 +691,7 @@ def graph_asset(
     backfill_policy: Optional[BackfillPolicy] = ...,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = ...,
     check_specs: Optional[Sequence[AssetCheckSpec]] = None,
+    code_version: Optional[str] = None,
     key: Optional[CoercibleToAssetKey] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]: ...
 
@@ -717,6 +718,7 @@ def graph_asset(
     backfill_policy: Optional[BackfillPolicy] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     check_specs: Optional[Sequence[AssetCheckSpec]] = None,
+    code_version: Optional[str] = None,
     key: Optional[CoercibleToAssetKey] = None,
 ) -> Union[AssetsDefinition, Callable[[Callable[..., Any]], AssetsDefinition]]:
     """Creates a software-defined asset that's computed using a graph of ops.
@@ -766,6 +768,9 @@ def graph_asset(
         automation_condition (Optional[AutomationCondition]): The AutomationCondition to use
             for this asset.
         backfill_policy (Optional[BackfillPolicy]): The BackfillPolicy to use for this asset.
+        code_version (Optional[str]): Version of the code that generates this asset. In
+            general, versions should be set only for code that deterministically produces the same
+            output when given the same inputs.
         key (Optional[CoeercibleToAssetKey]): The key for this asset. If provided, cannot specify key_prefix or name.
 
     Examples:
@@ -803,6 +808,7 @@ def graph_asset(
             backfill_policy=backfill_policy,
             resource_defs=resource_defs,
             check_specs=check_specs,
+            code_version=code_version,
             key=key,
         )
     else:
@@ -825,6 +831,7 @@ def graph_asset(
             backfill_policy=backfill_policy,
             resource_defs=resource_defs,
             check_specs=check_specs,
+            code_version=code_version,
             key=key,
         )
 
@@ -847,6 +854,7 @@ def graph_asset_no_defaults(
     backfill_policy: Optional[BackfillPolicy],
     resource_defs: Optional[Mapping[str, ResourceDefinition]],
     check_specs: Optional[Sequence[AssetCheckSpec]],
+    code_version: Optional[str],
     key: Optional[CoercibleToAssetKey],
 ) -> AssetsDefinition:
     ins = ins or {}
@@ -905,6 +913,7 @@ def graph_asset_no_defaults(
         resource_defs=resource_defs,
         check_specs=check_specs,
         owners_by_output_name={"result": owners} if owners else None,
+        code_versions_by_output_name={"result": code_version} if code_version else None,
     )
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -942,6 +942,7 @@ def test_graph_asset_with_args(automation_condition_arg):
         resource_defs={"foo": foo_resource},
         tags={"foo": "bar"},
         owners=["team:team1", "claire@dagsterlabs.com"],
+        code_version="v1",
         **automation_condition_arg,
     )
     def my_asset(x):
@@ -961,6 +962,7 @@ def test_graph_asset_with_args(automation_condition_arg):
         my_asset.automation_conditions_by_key[AssetKey("my_asset")] == AutomationCondition.eager()
     )
     assert my_asset.resource_defs["foo"] == foo_resource
+    assert my_asset.code_versions_by_key[AssetKey("my_asset")] == "v1"
 
 
 def test_graph_asset_partitioned():


### PR DESCRIPTION
## Summary & Motivation

This adds the `code_version` parameter to the `graph_asset` decorator and passes it to `AssetsDefinition.from_graph()`. Also removes the `(Experimental)` qualifier in the docstring of the `asset` decorator since it is no longer marked as experimental. Closes https://github.com/dagster-io/dagster/issues/20902

## How I Tested These Changes

Added to existing unit test

## Changelog

Added `code_version` parameter to the `@graph_asset` decorator
