### PR TITLE
Remove pydantic 1.x support

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -435,8 +435,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             "api_tests",
             "asset_defs_tests",
             "cli_tests",
-            "core_tests_pydantic1",
-            "core_tests_pydantic2",
+            "core_tests",
             "daemon_sensor_tests",
             "daemon_tests",
             "definitions_tests",
@@ -444,8 +443,7 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
             "general_tests_old_protobuf",
             "launcher_tests",
             "logging_tests",
-            "model_tests_pydantic1",
-            "model_tests_pydantic2",
+            "model_tests",
             "scheduler_tests",
             "storage_tests",
             "storage_tests_sqlalchemy_1_3",
@@ -503,16 +501,12 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
         "python_modules/libraries/dagster-dbt",
         pytest_tox_factors=[
             f"{deps_factor}-{command_factor}"
-            for deps_factor in ["dbt17", "dbt18", "pydantic1"]
+            for deps_factor in ["dbt17", "dbt18"]
             for command_factor in ["cloud", "core-main", "core-derived-metadata"]
         ],
     ),
     PackageSpec(
         "python_modules/libraries/dagster-snowflake",
-        pytest_tox_factors=[
-            "pydantic1",
-            "pydantic2",
-        ],
         env_vars=["SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER", "SNOWFLAKE_PASSWORD"],
     ),
     PackageSpec(
@@ -567,10 +561,6 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     ),
     PackageSpec(
         "python_modules/libraries/dagster-databricks",
-        pytest_tox_factors=[
-            "pydantic1",
-            "pydantic2",
-        ],
     ),
     PackageSpec(
         "python_modules/libraries/dagster-docker",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,6 @@ parameters:
     default:
       - api_tests
       - cli_tests
-      - core_tests_pydantic1
       - general_tests
       - launcher_tests
       - daemon_tests

--- a/examples/experimental/dagster-blueprints/dagster_blueprints_tests/__snapshots__/test_load_defs_from_yaml.ambr
+++ b/examples/experimental/dagster-blueprints/dagster_blueprints_tests/__snapshots__/test_load_defs_from_yaml.ambr
@@ -1,35 +1,5 @@
 # serializer version: 1
-# name: test_loader_schema[pydantic1]
-  dict({
-    '$ref': '#/definitions/SimpleAssetBlueprint',
-    'definitions': dict({
-      'SimpleAssetBlueprint': dict({
-        'additionalProperties': False,
-        'description': '''
-          A blob of user-provided, structured metadata that specifies a set of Dagster definitions,
-          like assets, jobs, schedules, sensors, resources, or asset checks.
-          
-          Base class for user-provided types. Users override and provide:
-          - The set of fields
-          - A build_defs implementation that generates Dagster Definitions from field values
-        ''',
-        'properties': dict({
-          'key': dict({
-            'title': 'Key',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'key',
-        ]),
-        'title': 'SimpleAssetBlueprint',
-        'type': 'object',
-      }),
-    }),
-    'title': 'ParsingModel[SimpleAssetBlueprint]',
-  })
-# ---
-# name: test_loader_schema[pydantic2]
+# name: test_loader_schema
   dict({
     'additionalProperties': False,
     'properties': dict({
@@ -45,40 +15,7 @@
     'type': 'object',
   })
 # ---
-# name: test_loader_schema_sequence[pydantic1]
-  dict({
-    'definitions': dict({
-      'SimpleAssetBlueprint': dict({
-        'additionalProperties': False,
-        'description': '''
-          A blob of user-provided, structured metadata that specifies a set of Dagster definitions,
-          like assets, jobs, schedules, sensors, resources, or asset checks.
-          
-          Base class for user-provided types. Users override and provide:
-          - The set of fields
-          - A build_defs implementation that generates Dagster Definitions from field values
-        ''',
-        'properties': dict({
-          'key': dict({
-            'title': 'Key',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'key',
-        ]),
-        'title': 'SimpleAssetBlueprint',
-        'type': 'object',
-      }),
-    }),
-    'items': dict({
-      '$ref': '#/definitions/SimpleAssetBlueprint',
-    }),
-    'title': 'ParsingModel[Sequence[dagster_blueprints_tests.test_load_defs_from_yaml.test_loader_schema_sequence.<locals>.SimpleAssetBlueprint]]',
-    'type': 'array',
-  })
-# ---
-# name: test_loader_schema_sequence[pydantic2]
+# name: test_loader_schema_sequence
   dict({
     '$defs': dict({
       'SimpleAssetBlueprint': dict({
@@ -102,82 +39,7 @@
     'type': 'array',
   })
 # ---
-# name: test_loader_schema_union[pydantic1]
-  dict({
-    'anyOf': list([
-      dict({
-        '$ref': '#/definitions/FooAssetBlueprint',
-      }),
-      dict({
-        '$ref': '#/definitions/BarAssetBlueprint',
-      }),
-    ]),
-    'definitions': dict({
-      'BarAssetBlueprint': dict({
-        'additionalProperties': False,
-        'description': '''
-          A blob of user-provided, structured metadata that specifies a set of Dagster definitions,
-          like assets, jobs, schedules, sensors, resources, or asset checks.
-          
-          Base class for user-provided types. Users override and provide:
-          - The set of fields
-          - A build_defs implementation that generates Dagster Definitions from field values
-        ''',
-        'properties': dict({
-          'string': dict({
-            'title': 'String',
-            'type': 'string',
-          }),
-          'type': dict({
-            'default': 'bar',
-            'enum': list([
-              'bar',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'string',
-        ]),
-        'title': 'BarAssetBlueprint',
-        'type': 'object',
-      }),
-      'FooAssetBlueprint': dict({
-        'additionalProperties': False,
-        'description': '''
-          A blob of user-provided, structured metadata that specifies a set of Dagster definitions,
-          like assets, jobs, schedules, sensors, resources, or asset checks.
-          
-          Base class for user-provided types. Users override and provide:
-          - The set of fields
-          - A build_defs implementation that generates Dagster Definitions from field values
-        ''',
-        'properties': dict({
-          'number': dict({
-            'title': 'Number',
-            'type': 'integer',
-          }),
-          'type': dict({
-            'default': 'foo',
-            'enum': list([
-              'foo',
-            ]),
-            'title': 'Type',
-            'type': 'string',
-          }),
-        }),
-        'required': list([
-          'number',
-        ]),
-        'title': 'FooAssetBlueprint',
-        'type': 'object',
-      }),
-    }),
-    'title': 'ParsingModel[Union[FooAssetBlueprint, BarAssetBlueprint]]',
-  })
-# ---
-# name: test_loader_schema_union[pydantic2]
+# name: test_loader_schema_union
   dict({
     '$defs': dict({
       'BarAssetBlueprint': dict({

--- a/pyright/alt-1/requirements-pinned.txt
+++ b/pyright/alt-1/requirements-pinned.txt
@@ -271,8 +271,8 @@ snowflake-sqlalchemy==1.5.1
 sortedcontainers==2.4.0
 soupsieve==2.6
 sqlalchemy==1.4.54
-sqlglot==25.27.0
-sqlglotrs==0.2.12
+sqlglot==25.28.0
+sqlglotrs==0.2.13
 sqlparse==0.5.1
 stack-data==0.6.3
 starlette==0.41.0

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -64,7 +64,7 @@ botocore==1.35.48
 botocore-stubs==1.35.48
 buildkite-test-collector==0.1.9
 cachecontrol==0.14.0
-cached-property==2.0
+cached-property==2.0.1
 cachelib==0.9.0
 cachetools==5.5.0
 caio==0.9.17
@@ -256,7 +256,7 @@ graphene==3.4
 graphql-core==3.2.5
 graphql-relay==3.2.0
 graphviz==0.20.3
-great-expectations==0.18.21
+great-expectations==0.18.22
 grpcio==1.67.0
 grpcio-health-checking==1.62.3
 grpcio-status==1.62.3
@@ -550,8 +550,8 @@ sphinxcontrib-serializinghtml==2.0.0
 sqlalchemy==1.4.54
 sqlalchemy-jsonfield==1.0.2
 sqlalchemy-utils==0.41.2
-sqlglot==25.27.0
-sqlglotrs==0.2.12
+sqlglot==25.28.0
+sqlglotrs==0.2.13
 sqlparse==0.5.1
 sshpubkeys==3.3.1
 sshtunnel==0.4.0

--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -28,7 +28,6 @@ from dagster._core.errors import (
     DagsterInvalidPythonicConfigDefinitionError,
 )
 from dagster._model.pydantic_compat_layer import (
-    USING_PYDANTIC_2,
     ModelFieldCompat,
     PydanticUndefined,
     model_config,
@@ -75,16 +74,9 @@ class MakeConfigCacheable(BaseModel):
     # - Frozen, to avoid complexity caused by mutation.
     # - arbitrary_types_allowed, to allow non-model class params to be validated with isinstance.
     # - Avoid pydantic reading a cached property class as part of the schema.
-    if USING_PYDANTIC_2:
-        model_config = ConfigDict(
-            frozen=True, arbitrary_types_allowed=True, ignored_types=(cached_property,)
-        )
-    else:
-
-        class Config:
-            frozen = True
-            arbitrary_types_allowed = True
-            keep_untouched = (cached_property,)
+    model_config = ConfigDict(
+        frozen=True, arbitrary_types_allowed=True, ignored_types=(cached_property,)
+    )
 
     def __setattr__(self, name: str, value: Any):
         from dagster._config.pythonic_config.resource import ConfigurableResourceFactory
@@ -263,14 +255,14 @@ class Config(MakeConfigCacheable, metaclass=BaseConfigMeta):
                 )
 
         super().__init__(**modified_data_by_config_key)
-        if USING_PYDANTIC_2:
-            modified_data_by_field_key = {}
-            for config_key, value in modified_data_by_config_key.items():
-                field_info = field_info_by_config_key.get(config_key)
-                field_key = field_info[0] if field_info else config_key
-                modified_data_by_field_key[field_key] = value
 
-            self.__dict__ = ensure_env_vars_set_post_init(self.__dict__, modified_data_by_field_key)
+        modified_data_by_field_key = {}
+        for config_key, value in modified_data_by_config_key.items():
+            field_info = field_info_by_config_key.get(config_key)
+            field_key = field_info[0] if field_info else config_key
+            modified_data_by_field_key[field_key] = value
+
+        self.__dict__ = ensure_env_vars_set_post_init(self.__dict__, modified_data_by_field_key)
 
     def _convert_to_config_dictionary(self) -> Mapping[str, Any]:
         """Converts this Config object to a Dagster config dictionary, in the same format as the dictionary
@@ -410,12 +402,7 @@ class PermissiveConfig(Config):
 
     # Pydantic config for this class
     # Cannot use kwargs for base class as this is not support for pydantic<1.8
-    if USING_PYDANTIC_2:
-        model_config = ConfigDict(extra="allow")
-    else:
-
-        class Config:
-            extra = "allow"
+    model_config = ConfigDict(extra="allow")
 
 
 def infer_schema_from_config_class(

--- a/python_modules/dagster/dagster/_model/__init__.py
+++ b/python_modules/dagster/dagster/_model/__init__.py
@@ -1,17 +1,8 @@
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Dict, Hashable, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from pydantic import BaseModel, ConfigDict, PrivateAttr
-from typing_extensions import Annotated, Self, TypeAlias
-
-from dagster._model.pydantic_compat_layer import USING_PYDANTIC_2
-
-if USING_PYDANTIC_2:
-    from pydantic import InstanceOf as InstanceOf  # type: ignore
-else:
-    # fallback to a no-op on pydantic 1 as there is no equivalent
-    AnyType = TypeVar("AnyType")
-    InstanceOf: TypeAlias = Annotated[AnyType, ...]
+from pydantic import BaseModel, ConfigDict
+from typing_extensions import Self
 
 
 class DagsterModel(BaseModel):
@@ -22,39 +13,20 @@ class DagsterModel(BaseModel):
     - Avoid pydantic reading a cached property class as part of the schema.
     """
 
-    if not USING_PYDANTIC_2:
-        # the setattr approach for cached_method works in pydantic 2 so only declare the PrivateAttr
-        # in pydantic 1 as it has non trivial performance impact
-        _cached_method_cache__internal__: Dict[Hashable, Any] = PrivateAttr(default_factory=dict)
-
     if TYPE_CHECKING:
         # without this, the type checker does not understand the constructor kwargs on subclasses
         def __init__(self, **data: Any) -> None: ...
 
-    if USING_PYDANTIC_2:
-        model_config = ConfigDict(
-            extra="forbid",
-            frozen=True,
-            arbitrary_types_allowed=True,
-            ignored_types=(cached_property,),
-        )
-    else:
-
-        class Config:
-            extra = "forbid"
-            frozen = True
-            arbitrary_types_allowed = True
-            keep_untouched = (cached_property,)
+    model_config = ConfigDict(
+        extra="forbid",
+        frozen=True,
+        arbitrary_types_allowed=True,
+        ignored_types=(cached_property,),
+    )
 
     def model_copy(self, *, update: Optional[Dict[str, Any]] = None) -> Self:
-        if USING_PYDANTIC_2:
-            return super().model_copy(update=update)
-        else:
-            return super().copy(update=update)
+        return super().model_copy(update=update)
 
     @classmethod
     def model_construct(cls, **kwargs: Any) -> Self:
-        if USING_PYDANTIC_2:
-            return super().model_construct(**kwargs)
-        else:
-            return super().construct(**kwargs)
+        return super().model_construct(**kwargs)

--- a/python_modules/dagster/dagster/_model/pydantic_compat_layer.py
+++ b/python_modules/dagster/dagster/_model/pydantic_compat_layer.py
@@ -1,17 +1,14 @@
-import json
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Sequence, Type, Union
 
-import pydantic
-from pydantic import BaseModel, ValidationError
+from pydantic import (
+    BaseModel,
+    TypeAdapter,
+    ValidationError,
+    model_validator as model_validator,
+)
+from pydantic_core import PydanticUndefined as _PydanticUndefined
 
-USING_PYDANTIC_1 = int(pydantic.__version__.split(".")[0]) == 1
-USING_PYDANTIC_2 = int(pydantic.__version__.split(".")[0]) >= 2
-
-PydanticUndefined = None
-if USING_PYDANTIC_2:
-    from pydantic_core import PydanticUndefined as _PydanticUndefined
-
-    PydanticUndefined = _PydanticUndefined
+PydanticUndefined = _PydanticUndefined
 
 
 if TYPE_CHECKING:
@@ -36,10 +33,7 @@ class ModelFieldCompat:
 
     @property
     def alias(self) -> Optional[str]:
-        if USING_PYDANTIC_2:
-            return self.field.alias
-        else:
-            return self.field.alias if self.field.alias != self.field.name else None
+        return self.field.alias
 
     @property
     def serialization_alias(self) -> Optional[str]:
@@ -55,26 +49,15 @@ class ModelFieldCompat:
 
     @property
     def description(self) -> Optional[str]:
-        if USING_PYDANTIC_2:
-            return getattr(self.field, "description", None)
-        else:
-            field_info = getattr(self.field, "field_info", None)
-            return field_info.description if field_info else None
+        return getattr(self.field, "description", None)
 
     def is_required(self) -> bool:
-        if USING_PYDANTIC_2:
-            return self.field.is_required()
-        else:
-            # required is of type 'BoolUndefined', which is a Union of bool and pydantic 1.x's UndefinedType
-            return self.field.required if isinstance(self.field.required, bool) else False
+        return self.field.is_required()
 
     @property
     def discriminator(self) -> Optional[str]:
-        if USING_PYDANTIC_2:
-            if hasattr(self.field, "discriminator"):
-                return self.field.discriminator if hasattr(self.field, "discriminator") else None
-        else:
-            return getattr(self.field, "discriminator_key", None)
+        if hasattr(self.field, "discriminator"):
+            return self.field.discriminator if hasattr(self.field, "discriminator") else None
 
 
 def model_fields(model) -> Dict[str, ModelFieldCompat]:
@@ -88,53 +71,11 @@ def model_fields(model) -> Dict[str, ModelFieldCompat]:
     return {k: ModelFieldCompat(v) for k, v in fields.items()}
 
 
-class Pydantic1ConfigWrapper:
-    """Config wrapper for Pydantic 1 style model config, which provides a
-    Pydantic 2 style interface for accessing mopdel config values.
-    """
-
-    def __init__(self, config):
-        self._config = config
-
-    def get(self, key):
-        return getattr(self._config, key)
-
-
 def model_config(model: Type[BaseModel]):
     """Returns the config for a given pydantic model, wrapped such that it has
     a Pydantic 2-style interface for accessing config values.
     """
-    if USING_PYDANTIC_2:
-        return getattr(model, "model_config")
-    else:
-        return Pydantic1ConfigWrapper(getattr(model, "__config__"))
-
-
-try:
-    # Pydantic 2.x
-    from pydantic import model_validator as model_validator  # type: ignore
-except ImportError:
-    # Pydantic 1.x
-    from pydantic import root_validator
-
-    def model_validator(mode="before"):
-        """Mimics the Pydantic 2.x model_validator decorator, which is used to
-        define validation logic for a Pydantic model. This decorator is used
-        to wrap a validation function which is called before or after the
-        model is constructed.
-        """
-
-        def _decorate(func):
-            return (
-                root_validator(pre=True)(func)
-                if mode == "before"
-                else root_validator(post=False)(func)
-            )
-
-        return _decorate
-
-
-compat_model_validator = model_validator
+    return getattr(model, "model_config")
 
 
 def build_validation_error(
@@ -143,27 +84,16 @@ def build_validation_error(
     hide_input: bool,
     input_type: Literal["python", "json"],
 ) -> ValidationError:
-    if USING_PYDANTIC_1:
-        return ValidationError(errors=line_errors, model=base_error.model)  # type: ignore
-    else:
-        return ValidationError.from_exception_data(
-            title=base_error.title,
-            line_errors=line_errors,
-            input_type=input_type,
-            hide_input=hide_input,
-        )
+    return ValidationError.from_exception_data(
+        title=base_error.title,
+        line_errors=line_errors,
+        input_type=input_type,
+        hide_input=hide_input,
+    )
 
 
 def json_schema_from_type(model_type: Union[Type[BaseModel], Type[Sequence[BaseModel]]]):
     """Pydantic version stable way to get the JSON schema for a Pydantic model."""
     # This nicely handles the case where the per_file_blueprint_type is actually
     # a union type etc.
-    if USING_PYDANTIC_1:
-        from pydantic.tools import schema_json_of
-
-        return json.loads(schema_json_of(model_type))
-
-    else:
-        from pydantic import TypeAdapter
-
-        return TypeAdapter(model_type).json_schema()
+    return TypeAdapter(model_type).json_schema()

--- a/python_modules/dagster/dagster/_utils/pydantic_yaml.py
+++ b/python_modules/dagster/dagster/_utils/pydantic_yaml.py
@@ -3,7 +3,6 @@ from typing import Sequence, Type, TypeVar
 from pydantic import BaseModel, ValidationError, parse_obj_as
 
 from dagster._core.errors import DagsterInvariantViolationError
-from dagster._model.pydantic_compat_layer import USING_PYDANTIC_1
 from dagster._utils.source_position import (
     KeyPath,
     ValueAndSourcePositionTree,
@@ -36,26 +35,23 @@ def _parse_and_populate_model_with_annotated_errors(
     try:
         model = parse_obj_as(cls, obj_parse_root.value)
     except ValidationError as e:
-        if USING_PYDANTIC_1:
-            raise e
-        else:
-            line_errors = []
-            for error in e.errors():
-                key_path_in_obj = list(error["loc"])
-                source_position = obj_parse_root.source_position_tree.lookup(key_path_in_obj)
+        line_errors = []
+        for error in e.errors():
+            key_path_in_obj = list(error["loc"])
+            source_position = obj_parse_root.source_position_tree.lookup(key_path_in_obj)
 
-                file_key_path: KeyPath = list(obj_key_path_prefix) + key_path_in_obj
-                file_key_path_str = ".".join(str(part) for part in file_key_path)
-                line_errors.append(
-                    {**error, "loc": [file_key_path_str + " at " + str(source_position)]}
-                )
+            file_key_path: KeyPath = list(obj_key_path_prefix) + key_path_in_obj
+            file_key_path_str = ".".join(str(part) for part in file_key_path)
+            line_errors.append(
+                {**error, "loc": [file_key_path_str + " at " + str(source_position)]}
+            )
 
-            raise ValidationError.from_exception_data(
-                title=e.title,
-                line_errors=line_errors,
-                input_type="json",
-                hide_input=False,
-            ) from None
+        raise ValidationError.from_exception_data(
+            title=e.title,
+            line_errors=line_errors,
+            input_type="json",
+            hide_input=False,
+        ) from None
 
     populate_source_position_and_key_paths(
         model, obj_parse_root.source_position_tree, obj_key_path_prefix

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_constraints.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_constraints.py
@@ -2,7 +2,6 @@ from typing import List
 
 import pytest
 from dagster._config.pythonic_config import Config
-from dagster._model.pydantic_compat_layer import USING_PYDANTIC_2
 from pydantic import Field, ValidationError, conlist, constr
 
 
@@ -118,18 +117,6 @@ def test_list_length() -> None:
         AListConfig(a_list=[1])
     with pytest.raises(ValidationError, match=" at most 10 items"):
         AListConfig(a_list=[1] * 11)
-
-
-@pytest.mark.skipif(USING_PYDANTIC_2, reason="Removed in pydantic 2")
-def test_list_uniqueness() -> None:
-    class AListConfig(Config):
-        a_list: List[int] = Field(unique_items=True)  # type: ignore
-
-    AListConfig(a_list=[1, 2])
-    with pytest.raises(ValidationError, match="the list has duplicated items"):
-        AListConfig(a_list=[1, 1])
-    with pytest.raises(ValidationError, match="the list has duplicated items"):
-        AListConfig(a_list=[1, 2, 1])
 
 
 def test_with_constr() -> None:

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_errors.py
@@ -18,7 +18,6 @@ from dagster._core.errors import (
     DagsterInvalidInvocationError,
     DagsterInvalidPythonicConfigDefinitionError,
 )
-from dagster._model.pydantic_compat_layer import USING_PYDANTIC_2
 
 
 def test_invalid_config_type_basic() -> None:
@@ -189,12 +188,8 @@ def test_annotate_with_resource_factory() -> None:
             return "hello"
 
     # https://github.com/dagster-io/dagster/issues/18017
-    if USING_PYDANTIC_2:  # pydantic 2 causing issues with Generic
-        target = "an unknown"  # should be "a '<class 'str'>'"
-        ttype = "Any"  # should be "str"
-    else:
-        target = "a '<class 'str'>'"
-        ttype = "str"
+    target = "an unknown"  # should be "a '<class 'str'>'"
+    ttype = "Any"  # should be "str"
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
@@ -269,12 +264,8 @@ def test_annotate_with_resource_factory_schedule_sensor() -> None:
             return "hello"
 
     # https://github.com/dagster-io/dagster/issues/18017
-    if USING_PYDANTIC_2:  # pydantic 2 causing issues with Generic
-        target = "an unknown"  # should be "a '<class 'str'>'"
-        ttype = "Any"  # should be "str"
-    else:
-        target = "a '<class 'str'>'"
-        ttype = "str"
+    target = "an unknown"  # should be "a '<class 'str'>'"
+    ttype = "Any"  # should be "str"
 
     with pytest.raises(
         DagsterInvalidDefinitionError,
@@ -405,43 +396,6 @@ def test_trying_to_set_a_field_resource() -> None:
     ):
         my_resource = MyResource(my_str="foo")
         my_resource.my_str = "bar"
-
-
-@pytest.mark.skipif(USING_PYDANTIC_2, reason="Does not throw error in Pydantic 2")
-def test_trying_to_set_an_undefined_field() -> None:
-    class MyConfig(Config):
-        my_str: str
-
-    with pytest.raises(
-        DagsterInvalidInvocationError,
-        match=(
-            "'MyConfig' is a Pythonic config class and does not support manipulating"
-            " undeclared attribute '_my_random_other_field' as it inherits from"
-            " 'pydantic.BaseModel' without extra=\\\"allow\\\"."
-        ),
-    ):
-        my_config = MyConfig(my_str="foo")
-        my_config._my_random_other_field = "bar"  # noqa: SLF001
-
-
-@pytest.mark.skipif(USING_PYDANTIC_2, reason="Does not throw error in Pydantic 2")
-def test_trying_to_set_an_undefined_field_resource() -> None:
-    class MyResource(ConfigurableResource):
-        my_str: str
-
-    with pytest.raises(
-        DagsterInvalidInvocationError,
-        match=(
-            "'MyResource' is a Pythonic resource and does not support manipulating"
-            " undeclared attribute '_my_random_other_field' as it inherits from"
-            " 'pydantic.BaseModel' without extra=\\\"allow\\\". If trying to maintain"
-            " state on this resource, consider building a separate, stateful client"
-            " class, and provide a method on the resource to construct and return the"
-            " stateful client."
-        ),
-    ):
-        my_resource = MyResource(my_str="foo")
-        my_resource._my_random_other_field = "bar"  # noqa: SLF001
 
 
 def test_custom_dagster_type_as_config_type() -> None:

--- a/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_op_invocation.py
@@ -1,5 +1,4 @@
 import asyncio
-import sys
 from datetime import datetime
 from functools import partial
 
@@ -45,7 +44,6 @@ from dagster._core.errors import (
 )
 from dagster._core.execution.context.compute import AssetExecutionContext, OpExecutionContext
 from dagster._core.execution.context.invocation import DirectOpExecutionContext, build_asset_context
-from dagster._model.pydantic_compat_layer import USING_PYDANTIC_1
 from dagster._time import create_datetime
 from dagster._utils.test import wrap_op_in_graph_and_execute
 
@@ -646,10 +644,6 @@ def test_missing_required_output_generator_async():
         asyncio.run(get_results())
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 12) and USING_PYDANTIC_1,
-    reason="something with py3.12 and pydantic1 and sqlite",
-)
 def test_missing_required_output_return():
     @op(
         out={

--- a/python_modules/dagster/dagster_tests/model_tests/test_dagster_model_serdes.py
+++ b/python_modules/dagster/dagster_tests/model_tests/test_dagster_model_serdes.py
@@ -4,7 +4,6 @@ Pydantic 1 and 2, while the general_tests do not.
 
 import pytest
 from dagster._model import DagsterModel
-from dagster._model.pydantic_compat_layer import USING_PYDANTIC_1
 from dagster._serdes.errors import SerializationError
 from dagster._serdes.serdes import (
     WhitelistMap,
@@ -54,7 +53,6 @@ def test_pydantic_alias_generator():
     assert deserialize_value(ser_o, whitelist_map=test_env) == o
 
 
-@pytest.mark.skipif(USING_PYDANTIC_1, reason="No serialization_alias in pydantic 1")
 def test_pydantic_serialization_alias():
     test_env = WhitelistMap.create()
 
@@ -77,7 +75,6 @@ def test_pydantic_serialization_alias():
         pack_value(o, whitelist_map=test_env)
 
 
-@pytest.mark.skipif(USING_PYDANTIC_1, reason="No validation_alias in pydantic 1")
 def test_pydantic_validation_alias():
     test_env = WhitelistMap.create()
 

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -110,7 +110,7 @@ setup(
         "universal_pathlib; python_version<'3.12'",
         "universal_pathlib>=0.2.0; python_version>='3.12'",
         # https://github.com/pydantic/pydantic/issues/5821
-        "pydantic>1.10.0,!=1.10.7,<2.10",
+        "pydantic>=2,<2.10",
         "rich",
         "filelock",
         f"dagster-pipes{pin}",

--- a/python_modules/dagster/tox.ini
+++ b/python_modules/dagster/tox.ini
@@ -24,11 +24,6 @@ deps =
   storage_tests_sqlalchemy_1_3: sqlalchemy<1.4
   storage_tests_sqlalchemy_1_4: sqlalchemy<2
   general_tests_old_protobuf: protobuf<4
-  core_tests_pydantic1:  pydantic!=1.10.7,<2.0.0
-  core_tests_pydantic2:  pydantic>=2.0.0
-  model_tests_pydantic1:  pydantic!=1.10.7,<2.0.0
-  model_tests_pydantic2:  pydantic>=2.0.0
-  type_signature_tests:  pydantic>=2.0.0
   -e ../dagster-test
   -e .[mypy,test,pyright]
   -e ../dagster-pipes
@@ -41,8 +36,7 @@ commands =
   api_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/api_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   asset_defs_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/asset_defs_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   cli_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/cli_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  core_tests_pydantic1: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  core_tests_pydantic2: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
+  core_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/core_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   daemon_sensor_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/daemon_sensor_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   daemon_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/daemon_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   definitions_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/definitions_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
@@ -58,8 +52,7 @@ commands =
   general_tests_old_protobuf: pytest -c ../../pyproject.toml -vv ./dagster_tests/general_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
   launcher_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/launcher_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   logging_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/logging_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  model_tests_pydantic1: pytest -c ../../pyproject.toml -vv ./dagster_tests/model_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
-  model_tests_pydantic2: pytest -c ../../pyproject.toml -vv ./dagster_tests/model_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
+  model_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/model_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   scheduler_tests: pytest -c ../../pyproject.toml -vv ./dagster_tests/scheduler_tests  {env:COVERAGE_ARGS} --durations 10 {posargs}
   scheduler_tests_pendulum_1: pytest -c ../../pyproject.toml -vv ./dagster_tests/scheduler_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}
   scheduler_tests_pendulum_2: pytest -c ../../pyproject.toml -vv ./dagster_tests/scheduler_tests  {env:COVERAGE_ARGS} --durations 10  {posargs}

--- a/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks/resources.py
@@ -2,8 +2,7 @@ from typing import Any, Dict, Optional
 
 from dagster import Config, ConfigurableResource, IAttachDifferentObjectToOpContext, resource
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
-from dagster._model.pydantic_compat_layer import compat_model_validator
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from dagster_databricks.databricks import DatabricksClient
 
@@ -61,7 +60,7 @@ class DatabricksClientResource(ConfigurableResource, IAttachDifferentObjectToOpC
         ),
     )
 
-    @compat_model_validator(mode="before")
+    @model_validator(mode="before")
     def has_token_or_oauth_credentials(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         token = values.get("token")
         oauth_credentials = values.get("oauth_credentials")

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/resource.py
@@ -18,7 +18,6 @@ from dagster import (
 from dagster._annotations import public
 from dagster._core.errors import DagsterInvalidPropertyError
 from dagster._core.execution.context.init import InitResourceContext
-from dagster._model.pydantic_compat_layer import compat_model_validator
 from dagster._utils import pushd
 from dbt.adapters.base.impl import BaseAdapter
 from dbt.adapters.factory import get_adapter, register_adapter, reset_adapters
@@ -28,7 +27,7 @@ from dbt.config.utils import parse_cli_vars
 from dbt.flags import get_flags, set_from_args
 from dbt.version import __version__ as dbt_version
 from packaging import version
-from pydantic import Field, validator
+from pydantic import Field, model_validator, validator
 from typing_extensions import Final
 
 from dagster_dbt.asset_utils import (
@@ -314,7 +313,7 @@ class DbtCliResource(ConfigurableResource):
 
         return dbt_executable
 
-    @compat_model_validator(mode="before")
+    @model_validator(mode="before")
     def validate_dbt_version(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Validate that the dbt version is supported."""
         if version.parse(dbt_version) < version.parse("1.7.0"):

--- a/python_modules/libraries/dagster-dbt/tox.ini
+++ b/python_modules/libraries/dagster-dbt/tox.ini
@@ -26,7 +26,6 @@ deps =
   dbt18: dbt-duckdb==1.8.*
   dbt18: dbt-snowflake==1.8.*
   dbt18: dbt-bigquery==1.8.*
-  pydantic1: pydantic!=1.10.7,<2.0.0
   -e .[test]
 allowlist_externals =
   /bin/bash

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -17,9 +17,8 @@ from dagster import (
 from dagster._annotations import public
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.storage.event_log.sql_event_log import SqlDbConnection
-from dagster._model.pydantic_compat_layer import compat_model_validator
 from dagster._utils.cached_method import cached_method
-from pydantic import Field, validator
+from pydantic import Field, model_validator, validator
 
 from dagster_snowflake.constants import (
     SNOWFLAKE_PARTNER_CONNECTION_IDENTIFIER,
@@ -278,7 +277,7 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
             )
         return v
 
-    @compat_model_validator(mode="before")
+    @model_validator(mode="before")
     def validate_authentication(cls, values):
         auths_set = 0
         auths_set += 1 if values.get("password") is not None else 0

--- a/python_modules/libraries/dagster-snowflake/tox.ini
+++ b/python_modules/libraries/dagster-snowflake/tox.ini
@@ -19,8 +19,6 @@ deps =
   -e ../../dagster-pipes
   -e ../dagster-pandas
   -e .
-  pydantic1: pydantic!=1.10.7,<2.0.0
-  pydantic2: pydantic>=2.0.0
 allowlist_externals =
   /bin/bash
   uv


### PR DESCRIPTION
Internal companion PR: https://github.com/dagster-io/internal/pull/12357

## Summary & Motivation

Bump min version of pydantic to 2.x in the `dagster` core. This rests on downstack work supporting pydantic 2 in some subsidiary packages. Changes include:

- Removing tox envs for pydantic 1/2-specific testing
- A bunch of code that branched on whether pydantic 1 vs 2 was installed in env

There is a whole additional "pydantic compat layer" that was designed to provide a uniform internal interface for our pydantic-using code depending on whether 1 or 2 was installed. I'll remove this in a followup.

## How I Tested These Changes

Existing test suite.

## Changelog

`dagster` now requires `pydantic>=2`.
