### PR TITLE
[helm] fix blockOpConcurrencyLimitedRuns

### DIFF
--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -23,6 +23,7 @@ from schema.charts.dagster.subschema.compute_log_manager import (
     S3ComputeLogManager as S3ComputeLogManagerModel,
 )
 from schema.charts.dagster.subschema.daemon import (
+    BlockOpConcurrencyLimitedRuns,
     ConfigurableClass,
     Daemon,
     QueuedRunCoordinatorConfig,
@@ -601,6 +602,10 @@ def test_queued_run_coordinator_config(
                         dequeueIntervalSeconds=dequeue_interval_seconds,
                         dequeueUseThreads=True,
                         dequeueNumWorkers=dequeue_num_workers,
+                        blockOpConcurrencyLimitedRuns=BlockOpConcurrencyLimitedRuns(
+                            enabled=True,
+                            opConcurrencySlotBuffer=0,
+                        ),
                     )
                 ),
             )
@@ -631,6 +636,14 @@ def test_queued_run_coordinator_config(
         assert run_coordinator_config["tag_concurrency_limits"] == [
             tag_concurrency_limit.dict() for tag_concurrency_limit in tag_concurrency_limits
         ]
+        assert run_coordinator_config["block_op_concurrency_limited_runs"]
+        assert run_coordinator_config["block_op_concurrency_limited_runs"]["enabled"] is True
+        assert (
+            run_coordinator_config["block_op_concurrency_limited_runs"][
+                "op_concurrency_slot_buffer"
+            ]
+            == 0
+        )
 
 
 def test_custom_run_coordinator_config(template: HelmTemplate):

--- a/helm/dagster/schema/setup.py
+++ b/helm/dagster/schema/setup.py
@@ -16,7 +16,10 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["schema_tests"]),
-    install_requires=["click", "pydantic>=1.10.0,<2.0.0"],
+    install_requires=[
+        "click",
+        "pydantic>=1.10.0,<2.0.0",
+    ],
     extras_require={
         "test": [
             # remove pin once minimum supported kubernetes version is 1.19

--- a/helm/dagster/templates/helpers/instance/_run-coordinator.tpl
+++ b/helm/dagster/templates/helpers/instance/_run-coordinator.tpl
@@ -23,6 +23,12 @@ config:
   {{- if $queuedRunCoordinatorConfig.dequeueNumWorkers }}
   dequeue_num_workers: {{ $queuedRunCoordinatorConfig.dequeueNumWorkers }}
   {{- end }}
+
+  {{- if $queuedRunCoordinatorConfig.blockOpConcurrencyLimitedRuns }}
+  block_op_concurrency_limited_runs:
+    enabled: {{ $queuedRunCoordinatorConfig.blockOpConcurrencyLimitedRuns.enabled }}
+    op_concurrency_slot_buffer: {{ $queuedRunCoordinatorConfig.blockOpConcurrencyLimitedRuns.opConcurrencySlotBuffer }}
+  {{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
we defined schema for it but did not thread it through the .tpl 

report from https://github.com/dagster-io/dagster/issues/15752

## How I Tested These Changes

added test

## Changelog

[helm] the blockOpConcurrencyLimitedRuns section of queuedRunCoordinator now correctly templates the appropriate config 
