### PR TITLE
[docs] display supersession info

### DIFF
--- a/docs/content/about/releases.mdx
+++ b/docs/content/about/releases.mdx
@@ -23,11 +23,21 @@ The "experimental" marker allows us to offer new APIs to users and rapidly itera
 
 Experimental APIs may change or disappear within any release, but we try to avoid breaking them within minor releases if they have been around for a long time.
 
+### Superseded APIs
+
+The "superseded" marker indicates that we recommend avoiding an API, usually because there's a preferred option that should be used instead.
+
+Like non-deprecated public stable APIs, deprecated public stable APIs will not break within any major release after 1.0.
+
+Superseded APIs do not have a known scheduled removal point, but we recommend avoiding them in new code.
+
 ### Deprecated APIs
 
 The "deprecated" marker indicates that we recommend avoiding an API, usually because there's a preferred option that should be used instead.
 
 Like non-deprecated public stable APIs, deprecated public stable APIs will not break within any major release after 1.0.
+
+Unlike superseded APIs, deprecated APIs have a known scheduled removal point. We will provide guidance on when to expect the removal.
 
 ---
 

--- a/docs/markdoc-component-documentation.md
+++ b/docs/markdoc-component-documentation.md
@@ -23,11 +23,11 @@ To see the rendered version of these tags, move this file into the `next/pages/g
 
 When the wire was despatched he had a cup of tea; over it he told me of a diary kept by Jonathan Harker when abroad, and gave me a typewritten copy of it, as also of Mrs. Harker's diary at Whitby. "Take these," he said, "and study them well. When I have returned you will be master of all the facts, and we can then better enter on our inquisition. Keep them safe, for there is in them much of treasure. You will need all your faith, even you who have had such an experience as that of to-day. What is here told," he laid his hand heavily and gravely on the packet of papers as he spoke, "may be the beginning of the end to you and me and many another; or it may sound the knell of the Un-Dead who walk the earth. Read all, I pray you, with the open mind; and if you can add in any way to the story here told do so, for it is all-important. You have kept diary of all these so strange things; is it not so? Yes! Then we shall go through all these together when we meet." He then made ready for his departure, and shortly after drove off to Liverpool Street. I took my way to Paddington, where I arrived about fifteen minutes before the train came in.
 
-## Complex Header Where You Definitely Want to Use an Anchor Link {% #complex-header %} 
+## Complex Header Where You Definitely Want to Use an Anchor Link {% #complex-header %}
 
 ```
-## Complex Header Where You Definitely Want to Use an 
-Anchor Link {\% #complex-header %} 
+## Complex Header Where You Definitely Want to Use an
+Anchor Link {\% #complex-header %}
 ```
 
 # Vanilla Markdown Nodes
@@ -229,9 +229,9 @@ You can invoke a cross with this tag `{% cross /}%` and it looks like this {% cr
 Crosses and checks can also be used in lists:
 - {% check /%} Completed task
 - {% cross /%} Incomplete task
-- {% cross /%} Super Incomplete task 
+- {% cross /%} Super Incomplete task
 
-You can also put crosses and checks into headers 
+You can also put crosses and checks into headers
 
 ### This is a header with a check {% check /%}
 Which is pretty neat.
@@ -242,7 +242,7 @@ Which is also pretty neat.
 ## Images
 In the old MDX way of doing things, images were a bit of a pain. You had to either manually specify the height and width of the image or run a script (`make MDX-format`) to do it for you.
 
-Document preprocessors like this have a number of issues such as being slow, error-prone, and making edits to the docs more difficult. 
+Document preprocessors like this have a number of issues such as being slow, error-prone, and making edits to the docs more difficult.
 
 To that end, I've opted to extended the default markdoc image node to automatically determine the height and width of the image during the transform step and use that to instantiate the image using the `Next/Image` component. Doing this allows us to retain the benefits of our current make script approach while also preserving the easy authoring experience of vanilla markdown.
 
@@ -277,10 +277,11 @@ The cool part about all of this is that it removes the need to run `make MDX-for
 ### API Status Badges
 We've also got a bunch of badges that you can use to indicate the level of support an API or feature has.
 
-There are three types of badges:
+There are the available badges:
 
 - `{% experimental /%}` {% experimental /%}
 - `{% deprecated /%}` {% deprecated /%}
+- `{% superseded /%}` {% superseded /%}
 - `{% legacy /%}` {% legacy /%}
 
 ## Code Reference Links : Block
@@ -329,7 +330,7 @@ Code fences
 
 ## Article Lists : Block
 
-Authors can use article lists. 
+Authors can use article lists.
 
 They work like this:
 `{% articleList %}`

--- a/docs/next/components/markdoc/Badges.tsx
+++ b/docs/next/components/markdoc/Badges.tsx
@@ -27,6 +27,14 @@ export const Deprecated = () => {
   );
 };
 
+export const Superseded = () => {
+  return (
+    <div className="superseded-tag">
+      <span className="hidden">(</span>Superseded<span className="hidden">)</span>
+    </div>
+  );
+};
+
 export const Legacy = () => {
   return (
     <div className="legacy-tag">

--- a/docs/next/components/mdx/MDXComponents.tsx
+++ b/docs/next/components/mdx/MDXComponents.tsx
@@ -441,6 +441,18 @@ const Deprecated = () => {
   );
 };
 
+////////////////////////
+//  SUPERSEDED BADGE  //
+////////////////////////
+
+const Superseded = () => {
+  return (
+    <div className="superseded-tag">
+      <span className="hidden">(</span>Superseded<span className="hidden">)</span>
+    </div>
+  );
+};
+
 //////////////////////
 //  LEGACY BADGE    //
 //////////////////////
@@ -853,6 +865,7 @@ export default {
   PlaceholderImage,
   Experimental,
   Deprecated,
+  Superseded,
   Legacy,
   Icons,
   ReferenceTable,

--- a/docs/next/markdoc/tags.js
+++ b/docs/next/markdoc/tags.js
@@ -1,5 +1,5 @@
 import {ArticleList, ArticleListItem} from '../components/markdoc/ArticleList';
-import {Badge, Experimental, Deprecated, Legacy} from '../components/markdoc/Badges';
+import {Badge, Experimental, Deprecated, Superseded, Legacy} from '../components/markdoc/Badges';
 import {Button, ButtonContainer} from '../components/markdoc/Button';
 import {Note, Warning} from '../components/markdoc/Callouts';
 import {Check, Cross} from '../components/markdoc/CheckCross';
@@ -82,6 +82,11 @@ export const experimental = {
 
 export const deprecated = {
   render: Deprecated,
+  selfClosing: true,
+};
+
+export const superseded = {
+  render: Superseded,
   selfClosing: true,
 };
 

--- a/docs/next/styles/globals.css
+++ b/docs/next/styles/globals.css
@@ -108,8 +108,17 @@ dt > a.reference.internal {
   @apply inline-flex items-center px-3 py-0.5 rounded-full align-middle text-xs uppercase font-medium bg-gray-300 text-gray-900
 }
 
+.superseded-tag {
+  @apply inline-flex items-center px-3 py-0.5 rounded-full align-middle text-xs uppercase font-medium bg-gray-300 text-gray-900
+}
+
 .legacy-tag,
 .flag.deprecated {
+  @apply inline-flex items-center px-3 py-0.5 rounded-full align-middle text-xs uppercase font-medium bg-yellow-200 text-yellow-700
+}
+
+.legacy-tag,
+.flag.superseded {
   @apply inline-flex items-center px-3 py-0.5 rounded-full align-middle text-xs uppercase font-medium bg-yellow-200 text-yellow-700
 }
 
@@ -576,7 +585,7 @@ dt > a.reference.internal {
 div.flag {
   background: theme("colors.gray.150");
   padding: 0 1rem;
-  margin-top: 1rem; 
+  margin-top: 1rem;
   border-radius: 0.25rem;
   border: 1px solid theme("colors.gray.200");
 }

--- a/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py
+++ b/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/__init__.py
@@ -6,11 +6,13 @@ from dagster._annotations import (
     get_deprecated_params,
     get_experimental_info,
     get_experimental_params,
+    get_superseded_info,
     has_deprecated_params,
     has_experimental_params,
     is_deprecated,
     is_experimental,
     is_public,
+    is_superseded,
 )
 from dagster._record import get_original_class, is_record
 from typing_extensions import Literal, TypeAlias
@@ -120,6 +122,9 @@ def process_docstring(
 
     if is_deprecated(obj):
         inject_object_flag(obj, get_deprecated_info(obj), lines)
+
+    if is_superseded(obj):
+        inject_object_flag(obj, get_superseded_info(obj), lines)
 
     if has_deprecated_params(obj):
         params = get_deprecated_params(obj)

--- a/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/docstring_flags.py
+++ b/docs/sphinx/_ext/dagster-sphinx/dagster_sphinx/docstring_flags.py
@@ -3,7 +3,7 @@ from typing import List, Union
 
 import dagster._check as check
 import docutils.nodes as nodes
-from dagster._annotations import DeprecatedInfo, ExperimentalInfo
+from dagster._annotations import DeprecatedInfo, ExperimentalInfo, SupersededInfo
 
 from sphinx.util.docutils import SphinxDirective
 
@@ -15,7 +15,7 @@ from sphinx.util.docutils import SphinxDirective
 
 
 def inject_object_flag(
-    obj: object, info: Union[DeprecatedInfo, ExperimentalInfo], docstring: List[str]
+    obj: object, info: Union[SupersededInfo, DeprecatedInfo, ExperimentalInfo], docstring: List[str]
 ) -> None:
     if isinstance(info, DeprecatedInfo):
         additional_text = f" {info.additional_warn_text}." if info.additional_warn_text else ""
@@ -27,6 +27,10 @@ def inject_object_flag(
         message = (
             f"This API may break in future versions, even between dot releases.\n{additional_text}"
         )
+    elif isinstance(info, SupersededInfo):
+        additional_text = f" {info.additional_warn_text}." if info.additional_warn_text else ""
+        flag_type = "superseded"
+        message = f"This API has been superseded and it's usage is discouraged.\n{additional_text}"
     else:
         check.failed(f"Unexpected info type {type(info)}")
     for line in reversed([f".. flag:: {flag_type}", "", f"   {message}", ""]):


### PR DESCRIPTION
## Summary & Motivation

Adding new `Supersession` helpers for docs.

This is done in alignment with the new [API lifecycle](https://www.notion.so/dagster/API-Lifecycle-Refresh-f72f6e199da3409c8c5da297a109b3c8) and as requested in [this](https://github.com/dagster-io/dagster/pull/25335#discussion_r1805034325) comment by @yuhan 

Example screenshot in the upstack [PR](https://github.com/dagster-io/dagster/pull/25335). 