### PR TITLE
Fix using the stop_timeout argument in DockerRunLauncher.container_kwargs

### DIFF
--- a/python_modules/dagster-test/dagster_test/test_project/test_jobs/repo.py
+++ b/python_modules/dagster-test/dagster_test/test_project/test_jobs/repo.py
@@ -31,6 +31,7 @@ from dagster._core.definitions.graph_definition import GraphDefinition
 from dagster._core.definitions.job_definition import JobDefinition
 from dagster._core.definitions.output import Out
 from dagster._core.definitions.resource_definition import ResourceDefinition
+from dagster._core.errors import DagsterExecutionInterruptedError
 from dagster._core.execution.plan.objects import StepSuccessData
 from dagster._core.test_utils import nesting_graph, poll_for_step_start
 from dagster._utils import segfault
@@ -175,10 +176,18 @@ def demo_slow_graph():
     count_letters(multiply_the_word_slow())
 
 
-@op
-def hanging_op(_):
-    while True:
-        time.sleep(0.1)
+@op(config_schema={"cleanup_delay": Field(int, is_required=False)})
+def hanging_op(context):
+    try:
+        while True:
+            time.sleep(0.1)
+    except DagsterExecutionInterruptedError:
+        cleanup_delay = context.op_config.get("cleanup_delay")
+        if cleanup_delay:
+            context.log.info(f"Delaying cleanup for {cleanup_delay} seconds")
+            time.sleep(cleanup_delay)
+            context.log.info("Done cleaning up")
+        raise
 
 
 @op(config_schema={"looking_for": str})

--- a/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker_tests/test_launch_docker.py
@@ -192,6 +192,7 @@ def test_terminate_launched_docker_run(aws_env):
     launcher_config = {
         "env_vars": aws_env,
         "network": "container:test-postgres-db-docker",
+        "container_kwargs": {"stop_timeout": 15},
     }
 
     if IS_BUILDKITE:
@@ -199,11 +200,14 @@ def test_terminate_launched_docker_run(aws_env):
     else:
         find_local_test_image(docker_image)
 
-    run_config = merge_yamls(
-        [
-            os.path.join(get_test_project_environments_path(), "env_s3.yaml"),
-        ]
-    )
+    run_config = {
+        **merge_yamls(
+            [
+                os.path.join(get_test_project_environments_path(), "env_s3.yaml"),
+            ]
+        ),
+        "ops": {"hanging_op": {"config": {"cleanup_delay": 10}}},
+    }
 
     with docker_postgres_instance(
         overrides={


### PR DESCRIPTION
## Summary & Motivation
container_kwargs.stop_timeout should work out of the box, but does not due to a longstanding docker-py bug. Move it into the terminate() method instead

## How I Tested These Changes
New test case

## Changelog
[dagster-docker] `container_kwargs.stop_timeout` can now be set when using the `DockerRunLauncher` or `docker_executor` to configure the amount of time that Docker will wait when terminating a run for it to clean up before forcibly stopping it with a SIGKILL signal.