### PR TITLE
[dagster-sigma] Standardize translator signature

### DIFF
--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -431,7 +431,7 @@ def _get_translator_spec_assert_keys_match(
     translator: DagsterSigmaTranslator, data: Union[SigmaDataset, SigmaWorkbook]
 ) -> AssetSpec:
     key = translator.get_asset_key(data)
-    spec = translator.get_asset_spec(key, data)
+    spec = translator.get_asset_spec(data)
     if spec.key != key:
         check.invariant(
             spec.key == key,

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -432,10 +432,11 @@ def _get_translator_spec_assert_keys_match(
 ) -> AssetSpec:
     key = translator.get_asset_key(data)
     spec = translator.get_asset_spec(key, data)
-    check.invariant(
-        spec.key == key,
-        f"Key on AssetSpec returned by {translator.__class__.__name__}.get_asset_spec {spec.key} does not match input key {key}",
-    )
+    if spec.key != key:
+        check.invariant(
+            spec.key == key,
+            f"Key on AssetSpec returned by {translator.__class__.__name__}.get_asset_spec {spec.key} does not match input key {key}",
+        )
     return spec
 
 

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/translator.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/translator.py
@@ -80,12 +80,8 @@ class DagsterSigmaTranslator:
         """Get the AssetKey for a Sigma object, such as a workbook or dataset."""
         return AssetKey(_coerce_input_to_valid_name(data.properties["name"]))
 
-    def get_asset_spec(
-        self, asset_key: AssetKey, data: Union[SigmaDataset, SigmaWorkbook]
-    ) -> AssetSpec:
-        """Get the AssetSpec for a Sigma object, such as a workbook or dataset. The key of the returned
-        spec must match the input asset_key.
-        """
+    def get_asset_spec(self, data: Union[SigmaDataset, SigmaWorkbook]) -> AssetSpec:
+        """Get the AssetSpec for a Sigma object, such as a workbook or dataset."""
         if isinstance(data, SigmaWorkbook):
             metadata = {
                 "dagster_sigma/web_url": MetadataValue.url(data.properties["url"]),
@@ -96,7 +92,7 @@ class DagsterSigmaTranslator:
             }
             datasets = [self._context.get_datasets_by_inode()[inode] for inode in data.datasets]
             return AssetSpec(
-                key=asset_key,
+                key=self.get_asset_key(data),
                 metadata=metadata,
                 kinds={"sigma"},
                 deps={self.get_asset_key(dataset) for dataset in datasets},
@@ -118,7 +114,7 @@ class DagsterSigmaTranslator:
             }
 
             return AssetSpec(
-                key=asset_key,
+                key=self.get_asset_key(data),
                 metadata=metadata,
                 kinds={"sigma"},
                 deps={

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/pending_repo_with_translator.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/pending_repo_with_translator.py
@@ -1,4 +1,5 @@
 from dagster import AssetSpec, EnvVar, define_asset_job
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils.env import environ
 from dagster_sigma import (
@@ -7,7 +8,7 @@ from dagster_sigma import (
     SigmaOrganization,
     load_sigma_asset_specs,
 )
-from dagster_sigma.translator import SigmaDataset, SigmaWorkbook
+from dagster_sigma.translator import SigmaDataset
 
 fake_client_id = "fake_client_id"
 fake_client_secret = "fake_client_secret"
@@ -16,12 +17,8 @@ with environ({"SIGMA_CLIENT_ID": fake_client_id, "SIGMA_CLIENT_SECRET": fake_cli
     fake_token = "fake_token"
 
     class MyCoolTranslator(DagsterSigmaTranslator):
-        def get_dataset_spec(self, data: SigmaDataset) -> AssetSpec:
-            spec = super().get_dataset_spec(data)
-            return spec._replace(key=spec.key.with_prefix("my_prefix"))
-
-        def get_workbook_spec(self, data: SigmaWorkbook) -> AssetSpec:
-            spec = super().get_workbook_spec(data)
+        def get_asset_spec(self, asset_key: AssetKey, data: SigmaDataset) -> AssetSpec:
+            spec = super().get_asset_spec(asset_key, data)
             return spec._replace(key=spec.key.with_prefix("my_prefix"))
 
     resource = SigmaOrganization(

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/pending_repo_with_translator.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/pending_repo_with_translator.py
@@ -1,4 +1,4 @@
-from dagster import AssetSpec, EnvVar, define_asset_job
+from dagster import EnvVar, define_asset_job
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._utils.env import environ
@@ -8,7 +8,6 @@ from dagster_sigma import (
     SigmaOrganization,
     load_sigma_asset_specs,
 )
-from dagster_sigma.translator import SigmaDataset
 
 fake_client_id = "fake_client_id"
 fake_client_secret = "fake_client_secret"
@@ -17,9 +16,8 @@ with environ({"SIGMA_CLIENT_ID": fake_client_id, "SIGMA_CLIENT_SECRET": fake_cli
     fake_token = "fake_token"
 
     class MyCoolTranslator(DagsterSigmaTranslator):
-        def get_asset_spec(self, asset_key: AssetKey, data: SigmaDataset) -> AssetSpec:
-            spec = super().get_asset_spec(asset_key, data)
-            return spec._replace(key=spec.key.with_prefix("my_prefix"))
+        def get_asset_key(self, data) -> AssetKey:
+            return super().get_asset_key(data).with_prefix("my_prefix")
 
     resource = SigmaOrganization(
         base_url=SigmaBaseUrl.AWS_US,

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_translator.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_translator.py
@@ -29,7 +29,9 @@ def test_workbook_translation() -> None:
         SigmaOrganizationData(workbooks=[sample_workbook], datasets=[sample_dataset])
     )
 
-    asset_spec = translator.get_workbook_spec(sample_workbook)
+    asset_spec = translator.get_asset_spec(
+        translator.get_asset_key(sample_workbook), sample_workbook
+    )
 
     assert asset_spec.key.path == ["Sample_Workbook"]
     assert asset_spec.metadata["dagster_sigma/web_url"].value == SAMPLE_WORKBOOK_DATA["url"]
@@ -51,7 +53,7 @@ def test_dataset_translation() -> None:
         SigmaOrganizationData(workbooks=[], datasets=[sample_dataset])
     )
 
-    asset_spec = translator.get_dataset_spec(sample_dataset)
+    asset_spec = translator.get_asset_spec(translator.get_asset_key(sample_dataset), sample_dataset)
 
     assert asset_spec.key.path == ["Orders_Dataset"]
     assert asset_spec.metadata["dagster_sigma/web_url"].value == SAMPLE_DATASET_DATA["url"]
@@ -74,11 +76,14 @@ def test_dataset_translation() -> None:
 
 def test_dataset_translation_custom_translator() -> None:
     class MyCustomTranslator(DagsterSigmaTranslator):
-        def get_dataset_key(self, data: SigmaDataset) -> AssetKey:
-            return super().get_dataset_key(data).with_prefix("sigma")
+        def get_asset_key(self, data: SigmaDataset) -> AssetKey:
+            return super().get_asset_key(data).with_prefix("sigma")
 
-        def get_dataset_spec(self, data: SigmaDataset) -> AssetSpec:
-            return super().get_dataset_spec(data)._replace(description="Custom description")
+        def get_asset_spec(self, asset_key: AssetKey, data: SigmaDataset) -> AssetSpec:
+            spec = super().get_asset_spec(asset_key, data)
+            if isinstance(data, SigmaDataset):
+                return spec._replace(description="Custom description")
+            return spec
 
     sample_dataset = SigmaDataset(
         properties=SAMPLE_DATASET_DATA,
@@ -88,7 +93,7 @@ def test_dataset_translation_custom_translator() -> None:
 
     translator = MyCustomTranslator(SigmaOrganizationData(workbooks=[], datasets=[sample_dataset]))
 
-    asset_spec = translator.get_dataset_spec(sample_dataset)
+    asset_spec = translator.get_asset_spec(translator.get_asset_key(sample_dataset), sample_dataset)
 
     assert asset_spec.key.path == ["sigma", "Orders_Dataset"]
     assert asset_spec.description == "Custom description"

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_translator.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_translator.py
@@ -29,9 +29,7 @@ def test_workbook_translation() -> None:
         SigmaOrganizationData(workbooks=[sample_workbook], datasets=[sample_dataset])
     )
 
-    asset_spec = translator.get_asset_spec(
-        translator.get_asset_key(sample_workbook), sample_workbook
-    )
+    asset_spec = translator.get_asset_spec(sample_workbook)
 
     assert asset_spec.key.path == ["Sample_Workbook"]
     assert asset_spec.metadata["dagster_sigma/web_url"].value == SAMPLE_WORKBOOK_DATA["url"]
@@ -53,7 +51,7 @@ def test_dataset_translation() -> None:
         SigmaOrganizationData(workbooks=[], datasets=[sample_dataset])
     )
 
-    asset_spec = translator.get_asset_spec(translator.get_asset_key(sample_dataset), sample_dataset)
+    asset_spec = translator.get_asset_spec(sample_dataset)
 
     assert asset_spec.key.path == ["Orders_Dataset"]
     assert asset_spec.metadata["dagster_sigma/web_url"].value == SAMPLE_DATASET_DATA["url"]
@@ -80,7 +78,7 @@ def test_dataset_translation_custom_translator() -> None:
             return super().get_asset_key(data).with_prefix("sigma")
 
         def get_asset_spec(self, asset_key: AssetKey, data: SigmaDataset) -> AssetSpec:
-            spec = super().get_asset_spec(asset_key, data)
+            spec = super().get_asset_spec(data)
             if isinstance(data, SigmaDataset):
                 return spec._replace(description="Custom description")
             return spec


### PR DESCRIPTION
## Summary

Standardizes the `DagsterSigmaTranslator` format to:

1) Have a central `get_asset_spec`, `get_asset_key` method
2) Pass the `asset_key` returned by `get_asset_key` to `get_asset_spec`
3) Enforce that the key returned by `get_asset_spec` matches the input key

## How I Tested These Changes

Updated unit tests

