### PR TITLE
Fix link in run launcher docs

### DIFF
--- a/docs/content/deployment/run-launcher.mdx
+++ b/docs/content/deployment/run-launcher.mdx
@@ -26,7 +26,7 @@ The core abstraction in the launch process is the run launcher, which is configu
 
 ## Built-in run launchers
 
-The simplest run launcher is the built-in run launcher, <PyObject object="DefaultRunLauncher" />. This run launcher spawns a new process per run on the same node as the job's code location.
+The simplest run launcher is the built-in run launcher, <PyObject module="dagster._core.launcher" object="DefaultRunLauncher" />. This run launcher spawns a new process per run on the same node as the job's code location.
 
 Other run launchers include:
 


### PR DESCRIPTION
## Summary & Motivation

Closes https://github.com/dagster-io/dagster/issues/18249

## How I Tested These Changes

Ran docs locally and confirmed the link is fixed
