### PR TITLE
Use AssetCheckSummaryRecord to compute subsets for asset checks

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -147,10 +147,23 @@ class AssetRecord(
         return [records_by_key.get(key) for key in keys]
 
 
-class AssetCheckSummaryRecord(NamedTuple):
-    asset_check_key: AssetCheckKey
-    last_check_execution_record: Optional[AssetCheckExecutionRecord]
-    last_run_id: Optional[str]
+class AssetCheckSummaryRecord(
+    NamedTuple(
+        "_AssetCheckSummaryRecord",
+        [
+            ("asset_check_key", AssetCheckKey),
+            ("last_check_execution_record", Optional[AssetCheckExecutionRecord]),
+            ("last_run_id", Optional[str]),
+        ],
+    ),
+    InstanceLoadableBy[AssetCheckKey],
+):
+    @classmethod
+    def _blocking_batch_load(
+        cls, keys: Iterable[AssetCheckKey], instance: DagsterInstance
+    ) -> Iterable[Optional["AssetCheckSummaryRecord"]]:
+        records_by_key = instance.event_log_storage.get_asset_check_summary_records(list(keys))
+        return [records_by_key[key] for key in keys]
 
 
 class PlannedMaterializationInfo(NamedTuple):


### PR DESCRIPTION
## Summary & Motivation
We realized that since that we already have a GraphQL query for to get asset check summary records `get_asset_check_summary_records`, we can just use that to get the `AssetCheckExecutionRecord`s we want instead of creating another query to get execution records.

## How I Tested These Changes
Existing tests should pass
