### PR TITLE
[check] dont allow str, bytes, or record for sequence or iterable

### DIFF
--- a/python_modules/dagster/dagster/_check/record.py
+++ b/python_modules/dagster/dagster/_check/record.py
@@ -1,0 +1,10 @@
+# record depends on check, but check needs to discern records so these pieces are defined here
+
+RECORD_MARKER_VALUE = object()
+# "I do want to release this as checkrepublic one day" - schrockn
+RECORD_MARKER_FIELD = "__checkrepublic__"
+
+
+def is_record(obj) -> bool:
+    """Whether or not this object was produced by a record decorator."""
+    return getattr(obj, RECORD_MARKER_FIELD, None) == RECORD_MARKER_VALUE

--- a/python_modules/dagster/dagster/_core/definitions/partition.py
+++ b/python_modules/dagster/dagster/_core/definitions/partition.py
@@ -325,7 +325,13 @@ class StaticPartitionsDefinition(PartitionsDefinition[str]):
     """
 
     def __init__(self, partition_keys: Sequence[str]):
-        check.sequence_param(partition_keys, "partition_keys", of_type=str)
+        # for back compat reasons we allow str as a Sequence[str] here
+        if not isinstance(partition_keys, str):
+            check.sequence_param(
+                partition_keys,
+                "partition_keys",
+                of_type=str,
+            )
 
         raise_error_on_invalid_partition_key_substring(partition_keys)
         raise_error_on_duplicate_partition_keys(partition_keys)

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2329,10 +2329,10 @@ class DagsterInstance(DynamicPartitionsStore):
 
         Args:
             partitions_def_name (str): The name of the `DynamicPartitionsDefinition`.
-            partition_key (Sequence[str]): Partition key to delete.
+            partition_key (str): Partition key to delete.
         """
         check.str_param(partitions_def_name, "partitions_def_name")
-        check.sequence_param(partition_key, "partition_key", of_type=str)
+        check.str_param(partition_key, "partition_key")
         self._event_storage.delete_dynamic_partition(partitions_def_name, partition_key)
 
     @public

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -869,9 +869,23 @@ def _dedup_partition_keys(keys: Sequence[str]) -> Sequence[str]:
 
 
 @whitelist_for_serdes(storage_name="ExternalStaticPartitionsDefinitionData")
-@record
-class StaticPartitionsSnap(PartitionsSnap):
+@record_custom(checked=False)
+class StaticPartitionsSnap(PartitionsSnap, IHaveNew):
     partition_keys: Sequence[str]
+
+    def __new__(cls, partition_keys: Sequence[str]):
+        # for back compat reasons we allow str as a Sequence[str] here
+        if not isinstance(partition_keys, str):
+            check.sequence_param(
+                partition_keys,
+                "partition_keys",
+                of_type=str,
+            )
+
+        return super().__new__(
+            cls,
+            partition_keys=partition_keys,
+        )
 
     @classmethod
     def from_def(cls, partitions_def: StaticPartitionsDefinition) -> Self:

--- a/python_modules/dagster/dagster/_record/__init__.py
+++ b/python_modules/dagster/dagster/_record/__init__.py
@@ -21,16 +21,13 @@ from typing_extensions import Self, dataclass_transform
 
 import dagster._check as check
 from dagster._check import EvalContext, build_check_call_str
+from dagster._check.record import RECORD_MARKER_FIELD, RECORD_MARKER_VALUE, is_record
 
 ImportFrom = check.ImportFrom  # re-expose for convenience
 TType = TypeVar("TType", bound=Type)
 TVal = TypeVar("TVal")
 
 
-_RECORD_MARKER_VALUE = object()
-_RECORD_MARKER_FIELD = (
-    "__checkrepublic__"  # "I do want to release this as checkrepublic one day" - schrockn
-)
 _RECORD_ANNOTATIONS_FIELD = "__record_annotations__"
 _CHECKED_NEW = "__checked_new__"
 _DEFAULTS_NEW = "__defaults_new__"
@@ -140,7 +137,7 @@ def _namedtuple_record_transform(
         "_fields": base._fields,
         "__hidden_iter__": nt_iter,
         "__hidden_replace__": base._replace,
-        _RECORD_MARKER_FIELD: _RECORD_MARKER_VALUE,
+        RECORD_MARKER_FIELD: RECORD_MARKER_VALUE,
         _RECORD_ANNOTATIONS_FIELD: field_set,
         _NAMED_TUPLE_BASE_NEW_FIELD: nt_new,
         _REMAPPING_FIELD: field_to_new_mapping or {},
@@ -325,11 +322,6 @@ class IHaveNew:
 
         # let type checker know these objects are sortable (by way of being a namedtuple)
         def __lt__(self, other) -> bool: ...
-
-
-def is_record(obj) -> bool:
-    """Whether or not this object was produced by a record decorator."""
-    return getattr(obj, _RECORD_MARKER_FIELD, None) == _RECORD_MARKER_VALUE
 
 
 def has_generated_new(obj) -> bool:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -544,9 +544,11 @@ def test_asset_selection_type_checking():
     test = KeysAssetSelection(selected_keys=valid_asset_key_sequence)
     assert isinstance(test, KeysAssetSelection)
 
-    # These 2 *should* error but requires making check.sequence not accept str
-    GroupsAssetSelection(selected_groups=invalid_argument, include_sources=False)
-    KeyPrefixesAssetSelection(selected_key_prefixes=invalid_argument, include_sources=False)
+    with pytest.raises(CheckError):
+        GroupsAssetSelection(selected_groups=invalid_argument, include_sources=False)
+
+    with pytest.raises(CheckError):
+        KeyPrefixesAssetSelection(selected_key_prefixes=invalid_argument, include_sources=False)
 
     test = KeyPrefixesAssetSelection(
         selected_key_prefixes=valid_string_sequence_sequence, include_sources=False

--- a/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
+++ b/python_modules/dagster/dagster_tests/core_tests/partition_tests/test_partition.py
@@ -29,6 +29,15 @@ def test_static_partitions(partition_keys: Sequence[str]):
     assert static_partitions.get_partition_keys() == partition_keys
 
 
+def test_static_partition_string_input() -> None:
+    # maintain backcompat by allowing str for Sequence[str] here
+    # str is technically a Sequence[str] so type wise things should still be sound,
+    # though this behavior was certainly not intentional
+    static_partitions = StaticPartitionsDefinition("abcdef")
+
+    assert static_partitions.get_partition_keys() == "abcdef"
+
+
 def test_invalid_partition_key():
     with pytest.raises(DagsterInvalidDefinitionError, match="'...'"):
         StaticPartitionsDefinition(["foo", "foo...bar"])

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definition_errors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definition_errors.py
@@ -35,10 +35,7 @@ def solid_a_b_list():
 
 
 def test_create_job_with_bad_ops_list():
-    with pytest.raises(
-        ParameterCheckError,
-        match=r'Param "node_defs" is not one of \[\'Sequence\'\]',
-    ):
+    with pytest.raises(ParameterCheckError, match=r'Param "node_defs" is not a Sequence'):
         GraphDefinition(name="a_pipeline", node_defs=create_stub_op("stub", [{"a key": "a value"}]))
 
 


### PR DESCRIPTION
expanded version of reverted attempt #25262, this also  disallows `@records` (including in tuple checks) and  hits all of the sequence and iterable variants 

## How I Tested These Changes

added tests 
ensure existing cloud customers workspace snapshots can still load 

## Changelog


