### PR TITLE
[2/n] [RFC] add 'Launch all' button on sensor/schedule evaluation result modals

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateScheduleDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateScheduleDialog.tsx
@@ -182,7 +182,12 @@ const EvaluateSchedule = ({repoAddress, name, onClose, jobName}: Props) => {
         </>
       );
     } else {
-      return <Button onClick={onClose}>Close</Button>;
+      return (
+        <>
+          <Button intent="primary">Launch all</Button>
+          <Button onClick={onClose}>Close</Button>
+        </>
+      );
     }
   }, [onClose, shouldEvaluate]);
 

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/SensorDryRunDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/SensorDryRunDialog.tsx
@@ -124,6 +124,7 @@ const SensorDryRun = ({repoAddress, name, currentCursor, onClose, jobName}: Prop
     if (sensorExecutionData || error) {
       return (
         <Box flex={{direction: 'row', gap: 8}}>
+          <Button>Launch all</Button>
           <Button
             data-testid={testId('test-again')}
             onClick={() => {


### PR DESCRIPTION
## Summary & Motivation
Linear: https://linear.app/dagster-labs/issue/FE-627/add-launch-all-frontend

Add "Launch all" button to these evaluation result modals

![image](https://github.com/user-attachments/assets/f9af2a71-4915-4d08-84d0-806fdd5d0f97)
![image](https://github.com/user-attachments/assets/e9e9eac0-01d9-41dd-8723-5f48d4656363)


## How I Tested These Changes
Tested locally

## Changelog

> Insert changelog entry or delete this section.
