### PR TITLE
Add support for Python 3.12 in scaffold template

### DIFF
--- a/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/pyproject.toml.tmpl
+++ b/python_modules/dagster/dagster/_generate/templates/CODE_LOCATION_NAME_PLACEHOLDER/pyproject.toml.tmpl
@@ -3,7 +3,7 @@ name = "{{ code_location_name }}"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8,<3.13"
 dependencies = [
     "dagster",
     "dagster-cloud",


### PR DESCRIPTION
It appears that Python 3.12 has been officially supported for months now [#17350], but the scaffold template has not been updated yet. This change increases the upper version bound in the template from <3.12 to <3.13.