### PR TITLE
[1.9] Hide references to AutoMaterializePolicy / FreshenssPolicy from docs / type signatures

### DIFF
--- a/docs/sphinx/sections/api/apidocs/assets.rst
+++ b/docs/sphinx/sections/api/apidocs/assets.rst
@@ -94,20 +94,14 @@ Refer to the `Asset observation <https://docs.dagster.io/concepts/assets/asset-o
 
 .. autoclass:: AssetObservation
 
-Auto-materialize and freshness policies
+Declarative Automation
 ---------------------------------------
 
-Refer to the `Auto-materialize policies <https://docs.dagster.io/concepts/assets/asset-auto-execution>`_ documentation for more information.
-
-.. autoclass:: AutoMaterializePolicy
-
-.. autoclass:: AutoMaterializeRule
-
-.. autoclass:: AutomationConditionSensorDefinition
+Refer to the `Declarative Automation <https://docs.dagster.io/concepts/automation/declarative-automation>`_ documentation for more information.
 
 .. autoclass:: AutomationCondition
 
-.. autoclass:: FreshnessPolicy
+.. autoclass:: AutomationConditionSensorDefinition
 
 Asset values
 ------------

--- a/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
+++ b/python_modules/dagster/dagster/_core/definitions/decorators/source_asset_decorator.py
@@ -1,7 +1,7 @@
 from typing import AbstractSet, Any, Callable, Mapping, Optional, Sequence, Set, Union, overload
 
 import dagster._check as check
-from dagster._annotations import deprecated_param, experimental
+from dagster._annotations import experimental, hidden_param
 from dagster._core.definitions.asset_check_spec import AssetCheckSpec
 from dagster._core.definitions.asset_spec import AssetExecutionType, AssetSpec
 from dagster._core.definitions.assets import AssetsDefinition
@@ -53,12 +53,12 @@ def observable_source_asset(
 ) -> "_ObservableSourceAsset": ...
 
 
-@deprecated_param(
+@hidden_param(
     param="auto_observe_interval_minutes",
     breaking_version="1.10.0",
     additional_warn_text="use `automation_condition` instead.",
 )
-@deprecated_param(
+@hidden_param(
     param="freshness_policy",
     breaking_version="1.10.0",
     additional_warn_text="use freshness checks instead.",
@@ -78,11 +78,10 @@ def observable_source_asset(
     required_resource_keys: Optional[AbstractSet[str]] = None,
     resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
     partitions_def: Optional[PartitionsDefinition] = None,
-    auto_observe_interval_minutes: Optional[float] = None,
-    freshness_policy: Optional[FreshnessPolicy] = None,
     automation_condition: Optional[AutomationCondition] = None,
     op_tags: Optional[Mapping[str, Any]] = None,
     tags: Optional[Mapping[str, str]] = None,
+    **kwargs,
 ) -> Union[SourceAsset, "_ObservableSourceAsset"]:
     """Create a `SourceAsset` with an associated observation function.
 
@@ -113,8 +112,6 @@ def observable_source_asset(
             the `io_manager_def` argument.
         partitions_def (Optional[PartitionsDefinition]): Defines the set of partition keys that
             compose the asset.
-        auto_observe_interval_minutes (Optional[float]): While the asset daemon is turned on, a run
-            of the observation function for this asset will be launched at this interval.
         op_tags (Optional[Dict[str, Any]]): A dictionary of tags for the op that computes the asset.
             Frameworks may expect and require certain metadata to be attached to a op. Values that
             are not strings will be json encoded and must meet the criteria that
@@ -140,8 +137,8 @@ def observable_source_asset(
         required_resource_keys,
         resource_defs,
         partitions_def,
-        auto_observe_interval_minutes,
-        freshness_policy,
+        kwargs.get("auto_observe_interval_minutes"),
+        kwargs.get("freshness_policy"),
         automation_condition,
         op_tags,
         tags=normalize_tags(tags, strict=True),

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -916,6 +916,8 @@ def test_graph_asset_decorator_no_args():
 @ignore_warning("Parameter `resource_defs` .* is experimental")
 @ignore_warning("Parameter `tags` .* is experimental")
 @ignore_warning("Parameter `owners` .* is experimental")
+@ignore_warning("Parameter `auto_materialize_policy` .* is deprecated")
+@ignore_warning("Parameter `freshness_policy` .* is deprecated")
 @pytest.mark.parametrize(
     "automation_condition_arg",
     [
@@ -1126,6 +1128,8 @@ def test_graph_asset_w_config_mapping():
 @ignore_warning("Function `AutoMaterializePolicy.lazy` is deprecated")
 @ignore_warning("Parameter `auto_materialize_policy` is deprecated")
 @ignore_warning("Parameter `resource_defs`")
+@ignore_warning("Parameter `auto_materialize_policy`")
+@ignore_warning("Parameter `freshness_policy`")
 @pytest.mark.parametrize(
     "automation_condition_arg",
     [
@@ -1352,7 +1356,7 @@ def test_multi_asset_with_bare_resource():
 @ignore_warning("Static method `AutomationCondition.on_cron` is experimental")
 @ignore_warning("Static method `AutomationCondition.eager` is experimental")
 @ignore_warning("Function `AutoMaterializePolicy.lazy` is deprecated")
-@ignore_warning("Parameter `auto_materialize_policy` is deprecated")
+@ignore_warning("Parameter `auto_materialize_policy`")
 def test_multi_asset_with_automation_conditions():
     ac2 = AutomationCondition.on_cron("@daily")
     ac3 = AutomationCondition.eager()

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_telemetry.py
@@ -26,7 +26,6 @@ from dagster import (
     resource,
 )
 from dagster._cli.job import job_execute_command
-from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
 from dagster._core.definitions.reconstruct import get_ephemeral_repository_name
 from dagster._core.definitions.resource_definition import dagster_maintained_resource
 from dagster._core.execution.context.input import InputContext
@@ -298,28 +297,6 @@ def test_get_stats_from_remote_repo_freshness_policies(instance):
     )
     stats = get_stats_from_remote_repo(remote_repo)
     assert stats["num_assets_with_freshness_policies_in_repo"] == "1"
-
-
-# TODO: FOU-243
-@pytest.mark.skip("obsolete EAGER vs. LAZY distinction")
-def test_get_status_from_remote_repo_auto_materialize_policy(instance):
-    @asset(auto_materialize_policy=AutoMaterializePolicy.lazy())
-    def asset1(): ...
-
-    @asset
-    def asset2(): ...
-
-    @asset(auto_materialize_policy=AutoMaterializePolicy.eager())
-    def asset3(): ...
-
-    remote_repo = RemoteRepository(
-        RepositorySnap.from_def(Definitions(assets=[asset1, asset2, asset3]).get_repository_def()),
-        repository_handle=RepositoryHandle.for_test(),
-        instance=instance,
-    )
-    stats = get_stats_from_remote_repo(remote_repo)
-    assert stats["num_assets_with_eager_auto_materialize_policies_in_repo"] == "1"
-    assert stats["num_assets_with_lazy_auto_materialize_policies_in_repo"] == "1"
 
 
 def test_get_stats_from_remote_repo_code_versions(instance):

--- a/python_modules/dagster/dagster_tests/general_tests/test_internal_init_implementations.py
+++ b/python_modules/dagster/dagster_tests/general_tests/test_internal_init_implementations.py
@@ -39,7 +39,10 @@ def test_dagster_internal_init_class_follow_rules(cls: Type):
         " dagster_internal_init methods cannot have default values"
     )
 
-    assert all(p.kind == Parameter.KEYWORD_ONLY for p in dagster_internal_init_params.values()), (
+    assert all(
+        p.kind == Parameter.KEYWORD_ONLY or (p.name == "kwargs" and p.kind == Parameter.VAR_KEYWORD)
+        for p in dagster_internal_init_params.values()
+    ), (
         f"{cls.__name__}.dagster_internal_init has one or more positional arguments,"
         " dagster_internal_init methods can only have keyword-only arguments"
     )


### PR DESCRIPTION
## Summary & Motivation

As title

## How I Tested These Changes

## Changelog

The `auto_materialize_policy` and `freshness_policy` arguments have been hidden from the type signature of `AssetSpec`, `AssetOut`, `@asset`, and `@graph_asset`. Existing code using these arguments will continue to function, but they will not show up in typeahead or docs.

The `auto_observe_interval_minutes` and `freshness_policy` arguments of `@observable_source_asset` have similarly been hidden.
