### PR TITLE
[external-renames] Misc `external_*` local variables/params/methods

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/backfill.py
@@ -146,7 +146,7 @@ def create_and_launch_partition_backfill(
         remote_partition_set = next(iter(matches))
 
         if backfill_params.get("allPartitions"):
-            result = graphene_info.context.get_external_partition_names(
+            result = graphene_info.context.get_partition_names(
                 repository_handle=repository.handle,
                 job_name=remote_partition_set.job_name,
                 instance=graphene_info.context.instance,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/external.py
@@ -92,15 +92,15 @@ def ensure_valid_config(remote_job: RemoteJob, run_config: object) -> object:
     return validated_config
 
 
-def get_external_execution_plan_or_raise(
+def get_remote_execution_plan_or_raise(
     graphql_context: BaseWorkspaceRequestContext,
-    external_pipeline: RemoteJob,
+    remote_job: RemoteJob,
     run_config: Mapping[str, object],
     step_keys_to_execute: Optional[Sequence[str]],
     known_state: Optional[KnownExecutionState],
 ) -> RemoteExecutionPlan:
-    return graphql_context.get_external_execution_plan(
-        remote_job=external_pipeline,
+    return graphql_context.get_execution_plan(
+        remote_job=remote_job,
         run_config=run_config,
         step_keys_to_execute=step_keys_to_execute,
         known_state=known_state,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_partition_sets.py
@@ -122,7 +122,7 @@ def get_partition_config(
     check.str_param(job_name, "job_name")
     check.str_param(partition_name, "partition_name")
 
-    result = graphene_info.context.get_external_partition_config(
+    result = graphene_info.context.get_partition_config(
         repository_handle, job_name, partition_name, graphene_info.context.instance
     )
 
@@ -146,7 +146,7 @@ def get_partition_tags(
     check.str_param(job_name, "job_name")
     check.str_param(partition_name, "partition_name")
 
-    result = graphene_info.context.get_external_partition_tags(
+    result = graphene_info.context.get_partition_tags(
         repository_handle,
         job_name,
         partition_name,

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_runs.py
@@ -327,9 +327,9 @@ def validate_pipeline_config(
 
     check.inst_param(selector, "selector", JobSubsetSelector)
 
-    external_job = get_remote_job_or_raise(graphene_info, selector)
-    ensure_valid_config(external_job, run_config)
-    return GraphenePipelineConfigValidationValid(pipeline_name=external_job.name)
+    remote_job = get_remote_job_or_raise(graphene_info, selector)
+    ensure_valid_config(remote_job, run_config)
+    return GraphenePipelineConfigValidationValid(pipeline_name=remote_job.name)
 
 
 def get_execution_plan(
@@ -341,11 +341,11 @@ def get_execution_plan(
 
     check.inst_param(selector, "selector", JobSubsetSelector)
 
-    external_job = get_remote_job_or_raise(graphene_info, selector)
-    ensure_valid_config(external_job, run_config)
+    remote_job = get_remote_job_or_raise(graphene_info, selector)
+    ensure_valid_config(remote_job, run_config)
     return GrapheneExecutionPlan(
-        graphene_info.context.get_external_execution_plan(
-            remote_job=external_job,
+        graphene_info.context.get_execution_plan(
+            remote_job=remote_job,
             run_config=run_config,
             step_keys_to_execute=None,
             known_state=None,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/execution.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/execution.py
@@ -30,13 +30,15 @@ class GrapheneExecutionStepInput(graphene.ObjectType):
     class Meta:
         name = "ExecutionStepInput"
 
-    def __init__(self, step_input_snap, external_execution_plan):
+    def __init__(
+        self, step_input_snap: ExecutionStepInputSnap, remote_execution_plan: RemoteExecutionPlan
+    ):
         super().__init__()
         self._step_input_snap = check.inst_param(
             step_input_snap, "step_input_snap", ExecutionStepInputSnap
         )
-        self._external_execution_plan = check.inst_param(
-            external_execution_plan, "external_execution_plan", RemoteExecutionPlan
+        self._remote_execution_plan = check.inst_param(
+            remote_execution_plan, "remote_execution_plan", RemoteExecutionPlan
         )
 
     def resolve_name(self, _graphene_info: ResolveInfo):
@@ -45,13 +47,13 @@ class GrapheneExecutionStepInput(graphene.ObjectType):
     def resolve_dependsOn(self, _graphene_info: ResolveInfo):
         return [
             GrapheneExecutionStep(
-                self._external_execution_plan,
-                self._external_execution_plan.get_step_by_key(key),
+                self._remote_execution_plan,
+                self._remote_execution_plan.get_step_by_key(key),
             )
             # We filter at this layer to ensure that we do not return outputs that
             # do not exist in the execution plan
             for key in filter(
-                self._external_execution_plan.key_in_plan,
+                self._remote_execution_plan.key_in_plan,
                 self._step_input_snap.upstream_step_keys,
             )
         ]
@@ -88,12 +90,14 @@ class GrapheneExecutionStep(graphene.ObjectType):
     class Meta:
         name = "ExecutionStep"
 
-    def __init__(self, external_execution_plan, execution_step_snap):
+    def __init__(
+        self, remote_execution_plan: RemoteExecutionPlan, execution_step_snap: ExecutionStepSnap
+    ):
         super().__init__()
-        self._external_execution_plan = check.inst_param(
-            external_execution_plan, "external_execution_plan", RemoteExecutionPlan
+        self._remote_execution_plan = check.inst_param(
+            remote_execution_plan, "remote_execution_plan", RemoteExecutionPlan
         )
-        self._plan_snapshot = external_execution_plan.execution_plan_snapshot
+        self._plan_snapshot = remote_execution_plan.execution_plan_snapshot
         self._step_snap = check.inst_param(
             execution_step_snap, "execution_step_snap", ExecutionStepSnap
         )
@@ -106,7 +110,7 @@ class GrapheneExecutionStep(graphene.ObjectType):
 
     def resolve_inputs(self, _graphene_info: ResolveInfo):
         return [
-            GrapheneExecutionStepInput(inp, self._external_execution_plan)
+            GrapheneExecutionStepInput(inp, self._remote_execution_plan)
             for inp in self._step_snap.inputs
         ]
 
@@ -130,23 +134,23 @@ class GrapheneExecutionPlan(graphene.ObjectType):
     class Meta:
         name = "ExecutionPlan"
 
-    def __init__(self, external_execution_plan):
+    def __init__(self, remote_execution_plan: RemoteExecutionPlan):
         super().__init__()
-        self._external_execution_plan = check.inst_param(
-            external_execution_plan, external_execution_plan, RemoteExecutionPlan
+        self._remote_execution_plan = check.inst_param(
+            remote_execution_plan, "remote_execution_plan", RemoteExecutionPlan
         )
 
     def resolve_steps(self, _graphene_info: ResolveInfo):
         return [
             GrapheneExecutionStep(
-                self._external_execution_plan,
-                self._external_execution_plan.get_step_by_key(step.key),
+                self._remote_execution_plan,
+                self._remote_execution_plan.get_step_by_key(step.key),
             )
-            for step in self._external_execution_plan.get_steps_in_plan()
+            for step in self._remote_execution_plan.get_steps_in_plan()
         ]
 
     def resolve_artifactsPersisted(self, _graphene_info: ResolveInfo):
-        return self._external_execution_plan.execution_plan_snapshot.artifacts_persisted
+        return self._remote_execution_plan.execution_plan_snapshot.artifacts_persisted
 
 
 types = [

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -370,7 +370,7 @@ class GraphenePartitionSet(graphene.ObjectType):
 
     def _get_partition_names(self, graphene_info: ResolveInfo) -> Sequence[str]:
         if self._partition_names is None:
-            result = graphene_info.context.get_external_partition_names(
+            result = graphene_info.context.get_partition_names(
                 repository_handle=self._repository_handle,
                 job_name=self._remote_partition_set.job_name,
                 instance=graphene_info.context.instance,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -973,7 +973,7 @@ class GraphenePipeline(GrapheneIPipelineSnapshotMixin, graphene.ObjectType):
         reverse: Optional[bool] = None,
         selected_asset_keys: Optional[List[GrapheneAssetKeyInput]] = None,
     ) -> GraphenePartitionKeys:
-        result = graphene_info.context.get_external_partition_names(
+        result = graphene_info.context.get_partition_names(
             repository_handle=self._remote_job.repository_handle,
             job_name=self._remote_job.name,
             selected_asset_keys=_asset_key_input_list_to_asset_key_set(selected_asset_keys),

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -180,7 +180,7 @@ def get_main_workspace(instance: DagsterInstance) -> Iterator[WorkspaceRequestCo
 
 
 @contextmanager
-def get_main_external_repo(instance: DagsterInstance) -> Iterator[RemoteRepository]:
+def get_main_remote_repo(instance: DagsterInstance) -> Iterator[RemoteRepository]:
     with get_main_workspace(instance) as workspace:
         location = workspace.get_code_location(main_repo_location_name())
         yield location.get_repository(main_repo_name())

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_all_snapshot_ids.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_all_snapshot_ids.py
@@ -1,7 +1,7 @@
 from dagster._core.test_utils import instance_for_test
 from dagster._serdes import serialize_pp
 
-from dagster_graphql_tests.graphql.repo import get_main_external_repo
+from dagster_graphql_tests.graphql.repo import get_main_remote_repo
 
 
 def test_all_snapshot_ids(snapshot):
@@ -9,7 +9,7 @@ def test_all_snapshot_ids(snapshot):
     # If you 1) change any pipelines in dagster_graphql_test or 2) change the
     # schema of PipelineSnapshots you are free to rerecord
     with instance_for_test() as instance:
-        with get_main_external_repo(instance) as repo:
+        with get_main_remote_repo(instance) as repo:
             for pipeline in sorted(repo.get_all_jobs(), key=lambda p: p.name):
                 snapshot.assert_match(serialize_pp(pipeline.job_snapshot))
                 snapshot.assert_match(pipeline.computed_job_snapshot_id)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sync_run_launcher.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sync_run_launcher.py
@@ -31,14 +31,14 @@ def test_sync_run_launcher_run():
     ) as instance:
         with get_main_workspace(instance) as workspace:
             location = workspace.get_code_location(main_repo_location_name())
-            external_repo = location.get_repository(main_repo_name())
-            external_pipeline = external_repo.get_full_job("noop_job")
+            repo = location.get_repository(main_repo_name())
+            job = repo.get_full_job("noop_job")
 
             run = create_run_for_test(
                 instance=instance,
-                job_name=external_pipeline.name,
-                remote_job_origin=external_pipeline.get_remote_origin(),
-                job_code_origin=external_pipeline.get_python_origin(),
+                job_name=job.name,
+                remote_job_origin=job.get_remote_origin(),
+                job_code_origin=job.get_python_origin(),
             )
 
             run = instance.launch_run(run_id=run.run_id, workspace=workspace)

--- a/python_modules/dagster-webserver/dagster_webserver/webserver.py
+++ b/python_modules/dagster-webserver/dagster_webserver/webserver.py
@@ -148,7 +148,7 @@ class DagsterWebserver(
             return PlainTextResponse("Invalid Path", status_code=400)
 
         # get ipynb content from grpc call
-        notebook_content = context.get_external_notebook_data(code_location_name, nb_path)
+        notebook_content = context.get_notebook_data(code_location_name, nb_path)
         check.inst_param(notebook_content, "notebook_content", bytes)
 
         # parse content to HTML

--- a/python_modules/dagster/dagster/_api/snapshot_repository.py
+++ b/python_modules/dagster/dagster/_api/snapshot_repository.py
@@ -21,7 +21,7 @@ def sync_get_streaming_external_repositories_data_grpc(
     for repository_name in code_location.repository_names:  # type: ignore
         external_repository_chunks = list(
             api_client.streaming_external_repository(
-                external_repository_origin=RemoteRepositoryOrigin(
+                remote_repository_origin=RemoteRepositoryOrigin(
                     code_location.origin,
                     repository_name,
                 )
@@ -57,7 +57,7 @@ async def gen_streaming_external_repositories_data_grpc(
         external_repository_chunks = [
             chunk
             async for chunk in api_client.gen_streaming_external_repository(
-                external_repository_origin=RemoteRepositoryOrigin(
+                remote_repository_origin=RemoteRepositoryOrigin(
                     code_location.origin,
                     repository_name,
                 )

--- a/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/remote_asset_graph.py
@@ -433,7 +433,7 @@ class RemoteAssetGraph(BaseAssetGraph[RemoteAssetNode]):
     def get_implicit_job_name_for_assets(
         self,
         asset_keys: Iterable[AssetKey],
-        external_repo: Optional[RemoteRepository],
+        remote_repo: Optional[RemoteRepository],
     ) -> Optional[str]:
         """Returns the name of the asset base job that contains all the given assets, or None if there is no such
         job.

--- a/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
+++ b/python_modules/dagster/dagster/_core/execution/submit_asset_runs.py
@@ -23,7 +23,7 @@ EXECUTION_PLAN_CREATION_RETRIES = 1
 
 class RunRequestExecutionData(NamedTuple):
     remote_job: RemoteJob
-    external_execution_plan: RemoteExecutionPlan
+    remote_execution_plan: RemoteExecutionPlan
 
 
 def _get_implicit_job_name_for_assets(
@@ -92,7 +92,7 @@ def _get_job_execution_data_from_run_request(
         code_location = workspace.get_code_location(handle.location_name)
         remote_job = code_location.get_job(pipeline_selector)
 
-        external_execution_plan = code_location.get_execution_plan(
+        remote_execution_plan = code_location.get_execution_plan(
             remote_job,
             {},
             step_keys_to_execute=None,
@@ -102,7 +102,7 @@ def _get_job_execution_data_from_run_request(
 
         run_request_execution_data_cache[pipeline_selector] = RunRequestExecutionData(
             remote_job,
-            external_execution_plan,
+            remote_execution_plan,
         )
 
     return run_request_execution_data_cache[pipeline_selector]
@@ -167,7 +167,7 @@ def _create_asset_run(
 
         if not should_retry:
             execution_plan_entity_keys = _get_execution_plan_entity_keys(
-                check.not_none(execution_data).external_execution_plan.execution_plan_snapshot
+                check.not_none(execution_data).remote_execution_plan.execution_plan_snapshot
             )
 
             if not all(
@@ -190,11 +190,11 @@ def _create_asset_run(
 
         if not should_retry:
             remote_job = check.not_none(execution_data).remote_job
-            external_execution_plan = check.not_none(execution_data).external_execution_plan
+            remote_execution_plan = check.not_none(execution_data).remote_execution_plan
 
             run = instance.create_run(
                 job_snapshot=remote_job.job_snapshot,
-                execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,
+                execution_plan_snapshot=remote_execution_plan.execution_plan_snapshot,
                 parent_job_snapshot=remote_job.parent_job_snapshot,
                 job_name=remote_job.name,
                 run_id=run_id,

--- a/python_modules/dagster/dagster/_core/remote_representation/__init__.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/__init__.py
@@ -34,7 +34,6 @@ from dagster._core.remote_representation.external_data import (
     SensorExecutionErrorSnap as SensorExecutionErrorSnap,
     SensorSnap as SensorSnap,
     TargetSnap as TargetSnap,
-    external_job_data_from_def as external_job_data_from_def,
 )
 from dagster._core.remote_representation.handle import (
     JobHandle as JobHandle,

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -248,7 +248,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
             .get_full_job(selector.job_name)
         )
 
-    def get_external_execution_plan(
+    def get_execution_plan(
         self,
         remote_job: RemoteJob,
         run_config: Mapping[str, object],
@@ -263,7 +263,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
             instance=self.instance,
         )
 
-    def get_external_partition_config(
+    def get_partition_config(
         self,
         repository_handle: RepositoryHandle,
         job_name: str,
@@ -277,7 +277,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
             instance=instance,
         )
 
-    def get_external_partition_tags(
+    def get_partition_tags(
         self,
         repository_handle: RepositoryHandle,
         job_name: str,
@@ -293,7 +293,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
             selected_asset_keys=selected_asset_keys,
         )
 
-    def get_external_partition_names(
+    def get_partition_names(
         self,
         repository_handle: RepositoryHandle,
         job_name: str,
@@ -307,7 +307,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
             selected_asset_keys=selected_asset_keys,
         )
 
-    def get_external_partition_set_execution_param_data(
+    def get_partition_set_execution_param_data(
         self,
         repository_handle: RepositoryHandle,
         partition_set_name: str,
@@ -323,7 +323,7 @@ class BaseWorkspaceRequestContext(LoadingContext):
             instance=instance,
         )
 
-    def get_external_notebook_data(self, code_location_name: str, notebook_path: str) -> bytes:
+    def get_notebook_data(self, code_location_name: str, notebook_path: str) -> bytes:
         check.str_param(code_location_name, "code_location_name")
         check.str_param(notebook_path, "notebook_path")
         code_location = self.get_code_location(code_location_name)

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -131,9 +131,9 @@ def retry_run(
         )
         return
 
-    external_repo = code_location.get_repository(repo_name)
+    repo = code_location.get_repository(repo_name)
 
-    if not external_repo.has_job(failed_run.job_name):
+    if not repo.has_job(failed_run.job_name):
         instance.report_engine_event(
             f"Could not find job {failed_run.job_name} in repository {repo_name}, unable"
             " to retry the run. It was likely renamed or deleted.",

--- a/python_modules/dagster/dagster/_grpc/client.py
+++ b/python_modules/dagster/dagster/_grpc/client.py
@@ -417,12 +417,12 @@ class DagsterGrpcClient:
 
     def external_repository(
         self,
-        external_repository_origin: RemoteRepositoryOrigin,
+        remote_repository_origin: RemoteRepositoryOrigin,
         defer_snapshots: bool = False,
     ) -> str:
         check.inst_param(
-            external_repository_origin,
-            "external_repository_origin",
+            remote_repository_origin,
+            "remote_repository_origin",
             RemoteRepositoryOrigin,
         )
 
@@ -430,7 +430,7 @@ class DagsterGrpcClient:
             "ExternalRepository",
             api_pb2.ExternalRepositoryRequest,
             # rename this param name
-            serialized_repository_python_origin=serialize_value(external_repository_origin),
+            serialized_repository_python_origin=serialize_value(remote_repository_origin),
             defer_snapshots=defer_snapshots,
         )
 
@@ -438,25 +438,25 @@ class DagsterGrpcClient:
 
     def external_job(
         self,
-        external_repository_origin: RemoteRepositoryOrigin,
+        remote_repository_origin: RemoteRepositoryOrigin,
         job_name: str,
     ) -> api_pb2.ExternalJobReply:
         check.inst_param(
-            external_repository_origin,
-            "external_repository_origin",
+            remote_repository_origin,
+            "remote_repository_origin",
             RemoteRepositoryOrigin,
         )
 
         return self._query(
             "ExternalJob",
             api_pb2.ExternalJobRequest,
-            serialized_repository_origin=serialize_value(external_repository_origin),
+            serialized_repository_origin=serialize_value(remote_repository_origin),
             job_name=job_name,
         )
 
     def streaming_external_repository(
         self,
-        external_repository_origin: RemoteRepositoryOrigin,
+        remote_repository_origin: RemoteRepositoryOrigin,
         defer_snapshots: bool = False,
         timeout=DEFAULT_REPOSITORY_GRPC_TIMEOUT,
     ) -> Iterator[dict]:
@@ -464,7 +464,7 @@ class DagsterGrpcClient:
             "StreamingExternalRepository",
             api_pb2.ExternalRepositoryRequest,
             # Rename parameter
-            serialized_repository_python_origin=serialize_value(external_repository_origin),
+            serialized_repository_python_origin=serialize_value(remote_repository_origin),
             defer_snapshots=defer_snapshots,
             timeout=timeout,
         ):
@@ -475,7 +475,7 @@ class DagsterGrpcClient:
 
     async def gen_streaming_external_repository(
         self,
-        external_repository_origin: RemoteRepositoryOrigin,
+        remote_repository_origin: RemoteRepositoryOrigin,
         defer_snapshots: bool = False,
         timeout=DEFAULT_REPOSITORY_GRPC_TIMEOUT,
     ) -> AsyncIterable[dict]:
@@ -483,7 +483,7 @@ class DagsterGrpcClient:
             "StreamingExternalRepository",
             api_pb2.ExternalRepositoryRequest,
             # Rename parameter
-            serialized_repository_python_origin=serialize_value(external_repository_origin),
+            serialized_repository_python_origin=serialize_value(remote_repository_origin),
             defer_snapshots=defer_snapshots,
             timeout=timeout,
         ):

--- a/python_modules/dagster/dagster/_grpc/impl.py
+++ b/python_modules/dagster/dagster/_grpc/impl.py
@@ -43,6 +43,7 @@ from dagster._core.execution.api import create_execution_plan, execute_run_itera
 from dagster._core.instance import DagsterInstance
 from dagster._core.instance.ref import InstanceRef
 from dagster._core.remote_representation.external_data import (
+    JobDataSnap,
     PartitionConfigSnap,
     PartitionExecutionErrorSnap,
     PartitionExecutionParamSnap,
@@ -52,7 +53,6 @@ from dagster._core.remote_representation.external_data import (
     RemoteJobSubsetResult,
     ScheduleExecutionErrorSnap,
     SensorExecutionErrorSnap,
-    external_job_data_from_def,
     job_name_for_partition_set_snap_name,
 )
 from dagster._core.remote_representation.origin import CodeLocationOrigin
@@ -287,7 +287,7 @@ def get_external_pipeline_subset_result(
             asset_selection=asset_selection,
             asset_check_selection=asset_check_selection,
         )
-        job_data_snap = external_job_data_from_def(
+        job_data_snap = JobDataSnap.from_job_def(
             definition, include_parent_snapshot=include_parent_snapshot
         )
         return RemoteJobSubsetResult(success=True, job_data_snap=job_data_snap)

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -46,13 +46,13 @@ from dagster._core.instance import DagsterInstance, InstanceRef
 from dagster._core.libraries import DagsterLibraryRegistry
 from dagster._core.origin import DEFAULT_DAGSTER_ENTRY_POINT, get_python_environment_entry_point
 from dagster._core.remote_representation.external_data import (
+    JobDataSnap,
     PartitionExecutionErrorSnap,
     RemoteJobSubsetResult,
     RepositoryErrorSnap,
     RepositorySnap,
     ScheduleExecutionErrorSnap,
     SensorExecutionErrorSnap,
-    external_job_data_from_def,
 )
 from dagster._core.remote_representation.origin import RemoteRepositoryOrigin
 from dagster._core.snap.execution_plan_snapshot import ExecutionPlanSnapshotErrorData
@@ -515,14 +515,14 @@ class DagsterApiServer(DagsterApiServicer):
 
     def _get_repo_for_origin(
         self,
-        external_repo_origin: RemoteRepositoryOrigin,
+        remote_repo_origin: RemoteRepositoryOrigin,
     ) -> RepositoryDefinition:
         loaded_repos = check.not_none(self._loaded_repositories)
-        if external_repo_origin.repository_name not in loaded_repos.definitions_by_name:
+        if remote_repo_origin.repository_name not in loaded_repos.definitions_by_name:
             raise Exception(
-                f'Could not find a repository called "{external_repo_origin.repository_name}"'
+                f'Could not find a repository called "{remote_repo_origin.repository_name}"'
             )
-        return loaded_repos.definitions_by_name[external_repo_origin.repository_name]
+        return loaded_repos.definitions_by_name[remote_repo_origin.repository_name]
 
     def ReloadCode(
         self, _request: api_pb2.ReloadCodeRequest, _context: grpc.ServicerContext
@@ -820,7 +820,7 @@ class DagsterApiServer(DagsterApiServicer):
 
             job_def = self._get_repo_for_origin(repository_origin).get_job(request.job_name)
             ser_job_data = serialize_value(
-                external_job_data_from_def(job_def, include_parent_snapshot=True)
+                JobDataSnap.from_job_def(job_def, include_parent_snapshot=True)
             )
             return api_pb2.ExternalJobReply(serialized_job_data=ser_job_data)
         except Exception:

--- a/python_modules/dagster/dagster/_utils/external.py
+++ b/python_modules/dagster/dagster/_utils/external.py
@@ -22,11 +22,11 @@ def remote_job_from_location(
         code_location.has_repository(repo_name),
         f"Could not find repository {repo_name} in location {code_location.name}",
     )
-    external_repo = code_location.get_repository(repo_name)
+    repo = code_location.get_repository(repo_name)
 
     pipeline_selector = JobSubsetSelector(
         location_name=code_location.name,
-        repository_name=external_repo.name,
+        repository_name=repo.name,
         job_name=job_name,
         op_selection=op_selection,
     )

--- a/python_modules/dagster/dagster/_utils/hosted_user_process.py
+++ b/python_modules/dagster/dagster/_utils/hosted_user_process.py
@@ -15,7 +15,7 @@ from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
 from dagster._core.origin import JobPythonOrigin, RepositoryPythonOrigin
 from dagster._core.remote_representation import RemoteJob
-from dagster._core.remote_representation.external_data import external_job_data_from_def
+from dagster._core.remote_representation.external_data import JobDataSnap
 from dagster._core.remote_representation.handle import RepositoryHandle
 
 
@@ -51,6 +51,6 @@ def remote_job_from_recon_job(
         job_def = recon_job.get_definition()
 
     return RemoteJob(
-        external_job_data_from_def(job_def, include_parent_snapshot=True),
+        JobDataSnap.from_job_def(job_def, include_parent_snapshot=True),
         repository_handle=repository_handle,
     )

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_job.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_job.py
@@ -26,10 +26,10 @@ def test_job_snapshot_api_grpc(instance):
         job_handle = JobHandle("foo", code_location.get_repository("bar_repo").handle)
         api_client = code_location.client
 
-        external_job_subset_result = _test_job_subset_grpc(job_handle, api_client)
-        assert isinstance(external_job_subset_result, RemoteJobSubsetResult)
-        assert external_job_subset_result.success is True
-        assert external_job_subset_result.job_data_snap.name == "foo"
+        remote_job_subset_result = _test_job_subset_grpc(job_handle, api_client)
+        assert isinstance(remote_job_subset_result, RemoteJobSubsetResult)
+        assert remote_job_subset_result.success is True
+        assert remote_job_subset_result.job_data_snap.name == "foo"
 
 
 def test_job_snapshot_deserialize_error(instance):
@@ -57,12 +57,12 @@ def test_job_with_valid_subset_snapshot_api_grpc(instance):
         job_handle = JobHandle("foo", code_location.get_repository("bar_repo").handle)
         api_client = code_location.client
 
-        external_job_subset_result = _test_job_subset_grpc(job_handle, api_client, ["do_something"])
-        assert isinstance(external_job_subset_result, RemoteJobSubsetResult)
-        assert external_job_subset_result.success is True
-        assert external_job_subset_result.job_data_snap.name == "foo"
+        remote_job_subset_result = _test_job_subset_grpc(job_handle, api_client, ["do_something"])
+        assert isinstance(remote_job_subset_result, RemoteJobSubsetResult)
+        assert remote_job_subset_result.success is True
+        assert remote_job_subset_result.job_data_snap.name == "foo"
         assert (
-            external_job_subset_result.job_data_snap.parent_job
+            remote_job_subset_result.job_data_snap.parent_job
             == code_location.get_repository("bar_repo").get_full_job("foo").job_snapshot
         )
 
@@ -72,13 +72,13 @@ def test_job_with_valid_subset_snapshot_without_parent_snapshot(instance):
         job_handle = JobHandle("foo", code_location.get_repository("bar_repo").handle)
         api_client = code_location.client
 
-        external_job_subset_result = _test_job_subset_grpc(
+        remote_job_subset_result = _test_job_subset_grpc(
             job_handle, api_client, ["do_something"], include_parent_snapshot=False
         )
-        assert isinstance(external_job_subset_result, RemoteJobSubsetResult)
-        assert external_job_subset_result.success is True
-        assert external_job_subset_result.job_data_snap.name == "foo"
-        assert not external_job_subset_result.job_data_snap.parent_job
+        assert isinstance(remote_job_subset_result, RemoteJobSubsetResult)
+        assert remote_job_subset_result.success is True
+        assert remote_job_subset_result.job_data_snap.name == "foo"
+        assert not remote_job_subset_result.job_data_snap.parent_job
 
 
 def test_job_with_invalid_subset_snapshot_api_grpc(instance):

--- a/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_sensor.py
+++ b/python_modules/dagster/dagster_tests/api_tests/test_api_snapshot_sensor.py
@@ -17,7 +17,7 @@ from dagster._serdes import deserialize_value
 from dagster_tests.api_tests.utils import get_bar_repo_handle
 
 
-def test_external_sensor_grpc(instance):
+def test_remote_sensor_grpc(instance):
     with get_bar_repo_handle(instance) as repository_handle:
         result = sync_get_external_sensor_execution_data_ephemeral_grpc(
             instance, repository_handle, "sensor_foo", None, None, None, None
@@ -29,7 +29,7 @@ def test_external_sensor_grpc(instance):
         assert run_request.tags == {"foo": "foo_tag", "dagster/sensor_name": "sensor_foo"}
 
 
-def test_external_sensor_grpc_fallback_to_streaming(instance):
+def test_remote_sensor_grpc_fallback_to_streaming(instance):
     with get_bar_repo_handle(instance) as repository_handle:
         origin = repository_handle.get_remote_origin()
         with ephemeral_grpc_api_client(
@@ -63,7 +63,7 @@ def test_external_sensor_grpc_fallback_to_streaming(instance):
                     }
 
 
-def test_external_sensor_error(instance):
+def test_remote_sensor_error(instance):
     with get_bar_repo_handle(instance) as repository_handle:
         with pytest.raises(DagsterUserCodeProcessError, match="womp womp"):
             sync_get_external_sensor_execution_data_ephemeral_grpc(
@@ -73,7 +73,7 @@ def test_external_sensor_error(instance):
 
 @pytest.mark.parametrize(argnames="timeout", argvalues=[0, 1], ids=["zero", "nonzero"])
 @pytest.mark.parametrize("env_var_default_val", [200, None], ids=["env-var-set", "env-var-not-set"])
-def test_external_sensor_client_timeout(instance, timeout: int, env_var_default_val: Optional[int]):
+def test_remote_sensor_client_timeout(instance, timeout: int, env_var_default_val: Optional[int]):
     if env_var_default_val:
         os.environ["DAGSTER_SENSOR_GRPC_TIMEOUT_SECONDS"] = str(env_var_default_val)
     with get_bar_repo_handle(instance) as repository_handle:
@@ -93,7 +93,7 @@ def test_external_sensor_client_timeout(instance, timeout: int, env_var_default_
             )
 
 
-def test_external_sensor_deserialize_error(instance):
+def test_remote_sensor_deserialize_error(instance):
     with get_bar_repo_handle(instance) as repository_handle:
         origin = repository_handle.get_remote_origin()
         with ephemeral_grpc_api_client(
@@ -115,7 +115,7 @@ def test_external_sensor_deserialize_error(instance):
             assert isinstance(result, SensorExecutionErrorSnap)
 
 
-def test_external_sensor_raises_dagster_error(instance):
+def test_remote_sensor_raises_dagster_error(instance):
     with get_bar_repo_handle(instance) as repository_handle:
         with pytest.raises(DagsterUserCodeProcessError, match="Dagster error"):
             sync_get_external_sensor_execution_data_ephemeral_grpc(

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_backfill_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_backfill_command.py
@@ -132,7 +132,7 @@ def test_backfill_tags_job(backfill_args_context: BackfillCommandTestContext):
         assert run.tags.get("foo") == "bar"
 
 
-def valid_external_job_backfill_cli_args():
+def valid_remote_job_backfill_cli_args():
     qux_job_args = [
         "-w",
         file_relative_path(__file__, "repository_file.yaml"),
@@ -151,7 +151,7 @@ def valid_external_job_backfill_cli_args():
     ]
 
 
-@pytest.mark.parametrize("job_cli_args", valid_external_job_backfill_cli_args())
+@pytest.mark.parametrize("job_cli_args", valid_remote_job_backfill_cli_args())
 def test_job_backfill_command_cli(job_cli_args):
     with instance_for_test():
         runner = CliRunner()

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_schedule_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_schedule_commands.py
@@ -189,7 +189,7 @@ def test_schedules_logs(gen_schedule_args):
             assert "scheduler.log" in result.output
 
 
-def test_check_repo_and_scheduler_no_external_schedules():
+def test_check_repo_and_scheduler_no_remote_schedules():
     repository = mock.MagicMock(spec=RemoteRepository)
     repository.get_schedules.return_value = []
     instance = mock.MagicMock(spec=DagsterInstance)

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -208,7 +208,7 @@ def test_update_repo_stats_dynamic_partitions(caplog):
         cleanup_telemetry_logger()
 
 
-def test_get_stats_from_external_repo_partitions(instance):
+def test_get_stats_from_remote_repo_partitions(instance):
     @asset(partitions_def=StaticPartitionsDefinition(["foo", "bar"]))
     def asset1(): ...
 
@@ -218,16 +218,16 @@ def test_get_stats_from_external_repo_partitions(instance):
     @asset
     def asset3(): ...
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(Definitions(assets=[asset1, asset2, asset3]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_remote_repo(external_repo)
+    stats = get_stats_from_remote_repo(remote_repo)
     assert stats["num_partitioned_assets_in_repo"] == "2"
 
 
-def test_get_stats_from_external_repo_multi_partitions(instance):
+def test_get_stats_from_remote_repo_multi_partitions(instance):
     @asset(
         partitions_def=MultiPartitionsDefinition(
             {
@@ -238,32 +238,32 @@ def test_get_stats_from_external_repo_multi_partitions(instance):
     )
     def multi_partitioned_asset(): ...
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(Definitions(assets=[multi_partitioned_asset]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_remote_repo(external_repo)
+    stats = get_stats_from_remote_repo(remote_repo)
     assert stats["num_multi_partitioned_assets_in_repo"] == "1"
     assert stats["num_partitioned_assets_in_repo"] == "1"
 
 
-def test_get_stats_from_external_repo_source_assets(instance):
+def test_get_stats_from_remote_repo_source_assets(instance):
     source_asset1 = SourceAsset("source_asset1")
 
     @asset
     def asset1(): ...
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(Definitions(assets=[source_asset1, asset1]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_remote_repo(external_repo)
+    stats = get_stats_from_remote_repo(remote_repo)
     assert stats["num_source_assets_in_repo"] == "1"
 
 
-def test_get_stats_from_external_repo_observable_source_assets(instance):
+def test_get_stats_from_remote_repo_observable_source_assets(instance):
     source_asset1 = SourceAsset("source_asset1")
 
     @observable_source_asset
@@ -272,37 +272,37 @@ def test_get_stats_from_external_repo_observable_source_assets(instance):
     @asset
     def asset1(): ...
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(
             Definitions(assets=[source_asset1, source_asset2, asset1]).get_repository_def()
         ),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_remote_repo(external_repo)
+    stats = get_stats_from_remote_repo(remote_repo)
     assert stats["num_source_assets_in_repo"] == "2"
     assert stats["num_observable_source_assets_in_repo"] == "1"
 
 
-def test_get_stats_from_external_repo_freshness_policies(instance):
+def test_get_stats_from_remote_repo_freshness_policies(instance):
     @asset(freshness_policy=FreshnessPolicy(maximum_lag_minutes=30))
     def asset1(): ...
 
     @asset
     def asset2(): ...
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(Definitions(assets=[asset1, asset2]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_remote_repo(external_repo)
+    stats = get_stats_from_remote_repo(remote_repo)
     assert stats["num_assets_with_freshness_policies_in_repo"] == "1"
 
 
 # TODO: FOU-243
 @pytest.mark.skip("obsolete EAGER vs. LAZY distinction")
-def test_get_status_from_external_repo_auto_materialize_policy(instance):
+def test_get_status_from_remote_repo_auto_materialize_policy(instance):
     @asset(auto_materialize_policy=AutoMaterializePolicy.lazy())
     def asset1(): ...
 
@@ -312,33 +312,33 @@ def test_get_status_from_external_repo_auto_materialize_policy(instance):
     @asset(auto_materialize_policy=AutoMaterializePolicy.eager())
     def asset3(): ...
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(Definitions(assets=[asset1, asset2, asset3]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_remote_repo(external_repo)
+    stats = get_stats_from_remote_repo(remote_repo)
     assert stats["num_assets_with_eager_auto_materialize_policies_in_repo"] == "1"
     assert stats["num_assets_with_lazy_auto_materialize_policies_in_repo"] == "1"
 
 
-def test_get_stats_from_external_repo_code_versions(instance):
+def test_get_stats_from_remote_repo_code_versions(instance):
     @asset(code_version="hello")
     def asset1(): ...
 
     @asset
     def asset2(): ...
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(Definitions(assets=[asset1, asset2]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_remote_repo(external_repo)
+    stats = get_stats_from_remote_repo(remote_repo)
     assert stats["num_assets_with_code_versions_in_repo"] == "1"
 
 
-def test_get_stats_from_external_repo_code_checks(instance):
+def test_get_stats_from_remote_repo_code_checks(instance):
     @asset
     def my_asset(): ...
 
@@ -351,7 +351,7 @@ def test_get_stats_from_external_repo_code_checks(instance):
     @asset
     def my_other_asset(): ...
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(
             Definitions(
                 assets=[my_asset, my_other_asset], asset_checks=[my_check, my_check_2]
@@ -360,28 +360,28 @@ def test_get_stats_from_external_repo_code_checks(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_remote_repo(external_repo)
+    stats = get_stats_from_remote_repo(remote_repo)
     assert stats["num_asset_checks"] == "2"
     assert stats["num_assets_with_checks"] == "1"
 
 
-def test_get_stats_from_external_repo_dbt(instance):
+def test_get_stats_from_remote_repo_dbt(instance):
     @asset(compute_kind="dbt")
     def asset1(): ...
 
     @asset
     def asset2(): ...
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(Definitions(assets=[asset1, asset2]).get_repository_def()),
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_remote_repo(external_repo)
+    stats = get_stats_from_remote_repo(remote_repo)
     assert stats["num_dbt_assets_in_repo"] == "1"
 
 
-def test_get_stats_from_external_repo_resources(instance):
+def test_get_stats_from_remote_repo_resources(instance):
     class MyResource(ConfigurableResource):
         foo: str
 
@@ -395,7 +395,7 @@ def test_get_stats_from_external_repo_resources(instance):
     @asset
     def asset1(my_resource: MyResource, custom_resource: CustomResource): ...
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(
             Definitions(
                 assets=[asset1],
@@ -408,14 +408,14 @@ def test_get_stats_from_external_repo_resources(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_remote_repo(external_repo)
+    stats = get_stats_from_remote_repo(remote_repo)
     assert stats["dagster_resources"] == [
         {"module_name": "dagster_tests", "class_name": "MyResource"}
     ]
     assert stats["has_custom_resources"] == "True"
 
 
-def test_get_stats_from_external_repo_io_managers(instance):
+def test_get_stats_from_remote_repo_io_managers(instance):
     class MyIOManager(ConfigurableIOManager):
         foo: str
 
@@ -441,7 +441,7 @@ def test_get_stats_from_external_repo_io_managers(instance):
     @asset
     def asset1(): ...
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(
             Definitions(
                 assets=[asset1],
@@ -454,14 +454,14 @@ def test_get_stats_from_external_repo_io_managers(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_remote_repo(external_repo)
+    stats = get_stats_from_remote_repo(remote_repo)
     assert stats["dagster_resources"] == [
         {"module_name": "dagster_tests", "class_name": "MyIOManager"}
     ]
     assert stats["has_custom_resources"] == "True"
 
 
-def test_get_stats_from_external_repo_functional_resources(instance):
+def test_get_stats_from_remote_repo_functional_resources(instance):
     @dagster_maintained_resource
     @resource(config_schema={"foo": str})
     def my_resource():
@@ -474,7 +474,7 @@ def test_get_stats_from_external_repo_functional_resources(instance):
     @asset(required_resource_keys={"my_resource", "custom_resource"})
     def asset1(): ...
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(
             Definitions(
                 assets=[asset1],
@@ -487,14 +487,14 @@ def test_get_stats_from_external_repo_functional_resources(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_remote_repo(external_repo)
+    stats = get_stats_from_remote_repo(remote_repo)
     assert stats["dagster_resources"] == [
         {"module_name": "dagster_tests", "class_name": "my_resource"}
     ]
     assert stats["has_custom_resources"] == "True"
 
 
-def test_get_stats_from_external_repo_functional_io_managers(instance):
+def test_get_stats_from_remote_repo_functional_io_managers(instance):
     @dagster_maintained_io_manager
     @io_manager(config_schema={"foo": str})
     def my_io_manager():
@@ -507,7 +507,7 @@ def test_get_stats_from_external_repo_functional_io_managers(instance):
     @asset
     def asset1(): ...
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(
             Definitions(
                 assets=[asset1],
@@ -520,15 +520,15 @@ def test_get_stats_from_external_repo_functional_io_managers(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_remote_repo(external_repo)
+    stats = get_stats_from_remote_repo(remote_repo)
     assert stats["dagster_resources"] == [
         {"module_name": "dagster_tests", "class_name": "my_io_manager"}
     ]
     assert stats["has_custom_resources"] == "True"
 
 
-def test_get_stats_from_external_repo_pipes_client(instance):
-    external_repo = RemoteRepository(
+def test_get_stats_from_remote_repo_pipes_client(instance):
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(
             Definitions(
                 resources={
@@ -539,14 +539,14 @@ def test_get_stats_from_external_repo_pipes_client(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_remote_repo(external_repo)
+    stats = get_stats_from_remote_repo(remote_repo)
     assert stats["dagster_resources"] == [
         {"module_name": "dagster", "class_name": "PipesSubprocessClient"}
     ]
     assert stats["has_custom_resources"] == "False"
 
 
-def test_get_stats_from_external_repo_delayed_resource_configuration(instance):
+def test_get_stats_from_remote_repo_delayed_resource_configuration(instance):
     class MyResource(ConfigurableResource):
         foo: str
 
@@ -583,7 +583,7 @@ def test_get_stats_from_external_repo_delayed_resource_configuration(instance):
     @asset(required_resource_keys={"my_other_resource"})
     def asset2(): ...
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(
             Definitions(
                 assets=[asset1, asset2],
@@ -598,7 +598,7 @@ def test_get_stats_from_external_repo_delayed_resource_configuration(instance):
         repository_handle=RepositoryHandle.for_test(),
         instance=instance,
     )
-    stats = get_stats_from_remote_repo(external_repo)
+    stats = get_stats_from_remote_repo(remote_repo)
     assert stats["dagster_resources"] == [
         {"module_name": "dagster_tests", "class_name": "MyIOManager"},
         {"module_name": "dagster_tests", "class_name": "my_io_manager"},

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/multi_location/test_multi_location_workspace.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/multi_location/test_multi_location_workspace.py
@@ -64,9 +64,9 @@ def test_multi_file_override_workspace(instance):
         loaded_from_file = workspace.create_request_context().get_code_location("loaded_from_file")
 
         # Ensure location `loaded_from_file` has been overridden
-        external_repositories = loaded_from_file.get_repositories()
-        assert len(external_repositories) == 1
-        assert "extra_repository" in external_repositories
+        remote_repos = loaded_from_file.get_repositories()
+        assert len(remote_repos) == 1
+        assert "extra_repository" in remote_repos
 
 
 def test_multi_file_extend_and_override_workspace(instance):
@@ -88,9 +88,9 @@ def test_multi_file_extend_and_override_workspace(instance):
         loaded_from_file = workspace.create_request_context().get_code_location("loaded_from_file")
 
         # Ensure location `loaded_from_file` has been overridden
-        external_repositories = loaded_from_file.get_repositories()
-        assert len(external_repositories) == 1
-        assert "extra_repository" in external_repositories
+        remote_repos = loaded_from_file.get_repositories()
+        assert len(remote_repos) == 1
+        assert "extra_repository" in remote_repos
 
 
 def _get_multi_location_workspace_yaml(executable):

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/__snapshots__/test_active_data.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_external_job_data
+# name: test_remote_job_data
   '''
   {
     "__class__": "ExternalPipelineData",
@@ -1122,7 +1122,7 @@
   }
   '''
 # ---
-# name: test_external_repository_data
+# name: test_repository_snap
   '''
   {
     "__class__": "ExternalRepositoryData",

--- a/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
+++ b/python_modules/dagster/dagster_tests/core_tests/snap_tests/test_repository_snap.py
@@ -50,13 +50,13 @@ def test_repository_snap_all_props():
     def noop_repo():
         return [noop_job]
 
-    external_repo_data = RepositorySnap.from_def(noop_repo)
+    repo_snap = RepositorySnap.from_def(noop_repo)
 
-    assert external_repo_data.name == "noop_repo"
-    assert len(external_repo_data.job_datas) == 1
-    assert isinstance(external_repo_data.job_datas[0], JobDataSnap)
+    assert repo_snap.name == "noop_repo"
+    assert len(repo_snap.job_datas) == 1
+    assert isinstance(repo_snap.job_datas[0], JobDataSnap)
 
-    job_snapshot = external_repo_data.job_datas[0].job
+    job_snapshot = repo_snap.job_datas[0].job
     assert isinstance(job_snapshot, JobSnap)
     assert job_snapshot.name == "noop_job"
     assert job_snapshot.description is None
@@ -105,12 +105,12 @@ def test_repository_snap_definitions_resources_nested() -> None:
     )
 
     repo = resolve_pending_repo_if_required(defs)
-    external_repo_data = RepositorySnap.from_def(repo)
-    assert external_repo_data.resources
+    repo_snap = RepositorySnap.from_def(repo)
+    assert repo_snap.resources
 
-    assert len(external_repo_data.resources) == 1
+    assert len(repo_snap.resources) == 1
 
-    foo = [data for data in external_repo_data.resources if data.name == "foo"]
+    foo = [data for data in repo_snap.resources if data.name == "foo"]
 
     assert len(foo) == 1
     assert (
@@ -138,13 +138,13 @@ def test_repository_snap_definitions_resources_nested_top_level() -> None:
     )
 
     repo = resolve_pending_repo_if_required(defs)
-    external_repo_data = RepositorySnap.from_def(repo)
-    assert external_repo_data.resources
+    repo_snap = RepositorySnap.from_def(repo)
+    assert repo_snap.resources
 
-    assert len(external_repo_data.resources) == 2
+    assert len(repo_snap.resources) == 2
 
-    foo = [data for data in external_repo_data.resources if data.name == "foo"]
-    inner = [data for data in external_repo_data.resources if data.name == "inner"]
+    foo = [data for data in repo_snap.resources if data.name == "foo"]
+    inner = [data for data in repo_snap.resources if data.name == "inner"]
 
     assert len(foo) == 1
     assert len(inner) == 1
@@ -180,13 +180,13 @@ def test_repository_snap_definitions_function_style_resources_nested() -> None:
     )
 
     repo = resolve_pending_repo_if_required(defs)
-    external_repo_data = RepositorySnap.from_def(repo)
-    assert external_repo_data.resources
+    repo_snap = RepositorySnap.from_def(repo)
+    assert repo_snap.resources
 
-    assert len(external_repo_data.resources) == 2
+    assert len(repo_snap.resources) == 2
 
-    foo = [data for data in external_repo_data.resources if data.name == "foo"]
-    inner = [data for data in external_repo_data.resources if data.name == "inner"]
+    foo = [data for data in repo_snap.resources if data.name == "foo"]
+    inner = [data for data in repo_snap.resources if data.name == "inner"]
 
     assert len(foo) == 1
     assert len(inner) == 1
@@ -228,12 +228,12 @@ def test_repository_snap_definitions_resources_nested_many() -> None:
     )
 
     repo = resolve_pending_repo_if_required(defs)
-    external_repo_data = RepositorySnap.from_def(repo)
-    assert external_repo_data.resources
+    repo_snap = RepositorySnap.from_def(repo)
+    assert repo_snap.resources
 
-    assert len(external_repo_data.resources) == 2
+    assert len(repo_snap.resources) == 2
 
-    outermost = [data for data in external_repo_data.resources if data.name == "outermost"]
+    outermost = [data for data in repo_snap.resources if data.name == "outermost"]
     assert len(outermost) == 1
 
     assert len(outermost[0].nested_resources) == 1
@@ -242,7 +242,7 @@ def test_repository_snap_definitions_resources_nested_many() -> None:
         NestedResourceType.TOP_LEVEL, "outer"
     )
 
-    outer = [data for data in external_repo_data.resources if data.name == "outer"]
+    outer = [data for data in repo_snap.resources if data.name == "outer"]
     assert len(outer) == 1
 
     assert len(outer[0].nested_resources) == 1
@@ -272,22 +272,22 @@ def test_repository_snap_definitions_resources_complex():
     )
 
     repo = resolve_pending_repo_if_required(defs)
-    external_repo_data = RepositorySnap.from_def(repo)
+    repo_snap = RepositorySnap.from_def(repo)
 
-    assert len(external_repo_data.resources) == 1
-    assert external_repo_data.resources[0].name == "foo"
-    assert external_repo_data.resources[0].resource_snapshot.name == "foo"
-    assert external_repo_data.resources[0].resource_snapshot.description == "My description."
+    assert len(repo_snap.resources) == 1
+    assert repo_snap.resources[0].name == "foo"
+    assert repo_snap.resources[0].resource_snapshot.name == "foo"
+    assert repo_snap.resources[0].resource_snapshot.description == "My description."
 
     # Ensure we get config snaps for the resource's fields
-    assert len(external_repo_data.resources[0].config_field_snaps) == 1
-    snap = external_repo_data.resources[0].config_field_snaps[0]
+    assert len(repo_snap.resources[0].config_field_snaps) == 1
+    snap = repo_snap.resources[0].config_field_snaps[0]
     assert snap.name == "my_string"
     assert not snap.is_required
     assert snap.default_value_as_json_str == '"bar"'
 
     # Ensure we get the configured values for the resource
-    assert external_repo_data.resources[0].configured_values == {
+    assert repo_snap.resources[0].configured_values == {
         "my_string": '"baz"',
     }
 
@@ -297,10 +297,10 @@ def test_repository_snap_empty():
     def empty_repo():
         return []
 
-    external_repo_data = RepositorySnap.from_def(empty_repo)
-    assert external_repo_data.name == "empty_repo"
-    assert len(external_repo_data.job_datas) == 0
-    assert len(external_repo_data.resources) == 0
+    repo_snap = RepositorySnap.from_def(empty_repo)
+    assert repo_snap.name == "empty_repo"
+    assert len(repo_snap.job_datas) == 0
+    assert len(repo_snap.resources) == 0
 
 
 def test_repository_snap_definitions_env_vars() -> None:
@@ -363,10 +363,10 @@ def test_repository_snap_definitions_env_vars() -> None:
     )
 
     repo = resolve_pending_repo_if_required(defs)
-    external_repo_data = RepositorySnap.from_def(repo)
-    assert external_repo_data.utilized_env_vars
+    repo_snap = RepositorySnap.from_def(repo)
+    assert repo_snap.utilized_env_vars
 
-    env_vars = dict(external_repo_data.utilized_env_vars)
+    env_vars = dict(repo_snap.utilized_env_vars)
 
     assert len(env_vars) == 5
     assert "MY_STRING" in env_vars
@@ -407,12 +407,12 @@ def test_repository_snap_definitions_resources_assets_usage() -> None:
     )
 
     repo = resolve_pending_repo_if_required(defs)
-    external_repo_data = RepositorySnap.from_def(repo)
-    assert external_repo_data.resources
+    repo_snap = RepositorySnap.from_def(repo)
+    assert repo_snap.resources
 
-    assert len(external_repo_data.resources) == 3
+    assert len(repo_snap.resources) == 3
 
-    foo = [data for data in external_repo_data.resources if data.name == "foo"]
+    foo = [data for data in repo_snap.resources if data.name == "foo"]
     assert len(foo) == 1
 
     assert sorted(foo[0].asset_keys_using, key=lambda k: "".join(k.path)) == [
@@ -420,14 +420,14 @@ def test_repository_snap_definitions_resources_assets_usage() -> None:
         AssetKey("my_other_asset"),
     ]
 
-    bar = [data for data in external_repo_data.resources if data.name == "bar"]
+    bar = [data for data in repo_snap.resources if data.name == "bar"]
     assert len(bar) == 1
 
     assert bar[0].asset_keys_using == [
         AssetKey("my_other_asset"),
     ]
 
-    baz = [data for data in external_repo_data.resources if data.name == "baz"]
+    baz = [data for data in repo_snap.resources if data.name == "baz"]
     assert len(baz) == 1
 
     assert baz[0].asset_keys_using == []
@@ -456,12 +456,12 @@ def test_repository_snap_definitions_function_style_resources_assets_usage() -> 
     )
 
     repo = resolve_pending_repo_if_required(defs)
-    external_repo_data = RepositorySnap.from_def(repo)
-    assert external_repo_data.resources
+    repo_snap = RepositorySnap.from_def(repo)
+    assert repo_snap.resources
 
-    assert len(external_repo_data.resources) == 1
+    assert len(repo_snap.resources) == 1
 
-    foo = external_repo_data.resources[0]
+    foo = repo_snap.resources[0]
 
     assert sorted(foo.asset_keys_using, key=lambda k: "".join(k.path)) == [
         AssetKey("my_asset"),
@@ -512,12 +512,12 @@ def test_repository_snap_definitions_resources_job_op_usage() -> None:
     )
 
     repo = resolve_pending_repo_if_required(defs)
-    external_repo_data = RepositorySnap.from_def(repo)
-    assert external_repo_data.resources
+    repo_snap = RepositorySnap.from_def(repo)
+    assert repo_snap.resources
 
-    assert len(external_repo_data.resources) == 2
+    assert len(repo_snap.resources) == 2
 
-    foo = [data for data in external_repo_data.resources if data.name == "foo"]
+    foo = [data for data in repo_snap.resources if data.name == "foo"]
     assert len(foo) == 1
 
     assert _to_dict(foo[0].job_ops_using) == {
@@ -526,7 +526,7 @@ def test_repository_snap_definitions_resources_job_op_usage() -> None:
         "my_second_job": ["my_op_in_other_job", "my_op_in_other_job_2"],
     }
 
-    bar = [data for data in external_repo_data.resources if data.name == "bar"]
+    bar = [data for data in repo_snap.resources if data.name == "bar"]
     assert len(bar) == 1
 
     assert _to_dict(bar[0].job_ops_using) == {
@@ -572,12 +572,12 @@ def test_repository_snap_definitions_resources_job_op_usage_graph() -> None:
     )
 
     repo = resolve_pending_repo_if_required(defs)
-    external_repo_data = RepositorySnap.from_def(repo)
-    assert external_repo_data.resources
+    repo_snap = RepositorySnap.from_def(repo)
+    assert repo_snap.resources
 
-    assert len(external_repo_data.resources) == 2
+    assert len(repo_snap.resources) == 2
 
-    foo = [data for data in external_repo_data.resources if data.name == "foo"]
+    foo = [data for data in repo_snap.resources if data.name == "foo"]
     assert len(foo) == 1
 
     assert _to_dict(foo[0].job_ops_using) == {
@@ -590,7 +590,7 @@ def test_repository_snap_definitions_resources_job_op_usage_graph() -> None:
         ]
     }
 
-    bar = [data for data in external_repo_data.resources if data.name == "bar"]
+    bar = [data for data in repo_snap.resources if data.name == "bar"]
     assert len(bar) == 1
 
     assert _to_dict(bar[0].job_ops_using) == {"my_job": ["my_graph.my_other_op"]}
@@ -613,11 +613,11 @@ def test_asset_check():
     )
 
     repo = resolve_pending_repo_if_required(defs)
-    external_repo_data = RepositorySnap.from_def(repo)
+    repo_snap = RepositorySnap.from_def(repo)
 
-    assert len(external_repo_data.asset_check_nodes) == 2
-    assert external_repo_data.asset_check_nodes[0].name == "my_asset_check"
-    assert external_repo_data.asset_check_nodes[1].name == "my_asset_check_2"
+    assert len(repo_snap.asset_check_nodes) == 2
+    assert repo_snap.asset_check_nodes[0].name == "my_asset_check"
+    assert repo_snap.asset_check_nodes[1].name == "my_asset_check_2"
 
 
 def test_asset_check_in_asset_op():
@@ -639,12 +639,12 @@ def test_asset_check_in_asset_op():
     )
 
     repo = resolve_pending_repo_if_required(defs)
-    external_repo_data = RepositorySnap.from_def(repo)
+    repo_snap = RepositorySnap.from_def(repo)
 
-    assert len(external_repo_data.asset_check_nodes) == 3
-    assert external_repo_data.asset_check_nodes[0].name == "my_asset_check"
-    assert external_repo_data.asset_check_nodes[1].name == "my_other_asset_check"
-    assert external_repo_data.asset_check_nodes[2].name == "my_other_asset_check_2"
+    assert len(repo_snap.asset_check_nodes) == 3
+    assert repo_snap.asset_check_nodes[0].name == "my_asset_check"
+    assert repo_snap.asset_check_nodes[1].name == "my_other_asset_check"
+    assert repo_snap.asset_check_nodes[2].name == "my_other_asset_check_2"
 
 
 def test_asset_check_multiple_jobs():
@@ -668,13 +668,13 @@ def test_asset_check_multiple_jobs():
     )
 
     repo = resolve_pending_repo_if_required(defs)
-    external_repo_data = RepositorySnap.from_def(repo)
-    assert external_repo_data.asset_check_nodes
-    assert len(external_repo_data.asset_check_nodes) == 2
-    assert external_repo_data.asset_check_nodes[0].name == "my_asset_check"
-    assert external_repo_data.asset_check_nodes[1].name == "my_other_asset_check"
-    assert external_repo_data.asset_check_nodes[0].job_names == ["__ASSET_JOB", "my_job"]
-    assert external_repo_data.asset_check_nodes[1].job_names == ["__ASSET_JOB", "my_job"]
+    repo_snap = RepositorySnap.from_def(repo)
+    assert repo_snap.asset_check_nodes
+    assert len(repo_snap.asset_check_nodes) == 2
+    assert repo_snap.asset_check_nodes[0].name == "my_asset_check"
+    assert repo_snap.asset_check_nodes[1].name == "my_other_asset_check"
+    assert repo_snap.asset_check_nodes[0].job_names == ["__ASSET_JOB", "my_job"]
+    assert repo_snap.asset_check_nodes[1].job_names == ["__ASSET_JOB", "my_job"]
 
 
 def test_asset_check_multi_asset():
@@ -691,11 +691,11 @@ def test_asset_check_multi_asset():
     defs = Definitions(assets=[my_multi_asset])
 
     repo = resolve_pending_repo_if_required(defs)
-    external_repo_data = RepositorySnap.from_def(repo)
-    assert external_repo_data.asset_check_nodes
-    assert len(external_repo_data.asset_check_nodes) == 1
-    assert external_repo_data.asset_check_nodes[0].name == "check_1"
-    assert external_repo_data.asset_check_nodes[0].job_names == ["__ASSET_JOB"]
+    repo_snap = RepositorySnap.from_def(repo)
+    assert repo_snap.asset_check_nodes
+    assert len(repo_snap.asset_check_nodes) == 1
+    assert repo_snap.asset_check_nodes[0].name == "check_1"
+    assert repo_snap.asset_check_nodes[0].job_names == ["__ASSET_JOB"]
 
 
 def test_repository_snap_definitions_resources_schedule_sensor_usage():
@@ -737,12 +737,12 @@ def test_repository_snap_definitions_resources_schedule_sensor_usage():
     )
 
     repo = resolve_pending_repo_if_required(defs)
-    external_repo_data = RepositorySnap.from_def(repo)
-    assert external_repo_data.resources
+    repo_snap = RepositorySnap.from_def(repo)
+    assert repo_snap.resources
 
-    assert len(external_repo_data.resources) == 3
+    assert len(repo_snap.resources) == 3
 
-    foo = [data for data in external_repo_data.resources if data.name == "foo"]
+    foo = [data for data in repo_snap.resources if data.name == "foo"]
     assert len(foo) == 1
 
     assert set(cast(ResourceSnap, foo[0]).schedules_using) == {
@@ -751,13 +751,13 @@ def test_repository_snap_definitions_resources_schedule_sensor_usage():
     }
     assert set(cast(ResourceSnap, foo[0]).sensors_using) == {"my_sensor", "my_sensor_two"}
 
-    bar = [data for data in external_repo_data.resources if data.name == "bar"]
+    bar = [data for data in repo_snap.resources if data.name == "bar"]
     assert len(bar) == 1
 
     assert set(cast(ResourceSnap, bar[0]).schedules_using) == set()
     assert set(cast(ResourceSnap, bar[0]).sensors_using) == {"my_sensor_two"}
 
-    baz = [data for data in external_repo_data.resources if data.name == "baz"]
+    baz = [data for data in repo_snap.resources if data.name == "baz"]
     assert len(baz) == 1
 
     assert set(cast(ResourceSnap, baz[0]).schedules_using) == set({"my_schedule_two"})

--- a/python_modules/dagster/dagster_tests/core_tests/test_job_execution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_job_execution.py
@@ -178,8 +178,8 @@ def test_external_diamond_toposort():
             attribute="create_diamond_job",
             working_directory=None,
         ).create_single_location(instance) as repo_location:
-            external_repo = next(iter(repo_location.get_repositories().values()))
-            remote_job = next(iter(external_repo.get_all_jobs()))
+            repo = next(iter(repo_location.get_repositories().values()))
+            remote_job = next(iter(repo.get_all_jobs()))
             assert remote_job.node_names_in_topological_order == [
                 "A_source",
                 "A",

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_run_status_sensors.py
@@ -648,11 +648,11 @@ def test_run_status_sensor_interleave(storage_config_fn, executor: Optional[Thre
         with instance_with_sensors(overrides=storage_config_fn(temp_dir)) as (
             instance,
             workspace_context,
-            external_repo,
+            remote_repo,
         ):
             # start sensor
             with freeze_time(freeze_datetime):
-                failure_sensor = external_repo.get_sensor("my_run_failure_sensor")
+                failure_sensor = remote_repo.get_sensor("my_run_failure_sensor")
                 instance.start_sensor(failure_sensor)
 
                 evaluate_sensors(workspace_context, executor)
@@ -672,7 +672,7 @@ def test_run_status_sensor_interleave(storage_config_fn, executor: Optional[Thre
                 time.sleep(1)
 
             with freeze_time(freeze_datetime):
-                remote_job = external_repo.get_full_job("hanging_job")
+                remote_job = remote_repo.get_full_job("hanging_job")
                 # start run 1
                 run1 = instance.create_run_for_job(
                     hanging_job,
@@ -749,10 +749,10 @@ def test_run_failure_sensor_empty_run_records(
         with instance_with_sensors(overrides=storage_config_fn(temp_dir)) as (
             instance,
             workspace_context,
-            external_repo,
+            remote_repo,
         ):
             with freeze_time(freeze_datetime):
-                failure_sensor = external_repo.get_sensor("my_run_failure_sensor")
+                failure_sensor = remote_repo.get_sensor("my_run_failure_sensor")
                 instance.start_sensor(failure_sensor)
 
                 evaluate_sensors(workspace_context, executor)

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_queued_run_coordinator_daemon.py
@@ -1,13 +1,15 @@
 import datetime
 import time
 from abc import ABC, abstractmethod
-from typing import Iterator
+from typing import Any, Iterator
 
 import pytest
 from dagster._core.definitions.events import AssetKey
 from dagster._core.definitions.selector import JobSubsetSelector
 from dagster._core.events import DagsterEvent, DagsterEventType
+from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.code_location import GrpcServerCodeLocation
+from dagster._core.remote_representation.external import RemoteJob
 from dagster._core.remote_representation.handle import JobHandle, RepositoryHandle
 from dagster._core.remote_representation.origin import ManagedGrpcPythonEnvCodeLocationOrigin
 from dagster._core.storage.dagster_run import IN_PROGRESS_RUN_STATUSES, DagsterRunStatus
@@ -20,6 +22,7 @@ from dagster._core.test_utils import (
     instance_for_test,
 )
 from dagster._core.utils import make_new_run_id
+from dagster._core.workspace.context import WorkspaceRequestContext
 from dagster._core.workspace.load_target import EmptyWorkspaceTarget, PythonFileTarget
 from dagster._daemon.run_coordinator.queued_run_coordinator_daemon import QueuedRunCoordinatorDaemon
 from dagster._record import copy
@@ -120,18 +123,24 @@ class QueuedRunCoordinatorDaemonTests(ABC):
 
         return instance.get_run_by_id(run.run_id)
 
-    def submit_run(self, instance, external_job, workspace, **kwargs):
-        location = workspace.get_code_location(external_job.handle.location_name)
+    def submit_run(
+        self,
+        instance: DagsterInstance,
+        remote_job: RemoteJob,
+        workspace: WorkspaceRequestContext,
+        **kwargs: Any,
+    ):
+        location = workspace.get_code_location(remote_job.handle.location_name)
         subset_job = location.get_job(
             JobSubsetSelector(
                 location_name=location.name,
-                repository_name=external_job.handle.repository_name,
-                job_name=external_job.handle.job_name,
+                repository_name=remote_job.handle.repository_name,
+                job_name=remote_job.handle.job_name,
                 op_selection=None,
                 asset_selection=kwargs.get("asset_selection"),
             )
         )
-        external_execution_plan = location.get_execution_plan(
+        execution_plan = location.get_execution_plan(
             subset_job,
             {},
             step_keys_to_execute=None,
@@ -143,7 +152,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
             remote_job_origin=subset_job.get_remote_origin(),
             job_code_origin=subset_job.get_python_origin(),
             job_name=subset_job.name,
-            execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,
+            execution_plan_snapshot=execution_plan.execution_plan_snapshot,
             job_snapshot=subset_job.job_snapshot,
             parent_job_snapshot=subset_job.parent_job_snapshot,
             status=DagsterRunStatus.NOT_STARTED,
@@ -856,11 +865,11 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     ):
         run_id_1, run_id_2, run_id_3 = [make_new_run_id() for _ in range(3)]
         workspace = concurrency_limited_workspace_context.create_request_context()
-        external_job = self.get_concurrency_job(workspace)
+        remote_job = self.get_concurrency_job(workspace)
         foo_key = AssetKey(["prefix", "foo_limited_asset"])
 
         self.submit_run(
-            instance, external_job, workspace, run_id=run_id_1, asset_selection=set([foo_key])
+            instance, remote_job, workspace, run_id=run_id_1, asset_selection=set([foo_key])
         )
 
         instance.event_log_storage.set_concurrency_slots("foo", 1)
@@ -869,14 +878,14 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         caplog.text.count("is blocked by global concurrency limits") == 0
 
         self.submit_run(
-            instance, external_job, workspace, run_id=run_id_2, asset_selection=set([foo_key])
+            instance, remote_job, workspace, run_id=run_id_2, asset_selection=set([foo_key])
         )
         list(daemon.run_iteration(concurrency_limited_workspace_context))
         assert set(self.get_run_ids(instance.run_launcher.queue())) == {run_id_1}
         caplog.text.count(f"Run {run_id_2} is blocked by global concurrency limits") == 1
 
         self.submit_run(
-            instance, external_job, workspace, run_id=run_id_3, asset_selection=set([foo_key])
+            instance, remote_job, workspace, run_id=run_id_3, asset_selection=set([foo_key])
         )
         list(daemon.run_iteration(concurrency_limited_workspace_context))
         assert set(self.get_run_ids(instance.run_launcher.queue())) == {run_id_1}
@@ -905,7 +914,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     ):
         run_id_1, run_id_2 = [make_new_run_id() for _ in range(2)]
         workspace = concurrency_limited_workspace_context.create_request_context()
-        external_job = self.get_concurrency_job(workspace)
+        remote_job = self.get_concurrency_job(workspace)
         foo_key = AssetKey(["prefix", "foo_limited_asset"])
         bar_key = AssetKey(["prefix", "bar_limited_asset"])
 
@@ -914,13 +923,13 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         instance.event_log_storage.set_concurrency_slots("bar", 1)
 
         self.submit_run(
-            instance, external_job, workspace, run_id=run_id_1, asset_selection=set([foo_key])
+            instance, remote_job, workspace, run_id=run_id_1, asset_selection=set([foo_key])
         )
         list(daemon.run_iteration(concurrency_limited_workspace_context))
         assert set(self.get_run_ids(instance.run_launcher.queue())) == set()
 
         self.submit_run(
-            instance, external_job, workspace, run_id=run_id_2, asset_selection=set([bar_key])
+            instance, remote_job, workspace, run_id=run_id_2, asset_selection=set([bar_key])
         )
         list(daemon.run_iteration(concurrency_limited_workspace_context))
         assert set(self.get_run_ids(instance.run_launcher.queue())) == {run_id_2}
@@ -939,7 +948,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     ):
         run_id_1 = make_new_run_id()
         workspace = concurrency_limited_workspace_context.create_request_context()
-        external_job = workspace.get_full_job(
+        remote_job = workspace.get_full_job(
             JobSubsetSelector(
                 location_name="test",
                 repository_name="__repository__",
@@ -949,7 +958,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         )
 
         instance.event_log_storage.set_concurrency_slots("foo", 0)
-        self.submit_run(instance, external_job, workspace, run_id=run_id_1)
+        self.submit_run(instance, remote_job, workspace, run_id=run_id_1)
         list(daemon.run_iteration(concurrency_limited_workspace_context))
         # is not blocked because there's an unconstrained node at the root
         assert set(self.get_run_ids(instance.run_launcher.queue())) == {run_id_1}
@@ -969,12 +978,12 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         run_id_1, run_id_2 = [make_new_run_id() for _ in range(2)]
         workspace = concurrency_limited_workspace_context.create_request_context()
         foo_key = AssetKey(["prefix", "foo_limited_asset"])
-        external_job = self.get_concurrency_job(workspace)
+        remote_job = self.get_concurrency_job(workspace)
         self.submit_run(
-            instance, external_job, workspace, run_id=run_id_1, asset_selection=set([foo_key])
+            instance, remote_job, workspace, run_id=run_id_1, asset_selection=set([foo_key])
         )
         self.submit_run(
-            instance, external_job, workspace, run_id=run_id_2, asset_selection=set([foo_key])
+            instance, remote_job, workspace, run_id=run_id_2, asset_selection=set([foo_key])
         )
         instance.event_log_storage.set_concurrency_slots("foo", 1)
         with environ({"DAGSTER_OP_CONCURRENCY_KEYS_ALLOTTED_FOR_STARTED_RUN_SECONDS": "0"}):
@@ -1015,15 +1024,15 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         run_id_1, run_id_2, run_id_3 = [make_new_run_id() for _ in range(3)]
         workspace = concurrency_limited_workspace_context.create_request_context()
         foo_key = AssetKey(["prefix", "foo_limited_asset"])
-        external_job = self.get_concurrency_job(workspace)
+        remote_job = self.get_concurrency_job(workspace)
         self.submit_run(
-            instance, external_job, workspace, run_id=run_id_1, asset_selection=set([foo_key])
+            instance, remote_job, workspace, run_id=run_id_1, asset_selection=set([foo_key])
         )
         self.submit_run(
-            instance, external_job, workspace, run_id=run_id_2, asset_selection=set([foo_key])
+            instance, remote_job, workspace, run_id=run_id_2, asset_selection=set([foo_key])
         )
         self.submit_run(
-            instance, external_job, workspace, run_id=run_id_3, asset_selection=set([foo_key])
+            instance, remote_job, workspace, run_id=run_id_3, asset_selection=set([foo_key])
         )
         instance.event_log_storage.set_concurrency_slots("foo", 1)
         list(daemon.run_iteration(concurrency_limited_workspace_context))
@@ -1046,15 +1055,15 @@ class QueuedRunCoordinatorDaemonTests(ABC):
         run_id_1, run_id_2, run_id_3 = [make_new_run_id() for _ in range(3)]
         workspace = concurrency_limited_workspace_context.create_request_context()
         foo_key = AssetKey(["prefix", "foo_limited_asset"])
-        external_job = self.get_concurrency_job(workspace)
+        remote_job = self.get_concurrency_job(workspace)
         self.submit_run(
-            instance, external_job, workspace, run_id=run_id_1, asset_selection=set([foo_key])
+            instance, remote_job, workspace, run_id=run_id_1, asset_selection=set([foo_key])
         )
         self.submit_run(
-            instance, external_job, workspace, run_id=run_id_2, asset_selection=set([foo_key])
+            instance, remote_job, workspace, run_id=run_id_2, asset_selection=set([foo_key])
         )
         self.submit_run(
-            instance, external_job, workspace, run_id=run_id_3, asset_selection=set([foo_key])
+            instance, remote_job, workspace, run_id=run_id_3, asset_selection=set([foo_key])
         )
         instance.event_log_storage.set_concurrency_slots("foo", 1)
         list(daemon.run_iteration(concurrency_limited_workspace_context))
@@ -1109,7 +1118,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
     ):
         run_id_1 = make_new_run_id()
         workspace = concurrency_limited_workspace_context.create_request_context()
-        external_job = self.get_concurrency_job(workspace)
+        remote_job = self.get_concurrency_job(workspace)
         foo_key = AssetKey(["prefix", "foo_limited_asset"])
 
         # foo is blocked, but bar is not
@@ -1117,7 +1126,7 @@ class QueuedRunCoordinatorDaemonTests(ABC):
 
         self.submit_run(
             instance,
-            external_job,
+            remote_job,
             workspace,
             run_id=run_id_1,
             asset_selection=set([foo_key]),

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -93,7 +93,7 @@ def test_default_auto_materialize_sensors(instance_with_auto_materialize_sensors
         location_name="foo_location",
         repository_name="bar_repo",
     )
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(
             defs.get_repository_def(),
         ),
@@ -101,11 +101,11 @@ def test_default_auto_materialize_sensors(instance_with_auto_materialize_sensors
         instance=instance,
     )
 
-    sensors = external_repo.get_sensors()
+    sensors = remote_repo.get_sensors()
 
     assert len(sensors) == 2
 
-    assert external_repo.has_sensor("normal_sensor")
+    assert remote_repo.has_sensor("normal_sensor")
 
     auto_materialize_sensors = [
         sensor for sensor in sensors if sensor.sensor_type == SensorType.AUTO_MATERIALIZE
@@ -115,7 +115,7 @@ def test_default_auto_materialize_sensors(instance_with_auto_materialize_sensors
     auto_materialize_sensor = auto_materialize_sensors[0]
 
     assert auto_materialize_sensor.name == "default_automation_condition_sensor"
-    assert external_repo.has_sensor(auto_materialize_sensor.name)
+    assert remote_repo.has_sensor(auto_materialize_sensor.name)
 
     assert auto_materialize_sensor.asset_selection == AssetSelection.all(include_sources=True)
 
@@ -130,7 +130,7 @@ def test_default_auto_materialize_sensors_without_observable(
         repository_name="bar_repo",
     )
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(
             defs_without_observables.get_repository_def(),
         ),
@@ -138,14 +138,14 @@ def test_default_auto_materialize_sensors_without_observable(
         instance=instance,
     )
 
-    sensors = external_repo.get_sensors()
+    sensors = remote_repo.get_sensors()
 
     assert len(sensors) == 1
 
     auto_materialize_sensor = sensors[0]
 
     assert auto_materialize_sensor.name == "default_automation_condition_sensor"
-    assert external_repo.has_sensor(auto_materialize_sensor.name)
+    assert remote_repo.has_sensor(auto_materialize_sensor.name)
 
     assert auto_materialize_sensor.asset_selection == AssetSelection.all(include_sources=False)
 
@@ -157,14 +157,14 @@ def test_no_default_auto_materialize_sensors(instance_without_auto_materialize_s
     )
 
     # If not opted in, no default sensors are created
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(
             defs.get_repository_def(),
         ),
         repository_handle=repo_handle,
         instance=instance_without_auto_materialize_sensors,
     )
-    sensors = external_repo.get_sensors()
+    sensors = remote_repo.get_sensors()
     assert len(sensors) == 1
     assert sensors[0].name == "normal_sensor"
 
@@ -191,7 +191,7 @@ def test_combine_default_sensors_with_non_default_sensors(instance_with_auto_mat
         repository_name="bar_repo",
     )
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(
             defs_with_auto_materialize_sensor.get_repository_def(),
         ),
@@ -199,19 +199,19 @@ def test_combine_default_sensors_with_non_default_sensors(instance_with_auto_mat
         instance=instance_with_auto_materialize_sensors,
     )
 
-    sensors = external_repo.get_sensors()
+    sensors = remote_repo.get_sensors()
 
     assert len(sensors) == 3
 
-    assert external_repo.has_sensor("normal_sensor")
-    assert external_repo.has_sensor("default_automation_condition_sensor")
-    assert external_repo.has_sensor("my_custom_policy_sensor")
+    assert remote_repo.has_sensor("normal_sensor")
+    assert remote_repo.has_sensor("default_automation_condition_sensor")
+    assert remote_repo.has_sensor("my_custom_policy_sensor")
 
-    asset_graph = external_repo.asset_graph
+    asset_graph = remote_repo.asset_graph
 
     # default sensor includes all assets that weren't covered by the custom one
 
-    default_sensor = external_repo.get_sensor("default_automation_condition_sensor")
+    default_sensor = remote_repo.get_sensor("default_automation_condition_sensor")
 
     assert (
         str(default_sensor.asset_selection)
@@ -225,7 +225,7 @@ def test_combine_default_sensors_with_non_default_sensors(instance_with_auto_mat
         AssetKey(["boring_observable_asset"]),
     }
 
-    custom_sensor = external_repo.get_sensor("my_custom_policy_sensor")
+    custom_sensor = remote_repo.get_sensor("my_custom_policy_sensor")
 
     assert custom_sensor.asset_selection.resolve(asset_graph) == {
         AssetKey(["auto_materialize_asset"]),
@@ -261,7 +261,7 @@ def test_custom_sensors_cover_all(instance_with_auto_materialize_sensors):
         repository_name="bar_repo",
     )
 
-    external_repo = RemoteRepository(
+    remote_repo = RemoteRepository(
         RepositorySnap.from_def(
             defs_with_auto_materialize_sensor.get_repository_def(),
         ),
@@ -269,17 +269,17 @@ def test_custom_sensors_cover_all(instance_with_auto_materialize_sensors):
         instance=instance_with_auto_materialize_sensors,
     )
 
-    sensors = external_repo.get_sensors()
+    sensors = remote_repo.get_sensors()
 
     assert len(sensors) == 2
 
-    assert external_repo.has_sensor("normal_sensor")
-    assert external_repo.has_sensor("my_custom_policy_sensor")
+    assert remote_repo.has_sensor("normal_sensor")
+    assert remote_repo.has_sensor("my_custom_policy_sensor")
 
-    asset_graph = external_repo.asset_graph
+    asset_graph = remote_repo.asset_graph
 
     # Custom sensor covered all the valid assets
-    custom_sensor = external_repo.get_sensor("my_custom_policy_sensor")
+    custom_sensor = remote_repo.get_sensor("my_custom_policy_sensor")
 
     assert custom_sensor.asset_selection.resolve(asset_graph) == {
         AssetKey(["auto_materialize_asset"]),

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_default_run_launcher.py
@@ -233,7 +233,7 @@ def test_successful_run_from_pending(
     run_id = make_new_run_id()
     code_location = pending_workspace.get_code_location("test2")
     remote_job = code_location.get_repository("pending").get_full_job("my_cool_asset_job")
-    external_execution_plan = code_location.get_execution_plan(
+    remote_execution_plan = code_location.get_execution_plan(
         remote_job=remote_job,
         run_config={},
         step_keys_to_execute=None,
@@ -264,7 +264,7 @@ def test_successful_run_from_pending(
         root_run_id=None,
         parent_run_id=None,
         job_snapshot=remote_job.job_snapshot,
-        execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,
+        execution_plan_snapshot=remote_execution_plan.execution_plan_snapshot,
         parent_job_snapshot=remote_job.parent_job_snapshot,
         remote_job_origin=remote_job.get_remote_origin(),
         job_code_origin=remote_job.get_python_origin(),

--- a/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
+++ b/python_modules/dagster/dagster_tests/launcher_tests/test_persistent_grpc_run_launcher.py
@@ -111,7 +111,7 @@ def test_run_from_pending_repository():
                 remote_job = code_location.get_repository("pending").get_full_job(
                     "my_cool_asset_job"
                 )
-                external_execution_plan = code_location.get_execution_plan(
+                remote_execution_plan = code_location.get_execution_plan(
                     remote_job=remote_job,
                     run_config={},
                     step_keys_to_execute=None,
@@ -144,7 +144,7 @@ def test_run_from_pending_repository():
                     root_run_id=None,
                     parent_run_id=None,
                     job_snapshot=remote_job.job_snapshot,
-                    execution_plan_snapshot=external_execution_plan.execution_plan_snapshot,
+                    execution_plan_snapshot=remote_execution_plan.execution_plan_snapshot,
                     parent_job_snapshot=remote_job.parent_job_snapshot,
                     remote_job_origin=remote_job.get_remote_origin(),
                     job_code_origin=remote_job.get_python_origin(),

--- a/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
+++ b/python_modules/dagster/dagster_tests/scheduler_tests/conftest.py
@@ -72,7 +72,7 @@ def workspace_fixture(
 
 
 @pytest.fixture(name="remote_repo", scope="session")
-def external_repo_fixture(workspace_context: WorkspaceProcessContext) -> RemoteRepository:
+def remote_repo_fixture(workspace_context: WorkspaceProcessContext) -> RemoteRepository:
     return next(
         iter(workspace_context.create_request_context().get_code_location_entries().values())
     ).code_location.get_repository(  # type: ignore  # (possible none)


### PR DESCRIPTION
Internal companion PR: https://github.com/dagster-io/internal/pull/12136

## Summary & Motivation

Rename straggler instances of private methods/attributes/variables that use the `external` qualifier. Renamed to use either `remote` qualifier or no qualifier depending on context. After this PR only gRPC-related code is still using "external", as I haven't assessed what we can do there for a rename yet.

Also, `JobDataSnap` and `JobRef` get `from_job_def` class methods to replace `*_from_def` top level functions (this is consistent with other downstack changes).

## How I Tested These Changes

Existing test suite.