### PR TITLE
feat: use has_metrics_tag and time expiration to inform ui on metrics availability

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_runs.py
@@ -1003,19 +1003,30 @@ def test_run_has_concurrency_slots():
 @pytest.mark.parametrize(
     "run_tag, run_tag_value, run_metrics_enabled, failure_message",
     [
-        (None, None, False, "run_metrics tag not present should result to false"),
-        (".dagster/run_metrics", "true", True, "run_metrics tag set to true should result to true"),
+        (None, None, False, "has_run_metrics tag not present should result to false"),
         (
-            ".dagster/run_metrics",
+            ".dagster/has_run_metrics",
+            "true",
+            True,
+            "has_run_metrics tag set to true should result to true",
+        ),
+        (
+            ".dagster/has_run_metrics",
             "false",
             False,
             "run_metrics tag set to falsy value should result to false",
         ),
         (
+            ".dagster/run_metrics",
+            "true",
+            True,
+            "hidden run_metrics tag set to true should result to true",
+        ),
+        (
             "dagster/run_metrics",
             "true",
             True,
-            "public run_metrics tag set to true should result to true",
+            "system run_metrics tag set to true should result to true",
         ),
     ],
 )

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -98,6 +98,8 @@ RUN_METRIC_TAGS = [
     f"{SYSTEM_TAG_PREFIX}run_metrics",
 ]
 
+HAS_RUN_METRICS_TAG = f"{HIDDEN_TAG_PREFIX}has_run_metrics"
+
 RUN_METRICS_POLLING_INTERVAL_TAG = f"{HIDDEN_TAG_PREFIX}run_metrics_polling_interval"
 RUN_METRICS_PYTHON_RUNTIME_TAG = f"{HIDDEN_TAG_PREFIX}python_runtime_metrics"
 


### PR DESCRIPTION
## Summary & Motivation

Change the conditions driving whether to show the _View container metrics_ drop down menu item.

1. Start using `.dagster/has_run_metrics` tag, with the goal of deprecating the other tags for this use.
2. Disable it when a run is more than 14 days old (retention limit)


## How I Tested These Changes

- BK

## Changelog

> NOCHANGELOG