### PR TITLE
[bk] Update individual package publish pipeline to handle rcs

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/prerelease_package.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/prerelease_package.py
@@ -17,13 +17,6 @@ def build_prerelease_package_steps() -> List[BuildkiteStep]:
         + _get_uncustomized_pkg_roots("examples/experimental", [])
     )
 
-    # Get only packages that have a fixed version in setup.py
-    filtered_packages = []
-    for package in packages:
-        setup_file = Path(package) / "setup.py"
-        contents = setup_file.read_text()
-        if re.findall(r"version=\"[\d\.]+\"", contents):
-            filtered_packages.append(package)
 
     input_step: BlockStep = {
         "block": ":question: Choose package",
@@ -39,7 +32,7 @@ def build_prerelease_package_steps() -> List[BuildkiteStep]:
                         else package,
                         "value": package,
                     }
-                    for package in filtered_packages
+                    for package in packages
                 ],
                 "hint": None,
                 "default": None,

--- a/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/prerelease_package.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/pipelines/prerelease_package.py
@@ -1,5 +1,3 @@
-import re
-from pathlib import Path
 from typing import List
 
 from dagster_buildkite.python_version import AvailablePythonVersion
@@ -16,7 +14,6 @@ def build_prerelease_package_steps() -> List[BuildkiteStep]:
         + _get_uncustomized_pkg_roots("python_modules/libraries", [])
         + _get_uncustomized_pkg_roots("examples/experimental", [])
     )
-
 
     input_step: BlockStep = {
         "block": ":question: Choose package",


### PR DESCRIPTION
## Summary

Updates the logic of our single-package publish BK pipeline to:
1) Allow selecting any package, not just those with fixed versions in the codebase
2) If a package is selected that doesn't have a fixed version in the codebase [meaning, it is a package released weekly with typical dagster release version numbers] mandate that the release version is a rc, so it doesn't interrupt typical user installs

The intent is that we can use this pipeline to (1) freeform release packages we don't regularly publish, e.g. `dagster-airlift` and (2) allow us to easily release release candidates for packages we do regularly publish, e.g. `dagster-looker`

## Test Plan

Successful release: 
https://buildkite.com/dagster/publish-single-python-package/builds/56#

Flagging non-rc version for traditional package:
https://buildkite.com/dagster/publish-single-python-package/builds/54

