### PR TITLE
[dagster-airlift] better errors when [in-airflow] is not installed, or apache-airflow is not installed

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/__init__.py
@@ -1,3 +1,14 @@
+def ensure_airflow_installed() -> None:
+    """Ensures that Airflow is installed."""
+    try:
+        import airflow  # noqa
+    except ImportError:
+        raise Exception(
+            "Airflow is not installed. Please install Apache Airflow >= 2.0.0 before using this functionality."
+        )
+
+
+ensure_airflow_installed()
 from .base_asset_operator import BaseDagsterAssetsOperator as BaseDagsterAssetsOperator
 from .dag_proxy_operator import (
     BaseProxyDAGToDagsterOperator as BaseProxyDAGToDagsterOperator,

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/scaffolding.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/scaffolding.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
 
@@ -6,13 +5,6 @@ import yaml
 
 if TYPE_CHECKING:
     from airflow import DAG
-
-
-def verify_airflow_home_set() -> None:
-    if not os.getenv("AIRFLOW_HOME"):
-        raise Exception(
-            "AIRFLOW_HOME not set. Please set AIRFLOW_HOME to the root of your Airflow installation."
-        )
 
 
 def get_airflow_dags_folder() -> Path:
@@ -32,8 +24,6 @@ def scaffold_proxied_state(logger: Any) -> None:
     """Scaffolds a proxied state folder for the current Airflow installation.
     Each proxied state is marked as False.
     """
-    verify_airflow_home_set()
-
     proxied_state_dir = get_airflow_dags_folder() / "proxied_state"
     if proxied_state_dir.exists():
         raise Exception(


### PR DESCRIPTION
## Summary & Motivation
Improves the error state when airflow is not installed when using the [in-airflow] module; and only throw errors when [in-airflow] isn't installed on import error.
## How I Tested These Changes
Created new venv without airflow and attempted to use scaffold cli.
## Changelog
NOCHANGELOG
