### PR TITLE
Add get_code_version to DagsterDbtTranslator

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/asset_utils.py
@@ -825,7 +825,7 @@ def build_dbt_multi_asset_args(
                 **dagster_dbt_translator.get_tags(dbt_resource_props),
             },
             group_name=dagster_dbt_translator.get_group_name(dbt_resource_props),
-            code_version=default_code_version_fn(dbt_resource_props),
+            code_version=dagster_dbt_translator.get_code_version(dbt_resource_props),
             freshness_policy=dagster_dbt_translator.get_freshness_policy(dbt_resource_props),
             automation_condition=dagster_dbt_translator.get_automation_condition(
                 dbt_resource_props
@@ -988,7 +988,7 @@ def get_asset_deps(
                 metadata=metadata,
                 is_required=False,
                 dagster_type=Nothing,
-                code_version=default_code_version_fn(dbt_resource_props),
+                code_version=dagster_dbt_translator.get_code_version(dbt_resource_props),
             ),
         )
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -317,7 +317,7 @@ class DagsterDbtTranslator:
 
                 class CustomDagsterDbtTranslator(DagsterDbtTranslator):
                     def get_code_version(self, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:
-                        return "custom_code_version"
+                        return dbt_resource_props["checksum"]["checksum"]
         """
         return default_code_version_fn(dbt_resource_props)
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/dagster_dbt_translator.py
@@ -15,6 +15,7 @@ from dagster._utils.tags import is_valid_tag_key
 from dagster_dbt.asset_utils import (
     default_asset_key_fn,
     default_auto_materialize_policy_fn,
+    default_code_version_fn,
     default_description_fn,
     default_freshness_policy_fn,
     default_group_from_dbt_resource_props,
@@ -287,6 +288,38 @@ class DagsterDbtTranslator:
                         return "custom_group_prefix" + dbt_resource_props.get("config", {}).get("group")
         """
         return default_group_from_dbt_resource_props(dbt_resource_props)
+
+    @public
+    def get_code_version(self, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:
+        """A function that takes a dictionary representing properties of a dbt resource, and
+        returns the Dagster code version for that resource.
+
+        Note that a dbt resource is unrelated to Dagster's resource concept, and simply represents
+        a model, seed, snapshot or source in a given dbt project. You can learn more about dbt
+        resources and the properties available in this dictionary here:
+        https://docs.getdbt.com/reference/artifacts/manifest-json#resource-details
+
+        This method can be overridden to provide a custom code version for a dbt resource.
+
+        Args:
+            dbt_resource_props (Mapping[str, Any]): A dictionary representing the dbt resource.
+
+        Returns:
+            Optional[str]: A Dagster code version.
+
+        Examples:
+            .. code-block:: python
+
+                from typing import Any, Mapping
+
+                from dagster_dbt import DagsterDbtTranslator
+
+
+                class CustomDagsterDbtTranslator(DagsterDbtTranslator):
+                    def get_code_version(self, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:
+                        return "custom_code_version"
+        """
+        return default_code_version_fn(dbt_resource_props)
 
     @public
     def get_owners(self, dbt_resource_props: Mapping[str, Any]) -> Optional[Sequence[str]]:

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_asset_decorator.py
@@ -651,6 +651,23 @@ def test_with_group_replacements(test_jaffle_shop_manifest: Dict[str, Any]) -> N
         assert expected_specs_by_key[asset_key].group_name == expected_group
 
 
+def test_with_code_version_replacements(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
+    expected_code_version = "customized_code_version"
+
+    class CustomDagsterDbtTranslator(DagsterDbtTranslator):
+        def get_code_version(self, _: Mapping[str, Any]) -> Optional[str]:
+            return expected_code_version
+
+    @dbt_assets(
+        manifest=test_jaffle_shop_manifest,
+        dagster_dbt_translator=CustomDagsterDbtTranslator(),
+    )
+    def my_dbt_assets(): ...
+
+    for code_version in my_dbt_assets.code_versions_by_key.values():
+        assert code_version == expected_code_version
+
+
 def test_with_freshness_policy_replacements(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
     expected_freshness_policy = FreshnessPolicy(maximum_lag_minutes=60)
 


### PR DESCRIPTION
## Summary & Motivation
I wanted to use AutomationCondition.code_version_changed with dbt seeds. Unfortunately, from what I was able to determine, code_version is not set for seeds. Or maybe I should say it is, but all seeds have same value because function default_code_version_fn, that is used as a default, sets it based on “raw_sql” or “raw_code” from dbt_resource_props and what I saw for seeds, value of those is an empty string. That wouldn’t be a problem if there was a function like get_code_version in DagsterDbtTranslator that one can override. I didn’t find any open issue on that topic, so I decided to try to implement that.

It’s the first time I’m contributing to any open-source project. I tried to do my best to comply to any standards I could find so please be understanding 😊

## How I Tested These Changes
I’ve added unit tests similar to other properties override by DagsterDbtTranslator like group_names in unit test test_with_group_replacements of test_asset_decorator.py module.

## Changelog

 Allow DagsterDbtTranslator to customize code_version
