### PR TITLE
[ui] Clip events if asset plots load data for different time ranges

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/groupByPartition.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/groupByPartition.tsx
@@ -54,9 +54,23 @@ export function useGroupedEvents(
   loadedPartitionKeys: string[] | undefined,
 ) {
   return useMemo<AssetEventGroup[]>(() => {
-    const events = [...materializations, ...observations].sort(
+    let events = [...materializations, ...observations].sort(
       (b, a) => Number(a.timestamp) - Number(b.timestamp),
     );
+
+    // If we're graphing datapoints for an asset that has both materializations and
+    // observations, they may be emitted at different rates so "last 100 events" may
+    // cover different amounts of time. The graph is only 'valid' for the time range
+    // containing both data streams, so we clip it to that timestamp.
+    if (materializations.length && observations.length) {
+      const minMaterializationTimestamp = Math.min(
+        ...materializations.map((m) => Number(m.timestamp)),
+      );
+      const minObservationTimestamp = Math.min(...observations.map((m) => Number(m.timestamp)));
+      const nearerTimestamp = Math.max(minMaterializationTimestamp, minObservationTimestamp);
+      events = events.filter((e) => Number(e.timestamp) > nearerTimestamp);
+    }
+
     if (xAxis === 'partition' && loadedPartitionKeys) {
       return groupByPartition(events, loadedPartitionKeys);
     } else {


### PR DESCRIPTION
## Summary & Motivation

https://linear.app/dagster-labs/issue/FE-387/assets-with-both-materializations-and-observations-can-have-plot

## How I Tested These Changes

I used an asset which materializes more often than observations about it are emitted, and verified that previously there was part of the graph showing only observations, and afterwards the displayed timerange is only the later portion where both event types are loaded.

Before:
<img width="1184" alt="Screenshot 2024-10-21 at 9 23 01 PM" src="https://github.com/user-attachments/assets/2951555b-c782-4f2a-9777-1ddcdeacbe41">

After:
<img width="1185" alt="Screenshot 2024-10-21 at 9 23 13 PM" src="https://github.com/user-attachments/assets/a4cc486b-8889-48e0-ad05-61f0584eb389">


## Changelog

[ui] Plots for assets that emit materialization and observation events at different rates no longer display a time period missing the more frequent event type.