### PR TITLE
[3/n] [RFC] add manual tick button to all rows in automation table

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/automation/VirtualizedAutomationScheduleRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/automation/VirtualizedAutomationScheduleRow.tsx
@@ -8,6 +8,7 @@ import {
 } from '@dagster-io/ui-components';
 import {forwardRef, useMemo} from 'react';
 import {Link} from 'react-router-dom';
+import styled from 'styled-components';
 
 import {AutomationTargetList} from './AutomationTargetList';
 import {AutomationRowGrid} from './VirtualizedAutomationRow';
@@ -24,6 +25,7 @@ import {
   ScheduleAssetSelectionQuery,
   ScheduleAssetSelectionQueryVariables,
 } from '../schedules/types/ScheduleAssetSelectionsQuery.types';
+import {EvaluateTickButtonSchedule} from '../ticks/EvaluateTickButtonSchedule';
 import {TickStatusTag} from '../ticks/TickStatusTag';
 import {RowCell} from '../ui/VirtualizedTable';
 import {SINGLE_SCHEDULE_QUERY} from '../workspace/VirtualizedScheduleRow';
@@ -138,22 +140,37 @@ export const VirtualizedAutomationScheduleRow = forwardRef(
             </Tooltip>
           </RowCell>
           <RowCell>
-            <Box flex={{direction: 'row', gap: 8, alignItems: 'flex-start'}}>
-              {scheduleData ? (
-                <Box flex={{direction: 'column', gap: 4}}>
-                  {/* Keyed so that a new switch is always rendered, otherwise it's reused and animates on/off */}
-                  <ScheduleSwitch key={name} repoAddress={repoAddress} schedule={scheduleData} />
-                  {errorDisplay(
-                    scheduleData.scheduleState.status,
-                    scheduleData.scheduleState.runningCount,
-                  )}
-                </Box>
-              ) : (
-                <div style={{width: 30}} />
-              )}
-              <Link to={workspacePathFromAddress(repoAddress, `/schedules/${name}`)}>
-                <MiddleTruncate text={name} />
-              </Link>
+            <Box
+              flex={{
+                direction: 'row',
+                gap: 8,
+                alignItems: 'flex-start',
+                justifyContent: 'space-between',
+              }}
+            >
+              <Box flex={{grow: 1, gap: 8}}>
+                {scheduleData ? (
+                  <>
+                    <ScheduleSwitch key={name} repoAddress={repoAddress} schedule={scheduleData} />
+                    {errorDisplay(
+                      scheduleData.scheduleState.status,
+                      scheduleData.scheduleState.runningCount,
+                    )}
+                  </>
+                ) : (
+                  <div style={{width: 30}} />
+                )}
+                <Link to={workspacePathFromAddress(repoAddress, `/schedules/${name}`)}>
+                  <MiddleTruncate text={name} />
+                </Link>
+              </Box>
+              <EvaluateTickButtonScheduleWrapper>
+                <EvaluateTickButtonSchedule
+                  name={scheduleData?.name || ''}
+                  repoAddress={repoAddress}
+                  jobName={scheduleData?.pipelineName || ''}
+                />
+              </EvaluateTickButtonScheduleWrapper>
             </Box>
           </RowCell>
           <RowCell>
@@ -225,3 +242,9 @@ export const VirtualizedAutomationScheduleRow = forwardRef(
     );
   },
 );
+
+const EvaluateTickButtonScheduleWrapper = styled.div`
+  button {
+    height: 24px;
+  }
+`;

--- a/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/schedules/ScheduleDetails.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Button,
   Code,
   Group,
   Heading,
@@ -8,7 +7,6 @@ import {
   PageHeader,
   Tag,
 } from '@dagster-io/ui-components';
-import {useState} from 'react';
 import {Link} from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -23,7 +21,7 @@ import {AutomationTargetList} from '../automation/AutomationTargetList';
 import {AutomationAssetSelectionFragment} from '../automation/types/AutomationAssetSelectionFragment.types';
 import {InstigationStatus} from '../graphql/types';
 import {RepositoryLink} from '../nav/RepositoryLink';
-import {EvaluateScheduleDialog} from '../ticks/EvaluateScheduleDialog';
+import {EvaluateTickButtonSchedule} from '../ticks/EvaluateTickButtonSchedule';
 import {TickStatusTag} from '../ticks/TickStatusTag';
 import {RepoAddress} from '../workspace/types';
 
@@ -41,8 +39,6 @@ export const ScheduleDetails = (props: {
   const {status, ticks} = scheduleState;
   const latestTick = ticks.length > 0 ? ticks[0] : null;
   const running = status === InstigationStatus.RUNNING;
-
-  const [showTestTickDialog, setShowTestTickDialog] = useState(false);
 
   return (
     <>
@@ -62,25 +58,13 @@ export const ScheduleDetails = (props: {
         right={
           <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
             <QueryRefreshCountdown refreshState={refreshState} />
-            <Button
-              onClick={() => {
-                setShowTestTickDialog(true);
-              }}
-            >
-              Evaluate tick
-            </Button>
+            <EvaluateTickButtonSchedule
+              name={schedule.name}
+              repoAddress={repoAddress}
+              jobName={pipelineName}
+            />
           </Box>
         }
-      />
-      <EvaluateScheduleDialog
-        key={showTestTickDialog ? '1' : '0'} // change key to reset dialog state
-        isOpen={showTestTickDialog}
-        onClose={() => {
-          setShowTestTickDialog(false);
-        }}
-        name={schedule.name}
-        repoAddress={repoAddress}
-        jobName={pipelineName}
       />
       <MetadataTableWIP>
         <tbody>

--- a/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/sensors/SensorDetails.tsx
@@ -17,6 +17,7 @@ import {EditCursorDialog} from './EditCursorDialog';
 import {SensorMonitoredAssets} from './SensorMonitoredAssets';
 import {SensorResetButton} from './SensorResetButton';
 import {SensorSwitch} from './SensorSwitch';
+import {EvaluateTickButtonSensor} from '../ticks/EvaluateTickButtonSensor';
 import {SensorFragment} from './types/SensorFragment.types';
 import {usePermissionsForLocation} from '../app/Permissions';
 import {QueryRefreshCountdown, QueryRefreshState} from '../app/QueryRefresh';
@@ -25,7 +26,6 @@ import {AutomationAssetSelectionFragment} from '../automation/types/AutomationAs
 import {InstigationStatus, SensorType} from '../graphql/types';
 import {RepositoryLink} from '../nav/RepositoryLink';
 import {TimestampDisplay} from '../schedules/TimestampDisplay';
-import {SensorDryRunDialog} from '../ticks/SensorDryRunDialog';
 import {TickStatusTag} from '../ticks/TickStatusTag';
 import {RepoAddress} from '../workspace/types';
 
@@ -92,7 +92,6 @@ export const SensorDetails = ({
     sensor.sensorState.typeSpecificData.__typename === 'SensorData' &&
     sensor.sensorState.typeSpecificData.lastCursor;
 
-  const [showTestTickDialog, setShowTestTickDialog] = useState(false);
   const running = status === InstigationStatus.RUNNING;
 
   return (
@@ -114,32 +113,15 @@ export const SensorDetails = ({
         right={
           <Box margin={{top: 4}} flex={{direction: 'row', alignItems: 'center', gap: 8}}>
             <QueryRefreshCountdown refreshState={refreshState} />
-            <Tooltip
-              canShow={sensor.sensorType !== SensorType.STANDARD}
-              content="Testing not available for this sensor type"
-              placement="top-end"
-            >
-              <Button
-                disabled={sensor.sensorType !== SensorType.STANDARD}
-                onClick={() => {
-                  setShowTestTickDialog(true);
-                }}
-              >
-                Evaluate tick
-              </Button>
-            </Tooltip>
+            <EvaluateTickButtonSensor
+              cursor={cursor || ''}
+              name={sensor.name}
+              repoAddress={repoAddress}
+              jobName={sensor.targets?.[0]?.pipelineName || ''}
+              sensorType={sensor.sensorType}
+            />
           </Box>
         }
-      />
-      <SensorDryRunDialog
-        isOpen={showTestTickDialog}
-        onClose={() => {
-          setShowTestTickDialog(false);
-        }}
-        currentCursor={cursor || ''}
-        name={sensor.name}
-        repoAddress={repoAddress}
-        jobName={sensor.targets?.[0]?.pipelineName || ''}
       />
       <MetadataTableWIP>
         <tbody>

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateTickButtonSchedule.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateTickButtonSchedule.tsx
@@ -1,0 +1,41 @@
+import {Box, Button} from '@dagster-io/ui-components';
+import {useState} from 'react';
+
+import {EvaluateScheduleDialog} from './EvaluateScheduleDialog';
+import {RepoAddress} from '../workspace/types';
+
+interface EvaluateTickButtonScheduleProps {
+  name: string;
+  repoAddress: RepoAddress;
+  jobName: string;
+}
+
+export const EvaluateTickButtonSchedule = ({
+  name,
+  repoAddress,
+  jobName,
+}: EvaluateTickButtonScheduleProps) => {
+  const [showTestTickDialog, setShowTestTickDialog] = useState(false);
+
+  return (
+    <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+      <Button
+        onClick={() => {
+          setShowTestTickDialog(true);
+        }}
+      >
+        Evaluate tick
+      </Button>
+      <EvaluateScheduleDialog
+        key={showTestTickDialog ? '1' : '0'} // change key to reset dialog state
+        isOpen={showTestTickDialog}
+        onClose={() => {
+          setShowTestTickDialog(false);
+        }}
+        name={name}
+        repoAddress={repoAddress}
+        jobName={jobName}
+      />
+    </Box>
+  );
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateTickButtonSensor.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ticks/EvaluateTickButtonSensor.tsx
@@ -1,0 +1,49 @@
+import {Box, Button, Tooltip} from '@dagster-io/ui-components';
+import {useState} from 'react';
+
+import {SensorDryRunDialog} from './SensorDryRunDialog';
+import {SensorType} from '../graphql/types';
+import {RepoAddress} from '../workspace/types';
+
+interface EvaluateTickButtonSensorProps {
+  cursor: string;
+  name: string;
+  repoAddress: RepoAddress;
+  jobName: string;
+  sensorType: SensorType;
+}
+
+export const EvaluateTickButtonSensor = ({
+  cursor,
+  name,
+  repoAddress,
+  jobName,
+  sensorType,
+}: EvaluateTickButtonSensorProps) => {
+  const [showTestTickDialog, setShowTestTickDialog] = useState(false);
+
+  return (
+    <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
+      <Tooltip
+        canShow={sensorType !== SensorType.STANDARD}
+        content="Testing not available for this sensor type"
+        placement="top-end"
+      >
+        <Button
+          disabled={sensorType !== SensorType.STANDARD}
+          onClick={() => setShowTestTickDialog(true)}
+        >
+          Evaluate tick
+        </Button>
+      </Tooltip>
+      <SensorDryRunDialog
+        isOpen={showTestTickDialog}
+        onClose={() => setShowTestTickDialog(false)}
+        currentCursor={cursor}
+        name={name}
+        repoAddress={repoAddress}
+        jobName={jobName}
+      />
+    </Box>
+  );
+};


### PR DESCRIPTION
## Summary & Motivation
Linear: https://linear.app/dagster-labs/issue/FE-628/add-manual-tick-button-to-all-rows-in-automations-table

Video:

https://github.com/user-attachments/assets/8a7993ff-babe-4fa2-8526-a448ef1e7c2b



## How I Tested These Changes
yarn lint, ts, tested locally

## Changelog

> Insert changelog entry or delete this section.
