### PR TITLE
[1.9] Update evaluation id logic to be in sync with tick ids

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/instigation.py
@@ -271,7 +271,7 @@ class GrapheneInstigationTick(graphene.ObjectType):
             cursor=tick.cursor,
             logKey=tick.log_key,
             endTimestamp=tick.end_timestamp,
-            autoMaterializeAssetEvaluationId=tick.tick_data.auto_materialize_evaluation_id,
+            autoMaterializeAssetEvaluationId=tick.automation_condition_evaluation_id,
         )
 
     def resolve_id(self, _):

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_condition_evaluations.py
@@ -165,8 +165,7 @@ class TestAutoMaterializeTicks(ExecutingGraphQLContextTestMatrix):
         assert len(result.data["autoMaterializeTicks"]) == 1
         tick = result.data["autoMaterializeTicks"][0]
         assert (
-            tick["autoMaterializeAssetEvaluationId"]
-            == success_2.tick_data.auto_materialize_evaluation_id
+            tick["autoMaterializeAssetEvaluationId"] == success_2.automation_condition_evaluation_id
         )
 
         result = execute_dagster_graphql(
@@ -186,7 +185,7 @@ class TestAutoMaterializeTicks(ExecutingGraphQLContextTestMatrix):
         assert ticks[0]["timestamp"] == success_1.timestamp
         assert (
             ticks[0]["autoMaterializeAssetEvaluationId"]
-            == success_1.tick_data.auto_materialize_evaluation_id
+            == success_1.automation_condition_evaluation_id
         )
 
         cursor = ticks[0]["id"]

--- a/python_modules/dagster/dagster/_core/scheduler/instigation.py
+++ b/python_modules/dagster/dagster/_core/scheduler/instigation.py
@@ -528,6 +528,17 @@ class InstigatorTick(NamedTuple("_InstigatorTick", [("tick_id", int), ("tick_dat
             if run_id in unrequested_run_ids
         ]
 
+    @property
+    def automation_condition_evaluation_id(self) -> int:
+        """Returns a unique identifier for the current automation condition evaluation. In general,
+        this will be identical to the current tick id, but in cases where an evaluation needs to
+        be retried, an override value may be set.
+        """
+        if self.tick_data.auto_materialize_evaluation_id is not None:
+            return self.tick_data.auto_materialize_evaluation_id
+        else:
+            return self.tick_id
+
 
 @whitelist_for_serdes(
     old_storage_names={"JobTickData"},

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_asset_daemon.py
@@ -45,7 +45,7 @@ from dagster._daemon.asset_daemon import (
     set_auto_materialize_paused,
 )
 from dagster._serdes.serdes import deserialize_value, serialize_value
-from dagster._time import get_current_datetime
+from dagster._time import get_current_datetime, get_current_timestamp
 
 from dagster_tests.definitions_tests.declarative_automation_tests.legacy_tests.updated_scenarios.basic_scenarios import (
     basic_scenarios,
@@ -327,7 +327,7 @@ def test_daemon_paused() -> None:
         assert ticks[0].status == TickStatus.SUCCESS
         assert ticks[0].timestamp == state.current_time.timestamp()
         assert ticks[0].tick_data.end_timestamp == state.current_time.timestamp()
-        assert ticks[0].tick_data.auto_materialize_evaluation_id == 1
+        assert ticks[0].automation_condition_evaluation_id == 1
 
         state = daemon_scenario.execution_fn(state)
         ticks = _get_asset_daemon_ticks(instance)
@@ -337,7 +337,7 @@ def test_daemon_paused() -> None:
         assert ticks[-1].status == TickStatus.SKIPPED
         assert ticks[-1].timestamp == state.current_time.timestamp()
         assert ticks[-1].tick_data.end_timestamp == state.current_time.timestamp()
-        assert ticks[-1].tick_data.auto_materialize_evaluation_id == 2
+        assert ticks[-1].automation_condition_evaluation_id == 2
 
 
 three_assets = ScenarioSpec(asset_specs=[AssetSpec("A"), AssetSpec("B"), AssetSpec("C")])
@@ -449,7 +449,19 @@ def test_auto_materialize_sensor_no_transition():
 def test_auto_materialize_sensor_transition():
     with get_daemon_instance(paused=False) as instance:
         # Have been using global AMP, so there is a cursor
-        pre_sensor_evaluation_id = 12345
+        pre_sensor_evaluation_id = 4
+        for _ in range(pre_sensor_evaluation_id):
+            # create junk ticks so that the next tick id will be 4
+            instance.create_tick(
+                TickData(
+                    instigator_origin_id="",
+                    instigator_name="",
+                    instigator_type=InstigatorType.SCHEDULE,
+                    status=TickStatus.SUCCESS,
+                    timestamp=get_current_timestamp(),
+                    run_ids=[],
+                )
+            )
 
         assert not get_has_migrated_to_sensors(instance)
 
@@ -578,13 +590,15 @@ def test_auto_materialize_sensor_name_transition() -> None:
             # skip over the old state for the old name
             if sensor_state.instigator_name == "default_auto_materialize_sensor":
                 continue
-            # ensure that we're properly accounting for the old cursor information
+            # we do not account for the old cursor as it is assumed that the current
+            # tick id will be strictly larger than the current asset daemon cursor
+            # value in the real world (as each evaluation creates a new tick)
             assert (
                 asset_daemon_cursor_from_instigator_serialized_cursor(
                     cast(SensorInstigatorData, sensor_state.instigator_data).cursor,
                     None,
                 ).evaluation_id
-                > 2
+                > 0  # real world should be larger
             )
 
 
@@ -600,7 +614,19 @@ def test_auto_materialize_sensor_ticks(num_threads):
         },
     ) as instance:
         with _get_threadpool_executor(instance) as threadpool_executor:
-            pre_sensor_evaluation_id = 12345
+            pre_sensor_evaluation_id = 3
+            for _ in range(pre_sensor_evaluation_id):
+                # create junk ticks so that the next tick id will be 4
+                instance.create_tick(
+                    TickData(
+                        instigator_origin_id="",
+                        instigator_name="",
+                        instigator_type=InstigatorType.SCHEDULE,
+                        status=TickStatus.SUCCESS,
+                        timestamp=get_current_timestamp(),
+                        run_ids=[],
+                    )
+                )
 
             instance.daemon_cursor_storage.set_cursor_values(
                 {
@@ -817,7 +843,7 @@ def test_auto_materialize_sensor_ticks(num_threads):
 
                 prev_evaluation_id = None
                 for tick in ticks:
-                    evaluation_id = tick.tick_data.auto_materialize_evaluation_id
+                    evaluation_id = tick.automation_condition_evaluation_id
                     assert evaluation_id > pre_sensor_evaluation_id
                     assert evaluation_id not in seen_evaluation_ids
                     seen_evaluation_ids.add(evaluation_id)

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/asset_daemon_scenario.py
@@ -266,7 +266,9 @@ class AssetDaemonScenarioState(ScenarioState):
     def evaluate_tick_daemon(self):
         with freeze_time(self.current_time):
             run_requests, cursor, _ = self._evaluate_tick_daemon()
-        new_state = self.with_serialized_cursor(serialize_value(cursor))
+        new_state = self.with_serialized_cursor(serialize_value(cursor)).with_current_time_advanced(
+            seconds=1
+        )
         return new_state, run_requests
 
     def evaluate_tick(self, label: Optional[str] = None) -> "AssetDaemonScenarioState":


### PR DESCRIPTION
## Summary & Motivation

When running in user-code mode, evaluation ids are always based off of the tick id. This prevents us from having to deserialize the AssetDaemonCursor server side, and just in general is an easier way of producing monotonically increasing integers across multiple values.

In general, the tick id is guaranteed to be strictly larger than the AssetDaemonCursor value, as the daemon cursor (unless manually edited) cannot increase without a new tick being created. This means that it is safe to switch from daemon-mode to user-mode, but if you switch from user-mode back to daemon-mode, you could end up with an evaluation id that was much smaller, with the end result being that new evaluation records you produce would have a lower evaluation_id than older ones, messing up the history.

This change makes it so that the daemon-mode id will stay in sync with the tick id, avoiding this issue.

## How I Tested These Changes

Existing tests, with some small updates.

## Changelog

NOCHANGELOG
