### PR TITLE
[dagster-looker] add related; use dagster as dg; use PyObject references

### DIFF
--- a/docs/content/integrations/looker.mdx
+++ b/docs/content/integrations/looker.mdx
@@ -27,9 +27,9 @@ This guide provides instructions for using Dagster with Looker. Your Looker asse
 
 ## Represent Looker assets in the asset graph
 
-To load Looker assets into the Dagster asset graph, you must first construct a `LookerResource`, which allows Dagster to communicate with your Looker instance. You'll need to supply your Looker instance URL and API credentials, which can be passed directly or accessed from the environment using `EnvVar`.
+To load Looker assets into the Dagster asset graph, you must first construct a <PyObject module="dagster_looker" object="LookerResource" />, which allows Dagster to communicate with your Looker instance. You'll need to supply your Looker instance URL and API credentials, which can be passed directly or accessed from the environment using <PyObject object="EnvVar" />.
 
-Dagster can automatically load all views, explores, and dashboards from your Looker instance. Call the `build_defs()` function, which returns a `Definitions` object containing all the asset definitions for these Looker assets.
+Dagster can automatically load all views, explores, and dashboards from your Looker instance. Call the <PyObject module="dagster_looker" object="LookerResource" method="build_defs" /> function, which returns a <PyObject object="Definitions" /> object containing all the asset definitions for these Looker assets.
 
 ```python file=/integrations/looker/representing-looker-assets.py
 from dagster_looker import LookerResource
@@ -47,7 +47,7 @@ defs = resource.build_defs()
 
 ### Customize asset definition metadata for Looker assets
 
-By default, Dagster will generate asset keys for each Looker asset based on its type and name and populate default metadata. You can further customize asset properties by passing a custom `DagsterLookerAPITranslator` subclass to the `LookerResource.build_defs(...)` function. This subclass can implement methods to customize the asset keys or specs for each Looker asset type.
+By default, Dagster will generate asset keys for each Looker asset based on its type and name and populate default metadata. You can further customize asset properties by passing a custom <PyObject module="dagster_looker" object="DagsterLookerApiTranslator" /> subclass to the <PyObject module="dagster_looker" object="LookerResource" method="build_defs" /> function. This subclass can implement methods to customize the asset keys or specs for each Looker asset type.
 
 ```python file=/integrations/looker/customize-looker-assets.py
 from dagster_looker import (
@@ -85,7 +85,7 @@ defs = resource.build_defs(dagster_looker_translator=CustomDagsterLookerApiTrans
 
 ### Materialize Looker PDTs from Dagster
 
-You can use Dagster to orchestrate the materialization of Looker PDTs. To model a PDT as an asset, pass its definition by passing `RequestStartPdtBuild` to `LookerResource.build_defs(...)` function.
+You can use Dagster to orchestrate the materialization of Looker PDTs. To model a PDT as an asset, pass its definition by passing <PyObject module="dagster_looker" object="RequestStartPdtBuild" /> to <PyObject module="dagster_looker" object="LookerResource" method="build_defs" /> function.
 
 ```python file=/integrations/looker/materializing-looker-pdts.py
 from dagster_looker import LookerResource, RequestStartPdtBuild
@@ -107,3 +107,10 @@ defs = resource.build_defs(
     ]
 )
 ```
+
+### Related
+
+- [`dagster-looker` API reference](/\_apidocs/libraries/dagster-looker)
+- [Asset definitions](/concepts/assets/software-defined-assets)
+- [Resources](/concepts/resources)
+- [Using environment variables and secrets](/guides/dagster/using-environment-variables-and-secrets)


### PR DESCRIPTION
## Summary & Motivation

- add related
- use `import dagster as dg`
- use PyObject references

## How I Tested These Changes

```
make next-watch-build
```

## Changelog

> Insert changelog entry or delete this section.
