### PR TITLE
[dagster-embedded-elt] fix `fetch_row_count()` for dlt assets using `merge` write disposition

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/dlt_event_iterator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/dlt_event_iterator.py
@@ -15,7 +15,7 @@ T = TypeVar("T", bound=DltEventType)
 
 def _fetch_row_count(
     dlt_pipeline: Pipeline,
-    schema_name: str,
+    schema_name: Optional[str],
     table_name: str,
 ) -> Optional[int]:
     """Exists in a separate function mostly for ease of testing."""
@@ -48,7 +48,8 @@ def fetch_row_count_metadata(
     if not jobs_metadata or not isinstance(jobs_metadata, list):
         raise Exception("Missing jobs metadata to retrieve row count.")
     table_name = jobs_metadata[0].get("table_name")
-    schema_name = str(materialization.metadata.get("dataset_name"))
+    dataset_name = materialization.metadata.get("dataset_name")
+    schema_name = dataset_name if isinstance(dataset_name, str) else None
     try:
         return TableMetadataSet(row_count=_fetch_row_count(dlt_pipeline, schema_name, table_name))
     # Filesystem does not have a SQL client and table might not be found


### PR DESCRIPTION
## Summary & Motivation
I have added dlt's `dataset_name` as the schema name to the query fetching row counts. This fixes an issue I faced with dlt assets that have `write_disposition="merge"` and `destination="duckdb"` since a staging schema is also created in the destination database. Hence, the previous query did not use a fully qualified table name since by itself it could refer to either the table in the staging schema, or the table in the destination schema. Have only faced this issue in DuckDB for some reason.

## How I Tested These Changes
- Manually tested with both DuckDB and Snowflake as destinations.
- `make ruff`
- `pytest`

## Changelog
[dagster-embedded-elt] dlt's `fetch_row_count()` method now works when using the `merge` write disposition
