### PR TITLE
Fix cluster permissions in databricks step launcher

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/databricks_pyspark_step_launcher.py
@@ -35,7 +35,7 @@ from dagster._serdes import deserialize_value
 from dagster._utils.backoff import backoff
 from dagster_pyspark.utils import build_pyspark_zip
 from databricks.sdk.core import DatabricksError
-from databricks.sdk.service import iam, jobs
+from databricks.sdk.service import iam
 
 from dagster_databricks import databricks_step_main
 from dagster_databricks.configs import (
@@ -478,9 +478,7 @@ class DatabricksPySparkStepLauncher(StepLauncher):
         for permission, accessors in input_permissions.items():
             access_control_list.extend(
                 [
-                    jobs.JobAccessControlRequest.from_dict(
-                        {"permission_level": permission, **accessor}
-                    )
+                    iam.AccessControlRequest.from_dict({"permission_level": permission, **accessor})
                     for accessor in accessors
                 ]
             )

--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pyspark.py
@@ -48,8 +48,14 @@ BASE_DATABRICKS_PYSPARK_STEP_LAUNCHER_CONFIG: Dict[str, object] = {
         ],
     },
     "permissions": {
-        "cluster_permissions": {"CAN_MANAGE": [{"group_name": "my_group"}]},
-        "job_permissions": {"CAN_MANAGE_RUN": [{"user_name": "my_user"}]},
+        "cluster_permissions": {
+            "CAN_MANAGE": [{"group_name": "my_group"}],
+            "CAN_RESTART": [{"user_name": "my_user"}],
+        },
+        "job_permissions": {
+            "CAN_MANAGE_RUN": [{"user_name": "my_user"}],
+            "CAN_MANAGE": [{"group_name": "my_group"}],
+        },
     },
     "secrets_to_env_variables": [],
     "env_variables": {},
@@ -236,6 +242,27 @@ def test_pyspark_databricks(
         assert mock_put_file.call_count == 4
         assert mock_read_file.call_count == 2
         assert mock_submit_run.call_count == 1
+
+        assert mock_perform_query.call_args_list[0].kwargs["body"]["access_control_list"] == [
+            {
+                "permission_level": "CAN_MANAGE_RUN",
+                "user_name": "my_user",
+            },
+            {
+                "permission_level": "CAN_MANAGE",
+                "group_name": "my_group",
+            },
+        ]
+        assert mock_perform_query.call_args_list[1].kwargs["body"]["access_control_list"] == [
+            {
+                "permission_level": "CAN_RESTART",
+                "user_name": "my_user",
+            },
+            {
+                "permission_level": "CAN_MANAGE",
+                "group_name": "my_group",
+            },
+        ]
 
     # Test 2 - attempting to update permissions for an existing cluster
 


### PR DESCRIPTION
## Summary & Motivation

This makes sure to use the `iam.AccessControlRequest` to format the permissions request instead of the `jobs.JobAccessControlRequest` because the latter would result in skipping a permission that is only defined on clusters (and not on jobs).

Closes https://github.com/dagster-io/dagster/issues/25106

## How I Tested These Changes

Added to the unit test to confirm that both permission request types are formatted correctly 
