### PR TITLE
[dagster-k8s] feat: add HA options to user deployments

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/deployment-user.yaml
@@ -10,7 +10,7 @@ metadata:
     deployment: {{ $deployment.name }}
   annotations: {{ $deployment.annotations | toYaml | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ $deployment.replicas | default 1 }}
   selector:
     matchLabels:
       {{- include "dagster.selectorLabels" $ | nindent 6 }}

--- a/helm/dagster/charts/dagster-user-deployments/templates/pdb-user.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/templates/pdb-user.yaml
@@ -1,0 +1,21 @@
+{{ range $deployment := .Values.deployments }}
+{{ if $deployment.pdb }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "dagster.fullname" $ -}}-{{- $deployment.name }}
+  labels:
+    {{- include "dagster.labels" $ | nindent 4 }}
+    component: user-deployments
+    deployment: {{ $deployment.name }}
+  annotations: {{ $deployment.annotations | toYaml | nindent 4 }}
+spec:
+  {{- $deployment.pdb | toYaml | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "dagster.selectorLabels" $ | nindent 6 }}
+      component: user-deployments
+      deployment: {{ $deployment.name }}
+---
+{{ end }}
+{{ end }}

--- a/helm/dagster/charts/dagster-user-deployments/values.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/values.yaml
@@ -23,6 +23,7 @@ celeryConfigSecretName: "dagster-celery-config-secret"
 ####################################################################################################
 deployments:
   - name: "k8s-example-user-code-1"
+    replicas: 1
     image:
       # When a tag is not supplied, it will default as the Helm chart version.
       repository: "docker.io/dagster/user-code-example"
@@ -129,6 +130,11 @@ deployments:
     securityContext: {}
     resources: {}
     labels: {}
+
+    # Add a PodDisruptionBudget to this Deployment
+    # pdb:
+    #   maxUnavailable: 1
+    pdb: {}
 
     # Override the default K8s scheduler
     # schedulerName: ~


### PR DESCRIPTION
## Summary & Motivation

Add options on the User Deployment Helm Chart to:
- Increase the Deployment `replicas`
- Add a `PodDisruptionBudget` to avoid disrupting the User Deployment

Fixes issue [!25360](https://github.com/dagster-io/dagster/issues/25360)

## How I Tested These Changes

Rendering the Helm Template with the default values (replicas is still 1 by default, and there is no PDB rendered):
```bash
$ helm template . -s templates/deployment-user.yaml # Check replicas
$ helm template . -s templates/pdb-user.yaml
Error: could not find template templates/pdb-user.yaml in chart
```

Running the same command but with a new values file containing:
```yaml
deployments:
  - name: "foo"
    replicas: 2
    port: 3030
    image:
      repository: "docker.io/dagster/user-code-example"
      tag: latest
      pullPolicy: IfNotPresent
    pdb:
      maxUnavailable: 1
```

This should render the `Deployment` with `replicas: 2` and a PDB:
```bash
$ helm template . -s templates/deployment-user.yaml -f values-test.yaml
$ helm template . -s templates/pdb-user.yaml -f values-test.yaml
```

## Changelog

> [dagster-k8s] Add HA options to User Deployments Helm Chart
