### PR TITLE
always fetch storage_ids by partition for latest materializations call

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -977,10 +977,6 @@ class GrapheneAssetNode(graphene.ObjectType):
         graphene_info: ResolveInfo,
         partitions: Optional[Sequence[str]] = None,
     ) -> Sequence[Optional[GrapheneMaterializationEvent]]:
-        get_partition = (
-            lambda event: event.dagster_event.step_materialization_data.materialization.partition
-        )
-
         latest_storage_ids = sorted(
             (
                 graphene_info.context.instance.event_log_storage.get_latest_storage_id_by_partition(
@@ -996,7 +992,9 @@ class GrapheneAssetNode(graphene.ObjectType):
             storage_ids=latest_storage_ids,
         )
         latest_materialization_by_partition = {
-            get_partition(event): event for event in events_for_partitions
+            event.dagster_event.step_materialization_data.materialization.partition: event
+            for event in events_for_partitions
+            if event.dagster_event
         }
 
         # return materializations in the same order as the provided partitions, None if

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -981,13 +981,12 @@ class GrapheneAssetNode(graphene.ObjectType):
             lambda event: event.dagster_event.step_materialization_data.materialization.partition
         )
 
-        partitions = self.get_partition_keys() if partitions is None else partitions
         latest_storage_ids = sorted(
             (
                 graphene_info.context.instance.event_log_storage.get_latest_storage_id_by_partition(
                     self._asset_node_snap.asset_key,
                     DagsterEventType.ASSET_MATERIALIZATION,
-                    set(partitions),
+                    set(partitions) if partitions else None,
                 )
             ).values()
         )
@@ -1002,6 +1001,7 @@ class GrapheneAssetNode(graphene.ObjectType):
 
         # return materializations in the same order as the provided partitions, None if
         # materialization does not exist
+        partitions = self.get_partition_keys() if partitions is None else partitions
         ordered_materializations = [
             latest_materialization_by_partition.get(partition) for partition in partitions
         ]

--- a/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/asset_graph.py
@@ -981,42 +981,24 @@ class GrapheneAssetNode(graphene.ObjectType):
             lambda event: event.dagster_event.step_materialization_data.materialization.partition
         )
 
-        query_all_partitions = partitions is None
-        partitions = self.get_partition_keys() if query_all_partitions else partitions
-
-        if query_all_partitions or len(partitions) > 1000:
-            # when there are many partitions, it's much more efficient to grab the latest storage
-            # id for all partitions and then query for the materialization events based on those
-            # storage ids
-            latest_storage_ids = sorted(
-                (
-                    graphene_info.context.instance.event_log_storage.get_latest_storage_id_by_partition(
-                        self._asset_node_snap.asset_key, DagsterEventType.ASSET_MATERIALIZATION
-                    )
-                ).values()
-            )
-            events_for_partitions = get_asset_materializations(
-                graphene_info,
-                asset_key=self._asset_node_snap.asset_key,
-                storage_ids=latest_storage_ids,
-            )
-            latest_materialization_by_partition = {
-                get_partition(event): event for event in events_for_partitions
-            }
-        else:
-            events_for_partitions = get_asset_materializations(
-                graphene_info,
-                self._asset_node_snap.asset_key,
-                partitions,
-            )
-
-            latest_materialization_by_partition = {}
-            for event in events_for_partitions:  # events are sorted in order of newest to oldest
-                event_partition = get_partition(event)
-                if event_partition not in latest_materialization_by_partition:
-                    latest_materialization_by_partition[event_partition] = event
-                if len(latest_materialization_by_partition) == len(partitions):
-                    break
+        partitions = self.get_partition_keys() if partitions is None else partitions
+        latest_storage_ids = sorted(
+            (
+                graphene_info.context.instance.event_log_storage.get_latest_storage_id_by_partition(
+                    self._asset_node_snap.asset_key,
+                    DagsterEventType.ASSET_MATERIALIZATION,
+                    set(partitions),
+                )
+            ).values()
+        )
+        events_for_partitions = get_asset_materializations(
+            graphene_info,
+            asset_key=self._asset_node_snap.asset_key,
+            storage_ids=latest_storage_ids,
+        )
+        latest_materialization_by_partition = {
+            get_partition(event): event for event in events_for_partitions
+        }
 
         # return materializations in the same order as the provided partitions, None if
         # materialization does not exist


### PR DESCRIPTION
## Summary & Motivation
Switches the latest materializations by partition resolver to always use the optimized latest storage ids by partition call.

## How I Tested These Changes
BK
