### PR TITLE
Various 1.9 kind cleanups

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
@@ -67,10 +67,10 @@ export const AssetKind = ({
             onClick: currentPageFilter
               ? () => currentPageFilter.setState(new Set([kind, ...currentPageFilter.state]))
               : shouldLink
-              ? () => {
-                  window.location.href = linkToAssetTableWithKindFilter(kind);
-                }
-              : () => {},
+                ? () => {
+                    window.location.href = linkToAssetTableWithKindFilter(kind);
+                  }
+                : () => {},
           },
         ]}
       />

--- a/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/graph/KindTags.tsx
@@ -67,10 +67,10 @@ export const AssetKind = ({
             onClick: currentPageFilter
               ? () => currentPageFilter.setState(new Set([kind, ...currentPageFilter.state]))
               : shouldLink
-                ? () => {
-                    window.location.href = linkToAssetTableWithKindFilter(kind);
-                  }
-                : () => {},
+              ? () => {
+                  window.location.href = linkToAssetTableWithKindFilter(kind);
+                }
+              : () => {},
           },
         ]}
       />

--- a/python_modules/dagster/dagster/_core/definitions/op_definition.py
+++ b/python_modules/dagster/dagster/_core/definitions/op_definition.py
@@ -44,10 +44,9 @@ from dagster._core.errors import (
     DagsterInvalidInvocationError,
     DagsterInvariantViolationError,
 )
-from dagster._core.storage.tags import COMPUTE_KIND_TAG, LEGACY_COMPUTE_KIND_TAG
 from dagster._core.types.dagster_type import DagsterType, DagsterTypeKind
 from dagster._utils import IHasInternalInit
-from dagster._utils.warnings import deprecation_warning, normalize_renamed_param
+from dagster._utils.warnings import normalize_renamed_param
 
 if TYPE_CHECKING:
     from dagster._core.definitions.asset_layer import AssetLayer
@@ -183,7 +182,7 @@ class OpDefinition(NodeDefinition, IHasInternalInit):
             input_defs=check.sequence_param(resolved_input_defs, "input_defs", InputDefinition),
             output_defs=check.sequence_param(output_defs, "output_defs", OutputDefinition),
             description=description,
-            tags=_normalize_op_tags(check.opt_mapping_param(tags, "tags", key_type=str)),
+            tags=(check.opt_mapping_param(tags, "tags", key_type=str)),
             positional_inputs=positional_inputs,
         )
 
@@ -583,18 +582,6 @@ def _validate_context_type_hint(fn):
                 f"Cannot annotate `context` parameter with type {params[0].annotation}. `context`"
                 " must be annotated with AssetExecutionContext, AssetCheckExecutionContext, OpExecutionContext, or left blank."
             )
-
-
-def _normalize_op_tags(tags: Mapping[str, str]) -> Mapping[str, str]:
-    if LEGACY_COMPUTE_KIND_TAG in tags:
-        deprecation_warning(
-            "Legacy compute kind tag '{LEGACY_COMPUTE_KIND_TAG}'",
-            breaking_version="1.9.0",
-            additional_warn_text="Please set the compute kind using the `compute_kind` argument on asset/op definition APIs.",
-        )
-        return {COMPUTE_KIND_TAG: tags[LEGACY_COMPUTE_KIND_TAG], **tags}
-    else:
-        return tags
 
 
 def _is_result_object_type(ttype):

--- a/python_modules/dagster/dagster/_core/definitions/tags/__init__.py
+++ b/python_modules/dagster/dagster/_core/definitions/tags/__init__.py
@@ -1,6 +1,5 @@
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Mapping
 
-from dagster._annotations import deprecated
 from dagster._core.definitions.tags.tag_set import NamespacedTagSet as NamespacedTagSet
 from dagster._core.storage.tags import KIND_PREFIX
 
@@ -15,19 +14,3 @@ def build_kind_tag_key(kind: str) -> str:
 
 def build_kind_tag(kind: str) -> Dict[str, Any]:
     return {build_kind_tag_key(kind): ""}
-
-
-@deprecated(breaking_version="1.9")
-class StorageKindTagSet(NamespacedTagSet):
-    """Tag entries which describe how an asset is stored.
-
-    Args:
-        storage_kind (Optional[str]): The storage type of the asset.
-            For example, "snowflake" or "s3".
-    """
-
-    storage_kind: Optional[str] = None
-
-    @classmethod
-    def namespace(cls) -> str:
-        return "dagster"

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_assets.py
@@ -47,7 +47,6 @@ from dagster._core.definitions.auto_materialize_policy import AutoMaterializePol
 from dagster._core.definitions.decorators.asset_decorator import graph_asset
 from dagster._core.definitions.events import AssetMaterialization
 from dagster._core.definitions.result import MaterializeResult
-from dagster._core.definitions.tags import StorageKindTagSet
 from dagster._core.errors import (
     DagsterInvalidDefinitionError,
     DagsterInvalidInvocationError,
@@ -2261,21 +2260,6 @@ def test_asset_with_tags():
 
         @asset(tags={"a%": "b"})  # key has illegal character
         def asset2(): ...
-
-
-def test_asset_with_storage_kind_tag() -> None:
-    @asset(tags={**StorageKindTagSet(storage_kind="snowflake")})
-    def asset1(): ...
-
-    assert asset1.specs_by_key[asset1.key].tags == {"dagster/storage_kind": "snowflake"}
-
-    @asset(tags={**StorageKindTagSet(storage_kind="snowflake"), "a": "b"})
-    def asset2(): ...
-
-    assert asset2.specs_by_key[asset2.key].tags == {
-        "dagster/storage_kind": "snowflake",
-        "a": "b",
-    }
 
 
 def test_asset_spec_with_tags():


### PR DESCRIPTION
## Summary

Removes the storage kind tag set, since storage kinds have been sundowned, and also removes the very-legacy op compute kind tag remapping logic.