### PR TITLE
[1.9] flip runs feed feature flag to opt-out

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
@@ -53,18 +53,10 @@ export const ContentRoot = memo(() => {
               />
             </AssetFeatureProvider>
           </Route>
-          {featureEnabled(FeatureFlag.flagRunsFeed)
+          {featureEnabled(FeatureFlag.flagLegacyRunsPage)
             ? // This is somewhat hacky but the Routes can't be wrapped by a fragment otherwise the Switch statement
               // stops working
               [
-                <Route path="/runs/b/:backfillId" key="1">
-                  <RunsFeedBackfillPage />
-                </Route>,
-                <Route path={['/runs', '/runs/scheduled']} exact key="2">
-                  <RunsFeedRoot />
-                </Route>,
-              ]
-            : [
                 <Route path="/runs-feed/b/:backfillId" key="3">
                   <RunsFeedBackfillPage />
                 </Route>,
@@ -76,6 +68,14 @@ export const ContentRoot = memo(() => {
                 </Route>,
                 <Route path="/runs/scheduled" exact key="6">
                   <ScheduledRunListRoot />
+                </Route>,
+              ]
+            : [
+                <Route path="/runs/b/:backfillId" key="1">
+                  <RunsFeedBackfillPage />
+                </Route>,
+                <Route path={['/runs', '/runs/scheduled']} exact key="2">
+                  <RunsFeedRoot />
                 </Route>,
               ]}
           <Route path="/runs/:runId" exact>

--- a/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
@@ -57,12 +57,6 @@ export const ContentRoot = memo(() => {
             ? // This is somewhat hacky but the Routes can't be wrapped by a fragment otherwise the Switch statement
               // stops working
               [
-                <Route path="/runs-feed/b/:backfillId" key="3">
-                  <RunsFeedBackfillPage />
-                </Route>,
-                <Route path={['/runs-feed', '/runs-feed/scheduled']} exact key="4">
-                  <RunsFeedRoot />
-                </Route>,
                 <Route path="/runs" exact key="5">
                   <RunsRoot />
                 </Route>,

--- a/js_modules/dagster-ui/packages/ui-core/src/app/FeatureFlags.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/FeatureFlags.oss.tsx
@@ -5,5 +5,5 @@ export enum FeatureFlag {
   flagDisableAutoLoadDefaults = 'flagDisableAutoLoadDefaults',
   flagLegacyNav = 'flagLegacyNav',
   flagCodeLocationPage = 'flagCodeLocationPage',
-  flagRunsFeed = 'flagRunsFeed',
+  flagLegacyRunsPage = 'flagLegacyRunsPage',
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
@@ -41,13 +41,12 @@ export const useVisibleFeatureFlagRows = () => [
     key: 'New code location page',
     flagType: FeatureFlag.flagCodeLocationPage,
   },
-  // Uncomment once we're ready for this to go live
   {
-    key: 'New Runs page',
-    flagType: FeatureFlag.flagRunsFeed,
+    key: 'Revert to legacy Runs page',
+    flagType: FeatureFlag.flagLegacyRunsPage,
     label: (
       <>
-        New Runs page (
+        Revert to legacy Runs page (
         <a
           href="https://github.com/dagster-io/dagster/discussions/24898"
           target="_blank"

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithData.tsx
@@ -209,8 +209,7 @@ export const AutomaterializeMiddlePanelWithData = ({
           </Box>
           {flagLegacyRunsPage ? (
             <AutomaterializeRunsTable runIds={selectedEvaluation.runIds} />
-          )
-          : (
+          ) : (
             <RunsFeedTableWithFilters filter={runsFilter} />
           )}
           <Box border="bottom" padding={{vertical: 12}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithData.tsx
@@ -53,7 +53,7 @@ export const AutomaterializeMiddlePanelWithData = ({
   specificPartitionData,
   selectedPartition,
 }: Props) => {
-  const {flagRunsFeed} = useFeatureFlags();
+  const {flagLegacyRunsPage} = useFeatureFlags();
   const evaluation = selectedEvaluation?.evaluation;
   const rootEvaluationNode = useMemo(
     () => evaluation?.evaluationNodes.find((node) => node.uniqueId === evaluation.rootUniqueId),
@@ -203,14 +203,15 @@ export const AutomaterializeMiddlePanelWithData = ({
           <Box
             border="bottom"
             padding={{vertical: 12}}
-            margin={flagRunsFeed ? {top: 12} : {vertical: 12}}
+            margin={flagLegacyRunsPage ? {vertical: 12} : {top: 12}}
           >
             <Subtitle2>Runs launched ({selectedEvaluation.runIds.length})</Subtitle2>
           </Box>
-          {flagRunsFeed ? (
-            <RunsFeedTableWithFilters filter={runsFilter} />
-          ) : (
+          {flagLegacyRunsPage ? (
             <AutomaterializeRunsTable runIds={selectedEvaluation.runIds} />
+          )
+          : (
+            <RunsFeedTableWithFilters filter={runsFilter} />
           )}
           <Box border="bottom" padding={{vertical: 12}}>
             <Subtitle2>Policy evaluation</Subtitle2>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/GlobalAutomaterializationContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/GlobalAutomaterializationContent.tsx
@@ -40,7 +40,7 @@ const RUNS_FILTER: RunsFilter = {tags: [{key: 'dagster/auto_materialize', value:
 
 export const GlobalAutomaterializationContent = () => {
   const automaterialize = useAutomaterializeDaemonStatus();
-  const {flagRunsFeed} = useFeatureFlags();
+  const {flagLegacyRunsPage} = useFeatureFlags();
   const confirm = useConfirmation();
 
   const {permissions: {canToggleAutoMaterialize} = {}} = useUnscopedPermissions();
@@ -219,15 +219,16 @@ export const GlobalAutomaterializationContent = () => {
               setTimerange={setTimerange}
               actionBarComponents={tableViewSwitch}
             />
-          ) : flagRunsFeed ? (
+          ) : flagLegacyRunsPage ? (
+            <AutomaterializeRunHistoryTable setTableView={setTableView} />
+          )
+          : (
             <Box margin={{top: 32}} border="top">
               <RunsFeedTableWithFilters
                 filter={RUNS_FILTER}
                 actionBarComponents={tableViewSwitch}
               />
             </Box>
-          ) : (
-            <AutomaterializeRunHistoryTable setTableView={setTableView} />
           )}
         </>
       )}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/GlobalAutomaterializationContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/GlobalAutomaterializationContent.tsx
@@ -221,8 +221,7 @@ export const GlobalAutomaterializationContent = () => {
             />
           ) : flagLegacyRunsPage ? (
             <AutomaterializeRunHistoryTable setTableView={setTableView} />
-          )
-          : (
+          ) : (
             <Box margin={{top: 32}} border="top">
               <RunsFeedTableWithFilters
                 filter={RUNS_FILTER}

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
@@ -160,8 +160,7 @@ export const BackfillRunsTab = ({
       actionBarComponents={actionBarComponents}
       belowActionBarComponents={belowActionBarComponents}
     />
-  )
-  : (
+  ) : (
     <RunsFeedTableWithFilters
       filter={filter}
       actionBarComponents={actionBarComponents}

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
@@ -58,7 +58,7 @@ export const BackfillRunsTab = ({
   backfill: BackfillDetailsBackfillFragment;
   view: 'timeline' | 'list' | 'both';
 }) => {
-  const {flagRunsFeed} = useFeatureFlags();
+  const {flagLegacyRunsPage} = useFeatureFlags();
 
   const [_view, setView] = useQueryPersistedState<'timeline' | 'list'>({
     defaults: {view: 'timeline'},
@@ -154,7 +154,14 @@ export const BackfillRunsTab = ({
       annotations={annotations}
       actionBarComponents={actionBarComponents}
     />
-  ) : flagRunsFeed ? (
+  ) : flagLegacyRunsPage ? (
+    <ExecutionRunTable
+      filter={filter}
+      actionBarComponents={actionBarComponents}
+      belowActionBarComponents={belowActionBarComponents}
+    />
+  )
+  : (
     <RunsFeedTableWithFilters
       filter={filter}
       actionBarComponents={actionBarComponents}
@@ -169,12 +176,6 @@ export const BackfillRunsTab = ({
           No runs have been launched.
         </Box>
       )}
-    />
-  ) : (
-    <ExecutionRunTable
-      filter={filter}
-      actionBarComponents={actionBarComponents}
-      belowActionBarComponents={belowActionBarComponents}
     />
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/RunsFeedBackfillPage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/RunsFeedBackfillPage.tsx
@@ -30,7 +30,6 @@ import {
   DaemonNotRunningAlert,
   useIsBackfillDaemonHealthy,
 } from '../../partitions/BackfillMessaging';
-import {getRunFeedPath} from '../../runs/RunsFeedUtils';
 import {testId} from '../../testing/testId';
 
 export const RunsFeedBackfillPage = () => {
@@ -125,7 +124,7 @@ export const RunsFeedBackfillPage = () => {
       <PageHeader
         title={
           <Heading>
-            <Link to={getRunFeedPath()} style={{color: Colors.textLight()}}>
+            <Link to="/runs/" style={{color: Colors.textLight()}}>
               Runs
             </Link>
             {' / '}

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
@@ -43,9 +43,8 @@ export const OverviewRoot = () => {
           )
         }
       />
-      {featureEnabled(FeatureFlag.flagRunsFeed)
-        ? null
-        : [
+      {featureEnabled(FeatureFlag.flagLegacyRunsPage)
+        ? [
             <Route
               path="/overview/backfills/:backfillId"
               render={() => <BackfillPage />}
@@ -57,7 +56,8 @@ export const OverviewRoot = () => {
               render={() => <InstanceBackfillsRoot />}
               key="2"
             />,
-          ]}
+          ]
+        : null}
       <Route path="/overview/resources">
         <OverviewResourcesRoot />
       </Route>

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
@@ -18,7 +18,7 @@ interface Props<TData> {
 export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TData>) => {
   const {refreshState, tab} = props;
 
-  const {flagLegacyNav, flagRunsFeed} = useFeatureFlags();
+  const {flagLegacyNav, flagLegacyRunsPage} = useFeatureFlags();
 
   const automaterialize = useAutomaterializeDaemonStatus();
   const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
@@ -64,9 +64,9 @@ export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TDa
           />
         ) : null}
         <TabLink id="resources" title="Resources" to="/overview/resources" />
-        {flagRunsFeed ? null : (
+        {flagLegacyRunsPage ? (
           <TabLink id="backfills" title="Backfills" to="/overview/backfills" />
-        )}
+        ) : null}
       </Tabs>
       {refreshState ? (
         <Box style={{alignSelf: 'center'}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRunsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRunsRoot.tsx
@@ -65,7 +65,7 @@ export const PipelineRunsRoot = (props: Props) => {
   if (flagLegacyRunsPage) {
     return <PipelineRunsRootOld {...props} />;
   } else {
-    return <PipelineRunsFeedRoot {...props} />;;
+    return <PipelineRunsFeedRoot {...props} />;
   }
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRunsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRunsRoot.tsx
@@ -60,12 +60,12 @@ interface Props {
 }
 
 export const PipelineRunsRoot = (props: Props) => {
-  const {flagRunsFeed} = useFeatureFlags();
+  const {flagLegacyRunsPage} = useFeatureFlags();
 
-  if (flagRunsFeed) {
-    return <PipelineRunsFeedRoot {...props} />;
-  } else {
+  if (flagLegacyRunsPage) {
     return <PipelineRunsRootOld {...props} />;
+  } else {
+    return <PipelineRunsFeedRoot {...props} />;;
   }
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
@@ -195,14 +195,14 @@ const RUN_ROOT_QUERY = gql`
 `;
 
 const RunHeaderTitle = ({run, runId}: {run: RunPageFragment | null; runId: string}) => {
-  const {flagRunsFeed} = useFeatureFlags();
+  const {flagLegacyRunsPage} = useFeatureFlags();
 
   const backfillTag = useMemo(
     () => run?.tags.find((tag) => tag.key === DagsterTag.Backfill),
     [run],
   );
 
-  if (flagRunsFeed && backfillTag) {
+  if (!flagLegacyRunsPage && backfillTag) {
     return (
       <Heading>
         <Link to="/runs" style={{color: Colors.textLight()}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTabs.tsx
@@ -5,7 +5,6 @@ import {useLocation} from 'react-router-dom';
 import styled, {css} from 'styled-components';
 
 import {failedStatuses, inProgressStatuses, queuedStatuses} from './RunStatuses';
-import {getRunFeedPath} from './RunsFeedUtils';
 import {runsPathWithFilters, useQueryPersistedRunFilters} from './RunsFilterInput';
 import {gql, useQuery} from '../apollo-client';
 import {RunFeedTabsCountQuery, RunFeedTabsCountQueryVariables} from './types/RunsFeedTabs.types';
@@ -65,7 +64,7 @@ export const useRunsFeedTabs = (filter: RunsFilter = {}, includeRunsFromBackfill
     const statusTokens = statuses.map((status) => ({token: 'status' as const, value: status}));
     return runsPathWithFilters(
       [...statusTokens, ...tokensMinusStatus],
-      getRunFeedPath(),
+      '/runs/',
       includeRunsFromBackfills,
     );
   };
@@ -87,9 +86,7 @@ export const useRunsFeedTabs = (filter: RunsFilter = {}, includeRunsFromBackfill
       <TabLink
         id="scheduled"
         title="Scheduled"
-        to={`${getRunFeedPath()}scheduled?${
-          includeRunsFromBackfills ? 'show_runs_within_backfills=true' : ''
-        }`}
+        to={`/runs/scheduled?${includeRunsFromBackfills ? 'show_runs_within_backfills=true' : ''}`}
       />
     </Tabs>
   );
@@ -122,7 +119,7 @@ export const ActivatableButton = styled(AnchorButton)<{$active: boolean}>`
 
 export const useSelectedRunsFeedTab = (filterTokens: TokenizingFieldValue[]) => {
   const {pathname} = useLocation();
-  if (pathname === `${getRunFeedPath()}scheduled`) {
+  if (pathname === '/runs/scheduled') {
     return 'scheduled';
   }
   const statusTokens = new Set(

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedUtils.tsx
@@ -4,7 +4,7 @@ import {runsPathWithFilters} from './RunsFilterInput';
 import {featureEnabled} from '../app/Flags';
 
 export function getBackfillPath(id: string, isAssetBackfill: boolean) {
-  if (featureEnabled(FeatureFlag.flagLegacyRunsFeed)) {
+  if (featureEnabled(FeatureFlag.flagLegacyRunsPage)) {
     if (isAssetBackfill) {
       return `/overview/backfills/${id}`;
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedUtils.tsx
@@ -3,26 +3,17 @@ import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 import {runsPathWithFilters} from './RunsFilterInput';
 import {featureEnabled} from '../app/Flags';
 
-export function getRunFeedPath() {
-  return featureEnabled(FeatureFlag.flagRunsFeed) ? `/runs/` : `/runs-feed/`;
-}
-
 export function getBackfillPath(id: string, isAssetBackfill: boolean) {
-  // THis is hacky but basically we're dark launching runs-feed, so if we're on the runs-feed path, stay on it.
-  if (location.pathname.includes('runs-feed')) {
-    return `/runs-feed/b/${id}`;
+  if (featureEnabled(FeatureFlag.flagLegacyRunsFeed)) {
+    if (isAssetBackfill) {
+      return `/overview/backfills/${id}`;
+    }
+    return runsPathWithFilters([
+      {
+        token: 'tag',
+        value: `dagster/backfill=${id}`,
+      },
+    ]);
   }
-
-  if (featureEnabled(FeatureFlag.flagRunsFeed)) {
-    return `/runs/b/${id}`;
-  }
-  if (isAssetBackfill) {
-    return `/overview/backfills/${id}`;
-  }
-  return runsPathWithFilters([
-    {
-      token: 'tag',
-      value: `dagster/backfill=${id}`,
-    },
-  ]);
+  return `/runs/b/${id}`;
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
@@ -127,8 +127,7 @@ export const ScheduleRoot = (props: Props) => {
                 schedule={scheduleOrError}
                 tabs={tabs}
               />
-            )
-            : (
+            ) : (
               <RunsFeedTableWithFilters filter={runsFilter} />
             )}
           </Page>

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
@@ -44,7 +44,7 @@ export const ScheduleRoot = (props: Props) => {
 
   const {repoAddress} = props;
   const {scheduleName} = useParams<{scheduleName: string}>();
-  const {flagRunsFeed} = useFeatureFlags();
+  const {flagLegacyRunsPage} = useFeatureFlags();
 
   useDocumentTitle(`Schedule: ${scheduleName}`);
 
@@ -120,20 +120,16 @@ export const ScheduleRoot = (props: Props) => {
               />
             ) : null}
             {selectedTab === 'ticks' ? (
-              <TicksTable
-                tabs={tabs}
-                tickResultType="runs"
-                repoAddress={repoAddress}
-                name={scheduleOrError.name}
-              />
-            ) : flagRunsFeed ? (
-              <RunsFeedTableWithFilters filter={runsFilter} />
-            ) : (
+              <TicksTable tabs={tabs} tickResultType="runs" repoAddress={repoAddress} name={scheduleOrError.name} />
+            ) : flagLegacyRunsPage ? (
               <SchedulePreviousRuns
                 repoAddress={repoAddress}
                 schedule={scheduleOrError}
                 tabs={tabs}
               />
+            )
+            : (
+              <RunsFeedTableWithFilters filter={runsFilter} />
             )}
           </Page>
         );

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
@@ -120,7 +120,12 @@ export const ScheduleRoot = (props: Props) => {
               />
             ) : null}
             {selectedTab === 'ticks' ? (
-              <TicksTable tabs={tabs} tickResultType="runs" repoAddress={repoAddress} name={scheduleOrError.name} />
+              <TicksTable
+                tabs={tabs}
+                tickResultType="runs"
+                repoAddress={repoAddress}
+                name={scheduleOrError.name}
+              />
             ) : flagLegacyRunsPage ? (
               <SchedulePreviousRuns
                 repoAddress={repoAddress}

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
@@ -39,7 +39,7 @@ interface Props {
 
 export const SensorPageAutomaterialize = (props: Props) => {
   const {repoAddress, sensor, loading, daemonStatus} = props;
-  const {flagRunsFeed} = useFeatureFlags();
+  const {flagLegacyRunsPage} = useFeatureFlags();
 
   const [isPaused, setIsPaused] = useState(false);
   const [statuses, setStatuses] = useState<undefined | InstigationTickStatus[]>(undefined);
@@ -213,15 +213,16 @@ export const SensorPageAutomaterialize = (props: Props) => {
             />
           ) : (
             <Box margin={{top: 32}} border="top">
-              {flagRunsFeed ? (
-                <RunsFeedTableWithFilters
-                  filter={runTableFilter}
-                  actionBarComponents={tableViewSwitch}
-                />
-              ) : (
+              {flagLegacyRunsPage ? (
                 <AutomaterializeRunHistoryTable
                   filterTags={runTableFilter.tags!}
                   setTableView={setTableView}
+                />
+              )
+              : (
+                <RunsFeedTableWithFilters
+                  filter={runTableFilter}
+                  actionBarComponents={tableViewSwitch}
                 />
               )}
             </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
@@ -218,8 +218,7 @@ export const SensorPageAutomaterialize = (props: Props) => {
                   filterTags={runTableFilter.tags!}
                   setTableView={setTableView}
                 />
-              )
-              : (
+              ) : (
                 <RunsFeedTableWithFilters
                   filter={runTableFilter}
                   actionBarComponents={tableViewSwitch}


### PR DESCRIPTION
## Summary & Motivation
Flips the feature flag for enabling the runs feed to an opt out flag. Also removes the `getRunFeedPath` function since we don't need the `/runs-feed/` link anymore

Will wait to merge this for the 1.9 release

## How I Tested These Changes

## Changelog

[ui] The new version of the Runs page is now enabled by default. To use the legacy version of the Runs page, toggle the "Revert to legacy Runs page" user setting
