### PR TITLE
dont return an execution set identifier for unexecutable assets

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph.py
@@ -298,7 +298,8 @@ class AssetGraph(BaseAssetGraph[AssetNode]):
             return (
                 assets_def.unique_id
                 if (
-                    not assets_def.can_subset
+                    assets_def.is_executable
+                    and not assets_def.can_subset
                     and (len(assets_def.keys) > 1 or assets_def.check_keys)
                 )
                 else None

--- a/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
+++ b/python_modules/dagster/dagster_tests/core_tests/host_representation_tests/test_external_data.py
@@ -1259,6 +1259,36 @@ def test_external_assets_def_to_asset_node_snaps():
     ]
 
 
+def test_asst_specs_in_defs_snaps():
+    asset_node_snaps = _get_asset_node_snaps_from_definitions(
+        Definitions(
+            assets=[
+                AssetSpec("asset1"),
+                AssetSpec("asset2", deps=["asset1"]),
+            ]
+        )
+    )
+
+    assert len(asset_node_snaps) == 2
+
+    assert asset_node_snaps == [
+        AssetNodeSnap(
+            asset_key=AssetKey(["asset1"]),
+            parent_edges=[],
+            child_edges=[AssetChildEdgeSnap(child_asset_key=AssetKey("asset2"))],
+            execution_type=AssetExecutionType.UNEXECUTABLE,
+            group_name=DEFAULT_GROUP_NAME,
+        ),
+        AssetNodeSnap(
+            asset_key=AssetKey("asset2"),
+            parent_edges=[AssetParentEdgeSnap(parent_asset_key=AssetKey(["asset1"]))],
+            child_edges=[],
+            execution_type=AssetExecutionType.UNEXECUTABLE,
+            group_name=DEFAULT_GROUP_NAME,
+        ),
+    ]
+
+
 def test_historical_asset_node_snap_that_models_underlying_external_assets_def() -> None:
     assert not AssetNodeSnap(
         asset_key=AssetKey("asset_one"),


### PR DESCRIPTION
`execution_set_identifier` behavior diverged when passing `AssetSpec` directly to `Definitions` due to the 
`AssetsDefinition` that is created in that code path causing `execution_set_identifier` to group unexecutable assets. 

Change`get_execution_set_identifier` to return for unexecutable assets. 

## How I Tested These Changes

added test that previously failed
