### PR TITLE
schema migration to add job_name to bulk actions table and backfill tags table

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/045_16e3655b4d9b045_add_bulk_actions_job_name_column_and_.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/045_16e3655b4d9b045_add_bulk_actions_job_name_column_and_.py
@@ -1,0 +1,57 @@
+"""add bulk_actions job_name column and backfill_tags table
+
+Revision ID: 16e3655b4d9b
+Revises: 63d7a8ec641a
+Create Date: 2024-10-23 13:13:13.390846
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import sqlite
+
+# revision identifiers, used by Alembic.
+revision = "16e3655b4d9b"
+down_revision = "63d7a8ec641a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    inspector = sa.inspect(op.get_bind())
+    has_tables = inspector.get_table_names()
+
+    if "bulk_actions" in has_tables:
+        columns = [x.get("name") for x in inspector.get_columns("bulk_actions")]
+        if "job_name" not in columns:
+            op.add_column("bulk_actions", sa.Column("job_name", sa.Text(), nullable=True))
+
+    if "backfill_tags" not in has_tables:
+        op.create_table(
+            "backfill_tags",
+            sa.Column(
+                "id",
+                sa.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"),
+                primary_key=True,
+                autoincrement=True,
+            ),
+            sa.Column("backfill_id", sa.String(length=255), nullable=True),
+            sa.Column("key", sa.Text(), nullable=True),
+            sa.Column("value", sa.Text(), nullable=True),
+            sa.Column("organization_id", sa.BigInteger(), nullable=False),
+            sa.Column("deployment_id", sa.BigInteger(), nullable=False),
+            sa.Column("bulk_actions_storage_id", sa.BigInteger(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+        )
+
+
+def downgrade():
+    inspector = sa.inspect(op.get_bind())
+    has_tables = inspector.get_table_names()
+    if "bulk_actions" in has_tables:
+        columns = [x.get("name") for x in inspector.get_columns("runs")]
+        if "job_name" in columns:
+            op.drop_column("bulk_actions", "job_name")
+
+    if "backfill_tags" in has_tables:
+        op.drop_table("backfill_tags")

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/046_16e3655b4d9b045_add_bulk_actions_job_name_column_and_tags_table.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/046_16e3655b4d9b045_add_bulk_actions_job_name_column_and_tags_table.py
@@ -44,7 +44,6 @@ def upgrade():
             ["bulk_actions_storage_id", "id"],
             unique=False,
             postgresql_concurrently=True,
-            mysql_length={"bulk_actions_storage_id": 255},
         )
 
 

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/046_16e3655b4d9b045_add_bulk_actions_job_name_column_and_tags_table.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/046_16e3655b4d9b045_add_bulk_actions_job_name_column_and_tags_table.py
@@ -38,6 +38,7 @@ def upgrade():
             sa.Column("backfill_id", sa.String(length=255), nullable=True),
             sa.Column("key", sa.Text(), nullable=True),
             sa.Column("value", sa.Text(), nullable=True),
+            sa.Column("bulk_actions_storage_id", sa.BigInteger(), nullable=True),
             sa.PrimaryKeyConstraint("id"),
         )
 

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/046_16e3655b4d9b045_add_bulk_actions_job_name_column_and_tags_table.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/046_16e3655b4d9b045_add_bulk_actions_job_name_column_and_tags_table.py
@@ -1,7 +1,7 @@
 """add bulk_actions job_name column and backfill_tags table
 
 Revision ID: 16e3655b4d9b
-Revises: 63d7a8ec641a
+Revises: 1aca709bba64
 Create Date: 2024-10-23 13:13:13.390846
 
 """
@@ -12,7 +12,7 @@ from sqlalchemy.dialects import sqlite
 
 # revision identifiers, used by Alembic.
 revision = "16e3655b4d9b"
-down_revision = "63d7a8ec641a"
+down_revision = "1aca709bba64"
 branch_labels = None
 depends_on = None
 

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/046_16e3655b4d9b045_add_bulk_actions_job_name_column_and_tags_table.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/046_16e3655b4d9b045_add_bulk_actions_job_name_column_and_tags_table.py
@@ -35,13 +35,12 @@ def upgrade():
             sa.Column("backfill_id", sa.String(length=255), nullable=True),
             sa.Column("key", sa.Text(), nullable=True),
             sa.Column("value", sa.Text(), nullable=True),
-            sa.Column("bulk_actions_storage_id", sa.BigInteger(), nullable=True),
             sa.PrimaryKeyConstraint("id"),
         )
         op.create_index(
-            "idx_backfill_tags_backfill_idx",
+            "idx_backfill_tags_backfill_id",
             "backfill_tags",
-            ["bulk_actions_storage_id", "id"],
+            ["backfill_id", "id"],
             unique=False,
             postgresql_concurrently=True,
         )
@@ -53,9 +52,9 @@ def downgrade():
             op.drop_column("bulk_actions", "job_name")
 
     if has_table("backfill_tags"):
-        if has_index("backfill_tags", "idx_backfill_tags_backfill_idx"):
+        if has_index("backfill_tags", "idx_backfill_tags_backfill_id"):
             op.drop_index(
-                "idx_backfill_tags_backfill_idx",
+                "idx_backfill_tags_backfill_id",
                 "backfill_tags",
                 postgresql_concurrently=True,
             )

--- a/python_modules/dagster/dagster/_core/storage/alembic/versions/046_16e3655b4d9b045_add_bulk_actions_job_name_column_and_tags_table.py
+++ b/python_modules/dagster/dagster/_core/storage/alembic/versions/046_16e3655b4d9b045_add_bulk_actions_job_name_column_and_tags_table.py
@@ -38,9 +38,6 @@ def upgrade():
             sa.Column("backfill_id", sa.String(length=255), nullable=True),
             sa.Column("key", sa.Text(), nullable=True),
             sa.Column("value", sa.Text(), nullable=True),
-            sa.Column("organization_id", sa.BigInteger(), nullable=False),
-            sa.Column("deployment_id", sa.BigInteger(), nullable=False),
-            sa.Column("bulk_actions_storage_id", sa.BigInteger(), nullable=True),
             sa.PrimaryKeyConstraint("id"),
         )
 
@@ -49,7 +46,7 @@ def downgrade():
     inspector = sa.inspect(op.get_bind())
     has_tables = inspector.get_table_names()
     if "bulk_actions" in has_tables:
-        columns = [x.get("name") for x in inspector.get_columns("runs")]
+        columns = [x.get("name") for x in inspector.get_columns("bulk_actions")]
         if "job_name" in columns:
             op.drop_column("bulk_actions", "job_name")
 

--- a/python_modules/dagster/dagster/_core/storage/runs/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/schema.py
@@ -203,3 +203,9 @@ db.Index(
         "backfill_id": 255,
     },
 )
+db.Index(
+    "idx_backfill_tags_backfill_idx",
+    BackfillTagsTable.c.bulk_actions_storage_id,
+    BackfillTagsTable.c.id,
+    mysql_length={"bulk_actions_storage_id": 255},
+)

--- a/python_modules/dagster/dagster/_core/storage/runs/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/schema.py
@@ -121,6 +121,22 @@ BulkActionsTable = db.Table(
     db.Column("body", db.Text),
     db.Column("action_type", db.String(32)),
     db.Column("selector_id", db.Text),
+    db.Column("job_name", db.Text, nullable=True),
+)
+
+BackfillTagsTable = db.Table(
+    "backfill_tags",
+    RunStorageSqlMetadata,
+    db.Column(
+        "id",
+        db.BigInteger().with_variant(sqlite.INTEGER(), "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    ),
+    db.Column("backfill_id", db.String(255)),
+    db.Column("key", db.Text),
+    db.Column("value", db.Text),
+    db.Column("bulk_actions_storage_id", db.BigInteger),
 )
 
 InstanceInfo = db.Table(

--- a/python_modules/dagster/dagster/_core/storage/runs/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/schema.py
@@ -207,5 +207,4 @@ db.Index(
     "idx_backfill_tags_backfill_idx",
     BackfillTagsTable.c.bulk_actions_storage_id,
     BackfillTagsTable.c.id,
-    mysql_length={"bulk_actions_storage_id": 255},
 )

--- a/python_modules/dagster/dagster/_core/storage/runs/schema.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/schema.py
@@ -136,7 +136,6 @@ BackfillTagsTable = db.Table(
     db.Column("backfill_id", db.String(255)),
     db.Column("key", db.Text),
     db.Column("value", db.Text),
-    db.Column("bulk_actions_storage_id", db.BigInteger),
 )
 
 InstanceInfo = db.Table(
@@ -204,7 +203,7 @@ db.Index(
     },
 )
 db.Index(
-    "idx_backfill_tags_backfill_idx",
-    BackfillTagsTable.c.bulk_actions_storage_id,
+    "idx_backfill_tags_backfill_id",
+    BackfillTagsTable.c.backfill_id,
     BackfillTagsTable.c.id,
 )

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -952,6 +952,7 @@ def test_add_bulk_actions_columns():
                 "body",
                 "action_type",
                 "selector_id",
+                "job_name",
             } == set(get_sqlite3_columns(db_path, "bulk_actions"))
             assert "idx_bulk_actions_action_type" in get_sqlite3_indexes(db_path, "bulk_actions")
             assert "idx_bulk_actions_selector_id" in get_sqlite3_indexes(db_path, "bulk_actions")

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1328,8 +1328,8 @@ def test_add_backfill_tags():
             assert "backfill_tags" in get_sqlite3_tables(db_path)
 
             # test downgrade
-            instance._run_storage._alembic_downgrade(rev="63d7a8ec641a")
-            assert get_current_alembic_version(db_path) == "63d7a8ec641a"
+            instance._run_storage._alembic_downgrade(rev="1aca709bba64")
+            assert get_current_alembic_version(db_path) == "1aca709bba64"
             assert "backfill_tags" not in get_sqlite3_tables(db_path)
 
 
@@ -1350,9 +1350,9 @@ def test_add_bulk_actions_job_name_column():
             assert "job_name" in backfill_columns
 
             # test downgrade
-            instance._run_storage._alembic_downgrade(rev="63d7a8ec641a")
+            instance._run_storage._alembic_downgrade(rev="1aca709bba64")
 
-            assert get_current_alembic_version(db_path) == "63d7a8ec641a"
+            assert get_current_alembic_version(db_path) == "1aca709bba64"
             backfill_columns = get_sqlite3_columns(db_path, "bulk_actions")
             assert "job_name" not in backfill_columns
 

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1330,7 +1330,7 @@ def test_add_backfill_tags():
             # test downgrade
             instance._run_storage._alembic_downgrade(rev="63d7a8ec641a")
             assert get_current_alembic_version(db_path) == "63d7a8ec641a"
-            assert "backfill_tags" in get_sqlite3_tables(db_path)
+            assert "backfill_tags" not in get_sqlite3_tables(db_path)
 
 
 def test_add_bulk_actions_job_name_column():

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1313,7 +1313,8 @@ def test_add_runs_by_backfill_id_idx():
             assert "idx_runs_by_backfill_id" not in get_sqlite3_indexes(db_path, "runs")
             instance.upgrade()
             assert "idx_runs_by_backfill_id" in get_sqlite3_indexes(db_path, "runs")
-            
+
+
 def test_add_backfill_tags():
     src_dir = file_relative_path(
         __file__, "snapshot_1_8_12_pre_add_backfill_id_column_to_runs_table/sqlite"

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -582,6 +582,7 @@ def test_add_runs_by_backfill_id_idx(conn_string):
             instance.upgrade()
             assert {"idx_runs_by_backfill_id"} <= get_indexes(instance, "runs")
 
+
 def test_add_backfill_tags(conn_string):
     hostname, port = _reconstruct_from_file(
         conn_string,

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -581,3 +581,49 @@ def test_add_runs_by_backfill_id_idx(conn_string):
             assert get_indexes(instance, "runs") & {"idx_runs_by_backfill_id"} == set()
             instance.upgrade()
             assert {"idx_runs_by_backfill_id"} <= get_indexes(instance, "runs")
+
+def test_add_backfill_tags(conn_string):
+    hostname, port = _reconstruct_from_file(
+        conn_string,
+        # use an old snapshot, it has the bulk actions table but not the new columns
+        file_relative_path(
+            __file__, "snapshot_1_8_12_pre_add_backfill_id_column_to_runs_table.sql"
+        ),
+    )
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        with open(
+            file_relative_path(__file__, "dagster.yaml"), "r", encoding="utf8"
+        ) as template_fd:
+            with open(os.path.join(tempdir, "dagster.yaml"), "w", encoding="utf8") as target_fd:
+                template = template_fd.read().format(hostname=hostname, port=port)
+                target_fd.write(template)
+
+        with DagsterInstance.from_config(tempdir) as instance:
+            assert "backfill_tags" not in get_tables(instance)
+
+            instance.upgrade()
+            assert "backfill_tags" in get_tables(instance)
+
+
+def test_add_bulk_actions_job_name_column(conn_string):
+    hostname, port = _reconstruct_from_file(
+        conn_string,
+        # use an old snapshot, it has the bulk actions table but not the new columns
+        file_relative_path(
+            __file__, "snapshot_1_8_12_pre_add_backfill_id_column_to_runs_table.sql"
+        ),
+    )
+    with tempfile.TemporaryDirectory() as tempdir:
+        with open(
+            file_relative_path(__file__, "dagster.yaml"), "r", encoding="utf8"
+        ) as template_fd:
+            with open(os.path.join(tempdir, "dagster.yaml"), "w", encoding="utf8") as target_fd:
+                template = template_fd.read().format(hostname=hostname, port=port)
+                target_fd.write(template)
+
+        with DagsterInstance.from_config(tempdir) as instance:
+            assert "job_name" not in get_columns(instance, "bulk_actions")
+
+            instance.upgrade()
+            assert "job_name" in get_columns(instance, "bulk_actions")

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -999,3 +999,54 @@ def test_add_runs_by_backfill_id_idx(hostname, conn_string):
             assert get_indexes(instance, "runs") & {"idx_runs_by_backfill_id"} == set()
             instance.upgrade()
             assert {"idx_runs_by_backfill_id"} <= get_indexes(instance, "runs")
+
+def test_add_backfill_tags(hostname, conn_string):
+    _reconstruct_from_file(
+        hostname,
+        conn_string,
+        file_relative_path(
+            __file__,
+            "snapshot_1_8_12_pre_add_backfill_id_column_to_runs_table/postgres/pg_dump.txt",
+        ),
+    )
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        with open(
+            file_relative_path(__file__, "dagster.yaml"), "r", encoding="utf8"
+        ) as template_fd:
+            with open(os.path.join(tempdir, "dagster.yaml"), "w", encoding="utf8") as target_fd:
+                template = template_fd.read().format(hostname=hostname)
+                target_fd.write(template)
+
+        with DagsterInstance.from_config(tempdir) as instance:
+            assert "backfill_tags" not in get_tables(instance)
+
+            instance.upgrade()
+            assert "backfill_tags" in get_tables(instance)
+
+
+def test_add_bulk_actions_job_name_column(hostname, conn_string):
+    _reconstruct_from_file(
+        hostname,
+        conn_string,
+        file_relative_path(
+            # use an old snapshot, it doesn't have the new column
+            __file__,
+            "snapshot_1_8_12_pre_add_backfill_id_column_to_runs_table/postgres/pg_dump.txt",
+        ),
+    )
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        with open(
+            file_relative_path(__file__, "dagster.yaml"), "r", encoding="utf8"
+        ) as template_fd:
+            with open(os.path.join(tempdir, "dagster.yaml"), "w", encoding="utf8") as target_fd:
+                template = template_fd.read().format(hostname=hostname)
+                target_fd.write(template)
+
+        with DagsterInstance.from_config(tempdir) as instance:
+            assert "job_name" not in get_columns(instance, "bulk_actions")
+
+            instance.upgrade()
+
+            assert "job_name" in get_columns(instance, "bulk_actions")

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -1000,6 +1000,7 @@ def test_add_runs_by_backfill_id_idx(hostname, conn_string):
             instance.upgrade()
             assert {"idx_runs_by_backfill_id"} <= get_indexes(instance, "runs")
 
+
 def test_add_backfill_tags(hostname, conn_string):
     _reconstruct_from_file(
         hostname,


### PR DESCRIPTION
## Summary & Motivation
This is the base of a stack to add two things to our storage - a `BackfillTags` table and a `job_name` column to the `BulkActions` table.

Adding `BackfillTags` allows us to do efficient tags filtering on backfills, which is a capability we introduced with the new Runs Page 

Adding `job_name` column allows us to do efficient job_name filtering on backfills, which is a capability we introduced with the new Runs Page. 

Previously, both of these kinds of filtering were done by filtering the RunsTable/RunTagsTable which made the queries more expensive

## How I Tested These Changes

