### PR TITLE
[ui] Fix shared/ imports, additional tweaks for backfill / runs consolidation

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetView.tsx
@@ -330,7 +330,7 @@ export const AssetView = ({assetKey, headerBreadcrumbs, writeAssetVisit, current
         }
         tabs={
           <div>
-            <IndeterminateLoadingBar loading={isLoading} />
+            <IndeterminateLoadingBar $loading={isLoading} />
             <Box flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}>
               <AssetTabs selectedTab={selectedTab} tabs={tabList} />
               <Box padding={{bottom: 8}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithData.tsx
@@ -14,8 +14,6 @@ import {
   TagSelectorWithSearch,
 } from '@dagster-io/ui-components';
 import {useMemo} from 'react';
-import {useFeatureFlags} from 'shared/app/Flags';
-import {RunsFeedTableWithFilters} from 'shared/runs/RunsFeedTable';
 import styled from 'styled-components';
 
 import {StatusDot} from './AutomaterializeLeftPanel';
@@ -31,9 +29,11 @@ import {
   GetEvaluationsSpecificPartitionQuery,
 } from './types/GetEvaluationsQuery.types';
 import {gql, useQuery} from '../../apollo-client';
+import {useFeatureFlags} from '../../app/Flags';
 import {formatElapsedTimeWithMsec} from '../../app/Util';
 import {Timestamp} from '../../app/time/Timestamp';
 import {DimensionPartitionKeys, RunsFilter} from '../../graphql/types';
+import {RunsFeedTableWithFilters} from '../../runs/RunsFeedTable';
 import {AssetViewDefinitionNodeFragment} from '../types/AssetView.types';
 
 const emptyArray: any[] = [];

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/GlobalAutomaterializationContent.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/GlobalAutomaterializationContent.tsx
@@ -8,8 +8,6 @@ import {
   Table,
 } from '@dagster-io/ui-components';
 import {useCallback, useMemo, useState} from 'react';
-import {useFeatureFlags} from 'shared/app/Flags';
-import {RunsFeedTableWithFilters} from 'shared/runs/RunsFeedTable';
 
 import {ASSET_DAEMON_TICKS_QUERY} from './AssetDaemonTicksQuery';
 import {AutomaterializationTickDetailDialog} from './AutomaterializationTickDetailDialog';
@@ -23,12 +21,14 @@ import {
 } from './types/AssetDaemonTicksQuery.types';
 import {useLazyQuery} from '../../apollo-client';
 import {useConfirmation} from '../../app/CustomConfirmationProvider';
+import {useFeatureFlags} from '../../app/Flags';
 import {useUnscopedPermissions} from '../../app/Permissions';
 import {useRefreshAtInterval} from '../../app/QueryRefresh';
 import {InstigationTickStatus, RunsFilter} from '../../graphql/types';
 import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
 import {LiveTickTimeline} from '../../instigation/LiveTickTimeline2';
 import {isStuckStartedTick} from '../../instigation/util';
+import {RunsFeedTableWithFilters} from '../../runs/RunsFeedTable';
 import {useAutomaterializeDaemonStatus} from '../useAutomaterializeDaemonStatus';
 
 const MINUTE = 60 * 1000;

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/backfill/BackfillRunsTab.tsx
@@ -12,6 +12,7 @@ import React, {useDeferredValue, useMemo} from 'react';
 
 import {ExecutionTimeline} from './ExecutionTimeline';
 import {BackfillDetailsBackfillFragment} from './types/useBackfillDetailsQuery.types';
+import {useFeatureFlags} from '../../app/Flags';
 import {
   FIFTEEN_SECONDS,
   QueryRefreshCountdown,
@@ -22,6 +23,7 @@ import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
 import {useTimelineRange} from '../../overview/OverviewTimelineRoot';
 import {RunTable} from '../../runs/RunTable';
 import {DagsterTag} from '../../runs/RunTag';
+import {RunsFeedTableWithFilters} from '../../runs/RunsFeedTable';
 import {
   RunFilterTokenType,
   runsFilterForSearchTokens,
@@ -34,6 +36,9 @@ import {useRunsForTimeline} from '../../runs/useRunsForTimeline';
 import {StickyTableContainer} from '../../ui/StickyTableContainer';
 
 const BACKFILL_RUNS_HOUR_WINDOW_KEY = 'dagster.backfill-run-timeline-hour-window';
+
+const BACKFILL_TAGS = [DagsterTag.Backfill];
+
 const PAGE_SIZE = 25;
 
 const filters: RunFilterTokenType[] = [
@@ -53,6 +58,8 @@ export const BackfillRunsTab = ({
   backfill: BackfillDetailsBackfillFragment;
   view: 'timeline' | 'list' | 'both';
 }) => {
+  const {flagRunsFeed} = useFeatureFlags();
+
   const [_view, setView] = useQueryPersistedState<'timeline' | 'list'>({
     defaults: {view: 'timeline'},
     queryKey: 'view',
@@ -146,6 +153,22 @@ export const BackfillRunsTab = ({
       rangeMs={rangeMs}
       annotations={annotations}
       actionBarComponents={actionBarComponents}
+    />
+  ) : flagRunsFeed ? (
+    <RunsFeedTableWithFilters
+      filter={filter}
+      actionBarComponents={actionBarComponents}
+      belowActionBarComponents={belowActionBarComponents}
+      hideTags={BACKFILL_TAGS}
+      emptyState={() => (
+        <Box
+          padding={{vertical: 24}}
+          border="top-and-bottom"
+          flex={{direction: 'column', alignItems: 'center'}}
+        >
+          No runs have been launched.
+        </Box>
+      )}
     />
   ) : (
     <ExecutionRunTable

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRunsEmptyState.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRunsEmptyState.tsx
@@ -1,8 +1,9 @@
 import {Box, Icon, NonIdealState} from '@dagster-io/ui-components';
-import {AnchorButton} from 'shared/ui/AnchorButton';
-import {isThisThingAnAssetJob, useRepository} from 'shared/workspace/WorkspaceContext/util';
-import {RepoAddress} from 'shared/workspace/types';
-import {workspacePathFromAddress} from 'shared/workspace/workspacePath';
+
+import {AnchorButton} from '../ui/AnchorButton';
+import {isThisThingAnAssetJob, useRepository} from '../workspace/WorkspaceContext/util';
+import {RepoAddress} from '../workspace/types';
+import {workspacePathFromAddress} from '../workspace/workspacePath';
 
 interface EmptyStateProps {
   repoAddress: RepoAddress | null;

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRunsFeedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRunsFeedRoot.tsx
@@ -1,12 +1,6 @@
 import {Box, ButtonLink, Tag, TokenizingFieldValue, tokenToString} from '@dagster-io/ui-components';
 import {useCallback, useMemo} from 'react';
 import {useParams} from 'react-router-dom';
-import {RunsFilter} from 'shared/graphql/types';
-import {RunsFeedError} from 'shared/runs/RunsFeedError';
-import {useIncludeRunsFromBackfillsOption} from 'shared/runs/RunsFeedRoot';
-import {RunsFeedTable} from 'shared/runs/RunsFeedTable';
-import {useRunsFeedEntries} from 'shared/runs/useRunsFeedEntries';
-import {RepoAddress} from 'shared/workspace/types';
 
 import {explorerPathFromString} from './PipelinePathUtils';
 import {PipelineRunsEmptyState} from './PipelineRunsEmptyState';
@@ -17,8 +11,12 @@ import {
   useQueryRefreshAtInterval,
 } from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
+import {RunsFilter} from '../graphql/types';
 import {DagsterTag} from '../runs/RunTag';
 import {RunsQueryRefetchContext} from '../runs/RunUtils';
+import {RunsFeedError} from '../runs/RunsFeedError';
+import {useIncludeRunsFromBackfillsOption} from '../runs/RunsFeedRoot';
+import {RunsFeedTable} from '../runs/RunsFeedTable';
 import {
   RunFilterToken,
   RunFilterTokenType,
@@ -26,8 +24,10 @@ import {
   useQueryPersistedRunFilters,
   useRunsFilterInput,
 } from '../runs/RunsFilterInput';
+import {useRunsFeedEntries} from '../runs/useRunsFeedEntries';
 import {isThisThingAJob, useRepository} from '../workspace/WorkspaceContext/util';
 import {repoAddressAsTag} from '../workspace/repoAddressAsString';
+import {RepoAddress} from '../workspace/types';
 
 const ENABLED_FILTERS: RunFilterTokenType[] = [
   'status',
@@ -112,11 +112,7 @@ export const PipelineRunsFeedRoot = (props: {repoAddress?: RepoAddress}) => {
   );
 
   const belowActionBarComponents = (
-    <Box
-      border="top"
-      flex={{direction: 'row', gap: 4, alignItems: 'center'}}
-      padding={{left: 24, right: 12, top: 12}}
-    >
+    <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>
       {permanentTokens.map(({token, value}) => (
         <Tag key={token}>{`${token}:${value}`}</Tag>
       ))}

--- a/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRunsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/pipelines/PipelineRunsRoot.tsx
@@ -10,7 +10,6 @@ import {
 } from '@dagster-io/ui-components';
 import {useCallback, useMemo} from 'react';
 import {useParams} from 'react-router-dom';
-import {useFeatureFlags} from 'shared/app/Flags';
 
 import {explorerPathFromString} from './PipelinePathUtils';
 import {PipelineRunsEmptyState} from './PipelineRunsEmptyState';
@@ -21,6 +20,7 @@ import {
 } from './types/PipelineRunsRoot.types';
 import {useJobTitle} from './useJobTitle';
 import {gql} from '../apollo-client';
+import {useFeatureFlags} from '../app/Flags';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {
   FIFTEEN_SECONDS,

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
@@ -9,7 +9,6 @@ import {
 } from '@dagster-io/ui-components';
 import {useMemo} from 'react';
 import {Link, useParams} from 'react-router-dom';
-import {useFeatureFlags} from 'shared/app/Flags';
 
 import {Run} from './Run';
 import {RunAssetCheckTags} from './RunAssetCheckTags';
@@ -24,6 +23,7 @@ import {TickTagForRun} from './TickTagForRun';
 import {RunPageFragment} from './types/RunFragments.types';
 import {RunRootQuery, RunRootQueryVariables} from './types/RunRoot.types';
 import {gql, useQuery} from '../apollo-client';
+import {useFeatureFlags} from '../app/Flags';
 import {useTrackPageView} from '../app/analytics';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
 import {AutomaterializeTagWithEvaluation} from '../assets/AutomaterializeTagWithEvaluation';

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRowTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRowTags.tsx
@@ -24,11 +24,13 @@ export const RunRowTags = ({
   onAddTag,
   isHovered,
   isJob,
+  hideTags,
 }: {
   run: Pick<RunTableRunFragment, 'tags' | 'assetSelection' | 'mode'>;
   onAddTag?: (token: RunFilterToken) => void;
   isHovered: boolean;
   isJob: boolean;
+  hideTags?: string[];
 }) => {
   const {isTagPinned, onToggleTagPin} = useTagPinning();
   const [showRunTags, setShowRunTags] = React.useState(false);
@@ -48,7 +50,7 @@ export const RunRowTags = ({
     const tagKeys: Set<string> = new Set([]);
     const tags: TagType[] = [];
 
-    if (targetBackfill && targetBackfill.pinned) {
+    if (targetBackfill && targetBackfill.pinned && !hideTags?.includes(DagsterTag.Backfill)) {
       const link = getBackfillPath(targetBackfill.value, !!run.assetSelection?.length);
       tags.push({
         ...targetBackfill,
@@ -61,12 +63,15 @@ export const RunRowTags = ({
         // We already added this tag
         return;
       }
+      if (hideTags?.includes(tag.key)) {
+        return;
+      }
       if (tag.pinned) {
         tags.push(tag);
       }
     });
     return tags;
-  }, [allTagsWithPinned, run.assetSelection?.length]);
+  }, [allTagsWithPinned, hideTags, run.assetSelection?.length]);
 
   return (
     <>

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunTable.tsx
@@ -132,7 +132,7 @@ export const RunTable = (props: RunTableProps) => {
         }
         bottom={belowActionBarComponents}
       />
-      <IndeterminateLoadingBar loading={loading} />
+      <IndeterminateLoadingBar $loading={loading} />
       {content()}
     </>
   );

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRoot.tsx
@@ -131,13 +131,7 @@ export const RunsFeedRoot = () => {
   );
 
   const belowActionBarComponents = activeFiltersJsx.length ? (
-    <Box
-      border="top"
-      flex={{direction: 'row', gap: 4, alignItems: 'center'}}
-      padding={{left: 24, right: 12, top: 12}}
-    >
-      {activeFiltersJsx}
-    </Box>
+    <Box flex={{direction: 'row', gap: 4, alignItems: 'center'}}>{activeFiltersJsx}</Box>
   ) : null;
 
   function content() {

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
@@ -39,6 +39,7 @@ export const RunsFeedRow = ({
   checked,
   onToggleChecked,
   refetch,
+  hideTags,
 }: {
   entry: RunsFeedTableEntryFragment;
   refetch: () => void;
@@ -47,6 +48,7 @@ export const RunsFeedRow = ({
   onToggleChecked?: (values: {checked: boolean; shiftKey: boolean}) => void;
   additionalColumns?: React.ReactNode[];
   hideCreatedBy?: boolean;
+  hideTags?: string[];
 }) => {
   const onChange = (e: React.FormEvent<HTMLInputElement>) => {
     if (e.target instanceof HTMLInputElement) {
@@ -105,6 +107,7 @@ export const RunsFeedRow = ({
               isJob={true}
               isHovered={isHovered}
               onAddTag={onAddTag}
+              hideTags={hideTags}
             />
 
             {entry.runStatus === RunStatus.QUEUED ? (

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedTabs.tsx
@@ -75,12 +75,12 @@ export const useRunsFeedTabs = (filter: RunsFilter = {}, includeRunsFromBackfill
       <TabLink id="all" title="Runs" to={urlForStatus([])} />
       <TabLink
         id="queued"
-        title={`Queued (${queuedCount})`}
+        title={queuedCount !== null ? `Queued (${queuedCount})` : `Queued`}
         to={urlForStatus(Array.from(queuedStatuses))}
       />
       <TabLink
         id="in-progress"
-        title={`In progress (${inProgressCount})`}
+        title={inProgressCount !== null ? `In progress (${inProgressCount})` : 'In progress'}
         to={urlForStatus(Array.from(inProgressStatuses))}
       />
       <TabLink id="failed" title="Failed" to={urlForStatus(Array.from(failedStatuses))} />

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedUtils.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedUtils.tsx
@@ -10,11 +10,11 @@ export function getRunFeedPath() {
 export function getBackfillPath(id: string, isAssetBackfill: boolean) {
   // THis is hacky but basically we're dark launching runs-feed, so if we're on the runs-feed path, stay on it.
   if (location.pathname.includes('runs-feed')) {
-    return `/runs-feed/b/${id}?tab=runs`;
+    return `/runs-feed/b/${id}`;
   }
 
   if (featureEnabled(FeatureFlag.flagRunsFeed)) {
-    return `/runs/b/${id}?tab=runs`;
+    return `/runs/b/${id}`;
   }
   if (isAssetBackfill) {
     return `/overview/backfills/${id}`;

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsFeedEntries.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsFeedEntries.tsx
@@ -1,5 +1,3 @@
-import {PYTHON_ERROR_FRAGMENT} from 'shared/app/PythonErrorFragment';
-
 import {RUNS_FEED_TABLE_ENTRY_FRAGMENT} from './RunsFeedRow';
 import {useSelectedRunsFeedTab} from './RunsFeedTabs';
 import {SCHEDULED_RUNS_LIST_QUERY} from './ScheduledRunListRoot';
@@ -10,6 +8,7 @@ import {
 import {RunsFeedRootQuery, RunsFeedRootQueryVariables} from './types/useRunsFeedEntries.types';
 import {useCursorPaginatedQuery} from './useCursorPaginatedQuery';
 import {gql, useQuery} from '../apollo-client';
+import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {RunsFilter} from '../graphql/types';
 
 const PAGE_SIZE = 25;

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleRoot.tsx
@@ -1,9 +1,6 @@
 import {NonIdealState, Page, Tab, Tabs} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {useParams} from 'react-router-dom';
-import {useFeatureFlags} from 'shared/app/Flags';
-import {RunsFilter} from 'shared/graphql/types';
-import {RunsFeedTableWithFilters} from 'shared/runs/RunsFeedTable';
 
 import {SCHEDULE_ASSET_SELECTIONS_QUERY} from './ScheduleAssetSelectionsQuery';
 import {ScheduleDetails} from './ScheduleDetails';
@@ -21,15 +18,18 @@ import {
 } from './types/ScheduleRoot.types';
 import {ScheduleFragment} from './types/ScheduleUtils.types';
 import {gql, useQuery} from '../apollo-client';
+import {useFeatureFlags} from '../app/Flags';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
 import {FIFTEEN_SECONDS, useMergedRefresh, useQueryRefreshAtInterval} from '../app/QueryRefresh';
 import {useTrackPageView} from '../app/analytics';
+import {RunsFilter} from '../graphql/types';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
 import {INSTANCE_HEALTH_FRAGMENT} from '../instance/InstanceHealthFragment';
 import {TicksTable} from '../instigation/TickHistory';
 import {RunTable} from '../runs/RunTable';
 import {RUN_TABLE_RUN_FRAGMENT} from '../runs/RunTableRunFragment';
 import {DagsterTag} from '../runs/RunTag';
+import {RunsFeedTableWithFilters} from '../runs/RunsFeedTable';
 import {Loading} from '../ui/Loading';
 import {repoAddressAsTag} from '../workspace/repoAddressAsString';
 import {repoAddressToSelector} from '../workspace/repoAddressToSelector';

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorPageAutomaterialize.tsx
@@ -1,8 +1,5 @@
 import {Box, ButtonGroup, Colors, Spinner, Subtitle2} from '@dagster-io/ui-components';
 import {useCallback, useMemo, useState} from 'react';
-import {useFeatureFlags} from 'shared/app/Flags';
-import {AutomaterializeRunHistoryTable} from 'shared/assets/auto-materialization/AutomaterializeRunHistoryTable';
-import {RunsFeedTableWithFilters} from 'shared/runs/RunsFeedTable';
 
 import {ASSET_SENSOR_TICKS_QUERY} from './AssetSensorTicksQuery';
 import {DaemonStatusForWarning, SensorInfo} from './SensorInfo';
@@ -12,8 +9,10 @@ import {
 } from './types/AssetSensorTicksQuery.types';
 import {SensorFragment} from './types/SensorFragment.types';
 import {useLazyQuery} from '../apollo-client';
+import {useFeatureFlags} from '../app/Flags';
 import {useRefreshAtInterval} from '../app/QueryRefresh';
 import {AutomaterializationTickDetailDialog} from '../assets/auto-materialization/AutomaterializationTickDetailDialog';
+import {AutomaterializeRunHistoryTable} from '../assets/auto-materialization/AutomaterializeRunHistoryTable';
 import {DeclarativeAutomationBanner} from '../assets/auto-materialization/DeclarativeAutomationBanner';
 import {SensorAutomaterializationEvaluationHistoryTable} from '../assets/auto-materialization/SensorAutomaterializationEvaluationHistoryTable';
 import {AssetDaemonTickFragment} from '../assets/auto-materialization/types/AssetDaemonTicksQuery.types';
@@ -22,6 +21,7 @@ import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
 import {LiveTickTimeline} from '../instigation/LiveTickTimeline2';
 import {isStuckStartedTick} from '../instigation/util';
 import {DagsterTag} from '../runs/RunTag';
+import {RunsFeedTableWithFilters} from '../runs/RunsFeedTable';
 import {repoAddressAsTag} from '../workspace/repoAddressAsString';
 import {RepoAddress} from '../workspace/types';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/IndeterminateLoadingBar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/IndeterminateLoadingBar.tsx
@@ -1,15 +1,15 @@
 import {Colors} from '@dagster-io/ui-components';
 import styled from 'styled-components';
 
-export const IndeterminateLoadingBar = styled.div<{loading?: boolean}>`
+export const IndeterminateLoadingBar = styled.div<{$loading?: boolean}>`
   height: 2px;
   width: 100%;
   background: ${Colors.backgroundGray()};
   border-radius: 0 0 8px 8px;
   overflow: hidden;
 
-  ${({loading}) =>
-    loading
+  ${({$loading}) =>
+    $loading
       ? `
   &::after {
     content: '';


### PR DESCRIPTION
## Summary & Motivation

This fixes the cloud build errors caused by my previous PR importing OSS code via `shared/`, and also includes some small tweaks to the backfill / runs consolidation:

- Fix react error caused by `loading` being applied to a DOM node
- Fix loading state of new runs feed table using old page-size Spinner
- Hide backfill tags in the runs table on the backfill page
- Land on Overview tab when clicking into a backfill page
- Empty state for the `In progress` and `Queued` tab counts is `null`

## How I Tested These Changes

Verified these manually on the impacted pages, verifying the internal build is fixed manually
