### PR TITLE
[daggy-u] Example code fixes for extra credit lesson in Dagster Essentials

### DIFF
--- a/docs/dagster-university/pages/dagster-essentials/extra-credit/asset-metadata-as-markdown.md
+++ b/docs/dagster-university/pages/dagster-essentials/extra-credit/asset-metadata-as-markdown.md
@@ -132,7 +132,7 @@ In Lesson 9, you created the `adhoc_request` asset. During materialization, the 
 At this point, the code for the `adhoc_request` asset should look like this:
 
 ```python
-from dagster import Config, asset, MaterializeResult, MetadataValue, get_dagster_logger
+from dagster import Config, asset, MaterializeResult, MetadataValue
 from dagster_duckdb import DuckDBResource
 
 import plotly.express as px

--- a/docs/dagster-university/pages/dagster-essentials/extra-credit/materialization-metadata.md
+++ b/docs/dagster-university/pages/dagster-essentials/extra-credit/materialization-metadata.md
@@ -88,7 +88,7 @@ Let’s add metadata to the `taxi_trips_file` asset to demonstrate further. This
 
    ```python
    import pandas as pd
-   from dagster import asset, MetadataValue
+   from dagster import asset, MetadataValue, MaterializeResult
 
    @asset(
        partitions_def=monthly_partition,


### PR DESCRIPTION
## Summary & Motivation

One example code snippet was missing an import (`MaterializeResult`) and the other had an additional unnecessary import (`get_dagster_logger`). This would be especially confusing for newbies, because `get_dagster_logger` isn't covered anywhere in the course.

## How I Tested These Changes

It's just a markdown typo and the code now works in my Dagster University project.