### PR TITLE
WorkspaceContext - wait for indexeddb data to load before checking for stale locations

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceContext.tsx
@@ -106,6 +106,7 @@ interface FetchLocationDataParams
   >;
 }
 
+const UNLOADED_CACHED_DATA = {};
 export const WorkspaceProvider = ({children}: {children: React.ReactNode}) => {
   const {localCacheIdPrefix} = useContext(AppContext);
   const client = useApolloClient();
@@ -113,15 +114,17 @@ export const WorkspaceProvider = ({children}: {children: React.ReactNode}) => {
   const clearCachedData = useClearCachedData();
   const getData = useGetData();
 
-  const [locationEntryData, setLocationEntryData] = useState<
-    Record<string, WorkspaceLocationNodeFragment | PythonErrorFragment>
-  >({});
+  const [locationEntryData, setLocationEntryData] =
+    useState<Record<string, WorkspaceLocationNodeFragment | PythonErrorFragment>>(
+      UNLOADED_CACHED_DATA,
+    );
 
   const previousLocationVersionsRef = useRef<Record<string, string>>({});
 
   const {locationStatuses, loading: loadingLocationStatuses} =
     useCodeLocationStatuses(localCacheIdPrefix);
 
+  const loadingCachedData = UNLOADED_CACHED_DATA === locationEntryData;
   const loading =
     loadingLocationStatuses ||
     !Object.keys(locationStatuses).every((locationName) => locationEntryData[locationName]);
@@ -139,7 +142,7 @@ export const WorkspaceProvider = ({children}: {children: React.ReactNode}) => {
   }, [localCacheIdPrefix, getCachedData]);
 
   useEffect(() => {
-    if (loading) {
+    if (loadingCachedData) {
       return;
     }
     const params: RefreshLocationsIfNeededParams = {
@@ -152,7 +155,7 @@ export const WorkspaceProvider = ({children}: {children: React.ReactNode}) => {
       previousLocationVersionsRef,
     };
     refreshLocationsIfNeeded(params);
-  }, [locationStatuses, locationEntryData, client, localCacheIdPrefix, getData, loading]);
+  }, [locationStatuses, locationEntryData, client, localCacheIdPrefix, getData, loadingCachedData]);
 
   useEffect(() => {
     if (loading) {

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceContext.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceContext/WorkspaceContext.tsx
@@ -139,6 +139,9 @@ export const WorkspaceProvider = ({children}: {children: React.ReactNode}) => {
   }, [localCacheIdPrefix, getCachedData]);
 
   useEffect(() => {
+    if (loading) {
+      return;
+    }
     const params: RefreshLocationsIfNeededParams = {
       locationStatuses,
       locationEntryData,


### PR DESCRIPTION
## Summary & Motivation

As titled

## How I Tested These Changes

Used app-proxy to confirm we don't make any LocationWorkspaceQuery calls anymore if the data is up to date.
Existing jest tests still pass

