### PR TITLE
[dagster-tableau] Standardize translator signature

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
@@ -12,8 +12,8 @@ from dagster._record import record
 TABLEAU_PREFIX = "tableau/"
 
 
-def _clean_asset_name(name: str) -> str:
-    """Cleans an input to be a valid Dagster asset name."""
+def _coerce_input_to_valid_name(name: str) -> str:
+    """Cleans an input to be a valid Dagster name."""
     return re.sub(r"[^a-z0-9A-Z.]+", "_", name).lower()
 
 
@@ -116,6 +116,16 @@ class DagsterTableauTranslator:
     def workspace_data(self) -> TableauWorkspaceData:
         return self._context
 
+    def get_asset_key(self, data: TableauContentData) -> AssetKey:
+        if data.content_type == TableauContentType.SHEET:
+            return self.get_sheet_asset_key(data)
+        elif data.content_type == TableauContentType.DASHBOARD:
+            return self.get_dashboard_asset_key(data)
+        elif data.content_type == TableauContentType.DATA_SOURCE:
+            return self.get_data_source_asset_key(data)
+        else:
+            check.assert_never(data.content_type)
+
     def get_asset_spec(self, data: TableauContentData) -> AssetSpec:
         if data.content_type == TableauContentType.SHEET:
             return self.get_sheet_spec(data)
@@ -131,9 +141,9 @@ class DagsterTableauTranslator:
         workbook_data = self.workspace_data.workbooks_by_id[workbook_id]
         return AssetKey(
             [
-                _clean_asset_name(workbook_data.properties["name"]),
+                _coerce_input_to_valid_name(workbook_data.properties["name"]),
                 "sheet",
-                _clean_asset_name(data.properties["name"]),
+                _coerce_input_to_valid_name(data.properties["name"]),
             ]
         )
 
@@ -146,12 +156,12 @@ class DagsterTableauTranslator:
         }
 
         data_source_keys = [
-            self.get_data_source_asset_key(self.workspace_data.data_sources_by_id[data_source_id])
+            self.get_asset_key(self.workspace_data.data_sources_by_id[data_source_id])
             for data_source_id in data_source_ids
         ]
 
         return AssetSpec(
-            key=self.get_sheet_asset_key(data),
+            key=self.get_asset_key(data),
             deps=data_source_keys if data_source_keys else None,
             tags={"dagster/storage_kind": "tableau", **TableauTagSet(asset_type="sheet")},
             metadata={
@@ -166,9 +176,9 @@ class DagsterTableauTranslator:
         workbook_data = self.workspace_data.workbooks_by_id[workbook_id]
         return AssetKey(
             [
-                _clean_asset_name(workbook_data.properties["name"]),
+                _coerce_input_to_valid_name(workbook_data.properties["name"]),
                 "dashboard",
-                _clean_asset_name(data.properties["name"]),
+                _coerce_input_to_valid_name(data.properties["name"]),
             ]
         )
 
@@ -177,12 +187,11 @@ class DagsterTableauTranslator:
         sheet_ids = {sheet["luid"] for sheet in dashboard_upstream_sheets if sheet["luid"]}
 
         sheet_keys = [
-            self.get_sheet_asset_key(self.workspace_data.sheets_by_id[sheet_id])
-            for sheet_id in sheet_ids
+            self.get_asset_key(self.workspace_data.sheets_by_id[sheet_id]) for sheet_id in sheet_ids
         ]
 
         return AssetSpec(
-            key=self.get_dashboard_asset_key(data),
+            key=self.get_asset_key(data),
             deps=sheet_keys if sheet_keys else None,
             tags={"dagster/storage_kind": "tableau", **TableauTagSet(asset_type="dashboard")},
             metadata={
@@ -193,11 +202,11 @@ class DagsterTableauTranslator:
         )
 
     def get_data_source_asset_key(self, data: TableauContentData) -> AssetKey:
-        return AssetKey([_clean_asset_name(data.properties["name"])])
+        return AssetKey([_coerce_input_to_valid_name(data.properties["name"])])
 
     def get_data_source_spec(self, data: TableauContentData) -> AssetSpec:
         return AssetSpec(
-            key=self.get_data_source_asset_key(data),
+            key=self.get_asset_key(data),
             tags={"dagster/storage_kind": "tableau", **TableauTagSet(asset_type="data_source")},
             metadata={**TableauMetadataSet(id=data.properties["luid"], workbook_id=None)},
         )

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
@@ -16,7 +16,7 @@ from dagster._core.instance_for_test import instance_for_test
 from dagster._utils.test.definitions import lazy_definitions
 from dagster_tableau.assets import build_tableau_executable_assets_definition
 from dagster_tableau.resources import TableauCloudWorkspace, load_tableau_asset_specs
-from dagster_tableau.translator import DagsterTableauTranslator, TableauContentData
+from dagster_tableau.translator import DagsterTableauTranslator
 
 from dagster_tableau_tests.conftest import (
     FAKE_CONNECTED_APP_CLIENT_ID,
@@ -76,7 +76,6 @@ def cacheable_asset_defs_custom_translator():
     class MyCoolTranslator(DagsterTableauTranslator):
         def get_asset_key(self, data) -> AssetKey:
             return super().get_asset_key(data).with_prefix("my_prefix")
-
 
     tableau_specs = load_tableau_asset_specs(
         workspace=resource, dagster_tableau_translator=MyCoolTranslator

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 from dagster._core.code_pointer import CodePointer
-from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.reconstruct import (
     ReconstructableJob,
@@ -74,17 +74,9 @@ def cacheable_asset_defs_refreshable_workbooks():
 @lazy_definitions
 def cacheable_asset_defs_custom_translator():
     class MyCoolTranslator(DagsterTableauTranslator):
-        def get_sheet_spec(self, data: TableauContentData) -> AssetSpec:
-            spec = super().get_sheet_spec(data)
-            return spec._replace(key=spec.key.with_prefix("my_prefix"))
+        def get_asset_key(self, data) -> AssetKey:
+            return super().get_asset_key(data).with_prefix("my_prefix")
 
-        def get_dashboard_spec(self, data: TableauContentData) -> AssetSpec:
-            spec = super().get_dashboard_spec(data)
-            return spec._replace(key=spec.key.with_prefix("my_prefix"))
-
-        def get_data_source_spec(self, data: TableauContentData) -> AssetSpec:
-            spec = super().get_data_source_spec(data)
-            return spec._replace(key=spec.key.with_prefix("my_prefix"))
 
     tableau_specs = load_tableau_asset_specs(
         workspace=resource, dagster_tableau_translator=MyCoolTranslator


### PR DESCRIPTION
## Summary

Standardizes the `DagsterTableauTranslator` format to have a central `get_asset_spec`, `get_asset_key` method.

## How I Tested These Changes

Updated unit tests

