### PR TITLE
[dagster-dlift] defs loader

### DIFF
--- a/examples/experimental/dagster-dlift/dagster_dlift/loader.py
+++ b/examples/experimental/dagster-dlift/dagster_dlift/loader.py
@@ -1,0 +1,27 @@
+from dagster import Definitions
+from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader
+from dagster._record import record
+
+from dagster_dlift.project import DBTCloudProjectEnvironment
+from dagster_dlift.translator import DbtCloudProjectEnvironmentData
+
+DBT_CLOUD_RECONSTRUCTION_METADATA_KEY_PREFIX = "__dbt_cloud"
+
+
+@record
+class DbtCloudProjectEnvironmentDefsLoader(
+    StateBackedDefinitionsLoader[DbtCloudProjectEnvironmentData]
+):
+    project_environment: DBTCloudProjectEnvironment
+
+    @property
+    def defs_key(self) -> str:
+        return (
+            f"{DBT_CLOUD_RECONSTRUCTION_METADATA_KEY_PREFIX}.{self.project_environment.unique_id}"
+        )
+
+    def fetch_state(self) -> DbtCloudProjectEnvironmentData:
+        return self.project_environment.compute_data()
+
+    def defs_from_state(self, state: DbtCloudProjectEnvironmentData) -> Definitions:
+        raise NotImplementedError("Not used")

--- a/examples/experimental/dagster-dlift/dagster_dlift/project.py
+++ b/examples/experimental/dagster-dlift/dagster_dlift/project.py
@@ -24,6 +24,10 @@ class DBTCloudProjectEnvironment:
         self.project_id = project_id
         self.environment_id = environment_id
 
+    @property
+    def unique_id(self) -> str:
+        return f"{self.project_id}-{self.environment_id}"
+
     @cached_property
     def client(self) -> DbtCloudClient:
         return DbtCloudClient(

--- a/examples/experimental/dagster-dlift/dagster_dlift/translator.py
+++ b/examples/experimental/dagster-dlift/dagster_dlift/translator.py
@@ -1,10 +1,14 @@
 from enum import Enum
-from typing import Any, Mapping, NamedTuple, Union
+from typing import Any, Mapping, Union
 
 from dagster import AssetCheckSpec, AssetSpec
+from dagster._record import record
+from dagster._serdes.serdes import whitelist_for_serdes
 
 
-class DbtCloudProjectEnvironmentData(NamedTuple):
+@whitelist_for_serdes
+@record
+class DbtCloudProjectEnvironmentData:
     project_id: int
     environment_id: int
     models_by_unique_id: Mapping[str, "DbtCloudContentData"]
@@ -12,13 +16,16 @@ class DbtCloudProjectEnvironmentData(NamedTuple):
     tests_by_unique_id: Mapping[str, "DbtCloudContentData"]
 
 
+@whitelist_for_serdes
 class DbtCloudContentType(Enum):
     MODEL = "MODEL"
     SOURCE = "SOURCE"
     TEST = "TEST"
 
 
-class DbtCloudContentData(NamedTuple):
+@whitelist_for_serdes
+@record
+class DbtCloudContentData:
     content_type: DbtCloudContentType
     properties: Mapping[str, Any]
 

--- a/examples/experimental/dagster-dlift/dagster_dlift_tests/test_loader.py
+++ b/examples/experimental/dagster-dlift/dagster_dlift_tests/test_loader.py
@@ -1,0 +1,37 @@
+from dagster_dlift.loader import DbtCloudProjectEnvironmentDefsLoader
+from dagster_dlift.translator import DbtCloudContentType
+
+from dagster_dlift_tests.conftest import create_jaffle_shop_project
+
+
+def test_multi_load() -> None:
+    """Test creation of data from a test environment."""
+    project = create_jaffle_shop_project()
+    loader = DbtCloudProjectEnvironmentDefsLoader(project_environment=project)
+    data = loader.get_or_fetch_state()
+    assert set(data.models_by_unique_id.keys()) == {
+        "model.jaffle_shop.customers",
+        "model.jaffle_shop.stg_customers",
+        "model.jaffle_shop.stg_orders",
+    }
+    assert set(data.sources_by_unique_id.keys()) == {
+        "source.jaffle_shop.jaffle_shop.customers",
+        "source.jaffle_shop.jaffle_shop.orders",
+    }
+    assert set(data.tests_by_unique_id.keys()) == {
+        "test.jaffle_shop.customers",
+        "test.jaffle_shop.orders",
+    }
+    assert all(
+        data.models_by_unique_id[model].content_type == DbtCloudContentType.MODEL
+        for model in data.models_by_unique_id
+    )
+    assert all(
+        data.sources_by_unique_id[source].content_type == DbtCloudContentType.SOURCE
+        for source in data.sources_by_unique_id
+    )
+    assert all(
+        data.tests_by_unique_id[test].content_type == DbtCloudContentType.TEST
+        for test in data.tests_by_unique_id
+    )
+    assert data == loader.get_or_fetch_state()


### PR DESCRIPTION
## Summary & Motivation
Introduce a state loader for dlift. As mentioned in the previous PR, this one doesn't implement build_defs and instead uses the fetched state directly.
## How I Tested These Changes
New test for loader.
