### PR TITLE
set DAGSTER_FROM_OSS in internal pipeline execution

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_main.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/dagster_oss_main.py
@@ -52,6 +52,7 @@ def build_dagster_oss_main_steps() -> List[BuildkiteStep]:
                     ),
                     "DAGSTER_CHECKOUT_DEPTH": _get_setting("DAGSTER_CHECKOUT_DEPTH") or "100",
                     "OSS_COMPAT_SLIM": "1" if oss_compat_slim else "",
+                    "DAGSTER_FROM_OSS": "1" if pipeline_name == "internal" else "0",
                 },
             ),
         )


### PR DESCRIPTION
## Summary & Motivation

indicates to the internal buildkite pipeline that this step has been triggered from an OSS merge. see https://github.com/dagster-io/internal/pull/11936