### PR TITLE
[kinds] Use kinds argument in integrations, add to translators

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/asset_decorator.py
@@ -8,7 +8,6 @@ from dagster import (
     multi_asset,
 )
 from dagster._annotations import deprecated_param
-from dagster._core.definitions.tags import build_kind_tag
 from dlt.extract.source import DltSource
 from dlt.pipeline.pipeline import Pipeline
 
@@ -38,7 +37,6 @@ def build_dlt_asset_specs(
 
     """
     dagster_dlt_translator = dagster_dlt_translator or DagsterDltTranslator()
-    destination_type = dlt_pipeline.destination.destination_name
     return [
         AssetSpec(
             key=dagster_dlt_translator.get_asset_key(dlt_source_resource),
@@ -55,11 +53,8 @@ def build_dlt_asset_specs(
                 META_KEY_TRANSLATOR: dagster_dlt_translator,
             },
             owners=dagster_dlt_translator.get_owners(dlt_source_resource),
-            tags={
-                **build_kind_tag("dlt"),
-                **build_kind_tag(destination_type),
-                **dagster_dlt_translator.get_tags(dlt_source_resource),
-            },
+            tags=dagster_dlt_translator.get_tags(dlt_source_resource),
+            kinds=dagster_dlt_translator.get_kinds(dlt_source_resource, dlt_pipeline.destination),
         )
         for dlt_source_resource in dlt_source.selected_resources.values()
     ]

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/translator.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
-from typing import Any, Iterable, Mapping, Optional, Sequence
+from typing import Any, Iterable, Mapping, Optional, Sequence, Set
 
 from dagster import AssetKey, AutoMaterializePolicy, AutomationCondition
 from dagster._annotations import public
+from dlt.common.destination import Destination
 from dlt.extract.resource import DltResource
 
 
@@ -149,3 +150,18 @@ class DagsterDltTranslator:
                 dlt resource.
         """
         return {}
+
+    @public
+    def get_kinds(self, resource: DltResource, destination: Destination) -> Set[str]:
+        """A method that takes in a dlt resource and returns the kinds which should be
+        attached. Defaults to the destination type and "dlt".
+
+        This method can be overriden to provide custom kinds for a dlt resource.
+
+        Args:
+            resource (DltResource): dlt resource
+
+        Returns:
+            Set[str]: The kinds of the asset.
+        """
+        return {"dlt", destination.destination_name}

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/asset_decorator.py
@@ -9,7 +9,6 @@ from dagster import (
     _check as check,
     multi_asset,
 )
-from dagster._core.definitions.tags import build_kind_tag
 from dagster._utils.merger import deep_merge_dicts
 from dagster._utils.security import non_secure_md5_hash_str
 
@@ -133,10 +132,8 @@ def sling_assets(
                     METADATA_KEY_TRANSLATOR: dagster_sling_translator,
                     METADATA_KEY_REPLICATION_CONFIG: replication_config,
                 },
-                tags={
-                    **build_kind_tag("sling"),
-                    **(dagster_sling_translator.get_tags(stream) or {}),
-                },
+                tags=dagster_sling_translator.get_tags(stream),
+                kinds=dagster_sling_translator.get_kinds(stream),
                 group_name=dagster_sling_translator.get_group_name(stream),
                 freshness_policy=dagster_sling_translator.get_freshness_policy(stream),
                 auto_materialize_policy=dagster_sling_translator.get_auto_materialize_policy(

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional, Set
 
 from dagster import AssetKey, AutoMaterializePolicy, FreshnessPolicy, MetadataValue
 from dagster._annotations import public
@@ -208,6 +208,21 @@ class DagsterSlingTranslator:
             Mapping[str, Any]: An empty dictionary.
         """
         return {}
+
+    @public
+    def get_kinds(self, stream_definition: Mapping[str, Any]) -> Set[str]:
+        """Retrieves the kinds for a given stream definition.
+
+        This method returns "sling" by default. This method can be overridden to provide custom kinds.
+
+        Parameters:
+            stream_definition (Mapping[str, Any]): A dictionary representing the stream definition,
+            which includes configuration details.
+
+        Returns:
+            Set[str]: A set containing kinds for the stream's assets.
+        """
+        return {"sling"}
 
     @public
     def get_group_name(self, stream_definition: Mapping[str, Any]) -> Optional[str]:

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_asset_decorator.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Mapping, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence, Set
 
 import dlt
 import duckdb
@@ -23,6 +23,7 @@ from dagster._core.definitions.metadata.table import TableColumn, TableSchema
 from dagster._core.definitions.tags import build_kind_tag, has_kind
 from dagster_embedded_elt.dlt import DagsterDltResource, DagsterDltTranslator, dlt_assets
 from dlt import Pipeline
+from dlt.common.destination import Destination
 from dlt.extract.resource import DltResource
 
 from dagster_embedded_elt_tests.dlt_tests.dlt_test_sources.duckdb_with_transformer import (
@@ -575,15 +576,22 @@ def test_with_owner_replacements(dlt_pipeline: Pipeline) -> None:
 
 
 def test_with_tag_replacements(dlt_pipeline: Pipeline) -> None:
-    expected_tags = {
+    custom_tags = {
         "customized": "tag",
+    }
+
+    expected_tags = {
+        **custom_tags,
         **build_kind_tag("dlt"),
-        **build_kind_tag("duckdb"),
+        **build_kind_tag("test"),
     }
 
     class CustomDagsterDltTranslator(DagsterDltTranslator):
         def get_tags(self, _) -> Optional[Mapping[str, str]]:
             return expected_tags
+
+        def get_kinds(self, resource: DltResource, destination: Destination) -> Set[str]:
+            return {"dlt", "test"}
 
     @dlt_assets(
         dlt_source=dlt_source(),

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_asset_decorator.py
@@ -227,6 +227,9 @@ def test_base_with_custom_tags_translator() -> None:
         def get_tags(self, stream_definition):
             return {"custom_tag": "custom_value"}
 
+        def get_kinds(self, stream_definition):
+            return ["sling", "foo"]
+
     @sling_assets(
         replication_config=replication_config_path,
         dagster_sling_translator=CustomSlingTranslator(),
@@ -237,6 +240,7 @@ def test_base_with_custom_tags_translator() -> None:
         assert my_sling_assets.tags_by_key[asset_key] == {
             "custom_tag": "custom_value",
             **build_kind_tag("sling"),
+            **build_kind_tag("foo"),
         }
 
 

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -11,7 +11,6 @@ from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.metadata.metadata_set import NamespacedMetadataSet
 from dagster._core.definitions.metadata.metadata_value import MetadataValue
-from dagster._core.definitions.tags import build_kind_tag
 from dagster._core.definitions.tags.tag_set import NamespacedTagSet
 from dagster._record import record
 from dagster._serdes.serdes import whitelist_for_serdes
@@ -158,7 +157,8 @@ class DagsterPowerBITranslator:
             key=self.get_dashboard_asset_key(data),
             deps=report_keys,
             metadata={**PowerBIMetadataSet(web_url=MetadataValue.url(url) if url else None)},
-            tags={**PowerBITagSet(asset_type="dashboard"), **build_kind_tag("powerbi")},
+            tags={**PowerBITagSet(asset_type="dashboard")},
+            kinds={"powerbi"},
         )
 
     def get_report_asset_key(self, data: PowerBIContentData) -> AssetKey:
@@ -174,7 +174,8 @@ class DagsterPowerBITranslator:
             key=self.get_report_asset_key(data),
             deps=[dataset_key] if dataset_key else None,
             metadata={**PowerBIMetadataSet(web_url=MetadataValue.url(url) if url else None)},
-            tags={**PowerBITagSet(asset_type="report"), **build_kind_tag("powerbi")},
+            tags={**PowerBITagSet(asset_type="report")},
+            kinds={"powerbi"},
         )
 
     def get_semantic_model_asset_key(self, data: PowerBIContentData) -> AssetKey:
@@ -192,7 +193,8 @@ class DagsterPowerBITranslator:
             key=self.get_semantic_model_asset_key(data),
             deps=source_keys,
             metadata={**PowerBIMetadataSet(web_url=MetadataValue.url(url) if url else None)},
-            tags={**PowerBITagSet(asset_type="semantic_model"), **build_kind_tag("powerbi")},
+            tags={**PowerBITagSet(asset_type="semantic_model")},
+            kinds={"powerbi"},
         )
 
     def get_data_source_asset_key(self, data: PowerBIContentData) -> AssetKey:
@@ -210,5 +212,6 @@ class DagsterPowerBITranslator:
     def get_data_source_spec(self, data: PowerBIContentData) -> AssetSpec:
         return AssetSpec(
             key=self.get_data_source_asset_key(data),
-            tags={**PowerBITagSet(asset_type="data_source"), **build_kind_tag("powerbi")},
+            tags={**PowerBITagSet(asset_type="data_source")},
+            kinds={"powerbi"},
         )

--- a/python_modules/libraries/dagster-sdf/dagster_sdf/sdf_information_schema.py
+++ b/python_modules/libraries/dagster-sdf/dagster_sdf/sdf_information_schema.py
@@ -33,7 +33,6 @@ from dagster._core.definitions.metadata import (
     TableMetadataSet,
     TableSchema,
 )
-from dagster._core.definitions.tags import build_kind_tag
 from dagster._record import IHaveNew, record_custom
 
 from dagster_sdf.asset_utils import exists_in_selected, get_info_schema_dir, get_output_dir
@@ -218,9 +217,7 @@ class SdfInformationSchema(IHaveNew):
                             get_output_dir(self.target_dir, self.environment),
                         ),
                         metadata=metadata,
-                        tags={
-                            **build_kind_tag("sdf"),
-                        },
+                        kinds={"sdf"},
                         skippable=True,
                     )
                 )

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/translator.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/translator.py
@@ -4,7 +4,6 @@ from typing import AbstractSet, Any, Dict, List, Optional
 from dagster import AssetKey, AssetSpec, MetadataValue, TableSchema
 from dagster._core.definitions.metadata.metadata_set import TableMetadataSet
 from dagster._core.definitions.metadata.table import TableColumn
-from dagster._core.definitions.tags import build_kind_tag
 from dagster._record import record
 from dagster._serdes.serdes import whitelist_for_serdes
 from dagster._utils.cached_method import cached_method
@@ -87,9 +86,7 @@ class DagsterSigmaTranslator:
         return AssetSpec(
             key=self.get_workbook_key(data),
             metadata=metadata,
-            tags={
-                **build_kind_tag("sigma"),
-            },
+            kinds={"sigma"},
             deps={self.get_dataset_key(dataset) for dataset in datasets},
             owners=[data.owner_email] if data.owner_email else None,
         )
@@ -113,9 +110,7 @@ class DagsterSigmaTranslator:
         return AssetSpec(
             key=self.get_dataset_key(data),
             metadata=metadata,
-            tags={
-                **build_kind_tag("sigma"),
-            },
+            kinds={"sigma"},
             deps={AssetKey(input_name.lower().split(".")) for input_name in data.inputs},
             description=data.properties.get("description"),
         )


### PR DESCRIPTION
## Summary

Begin using `kinds=` in internal integration implementations instead of `build_kind_tags`.

Also add translator methods for a few integrations to let users specify custom kinds.

## How I Tested These Changes

Existing unit tests, new unit test.

