### PR TITLE
filter.exclude_subruns uses backfill_id column if present

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -274,7 +274,7 @@ def migrate_run_backfill_id(storage: RunStorage, print_fn: Optional[PrintFn] = N
         print_fn("Querying run storage.")
 
     for run in chunked_run_iterator(storage, print_fn):
-        if BACKFILL_ID_TAG not in run.tags:
+        if run.tags.get(BACKFILL_ID_TAG) is None:
             continue
 
         add_backfill_id(

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -42,6 +42,7 @@ from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, Runs
 from dagster._core.storage.event_log.migration import migrate_event_log_data
 from dagster._core.storage.event_log.sql_event_log import SqlEventLogStorage
 from dagster._core.storage.migration.utils import upgrading_instance
+from dagster._core.storage.runs.migration import RUN_BACKFILL_ID
 from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import (
     BACKFILL_ID_TAG,
@@ -1227,6 +1228,7 @@ def test_add_backfill_id_column():
             assert len(instance.get_runs(filters=RunsFilter(exclude_subruns=True))) == 2
 
             instance.upgrade()
+            assert instance.run_storage.has_built_index(RUN_BACKFILL_ID)
 
             columns = get_sqlite3_columns(db_path, "runs")
             assert {

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -42,6 +42,7 @@ from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, Runs
 from dagster._core.storage.event_log.migration import migrate_event_log_data
 from dagster._core.storage.event_log.sql_event_log import SqlEventLogStorage
 from dagster._core.storage.migration.utils import upgrading_instance
+from dagster._core.storage.runs.migration import migrate_run_backfill_id
 from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import (
     BACKFILL_ID_TAG,
@@ -1224,6 +1225,10 @@ def test_add_backfill_id_column():
             )
 
             instance.upgrade()
+            # sqlite storage .from_local runs the migrations on instantiation. This means the data migration
+            # doesn't get run when we call instance.upgrade. So we manually run the migration here to test that
+            # it works
+            migrate_run_backfill_id(instance.run_storage)
 
             columns = get_sqlite3_columns(db_path, "runs")
             assert {

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1223,6 +1223,9 @@ def test_add_backfill_id_column():
                 )
             )
 
+            # exclude_subruns filter works before migration
+            assert len(instance.get_runs(filters=RunsFilter(exclude_subruns=True))) == 2
+
             instance.upgrade()
 
             columns = get_sqlite3_columns(db_path, "runs")
@@ -1270,6 +1273,9 @@ def test_add_backfill_id_column():
             assert backfill_ids[run_in_backfill_pre_migration.run_id] == "backfillid"
             assert backfill_ids[run_not_in_backfill_post_migration.run_id] is None
             assert backfill_ids[run_in_backfill_post_migration.run_id] == "backfillid"
+
+            # exclude_subruns filter works after migration, but should use new column
+            assert len(instance.get_runs(filters=RunsFilter(exclude_subruns=True))) == 3
 
             # test downgrade
             instance._run_storage._alembic_downgrade(rev="284a732df317")

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -42,7 +42,6 @@ from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, Runs
 from dagster._core.storage.event_log.migration import migrate_event_log_data
 from dagster._core.storage.event_log.sql_event_log import SqlEventLogStorage
 from dagster._core.storage.migration.utils import upgrading_instance
-from dagster._core.storage.runs.migration import migrate_run_backfill_id
 from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import (
     BACKFILL_ID_TAG,
@@ -1225,10 +1224,6 @@ def test_add_backfill_id_column():
             )
 
             instance.upgrade()
-            # TODO: sqlite storage .from_local runs the migrations on instantiation. This means the data migration
-            # doesn't get run when we call instance.upgrade. So we manually run the migration here to test that
-            # it works
-            migrate_run_backfill_id(instance.run_storage)
 
             columns = get_sqlite3_columns(db_path, "runs")
             assert {

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1225,7 +1225,7 @@ def test_add_backfill_id_column():
             )
 
             instance.upgrade()
-            # sqlite storage .from_local runs the migrations on instantiation. This means the data migration
+            # TODO: sqlite storage .from_local runs the migrations on instantiation. This means the data migration
             # doesn't get run when we call instance.upgrade. So we manually run the migration here to test that
             # it works
             migrate_run_backfill_id(instance.run_storage)

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1267,7 +1267,7 @@ def test_add_backfill_id_column():
                 )
             }
             assert backfill_ids[run_not_in_backfill_pre_migration.run_id] is None
-            assert backfill_ids[run_in_backfill_pre_migration.run_id] is None
+            assert backfill_ids[run_in_backfill_pre_migration.run_id] == "backfillid"
             assert backfill_ids[run_not_in_backfill_post_migration.run_id] is None
             assert backfill_ids[run_in_backfill_post_migration.run_id] == "backfillid"
 

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -549,7 +549,7 @@ def test_add_backfill_id_column(conn_string):
                 )
             }
             assert backfill_ids[run_not_in_backfill_pre_migration.run_id] is None
-            assert backfill_ids[run_in_backfill_pre_migration.run_id] is None
+            assert backfill_ids[run_in_backfill_pre_migration.run_id] == "backfillid"
             assert backfill_ids[run_not_in_backfill_post_migration.run_id] is None
             assert backfill_ids[run_in_backfill_post_migration.run_id] == "backfillid"
 

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -11,7 +11,7 @@ from dagster import AssetKey, AssetMaterialization, AssetObservation, Output, jo
 from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.instance import DagsterInstance
-from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
+from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster._core.storage.migration.bigint_migration import run_bigint_migration
 from dagster._core.storage.sqlalchemy_compat import db_select
@@ -522,6 +522,9 @@ def test_add_backfill_id_column(conn_string):
                 )
             )
 
+            # exclude_subruns filter works before migration
+            assert len(instance.get_runs(filters=RunsFilter(exclude_subruns=True))) == 2
+
             instance.upgrade()
             assert new_columns <= get_columns(instance, "runs")
 
@@ -552,6 +555,8 @@ def test_add_backfill_id_column(conn_string):
             assert backfill_ids[run_in_backfill_pre_migration.run_id] == "backfillid"
             assert backfill_ids[run_not_in_backfill_post_migration.run_id] is None
             assert backfill_ids[run_in_backfill_post_migration.run_id] == "backfillid"
+            # exclude_subruns filter works after migration, but should use new column
+            assert len(instance.get_runs(filters=RunsFilter(exclude_subruns=True))) == 3
 
 
 def test_add_runs_by_backfill_id_idx(conn_string):

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -14,6 +14,7 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster._core.storage.migration.bigint_migration import run_bigint_migration
+from dagster._core.storage.runs.migration import RUN_BACKFILL_ID
 from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import BACKFILL_ID_TAG
 from dagster._core.utils import make_new_run_id
@@ -526,6 +527,7 @@ def test_add_backfill_id_column(conn_string):
             assert len(instance.get_runs(filters=RunsFilter(exclude_subruns=True))) == 2
 
             instance.upgrade()
+            assert instance.run_storage.has_built_index(RUN_BACKFILL_ID)
             assert new_columns <= get_columns(instance, "runs")
 
             run_not_in_backfill_post_migration = instance.run_storage.add_run(

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -23,6 +23,7 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster._core.storage.migration.bigint_migration import run_bigint_migration
+from dagster._core.storage.runs.migration import RUN_BACKFILL_ID
 from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import BACKFILL_ID_TAG, PARTITION_NAME_TAG, PARTITION_SET_TAG
 from dagster._core.utils import make_new_run_id
@@ -942,6 +943,8 @@ def test_add_backfill_id_column(hostname, conn_string):
             assert len(instance.get_runs(filters=RunsFilter(exclude_subruns=True))) == 2
 
             instance.upgrade()
+            assert instance.run_storage.has_built_index(RUN_BACKFILL_ID)
+
             assert new_columns <= get_columns(instance, "runs")
             run_not_in_backfill_post_migration = instance.run_storage.add_run(
                 DagsterRun(

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -20,7 +20,7 @@ from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.execution.api import execute_job
 from dagster._core.instance import DagsterInstance
-from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus
+from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster._core.storage.migration.bigint_migration import run_bigint_migration
 from dagster._core.storage.sqlalchemy_compat import db_select
@@ -938,6 +938,9 @@ def test_add_backfill_id_column(hostname, conn_string):
                 )
             )
 
+            # exclude_subruns filter works before migration
+            assert len(instance.get_runs(filters=RunsFilter(exclude_subruns=True))) == 2
+
             instance.upgrade()
             assert new_columns <= get_columns(instance, "runs")
             run_not_in_backfill_post_migration = instance.run_storage.add_run(
@@ -967,6 +970,8 @@ def test_add_backfill_id_column(hostname, conn_string):
             assert backfill_ids[run_in_backfill_pre_migration.run_id] == "backfillid"
             assert backfill_ids[run_not_in_backfill_post_migration.run_id] is None
             assert backfill_ids[run_in_backfill_post_migration.run_id] == "backfillid"
+             # exclude_subruns filter works after migration, but should use new column
+            assert len(instance.get_runs(filters=RunsFilter(exclude_subruns=True))) == 3
 
 
 def test_add_runs_by_backfill_id_idx(hostname, conn_string):

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -964,7 +964,7 @@ def test_add_backfill_id_column(hostname, conn_string):
                 )
             }
             assert backfill_ids[run_not_in_backfill_pre_migration.run_id] is None
-            assert backfill_ids[run_in_backfill_pre_migration.run_id] is None
+            assert backfill_ids[run_in_backfill_pre_migration.run_id] == "backfillid"
             assert backfill_ids[run_not_in_backfill_post_migration.run_id] is None
             assert backfill_ids[run_in_backfill_post_migration.run_id] == "backfillid"
 

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -973,7 +973,7 @@ def test_add_backfill_id_column(hostname, conn_string):
             assert backfill_ids[run_in_backfill_pre_migration.run_id] == "backfillid"
             assert backfill_ids[run_not_in_backfill_post_migration.run_id] is None
             assert backfill_ids[run_in_backfill_post_migration.run_id] == "backfillid"
-             # exclude_subruns filter works after migration, but should use new column
+            # exclude_subruns filter works after migration, but should use new column
             assert len(instance.get_runs(filters=RunsFilter(exclude_subruns=True))) == 3
 
 


### PR DESCRIPTION
## Summary & Motivation
If the data migration to populate the `RunsTable.backfill_id` column has been run, we can use the column to power the `exclude_subruns` filter

## How I Tested These Changes
updated backcompat tests to show that querying runs with the `exclude_subruns` filter works before and after the migration. 

Also ran some perf tests locally against a DB with ~9 million runs and observed that the Runs Feed loads in about a second

## Changelog

Added a new column to the Runs table to improve performance of the Runs page. To take advantage of these performance improvements, run `dagster instance migrate`. This migration involves a schema migration to add the new column, and a data migration to populate the new column for historical runs.
