### PR TITLE
Normalizes the metadata object in asset_check_evaluation.py

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_check_evaluation.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_check_evaluation.py
@@ -3,6 +3,7 @@ from typing import Mapping, NamedTuple, Optional
 import dagster._check as check
 from dagster._core.definitions.asset_check_spec import AssetCheckKey, AssetCheckSeverity
 from dagster._core.definitions.events import AssetKey, MetadataValue
+from dagster._core.definitions.metadata import normalize_metadata
 from dagster._serdes import whitelist_for_serdes
 
 
@@ -101,12 +102,16 @@ class AssetCheckEvaluation(
         severity: AssetCheckSeverity = AssetCheckSeverity.ERROR,
         description: Optional[str] = None,
     ):
+        normed_metadata = normalize_metadata(
+            check.dict_param(metadata, "metadata", key_type=str),
+        )
+
         return super(AssetCheckEvaluation, cls).__new__(
             cls,
             asset_key=check.inst_param(asset_key, "asset_key", AssetKey),
             check_name=check.str_param(check_name, "check_name"),
             passed=check.bool_param(passed, "passed"),
-            metadata=check.dict_param(metadata, "metadata", key_type=str),
+            metadata=normed_metadata,
             target_materialization_data=check.opt_inst_param(
                 target_materialization_data,
                 "target_materialization_data",


### PR DESCRIPTION
## Summary & Motivation
When sending a request like:

```
curl --location 'localhost:3000/report_asset_check/' \
--header 'Content-Type: application/json' \
--data '{
    "asset_key": "meta_subs_bucket",
    "check_name": "freshness_check",
    "passed": true,
    "metadata": {
        "dagster/row_count": 20,
        "dagster/fresh_until_timestamp": 1729526344
    }
}'
```

I would get an error in the asset check page like:

```
Operation name: {AssetGraphLiveQuery}

Message: Not implemented: <class 'int'> unsupported metadata entry for now

Path: ["assetNodes",0,"assetChecksOrError","checks",0,"executionForLatestMaterialization"]

Locations: [{"line":77,"column":3}]

Stack Trace:
  File "/Users/pablo.recio/.pyenv/versions/3.12.2/envs/dagster/lib/python3.12/site-packages/graphql/execution/execute.py", line 530, in await_result
    return_type, field_nodes, info, path, await result
                                          ^^^^^^^^^^^^
  File "/Users/pablo.recio/.pyenv/versions/3.12.2/envs/dagster/lib/python3.12/site-packages/dagster_graphql/schema/asset_checks.py", line 160, in resolve_executionForLatestMaterialization
    GrapheneAssetCheckExecution(record)
  File "/Users/pablo.recio/.pyenv/versions/3.12.2/envs/dagster/lib/python3.12/site-packages/dagster_graphql/schema/asset_checks.py", line 105, in __init__
    GrapheneAssetCheckEvaluation(execution.event)
  File "/Users/pablo.recio/.pyenv/versions/3.12.2/envs/dagster/lib/python3.12/site-packages/dagster_graphql/schema/asset_checks.py", line 78, in __init__
    self.metadataEntries = list(iterate_metadata_entries(evaluation_data.metadata))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pablo.recio/.pyenv/versions/3.12.2/envs/dagster/lib/python3.12/site-packages/dagster_graphql/implementation/events.py", line 207, in iterate_metadata_entries
    check.not_implemented(f"{type(value)} unsupported metadata entry for now")
  File "/Users/pablo.recio/.pyenv/versions/3.12.2/envs/dagster/lib/python3.12/site-packages/dagster/_check/functions.py", line 1648, in not_implemented
    raise NotImplementedCheckError(f"Not implemented: {desc}")
```

After a bit of digging, I saw that we are normalizing the metadata object when we are sending the request there, as we do in other cases.

## How I Tested These Changes
Implemented the change in my local Dagster, repeated the process and it worked well this time.
