### PR TITLE
Skip "definitions loaded with errors" toast on first loaded render

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/nav/useCodeLocationsStatus.tsx
@@ -79,9 +79,16 @@ export const useCodeLocationsStatus = (): StatusAndMessage | null => {
     erroredLocationEntries = previousErroredLocationEntries.current;
   }
 
+  const isFirstLoadedRender = useRef(true);
+
   // Reload the workspace, and show a success or error toast upon completion.
   useLayoutEffect(() => {
     if (loading) {
+      return;
+    }
+
+    if (isFirstLoadedRender.current) {
+      isFirstLoadedRender.current = false;
       return;
     }
 


### PR DESCRIPTION
## Summary & Motivation
As titled


## How I Tested These Changes

Connected to dogfood-test-1 with app-proxy and saw that the toast did not appear.

Clicked re-deploy and saw that it did show up after it failed:
<img width="1104" alt="Screenshot 2024-10-23 at 4 59 26 PM" src="https://github.com/user-attachments/assets/e2f7f2c8-1cf9-4ac6-ae08-77599c32785e">
