### PR TITLE
[asset-graph-view] Make deserializing subsets safer

### DIFF
--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -192,13 +192,12 @@ class AssetGraphView(LoadingContext):
     def get_subset_from_serializable_subset(
         self, serializable_subset: SerializableEntitySubset[T_EntityKey]
     ) -> Optional[EntitySubset[T_EntityKey]]:
-        if serializable_subset.is_compatible_with_partitions_def(
-            self._get_partitions_def(serializable_subset.key)
+        key = serializable_subset.key
+        if self.asset_graph.has(key) and serializable_subset.is_compatible_with_partitions_def(
+            self._get_partitions_def(key)
         ):
             return EntitySubset(
-                self,
-                key=serializable_subset.key,
-                value=_ValidatedEntitySubsetValue(serializable_subset.value),
+                self, key=key, value=_ValidatedEntitySubsetValue(serializable_subset.value)
             )
         else:
             return None

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -238,8 +238,8 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
     def nodes(self) -> Iterable[BaseEntityNode]:
         return [*self._asset_nodes_by_key.values(), *self._asset_check_nodes_by_key.values()]
 
-    def has(self, asset_key: AssetKey) -> bool:
-        return asset_key in self._asset_nodes_by_key
+    def has(self, key: EntityKey) -> bool:
+        return key in self._asset_nodes_by_key or key in self._asset_check_nodes_by_key
 
     @overload
     def get(self, key: AssetKey) -> T_AssetNode: ...


### PR DESCRIPTION
## Summary & Motivation

As title. This guards against situations in which an asset is completely removed from the graph and we try to get an EntitySubset from a SerializedEntitySubset.

## How I Tested These Changes

## Changelog

NOCHANGELOG
