### PR TITLE
[dagster-powerbi] Detach spec loading, assets def building from Power BI resource

### DIFF
--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/__init__.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/__init__.py
@@ -1,9 +1,13 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
+from dagster_powerbi.assets import (
+    build_semantic_model_refresh_asset_definition as build_semantic_model_refresh_asset_definition,
+)
 from dagster_powerbi.resource import (
     PowerBIServicePrincipal as PowerBIServicePrincipal,
     PowerBIToken as PowerBIToken,
     PowerBIWorkspace as PowerBIWorkspace,
+    load_powerbi_asset_specs as load_powerbi_asset_specs,
 )
 from dagster_powerbi.translator import DagsterPowerBITranslator as DagsterPowerBITranslator
 

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/assets.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/assets.py
@@ -1,0 +1,31 @@
+from typing import cast
+
+from dagster import (
+    _check as check,
+    multi_asset,
+)
+from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.assets import AssetsDefinition
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+
+from dagster_powerbi.resource import PowerBIWorkspace
+from dagster_powerbi.translator import PowerBIMetadataSet, PowerBITagSet
+
+
+def build_semantic_model_refresh_asset_definition(
+    resource_key: str, spec: AssetSpec
+) -> AssetsDefinition:
+    """Builds an asset definition for refreshing a PowerBI semantic model."""
+    check.invariant(PowerBITagSet.extract(spec.tags).asset_type == "semantic_model")
+    dataset_id = check.not_none(PowerBIMetadataSet.extract(spec.metadata).id)
+
+    @multi_asset(
+        specs=[spec],
+        name="_".join(spec.key.path),
+        required_resource_keys={resource_key},
+    )
+    def asset_fn(context: AssetExecutionContext) -> None:
+        power_bi = cast(PowerBIWorkspace, getattr(context.resources, resource_key))
+        power_bi.trigger_and_poll_refresh(dataset_id)
+
+    return asset_fn

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/translator.py
@@ -105,6 +105,7 @@ class PowerBITagSet(NamespacedTagSet):
 
 class PowerBIMetadataSet(NamespacedMetadataSet):
     web_url: Optional[UrlMetadataValue] = None
+    id: Optional[str] = None
 
     @classmethod
     def namespace(cls) -> str:
@@ -192,7 +193,11 @@ class DagsterPowerBITranslator:
         return AssetSpec(
             key=self.get_semantic_model_asset_key(data),
             deps=source_keys,
-            metadata={**PowerBIMetadataSet(web_url=MetadataValue.url(url) if url else None)},
+            metadata={
+                **PowerBIMetadataSet(
+                    web_url=MetadataValue.url(url) if url else None, id=data.properties["id"]
+                )
+            },
             tags={**PowerBITagSet(asset_type="semantic_model")},
             kinds={"powerbi"},
         )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/repos/pending_repo.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/repos/pending_repo.py
@@ -3,13 +3,14 @@ import uuid
 from dagster import asset, define_asset_job
 from dagster._core.definitions.definitions_class import Definitions
 from dagster_powerbi import PowerBIToken, PowerBIWorkspace
+from dagster_powerbi.resource import load_powerbi_asset_specs
 
 fake_token = uuid.uuid4().hex
 resource = PowerBIWorkspace(
     credentials=PowerBIToken(api_token=fake_token),
     workspace_id="a2122b8f-d7e1-42e8-be2b-a5e636ca3221",
 )
-pbi_defs = resource.build_defs()
+pbi_specs = load_powerbi_asset_specs(resource)
 
 
 @asset
@@ -17,7 +18,6 @@ def my_materializable_asset():
     pass
 
 
-defs = Definitions.merge(
-    Definitions(assets=[my_materializable_asset], jobs=[define_asset_job("all_asset_job")]),
-    pbi_defs,
+defs = Definitions(
+    assets=[my_materializable_asset, *pbi_specs], jobs=[define_asset_job("all_asset_job")]
 )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -6,7 +6,7 @@ import responses
 from dagster import materialize
 from dagster._config.field_utils import EnvVar
 from dagster._core.code_pointer import CodePointer
-from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.decorators.asset_decorator import asset
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.reconstruct import (
@@ -15,13 +15,15 @@ from dagster._core.definitions.reconstruct import (
     initialize_repository_def_from_pointer,
 )
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
+from dagster._core.errors import DagsterInvalidDefinitionError
 from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.instance_for_test import instance_for_test
 from dagster._utils.env import environ
 from dagster._utils.test.definitions import lazy_definitions
 from dagster_powerbi import PowerBIWorkspace
-from dagster_powerbi.resource import BASE_API_URL, PowerBIToken
+from dagster_powerbi.assets import build_semantic_model_refresh_asset_definition
+from dagster_powerbi.resource import BASE_API_URL, PowerBIToken, load_powerbi_asset_specs
 
 from dagster_powerbi_tests.conftest import SAMPLE_SEMANTIC_MODEL
 
@@ -46,10 +48,10 @@ def test_translator_dashboard_spec(workspace_data_api_mocks: None, workspace_id:
         credentials=PowerBIToken(api_token=fake_token),
         workspace_id=workspace_id,
     )
-    all_assets = resource.build_defs().get_asset_graph().assets_defs
+    all_assets = load_powerbi_asset_specs(resource)
 
-    # 1 dashboard, 1 report, 1 semantic model, 2 data sources
-    assert len(all_assets) == 5
+    # 1 dashboard, 1 report, 1 semantic model
+    assert len(all_assets) == 3
 
     # Sanity check outputs, translator tests cover details here
     dashboard_asset = next(asset for asset in all_assets if asset.key.path[0] == "dashboard")
@@ -63,19 +65,6 @@ def test_translator_dashboard_spec(workspace_data_api_mocks: None, workspace_id:
     )
     assert semantic_model_asset.key.path == ["semantic_model", "Sales_Returns_Sample_v201912"]
 
-    data_source_assets = [
-        asset
-        for asset in all_assets
-        if asset.key.path[0] not in ("dashboard", "report", "semantic_model")
-    ]
-    assert len(data_source_assets) == 2
-
-    data_source_keys = {spec.key for spec in data_source_assets}
-    assert data_source_keys == {
-        AssetKey(["data_27_09_2019_xlsx"]),
-        AssetKey(["sales_marketing_datas_xlsx"]),
-    }
-
 
 @lazy_definitions
 def state_derived_defs_two_workspaces() -> Definitions:
@@ -87,9 +76,11 @@ def state_derived_defs_two_workspaces() -> Definitions:
         credentials=PowerBIToken(api_token=EnvVar("FAKE_API_TOKEN")),
         workspace_id="c5322b8a-d7e1-42e8-be2b-a5e636ca3221",
     )
-    return Definitions.merge(
-        resource.build_defs(),
-        resource_second_workspace.build_defs(),
+    return Definitions(
+        assets=[
+            *load_powerbi_asset_specs(resource),
+            *load_powerbi_asset_specs(resource_second_workspace),
+        ]
     )
 
 
@@ -118,18 +109,80 @@ def test_refreshable_semantic_model(
         workspace_id=workspace_id,
         refresh_poll_interval=0,
     )
-    all_assets = (
-        resource.build_defs(enable_refresh_semantic_models=True).get_asset_graph().assets_defs
-    )
+    all_specs = load_powerbi_asset_specs(resource)
 
-    # 1 dashboard, 1 report, 1 semantic model, 2 data sources
-    assert len(all_assets) == 5
+    assets_with_semantic_models = [
+        build_semantic_model_refresh_asset_definition(resource_key="powerbi", spec=spec)
+        if spec.tags.get("dagster-powerbi/asset_type") == "semantic_model"
+        else spec
+        for spec in all_specs
+    ]
+
+    # 1 dashboard, 1 report, 1 semantic model
+    assert len(assets_with_semantic_models) == 3
 
     semantic_model_asset = next(
-        asset for asset in all_assets if asset.key.path[0] == "semantic_model"
+        asset for asset in assets_with_semantic_models if asset.key.path[0] == "semantic_model"
     )
+
     assert semantic_model_asset.key.path == ["semantic_model", "Sales_Returns_Sample_v201912"]
-    assert semantic_model_asset.is_executable
+    assert isinstance(semantic_model_asset, AssetsDefinition) and semantic_model_asset.is_executable
+
+    # materialize the semantic model
+
+    workspace_data_api_mocks.add(
+        method=responses.POST,
+        url=f"{BASE_API_URL}/groups/{workspace_id}/datasets/{SAMPLE_SEMANTIC_MODEL['id']}/refreshes",
+        json={"notifyOption": "NoNotification"},
+        status=202,
+    )
+
+    workspace_data_api_mocks.add(
+        method=responses.GET,
+        url=f"{BASE_API_URL}/groups/{workspace_id}/datasets/{SAMPLE_SEMANTIC_MODEL['id']}/refreshes",
+        json={"value": [{"status": "Unknown"}]},
+        status=200,
+    )
+    workspace_data_api_mocks.add(
+        method=responses.GET,
+        url=f"{BASE_API_URL}/groups/{workspace_id}/datasets/{SAMPLE_SEMANTIC_MODEL['id']}/refreshes",
+        json={
+            "value": [{"status": "Completed" if success else "Failed", "serviceExceptionJson": {}}]
+        },
+        status=200,
+    )
+
+    # Missing resource
+    with pytest.raises(DagsterInvalidDefinitionError):
+        materialize([semantic_model_asset], raise_on_error=False)
+
+    result = materialize(
+        [semantic_model_asset], raise_on_error=False, resources={"powerbi": resource}
+    )
+    assert result.success is success
+
+
+@pytest.mark.parametrize("success", [True, False])
+def test_refreshable_semantic_model_legacy(
+    workspace_data_api_mocks: responses.RequestsMock, workspace_id: str, success: bool
+) -> None:
+    fake_token = uuid.uuid4().hex
+    resource = PowerBIWorkspace(
+        credentials=PowerBIToken(api_token=fake_token),
+        workspace_id=workspace_id,
+        refresh_poll_interval=0,
+    )
+
+    defs = resource.build_defs(enable_refresh_semantic_models=True)
+
+    semantic_model_asset = next(
+        asset
+        for asset in defs.get_asset_graph().assets_defs
+        if asset.is_executable and asset.key.path[0] == "semantic_model"
+    )
+
+    assert semantic_model_asset.key.path == ["semantic_model", "Sales_Returns_Sample_v201912"]
+    assert isinstance(semantic_model_asset, AssetsDefinition) and semantic_model_asset.is_executable
 
     # materialize the semantic model
 
@@ -166,14 +219,13 @@ def state_derived_defs() -> Definitions:
         credentials=PowerBIToken(api_token=fake_token),
         workspace_id="a2122b8f-d7e1-42e8-be2b-a5e636ca3221",
     )
-    pbi_defs = resource.build_defs()
+    powerbi_specs = load_powerbi_asset_specs(resource)
 
     @asset
     def my_materializable_asset(): ...
 
-    return Definitions.merge(
-        Definitions(assets=[my_materializable_asset], jobs=[define_asset_job("all_asset_job")]),
-        pbi_defs,
+    return Definitions(
+        assets=[my_materializable_asset, *powerbi_specs], jobs=[define_asset_job("all_asset_job")]
     )
 
 

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_translator.py
@@ -59,7 +59,8 @@ def test_translator_semantic_model(workspace_data: PowerBIWorkspaceData) -> None
     assert asset_spec.metadata == {
         "dagster-powerbi/web_url": MetadataValue.url(
             "https://app.powerbi.com/groups/a2122b8f-d7e1-42e8-be2b-a5e636ca3221/datasets/8e9c85a1-7b33-4223-9590-76bde70f9a20"
-        )
+        ),
+        "dagster-powerbi/id": "8e9c85a1-7b33-4223-9590-76bde70f9a20",
     }
     assert asset_spec.tags == {
         "dagster-powerbi/asset_type": "semantic_model",


### PR DESCRIPTION
## Summary

As part of migrating to the APIs mocked out in https://www.notion.so/dagster/Asset-integration-customization-options-11a18b92e462807c94c2f84675021120  and https://www.notion.so/dagster/Power-BI-semantic-model-API-options-11918b92e4628006a25af3f58a6b48d9, detaches the asset spec loading process from the Power BI resource, and
moves building asset definitions explicitly into user code.

```python
resource = PowerBIWorkspace(
    credentials=PowerBIToken(api_token=fake_token),
    workspace_id=workspace_id,
    refresh_poll_interval=0,
)
powerbi_specs = load_powerbi_asset_specs(resource, translator=MyPowerBITranslator)

powerbi_specs_and_defs = [
    build_semantic_model_refresh_asset_definition(resource_key="powerbi", spec=spec)
    if spec.tags.get("dagster-powerbi/asset_type") == "semantic_model"
    else spec
    for spec in powerbi_specs
]

defs = Definitions(assets=powerbi_specs_and_defs, resources={"powerbi": resource})
```

Alternatively, users can entirely customize execution:

```python
resource = PowerBIWorkspace(
    credentials=PowerBIToken(api_token=fake_token),
    workspace_id=workspace_id,
    refresh_poll_interval=0,
)
powerbi_specs = load_powerbi_asset_specs(resource, translator=MyPowerBITranslator)


def build_executable_semantic_model(
    resource_key: str, spec: AssetSpec
) -> AssetsDefinition:
    dataset_id = spec.metadata["dagster-powerbi/id"]
    @multi_asset(specs=[spec], name=spec.key.to_python_identifier())
    def rebuild_semantic_model(context: AssetExecutionContext, powerbi: PowerBIWorkspace) -> None:
        power_bi.trigger_and_poll_refresh(dataset_id)
        # Do some custom work after refreshing here

    return rebuild_semantic_model

powerbi_specs_and_defs = [
    build_executable_semantic_model(resource_key="powerbi", spec=spec)
    if spec.tags.get("dagster-powerbi/asset_type") == "semantic_model"
    else spec
    for spec in powerbi_specs
]

defs = Definitions(assets=powerbi_specs_and_defs, resources={"powerbi": resource})
```


## How I Tested These Changes

New unit test, updated existing unit tests.

