### PR TITLE
[bug] Fix issue with partition mapping handling in the EntityMatches condition

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/entity_subset.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/entity_subset.py
@@ -1,5 +1,15 @@
 import operator
-from typing import TYPE_CHECKING, AbstractSet, Any, Callable, Generic, NamedTuple, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Any,
+    Callable,
+    Generic,
+    Literal,
+    NamedTuple,
+    TypeVar,
+    Union,
+)
 
 from typing_extensions import Self
 
@@ -105,8 +115,10 @@ class EntitySubset(Generic[T_EntityKey]):
         return self._asset_graph_view.compute_child_subset(child_key, self)
 
     @cached_method
-    def compute_mapped_subset(self, to_key: U_EntityKey) -> "EntitySubset[U_EntityKey]":
-        return self._asset_graph_view.compute_mapped_subset(to_key, self)
+    def compute_mapped_subset(
+        self, to_key: U_EntityKey, direction: Literal["up", "down"]
+    ) -> "EntitySubset[U_EntityKey]":
+        return self._asset_graph_view.compute_mapped_subset(to_key, self, direction=direction)
 
     @property
     def size(self) -> int:

--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/automation_condition_evaluator.py
@@ -177,7 +177,9 @@ class AutomationConditionEvaluator:
                 # evaluated it may have had a different requested subset. however, because
                 # all these neighbors must be executed as a unit, we need to union together
                 # the subset of all required neighbors
-                neighbor_true_subset = result.true_subset.compute_mapped_subset(neighbor_key)
+                neighbor_true_subset = result.true_subset.compute_mapped_subset(
+                    neighbor_key, direction="up"
+                )
                 if neighbor_key in self.current_results_by_key:
                     self.current_results_by_key[
                         neighbor_key


### PR DESCRIPTION
## Summary & Motivation

As title.

For self-dependent assets, the inference logic that determines the direction we should map partitions in does not work for self-dependent assets, as these are always upstream of themselves, meaning from_key will always be a parent of to_key, and we will always take the first branch.

This solves the issue by adding an optional direction parameter to the EntityMatches condition, and threads that through to the underlying mapping function, allowing us to determine what direction we should map our partitions in.

## How I Tested These Changes

## Changelog

Fixed an issue which could cause incorrect evaluation results when using self-dependent partition mappings with `AutomationConditions` that operate over dependencies.
