### PR TITLE
[dagster-sigma] Use aiohttp to fetch data from Sigma APIs

### DIFF
--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -5,6 +5,7 @@ aiofiles==24.1.0
 aiohappyeyeballs==2.4.3
 aiohttp==3.10.10
 aiohttp-retry==2.8.3
+aioresponses==0.7.6
 aiosignal==1.3.1
 alabaster==1.0.0
 alembic==1.13.3
@@ -379,18 +380,6 @@ nodeenv==1.9.1
 notebook==7.2.2
 notebook-shim==0.2.4
 numpy==1.26.4
-nvidia-cublas-cu12==12.1.3.1
-nvidia-cuda-cupti-cu12==12.1.105
-nvidia-cuda-nvrtc-cu12==12.1.105
-nvidia-cuda-runtime-cu12==12.1.105
-nvidia-cudnn-cu12==9.1.0.70
-nvidia-cufft-cu12==11.0.2.54
-nvidia-curand-cu12==10.3.2.106
-nvidia-cusolver-cu12==11.4.5.107
-nvidia-cusparse-cu12==12.1.0.106
-nvidia-nccl-cu12==2.20.5
-nvidia-nvjitlink-cu12==12.6.77
-nvidia-nvtx-cu12==12.1.105
 oauth2client==4.1.3
 oauthlib==3.2.2
 objgraph==3.6.2
@@ -592,7 +581,6 @@ tqdm==4.66.5
 traitlets==5.14.3
 trio==0.26.2
 trio-websocket==0.11.1
-triton==3.0.0
 -e examples/experimental/dagster-airlift/examples/tutorial-example
 -e examples/tutorial_notebook_assets
 twilio==9.3.3

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import urllib.parse
 import warnings
@@ -6,14 +7,15 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import AbstractSet, Any, Dict, Iterator, List, Mapping, Optional, Type
 
+import aiohttp
 import requests
+from aiohttp.client_exceptions import ClientResponseError
 from dagster import ConfigurableResource
 from dagster._annotations import public
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader
 from dagster._utils.cached_method import cached_method
 from pydantic import Field, PrivateAttr
-from requests import HTTPError
 from sqlglot import exp, parse_one
 
 from dagster_sigma.translator import (
@@ -86,197 +88,257 @@ class SigmaOrganization(ConfigurableResource):
 
         return self._api_token
 
-    def _fetch_json(
+    async def _fetch_json_async(
         self, endpoint: str, method: str = "GET", query_params: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
         url = f"{self.base_url}/v2/{endpoint}"
         if query_params:
             url = f"{url}?{urllib.parse.urlencode(query_params)}"
 
-        response = requests.request(
-            method=method,
-            url=f"{self.base_url}/v2/{endpoint}",
-            headers={
-                "Accept": "application/json",
-                "Authorization": f"Bearer {self.api_token}",
-                **SIGMA_PARTNER_ID_TAG,
-            },
+        async with aiohttp.ClientSession() as session:
+            async with session.request(
+                method=method,
+                url=f"{self.base_url}/v2/{endpoint}",
+                headers={
+                    "Accept": "application/json",
+                    "Authorization": f"Bearer {self.api_token}",
+                    **SIGMA_PARTNER_ID_TAG,
+                },
+            ) as response:
+                response.raise_for_status()
+                return await response.json()
+
+    @cached_method
+    async def _fetch_workbooks(self) -> List[Dict[str, Any]]:
+        return (await self._fetch_json_async("workbooks"))["entries"]
+
+    @cached_method
+    async def _fetch_datasets(self) -> List[Dict[str, Any]]:
+        return (await self._fetch_json_async("datasets"))["entries"]
+
+    @cached_method
+    async def _fetch_pages_for_workbook(self, workbook_id: str) -> List[Dict[str, Any]]:
+        return (await self._fetch_json_async(f"workbooks/{workbook_id}/pages"))["entries"]
+
+    @cached_method
+    async def _fetch_elements_for_page(
+        self, workbook_id: str, page_id: str
+    ) -> List[Dict[str, Any]]:
+        return (await self._fetch_json_async(f"workbooks/{workbook_id}/pages/{page_id}/elements"))[
+            "entries"
+        ]
+
+    @cached_method
+    async def _fetch_lineage_for_element(self, workbook_id: str, element_id: str) -> Dict[str, Any]:
+        return await self._fetch_json_async(
+            f"workbooks/{workbook_id}/lineage/elements/{element_id}"
         )
-        response.raise_for_status()
-        return response.json()
 
     @cached_method
-    def _fetch_workbooks(self) -> List[Dict[str, Any]]:
-        return self._fetch_json("workbooks")["entries"]
+    async def _fetch_columns_for_element(
+        self, workbook_id: str, element_id: str
+    ) -> List[Dict[str, Any]]:
+        return (
+            await self._fetch_json_async(f"workbooks/{workbook_id}/elements/{element_id}/columns")
+        )["entries"]
 
     @cached_method
-    def _fetch_datasets(self) -> List[Dict[str, Any]]:
-        return self._fetch_json("datasets")["entries"]
-
-    @cached_method
-    def _fetch_pages_for_workbook(self, workbook_id: str) -> List[Dict[str, Any]]:
-        return self._fetch_json(f"workbooks/{workbook_id}/pages")["entries"]
-
-    @cached_method
-    def _fetch_elements_for_page(self, workbook_id: str, page_id: str) -> List[Dict[str, Any]]:
-        return self._fetch_json(f"workbooks/{workbook_id}/pages/{page_id}/elements")["entries"]
-
-    @cached_method
-    def _fetch_lineage_for_element(self, workbook_id: str, element_id: str) -> Dict[str, Any]:
-        return self._fetch_json(f"workbooks/{workbook_id}/lineage/elements/{element_id}")
-
-    @cached_method
-    def _fetch_columns_for_element(self, workbook_id: str, element_id: str) -> List[Dict[str, Any]]:
-        return self._fetch_json(f"workbooks/{workbook_id}/elements/{element_id}/columns")["entries"]
-
-    @cached_method
-    def _fetch_queries_for_workbook(self, workbook_id: str) -> List[Dict[str, Any]]:
-        return self._fetch_json(f"workbooks/{workbook_id}/queries")["entries"]
+    async def _fetch_queries_for_workbook(self, workbook_id: str) -> List[Dict[str, Any]]:
+        return (await self._fetch_json_async(f"workbooks/{workbook_id}/queries"))["entries"]
 
     @contextlib.contextmanager
     def try_except_http_warn(self, should_catch: bool, msg: str) -> Iterator[None]:
         try:
             yield
-        except HTTPError as e:
+        except ClientResponseError as e:
             if should_catch:
                 warnings.warn(f"{msg} {e}")
             else:
                 raise
 
     @cached_method
-    def _fetch_dataset_upstreams_by_inode(self) -> Mapping[str, AbstractSet[str]]:
+    async def _fetch_dataset_upstreams_by_inode(self) -> Mapping[str, AbstractSet[str]]:
         """Builds a mapping of dataset inodes to the upstream inputs they depend on.
         Sigma does not expose this information directly, so we have to infer it from
         the lineage of workbooks and the workbook queries.
         """
         deps_by_dataset_inode = defaultdict(set)
 
-        raw_workbooks = self._fetch_workbooks()
+        raw_workbooks = await self._fetch_workbooks()
 
-        # We first figure out which tables/visualizations ("elements") in each workbook
-        # depend on which datasets.
-        for workbook in raw_workbooks:
-            queries = self._fetch_queries_for_workbook(workbook["workbookId"])
+        async def process_workbook(workbook: Dict[str, Any]) -> None:
+            queries = await self._fetch_queries_for_workbook(workbook["workbookId"])
             queries_by_element_id = defaultdict(list)
             for query in queries:
                 queries_by_element_id[query["elementId"]].append(query)
 
-            pages = self._fetch_pages_for_workbook(workbook["workbookId"])
+            pages = await self._fetch_pages_for_workbook(workbook["workbookId"])
+            elements = await asyncio.gather(
+                *[
+                    self._fetch_elements_for_page(workbook["workbookId"], page["pageId"])
+                    for page in pages
+                ]
+            )
 
-            for page in pages:
-                elements = self._fetch_elements_for_page(workbook["workbookId"], page["pageId"])
-                for element in elements:
-                    # We extract the list of dataset dependencies from the lineage of each element
-                    # If there is a single dataset dependency, we can then know the queries for that element
-                    # are associated with that dataset
-                    with self.try_except_http_warn(
-                        self.warn_on_lineage_fetch_error,
-                        f"Failed to fetch lineage for element {element['elementId']} in workbook {workbook['workbookId']}",
-                    ):
-                        lineage = self._fetch_lineage_for_element(
-                            workbook["workbookId"], element["elementId"]
+            async def build_deps_from_element(element: Dict[str, Any]) -> None:
+                # We extract the list of dataset dependencies from the lineage of each element
+                # If there is a single dataset dependency, we can then know the queries for that element
+                # are associated with that dataset
+                with self.try_except_http_warn(
+                    self.warn_on_lineage_fetch_error,
+                    f"Failed to fetch lineage for element {element['elementId']} in workbook {workbook['workbookId']}",
+                ):
+                    lineage = await self._fetch_lineage_for_element(
+                        workbook["workbookId"], element["elementId"]
+                    )
+                    dataset_dependencies = [
+                        dep
+                        for dep in lineage["dependencies"].values()
+                        if dep.get("type") == "dataset"
+                    ]
+                    if len(dataset_dependencies) != 1:
+                        return
+
+                    inode = dataset_dependencies[0]["nodeId"]
+                    for query in queries_by_element_id[element["elementId"]]:
+                        # Use sqlglot to extract the tables used in each query and add them to the dataset's
+                        # list of dependencies
+                        table_deps = set(
+                            [
+                                f"{table.catalog}.{table.db}.{table.this}"
+                                for table in list(parse_one(query["sql"]).find_all(exp.Table))
+                                if table.catalog
+                            ]
                         )
-                        dataset_dependencies = [
-                            dep
-                            for dep in lineage["dependencies"].values()
-                            if dep.get("type") == "dataset"
-                        ]
-                        if len(dataset_dependencies) != 1:
-                            continue
 
-                        inode = dataset_dependencies[0]["nodeId"]
-                        for query in queries_by_element_id[element["elementId"]]:
-                            # Use sqlglot to extract the tables used in each query and add them to the dataset's
-                            # list of dependencies
-                            table_deps = set(
-                                [
-                                    f"{table.catalog}.{table.db}.{table.this}"
-                                    for table in list(parse_one(query["sql"]).find_all(exp.Table))
-                                    if table.catalog
-                                ]
-                            )
+                        deps_by_dataset_inode[inode] = deps_by_dataset_inode[inode].union(
+                            table_deps
+                        )
 
-                            deps_by_dataset_inode[inode] = deps_by_dataset_inode[inode].union(
-                                table_deps
-                            )
+            await asyncio.gather(
+                *[
+                    build_deps_from_element(element)
+                    for page_elements in elements
+                    for element in page_elements
+                ]
+            )
+
+        await asyncio.gather(*[process_workbook(workbook) for workbook in raw_workbooks])
 
         return deps_by_dataset_inode
 
     @cached_method
-    def _fetch_dataset_columns_by_inode(self) -> Mapping[str, AbstractSet[str]]:
+    async def _fetch_dataset_columns_by_inode(self) -> Mapping[str, AbstractSet[str]]:
         """Builds a mapping of dataset inodes to the columns they contain. Note that
         this is a partial list and will only include columns which are referenced in
         workbooks, since Sigma does not expose a direct API for querying dataset columns.
         """
         columns_by_dataset_inode = defaultdict(set)
 
-        for workbook in self._fetch_workbooks():
-            pages = self._fetch_pages_for_workbook(workbook["workbookId"])
-            for page in pages:
-                elements = self._fetch_elements_for_page(workbook["workbookId"], page["pageId"])
-                for element in elements:
-                    # We can't query the list of columns in a dataset directly, so we have to build a partial
-                    # list from the columns which appear in any workbook.
-                    columns = self._fetch_columns_for_element(
-                        workbook["workbookId"], element["elementId"]
-                    )
-                    for column in columns:
-                        split = column["columnId"].split("/")
-                        if len(split) == 2:
-                            inode, column_name = split
-                        columns_by_dataset_inode[inode].add(column_name)
+        workbooks = await self._fetch_workbooks()
+
+        async def process_workbook(workbook: Dict[str, Any]) -> None:
+            pages = await self._fetch_pages_for_workbook(workbook["workbookId"])
+            elements = [
+                element
+                for page_elements in await asyncio.gather(
+                    *[
+                        self._fetch_elements_for_page(workbook["workbookId"], page["pageId"])
+                        for page in pages
+                    ]
+                )
+                for element in page_elements
+            ]
+            columns = [
+                column
+                for element_cols in await asyncio.gather(
+                    *[
+                        self._fetch_columns_for_element(
+                            workbook["workbookId"], element["elementId"]
+                        )
+                        for element in elements
+                    ]
+                )
+                for column in element_cols
+            ]
+            for column in columns:
+                split = column["columnId"].split("/")
+                if len(split) == 2:
+                    inode, column_name = split
+                columns_by_dataset_inode[inode].add(column_name)
+
+        await asyncio.gather(*[process_workbook(workbook) for workbook in workbooks])
 
         return columns_by_dataset_inode
 
     @cached_method
-    def build_member_id_to_email_mapping(self) -> Mapping[str, str]:
+    async def build_member_id_to_email_mapping(self) -> Mapping[str, str]:
         """Retrieves all members in the Sigma organization and builds a mapping
         from member ID to email address.
         """
-        members = self._fetch_json("members", query_params={"limit": 500})["entries"]
+        members = (await self._fetch_json_async("members", query_params={"limit": 500}))["entries"]
         return {member["memberId"]: member["email"] for member in members}
 
+    async def load_workbook_data(self, raw_workbook_data: Dict[str, Any]) -> SigmaWorkbook:
+        workbook_deps = set()
+
+        pages = await self._fetch_pages_for_workbook(raw_workbook_data["workbookId"])
+        elements = [
+            element
+            for page_elements in await asyncio.gather(
+                *[
+                    self._fetch_elements_for_page(raw_workbook_data["workbookId"], page["pageId"])
+                    for page in pages
+                ]
+            )
+            for element in page_elements
+        ]
+
+        async def safe_fetch_lineage_for_element(
+            workbook_id: str, element_id: str
+        ) -> Dict[str, Any]:
+            with self.try_except_http_warn(
+                self.warn_on_lineage_fetch_error,
+                f"Failed to fetch lineage for element {element_id} in workbook {workbook_id}",
+            ):
+                return await self._fetch_lineage_for_element(workbook_id, element_id)
+
+            return {"dependencies": {}}
+
+        lineages = await asyncio.gather(
+            *[
+                safe_fetch_lineage_for_element(
+                    raw_workbook_data["workbookId"], element["elementId"]
+                )
+                for element in elements
+            ]
+        )
+        for lineage in lineages:
+            for item in lineage["dependencies"].values():
+                if item.get("type") == "dataset":
+                    workbook_deps.add(item["nodeId"])
+
+        return SigmaWorkbook(
+            properties=raw_workbook_data,
+            datasets=workbook_deps,
+            owner_email=None,
+        )
+
     @cached_method
-    def build_organization_data(self) -> SigmaOrganizationData:
+    async def build_organization_data(self) -> SigmaOrganizationData:
         """Retrieves all workbooks and datasets in the Sigma organization and builds a
         SigmaOrganizationData object representing the organization's assets.
         """
-        member_id_to_email = self.build_member_id_to_email_mapping()
-
-        raw_workbooks = self._fetch_workbooks()
-
-        workbooks: List[SigmaWorkbook] = []
-        for workbook in raw_workbooks:
-            workbook_deps = set()
-            pages = self._fetch_pages_for_workbook(workbook["workbookId"])
-            for page in pages:
-                elements = self._fetch_elements_for_page(workbook["workbookId"], page["pageId"])
-                for element in elements:
-                    # We extract the list of dataset dependencies from the lineage of each workbook.
-                    with self.try_except_http_warn(
-                        self.warn_on_lineage_fetch_error,
-                        f"Failed to fetch lineage for element {element['elementId']} in workbook {workbook['workbookId']}",
-                    ):
-                        lineage = self._fetch_lineage_for_element(
-                            workbook["workbookId"], element["elementId"]
-                        )
-                        for inode, item in lineage["dependencies"].items():
-                            if item.get("type") == "dataset":
-                                workbook_deps.add(item["nodeId"])
-
-            workbooks.append(
-                SigmaWorkbook(
-                    properties=workbook,
-                    datasets=workbook_deps,
-                    owner_email=member_id_to_email.get(workbook["ownerId"]),
-                )
-            )
+        raw_workbooks = await self._fetch_workbooks()
+        workbooks: List[SigmaWorkbook] = await asyncio.gather(
+            *[self.load_workbook_data(workbook) for workbook in raw_workbooks]
+        )
 
         datasets: List[SigmaDataset] = []
-        deps_by_dataset_inode = self._fetch_dataset_upstreams_by_inode()
-        columns_by_dataset_inode = self._fetch_dataset_columns_by_inode()
+        deps_by_dataset_inode = await self._fetch_dataset_upstreams_by_inode()
+        columns_by_dataset_inode = await self._fetch_dataset_columns_by_inode()
 
-        for dataset in self._fetch_datasets():
+        for dataset in await self._fetch_datasets():
             inode = _inode_from_url(dataset["url"])
             datasets.append(
                 SigmaDataset(
@@ -317,7 +379,7 @@ class SigmaOrganizationDefsLoader(StateBackedDefinitionsLoader[SigmaOrganization
         return f"sigma_{self.organization.client_id}"
 
     def fetch_state(self) -> SigmaOrganizationData:
-        return self.organization.build_organization_data()
+        return asyncio.run(self.organization.build_organization_data())
 
     def defs_from_state(self, state: SigmaOrganizationData) -> Definitions:
         translator = self.translator_cls(context=state)

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/conftest.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/conftest.py
@@ -1,17 +1,26 @@
+import json
 import uuid
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterator, List
 
 import pytest
-import responses
+import responses as request_responses
+from aiohttp import hdrs
+from aioresponses import aioresponses
 from dagster_sigma import SigmaBaseUrl
+
+
+@pytest.fixture(name="responses")
+def mock_responses() -> Iterator[aioresponses]:
+    with aioresponses() as m:
+        yield m
 
 
 @pytest.fixture(name="sigma_auth_token")
 def sigma_auth_fixture() -> str:
     fake_access_token: str = uuid.uuid4().hex
 
-    responses.add(
-        method=responses.POST,
+    request_responses.add(
+        method=request_responses.POST,
         url=f"{SigmaBaseUrl.AWS_US.value}/v2/auth/token",
         json={"access_token": fake_access_token},
         status=200,
@@ -57,204 +66,244 @@ SAMPLE_DATASET_DATA = {
 
 
 @pytest.fixture(name="lineage_warn")
-def lineage_warn_fixture() -> None:
-    responses.replace(
-        method_or_response=responses.GET,
-        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/lineage/elements/_MuHPbskp0",
-        status=400,
-    )
+def lineage_warn_fixture(responses: aioresponses) -> None:
+    # clear out the existing response
+    url_to_warn = "https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/lineage/elements/_MuHPbskp0"
+    key_to_del = None
+    for key, response in responses._matches.items():  # noqa: SLF001
+        if str(response.url_or_pattern) == url_to_warn:
+            key_to_del = key
+
+    assert key_to_del
+    del responses._matches[key_to_del]  # noqa: SLF001
+
+    # failed responses don't get cached
+    for _ in range(2):
+        responses.add(
+            method=hdrs.METH_GET,
+            url=url_to_warn,
+            status=400,
+        )
 
 
 @pytest.fixture(name="sigma_sample_data")
-def sigma_sample_data_fixture() -> None:
+def sigma_sample_data_fixture(responses: aioresponses) -> None:
     # Single workbook, dataset
     responses.add(
-        method=responses.GET,
+        method=hdrs.METH_GET,
         url="https://aws-api.sigmacomputing.com/v2/workbooks",
-        json=_build_paginated_response([SAMPLE_WORKBOOK_DATA]),
+        body=json.dumps(_build_paginated_response([SAMPLE_WORKBOOK_DATA])),
         status=200,
     )
     responses.add(
-        method=responses.GET,
+        method=hdrs.METH_GET,
         url="https://aws-api.sigmacomputing.com/v2/datasets",
-        json=_build_paginated_response([SAMPLE_DATASET_DATA]),
+        body=json.dumps(_build_paginated_response([SAMPLE_DATASET_DATA])),
         status=200,
     )
 
     responses.add(
-        method=responses.GET,
+        method=hdrs.METH_GET,
         url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/pages",
-        json=_build_paginated_response([{"pageId": "qwMyyHBCuC", "name": "Page 1"}]),
+        body=json.dumps(_build_paginated_response([{"pageId": "qwMyyHBCuC", "name": "Page 1"}])),
         status=200,
     )
     responses.add(
-        method=responses.GET,
+        method=hdrs.METH_GET,
         url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/pages/qwMyyHBCuC/elements",
-        json=_build_paginated_response(
-            [
-                {
-                    "elementId": "_MuHPbskp0",
-                    "type": "table",
-                    "name": "sample elementl",
-                    "columns": [
-                        "Order Id",
-                        "Customer Id",
-                        "workbook renamed date",
-                        "Modified Date",
-                    ],
-                    "vizualizationType": "levelTable",
-                },
-                {
-                    "elementId": "V29pknzHb6",
-                    "type": "visualization",
-                    "name": "Count of Order Date by Status",
-                    "columns": [
-                        "Order Id",
-                        "Customer Id",
-                        "Order Date",
-                        "Status",
-                        "Modified Date",
-                        "Count of Order Date",
-                    ],
-                    "vizualizationType": "bar",
-                },
-            ]
+        body=json.dumps(
+            _build_paginated_response(
+                [
+                    {
+                        "elementId": "_MuHPbskp0",
+                        "type": "table",
+                        "name": "sample elementl",
+                        "columns": [
+                            "Order Id",
+                            "Customer Id",
+                            "workbook renamed date",
+                            "Modified Date",
+                        ],
+                        "vizualizationType": "levelTable",
+                    },
+                    {
+                        "elementId": "V29pknzHb6",
+                        "type": "visualization",
+                        "name": "Count of Order Date by Status",
+                        "columns": [
+                            "Order Id",
+                            "Customer Id",
+                            "Order Date",
+                            "Status",
+                            "Modified Date",
+                            "Count of Order Date",
+                        ],
+                        "vizualizationType": "bar",
+                    },
+                ]
+            )
         ),
         status=200,
     )
     responses.add(
-        method=responses.GET,
+        method=hdrs.METH_GET,
         url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/lineage/elements/_MuHPbskp0",
-        json={
-            "dependencies": {
-                "qy_ARjTKcT": {
-                    "nodeId": "qy_ARjTKcT",
-                    "type": "sheet",
-                    "name": "sample elementl",
-                    "elementId": "_MuHPbskp0",
+        body=json.dumps(
+            {
+                "dependencies": {
+                    "qy_ARjTKcT": {
+                        "nodeId": "qy_ARjTKcT",
+                        "type": "sheet",
+                        "name": "sample elementl",
+                        "elementId": "_MuHPbskp0",
+                    },
+                    "inode-Iq557kfHN8KRu76HdGSWi": {
+                        "nodeId": "inode-Iq557kfHN8KRu76HdGSWi",
+                        "type": "dataset",
+                        "name": "Orders Dataset",
+                    },
                 },
-                "inode-Iq557kfHN8KRu76HdGSWi": {
-                    "nodeId": "inode-Iq557kfHN8KRu76HdGSWi",
-                    "type": "dataset",
-                    "name": "Orders Dataset",
-                },
-            },
-            "edges": [
-                {"source": "inode-Iq557kfHN8KRu76HdGSWi", "target": "qy_ARjTKcT", "type": "source"}
-            ],
-        },
+                "edges": [
+                    {
+                        "source": "inode-Iq557kfHN8KRu76HdGSWi",
+                        "target": "qy_ARjTKcT",
+                        "type": "source",
+                    }
+                ],
+            }
+        ),
         status=200,
     )
     responses.add(
-        method=responses.GET,
+        method=hdrs.METH_GET,
         url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/elements/_MuHPbskp0/columns",
-        json=_build_paginated_response(
-            [
-                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Order Id", "label": "Order Id"},
-                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Customer Id", "label": "Customer Id"},
-                {
-                    "columnId": "inode-Iq557kfHN8KRu76HdGSWi/Order Date",
-                    "label": "workbook renamed date",
-                },
-                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Modified Date", "label": "Modified Date"},
-            ]
+        body=json.dumps(
+            _build_paginated_response(
+                [
+                    {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Order Id", "label": "Order Id"},
+                    {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Customer Id", "label": "Customer Id"},
+                    {
+                        "columnId": "inode-Iq557kfHN8KRu76HdGSWi/Order Date",
+                        "label": "workbook renamed date",
+                    },
+                    {
+                        "columnId": "inode-Iq557kfHN8KRu76HdGSWi/Modified Date",
+                        "label": "Modified Date",
+                    },
+                ]
+            )
         ),
         status=200,
     )
     responses.add(
-        method=responses.GET,
+        method=hdrs.METH_GET,
         url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/lineage/elements/V29pknzHb6",
-        json={
-            "dependencies": {
-                "SBvQYKT6ui": {
-                    "nodeId": "SBvQYKT6ui",
-                    "type": "sheet",
-                    "name": "Count of Order Date by Status",
-                    "elementId": "V29pknzHb6",
+        body=json.dumps(
+            {
+                "dependencies": {
+                    "SBvQYKT6ui": {
+                        "nodeId": "SBvQYKT6ui",
+                        "type": "sheet",
+                        "name": "Count of Order Date by Status",
+                        "elementId": "V29pknzHb6",
+                    },
+                    "inode-Iq557kfHN8KRu76HdGSWi": {
+                        "nodeId": "inode-Iq557kfHN8KRu76HdGSWi",
+                        "type": "dataset",
+                        "name": "Orders Dataset",
+                    },
                 },
-                "inode-Iq557kfHN8KRu76HdGSWi": {
-                    "nodeId": "inode-Iq557kfHN8KRu76HdGSWi",
-                    "type": "dataset",
-                    "name": "Orders Dataset",
-                },
-            },
-            "edges": [
-                {"source": "inode-Iq557kfHN8KRu76HdGSWi", "target": "SBvQYKT6ui", "type": "source"}
-            ],
-        },
-        status=200,
-    )
-    responses.add(
-        method=responses.GET,
-        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/elements/V29pknzHb6/columns",
-        json=_build_paginated_response(
-            [
-                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Order Id", "label": "Order Id"},
-                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Customer Id", "label": "Customer Id"},
-                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Order Date", "label": "Order Date"},
-                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Status", "label": "Status"},
-                {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Modified Date", "label": "Modified Date"},
-                {"columnId": "VBKAHQgx58", "label": "Count of Order Date"},
-            ]
+                "edges": [
+                    {
+                        "source": "inode-Iq557kfHN8KRu76HdGSWi",
+                        "target": "SBvQYKT6ui",
+                        "type": "source",
+                    }
+                ],
+            }
         ),
         status=200,
     )
     responses.add(
-        method=responses.GET,
+        method=hdrs.METH_GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/elements/V29pknzHb6/columns",
+        body=json.dumps(
+            _build_paginated_response(
+                [
+                    {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Order Id", "label": "Order Id"},
+                    {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Customer Id", "label": "Customer Id"},
+                    {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Order Date", "label": "Order Date"},
+                    {"columnId": "inode-Iq557kfHN8KRu76HdGSWi/Status", "label": "Status"},
+                    {
+                        "columnId": "inode-Iq557kfHN8KRu76HdGSWi/Modified Date",
+                        "label": "Modified Date",
+                    },
+                    {"columnId": "VBKAHQgx58", "label": "Count of Order Date"},
+                ]
+            )
+        ),
+        status=200,
+    )
+    responses.add(
+        method=hdrs.METH_GET,
         url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/queries",
-        json=_build_paginated_response(
-            [
-                {
-                    "elementId": "_MuHPbskp0",
-                    "name": "sample elementl",
-                    "sql": 'select ORDER_ID_7 "Order Id", CUSTOMER_ID_8 "Customer Id", CAST_DATE_TO_DATETIME_9 "workbook renamed date", CAST_DATE_TO_DATETIME_11 "Modified Date" from (select ORDER_ID ORDER_ID_7, CUSTOMER_ID CUSTOMER_ID_8, ORDER_DATE::timestamp_ltz CAST_DATE_TO_DATETIME_9, ORDER_DATE::timestamp_ltz CAST_DATE_TO_DATETIME_11 from (select * from TESTDB.JAFFLE_SHOP.STG_ORDERS STG_ORDERS limit 1000) Q1) Q2 limit 1000\n\n-- Sigma \u03a3 {"request-id":"69ac9a35-64b3-4840-a53d-3aed43a575ec","email":"ben@dagsterlabs.com"}',
-                },
-                {
-                    "elementId": "V29pknzHb6",
-                    "name": "Count of Order Date by Status",
-                    "sql": 'with Q1 as (select ORDER_ID, CUSTOMER_ID, STATUS, ORDER_DATE::timestamp_ltz CAST_DATE_TO_DATETIME_5, ORDER_DATE::timestamp_ltz CAST_DATE_TO_DATETIME_6 from TESTDB.JAFFLE_SHOP.STG_ORDERS STG_ORDERS) select STATUS_10 "Status", COUNT_22 "Count of Order Date", ORDER_ID_7 "Order Id", CUSTOMER_ID_8 "Customer Id", CAST_DATE_TO_DATETIME_7 "Order Date", CAST_DATE_TO_DATETIME_8 "Modified Date" from (select Q3.ORDER_ID_7 ORDER_ID_7, Q3.CUSTOMER_ID_8 CUSTOMER_ID_8, Q3.CAST_DATE_TO_DATETIME_7 CAST_DATE_TO_DATETIME_7, Q3.STATUS_10 STATUS_10, Q3.CAST_DATE_TO_DATETIME_8 CAST_DATE_TO_DATETIME_8, Q6.COUNT_22 COUNT_22, Q6.STATUS_11 STATUS_11 from (select ORDER_ID ORDER_ID_7, CUSTOMER_ID CUSTOMER_ID_8, CAST_DATE_TO_DATETIME_6 CAST_DATE_TO_DATETIME_7, STATUS STATUS_10, CAST_DATE_TO_DATETIME_5 CAST_DATE_TO_DATETIME_8 from Q1 Q2 order by STATUS_10 asc limit 1000) Q3 left join (select count(CAST_DATE_TO_DATETIME_7) COUNT_22, STATUS_10 STATUS_11 from (select CAST_DATE_TO_DATETIME_6 CAST_DATE_TO_DATETIME_7, STATUS STATUS_10 from Q1 Q4) Q5 group by STATUS_10) Q6 on equal_null(Q3.STATUS_10, Q6.STATUS_11)) Q8 order by STATUS_10 asc limit 1000\n\n-- Sigma \u03a3 {"request-id":"69ac9a35-64b3-4840-a53d-3aed43a575ec","email":"ben@dagsterlabs.com"}',
-                },
-            ]
+        body=json.dumps(
+            _build_paginated_response(
+                [
+                    {
+                        "elementId": "_MuHPbskp0",
+                        "name": "sample elementl",
+                        "sql": 'select ORDER_ID_7 "Order Id", CUSTOMER_ID_8 "Customer Id", CAST_DATE_TO_DATETIME_9 "workbook renamed date", CAST_DATE_TO_DATETIME_11 "Modified Date" from (select ORDER_ID ORDER_ID_7, CUSTOMER_ID CUSTOMER_ID_8, ORDER_DATE::timestamp_ltz CAST_DATE_TO_DATETIME_9, ORDER_DATE::timestamp_ltz CAST_DATE_TO_DATETIME_11 from (select * from TESTDB.JAFFLE_SHOP.STG_ORDERS STG_ORDERS limit 1000) Q1) Q2 limit 1000\n\n-- Sigma \u03a3 {"request-id":"69ac9a35-64b3-4840-a53d-3aed43a575ec","email":"ben@dagsterlabs.com"}',
+                    },
+                    {
+                        "elementId": "V29pknzHb6",
+                        "name": "Count of Order Date by Status",
+                        "sql": 'with Q1 as (select ORDER_ID, CUSTOMER_ID, STATUS, ORDER_DATE::timestamp_ltz CAST_DATE_TO_DATETIME_5, ORDER_DATE::timestamp_ltz CAST_DATE_TO_DATETIME_6 from TESTDB.JAFFLE_SHOP.STG_ORDERS STG_ORDERS) select STATUS_10 "Status", COUNT_22 "Count of Order Date", ORDER_ID_7 "Order Id", CUSTOMER_ID_8 "Customer Id", CAST_DATE_TO_DATETIME_7 "Order Date", CAST_DATE_TO_DATETIME_8 "Modified Date" from (select Q3.ORDER_ID_7 ORDER_ID_7, Q3.CUSTOMER_ID_8 CUSTOMER_ID_8, Q3.CAST_DATE_TO_DATETIME_7 CAST_DATE_TO_DATETIME_7, Q3.STATUS_10 STATUS_10, Q3.CAST_DATE_TO_DATETIME_8 CAST_DATE_TO_DATETIME_8, Q6.COUNT_22 COUNT_22, Q6.STATUS_11 STATUS_11 from (select ORDER_ID ORDER_ID_7, CUSTOMER_ID CUSTOMER_ID_8, CAST_DATE_TO_DATETIME_6 CAST_DATE_TO_DATETIME_7, STATUS STATUS_10, CAST_DATE_TO_DATETIME_5 CAST_DATE_TO_DATETIME_8 from Q1 Q2 order by STATUS_10 asc limit 1000) Q3 left join (select count(CAST_DATE_TO_DATETIME_7) COUNT_22, STATUS_10 STATUS_11 from (select CAST_DATE_TO_DATETIME_6 CAST_DATE_TO_DATETIME_7, STATUS STATUS_10 from Q1 Q4) Q5 group by STATUS_10) Q6 on equal_null(Q3.STATUS_10, Q6.STATUS_11)) Q8 order by STATUS_10 asc limit 1000\n\n-- Sigma \u03a3 {"request-id":"69ac9a35-64b3-4840-a53d-3aed43a575ec","email":"ben@dagsterlabs.com"}',
+                    },
+                ]
+            )
         ),
         status=200,
     )
 
     responses.add(
-        method=responses.GET,
+        method=hdrs.METH_GET,
         url="https://aws-api.sigmacomputing.com/v2/members",
-        json=_build_paginated_response(
-            [
-                {
-                    "organizationId": "4d55c33f-dbb8-4426-9d70-97742e01f002",
-                    "memberId": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
-                    "memberType": "admin",
-                    "firstName": "Ben",
-                    "lastName": "Pankow",
-                    "email": "ben@dagsterlabs.com",
-                    "profileImgUrl": None,
-                    "createdBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
-                    "updatedBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
-                    "createdAt": "2024-09-12T20:44:19.736Z",
-                    "updatedAt": "2024-09-12T20:44:19.736Z",
-                    "homeFolderId": "bd7e1b16-dad3-45d4-91e7-5687be2819cc",
-                    "userKind": "internal",
-                },
-                {
-                    "organizationId": "4d55c33f-dbb8-4426-9d70-97742e01f002",
-                    "memberId": "SigmaSchedulerRobot",
-                    "memberType": "admin",
-                    "firstName": "Scheduler",
-                    "lastName": "User",
-                    "email": "scheduler-robot@sigmacomputing.com",
-                    "profileImgUrl": None,
-                    "createdBy": "SigmaSchedulerRobot",
-                    "updatedBy": "SigmaSchedulerRobot",
-                    "createdAt": "2024-09-12T20:44:20.182Z",
-                    "updatedAt": "2024-09-12T20:44:20.182Z",
-                    "homeFolderId": "4537ec2e-ced7-4aa6-b511-ed0437e0165f",
-                    "userKind": "internal",
-                },
-            ]
+        body=json.dumps(
+            _build_paginated_response(
+                [
+                    {
+                        "organizationId": "4d55c33f-dbb8-4426-9d70-97742e01f002",
+                        "memberId": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+                        "memberType": "admin",
+                        "firstName": "Ben",
+                        "lastName": "Pankow",
+                        "email": "ben@dagsterlabs.com",
+                        "profileImgUrl": None,
+                        "createdBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+                        "updatedBy": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
+                        "createdAt": "2024-09-12T20:44:19.736Z",
+                        "updatedAt": "2024-09-12T20:44:19.736Z",
+                        "homeFolderId": "bd7e1b16-dad3-45d4-91e7-5687be2819cc",
+                        "userKind": "internal",
+                    },
+                    {
+                        "organizationId": "4d55c33f-dbb8-4426-9d70-97742e01f002",
+                        "memberId": "SigmaSchedulerRobot",
+                        "memberType": "admin",
+                        "firstName": "Scheduler",
+                        "lastName": "User",
+                        "email": "scheduler-robot@sigmacomputing.com",
+                        "profileImgUrl": None,
+                        "createdBy": "SigmaSchedulerRobot",
+                        "updatedBy": "SigmaSchedulerRobot",
+                        "createdAt": "2024-09-12T20:44:20.182Z",
+                        "updatedAt": "2024-09-12T20:44:20.182Z",
+                        "homeFolderId": "4537ec2e-ced7-4aa6-b511-ed0437e0165f",
+                        "userKind": "internal",
+                    },
+                ]
+            )
         ),
         status=200,
     )

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_asset_specs.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import responses
 from dagster._core.code_pointer import CodePointer
-from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.definitions_load_context import DefinitionsLoadType
 from dagster._core.definitions.reconstruct import repository_def_from_pointer
 from dagster._core.instance_for_test import instance_for_test
@@ -23,10 +22,11 @@ def test_load_assets_organization_data(sigma_auth_token: str, sigma_sample_data:
         # 2 Sigma external assets, one materializable asset
         assert len(repository_def.assets_defs_by_key) == 2 + 1
 
-        workbook_key = AssetKey("Sample_Workbook")
-        assert repository_def.assets_defs_by_key[workbook_key].owners_by_key[workbook_key] == [
-            "ben@dagsterlabs.com"
-        ]
+        # No longer fetch owner for now, since this can be expensive
+        # workbook_key = AssetKey("Sample_Workbook")
+        # assert repository_def.assets_defs_by_key[workbook_key].owners_by_key[workbook_key] == [
+        #     "ben@dagsterlabs.com"
+        # ]
 
         calls = len(responses.calls)
 

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/utils.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/utils.py
@@ -1,0 +1,23 @@
+from typing import Any, Dict, List
+
+from aioresponses import aioresponses
+
+
+class RequestToMock:
+    def __init__(self, value: Dict[str, Any]) -> None:
+        self.value = value
+
+    @property
+    def headers(self) -> Dict[str, Any]:
+        return self.value["headers"]
+
+    @property
+    def body(self) -> str:
+        return self.value["data"]
+
+    def urlencoded_form_data(self) -> str:
+        return self.value["data"]().decode()
+
+
+def get_requests(responses: aioresponses) -> List[RequestToMock]:
+    return [RequestToMock(value[0].kwargs) for value in responses.requests.values()]

--- a/python_modules/libraries/dagster-sigma/setup.py
+++ b/python_modules/libraries/dagster-sigma/setup.py
@@ -22,10 +22,12 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_sigma_tests*"]),
-    install_requires=[
-        f"dagster{pin}",
-        "sqlglot",
-    ],
+    install_requires=[f"dagster{pin}", "sqlglot", "aiohttp"],
+    extras_require={
+        "test": [
+            "aioresponses",
+        ]
+    },
     include_package_data=True,
     python_requires=">=3.8,<3.13",
     zip_safe=False,

--- a/python_modules/libraries/dagster-sigma/tox.ini
+++ b/python_modules/libraries/dagster-sigma/tox.ini
@@ -11,7 +11,7 @@ install_command = uv pip install {opts} {packages}
 deps =
   -e ../../dagster-pipes
   -e ../../dagster[test]
-  -e .
+  -e .[test]
 allowlist_externals =
   /bin/bash
   uv


### PR DESCRIPTION
## Summary

Rewrites the internals of `dagster-sigma` to fetch from APIs using aiohttp instead of requests, letting us parallelize many fetches.

Drops the owner fetch for now, since this can also introduce delay and is not super important.

## Test Plan

Existing unit tests, tested vs live instance.

## Changelog

> [dagster-sigma] The Sigma integration now fetches initial API responses in parallel, speeding up initial load.
