### PR TITLE
[dagster-embedded-elt] clean up extraction of dlt metadata

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/dlt_test_sources/duckdb_with_transformer.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/dlt_test_sources/duckdb_with_transformer.py
@@ -52,7 +52,8 @@ def pipeline(month: Optional[str] = None):
         primary_key=["repo_id", "issue_id"],
         write_disposition="merge",
         data_from=repos,
-        table_name="RepoIssues",
+        # Test the case where source identifier 'Repo__Issues' differs from destination identifier 'repo_issues'.
+        table_name="Repo__Issues",
     )
     def repo_issues(repo):
         """Extracted list of issues from repositories."""


### PR DESCRIPTION
## Summary & Motivation
[Previous PR](https://github.com/dagster-io/dagster/pull/25266) needed some cleaning up as we don't actually need to call as many methods and functions as I thought at first. I also found a counter-example to the solution when using double underscores in the table name which would still fail to extract metadata. So the code should be cleaner and cover more table identifier cases.

I also spotted a `dlt_source.discover_schema()` that was not supposed to be there.

## How I Tested These Changes
`make ruff`
`pythom -m pytest`

Make the test dlt source use `Repo__Issues` as `table_name` to make sure we can extract metadata when the table name contains double underscores.