### PR TITLE
Make AutomationCondition evaluate optionally async

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -118,7 +118,7 @@ class AutomationConditionEvaluator:
             )
 
             try:
-                self.evaluate_entity(entity_key)
+                await self.evaluate_entity(entity_key)
             except Exception as e:
                 raise Exception(
                     f"Error while evaluating conditions for {entity_key.to_user_string()}"
@@ -150,10 +150,9 @@ class AutomationConditionEvaluator:
             v for v in self.request_subsets_by_key.values() if not v.is_empty
         ]
 
-    def evaluate_entity(self, key: EntityKey) -> None:
+    async def evaluate_entity(self, key: EntityKey) -> None:
         # evaluate the condition of this asset
-        context = AutomationContext.create(key=key, evaluator=self)
-        result = context.condition.evaluate(context)
+        result = await AutomationContext.create(key=key, evaluator=self).evaluate_async()
 
         # update dictionaries to keep track of this result
         self.current_results_by_key[key] = result

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
@@ -10,6 +10,7 @@ from dagster._core.asset_graph_view.entity_subset import EntitySubset
 from dagster._core.definitions.asset_key import AssetCheckKey, AssetKey, EntityKey, T_EntityKey
 from dagster._core.definitions.declarative_automation.automation_condition import (
     AutomationCondition,
+    AutomationResult,
 )
 from dagster._core.definitions.declarative_automation.legacy.legacy_context import (
     LegacyRuleEvaluationContext,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_context.py
@@ -1,4 +1,5 @@
 import datetime
+import inspect
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generic, Mapping, Optional, Type, TypeVar
@@ -108,6 +109,11 @@ class AutomationContext(Generic[T_EntityKey]):
             else None,
             _root_log=self._root_log,
         )
+
+    async def evaluate_async(self) -> AutomationResult[T_EntityKey]:
+        if inspect.iscoroutinefunction(self.condition.evaluate):
+            return await self.condition.evaluate(self)
+        return self.condition.evaluate(self)
 
     @property
     def log(self) -> logging.Logger:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/any_downstream_conditions_operator.py
@@ -94,15 +94,13 @@ class AnyDownstreamConditionsCondition(BuiltinAutomationCondition[AssetKey]):
         ):
             if downstream_condition in ignored_conditions:
                 continue
-            child_condition = DownstreamConditionWrapperCondition(
-                downstream_keys=list(sorted(asset_keys)), operand=downstream_condition
-            )
-            child_context = context.for_child_condition(
-                child_condition=child_condition,
+            child_result = await context.for_child_condition(
+                child_condition=DownstreamConditionWrapperCondition(
+                    downstream_keys=list(sorted(asset_keys)), operand=downstream_condition
+                ),
                 child_index=i,
                 candidate_subset=context.candidate_subset,
-            )
-            child_result = await child_condition.evaluate(child_context)
+            ).evaluate_async()
 
             child_results.append(child_result)
             true_subset = true_subset.compute_union(child_result.true_subset)

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/boolean_operators.py
@@ -35,14 +35,16 @@ class AndAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     def requires_cursor(self) -> bool:
         return False
 
-    def evaluate(self, context: AutomationContext[T_EntityKey]) -> AutomationResult[T_EntityKey]:
+    async def evaluate(
+        self, context: AutomationContext[T_EntityKey]
+    ) -> AutomationResult[T_EntityKey]:
         child_results: List[AutomationResult] = []
         true_subset = context.candidate_subset
         for i, child in enumerate(self.children):
             child_context = context.for_child_condition(
                 child_condition=child, child_index=i, candidate_subset=true_subset
             )
-            child_result = child.evaluate(child_context)
+            child_result = await child_context.evaluate_async()
             child_results.append(child_result)
             true_subset = true_subset.compute_intersection(child_result.true_subset)
         return AutomationResult(context, true_subset, child_results=child_results)
@@ -83,14 +85,16 @@ class OrAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     def requires_cursor(self) -> bool:
         return False
 
-    def evaluate(self, context: AutomationContext[T_EntityKey]) -> AutomationResult[T_EntityKey]:
+    async def evaluate(
+        self, context: AutomationContext[T_EntityKey]
+    ) -> AutomationResult[T_EntityKey]:
         child_results: List[AutomationResult] = []
         true_subset = context.get_empty_subset()
         for i, child in enumerate(self.children):
             child_context = context.for_child_condition(
                 child_condition=child, child_index=i, candidate_subset=context.candidate_subset
             )
-            child_result = child.evaluate(child_context)
+            child_result = await child_context.evaluate_async()
             child_results.append(child_result)
             true_subset = true_subset.compute_union(child_result.true_subset)
 
@@ -116,11 +120,13 @@ class NotAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
     def children(self) -> Sequence[AutomationCondition[T_EntityKey]]:
         return [self.operand]
 
-    def evaluate(self, context: AutomationContext[T_EntityKey]) -> AutomationResult[T_EntityKey]:
+    async def evaluate(
+        self, context: AutomationContext[T_EntityKey]
+    ) -> AutomationResult[T_EntityKey]:
         child_context = context.for_child_condition(
             child_condition=self.operand, child_index=0, candidate_subset=context.candidate_subset
         )
-        child_result = self.operand.evaluate(child_context)
+        child_result = await child_context.evaluate_async()
         true_subset = context.candidate_subset.compute_difference(child_result.true_subset)
 
         return AutomationResult(context, true_subset, child_results=[child_result])

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/check_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/check_operators.py
@@ -54,7 +54,7 @@ class AnyChecksCondition(ChecksAutomationCondition):
     def base_name(self) -> str:
         return "ANY_CHECKS_MATCH"
 
-    def evaluate(self, context: AutomationContext[AssetKey]) -> AutomationResult[AssetKey]:
+    async def evaluate(self, context: AutomationContext[AssetKey]) -> AutomationResult[AssetKey]:
         check_results = []
         true_subset = context.get_empty_subset()
 
@@ -62,7 +62,7 @@ class AnyChecksCondition(ChecksAutomationCondition):
             sorted(self._get_check_keys(context.key, context.asset_graph))
         ):
             check_condition = EntityMatchesCondition(key=check_key, operand=self.operand)
-            check_result = check_condition.evaluate(
+            check_result = await check_condition.evaluate(
                 context.for_child_condition(
                     child_condition=check_condition,
                     child_index=i,
@@ -83,7 +83,7 @@ class AllChecksCondition(ChecksAutomationCondition):
     def base_name(self) -> str:
         return "ALL_CHECKS_MATCH"
 
-    def evaluate(self, context: AutomationContext[AssetKey]) -> AutomationResult[AssetKey]:
+    async def evaluate(self, context: AutomationContext[AssetKey]) -> AutomationResult[AssetKey]:
         check_results = []
         true_subset = context.candidate_subset
 
@@ -91,7 +91,7 @@ class AllChecksCondition(ChecksAutomationCondition):
             sorted(self._get_check_keys(context.key, context.asset_graph))
         ):
             check_condition = EntityMatchesCondition(key=check_key, operand=self.operand)
-            check_result = check_condition.evaluate(
+            check_result = await check_condition.evaluate(
                 context.for_child_condition(
                     child_condition=check_condition,
                     child_index=i,

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -135,14 +135,11 @@ class AnyDepsCondition(DepsAutomationCondition[T_EntityKey]):
         true_subset = context.get_empty_subset()
 
         for i, dep_key in enumerate(sorted(self._get_dep_keys(context.key, context.asset_graph))):
-            dep_condition = EntityMatchesCondition(key=dep_key, operand=self.operand)
-            dep_result = await dep_condition.evaluate(
-                context.for_child_condition(
-                    child_condition=dep_condition,
-                    child_index=i,
-                    candidate_subset=context.candidate_subset,
-                )
-            )
+            dep_result = await context.for_child_condition(
+                child_condition=EntityMatchesCondition(key=dep_key, operand=self.operand),
+                child_index=i,
+                candidate_subset=context.candidate_subset,
+            ).evaluate_async()
             dep_results.append(dep_result)
             true_subset = true_subset.compute_union(dep_result.true_subset)
 
@@ -163,14 +160,11 @@ class AllDepsCondition(DepsAutomationCondition[T_EntityKey]):
         true_subset = context.candidate_subset
 
         for i, dep_key in enumerate(sorted(self._get_dep_keys(context.key, context.asset_graph))):
-            dep_condition = EntityMatchesCondition(key=dep_key, operand=self.operand)
-            dep_result = await dep_condition.evaluate(
-                context.for_child_condition(
-                    child_condition=dep_condition,
-                    child_index=i,
-                    candidate_subset=context.candidate_subset,
-                )
-            )
+            dep_result = await context.for_child_condition(
+                child_condition=EntityMatchesCondition(key=dep_key, operand=self.operand),
+                child_index=i,
+                candidate_subset=context.candidate_subset,
+            ).evaluate_async()
             dep_results.append(dep_result)
             true_subset = true_subset.compute_intersection(dep_result.true_subset)
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
@@ -37,7 +37,7 @@ class NewlyTrueCondition(BuiltinAutomationCondition[T_EntityKey]):
             return None
         return context.asset_graph_view.get_subset_from_serializable_subset(true_subset)
 
-    def evaluate(self, context: AutomationContext) -> AutomationResult:
+    async def evaluate(self, context: AutomationContext) -> AutomationResult:
         # evaluate child condition
         child_context = context.for_child_condition(
             self.operand,
@@ -45,7 +45,7 @@ class NewlyTrueCondition(BuiltinAutomationCondition[T_EntityKey]):
             # must evaluate child condition over the entire subset to avoid missing state transitions
             candidate_subset=context.asset_graph_view.get_full_subset(key=context.key),
         )
-        child_result = self.operand.evaluate(child_context)
+        child_result = await child_context.evaluate_async()
 
         # get the set of asset partitions of the child which newly became true
         newly_true_child_subset = child_result.true_subset.compute_difference(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/newly_true_operator.py
@@ -39,13 +39,12 @@ class NewlyTrueCondition(BuiltinAutomationCondition[T_EntityKey]):
 
     async def evaluate(self, context: AutomationContext) -> AutomationResult:
         # evaluate child condition
-        child_context = context.for_child_condition(
+        child_result = await context.for_child_condition(
             self.operand,
             child_index=0,
             # must evaluate child condition over the entire subset to avoid missing state transitions
             candidate_subset=context.asset_graph_view.get_full_subset(key=context.key),
-        )
-        child_result = await child_context.evaluate_async()
+        ).evaluate_async()
 
         # get the set of asset partitions of the child which newly became true
         newly_true_child_subset = child_result.true_subset.compute_difference(

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
@@ -32,16 +32,14 @@ class SinceCondition(BuiltinAutomationCondition[T_EntityKey]):
         child_candidate_subset = context.asset_graph_view.get_full_subset(key=context.key)
 
         # compute result for trigger condition
-        trigger_context = context.for_child_condition(
+        trigger_result = await context.for_child_condition(
             self.trigger_condition, child_index=0, candidate_subset=child_candidate_subset
-        )
-        trigger_result = await trigger_context.evaluate_async()
+        ).evaluate_async()
 
         # compute result for reset condition
-        reset_context = context.for_child_condition(
+        reset_result = await context.for_child_condition(
             self.reset_condition, child_index=1, candidate_subset=child_candidate_subset
-        )
-        reset_result = await reset_context.evaluate_async()
+        ).evaluate_async()
 
         # take the previous subset that this was true for
         true_subset = context.previous_true_subset or context.get_empty_subset()

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/since_operator.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Sequence
 
 from dagster._core.definitions.asset_key import T_EntityKey
@@ -31,15 +32,17 @@ class SinceCondition(BuiltinAutomationCondition[T_EntityKey]):
         # must evaluate child condition over the entire subset to avoid missing state transitions
         child_candidate_subset = context.asset_graph_view.get_full_subset(key=context.key)
 
-        # compute result for trigger condition
-        trigger_result = await context.for_child_condition(
-            self.trigger_condition, child_index=0, candidate_subset=child_candidate_subset
-        ).evaluate_async()
-
-        # compute result for reset condition
-        reset_result = await context.for_child_condition(
-            self.reset_condition, child_index=1, candidate_subset=child_candidate_subset
-        ).evaluate_async()
+        # compute result for trigger and reset conditions
+        trigger_result, reset_result = await asyncio.gather(
+            *[
+                context.for_child_condition(
+                    self.trigger_condition, child_index=0, candidate_subset=child_candidate_subset
+                ).evaluate_async(),
+                context.for_child_condition(
+                    self.reset_condition, child_index=1, candidate_subset=child_candidate_subset
+                ).evaluate_async(),
+            ]
+        )
 
         # take the previous subset that this was true for
         true_subset = context.previous_true_subset or context.get_empty_subset()

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_check_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_check_condition.py
@@ -65,9 +65,10 @@ def get_hardcoded_condition():
     return HardcodedCondition(), true_set
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("is_any", [True, False])
 @pytest.mark.parametrize("blocking_only", [True, False])
-def test_check_operators_partitioned(is_any: bool, blocking_only: bool) -> None:
+async def test_check_operators_partitioned(is_any: bool, blocking_only: bool) -> None:
     inner_condition, true_set = get_hardcoded_condition()
     condition = (
         AutomationCondition.any_checks_match(inner_condition, blocking_only=blocking_only)
@@ -79,25 +80,26 @@ def test_check_operators_partitioned(is_any: bool, blocking_only: bool) -> None:
     ).with_asset_properties(partitions_def=two_partitions_def)
 
     # no checks true
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     true_set.add(AssetCheckKey(AssetKey("A"), "a1"))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     if is_any:
         assert result.true_subset.size == 2
     else:
         assert result.true_subset.size == (2 if blocking_only else 0)
 
     true_set.add(AssetCheckKey(AssetKey("A"), "a2"))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     if is_any:
         assert result.true_subset.size == 2
     else:
         assert result.true_subset.size == 2
 
 
-def test_any_checks_match_basic() -> None:
+@pytest.mark.asyncio
+async def test_any_checks_match_basic() -> None:
     # always true
     true_condition = AutomationCondition.cron_tick_passed(
         "* * * * *"
@@ -110,11 +112,11 @@ def test_any_checks_match_basic() -> None:
     state = AutomationConditionScenarioState(downstream_of_check, automation_condition=condition)
 
     # there is an upstream check for C
-    state, result = state.evaluate("C")
+    state, result = await state.evaluate("C")
     assert result.true_subset.size == 1
 
     # there is no upstream check for D
-    state, result = state.evaluate("D")
+    state, result = await state.evaluate("D")
     assert result.true_subset.size == 0
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_code_version_changed_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_code_version_changed_condition.py
@@ -1,3 +1,4 @@
+import pytest
 from dagster import AutomationCondition
 
 from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils.automation_condition_scenario import (
@@ -8,38 +9,39 @@ from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils
 )
 
 
-def test_code_version_changed_condition() -> None:
+@pytest.mark.asyncio
+async def test_code_version_changed_condition() -> None:
     state = AutomationConditionScenarioState(
         one_asset, automation_condition=AutomationCondition.code_version_changed()
     ).with_asset_properties(code_version="1")
 
     # not changed
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # still not changed
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # newly changed
     state = state.with_asset_properties(code_version="2")
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
 
     # not newly changed
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # newly changed
     state = state.with_asset_properties(code_version="3")
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
 
     # newly changed
     state = state.with_asset_properties(code_version="2")
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
 
     # not newly changed
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_missing_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_missing_condition.py
@@ -1,3 +1,4 @@
+import pytest
 from dagster import AutomationCondition
 
 from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils.automation_condition_scenario import (
@@ -12,36 +13,38 @@ from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils
 )
 
 
-def test_missing_unpartitioned() -> None:
+@pytest.mark.asyncio
+async def test_missing_unpartitioned() -> None:
     state = AutomationConditionScenarioState(
         one_asset, automation_condition=AutomationCondition.missing()
     )
 
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
 
     state = state.with_runs(run_request("A"))
-    _, result = state.evaluate("A")
+    _, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
 
-def test_missing_partitioned() -> None:
+@pytest.mark.asyncio
+async def test_missing_partitioned() -> None:
     state = AutomationConditionScenarioState(
         one_asset, automation_condition=AutomationCondition.missing()
     ).with_asset_properties(partitions_def=two_partitions_def)
 
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 2
 
     state = state.with_runs(run_request("A", "1"))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
 
     # same partition materialized again
     state = state.with_runs(run_request("A", "1"))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
 
     state = state.with_runs(run_request("A", "2"))
-    _, result = state.evaluate("A")
+    _, result = await state.evaluate("A")
     assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_newly_true_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_newly_true_condition.py
@@ -1,3 +1,4 @@
+import pytest
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.events import AssetKeyPartitionKey
 
@@ -12,47 +13,48 @@ from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils
 )
 
 
-def test_newly_true_condition() -> None:
+@pytest.mark.asyncio
+async def test_newly_true_condition() -> None:
     inner_condition, true_set = get_hardcoded_condition()
 
     condition = inner_condition.newly_true()
     state = AutomationConditionScenarioState(one_asset, automation_condition=condition)
 
     # nothing true
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # becomes true
     true_set.add(AssetKeyPartitionKey(AssetKey("A")))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
 
     # now on the next tick, this asset is no longer newly true
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # see above
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # see above
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # now condition becomes false, result still false
     true_set.remove(AssetKeyPartitionKey(AssetKey("A")))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # see above
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # becomes true again
     true_set.add(AssetKeyPartitionKey(AssetKey("A")))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
 
     # no longer newly true
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_newly_updated_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_newly_updated_condition.py
@@ -1,3 +1,4 @@
+import pytest
 from dagster import (
     AssetCheckResult,
     AssetMaterialization,
@@ -18,43 +19,45 @@ from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils
 )
 
 
-def test_newly_updated_condition() -> None:
+@pytest.mark.asyncio
+async def test_newly_updated_condition() -> None:
     state = AutomationConditionScenarioState(
         one_asset, automation_condition=AutomationCondition.newly_updated()
     )
 
     # not updated
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # newly updated
     state = state.with_reported_materialization("A")
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
 
     # not newly updated
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # still not newly updated
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # newly updated twice in a row
     state = state.with_reported_materialization("A")
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
 
     state = state.with_reported_materialization("A")
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
 
     # not newly updated
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
 
-def test_newly_updated_condition_data_version() -> None:
+@pytest.mark.asyncio
+async def test_newly_updated_condition_data_version() -> None:
     state = AutomationConditionScenarioState(
         one_upstream_observable_asset,
         automation_condition=AutomationCondition.any_deps_match(
@@ -63,35 +66,35 @@ def test_newly_updated_condition_data_version() -> None:
     )
 
     # not updated
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # newly updated
     state = state.with_reported_observation("A", data_version="1")
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 1
 
     # not newly updated
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # same data version, not newly updated
     state = state.with_reported_observation("A", data_version="1")
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # new data version
     state = state.with_reported_observation("A", data_version="2")
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 1
 
     # new data version
     state = state.with_reported_observation("A", data_version="3")
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 1
 
     # no new data version
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_on_cron_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_on_cron_condition.py
@@ -1,5 +1,6 @@
 import datetime
 
+import pytest
 from dagster import (
     AssetMaterialization,
     AutomationCondition,
@@ -23,7 +24,8 @@ from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils
 )
 
 
-def test_on_cron_unpartitioned() -> None:
+@pytest.mark.asyncio
+async def test_on_cron_unpartitioned() -> None:
     state = AutomationConditionScenarioState(
         two_assets_in_sequence,
         automation_condition=AutomationCondition.on_cron(cron_schedule="0 * * * *"),
@@ -31,17 +33,17 @@ def test_on_cron_unpartitioned() -> None:
     ).with_current_time("2020-02-02T00:55:00")
 
     # no cron boundary crossed
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # now crossed a cron boundary parent hasn't updated yet
     state = state.with_current_time_advanced(minutes=10)
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # parent updated, now can execute
     state = state.with_runs(run_request("A"))
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 1
     state = state.with_runs(
         *(
@@ -51,26 +53,27 @@ def test_on_cron_unpartitioned() -> None:
     )
 
     # now B has been materialized, so don't execute again
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # A gets materialized again before the hour, so don't execute B again
     state = state.with_runs(run_request("A"))
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # now a new cron tick, but A still hasn't been materialized since the hour
     state = state.with_current_time_advanced(hours=1)
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # A gets materialized again after the hour, so execute B again
     state = state.with_runs(run_request("A"))
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 1
 
 
-def test_on_cron_hourly_partitioned() -> None:
+@pytest.mark.asyncio
+async def test_on_cron_hourly_partitioned() -> None:
     state = (
         AutomationConditionScenarioState(
             two_assets_in_sequence,
@@ -82,22 +85,22 @@ def test_on_cron_hourly_partitioned() -> None:
     )
 
     # no cron boundary crossed
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # now crossed a cron boundary parent hasn't updated yet
     state = state.with_current_time_advanced(minutes=10)
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # historical parent updated, doesn't matter
     state = state.with_runs(run_request("A", "2019-07-05-00:00"))
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # latest parent updated, now can execute
     state = state.with_runs(run_request("A", "2020-02-02-00:00"))
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 1
     state = state.with_runs(
         *(
@@ -107,22 +110,22 @@ def test_on_cron_hourly_partitioned() -> None:
     )
 
     # now B has been materialized, so don't execute again
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # now a new cron tick, but A still hasn't been materialized since the hour
     state = state.with_current_time_advanced(hours=1)
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # A gets materialized with the previous partition after the hour, but that doesn't matter
     state = state.with_runs(run_request("A", "2020-02-02-00:00"))
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # A gets materialized with the latest partition, fire
     state = state.with_runs(run_request("A", "2020-02-02-01:00"))
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 1
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_on_missing_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_on_missing_condition.py
@@ -1,3 +1,4 @@
+import pytest
 from dagster import AutomationCondition
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.events import AssetMaterialization
@@ -14,7 +15,8 @@ from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils
 )
 
 
-def test_on_missing_unpartitioned() -> None:
+@pytest.mark.asyncio
+async def test_on_missing_unpartitioned() -> None:
     state = AutomationConditionScenarioState(
         two_assets_in_sequence,
         automation_condition=AutomationCondition.on_missing(),
@@ -23,30 +25,30 @@ def test_on_missing_unpartitioned() -> None:
 
     # B starts off as materialized
     state.instance.report_runless_asset_event(AssetMaterialization(asset_key=AssetKey("B")))
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # parent materialized, now could execute, but B is not missing
     state = state.with_runs(run_request("A"))
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # now wipe B so that it is newly missing, should update
     state.instance.wipe_assets([AssetKey("B")])
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 1
 
     # B has not yet materialized, but it has been requested, so don't request again
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # same as above
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # parent materialized again, no impact
     state = state.with_runs(run_request("A"))
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # now B has been materialized, so really shouldn't execute again
@@ -56,16 +58,17 @@ def test_on_missing_unpartitioned() -> None:
             for ak, pk in result.true_subset.expensively_compute_asset_partitions()
         )
     )
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # parent materialized again, no impact
     state = state.with_runs(run_request("A"))
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
 
-def test_on_missing_hourly_partitioned() -> None:
+@pytest.mark.asyncio
+async def test_on_missing_hourly_partitioned() -> None:
     state = (
         AutomationConditionScenarioState(
             two_assets_in_sequence,
@@ -77,42 +80,43 @@ def test_on_missing_hourly_partitioned() -> None:
     )
 
     # parent hasn't updated yet
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     state = state.with_current_time_advanced(hours=1)
 
     # historical parent updated, doesn't matter
     state = state.with_runs(run_request("A", "2019-07-05-00:00"))
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # latest parent updated, now can execute
     state = state.with_runs(run_request("A", "2020-02-02-00:00"))
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 1
 
     # B has been requested, so don't request again
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # new partition comes into being, parent hasn't been materialized yet
     state = state.with_current_time_advanced(hours=1)
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # latest parent updated, now can execute
     state = state.with_runs(run_request("A", "2020-02-02-01:00"))
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 1
 
     # latest parent updated again, don't re execute
     state = state.with_runs(run_request("A", "2020-02-02-01:00"))
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
 
-def test_on_missing_without_time_limit() -> None:
+@pytest.mark.asyncio
+async def test_on_missing_without_time_limit() -> None:
     state = (
         AutomationConditionScenarioState(
             two_assets_in_sequence,
@@ -126,7 +130,7 @@ def test_on_missing_without_time_limit() -> None:
     )
 
     # parent hasn't updated yet
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     state = state.with_current_time_advanced(years=1)
@@ -134,9 +138,9 @@ def test_on_missing_without_time_limit() -> None:
     # historical parents updated, matters
     state = state.with_runs(run_request("A", "2019-07-05-00:00"))
     state = state.with_runs(run_request("A", "2019-04-05-00:00"))
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 2
 
     # B has been requested, so don't request again
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_since_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_since_condition.py
@@ -1,3 +1,4 @@
+import pytest
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.declarative_automation.operators import SinceCondition
 from dagster._core.definitions.events import AssetKeyPartitionKey
@@ -13,7 +14,8 @@ from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils
 )
 
 
-def test_since_condition_unpartitioned() -> None:
+@pytest.mark.asyncio
+async def test_since_condition_unpartitioned() -> None:
     primary_condition, true_set_primary = get_hardcoded_condition()
     reference_condition, true_set_reference = get_hardcoded_condition()
 
@@ -23,43 +25,43 @@ def test_since_condition_unpartitioned() -> None:
     state = AutomationConditionScenarioState(one_asset, automation_condition=condition)
 
     # nothing true
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # primary becomes true, but reference has never been true
     true_set_primary.add(AssetKeyPartitionKey(AssetKey("A")))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
     true_set_primary.remove(AssetKeyPartitionKey(AssetKey("A")))
 
     # reference becomes true, and it's after primary
     true_set_reference.add(AssetKeyPartitionKey(AssetKey("A")))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
     true_set_reference.remove(AssetKeyPartitionKey(AssetKey("A")))
 
     # primary becomes true again, and it's since reference has become true
     true_set_primary.add(AssetKeyPartitionKey(AssetKey("A")))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
     true_set_primary.remove(AssetKeyPartitionKey(AssetKey("A")))
 
     # remains true on the neprimaryt evaluation
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
 
     # primary becomes true again, still doesn't change anything
     true_set_primary.add(AssetKeyPartitionKey(AssetKey("A")))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
     true_set_primary.remove(AssetKeyPartitionKey(AssetKey("A")))
 
     # now reference becomes true again
     true_set_reference.add(AssetKeyPartitionKey(AssetKey("A")))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
     true_set_reference.remove(AssetKeyPartitionKey(AssetKey("A")))
 
     # remains false on the neprimaryt evaluation
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_updated_since_cron_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_updated_since_cron_condition.py
@@ -1,3 +1,4 @@
+import pytest
 from dagster import AutomationCondition
 
 from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils.automation_condition_scenario import (
@@ -12,7 +13,8 @@ from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils
 )
 
 
-def test_updated_since_cron_unpartitioned() -> None:
+@pytest.mark.asyncio
+async def test_updated_since_cron_unpartitioned() -> None:
     state = AutomationConditionScenarioState(
         one_asset,
         automation_condition=AutomationCondition.newly_updated().since(
@@ -20,29 +22,30 @@ def test_updated_since_cron_unpartitioned() -> None:
         ),
     ).with_current_time("2020-02-02T00:55:00")
 
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # now pass a cron tick, still haven't updated since that time
     state = state.with_current_time_advanced(minutes=10)
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # now A is updated, so have been updated since cron tick
     state = state.with_runs(run_request("A"))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
 
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
 
     # new cron tick, no longer materialized since it
     state = state.with_current_time_advanced(hours=1)
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
 
-def test_updated_since_cron_partitioned() -> None:
+@pytest.mark.asyncio
+async def test_updated_since_cron_partitioned() -> None:
     state = (
         AutomationConditionScenarioState(
             one_asset,
@@ -54,43 +57,43 @@ def test_updated_since_cron_partitioned() -> None:
         .with_current_time("2020-02-02T00:55:00")
     )
 
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # now pass a cron tick, still haven't updated since that time
     state = state.with_current_time_advanced(minutes=10)
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # one materialized
     state = state.with_runs(run_request("A", "1"))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
 
     # now both materialized
     state = state.with_runs(run_request("A", "2"))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 2
 
     # nothing changed
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 2
 
     # A 1 materialized again before the hour
     state = state.with_runs(run_request("A", "1"))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 2
 
     # new hour passes, nothing materialized since then
     state = state.with_current_time_advanced(hours=1)
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 0
 
     # A 2 materialized again after the hour
     state = state.with_runs(run_request("A", "2"))
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1
 
     # nothing changed
-    state, result = state.evaluate("A")
+    state, result = await state.evaluate("A")
     assert result.true_subset.size == 1

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_will_be_requested_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_will_be_requested_condition.py
@@ -1,3 +1,4 @@
+import pytest
 from dagster import AssetKey, AutomationCondition
 from dagster._core.definitions.events import AssetKeyPartitionKey
 
@@ -10,33 +11,35 @@ from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils
 )
 
 
-def test_will_be_requested_unpartitioned() -> None:
+@pytest.mark.asyncio
+async def test_will_be_requested_unpartitioned() -> None:
     condition = AutomationCondition.any_deps_match(AutomationCondition.will_be_requested())
     state = AutomationConditionScenarioState(two_assets_in_sequence, automation_condition=condition)
 
     # no requested parents
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # parent is requested
     state = state.with_requested_asset_partitions([AssetKeyPartitionKey(AssetKey("A"))])
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 1
 
 
-def test_will_be_requested_static_partitioned() -> None:
+@pytest.mark.asyncio
+async def test_will_be_requested_static_partitioned() -> None:
     condition = AutomationCondition.any_deps_match(AutomationCondition.will_be_requested())
     state = AutomationConditionScenarioState(
         two_assets_in_sequence, automation_condition=condition
     ).with_asset_properties(partitions_def=two_partitions_def)
 
     # no requested parents
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # one requested parent
     state = state.with_requested_asset_partitions([AssetKeyPartitionKey(AssetKey("A"), "1")])
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 1
     assert result.true_subset.expensively_compute_asset_partitions() == {
         AssetKeyPartitionKey(AssetKey("B"), "1")
@@ -46,28 +49,29 @@ def test_will_be_requested_static_partitioned() -> None:
     state = state.with_requested_asset_partitions(
         [AssetKeyPartitionKey(AssetKey("A"), "1"), AssetKeyPartitionKey(AssetKey("A"), "2")]
     )
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 2
 
 
-def test_will_be_requested_different_partitions() -> None:
+@pytest.mark.asyncio
+async def test_will_be_requested_different_partitions() -> None:
     condition = AutomationCondition.any_deps_match(AutomationCondition.will_be_requested())
     state = AutomationConditionScenarioState(
         two_assets_in_sequence, automation_condition=condition
     ).with_asset_properties("A", partitions_def=two_partitions_def)
 
     # no requested parents
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # one requested parent, but can't execute in same run
     state = state.with_requested_asset_partitions([AssetKeyPartitionKey(AssetKey("A"), "1")])
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0
 
     # two requested parents, but can't execute in same run
     state = state.with_requested_asset_partitions(
         [AssetKeyPartitionKey(AssetKey("A"), "1"), AssetKeyPartitionKey(AssetKey("A"), "2")]
     )
-    state, result = state.evaluate("B")
+    state, result = await state.evaluate("B")
     assert result.true_subset.size == 0

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_result_value_hash.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_result_value_hash.py
@@ -26,6 +26,7 @@ one_parent_daily = one_parent.with_asset_properties(partitions_def=daily_partiti
 two_parents_daily = two_parents.with_asset_properties(partitions_def=daily_partitions)
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ["expected_value_hash", "condition", "scenario_spec", "materialize_A"],
     [
@@ -51,16 +52,16 @@ two_parents_daily = two_parents.with_asset_properties(partitions_def=daily_parti
         ("7f852ab7408c67e0830530d025505a37", SC.missing(), one_parent_daily, False),
     ],
 )
-def test_value_hash(
+async def test_value_hash(
     condition: SC, scenario_spec: ScenarioSpec, expected_value_hash: str, materialize_A: bool
 ) -> None:
     state = AutomationConditionScenarioState(
         scenario_spec, automation_condition=condition
     ).with_current_time("2024-01-01T00:00")
 
-    state, _ = state.evaluate("downstream")
+    state, _ = await state.evaluate("downstream")
     if materialize_A:
         state = state.with_runs(run_request("A"))
 
-    state, result = state.evaluate("downstream")
+    state, result = await state.evaluate("downstream")
     assert result.value_hash == expected_value_hash

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
@@ -64,7 +64,7 @@ class AutomationConditionScenarioState(ScenarioState):
             for asset_key, aps in ap_by_key.items()
         }
 
-    def evaluate(
+    async def evaluate(
         self, asset: CoercibleToAssetKey
     ) -> Tuple["AutomationConditionScenarioState", AutomationResult]:
         asset_key = AssetKey.from_coercible(asset)
@@ -100,7 +100,7 @@ class AutomationConditionScenarioState(ScenarioState):
             )  # type: ignore
             context = AutomationContext.create(key=asset_key, evaluator=evaluator)
 
-            full_result = asset_condition.evaluate(context)
+            full_result = await asset_condition.evaluate(context)  # type: ignore
             new_state = dataclasses.replace(self, condition_cursor=full_result.get_new_cursor())
             result = full_result.child_results[0] if self.ensure_empty_result else full_result
 


### PR DESCRIPTION
## Summary & Motivation
We now want to make each the `AutomationCondition.evaluate` function optionally async. This is because we still want to keep it non async if users want to make their own automation conditions. To handle this, added a wrapper async evaluate function on `AutomationContext` that checks if the evaluate function is async or not.

## How I Tested These Changes
Existing tests should pass