### PR TITLE
Fix bug when switching from non-user-code to user-code

### DIFF
--- a/python_modules/dagster/dagster/_daemon/sensor.py
+++ b/python_modules/dagster/dagster/_daemon/sensor.py
@@ -371,11 +371,6 @@ def execute_sensor_iteration(
     all_sensor_states = {
         sensor_state.selector_id: sensor_state
         for sensor_state in instance.all_instigator_state(instigator_type=InstigatorType.SENSOR)
-        if not (  # filter out sensors state handled by asset daemon
-            sensor_state.sensor_instigator_data
-            and sensor_state.sensor_instigator_data.sensor_type
-            and sensor_state.sensor_instigator_data.sensor_type.is_handled_by_asset_daemon
-        )
     }
 
     tick_retention_settings = instance.get_tick_retention_settings(InstigatorType.SENSOR)

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/simple_defs.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/simple_defs.py
@@ -1,0 +1,12 @@
+import dagster as dg
+
+
+@dg.asset
+def root() -> None: ...
+
+
+@dg.asset(deps=[root], automation_condition=dg.AutomationCondition.eager())
+def downstream() -> None: ...
+
+
+defs = dg.Definitions(assets=[root, downstream])

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/simple_non_user_code.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/simple_non_user_code.py
@@ -1,0 +1,17 @@
+import dagster as dg
+
+
+def get_defs() -> dg.Definitions:
+    from .simple_defs import defs as simple_defs  # noqa
+
+    return dg.Definitions(
+        assets=simple_defs.assets,
+        sensors=[
+            dg.AutomationConditionSensorDefinition(
+                name="the_sensor", asset_selection="*", user_code=False
+            )
+        ],
+    )
+
+
+defs = get_defs()

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/simple_user_code.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/simple_user_code.py
@@ -1,0 +1,17 @@
+import dagster as dg
+
+
+def get_defs() -> dg.Definitions:
+    from .simple_defs import defs as simple_defs  # noqa
+
+    return dg.Definitions(
+        assets=simple_defs.assets,
+        sensors=[
+            dg.AutomationConditionSensorDefinition(
+                name="the_sensor", asset_selection="*", user_code=True
+            )
+        ],
+    )
+
+
+defs = get_defs()


### PR DESCRIPTION
## Summary & Motivation

As title. Previous codepaths assumed that for a given instigator, the `handled_by_asset_daemon` property would never change, which is not the case. To avoid this issue, we ignore the instigator state in these codepaths, and instead use the current value based off of the workspace snapshot.

## How I Tested These Changes

Added test which failed before these changes, and now passes.

## Changelog

Fixed an issue which would cause `AutomationConditionSensorDefinitions` to not be evaluated if the `use_user_code_server` value was toggled after the initial evaluation.
