### PR TITLE
[dagster-aws] use datetime for since_last_modified; include unit test

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
@@ -16,7 +16,7 @@ def get_objects(
     bucket: str,
     prefix: str = "",
     since_key: Optional[str] = None,
-    since_last_modified: Optional[str] = None,
+    since_last_modified: Optional[datetime] = None,
     client=None,
 ) -> List[ObjectTypeDef]:
     """Retrieves a list of object keys in S3 for a given `bucket`, `prefix`, and filter option.
@@ -24,7 +24,7 @@ def get_objects(
     Args:
         bucket (str): s3 bucket
         prefix (str): s3 object prefix
-        since_key (Optional[str]): retrieve objects after the modified date of this key
+        since_key (Optional[str]): retrieve objects modified after the last modified timestamp of this key
         since_last_modified (Optional[str]): retrieve objects after this timestamp
         client (Optional[boto3.Client]): s3 client
 
@@ -35,7 +35,7 @@ def get_objects(
     check.str_param(bucket, "bucket")
     check.str_param(prefix, "prefix")
     check.opt_str_param(since_key, "since_key")
-    check.opt_str_param(since_last_modified, "since_last_modified")
+    check.opt_inst_param(since_last_modified, "since_last_modified", datetime)
 
     if not client:
         client = boto3.client("s3")
@@ -56,15 +56,14 @@ def get_objects(
 
     sorted_objects = [obj for obj in sorted(objects, key=lambda x: x.get("LastModified"))]
 
-    if since_key and since_key:
+    if since_key:
         for idx, obj in enumerate(sorted_objects):
             if obj.get("Key") == since_key:
                 return sorted_objects[idx + 1 :]
 
     if since_last_modified:
-        since_last_modified_dt = datetime.fromisoformat(since_last_modified)
         for idx, obj in enumerate(sorted_objects):
-            if obj.get("LastModified") >= since_last_modified_dt:
+            if obj.get("LastModified") >= since_last_modified:
                 return sorted_objects[idx + 1 :]
 
     return sorted_objects

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
@@ -25,7 +25,7 @@ def get_objects(
         bucket (str): s3 bucket
         prefix (str): s3 object prefix
         since_key (Optional[str]): retrieve objects modified after the last modified timestamp of this key
-        since_last_modified (Optional[str]): retrieve objects after this timestamp (non-inclusive)
+        since_last_modified (Optional[datetime]): retrieve objects after this timestamp (non-inclusive)
         client (Optional[boto3.Client]): s3 client
 
     Returns:

--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
@@ -25,7 +25,7 @@ def get_objects(
         bucket (str): s3 bucket
         prefix (str): s3 object prefix
         since_key (Optional[str]): retrieve objects modified after the last modified timestamp of this key
-        since_last_modified (Optional[str]): retrieve objects after this timestamp
+        since_last_modified (Optional[str]): retrieve objects after this timestamp (non-inclusive)
         client (Optional[boto3.Client]): s3 client
 
     Returns:
@@ -63,8 +63,8 @@ def get_objects(
 
     if since_last_modified:
         for idx, obj in enumerate(sorted_objects):
-            if obj.get("LastModified") >= since_last_modified:
-                return sorted_objects[idx + 1 :]
+            if obj.get("LastModified") > since_last_modified:
+                return sorted_objects[idx:]
 
     return sorted_objects
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/s3_tests/test_s3_sensor.py
@@ -4,127 +4,221 @@ import boto3
 import moto
 import pytest
 
-from dagster_aws.s3.sensor import get_s3_keys
+from dagster_aws.s3.sensor import get_objects, get_s3_keys
+
+BUCKET_NAME = "test-bucket"
+PREFIX = "content"
+
+
+def _put_object(client, bucket_name, prefix, key, body, delay=0) -> None:
+    r = client.put_object(Bucket=bucket_name, Key=f"{prefix}/{key}", Body=body)
+    time.sleep(delay)
+    if not r:
+        raise Exception("Failed to create object")
 
 
 def test_get_s3_keys():
-    bucket_name = "test-bucket"
-    prefix = "content"
-
     with moto.mock_s3():
         s3_client = boto3.client("s3", region_name="us-east-1")
-        response = s3_client.create_bucket(Bucket=bucket_name)
+        response = s3_client.create_bucket(Bucket=BUCKET_NAME)
         if not response:
             raise Exception("Failed to create bucket")
 
-        def put_key_in_bucket(key, body):
-            r = s3_client.put_object(Bucket=bucket_name, Key=f"{prefix}/{key}", Body=body)
-            if not r:
-                raise Exception("Failed to create object")
-
-        no_key = get_s3_keys(bucket=bucket_name, prefix=prefix)
+        no_key = get_s3_keys(bucket=BUCKET_NAME, prefix=PREFIX)
         assert len(no_key) == 0  # no keys in bucket
 
-        put_key_in_bucket(key="foo-1", body="test")
-        one_key = get_s3_keys(bucket=bucket_name, prefix=prefix)
+        _put_object(
+            client=s3_client,
+            bucket_name=BUCKET_NAME,
+            prefix=PREFIX,
+            key="foo-1",
+            body="test",
+        )
+        one_key = get_s3_keys(bucket=BUCKET_NAME, prefix=PREFIX)
         assert len(one_key) == 1
 
-        put_key_in_bucket(key="foo-2", body="test")
-        two_keys = get_s3_keys(bucket=bucket_name, prefix=prefix)
+        _put_object(
+            client=s3_client,
+            bucket_name=BUCKET_NAME,
+            prefix=PREFIX,
+            key="foo-2",
+            body="test",
+        )
+        two_keys = get_s3_keys(bucket=BUCKET_NAME, prefix=PREFIX)
         assert len(two_keys) == 2, "both keys should be returned"
 
-        one_key_shift = get_s3_keys(bucket=bucket_name, prefix=prefix, since_key=two_keys[0])
+        one_key_shift = get_s3_keys(bucket=BUCKET_NAME, prefix=PREFIX, since_key=two_keys[0])
         assert len(one_key_shift) == 1, "only one key should be returned"
 
-        two_key_shift = get_s3_keys(bucket=bucket_name, prefix=prefix, since_key=two_keys[1])
+        two_key_shift = get_s3_keys(bucket=BUCKET_NAME, prefix=PREFIX, since_key=two_keys[1])
         assert len(two_key_shift) == 0, "no keys should be returned"
 
         # test pagination
         for i in range(3, 1002):
-            put_key_in_bucket(key=f"foo-{i}", body="test")
-        thousand_and_one_keys = get_s3_keys(bucket=bucket_name, prefix=prefix)
+            _put_object(
+                client=s3_client,
+                bucket_name=BUCKET_NAME,
+                prefix=PREFIX,
+                key=f"foo-{i}",
+                body="test",
+            )
+        thousand_and_one_keys = get_s3_keys(bucket=BUCKET_NAME, prefix=PREFIX)
         assert len(thousand_and_one_keys) == 1001, "1001 keys should be returned"
 
         #  test pagination with since_key
         # keys are sorted by LastModified time, with a resolution of 1 second, so the key at index 999 will vary.
         # The test would be flaky if sorted was not guaranteed to be stable, which it is
         # according to: https://wiki.python.org/moin/HowTo/Sorting/.
-        keys = get_s3_keys(bucket=bucket_name, prefix=prefix, since_key=thousand_and_one_keys[999])
+        keys = get_s3_keys(bucket=BUCKET_NAME, prefix=PREFIX, since_key=thousand_and_one_keys[999])
         assert len(keys) == 1, "1 key should be returned"
 
         #  test pagination with since_key > 1000
         for i in range(1002, 1101):
-            put_key_in_bucket(key=f"foo-{i}", body="test")
-        thousand_and_one_hundred_keys = get_s3_keys(bucket=bucket_name, prefix=prefix)
+            _put_object(
+                client=s3_client,
+                bucket_name=BUCKET_NAME,
+                prefix=PREFIX,
+                key=f"foo-{i}",
+                body="test",
+            )
+        thousand_and_one_hundred_keys = get_s3_keys(bucket=BUCKET_NAME, prefix=PREFIX)
         assert len(thousand_and_one_hundred_keys) == 1100, "1100 keys should be returned"
 
         # keys are sorted by LastModified time, with a resolution of 1 second, so the key at index 999 will vary.
         # The test would be flaky if sorted was not guaranteed to be stable, which it is
         # according to: https://wiki.python.org/moin/HowTo/Sorting/.
         keys = get_s3_keys(
-            bucket=bucket_name,
-            prefix=prefix,
+            bucket=BUCKET_NAME,
+            prefix=PREFIX,
             since_key=thousand_and_one_hundred_keys[1090],
         )
         assert len(keys) == 9, "9 keys should be returned"
 
 
-def test_get_s3_keys_missing_since_key():
-    bucket_name = "test-bucket"
-    prefix = "content"
-
+def test_get_s3_keys_missing_key_raises_exception():
     with moto.mock_s3():
         s3_client = boto3.client("s3", region_name="us-east-1")
-        response = s3_client.create_bucket(Bucket=bucket_name)
+        response = s3_client.create_bucket(Bucket=BUCKET_NAME)
         if not response:
             raise Exception("Failed to create bucket")
 
-        def put_key_in_bucket(key, body):
-            r = s3_client.put_object(Bucket=bucket_name, Key=f"{prefix}/{key}", Body=body)
-            if not r:
-                raise Exception("Failed to create object")
-
-        no_key = get_s3_keys(bucket=bucket_name, prefix=prefix)
+        no_key = get_s3_keys(bucket=BUCKET_NAME, prefix=PREFIX)
         assert len(no_key) == 0  # no keys in bucket
 
-        put_key_in_bucket(key="foo-1", body="test")
-        put_key_in_bucket(key="foo-2", body="test")
-        two_keys = get_s3_keys(bucket=bucket_name, prefix=prefix)
+        _put_object(
+            client=s3_client,
+            bucket_name=BUCKET_NAME,
+            prefix=PREFIX,
+            key="foo-1",
+            body="test",
+        )
+        _put_object(
+            client=s3_client,
+            bucket_name=BUCKET_NAME,
+            prefix=PREFIX,
+            key="foo-2",
+            body="test",
+        )
+        two_keys = get_s3_keys(bucket=BUCKET_NAME, prefix=PREFIX)
         assert len(two_keys) == 2
 
         # if `since_key` is not present in the list of objects, then an exception is thrown
         with pytest.raises(Exception):
-            _ = get_s3_keys(bucket=bucket_name, prefix=prefix, since_key="content/foo-z")
+            _ = get_s3_keys(bucket=BUCKET_NAME, prefix=PREFIX, since_key="content/foo-z")
 
 
-def test_get_s3_keys_with_modified_files():
-    bucket_name = "test-bucket"
-    prefix = "content"
-
+def test_get_s3_since_key_with_modified_files():
     with moto.mock_s3():
         s3_client = boto3.client("s3", region_name="us-east-1")
-        s3_client.create_bucket(Bucket=bucket_name)
+        s3_client.create_bucket(Bucket=BUCKET_NAME)
 
-        def put_key_in_bucket(key, body):
-            s3_client.put_object(Bucket=bucket_name, Key=f"{prefix}/{key}", Body=body)
-            time.sleep(1)  # Ensure each file has a unique timestamp
+        _put_object(
+            client=s3_client,
+            bucket_name=BUCKET_NAME,
+            prefix=PREFIX,
+            key="A",
+            body="initial content",
+            delay=1,
+        )
 
-        # Create file "A" at timestamp 1
-        put_key_in_bucket(key="A", body="initial content")
-
-        # Simulate first sensor run
-        initial_keys = get_s3_keys(bucket=bucket_name, prefix=prefix)
+        initial_keys = get_s3_keys(bucket=BUCKET_NAME, prefix=PREFIX)
         assert len(initial_keys) == 1
         assert initial_keys[0].endswith("A")
 
-        # Create files "B" and "C", and modify "A" between sensor runs
-        put_key_in_bucket(key="B", body="content B")
-        put_key_in_bucket(key="C", body="content C")
-        put_key_in_bucket(key="A", body="modified content")
+        _put_object(
+            client=s3_client,
+            bucket_name=BUCKET_NAME,
+            prefix=PREFIX,
+            key="B",
+            body="content B",
+            delay=1,
+        )
+        _put_object(
+            client=s3_client,
+            bucket_name=BUCKET_NAME,
+            prefix=PREFIX,
+            key="C",
+            body="content C",
+            delay=1,
+        )
 
-        # Simulate second sensor run
-        new_keys = get_s3_keys(bucket=bucket_name, prefix=prefix, since_key=initial_keys[0])
+        # Modify the original `A` object
+        _put_object(
+            client=s3_client,
+            bucket_name=BUCKET_NAME,
+            prefix=PREFIX,
+            key="A",
+            body="modified content",
+            delay=1,
+        )
 
-        # Because `since_key` has been modified, and our files are sorted by last modified date, we
-        # will _not_ get keys for objecfts B and C
+        new_keys = get_s3_keys(bucket=BUCKET_NAME, prefix=PREFIX, since_key=initial_keys[0])
+
+        # Since A has been modified, and B and C were created before this key, we will not get new keys
         assert len(new_keys) == 0
+
+
+def test_get_objects():
+    with moto.mock_s3():
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        s3_client.create_bucket(Bucket=BUCKET_NAME)
+
+        _put_object(
+            client=s3_client,
+            bucket_name=BUCKET_NAME,
+            prefix=PREFIX,
+            key="A",
+            body="initial content",
+            delay=1,
+        )
+
+        objects = get_objects(bucket=BUCKET_NAME, prefix=PREFIX)
+
+        obj = objects[0]
+        object_key = obj.get("Key")
+        object_last_modified = obj.get("LastModified")
+        assert len(objects) == 1
+        assert object_key.endswith("A")
+
+        _put_object(
+            client=s3_client,
+            bucket_name=BUCKET_NAME,
+            prefix=PREFIX,
+            key="B",
+            body="content B",
+            delay=1,
+        )
+        _put_object(
+            client=s3_client,
+            bucket_name=BUCKET_NAME,
+            prefix=PREFIX,
+            key="C",
+            body="content C",
+            delay=1,
+        )
+
+        new_keys = get_objects(
+            bucket=BUCKET_NAME, prefix=PREFIX, since_last_modified=object_last_modified
+        )
+
+        assert len(new_keys) == 2


### PR DESCRIPTION
## Summary & Motivation

- Change `since_last_modified` to be `datetime` as this is the type of `obj.get("LastModified")`
- Adds unit test for `get_objects`

## How I Tested These Changes

```
pytest
```

## Changelog

- [dagster-aws] `get_objects` takes a `datetime` for the `since_last_modified` parameter to improve ergonomics
