### PR TITLE
[RFC] make docker termination timeout configurable

### DIFF
--- a/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/docker_run_launcher.py
@@ -36,11 +36,13 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
         network=None,
         networks=None,
         container_kwargs=None,
+        termination_timeout_seconds=None,
     ):
         self._inst_data = inst_data
         self.image = image
         self.registry = registry
         self.env_vars = env_vars
+        self.termination_timeout_seconds = termination_timeout_seconds
 
         validate_docker_config(network, networks, container_kwargs)
 
@@ -216,7 +218,7 @@ class DockerRunLauncher(RunLauncher, ConfigurableClass):
             )
             return False
 
-        container.stop()
+        container.stop(timeout=self.termination_timeout_seconds)
 
         return True
 

--- a/python_modules/libraries/dagster-docker/dagster_docker/utils.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/utils.py
@@ -1,5 +1,6 @@
 from dagster import (
     Field,
+    IntSource,
     StringSource,
     _check as check,
 )
@@ -21,6 +22,13 @@ DOCKER_CONFIG_SCHEMA = merge_dicts(
             description=(
                 "Name of the network to which to connect the launched container at creation time"
             ),
+        ),
+        "termination_timeout_seconds": Field(
+            IntSource,
+            is_required=False,
+            description="During a cancellation, the number of seconds to wait for the container "
+            "to terminate before forcefully killing it.",
+            default=10,
         ),
     },
     DOCKER_CONTAINER_CONTEXT_SCHEMA,


### PR DESCRIPTION
## Summary & Motivation

Not a part of the codebase I am super familiar with, but makes it possible to configure the timeout when canceling a run launched by the docker run launcher.

A couple questions:
- Does it make sense to set a termination timeout on the docker executor?
- If so, is there somewhere that we test step termination

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
