### PR TITLE
[dagster-airlift] Ensure cli requirements are installed

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/cli.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/cli.py
@@ -15,7 +15,7 @@ def proxy() -> None:
     """Commands for working with the Dagster-Airlift proxied state. Requires the `dagster-airlift[in-airflow]` package."""
     try:
         import dagster_airlift.in_airflow  # noqa
-    except:
+    except ImportError:
         raise Exception(
             "dagster-airlift[in-airflow] must be installed in the environment to use any `dagster-airlift proxy` commands."
         )

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/__init__.py
@@ -5,6 +5,8 @@ def ensure_airflow_installed() -> None:
     except ImportError:
         raise Exception(
             "Airflow is not installed. Please install Apache Airflow >= 2.0.0 before using this functionality."
+            "Airflow has very specific installation instructions, please refer to the official installation guide: "
+            "https://airflow.apache.org/docs/apache-airflow/stable/installation/installing-from-pypi.html"
         )
 
 

--- a/examples/experimental/dagster-airlift/setup.py
+++ b/examples/experimental/dagster-airlift/setup.py
@@ -31,6 +31,8 @@ AIRFLOW_REQUIREMENTS = [
     "connexion<3.0.0",
 ]
 
+CLI_REQUIREMENTS = ["click", "structlog"]
+
 
 setup(
     name="dagster-airlift",
@@ -55,18 +57,20 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_airlift_tests*", "examples*"]),
-    requires=["click"],
+    requires=CLI_REQUIREMENTS,
     extras_require={
         "core": [
             f"dagster{pin}",
+            *CLI_REQUIREMENTS,
         ],
         # [in-airflow] doesn't directly have a dependency on airflow because Airflow cannot be installed via setup.py reliably. Instead, users need to install from a constraints
         # file as recommended by the Airflow project.
-        "in-airflow": [],
+        "in-airflow": CLI_REQUIREMENTS,
         # [tutorial] includes additional dependencies needed to run the tutorial. Namely, the dagster-webserver and the constrained airflow packages.
         "tutorial": [
             "dagster-webserver",
             *AIRFLOW_REQUIREMENTS,
+            *CLI_REQUIREMENTS,
         ],
         "mwaa": [
             "boto3>=1.18.0"
@@ -80,6 +84,7 @@ setup(
             "boto3",
             "dagster-webserver",
             *AIRFLOW_REQUIREMENTS,
+            *CLI_REQUIREMENTS,
         ],
     },
     entry_points={


### PR DESCRIPTION
## Summary & Motivation
The normal `requires` of a package is not installed when installing submodules. As a result, we need to separately specify these dependencies in order to use the CLI if someone, for example, just installs [in-airflow].

I don't love needing to repeat this installation step over and over. Could be more convenient to just have a [cli] extras installation pathway.

## How I Tested These Changes
Fixed problem I was running into with installation.
## Changelog
NOCHANGELOG