### PR TITLE
Add lint rule to auto-fix incorrect `shared/` imports

### DIFF
--- a/js_modules/dagster-ui/packages/eslint-config/rules/index.js
+++ b/js_modules/dagster-ui/packages/eslint-config/rules/index.js
@@ -6,6 +6,7 @@ const rules = {
   'no-oss-imports': require('./no-oss-imports'),
   'no-apollo-client': require('./no-apollo-client'),
   'no-react-router-route': require('./no-react-router-route'),
+  'missing-shared-import': require('./missing-shared-import'),
 };
 
 module.exports = {
@@ -18,6 +19,7 @@ module.exports = {
         [`${projectName}/no-oss-imports`]: 'error',
         [`${projectName}/no-apollo-client`]: 'error',
         [`${projectName}/no-react-router-route`]: 'error',
+        [`${projectName}/missing-shared-import`]: 'error',
       },
     },
   },

--- a/js_modules/dagster-ui/packages/eslint-config/rules/missing-graphql-variables-type.js
+++ b/js_modules/dagster-ui/packages/eslint-config/rules/missing-graphql-variables-type.js
@@ -1,7 +1,4 @@
 /* eslint-disable */
-
-const fs = require('fs');
-const path = require('path');
 const {ESLintUtils, AST_NODE_TYPES} = require('@typescript-eslint/utils');
 
 const createRule = ESLintUtils.RuleCreator((name) => name);

--- a/js_modules/dagster-ui/packages/eslint-config/rules/missing-shared-import.js
+++ b/js_modules/dagster-ui/packages/eslint-config/rules/missing-shared-import.js
@@ -1,0 +1,85 @@
+const {ESLintUtils, AST_NODE_TYPES} = require('@typescript-eslint/utils');
+
+const createRule = ESLintUtils.RuleCreator((name) => name);
+
+module.exports = createRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow importing files using the shared/ path when the file does not end with ".oss.ts", ".oss.tsx", or ".oss.js".',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    messages: {
+      invalidSharedImport:
+        'Imports using the "shared/" path must reference a file ending with ".oss.ts", ".oss.tsx", or ".oss.js".',
+    },
+    fixable: 'code', // Enable autofixing
+    schema: [], // no options
+  },
+  defaultOptions: [],
+  create: function create(context) {
+    const path = require('path');
+
+    /**
+     * Converts a shared import path to a relative path based on the current file.
+     * @param {string} importPath - The original import path starting with 'shared/'.
+     * @returns {string} - The corrected relative import path.
+     */
+    function convertToRelativePath(importPath) {
+      // Remove the 'shared/' prefix
+      const targetPath = importPath.replace(/^shared\//, '');
+      // Resolve the absolute path of the target file
+      const absoluteTargetPath = path.resolve(__dirname, '../../ui-core/src/', targetPath);
+      // Get the directory of the current file
+      const currentDir = path.dirname(context.getFilename());
+      // Compute the relative path from the current file to the target file
+      let relativePath = path.relative(currentDir, absoluteTargetPath);
+      // Ensure the relative path starts with './' or '../'
+      if (!relativePath.startsWith('.')) {
+        relativePath = `./${relativePath}`;
+      }
+      // Replace Windows backslashes with POSIX forward slashes
+      return relativePath.replace(/\\/g, '/');
+    }
+
+    /**
+     * Checks if the import path starts with 'shared/' and does not end with a valid suffix.
+     * If so, reports an error and provides a fix to convert to a relative import.
+     * @param {string} importPath - The path of the import.
+     * @param {ASTNode} node - The AST node representing the import.
+     * @returns {void}
+     */
+    function checkSharedImport(importPath, node) {
+      if (typeof importPath !== 'string') {
+        return;
+      }
+
+      if (importPath.startsWith('shared/')) {
+        const validSuffixRegex = /\.oss$/;
+        if (!validSuffixRegex.test(importPath)) {
+          context.report({
+            node,
+            messageId: 'invalidSharedImport',
+            fix: (fixer) => {
+              const relativeImport = convertToRelativePath(importPath);
+              return fixer.replaceText(node.source, `'${relativeImport}'`);
+            },
+          });
+        }
+      }
+    }
+
+    return {
+      [AST_NODE_TYPES.ImportDeclaration](node) {
+        checkSharedImport(node.source.value, node);
+      },
+      [AST_NODE_TYPES.ImportExpression](node) {
+        if (node.source && node.source.type === AST_NODE_TYPES.Literal) {
+          checkSharedImport(node.source.value, node);
+        }
+      },
+    };
+  },
+});

--- a/js_modules/dagster-ui/packages/eslint-config/rules/missing-shared-import.js
+++ b/js_modules/dagster-ui/packages/eslint-config/rules/missing-shared-import.js
@@ -7,13 +7,13 @@ module.exports = createRule({
     type: 'problem',
     docs: {
       description:
-        'Disallow importing files using the shared/ path when the file does not end with ".oss.ts", ".oss.tsx", or ".oss.js".',
+        'Disallow importing files using the shared/ path when the import does not end with ".oss"',
       category: 'Best Practices',
       recommended: false,
     },
     messages: {
       invalidSharedImport:
-        'Imports using the "shared/" path must reference a file ending with ".oss.ts", ".oss.tsx", or ".oss.js".',
+        'Imports using the "shared/" path must reference an import ending with ".oss"',
     },
     fixable: 'code', // Enable autofixing
     schema: [], // no options

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useDefinitionTagFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/Filters/useDefinitionTagFilter.tsx
@@ -1,10 +1,10 @@
 import isEqual from 'lodash/isEqual';
 import memoize from 'lodash/memoize';
 import {useCallback, useMemo} from 'react';
-import {useQueryPersistedState} from 'shared/hooks/useQueryPersistedState';
 
 import {isKindTag} from '../../graph/KindTags';
 import {DefinitionTag} from '../../graphql/types';
+import {useQueryPersistedState} from '../../hooks/useQueryPersistedState';
 import {TruncatedTextWithFullTextOnHover} from '../../nav/getLeftNavItemsForOption';
 import {StaticBaseConfig, useStaticSetFilter} from '../BaseFilters/useStaticSetFilter';
 import {buildTagString} from '../tagAsString';


### PR DESCRIPTION
## Summary & Motivation

This PR introduces a lint rule to prevent `shared/` imports that are incompatible with the cloud build process.

In OSS, we use a [virtual path mapping](https://github.com/dagster-io/dagster/blob/22cf05f516036a780e7971ccd70e2e92ab682c3b/js_modules/dagster-ui/packages/ui-core/tsconfig.json#L5) `shared/` to `src/`, avoiding the need to run a script to generate a `tsconfig.json` for shared components. However, in the cloud environment, this mapping doesn't exist. Instead, [a script generates specific path mappings](https://github.com/dagster-io/internal/blob/089cba51954742e8e0697f080a479825cad19be5/dagster-cloud/js_modules/app-cloud/scripts/generateResolutions.ts#L38) for the cloud `tsconfig.json`. While the `shared/` imports work fine in the OSS build due to Next.js using the local `tsconfig.json`, they break in the cloud build where the mapping isn't present.

Although switching to direct `src/` imports would resolve the issue, we opted to retain the `shared/` mapping for clearer intent. 

## How I Tested These Changes

Added a bad shared import, ran `yarn lint`, saw it autofixed it to a relative import.