### PR TITLE
[dagster-sigma] Add SigmaFilter to filter set of incoming workbooks

### DIFF
--- a/python_modules/libraries/dagster-sigma/dagster_sigma/__init__.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/__init__.py
@@ -2,6 +2,7 @@ from dagster._core.libraries import DagsterLibraryRegistry
 
 from dagster_sigma.resource import (
     SigmaBaseUrl as SigmaBaseUrl,
+    SigmaFilter as SigmaFilter,
     SigmaOrganization as SigmaOrganization,
     load_sigma_asset_specs as load_sigma_asset_specs,
 )

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -17,6 +17,7 @@ from dagster._annotations import deprecated, public
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.definitions_load_context import StateBackedDefinitionsLoader
+from dagster._record import IHaveNew, record_custom
 from dagster._utils.cached_method import cached_method
 from pydantic import Field, PrivateAttr
 from sqlglot import exp, parse_one
@@ -30,6 +31,24 @@ from dagster_sigma.translator import (
 )
 
 SIGMA_PARTNER_ID_TAG = {"X-Sigma-Partner-Id": "dagster"}
+
+
+@record_custom
+class SigmaFilter(IHaveNew):
+    """Filters the set of Sigma objects to fetch.
+
+    Args:
+        workbook_folders (Optional[Sequence[Sequence[str]]]): A list of folder paths to fetch workbooks from.
+            Each folder path is a list of folder names, starting from the root folder. All workbooks
+            contained in the specified folders will be fetched. If not provided, all workbooks will be fetched.
+    """
+
+    workbook_folders: Optional[Sequence[Sequence[str]]] = None
+
+    def __new__(cls, workbook_folders: Optional[Sequence[Sequence[str]]] = None):
+        return super().__new__(
+            cls, workbook_folders=tuple([tuple(folder) for folder in workbook_folders or []])
+        )
 
 
 class SigmaBaseUrl(str, Enum):
@@ -356,13 +375,31 @@ class SigmaOrganization(ConfigurableResource):
         )
 
     @cached_method
-    async def build_organization_data(self) -> SigmaOrganizationData:
+    async def build_organization_data(
+        self, sigma_filter: Optional[SigmaFilter]
+    ) -> SigmaOrganizationData:
         """Retrieves all workbooks and datasets in the Sigma organization and builds a
         SigmaOrganizationData object representing the organization's assets.
         """
+        _sigma_filter = sigma_filter or SigmaFilter()
+
         raw_workbooks = await self._fetch_workbooks()
+        workbooks_to_fetch = []
+        if _sigma_filter.workbook_folders:
+            workbook_filter_strings = [
+                "/".join(folder).lower() for folder in _sigma_filter.workbook_folders
+            ]
+            for workbook in raw_workbooks:
+                workbook_path = str(workbook["path"]).lower()
+                if any(
+                    workbook_path.startswith(folder_str) for folder_str in workbook_filter_strings
+                ):
+                    workbooks_to_fetch.append(workbook)
+        else:
+            workbooks_to_fetch = raw_workbooks
+
         workbooks: List[SigmaWorkbook] = await asyncio.gather(
-            *[self.load_workbook_data(workbook) for workbook in raw_workbooks]
+            *[self.load_workbook_data(workbook) for workbook in workbooks_to_fetch]
         )
 
         datasets: List[SigmaDataset] = []
@@ -389,6 +426,7 @@ class SigmaOrganization(ConfigurableResource):
     def build_defs(
         self,
         dagster_sigma_translator: Type[DagsterSigmaTranslator] = DagsterSigmaTranslator,
+        sigma_filter: Optional[SigmaFilter] = None,
     ) -> Definitions:
         """Returns a Definitions object representing the Sigma content in the organization.
 
@@ -399,7 +437,9 @@ class SigmaOrganization(ConfigurableResource):
         Returns:
             Definitions: The set of assets representing the Sigma content in the organization.
         """
-        return Definitions(assets=load_sigma_asset_specs(self, dagster_sigma_translator))
+        return Definitions(
+            assets=load_sigma_asset_specs(self, dagster_sigma_translator, sigma_filter)
+        )
 
 
 def load_sigma_asset_specs(
@@ -407,6 +447,7 @@ def load_sigma_asset_specs(
     dagster_sigma_translator: Callable[
         [SigmaOrganizationData], DagsterSigmaTranslator
     ] = DagsterSigmaTranslator,
+    sigma_filter: Optional[SigmaFilter] = None,
 ) -> Sequence[AssetSpec]:
     """Returns a list of AssetSpecs representing the Sigma content in the organization.
 
@@ -419,7 +460,9 @@ def load_sigma_asset_specs(
     with organization.process_config_and_initialize_cm() as initialized_organization:
         return check.is_list(
             SigmaOrganizationDefsLoader(
-                organization=initialized_organization, translator_cls=dagster_sigma_translator
+                organization=initialized_organization,
+                translator_cls=dagster_sigma_translator,
+                sigma_filter=sigma_filter,
             )
             .build_defs()
             .assets,
@@ -444,13 +487,16 @@ def _get_translator_spec_assert_keys_match(
 class SigmaOrganizationDefsLoader(StateBackedDefinitionsLoader[SigmaOrganizationData]):
     organization: SigmaOrganization
     translator_cls: Callable[[SigmaOrganizationData], DagsterSigmaTranslator]
+    sigma_filter: Optional[SigmaFilter] = None
 
     @property
     def defs_key(self) -> str:
         return f"sigma_{self.organization.client_id}"
 
     def fetch_state(self) -> SigmaOrganizationData:
-        return asyncio.run(self.organization.build_organization_data())
+        return asyncio.run(
+            self.organization.build_organization_data(sigma_filter=self.sigma_filter)
+        )
 
     def defs_from_state(self, state: SigmaOrganizationData) -> Definitions:
         translator = self.translator_cls(state)

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/conftest.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/conftest.py
@@ -59,7 +59,7 @@ SAMPLE_WORKBOOK_DATA = {
     "updatedAt": "2024-09-12T22:20:39.848Z",
     "name": "Sample Workbook",
     "url": "https://app.sigmacomputing.com/dagster-labs/workbook/2opi6VLEne4BaPyj00US50",
-    "path": "My Documents",
+    "path": "My Documents/My Subfolder",
     "latestVersion": 5,
     "ownerId": "8TUQL5YbOwebkUGS0SAdqxlU5R0gD",
 }


### PR DESCRIPTION
## Summary

Adds the ability to filter Sigma workbooks to the Looker API resource loading method.

```python
load_sigma_asset_specs(
    sigma_org,
    sigma_filter=SigmaFilter(
        workbook_folders=[["my_folder", "my_subfolder"]],
    ),
)
```

This can help with load times for organizations which have to fetch many workbooks.


## Test Plan

New unit test.
