### PR TITLE
Use asset check docstring as description

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_check_decorator.py
@@ -4,6 +4,7 @@ from typing_extensions import TypeAlias
 
 from dagster import _check as check
 from dagster._config import UserConfigSchema
+from dagster._core.decorator_utils import format_docstring_for_description
 from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
 from dagster._core.definitions.asset_checks import AssetChecksDefinition
@@ -203,7 +204,7 @@ def asset_check(
 
         spec = AssetCheckSpec(
             name=resolved_name,
-            description=description,
+            description=description or format_docstring_for_description(fn),
             asset=asset_key,
             additional_deps=additional_ins_and_deps,
             blocking=blocking,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -507,6 +507,32 @@ def test_infer_output_dagster_type_empty():
     assert my_asset.op.outs["result"].dagster_type.display_name == "Any"
 
 
+def test_asset_with_docstring_description():
+    @asset
+    def asset1():
+        """Docstring."""
+        pass
+
+    assert asset1.op.description == "Docstring."
+
+
+def test_asset_with_parameter_description():
+    @asset(description="parameter")
+    def asset1():
+        pass
+
+    assert asset1.op.description == "parameter"
+
+
+def test_asset_with_docstring_and_parameter_description():
+    @asset(description="parameter")
+    def asset1():
+        """Docstring."""
+        pass
+
+    assert asset1.op.description == "parameter"
+
+
 def test_invoking_simple_assets():
     @asset
     def no_input_asset():

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
@@ -83,9 +83,9 @@ def test_asset_check_decorator_name() -> None:
 
 def test_asset_check_decorator_docstring_description() -> None:
     @asset_check(asset="asset1")
-    def check1() -> AssetCheckResult:
+    def check1():
         """Docstring."""
-        return AssetCheckResult(passed=True)
+        pass
 
     assert (
         check1.get_spec_for_check_key(AssetCheckKey(AssetKey(["asset1"]), "check1")).description
@@ -95,9 +95,8 @@ def test_asset_check_decorator_docstring_description() -> None:
 
 def test_asset_check_decorator_parameter_description() -> None:
     @asset_check(asset="asset1", description="parameter")
-    def check1() -> AssetCheckResult:
+    def check1():
         """Docstring."""
-        return AssetCheckResult(passed=True)
 
     assert (
         check1.get_spec_for_check_key(AssetCheckKey(AssetKey(["asset1"]), "check1")).description

--- a/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/decorators_tests/test_asset_check_decorator.py
@@ -81,6 +81,30 @@ def test_asset_check_decorator_name() -> None:
     assert spec.name == "check1"
 
 
+def test_asset_check_decorator_docstring_description() -> None:
+    @asset_check(asset="asset1")
+    def check1() -> AssetCheckResult:
+        """Docstring."""
+        return AssetCheckResult(passed=True)
+
+    assert (
+        check1.get_spec_for_check_key(AssetCheckKey(AssetKey(["asset1"]), "check1")).description
+        == "Docstring."
+    )
+
+
+def test_asset_check_decorator_parameter_description() -> None:
+    @asset_check(asset="asset1", description="parameter")
+    def check1() -> AssetCheckResult:
+        """Docstring."""
+        return AssetCheckResult(passed=True)
+
+    assert (
+        check1.get_spec_for_check_key(AssetCheckKey(AssetKey(["asset1"]), "check1")).description
+        == "parameter"
+    )
+
+
 def test_asset_check_with_prefix() -> None:
     @asset(key_prefix="prefix")
     def asset1() -> None: ...


### PR DESCRIPTION
## Summary & Motivation

This makes sure the `@asset_check` function docstring is used as description if the `description` parameter is not given. This makes it consistent with the behavior of `@asset`

Closes https://github.com/dagster-io/dagster/issues/23048

## How I Tested These Changes

Added unit tests. Also added similar tests for the `@asset` decorator

## Changelog

> Insert changelog entry or delete this section.
