### PR TITLE
storage reads from backfill tags table and backfill job_name column if they are populated

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -11,7 +11,12 @@ import dagster._check as check
 from dagster._core.execution.job_backfill import PartitionBackfill
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunRecord
 from dagster._core.storage.runs.base import RunStorage
-from dagster._core.storage.runs.schema import BulkActionsTable, RunsTable, RunTagsTable
+from dagster._core.storage.runs.schema import (
+    BackfillTagsTable,
+    BulkActionsTable,
+    RunsTable,
+    RunTagsTable,
+)
 from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import (
     BACKFILL_ID_TAG,
@@ -28,6 +33,7 @@ RUN_START_END = (  # was run_start_end, but renamed to overwrite bad timestamps 
 RUN_REPO_LABEL_TAGS = "run_repo_label_tags"
 BULK_ACTION_TYPES = "bulk_action_types"
 RUN_BACKFILL_ID = "run_backfill_id"
+BACKFILL_JOB_NAME_AND_TAGS = "backfill_job_name_and_tags"
 
 PrintFn: TypeAlias = Callable[[Any], None]
 MigrationFn: TypeAlias = Callable[[RunStorage, Optional[PrintFn]], None]
@@ -38,6 +44,7 @@ REQUIRED_DATA_MIGRATIONS: Final[Mapping[str, Callable[[], MigrationFn]]] = {
     RUN_REPO_LABEL_TAGS: lambda: migrate_run_repo_tags,
     BULK_ACTION_TYPES: lambda: migrate_bulk_actions,
     RUN_BACKFILL_ID: lambda: migrate_run_backfill_id,
+    BACKFILL_JOB_NAME_AND_TAGS: lambda: migrate_backfill_job_name_and_tags,
 }
 # for `dagster instance reindex`, optionally run for better read performance
 OPTIONAL_DATA_MIGRATIONS: Final[Mapping[str, Callable[[], MigrationFn]]] = {
@@ -99,6 +106,31 @@ def chunked_run_records_iterator(
             for run in chunk:
                 cursor = run.dagster_run.run_id
                 yield run
+
+            if progress:
+                progress.update(len(chunk))
+
+
+def chunked_backfill_iterator(
+    storage: RunStorage, print_fn: Optional[PrintFn] = None, chunk_size: int = CHUNK_SIZE
+) -> Iterator[PartitionBackfill]:
+    with ExitStack() as stack:
+        if print_fn:
+            backfill_count = storage.get_backfills_count()
+            progress = stack.enter_context(tqdm(total=backfill_count))
+        else:
+            progress = None
+
+        cursor = None
+        has_more = True
+
+        while has_more:
+            chunk = storage.get_backfills(cursor=cursor, limit=chunk_size)
+            has_more = chunk_size and len(chunk) >= chunk_size
+
+            for backfill in chunk:
+                cursor = backfill.backfill_id
+                yield backfill
 
             if progress:
                 progress.update(len(chunk))
@@ -298,4 +330,67 @@ def add_backfill_id(run_storage: RunStorage, run_id: str, backfill_id) -> None:
             .values(
                 backfill_id=backfill_id,
             )
+        )
+
+
+def migrate_backfill_job_name_and_tags(
+    storage: RunStorage, print_fn: Optional[PrintFn] = None
+) -> None:
+    """Utility method to add a backfill's job_name to the bulk_actions table and tags to the backfill_tags table."""
+    if print_fn:
+        print_fn("Querying run storage.")
+
+    for backfill in chunked_backfill_iterator(storage, print_fn):
+        if backfill.tags:
+            add_backfill_tags(
+                run_storage=storage, backfill_id=backfill.backfill_id, tags=backfill.tags
+            )
+
+        if backfill.job_name is not None:
+            add_backfill_job_name(
+                run_storage=storage, backfill_id=backfill.backfill_id, job_name=backfill.job_name
+            )
+
+
+def add_backfill_tags(run_storage: RunStorage, backfill_id: str, tags: Mapping[str, str]):
+    from dagster._core.storage.runs.sql_run_storage import SqlRunStorage
+
+    check.str_param(backfill_id, "run_id")
+    check.dict_param(tags, "tags", key_type=str, value_type=str)
+    check.inst_param(run_storage, "run_storage", RunStorage)
+
+    if not isinstance(run_storage, SqlRunStorage):
+        return
+
+    with run_storage.connect() as conn:
+        conn.execute(
+            BackfillTagsTable.insert(),
+            [
+                dict(
+                    backfill_id=backfill_id,
+                    key=k,
+                    value=v,
+                )
+                for k, v in tags.items()
+            ],
+        )
+
+
+def add_backfill_job_name(run_storage: RunStorage, backfill_id: str, job_name: str):
+    from dagster._core.storage.runs.sql_run_storage import SqlRunStorage
+
+    check.str_param(backfill_id, "run_id")
+    check.str_param(job_name, "job_name")
+    check.inst_param(run_storage, "run_storage", RunStorage)
+
+    if not isinstance(run_storage, SqlRunStorage):
+        return
+
+    with run_storage.connect() as conn:
+        conn.execute(
+            BulkActionsTable.update()
+            .values(
+                job_name=job_name,
+            )
+            .where(BulkActionsTable.c.key == backfill_id)
         )

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -870,7 +870,7 @@ class SqlRunStorage(RunStorage):
                 intersections = []
                 for key, value in filters.tags.items():
                     intersections.append(
-                        db.select(BackfillTagsTable.c.backfill_id).where(
+                        db_select([BackfillTagsTable.c.backfill_id]).where(
                             db.and_(
                                 BackfillTagsTable.c.key == key,
                                 (BackfillTagsTable.c.value == value)

--- a/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/sql_run_storage.py
@@ -996,7 +996,8 @@ class SqlRunStorage(RunStorage):
         rows = self.fetchall(query)
         backfill_candidates = deserialize_values((row["body"] for row in rows), PartitionBackfill)
 
-        if filters and filters.tags:
+        if filters and filters.tags and not self.has_built_index(BACKFILL_JOB_NAME_AND_TAGS):
+            # if we are still using the run tags table to get backfills by tag, we need to do an additional check.
             # runs can have more tags than the backfill that launched them. Since we filtered tags by
             # querying for runs with those tags, we need to do an additional check that the backfills
             # also have the requested tags

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1490,7 +1490,7 @@ def test_add_bulk_actions_job_name_column():
             assert ids_to_job_name[before_migration.backfill_id] == before_migration.job_name
             assert ids_to_job_name[after_migration.backfill_id] == after_migration.job_name
 
-            # filtering by tags works after migration
+            # filtering by job_name works after migration
             assert instance.run_storage.has_built_index(BACKFILL_JOB_NAME_AND_TAGS)
             # delete the run that was added pre-migration to prove that tags filtering is happening on the
             # backfill_tags table

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -1357,9 +1357,9 @@ def test_add_backfill_tags():
             cursor.execute("SELECT backfill_id, key, value FROM backfill_tags")
             rows = cursor.fetchall()
 
-            assert len(rows) == 1
+            assert len(rows) == 2
             ids_to_tags = {row[0]: {row[1]: row[2]} for row in rows}
-            assert ids_to_tags.get(before_migration.backfill_id) is None
+            assert ids_to_tags.get(before_migration.backfill_id) == before_migration.tags
             assert ids_to_tags[after_migration.backfill_id] == after_migration.tags
 
             # test downgrade
@@ -1426,7 +1426,7 @@ def test_add_bulk_actions_job_name_column():
 
             assert len(rows) == 3  # a backfill exists in the db snapshot
             ids_to_job_name = {row[0]: row[1] for row in rows}
-            assert ids_to_job_name[before_migration.backfill_id] is None
+            assert ids_to_job_name[before_migration.backfill_id] == before_migration.job_name
             assert ids_to_job_name[after_migration.backfill_id] == after_migration.job_name
 
             # test downgrade

--- a/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
+++ b/python_modules/dagster/dagster_tests/general_tests/compat_tests/test_back_compat.py
@@ -31,7 +31,7 @@ from dagster._core.definitions.partition import StaticPartitionsDefinition
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.events import DagsterEvent, StepMaterializationData
 from dagster._core.events.log import EventLogEntry
-from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
+from dagster._core.execution.backfill import BulkActionsFilter, BulkActionStatus, PartitionBackfill
 from dagster._core.execution.plan.outputs import StepOutputHandle
 from dagster._core.execution.plan.state import KnownExecutionState
 from dagster._core.instance import DagsterInstance, InstanceRef
@@ -45,7 +45,7 @@ from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, Runs
 from dagster._core.storage.event_log.migration import migrate_event_log_data
 from dagster._core.storage.event_log.sql_event_log import SqlEventLogStorage
 from dagster._core.storage.migration.utils import upgrading_instance
-from dagster._core.storage.runs.migration import RUN_BACKFILL_ID
+from dagster._core.storage.runs.migration import BACKFILL_JOB_NAME_AND_TAGS, RUN_BACKFILL_ID
 from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import (
     BACKFILL_ID_TAG,
@@ -1338,6 +1338,23 @@ def test_add_backfill_tags():
                 backfill_timestamp=get_current_timestamp(),
             )
             instance.add_backfill(before_migration)
+            # filtering pre-migration relies on filtering runs, so add a run with the expected tags
+            pre_migration_run = instance.run_storage.add_run(
+                DagsterRun(
+                    job_name="foo",
+                    run_id=make_new_run_id(),
+                    tags={"before": "migration", BACKFILL_ID_TAG: before_migration.backfill_id},
+                    status=DagsterRunStatus.NOT_STARTED,
+                )
+            )
+
+            # filtering by tags works before migration
+            assert (
+                instance.get_backfills(filters=BulkActionsFilter(tags={"before": "migration"}))[
+                    0
+                ].backfill_id
+                == before_migration.backfill_id
+            )
 
             instance.upgrade()
             assert "backfill_tags" in get_sqlite3_tables(db_path)
@@ -1361,6 +1378,24 @@ def test_add_backfill_tags():
             ids_to_tags = {row[0]: {row[1]: row[2]} for row in rows}
             assert ids_to_tags.get(before_migration.backfill_id) == before_migration.tags
             assert ids_to_tags[after_migration.backfill_id] == after_migration.tags
+
+            # filtering by tags works after migration
+            assert instance.run_storage.has_built_index(BACKFILL_JOB_NAME_AND_TAGS)
+            # delete the run that was added pre-migration to prove that tags filtering is happening on the
+            # backfill_tags table
+            instance.delete_run(pre_migration_run.run_id)
+            assert (
+                instance.get_backfills(filters=BulkActionsFilter(tags={"before": "migration"}))[
+                    0
+                ].backfill_id
+                == before_migration.backfill_id
+            )
+            assert (
+                instance.get_backfills(filters=BulkActionsFilter(tags={"after": "migration"}))[
+                    0
+                ].backfill_id
+                == after_migration.backfill_id
+            )
 
             # test downgrade
             instance._run_storage._alembic_downgrade(rev="1aca709bba64")
@@ -1392,7 +1427,7 @@ def test_add_bulk_actions_job_name_column():
                     ),
                     repository_name="the_repo",
                 ),
-                partition_set_name=partition_set_snap_name_for_job_name("foo"),
+                partition_set_name=partition_set_snap_name_for_job_name("before_migration"),
             )
             before_migration = PartitionBackfill(
                 "before_job_migration",
@@ -1403,12 +1438,38 @@ def test_add_bulk_actions_job_name_column():
                 backfill_timestamp=get_current_timestamp(),
             )
             instance.add_backfill(before_migration)
+            # filtering pre-migration relies on filtering runs, so add a run with the expected job_name
+            pre_migration_run = instance.run_storage.add_run(
+                DagsterRun(
+                    job_name=before_migration.job_name,
+                    run_id=make_new_run_id(),
+                    tags={BACKFILL_ID_TAG: before_migration.backfill_id},
+                    status=DagsterRunStatus.NOT_STARTED,
+                )
+            )
+
+            # filtering by job_name works before migration
+            assert (
+                instance.get_backfills(
+                    filters=BulkActionsFilter(job_name=before_migration.job_name)
+                )[0].backfill_id
+                == before_migration.backfill_id
+            )
 
             instance.upgrade()
 
             backfill_columns = get_sqlite3_columns(db_path, "bulk_actions")
             assert "job_name" in backfill_columns
 
+            partition_set_origin = RemotePartitionSetOrigin(
+                repository_origin=RemoteRepositoryOrigin(
+                    code_location_origin=GrpcServerCodeLocationOrigin(
+                        host="localhost", port=1234, location_name="test_location"
+                    ),
+                    repository_name="the_repo",
+                ),
+                partition_set_name=partition_set_snap_name_for_job_name("after_migration"),
+            )
             after_migration = PartitionBackfill(
                 "after_job_migration",
                 partition_set_origin=partition_set_origin,
@@ -1428,6 +1489,24 @@ def test_add_bulk_actions_job_name_column():
             ids_to_job_name = {row[0]: row[1] for row in rows}
             assert ids_to_job_name[before_migration.backfill_id] == before_migration.job_name
             assert ids_to_job_name[after_migration.backfill_id] == after_migration.job_name
+
+            # filtering by tags works after migration
+            assert instance.run_storage.has_built_index(BACKFILL_JOB_NAME_AND_TAGS)
+            # delete the run that was added pre-migration to prove that tags filtering is happening on the
+            # backfill_tags table
+            instance.delete_run(pre_migration_run.run_id)
+            assert (
+                instance.get_backfills(
+                    filters=BulkActionsFilter(job_name=before_migration.job_name)
+                )[0].backfill_id
+                == before_migration.backfill_id
+            )
+            assert (
+                instance.get_backfills(
+                    filters=BulkActionsFilter(job_name=after_migration.job_name)
+                )[0].backfill_id
+                == after_migration.backfill_id
+            )
 
             # test downgrade
             instance._run_storage._alembic_downgrade(rev="1aca709bba64")

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -774,7 +774,7 @@ def test_add_bulk_actions_job_name_column(conn_string):
                 assert ids_to_job_name[before_migration.backfill_id] == before_migration.job_name
                 assert ids_to_job_name[after_migration.backfill_id] == after_migration.job_name
 
-                # filtering by tags works after migration
+                # filtering by job_name works after migration
                 assert instance.run_storage.has_built_index(BACKFILL_JOB_NAME_AND_TAGS)
                 # delete the run that was added pre-migration to prove that tags filtering is happening on the
                 # backfill_tags table

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -640,9 +640,9 @@ def test_add_backfill_tags(conn_string):
                         ]
                     )
                 ).fetchall()
-                assert len(rows) == 1
+                assert len(rows) == 2
                 ids_to_tags = {row[0]: {row[1]: row[2]} for row in rows}
-                assert ids_to_tags.get(before_migration.backfill_id) is None
+                assert ids_to_tags.get(before_migration.backfill_id) == before_migration.tags
                 assert ids_to_tags[after_migration.backfill_id] == after_migration.tags
 
 
@@ -710,5 +710,5 @@ def test_add_bulk_actions_job_name_column(conn_string):
                 ).fetchall()
                 assert len(rows) == 2
                 ids_to_job_name = {row[0]: row[1] for row in rows}
-                assert ids_to_job_name[before_migration.backfill_id] is None
+                assert ids_to_job_name[before_migration.backfill_id] == before_migration.job_name
                 assert ids_to_job_name[after_migration.backfill_id] == after_migration.job_name

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/compat_tests/test_back_compat.py
@@ -10,13 +10,13 @@ import sqlalchemy as db
 from dagster import AssetKey, AssetMaterialization, AssetObservation, Output, job, op
 from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.errors import DagsterInvalidInvocationError
-from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
+from dagster._core.execution.backfill import BulkActionsFilter, BulkActionStatus, PartitionBackfill
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.external_data import partition_set_snap_name_for_job_name
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster._core.storage.migration.bigint_migration import run_bigint_migration
-from dagster._core.storage.runs.migration import RUN_BACKFILL_ID
+from dagster._core.storage.runs.migration import BACKFILL_JOB_NAME_AND_TAGS, RUN_BACKFILL_ID
 from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import BACKFILL_ID_TAG
 from dagster._core.utils import make_new_run_id
@@ -616,6 +616,23 @@ def test_add_backfill_tags(conn_string):
                 backfill_timestamp=get_current_timestamp(),
             )
             instance.add_backfill(before_migration)
+            # filtering pre-migration relies on filtering runs, so add a run with the expected tags
+            pre_migration_run = instance.run_storage.add_run(
+                DagsterRun(
+                    job_name="foo",
+                    run_id=make_new_run_id(),
+                    tags={"before": "migration", BACKFILL_ID_TAG: before_migration.backfill_id},
+                    status=DagsterRunStatus.NOT_STARTED,
+                )
+            )
+
+            # filtering by tags works before migration
+            assert (
+                instance.get_backfills(filters=BulkActionsFilter(tags={"before": "migration"}))[
+                    0
+                ].backfill_id
+                == before_migration.backfill_id
+            )
 
             instance.upgrade()
             assert "backfill_tags" in get_tables(instance)
@@ -644,6 +661,24 @@ def test_add_backfill_tags(conn_string):
                 ids_to_tags = {row[0]: {row[1]: row[2]} for row in rows}
                 assert ids_to_tags.get(before_migration.backfill_id) == before_migration.tags
                 assert ids_to_tags[after_migration.backfill_id] == after_migration.tags
+
+                # filtering by tags works after migration
+                assert instance.run_storage.has_built_index(BACKFILL_JOB_NAME_AND_TAGS)
+                # delete the run that was added pre-migration to prove that tags filtering is happening on the
+                # backfill_tags table
+                instance.delete_run(pre_migration_run.run_id)
+                assert (
+                    instance.get_backfills(filters=BulkActionsFilter(tags={"before": "migration"}))[
+                        0
+                    ].backfill_id
+                    == before_migration.backfill_id
+                )
+                assert (
+                    instance.get_backfills(filters=BulkActionsFilter(tags={"after": "migration"}))[
+                        0
+                    ].backfill_id
+                    == after_migration.backfill_id
+                )
 
 
 def test_add_bulk_actions_job_name_column(conn_string):
@@ -678,7 +713,7 @@ def test_add_bulk_actions_job_name_column(conn_string):
                     ),
                     repository_name="the_repo",
                 ),
-                partition_set_name=partition_set_snap_name_for_job_name("foo"),
+                partition_set_name=partition_set_snap_name_for_job_name("before_migration"),
             )
             before_migration = PartitionBackfill(
                 "before_migration",
@@ -689,11 +724,37 @@ def test_add_bulk_actions_job_name_column(conn_string):
                 backfill_timestamp=get_current_timestamp(),
             )
             instance.add_backfill(before_migration)
+            # filtering pre-migration relies on filtering runs, so add a run with the expected job_name
+            pre_migration_run = instance.run_storage.add_run(
+                DagsterRun(
+                    job_name=before_migration.job_name,
+                    run_id=make_new_run_id(),
+                    tags={BACKFILL_ID_TAG: before_migration.backfill_id},
+                    status=DagsterRunStatus.NOT_STARTED,
+                )
+            )
+
+            # filtering by job_name works before migration
+            assert (
+                instance.get_backfills(
+                    filters=BulkActionsFilter(job_name=before_migration.job_name)
+                )[0].backfill_id
+                == before_migration.backfill_id
+            )
 
             instance.upgrade()
 
             assert "job_name" in get_columns(instance, "bulk_actions")
 
+            partition_set_origin = RemotePartitionSetOrigin(
+                repository_origin=RemoteRepositoryOrigin(
+                    code_location_origin=GrpcServerCodeLocationOrigin(
+                        host="localhost", port=1234, location_name="test_location"
+                    ),
+                    repository_name="the_repo",
+                ),
+                partition_set_name=partition_set_snap_name_for_job_name("after_migration"),
+            )
             after_migration = PartitionBackfill(
                 "after_migration",
                 partition_set_origin=partition_set_origin,
@@ -712,3 +773,21 @@ def test_add_bulk_actions_job_name_column(conn_string):
                 ids_to_job_name = {row[0]: row[1] for row in rows}
                 assert ids_to_job_name[before_migration.backfill_id] == before_migration.job_name
                 assert ids_to_job_name[after_migration.backfill_id] == after_migration.job_name
+
+                # filtering by tags works after migration
+                assert instance.run_storage.has_built_index(BACKFILL_JOB_NAME_AND_TAGS)
+                # delete the run that was added pre-migration to prove that tags filtering is happening on the
+                # backfill_tags table
+                instance.delete_run(pre_migration_run.run_id)
+                assert (
+                    instance.get_backfills(
+                        filters=BulkActionsFilter(job_name=before_migration.job_name)
+                    )[0].backfill_id
+                    == before_migration.backfill_id
+                )
+                assert (
+                    instance.get_backfills(
+                        filters=BulkActionsFilter(job_name=after_migration.job_name)
+                    )[0].backfill_id
+                    == after_migration.backfill_id
+                )

--- a/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_run_storage.py
+++ b/python_modules/libraries/dagster-mysql/dagster_mysql_tests/test_run_storage.py
@@ -13,6 +13,7 @@ TestRunStorage.__test__ = False
 
 class TestMySQLRunStorage(TestRunStorage):
     __test__ = True
+    # TestMySQLRunStorage::test_backfill_tags_filtering_multiple_results
 
     def supports_backfill_tags_filtering_queries(self):
         return True

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -19,13 +19,13 @@ from dagster import (
 from dagster._core.definitions.data_version import DATA_VERSION_TAG
 from dagster._core.errors import DagsterInvalidInvocationError
 from dagster._core.execution.api import execute_job
-from dagster._core.execution.backfill import BulkActionStatus, PartitionBackfill
+from dagster._core.execution.backfill import BulkActionsFilter, BulkActionStatus, PartitionBackfill
 from dagster._core.instance import DagsterInstance
 from dagster._core.remote_representation.external_data import partition_set_snap_name_for_job_name
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.event_log.migration import ASSET_KEY_INDEX_COLS
 from dagster._core.storage.migration.bigint_migration import run_bigint_migration
-from dagster._core.storage.runs.migration import RUN_BACKFILL_ID
+from dagster._core.storage.runs.migration import BACKFILL_JOB_NAME_AND_TAGS, RUN_BACKFILL_ID
 from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import BACKFILL_ID_TAG, PARTITION_NAME_TAG, PARTITION_SET_TAG
 from dagster._core.utils import make_new_run_id
@@ -1025,6 +1025,8 @@ def test_add_backfill_tags(hostname, conn_string):
                 target_fd.write(template)
 
         with DagsterInstance.from_config(tempdir) as instance:
+            assert "backfill_tags" not in get_tables(instance)
+
             before_migration = PartitionBackfill(
                 "before_tag_migration",
                 serialized_asset_backfill_data="foo",
@@ -1034,7 +1036,24 @@ def test_add_backfill_tags(hostname, conn_string):
                 backfill_timestamp=get_current_timestamp(),
             )
             instance.add_backfill(before_migration)
-            assert "backfill_tags" not in get_tables(instance)
+
+            # filtering pre-migration relies on filtering runs, so add a run with the expected tags
+            pre_migration_run = instance.run_storage.add_run(
+                DagsterRun(
+                    job_name="foo",
+                    run_id=make_new_run_id(),
+                    tags={"before": "migration", BACKFILL_ID_TAG: before_migration.backfill_id},
+                    status=DagsterRunStatus.NOT_STARTED,
+                )
+            )
+
+            # filtering by tags works before migration
+            assert (
+                instance.get_backfills(filters=BulkActionsFilter(tags={"before": "migration"}))[
+                    0
+                ].backfill_id
+                == before_migration.backfill_id
+            )
 
             instance.upgrade()
             assert "backfill_tags" in get_tables(instance)
@@ -1062,6 +1081,24 @@ def test_add_backfill_tags(hostname, conn_string):
                 ids_to_tags = {row[0]: {row[1]: row[2]} for row in rows}
                 assert ids_to_tags.get(before_migration.backfill_id) == before_migration.tags
                 assert ids_to_tags[after_migration.backfill_id] == after_migration.tags
+
+                # filtering by tags works after migration
+                assert instance.run_storage.has_built_index(BACKFILL_JOB_NAME_AND_TAGS)
+                # delete the run that was added pre-migration to prove that tags filtering is happening on the
+                # backfill_tags table
+                instance.delete_run(pre_migration_run.run_id)
+                assert (
+                    instance.get_backfills(filters=BulkActionsFilter(tags={"before": "migration"}))[
+                        0
+                    ].backfill_id
+                    == before_migration.backfill_id
+                )
+                assert (
+                    instance.get_backfills(filters=BulkActionsFilter(tags={"after": "migration"}))[
+                        0
+                    ].backfill_id
+                    == after_migration.backfill_id
+                )
 
 
 def test_add_bulk_actions_job_name_column(hostname, conn_string):
@@ -1099,7 +1136,7 @@ def test_add_bulk_actions_job_name_column(hostname, conn_string):
                     ),
                     repository_name="the_repo",
                 ),
-                partition_set_name=partition_set_snap_name_for_job_name("foo"),
+                partition_set_name=partition_set_snap_name_for_job_name("before_migration"),
             )
             before_migration = PartitionBackfill(
                 "before_migration",
@@ -1110,11 +1147,36 @@ def test_add_bulk_actions_job_name_column(hostname, conn_string):
                 backfill_timestamp=get_current_timestamp(),
             )
             instance.add_backfill(before_migration)
+            # filtering pre-migration relies on filtering runs, so add a run with the expected job_name
+            pre_migration_run = instance.run_storage.add_run(
+                DagsterRun(
+                    job_name=before_migration.job_name,
+                    run_id=make_new_run_id(),
+                    tags={BACKFILL_ID_TAG: before_migration.backfill_id},
+                    status=DagsterRunStatus.NOT_STARTED,
+                )
+            )
+            # filtering by job_name works before migration
+            assert (
+                instance.get_backfills(
+                    filters=BulkActionsFilter(job_name=before_migration.job_name)
+                )[0].backfill_id
+                == before_migration.backfill_id
+            )
 
             instance.upgrade()
 
             assert "job_name" in get_columns(instance, "bulk_actions")
 
+            partition_set_origin = RemotePartitionSetOrigin(
+                repository_origin=RemoteRepositoryOrigin(
+                    code_location_origin=GrpcServerCodeLocationOrigin(
+                        host="localhost", port=1234, location_name="test_location"
+                    ),
+                    repository_name="the_repo",
+                ),
+                partition_set_name=partition_set_snap_name_for_job_name("after_migration"),
+            )
             after_migration = PartitionBackfill(
                 "after_migration",
                 partition_set_origin=partition_set_origin,
@@ -1133,3 +1195,21 @@ def test_add_bulk_actions_job_name_column(hostname, conn_string):
                 ids_to_job_name = {row[0]: row[1] for row in rows}
                 assert ids_to_job_name[before_migration.backfill_id] == before_migration.job_name
                 assert ids_to_job_name[after_migration.backfill_id] == after_migration.job_name
+
+                # filtering by tags works after migration
+                assert instance.run_storage.has_built_index(BACKFILL_JOB_NAME_AND_TAGS)
+                # delete the run that was added pre-migration to prove that tags filtering is happening on the
+                # backfill_tags table
+                instance.delete_run(pre_migration_run.run_id)
+                assert (
+                    instance.get_backfills(
+                        filters=BulkActionsFilter(job_name=before_migration.job_name)
+                    )[0].backfill_id
+                    == before_migration.backfill_id
+                )
+                assert (
+                    instance.get_backfills(
+                        filters=BulkActionsFilter(job_name=after_migration.job_name)
+                    )[0].backfill_id
+                    == after_migration.backfill_id
+                )

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -1058,9 +1058,9 @@ def test_add_backfill_tags(hostname, conn_string):
                         ]
                     )
                 ).fetchall()
-                assert len(rows) == 1
+                assert len(rows) == 2
                 ids_to_tags = {row[0]: {row[1]: row[2]} for row in rows}
-                assert ids_to_tags.get(before_migration.backfill_id) is None
+                assert ids_to_tags.get(before_migration.backfill_id) == before_migration.tags
                 assert ids_to_tags[after_migration.backfill_id] == after_migration.tags
 
 
@@ -1131,5 +1131,5 @@ def test_add_bulk_actions_job_name_column(hostname, conn_string):
                 ).fetchall()
                 assert len(rows) == 2
                 ids_to_job_name = {row[0]: row[1] for row in rows}
-                assert ids_to_job_name[before_migration.backfill_id] is None
+                assert ids_to_job_name[before_migration.backfill_id] == before_migration.job_name
                 assert ids_to_job_name[after_migration.backfill_id] == after_migration.job_name

--- a/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
+++ b/python_modules/libraries/dagster-postgres/dagster_postgres_tests/compat_tests/test_back_compat.py
@@ -1196,7 +1196,7 @@ def test_add_bulk_actions_job_name_column(hostname, conn_string):
                 assert ids_to_job_name[before_migration.backfill_id] == before_migration.job_name
                 assert ids_to_job_name[after_migration.backfill_id] == after_migration.job_name
 
-                # filtering by tags works after migration
+                # filtering by job_name works after migration
                 assert instance.run_storage.has_built_index(BACKFILL_JOB_NAME_AND_TAGS)
                 # delete the run that was added pre-migration to prove that tags filtering is happening on the
                 # backfill_tags table


### PR DESCRIPTION
## Summary & Motivation
See https://github.com/dagster-io/dagster/pull/25460 for additional context

updates backfill queries to use the job_name column and backfill tags table if the migrations have run

## How I Tested These Changes

## Changelog

Added a new column to the BulkActions table and a new BackfillTags table to improve performance when filtering Backfills. To take advantage of these performance improvements, run `dagster instance migrate`. This migration involves a schema migration to add the new column and table, and a data migration to populate the new column for historical backfills.