### PR TITLE
AssetKey as deps backcompat

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/asset_decorator.py
@@ -65,7 +65,7 @@ from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariant
 from dagster._core.storage.tags import KIND_PREFIX
 from dagster._core.types.dagster_type import DagsterType
 from dagster._utils.tags import normalize_tags
-from dagster._utils.warnings import disable_dagster_warnings
+from dagster._utils.warnings import deprecation_warning, disable_dagster_warnings
 
 
 @overload
@@ -1142,6 +1142,15 @@ def _deps_and_non_argument_deps_to_asset_deps(
 def make_asset_deps(deps: Optional[Iterable[CoercibleToAssetDep]]) -> Optional[Iterable[AssetDep]]:
     if deps is None:
         return None
+
+    # when AssetKey was a plain NamedTuple, it also happened to be Iterable[CoercibleToAssetKey]
+    # so continue to support it here
+    if isinstance(deps, AssetKey):
+        deprecation_warning(
+            subject="Passing a single AssetKey to deps",
+            breaking_version="1.10.0",
+        )
+        deps = [deps]
 
     # expand any multi_assets into a list of keys
     all_deps = []

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2423,3 +2423,10 @@ def test_index_in_to_key() -> None:
         "Use asset_key.path instead to access the list of key components.",
     ):
         key[0][0]  # type: ignore # good job type checker
+
+
+def test_asset_dep_backcompat() -> None:
+    # AssetKey used to be an iterable tuple, which unintentionally made this work so continue supporting it
+
+    @asset(deps=AssetKey("oops"))  # type: ignore # good job type checker
+    def _(): ...


### PR DESCRIPTION
Missed in https://github.com/dagster-io/dagster/pull/25240, we are now failing when an `AssetKey` is passed to `deps`. This used to work since you could iterate over it and get back just the `path` which is coerces back to the same `AssetKey`. 

Our callsites which exhibit this problem here https://github.com/dagster-io/dagster/pull/25462/files

## How I Tested These Changes

added test