### PR TITLE
feat(config): enable assets_directory as config option in pyproject.toml

### DIFF
--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -200,6 +200,7 @@ def get_workspace_load_target(kwargs: ClickArgMapping) -> WorkspaceLoadTarget:
                 attribute=check.opt_str_elem(kwargs, "attribute"),
                 working_directory=working_directory,
                 location_name=None,
+                assets_directory=None,
             )
         else:
             # multiple modules
@@ -217,6 +218,7 @@ def get_workspace_load_target(kwargs: ClickArgMapping) -> WorkspaceLoadTarget:
                         attribute=None,
                         working_directory=working_directory,
                         location_name=None,
+                        assets_directory=None,
                     )
                     for module_name in module_names
                 ]

--- a/python_modules/dagster/dagster/_core/workspace/load_target.py
+++ b/python_modules/dagster/dagster/_core/workspace/load_target.py
@@ -99,6 +99,7 @@ def get_origins_from_toml(
                 attribute=None,
                 working_directory=os.getcwd(),
                 location_name=dagster_block.get("code_location_name"),
+                assets_directory=None,
             ).create_origins()
         elif "modules" in dagster_block and is_valid_modules_list(dagster_block.get("modules")):
             origins = []
@@ -110,6 +111,7 @@ def get_origins_from_toml(
                             attribute=None,
                             working_directory=os.getcwd(),
                             location_name=dagster_block.get("code_location_name"),
+                            assets_directory=dagster_block.get("assets_directory" , "assets"),
                         ).create_origins()
                     )
             return origins
@@ -153,6 +155,7 @@ class ModuleTarget(
             ("attribute", Optional[str]),
             ("working_directory", Optional[str]),
             ("location_name", Optional[str]),
+            ("assets_directory", Optional[str]), 
         ],
     ),
     WorkspaceLoadTarget,


### PR DESCRIPTION
## Summary & Motivation

dagster webserver is hardcoded to locate assets in "/assets/.." . The pyproject.toml tool.dagster.modules.assets_directory is intended to be integrated with the webserver making --python-file configurable from pyproject.toml

## How I Tested These Changes

I changed as few lines as possible. I can't run the tests on my intel macbook.

## Changelog

add configuration option `tool.dagster.modules.assets_directory` to pyproject.toml
