### PR TITLE
[ui] Resolve AMP state before handling Overview AMP route

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
@@ -8,14 +8,12 @@ import {OverviewSchedulesRoot} from './OverviewSchedulesRoot';
 import {OverviewSensorsRoot} from './OverviewSensorsRoot';
 import {featureEnabled, useFeatureFlags} from '../app/Flags';
 import {Route} from '../app/Route';
-import {useAutoMaterializeSensorFlag} from '../assets/AutoMaterializeSensorFlag';
 import {AutomaterializationRoot} from '../assets/auto-materialization/AutomaterializationRoot';
 import {InstanceBackfillsRoot} from '../instance/InstanceBackfillsRoot';
 import {BackfillPage} from '../instance/backfill/BackfillPage';
 
 export const OverviewRoot = () => {
   const {flagLegacyNav} = useFeatureFlags();
-  const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
   return (
     <Switch>
       <Route path="/overview/activity" isNestingRoute>
@@ -33,16 +31,7 @@ export const OverviewRoot = () => {
         path="/overview/sensors"
         render={() => (flagLegacyNav ? <OverviewSensorsRoot /> : <Redirect to="/automation" />)}
       />
-      <Route
-        path="/overview/automation"
-        render={() =>
-          !flagLegacyNav && automaterializeSensorsFlagState !== 'has-global-amp' ? (
-            <Redirect to="/automation" />
-          ) : (
-            <AutomaterializationRoot />
-          )
-        }
-      />
+      <Route path="/overview/automation" render={() => <AutomaterializationRoot />} />
       {featureEnabled(FeatureFlag.flagLegacyRunsPage)
         ? [
             <Route


### PR DESCRIPTION
## Summary & Motivation

Fix the `'unknown'` state for AMP flags, when navigating directly to `/overview/automation`.

This route currently redirects to `/automation` if the user is not using the legacy nav and if the AMP sensor flag state is not `'has-global-amp'`. Unfortunately, on initial pageload we may not yet have received the response from the GraphQL request that asks for the flag state, so this is likely to be `'unknown'`, and the page redirects.

Fix this by waiting until the query resolves before redirecting or rendering anything other than a `div`.

## How I Tested These Changes

Test permutations of legacy nav and AMP sensor flag state.

- Verify that redirect to `/overview/automation` occurs when the flag is `'has-global-amp'`, on navigation and full pageload.
- Verify that when the flag is set to `'has-sensor-amp'`, the page redirects to `/overview/sensors` for legacy nav and `/automation` for new nav.

## Changelog

[ui] Fix redirect behavior on full pageloads of auto-materialize overview page.