### PR TITLE
[1.9] AssetKey path as a tuple

### DIFF
--- a/docs/content/integrations/dbt/using-dbt-with-dagster/downstream-assets.mdx
+++ b/docs/content/integrations/dbt/using-dbt-with-dagster/downstream-assets.mdx
@@ -60,7 +60,7 @@ To add the `order_count_chart` asset:
    ```python file=integrations/dbt/tutorial/downstream_assets/assets.py startafter=start_downstream_asset endbefore=end_downstream_asset
    @asset(
        compute_kind="python",
-       deps=get_asset_key_for_model([jaffle_shop_dbt_assets], "customers"),
+       deps=[get_asset_key_for_model([jaffle_shop_dbt_assets], "customers")],
    )
    def order_count_chart(context: AssetExecutionContext):
        # read the contents of the customers table into a Pandas DataFrame

--- a/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/downstream_assets/assets.py
+++ b/examples/docs_snippets/docs_snippets/integrations/dbt/tutorial/downstream_assets/assets.py
@@ -36,7 +36,7 @@ def jaffle_shop_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
 # start_downstream_asset
 @asset(
     compute_kind="python",
-    deps=get_asset_key_for_model([jaffle_shop_dbt_assets], "customers"),
+    deps=[get_asset_key_for_model([jaffle_shop_dbt_assets], "customers")],
 )
 def order_count_chart(context: AssetExecutionContext):
     # read the contents of the customers table into a Pandas DataFrame

--- a/python_modules/dagster/dagster/_core/definitions/asset_key.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_key.py
@@ -1,9 +1,12 @@
 import re
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, List, Mapping, NamedTuple, Optional, Sequence, TypeVar, Union
 
 import dagster._check as check
 import dagster._seven as seven
-from dagster._annotations import PublicAttr
+from dagster._annotations import PublicAttr, public
+from dagster._core.errors import DagsterInvariantViolationError
+from dagster._record import IHaveNew, record_custom
 from dagster._serdes import whitelist_for_serdes
 
 ASSET_KEY_SPLIT_REGEX = re.compile("[^a-zA-Z0-9_]")
@@ -19,7 +22,11 @@ def parse_asset_key_string(s: str) -> Sequence[str]:
 
 
 @whitelist_for_serdes
-class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
+@record_custom(
+    checked=False,
+    field_to_new_mapping={"parts": "path"},
+)
+class AssetKey(IHaveNew):
     """Object representing the structure of an asset key.  Takes in a sanitized string, list of
     strings, or tuple of strings.
 
@@ -39,28 +46,30 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
             strings represent the hierarchical structure of the asset_key.
     """
 
-    def __new__(cls, path: Union[str, Sequence[str]]):
-        if isinstance(path, str):
-            path = [path]
-        else:
-            path = list(check.sequence_param(path, "path", of_type=str))
+    # Originally AssetKey contained "path" as a list. In order to change to using a tuple, we now have
+    parts: Sequence[str]  # with path available as a property defined below still returning a list.
 
-        return super(AssetKey, cls).__new__(cls, path=path)
+    def __new__(
+        cls,
+        path: Union[str, Sequence[str]],
+    ):
+        if isinstance(path, str):
+            parts = (path,)
+        else:
+            parts = tuple(check.sequence_param(path, "path", of_type=str))
+
+        return super().__new__(cls, parts=parts)
+
+    @public
+    @cached_property
+    def path(self) -> Sequence[str]:
+        return list(self.parts)
 
     def __str__(self):
         return f"AssetKey({self.path})"
 
     def __repr__(self):
         return f"AssetKey({self.path})"
-
-    def __hash__(self):
-        return hash(tuple(self.path))
-
-    def __eq__(self, other):
-        if other.__class__ is not self.__class__:
-            return False
-
-        return self.path == other.path
 
     def to_string(self) -> str:
         """E.g. '["first_component", "second_component"]'."""
@@ -149,6 +158,19 @@ class AssetKey(NamedTuple("_AssetKey", [("path", PublicAttr[Sequence[str]])])):
     def with_prefix(self, prefix: "CoercibleToAssetKeyPrefix") -> "AssetKey":
         prefix = key_prefix_from_coercible(prefix)
         return AssetKey(list(prefix) + list(self.path))
+
+    def __iter__(self):
+        raise DagsterInvariantViolationError(
+            "You have attempted to iterate a single AssetKey object. "
+            "As of 1.9, this behavior is disallowed because it is likely unintentional and a bug."
+        )
+
+    def __getitem__(self, _):
+        raise DagsterInvariantViolationError(
+            "You have attempted to index directly in to the AssetKey object. "
+            "As of 1.9, this behavior is disallowed because it is likely unintentional and a bug. "
+            "Use asset_key.path instead to access the list of key components."
+        )
 
 
 CoercibleToAssetKey = Union[AssetKey, str, Sequence[str]]

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -28,7 +28,7 @@ from dagster._core.selector.subset_selector import (
     fetch_sources,
     parse_clause,
 )
-from dagster._model import DagsterModel
+from dagster._record import copy, record
 from dagster._serdes.serdes import whitelist_for_serdes
 
 CoercibleToAssetSelection: TypeAlias = Union[
@@ -41,13 +41,14 @@ CoercibleToAssetSelection: TypeAlias = Union[
 
 
 def is_coercible_to_asset_selection(obj: object) -> TypeGuard[CoercibleToAssetSelection]:
-    return isinstance(obj, (str, AssetSelection)) or (
+    # can coerce to (but is not already) an AssetSelection
+    return isinstance(obj, str) or (
         isinstance(obj, Sequence)
         and all(isinstance(x, (str, AssetKey, AssetsDefinition, SourceAsset)) for x in obj)
     )
 
 
-class AssetSelection(ABC, DagsterModel):
+class AssetSelection(ABC):
     """An AssetSelection defines a query over a set of assets and asset checks, normally all that are defined in a code location.
 
     You can use the "|", "&", and "-" operators to create unions, intersections, and differences of selections, respectively.
@@ -533,6 +534,7 @@ class AssetSelection(ABC, DagsterModel):
 
 
 @whitelist_for_serdes
+@record
 class AllSelection(AssetSelection):
     include_sources: Optional[bool] = None
 
@@ -553,6 +555,7 @@ class AllSelection(AssetSelection):
 
 
 @whitelist_for_serdes
+@record
 class AllAssetCheckSelection(AssetSelection):
     def resolve_inner(
         self, asset_graph: BaseAssetGraph, allow_missing: bool
@@ -572,6 +575,7 @@ class AllAssetCheckSelection(AssetSelection):
 
 
 @whitelist_for_serdes
+@record
 class AssetChecksForAssetKeysSelection(AssetSelection):
     selected_asset_keys: Sequence[AssetKey]
 
@@ -599,6 +603,7 @@ class AssetChecksForAssetKeysSelection(AssetSelection):
 
 
 @whitelist_for_serdes
+@record
 class AssetCheckKeysSelection(AssetSelection):
     selected_asset_check_keys: Sequence[AssetCheckKey]
 
@@ -631,6 +636,7 @@ class AssetCheckKeysSelection(AssetSelection):
         return f"asset_check:({' or '.join(k.to_user_string() for k in self.selected_asset_check_keys)})"
 
 
+@record
 class OperandListAssetSelection(AssetSelection):
     """Superclass for classes like `AndAssetSelection` and `OrAssetSelection` that operate on
     a list of sub-AssetSelections.
@@ -639,13 +645,11 @@ class OperandListAssetSelection(AssetSelection):
     operands: Sequence[AssetSelection]
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self.model_copy(
-            update=dict(
-                operands=[
-                    operand.to_serializable_asset_selection(asset_graph)
-                    for operand in self.operands
-                ]
-            )
+        return copy(
+            self,
+            operands=[
+                operand.to_serializable_asset_selection(asset_graph) for operand in self.operands
+            ],
         )
 
     def __eq__(self, other):
@@ -718,6 +722,7 @@ class OrAssetSelection(OperandListAssetSelection):
 
 
 @whitelist_for_serdes
+@record
 class SubtractAssetSelection(AssetSelection):
     left: AssetSelection
     right: AssetSelection
@@ -737,11 +742,10 @@ class SubtractAssetSelection(AssetSelection):
         ) - self.right.resolve_checks_inner(asset_graph, allow_missing=allow_missing)
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self.model_copy(
-            update=dict(
-                left=self.left.to_serializable_asset_selection(asset_graph),
-                right=self.right.to_serializable_asset_selection(asset_graph),
-            )
+        return copy(
+            self,
+            left=self.left.to_serializable_asset_selection(asset_graph),
+            right=self.right.to_serializable_asset_selection(asset_graph),
         )
 
     def needs_parentheses_when_operand(self) -> bool:
@@ -751,6 +755,7 @@ class SubtractAssetSelection(AssetSelection):
         return f"{self.left.operand__str__()} - {self.right.operand__str__()}"
 
 
+@record
 class ChainedAssetSelection(AssetSelection):
     """Superclass for AssetSelection classes that contain a single child AssetSelection and are
     resolved by applying some operation to the result of resolving the child selection.
@@ -759,9 +764,7 @@ class ChainedAssetSelection(AssetSelection):
     child: AssetSelection
 
     def to_serializable_asset_selection(self, asset_graph: BaseAssetGraph) -> "AssetSelection":
-        return self.model_copy(
-            update=dict(child=self.child.to_serializable_asset_selection(asset_graph))
-        )
+        return copy(self, child=self.child.to_serializable_asset_selection(asset_graph))
 
 
 @whitelist_for_serdes
@@ -807,6 +810,7 @@ class MaterializableAssetSelection(ChainedAssetSelection):
 
 
 @whitelist_for_serdes
+@record
 class DownstreamAssetSelection(ChainedAssetSelection):
     depth: Optional[int]
     include_self: bool
@@ -834,6 +838,7 @@ class DownstreamAssetSelection(ChainedAssetSelection):
 
 
 @whitelist_for_serdes
+@record
 class GroupsAssetSelection(AssetSelection):
     selected_groups: Sequence[str]
     include_sources: bool
@@ -864,6 +869,7 @@ class GroupsAssetSelection(AssetSelection):
 
 
 @whitelist_for_serdes
+@record
 class TagAssetSelection(AssetSelection):
     key: str
     value: str
@@ -885,6 +891,7 @@ class TagAssetSelection(AssetSelection):
 
 
 @whitelist_for_serdes
+@record
 class OwnerAssetSelection(AssetSelection):
     selected_owner: str
 
@@ -902,6 +909,7 @@ class OwnerAssetSelection(AssetSelection):
 
 
 @whitelist_for_serdes
+@record
 class CodeLocationAssetSelection(AssetSelection):
     """Used to represent a UI asset selection by code location. This should not be resolved against
     an in-process asset graph.
@@ -920,6 +928,7 @@ class CodeLocationAssetSelection(AssetSelection):
 
 
 @whitelist_for_serdes
+@record
 class KeysAssetSelection(AssetSelection):
     selected_keys: Sequence[AssetKey]
 
@@ -970,6 +979,7 @@ class KeysAssetSelection(AssetSelection):
 
 
 @whitelist_for_serdes
+@record
 class KeyPrefixesAssetSelection(AssetSelection):
     selected_key_prefixes: Sequence[Sequence[str]]
     include_sources: bool
@@ -1025,6 +1035,7 @@ def _fetch_all_upstream(
 
 
 @whitelist_for_serdes
+@record
 class UpstreamAssetSelection(ChainedAssetSelection):
     depth: Optional[int]
     include_self: bool

--- a/python_modules/dagster/dagster/_core/definitions/resolved_asset_deps.py
+++ b/python_modules/dagster/dagster/_core/definitions/resolved_asset_deps.py
@@ -105,7 +105,7 @@ def resolve_similar_asset_names(
         # If the asset key provided has no prefix and the upstream key has
         # the same name but a prefix of any length
         no_prefix_but_is_match_with_prefix = (
-            len(target_asset_key) == 1 and asset_key.path[-1] == target_asset_key.path[-1]
+            len(target_asset_key.path) == 1 and asset_key.path[-1] == target_asset_key.path[-1]
         )
 
         matches_slashes_turned_to_prefix_gaps = asset_key.path == target_asset_key_split

--- a/python_modules/dagster/dagster/_core/definitions/target.py
+++ b/python_modules/dagster/dagster/_core/definitions/target.py
@@ -100,6 +100,9 @@ class AutomationTarget(
             if isinstance(coercible, AssetsDefinition):
                 asset_selection = AssetSelection.assets(coercible)
                 assets_defs = [coercible]
+            elif isinstance(coercible, AssetSelection):
+                asset_selection = coercible
+                assets_defs = []
             elif is_coercible_to_asset_selection(coercible):
                 asset_selection = AssetSelection.from_coercible(coercible)
                 assets_defs = (

--- a/python_modules/dagster/dagster/_record/__init__.py
+++ b/python_modules/dagster/dagster/_record/__init__.py
@@ -130,14 +130,15 @@ def _namedtuple_record_transform(
     # the default namedtuple record cannot handle subclasses that have different fields from their
     # parents if both are records
     base.__repr__ = _repr
+    nt_iter = base.__iter__
+    base.__iter__ = _banned_iter
+    base.__getitem__ = _banned_idx
 
     # these will override an implementation on the class if it exists
     new_class_dict = {
         **{n: getattr(base, n) for n in field_set.keys()},
         "_fields": base._fields,
-        "__iter__": _banned_iter,
-        "__getitem__": _banned_idx,
-        "__hidden_iter__": base.__iter__,
+        "__hidden_iter__": nt_iter,
         "__hidden_replace__": base._replace,
         _RECORD_MARKER_FIELD: _RECORD_MARKER_VALUE,
         _RECORD_ANNOTATIONS_FIELD: field_set,
@@ -321,6 +322,9 @@ class IHaveNew:
     if TYPE_CHECKING:
 
         def __new__(cls, **kwargs) -> Self: ...
+
+        # let type checker know these objects are sortable (by way of being a namedtuple)
+        def __lt__(self, other) -> bool: ...
 
 
 def is_record(obj) -> bool:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -20,6 +20,7 @@ from dagster import (
     multi_asset,
     observable_source_asset,
 )
+from dagster._check.functions import CheckError
 from dagster._core.definitions import AssetSelection, asset
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_graph import AssetGraph
@@ -47,7 +48,6 @@ from dagster._core.definitions.base_asset_graph import BaseAssetGraph
 from dagster._core.definitions.events import AssetKey
 from dagster._serdes import deserialize_value
 from dagster._serdes.serdes import _WHITELIST_MAP
-from pydantic import ValidationError
 from typing_extensions import TypeAlias
 
 earth = SourceAsset(["celestial", "earth"], group_name="planets")
@@ -491,74 +491,74 @@ def test_asset_selection_type_checking():
 
     invalid_argument = "invalid_argument"
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(CheckError):
         AssetChecksForAssetKeysSelection(selected_asset_keys=invalid_argument)
     test = AssetChecksForAssetKeysSelection(selected_asset_keys=valid_asset_key_sequence)
     assert isinstance(test, AssetChecksForAssetKeysSelection)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(CheckError):
         AssetCheckKeysSelection(selected_asset_check_keys=invalid_argument)
     test = AssetCheckKeysSelection(selected_asset_check_keys=valid_asset_check_key_sequence)
     assert isinstance(test, AssetCheckKeysSelection)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(CheckError):
         AndAssetSelection(operands=invalid_argument)
     test = AndAssetSelection(operands=valid_asset_selection_sequence)
     assert isinstance(test, AndAssetSelection)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(CheckError):
         OrAssetSelection(operands=invalid_argument)
     test = OrAssetSelection(operands=valid_asset_selection_sequence)
     assert isinstance(test, OrAssetSelection)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(CheckError):
         SubtractAssetSelection(left=invalid_argument, right=invalid_argument)
     test = SubtractAssetSelection(left=valid_asset_selection, right=valid_asset_selection)
     assert isinstance(test, SubtractAssetSelection)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(CheckError):
         SinksAssetSelection(child=invalid_argument)
     test = SinksAssetSelection(child=valid_asset_selection)
     assert isinstance(test, SinksAssetSelection)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(CheckError):
         RequiredNeighborsAssetSelection(child=invalid_argument)
     test = RequiredNeighborsAssetSelection(child=valid_asset_selection)
     assert isinstance(test, RequiredNeighborsAssetSelection)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(CheckError):
         RootsAssetSelection(child=invalid_argument)
     test = RootsAssetSelection(child=valid_asset_selection)
     assert isinstance(test, RootsAssetSelection)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(CheckError):
         DownstreamAssetSelection(child=invalid_argument, depth=0, include_self=False)
     test = DownstreamAssetSelection(child=valid_asset_selection, depth=0, include_self=False)
     assert isinstance(test, DownstreamAssetSelection)
 
-    with pytest.raises(ValidationError):
-        GroupsAssetSelection(selected_groups=invalid_argument, include_sources=False)
     test = GroupsAssetSelection(selected_groups=valid_string_sequence, include_sources=False)
     assert isinstance(test, GroupsAssetSelection)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(CheckError):
         KeysAssetSelection(selected_keys=invalid_argument)
     test = KeysAssetSelection(selected_keys=valid_asset_key_sequence)
     assert isinstance(test, KeysAssetSelection)
 
-    with pytest.raises(ValidationError):
-        KeyPrefixesAssetSelection(selected_key_prefixes=invalid_argument, include_sources=False)
+    # These 2 *should* error but requires making check.sequence not accept str
+    GroupsAssetSelection(selected_groups=invalid_argument, include_sources=False)
+    KeyPrefixesAssetSelection(selected_key_prefixes=invalid_argument, include_sources=False)
+
     test = KeyPrefixesAssetSelection(
         selected_key_prefixes=valid_string_sequence_sequence, include_sources=False
     )
     assert isinstance(test, KeyPrefixesAssetSelection)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(CheckError):
         UpstreamAssetSelection(child=invalid_argument, depth=0, include_self=False)
     test = UpstreamAssetSelection(child=valid_asset_selection, depth=0, include_self=False)
     assert isinstance(test, UpstreamAssetSelection)
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(CheckError):
         ParentSourcesAssetSelection(child=invalid_argument)
     test = ParentSourcesAssetSelection(child=valid_asset_selection)
     assert isinstance(test, ParentSourcesAssetSelection)

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2402,3 +2402,24 @@ def test_multiple_keys_per_output_name():
         AssetsDefinition(
             node_def=op1, keys_by_output_name={"out1": AssetKey("a"), "out2": AssetKey("a")}
         )
+
+
+def test_iterate_over_single_key():
+    key = AssetKey("ouch")
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="You have attempted to iterate a single AssetKey object. "
+        "As of 1.9, this behavior is disallowed because it is likely unintentional and a bug.",
+    ):
+        [_ for _ in key]
+
+
+def test_index_in_to_key():
+    key = AssetKey("ouch")
+    with pytest.raises(
+        DagsterInvariantViolationError,
+        match="You have attempted to index directly in to the AssetKey object. "
+        "As of 1.9, this behavior is disallowed because it is likely unintentional and a bug. "
+        "Use asset_key.path instead to access the list of key components.",
+    ):
+        key[0][0]

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/base_scenario.py
@@ -592,13 +592,18 @@ FAIL_TAG = "test/fail"
 
 
 def run_request(
-    asset_keys: Sequence[CoercibleToAssetKey],
+    asset_keys: Union[AssetKey, Sequence[CoercibleToAssetKey]],
     partition_key: Optional[str] = None,
     fail_keys: Optional[Sequence[str]] = None,
     tags: Optional[Mapping[str, str]] = None,
 ) -> RunRequest:
+    if isinstance(asset_keys, AssetKey):
+        asset_selection = [asset_keys]
+    else:
+        asset_selection = [AssetKey.from_coercible(key) for key in asset_keys]
+
     return RunRequest(
-        asset_selection=[AssetKey.from_coercible(key) for key in asset_keys],
+        asset_selection=asset_selection,
         partition_key=partition_key,
         tags={**(tags or {}), **({FAIL_TAG: json.dumps(fail_keys)} if fail_keys else {})},
     )

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dbt_manifest_asset_selection.py
@@ -7,6 +7,7 @@ from dagster import (
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.base_asset_graph import BaseAssetGraph
+from dagster._record import record
 
 from dagster_dbt.asset_utils import get_asset_check_key_for_test, is_non_asset_node
 from dagster_dbt.dagster_dbt_translator import DagsterDbtTranslator
@@ -18,7 +19,8 @@ from dagster_dbt.utils import (
 )
 
 
-class DbtManifestAssetSelection(AssetSelection, arbitrary_types_allowed=True):
+@record
+class DbtManifestAssetSelection(AssetSelection):
     """Defines a selection of assets from a dbt manifest wrapper and a dbt selection string.
 
     Args:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_selection.py
@@ -8,6 +8,7 @@ import pytest
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_selection import AndAssetSelection
 from dagster._core.definitions.events import AssetKey
+from dagster._record import replace
 from dagster_dbt import build_dbt_asset_selection
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster_dbt.dbt_manifest_asset_selection import DbtManifestAssetSelection
@@ -273,25 +274,30 @@ def test_dbt_asset_selection_equality(
         altered_manifest = copy.deepcopy(dbt_manifest_asset_selection.manifest)
         altered_manifest["metadata"]["project_id"] = 12345
 
-        assert dbt_manifest_asset_selection != dbt_manifest_asset_selection.model_copy(
-            update={"manifest": altered_manifest}
+        assert dbt_manifest_asset_selection != replace(
+            dbt_manifest_asset_selection,
+            manifest=altered_manifest,
         )
 
-        assert dbt_manifest_asset_selection != dbt_manifest_asset_selection.model_copy(
-            update={"select": "other_select"}
+        assert dbt_manifest_asset_selection != replace(
+            dbt_manifest_asset_selection,
+            select="other_select",
         )
 
-        assert dbt_manifest_asset_selection != dbt_manifest_asset_selection.model_copy(
-            update={"dagster_dbt_translator": mock.MagicMock()}
+        assert dbt_manifest_asset_selection != replace(
+            dbt_manifest_asset_selection,
+            dagster_dbt_translator=mock.MagicMock(),
         )
 
-        assert dbt_manifest_asset_selection != dbt_manifest_asset_selection.model_copy(
-            update={"exclude": "other_exclude"}
+        assert dbt_manifest_asset_selection != replace(
+            dbt_manifest_asset_selection,
+            exclude="other_exclude",
         )
 
         # changing non-metadata fields does not affect equality
         altered_nodes_manifest = dict(copy.deepcopy(dbt_manifest_asset_selection.manifest))
         altered_nodes_manifest["nodes"] = []
-        assert dbt_manifest_asset_selection == dbt_manifest_asset_selection.model_copy(
-            update={"manifest": altered_nodes_manifest}
+        assert dbt_manifest_asset_selection == replace(
+            dbt_manifest_asset_selection,
+            manifest=altered_nodes_manifest,
         )

--- a/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
+++ b/python_modules/libraries/dagster-wandb/dagster_wandb/io_manager.py
@@ -395,7 +395,7 @@ class ArtifactsIOManager(IOManager):
 
                 artifact_name = parameters.get("name")
                 if artifact_name is None:
-                    artifact_name = context.asset_key[0][0]  # name of asset
+                    artifact_name = context.asset_key.path[0]  # name of asset
 
                 partitions = [
                     (key, f"{artifact_name}.{ str(key).replace('|', '-')}")


### PR DESCRIPTION
Storing `path` as a tuple and avoiding custom `__eq__` and `__hash__` functions results in a substantial performance improvement for operations like building up a large global asset graph. 

## How I Tested These Changes
For this target large graph, function calls decreased by ~70% and execution time decreased by ~50%

Before:
```
Profiling asset graph...
         353461 function calls in 0.083 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   119166    0.021    0.000    0.027    0.000 asset_key.py:56(__hash__)
        1    0.012    0.012    0.080    0.080 remote_asset_graph.py:303(_build)
        1    0.008    0.008    0.018    0.018 remote_asset_graph.py:355(<dictcomp>)
   119166    0.006    0.000    0.006    0.000 {built-in method builtins.hash}
        1    0.005    0.005    0.012    0.012 remote_asset_graph.py:502(_build_execution_set_index)
     7790    0.003    0.000    0.006    0.000 external_data.py:1313(key)
        2    0.003    0.002    0.006    0.003 remote_asset_graph.py:481(_warn_on_duplicates_within_subset)
    17250    0.003    0.000    0.007    0.000 {method 'add' of 'set' objects}
        1    0.002    0.002    0.083    0.083 remote_asset_graph.py:276(from_workspace_snapshot)
     5012    0.002    0.000    0.004    0.000 remote_asset_graph.py:51(__init__)
     9598    0.002    0.000    0.002    0.000 asset_key.py:59(__eq__)
        1    0.002    0.002    0.003    0.003 remote_asset_graph.py:330(<dictcomp>)
     5012    0.002    0.000    0.002    0.000 remote_asset_graph.py:64(<listcomp>)
        1    0.001    0.001    0.003    0.003 remote_asset_graph.py:329(<dictcomp>)
     7790    0.001    0.000    0.002    0.000 <string>:1(<lambda>)
        1    0.001    0.001    0.002    0.002 remote_asset_graph.py:350(<dictcomp>)
        1    0.001    0.001    0.008    0.008 remote_asset_graph.py:455(_warn_on_duplicate_nodes)
     7798    0.001    0.000    0.001    0.000 {built-in method __new__ of type object at 0x10320bcb0}
        1    0.001    0.001    0.002    0.002 remote_asset_graph.py:328(<setcomp>)
    21747    0.001    0.000    0.001    0.000 {method 'append' of 'list' objects}
    19842    0.001    0.000    0.001    0.000 {built-in method builtins.isinstance}
        1    0.001    0.001    0.001    0.001 remote_asset_graph.py:256(<dictcomp>)
        2    0.001    0.000    0.001    0.000 remote_asset_graph.py:489(<dictcomp>)
...
```

After:
```
Profiling asset graph...
         105531 function calls in 0.043 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.009    0.009    0.040    0.040 remote_asset_graph.py:303(_build)
        1    0.006    0.006    0.010    0.010 remote_asset_graph.py:355(<dictcomp>)
        1    0.004    0.004    0.006    0.006 remote_asset_graph.py:502(_build_execution_set_index)
        2    0.003    0.001    0.004    0.002 remote_asset_graph.py:481(_warn_on_duplicates_within_subset)
     7790    0.003    0.000    0.004    0.000 external_data.py:1313(key)
     5012    0.002    0.000    0.002    0.000 remote_asset_graph.py:64(<listcomp>)
        1    0.002    0.002    0.043    0.043 remote_asset_graph.py:276(from_workspace_snapshot)
     5012    0.002    0.000    0.004    0.000 remote_asset_graph.py:51(__init__)
    17250    0.002    0.000    0.002    0.000 {method 'add' of 'set' objects}
        1    0.001    0.001    0.001    0.001 remote_asset_graph.py:329(<dictcomp>)
        1    0.001    0.001    0.005    0.005 remote_asset_graph.py:455(_warn_on_duplicate_nodes)
        1    0.001    0.001    0.001    0.001 remote_asset_graph.py:330(<dictcomp>)
     7790    0.001    0.000    0.002    0.000 <string>:1(<lambda>)
        1    0.001    0.001    0.001    0.001 remote_asset_graph.py:350(<dictcomp>)
     7798    0.001    0.000    0.001    0.000 {built-in method __new__ of type object at 0x1050b3cb0}
    21747    0.001    0.000    0.001    0.000 {method 'append' of 'list' objects}
    19842    0.001    0.000    0.001    0.000 {built-in method builtins.isinstance}
        1    0.001    0.001    0.001    0.001 remote_asset_graph.py:256(<dictcomp>)
        2    0.001    0.000    0.001    0.000 remote_asset_graph.py:489(<dictcomp>)
        1    0.001    0.001    0.001    0.001 remote_asset_graph.py:328(<setcomp>)
...
```

## Changelog

[breaking] `AssetKey` can no longer be iterated over or indexed in to. This behavior was never an intended access pattern and in all observed cases was a mistake.