### PR TITLE
runs table backfill_id column - data migration

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -274,7 +274,7 @@ def migrate_run_backfill_id(storage: RunStorage, print_fn: Optional[PrintFn] = N
         print_fn("Querying run storage.")
 
     for run in chunked_run_iterator(storage, print_fn):
-        if BACKFILL_ID_TAG not in run.tags:
+        if run.tags.get(BACKFILL_ID_TAG) is None:
             continue
 
         add_backfill_id(

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -42,6 +42,7 @@ from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, Runs
 from dagster._core.storage.event_log.migration import migrate_event_log_data
 from dagster._core.storage.event_log.sql_event_log import SqlEventLogStorage
 from dagster._core.storage.migration.utils import upgrading_instance
+from dagster._core.storage.runs.migration import migrate_run_backfill_id
 from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import (
     BACKFILL_ID_TAG,
@@ -1224,6 +1225,10 @@ def test_add_backfill_id_column():
             )
 
             instance.upgrade()
+            # sqlite storage .from_local runs the migrations on instantiation. This means the data migration
+            # doesn't get run when we call instance.upgrade. So we manually run the migration here to test that
+            # it works
+            migrate_run_backfill_id(instance.run_storage)
 
             columns = get_sqlite3_columns(db_path, "runs")
             assert {

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -42,7 +42,6 @@ from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, Runs
 from dagster._core.storage.event_log.migration import migrate_event_log_data
 from dagster._core.storage.event_log.sql_event_log import SqlEventLogStorage
 from dagster._core.storage.migration.utils import upgrading_instance
-from dagster._core.storage.runs.migration import migrate_run_backfill_id
 from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import (
     BACKFILL_ID_TAG,
@@ -1225,10 +1224,6 @@ def test_add_backfill_id_column():
             )
 
             instance.upgrade()
-            # TODO: sqlite storage .from_local runs the migrations on instantiation. This means the data migration
-            # doesn't get run when we call instance.upgrade. So we manually run the migration here to test that
-            # it works
-            migrate_run_backfill_id(instance.run_storage)
 
             columns = get_sqlite3_columns(db_path, "runs")
             assert {

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1225,7 +1225,7 @@ def test_add_backfill_id_column():
             )
 
             instance.upgrade()
-            # sqlite storage .from_local runs the migrations on instantiation. This means the data migration
+            # TODO: sqlite storage .from_local runs the migrations on instantiation. This means the data migration
             # doesn't get run when we call instance.upgrade. So we manually run the migration here to test that
             # it works
             migrate_run_backfill_id(instance.run_storage)

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1267,7 +1267,7 @@ def test_add_backfill_id_column():
                 )
             }
             assert backfill_ids[run_not_in_backfill_pre_migration.run_id] is None
-            assert backfill_ids[run_in_backfill_pre_migration.run_id] is None
+            assert backfill_ids[run_in_backfill_pre_migration.run_id] == "backfillid"
             assert backfill_ids[run_not_in_backfill_post_migration.run_id] is None
             assert backfill_ids[run_in_backfill_post_migration.run_id] == "backfillid"
 

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -549,7 +549,7 @@ def test_add_backfill_id_column(conn_string):
                 )
             }
             assert backfill_ids[run_not_in_backfill_pre_migration.run_id] is None
-            assert backfill_ids[run_in_backfill_pre_migration.run_id] is None
+            assert backfill_ids[run_in_backfill_pre_migration.run_id] == "backfillid"
             assert backfill_ids[run_not_in_backfill_post_migration.run_id] is None
             assert backfill_ids[run_in_backfill_post_migration.run_id] == "backfillid"
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -964,7 +964,7 @@ def test_add_backfill_id_column(hostname, conn_string):
                 )
             }
             assert backfill_ids[run_not_in_backfill_pre_migration.run_id] is None
-            assert backfill_ids[run_in_backfill_pre_migration.run_id] is None
+            assert backfill_ids[run_in_backfill_pre_migration.run_id] == "backfillid"
             assert backfill_ids[run_not_in_backfill_post_migration.run_id] is None
             assert backfill_ids[run_in_backfill_post_migration.run_id] == "backfillid"
 


### PR DESCRIPTION
## Summary & Motivation
Adds a migration to fill out the `backfill_id` column for existing runs

## How I Tested These Changes
