### PR TITLE
Skip all but default python version on docs_snippets, automation tests

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/python_version.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/python_version.py
@@ -21,6 +21,12 @@ class AvailablePythonVersion(str, Enum):
     def get_default(cls) -> "AvailablePythonVersion":
         return cls["V3_11"]
 
+    # Useful for providing to `PackageSpec.unsupported_python_versions` when you only want to test
+    # the default version.
+    @classmethod
+    def get_all_except_default(cls) -> List["AvailablePythonVersion"]:
+        return [v for v in cls.get_all() if v != cls.get_default()]
+
     @classmethod
     def get_pytest_defaults(cls) -> List["AvailablePythonVersion"]:
         branch_name = safe_getenv("BUILDKITE_BRANCH")

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -288,15 +288,19 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     PackageSpec(
         "examples/docs_snippets",
         pytest_extra_cmds=docs_snippets_extra_cmds,
-        unsupported_python_versions=[
-            # dependency on 3.9-incompatible extension libs
-            AvailablePythonVersion.V3_9,
-            # dagster-airflow dep
-            AvailablePythonVersion.V3_12,
-        ],
+        # The docs_snippets test suite also installs a ton of packages in the same environment,
+        # which is liable to cause dependency collisions. It's not necessary to test all these
+        # snippets in all python versions since we are testing the core code exercised by the
+        # snippets against all supported python versions.
+        unsupported_python_versions=AvailablePythonVersion.get_all_except_default(),
     ),
     PackageSpec(
         "examples/docs_beta_snippets",
+        # The docs_snippets test suite also installs a ton of packages in the same environment,
+        # which is liable to cause dependency collisions. It's not necessary to test all these
+        # snippets in all python versions since we are testing the core code exercised by the
+        # snippets against all supported python versions.
+        unsupported_python_versions=AvailablePythonVersion.get_all_except_default(),
         pytest_tox_factors=["all", "integrations"],
     ),
     PackageSpec(
@@ -418,7 +422,10 @@ def tox_factors_for_folder(tests_folder_name: str) -> List[str]:
 LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     PackageSpec(
         "python_modules/automation",
-        unsupported_python_versions=[AvailablePythonVersion.V3_12],
+        # automation is internal code that doesn't need to be tested in every python version. The
+        # test suite also installs a ton of packages in the same environment, which is liable to
+        # cause dependency collisions.
+        unsupported_python_versions=AvailablePythonVersion.get_all_except_default(),
     ),
     PackageSpec("python_modules/dagster-webserver", pytest_extra_cmds=ui_extra_cmds),
     PackageSpec(


### PR DESCRIPTION
## Summary & Motivation

The `docs_snippets`, `docs_snippets_beta`, and `automation` packages all install large numbers of dagster packages in the same environment. This can sometimes cause second-order dependency collisions, particularly in older python versions. We reduce the likelihood of this occurring by only testing these packages against the default python version.

- In the case of `automation`, this is not a problem because `automation` code only runs internally.
- For `docs_snippets` and `docs_snippets_beta`, the loss in coverage is minimal since all the dagster code actually targeted by our snippets is tested on all (compatible) versions.

## How I Tested These Changes

Existing test suite, with `test-all` to make sure the full suite (all specified versions) are tested in the branch build.