### PR TITLE
write bulk actions job name and tags if new column/table exists

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -1025,10 +1025,9 @@ class SqlRunStorage(RunStorage):
             values["job_name"] = partition_backfill.job_name
 
         with self.connect() as conn:
-            res = conn.execute(BulkActionsTable.insert().values(**values)).fetchone()
+            conn.execute(BulkActionsTable.insert().values(**values))
             if self.has_backfill_tags_table():
                 tags_to_insert = partition_backfill.tags
-                bulk_actions_storage_id = res[0]
                 if len(tags_to_insert.items()) > 0:
                     conn.execute(
                         BackfillTagsTable.insert(),
@@ -1037,7 +1036,6 @@ class SqlRunStorage(RunStorage):
                                 backfill_id=partition_backfill.backfill_id,
                                 key=k,
                                 value=v,
-                                bulk_actions_storage_id=bulk_actions_storage_id,
                             )
                             for k, v in tags_to_insert.items()
                         ],

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1360,7 +1360,7 @@ def test_add_backfill_tags():
             assert len(rows) == 1
             ids_to_tags = {row[0]: {row[1]: row[2]} for row in rows}
             assert ids_to_tags.get(before_migration.backfill_id) is None
-            assert ids_to_tags[after_migration.backfill_id] == {"after": "migration"}
+            assert ids_to_tags[after_migration.backfill_id] == after_migration.tags
 
             # test downgrade
             instance._run_storage._alembic_downgrade(rev="1aca709bba64")
@@ -1427,7 +1427,7 @@ def test_add_bulk_actions_job_name_column():
             assert len(rows) == 3  # a backfill exists in the db snapshot
             ids_to_job_name = {row[0]: row[1] for row in rows}
             assert ids_to_job_name[before_migration.backfill_id] is None
-            assert ids_to_job_name[after_migration.backfill_id] == "foo"
+            assert ids_to_job_name[after_migration.backfill_id] == after_migration.job_name
 
             # test downgrade
             instance._run_storage._alembic_downgrade(rev="1aca709bba64")

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -641,7 +641,7 @@ def test_add_backfill_tags(conn_string):
                 assert len(rows) == 1
                 ids_to_tags = {row[0]: {row[1]: row[2]} for row in rows}
                 assert ids_to_tags.get(before_migration.backfill_id) is None
-                assert ids_to_tags[after_migration.backfill_id] == {"after": "migration"}
+                assert ids_to_tags[after_migration.backfill_id] == after_migration.tags
 
 
 def test_add_bulk_actions_job_name_column(conn_string):
@@ -700,7 +700,7 @@ def test_add_bulk_actions_job_name_column(conn_string):
                 tags={},
                 backfill_timestamp=get_current_timestamp(),
             )
-            instance.add_backfill(before_migration)
+            instance.add_backfill(after_migration)
 
             with instance.run_storage.connect() as conn:
                 rows = conn.execute(
@@ -709,4 +709,4 @@ def test_add_bulk_actions_job_name_column(conn_string):
                 assert len(rows) == 2
                 ids_to_job_name = {row[0]: row[1] for row in rows}
                 assert ids_to_job_name[before_migration.backfill_id] is None
-                assert ids_to_job_name[after_migration.backfill_id] == "foo"
+                assert ids_to_job_name[after_migration.backfill_id] == after_migration.job_name

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -632,10 +632,12 @@ def test_add_backfill_tags(conn_string):
 
             with instance.run_storage.connect() as conn:
                 rows = conn.execute(
-                    db.select(
-                        BackfillTagsTable.c.backfill_id,
-                        BackfillTagsTable.c.key,
-                        BackfillTagsTable.c.value,
+                    db_select(
+                        [
+                            BackfillTagsTable.c.backfill_id,
+                            BackfillTagsTable.c.key,
+                            BackfillTagsTable.c.value,
+                        ]
                     )
                 ).fetchall()
                 assert len(rows) == 1
@@ -704,7 +706,7 @@ def test_add_bulk_actions_job_name_column(conn_string):
 
             with instance.run_storage.connect() as conn:
                 rows = conn.execute(
-                    db.select(BulkActionsTable.c.key, BulkActionsTable.c.job_name)
+                    db_select([BulkActionsTable.c.key, BulkActionsTable.c.job_name])
                 ).fetchall()
                 assert len(rows) == 2
                 ids_to_job_name = {row[0]: row[1] for row in rows}

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -10,7 +10,9 @@ import sqlalchemy as db
 from dagster import AssetKey, AssetMaterialization, AssetObservation, Output, job, op
 from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.errors import DagsterInvalidInvocationError
+from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.instance import DagsterInstance
+from dagster._core.remote_representation.external_data import partition_set_snap_name_for_job_name
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster._core.storage.migration.bigint_migration import run_bigint_migration
@@ -19,6 +21,7 @@ from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import BACKFILL_ID_TAG
 from dagster._core.utils import make_new_run_id
 from dagster._daemon.types import DaemonHeartbeat
+from dagster._time import get_current_timestamp
 from dagster._utils import file_relative_path
 
 
@@ -608,6 +611,13 @@ def test_add_backfill_tags(conn_string):
 
 
 def test_add_bulk_actions_job_name_column(conn_string):
+    from dagster._core.remote_representation.origin import (
+        GrpcServerCodeLocationOrigin,
+        RemotePartitionSetOrigin,
+        RemoteRepositoryOrigin,
+    )
+    from dagster._core.storage.runs.schema import BulkActionsTable
+
     hostname, port = _reconstruct_from_file(
         conn_string,
         # use an old snapshot, it has the bulk actions table but not the new columns
@@ -625,6 +635,44 @@ def test_add_bulk_actions_job_name_column(conn_string):
 
         with DagsterInstance.from_config(tempdir) as instance:
             assert "job_name" not in get_columns(instance, "bulk_actions")
+            partition_set_origin = RemotePartitionSetOrigin(
+                repository_origin=RemoteRepositoryOrigin(
+                    code_location_origin=GrpcServerCodeLocationOrigin(
+                        host="localhost", port=1234, location_name="test_location"
+                    ),
+                    repository_name="the_repo",
+                ),
+                partition_set_name=partition_set_snap_name_for_job_name("foo"),
+            )
+            before_migration = PartitionBackfill(
+                "before_migration",
+                partition_set_origin=partition_set_origin,
+                status=BulkActionStatus.REQUESTED,
+                from_failure=False,
+                tags={},
+                backfill_timestamp=get_current_timestamp(),
+            )
+            instance.add_backfill(before_migration)
 
             instance.upgrade()
+
             assert "job_name" in get_columns(instance, "bulk_actions")
+
+            after_migration = PartitionBackfill(
+                "after_migration",
+                partition_set_origin=partition_set_origin,
+                status=BulkActionStatus.REQUESTED,
+                from_failure=False,
+                tags={},
+                backfill_timestamp=get_current_timestamp(),
+            )
+            instance.add_backfill(before_migration)
+
+            with instance.run_storage.connect() as conn:
+                rows = conn.execute(
+                    db.select(BulkActionsTable.c.key, BulkActionsTable.c.job_name)
+                ).fetchall()
+                assert len(rows) == 2
+                ids_to_job_name = {row[0]: row[1] for row in rows}
+                assert ids_to_job_name[before_migration.key] is None
+                assert ids_to_job_name[after_migration.key] == "foo"

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -1005,6 +1005,8 @@ def test_add_runs_by_backfill_id_idx(hostname, conn_string):
 
 
 def test_add_backfill_tags(hostname, conn_string):
+    from dagster._core.storage.runs.schema import BackfillTagsTable
+
     _reconstruct_from_file(
         hostname,
         conn_string,
@@ -1023,15 +1025,41 @@ def test_add_backfill_tags(hostname, conn_string):
                 target_fd.write(template)
 
         with DagsterInstance.from_config(tempdir) as instance:
-            instance.add_backfill(
-                PartitionBackfill(
-                    backfill_id="backfillid",
-                )
+            before_migration = PartitionBackfill(
+                "before_tag_migration",
+                serialized_asset_backfill_data="foo",
+                status=BulkActionStatus.REQUESTED,
+                from_failure=False,
+                tags={"before": "migration"},
+                backfill_timestamp=get_current_timestamp(),
             )
+            instance.add_backfill(before_migration)
             assert "backfill_tags" not in get_tables(instance)
 
             instance.upgrade()
             assert "backfill_tags" in get_tables(instance)
+            after_migration = PartitionBackfill(
+                "after_tag_migration",
+                serialized_asset_backfill_data="foo",
+                status=BulkActionStatus.REQUESTED,
+                from_failure=False,
+                tags={"after": "migration"},
+                backfill_timestamp=get_current_timestamp(),
+            )
+            instance.add_backfill(after_migration)
+
+            with instance.run_storage.connect() as conn:
+                rows = conn.execute(
+                    db.select(
+                        BackfillTagsTable.c.backfill_id,
+                        BackfillTagsTable.c.key,
+                        BackfillTagsTable.c.value,
+                    )
+                ).fetchall()
+                assert len(rows) == 1
+                ids_to_tags = {row[0]: {row[1]: row[2]} for row in rows}
+                assert ids_to_tags.get(before_migration.backfill_id) is None
+                assert ids_to_tags[after_migration.backfill_id] == {"after": "migration"}
 
 
 def test_add_bulk_actions_job_name_column(hostname, conn_string):

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -1059,7 +1059,7 @@ def test_add_backfill_tags(hostname, conn_string):
                 assert len(rows) == 1
                 ids_to_tags = {row[0]: {row[1]: row[2]} for row in rows}
                 assert ids_to_tags.get(before_migration.backfill_id) is None
-                assert ids_to_tags[after_migration.backfill_id] == {"after": "migration"}
+                assert ids_to_tags[after_migration.backfill_id] == after_migration.tags
 
 
 def test_add_bulk_actions_job_name_column(hostname, conn_string):
@@ -1121,7 +1121,7 @@ def test_add_bulk_actions_job_name_column(hostname, conn_string):
                 tags={},
                 backfill_timestamp=get_current_timestamp(),
             )
-            instance.add_backfill(before_migration)
+            instance.add_backfill(after_migration)
 
             with instance.run_storage.connect() as conn:
                 rows = conn.execute(
@@ -1129,5 +1129,5 @@ def test_add_bulk_actions_job_name_column(hostname, conn_string):
                 ).fetchall()
                 assert len(rows) == 2
                 ids_to_job_name = {row[0]: row[1] for row in rows}
-                assert ids_to_job_name[before_migration.key] is None
-                assert ids_to_job_name[after_migration.key] == "foo"
+                assert ids_to_job_name[before_migration.backfill_id] is None
+                assert ids_to_job_name[after_migration.backfill_id] == after_migration.job_name

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -1050,10 +1050,12 @@ def test_add_backfill_tags(hostname, conn_string):
 
             with instance.run_storage.connect() as conn:
                 rows = conn.execute(
-                    db.select(
-                        BackfillTagsTable.c.backfill_id,
-                        BackfillTagsTable.c.key,
-                        BackfillTagsTable.c.value,
+                    db_select(
+                        [
+                            BackfillTagsTable.c.backfill_id,
+                            BackfillTagsTable.c.key,
+                            BackfillTagsTable.c.value,
+                        ]
                     )
                 ).fetchall()
                 assert len(rows) == 1
@@ -1125,7 +1127,7 @@ def test_add_bulk_actions_job_name_column(hostname, conn_string):
 
             with instance.run_storage.connect() as conn:
                 rows = conn.execute(
-                    db.select(BulkActionsTable.c.key, BulkActionsTable.c.job_name)
+                    db_select([BulkActionsTable.c.key, BulkActionsTable.c.job_name])
                 ).fetchall()
                 assert len(rows) == 2
                 ids_to_job_name = {row[0]: row[1] for row in rows}

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -19,7 +19,9 @@ from dagster import (
 from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.execution.api import execute_job
+from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
 from dagster._core.instance import DagsterInstance
+from dagster._core.remote_representation.external_data import partition_set_snap_name_for_job_name
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster._core.storage.migration.bigint_migration import run_bigint_migration
@@ -28,6 +30,7 @@ from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import BACKFILL_ID_TAG, PARTITION_NAME_TAG, PARTITION_SET_TAG
 from dagster._core.utils import make_new_run_id
 from dagster._daemon.types import DaemonHeartbeat
+from dagster._time import get_current_timestamp
 from dagster._utils import file_relative_path
 from sqlalchemy import inspect
 
@@ -1020,6 +1023,11 @@ def test_add_backfill_tags(hostname, conn_string):
                 target_fd.write(template)
 
         with DagsterInstance.from_config(tempdir) as instance:
+            instance.add_backfill(
+                PartitionBackfill(
+                    backfill_id="backfillid",
+                )
+            )
             assert "backfill_tags" not in get_tables(instance)
 
             instance.upgrade()
@@ -1027,6 +1035,13 @@ def test_add_backfill_tags(hostname, conn_string):
 
 
 def test_add_bulk_actions_job_name_column(hostname, conn_string):
+    from dagster._core.remote_representation.origin import (
+        GrpcServerCodeLocationOrigin,
+        RemotePartitionSetOrigin,
+        RemoteRepositoryOrigin,
+    )
+    from dagster._core.storage.runs.schema import BulkActionsTable
+
     _reconstruct_from_file(
         hostname,
         conn_string,
@@ -1047,7 +1062,44 @@ def test_add_bulk_actions_job_name_column(hostname, conn_string):
 
         with DagsterInstance.from_config(tempdir) as instance:
             assert "job_name" not in get_columns(instance, "bulk_actions")
+            partition_set_origin = RemotePartitionSetOrigin(
+                repository_origin=RemoteRepositoryOrigin(
+                    code_location_origin=GrpcServerCodeLocationOrigin(
+                        host="localhost", port=1234, location_name="test_location"
+                    ),
+                    repository_name="the_repo",
+                ),
+                partition_set_name=partition_set_snap_name_for_job_name("foo"),
+            )
+            before_migration = PartitionBackfill(
+                "before_migration",
+                partition_set_origin=partition_set_origin,
+                status=BulkActionStatus.REQUESTED,
+                from_failure=False,
+                tags={},
+                backfill_timestamp=get_current_timestamp(),
+            )
+            instance.add_backfill(before_migration)
 
             instance.upgrade()
 
             assert "job_name" in get_columns(instance, "bulk_actions")
+
+            after_migration = PartitionBackfill(
+                "after_migration",
+                partition_set_origin=partition_set_origin,
+                status=BulkActionStatus.REQUESTED,
+                from_failure=False,
+                tags={},
+                backfill_timestamp=get_current_timestamp(),
+            )
+            instance.add_backfill(before_migration)
+
+            with instance.run_storage.connect() as conn:
+                rows = conn.execute(
+                    db.select(BulkActionsTable.c.key, BulkActionsTable.c.job_name)
+                ).fetchall()
+                assert len(rows) == 2
+                ids_to_job_name = {row[0]: row[1] for row in rows}
+                assert ids_to_job_name[before_migration.key] is None
+                assert ids_to_job_name[after_migration.key] == "foo"


### PR DESCRIPTION
## Summary & Motivation
See https://github.com/dagster-io/dagster/pull/25460 for additional context 

updates storage to write to the new backfill_tags and job_name table/column if they are present

## How I Tested These Changes

