### PR TITLE
[dagster-airlift][rfc] Proxy operator launches partitioned runs

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_instance.py
@@ -270,6 +270,17 @@ class AirflowInstance:
             metadata=response.json(),
         )
 
+    def unpause_dag(self, dag_id: str) -> None:
+        response = self.auth_backend.get_session().patch(
+            f"{self.get_api_url()}/dags",
+            json={"is_paused": False},
+            params={"dag_id_pattern": dag_id},
+        )
+        if response.status_code != 200:
+            raise DagsterError(
+                f"Failed to unpause dag {dag_id}. Status code: {response.status_code}, Message: {response.text}"
+            )
+
     def wait_for_run_completion(self, dag_id: str, run_id: str, timeout: int = 30) -> None:
         start_time = get_current_datetime()
         while get_current_datetime() - start_time < datetime.timedelta(seconds=timeout):

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/gql_queries.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/gql_queries.py
@@ -34,6 +34,13 @@ query AssetNodeQuery {
                 }
             }
         }
+        isPartitioned
+        partitionDefinition {
+          type
+          name
+          fmt
+        }
+        partitionKeys
     }
 }
 """

--- a/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/partition_utils.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/in_airflow/partition_utils.py
@@ -1,0 +1,124 @@
+from datetime import (
+    datetime,
+    timezone as tz,
+)
+from enum import Enum
+from typing import Any, Mapping, NamedTuple, Optional, Sequence
+
+PARTITION_NAME_TAG = "dagster/partition"
+
+
+class PartitionDefinitionType(Enum):
+    TIME_WINDOW = "TIME_WINDOW"
+    STATIC = "STATIC"
+    MULTIPARTITIONED = "MULTIPARTITIONED"
+    DYNAMIC = "DYNAMIC"
+
+
+class TimeWindowPartitioningInformation(NamedTuple):
+    fmt: str
+
+
+class PartitioningInformation(NamedTuple):
+    partitioning_type: PartitionDefinitionType
+    partition_keys: Sequence[str]
+    # Eventually we can add more of these for different partitioning types
+    additional_info: Optional[TimeWindowPartitioningInformation]
+
+    @staticmethod
+    def from_asset_node_graphql(
+        asset_nodes: Sequence[Mapping[str, Any]],
+    ) -> Optional["PartitioningInformation"]:
+        assets_partitioned = [_asset_is_partitioned(asset_node) for asset_node in asset_nodes]
+        if any(assets_partitioned) and not all(assets_partitioned):
+            raise Exception(
+                "Found some unpartitioned assets and some partitioned assets in the same task. "
+                "For a given task, all assets must have the same partitions definition. "
+            )
+        partition_keys_per_asset = [
+            set(asset_node["partitionKeys"])
+            for asset_node in asset_nodes
+            if asset_node["isPartitioned"]
+        ]
+        if not all_sets_equal(partition_keys_per_asset):
+            raise Exception(
+                "Found differing partition keys across assets in this task. "
+                "For a given task, all assets must have the same partitions definition. "
+            )
+        # Now we can proceed with the assumption that all assets are partitioned and have the same partition keys.
+        # This, we only look at the first asset node.
+        asset_node = next(iter(asset_nodes))
+        if not asset_node["isPartitioned"]:
+            return None
+        partitioning_type = PartitionDefinitionType(asset_node["partitionDefinition"]["type"])
+        return PartitioningInformation(
+            partitioning_type=partitioning_type,
+            partition_keys=asset_node["partitionKeys"],
+            additional_info=_build_additional_info_for_type(asset_node, partitioning_type),
+        )
+
+    @property
+    def time_window_partitioning_info(self) -> TimeWindowPartitioningInformation:
+        if self.partitioning_type != PartitionDefinitionType.TIME_WINDOW:
+            raise Exception(
+                f"Partitioning type is {self.partitioning_type}, but expected {PartitionDefinitionType.TIME_WINDOW}"
+            )
+        if self.additional_info is None:
+            raise Exception(
+                f"Partitioning type is {self.partitioning_type}, but no additional info was provided."
+            )
+        return self.additional_info
+
+
+def _build_additional_info_for_type(
+    asset_node: Mapping[str, Any], partitioning_type: PartitionDefinitionType
+) -> Optional[TimeWindowPartitioningInformation]:
+    if partitioning_type != PartitionDefinitionType.TIME_WINDOW:
+        return None
+    return TimeWindowPartitioningInformation(fmt=asset_node["partitionDefinition"]["fmt"])
+
+
+def all_sets_equal(list_of_sets):
+    if not list_of_sets:
+        return True
+    return len(set.union(*list_of_sets)) == len(set.intersection(*list_of_sets))
+
+
+def translate_logical_date_to_partition_key(
+    logical_date: datetime, partitioning_info: PartitioningInformation
+) -> str:
+    if not partitioning_info.partitioning_type == PartitionDefinitionType.TIME_WINDOW:
+        raise Exception(
+            "Only time-window partitioned assets or non-partitioned assets are supported out of the box."
+        )
+    fmt = partitioning_info.time_window_partitioning_info.fmt
+    partitions_and_datetimes = [
+        (_get_partition_datetime(partition_key, fmt), partition_key)
+        for partition_key in partitioning_info.partition_keys
+    ]
+    matching_partition = next(
+        (
+            partition_key
+            for datetime, partition_key in partitions_and_datetimes
+            if datetime.timestamp() == logical_date.timestamp()
+        ),
+        None,
+    )
+    if matching_partition is None:
+        raise Exception(f"No partition key found for logical date {logical_date}")
+    return matching_partition
+
+
+def _asset_is_partitioned(asset_node: Mapping[str, Any]) -> bool:
+    return asset_node["isPartitioned"]
+
+
+def _get_partition_datetime(partition_key: str, fmt: str) -> datetime:
+    try:
+        return _add_default_utc_timezone_if_none(datetime.strptime(partition_key, fmt))
+    except ValueError:
+        raise Exception(f"Could not parse partition key {partition_key} with format {fmt}.")
+
+
+def _add_default_utc_timezone_if_none(dt: datetime) -> datetime:
+    return dt.replace(tzinfo=tz.utc) if dt.tzinfo is None else dt

--- a/examples/experimental/dagster-airlift/dagster_airlift/test/shared_fixtures.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/test/shared_fixtures.py
@@ -126,7 +126,15 @@ def dagster_dev_cmd(dagster_defs_path: str) -> List[str]:
 
 
 @pytest.fixture(name="dagster_dev")
-def setup_dagster(dagster_home: str, dagster_dev_cmd: List[str]) -> Generator[Any, None, None]:
+def setup_dagster(
+    airflow_instance: None, dagster_home: str, dagster_dev_cmd: List[str]
+) -> Generator[Any, None, None]:
+    with stand_up_dagster(dagster_dev_cmd) as process:
+        yield process
+
+
+@contextmanager
+def stand_up_dagster(dagster_dev_cmd: List[str]) -> Generator[subprocess.Popen, None, None]:
     """Stands up a dagster instance using the dagster dev CLI. dagster_defs_path must be provided
     by a fixture included in the callsite.
     """

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/Makefile
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/Makefile
@@ -17,7 +17,7 @@ dev_install:
 	uv pip install -e ../../../dagster-airlift
 	uv pip install -e .
 
-setup_local_env: 
+setup_local_env:
 	$(MAKE) wipe
 	mkdir -p $(AIRFLOW_HOME)
 	mkdir -p $(DAGSTER_HOME)

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/migrated_partitioned.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/migrated_partitioned.py
@@ -1,0 +1,35 @@
+from datetime import timedelta
+from pathlib import Path
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from dagster._time import get_current_datetime_midnight
+from dagster_airlift.in_airflow import proxying_to_dagster
+from dagster_airlift.in_airflow.proxied_state import load_proxied_state_from_yaml
+
+
+def print_hello() -> None:
+    print("Hello")  # noqa: T201
+
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "retries": 0,
+}
+
+with DAG(
+    dag_id="migrated_daily_interval_dag",
+    default_args=default_args,
+    schedule="@daily",
+    start_date=get_current_datetime_midnight() - timedelta(days=1),
+    # We pause this dag upon creation to avoid running it immediately
+    is_paused_upon_creation=True,
+) as minute_dag:
+    PythonOperator(task_id="my_task", python_callable=print_hello)
+
+
+proxying_to_dagster(
+    proxied_state=load_proxied_state_from_yaml(Path(__file__).parent / "proxied_state"),
+    global_vars=globals(),
+)

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/proxied_state/migrated_daily_interval_dag.yaml
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/proxied_state/migrated_daily_interval_dag.yaml
@@ -1,0 +1,3 @@
+tasks:
+  - id: my_task 
+    proxied: True 

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/simple_unproxied.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink/airflow_dags/simple_unproxied.py
@@ -15,13 +15,12 @@ default_args = {
     "retries": 1,
 }
 
-
 with DAG(
     "simple_unproxied_dag",
     default_args=default_args,
     schedule_interval=None,
     is_paused_upon_creation=False,
-) as dag:
+) as the_dag:
     PythonOperator(task_id="print_task", python_callable=print_hello) >> PythonOperator(
         task_id="downstream_print_task", python_callable=print_hello
     )  # type: ignore

--- a/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_observation.py
+++ b/examples/experimental/dagster-airlift/examples/kitchen-sink/kitchen_sink_tests/integration_tests/test_e2e_observation.py
@@ -56,6 +56,8 @@ def test_observation_defs_are_observed(
     from kitchen_sink.dagster_defs.airflow_instance import local_airflow_instance
 
     af_instance = local_airflow_instance()
+    dag_ids = [dag_info.dag_id for dag_info in af_instance.list_dags()]
+    assert "simple_unproxied_dag" in dag_ids
 
     expected_obs_per_dag = {
         "simple_unproxied_dag": [AssetKey("my_asset"), AssetKey("my_downstream_asset")],
@@ -63,7 +65,7 @@ def test_observation_defs_are_observed(
 
     for dag_id, expected_asset_keys in expected_obs_per_dag.items():
         airflow_run_id = af_instance.trigger_dag(dag_id=dag_id)
-        af_instance.wait_for_run_completion(dag_id=dag_id, run_id=airflow_run_id, timeout=60)
+        af_instance.wait_for_run_completion(dag_id=dag_id, run_id=airflow_run_id, timeout=120)
         dagster_instance = DagsterInstance.get()
 
         dag_asset_key = AssetKey(["my_airflow_instance", "dag", dag_id])

--- a/examples/experimental/dagster-airlift/setup.py
+++ b/examples/experimental/dagster-airlift/setup.py
@@ -17,9 +17,17 @@ def get_version() -> str:
 ver = get_version()
 pin = "" if ver == "1!0+dev" else NON_EDITABLE_INSTALL_DAGSTER_PIN
 
+# The [in-airflow] subpackage does not have a setup dependency on Airflow because
+# Airflow cannot be installed via setup.py reliably. Instead, users need to install
+# from a constraints file as recommended by the Airflow project.
+# However, to ensure a reliable test and tutorial setup, we pin a version of Airflow
+# that is compatible with the current version of dagster-airlift for all supported
+# versions of python.
+# Eventually, we could consider adding a test suite that runs across different versions of airflow
+# to ensure compatibility.
 AIRFLOW_REQUIREMENTS = [
     # Requirements for python versions under 3.12.
-    "apache-airflow>=2.0.0; python_version < '3.12'",
+    "apache-airflow==2.7.3; python_version < '3.12'",
     "pendulum>=2.0.0,<3.0.0; python_version < '3.12'",
     # Requirements for python versions 3.12 and above.
     "apache-airflow>=2.9.0; python_version >= '3.12'",

--- a/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/partition_sets.py
@@ -507,6 +507,7 @@ class GraphenePartitionDefinition(graphene.ObjectType):
     type = graphene.NonNull(GraphenePartitionDefinitionType)
     dimensionTypes = non_null_list(GrapheneDimensionDefinitionType)
     name = graphene.Field(graphene.String)
+    fmt = graphene.Field(graphene.String)
 
     class Meta:
         name = "PartitionDefinition"
@@ -560,6 +561,11 @@ class GraphenePartitionDefinition(graphene.ObjectType):
             name=(
                 partition_def_data.name
                 if isinstance(partition_def_data, DynamicPartitionsSnap)
+                else None
+            ),
+            fmt=(
+                partition_def_data.fmt
+                if isinstance(partition_def_data, TimeWindowPartitionsSnap)
                 else None
             ),
         )


### PR DESCRIPTION
## Summary & Motivation
Adds a pluggable implementation to BaseAssetsOperator which handles mapping the current airflow run to a partitioned run in Dagster. By default, we do the same thing that we do in the sensor - we attempt to map the logical date directly to a partition. 

Important points to note:
- I make the simplifying assumption that all assets within a given task share the same partitions definition. This makes it so that we can keep to the "one run" constraint from a previous PR.
- There's two points of pluggability that I think make sense to expose. The first is the method get_partition_key(context, partition_keys), which allows users to pick a partition key from the list to use.
The second is a pluggable default implementation translate_logical_date_to_partition_key, which takes a list of partition key formats. This is to support TimeWindowPartitionsDefinitions that use a custom format / cron schedule without needing to do a full reimplementation. All they would do is override get_partition_key to call translate_logical_date_to_partition_key with their custom format.
## How I Tested These Changes
Added a new test which takes a daily dag and constructs a daily partitioned materialization. Might be worth testing all the other formatting cases, as well as pluggability.
## Changelog
NOCHANGELOG
