### PR TITLE
[1.9] Update asset_selection paramter of AutomationConditionSensorDefinition to `target`

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/repo.py
@@ -1249,7 +1249,7 @@ def define_sensors():
 
     auto_materialize_sensor = AutomationConditionSensorDefinition(
         "my_auto_materialize_sensor",
-        asset_selection=AssetSelection.assets(
+        target=AssetSelection.assets(
             "fresh_diamond_bottom",
             "asset_with_automation_condition",
             "asset_with_custom_automation_condition",

--- a/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/automation_condition_sensor_definition.py
@@ -81,8 +81,8 @@ class AutomationConditionSensorDefinition(SensorDefinition):
 
     Args:
         name: The name of the sensor.
-        asset_selection (Union[str, Sequence[str], Sequence[AssetKey], Sequence[Union[AssetsDefinition, SourceAsset]], AssetSelection]):
-            The assets to evaluate AutomationConditions of and request runs for.
+        target (Union[str, Sequence[str], Sequence[AssetKey], Sequence[Union[AssetsDefinition, SourceAsset]], AssetSelection]):
+            A selection of assets to evaluate AutomationConditions of and request runs for.
         tags (Optional[Mapping[str, str]]): A set of key-value tags that annotate the sensor and can
             be used for searching and filtering in the UI.
         run_tags (Optional[Mapping[str, Any]]): Tags that will be automatically attached to runs launched by this sensor.
@@ -110,7 +110,7 @@ class AutomationConditionSensorDefinition(SensorDefinition):
         self,
         name: str,
         *,
-        asset_selection: CoercibleToAssetSelection,
+        target: CoercibleToAssetSelection,
         tags: Optional[Mapping[str, str]] = None,
         run_tags: Optional[Mapping[str, Any]] = None,
         default_status: DefaultSensorStatus = DefaultSensorStatus.STOPPED,
@@ -149,7 +149,7 @@ class AutomationConditionSensorDefinition(SensorDefinition):
             jobs=None,
             default_status=default_status,
             required_resource_keys=None,
-            asset_selection=asset_selection,
+            asset_selection=target,
             tags=tags,
             metadata=metadata,
         )

--- a/python_modules/dagster/dagster/_core/definitions/utils.py
+++ b/python_modules/dagster/dagster/_core/definitions/utils.py
@@ -343,7 +343,7 @@ def add_default_automation_condition_sensor(
         sensor_selection = get_default_automation_condition_sensor_selection(sensors, asset_graph)
         if sensor_selection:
             default_sensor = AutomationConditionSensorDefinition(
-                DEFAULT_AUTOMATION_CONDITION_SENSOR_NAME, asset_selection=sensor_selection
+                DEFAULT_AUTOMATION_CONDITION_SENSOR_NAME, target=sensor_selection
             )
             sensors = [*sensors, default_sensor]
 

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -792,7 +792,7 @@ def auto_materialize_asset():
 
 auto_materialize_sensor = AutomationConditionSensorDefinition(
     "my_auto_materialize_sensor",
-    asset_selection=[auto_materialize_asset],
+    target=[auto_materialize_asset],
 )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -173,7 +173,7 @@ def test_opt_out_default_auto_materialize_sensors(instance_without_auto_material
 def test_combine_default_sensors_with_non_default_sensors(instance_with_auto_materialize_sensors):
     auto_materialize_sensor = AutomationConditionSensorDefinition(
         "my_custom_policy_sensor",
-        asset_selection=[auto_materialize_asset, auto_observe_asset],
+        target=[auto_materialize_asset, auto_observe_asset],
     )
 
     defs_with_auto_materialize_sensor = Definitions(
@@ -237,7 +237,7 @@ def test_combine_default_sensors_with_non_default_sensors(instance_with_auto_mat
 def test_custom_sensors_cover_all(instance_with_auto_materialize_sensors):
     auto_materialize_sensor = AutomationConditionSensorDefinition(
         "my_custom_policy_sensor",
-        asset_selection=[
+        target=[
             auto_materialize_asset,
             auto_observe_asset,
             other_auto_materialize_asset,

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/500_eager_assets.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/500_eager_assets.py
@@ -27,9 +27,7 @@ def get_defs(n: int) -> Definitions:
     return Definitions(
         assets=assets,
         sensors=[
-            AutomationConditionSensorDefinition(
-                "the_sensor", asset_selection="*", use_user_code_server=True
-            )
+            AutomationConditionSensorDefinition("the_sensor", target="*", use_user_code_server=True)
         ],
     )
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_simple_non_user_code.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_simple_non_user_code.py
@@ -6,7 +6,7 @@ def get_defs() -> dg.Definitions:
 
     return dg.Definitions(
         assets=uc_defs.assets,
-        sensors=[dg.AutomationConditionSensorDefinition(name="the_sensor", asset_selection="*")],
+        sensors=[dg.AutomationConditionSensorDefinition(name="the_sensor", target="*")],
     )
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_simple_user_code.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_simple_user_code.py
@@ -46,8 +46,6 @@ def E() -> None: ...
 defs = dg.Definitions(
     assets=[A, B, C, D, E],
     sensors=[
-        dg.AutomationConditionSensorDefinition(
-            "the_sensor", asset_selection="*", use_user_code_server=True
-        )
+        dg.AutomationConditionSensorDefinition("the_sensor", target="*", use_user_code_server=True)
     ],
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_with_runs_and_checks.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/backfill_with_runs_and_checks.py
@@ -71,8 +71,6 @@ defs = dg.Definitions(
     assets=[backfillA, backfillB, backfillC, run1, run2],
     asset_checks=[outsideA, outsideB, outside1, outside2],
     sensors=[
-        dg.AutomationConditionSensorDefinition(
-            "the_sensor", asset_selection="*", use_user_code_server=True
-        )
+        dg.AutomationConditionSensorDefinition("the_sensor", target="*", use_user_code_server=True)
     ],
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/custom_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/custom_condition.py
@@ -21,8 +21,6 @@ def foo() -> None: ...
 defs = dg.Definitions(
     assets=[foo],
     sensors=[
-        dg.AutomationConditionSensorDefinition(
-            "the_sensor", asset_selection="*", use_user_code_server=True
-        )
+        dg.AutomationConditionSensorDefinition("the_sensor", target="*", use_user_code_server=True)
     ],
 )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/default_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/default_condition.py
@@ -14,7 +14,7 @@ defs = dg.Definitions(
     sensors=[
         dg.AutomationConditionSensorDefinition(
             name="all_assets",
-            asset_selection=dg.AssetSelection.all(),
+            target=dg.AssetSelection.all(),
             default_condition=dg.AutomationCondition.cron_tick_passed("*/5 * * * *"),
             use_user_code_server=True,
         )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/simple_non_user_code.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/simple_non_user_code.py
@@ -8,7 +8,7 @@ def get_defs() -> dg.Definitions:
         assets=simple_defs.assets,
         sensors=[
             dg.AutomationConditionSensorDefinition(
-                name="the_sensor", asset_selection="*", use_user_code_server=False
+                name="the_sensor", target="*", use_user_code_server=False
             )
         ],
     )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/simple_user_code.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/definitions/simple_user_code.py
@@ -8,7 +8,7 @@ def get_defs() -> dg.Definitions:
         assets=simple_defs.assets,
         sensors=[
             dg.AutomationConditionSensorDefinition(
-                name="the_sensor", asset_selection="*", use_user_code_server=True
+                name="the_sensor", target="*", use_user_code_server=True
             )
         ],
     )

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_asset_daemon.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/daemon_tests/test_asset_daemon.py
@@ -348,7 +348,7 @@ daemon_sensor_scenario = AssetDaemonScenario(
         [
             AutomationConditionSensorDefinition(
                 name="auto_materialize_sensor_a",
-                asset_selection=AssetSelection.assets("A"),
+                target=AssetSelection.assets("A"),
                 default_status=DefaultSensorStatus.RUNNING,
                 run_tags={
                     "foo_tag": "bar_val",
@@ -356,7 +356,7 @@ daemon_sensor_scenario = AssetDaemonScenario(
             ),
             AutomationConditionSensorDefinition(
                 name="auto_materialize_sensor_b",
-                asset_selection=AssetSelection.assets("B"),
+                target=AssetSelection.assets("B"),
                 default_status=DefaultSensorStatus.STOPPED,
                 minimum_interval_seconds=15,
             ),
@@ -524,7 +524,7 @@ single_daemon_sensor_scenario = AssetDaemonScenario(
         [
             AutomationConditionSensorDefinition(
                 name="named_sensor",
-                asset_selection=AssetSelection.assets("C"),
+                target=AssetSelection.assets("C"),
                 default_status=DefaultSensorStatus.RUNNING,
             ),
         ]

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_automation_condition_sensor_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_automation_condition_sensor_definition.py
@@ -21,7 +21,7 @@ def test_constructor(selection: AssetSelection, user_code: bool) -> None:
     tags = {"apple": "banana", "orange": "kiwi"}
     automation_sensor = AutomationConditionSensorDefinition(
         "foo",
-        asset_selection=selection,
+        target=selection,
         run_tags=tags,
         description="fdsjkl",
         default_status=DefaultSensorStatus.RUNNING,
@@ -46,12 +46,12 @@ def test_constructor(selection: AssetSelection, user_code: bool) -> None:
 def test_default_condition() -> None:
     with pytest.raises(ParameterCheckError, match="non-user-code"):
         AutomationConditionSensorDefinition(
-            "foo", asset_selection="*", default_condition=AutomationCondition.eager()
+            "foo", target="*", default_condition=AutomationCondition.eager()
         )
 
     sensor = AutomationConditionSensorDefinition(
         "foo",
-        asset_selection="*",
+        target="*",
         default_condition=AutomationCondition.eager(),
         use_user_code_server=True,
     )
@@ -59,9 +59,7 @@ def test_default_condition() -> None:
 
 
 def test_limits() -> None:
-    sensor = AutomationConditionSensorDefinition(
-        "foo", asset_selection="*", use_user_code_server=True
-    )
+    sensor = AutomationConditionSensorDefinition("foo", target="*", use_user_code_server=True)
 
     defs = Definitions(
         assets=build_assets(

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_repository_definition.py
@@ -1439,8 +1439,8 @@ def test_auto_materialize_sensors_do_not_conflict():
         return [
             asset1,
             asset2,
-            AutomationConditionSensorDefinition("a", asset_selection=[asset1]),
-            AutomationConditionSensorDefinition("b", asset_selection=[asset2]),
+            AutomationConditionSensorDefinition("a", target=[asset1]),
+            AutomationConditionSensorDefinition("b", target=[asset2]),
         ]
 
 
@@ -1456,7 +1456,7 @@ def test_auto_materialize_sensors_incomplete_cover():
         return [
             asset1,
             asset2,
-            AutomationConditionSensorDefinition("a", asset_selection=[asset1]),
+            AutomationConditionSensorDefinition("a", target=[asset1]),
         ]
 
 
@@ -1478,6 +1478,6 @@ def test_auto_materialize_sensors_conflict():
             return [
                 asset1,
                 asset2,
-                AutomationConditionSensorDefinition("a", asset_selection=[asset1]),
-                AutomationConditionSensorDefinition("b", asset_selection=[asset1, asset2]),
+                AutomationConditionSensorDefinition("a", target=[asset1]),
+                AutomationConditionSensorDefinition("b", target=[asset1, asset2]),
             ]


### PR DESCRIPTION
## Summary & Motivation

This is the standard naming convention for sensors.

## How I Tested These Changes

## Changelog

[breaking] Renamed the `asset_selection` parameter on `AutomationConditionSensorDefinition` to `target`, to align with existing sensor APIs.
