### PR TITLE
[docs] deprecated badge yellow -> orange

### DIFF
--- a/docs/next/styles/globals.css
+++ b/docs/next/styles/globals.css
@@ -114,7 +114,7 @@ dt > a.reference.internal {
 
 .legacy-tag,
 .flag.deprecated {
-  @apply inline-flex items-center px-3 py-0.5 rounded-full align-middle text-xs uppercase font-medium bg-yellow-200 text-yellow-700
+  @apply inline-flex items-center px-3 py-0.5 rounded-full align-middle text-xs uppercase font-medium bg-orange-200 text-orange-700
 }
 
 .legacy-tag,

--- a/docs/next/tailwind.config.js
+++ b/docs/next/tailwind.config.js
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 const defaultTheme = require('tailwindcss/defaultTheme');
+const colors = require('tailwindcss/colors')
 
 module.exports = {
   important: 'html',
@@ -62,6 +63,7 @@ module.exports = {
           100: '#F5F4F2',
           50: '#FAF9F7',
         },
+        orange: colors.orange,
       },
       animation: {
         wiggle: 'wiggle 1s ease-in-out infinite',


### PR DESCRIPTION
## Summary & Motivation

Making deprecation badge orange since yellow will be used for supersession. This was supposed to be part of https://github.com/dagster-io/dagster/pull/25362 but I forgot to push this change