### PR TITLE
Stash, retrieve `StateBackedDefinitionsLoader` reconstruction data in `DefinitionsLoadContext` 

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import cast
 
 import mock
@@ -15,9 +16,13 @@ from dagster import (
     schedule,
     sensor,
 )
+from dagster._core.code_pointer import CodePointer
 from dagster._core.definitions.asset_dep import AssetDep
+from dagster._core.definitions.definitions_load_context import DefinitionsLoadType
+from dagster._core.definitions.reconstruct import repository_def_from_pointer
 from dagster._serdes.serdes import deserialize_value
 from dagster._utils.test.definitions import (
+    lazy_definitions,
     scoped_reconstruction_metadata,
     unwrap_reconstruction_metadata,
 )
@@ -332,8 +337,8 @@ def test_local_airflow_instance() -> None:
     assert len(repo_def.assets_defs_by_key) == 2
 
 
-def test_cached_loading() -> None:
-    """Test cached loading behavior."""
+@lazy_definitions
+def airflow_instance_defs() -> Definitions:
     a = AssetKey("a")
     spec = AssetSpec(
         key=a,
@@ -342,46 +347,54 @@ def test_cached_loading() -> None:
     instance = make_instance({"dag": ["task"]})
     passed_in_defs = Definitions(assets=[spec])
 
-    defs = build_defs_from_airflow_instance(airflow_instance=instance, defs=passed_in_defs)
-    assert defs.assets
-    assert len(list(defs.assets)) == 2
-    assert {
-        key for assets_def in defs.assets for key in cast(AssetsDefinition, assets_def).keys
-    } == {a, make_test_dag_asset_key("dag")}
-    assert len(defs.metadata) == 1
-    assert "dagster-airlift/source/test_instance" in defs.metadata
-    assert isinstance(defs.metadata["dagster-airlift/source/test_instance"].value, str)
+    return build_defs_from_airflow_instance(airflow_instance=instance, defs=passed_in_defs)
+
+
+def test_cached_loading() -> None:
+    repository_def = repository_def_from_pointer(
+        CodePointer.from_python_file(str(Path(__file__)), "airflow_instance_defs", None),
+        DefinitionsLoadType.INITIALIZATION,
+        None,
+    )
+    assert repository_def.repository_load_data
+    assert len(repository_def.repository_load_data.reconstruction_metadata) == 1
+    assert (
+        "dagster-airlift/source/test_instance"
+        in repository_def.repository_load_data.reconstruction_metadata
+    )
     assert isinstance(
-        deserialize_value(defs.metadata["dagster-airlift/source/test_instance"].value),
+        repository_def.repository_load_data.reconstruction_metadata[
+            "dagster-airlift/source/test_instance"
+        ].value,
+        str,
+    )
+    assert isinstance(
+        deserialize_value(
+            repository_def.repository_load_data.reconstruction_metadata[
+                "dagster-airlift/source/test_instance"
+            ].value
+        ),
         SerializedAirflowDefinitionsData,
     )
 
-    with scoped_reconstruction_metadata(unwrap_reconstruction_metadata(defs)):
+    with scoped_reconstruction_metadata(unwrap_reconstruction_metadata(repository_def)):
         with mock.patch(
             "dagster_airlift.core.serialization.compute.compute_serialized_data",
             wraps=compute_serialized_data,
         ) as mock_compute_serialized_data:
-            reloaded_defs = build_defs_from_airflow_instance(
-                airflow_instance=instance, defs=passed_in_defs
+            reloaded_repo_def = repository_def_from_pointer(
+                CodePointer.from_python_file(str(Path(__file__)), "airflow_instance_defs", None),
+                DefinitionsLoadType.INITIALIZATION,
+                None,
             )
             assert mock_compute_serialized_data.call_count == 0
-            reloaded_defs = build_defs_from_airflow_instance(
-                airflow_instance=instance, defs=passed_in_defs
-            )
-            assert reloaded_defs.assets
-            assert len(list(reloaded_defs.assets)) == 2
+            assert reloaded_repo_def.assets_defs_by_key
+            assert len(list(reloaded_repo_def.assets_defs_by_key.keys())) == 2
             assert {
                 key
-                for assets_def in reloaded_defs.assets
+                for assets_def in reloaded_repo_def.assets_defs_by_key.values()
                 for key in cast(AssetsDefinition, assets_def).keys
-            } == {a, make_test_dag_asset_key("dag")}
-            assert len(reloaded_defs.metadata) == 1
-            assert "dagster-airlift/source/test_instance" in reloaded_defs.metadata
-            # Reconstruction data should remain the same.
-            assert (
-                reloaded_defs.metadata["dagster-airlift/source/test_instance"].value
-                == defs.metadata["dagster-airlift/source/test_instance"].value
-            )
+            } == {AssetKey("a"), make_test_dag_asset_key("dag")}
 
 
 def test_multiple_tasks_per_asset(init_load_context: None) -> None:

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -18,8 +18,7 @@ from dagster import (
 )
 from dagster._core.code_pointer import CodePointer
 from dagster._core.definitions.asset_dep import AssetDep
-from dagster._core.definitions.definitions_load_context import DefinitionsLoadType
-from dagster._core.definitions.reconstruct import repository_def_from_pointer
+from dagster._core.definitions.reconstruct import initialize_repository_def_from_pointer
 from dagster._serdes.serdes import deserialize_value
 from dagster._utils.test.definitions import (
     lazy_definitions,
@@ -351,10 +350,8 @@ def airflow_instance_defs() -> Definitions:
 
 
 def test_cached_loading() -> None:
-    repository_def = repository_def_from_pointer(
+    repository_def = initialize_repository_def_from_pointer(
         CodePointer.from_python_file(str(Path(__file__)), "airflow_instance_defs", None),
-        DefinitionsLoadType.INITIALIZATION,
-        None,
     )
     assert repository_def.repository_load_data
     assert len(repository_def.repository_load_data.reconstruction_metadata) == 1
@@ -382,10 +379,8 @@ def test_cached_loading() -> None:
             "dagster_airlift.core.serialization.compute.compute_serialized_data",
             wraps=compute_serialized_data,
         ) as mock_compute_serialized_data:
-            reloaded_repo_def = repository_def_from_pointer(
+            reloaded_repo_def = initialize_repository_def_from_pointer(
                 CodePointer.from_python_file(str(Path(__file__)), "airflow_instance_defs", None),
-                DefinitionsLoadType.INITIALIZATION,
-                None,
             )
             assert mock_compute_serialized_data.call_count == 0
             assert reloaded_repo_def.assets_defs_by_key

--- a/python_modules/dagster/dagster/_cli/workspace/cli_target.py
+++ b/python_modules/dagster/dagster/_cli/workspace/cli_target.py
@@ -24,7 +24,6 @@ from typing_extensions import Never, TypeAlias
 
 import dagster._check as check
 from dagster._core.code_pointer import CodePointer
-from dagster._core.definitions.definitions_load_context import DefinitionsLoadType
 from dagster._core.definitions.reconstruct import repository_def_from_target_def
 from dagster._core.definitions.repository_definition import RepositoryDefinition
 from dagster._core.instance import DagsterInstance
@@ -571,7 +570,7 @@ def _get_code_pointer_dict_from_kwargs(kwargs: ClickArgMapping) -> Mapping[str, 
             cast(
                 RepositoryDefinition,
                 repository_def_from_target_def(
-                    loadable_target.target_definition, DefinitionsLoadType.INITIALIZATION
+                    loadable_target.target_definition,
                 ),
             ).name: CodePointer.from_python_file(
                 python_file, loadable_target.attribute, working_directory
@@ -586,7 +585,7 @@ def _get_code_pointer_dict_from_kwargs(kwargs: ClickArgMapping) -> Mapping[str, 
             cast(
                 RepositoryDefinition,
                 repository_def_from_target_def(
-                    loadable_target.target_definition, DefinitionsLoadType.INITIALIZATION
+                    loadable_target.target_definition,
                 ),
             ).name: CodePointer.from_module(
                 module_name, loadable_target.attribute, working_directory
@@ -601,7 +600,7 @@ def _get_code_pointer_dict_from_kwargs(kwargs: ClickArgMapping) -> Mapping[str, 
             cast(
                 RepositoryDefinition,
                 repository_def_from_target_def(
-                    loadable_target.target_definition, DefinitionsLoadType.INITIALIZATION
+                    loadable_target.target_definition,
                 ),
             ).name: CodePointer.from_python_package(
                 package_name, loadable_target.attribute, working_directory

--- a/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from enum import Enum
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Generic, Mapping, Optional, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Mapping, Optional, TypeVar, cast
 
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.errors import DagsterInvariantViolationError
@@ -58,10 +58,6 @@ class DefinitionsLoadContext:
     @classmethod
     def set(cls, instance: "DefinitionsLoadContext") -> None:
         """Get the current DefinitionsLoadContext."""
-        current_pending_metadata = (
-            cls._instance.get_pending_reconstruction_metadata() if cls._instance else {}
-        )
-        instance.replace_pending_reconstruction_metadata(current_pending_metadata)
         cls._instance = instance
 
     @property
@@ -71,9 +67,6 @@ class DefinitionsLoadContext:
 
     def add_to_pending_reconstruction_metadata(self, key: str, metadata: Any) -> None:
         self._pending_reconstruction_metadata[key] = metadata
-
-    def replace_pending_reconstruction_metadata(self, metadata: Dict[str, Any]) -> None:
-        self._pending_reconstruction_metadata = metadata
 
     def get_pending_reconstruction_metadata(self) -> Any:
         return self._pending_reconstruction_metadata

--- a/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_load_context.py
@@ -68,7 +68,7 @@ class DefinitionsLoadContext:
     def add_to_pending_reconstruction_metadata(self, key: str, metadata: Any) -> None:
         self._pending_reconstruction_metadata[key] = metadata
 
-    def get_pending_reconstruction_metadata(self) -> Any:
+    def get_pending_reconstruction_metadata(self) -> Mapping[str, Any]:
         return self._pending_reconstruction_metadata
 
     @cached_property

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -767,8 +767,8 @@ def initialize_repository_def_from_pointer(
     pointer: CodePointer,
 ) -> "RepositoryDefinition":
     """Initialize a repository definition from a code pointer
-    as part of an initial load."""
-
+    as part of an initial load.
+    """
     from dagster._core.definitions.definitions_load_context import (
         DefinitionsLoadContext,
         DefinitionsLoadType,
@@ -802,8 +802,8 @@ def reconstruct_repository_def_from_pointer(
     repository_load_data: Optional["RepositoryLoadData"] = None,
 ) -> "RepositoryDefinition":
     """Reconstruct a repository definition from a code pointer,
-    avoiding recomputation of expensive load functions."""
-
+    avoiding recomputation of expensive load functions.
+    """
     from dagster._core.definitions.definitions_load_context import (
         DefinitionsLoadContext,
         DefinitionsLoadType,

--- a/python_modules/dagster/dagster/_core/definitions/reconstruct.py
+++ b/python_modules/dagster/dagster/_core/definitions/reconstruct.py
@@ -48,7 +48,6 @@ from dagster._utils import hash_collection
 
 if TYPE_CHECKING:
     from dagster._core.definitions.assets import AssetsDefinition
-    from dagster._core.definitions.definitions_load_context import DefinitionsLoadType
     from dagster._core.definitions.graph_definition import GraphDefinition
     from dagster._core.definitions.job_definition import JobDefinition
     from dagster._core.definitions.repository_definition import (
@@ -115,11 +114,7 @@ class ReconstructableRepository(
         return self._replace(repository_load_data=metadata)
 
     def get_definition(self) -> "RepositoryDefinition":
-        from dagster._core.definitions.definitions_load_context import DefinitionsLoadType
-
-        return repository_def_from_pointer(
-            self.pointer, DefinitionsLoadType.RECONSTRUCTION, self.repository_load_data
-        )
+        return reconstruct_repository_def_from_pointer(self.pointer, self.repository_load_data)
 
     def get_reconstructable_job(self, name: str) -> "ReconstructableJob":
         return ReconstructableJob(self, name)
@@ -695,24 +690,20 @@ def job_def_from_pointer(pointer: CodePointer) -> "JobDefinition":
 @overload
 def repository_def_from_target_def(
     target: Union["RepositoryDefinition", "JobDefinition", "GraphDefinition"],
-    load_type: "DefinitionsLoadType",
-    repository_load_data: Optional["RepositoryLoadData"] = None,
-) -> "RepositoryDefinition": ...
+) -> Optional["RepositoryDefinition"]: ...
 
 
 @overload
 def repository_def_from_target_def(
     target: object,
-    load_type: "DefinitionsLoadType",
-    repository_load_data: Optional["RepositoryLoadData"] = None,
-    set_new_context: bool = True,
-) -> None: ...
+) -> Optional["RepositoryDefinition"]: ...
 
 
 def _repository_def_from_target_def_inner(
     target: object, repository_load_data: Optional["RepositoryLoadData"]
 ) -> Optional["RepositoryDefinition"]:
     from dagster._core.definitions.assets import AssetsDefinition
+    from dagster._core.definitions.definitions_class import Definitions
     from dagster._core.definitions.graph_definition import GraphDefinition
     from dagster._core.definitions.job_definition import JobDefinition
     from dagster._core.definitions.repository_definition import (
@@ -722,6 +713,15 @@ def _repository_def_from_target_def_inner(
         RepositoryDefinition,
     )
     from dagster._core.definitions.source_asset import SourceAsset
+    from dagster._utils.test.definitions import LazyDefinitions
+
+    # LazyDefinitions is a private test utility
+    if isinstance(target, LazyDefinitions):
+        target = target()
+
+    if isinstance(target, Definitions):
+        # reassign to handle both repository and pending repo case
+        target = target.get_inner_repository()
 
     if isinstance(target, (JobDefinition, GraphDefinition)):
         # consider including job name in generated repo name
@@ -750,28 +750,10 @@ def _repository_def_from_target_def_inner(
 
 def repository_def_from_target_def(
     target: object,
-    load_type: "DefinitionsLoadType",
-    repository_load_data: Optional["RepositoryLoadData"] = None,
-    set_new_context: bool = True,
 ) -> Optional["RepositoryDefinition"]:
-    from dagster._core.definitions.definitions_class import Definitions
     from dagster._core.definitions.definitions_load_context import DefinitionsLoadContext
-    from dagster._utils.test.definitions import LazyDefinitions
 
-    if set_new_context:
-        DefinitionsLoadContext.set(
-            DefinitionsLoadContext(load_type=load_type, repository_load_data=repository_load_data)
-        )
-
-    # LazyDefinitions is a private test utility
-    if isinstance(target, LazyDefinitions):
-        target = target()
-
-    if isinstance(target, Definitions):
-        # reassign to handle both repository and pending repo case
-        target = target.get_inner_repository()
-
-    repo_def = _repository_def_from_target_def_inner(target, repository_load_data)
+    repo_def = _repository_def_from_target_def_inner(target, None)
     return (
         repo_def.replace_reconstruction_metadata(
             DefinitionsLoadContext.get().get_pending_reconstruction_metadata()
@@ -781,20 +763,62 @@ def repository_def_from_target_def(
     )
 
 
-def repository_def_from_pointer(
+def initialize_repository_def_from_pointer(
     pointer: CodePointer,
-    load_type: "DefinitionsLoadType",
-    repository_load_data: Optional["RepositoryLoadData"] = None,
 ) -> "RepositoryDefinition":
-    from dagster._core.definitions.definitions_load_context import DefinitionsLoadContext
+    """Initialize a repository definition from a code pointer
+    as part of an initial load."""
+
+    from dagster._core.definitions.definitions_load_context import (
+        DefinitionsLoadContext,
+        DefinitionsLoadType,
+    )
     from dagster._core.definitions.repository_definition import RepositoryDefinition
 
     DefinitionsLoadContext.set(
-        DefinitionsLoadContext(load_type=load_type, repository_load_data=repository_load_data)
+        DefinitionsLoadContext(
+            load_type=DefinitionsLoadType.INITIALIZATION, repository_load_data=None
+        )
     )
     target = def_from_pointer(pointer)
-    repo_def = repository_def_from_target_def(
-        target, load_type, repository_load_data, set_new_context=False
+    repo_def = _repository_def_from_target_def_inner(
+        target,
+        None,
+    )
+    if not repo_def:
+        raise DagsterInvariantViolationError(
+            f"CodePointer ({pointer.describe()}) must resolve to a "
+            "RepositoryDefinition, JobDefinition, or JobDefinition. "
+            f"Received a {type(target)}"
+        )
+
+    return check.inst(repo_def, RepositoryDefinition).replace_reconstruction_metadata(
+        DefinitionsLoadContext.get().get_pending_reconstruction_metadata()
+    )
+
+
+def reconstruct_repository_def_from_pointer(
+    pointer: CodePointer,
+    repository_load_data: Optional["RepositoryLoadData"] = None,
+) -> "RepositoryDefinition":
+    """Reconstruct a repository definition from a code pointer,
+    avoiding recomputation of expensive load functions."""
+
+    from dagster._core.definitions.definitions_load_context import (
+        DefinitionsLoadContext,
+        DefinitionsLoadType,
+    )
+    from dagster._core.definitions.repository_definition import RepositoryDefinition
+
+    DefinitionsLoadContext.set(
+        DefinitionsLoadContext(
+            load_type=DefinitionsLoadType.RECONSTRUCTION, repository_load_data=repository_load_data
+        )
+    )
+    target = def_from_pointer(pointer)
+    repo_def = _repository_def_from_target_def_inner(
+        target,
+        repository_load_data,
     )
     if not repo_def:
         raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -148,6 +148,9 @@ class RepositoryDefinition:
     ) -> "RepositoryDefinition":
         """Add reconstruction metadata to this RepositoryDefinition object."""
         check.mapping_param(reconstruction_metadata, "reconstruction_metadata", key_type=str)
+        if not reconstruction_metadata:
+            return self
+
         for k, v in reconstruction_metadata.items():
             if not isinstance(v, str):
                 raise DagsterInvariantViolationError(

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -143,10 +143,10 @@ class RepositoryDefinition:
         return self._repository_load_data
 
     @experimental
-    def with_reconstruction_metadata(
+    def replace_reconstruction_metadata(
         self, reconstruction_metadata: Mapping[str, str]
     ) -> "RepositoryDefinition":
-        """Add reconstruction metadata to this RepositoryDefinition object."""
+        """Modifies the repository load data to include the provided reconstruction metadata."""
         check.mapping_param(reconstruction_metadata, "reconstruction_metadata", key_type=str)
         if not reconstruction_metadata:
             return self
@@ -166,7 +166,7 @@ class RepositoryDefinition:
             self._name,
             repository_data=self._repository_data,
             description=self._description,
-            metadata={**self._metadata, **normalized_metadata},
+            metadata=self._metadata,
             repository_load_data=self._repository_load_data.replace_reconstruction_metadata(
                 normalized_metadata
             )

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py
@@ -14,7 +14,7 @@ from typing import (
 )
 
 import dagster._check as check
-from dagster._annotations import experimental, public
+from dagster._annotations import public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_job import IMPLICIT_ASSET_JOB_NAME
@@ -142,7 +142,6 @@ class RepositoryDefinition:
     def repository_load_data(self) -> Optional[RepositoryLoadData]:
         return self._repository_load_data
 
-    @experimental
     def replace_reconstruction_metadata(
         self, reconstruction_metadata: Mapping[str, str]
     ) -> "RepositoryDefinition":

--- a/python_modules/dagster/dagster/_utils/test/definitions.py
+++ b/python_modules/dagster/dagster/_utils/test/definitions.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from typing import Any, Callable, Generic, Iterator, Mapping, Optional, TypeVar
 
+from dagster import _check as check
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.definitions_load_context import (
     DefinitionsLoadContext,
@@ -193,12 +194,14 @@ def scoped_reconstruction_metadata(
         DefinitionsLoadContext.set(prev_context)
 
 
-def unwrap_reconstruction_metadata(defs: Definitions) -> Mapping[str, Any]:
+def unwrap_reconstruction_metadata(repo_def: RepositoryDefinition) -> Mapping[str, Any]:
     """Takes the metadata from a Definitions object and unwraps the CodeLocationReconstructionMetadataValue
     metadata values into a dictionary.
     """
     return {
         k: metadata_value.value
-        for k, metadata_value in defs.metadata.items()
+        for k, metadata_value in check.not_none(
+            repo_def.repository_load_data
+        ).reconstruction_metadata.items()
         if isinstance(metadata_value, CodeLocationReconstructionMetadataValue)
     }

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/test_autodiscovery.py
@@ -4,8 +4,7 @@ import sys
 import pytest
 from dagster import DagsterInvariantViolationError, RepositoryDefinition
 from dagster._core.code_pointer import CodePointer
-from dagster._core.definitions.definitions_load_context import DefinitionsLoadType
-from dagster._core.definitions.reconstruct import repository_def_from_pointer
+from dagster._core.definitions.reconstruct import initialize_repository_def_from_pointer
 from dagster._core.definitions.repository_definition import PendingRepositoryDefinition
 from dagster._core.errors import DagsterImportError
 from dagster._core.workspace.autodiscovery import (
@@ -17,7 +16,7 @@ from dagster._core.workspace.autodiscovery import (
 from dagster._utils import alter_sys_path, file_relative_path, restore_sys_modules
 
 
-def test_single_repository():
+def test_single_repository() -> None:
     single_repo_path = file_relative_path(__file__, "single_repository.py")
     loadable_targets = loadable_targets_from_python_file(single_repo_path)
 
@@ -31,7 +30,7 @@ def test_single_repository():
     assert repo_def.name == "single_repository"
 
 
-def test_double_repository():
+def test_double_repository() -> None:
     loadable_repos = loadable_targets_from_python_file(
         file_relative_path(__file__, "double_repository.py"),
     )
@@ -44,7 +43,7 @@ def test_double_repository():
     assert found_names == {"repo_one", "repo_two"}
 
 
-def test_single_job():
+def test_single_job() -> None:
     single_job_path = file_relative_path(__file__, "single_job.py")
     loadable_targets = loadable_targets_from_python_file(single_job_path)
 
@@ -52,16 +51,15 @@ def test_single_job():
     symbol = loadable_targets[0].attribute
     assert symbol == "a_job"
 
-    repo_def = repository_def_from_pointer(
+    repo_def = initialize_repository_def_from_pointer(
         CodePointer.from_python_file(single_job_path, symbol, None),
-        DefinitionsLoadType.INITIALIZATION,
     )
 
     assert isinstance(repo_def, RepositoryDefinition)
     assert repo_def.get_job("a_job")
 
 
-def test_double_job():
+def test_double_job() -> None:
     double_job_path = file_relative_path(__file__, "double_job.py")
     with pytest.raises(DagsterInvariantViolationError) as exc_info:
         loadable_targets_from_python_file(double_job_path)
@@ -74,7 +72,7 @@ def test_double_job():
     )
 
 
-def test_single_graph():
+def test_single_graph() -> None:
     single_graph_path = file_relative_path(__file__, "single_graph.py")
     loadable_targets = loadable_targets_from_python_file(single_graph_path)
 
@@ -82,16 +80,15 @@ def test_single_graph():
     symbol = loadable_targets[0].attribute
     assert symbol == "graph_one"
 
-    repo_def = repository_def_from_pointer(
+    repo_def = initialize_repository_def_from_pointer(
         CodePointer.from_python_file(single_graph_path, symbol, None),
-        DefinitionsLoadType.INITIALIZATION,
     )
 
     assert isinstance(repo_def, RepositoryDefinition)
     assert repo_def.get_job("graph_one")
 
 
-def test_double_graph():
+def test_double_graph() -> None:
     double_job_path = file_relative_path(__file__, "double_graph.py")
     with pytest.raises(DagsterInvariantViolationError) as exc_info:
         loadable_targets_from_python_file(double_job_path)
@@ -104,7 +101,7 @@ def test_double_graph():
     )
 
 
-def test_multiple_assets():
+def test_multiple_assets() -> None:
     path = file_relative_path(__file__, "multiple_assets.py")
     loadable_targets = loadable_targets_from_python_file(path)
 
@@ -112,9 +109,8 @@ def test_multiple_assets():
     symbol = loadable_targets[0].attribute
     assert symbol == LOAD_ALL_ASSETS
 
-    repo_def = repository_def_from_pointer(
+    repo_def = initialize_repository_def_from_pointer(
         CodePointer.from_python_file(path, symbol, None),
-        DefinitionsLoadType.INITIALIZATION,
     )
 
     assert isinstance(repo_def, RepositoryDefinition)
@@ -122,7 +118,7 @@ def test_multiple_assets():
     assert len(the_job.graph.node_defs) == 2
 
 
-def test_no_loadable_targets():
+def test_no_loadable_targets() -> None:
     with pytest.raises(DagsterInvariantViolationError) as exc_info:
         loadable_targets_from_python_file(file_relative_path(__file__, "nada.py"))
 
@@ -132,7 +128,7 @@ def test_no_loadable_targets():
     )
 
 
-def test_single_pending_repository():
+def test_single_pending_repository() -> None:
     single_pending_repo_path = file_relative_path(__file__, "single_pending_repository.py")
     loadable_targets = loadable_targets_from_python_file(single_pending_repo_path)
 
@@ -145,7 +141,7 @@ def test_single_pending_repository():
     assert repo_def.name == "single_pending_repository"
 
 
-def test_single_repository_in_module():
+def test_single_repository_in_module() -> None:
     loadable_targets = loadable_targets_from_python_module(
         "dagster.utils.test.toys.single_repository",
         working_directory=None,
@@ -161,7 +157,7 @@ def test_single_repository_in_module():
     assert repo_def.name == "single_repository"
 
 
-def test_single_repository_in_package():
+def test_single_repository_in_package() -> None:
     loadable_targets = loadable_targets_from_python_package(
         "dagster.utils.test.toys.single_repository",
         working_directory=None,
@@ -177,7 +173,7 @@ def test_single_repository_in_package():
     assert repo_def.name == "single_repository"
 
 
-def test_single_defs_in_file():
+def test_single_defs_in_file() -> None:
     dagster_defs_path = file_relative_path(__file__, "single_defs.py")
     loadable_targets = loadable_targets_from_python_file(dagster_defs_path)
 
@@ -185,15 +181,14 @@ def test_single_defs_in_file():
     symbol = loadable_targets[0].attribute
     assert symbol == "defs"
 
-    repo_def = repository_def_from_pointer(
+    repo_def = initialize_repository_def_from_pointer(
         CodePointer.from_python_file(dagster_defs_path, symbol, None),
-        DefinitionsLoadType.INITIALIZATION,
     )
 
     assert isinstance(repo_def, RepositoryDefinition)
 
 
-def test_single_def_any_name():
+def test_single_def_any_name() -> None:
     dagster_defs_path = file_relative_path(__file__, "single_defs_any_name.py")
     loadable_targets = loadable_targets_from_python_file(dagster_defs_path)
 
@@ -202,7 +197,7 @@ def test_single_def_any_name():
     assert symbol == "not_defs"
 
 
-def test_double_defs_in_file():
+def test_double_defs_in_file() -> None:
     dagster_defs_path = file_relative_path(__file__, "double_defs.py")
     with pytest.raises(
         DagsterInvariantViolationError,
@@ -220,7 +215,7 @@ def _current_test_directory_paths():
     return [os.path.dirname(__file__)]
 
 
-def test_local_directory_module():
+def test_local_directory_module() -> None:
     # this is testing that modules that *can* be resolved using the current working directory
     # for local python modules instead of installed packages will succeed.
 
@@ -254,7 +249,7 @@ def test_local_directory_module():
     assert len(loadable_targets) == 1
 
 
-def test_local_directory_file():
+def test_local_directory_file() -> None:
     path = file_relative_path(__file__, "autodiscover_file_in_directory/repository.py")
 
     with restore_sys_modules():
@@ -267,7 +262,7 @@ def test_local_directory_file():
         loadable_targets_from_python_file(path, working_directory=os.path.dirname(path))
 
 
-def test_lazy_definitions():
+def test_lazy_definitions() -> None:
     module_path = file_relative_path(__file__, "lazy_definitions.py")
     loadable_targets = loadable_targets_from_python_file(module_path)
 
@@ -275,10 +270,8 @@ def test_lazy_definitions():
     symbol = loadable_targets[0].attribute
     assert symbol == "defs"
 
-    repo_def = repository_def_from_pointer(
+    repo_def = initialize_repository_def_from_pointer(
         CodePointer.from_python_file(module_path, symbol, None),
-        DefinitionsLoadType.INITIALIZATION,
-        None,
     )
 
     assert isinstance(repo_def, RepositoryDefinition)

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_load_context.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_definitions_load_context.py
@@ -18,7 +18,7 @@ from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._core.definitions.reconstruct import (
     ReconstructableJob,
     ReconstructableRepository,
-    repository_def_from_pointer,
+    initialize_repository_def_from_pointer,
     repository_def_from_target_def,
 )
 from dagster._core.definitions.repository_definition.repository_definition import (
@@ -85,7 +85,7 @@ def metadata_defs():
 
 
 def test_reconstruction_metadata():
-    repo = repository_def_from_target_def(metadata_defs, DefinitionsLoadType.INITIALIZATION)
+    repo = repository_def_from_target_def(metadata_defs)
     assert repo
     assert repo.assets_defs_by_key.keys() == {
         AssetKey("regular_asset"),
@@ -151,11 +151,11 @@ def load_type_test_defs() -> Definitions:
     return Definitions(assets=[foo], jobs=[foo_job])
 
 
-def test_definitions_load_type():
+def test_definitions_load_type() -> None:
     pointer = CodePointer.from_python_file(__file__, "load_type_test_defs", None)
 
     # Load type is INITIALIZATION so should not raise
-    assert repository_def_from_pointer(pointer, DefinitionsLoadType.INITIALIZATION, None)
+    assert initialize_repository_def_from_pointer(pointer)
 
     recon_job = ReconstructableJob(
         repository=ReconstructableRepository(pointer),

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_reconstructable.py
@@ -194,7 +194,7 @@ def test_reconstruct_from_origin():
     assert recon_job.repository.container_context == origin.repository_origin.container_context
 
 
-def test_reconstructable_memoize():
+def test_reconstructable_memoize() -> None:
     recon_job = reconstructable(some_job)
 
     # warm the cache

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_pipes.py
@@ -491,7 +491,7 @@ def test_cloudwatch_logs_reader(cloudwatch_client: "CloudWatchLogsClient", capsy
 
     time.sleep(1)
 
-    assert capsys.readouterr().out == "1\n2\n3\n"
+    assert capsys.readouterr().out.strip() == "1\n2\n3"
 
 
 def test_cloudwatch_message_reader(cloudwatch_client: "CloudWatchLogsClient", capsys):

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -9,11 +9,10 @@ from dagster._core.code_pointer import CodePointer
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.definitions_load_context import DefinitionsLoadType
 from dagster._core.definitions.reconstruct import (
     ReconstructableJob,
     ReconstructableRepository,
-    repository_def_from_pointer,
+    initialize_repository_def_from_pointer,
 )
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.events import DagsterEventType
@@ -184,10 +183,8 @@ def test_state_derived_defs(
     with instance_for_test() as instance:
         assert len(workspace_data_api_mocks.calls) == 0
 
-        repository_def = repository_def_from_pointer(
+        repository_def = initialize_repository_def_from_pointer(
             CodePointer.from_python_file(str(Path(__file__)), "state_derived_defs", None),
-            DefinitionsLoadType.INITIALIZATION,
-            None,
         )
 
         # first, we resolve the repository to generate our cached metadata

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -1,13 +1,20 @@
 import uuid
+from pathlib import Path
 
 import pytest
 import responses
 from dagster import materialize
 from dagster._config.field_utils import EnvVar
+from dagster._core.code_pointer import CodePointer
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
-from dagster._core.definitions.reconstruct import ReconstructableJob, ReconstructableRepository
+from dagster._core.definitions.definitions_load_context import DefinitionsLoadType
+from dagster._core.definitions.reconstruct import (
+    ReconstructableJob,
+    ReconstructableRepository,
+    repository_def_from_pointer,
+)
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import create_execution_plan, execute_plan
@@ -177,8 +184,13 @@ def test_state_derived_defs(
     with instance_for_test() as instance:
         assert len(workspace_data_api_mocks.calls) == 0
 
+        repository_def = repository_def_from_pointer(
+            CodePointer.from_python_file(str(Path(__file__)), "state_derived_defs", None),
+            DefinitionsLoadType.INITIALIZATION,
+            None,
+        )
+
         # first, we resolve the repository to generate our cached metadata
-        repository_def = state_derived_defs().get_repository_def()
         assert len(workspace_data_api_mocks.calls) == 5
 
         # 3 PowerBI external assets, one materializable asset

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_asset_specs.py
@@ -2,8 +2,10 @@ from pathlib import Path
 
 import responses
 from dagster._core.code_pointer import CodePointer
-from dagster._core.definitions.definitions_load_context import DefinitionsLoadType
-from dagster._core.definitions.reconstruct import repository_def_from_pointer
+from dagster._core.definitions.reconstruct import (
+    initialize_repository_def_from_pointer,
+    reconstruct_repository_def_from_pointer,
+)
 from dagster._core.instance_for_test import instance_for_test
 
 
@@ -11,12 +13,10 @@ from dagster._core.instance_for_test import instance_for_test
 def test_load_assets_organization_data(sigma_auth_token: str, sigma_sample_data: None) -> None:
     with instance_for_test() as _instance:
         # first, we resolve the repository to generate our cached metadata
-        repository_def = repository_def_from_pointer(
+        repository_def = initialize_repository_def_from_pointer(
             CodePointer.from_python_file(
                 str(Path(__file__).parent / "pending_repo.py"), "defs", None
             ),
-            DefinitionsLoadType.INITIALIZATION,
-            None,
         )
 
         # 2 Sigma external assets, one materializable asset
@@ -35,11 +35,10 @@ def test_load_assets_organization_data(sigma_auth_token: str, sigma_sample_data:
         data = repository_def.repository_load_data
 
         # We use a separate file here just to ensure we get a fresh load
-        recon_repository_def = repository_def_from_pointer(
+        recon_repository_def = reconstruct_repository_def_from_pointer(
             CodePointer.from_python_file(
                 str(Path(__file__).parent / "pending_repo_2.py"), "defs", None
             ),
-            DefinitionsLoadType.RECONSTRUCTION,
             data,
         )
         assert len(recon_repository_def.assets_defs_by_key) == 2 + 1


### PR DESCRIPTION
## Summary

Currently, `StateBackedDefinitionsLoader` stashes its reconstruction data in the output `Definitions`. This means that in order for it to be persisted, that `Definitions` object must make its way to the terminal user-specified `defs`. In the case that we build APIs which emit non-Definitions objects as a result of cached computation (e.g. specs), we lose that reconstruction data.

This PR moves to a paradigm where we store this reconstruction data in the `DefinitionsLoadContext`, where it's retrieved and attached to the final `RepositoryDefinition`.

## Test Plan

Existing tests.