### PR TITLE
[dlt] remove deprecated parameter dlt_dagster_translator (use dagster…

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/asset_decorator.py
@@ -7,7 +7,6 @@ from dagster import (
     _check as check,
     multi_asset,
 )
-from dagster._annotations import deprecated_param
 from dlt.extract.source import DltSource
 from dlt.pipeline.pipeline import Pipeline
 
@@ -59,18 +58,12 @@ def build_dlt_asset_specs(
     ]
 
 
-@deprecated_param(
-    param="dlt_dagster_translator",
-    breaking_version="1.8",
-    additional_warn_text="Use `dagster_dlt_translator` instead.",
-)
 def dlt_assets(
     *,
     dlt_source: DltSource,
     dlt_pipeline: Pipeline,
     name: Optional[str] = None,
     group_name: Optional[str] = None,
-    dlt_dagster_translator: Optional[DagsterDltTranslator] = None,
     dagster_dlt_translator: Optional[DagsterDltTranslator] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
@@ -81,7 +74,7 @@ def dlt_assets(
         dlt_pipeline (Pipeline): The dlt Pipeline defining the destination parameters.
         name (Optional[str], optional): The name of the op.
         group_name (Optional[str], optional): The name of the asset group.
-        dlt_dagster_translator (DltDagsterTranslator, optional): Customization object for defining asset parameters from dlt resources.
+        dagster_dlt_translator (DltDagsterTranslator, optional): Customization object for defining asset parameters from dlt resources.
 
     Examples:
         Loading Hubspot data to Snowflake with an auto materialize policy using the dlt verified source:
@@ -106,7 +99,7 @@ def dlt_assets(
                 ),
                 name="hubspot",
                 group_name="hubspot",
-                dlt_dagster_translator=HubspotDltDagsterTranslator(),
+                dagster_dlt_translator=HubspotDltDagsterTranslator(),
             )
             def hubspot_assets(context: AssetExecutionContext, dlt: DltDagsterResource):
                 yield from dlt.run(context=context)
@@ -133,7 +126,7 @@ def dlt_assets(
 
     """
     dagster_dlt_translator = check.inst_param(
-        dagster_dlt_translator or dlt_dagster_translator or DagsterDltTranslator(),
+        dagster_dlt_translator or DagsterDltTranslator(),
         "dagster_dlt_translator",
         DagsterDltTranslator,
     )


### PR DESCRIPTION
…_dlt_translator instead)

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
