### PR TITLE
[AssetKey] hide __iter__ and __getitem__ from type checker

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_key.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_key.py
@@ -159,18 +159,20 @@ class AssetKey(IHaveNew):
         prefix = key_prefix_from_coercible(prefix)
         return AssetKey(list(prefix) + list(self.path))
 
-    def __iter__(self):
-        raise DagsterInvariantViolationError(
-            "You have attempted to iterate a single AssetKey object. "
-            "As of 1.9, this behavior is disallowed because it is likely unintentional and a bug."
-        )
+    if not TYPE_CHECKING:
+        # hide these from type checker so it doesn't believe AssetKey is iterable/indexable
+        def __iter__(self):
+            raise DagsterInvariantViolationError(
+                "You have attempted to iterate a single AssetKey object. "
+                "As of 1.9, this behavior is disallowed because it is likely unintentional and a bug."
+            )
 
-    def __getitem__(self, _):
-        raise DagsterInvariantViolationError(
-            "You have attempted to index directly in to the AssetKey object. "
-            "As of 1.9, this behavior is disallowed because it is likely unintentional and a bug. "
-            "Use asset_key.path instead to access the list of key components."
-        )
+        def __getitem__(self, _):
+            raise DagsterInvariantViolationError(
+                "You have attempted to index directly in to the AssetKey object. "
+                "As of 1.9, this behavior is disallowed because it is likely unintentional and a bug. "
+                "Use asset_key.path instead to access the list of key components."
+            )
 
 
 CoercibleToAssetKey = Union[AssetKey, str, Sequence[str]]

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -2404,17 +2404,17 @@ def test_multiple_keys_per_output_name():
         )
 
 
-def test_iterate_over_single_key():
+def test_iterate_over_single_key() -> None:
     key = AssetKey("ouch")
     with pytest.raises(
         DagsterInvariantViolationError,
         match="You have attempted to iterate a single AssetKey object. "
         "As of 1.9, this behavior is disallowed because it is likely unintentional and a bug.",
     ):
-        [_ for _ in key]
+        [_ for _ in key]  # type: ignore # good job type checker
 
 
-def test_index_in_to_key():
+def test_index_in_to_key() -> None:
     key = AssetKey("ouch")
     with pytest.raises(
         DagsterInvariantViolationError,
@@ -2422,4 +2422,4 @@ def test_index_in_to_key():
         "As of 1.9, this behavior is disallowed because it is likely unintentional and a bug. "
         "Use asset_key.path instead to access the list of key components.",
     ):
-        key[0][0]
+        key[0][0]  # type: ignore # good job type checker


### PR DESCRIPTION
having these overridden to throw better messages leads the type checker to think it is iterable/indexable so hide it

## How I Tested These Changes

updated tests