### PR TITLE
[docs] add note about enabling PYTHONLEGACYWINDOWSSTDIO

### DIFF
--- a/docs/next/components/mdx/includes/dagster/concepts/logging/RawComputeLogs.mdx
+++ b/docs/next/components/mdx/includes/dagster/concepts/logging/RawComputeLogs.mdx
@@ -5,8 +5,10 @@ Custom log messages are also included in these logs. Notice in the following ima
 <!-- ![Raw compute logs in the Run details page](/images/concepts/logging/loggers-compute-logs.png) -->
 
 <Image
-alt="Raw compute logs in the Run details page"
-src="/images/concepts/logging/loggers-compute-logs.png"
-width={3046}
-height={1618}
+  alt="Raw compute logs in the Run details page"
+  src="/images/concepts/logging/loggers-compute-logs.png"
+  width={3046}
+  height={1618}
 />
+
+**Note:** Windows / Azure users may need to enable the environment variable `PYTHONLEGACYWINDOWSSTDIO` in order for compute logs to be displayed in the Dagster UI. To do that in PowerShell, run `$Env:PYTHONLEGACYWINDOWSSTDIO = 1` and then restart the Dagster instance.


### PR DESCRIPTION
## Summary & Motivation
Addresses https://github.com/dagster-io/dagster/issues/24043

Windows / Azure users may not be able to see compute logs in the Dagster UI and encounter this warning in their terminal:

>UserWarning: WARNING: Compute log capture is disabled for the current environment. Set the environment variable PYTHONLEGACYWINDOWSSTDIO to enable.
>warnings.warn(WIN_PY36_COMPUTE_LOG_DISABLED_MSG)

## How I Tested These Changes
👀