### PR TITLE
[daggy-u] Example code fix for Lesson 8 in Dagster Essentials

### DIFF
--- a/docs/dagster-university/pages/dagster-essentials/lesson-8/coding-practice-partition-taxi-trips.md
+++ b/docs/dagster-university/pages/dagster-essentials/lesson-8/coding-practice-partition-taxi-trips.md
@@ -42,7 +42,7 @@ The updated asset should look similar to the following code. Click **View answer
 ```python {% obfuscated="true" %}
 from dagster import asset, AssetExecutionContext
 from dagster_duckdb import DuckDBResource
-from ..partitions import monthly_partitions
+from ..partitions import monthly_partition
 
 @asset(
   deps=["taxi_trips_file"],


### PR DESCRIPTION
## Summary & Motivation

Noticed this typo in the code for Lesson 8 of Dagster Essentials which lead to the example code no longer working. This is part of the "Practice: Partition the taxi_trips asset" section of Lesson 8.

## How I Tested These Changes

It's just a markdown typo and the code now works in my Dagster University project.
