### PR TITLE
[snowflake] Support ignoring missing tables when using `fetch_last_updated_timestamps`

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -336,9 +336,7 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
             self._resolved_config_dict.get("private_key", None) is not None
             or self._resolved_config_dict.get("private_key_path", None) is not None
         ):
-            conn_args["private_key"] = self._snowflake_private_key(
-                self._resolved_config_dict
-            )
+            conn_args["private_key"] = self._snowflake_private_key(self._resolved_config_dict)
 
         conn_args["application"] = SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER
         return conn_args
@@ -529,9 +527,7 @@ class SnowflakeConnection:
                         return conn.get_query_status(query_id)
 
         """
-        with self.snowflake_connection_resource.get_connection(
-            raw_conn=raw_conn
-        ) as conn:
+        with self.snowflake_connection_resource.get_connection(raw_conn=raw_conn) as conn:
             yield conn
 
     @public
@@ -571,9 +567,7 @@ class SnowflakeConnection:
         check.opt_inst_param(parameters, "parameters", (list, dict))
         check.bool_param(fetch_results, "fetch_results")
         if not fetch_results and use_pandas_result:
-            check.failed(
-                "If use_pandas_result is True, fetch_results must also be True."
-            )
+            check.failed("If use_pandas_result is True, fetch_results must also be True.")
 
         with self.get_connection() as conn:
             with closing(conn.cursor()) as cursor:
@@ -581,9 +575,7 @@ class SnowflakeConnection:
                     sql = sql.encode("utf-8")
 
                 self.log.info("Executing query: " + sql)
-                parameters = (
-                    dict(parameters) if isinstance(parameters, Mapping) else parameters
-                )
+                parameters = dict(parameters) if isinstance(parameters, Mapping) else parameters
                 cursor.execute(sql, parameters)
                 if use_pandas_result:
                     return cursor.fetch_pandas_all()
@@ -630,23 +622,15 @@ class SnowflakeConnection:
         check.opt_inst_param(parameters, "parameters", (list, dict))
         check.bool_param(fetch_results, "fetch_results")
         if not fetch_results and use_pandas_result:
-            check.failed(
-                "If use_pandas_result is True, fetch_results must also be True."
-            )
+            check.failed("If use_pandas_result is True, fetch_results must also be True.")
 
         results: List[Any] = []
         with self.get_connection() as conn:
             with closing(conn.cursor()) as cursor:
                 for raw_sql in sql_queries:
-                    sql = (
-                        raw_sql.encode("utf-8") if sys.version_info[0] < 3 else raw_sql
-                    )
+                    sql = raw_sql.encode("utf-8") if sys.version_info[0] < 3 else raw_sql
                     self.log.info("Executing query: " + sql)
-                    parameters = (
-                        dict(parameters)
-                        if isinstance(parameters, Mapping)
-                        else parameters
-                    )
+                    parameters = dict(parameters) if isinstance(parameters, Mapping) else parameters
                     cursor.execute(sql, parameters)
                     if use_pandas_result:
                         results = results.append(cursor.fetch_pandas_all())  # type: ignore
@@ -747,9 +731,7 @@ def snowflake_resource(context) -> SnowflakeConnection:
 
 def fetch_last_updated_timestamps(
     *,
-    snowflake_connection: Union[
-        SqlDbConnection, snowflake.connector.SnowflakeConnection
-    ],
+    snowflake_connection: Union[SqlDbConnection, snowflake.connector.SnowflakeConnection],
     schema: str,
     tables: Sequence[str],
     database: Optional[str] = None,
@@ -773,16 +755,12 @@ def fetch_last_updated_timestamps(
     Returns:
         Mapping[str, datetime]: A dictionary of table names to their last updated time in UTC.
     """
-    check.invariant(
-        len(tables) > 0, "Must provide at least one table name to query upon."
-    )
+    check.invariant(len(tables) > 0, "Must provide at least one table name to query upon.")
     # Table names in snowflake's information schema are stored in uppercase
     uppercase_tables = [table.upper() for table in tables]
     tables_str = ", ".join([f"'{table_name}'" for table_name in uppercase_tables])
     fully_qualified_table_name = (
-        f"{database}.information_schema.tables"
-        if database
-        else "information_schema.tables"
+        f"{database}.information_schema.tables" if database else "information_schema.tables"
     )
 
     query = f"""

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -455,8 +455,7 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
             from sqlalchemy import create_engine
 
             engine = create_engine(
-                URL(**self._sqlalchemy_connection_args),
-                connect_args=self._sqlalchemy_engine_args,
+                URL(**self._sqlalchemy_connection_args), connect_args=self._sqlalchemy_engine_args,
             )
             conn = engine.raw_connection() if raw_conn else engine.connect()
 
@@ -491,10 +490,7 @@ class SnowflakeConnection:
     """
 
     def __init__(
-        self,
-        config: Mapping[str, str],
-        log,
-        snowflake_connection_resource: SnowflakeResource,
+        self, config: Mapping[str, str], log, snowflake_connection_resource: SnowflakeResource,
     ):
         self.snowflake_connection_resource = snowflake_connection_resource
         self.log = log

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -455,7 +455,7 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
             from sqlalchemy import create_engine
 
             engine = create_engine(
-                URL(**self._sqlalchemy_connection_args), connect_args=self._sqlalchemy_engine_args,
+                URL(**self._sqlalchemy_connection_args), connect_args=self._sqlalchemy_engine_args
             )
             conn = engine.raw_connection() if raw_conn else engine.connect()
 
@@ -490,7 +490,7 @@ class SnowflakeConnection:
     """
 
     def __init__(
-        self, config: Mapping[str, str], log, snowflake_connection_resource: SnowflakeResource,
+        self, config: Mapping[str, str], log, snowflake_connection_resource: SnowflakeResource
     ):
         self.snowflake_connection_resource = snowflake_connection_resource
         self.log = log
@@ -719,9 +719,7 @@ def snowflake_resource(context) -> SnowflakeConnection:
     """
     snowflake_resource = SnowflakeResource.from_resource_context(context)
     return SnowflakeConnection(
-        config=context,
-        log=context.log,
-        snowflake_connection_resource=snowflake_resource,
+        config=context, log=context.log, snowflake_connection_resource=snowflake_resource
     )
 
 

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
@@ -22,11 +22,7 @@ from dagster._core.definitions.metadata import FloatMetadataValue
 from dagster._core.definitions.observe import observe
 from dagster._core.test_utils import environ
 from dagster._time import get_current_timestamp
-from dagster_snowflake import (
-    SnowflakeResource,
-    fetch_last_updated_timestamps,
-    snowflake_resource,
-)
+from dagster_snowflake import SnowflakeResource, fetch_last_updated_timestamps, snowflake_resource
 from dagster_snowflake.constants import SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER
 
 from dagster_snowflake_tests.utils import create_mock_connector
@@ -302,9 +298,7 @@ def test_fetch_last_updated_timestamps_empty():
         )
 
 
-@pytest.mark.skipif(
-    not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB"
-)
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
 @pytest.mark.importorskip(
     "snowflake.sqlalchemy", reason="sqlalchemy is not available in the test environment"
 )
@@ -345,13 +339,9 @@ def test_fetch_last_updated_timestamps_missing_table():
             conn.cursor().execute(f"drop table if exists {table_name}")
 
 
-@pytest.mark.skipif(
-    not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB"
-)
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
 @pytest.mark.integration
-@pytest.mark.parametrize(
-    "db_str", [None, "TESTDB"], ids=["db_from_resource", "db_from_param"]
-)
+@pytest.mark.parametrize("db_str", [None, "TESTDB"], ids=["db_from_resource", "db_from_param"])
 def test_fetch_last_updated_timestamps(db_str: str):
     start_time = get_current_timestamp()
     with temporary_snowflake_table() as table_name:
@@ -398,9 +388,7 @@ def test_fetch_last_updated_timestamps(db_str: str):
         assert freshness_val.value > start_time
 
 
-@pytest.mark.skipif(
-    not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB"
-)
+@pytest.mark.skipif(not IS_BUILDKITE, reason="Requires access to the BUILDKITE snowflake DB")
 @pytest.mark.importorskip(
     "snowflake.sqlalchemy", reason="sqlalchemy is not available in the test environment"
 )


### PR DESCRIPTION
## Summary & Motivation
This PR adds an optional argument `ignore_missing_tables: Optional[bool] = False` to `dagster_snowflake.fetch_last_updated_timestamps`. When true, this argument will not raise an error when a table is not found in Snowflake. Instead, it will just continue and exclude the table from the resulting freshness map.

This is useful when you deploy a dagster project to multiple environments, where your development environment may not have all tables available. We use this function to generate observation events for source tables, and this allows us to generate observations for the tables that do exist, but ignore tables that don't.

Linked issue: https://github.com/dagster-io/dagster/issues/24245

## How I Tested These Changes

Unit test is included.

## Changelog

> `dagster_snowflake.fetch_last_updated_timestamps` now supports ignoring tables not found in Snowflake instead of raising an error
