### PR TITLE
Make 'multiple Definitions objects' error message more actionable

### DIFF
--- a/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
+++ b/python_modules/dagster/dagster/_core/workspace/autodiscovery.py
@@ -46,6 +46,10 @@ def loadable_targets_from_python_package(
     return loadable_targets_from_loaded_module(module)
 
 
+def _format_loadable_def(module: ModuleType, loadable_target: LoadableTarget) -> str:
+    return f"{module.__name__}.{loadable_target.attribute}"
+
+
 def loadable_targets_from_loaded_module(module: ModuleType) -> Sequence[LoadableTarget]:
     from dagster._core.definitions import JobDefinition
     from dagster._utils.test.definitions import LazyDefinitions
@@ -64,8 +68,12 @@ def loadable_targets_from_loaded_module(module: ModuleType) -> Sequence[Loadable
 
     if loadable_defs:
         if len(loadable_defs) > 1:
+            loadable_def_names = ", ".join(
+                _format_loadable_def(module, loadable_def) for loadable_def in loadable_defs
+            )
             raise DagsterInvariantViolationError(
-                "Cannot have more than one Definitions object defined at module scope"
+                "Cannot have more than one Definitions object defined at module scope."
+                f" Found Definitions objects: {loadable_def_names}"
             )
 
         return loadable_defs

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/autodiscover_in_module_multiple/__init__.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/autodiscover_in_module_multiple/__init__.py
@@ -1,0 +1,9 @@
+from dagster import Definitions
+
+from .defs1 import defs1  # noqa: TID252
+from .defs2 import defs2  # noqa: TID252
+
+defs = Definitions.merge(
+    defs1,
+    defs2,
+)

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/autodiscover_in_module_multiple/defs1.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/autodiscover_in_module_multiple/defs1.py
@@ -1,0 +1,3 @@
+from dagster import Definitions
+
+defs1 = Definitions()

--- a/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/autodiscover_in_module_multiple/defs2.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/workspace_tests/autodiscovery_tests/autodiscover_in_module_multiple/defs2.py
@@ -1,0 +1,3 @@
+from dagster import Definitions
+
+defs2 = Definitions()


### PR DESCRIPTION
## Summary

Ran into this with a user - the "Cannot have more than one Definitions object defined at module scope." error can be a bit of a rabbithole to track down. The case we hit in particular was
when one of the `Definitions` objects was being imported unknowingly.

This PR updates the error message to include the names of all the located `Definitions` objects, so it's easier to track down where they're coming from and rectify the error.

## How I Tested These Changes

Update unit tests.

## Changelog

> Errors raised from defining more than one `Definitions` object at module scope now include the object names so that the source is easier to determine.
