### PR TITLE
Dedupe AssetDefinitions before passing them into AssetGraph.from_assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -319,10 +319,12 @@ def build_caching_repository_data_from_list(
     assets_without_keys = [ad for ad in assets_defs if not ad.keys]
     asset_graph = AssetGraph.from_assets(
         [
-            *assets_defs_by_key.values(),
+            # Ensure that the same AssetsDefinition doesn't need to be considered twice by the graph if
+            # it produces multiple asset keys
+            *set(assets_defs_by_key.values()),
             *assets_without_keys,
             *asset_checks_defs,
-            *source_assets_by_key.values(),
+            *source_assets_by_key.values(),  # only ever one key per source asset so no need to dedupe
         ]
     )
     if assets_defs or asset_checks_defs or source_assets:


### PR DESCRIPTION
## Summary & Motivation
In https://github.com/dagster-io/dagster/pull/22569/ we started breaking this list out by asset key so that we could add assets that were referenced by sensors and schedules. This means that if a single AssetsDefinition has 50 keys, 50 Assetsdefinitions now go into AssetGraph.from_assets, which appears to be much slower. This PR adds a deduping step so that only one of each AssetsDefinition goes into AssetGraph.from_assets.

## How I Tested These Changes
BK, run a benchmark where a single AssetsDefinition produced 5000 asset keys and observe this codepath getting much faster again

## Changelog
Performance improvements when loading definitions with multi-assets with many asset keys.
