### PR TITLE
Update dagster-helm to use pydantic 2

### DIFF
--- a/helm/dagster/Chart.yaml
+++ b/helm/dagster/Chart.yaml
@@ -1,36 +1,37 @@
+---
 apiVersion: v2
-appVersion: dev
-dependencies:
-- condition: dagster-user-deployments.enableSubchart
-  name: dagster-user-deployments
-  version: 0.0.1-dev
-- condition: postgresql.enabled
-  name: postgresql
-  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-  version: 8.1.0
-- condition: rabbitmq.enabled
-  name: rabbitmq
-  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-  version: 6.16.3
-- condition: redis.internal
-  name: redis
-  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-  version: 12.7.4
-description: The data orchestration platform built for productivity.
-icon: https://dagster.io/images/brand/logos/dagster-primary-mark.png
-keywords:
-- analytics
-- data-orchestrator
-- data-pipelines
-- etl
-- workflow
-kubeVersion: '>= 1.18.0-0'
-maintainers:
-- email: support@dagsterlabs.com
-  name: Dagster Labs
-  url: https://dagster.io/about
 name: dagster
-sources:
-- https://github.com/dagster-io/dagster/tree/master/helm/dagster
+version: 0.0.1-dev
+kubeVersion: ">= 1.18.0-0"
+description: The data orchestration platform built for productivity.
 type: application
-version: 0.11.0
+keywords:
+  - analytics
+  - data-orchestrator
+  - data-pipelines
+  - etl
+  - workflow
+sources:
+  - https://github.com/dagster-io/dagster/tree/master/helm/dagster
+dependencies:
+  - name: dagster-user-deployments
+    version: 0.0.1-dev
+    condition: dagster-user-deployments.enableSubchart
+  - name: postgresql
+    version: 8.1.0
+    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
+    condition: postgresql.enabled
+  - name: rabbitmq
+    version: 6.16.3
+    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
+    condition: rabbitmq.enabled
+  - name: redis
+    version: 12.7.4
+    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
+    condition: redis.internal
+maintainers:
+  - name: Dagster Labs
+    email: support@dagsterlabs.com
+    url: https://dagster.io/about
+icon: https://dagster.io/images/brand/logos/dagster-primary-mark.png
+appVersion: dev

--- a/helm/dagster/Chart.yaml
+++ b/helm/dagster/Chart.yaml
@@ -1,37 +1,36 @@
----
 apiVersion: v2
-name: dagster
-version: 0.0.1-dev
-kubeVersion: ">= 1.18.0-0"
-description: The data orchestration platform built for productivity.
-type: application
-keywords:
-  - analytics
-  - data-orchestrator
-  - data-pipelines
-  - etl
-  - workflow
-sources:
-  - https://github.com/dagster-io/dagster/tree/master/helm/dagster
-dependencies:
-  - name: dagster-user-deployments
-    version: 0.0.1-dev
-    condition: dagster-user-deployments.enableSubchart
-  - name: postgresql
-    version: 8.1.0
-    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-    condition: postgresql.enabled
-  - name: rabbitmq
-    version: 6.16.3
-    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-    condition: rabbitmq.enabled
-  - name: redis
-    version: 12.7.4
-    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-    condition: redis.internal
-maintainers:
-  - name: Dagster Labs
-    email: support@dagsterlabs.com
-    url: https://dagster.io/about
-icon: https://dagster.io/images/brand/logos/dagster-primary-mark.png
 appVersion: dev
+dependencies:
+- condition: dagster-user-deployments.enableSubchart
+  name: dagster-user-deployments
+  version: 0.0.1-dev
+- condition: postgresql.enabled
+  name: postgresql
+  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
+  version: 8.1.0
+- condition: rabbitmq.enabled
+  name: rabbitmq
+  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
+  version: 6.16.3
+- condition: redis.internal
+  name: redis
+  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
+  version: 12.7.4
+description: The data orchestration platform built for productivity.
+icon: https://dagster.io/images/brand/logos/dagster-primary-mark.png
+keywords:
+- analytics
+- data-orchestrator
+- data-pipelines
+- etl
+- workflow
+kubeVersion: '>= 1.18.0-0'
+maintainers:
+- email: support@dagsterlabs.com
+  name: Dagster Labs
+  url: https://dagster.io/about
+name: dagster
+sources:
+- https://github.com/dagster-io/dagster/tree/master/helm/dagster
+type: application
+version: 0.11.0

--- a/helm/dagster/charts/dagster-user-deployments/Chart.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/Chart.yaml
@@ -1,21 +1,20 @@
----
 apiVersion: v2
-name: dagster-user-deployments
-version: 0.0.1-dev
-kubeVersion: ">= 1.18.0-0"
-description: A chart to deploy code servers for your Dagster deployment.
-type: application
-keywords:
-  - analytics
-  - data-orchestrator
-  - data-pipelines
-  - etl
-  - workflow
-sources:
-  - https://github.com/dagster-io/dagster/tree/master/helm/dagster/charts/dagster-user-deployments
-maintainers:
-  - name: Dagster Labs
-    email: support@dagsterlabs.com
-    url: https://dagster.io/about
-icon: https://dagster.io/images/brand/logos/dagster-primary-mark.png
 appVersion: dev
+description: A chart to deploy code servers for your Dagster deployment.
+icon: https://dagster.io/images/brand/logos/dagster-primary-mark.png
+keywords:
+- analytics
+- data-orchestrator
+- data-pipelines
+- etl
+- workflow
+kubeVersion: '>= 1.18.0-0'
+maintainers:
+- email: support@dagsterlabs.com
+  name: Dagster Labs
+  url: https://dagster.io/about
+name: dagster-user-deployments
+sources:
+- https://github.com/dagster-io/dagster/tree/master/helm/dagster/charts/dagster-user-deployments
+type: application
+version: 0.11.0

--- a/helm/dagster/charts/dagster-user-deployments/Chart.yaml
+++ b/helm/dagster/charts/dagster-user-deployments/Chart.yaml
@@ -1,20 +1,21 @@
+---
 apiVersion: v2
-appVersion: dev
-description: A chart to deploy code servers for your Dagster deployment.
-icon: https://dagster.io/images/brand/logos/dagster-primary-mark.png
-keywords:
-- analytics
-- data-orchestrator
-- data-pipelines
-- etl
-- workflow
-kubeVersion: '>= 1.18.0-0'
-maintainers:
-- email: support@dagsterlabs.com
-  name: Dagster Labs
-  url: https://dagster.io/about
 name: dagster-user-deployments
-sources:
-- https://github.com/dagster-io/dagster/tree/master/helm/dagster/charts/dagster-user-deployments
+version: 0.0.1-dev
+kubeVersion: ">= 1.18.0-0"
+description: A chart to deploy code servers for your Dagster deployment.
 type: application
-version: 0.11.0
+keywords:
+  - analytics
+  - data-orchestrator
+  - data-pipelines
+  - etl
+  - workflow
+sources:
+  - https://github.com/dagster-io/dagster/tree/master/helm/dagster/charts/dagster-user-deployments
+maintainers:
+  - name: Dagster Labs
+    email: support@dagsterlabs.com
+    url: https://dagster.io/about
+icon: https://dagster.io/images/brand/logos/dagster-primary-mark.png
+appVersion: dev

--- a/helm/dagster/charts/dagster-user-deployments/values.schema.json
+++ b/helm/dagster/charts/dagster-user-deployments/values.schema.json
@@ -1,383 +1,40 @@
 {
-    "title": "DagsterUserDeploymentsHelmValues",
-    "description": "@generated",
-    "type": "object",
-    "properties": {
-        "dagsterHome": {
-            "title": "Dagsterhome",
-            "type": "string"
-        },
-        "postgresqlSecretName": {
-            "title": "Postgresqlsecretname",
-            "type": "string"
-        },
-        "celeryConfigSecretName": {
-            "title": "Celeryconfigsecretname",
-            "type": "string"
-        },
-        "deployments": {
-            "title": "Deployments",
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/UserDeployment"
-            }
-        },
-        "imagePullSecrets": {
-            "title": "Imagepullsecrets",
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/SecretRef"
-            }
-        },
-        "serviceAccount": {
-            "$ref": "#/definitions/ServiceAccount"
-        },
-        "global": {
-            "$ref": "#/definitions/Global"
-        }
-    },
-    "required": [
-        "dagsterHome",
-        "postgresqlSecretName",
-        "celeryConfigSecretName",
-        "deployments",
-        "imagePullSecrets",
-        "serviceAccount",
-        "global"
-    ],
-    "definitions": {
-        "PullPolicy": {
-            "title": "PullPolicy",
-            "description": "An enumeration.",
-            "enum": [
-                "Always",
-                "IfNotPresent",
-                "Never"
-            ],
-            "type": "string"
-        },
-        "Image": {
-            "title": "Image",
-            "type": "object",
-            "properties": {
-                "repository": {
-                    "title": "Repository",
-                    "type": "string"
-                },
-                "tag": {
-                    "title": "Tag",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "pullPolicy": {
-                    "$ref": "#/definitions/PullPolicy"
-                }
-            },
-            "required": [
-                "repository",
-                "pullPolicy"
-            ]
-        },
-        "UserDeploymentIncludeConfigInLaunchedRuns": {
-            "title": "UserDeploymentIncludeConfigInLaunchedRuns",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "title": "Enabled",
-                    "type": "boolean"
-                }
-            },
-            "required": [
-                "enabled"
-            ]
-        },
-        "EnvVar": {
-            "title": "EnvVar",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
-        },
-        "ConfigMapEnvSource": {
-            "title": "ConfigMapEnvSource",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource"
-        },
-        "SecretEnvSource": {
-            "title": "SecretEnvSource",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecretEnvSource"
+    "$defs": {
+        "Affinity": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
+            "title": "Affinity",
+            "type": "object"
         },
         "Annotations": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+            "additionalProperties": {
+                "type": "string"
+            },
             "title": "Annotations",
-            "type": "object",
-            "additionalProperties": {
-                "type": "string"
-            },
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+            "type": "object"
         },
-        "NodeSelector": {
-            "title": "NodeSelector",
-            "type": "object",
-            "additionalProperties": {
-                "type": "string"
-            },
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector"
-        },
-        "Affinity": {
-            "title": "Affinity",
-            "type": "object",
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity"
-        },
-        "Tolerations": {
-            "title": "Tolerations",
-            "type": "array",
-            "items": {
-                "type": "object"
-            },
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations"
-        },
-        "PodSecurityContext": {
-            "title": "PodSecurityContext",
-            "type": "object",
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext"
-        },
-        "SecurityContext": {
-            "title": "SecurityContext",
-            "type": "object",
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext"
-        },
-        "Resources": {
-            "title": "Resources",
-            "type": "object",
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
-        },
-        "LivenessProbe": {
-            "title": "LivenessProbe",
-            "type": "object",
+        "ConfigMapEnvSource": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource",
+            "additionalProperties": true,
             "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
-        },
-        "ReadinessProbeWithEnabled": {
-            "title": "ReadinessProbeWithEnabled",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
-        },
-        "StartupProbe": {
-            "title": "StartupProbe",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "title": "Enabled",
-                    "default": true,
-                    "type": "boolean"
-                }
-            },
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
-        },
-        "VolumeMount": {
-            "title": "VolumeMount",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
-        },
-        "Volume": {
-            "title": "Volume",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
+            "title": "ConfigMapEnvSource",
+            "type": "object"
         },
         "Container": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container",
+            "additionalProperties": true,
+            "properties": {},
             "title": "Container",
-            "type": "object",
+            "type": "object"
+        },
+        "EnvVar": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar",
+            "additionalProperties": true,
             "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
-        },
-        "UserDeployment": {
-            "title": "UserDeployment",
-            "type": "object",
-            "properties": {
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                },
-                "image": {
-                    "$ref": "#/definitions/Image"
-                },
-                "dagsterApiGrpcArgs": {
-                    "title": "Dagsterapigrpcargs",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "codeServerArgs": {
-                    "title": "Codeserverargs",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "includeConfigInLaunchedRuns": {
-                    "$ref": "#/definitions/UserDeploymentIncludeConfigInLaunchedRuns"
-                },
-                "deploymentNamespace": {
-                    "title": "Deploymentnamespace",
-                    "type": "string"
-                },
-                "port": {
-                    "title": "Port",
-                    "type": "integer"
-                },
-                "env": {
-                    "title": "Env",
-                    "anyOf": [
-                        {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        },
-                        {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/EnvVar"
-                            }
-                        }
-                    ]
-                },
-                "envConfigMaps": {
-                    "title": "Envconfigmaps",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/ConfigMapEnvSource"
-                    }
-                },
-                "envSecrets": {
-                    "title": "Envsecrets",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/SecretEnvSource"
-                    }
-                },
-                "annotations": {
-                    "$ref": "#/definitions/Annotations"
-                },
-                "nodeSelector": {
-                    "$ref": "#/definitions/NodeSelector"
-                },
-                "affinity": {
-                    "$ref": "#/definitions/Affinity"
-                },
-                "tolerations": {
-                    "$ref": "#/definitions/Tolerations"
-                },
-                "podSecurityContext": {
-                    "$ref": "#/definitions/PodSecurityContext"
-                },
-                "securityContext": {
-                    "$ref": "#/definitions/SecurityContext"
-                },
-                "resources": {
-                    "$ref": "#/definitions/Resources"
-                },
-                "livenessProbe": {
-                    "$ref": "#/definitions/LivenessProbe"
-                },
-                "readinessProbe": {
-                    "$ref": "#/definitions/ReadinessProbeWithEnabled"
-                },
-                "startupProbe": {
-                    "$ref": "#/definitions/StartupProbe"
-                },
-                "labels": {
-                    "title": "Labels",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "volumeMounts": {
-                    "title": "Volumemounts",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/VolumeMount"
-                    }
-                },
-                "volumes": {
-                    "title": "Volumes",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Volume"
-                    }
-                },
-                "schedulerName": {
-                    "title": "Schedulername",
-                    "type": "string"
-                },
-                "initContainers": {
-                    "title": "Initcontainers",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Container"
-                    }
-                },
-                "sidecarContainers": {
-                    "title": "Sidecarcontainers",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Container"
-                    }
-                }
-            },
-            "required": [
-                "name",
-                "image",
-                "port"
-            ]
-        },
-        "SecretRef": {
-            "title": "SecretRef",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.LocalObjectReference"
-        },
-        "ServiceAccount": {
-            "title": "ServiceAccount",
-            "type": "object",
-            "properties": {
-                "create": {
-                    "title": "Create",
-                    "type": "boolean"
-                },
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                },
-                "annotations": {
-                    "$ref": "#/definitions/Annotations"
-                }
-            },
-            "required": [
-                "create",
-                "name",
-                "annotations"
-            ]
+            "title": "EnvVar",
+            "type": "object"
         },
         "Global": {
-            "title": "Global",
-            "type": "object",
             "properties": {
                 "postgresqlSecretName": {
                     "title": "Postgresqlsecretname",
@@ -401,7 +58,549 @@
                 "dagsterHome",
                 "serviceAccountName",
                 "celeryConfigSecretName"
-            ]
+            ],
+            "title": "Global",
+            "type": "object"
+        },
+        "Image": {
+            "properties": {
+                "repository": {
+                    "title": "Repository",
+                    "type": "string"
+                },
+                "tag": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Tag"
+                },
+                "pullPolicy": {
+                    "$ref": "#/$defs/PullPolicy"
+                }
+            },
+            "required": [
+                "repository",
+                "pullPolicy"
+            ],
+            "title": "Image",
+            "type": "object"
+        },
+        "LivenessProbe": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "LivenessProbe",
+            "type": "object"
+        },
+        "NodeSelector": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
+            "additionalProperties": {
+                "type": "string"
+            },
+            "extra": "allow",
+            "title": "NodeSelector",
+            "type": "object"
+        },
+        "PodSecurityContext": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+            "title": "PodSecurityContext",
+            "type": "object"
+        },
+        "PullPolicy": {
+            "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+            ],
+            "title": "PullPolicy",
+            "type": "string"
+        },
+        "ReadinessProbeWithEnabled": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "additionalProperties": true,
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "enabled"
+            ],
+            "title": "ReadinessProbeWithEnabled",
+            "type": "object"
+        },
+        "Resources": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+            "title": "Resources",
+            "type": "object"
+        },
+        "SecretEnvSource": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecretEnvSource",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "SecretEnvSource",
+            "type": "object"
+        },
+        "SecretRef": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "SecretRef",
+            "type": "object"
+        },
+        "SecurityContext": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+            "title": "SecurityContext",
+            "type": "object"
+        },
+        "ServiceAccount": {
+            "properties": {
+                "create": {
+                    "title": "Create",
+                    "type": "boolean"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations"
+                }
+            },
+            "required": [
+                "create",
+                "name",
+                "annotations"
+            ],
+            "title": "ServiceAccount",
+            "type": "object"
+        },
+        "StartupProbe": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "additionalProperties": true,
+            "properties": {
+                "enabled": {
+                    "default": true,
+                    "title": "Enabled",
+                    "type": "boolean"
+                }
+            },
+            "title": "StartupProbe",
+            "type": "object"
+        },
+        "Tolerations": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations",
+            "items": {
+                "type": "object"
+            },
+            "title": "Tolerations",
+            "type": "array"
+        },
+        "UserDeployment": {
+            "properties": {
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "image": {
+                    "$ref": "#/$defs/Image"
+                },
+                "dagsterApiGrpcArgs": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Dagsterapigrpcargs"
+                },
+                "codeServerArgs": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Codeserverargs"
+                },
+                "includeConfigInLaunchedRuns": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/UserDeploymentIncludeConfigInLaunchedRuns"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "deploymentNamespace": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Deploymentnamespace"
+                },
+                "port": {
+                    "title": "Port",
+                    "type": "integer"
+                },
+                "env": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/$defs/EnvVar"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Env"
+                },
+                "envConfigMaps": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/ConfigMapEnvSource"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Envconfigmaps"
+                },
+                "envSecrets": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/SecretEnvSource"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Envsecrets"
+                },
+                "annotations": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Annotations"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "nodeSelector": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/NodeSelector"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "affinity": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Affinity"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "tolerations": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Tolerations"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "podSecurityContext": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/PodSecurityContext"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "securityContext": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/SecurityContext"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "resources": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Resources"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "livenessProbe": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/LivenessProbe"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "readinessProbe": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ReadinessProbeWithEnabled"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "startupProbe": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/StartupProbe"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "labels": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Labels"
+                },
+                "volumeMounts": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/VolumeMount"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Volumemounts"
+                },
+                "volumes": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Volume"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Volumes"
+                },
+                "schedulerName": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Schedulername"
+                },
+                "initContainers": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Container"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Initcontainers"
+                },
+                "sidecarContainers": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Container"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Sidecarcontainers"
+                }
+            },
+            "required": [
+                "name",
+                "image",
+                "port"
+            ],
+            "title": "UserDeployment",
+            "type": "object"
+        },
+        "UserDeploymentIncludeConfigInLaunchedRuns": {
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "enabled"
+            ],
+            "title": "UserDeploymentIncludeConfigInLaunchedRuns",
+            "type": "object"
+        },
+        "Volume": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "Volume",
+            "type": "object"
+        },
+        "VolumeMount": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "VolumeMount",
+            "type": "object"
         }
-    }
+    },
+    "description": "@generated",
+    "properties": {
+        "dagsterHome": {
+            "title": "Dagsterhome",
+            "type": "string"
+        },
+        "postgresqlSecretName": {
+            "title": "Postgresqlsecretname",
+            "type": "string"
+        },
+        "celeryConfigSecretName": {
+            "title": "Celeryconfigsecretname",
+            "type": "string"
+        },
+        "deployments": {
+            "items": {
+                "$ref": "#/$defs/UserDeployment"
+            },
+            "title": "Deployments",
+            "type": "array"
+        },
+        "imagePullSecrets": {
+            "items": {
+                "$ref": "#/$defs/SecretRef"
+            },
+            "title": "Imagepullsecrets",
+            "type": "array"
+        },
+        "serviceAccount": {
+            "$ref": "#/$defs/ServiceAccount"
+        },
+        "global": {
+            "$ref": "#/$defs/Global"
+        }
+    },
+    "required": [
+        "dagsterHome",
+        "postgresqlSecretName",
+        "celeryConfigSecretName",
+        "deployments",
+        "imagePullSecrets",
+        "serviceAccount",
+        "global"
+    ],
+    "title": "DagsterUserDeploymentsHelmValues",
+    "type": "object"
 }

--- a/helm/dagster/schema/schema/charts/dagster/subschema/compute_log_manager.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/compute_log_manager.py
@@ -18,45 +18,42 @@ class ComputeLogManagerType(str, Enum):
 class AzureBlobComputeLogManager(BaseModel):
     storageAccount: StringSource
     container: StringSource
-    secretKey: Optional[StringSource]
-    defaultAzureCredential: Optional[dict]
-    localDir: Optional[StringSource]
-    prefix: Optional[StringSource]
-    uploadInterval: Optional[int]
+    secretKey: Optional[StringSource] = None
+    defaultAzureCredential: Optional[dict] = None
+    localDir: Optional[StringSource] = None
+    prefix: Optional[StringSource] = None
+    uploadInterval: Optional[int] = None
 
 
 class GCSComputeLogManager(BaseModel):
     bucket: StringSource
-    localDir: Optional[StringSource]
-    prefix: Optional[StringSource]
-    jsonCredentialsEnvvar: Optional[StringSource]
-    uploadInterval: Optional[int]
-    showUrlOnly: Optional[bool]
+    localDir: Optional[StringSource] = None
+    prefix: Optional[StringSource] = None
+    jsonCredentialsEnvvar: Optional[StringSource] = None
+    uploadInterval: Optional[int] = None
+    showUrlOnly: Optional[bool] = None
 
 
 class S3ComputeLogManager(BaseModel):
     bucket: StringSource
-    localDir: Optional[StringSource]
-    prefix: Optional[StringSource]
-    useSsl: Optional[bool]
-    verify: Optional[bool]
-    verifyCertPath: Optional[StringSource]
-    endpointUrl: Optional[StringSource]
-    skipEmptyFiles: Optional[bool]
-    uploadInterval: Optional[int]
-    uploadExtraArgs: Optional[dict]
-    showUrlOnly: Optional[bool]
-    region: Optional[StringSource]
+    localDir: Optional[StringSource] = None
+    prefix: Optional[StringSource] = None
+    useSsl: Optional[bool] = None
+    verify: Optional[bool] = None
+    verifyCertPath: Optional[StringSource] = None
+    endpointUrl: Optional[StringSource] = None
+    skipEmptyFiles: Optional[bool] = None
+    uploadInterval: Optional[int] = None
+    uploadExtraArgs: Optional[dict] = None
+    showUrlOnly: Optional[bool] = None
+    region: Optional[StringSource] = None
 
 
-class ComputeLogManagerConfig(BaseModel):
-    azureBlobComputeLogManager: Optional[AzureBlobComputeLogManager]
-    gcsComputeLogManager: Optional[GCSComputeLogManager]
-    s3ComputeLogManager: Optional[S3ComputeLogManager]
-    customComputeLogManager: Optional[ConfigurableClass]
-
-    class Config:
-        extra = Extra.forbid
+class ComputeLogManagerConfig(BaseModel, extra="forbid"):
+    azureBlobComputeLogManager: Optional[AzureBlobComputeLogManager] = None
+    gcsComputeLogManager: Optional[GCSComputeLogManager] = None
+    s3ComputeLogManager: Optional[S3ComputeLogManager] = None
+    customComputeLogManager: Optional[ConfigurableClass] = None
 
 
 class ComputeLogManager(BaseModel):
@@ -67,8 +64,8 @@ class ComputeLogManager(BaseModel):
         extra = Extra.forbid
 
         @staticmethod
-        def schema_extra(schema: Dict[str, Any], model: Type["ComputeLogManager"]):
-            BaseModel.Config.schema_extra(schema, model)
+        def json_schema_extra(schema: Dict[str, Any], model: Type["ComputeLogManager"]):
+            BaseModel.Config.json_schema_extra(schema, model)
             schema["allOf"] = create_json_schema_conditionals(
                 {
                     ComputeLogManagerType.AZURE: "azureBlobComputeLogManager",

--- a/helm/dagster/schema/schema/charts/dagster/subschema/compute_log_manager.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/compute_log_manager.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, Optional, Type
 
-from pydantic import Extra
+from pydantic import ConfigDict
 
 from schema.charts.dagster.subschema.config import StringSource
 from schema.charts.utils.utils import BaseModel, ConfigurableClass, create_json_schema_conditionals
@@ -60,17 +60,18 @@ class ComputeLogManager(BaseModel):
     type: ComputeLogManagerType
     config: ComputeLogManagerConfig
 
-    class Config:
-        extra = Extra.forbid
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra=lambda schema, model: ComputeLogManager.json_schema_extra(schema, model),
+    )
 
-        @staticmethod
-        def json_schema_extra(schema: Dict[str, Any], model: Type["ComputeLogManager"]):
-            BaseModel.Config.json_schema_extra(schema, model)
-            schema["allOf"] = create_json_schema_conditionals(
-                {
-                    ComputeLogManagerType.AZURE: "azureBlobComputeLogManager",
-                    ComputeLogManagerType.GCS: "gcsComputeLogManager",
-                    ComputeLogManagerType.S3: "s3ComputeLogManager",
-                    ComputeLogManagerType.CUSTOM: "customComputeLogManager",
-                }
-            )
+    @staticmethod
+    def json_schema_extra(schema: Dict[str, Any], model: Type["ComputeLogManager"]):
+        schema["allOf"] = create_json_schema_conditionals(
+            {
+                ComputeLogManagerType.AZURE: "azureBlobComputeLogManager",
+                ComputeLogManagerType.GCS: "gcsComputeLogManager",
+                ComputeLogManagerType.S3: "s3ComputeLogManager",
+                ComputeLogManagerType.CUSTOM: "customComputeLogManager",
+            }
+        )

--- a/helm/dagster/schema/schema/charts/dagster/subschema/config.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/config.py
@@ -1,14 +1,12 @@
 from typing import Union
 
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel
+from typing_extensions import TypeAlias
 
 
-class Source(BaseModel):
+class Source(BaseModel, extra="forbid"):
     env: str
 
-    class Config:
-        extra = Extra.forbid
 
-
-StringSource = Union[str, Source]
-IntSource = Union[int, Source]
+StringSource: TypeAlias = Union[str, Source]
+IntSource: TypeAlias = Union[int, Source]

--- a/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/daemon.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import Extra
+from pydantic import ConfigDict
 
 from schema.charts.dagster.subschema.config import IntSource
 from schema.charts.utils import kubernetes
@@ -13,20 +13,14 @@ class RunCoordinatorType(str, Enum):
     CUSTOM = "CustomRunCoordinator"
 
 
-class TagConcurrencyLimitConfig(BaseModel):
+class TagConcurrencyLimitConfig(BaseModel, extra="forbid"):
     applyLimitPerUniqueValue: bool
 
-    class Config:
-        extra = Extra.forbid
 
-
-class TagConcurrencyLimit(BaseModel):
+class TagConcurrencyLimit(BaseModel, extra="forbid"):
     key: str
-    value: Optional[Union[str, TagConcurrencyLimitConfig]]
+    value: Optional[Union[str, TagConcurrencyLimitConfig]] = None
     limit: int
-
-    class Config:
-        extra = Extra.forbid
 
 
 class BlockOpConcurrencyLimitedRuns(BaseModel):
@@ -34,21 +28,18 @@ class BlockOpConcurrencyLimitedRuns(BaseModel):
     opConcurrencySlotBuffer: int
 
 
-class QueuedRunCoordinatorConfig(BaseModel):
-    maxConcurrentRuns: Optional[IntSource]
-    tagConcurrencyLimits: Optional[List[TagConcurrencyLimit]]
-    dequeueIntervalSeconds: Optional[IntSource]
-    dequeueNumWorkers: Optional[IntSource]
-    dequeueUseThreads: Optional[bool]
-    blockOpConcurrencyLimitedRuns: Optional[BlockOpConcurrencyLimitedRuns]
-
-    class Config:
-        extra = Extra.forbid
+class QueuedRunCoordinatorConfig(BaseModel, extra="forbid"):
+    maxConcurrentRuns: Optional[IntSource] = None
+    tagConcurrencyLimits: Optional[List[TagConcurrencyLimit]] = None
+    dequeueIntervalSeconds: Optional[IntSource] = None
+    dequeueNumWorkers: Optional[IntSource] = None
+    dequeueUseThreads: Optional[bool] = None
+    blockOpConcurrencyLimitedRuns: Optional[BlockOpConcurrencyLimitedRuns] = None
 
 
 class RunCoordinatorConfig(BaseModel):
-    queuedRunCoordinator: Optional[QueuedRunCoordinatorConfig]
-    customRunCoordinator: Optional[ConfigurableClass]
+    queuedRunCoordinator: Optional[QueuedRunCoordinatorConfig] = None
+    customRunCoordinator: Optional[ConfigurableClass] = None
 
 
 class RunCoordinator(BaseModel):
@@ -56,37 +47,38 @@ class RunCoordinator(BaseModel):
     type: RunCoordinatorType
     config: RunCoordinatorConfig
 
-    class Config:
-        extra = Extra.forbid
-        schema_extra = {
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
             "allOf": create_json_schema_conditionals(
                 {
                     RunCoordinatorType.QUEUED: "queuedRunCoordinator",
                     RunCoordinatorType.CUSTOM: "customRunCoordinator",
                 }
             )
-        }
+        },
+    )
 
 
 class Sensors(BaseModel):
     useThreads: bool
-    numWorkers: Optional[int]
-    numSubmitWorkers: Optional[int]
+    numWorkers: Optional[int] = None
+    numSubmitWorkers: Optional[int] = None
 
 
 class Schedules(BaseModel):
     useThreads: bool
-    numWorkers: Optional[int]
-    numSubmitWorkers: Optional[int]
+    numWorkers: Optional[int] = None
+    numSubmitWorkers: Optional[int] = None
 
 
 class RunRetries(BaseModel):
     enabled: bool
-    maxRetries: Optional[int]
-    retryOnAssetOrOpFailure: Optional[bool]
+    maxRetries: Optional[int] = None
+    retryOnAssetOrOpFailure: Optional[bool] = None
 
 
-class Daemon(BaseModel):
+class Daemon(BaseModel, extra="forbid"):
     enabled: bool
     image: kubernetes.Image
     runCoordinator: RunCoordinator
@@ -110,10 +102,7 @@ class Daemon(BaseModel):
     runRetries: RunRetries
     sensors: Sensors
     schedules: Schedules
-    schedulerName: Optional[str]
-    volumeMounts: Optional[List[kubernetes.VolumeMount]]
-    volumes: Optional[List[kubernetes.Volume]]
-    initContainerResources: Optional[kubernetes.Resources]
-
-    class Config:
-        extra = Extra.forbid
+    schedulerName: Optional[str] = None
+    volumeMounts: Optional[List[kubernetes.VolumeMount]] = None
+    volumes: Optional[List[kubernetes.Volume]] = None
+    initContainerResources: Optional[kubernetes.Resources] = None

--- a/helm/dagster/schema/schema/charts/dagster/subschema/flower.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/flower.py
@@ -16,5 +16,5 @@ class Flower(BaseModel):
     resources: kubernetes.Resources
     livenessProbe: kubernetes.LivenessProbe
     startupProbe: kubernetes.StartupProbe
-    annotations: Optional[kubernetes.Annotations]
-    schedulerName: Optional[str]
+    annotations: Optional[kubernetes.Annotations] = None
+    schedulerName: Optional[str] = None

--- a/helm/dagster/schema/schema/charts/dagster/subschema/ingress.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/ingress.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from schema.charts.utils import kubernetes
 
@@ -53,5 +53,5 @@ class Ingress(BaseModel, extra="allow"):
     labels: kubernetes.Labels
     annotations: kubernetes.Annotations
     flower: FlowerIngressConfiguration
-    dagsterWebserver: WebserverIngressConfiguration = Field(alias="dagit")
+    dagsterWebserver: WebserverIngressConfiguration
     readOnlyDagsterWebserver: WebserverIngressConfiguration

--- a/helm/dagster/schema/schema/charts/dagster/subschema/ingress.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/ingress.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import List, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from schema.charts.utils import kubernetes
 
@@ -43,11 +43,15 @@ class FlowerIngressConfiguration(BaseModel):
     succeedingPaths: List[IngressPath]
 
 
-class Ingress(BaseModel):
+# We have `extra="allow"` here to support passing `dagit` as an alias for `dagsterWebserver` when
+# constructing without validation. This can be removed in 2.0 since we will no longer support the
+# dagit alias. It is possible there is a better way to do this using Pydantic field aliases, but the
+# current solution does work.
+class Ingress(BaseModel, extra="allow"):
     enabled: bool
-    apiVersion: Optional[str]
+    apiVersion: Optional[str] = None
     labels: kubernetes.Labels
     annotations: kubernetes.Annotations
     flower: FlowerIngressConfiguration
-    dagsterWebserver: WebserverIngressConfiguration
+    dagsterWebserver: WebserverIngressConfiguration = Field(alias="dagit")
     readOnlyDagsterWebserver: WebserverIngressConfiguration

--- a/helm/dagster/schema/schema/charts/dagster/subschema/postgresql.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/postgresql.py
@@ -17,5 +17,5 @@ class PostgreSQL(BaseModel):
     postgresqlPassword: str
     postgresqlDatabase: str
     postgresqlParams: dict
-    postgresqlScheme: Optional[str]
+    postgresqlScheme: Optional[str] = None
     service: Service

--- a/helm/dagster/schema/schema/charts/dagster/subschema/python_logs.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/python_logs.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel
 
 
 class PythonLogLevel(str, Enum):
@@ -15,10 +15,7 @@ class PythonLogLevel(str, Enum):
     NOTSET = "NOTSET"
 
 
-class PythonLogs(BaseModel):
-    pythonLogLevel: Optional[PythonLogLevel]
-    managedPythonLoggers: Optional[List[str]]
-    dagsterHandlerConfig: Optional[Dict[str, Any]]
-
-    class Config:
-        extra = Extra.forbid
+class PythonLogs(BaseModel, extra="forbid"):
+    pythonLogLevel: Optional[PythonLogLevel] = None
+    managedPythonLoggers: Optional[List[str]] = None
+    dagsterHandlerConfig: Optional[Dict[str, Any]] = None

--- a/helm/dagster/schema/schema/charts/dagster/subschema/rabbitmq.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/rabbitmq.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel, Field
+from typing import Literal
+
+from pydantic import BaseModel
 
 from schema.charts.utils.kubernetes import ExternalImage
 
@@ -13,7 +15,7 @@ class Service(BaseModel):
 
 
 class VolumePermissions(BaseModel):
-    enabled: bool = Field(default=True, const=True)
+    enabled: Literal[True] = True
     image: ExternalImage
 
 

--- a/helm/dagster/schema/schema/charts/dagster/subschema/redis.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/redis.py
@@ -1,7 +1,7 @@
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel
 
 
-class Redis(BaseModel):
+class Redis(BaseModel, extra="allow"):
     enabled: bool
     internal: bool
     usePassword: bool
@@ -12,6 +12,3 @@ class Redis(BaseModel):
     backendDbNumber: int
     brokerUrl: str
     backendUrl: str
-
-    class Config:
-        extra = Extra.allow

--- a/helm/dagster/schema/schema/charts/dagster/subschema/retention.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/retention.py
@@ -1,27 +1,21 @@
 from typing import Optional, Union
 
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel
 
 
-class TickRetentionByType(BaseModel):
+class TickRetentionByType(BaseModel, extra="forbid"):
     skipped: int
     success: int
     failure: int
     started: int
-
-    class Config:
-        extra = Extra.forbid
 
 
 class TickRetention(BaseModel):
     purgeAfterDays: Union[int, TickRetentionByType]
 
 
-class Retention(BaseModel):
+class Retention(BaseModel, extra="forbid"):
     enabled: bool
     sensor: TickRetention
     schedule: TickRetention
-    autoMaterialize: Optional[TickRetention]
-
-    class Config:
-        extra = Extra.forbid
+    autoMaterialize: Optional[TickRetention] = None

--- a/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import Extra, Field
+from pydantic import ConfigDict, Field
 
 from schema.charts.utils import kubernetes
 from schema.charts.utils.utils import BaseModel, ConfigurableClass, create_json_schema_conditionals
@@ -13,7 +13,7 @@ class RunLauncherType(str, Enum):
     CUSTOM = "CustomRunLauncher"
 
 
-class CeleryWorkerQueue(BaseModel, extra="forbid"):
+class CeleryWorkerQueue(BaseModel):
     replicaCount: int = Field(gt=0)
     name: str
     labels: Optional[kubernetes.Labels] = None
@@ -21,8 +21,10 @@ class CeleryWorkerQueue(BaseModel, extra="forbid"):
     configSource: Optional[dict] = None
     additionalCeleryArgs: Optional[List[str]] = None
 
+    model_config = ConfigDict(extra="forbid")
 
-class CeleryK8sRunLauncherConfig(BaseModel, extra="forbid"):
+
+class CeleryK8sRunLauncherConfig(BaseModel):
     image: kubernetes.Image
     imagePullPolicy: Optional[kubernetes.PullPolicy] = None
     nameOverride: str
@@ -46,16 +48,20 @@ class CeleryK8sRunLauncherConfig(BaseModel, extra="forbid"):
     schedulerName: Optional[str] = None
     jobNamespace: Optional[str] = None
 
+    model_config = ConfigDict(extra="forbid")
 
-class RunK8sConfig(BaseModel, extra="forbid"):
+
+class RunK8sConfig(BaseModel):
     containerConfig: Optional[Dict[str, Any]] = None
     podSpecConfig: Optional[Dict[str, Any]] = None
     podTemplateSpecMetadata: Optional[Dict[str, Any]] = None
     jobSpecConfig: Optional[Dict[str, Any]] = None
     jobMetadata: Optional[Dict[str, Any]] = None
 
+    model_config = ConfigDict(extra="forbid")
 
-class K8sRunLauncherConfig(BaseModel, extra="forbid"):
+
+class K8sRunLauncherConfig(BaseModel):
     image: Optional[kubernetes.Image] = None
     imagePullPolicy: kubernetes.PullPolicy
     jobNamespace: Optional[str] = None
@@ -73,6 +79,8 @@ class K8sRunLauncherConfig(BaseModel, extra="forbid"):
     securityContext: Optional[kubernetes.SecurityContext] = None
     runK8sConfig: Optional[RunK8sConfig] = None
 
+    model_config = ConfigDict(extra="forbid")
+
 
 class RunLauncherConfig(BaseModel):
     celeryK8sRunLauncher: Optional[CeleryK8sRunLauncherConfig] = None
@@ -84,9 +92,9 @@ class RunLauncher(BaseModel):
     type: RunLauncherType
     config: RunLauncherConfig
 
-    class Config:
-        extra = Extra.forbid
-        schema_extra = {
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
             "allOf": create_json_schema_conditionals(
                 {
                     RunLauncherType.CELERY: "celeryK8sRunLauncher",
@@ -94,4 +102,5 @@ class RunLauncher(BaseModel):
                     RunLauncherType.CUSTOM: "customRunLauncher",
                 }
             )
-        }
+        },
+    )

--- a/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/run_launcher.py
@@ -13,21 +13,18 @@ class RunLauncherType(str, Enum):
     CUSTOM = "CustomRunLauncher"
 
 
-class CeleryWorkerQueue(BaseModel):
+class CeleryWorkerQueue(BaseModel, extra="forbid"):
     replicaCount: int = Field(gt=0)
     name: str
-    labels: Optional[kubernetes.Labels]
-    nodeSelector: Optional[kubernetes.NodeSelector]
-    configSource: Optional[dict]
-    additionalCeleryArgs: Optional[List[str]]
-
-    class Config:
-        extra = Extra.forbid
+    labels: Optional[kubernetes.Labels] = None
+    nodeSelector: Optional[kubernetes.NodeSelector] = None
+    configSource: Optional[dict] = None
+    additionalCeleryArgs: Optional[List[str]] = None
 
 
-class CeleryK8sRunLauncherConfig(BaseModel):
+class CeleryK8sRunLauncherConfig(BaseModel, extra="forbid"):
     image: kubernetes.Image
-    imagePullPolicy: Optional[kubernetes.PullPolicy]
+    imagePullPolicy: Optional[kubernetes.PullPolicy] = None
     nameOverride: str
     configSource: dict
     workerQueues: List[CeleryWorkerQueue] = Field(min_items=1)
@@ -44,52 +41,43 @@ class CeleryK8sRunLauncherConfig(BaseModel):
     livenessProbe: kubernetes.LivenessProbe
     volumeMounts: List[kubernetes.VolumeMount]
     volumes: List[kubernetes.Volume]
-    labels: Optional[Dict[str, str]]
-    failPodOnRunFailure: Optional[bool]
-    schedulerName: Optional[str]
-    jobNamespace: Optional[str]
-
-    class Config:
-        extra = Extra.forbid
+    labels: Optional[Dict[str, str]] = None
+    failPodOnRunFailure: Optional[bool] = None
+    schedulerName: Optional[str] = None
+    jobNamespace: Optional[str] = None
 
 
-class RunK8sConfig(BaseModel):
-    containerConfig: Optional[Dict[str, Any]]
-    podSpecConfig: Optional[Dict[str, Any]]
-    podTemplateSpecMetadata: Optional[Dict[str, Any]]
-    jobSpecConfig: Optional[Dict[str, Any]]
-    jobMetadata: Optional[Dict[str, Any]]
-
-    class Config:
-        extra = Extra.forbid
+class RunK8sConfig(BaseModel, extra="forbid"):
+    containerConfig: Optional[Dict[str, Any]] = None
+    podSpecConfig: Optional[Dict[str, Any]] = None
+    podTemplateSpecMetadata: Optional[Dict[str, Any]] = None
+    jobSpecConfig: Optional[Dict[str, Any]] = None
+    jobMetadata: Optional[Dict[str, Any]] = None
 
 
-class K8sRunLauncherConfig(BaseModel):
-    image: Optional[kubernetes.Image]
+class K8sRunLauncherConfig(BaseModel, extra="forbid"):
+    image: Optional[kubernetes.Image] = None
     imagePullPolicy: kubernetes.PullPolicy
-    jobNamespace: Optional[str]
+    jobNamespace: Optional[str] = None
     loadInclusterConfig: bool
-    kubeconfigFile: Optional[str]
+    kubeconfigFile: Optional[str] = None
     envConfigMaps: List[kubernetes.ConfigMapEnvSource]
     envSecrets: List[kubernetes.SecretEnvSource]
     envVars: List[str]
     volumeMounts: List[kubernetes.VolumeMount]
     volumes: List[kubernetes.Volume]
-    labels: Optional[Dict[str, str]]
-    failPodOnRunFailure: Optional[bool]
-    resources: Optional[kubernetes.ResourceRequirements]
-    schedulerName: Optional[str]
-    securityContext: Optional[kubernetes.SecurityContext]
-    runK8sConfig: Optional[RunK8sConfig]
-
-    class Config:
-        extra = Extra.forbid
+    labels: Optional[Dict[str, str]] = None
+    failPodOnRunFailure: Optional[bool] = None
+    resources: Optional[kubernetes.ResourceRequirements] = None
+    schedulerName: Optional[str] = None
+    securityContext: Optional[kubernetes.SecurityContext] = None
+    runK8sConfig: Optional[RunK8sConfig] = None
 
 
 class RunLauncherConfig(BaseModel):
-    celeryK8sRunLauncher: Optional[CeleryK8sRunLauncherConfig]
-    k8sRunLauncher: Optional[K8sRunLauncherConfig]
-    customRunLauncher: Optional[ConfigurableClass]
+    celeryK8sRunLauncher: Optional[CeleryK8sRunLauncherConfig] = None
+    k8sRunLauncher: Optional[K8sRunLauncherConfig] = None
+    customRunLauncher: Optional[ConfigurableClass] = None
 
 
 class RunLauncher(BaseModel):

--- a/helm/dagster/schema/schema/charts/dagster/subschema/scheduler.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/scheduler.py
@@ -1,8 +1,6 @@
 from enum import Enum
 from typing import Optional
 
-from pydantic import Extra
-
 from schema.charts.utils.utils import BaseModel, ConfigurableClass, create_json_schema_conditionals
 
 
@@ -12,24 +10,21 @@ class SchedulerType(str, Enum):
 
 
 class DaemonSchedulerConfig(BaseModel):
-    maxCatchupRuns: Optional[int]
-    maxTickRetries: Optional[int]
+    maxCatchupRuns: Optional[int] = None
+    maxTickRetries: Optional[int] = None
 
 
-class SchedulerConfig(BaseModel):
-    daemonScheduler: Optional[DaemonSchedulerConfig]
-    customScheduler: Optional[ConfigurableClass]
-
-    class Config:
-        extra = Extra.forbid
+class SchedulerConfig(BaseModel, extra="forbid"):
+    daemonScheduler: Optional[DaemonSchedulerConfig] = None
+    customScheduler: Optional[ConfigurableClass] = None
 
 
-class Scheduler(BaseModel):
+class Scheduler(
+    BaseModel,
+    extra="forbid",
+    json_schema_extra={
+        "allOf": create_json_schema_conditionals({SchedulerType.CUSTOM: "customScheduler"})
+    },
+):
     type: SchedulerType
     config: SchedulerConfig
-
-    class Config:
-        extra = Extra.forbid
-        schema_extra = {
-            "allOf": create_json_schema_conditionals({SchedulerType.CUSTOM: "customScheduler"})
-        }

--- a/helm/dagster/schema/schema/charts/dagster/subschema/telemetry.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/telemetry.py
@@ -1,8 +1,5 @@
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel
 
 
-class Telemetry(BaseModel):
+class Telemetry(BaseModel, extra="forbid"):
     enabled: bool
-
-    class Config:
-        extra = Extra.forbid

--- a/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
+++ b/helm/dagster/schema/schema/charts/dagster/subschema/webserver.py
@@ -1,7 +1,5 @@
 from typing import Dict, List, Optional, Union
 
-from pydantic import Extra
-
 from schema.charts.utils import kubernetes
 from schema.charts.utils.utils import BaseModel
 
@@ -9,21 +7,21 @@ from schema.charts.utils.utils import BaseModel
 class Server(BaseModel):
     host: str
     port: int
-    name: Optional[str]
-    ssl: Optional[bool]
+    name: Optional[str] = None
+    ssl: Optional[bool] = None
 
 
 class Workspace(BaseModel):
     enabled: bool
     servers: List[Server]
-    externalConfigmap: Optional[str]
+    externalConfigmap: Optional[str] = None
 
 
-class Webserver(BaseModel):
+class Webserver(BaseModel, extra="forbid"):
     replicaCount: int
     image: kubernetes.Image
     nameOverride: str
-    pathPrefix: Optional[str]
+    pathPrefix: Optional[str] = None
     service: kubernetes.Service
     workspace: Workspace
     env: Union[Dict[str, str], List[kubernetes.EnvVar]]
@@ -42,13 +40,10 @@ class Webserver(BaseModel):
     startupProbe: kubernetes.StartupProbe
     annotations: kubernetes.Annotations
     enableReadOnly: bool
-    dbStatementTimeout: Optional[int]
-    dbPoolRecycle: Optional[int]
-    logLevel: Optional[str]
-    schedulerName: Optional[str]
-    volumeMounts: Optional[List[kubernetes.VolumeMount]]
-    volumes: Optional[List[kubernetes.Volume]]
-    initContainerResources: Optional[kubernetes.Resources]
-
-    class Config:
-        extra = Extra.forbid
+    dbStatementTimeout: Optional[int] = None
+    dbPoolRecycle: Optional[int] = None
+    logLevel: Optional[str] = None
+    schedulerName: Optional[str] = None
+    volumeMounts: Optional[List[kubernetes.VolumeMount]] = None
+    volumes: Optional[List[kubernetes.Volume]] = None
+    initContainerResources: Optional[kubernetes.Resources] = None

--- a/helm/dagster/schema/schema/charts/dagster/values.py
+++ b/helm/dagster/schema/schema/charts/dagster/values.py
@@ -7,7 +7,11 @@ from schema.charts.dagster_user_deployments.subschema.user_deployments import Us
 from schema.charts.utils import kubernetes
 
 
-class DagsterHelmValues(BaseModel):
+# We have `extra="allow"` here to support passing `dagit` as an alias for `dagsterWebserver` when
+# constructing without validation. This can be removed in 2.0 since we will no longer support the
+# dagit alias. It is possible there is a better way to do this using Pydantic field aliases, but the
+# current solution does work.
+class DagsterHelmValues(BaseModel, extra="allow"):
     __doc__ = "@" + "generated"
 
     dagsterWebserver: subschema.Webserver
@@ -31,4 +35,4 @@ class DagsterHelmValues(BaseModel):
     serviceAccount: subschema.ServiceAccount
     global_: subschema.Global = Field(..., alias="global")
     retention: subschema.Retention
-    additionalInstanceConfig: Optional[Mapping[str, Any]]
+    additionalInstanceConfig: Optional[Mapping[str, Any]] = None

--- a/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
+++ b/helm/dagster/schema/schema/charts/dagster_user_deployments/subschema/user_deployments.py
@@ -10,37 +10,37 @@ class UserDeploymentIncludeConfigInLaunchedRuns(BaseModel):
 
 
 ReadinessProbeWithEnabled = create_model(
-    "ReadinessProbeWithEnabled", __base__=(kubernetes.ReadinessProbe), enabled=(bool)
+    "ReadinessProbeWithEnabled", __base__=(kubernetes.ReadinessProbe), enabled=(bool, ...)
 )
 
 
 class UserDeployment(BaseModel):
     name: str
     image: kubernetes.Image
-    dagsterApiGrpcArgs: Optional[List[str]]
-    codeServerArgs: Optional[List[str]]
-    includeConfigInLaunchedRuns: Optional[UserDeploymentIncludeConfigInLaunchedRuns]
-    deploymentNamespace: Optional[str]
+    dagsterApiGrpcArgs: Optional[List[str]] = None
+    codeServerArgs: Optional[List[str]] = None
+    includeConfigInLaunchedRuns: Optional[UserDeploymentIncludeConfigInLaunchedRuns] = None
+    deploymentNamespace: Optional[str] = None
     port: int
-    env: Optional[Union[Dict[str, str], List[kubernetes.EnvVar]]]
-    envConfigMaps: Optional[List[kubernetes.ConfigMapEnvSource]]
-    envSecrets: Optional[List[kubernetes.SecretEnvSource]]
-    annotations: Optional[kubernetes.Annotations]
-    nodeSelector: Optional[kubernetes.NodeSelector]
-    affinity: Optional[kubernetes.Affinity]
-    tolerations: Optional[kubernetes.Tolerations]
-    podSecurityContext: Optional[kubernetes.PodSecurityContext]
-    securityContext: Optional[kubernetes.SecurityContext]
-    resources: Optional[kubernetes.Resources]
-    livenessProbe: Optional[kubernetes.LivenessProbe]
-    readinessProbe: Optional[ReadinessProbeWithEnabled]
-    startupProbe: Optional[kubernetes.StartupProbe]
-    labels: Optional[Dict[str, str]]
-    volumeMounts: Optional[List[kubernetes.VolumeMount]]
-    volumes: Optional[List[kubernetes.Volume]]
-    schedulerName: Optional[str]
-    initContainers: Optional[List[kubernetes.Container]]
-    sidecarContainers: Optional[List[kubernetes.Container]]
+    env: Optional[Union[Dict[str, str], List[kubernetes.EnvVar]]] = None
+    envConfigMaps: Optional[List[kubernetes.ConfigMapEnvSource]] = None
+    envSecrets: Optional[List[kubernetes.SecretEnvSource]] = None
+    annotations: Optional[kubernetes.Annotations] = None
+    nodeSelector: Optional[kubernetes.NodeSelector] = None
+    affinity: Optional[kubernetes.Affinity] = None
+    tolerations: Optional[kubernetes.Tolerations] = None
+    podSecurityContext: Optional[kubernetes.PodSecurityContext] = None
+    securityContext: Optional[kubernetes.SecurityContext] = None
+    resources: Optional[kubernetes.Resources] = None
+    livenessProbe: Optional[kubernetes.LivenessProbe] = None
+    readinessProbe: Optional[ReadinessProbeWithEnabled] = None
+    startupProbe: Optional[kubernetes.StartupProbe] = None
+    labels: Optional[Dict[str, str]] = None
+    volumeMounts: Optional[List[kubernetes.VolumeMount]] = None
+    volumes: Optional[List[kubernetes.Volume]] = None
+    schedulerName: Optional[str] = None
+    initContainers: Optional[List[kubernetes.Container]] = None
+    sidecarContainers: Optional[List[kubernetes.Container]] = None
 
 
 class UserDeployments(BaseModel):

--- a/helm/dagster/schema/schema/charts/utils/kubernetes.py
+++ b/helm/dagster/schema/schema/charts/utils/kubernetes.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel, RootModel
 
 from schema.charts.utils.utils import (
     BaseModel as BaseModelWithNullableRequiredFields,
@@ -9,24 +9,25 @@ from schema.charts.utils.utils import (
 )
 
 
-class Annotations(BaseModel):
-    __root__: Dict[str, str]
-
-    class Config:
-        schema_extra = {
+class Annotations(RootModel[Dict[str, str]]):
+    model_config = {
+        "json_schema_extra": {
             "$ref": create_definition_ref(
                 "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
             )
         }
+    }
 
 
 class Labels(BaseModel):
-    class Config:
-        schema_extra = {
+    model_config = {
+        "extra": "allow",
+        "json_schema_extra": {
             "$ref": create_definition_ref(
                 "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
             )
-        }
+        },
+    }
 
 
 class PullPolicy(str, Enum):
@@ -37,7 +38,7 @@ class PullPolicy(str, Enum):
 
 class Image(BaseModelWithNullableRequiredFields):
     repository: str
-    tag: Optional[Union[str, int]]
+    tag: Optional[Union[str, int]] = None
     pullPolicy: PullPolicy
 
     @property
@@ -49,120 +50,147 @@ class ExternalImage(Image):
     tag: str
 
 
-class Service(BaseModel):
+class Service(BaseModel, extra="forbid"):
     type: str
     port: int
-    annotations: Optional[Annotations]
-
-    class Config:
-        extra = Extra.forbid
+    annotations: Optional[Annotations] = None
 
 
-class NodeSelector(BaseModel):
-    __root__: Dict[str, str]
-
-    class Config:
-        schema_extra = {
-            "$ref": create_definition_ref("io.k8s.api.core.v1.PodSpec/properties/nodeSelector")
+class NodeSelector(RootModel[Dict[str, str]]):
+    model_config = {
+        "json_schema_extra": {
+            "extra": "allow",
+            "$ref": create_definition_ref("io.k8s.api.core.v1.PodSpec/properties/nodeSelector"),
         }
+    }
 
 
-class Affinity(BaseModel):
-    __root__: Dict[str, Any]
+class Affinity(RootModel[Dict[str, Any]]):
+    model_config = {
+        "json_schema_extra": {"$ref": create_definition_ref("io.k8s.api.core.v1.Affinity")}
+    }
 
-    class Config:
-        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.Affinity")}
 
-
-class Tolerations(BaseModel):
-    __root__: List[Dict[str, Any]]
-
-    class Config:
-        schema_extra = {
+class Tolerations(RootModel[List[Dict[str, Any]]]):
+    model_config = {
+        "json_schema_extra": {
             "$ref": create_definition_ref("io.k8s.api.core.v1.PodSpec/properties/tolerations")
         }
+    }
 
 
-class PodSecurityContext(BaseModel):
-    __root__: Dict[str, Any]
+class PodSecurityContext(RootModel[Dict[str, Any]]):
+    model_config = {
+        "json_schema_extra": {
+            "$ref": create_definition_ref("io.k8s.api.core.v1.PodSecurityContext")
+        }
+    }
 
-    class Config:
-        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.PodSecurityContext")}
 
-
-class SecurityContext(BaseModel):
-    __root__: Dict[str, Any]
-
-    class Config:
-        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.SecurityContext")}
+class SecurityContext(
+    RootModel[Dict[str, Any]],
+    json_schema_extra={"$ref": create_definition_ref("io.k8s.api.core.v1.SecurityContext")},
+):
+    pass
 
 
 class InitContainer(BaseModel):
-    class Config:
-        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.Container")}
+    model_config = {
+        "extra": "allow",
+        "json_schema_extra": {"$ref": create_definition_ref("io.k8s.api.core.v1.Container")},
+    }
 
 
-class Resources(BaseModel):
-    __root__: Dict[str, Any]
-
-    class Config:
-        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.ResourceRequirements")}
+class Resources(RootModel[Dict[str, Any]]):
+    model_config = {
+        "json_schema_extra": {
+            "$ref": create_definition_ref("io.k8s.api.core.v1.ResourceRequirements")
+        }
+    }
 
 
 class LivenessProbe(BaseModel):
-    class Config:
-        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.Probe")}
+    model_config = {
+        "extra": "allow",
+        "json_schema_extra": {"$ref": create_definition_ref("io.k8s.api.core.v1.Probe")},
+    }
 
 
 class ReadinessProbe(BaseModel):
-    class Config:
-        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.Probe")}
+    model_config = {
+        "extra": "allow",
+        "json_schema_extra": {"$ref": create_definition_ref("io.k8s.api.core.v1.Probe")},
+    }
 
 
 class StartupProbe(BaseModel):
     enabled: bool = True
 
-    class Config:
-        schema_extra = {
+    model_config = {
+        "extra": "allow",
+        "json_schema_extra": {
             "$ref": create_definition_ref("io.k8s.api.core.v1.Probe"),
-        }
+        },
+    }
 
 
 class SecretRef(BaseModel):
-    class Config:
-        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.LocalObjectReference")}
+    model_config = {
+        "extra": "allow",
+        "json_schema_extra": {
+            "$ref": create_definition_ref("io.k8s.api.core.v1.LocalObjectReference")
+        },
+    }
 
 
 class SecretEnvSource(BaseModel):
-    class Config:
-        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.SecretEnvSource")}
+    model_config = {
+        "extra": "allow",
+        "json_schema_extra": {"$ref": create_definition_ref("io.k8s.api.core.v1.SecretEnvSource")},
+    }
 
 
 class ConfigMapEnvSource(BaseModel):
-    class Config:
-        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.ConfigMapEnvSource")}
+    model_config = {
+        "extra": "allow",
+        "json_schema_extra": {
+            "$ref": create_definition_ref("io.k8s.api.core.v1.ConfigMapEnvSource")
+        },
+    }
 
 
 class VolumeMount(BaseModel):
-    class Config:
-        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.VolumeMount")}
+    model_config = {
+        "extra": "allow",
+        "json_schema_extra": {"$ref": create_definition_ref("io.k8s.api.core.v1.VolumeMount")},
+    }
 
 
 class Volume(BaseModel):
-    class Config:
-        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.Volume")}
+    model_config = {
+        "extra": "allow",
+        "json_schema_extra": {"$ref": create_definition_ref("io.k8s.api.core.v1.Volume")},
+    }
 
 
 class ResourceRequirements(BaseModel):
-    class Config:
-        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.ResourceRequirements")}
+    model_config = {
+        "extra": "allow",
+        "json_schema_extra": {
+            "$ref": create_definition_ref("io.k8s.api.core.v1.ResourceRequirements")
+        },
+    }
 
 
 class EnvVar(BaseModel):
-    class Config:
-        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.EnvVar")}
+    model_config = {
+        "extra": "allow",
+        "json_schema_extra": {"$ref": create_definition_ref("io.k8s.api.core.v1.EnvVar")},
+    }
 
 
 class Container(BaseModel):
-    class Config:
-        schema_extra = {"$ref": create_definition_ref("io.k8s.api.core.v1.Container")}
+    model_config = {
+        "extra": "allow",
+        "json_schema_extra": {"$ref": create_definition_ref("io.k8s.api.core.v1.Container")},
+    }

--- a/helm/dagster/schema/schema/charts/utils/utils.py
+++ b/helm/dagster/schema/schema/charts/utils/utils.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 
 from pydantic import (
     BaseModel as PydanticBaseModel,
-    Extra,
+    Field,
 )
 
 
@@ -11,14 +11,10 @@ class SupportedKubernetes(str, Enum):
     V1_18 = "1.18.0"
 
 
-class ConfigurableClass(PydanticBaseModel):
+class ConfigurableClass(PydanticBaseModel, extra="forbid"):
     module: str
-    class_: str
+    class_: str = Field(alias="class")
     config: dict
-
-    class Config:
-        fields = {"class_": "class"}
-        extra = Extra.forbid
 
 
 class BaseModel(PydanticBaseModel):
@@ -33,7 +29,7 @@ class BaseModel(PydanticBaseModel):
         def schema_extra(schema, model):
             for prop, value in schema.get("properties", {}).items():
                 # retrieve right field from alias or name
-                field = next(x for x in model.__fields__.values() if x.alias == prop)
+                field = next(x for x in model.model_fields.values() if x.alias == prop)
                 if field.allow_none:
                     # only one type e.g. {'type': 'integer'}
                     if "type" in value:

--- a/helm/dagster/schema/schema/charts/utils/utils.py
+++ b/helm/dagster/schema/schema/charts/utils/utils.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, List
+from typing import Any, Dict, List, Mapping
 
 from pydantic import (
     BaseModel as PydanticBaseModel,
@@ -51,7 +51,7 @@ def create_definition_ref(definition: str, version: str = SupportedKubernetes.V1
 
 def create_json_schema_conditionals(
     enum_type_to_config_name_mapping: Dict[Enum, str],
-) -> List[dict]:
+) -> List[Mapping[str, Any]]:
     return [
         {
             "if": {

--- a/helm/dagster/schema/schema/utils/helm_template.py
+++ b/helm/dagster/schema/schema/utils/helm_template.py
@@ -44,7 +44,9 @@ class HelmTemplate:
             helm_dir_path = os.path.join(git_repo_root(), self.helm_dir_path)
 
             values_json = (
-                json.loads(values.json(exclude_none=True, by_alias=True)) if values else values_dict
+                json.loads(values.model_dump_json(exclude_none=True, by_alias=True))
+                if values
+                else values_dict
             )
             pprint(values_json)  # noqa: T203
             content = yaml.dump(values_json)

--- a/helm/dagster/schema/schema_tests/test_dagit.py
+++ b/helm/dagster/schema/schema_tests/test_dagit.py
@@ -495,7 +495,9 @@ def test_webserver_security_context(deployment_template: HelmTemplate):
         },
     }
     helm_values = DagsterHelmValues.construct(
-        dagsterWebserver=Webserver.construct(securityContext=security_context)
+        dagsterWebserver=Webserver.construct(
+            securityContext=kubernetes.SecurityContext.parse_obj(security_context)
+        )
     )
 
     [webserver_deployment] = deployment_template.render(helm_values)
@@ -515,7 +517,9 @@ def test_webserver_security_context(deployment_template: HelmTemplate):
 def test_init_container_resources(deployment_template: HelmTemplate):
     init_container_resources = {"limits": {"cpu": "200m"}, "requests": {"memory": "1Gi"}}
     helm_values = DagsterHelmValues.construct(
-        dagsterWebserver=Webserver.construct(initContainerResources=init_container_resources)
+        dagsterWebserver=Webserver.construct(
+            initContainerResources=kubernetes.Resources.parse_obj(init_container_resources)
+        )
     )
 
     [webserver_deployment] = deployment_template.render(helm_values)

--- a/helm/dagster/schema/schema_tests/test_dagster_daemon.py
+++ b/helm/dagster/schema/schema_tests/test_dagster_daemon.py
@@ -582,7 +582,9 @@ def test_scheduler_name(template: HelmTemplate):
 def test_init_container_resources(template: HelmTemplate):
     init_container_resources = {"limits": {"cpu": "200m"}, "requests": {"memory": "1Gi"}}
     helm_values = DagsterHelmValues.construct(
-        dagsterDaemon=Daemon.construct(initContainerResources=init_container_resources)
+        dagsterDaemon=Daemon.construct(
+            initContainerResources=kubernetes.Resources.parse_obj(init_container_resources)
+        )
     )
 
     [webserver_deployment] = template.render(helm_values)

--- a/helm/dagster/schema/schema_tests/test_instance.py
+++ b/helm/dagster/schema/schema_tests/test_instance.py
@@ -45,6 +45,7 @@ from schema.charts.dagster.subschema.run_launcher import (
 )
 from schema.charts.dagster.subschema.telemetry import Telemetry
 from schema.charts.dagster.values import DagsterHelmValues
+from schema.charts.utils import kubernetes
 from schema.utils.helm_template import HelmTemplate
 
 
@@ -339,7 +340,7 @@ def test_k8s_run_launcher_security_context(template: HelmTemplate):
                     envVars=[],
                     volumeMounts=[],
                     volumes=[],
-                    securityContext=sacred_rites_of_debugging,
+                    securityContext=kubernetes.SecurityContext.parse_obj(sacred_rites_of_debugging),
                 )
             ),
         )

--- a/helm/dagster/schema/schema_tests/test_service_account.py
+++ b/helm/dagster/schema/schema_tests/test_service_account.py
@@ -6,6 +6,7 @@ from schema.charts.dagster.subschema.global_ import Global
 from schema.charts.dagster.subschema.service_account import ServiceAccount
 from schema.charts.dagster.values import DagsterHelmValues
 from schema.charts.dagster_user_deployments.values import DagsterUserDeploymentsHelmValues
+from schema.charts.utils import kubernetes
 from schema.utils.helm_template import HelmTemplate
 
 
@@ -126,7 +127,9 @@ def test_service_account_annotations(template: HelmTemplate):
     service_account_annotations = {"hello": "world"}
     service_account_values = DagsterHelmValues.construct(
         serviceAccount=ServiceAccount.construct(
-            name=service_account_name, create=True, annotations=service_account_annotations
+            name=service_account_name,
+            create=True,
+            annotations=kubernetes.Annotations.parse_obj(service_account_annotations),
         )
     )
 
@@ -147,7 +150,9 @@ def test_standalone_subchart_service_account_annotations(
     service_account_annotations = {"hello": "world"}
     service_account_values = DagsterUserDeploymentsHelmValues.construct(
         serviceAccount=ServiceAccount.construct(
-            name=service_account_name, create=True, annotations=service_account_annotations
+            name=service_account_name,
+            create=True,
+            annotations=kubernetes.Annotations.parse_obj(service_account_annotations),
         ),
     )
 

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -884,7 +884,7 @@ def test_user_deployment_labels(template: HelmTemplate, include_config_in_launch
 def test_annotations(template: HelmTemplate, include_config_in_launched_runs: bool):
     name = "foo"
 
-    annotations = {"my-annotation-key": "my-annotation-val"}
+    annotations = kubernetes.Annotations.parse_obj({"my-annotation-key": "my-annotation-val"})
 
     deployment = UserDeployment.construct(
         name=name,
@@ -925,7 +925,7 @@ def test_annotations(template: HelmTemplate, include_config_in_launched_runs: bo
                         "automount_service_account_token": True,
                     },
                     "pod_template_spec_metadata": {
-                        "annotations": annotations,
+                        "annotations": annotations.model_dump(),
                     },
                 },
             }
@@ -938,10 +938,12 @@ def test_annotations(template: HelmTemplate, include_config_in_launched_runs: bo
 def test_user_deployment_resources(template: HelmTemplate, include_config_in_launched_runs: bool):
     name = "foo"
 
-    resources = {
-        "requests": {"memory": "64Mi", "cpu": "250m"},
-        "limits": {"memory": "128Mi", "cpu": "500m"},
-    }
+    resources = kubernetes.Resources.parse_obj(
+        {
+            "requests": {"memory": "64Mi", "cpu": "250m"},
+            "limits": {"memory": "128Mi", "cpu": "500m"},
+        }
+    )
 
     deployment = UserDeployment.construct(
         name=name,
@@ -973,7 +975,7 @@ def test_user_deployment_resources(template: HelmTemplate, include_config_in_lau
                 "env_config_maps": [
                     "release-name-dagster-user-deployments-foo-user-env",
                 ],
-                "resources": resources,
+                "resources": resources.model_dump(),
                 "namespace": "default",
                 "service_account_name": "release-name-dagster-user-deployments-user-deployments",
                 "run_k8s_config": {

--- a/helm/dagster/schema/setup.py
+++ b/helm/dagster/schema/setup.py
@@ -18,7 +18,8 @@ setup(
     packages=find_packages(exclude=["schema_tests"]),
     install_requires=[
         "click",
-        "pydantic>=1.10.0,<2.0.0",
+        # "pydantic>=1.10.0,<2.0.0",
+        "pydantic>=2",
     ],
     extras_require={
         "test": [

--- a/helm/dagster/schema/setup.py
+++ b/helm/dagster/schema/setup.py
@@ -18,7 +18,6 @@ setup(
     packages=find_packages(exclude=["schema_tests"]),
     install_requires=[
         "click",
-        # "pydantic>=1.10.0,<2.0.0",
         "pydantic>=2",
     ],
     extras_require={

--- a/helm/dagster/schema/tox.ini
+++ b/helm/dagster/schema/tox.ini
@@ -25,4 +25,4 @@ allowlist_externals =
   uv
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster'
-  pytest --reruns 2 -vv {posargs}
+  pytest -vv {posargs}

--- a/helm/dagster/values.schema.json
+++ b/helm/dagster/values.schema.json
@@ -1,1301 +1,58 @@
 {
-    "title": "DagsterHelmValues",
-    "description": "@generated",
-    "type": "object",
-    "properties": {
-        "dagsterWebserver": {
-            "$ref": "#/definitions/Webserver"
-        },
-        "dagster-user-deployments": {
-            "$ref": "#/definitions/UserDeployments"
-        },
-        "postgresql": {
-            "$ref": "#/definitions/PostgreSQL"
-        },
-        "generatePostgresqlPasswordSecret": {
-            "title": "Generatepostgresqlpasswordsecret",
-            "type": "boolean"
-        },
-        "generateCeleryConfigSecret": {
-            "title": "Generateceleryconfigsecret",
-            "type": "boolean"
-        },
-        "rabbitmq": {
-            "$ref": "#/definitions/RabbitMQ"
-        },
-        "redis": {
-            "$ref": "#/definitions/Redis"
-        },
-        "flower": {
-            "$ref": "#/definitions/Flower"
-        },
-        "ingress": {
-            "$ref": "#/definitions/Ingress"
-        },
-        "imagePullSecrets": {
-            "title": "Imagepullsecrets",
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/SecretRef"
-            }
-        },
-        "computeLogManager": {
-            "$ref": "#/definitions/ComputeLogManager"
-        },
-        "scheduler": {
-            "$ref": "#/definitions/Scheduler"
-        },
-        "runLauncher": {
-            "$ref": "#/definitions/RunLauncher"
-        },
-        "pythonLogs": {
-            "$ref": "#/definitions/PythonLogs"
-        },
-        "dagsterDaemon": {
-            "$ref": "#/definitions/Daemon"
-        },
-        "busybox": {
-            "$ref": "#/definitions/Busybox"
-        },
-        "migrate": {
-            "$ref": "#/definitions/Migrate"
-        },
-        "telemetry": {
-            "$ref": "#/definitions/Telemetry"
-        },
-        "serviceAccount": {
-            "$ref": "#/definitions/ServiceAccount"
-        },
-        "global": {
-            "$ref": "#/definitions/Global"
-        },
-        "retention": {
-            "$ref": "#/definitions/Retention"
-        },
-        "additionalInstanceConfig": {
-            "title": "Additionalinstanceconfig",
+    "$defs": {
+        "Affinity": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity",
+            "title": "Affinity",
             "type": "object"
-        }
-    },
-    "required": [
-        "dagsterWebserver",
-        "dagster-user-deployments",
-        "postgresql",
-        "generatePostgresqlPasswordSecret",
-        "generateCeleryConfigSecret",
-        "rabbitmq",
-        "redis",
-        "flower",
-        "ingress",
-        "imagePullSecrets",
-        "computeLogManager",
-        "scheduler",
-        "runLauncher",
-        "pythonLogs",
-        "dagsterDaemon",
-        "busybox",
-        "migrate",
-        "telemetry",
-        "serviceAccount",
-        "global",
-        "retention"
-    ],
-    "definitions": {
-        "PullPolicy": {
-            "title": "PullPolicy",
-            "description": "An enumeration.",
-            "enum": [
-                "Always",
-                "IfNotPresent",
-                "Never"
-            ],
-            "type": "string"
-        },
-        "Image": {
-            "title": "Image",
-            "type": "object",
-            "properties": {
-                "repository": {
-                    "title": "Repository",
-                    "type": "string"
-                },
-                "tag": {
-                    "title": "Tag",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "pullPolicy": {
-                    "$ref": "#/definitions/PullPolicy"
-                }
-            },
-            "required": [
-                "repository",
-                "pullPolicy"
-            ]
         },
         "Annotations": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+            "additionalProperties": {
+                "type": "string"
+            },
             "title": "Annotations",
-            "type": "object",
-            "additionalProperties": {
-                "type": "string"
-            },
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
-        },
-        "schema__charts__utils__kubernetes__Service": {
-            "title": "Service",
-            "type": "object",
-            "properties": {
-                "type": {
-                    "title": "Type",
-                    "type": "string"
-                },
-                "port": {
-                    "title": "Port",
-                    "type": "integer"
-                },
-                "annotations": {
-                    "$ref": "#/definitions/Annotations"
-                }
-            },
-            "required": [
-                "type",
-                "port"
-            ],
-            "additionalProperties": false
-        },
-        "Server": {
-            "title": "Server",
-            "type": "object",
-            "properties": {
-                "host": {
-                    "title": "Host",
-                    "type": "string"
-                },
-                "port": {
-                    "title": "Port",
-                    "type": "integer"
-                },
-                "name": {
-                    "title": "Name",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "ssl": {
-                    "title": "Ssl",
-                    "anyOf": [
-                        {
-                            "type": "boolean"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
-            },
-            "required": [
-                "host",
-                "port"
-            ]
-        },
-        "Workspace": {
-            "title": "Workspace",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "title": "Enabled",
-                    "type": "boolean"
-                },
-                "servers": {
-                    "title": "Servers",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Server"
-                    }
-                },
-                "externalConfigmap": {
-                    "title": "Externalconfigmap",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
-            },
-            "required": [
-                "enabled",
-                "servers"
-            ]
-        },
-        "EnvVar": {
-            "title": "EnvVar",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar"
-        },
-        "ConfigMapEnvSource": {
-            "title": "ConfigMapEnvSource",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource"
-        },
-        "SecretEnvSource": {
-            "title": "SecretEnvSource",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecretEnvSource"
-        },
-        "NodeSelector": {
-            "title": "NodeSelector",
-            "type": "object",
-            "additionalProperties": {
-                "type": "string"
-            },
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector"
-        },
-        "Affinity": {
-            "title": "Affinity",
-            "type": "object",
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Affinity"
-        },
-        "Tolerations": {
-            "title": "Tolerations",
-            "type": "array",
-            "items": {
-                "type": "object"
-            },
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations"
-        },
-        "PodSecurityContext": {
-            "title": "PodSecurityContext",
-            "type": "object",
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext"
-        },
-        "SecurityContext": {
-            "title": "SecurityContext",
-            "type": "object",
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext"
-        },
-        "Resources": {
-            "title": "Resources",
-            "type": "object",
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
-        },
-        "ReadinessProbe": {
-            "title": "ReadinessProbe",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
-        },
-        "LivenessProbe": {
-            "title": "LivenessProbe",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
-        },
-        "StartupProbe": {
-            "title": "StartupProbe",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "title": "Enabled",
-                    "default": true,
-                    "type": "boolean"
-                }
-            },
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
-        },
-        "VolumeMount": {
-            "title": "VolumeMount",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount"
-        },
-        "Volume": {
-            "title": "Volume",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume"
-        },
-        "Webserver": {
-            "title": "Webserver",
-            "type": "object",
-            "properties": {
-                "replicaCount": {
-                    "title": "Replicacount",
-                    "type": "integer"
-                },
-                "image": {
-                    "$ref": "#/definitions/Image"
-                },
-                "nameOverride": {
-                    "title": "Nameoverride",
-                    "type": "string"
-                },
-                "pathPrefix": {
-                    "title": "Pathprefix",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "service": {
-                    "$ref": "#/definitions/schema__charts__utils__kubernetes__Service"
-                },
-                "workspace": {
-                    "$ref": "#/definitions/Workspace"
-                },
-                "env": {
-                    "title": "Env",
-                    "anyOf": [
-                        {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        },
-                        {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/EnvVar"
-                            }
-                        }
-                    ]
-                },
-                "envConfigMaps": {
-                    "title": "Envconfigmaps",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/ConfigMapEnvSource"
-                    }
-                },
-                "envSecrets": {
-                    "title": "Envsecrets",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/SecretEnvSource"
-                    }
-                },
-                "deploymentLabels": {
-                    "title": "Deploymentlabels",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "labels": {
-                    "title": "Labels",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "nodeSelector": {
-                    "$ref": "#/definitions/NodeSelector"
-                },
-                "affinity": {
-                    "$ref": "#/definitions/Affinity"
-                },
-                "tolerations": {
-                    "$ref": "#/definitions/Tolerations"
-                },
-                "podSecurityContext": {
-                    "$ref": "#/definitions/PodSecurityContext"
-                },
-                "securityContext": {
-                    "$ref": "#/definitions/SecurityContext"
-                },
-                "resources": {
-                    "$ref": "#/definitions/Resources"
-                },
-                "readinessProbe": {
-                    "$ref": "#/definitions/ReadinessProbe"
-                },
-                "livenessProbe": {
-                    "$ref": "#/definitions/LivenessProbe"
-                },
-                "startupProbe": {
-                    "$ref": "#/definitions/StartupProbe"
-                },
-                "annotations": {
-                    "$ref": "#/definitions/Annotations"
-                },
-                "enableReadOnly": {
-                    "title": "Enablereadonly",
-                    "type": "boolean"
-                },
-                "dbStatementTimeout": {
-                    "title": "Dbstatementtimeout",
-                    "anyOf": [
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "dbPoolRecycle": {
-                    "title": "Dbpoolrecycle",
-                    "anyOf": [
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "logLevel": {
-                    "title": "Loglevel",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "schedulerName": {
-                    "title": "Schedulername",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "volumeMounts": {
-                    "title": "Volumemounts",
-                    "items": {
-                        "$ref": "#/definitions/VolumeMount"
-                    },
-                    "anyOf": [
-                        {
-                            "type": "array"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "volumes": {
-                    "title": "Volumes",
-                    "items": {
-                        "$ref": "#/definitions/Volume"
-                    },
-                    "anyOf": [
-                        {
-                            "type": "array"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "initContainerResources": {
-                    "title": "Resources",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/Resources"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
-            },
-            "required": [
-                "replicaCount",
-                "image",
-                "nameOverride",
-                "service",
-                "workspace",
-                "env",
-                "envConfigMaps",
-                "envSecrets",
-                "deploymentLabels",
-                "labels",
-                "nodeSelector",
-                "affinity",
-                "tolerations",
-                "podSecurityContext",
-                "securityContext",
-                "resources",
-                "readinessProbe",
-                "livenessProbe",
-                "startupProbe",
-                "annotations",
-                "enableReadOnly"
-            ],
-            "additionalProperties": false
-        },
-        "SecretRef": {
-            "title": "SecretRef",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.LocalObjectReference"
-        },
-        "UserDeploymentIncludeConfigInLaunchedRuns": {
-            "title": "UserDeploymentIncludeConfigInLaunchedRuns",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "title": "Enabled",
-                    "type": "boolean"
-                }
-            },
-            "required": [
-                "enabled"
-            ]
-        },
-        "ReadinessProbeWithEnabled": {
-            "title": "ReadinessProbeWithEnabled",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
-        },
-        "Container": {
-            "title": "Container",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container"
-        },
-        "UserDeployment": {
-            "title": "UserDeployment",
-            "type": "object",
-            "properties": {
-                "name": {
-                    "title": "Name",
-                    "type": "string"
-                },
-                "image": {
-                    "$ref": "#/definitions/Image"
-                },
-                "dagsterApiGrpcArgs": {
-                    "title": "Dagsterapigrpcargs",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "codeServerArgs": {
-                    "title": "Codeserverargs",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "includeConfigInLaunchedRuns": {
-                    "$ref": "#/definitions/UserDeploymentIncludeConfigInLaunchedRuns"
-                },
-                "deploymentNamespace": {
-                    "title": "Deploymentnamespace",
-                    "type": "string"
-                },
-                "port": {
-                    "title": "Port",
-                    "type": "integer"
-                },
-                "env": {
-                    "title": "Env",
-                    "anyOf": [
-                        {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        },
-                        {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/EnvVar"
-                            }
-                        }
-                    ]
-                },
-                "envConfigMaps": {
-                    "title": "Envconfigmaps",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/ConfigMapEnvSource"
-                    }
-                },
-                "envSecrets": {
-                    "title": "Envsecrets",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/SecretEnvSource"
-                    }
-                },
-                "annotations": {
-                    "$ref": "#/definitions/Annotations"
-                },
-                "nodeSelector": {
-                    "$ref": "#/definitions/NodeSelector"
-                },
-                "affinity": {
-                    "$ref": "#/definitions/Affinity"
-                },
-                "tolerations": {
-                    "$ref": "#/definitions/Tolerations"
-                },
-                "podSecurityContext": {
-                    "$ref": "#/definitions/PodSecurityContext"
-                },
-                "securityContext": {
-                    "$ref": "#/definitions/SecurityContext"
-                },
-                "resources": {
-                    "$ref": "#/definitions/Resources"
-                },
-                "livenessProbe": {
-                    "$ref": "#/definitions/LivenessProbe"
-                },
-                "readinessProbe": {
-                    "$ref": "#/definitions/ReadinessProbeWithEnabled"
-                },
-                "startupProbe": {
-                    "$ref": "#/definitions/StartupProbe"
-                },
-                "labels": {
-                    "title": "Labels",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "volumeMounts": {
-                    "title": "Volumemounts",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/VolumeMount"
-                    }
-                },
-                "volumes": {
-                    "title": "Volumes",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Volume"
-                    }
-                },
-                "schedulerName": {
-                    "title": "Schedulername",
-                    "type": "string"
-                },
-                "initContainers": {
-                    "title": "Initcontainers",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Container"
-                    }
-                },
-                "sidecarContainers": {
-                    "title": "Sidecarcontainers",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Container"
-                    }
-                }
-            },
-            "required": [
-                "name",
-                "image",
-                "port"
-            ]
-        },
-        "UserDeployments": {
-            "title": "UserDeployments",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "title": "Enabled",
-                    "type": "boolean"
-                },
-                "enableSubchart": {
-                    "title": "Enablesubchart",
-                    "type": "boolean"
-                },
-                "imagePullSecrets": {
-                    "title": "Imagepullsecrets",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/SecretRef"
-                    }
-                },
-                "deployments": {
-                    "title": "Deployments",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/UserDeployment"
-                    }
-                }
-            },
-            "required": [
-                "enabled",
-                "enableSubchart",
-                "imagePullSecrets",
-                "deployments"
-            ]
-        },
-        "ExternalImage": {
-            "title": "ExternalImage",
-            "type": "object",
-            "properties": {
-                "repository": {
-                    "title": "Repository",
-                    "type": "string"
-                },
-                "tag": {
-                    "title": "Tag",
-                    "type": "string"
-                },
-                "pullPolicy": {
-                    "$ref": "#/definitions/PullPolicy"
-                }
-            },
-            "required": [
-                "repository",
-                "tag",
-                "pullPolicy"
-            ]
-        },
-        "schema__charts__dagster__subschema__postgresql__Service": {
-            "title": "Service",
-            "type": "object",
-            "properties": {
-                "port": {
-                    "title": "Port",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "port"
-            ]
-        },
-        "PostgreSQL": {
-            "title": "PostgreSQL",
-            "type": "object",
-            "properties": {
-                "image": {
-                    "$ref": "#/definitions/ExternalImage"
-                },
-                "enabled": {
-                    "title": "Enabled",
-                    "type": "boolean"
-                },
-                "postgresqlHost": {
-                    "title": "Postgresqlhost",
-                    "type": "string"
-                },
-                "postgresqlUsername": {
-                    "title": "Postgresqlusername",
-                    "type": "string"
-                },
-                "postgresqlPassword": {
-                    "title": "Postgresqlpassword",
-                    "type": "string"
-                },
-                "postgresqlDatabase": {
-                    "title": "Postgresqldatabase",
-                    "type": "string"
-                },
-                "postgresqlParams": {
-                    "title": "Postgresqlparams",
-                    "type": "object"
-                },
-                "postgresqlScheme": {
-                    "title": "Postgresqlscheme",
-                    "type": "string"
-                },
-                "service": {
-                    "$ref": "#/definitions/schema__charts__dagster__subschema__postgresql__Service"
-                }
-            },
-            "required": [
-                "image",
-                "enabled",
-                "postgresqlHost",
-                "postgresqlUsername",
-                "postgresqlPassword",
-                "postgresqlDatabase",
-                "postgresqlParams",
-                "service"
-            ]
-        },
-        "RabbitMQConfiguration": {
-            "title": "RabbitMQConfiguration",
-            "type": "object",
-            "properties": {
-                "username": {
-                    "title": "Username",
-                    "type": "string"
-                },
-                "password": {
-                    "title": "Password",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "username",
-                "password"
-            ]
-        },
-        "schema__charts__dagster__subschema__rabbitmq__Service": {
-            "title": "Service",
-            "type": "object",
-            "properties": {
-                "port": {
-                    "title": "Port",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "port"
-            ]
-        },
-        "VolumePermissions": {
-            "title": "VolumePermissions",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "title": "Enabled",
-                    "default": true,
-                    "const": true,
-                    "type": "boolean"
-                },
-                "image": {
-                    "$ref": "#/definitions/ExternalImage"
-                }
-            },
-            "required": [
-                "image"
-            ]
-        },
-        "RabbitMQ": {
-            "title": "RabbitMQ",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "title": "Enabled",
-                    "type": "boolean"
-                },
-                "image": {
-                    "$ref": "#/definitions/ExternalImage"
-                },
-                "rabbitmq": {
-                    "$ref": "#/definitions/RabbitMQConfiguration"
-                },
-                "service": {
-                    "$ref": "#/definitions/schema__charts__dagster__subschema__rabbitmq__Service"
-                },
-                "volumePermissions": {
-                    "$ref": "#/definitions/VolumePermissions"
-                }
-            },
-            "required": [
-                "enabled",
-                "image",
-                "rabbitmq",
-                "service",
-                "volumePermissions"
-            ]
-        },
-        "Redis": {
-            "title": "Redis",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "title": "Enabled",
-                    "type": "boolean"
-                },
-                "internal": {
-                    "title": "Internal",
-                    "type": "boolean"
-                },
-                "usePassword": {
-                    "title": "Usepassword",
-                    "type": "boolean"
-                },
-                "password": {
-                    "title": "Password",
-                    "type": "string"
-                },
-                "host": {
-                    "title": "Host",
-                    "type": "string"
-                },
-                "port": {
-                    "title": "Port",
-                    "type": "integer"
-                },
-                "brokerDbNumber": {
-                    "title": "Brokerdbnumber",
-                    "type": "integer"
-                },
-                "backendDbNumber": {
-                    "title": "Backenddbnumber",
-                    "type": "integer"
-                },
-                "brokerUrl": {
-                    "title": "Brokerurl",
-                    "type": "string"
-                },
-                "backendUrl": {
-                    "title": "Backendurl",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "enabled",
-                "internal",
-                "usePassword",
-                "password",
-                "host",
-                "port",
-                "brokerDbNumber",
-                "backendDbNumber",
-                "brokerUrl",
-                "backendUrl"
-            ]
-        },
-        "Flower": {
-            "title": "Flower",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "title": "Enabled",
-                    "type": "boolean"
-                },
-                "service": {
-                    "$ref": "#/definitions/schema__charts__utils__kubernetes__Service"
-                },
-                "nodeSelector": {
-                    "$ref": "#/definitions/NodeSelector"
-                },
-                "affinity": {
-                    "$ref": "#/definitions/Affinity"
-                },
-                "tolerations": {
-                    "$ref": "#/definitions/Tolerations"
-                },
-                "podSecurityContext": {
-                    "$ref": "#/definitions/PodSecurityContext"
-                },
-                "securityContext": {
-                    "$ref": "#/definitions/SecurityContext"
-                },
-                "resources": {
-                    "$ref": "#/definitions/Resources"
-                },
-                "livenessProbe": {
-                    "$ref": "#/definitions/LivenessProbe"
-                },
-                "startupProbe": {
-                    "$ref": "#/definitions/StartupProbe"
-                },
-                "annotations": {
-                    "$ref": "#/definitions/Annotations"
-                },
-                "schedulerName": {
-                    "title": "Schedulername",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "enabled",
-                "service",
-                "nodeSelector",
-                "affinity",
-                "tolerations",
-                "podSecurityContext",
-                "securityContext",
-                "resources",
-                "livenessProbe",
-                "startupProbe"
-            ]
-        },
-        "Labels": {
-            "title": "Labels",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
-        },
-        "IngressPathType": {
-            "title": "IngressPathType",
-            "description": "An enumeration.",
-            "enum": [
-                "Exact",
-                "Prefix",
-                "ImplementationSpecific"
-            ],
-            "type": "string"
-        },
-        "IngressTLSConfiguration": {
-            "title": "IngressTLSConfiguration",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "title": "Enabled",
-                    "type": "boolean"
-                },
-                "secretName": {
-                    "title": "Secretname",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "enabled",
-                "secretName"
-            ]
-        },
-        "IngressPath": {
-            "title": "IngressPath",
-            "type": "object",
-            "properties": {
-                "path": {
-                    "title": "Path",
-                    "type": "string"
-                },
-                "pathType": {
-                    "$ref": "#/definitions/IngressPathType"
-                },
-                "serviceName": {
-                    "title": "Servicename",
-                    "type": "string"
-                },
-                "servicePort": {
-                    "title": "Serviceport",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "integer"
-                        }
-                    ]
-                }
-            },
-            "required": [
-                "path",
-                "pathType",
-                "serviceName",
-                "servicePort"
-            ]
-        },
-        "FlowerIngressConfiguration": {
-            "title": "FlowerIngressConfiguration",
-            "type": "object",
-            "properties": {
-                "host": {
-                    "title": "Host",
-                    "type": "string"
-                },
-                "path": {
-                    "title": "Path",
-                    "type": "string"
-                },
-                "pathType": {
-                    "$ref": "#/definitions/IngressPathType"
-                },
-                "tls": {
-                    "$ref": "#/definitions/IngressTLSConfiguration"
-                },
-                "precedingPaths": {
-                    "title": "Precedingpaths",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/IngressPath"
-                    }
-                },
-                "succeedingPaths": {
-                    "title": "Succeedingpaths",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/IngressPath"
-                    }
-                }
-            },
-            "required": [
-                "host",
-                "path",
-                "pathType",
-                "tls",
-                "precedingPaths",
-                "succeedingPaths"
-            ]
-        },
-        "WebserverIngressConfiguration": {
-            "title": "WebserverIngressConfiguration",
-            "type": "object",
-            "properties": {
-                "host": {
-                    "title": "Host",
-                    "type": "string"
-                },
-                "path": {
-                    "title": "Path",
-                    "type": "string"
-                },
-                "pathType": {
-                    "$ref": "#/definitions/IngressPathType"
-                },
-                "tls": {
-                    "$ref": "#/definitions/IngressTLSConfiguration"
-                },
-                "precedingPaths": {
-                    "title": "Precedingpaths",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/IngressPath"
-                    }
-                },
-                "succeedingPaths": {
-                    "title": "Succeedingpaths",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/IngressPath"
-                    }
-                }
-            },
-            "required": [
-                "host",
-                "path",
-                "pathType",
-                "tls",
-                "precedingPaths",
-                "succeedingPaths"
-            ]
-        },
-        "Ingress": {
-            "title": "Ingress",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "title": "Enabled",
-                    "type": "boolean"
-                },
-                "apiVersion": {
-                    "title": "Apiversion",
-                    "type": "string"
-                },
-                "labels": {
-                    "$ref": "#/definitions/Labels"
-                },
-                "annotations": {
-                    "$ref": "#/definitions/Annotations"
-                },
-                "flower": {
-                    "$ref": "#/definitions/FlowerIngressConfiguration"
-                },
-                "dagsterWebserver": {
-                    "$ref": "#/definitions/WebserverIngressConfiguration"
-                },
-                "readOnlyDagsterWebserver": {
-                    "$ref": "#/definitions/WebserverIngressConfiguration"
-                }
-            },
-            "required": [
-                "enabled",
-                "labels",
-                "annotations",
-                "flower",
-                "dagsterWebserver",
-                "readOnlyDagsterWebserver"
-            ]
-        },
-        "ComputeLogManagerType": {
-            "title": "ComputeLogManagerType",
-            "description": "An enumeration.",
-            "enum": [
-                "NoOpComputeLogManager",
-                "AzureBlobComputeLogManager",
-                "GCSComputeLogManager",
-                "S3ComputeLogManager",
-                "CustomComputeLogManager"
-            ],
-            "type": "string"
-        },
-        "Source": {
-            "title": "Source",
-            "type": "object",
-            "properties": {
-                "env": {
-                    "title": "Env",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "env"
-            ],
-            "additionalProperties": false
+            "type": "object"
         },
         "AzureBlobComputeLogManager": {
-            "title": "AzureBlobComputeLogManager",
-            "type": "object",
             "properties": {
                 "storageAccount": {
-                    "title": "Storageaccount",
                     "anyOf": [
                         {
                             "type": "string"
                         },
                         {
-                            "$ref": "#/definitions/Source"
+                            "$ref": "#/$defs/Source"
                         }
-                    ]
+                    ],
+                    "title": "Storageaccount"
                 },
                 "container": {
-                    "title": "Container",
                     "anyOf": [
                         {
                             "type": "string"
                         },
                         {
-                            "$ref": "#/definitions/Source"
+                            "$ref": "#/$defs/Source"
                         }
-                    ]
+                    ],
+                    "title": "Container"
                 },
                 "secretKey": {
-                    "title": "Secretkey",
                     "anyOf": [
                         {
                             "type": "string"
                         },
                         {
-                            "$ref": "#/definitions/Source"
+                            "$ref": "#/$defs/Source"
                         },
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Secretkey"
                 },
                 "defaultAzureCredential": {
-                    "title": "Defaultazurecredential",
                     "anyOf": [
                         {
                             "type": "object"
@@ -1303,38 +60,41 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Defaultazurecredential"
                 },
                 "localDir": {
-                    "title": "Localdir",
                     "anyOf": [
                         {
                             "type": "string"
                         },
                         {
-                            "$ref": "#/definitions/Source"
+                            "$ref": "#/$defs/Source"
                         },
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Localdir"
                 },
                 "prefix": {
-                    "title": "Prefix",
                     "anyOf": [
                         {
                             "type": "string"
                         },
                         {
-                            "$ref": "#/definitions/Source"
+                            "$ref": "#/$defs/Source"
                         },
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Prefix"
                 },
                 "uploadInterval": {
-                    "title": "Uploadinterval",
                     "anyOf": [
                         {
                             "type": "integer"
@@ -1342,143 +102,156 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Uploadinterval"
                 }
             },
             "required": [
                 "storageAccount",
                 "container"
-            ]
+            ],
+            "title": "AzureBlobComputeLogManager",
+            "type": "object"
         },
-        "GCSComputeLogManager": {
-            "title": "GCSComputeLogManager",
-            "type": "object",
+        "BlockOpConcurrencyLimitedRuns": {
             "properties": {
-                "bucket": {
-                    "title": "Bucket",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "$ref": "#/definitions/Source"
-                        }
-                    ]
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
                 },
-                "localDir": {
-                    "title": "Localdir",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "$ref": "#/definitions/Source"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "prefix": {
-                    "title": "Prefix",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "$ref": "#/definitions/Source"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "jsonCredentialsEnvvar": {
-                    "title": "Jsoncredentialsenvvar",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "$ref": "#/definitions/Source"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "uploadInterval": {
-                    "title": "Uploadinterval",
-                    "anyOf": [
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "showUrlOnly": {
-                    "title": "Showurlonly",
-                    "anyOf": [
-                        {
-                            "type": "boolean"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                "opConcurrencySlotBuffer": {
+                    "title": "Opconcurrencyslotbuffer",
+                    "type": "integer"
                 }
             },
             "required": [
-                "bucket"
-            ]
+                "enabled",
+                "opConcurrencySlotBuffer"
+            ],
+            "title": "BlockOpConcurrencyLimitedRuns",
+            "type": "object"
         },
-        "S3ComputeLogManager": {
-            "title": "S3ComputeLogManager",
-            "type": "object",
+        "Busybox": {
             "properties": {
-                "bucket": {
-                    "title": "Bucket",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "$ref": "#/definitions/Source"
-                        }
-                    ]
+                "image": {
+                    "$ref": "#/$defs/ExternalImage"
+                }
+            },
+            "required": [
+                "image"
+            ],
+            "title": "Busybox",
+            "type": "object"
+        },
+        "CeleryK8sRunLauncherConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "image": {
+                    "$ref": "#/$defs/Image"
                 },
-                "localDir": {
-                    "title": "Localdir",
+                "imagePullPolicy": {
                     "anyOf": [
                         {
-                            "type": "string"
-                        },
-                        {
-                            "$ref": "#/definitions/Source"
+                            "$ref": "#/$defs/PullPolicy"
                         },
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null
                 },
-                "prefix": {
-                    "title": "Prefix",
+                "nameOverride": {
+                    "title": "Nameoverride",
+                    "type": "string"
+                },
+                "configSource": {
+                    "title": "Configsource",
+                    "type": "object"
+                },
+                "workerQueues": {
+                    "items": {
+                        "$ref": "#/$defs/CeleryWorkerQueue"
+                    },
+                    "minItems": 1,
+                    "title": "Workerqueues",
+                    "type": "array"
+                },
+                "env": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "title": "Env",
+                    "type": "object"
+                },
+                "envConfigMaps": {
+                    "items": {
+                        "$ref": "#/$defs/ConfigMapEnvSource"
+                    },
+                    "title": "Envconfigmaps",
+                    "type": "array"
+                },
+                "envSecrets": {
+                    "items": {
+                        "$ref": "#/$defs/SecretEnvSource"
+                    },
+                    "title": "Envsecrets",
+                    "type": "array"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations"
+                },
+                "nodeSelector": {
+                    "$ref": "#/$defs/NodeSelector"
+                },
+                "affinity": {
+                    "$ref": "#/$defs/Affinity"
+                },
+                "tolerations": {
+                    "$ref": "#/$defs/Tolerations"
+                },
+                "podSecurityContext": {
+                    "$ref": "#/$defs/PodSecurityContext"
+                },
+                "securityContext": {
+                    "$ref": "#/$defs/SecurityContext"
+                },
+                "resources": {
+                    "$ref": "#/$defs/Resources"
+                },
+                "livenessProbe": {
+                    "$ref": "#/$defs/LivenessProbe"
+                },
+                "volumeMounts": {
+                    "items": {
+                        "$ref": "#/$defs/VolumeMount"
+                    },
+                    "title": "Volumemounts",
+                    "type": "array"
+                },
+                "volumes": {
+                    "items": {
+                        "$ref": "#/$defs/Volume"
+                    },
+                    "title": "Volumes",
+                    "type": "array"
+                },
+                "labels": {
                     "anyOf": [
                         {
-                            "type": "string"
-                        },
-                        {
-                            "$ref": "#/definitions/Source"
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
                         },
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Labels"
                 },
-                "useSsl": {
-                    "title": "Usessl",
+                "failPodOnRunFailure": {
                     "anyOf": [
                         {
                             "type": "boolean"
@@ -1486,71 +259,92 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Failpodonrunfailure"
                 },
-                "verify": {
-                    "title": "Verify",
-                    "anyOf": [
-                        {
-                            "type": "boolean"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "verifyCertPath": {
-                    "title": "Verifycertpath",
+                "schedulerName": {
                     "anyOf": [
                         {
                             "type": "string"
                         },
                         {
-                            "$ref": "#/definitions/Source"
-                        },
-                        {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Schedulername"
                 },
-                "endpointUrl": {
-                    "title": "Endpointurl",
+                "jobNamespace": {
                     "anyOf": [
                         {
                             "type": "string"
                         },
                         {
-                            "$ref": "#/definitions/Source"
-                        },
-                        {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Jobnamespace"
+                }
+            },
+            "required": [
+                "image",
+                "nameOverride",
+                "configSource",
+                "workerQueues",
+                "env",
+                "envConfigMaps",
+                "envSecrets",
+                "annotations",
+                "nodeSelector",
+                "affinity",
+                "tolerations",
+                "podSecurityContext",
+                "securityContext",
+                "resources",
+                "livenessProbe",
+                "volumeMounts",
+                "volumes"
+            ],
+            "title": "CeleryK8sRunLauncherConfig",
+            "type": "object"
+        },
+        "CeleryWorkerQueue": {
+            "additionalProperties": false,
+            "properties": {
+                "replicaCount": {
+                    "exclusiveMinimum": 0,
+                    "title": "Replicacount",
+                    "type": "integer"
                 },
-                "skipEmptyFiles": {
-                    "title": "Skipemptyfiles",
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "labels": {
                     "anyOf": [
                         {
-                            "type": "boolean"
+                            "$ref": "#/$defs/Labels"
                         },
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null
                 },
-                "uploadInterval": {
-                    "title": "Uploadinterval",
+                "nodeSelector": {
                     "anyOf": [
                         {
-                            "type": "integer"
+                            "$ref": "#/$defs/NodeSelector"
                         },
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null
                 },
-                "uploadExtraArgs": {
-                    "title": "Uploadextraargs",
+                "configSource": {
                     "anyOf": [
                         {
                             "type": "object"
@@ -1558,128 +352,34 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Configsource"
                 },
-                "showUrlOnly": {
-                    "title": "Showurlonly",
+                "additionalCeleryArgs": {
                     "anyOf": [
                         {
-                            "type": "boolean"
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         {
                             "type": "null"
                         }
-                    ]
-                },
-                "region": {
-                    "title": "Region",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "$ref": "#/definitions/Source"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Additionalceleryargs"
                 }
             },
             "required": [
-                "bucket"
-            ]
-        },
-        "ConfigurableClass": {
-            "title": "ConfigurableClass",
-            "type": "object",
-            "properties": {
-                "module": {
-                    "title": "Module",
-                    "type": "string"
-                },
-                "class": {
-                    "title": "Class",
-                    "type": "string"
-                },
-                "config": {
-                    "title": "Config",
-                    "type": "object"
-                }
-            },
-            "required": [
-                "module",
-                "class",
-                "config"
+                "replicaCount",
+                "name"
             ],
-            "additionalProperties": false
-        },
-        "ComputeLogManagerConfig": {
-            "title": "ComputeLogManagerConfig",
-            "type": "object",
-            "properties": {
-                "azureBlobComputeLogManager": {
-                    "title": "AzureBlobComputeLogManager",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/AzureBlobComputeLogManager"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "gcsComputeLogManager": {
-                    "title": "GCSComputeLogManager",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/GCSComputeLogManager"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "s3ComputeLogManager": {
-                    "title": "S3ComputeLogManager",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/S3ComputeLogManager"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "customComputeLogManager": {
-                    "title": "ConfigurableClass",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/ConfigurableClass"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
-            },
-            "additionalProperties": false
+            "title": "CeleryWorkerQueue",
+            "type": "object"
         },
         "ComputeLogManager": {
-            "title": "ComputeLogManager",
-            "type": "object",
-            "properties": {
-                "type": {
-                    "$ref": "#/definitions/ComputeLogManagerType"
-                },
-                "config": {
-                    "$ref": "#/definitions/ComputeLogManagerConfig"
-                }
-            },
-            "required": [
-                "type",
-                "config"
-            ],
             "additionalProperties": false,
             "allOf": [
                 {
@@ -1754,337 +454,291 @@
                         }
                     }
                 }
-            ]
-        },
-        "SchedulerType": {
-            "title": "SchedulerType",
-            "description": "An enumeration.",
-            "enum": [
-                "DagsterDaemonScheduler",
-                "CustomScheduler"
             ],
-            "type": "string"
-        },
-        "DaemonSchedulerConfig": {
-            "title": "DaemonSchedulerConfig",
-            "type": "object",
-            "properties": {
-                "maxCatchupRuns": {
-                    "title": "Maxcatchupruns",
-                    "anyOf": [
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "maxTickRetries": {
-                    "title": "Maxtickretries",
-                    "anyOf": [
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
-            }
-        },
-        "SchedulerConfig": {
-            "title": "SchedulerConfig",
-            "type": "object",
-            "properties": {
-                "daemonScheduler": {
-                    "title": "DaemonSchedulerConfig",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/DaemonSchedulerConfig"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "customScheduler": {
-                    "title": "ConfigurableClass",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/ConfigurableClass"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
-            },
-            "additionalProperties": false
-        },
-        "Scheduler": {
-            "title": "Scheduler",
-            "type": "object",
             "properties": {
                 "type": {
-                    "$ref": "#/definitions/SchedulerType"
+                    "$ref": "#/$defs/ComputeLogManagerType"
                 },
                 "config": {
-                    "$ref": "#/definitions/SchedulerConfig"
+                    "$ref": "#/$defs/ComputeLogManagerConfig"
                 }
             },
             "required": [
                 "type",
                 "config"
             ],
-            "additionalProperties": false,
-            "allOf": [
-                {
-                    "if": {
-                        "properties": {
-                            "type": {
-                                "const": "CustomScheduler"
-                            }
-                        }
-                    },
-                    "then": {
-                        "properties": {
-                            "config": {
-                                "required": [
-                                    "customScheduler"
-                                ]
-                            }
-                        }
-                    }
-                }
-            ]
+            "title": "ComputeLogManager",
+            "type": "object"
         },
-        "RunLauncherType": {
-            "title": "RunLauncherType",
-            "description": "An enumeration.",
+        "ComputeLogManagerConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "azureBlobComputeLogManager": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/AzureBlobComputeLogManager"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "gcsComputeLogManager": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/GCSComputeLogManager"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "s3ComputeLogManager": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/S3ComputeLogManager"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "customComputeLogManager": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ConfigurableClass"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                }
+            },
+            "title": "ComputeLogManagerConfig",
+            "type": "object"
+        },
+        "ComputeLogManagerType": {
             "enum": [
-                "CeleryK8sRunLauncher",
-                "K8sRunLauncher",
-                "CustomRunLauncher"
+                "NoOpComputeLogManager",
+                "AzureBlobComputeLogManager",
+                "GCSComputeLogManager",
+                "S3ComputeLogManager",
+                "CustomComputeLogManager"
             ],
+            "title": "ComputeLogManagerType",
             "type": "string"
         },
-        "CeleryWorkerQueue": {
-            "title": "CeleryWorkerQueue",
-            "type": "object",
+        "ConfigMapEnvSource": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "ConfigMapEnvSource",
+            "type": "object"
+        },
+        "ConfigurableClass": {
+            "additionalProperties": false,
             "properties": {
-                "replicaCount": {
-                    "title": "Replicacount",
-                    "exclusiveMinimum": 0,
-                    "type": "integer"
-                },
-                "name": {
-                    "title": "Name",
+                "module": {
+                    "title": "Module",
                     "type": "string"
                 },
-                "labels": {
-                    "title": "Labels",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/Labels"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                "class": {
+                    "title": "Class",
+                    "type": "string"
                 },
-                "nodeSelector": {
-                    "title": "NodeSelector",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/NodeSelector"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                "config": {
+                    "title": "Config",
+                    "type": "object"
+                }
+            },
+            "required": [
+                "module",
+                "class",
+                "config"
+            ],
+            "title": "ConfigurableClass",
+            "type": "object"
+        },
+        "Container": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Container",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "Container",
+            "type": "object"
+        },
+        "Daemon": {
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
                 },
-                "configSource": {
-                    "title": "Configsource",
+                "image": {
+                    "$ref": "#/$defs/Image"
+                },
+                "runCoordinator": {
+                    "$ref": "#/$defs/RunCoordinator"
+                },
+                "heartbeatTolerance": {
+                    "title": "Heartbeattolerance",
+                    "type": "integer"
+                },
+                "env": {
                     "anyOf": [
                         {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
                             "type": "object"
                         },
                         {
-                            "type": "null"
+                            "items": {
+                                "$ref": "#/$defs/EnvVar"
+                            },
+                            "type": "array"
                         }
-                    ]
+                    ],
+                    "title": "Env"
                 },
-                "additionalCeleryArgs": {
-                    "title": "Additionalceleryargs",
+                "envConfigMaps": {
                     "items": {
+                        "$ref": "#/$defs/ConfigMapEnvSource"
+                    },
+                    "title": "Envconfigmaps",
+                    "type": "array"
+                },
+                "envSecrets": {
+                    "items": {
+                        "$ref": "#/$defs/SecretEnvSource"
+                    },
+                    "title": "Envsecrets",
+                    "type": "array"
+                },
+                "deploymentLabels": {
+                    "additionalProperties": {
                         "type": "string"
                     },
+                    "title": "Deploymentlabels",
+                    "type": "object"
+                },
+                "labels": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "title": "Labels",
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "$ref": "#/$defs/NodeSelector"
+                },
+                "affinity": {
+                    "$ref": "#/$defs/Affinity"
+                },
+                "tolerations": {
+                    "$ref": "#/$defs/Tolerations"
+                },
+                "podSecurityContext": {
+                    "$ref": "#/$defs/PodSecurityContext"
+                },
+                "securityContext": {
+                    "$ref": "#/$defs/SecurityContext"
+                },
+                "resources": {
+                    "$ref": "#/$defs/Resources"
+                },
+                "livenessProbe": {
+                    "$ref": "#/$defs/LivenessProbe"
+                },
+                "readinessProbe": {
+                    "$ref": "#/$defs/ReadinessProbe"
+                },
+                "startupProbe": {
+                    "$ref": "#/$defs/StartupProbe"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations"
+                },
+                "runMonitoring": {
+                    "title": "Runmonitoring",
+                    "type": "object"
+                },
+                "runRetries": {
+                    "$ref": "#/$defs/RunRetries"
+                },
+                "sensors": {
+                    "$ref": "#/$defs/Sensors"
+                },
+                "schedules": {
+                    "$ref": "#/$defs/Schedules"
+                },
+                "schedulerName": {
                     "anyOf": [
                         {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Schedulername"
+                },
+                "volumeMounts": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/VolumeMount"
+                            },
                             "type": "array"
                         },
                         {
                             "type": "null"
                         }
-                    ]
-                }
-            },
-            "required": [
-                "replicaCount",
-                "name"
-            ],
-            "additionalProperties": false
-        },
-        "CeleryK8sRunLauncherConfig": {
-            "title": "CeleryK8sRunLauncherConfig",
-            "type": "object",
-            "properties": {
-                "image": {
-                    "$ref": "#/definitions/Image"
-                },
-                "imagePullPolicy": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/PullPolicy"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "nameOverride": {
-                    "title": "Nameoverride",
-                    "type": "string"
-                },
-                "configSource": {
-                    "title": "Configsource",
-                    "type": "object"
-                },
-                "workerQueues": {
-                    "title": "Workerqueues",
-                    "minItems": 1,
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/CeleryWorkerQueue"
-                    }
-                },
-                "env": {
-                    "title": "Env",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "envConfigMaps": {
-                    "title": "Envconfigmaps",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/ConfigMapEnvSource"
-                    }
-                },
-                "envSecrets": {
-                    "title": "Envsecrets",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/SecretEnvSource"
-                    }
-                },
-                "annotations": {
-                    "$ref": "#/definitions/Annotations"
-                },
-                "nodeSelector": {
-                    "$ref": "#/definitions/NodeSelector"
-                },
-                "affinity": {
-                    "$ref": "#/definitions/Affinity"
-                },
-                "tolerations": {
-                    "$ref": "#/definitions/Tolerations"
-                },
-                "podSecurityContext": {
-                    "$ref": "#/definitions/PodSecurityContext"
-                },
-                "securityContext": {
-                    "$ref": "#/definitions/SecurityContext"
-                },
-                "resources": {
-                    "$ref": "#/definitions/Resources"
-                },
-                "livenessProbe": {
-                    "$ref": "#/definitions/LivenessProbe"
-                },
-                "volumeMounts": {
-                    "title": "Volumemounts",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/VolumeMount"
-                    }
+                    ],
+                    "default": null,
+                    "title": "Volumemounts"
                 },
                 "volumes": {
-                    "title": "Volumes",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Volume"
-                    }
-                },
-                "labels": {
-                    "title": "Labels",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
                     "anyOf": [
                         {
-                            "type": "object"
+                            "items": {
+                                "$ref": "#/$defs/Volume"
+                            },
+                            "type": "array"
                         },
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Volumes"
                 },
-                "failPodOnRunFailure": {
-                    "title": "Failpodonrunfailure",
+                "initContainerResources": {
                     "anyOf": [
                         {
-                            "type": "boolean"
+                            "$ref": "#/$defs/Resources"
                         },
                         {
                             "type": "null"
                         }
-                    ]
-                },
-                "schedulerName": {
-                    "title": "Schedulername",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "jobNamespace": {
-                    "title": "Jobnamespace",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                    ],
+                    "default": null
                 }
             },
             "required": [
+                "enabled",
                 "image",
-                "nameOverride",
-                "configSource",
-                "workerQueues",
+                "runCoordinator",
+                "heartbeatTolerance",
                 "env",
                 "envConfigMaps",
                 "envSecrets",
-                "annotations",
+                "deploymentLabels",
+                "labels",
                 "nodeSelector",
                 "affinity",
                 "tolerations",
@@ -2092,114 +746,121 @@
                 "securityContext",
                 "resources",
                 "livenessProbe",
-                "volumeMounts",
-                "volumes"
+                "readinessProbe",
+                "startupProbe",
+                "annotations",
+                "runMonitoring",
+                "runRetries",
+                "sensors",
+                "schedules"
             ],
-            "additionalProperties": false
+            "title": "Daemon",
+            "type": "object"
         },
-        "ResourceRequirements": {
-            "title": "ResourceRequirements",
-            "type": "object",
-            "properties": {},
-            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
-        },
-        "RunK8sConfig": {
-            "title": "RunK8sConfig",
-            "type": "object",
+        "DaemonSchedulerConfig": {
             "properties": {
-                "containerConfig": {
-                    "title": "Containerconfig",
+                "maxCatchupRuns": {
                     "anyOf": [
                         {
-                            "type": "object"
+                            "type": "integer"
                         },
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Maxcatchupruns"
                 },
-                "podSpecConfig": {
-                    "title": "Podspecconfig",
+                "maxTickRetries": {
                     "anyOf": [
                         {
-                            "type": "object"
+                            "type": "integer"
                         },
                         {
                             "type": "null"
                         }
-                    ]
-                },
-                "podTemplateSpecMetadata": {
-                    "title": "Podtemplatespecmetadata",
-                    "anyOf": [
-                        {
-                            "type": "object"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "jobSpecConfig": {
-                    "title": "Jobspecconfig",
-                    "anyOf": [
-                        {
-                            "type": "object"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "jobMetadata": {
-                    "title": "Jobmetadata",
-                    "anyOf": [
-                        {
-                            "type": "object"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Maxtickretries"
                 }
             },
-            "additionalProperties": false
+            "title": "DaemonSchedulerConfig",
+            "type": "object"
         },
-        "K8sRunLauncherConfig": {
-            "title": "K8sRunLauncherConfig",
-            "type": "object",
+        "EnvVar": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "EnvVar",
+            "type": "object"
+        },
+        "ExternalImage": {
             "properties": {
-                "image": {
-                    "title": "Image",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/Image"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                "repository": {
+                    "title": "Repository",
+                    "type": "string"
                 },
-                "imagePullPolicy": {
-                    "$ref": "#/definitions/PullPolicy"
+                "tag": {
+                    "title": "Tag",
+                    "type": "string"
                 },
-                "jobNamespace": {
-                    "title": "Jobnamespace",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "loadInclusterConfig": {
-                    "title": "Loadinclusterconfig",
+                "pullPolicy": {
+                    "$ref": "#/$defs/PullPolicy"
+                }
+            },
+            "required": [
+                "repository",
+                "tag",
+                "pullPolicy"
+            ],
+            "title": "ExternalImage",
+            "type": "object"
+        },
+        "Flower": {
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
                     "type": "boolean"
                 },
-                "kubeconfigFile": {
-                    "title": "Kubeconfigfile",
+                "service": {
+                    "$ref": "#/$defs/schema__charts__utils__kubernetes__Service"
+                },
+                "nodeSelector": {
+                    "$ref": "#/$defs/NodeSelector"
+                },
+                "affinity": {
+                    "$ref": "#/$defs/Affinity"
+                },
+                "tolerations": {
+                    "$ref": "#/$defs/Tolerations"
+                },
+                "podSecurityContext": {
+                    "$ref": "#/$defs/PodSecurityContext"
+                },
+                "securityContext": {
+                    "$ref": "#/$defs/SecurityContext"
+                },
+                "resources": {
+                    "$ref": "#/$defs/Resources"
+                },
+                "livenessProbe": {
+                    "$ref": "#/$defs/LivenessProbe"
+                },
+                "startupProbe": {
+                    "$ref": "#/$defs/StartupProbe"
+                },
+                "annotations": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Annotations"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "schedulerName": {
                     "anyOf": [
                         {
                             "type": "string"
@@ -2207,59 +868,139 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Schedulername"
+                }
+            },
+            "required": [
+                "enabled",
+                "service",
+                "nodeSelector",
+                "affinity",
+                "tolerations",
+                "podSecurityContext",
+                "securityContext",
+                "resources",
+                "livenessProbe",
+                "startupProbe"
+            ],
+            "title": "Flower",
+            "type": "object"
+        },
+        "FlowerIngressConfiguration": {
+            "properties": {
+                "host": {
+                    "title": "Host",
+                    "type": "string"
                 },
-                "envConfigMaps": {
-                    "title": "Envconfigmaps",
-                    "type": "array",
+                "path": {
+                    "title": "Path",
+                    "type": "string"
+                },
+                "pathType": {
+                    "$ref": "#/$defs/IngressPathType"
+                },
+                "tls": {
+                    "$ref": "#/$defs/IngressTLSConfiguration"
+                },
+                "precedingPaths": {
                     "items": {
-                        "$ref": "#/definitions/ConfigMapEnvSource"
-                    }
-                },
-                "envSecrets": {
-                    "title": "Envsecrets",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/SecretEnvSource"
-                    }
-                },
-                "envVars": {
-                    "title": "Envvars",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "volumeMounts": {
-                    "title": "Volumemounts",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/VolumeMount"
-                    }
-                },
-                "volumes": {
-                    "title": "Volumes",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Volume"
-                    }
-                },
-                "labels": {
-                    "title": "Labels",
-                    "additionalProperties": {
-                        "type": "string"
+                        "$ref": "#/$defs/IngressPath"
                     },
+                    "title": "Precedingpaths",
+                    "type": "array"
+                },
+                "succeedingPaths": {
+                    "items": {
+                        "$ref": "#/$defs/IngressPath"
+                    },
+                    "title": "Succeedingpaths",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "host",
+                "path",
+                "pathType",
+                "tls",
+                "precedingPaths",
+                "succeedingPaths"
+            ],
+            "title": "FlowerIngressConfiguration",
+            "type": "object"
+        },
+        "GCSComputeLogManager": {
+            "properties": {
+                "bucket": {
                     "anyOf": [
                         {
-                            "type": "object"
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/$defs/Source"
+                        }
+                    ],
+                    "title": "Bucket"
+                },
+                "localDir": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/$defs/Source"
                         },
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Localdir"
                 },
-                "failPodOnRunFailure": {
-                    "title": "Failpodonrunfailure",
+                "prefix": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/$defs/Source"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Prefix"
+                },
+                "jsonCredentialsEnvvar": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/$defs/Source"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Jsoncredentialsenvvar"
+                },
+                "uploadInterval": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Uploadinterval"
+                },
+                "showUrlOnly": {
                     "anyOf": [
                         {
                             "type": "boolean"
@@ -2267,21 +1008,85 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Showurlonly"
+                }
+            },
+            "required": [
+                "bucket"
+            ],
+            "title": "GCSComputeLogManager",
+            "type": "object"
+        },
+        "Global": {
+            "properties": {
+                "postgresqlSecretName": {
+                    "title": "Postgresqlsecretname",
+                    "type": "string"
                 },
-                "resources": {
-                    "title": "ResourceRequirements",
+                "dagsterHome": {
+                    "title": "Dagsterhome",
+                    "type": "string"
+                },
+                "serviceAccountName": {
+                    "title": "Serviceaccountname",
+                    "type": "string"
+                },
+                "celeryConfigSecretName": {
+                    "title": "Celeryconfigsecretname",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "postgresqlSecretName",
+                "dagsterHome",
+                "serviceAccountName",
+                "celeryConfigSecretName"
+            ],
+            "title": "Global",
+            "type": "object"
+        },
+        "Image": {
+            "properties": {
+                "repository": {
+                    "title": "Repository",
+                    "type": "string"
+                },
+                "tag": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ResourceRequirements"
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
                         },
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Tag"
                 },
-                "schedulerName": {
-                    "title": "Schedulername",
+                "pullPolicy": {
+                    "$ref": "#/$defs/PullPolicy"
+                }
+            },
+            "required": [
+                "repository",
+                "pullPolicy"
+            ],
+            "title": "Image",
+            "type": "object"
+        },
+        "Ingress": {
+            "additionalProperties": true,
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
+                },
+                "apiVersion": {
                     "anyOf": [
                         {
                             "type": "string"
@@ -2289,29 +1094,249 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Apiversion"
+                },
+                "labels": {
+                    "$ref": "#/$defs/Labels"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations"
+                },
+                "flower": {
+                    "$ref": "#/$defs/FlowerIngressConfiguration"
+                },
+                "dagsterWebserver": {
+                    "$ref": "#/$defs/WebserverIngressConfiguration"
+                },
+                "readOnlyDagsterWebserver": {
+                    "$ref": "#/$defs/WebserverIngressConfiguration"
+                }
+            },
+            "required": [
+                "enabled",
+                "labels",
+                "annotations",
+                "flower",
+                "dagsterWebserver",
+                "readOnlyDagsterWebserver"
+            ],
+            "title": "Ingress",
+            "type": "object"
+        },
+        "IngressPath": {
+            "properties": {
+                "path": {
+                    "title": "Path",
+                    "type": "string"
+                },
+                "pathType": {
+                    "$ref": "#/$defs/IngressPathType"
+                },
+                "serviceName": {
+                    "title": "Servicename",
+                    "type": "string"
+                },
+                "servicePort": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "title": "Serviceport"
+                }
+            },
+            "required": [
+                "path",
+                "pathType",
+                "serviceName",
+                "servicePort"
+            ],
+            "title": "IngressPath",
+            "type": "object"
+        },
+        "IngressPathType": {
+            "enum": [
+                "Exact",
+                "Prefix",
+                "ImplementationSpecific"
+            ],
+            "title": "IngressPathType",
+            "type": "string"
+        },
+        "IngressTLSConfiguration": {
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
+                },
+                "secretName": {
+                    "title": "Secretname",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "enabled",
+                "secretName"
+            ],
+            "title": "IngressTLSConfiguration",
+            "type": "object"
+        },
+        "K8sRunLauncherConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "image": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Image"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "imagePullPolicy": {
+                    "$ref": "#/$defs/PullPolicy"
+                },
+                "jobNamespace": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Jobnamespace"
+                },
+                "loadInclusterConfig": {
+                    "title": "Loadinclusterconfig",
+                    "type": "boolean"
+                },
+                "kubeconfigFile": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Kubeconfigfile"
+                },
+                "envConfigMaps": {
+                    "items": {
+                        "$ref": "#/$defs/ConfigMapEnvSource"
+                    },
+                    "title": "Envconfigmaps",
+                    "type": "array"
+                },
+                "envSecrets": {
+                    "items": {
+                        "$ref": "#/$defs/SecretEnvSource"
+                    },
+                    "title": "Envsecrets",
+                    "type": "array"
+                },
+                "envVars": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "Envvars",
+                    "type": "array"
+                },
+                "volumeMounts": {
+                    "items": {
+                        "$ref": "#/$defs/VolumeMount"
+                    },
+                    "title": "Volumemounts",
+                    "type": "array"
+                },
+                "volumes": {
+                    "items": {
+                        "$ref": "#/$defs/Volume"
+                    },
+                    "title": "Volumes",
+                    "type": "array"
+                },
+                "labels": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Labels"
+                },
+                "failPodOnRunFailure": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Failpodonrunfailure"
+                },
+                "resources": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ResourceRequirements"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "schedulerName": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Schedulername"
                 },
                 "securityContext": {
-                    "title": "SecurityContext",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/SecurityContext"
+                            "$ref": "#/$defs/SecurityContext"
                         },
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null
                 },
                 "runK8sConfig": {
-                    "title": "RunK8sConfig",
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/RunK8sConfig"
+                            "$ref": "#/$defs/RunK8sConfig"
                         },
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null
                 }
             },
             "required": [
@@ -2323,62 +1348,603 @@
                 "volumeMounts",
                 "volumes"
             ],
-            "additionalProperties": false
+            "title": "K8sRunLauncherConfig",
+            "type": "object"
         },
-        "RunLauncherConfig": {
-            "title": "RunLauncherConfig",
-            "type": "object",
-            "properties": {
-                "celeryK8sRunLauncher": {
-                    "title": "CeleryK8sRunLauncherConfig",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/CeleryK8sRunLauncherConfig"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "k8sRunLauncher": {
-                    "title": "K8sRunLauncherConfig",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/K8sRunLauncherConfig"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "customRunLauncher": {
-                    "title": "ConfigurableClass",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/ConfigurableClass"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
-            }
+        "Labels": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "Labels",
+            "type": "object"
         },
-        "RunLauncher": {
-            "title": "RunLauncher",
-            "type": "object",
+        "LivenessProbe": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "LivenessProbe",
+            "type": "object"
+        },
+        "Migrate": {
             "properties": {
-                "type": {
-                    "$ref": "#/definitions/RunLauncherType"
-                },
-                "config": {
-                    "$ref": "#/definitions/RunLauncherConfig"
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
                 }
             },
             "required": [
+                "enabled"
+            ],
+            "title": "Migrate",
+            "type": "object"
+        },
+        "NodeSelector": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
+            "additionalProperties": {
+                "type": "string"
+            },
+            "extra": "allow",
+            "title": "NodeSelector",
+            "type": "object"
+        },
+        "PodSecurityContext": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+            "title": "PodSecurityContext",
+            "type": "object"
+        },
+        "PostgreSQL": {
+            "properties": {
+                "image": {
+                    "$ref": "#/$defs/ExternalImage"
+                },
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
+                },
+                "postgresqlHost": {
+                    "title": "Postgresqlhost",
+                    "type": "string"
+                },
+                "postgresqlUsername": {
+                    "title": "Postgresqlusername",
+                    "type": "string"
+                },
+                "postgresqlPassword": {
+                    "title": "Postgresqlpassword",
+                    "type": "string"
+                },
+                "postgresqlDatabase": {
+                    "title": "Postgresqldatabase",
+                    "type": "string"
+                },
+                "postgresqlParams": {
+                    "title": "Postgresqlparams",
+                    "type": "object"
+                },
+                "postgresqlScheme": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Postgresqlscheme"
+                },
+                "service": {
+                    "$ref": "#/$defs/schema__charts__dagster__subschema__postgresql__Service"
+                }
+            },
+            "required": [
+                "image",
+                "enabled",
+                "postgresqlHost",
+                "postgresqlUsername",
+                "postgresqlPassword",
+                "postgresqlDatabase",
+                "postgresqlParams",
+                "service"
+            ],
+            "title": "PostgreSQL",
+            "type": "object"
+        },
+        "PullPolicy": {
+            "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+            ],
+            "title": "PullPolicy",
+            "type": "string"
+        },
+        "PythonLogLevel": {
+            "enum": [
+                "CRITICAL",
+                "FATAL",
+                "ERROR",
+                "WARN",
+                "WARNING",
+                "INFO",
+                "DEBUG",
+                "NOTSET"
+            ],
+            "title": "PythonLogLevel",
+            "type": "string"
+        },
+        "PythonLogs": {
+            "additionalProperties": false,
+            "properties": {
+                "pythonLogLevel": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/PythonLogLevel"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "managedPythonLoggers": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Managedpythonloggers"
+                },
+                "dagsterHandlerConfig": {
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Dagsterhandlerconfig"
+                }
+            },
+            "title": "PythonLogs",
+            "type": "object"
+        },
+        "QueuedRunCoordinatorConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "maxConcurrentRuns": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "$ref": "#/$defs/Source"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Maxconcurrentruns"
+                },
+                "tagConcurrencyLimits": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/TagConcurrencyLimit"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Tagconcurrencylimits"
+                },
+                "dequeueIntervalSeconds": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "$ref": "#/$defs/Source"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Dequeueintervalseconds"
+                },
+                "dequeueNumWorkers": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "$ref": "#/$defs/Source"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Dequeuenumworkers"
+                },
+                "dequeueUseThreads": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Dequeueusethreads"
+                },
+                "blockOpConcurrencyLimitedRuns": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/BlockOpConcurrencyLimitedRuns"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                }
+            },
+            "title": "QueuedRunCoordinatorConfig",
+            "type": "object"
+        },
+        "RabbitMQ": {
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
+                },
+                "image": {
+                    "$ref": "#/$defs/ExternalImage"
+                },
+                "rabbitmq": {
+                    "$ref": "#/$defs/RabbitMQConfiguration"
+                },
+                "service": {
+                    "$ref": "#/$defs/schema__charts__dagster__subschema__rabbitmq__Service"
+                },
+                "volumePermissions": {
+                    "$ref": "#/$defs/VolumePermissions"
+                }
+            },
+            "required": [
+                "enabled",
+                "image",
+                "rabbitmq",
+                "service",
+                "volumePermissions"
+            ],
+            "title": "RabbitMQ",
+            "type": "object"
+        },
+        "RabbitMQConfiguration": {
+            "properties": {
+                "username": {
+                    "title": "Username",
+                    "type": "string"
+                },
+                "password": {
+                    "title": "Password",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "username",
+                "password"
+            ],
+            "title": "RabbitMQConfiguration",
+            "type": "object"
+        },
+        "ReadinessProbe": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "ReadinessProbe",
+            "type": "object"
+        },
+        "ReadinessProbeWithEnabled": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "additionalProperties": true,
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "enabled"
+            ],
+            "title": "ReadinessProbeWithEnabled",
+            "type": "object"
+        },
+        "Redis": {
+            "additionalProperties": true,
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
+                },
+                "internal": {
+                    "title": "Internal",
+                    "type": "boolean"
+                },
+                "usePassword": {
+                    "title": "Usepassword",
+                    "type": "boolean"
+                },
+                "password": {
+                    "title": "Password",
+                    "type": "string"
+                },
+                "host": {
+                    "title": "Host",
+                    "type": "string"
+                },
+                "port": {
+                    "title": "Port",
+                    "type": "integer"
+                },
+                "brokerDbNumber": {
+                    "title": "Brokerdbnumber",
+                    "type": "integer"
+                },
+                "backendDbNumber": {
+                    "title": "Backenddbnumber",
+                    "type": "integer"
+                },
+                "brokerUrl": {
+                    "title": "Brokerurl",
+                    "type": "string"
+                },
+                "backendUrl": {
+                    "title": "Backendurl",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "enabled",
+                "internal",
+                "usePassword",
+                "password",
+                "host",
+                "port",
+                "brokerDbNumber",
+                "backendDbNumber",
+                "brokerUrl",
+                "backendUrl"
+            ],
+            "title": "Redis",
+            "type": "object"
+        },
+        "ResourceRequirements": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "ResourceRequirements",
+            "type": "object"
+        },
+        "Resources": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+            "title": "Resources",
+            "type": "object"
+        },
+        "Retention": {
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
+                },
+                "sensor": {
+                    "$ref": "#/$defs/TickRetention"
+                },
+                "schedule": {
+                    "$ref": "#/$defs/TickRetention"
+                },
+                "autoMaterialize": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TickRetention"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                }
+            },
+            "required": [
+                "enabled",
+                "sensor",
+                "schedule"
+            ],
+            "title": "Retention",
+            "type": "object"
+        },
+        "RunCoordinator": {
+            "additionalProperties": false,
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "QueuedRunCoordinator"
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "config": {
+                                "required": [
+                                    "queuedRunCoordinator"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "CustomRunCoordinator"
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "config": {
+                                "required": [
+                                    "customRunCoordinator"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ],
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
+                },
+                "type": {
+                    "$ref": "#/$defs/RunCoordinatorType"
+                },
+                "config": {
+                    "$ref": "#/$defs/RunCoordinatorConfig"
+                }
+            },
+            "required": [
+                "enabled",
                 "type",
                 "config"
             ],
+            "title": "RunCoordinator",
+            "type": "object"
+        },
+        "RunCoordinatorConfig": {
+            "properties": {
+                "queuedRunCoordinator": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/QueuedRunCoordinatorConfig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "customRunCoordinator": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ConfigurableClass"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                }
+            },
+            "title": "RunCoordinatorConfig",
+            "type": "object"
+        },
+        "RunCoordinatorType": {
+            "enum": [
+                "QueuedRunCoordinator",
+                "CustomRunCoordinator"
+            ],
+            "title": "RunCoordinatorType",
+            "type": "string"
+        },
+        "RunK8sConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "containerConfig": {
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Containerconfig"
+                },
+                "podSpecConfig": {
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Podspecconfig"
+                },
+                "podTemplateSpecMetadata": {
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Podtemplatespecmetadata"
+                },
+                "jobSpecConfig": {
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Jobspecconfig"
+                },
+                "jobMetadata": {
+                    "anyOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Jobmetadata"
+                }
+            },
+            "title": "RunK8sConfig",
+            "type": "object"
+        },
+        "RunLauncher": {
             "additionalProperties": false,
             "allOf": [
                 {
@@ -2435,301 +2001,77 @@
                         }
                     }
                 }
-            ]
-        },
-        "PythonLogLevel": {
-            "title": "PythonLogLevel",
-            "description": "An enumeration.",
-            "enum": [
-                "CRITICAL",
-                "FATAL",
-                "ERROR",
-                "WARN",
-                "WARNING",
-                "INFO",
-                "DEBUG",
-                "NOTSET"
             ],
-            "type": "string"
-        },
-        "PythonLogs": {
-            "title": "PythonLogs",
-            "type": "object",
             "properties": {
-                "pythonLogLevel": {
-                    "$ref": "#/definitions/PythonLogLevel"
-                },
-                "managedPythonLoggers": {
-                    "title": "Managedpythonloggers",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "dagsterHandlerConfig": {
-                    "title": "Dagsterhandlerconfig",
-                    "type": "object"
-                }
-            },
-            "additionalProperties": false
-        },
-        "RunCoordinatorType": {
-            "title": "RunCoordinatorType",
-            "description": "An enumeration.",
-            "enum": [
-                "QueuedRunCoordinator",
-                "CustomRunCoordinator"
-            ],
-            "type": "string"
-        },
-        "TagConcurrencyLimitConfig": {
-            "title": "TagConcurrencyLimitConfig",
-            "type": "object",
-            "properties": {
-                "applyLimitPerUniqueValue": {
-                    "title": "Applylimitperuniquevalue",
-                    "type": "boolean"
-                }
-            },
-            "required": [
-                "applyLimitPerUniqueValue"
-            ],
-            "additionalProperties": false
-        },
-        "TagConcurrencyLimit": {
-            "title": "TagConcurrencyLimit",
-            "type": "object",
-            "properties": {
-                "key": {
-                    "title": "Key",
-                    "type": "string"
-                },
-                "value": {
-                    "title": "Value",
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "$ref": "#/definitions/TagConcurrencyLimitConfig"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "limit": {
-                    "title": "Limit",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "key",
-                "limit"
-            ],
-            "additionalProperties": false
-        },
-        "BlockOpConcurrencyLimitedRuns": {
-            "title": "BlockOpConcurrencyLimitedRuns",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "title": "Enabled",
-                    "type": "boolean"
-                },
-                "opConcurrencySlotBuffer": {
-                    "title": "Opconcurrencyslotbuffer",
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "enabled",
-                "opConcurrencySlotBuffer"
-            ]
-        },
-        "QueuedRunCoordinatorConfig": {
-            "title": "QueuedRunCoordinatorConfig",
-            "type": "object",
-            "properties": {
-                "maxConcurrentRuns": {
-                    "title": "Maxconcurrentruns",
-                    "anyOf": [
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "$ref": "#/definitions/Source"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "tagConcurrencyLimits": {
-                    "title": "Tagconcurrencylimits",
-                    "items": {
-                        "$ref": "#/definitions/TagConcurrencyLimit"
-                    },
-                    "anyOf": [
-                        {
-                            "type": "array"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "dequeueIntervalSeconds": {
-                    "title": "Dequeueintervalseconds",
-                    "anyOf": [
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "$ref": "#/definitions/Source"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "dequeueNumWorkers": {
-                    "title": "Dequeuenumworkers",
-                    "anyOf": [
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "$ref": "#/definitions/Source"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "dequeueUseThreads": {
-                    "title": "Dequeueusethreads",
-                    "anyOf": [
-                        {
-                            "type": "boolean"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "blockOpConcurrencyLimitedRuns": {
-                    "title": "BlockOpConcurrencyLimitedRuns",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/BlockOpConcurrencyLimitedRuns"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
-            },
-            "additionalProperties": false
-        },
-        "RunCoordinatorConfig": {
-            "title": "RunCoordinatorConfig",
-            "type": "object",
-            "properties": {
-                "queuedRunCoordinator": {
-                    "title": "QueuedRunCoordinatorConfig",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/QueuedRunCoordinatorConfig"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "customRunCoordinator": {
-                    "title": "ConfigurableClass",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/ConfigurableClass"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
-            }
-        },
-        "RunCoordinator": {
-            "title": "RunCoordinator",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "title": "Enabled",
-                    "type": "boolean"
-                },
                 "type": {
-                    "$ref": "#/definitions/RunCoordinatorType"
+                    "$ref": "#/$defs/RunLauncherType"
                 },
                 "config": {
-                    "$ref": "#/definitions/RunCoordinatorConfig"
+                    "$ref": "#/$defs/RunLauncherConfig"
                 }
             },
             "required": [
-                "enabled",
                 "type",
                 "config"
             ],
-            "additionalProperties": false,
-            "allOf": [
-                {
-                    "if": {
-                        "properties": {
-                            "type": {
-                                "const": "QueuedRunCoordinator"
-                            }
+            "title": "RunLauncher",
+            "type": "object"
+        },
+        "RunLauncherConfig": {
+            "properties": {
+                "celeryK8sRunLauncher": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/CeleryK8sRunLauncherConfig"
+                        },
+                        {
+                            "type": "null"
                         }
-                    },
-                    "then": {
-                        "properties": {
-                            "config": {
-                                "required": [
-                                    "queuedRunCoordinator"
-                                ]
-                            }
-                        }
-                    }
+                    ],
+                    "default": null
                 },
-                {
-                    "if": {
-                        "properties": {
-                            "type": {
-                                "const": "CustomRunCoordinator"
-                            }
+                "k8sRunLauncher": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/K8sRunLauncherConfig"
+                        },
+                        {
+                            "type": "null"
                         }
-                    },
-                    "then": {
-                        "properties": {
-                            "config": {
-                                "required": [
-                                    "customRunCoordinator"
-                                ]
-                            }
+                    ],
+                    "default": null
+                },
+                "customRunLauncher": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ConfigurableClass"
+                        },
+                        {
+                            "type": "null"
                         }
-                    }
+                    ],
+                    "default": null
                 }
-            ]
+            },
+            "title": "RunLauncherConfig",
+            "type": "object"
+        },
+        "RunLauncherType": {
+            "enum": [
+                "CeleryK8sRunLauncher",
+                "K8sRunLauncher",
+                "CustomRunLauncher"
+            ],
+            "title": "RunLauncherType",
+            "type": "string"
         },
         "RunRetries": {
-            "title": "RunRetries",
-            "type": "object",
             "properties": {
                 "enabled": {
                     "title": "Enabled",
                     "type": "boolean"
                 },
                 "maxRetries": {
-                    "title": "Maxretries",
                     "anyOf": [
                         {
                             "type": "integer"
@@ -2737,10 +2079,11 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Maxretries"
                 },
                 "retryOnAssetOrOpFailure": {
-                    "title": "Retryonassetoropfailure",
                     "anyOf": [
                         {
                             "type": "boolean"
@@ -2748,23 +2091,127 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Retryonassetoropfailure"
                 }
             },
             "required": [
                 "enabled"
-            ]
+            ],
+            "title": "RunRetries",
+            "type": "object"
         },
-        "Sensors": {
-            "title": "Sensors",
-            "type": "object",
+        "S3ComputeLogManager": {
             "properties": {
-                "useThreads": {
-                    "title": "Usethreads",
-                    "type": "boolean"
+                "bucket": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/$defs/Source"
+                        }
+                    ],
+                    "title": "Bucket"
                 },
-                "numWorkers": {
-                    "title": "Numworkers",
+                "localDir": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/$defs/Source"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Localdir"
+                },
+                "prefix": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/$defs/Source"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Prefix"
+                },
+                "useSsl": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Usessl"
+                },
+                "verify": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Verify"
+                },
+                "verifyCertPath": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/$defs/Source"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Verifycertpath"
+                },
+                "endpointUrl": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/$defs/Source"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Endpointurl"
+                },
+                "skipEmptyFiles": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Skipemptyfiles"
+                },
+                "uploadInterval": {
                     "anyOf": [
                         {
                             "type": "integer"
@@ -2772,34 +2219,137 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Uploadinterval"
                 },
-                "numSubmitWorkers": {
-                    "title": "Numsubmitworkers",
+                "uploadExtraArgs": {
                     "anyOf": [
                         {
-                            "type": "integer"
+                            "type": "object"
                         },
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Uploadextraargs"
+                },
+                "showUrlOnly": {
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Showurlonly"
+                },
+                "region": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/$defs/Source"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Region"
                 }
             },
             "required": [
-                "useThreads"
-            ]
+                "bucket"
+            ],
+            "title": "S3ComputeLogManager",
+            "type": "object"
+        },
+        "Scheduler": {
+            "additionalProperties": false,
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "CustomScheduler"
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "config": {
+                                "required": [
+                                    "customScheduler"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ],
+            "properties": {
+                "type": {
+                    "$ref": "#/$defs/SchedulerType"
+                },
+                "config": {
+                    "$ref": "#/$defs/SchedulerConfig"
+                }
+            },
+            "required": [
+                "type",
+                "config"
+            ],
+            "title": "Scheduler",
+            "type": "object"
+        },
+        "SchedulerConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "daemonScheduler": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/DaemonSchedulerConfig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "customScheduler": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ConfigurableClass"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                }
+            },
+            "title": "SchedulerConfig",
+            "type": "object"
+        },
+        "SchedulerType": {
+            "enum": [
+                "DagsterDaemonScheduler",
+                "CustomScheduler"
+            ],
+            "title": "SchedulerType",
+            "type": "string"
         },
         "Schedules": {
-            "title": "Schedules",
-            "type": "object",
             "properties": {
                 "useThreads": {
                     "title": "Usethreads",
                     "type": "boolean"
                 },
                 "numWorkers": {
-                    "title": "Numworkers",
                     "anyOf": [
                         {
                             "type": "integer"
@@ -2807,10 +2357,11 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Numworkers"
                 },
                 "numSubmitWorkers": {
-                    "title": "Numsubmitworkers",
                     "anyOf": [
                         {
                             "type": "integer"
@@ -2818,121 +2369,84 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Numsubmitworkers"
                 }
             },
             "required": [
                 "useThreads"
-            ]
+            ],
+            "title": "Schedules",
+            "type": "object"
         },
-        "Daemon": {
-            "title": "Daemon",
-            "type": "object",
+        "SecretEnvSource": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecretEnvSource",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "SecretEnvSource",
+            "type": "object"
+        },
+        "SecretRef": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "SecretRef",
+            "type": "object"
+        },
+        "SecurityContext": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+            "title": "SecurityContext",
+            "type": "object"
+        },
+        "Sensors": {
             "properties": {
-                "enabled": {
-                    "title": "Enabled",
+                "useThreads": {
+                    "title": "Usethreads",
                     "type": "boolean"
                 },
-                "image": {
-                    "$ref": "#/definitions/Image"
-                },
-                "runCoordinator": {
-                    "$ref": "#/definitions/RunCoordinator"
-                },
-                "heartbeatTolerance": {
-                    "title": "Heartbeattolerance",
-                    "type": "integer"
-                },
-                "env": {
-                    "title": "Env",
+                "numWorkers": {
                     "anyOf": [
                         {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "type": "integer"
                         },
                         {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/EnvVar"
-                            }
+                            "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Numworkers"
                 },
-                "envConfigMaps": {
-                    "title": "Envconfigmaps",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/ConfigMapEnvSource"
-                    }
+                "numSubmitWorkers": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Numsubmitworkers"
+                }
+            },
+            "required": [
+                "useThreads"
+            ],
+            "title": "Sensors",
+            "type": "object"
+        },
+        "Server": {
+            "properties": {
+                "host": {
+                    "title": "Host",
+                    "type": "string"
                 },
-                "envSecrets": {
-                    "title": "Envsecrets",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/SecretEnvSource"
-                    }
+                "port": {
+                    "title": "Port",
+                    "type": "integer"
                 },
-                "deploymentLabels": {
-                    "title": "Deploymentlabels",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "labels": {
-                    "title": "Labels",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "nodeSelector": {
-                    "$ref": "#/definitions/NodeSelector"
-                },
-                "affinity": {
-                    "$ref": "#/definitions/Affinity"
-                },
-                "tolerations": {
-                    "$ref": "#/definitions/Tolerations"
-                },
-                "podSecurityContext": {
-                    "$ref": "#/definitions/PodSecurityContext"
-                },
-                "securityContext": {
-                    "$ref": "#/definitions/SecurityContext"
-                },
-                "resources": {
-                    "$ref": "#/definitions/Resources"
-                },
-                "livenessProbe": {
-                    "$ref": "#/definitions/LivenessProbe"
-                },
-                "readinessProbe": {
-                    "$ref": "#/definitions/ReadinessProbe"
-                },
-                "startupProbe": {
-                    "$ref": "#/definitions/StartupProbe"
-                },
-                "annotations": {
-                    "$ref": "#/definitions/Annotations"
-                },
-                "runMonitoring": {
-                    "title": "Runmonitoring",
-                    "type": "object"
-                },
-                "runRetries": {
-                    "$ref": "#/definitions/RunRetries"
-                },
-                "sensors": {
-                    "$ref": "#/definitions/Sensors"
-                },
-                "schedules": {
-                    "$ref": "#/definitions/Schedules"
-                },
-                "schedulerName": {
-                    "title": "Schedulername",
+                "name": {
                     "anyOf": [
                         {
                             "type": "string"
@@ -2940,117 +2454,31 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Name"
                 },
-                "volumeMounts": {
-                    "title": "Volumemounts",
-                    "items": {
-                        "$ref": "#/definitions/VolumeMount"
-                    },
+                "ssl": {
                     "anyOf": [
                         {
-                            "type": "array"
+                            "type": "boolean"
                         },
                         {
                             "type": "null"
                         }
-                    ]
-                },
-                "volumes": {
-                    "title": "Volumes",
-                    "items": {
-                        "$ref": "#/definitions/Volume"
-                    },
-                    "anyOf": [
-                        {
-                            "type": "array"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "initContainerResources": {
-                    "title": "Resources",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/Resources"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Ssl"
                 }
             },
             "required": [
-                "enabled",
-                "image",
-                "runCoordinator",
-                "heartbeatTolerance",
-                "env",
-                "envConfigMaps",
-                "envSecrets",
-                "deploymentLabels",
-                "labels",
-                "nodeSelector",
-                "affinity",
-                "tolerations",
-                "podSecurityContext",
-                "securityContext",
-                "resources",
-                "livenessProbe",
-                "readinessProbe",
-                "startupProbe",
-                "annotations",
-                "runMonitoring",
-                "runRetries",
-                "sensors",
-                "schedules"
+                "host",
+                "port"
             ],
-            "additionalProperties": false
-        },
-        "Busybox": {
-            "title": "Busybox",
-            "type": "object",
-            "properties": {
-                "image": {
-                    "$ref": "#/definitions/ExternalImage"
-                }
-            },
-            "required": [
-                "image"
-            ]
-        },
-        "Migrate": {
-            "title": "Migrate",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "title": "Enabled",
-                    "type": "boolean"
-                }
-            },
-            "required": [
-                "enabled"
-            ]
-        },
-        "Telemetry": {
-            "title": "Telemetry",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "title": "Enabled",
-                    "type": "boolean"
-                }
-            },
-            "required": [
-                "enabled"
-            ],
-            "additionalProperties": false
+            "title": "Server",
+            "type": "object"
         },
         "ServiceAccount": {
-            "title": "ServiceAccount",
-            "type": "object",
             "properties": {
                 "create": {
                     "title": "Create",
@@ -3061,46 +2489,128 @@
                     "type": "string"
                 },
                 "annotations": {
-                    "$ref": "#/definitions/Annotations"
+                    "$ref": "#/$defs/Annotations"
                 }
             },
             "required": [
                 "create",
                 "name",
                 "annotations"
-            ]
+            ],
+            "title": "ServiceAccount",
+            "type": "object"
         },
-        "Global": {
-            "title": "Global",
-            "type": "object",
+        "Source": {
+            "additionalProperties": false,
             "properties": {
-                "postgresqlSecretName": {
-                    "title": "Postgresqlsecretname",
-                    "type": "string"
-                },
-                "dagsterHome": {
-                    "title": "Dagsterhome",
-                    "type": "string"
-                },
-                "serviceAccountName": {
-                    "title": "Serviceaccountname",
-                    "type": "string"
-                },
-                "celeryConfigSecretName": {
-                    "title": "Celeryconfigsecretname",
+                "env": {
+                    "title": "Env",
                     "type": "string"
                 }
             },
             "required": [
-                "postgresqlSecretName",
-                "dagsterHome",
-                "serviceAccountName",
-                "celeryConfigSecretName"
-            ]
+                "env"
+            ],
+            "title": "Source",
+            "type": "object"
+        },
+        "StartupProbe": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe",
+            "additionalProperties": true,
+            "properties": {
+                "enabled": {
+                    "default": true,
+                    "title": "Enabled",
+                    "type": "boolean"
+                }
+            },
+            "title": "StartupProbe",
+            "type": "object"
+        },
+        "TagConcurrencyLimit": {
+            "additionalProperties": false,
+            "properties": {
+                "key": {
+                    "title": "Key",
+                    "type": "string"
+                },
+                "value": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/$defs/TagConcurrencyLimitConfig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Value"
+                },
+                "limit": {
+                    "title": "Limit",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "key",
+                "limit"
+            ],
+            "title": "TagConcurrencyLimit",
+            "type": "object"
+        },
+        "TagConcurrencyLimitConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "applyLimitPerUniqueValue": {
+                    "title": "Applylimitperuniquevalue",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "applyLimitPerUniqueValue"
+            ],
+            "title": "TagConcurrencyLimitConfig",
+            "type": "object"
+        },
+        "Telemetry": {
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "enabled"
+            ],
+            "title": "Telemetry",
+            "type": "object"
+        },
+        "TickRetention": {
+            "properties": {
+                "purgeAfterDays": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "$ref": "#/$defs/TickRetentionByType"
+                        }
+                    ],
+                    "title": "Purgeafterdays"
+                }
+            },
+            "required": [
+                "purgeAfterDays"
+            ],
+            "title": "TickRetention",
+            "type": "object"
         },
         "TickRetentionByType": {
-            "title": "TickRetentionByType",
-            "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "skipped": {
                     "title": "Skipped",
@@ -3125,52 +2635,889 @@
                 "failure",
                 "started"
             ],
-            "additionalProperties": false
+            "title": "TickRetentionByType",
+            "type": "object"
         },
-        "TickRetention": {
-            "title": "TickRetention",
-            "type": "object",
+        "Tolerations": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSpec/properties/tolerations",
+            "items": {
+                "type": "object"
+            },
+            "title": "Tolerations",
+            "type": "array"
+        },
+        "UserDeployment": {
             "properties": {
-                "purgeAfterDays": {
-                    "title": "Purgeafterdays",
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                },
+                "image": {
+                    "$ref": "#/$defs/Image"
+                },
+                "dagsterApiGrpcArgs": {
                     "anyOf": [
                         {
-                            "type": "integer"
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         },
                         {
-                            "$ref": "#/definitions/TickRetentionByType"
+                            "type": "null"
                         }
-                    ]
+                    ],
+                    "default": null,
+                    "title": "Dagsterapigrpcargs"
+                },
+                "codeServerArgs": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Codeserverargs"
+                },
+                "includeConfigInLaunchedRuns": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/UserDeploymentIncludeConfigInLaunchedRuns"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "deploymentNamespace": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Deploymentnamespace"
+                },
+                "port": {
+                    "title": "Port",
+                    "type": "integer"
+                },
+                "env": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/$defs/EnvVar"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Env"
+                },
+                "envConfigMaps": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/ConfigMapEnvSource"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Envconfigmaps"
+                },
+                "envSecrets": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/SecretEnvSource"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Envsecrets"
+                },
+                "annotations": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Annotations"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "nodeSelector": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/NodeSelector"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "affinity": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Affinity"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "tolerations": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Tolerations"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "podSecurityContext": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/PodSecurityContext"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "securityContext": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/SecurityContext"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "resources": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Resources"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "livenessProbe": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/LivenessProbe"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "readinessProbe": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ReadinessProbeWithEnabled"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "startupProbe": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/StartupProbe"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "labels": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Labels"
+                },
+                "volumeMounts": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/VolumeMount"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Volumemounts"
+                },
+                "volumes": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Volume"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Volumes"
+                },
+                "schedulerName": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Schedulername"
+                },
+                "initContainers": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Container"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Initcontainers"
+                },
+                "sidecarContainers": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Container"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Sidecarcontainers"
                 }
             },
             "required": [
-                "purgeAfterDays"
-            ]
+                "name",
+                "image",
+                "port"
+            ],
+            "title": "UserDeployment",
+            "type": "object"
         },
-        "Retention": {
-            "title": "Retention",
-            "type": "object",
+        "UserDeploymentIncludeConfigInLaunchedRuns": {
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "enabled"
+            ],
+            "title": "UserDeploymentIncludeConfigInLaunchedRuns",
+            "type": "object"
+        },
+        "UserDeployments": {
             "properties": {
                 "enabled": {
                     "title": "Enabled",
                     "type": "boolean"
                 },
-                "sensor": {
-                    "$ref": "#/definitions/TickRetention"
+                "enableSubchart": {
+                    "title": "Enablesubchart",
+                    "type": "boolean"
                 },
-                "schedule": {
-                    "$ref": "#/definitions/TickRetention"
+                "imagePullSecrets": {
+                    "items": {
+                        "$ref": "#/$defs/SecretRef"
+                    },
+                    "title": "Imagepullsecrets",
+                    "type": "array"
                 },
-                "autoMaterialize": {
-                    "$ref": "#/definitions/TickRetention"
+                "deployments": {
+                    "items": {
+                        "$ref": "#/$defs/UserDeployment"
+                    },
+                    "title": "Deployments",
+                    "type": "array"
                 }
             },
             "required": [
                 "enabled",
-                "sensor",
-                "schedule"
+                "enableSubchart",
+                "imagePullSecrets",
+                "deployments"
             ],
-            "additionalProperties": false
+            "title": "UserDeployments",
+            "type": "object"
+        },
+        "Volume": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.Volume",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "Volume",
+            "type": "object"
+        },
+        "VolumeMount": {
+            "$ref": "https://kubernetesjsonschema.dev/v1.18.0/_definitions.json#/definitions/io.k8s.api.core.v1.VolumeMount",
+            "additionalProperties": true,
+            "properties": {},
+            "title": "VolumeMount",
+            "type": "object"
+        },
+        "VolumePermissions": {
+            "properties": {
+                "enabled": {
+                    "const": true,
+                    "default": true,
+                    "enum": [
+                        true
+                    ],
+                    "title": "Enabled",
+                    "type": "boolean"
+                },
+                "image": {
+                    "$ref": "#/$defs/ExternalImage"
+                }
+            },
+            "required": [
+                "image"
+            ],
+            "title": "VolumePermissions",
+            "type": "object"
+        },
+        "Webserver": {
+            "additionalProperties": false,
+            "properties": {
+                "replicaCount": {
+                    "title": "Replicacount",
+                    "type": "integer"
+                },
+                "image": {
+                    "$ref": "#/$defs/Image"
+                },
+                "nameOverride": {
+                    "title": "Nameoverride",
+                    "type": "string"
+                },
+                "pathPrefix": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Pathprefix"
+                },
+                "service": {
+                    "$ref": "#/$defs/schema__charts__utils__kubernetes__Service"
+                },
+                "workspace": {
+                    "$ref": "#/$defs/Workspace"
+                },
+                "env": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/$defs/EnvVar"
+                            },
+                            "type": "array"
+                        }
+                    ],
+                    "title": "Env"
+                },
+                "envConfigMaps": {
+                    "items": {
+                        "$ref": "#/$defs/ConfigMapEnvSource"
+                    },
+                    "title": "Envconfigmaps",
+                    "type": "array"
+                },
+                "envSecrets": {
+                    "items": {
+                        "$ref": "#/$defs/SecretEnvSource"
+                    },
+                    "title": "Envsecrets",
+                    "type": "array"
+                },
+                "deploymentLabels": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "title": "Deploymentlabels",
+                    "type": "object"
+                },
+                "labels": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "title": "Labels",
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "$ref": "#/$defs/NodeSelector"
+                },
+                "affinity": {
+                    "$ref": "#/$defs/Affinity"
+                },
+                "tolerations": {
+                    "$ref": "#/$defs/Tolerations"
+                },
+                "podSecurityContext": {
+                    "$ref": "#/$defs/PodSecurityContext"
+                },
+                "securityContext": {
+                    "$ref": "#/$defs/SecurityContext"
+                },
+                "resources": {
+                    "$ref": "#/$defs/Resources"
+                },
+                "readinessProbe": {
+                    "$ref": "#/$defs/ReadinessProbe"
+                },
+                "livenessProbe": {
+                    "$ref": "#/$defs/LivenessProbe"
+                },
+                "startupProbe": {
+                    "$ref": "#/$defs/StartupProbe"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations"
+                },
+                "enableReadOnly": {
+                    "title": "Enablereadonly",
+                    "type": "boolean"
+                },
+                "dbStatementTimeout": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Dbstatementtimeout"
+                },
+                "dbPoolRecycle": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Dbpoolrecycle"
+                },
+                "logLevel": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Loglevel"
+                },
+                "schedulerName": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Schedulername"
+                },
+                "volumeMounts": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/VolumeMount"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Volumemounts"
+                },
+                "volumes": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Volume"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Volumes"
+                },
+                "initContainerResources": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Resources"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                }
+            },
+            "required": [
+                "replicaCount",
+                "image",
+                "nameOverride",
+                "service",
+                "workspace",
+                "env",
+                "envConfigMaps",
+                "envSecrets",
+                "deploymentLabels",
+                "labels",
+                "nodeSelector",
+                "affinity",
+                "tolerations",
+                "podSecurityContext",
+                "securityContext",
+                "resources",
+                "readinessProbe",
+                "livenessProbe",
+                "startupProbe",
+                "annotations",
+                "enableReadOnly"
+            ],
+            "title": "Webserver",
+            "type": "object"
+        },
+        "WebserverIngressConfiguration": {
+            "properties": {
+                "host": {
+                    "title": "Host",
+                    "type": "string"
+                },
+                "path": {
+                    "title": "Path",
+                    "type": "string"
+                },
+                "pathType": {
+                    "$ref": "#/$defs/IngressPathType"
+                },
+                "tls": {
+                    "$ref": "#/$defs/IngressTLSConfiguration"
+                },
+                "precedingPaths": {
+                    "items": {
+                        "$ref": "#/$defs/IngressPath"
+                    },
+                    "title": "Precedingpaths",
+                    "type": "array"
+                },
+                "succeedingPaths": {
+                    "items": {
+                        "$ref": "#/$defs/IngressPath"
+                    },
+                    "title": "Succeedingpaths",
+                    "type": "array"
+                }
+            },
+            "required": [
+                "host",
+                "path",
+                "pathType",
+                "tls",
+                "precedingPaths",
+                "succeedingPaths"
+            ],
+            "title": "WebserverIngressConfiguration",
+            "type": "object"
+        },
+        "Workspace": {
+            "properties": {
+                "enabled": {
+                    "title": "Enabled",
+                    "type": "boolean"
+                },
+                "servers": {
+                    "items": {
+                        "$ref": "#/$defs/Server"
+                    },
+                    "title": "Servers",
+                    "type": "array"
+                },
+                "externalConfigmap": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Externalconfigmap"
+                }
+            },
+            "required": [
+                "enabled",
+                "servers"
+            ],
+            "title": "Workspace",
+            "type": "object"
+        },
+        "schema__charts__dagster__subschema__postgresql__Service": {
+            "properties": {
+                "port": {
+                    "title": "Port",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "port"
+            ],
+            "title": "Service",
+            "type": "object"
+        },
+        "schema__charts__dagster__subschema__rabbitmq__Service": {
+            "properties": {
+                "port": {
+                    "title": "Port",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "port"
+            ],
+            "title": "Service",
+            "type": "object"
+        },
+        "schema__charts__utils__kubernetes__Service": {
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "title": "Type",
+                    "type": "string"
+                },
+                "port": {
+                    "title": "Port",
+                    "type": "integer"
+                },
+                "annotations": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Annotations"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                }
+            },
+            "required": [
+                "type",
+                "port"
+            ],
+            "title": "Service",
+            "type": "object"
         }
-    }
+    },
+    "additionalProperties": true,
+    "description": "@generated",
+    "properties": {
+        "dagsterWebserver": {
+            "$ref": "#/$defs/Webserver"
+        },
+        "dagster-user-deployments": {
+            "$ref": "#/$defs/UserDeployments"
+        },
+        "postgresql": {
+            "$ref": "#/$defs/PostgreSQL"
+        },
+        "generatePostgresqlPasswordSecret": {
+            "title": "Generatepostgresqlpasswordsecret",
+            "type": "boolean"
+        },
+        "generateCeleryConfigSecret": {
+            "title": "Generateceleryconfigsecret",
+            "type": "boolean"
+        },
+        "rabbitmq": {
+            "$ref": "#/$defs/RabbitMQ"
+        },
+        "redis": {
+            "$ref": "#/$defs/Redis"
+        },
+        "flower": {
+            "$ref": "#/$defs/Flower"
+        },
+        "ingress": {
+            "$ref": "#/$defs/Ingress"
+        },
+        "imagePullSecrets": {
+            "items": {
+                "$ref": "#/$defs/SecretRef"
+            },
+            "title": "Imagepullsecrets",
+            "type": "array"
+        },
+        "computeLogManager": {
+            "$ref": "#/$defs/ComputeLogManager"
+        },
+        "scheduler": {
+            "$ref": "#/$defs/Scheduler"
+        },
+        "runLauncher": {
+            "$ref": "#/$defs/RunLauncher"
+        },
+        "pythonLogs": {
+            "$ref": "#/$defs/PythonLogs"
+        },
+        "dagsterDaemon": {
+            "$ref": "#/$defs/Daemon"
+        },
+        "busybox": {
+            "$ref": "#/$defs/Busybox"
+        },
+        "migrate": {
+            "$ref": "#/$defs/Migrate"
+        },
+        "telemetry": {
+            "$ref": "#/$defs/Telemetry"
+        },
+        "serviceAccount": {
+            "$ref": "#/$defs/ServiceAccount"
+        },
+        "global": {
+            "$ref": "#/$defs/Global"
+        },
+        "retention": {
+            "$ref": "#/$defs/Retention"
+        },
+        "additionalInstanceConfig": {
+            "anyOf": [
+                {
+                    "type": "object"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "title": "Additionalinstanceconfig"
+        }
+    },
+    "required": [
+        "dagsterWebserver",
+        "dagster-user-deployments",
+        "postgresql",
+        "generatePostgresqlPasswordSecret",
+        "generateCeleryConfigSecret",
+        "rabbitmq",
+        "redis",
+        "flower",
+        "ingress",
+        "imagePullSecrets",
+        "computeLogManager",
+        "scheduler",
+        "runLauncher",
+        "pythonLogs",
+        "dagsterDaemon",
+        "busybox",
+        "migrate",
+        "telemetry",
+        "serviceAccount",
+        "global",
+        "retention"
+    ],
+    "title": "DagsterHelmValues",
+    "type": "object"
 }

--- a/pyright/master/requirements-pinned.txt
+++ b/pyright/master/requirements-pinned.txt
@@ -11,6 +11,7 @@ alabaster==1.0.0
 alembic==1.13.3
 altair==4.2.2
 amqp==5.2.0
+annotated-types==0.7.0
 ansicolors==1.1.8
 anyio==4.6.2.post1
 apache-airflow==2.7.3
@@ -447,7 +448,8 @@ pyarrow-hotfix==0.6
 pyasn1==0.6.1
 pyasn1-modules==0.4.1
 pycparser==2.22
-pydantic==1.10.18
+pydantic==2.9.2
+pydantic-core==2.23.4
 pydata-google-auth==1.8.2
 pyflakes==3.2.0
 pygments==2.18.0

--- a/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/sleepy.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/client_tests/sleepy.py
@@ -20,7 +20,7 @@ def sleeper(context, units):
 
 
 class GiverConfig(Config):
-    units: typing.List[int] = Field(default_value=[1, 1, 1, 1])
+    units: typing.List[int] = Field(default_value=[1, 1, 1, 1])  # type: ignore
 
 
 @op(

--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -76,7 +76,7 @@ class MakeConfigCacheable(BaseModel):
     # - arbitrary_types_allowed, to allow non-model class params to be validated with isinstance.
     # - Avoid pydantic reading a cached property class as part of the schema.
     if USING_PYDANTIC_2:
-        model_config = ConfigDict(  # type: ignore
+        model_config = ConfigDict(
             frozen=True, arbitrary_types_allowed=True, ignored_types=(cached_property,)
         )
     else:
@@ -411,7 +411,7 @@ class PermissiveConfig(Config):
     # Pydantic config for this class
     # Cannot use kwargs for base class as this is not support for pydantic<1.8
     if USING_PYDANTIC_2:
-        model_config = ConfigDict(extra="allow")  # type: ignore
+        model_config = ConfigDict(extra="allow")
     else:
 
         class Config:

--- a/python_modules/dagster/dagster/_config/pythonic_config/conversion_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/conversion_utils.py
@@ -165,12 +165,12 @@ def _config_type_for_type_on_pydantic_field(
         from pydantic import ConstrainedFloat, ConstrainedInt, ConstrainedStr
 
         # special case pydantic constrained types to their source equivalents
-        if safe_is_subclass(potential_dagster_type, ConstrainedStr):
+        if safe_is_subclass(potential_dagster_type, ConstrainedStr):  # type: ignore
             return StringSource
         # no FloatSource, so we just return float
-        elif safe_is_subclass(potential_dagster_type, ConstrainedFloat):
+        elif safe_is_subclass(potential_dagster_type, ConstrainedFloat):  # type: ignore
             potential_dagster_type = float
-        elif safe_is_subclass(potential_dagster_type, ConstrainedInt):
+        elif safe_is_subclass(potential_dagster_type, ConstrainedInt):  # type: ignore
             return IntSource
     except ImportError:
         # These types do not exist in Pydantic 2.x

--- a/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/typing_utils.py
@@ -8,7 +8,7 @@ from dagster._core.errors import DagsterInvalidDagsterTypeInPythonicConfigDefini
 
 try:
     # Pydantic 1.x
-    from pydantic._internal._model_construction import ModelMetaclass  # type: ignore
+    from pydantic._internal._model_construction import ModelMetaclass
 except ImportError:
     # Pydantic 2.x
     from pydantic.main import ModelMetaclass

--- a/python_modules/dagster/dagster/_model/__init__.py
+++ b/python_modules/dagster/dagster/_model/__init__.py
@@ -32,7 +32,7 @@ class DagsterModel(BaseModel):
         def __init__(self, **data: Any) -> None: ...
 
     if USING_PYDANTIC_2:
-        model_config = ConfigDict(  # type: ignore
+        model_config = ConfigDict(
             extra="forbid",
             frozen=True,
             arbitrary_types_allowed=True,
@@ -48,13 +48,13 @@ class DagsterModel(BaseModel):
 
     def model_copy(self, *, update: Optional[Dict[str, Any]] = None) -> Self:
         if USING_PYDANTIC_2:
-            return super().model_copy(update=update)  # type: ignore
+            return super().model_copy(update=update)
         else:
             return super().copy(update=update)
 
     @classmethod
     def model_construct(cls, **kwargs: Any) -> Self:
         if USING_PYDANTIC_2:
-            return super().model_construct(**kwargs)  # type: ignore
+            return super().model_construct(**kwargs)
         else:
             return super().construct(**kwargs)

--- a/python_modules/dagster/dagster/_model/pydantic_compat_layer.py
+++ b/python_modules/dagster/dagster/_model/pydantic_compat_layer.py
@@ -9,13 +9,13 @@ USING_PYDANTIC_2 = int(pydantic.__version__.split(".")[0]) >= 2
 
 PydanticUndefined = None
 if USING_PYDANTIC_2:
-    from pydantic_core import PydanticUndefined as _PydanticUndefined  # type: ignore
+    from pydantic_core import PydanticUndefined as _PydanticUndefined
 
     PydanticUndefined = _PydanticUndefined
 
 
 if TYPE_CHECKING:
-    from pydantic.fields import ModelField
+    from pydantic.fields import ModelField  # type: ignore
 
 
 class ModelFieldCompat:
@@ -63,7 +63,7 @@ class ModelFieldCompat:
 
     def is_required(self) -> bool:
         if USING_PYDANTIC_2:
-            return self.field.is_required()  # type: ignore
+            return self.field.is_required()
         else:
             # required is of type 'BoolUndefined', which is a Union of bool and pydantic 1.x's UndefinedType
             return self.field.required if isinstance(self.field.required, bool) else False
@@ -72,7 +72,7 @@ class ModelFieldCompat:
     def discriminator(self) -> Optional[str]:
         if USING_PYDANTIC_2:
             if hasattr(self.field, "discriminator"):
-                return self.field.discriminator if hasattr(self.field, "discriminator") else None  # type: ignore
+                return self.field.discriminator if hasattr(self.field, "discriminator") else None
         else:
             return getattr(self.field, "discriminator_key", None)
 
@@ -144,10 +144,10 @@ def build_validation_error(
     input_type: Literal["python", "json"],
 ) -> ValidationError:
     if USING_PYDANTIC_1:
-        return ValidationError(errors=line_errors, model=base_error.model)
+        return ValidationError(errors=line_errors, model=base_error.model)  # type: ignore
     else:
-        return ValidationError.from_exception_data(  # type: ignore
-            title=base_error.title,  # type: ignore
+        return ValidationError.from_exception_data(
+            title=base_error.title,
             line_errors=line_errors,
             input_type=input_type,
             hide_input=hide_input,
@@ -164,6 +164,6 @@ def json_schema_from_type(model_type: Union[Type[BaseModel], Type[Sequence[BaseM
         return json.loads(schema_json_of(model_type))
 
     else:
-        from pydantic import TypeAdapter  # type: ignore
+        from pydantic import TypeAdapter
 
         return TypeAdapter(model_type).json_schema()

--- a/python_modules/dagster/dagster/_utils/pydantic_yaml.py
+++ b/python_modules/dagster/dagster/_utils/pydantic_yaml.py
@@ -50,8 +50,8 @@ def _parse_and_populate_model_with_annotated_errors(
                     {**error, "loc": [file_key_path_str + " at " + str(source_position)]}
                 )
 
-            raise ValidationError.from_exception_data(  # type: ignore
-                title=e.title,  # type: ignore
+            raise ValidationError.from_exception_data(
+                title=e.title,
                 line_errors=line_errors,
                 input_type="json",
                 hide_input=False,

--- a/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_constraints.py
+++ b/python_modules/dagster/dagster_tests/core_tests/pythonic_config_tests/test_constraints.py
@@ -21,7 +21,7 @@ def test_str_regex() -> None:
     try:
 
         class AStringConfig(Config):  # type: ignore
-            a_str: str = Field(regex=r"^(foo)+$")
+            a_str: str = Field(regex=r"^(foo)+$")  # type: ignore
 
     except:
 
@@ -111,7 +111,7 @@ def test_float_multiple() -> None:
 
 def test_list_length() -> None:
     class AListConfig(Config):
-        a_list: List[int] = Field(min_items=2, max_items=10)
+        a_list: List[int] = Field(min_items=2, max_items=10)  # type: ignore
 
     AListConfig(a_list=[1, 2])
     with pytest.raises(ValidationError, match=" at least 2 items"):
@@ -123,7 +123,7 @@ def test_list_length() -> None:
 @pytest.mark.skipif(USING_PYDANTIC_2, reason="Removed in pydantic 2")
 def test_list_uniqueness() -> None:
     class AListConfig(Config):
-        a_list: List[int] = Field(unique_items=True)
+        a_list: List[int] = Field(unique_items=True)  # type: ignore
 
     AListConfig(a_list=[1, 2])
     with pytest.raises(ValidationError, match="the list has duplicated items"):

--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake/resources.py
@@ -235,7 +235,7 @@ class SnowflakeResource(ConfigurableResource, IAttachDifferentObjectToOpContext)
             "Indicate alternative database connection engine. Permissible option is "
             "'sqlalchemy' otherwise defaults to use the Snowflake Connector for Python."
         ),
-        is_required=False,
+        is_required=False,  # type: ignore
     )
 
     cache_column_metadata: Optional[str] = Field(


### PR DESCRIPTION
Internal companion PR: https://github.com/dagster-io/internal/pull/12359

## Summary & Motivation

Update `dagster-helm` to use Pydantic 2+ instead of Pydantic 1. This unblocks updating `dagster` to use exclusively 2+ (Pydantic 1.x is EOL).

Because the entire purpose of `dagster-helm` is to define our helm schema with pydantic, and Pydantic 1 -> 2 has many breaking changes, there are a lot of updates here:

- Fields of form: `field: Optional[SomeType]` were updated to `field: Optional[SomeType] = None`. The `None` default is automatically applied in v1 but not v2.
- `Config` classes in our models were removed in favor of `model_config=ConfigDict(...)` or setting config directly in the class args. This is the preferred API in v2.
- Renamed `schema_extra` config specifications to `json_schema_extra`
- Kubernetes models with no defined fields but a `json_schema_extra` pointing to an external schema now have `extra=allow` on them. This allows fields to actually be set on these objects-- this was possible in v1 because `BaseModel.construct()` ignored the `extra` setting and always set extra fields, but that behavior changed in v2.
- Tests that constructed an object for a schema with nested models previously sometimes just used a dict instead of a model object on the test object. This stopped working and now we make sure the test object contains all the nested model objects.
- Few other tweaks for niche API breakages.

## How I Tested These Changes

Existing test suite.
