### PR TITLE
[ui] Export Apollo error utilities

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/apollo-client/index.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/apollo-client/index.tsx
@@ -9,6 +9,7 @@ import {
 import {useBlockTraceOnQueryResult} from '../performance/TraceContext';
 
 export * from '@apollo/client';
+export * from '@apollo/client/link/error';
 
 interface ExtendedQueryOptions<TData = any, TVariables extends OperationVariables = any>
   extends QueryHookOptions<TData, TVariables> {


### PR DESCRIPTION
## Summary & Motivation

In internal, we consume a couple of Apollo error utilities for an error link. Expose these via `apollo-client` exports in `ui-core` so that the internal app can appease our eslint-config.

## How I Tested These Changes

Run TS and lint in internal.