### PR TITLE
[ui] Turn on new code location pages

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/FeatureFlags.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/FeatureFlags.oss.tsx
@@ -4,6 +4,5 @@ export enum FeatureFlag {
   flagSidebarResources = 'flagSidebarResources',
   flagDisableAutoLoadDefaults = 'flagDisableAutoLoadDefaults',
   flagLegacyNav = 'flagLegacyNav',
-  flagCodeLocationPage = 'flagCodeLocationPage',
   flagLegacyRunsPage = 'flagLegacyRunsPage',
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
@@ -38,10 +38,6 @@ export const useVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagLegacyNav,
   },
   {
-    key: 'New code location page',
-    flagType: FeatureFlag.flagCodeLocationPage,
-  },
-  {
     key: 'Revert to legacy Runs page',
     flagType: FeatureFlag.flagLegacyRunsPage,
     label: (

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceRoot.tsx
@@ -4,24 +4,16 @@ import {Redirect, Switch, useParams} from 'react-router-dom';
 
 import {CodeLocationNotFound} from './CodeLocationNotFound';
 import {GraphRoot} from './GraphRoot';
-import {WorkspaceAssetsRoot} from './WorkspaceAssetsRoot';
 import {WorkspaceContext} from './WorkspaceContext/WorkspaceContext';
-import {WorkspaceGraphsRoot} from './WorkspaceGraphsRoot';
-import {WorkspaceJobsRoot} from './WorkspaceJobsRoot';
-import {WorkspaceOpsRoot} from './WorkspaceOpsRoot';
-import {WorkspaceSchedulesRoot} from './WorkspaceSchedulesRoot';
-import {WorkspaceSensorsRoot} from './WorkspaceSensorsRoot';
 import {repoAddressAsHumanString} from './repoAddressAsString';
 import {repoAddressFromPath} from './repoAddressFromPath';
 import {workspacePathFromAddress} from './workspacePath';
-import {useFeatureFlags} from '../app/Flags';
 import {Route} from '../app/Route';
 import {AssetGroupRoot} from '../assets/AssetGroupRoot';
 import {CodeLocationDefinitionsRoot} from '../code-location/CodeLocationDefinitionsRoot';
 import CodeLocationOverviewRoot from '../code-location/CodeLocationOverviewRoot';
 import {PipelineRoot} from '../pipelines/PipelineRoot';
 import {ResourceRoot} from '../resources/ResourceRoot';
-import {WorkspaceResourcesRoot} from '../resources/WorkspaceResourcesRoot';
 import {ScheduleRoot} from '../schedules/ScheduleRoot';
 import {SensorRoot} from '../sensors/SensorRoot';
 
@@ -29,7 +21,6 @@ const RepoRouteContainer = () => {
   const {repoPath} = useParams<{repoPath: string}>();
   const workspaceState = useContext(WorkspaceContext);
   const addressForPath = repoAddressFromPath(repoPath);
-  const {flagCodeLocationPage} = useFeatureFlags();
 
   const {loading} = workspaceState;
 
@@ -118,60 +109,29 @@ const RepoRouteContainer = () => {
       >
         <AssetGroupRoot repoAddress={addressForPath} tab="lineage" />
       </Route>
-      {flagCodeLocationPage ? (
-        <>
-          <Route path="/locations/:repoPath" exact>
-            <CodeLocationOverviewRoot repoAddress={addressForPath} />
-          </Route>
-          <Route path="/locations/:repoPath/definitions" exact>
-            <Redirect to={workspacePathFromAddress(addressForPath, '/assets')} />
-          </Route>
-          <Route
-            path={[
-              '/locations/:repoPath/assets',
-              '/locations/:repoPath/jobs',
-              '/locations/:repoPath/resources',
-              '/locations/:repoPath/schedules',
-              '/locations/:repoPath/sensors',
-              '/locations/:repoPath/graphs',
-              '/locations/:repoPath/ops/:name?',
-            ]}
-            exact
-          >
-            <CodeLocationDefinitionsRoot
-              repoAddress={addressForPath}
-              repository={matchingRepo.repository}
-            />
-          </Route>
-        </>
-      ) : (
-        <>
-          <Route path="/locations/:repoPath" exact>
-            <Redirect to={workspacePathFromAddress(addressForPath, '/assets')} />
-          </Route>
-          <Route path="/locations/:repoPath/resources" exact>
-            <WorkspaceResourcesRoot repoAddress={addressForPath} />
-          </Route>
-          <Route path="/locations/:repoPath/assets" exact>
-            <WorkspaceAssetsRoot repoAddress={addressForPath} />
-          </Route>
-          <Route path="/locations/:repoPath/jobs" exact>
-            <WorkspaceJobsRoot repoAddress={addressForPath} />
-          </Route>
-          <Route path="/locations/:repoPath/schedules" exact>
-            <WorkspaceSchedulesRoot repoAddress={addressForPath} />
-          </Route>
-          <Route path="/locations/:repoPath/sensors" exact>
-            <WorkspaceSensorsRoot repoAddress={addressForPath} />
-          </Route>
-          <Route path="/locations/:repoPath/graphs" exact>
-            <WorkspaceGraphsRoot repoAddress={addressForPath} />
-          </Route>
-          <Route path="/locations/:repoPath/ops/:name?" exact>
-            <WorkspaceOpsRoot repoAddress={addressForPath} />
-          </Route>
-        </>
-      )}
+      <Route path="/locations/:repoPath" exact>
+        <CodeLocationOverviewRoot repoAddress={addressForPath} />
+      </Route>
+      <Route path="/locations/:repoPath/definitions" exact>
+        <Redirect to={workspacePathFromAddress(addressForPath, '/assets')} />
+      </Route>
+      <Route
+        path={[
+          '/locations/:repoPath/assets',
+          '/locations/:repoPath/jobs',
+          '/locations/:repoPath/resources',
+          '/locations/:repoPath/schedules',
+          '/locations/:repoPath/sensors',
+          '/locations/:repoPath/graphs',
+          '/locations/:repoPath/ops/:name?',
+        ]}
+        exact
+      >
+        <CodeLocationDefinitionsRoot
+          repoAddress={addressForPath}
+          repository={matchingRepo.repository}
+        />
+      </Route>
       <Route path={['/locations/:repoPath/*', '/locations/:repoPath/']}>
         <Redirect to={workspacePathFromAddress(addressForPath, '/assets')} />
       </Route>


### PR DESCRIPTION
## Summary & Motivation

Remove the `flagCodeLocationPage` flag, permanently enabling the new code location pages in OSS.

## How I Tested These Changes

View app with legacy nav turned on and off, navigate to Deployment. Click on code locations, verify that their new pages render correctly.

## Changelog

[ui] New code location pages with library versions, metadata, and definitions.