### PR TITLE
Allow passing in a string to StaticPartitionsDefinition

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -325,6 +325,9 @@ class StaticPartitionsDefinition(PartitionsDefinition[str]):
     """
 
     def __init__(self, partition_keys: Sequence[str]):
+        if isinstance(partition_keys, str):
+            # backcompat
+            partition_keys = [pk for pk in partition_keys]
         check.sequence_param(partition_keys, "partition_keys", of_type=str)
 
         raise_error_on_invalid_partition_key_substring(partition_keys)

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -869,9 +869,16 @@ def _dedup_partition_keys(keys: Sequence[str]) -> Sequence[str]:
 
 
 @whitelist_for_serdes(storage_name="ExternalStaticPartitionsDefinitionData")
-@record
-class StaticPartitionsSnap(PartitionsSnap):
+@record_custom
+class StaticPartitionsSnap(PartitionsSnap, IHaveNew):
     partition_keys: Sequence[str]
+
+    def __new__(cls, partition_keys: Sequence[str]):
+        if isinstance(partition_keys, str):
+            partition_keys = [pk for pk in partition_keys]
+        return super().__new__(
+            cls, partition_keys=check.sequence_param(partition_keys, "partition_keys", of_type=str)
+        )
 
     @classmethod
     def from_def(cls, partitions_def: StaticPartitionsDefinition) -> Self:

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -29,6 +29,13 @@ def test_static_partitions(partition_keys: Sequence[str]):
     assert static_partitions.get_partition_keys() == partition_keys
 
 
+def test_static_partition_string_input() -> None:
+    # backcompat
+    static_partitions = StaticPartitionsDefinition("abcdef")
+
+    assert static_partitions.get_partition_keys() == ["a", "b", "c", "d", "e", "f"]
+
+
 def test_invalid_partition_key():
     with pytest.raises(DagsterInvalidDefinitionError, match="'...'"):
         StaticPartitionsDefinition(["foo", "foo...bar"])


### PR DESCRIPTION
## Summary & Motivation

As title -- this was allowed before, so we should keep allowing it

## How I Tested These Changes

## Changelog

NOCHANGELOG
