### PR TITLE
Make compute asset/check subset functions async

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_checks.py
@@ -158,7 +158,7 @@ class GrapheneAssetCheck(graphene.ObjectType):
         record = await AssetCheckExecutionRecord.gen(graphene_info.context, self._asset_check.key)
         return (
             GrapheneAssetCheckExecution(record)
-            if record and record.targets_latest_materialization(graphene_info.context)
+            if record and await record.targets_latest_materialization(graphene_info.context)
             else None
         )
 

--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -32,6 +32,7 @@ from dagster._core.definitions.time_window_partitions import (
 from dagster._core.loader import LoadingContext
 from dagster._time import get_current_datetime
 from dagster._utils.aiodataloader import DataLoader
+from dagster._utils.cached_method import cached_method
 
 if TYPE_CHECKING:
     from dagster._core.definitions.base_asset_graph import BaseAssetGraph, BaseAssetNode
@@ -170,6 +171,7 @@ class AssetGraphView(LoadingContext):
         else:
             return None
 
+    @cached_method
     def get_full_subset(self, *, key: T_EntityKey) -> EntitySubset[T_EntityKey]:
         partitions_def = self._get_partitions_def(key)
         value = (
@@ -183,6 +185,7 @@ class AssetGraphView(LoadingContext):
         )
         return EntitySubset(self, key=key, value=_ValidatedEntitySubsetValue(value))
 
+    @cached_method
     def get_empty_subset(self, *, key: T_EntityKey) -> EntitySubset[T_EntityKey]:
         partitions_def = self._get_partitions_def(key)
         value = partitions_def.empty_subset() if partitions_def else False
@@ -476,6 +479,7 @@ class AssetGraphView(LoadingContext):
                 key=key, asset_partitions=missing_asset_partitions
             )
 
+    @cached_method
     async def compute_run_in_progress_subset(self, *, key: EntityKey) -> EntitySubset:
         return await _dispatch(
             key=key,
@@ -483,6 +487,7 @@ class AssetGraphView(LoadingContext):
             asset_method=self._compute_run_in_progress_asset_subset,
         )
 
+    @cached_method
     async def compute_backfill_in_progress_subset(self, *, key: EntityKey) -> EntitySubset:
         async def get_empty_subset(key: EntityKey) -> EntitySubset:
             return self.get_empty_subset(key=key)
@@ -494,6 +499,7 @@ class AssetGraphView(LoadingContext):
             asset_method=self._compute_backfill_in_progress_asset_subset,
         )
 
+    @cached_method
     async def compute_execution_failed_subset(self, *, key: EntityKey) -> EntitySubset:
         return await _dispatch(
             key=key,
@@ -501,6 +507,7 @@ class AssetGraphView(LoadingContext):
             asset_method=self._compute_execution_failed_asset_subset,
         )
 
+    @cached_method
     async def compute_missing_subset(
         self, *, key: EntityKey, from_subset: EntitySubset
     ) -> EntitySubset:
@@ -619,6 +626,7 @@ class AssetGraphView(LoadingContext):
         else:
             return self.get_full_subset(key=key)
 
+    @cached_method
     async def compute_updated_since_temporal_context_subset(
         self, *, key: EntityKey, temporal_context: TemporalContext
     ) -> EntitySubset:

--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -367,7 +367,7 @@ class AssetGraphView(LoadingContext):
         latest_record = summary.last_check_execution_record if summary else None
         resolved_status = (
             latest_record.resolve_status(self)
-            if latest_record and latest_record.targets_latest_materialization(self)
+            if latest_record and await latest_record.targets_latest_materialization(self)
             else None
         )
         if resolved_status == status:

--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -32,7 +32,6 @@ from dagster._core.definitions.time_window_partitions import (
 from dagster._core.loader import LoadingContext
 from dagster._time import get_current_datetime
 from dagster._utils.aiodataloader import DataLoader
-from dagster._utils.cached_method import cached_method
 
 if TYPE_CHECKING:
     from dagster._core.definitions.base_asset_graph import BaseAssetGraph, BaseAssetNode
@@ -171,7 +170,6 @@ class AssetGraphView(LoadingContext):
         else:
             return None
 
-    @cached_method
     def get_full_subset(self, *, key: T_EntityKey) -> EntitySubset[T_EntityKey]:
         partitions_def = self._get_partitions_def(key)
         value = (
@@ -185,7 +183,6 @@ class AssetGraphView(LoadingContext):
         )
         return EntitySubset(self, key=key, value=_ValidatedEntitySubsetValue(value))
 
-    @cached_method
     def get_empty_subset(self, *, key: T_EntityKey) -> EntitySubset[T_EntityKey]:
         partitions_def = self._get_partitions_def(key)
         value = partitions_def.empty_subset() if partitions_def else False
@@ -363,7 +360,7 @@ class AssetGraphView(LoadingContext):
         """Returns the subset of an asset check that matches a given status."""
         from dagster._core.storage.event_log.base import AssetCheckSummaryRecord
 
-        summary = AssetCheckSummaryRecord.blocking_get(self, key)
+        summary = await AssetCheckSummaryRecord.gen(self, key)
         latest_record = summary.last_check_execution_record if summary else None
         resolved_status = (
             latest_record.resolve_status(self)
@@ -479,7 +476,6 @@ class AssetGraphView(LoadingContext):
                 key=key, asset_partitions=missing_asset_partitions
             )
 
-    @cached_method
     async def compute_run_in_progress_subset(self, *, key: EntityKey) -> EntitySubset:
         return await _dispatch(
             key=key,
@@ -487,7 +483,6 @@ class AssetGraphView(LoadingContext):
             asset_method=self._compute_run_in_progress_asset_subset,
         )
 
-    @cached_method
     async def compute_backfill_in_progress_subset(self, *, key: EntityKey) -> EntitySubset:
         async def get_empty_subset(key: EntityKey) -> EntitySubset:
             return self.get_empty_subset(key=key)
@@ -499,7 +494,6 @@ class AssetGraphView(LoadingContext):
             asset_method=self._compute_backfill_in_progress_asset_subset,
         )
 
-    @cached_method
     async def compute_execution_failed_subset(self, *, key: EntityKey) -> EntitySubset:
         return await _dispatch(
             key=key,
@@ -507,7 +501,6 @@ class AssetGraphView(LoadingContext):
             asset_method=self._compute_execution_failed_asset_subset,
         )
 
-    @cached_method
     async def compute_missing_subset(
         self, *, key: EntityKey, from_subset: EntitySubset
     ) -> EntitySubset:
@@ -614,7 +607,7 @@ class AssetGraphView(LoadingContext):
         from dagster._core.storage.event_log.base import AssetCheckSummaryRecord
 
         # intentionally left unimplemented for AssetKey, as this is a less performant query
-        summary = AssetCheckSummaryRecord.blocking_get(self, key)
+        summary = await AssetCheckSummaryRecord.gen(self, key)
         record = summary.last_check_execution_record if summary else None
         if (
             record is None
@@ -626,7 +619,6 @@ class AssetGraphView(LoadingContext):
         else:
             return self.get_full_subset(key=key)
 
-    @cached_method
     async def compute_updated_since_temporal_context_subset(
         self, *, key: EntityKey, temporal_context: TemporalContext
     ) -> EntitySubset:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/operands.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/operands.py
@@ -60,8 +60,8 @@ class MissingAutomationCondition(SubsetAutomationCondition):
     def name(self) -> str:
         return "missing"
 
-    def compute_subset(self, context: AutomationContext) -> EntitySubset:
-        return context.asset_graph_view.compute_missing_subset(
+    async def compute_subset(self, context: AutomationContext) -> EntitySubset:
+        return await context.asset_graph_view.compute_missing_subset(
             key=context.key, from_subset=context.candidate_subset
         )
 
@@ -95,8 +95,8 @@ class ExecutionFailedAutomationCondition(SubsetAutomationCondition):
     def name(self) -> str:
         return "execution_failed"
 
-    def compute_subset(self, context: AutomationContext) -> EntitySubset:
-        return context.asset_graph_view.compute_execution_failed_subset(key=context.key)
+    async def compute_subset(self, context: AutomationContext) -> EntitySubset:
+        return await context.asset_graph_view.compute_execution_failed_subset(key=context.key)
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/operands.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/operands.py
@@ -73,8 +73,8 @@ class RunInProgressAutomationCondition(SubsetAutomationCondition):
     def name(self) -> str:
         return "execution_in_progress"
 
-    def compute_subset(self, context: AutomationContext) -> EntitySubset:
-        return context.asset_graph_view.compute_run_in_progress_subset(key=context.key)
+    async def compute_subset(self, context: AutomationContext) -> EntitySubset:
+        return await context.asset_graph_view.compute_run_in_progress_subset(key=context.key)
 
 
 @whitelist_for_serdes
@@ -84,8 +84,8 @@ class BackfillInProgressAutomationCondition(SubsetAutomationCondition):
     def name(self) -> str:
         return "backfill_in_progress"
 
-    def compute_subset(self, context: AutomationContext) -> EntitySubset:
-        return context.asset_graph_view.compute_backfill_in_progress_subset(key=context.key)
+    async def compute_subset(self, context: AutomationContext) -> EntitySubset:
+        return await context.asset_graph_view.compute_backfill_in_progress_subset(key=context.key)
 
 
 @whitelist_for_serdes(storage_name="FailedAutomationCondition")
@@ -160,11 +160,11 @@ class NewlyUpdatedCondition(SubsetAutomationCondition):
     def name(self) -> str:
         return "newly_updated"
 
-    def compute_subset(self, context: AutomationContext) -> EntitySubset:
+    async def compute_subset(self, context: AutomationContext) -> EntitySubset:
         # if it's the first time evaluating, just return the empty subset
         if context.previous_temporal_context is None:
             return context.get_empty_subset()
-        return context.asset_graph_view.compute_updated_since_temporal_context_subset(
+        return await context.asset_graph_view.compute_updated_since_temporal_context_subset(
             key=context.key, temporal_context=context.previous_temporal_context
         )
 
@@ -253,7 +253,7 @@ class CheckResultCondition(SubsetAutomationCondition[AssetCheckKey]):
     def name(self) -> str:
         return "check_passed" if self.passed else "check_failed"
 
-    def compute_subset(
+    async def compute_subset(
         self, context: AutomationContext[AssetCheckKey]
     ) -> EntitySubset[AssetCheckKey]:
         from dagster._core.storage.asset_check_execution_record import (
@@ -265,6 +265,6 @@ class CheckResultCondition(SubsetAutomationCondition[AssetCheckKey]):
             if self.passed
             else AssetCheckExecutionResolvedStatus.FAILED
         )
-        return context.asset_graph_view.compute_subset_with_status(
+        return await context.asset_graph_view.compute_subset_with_status(
             key=context.key, status=target_status
         )

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/operands.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/operands.py
@@ -147,8 +147,8 @@ class LatestRunExecutedWithRootTargetCondition(SubsetAutomationCondition):
     def name(self) -> str:
         return "executed_with_root_target"
 
-    def compute_subset(self, context: AutomationContext) -> EntitySubset:
-        return context.asset_graph_view.compute_latest_run_executed_with_subset(
+    async def compute_subset(self, context: AutomationContext) -> EntitySubset:
+        return await context.asset_graph_view.compute_latest_run_executed_with_subset(
             from_subset=context.candidate_subset, target=context.root_context.key
         )
 

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/subset_automation_condition.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operands/subset_automation_condition.py
@@ -1,3 +1,4 @@
+import inspect
 from abc import abstractmethod
 
 from dagster._core.asset_graph_view.entity_subset import EntitySubset
@@ -23,10 +24,14 @@ class SubsetAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         self, context: AutomationContext[T_EntityKey]
     ) -> EntitySubset[T_EntityKey]: ...
 
-    def evaluate(self, context: AutomationContext[T_EntityKey]) -> AutomationResult[T_EntityKey]:
+    async def evaluate(
+        self, context: AutomationContext[T_EntityKey]
+    ) -> AutomationResult[T_EntityKey]:
         # don't compute anything if there are no candidates
         if context.candidate_subset.is_empty:
             true_subset = context.get_empty_subset()
+        elif inspect.iscoroutinefunction(self.compute_subset):
+            true_subset = await self.compute_subset(context)
         else:
             true_subset = self.compute_subset(context)
 


### PR DESCRIPTION
## Summary & Motivation
We now want to make the compute asset and asset check subset functions on `AssetGraphView` async so we can use `AssetStatusCacheValue.gen()` instead of `AssetStatusCacheValue.blocking_get()`. Same for `AssetCheckExecutionRecord`.

## How I Tested These Changes
Existing tests should pass
