### PR TITLE
Revert "[check] dont allow str or bytes for sequence_param"

### DIFF
--- a/python_modules/dagster/dagster/_check/functions.py
+++ b/python_modules/dagster/dagster/_check/functions.py
@@ -1108,12 +1108,7 @@ def sequence_param(
 ) -> Sequence[T]:
     ttype = type(obj)
     # isinstance check against abc is costly, so try to handle common cases with cheapest check possible
-    if not (
-        ttype is list
-        or ttype is tuple
-        # even though str/bytes are technically sequences, its likely not desired so error
-        or (isinstance(obj, collections.abc.Sequence) and ttype not in (str, bytes))
-    ):
+    if not (ttype is list or ttype is tuple or isinstance(obj, collections.abc.Sequence)):
         raise _param_type_mismatch_exception(
             obj, (collections.abc.Sequence,), param_name, additional_message
         )

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2324,10 +2324,10 @@ class DagsterInstance(DynamicPartitionsStore):
 
         Args:
             partitions_def_name (str): The name of the `DynamicPartitionsDefinition`.
-            partition_key (str): Partition key to delete.
+            partition_key (Sequence[str]): Partition key to delete.
         """
         check.str_param(partitions_def_name, "partitions_def_name")
-        check.str_param(partition_key, "partition_key")
+        check.sequence_param(partition_key, "partition_key", of_type=str)
         self._event_storage.delete_dynamic_partition(partitions_def_name, partition_key)
 
     @public

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -1115,6 +1115,8 @@ def test_sequence_param():
     assert check.sequence_param(tuple(), "sequence_param") == tuple()
 
     assert check.sequence_param(["foo"], "sequence_param", of_type=str) == ["foo"]
+    assert check.sequence_param("foo", "sequence_param") == "foo"
+    assert check.sequence_param("foo", "sequence_param", of_type=str) == "foo"
 
     with pytest.raises(ParameterCheckError):
         check.sequence_param(None, "sequence_param")
@@ -1124,12 +1126,6 @@ def test_sequence_param():
 
     with pytest.raises(CheckError):
         check.sequence_param(["foo"], "sequence_param", of_type=int)
-
-    with pytest.raises(CheckError):
-        check.sequence_param("foo", "sequence_param")
-
-    with pytest.raises(CheckError):
-        check.sequence_param("foo", "sequence_param", of_type=str)
 
 
 def test_opt_sequence_param():
@@ -1620,7 +1616,7 @@ BUILD_CASES = [
     (Bar, [Bar()], [Foo()]),
     (Optional[Bar], [Bar()], [Foo()]),
     (List[str], [["a", "b"]], [[1, 2]]),
-    (Sequence[str], [["a", "b"]], [[1, 2], "just_a_string"]),
+    (Sequence[str], [["a", "b"]], [[1, 2]]),
     (Iterable[str], [["a", "b"]], [[1, 2]]),
     (Set[str], [{"a", "b"}], [{1, 2}]),
     (AbstractSet[str], [{"a", "b"}], [{1, 2}]),


### PR DESCRIPTION
Reverts dagster-io/dagster#25262

Reverting because we saw some unexpected errors when partition_keys was a string.
