### PR TITLE
[embedded-elt] rm deprecated dlt_dagster_translator param

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/asset_decorator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/dlt/asset_decorator.py
@@ -7,7 +7,6 @@ from dagster import (
     _check as check,
     multi_asset,
 )
-from dagster._annotations import deprecated_param
 from dlt.extract.source import DltSource
 from dlt.pipeline.pipeline import Pipeline
 
@@ -60,18 +59,12 @@ def build_dlt_asset_specs(
     ]
 
 
-@deprecated_param(
-    param="dlt_dagster_translator",
-    breaking_version="1.9",
-    additional_warn_text="Use `dagster_dlt_translator` instead.",
-)
 def dlt_assets(
     *,
     dlt_source: DltSource,
     dlt_pipeline: Pipeline,
     name: Optional[str] = None,
     group_name: Optional[str] = None,
-    dlt_dagster_translator: Optional[DagsterDltTranslator] = None,
     dagster_dlt_translator: Optional[DagsterDltTranslator] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
@@ -82,7 +75,7 @@ def dlt_assets(
         dlt_pipeline (Pipeline): The dlt Pipeline defining the destination parameters.
         name (Optional[str], optional): The name of the op.
         group_name (Optional[str], optional): The name of the asset group.
-        dlt_dagster_translator (DltDagsterTranslator, optional): Customization object for defining asset parameters from dlt resources.
+        dagster_dlt_translator (DltDagsterTranslator, optional): Customization object for defining asset parameters from dlt resources.
 
     Examples:
         Loading Hubspot data to Snowflake with an auto materialize policy using the dlt verified source:
@@ -107,7 +100,7 @@ def dlt_assets(
                 ),
                 name="hubspot",
                 group_name="hubspot",
-                dlt_dagster_translator=HubspotDltDagsterTranslator(),
+                dagster_dlt_translator=HubspotDltDagsterTranslator(),
             )
             def hubspot_assets(context: AssetExecutionContext, dlt: DltDagsterResource):
                 yield from dlt.run(context=context)
@@ -134,7 +127,7 @@ def dlt_assets(
 
     """
     dagster_dlt_translator = check.inst_param(
-        dagster_dlt_translator or dlt_dagster_translator or DagsterDltTranslator(),
+        dagster_dlt_translator or DagsterDltTranslator(),
         "dagster_dlt_translator",
         DagsterDltTranslator,
     )


### PR DESCRIPTION
## Summary & Motivation

- `dlt_dagster_translator` has been replaced by `dagster_dlt_translator` for standard naming convention

## How I Tested These Changes

## Changelog

[embedded-elt] removes deprecated parameter `dlt_dagster_translator`
