### PR TITLE
[dagster-looker] Standardize translator signature

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Any, Dict, Mapping, Optional, Union
 
 from dagster import (
+    AssetKey,
     AssetSpec,
     _check as check,
 )
@@ -91,14 +92,27 @@ class LookerStructureData:
 
 
 class DagsterLookerApiTranslator:
-    def get_view_asset_spec(self, lookml_view: LookmlView) -> AssetSpec:
+    def get_view_asset_key(self, looker_structure: LookerStructureData) -> AssetKey:
+        lookml_view = check.inst(looker_structure.data, LookmlView)
+        return AssetKey(["view", lookml_view.view_name])
+
+    def get_view_asset_spec(self, looker_structure: LookerStructureData) -> AssetSpec:
+        _ = check.inst(looker_structure.data, LookmlView)
         return AssetSpec(
-            key=["view", lookml_view.view_name],
+            key=self.get_asset_key(looker_structure),
         )
 
-    def get_explore_asset_spec(
-        self, lookml_explore: Union[LookmlModelExplore, DashboardFilter]
-    ) -> AssetSpec:
+    def get_explore_asset_key(self, looker_structure: LookerStructureData) -> AssetKey:
+        lookml_explore = check.inst(looker_structure.data, (LookmlModelExplore, DashboardFilter))
+        if isinstance(lookml_explore, LookmlModelExplore):
+            return AssetKey(check.not_none(lookml_explore.id))
+        elif isinstance(lookml_explore, DashboardFilter):
+            lookml_model_name = check.not_none(lookml_explore.model)
+            lookml_explore_name = check.not_none(lookml_explore.explore)
+            return AssetKey(f"{lookml_model_name}::{lookml_explore_name}")
+
+    def get_explore_asset_spec(self, looker_structure: LookerStructureData) -> AssetSpec:
+        lookml_explore = check.inst(looker_structure.data, (LookmlModelExplore, DashboardFilter))
         if isinstance(lookml_explore, LookmlModelExplore):
             explore_base_view = LookmlView(
                 view_name=check.not_none(lookml_explore.view_name),
@@ -114,10 +128,14 @@ class DagsterLookerApiTranslator:
             ]
 
             return AssetSpec(
-                key=check.not_none(lookml_explore.id),
+                key=self.get_asset_key(looker_structure),
                 deps=list(
                     {
-                        self.get_view_asset_spec(lookml_view).key
+                        self.get_view_asset_spec(
+                            LookerStructureData(
+                                structure_type=LookerStructureType.VIEW, data=lookml_view
+                            )
+                        ).key
                         for lookml_view in [explore_base_view, *explore_join_views]
                     }
                 ),
@@ -127,17 +145,23 @@ class DagsterLookerApiTranslator:
                 },
             )
         elif isinstance(lookml_explore, DashboardFilter):
-            lookml_model_name = check.not_none(lookml_explore.model)
-            lookml_explore_name = check.not_none(lookml_explore.explore)
+            return AssetSpec(key=self.get_asset_key(looker_structure))
 
-            return AssetSpec(key=f"{lookml_model_name}::{lookml_explore_name}")
+    def get_dashboard_asset_key(self, looker_structure: LookerStructureData) -> AssetKey:
+        looker_dashboard = check.inst(looker_structure.data, Dashboard)
+        return AssetKey(f"{check.not_none(looker_dashboard.title)}_{looker_dashboard.id}")
 
-    def get_dashboard_asset_spec(self, looker_dashboard: Dashboard) -> AssetSpec:
+    def get_dashboard_asset_spec(self, looker_structure: LookerStructureData) -> AssetSpec:
+        looker_dashboard = check.inst(looker_structure.data, Dashboard)
         return AssetSpec(
-            key=f"{check.not_none(looker_dashboard.title)}_{looker_dashboard.id}",
+            key=self.get_asset_key(looker_structure),
             deps=list(
                 {
-                    self.get_explore_asset_spec(dashboard_filter).key
+                    self.get_explore_asset_spec(
+                        LookerStructureData(
+                            structure_type=LookerStructureType.EXPLORE, data=dashboard_filter
+                        )
+                    ).key
                     for dashboard_filter in looker_dashboard.dashboard_filters or []
                 }
             ),
@@ -150,16 +174,21 @@ class DagsterLookerApiTranslator:
     @public
     def get_asset_spec(self, looker_structure: LookerStructureData) -> AssetSpec:
         if looker_structure.structure_type == LookerStructureType.VIEW:
-            data = check.inst(looker_structure.data, LookmlView)
-
-            return self.get_view_asset_spec(data)
+            return self.get_view_asset_spec(looker_structure)
         if looker_structure.structure_type == LookerStructureType.EXPLORE:
-            data = check.inst(looker_structure.data, (LookmlModelExplore, DashboardFilter))
-
-            return self.get_explore_asset_spec(data)
+            return self.get_explore_asset_spec(looker_structure)
         elif looker_structure.structure_type == LookerStructureType.DASHBOARD:
-            data = check.inst(looker_structure.data, Dashboard)
+            return self.get_dashboard_asset_spec(looker_structure)
+        else:
+            check.assert_never(looker_structure.structure_type)
 
-            return self.get_dashboard_asset_spec(data)
+    @public
+    def get_asset_key(self, looker_structure: LookerStructureData) -> AssetKey:
+        if looker_structure.structure_type == LookerStructureType.VIEW:
+            return self.get_view_asset_key(looker_structure)
+        if looker_structure.structure_type == LookerStructureType.EXPLORE:
+            return self.get_explore_asset_key(looker_structure)
+        elif looker_structure.structure_type == LookerStructureType.DASHBOARD:
+            return self.get_dashboard_asset_key(looker_structure)
         else:
             check.assert_never(looker_structure.structure_type)

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
@@ -110,6 +110,8 @@ class DagsterLookerApiTranslator:
             lookml_model_name = check.not_none(lookml_explore.model)
             lookml_explore_name = check.not_none(lookml_explore.explore)
             return AssetKey(f"{lookml_model_name}::{lookml_explore_name}")
+        else:
+            check.assert_never(lookml_explore)
 
     def get_explore_asset_spec(self, looker_structure: LookerStructureData) -> AssetSpec:
         lookml_explore = check.inst(looker_structure.data, (LookmlModelExplore, DashboardFilter))
@@ -146,6 +148,8 @@ class DagsterLookerApiTranslator:
             )
         elif isinstance(lookml_explore, DashboardFilter):
             return AssetSpec(key=self.get_asset_key(looker_structure))
+        else:
+            check.assert_never(lookml_explore)
 
     def get_dashboard_asset_key(self, looker_structure: LookerStructureData) -> AssetKey:
         looker_dashboard = check.inst(looker_structure.data, Dashboard)

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_build_defs.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/api/test_build_defs.py
@@ -134,6 +134,9 @@ def test_custom_asset_specs(
     expected_metadata = {"custom": "metadata"}
 
     class CustomDagsterLookerApiTranslator(DagsterLookerApiTranslator):
+        def get_asset_key(self, looker_structure: LookerStructureData) -> AssetKey:
+            return super().get_asset_key(looker_structure).with_prefix("my_prefix")
+
         def get_asset_spec(self, looker_structure: LookerStructureData) -> AssetSpec:
             return super().get_asset_spec(looker_structure)._replace(metadata=expected_metadata)
 
@@ -150,3 +153,4 @@ def test_custom_asset_specs(
     for asset in all_assets:
         for metadata in asset.metadata_by_key.values():
             assert metadata == expected_metadata
+        assert all(key.path[0] == "my_prefix" for key in asset.keys)


### PR DESCRIPTION
## Summary

Standardizes the `DagsterLookerApiTranslator` format to have a central `get_asset_spec`, `get_asset_key` method. Updates all methods so that they receive a LookerStructureData object as input.

## How I Tested These Changes

Updated unit tests

