### PR TITLE
[dagster-sigma] Fix client ID when using env var

### DIFF
--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -364,9 +364,10 @@ class SigmaOrganization(ConfigurableResource):
         Returns:
             Definitions: The set of assets representing the Sigma content in the organization.
         """
-        return SigmaOrganizationDefsLoader(
-            organization=self, translator_cls=dagster_sigma_translator
-        ).build_defs()
+        with self.process_config_and_initialize_cm() as initialized_organization:
+            return SigmaOrganizationDefsLoader(
+                organization=initialized_organization, translator_cls=dagster_sigma_translator
+            ).build_defs()
 
 
 @dataclass

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/pending_repo.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/pending_repo.py
@@ -1,25 +1,25 @@
-from dagster import asset, define_asset_job
+from dagster import EnvVar, asset, define_asset_job
 from dagster._core.definitions.definitions_class import Definitions
+from dagster._utils.env import environ
 from dagster_sigma import SigmaBaseUrl, SigmaOrganization
 
 fake_client_id = "fake_client_id"
 fake_client_secret = "fake_client_secret"
 
-fake_token = "fake_token"
-resource = SigmaOrganization(
-    base_url=SigmaBaseUrl.AWS_US,
-    client_id=fake_client_id,
-    client_secret=fake_client_secret,
-)
+with environ({"SIGMA_CLIENT_ID": fake_client_id, "SIGMA_CLIENT_SECRET": fake_client_secret}):
+    fake_token = "fake_token"
+    resource = SigmaOrganization(
+        base_url=SigmaBaseUrl.AWS_US,
+        client_id=EnvVar("SIGMA_CLIENT_ID"),
+        client_secret=EnvVar("SIGMA_CLIENT_SECRET"),
+    )
 
+    @asset
+    def my_materializable_asset():
+        pass
 
-@asset
-def my_materializable_asset():
-    pass
-
-
-sigma_defs = resource.build_defs()
-defs = Definitions.merge(
-    Definitions(assets=[my_materializable_asset], jobs=[define_asset_job("all_asset_job")]),
-    sigma_defs,
-)
+    sigma_defs = resource.build_defs()
+    defs = Definitions.merge(
+        Definitions(assets=[my_materializable_asset], jobs=[define_asset_job("all_asset_job")]),
+        sigma_defs,
+    )


### PR DESCRIPTION
## Summary

Fixes an issue where we would request the client ID as part of the cached data ID, but this would not be resolved from its env var status.

## Test Plan

Update test to ensure env vars are tested properly