### PR TITLE
[core] modify context type signatures and usage for making AssetExecutionContext a standalone class

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -90,7 +90,7 @@ def wrap_source_asset_observe_fn_in_op_compute_fn(
 
     observe_fn_has_context = is_context_provided(get_function_params(observe_fn))
 
-    def fn(context: OpExecutionContext) -> Output[None]:  # TODO - does this one need to change
+    def fn(context: OpExecutionContext) -> Output[None]:
         resource_kwarg_keys = [param.name for param in get_resource_args(observe_fn)]
         resource_kwargs = {
             key: context.resources.original_resource_dict.get(key) for key in resource_kwarg_keys

--- a/python_modules/dagster/dagster/_core/definitions/source_asset.py
+++ b/python_modules/dagster/dagster/_core/definitions/source_asset.py
@@ -90,7 +90,7 @@ def wrap_source_asset_observe_fn_in_op_compute_fn(
 
     observe_fn_has_context = is_context_provided(get_function_params(observe_fn))
 
-    def fn(context: OpExecutionContext) -> Output[None]:
+    def fn(context: OpExecutionContext) -> Output[None]:  # TODO - does this one need to change
         resource_kwarg_keys = [param.name for param in get_resource_args(observe_fn)]
         resource_kwargs = {
             key: context.resources.original_resource_dict.get(key) for key in resource_kwarg_keys

--- a/python_modules/dagster/dagster/_core/execution/context/asset_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/asset_execution_context.py
@@ -82,7 +82,7 @@ def _get_deprecation_kwargs(attr: str) -> Mapping[str, Any]:
     return deprecation_kwargs
 
 
-class AssetExecutionContext(OpExecutionContext):
+class AssetExecutionContext:
     def __init__(self, op_execution_context: OpExecutionContext) -> None:
         self._op_execution_context = check.inst_param(
             op_execution_context, "op_execution_context", OpExecutionContext
@@ -382,6 +382,12 @@ class AssetExecutionContext(OpExecutionContext):
     @_copy_docs_from_op_execution_context
     def partition_keys(self) -> Sequence[str]:
         return self.op_execution_context.partition_keys
+
+    @public
+    @property
+    @_copy_docs_from_op_execution_context
+    def has_partition_key_range(self) -> bool:
+        return self.op_execution_context.has_partition_key_range
 
     @deprecated(breaking_version="2.0", additional_warn_text="Use `partition_key_range` instead.")
     @public

--- a/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
+++ b/python_modules/dagster/dagster/_core/execution/context/op_execution_context.py
@@ -1,4 +1,4 @@
-from abc import ABC, ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from typing import AbstractSet, Any, Dict, Iterator, List, Mapping, Optional, Sequence, cast
 
 import dagster._check as check
@@ -34,15 +34,9 @@ from dagster._core.instance import DagsterInstance
 from dagster._core.log_manager import DagsterLogManager
 from dagster._core.storage.dagster_run import DagsterRun
 from dagster._utils.forked_pdb import ForkedPdb
-from dagster._utils.warnings import deprecation_warning
 
 
-# This metaclass has to exist for OpExecutionContext to have a metaclass
-class AbstractComputeMetaclass(ABCMeta):
-    pass
-
-
-class AbstractComputeExecutionContext(ABC, metaclass=AbstractComputeMetaclass):
+class AbstractComputeExecutionContext(ABC):
     """Base class for op context implemented by OpExecutionContext and DagstermillExecutionContext."""
 
     @abstractmethod
@@ -94,27 +88,7 @@ class AbstractComputeExecutionContext(ABC, metaclass=AbstractComputeMetaclass):
         """The parsed config specific to this op."""
 
 
-class OpExecutionContextMetaClass(AbstractComputeMetaclass):
-    def __instancecheck__(cls, instance) -> bool:
-        from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
-
-        # This makes isinstance(context, OpExecutionContext) throw a deprecation warning when
-        # context is an AssetExecutionContext. This metaclass can be deleted once AssetExecutionContext
-        # has been split into it's own class in 1.9.0
-        if type(instance) is AssetExecutionContext and cls is not AssetExecutionContext:
-            deprecation_warning(
-                subject="AssetExecutionContext",
-                additional_warn_text=(
-                    "Starting in version 1.9.0 AssetExecutionContext will no longer be a subclass"
-                    " of OpExecutionContext."
-                ),
-                breaking_version="1.9.0",
-                stacklevel=1,
-            )
-        return super().__instancecheck__(instance)
-
-
-class OpExecutionContext(AbstractComputeExecutionContext, metaclass=OpExecutionContextMetaClass):
+class OpExecutionContext(AbstractComputeExecutionContext):
     """The ``context`` object that can be made available as the first argument to the function
     used for computing an op or asset.
 

--- a/python_modules/dagster/dagster/_core/execution/plan/compute.py
+++ b/python_modules/dagster/dagster/_core/execution/plan/compute.py
@@ -22,11 +22,7 @@ from dagster._core.definitions.op_definition import OpComputeFunction
 from dagster._core.definitions.result import AssetResult, MaterializeResult, ObserveResult
 from dagster._core.errors import DagsterExecutionStepExecutionError, DagsterInvariantViolationError
 from dagster._core.events import DagsterEvent
-from dagster._core.execution.context.compute import (
-    AssetCheckExecutionContext,
-    AssetExecutionContext,
-    OpExecutionContext,
-)
+from dagster._core.execution.context.compute import ExecutionContextTypes
 from dagster._core.execution.context.system import StepExecutionContext
 from dagster._core.execution.plan.outputs import StepOutput, StepOutputProperties
 from dagster._core.execution.plan.utils import op_execution_error_boundary
@@ -142,7 +138,7 @@ def _yield_compute_results(
     step_context: StepExecutionContext,
     inputs: Mapping[str, Any],
     compute_fn: OpComputeFunction,
-    compute_context: Union[OpExecutionContext, AssetExecutionContext, AssetCheckExecutionContext],
+    compute_context: ExecutionContextTypes,
 ) -> Iterator[OpOutputUnion]:
     user_event_generator = compute_fn(compute_context, inputs)
 
@@ -186,7 +182,7 @@ def execute_core_compute(
     step_context: StepExecutionContext,
     inputs: Mapping[str, Any],
     compute_fn: OpComputeFunction,
-    compute_context: Union[OpExecutionContext, AssetExecutionContext, AssetCheckExecutionContext],
+    compute_context: ExecutionContextTypes,
 ) -> Iterator[OpOutputUnion]:
     """Execute the user-specified compute for the op. Wrap in an error boundary and do
     all relevant logging and metrics tracking.

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_decorators.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 from dagster import (
     AllPartitionMapping,
+    AssetExecutionContext,
     AssetKey,
     AssetOut,
     DagsterInvalidDefinitionError,
@@ -15,7 +16,6 @@ from dagster import (
     MultiPartitionMapping,
     MultiPartitionsDefinition,
     Nothing,
-    OpExecutionContext,
     Out,
     Output,
     StaticPartitionsDefinition,
@@ -553,7 +553,7 @@ def test_invoking_asset_with_deps():
 def test_invoking_asset_with_context():
     @asset
     def asset_with_context(context, arg1):
-        assert isinstance(context, OpExecutionContext)
+        assert isinstance(context, AssetExecutionContext)
         return arg1
 
     ctx = build_asset_context()

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_execution_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_asset_execution_context.py
@@ -1,10 +1,10 @@
-import pytest
-from dagster import AssetExecutionContext, OpExecutionContext, asset, materialize
-from dagster._core.execution.context.asset_execution_context import _get_deprecation_kwargs
-from dagster._core.test_utils import raise_exception_on_warnings
+from dagster import AssetExecutionContext, OpExecutionContext
 
 
 def test_doc_strings():
+    """Tests that methods on AssetExecutionContext correctly get their doc strings from the corresponding
+    method on OpExecutionContext.
+    """
     ignores = [
         "_abc_impl",
         "_events",
@@ -26,129 +26,3 @@ def test_doc_strings():
             asset_attr = getattr(AssetExecutionContext, attr_name)
 
             assert op_attr.__doc__ == asset_attr.__doc__
-
-
-def test_deprecation_warnings():
-    # Test that every method on OpExecutionContext is either reimplemented by AssetExecutionContext
-    # or throws a deprecation warning on AssetExecutionContext. This will allow us to eventually make
-    # AssetExecutionContext not a subclass of OpExecutionContext without doing a breaking change.
-
-    # If this test fails, it is likely because you added a method to OpExecutionContext without
-    # also adding that method to AssetExecutionContext. Please add the same method to AssetExecutionContext
-    # with an appropriate deprecation warning (see existing deprecated methods for examples).
-    # If the method should not be deprecated for AssetExecutionContext, please still add the same method
-    # to AssetExecutionContext and add the method name to asset_context_not_deprecated
-
-    # This list maintains all methods on OpExecutionContext that are not deprecated on AssetExecutionContext
-    asset_context_not_deprecated = [
-        # will not be deprecated
-        "job_def",
-        "log",
-        "pdb",
-        "run",
-        "get",
-        # methods/properties that may be deprecated in future PRs
-        "add_output_metadata",
-        "asset_check_spec",
-        "asset_checks_def",
-        "asset_key",
-        "asset_key_for_input",
-        "asset_key_for_output",
-        "asset_partition_key_for_input",
-        "asset_partition_key_range",
-        "asset_partition_key_range_for_input",
-        "asset_partition_keys_for_input",
-        "asset_partitions_def_for_input",
-        "asset_partitions_time_window_for_input",
-        "assets_def",
-        "get_output_metadata",
-        "has_asset_checks_def",
-        "has_partition_key",
-        "has_partition_key_range",
-        "instance",
-        "job_name",
-        "output_for_asset_key",
-        "partition_key",
-        "partition_key_range",
-        "partition_time_window",
-        "requires_typed_event_stream",
-        "resources",
-        "selected_asset_check_keys",
-        "selected_asset_keys",
-        "set_data_version",
-        "set_requires_typed_event_stream",
-        "typed_event_stream_error_message",
-        "describe_op",
-        "op_def",
-        "has_assets_def",
-        "get_step_execution_context",
-        "step_launcher",
-        "has_events",
-        "consume_events",
-        "log_event",
-        "get_asset_provenance",
-        "is_subset",
-        "partition_keys",
-        "retry_number",
-        "op_execution_context",
-        "repository_def",
-    ]
-
-    other_ignores = [
-        "_abc_impl",
-        "_events",
-        "_output_metadata",
-        "_pdb",
-        "_step_execution_context",
-    ]
-
-    def assert_deprecation_messages_as_expected(received_info, expected_info):
-        assert received_info.breaking_version == expected_info["breaking_version"]
-        assert received_info.additional_warn_text == expected_info["additional_warn_text"]
-        assert received_info.subject == expected_info["subject"]
-
-    for attr in dir(OpExecutionContext):
-        if attr.startswith("__") or attr in other_ignores:
-            continue
-        if not hasattr(AssetExecutionContext, attr):
-            raise Exception(
-                f"Property {attr} on OpExecutionContext does not have an implementation on"
-                " AssetExecutionContext. All properties on OpExecutionContext must be"
-                " re-implemented on AssetExecutionContext with appropriate deprecation"
-                " warnings. See the class implementation of AssetExecutionContext for more details."
-            )
-
-        asset_context_attr = getattr(AssetExecutionContext, attr)
-
-        if attr not in asset_context_not_deprecated:
-            if isinstance(asset_context_attr, property):
-                asset_context_fn = asset_context_attr.fget
-            else:
-                asset_context_fn = asset_context_attr
-            if not hasattr(asset_context_fn, "_deprecated"):
-                raise Exception(
-                    f"Property {attr} on OpExecutionContext is implemented but not deprecated on"
-                    " AssetExecutionContext. If this in intended, update asset_context_not_deprecated."
-                    f" Otherwise, add a deprecation warning to {attr}."
-                )
-
-            deprecation_info = asset_context_fn._deprecated  # noqa: SLF001
-            expected_deprecation_args = _get_deprecation_kwargs(attr)
-            assert_deprecation_messages_as_expected(deprecation_info, expected_deprecation_args)
-
-
-def test_instance_check():
-    raise_exception_on_warnings()
-
-    @asset
-    def test_op_context_instance_check(context: AssetExecutionContext):
-        assert isinstance(context, OpExecutionContext)
-
-    with pytest.raises(DeprecationWarning):
-        materialize([test_op_context_instance_check])
-
-    @asset
-    def test_asset_context_instance_check(context: AssetExecutionContext):
-        assert isinstance(context, AssetExecutionContext)
-
-    assert materialize([test_asset_context_instance_check]).success

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_context.py
@@ -31,7 +31,7 @@ from dagster._core.definitions.repository_definition.repository_definition impor
 )
 from dagster._core.errors import DagsterInvalidDefinitionError, DagsterInvariantViolationError
 from dagster._core.storage.dagster_run import DagsterRun
-from dagster._core.test_utils import instance_for_test, raise_exception_on_warnings
+from dagster._core.test_utils import instance_for_test
 
 
 def test_op_execution_context():
@@ -95,46 +95,6 @@ def test_asset_execution_repo_context():
     with instance_for_test() as instance:
         result = execute_job(recon_job, instance)
         assert result.success
-
-
-def test_instance_check():
-    raise_exception_on_warnings()
-
-    class AssetExecutionContextSubclass(AssetExecutionContext):
-        # allows us to confirm isinstance(context, AssetExecutionContext)
-        # does not throw deprecation warnings
-        def __init__(self):
-            pass
-
-    @op
-    def test_op_context_instance_check(context: OpExecutionContext):
-        step_context = context._step_execution_context  # noqa: SLF001
-        op_context = OpExecutionContext(step_execution_context=step_context)
-        asset_context = AssetExecutionContext(op_execution_context=op_context)
-        with pytest.raises(DeprecationWarning):
-            isinstance(asset_context, OpExecutionContext)
-        assert not isinstance(op_context, AssetExecutionContext)
-
-        # the instance checks below will not hit the metaclass __instancecheck__ method because
-        # python returns early if the type is the same
-        # https://github.com/python/cpython/blob/b57b4ac042b977e0b42a2f5ddb30ca7edffacfa9/Objects/abstract.c#L2404
-        # but still test for completeness
-        assert isinstance(asset_context, AssetExecutionContext)
-        assert isinstance(op_context, OpExecutionContext)
-
-        # since python short circuits when context is AssetExecutionContext and you call
-        # isinstance(context, AssetExecutionContext), make a subclass of AssetExecutionContext
-        # so that we can ensure isinstance(context, AssetExecutionContext) doesn't throw a
-        # deprecation warning
-
-        asset_subclass_context = AssetExecutionContextSubclass()
-        assert isinstance(asset_subclass_context, AssetExecutionContext)
-
-    @job
-    def test_isinstance():
-        test_op_context_instance_check()
-
-    test_isinstance.execute_in_process()
 
 
 def test_context_provided_to_asset():

--- a/python_modules/libraries/dagster-celery/example/example_code/definitions.py
+++ b/python_modules/libraries/dagster-celery/example/example_code/definitions.py
@@ -2,8 +2,8 @@ import random
 import time
 
 from dagster import (
+    AssetExecutionContext,
     Definitions,
-    OpExecutionContext,
     StaticPartitionsDefinition,
     asset,
     define_asset_job,
@@ -20,7 +20,7 @@ example_partition_def = StaticPartitionsDefinition(
 @asset(
     partitions_def=example_partition_def,
 )
-def partitioned_asset(context: OpExecutionContext) -> None:
+def partitioned_asset(context: AssetExecutionContext) -> None:
     """This asset is partitioned."""
     context.log.info("Preparing to greet the world!")
     time.sleep(10)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -18,6 +18,7 @@ import dateutil.parser
 from dagster import (
     AssetCheckResult,
     AssetCheckSeverity,
+    AssetExecutionContext,
     AssetMaterialization,
     AssetObservation,
     OpExecutionContext,
@@ -277,7 +278,7 @@ class DbtCliEventMessage:
         self,
         manifest: DbtManifestParam,
         dagster_dbt_translator: DagsterDbtTranslator = DagsterDbtTranslator(),
-        context: Optional[OpExecutionContext] = None,
+        context: Optional[Union[OpExecutionContext, AssetExecutionContext]] = None,
         target_path: Optional[Path] = None,
     ) -> Iterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]:
         """Convert a dbt CLI event to a set of corresponding Dagster events.
@@ -286,7 +287,7 @@ class DbtCliEventMessage:
             manifest (Union[Mapping[str, Any], str, Path]): The dbt manifest blob.
             dagster_dbt_translator (DagsterDbtTranslator): Optionally, a custom translator for
                 linking dbt nodes to Dagster assets.
-            context (Optional[OpExecutionContext]): The execution context.
+            context (Optional[Union[OpExecutionContext, AssetExecutionContext]]): The execution context.
             target_path (Optional[Path]): An explicit path to a target folder used to retrieve
                 dbt artifacts while generating events.
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_invocation.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_invocation.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Iterator, List, Mapping, NamedTuple, Optional, Seq
 import orjson
 from dagster import (
     AssetCheckResult,
+    AssetExecutionContext,
     AssetMaterialization,
     AssetObservation,
     OpExecutionContext,
@@ -83,7 +84,9 @@ class DbtCliInvocation:
     project_dir: Path
     target_path: Path
     raise_on_error: bool
-    context: Optional[OpExecutionContext] = field(default=None, repr=False)
+    context: Optional[Union[OpExecutionContext, AssetExecutionContext]] = field(
+        default=None, repr=False
+    )
     termination_timeout_seconds: float = field(
         init=False, default=DAGSTER_DBT_TERMINATION_TIMEOUT_SECONDS
     )
@@ -133,7 +136,7 @@ class DbtCliInvocation:
         project_dir: Path,
         target_path: Path,
         raise_on_error: bool,
-        context: Optional[OpExecutionContext],
+        context: Optional[Union[OpExecutionContext, AssetExecutionContext]],
         adapter: Optional[BaseAdapter],
     ) -> "DbtCliInvocation":
         # Attempt to take advantage of partial parsing. If there is a `partial_parse.msgpack` in

--- a/python_modules/libraries/dagster-sdf/dagster_sdf/sdf_cli_event.py
+++ b/python_modules/libraries/dagster-sdf/dagster_sdf/sdf_cli_event.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
-from typing import AbstractSet, Any, Dict, Iterator, Optional
+from typing import AbstractSet, Any, Dict, Iterator, Optional, Union
 
 from dagster import (
     AssetCheckResult,
     AssetCheckSeverity,
+    AssetExecutionContext,
     AssetMaterialization,
     OpExecutionContext,
     Output,
@@ -49,12 +50,12 @@ class SdfCliEventMessage:
     def to_default_asset_events(
         self,
         dagster_sdf_translator: DagsterSdfTranslator = DagsterSdfTranslator(),
-        context: Optional[OpExecutionContext] = None,
+        context: Optional[Union[OpExecutionContext, AssetExecutionContext]] = None,
     ) -> Iterator[SdfDagsterEventType]:
         """Convert an sdf CLI event to a set of corresponding Dagster events.
 
         Args:
-            context (Optional[OpExecutionContext]): The execution context.
+            context (Optional[Union[OpExecutionContext, AssetExecutionContext]]): The execution context.
 
         Returns:
             Iterator[Union[Output, AssetMaterialization]]:
@@ -74,7 +75,7 @@ class SdfCliEventMessage:
             return
 
         selected_output_names: AbstractSet[str] = (
-            context.selected_output_names if context else set()
+            context.op_execution_context.selected_output_names if context else set()
         )
 
         catalog = self.raw_event["ev_tb_catalog"]

--- a/python_modules/libraries/dagster-sdf/dagster_sdf/sdf_cli_invocation.py
+++ b/python_modules/libraries/dagster-sdf/dagster_sdf/sdf_cli_invocation.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Union, cast
 
 import orjson
-from dagster import OpExecutionContext, get_dagster_logger
+from dagster import AssetExecutionContext, OpExecutionContext, get_dagster_logger
 from dagster._annotations import public
 from dagster._core.errors import DagsterExecutionInterruptedError
 from typing_extensions import Literal
@@ -44,7 +44,9 @@ class SdfCliInvocation:
     environment: str
     dagster_sdf_translator: DagsterSdfTranslator
     raise_on_error: bool
-    context: Optional[OpExecutionContext] = field(default=None, repr=False)
+    context: Optional[Union[OpExecutionContext, AssetExecutionContext]] = field(
+        default=None, repr=False
+    )
     termination_timeout_seconds: float = field(
         init=False, default=DAGSTER_SDF_TERMINATION_TIMEOUT_SECONDS
     )
@@ -60,7 +62,7 @@ class SdfCliInvocation:
         environment: str,
         dagster_sdf_translator: DagsterSdfTranslator,
         raise_on_error: bool,
-        context: Optional[OpExecutionContext],
+        context: Optional[Union[OpExecutionContext, AssetExecutionContext]],
     ) -> "SdfCliInvocation":
         # Create a subprocess that runs the sdf CLI command.
         process = subprocess.Popen(

--- a/python_modules/libraries/dagster-sdf/dagster_sdf/sdf_information_schema.py
+++ b/python_modules/libraries/dagster-sdf/dagster_sdf/sdf_information_schema.py
@@ -18,6 +18,7 @@ import dagster._check as check
 import polars as pl
 from dagster import (
     AssetCheckSpec,
+    AssetExecutionContext,
     AssetKey,
     AssetObservation,
     AssetSpec,
@@ -289,10 +290,10 @@ class SdfInformationSchema(IHaveNew):
     def stream_asset_observations(
         self,
         dagster_sdf_translator: DagsterSdfTranslator,
-        context: Optional[OpExecutionContext] = None,
+        context: Optional[Union[OpExecutionContext, AssetExecutionContext]] = None,
     ) -> Iterator[SdfDagsterEventType]:
         selected_output_names: AbstractSet[str] = (
-            context.selected_output_names if context else set()
+            context.op_execution_context.selected_output_names if context else set()
         )
         tables = self.read_table("tables")
         tables = tables.filter(~pl.col("purpose").is_in(["system", "external-system"]))


### PR DESCRIPTION
## Summary & Motivation

Now that all of the libraries have been updated to support `AssetExecutionContext`, we can make `AssetExecutionContext` not a subclass of `OpExecutionContext`

`AssetExecutionContext` is marked to be made a standalone class (ie not a subclass of `OpExecutionContext`) in 1.9. These are the changes in the core dagster module that are required to make that happen. It's just removing the metaclass that enables the `isinstance` check to raise a deprecation warning, and removing the actual inheritance. 

I also delete the tests that ensure `OpExecutionContext` and `AssetExecutionContext` implement the same methods since we don't need/want to enforce that now that they are separate classes. 

## How I Tested These Changes
existing tests

## Changelog

`AssetExecutionContext` is no longer a subclass of `OpExecutionContext`. At this release, `AssetExecutionContext` and `OpExecutionContext` implement the same methods, but in the future, the methods implemented by each class may diverge. If you have written helper functions with `OpExecutionContext` type annotations, they may need to be updated to include `AssetExecutionContext` depending on your usage. Explicit calls to `isinstance(context, OpExecutionContext)` will now fail if `context` is an `AssetExecutionContext`.

