### PR TITLE
[pipes] modify context type signatures and usage for making AssetExecutionContext a standalone class

### DIFF
--- a/integration_tests/test_suites/k8s-test-suite/tests/test_pipes.py
+++ b/integration_tests/test_suites/k8s-test-suite/tests/test_pipes.py
@@ -194,7 +194,7 @@ def test_use_execute_k8s_job(namespace, cluster_provider):
 
             # stand-in for any means of creating kubernetes work
             execute_k8s_job(
-                context=context,
+                context=context.op_execution_context,
                 image=docker_image,
                 command=[
                     "python",

--- a/python_modules/dagster/dagster/_core/pipes/client.py
+++ b/python_modules/dagster/dagster/_core/pipes/client.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Sequence, Union
 
 from dagster_pipes import (
     DagsterPipesError,
@@ -14,7 +14,8 @@ import dagster._check as check
 from dagster._annotations import public
 from dagster._core.definitions.asset_check_result import AssetCheckResult
 from dagster._core.definitions.result import MaterializeResult
-from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from dagster._core.execution.context.op_execution_context import OpExecutionContext
 from dagster._core.pipes.context import PipesExecutionResult, PipesLaunchedData, PipesSession
 
 if TYPE_CHECKING:
@@ -32,7 +33,7 @@ class PipesClient(ABC):
     def run(
         self,
         *,
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
         extras: Optional[PipesExtras] = None,
         **kwargs,
     ) -> "PipesClientCompletedInvocation":
@@ -41,7 +42,7 @@ class PipesClient(ABC):
          arguments that are appropriate for their own implementation.
 
         Args:
-            context (OpExecutionContext): The context from the executing op/asset.
+            context (Union[OpExecutionContext, AssetExecutionContext]): The context from the executing op/asset.
             extras (Optional[PipesExtras]): Arbitrary data to pass to the external environment.
 
         Returns:

--- a/python_modules/dagster/dagster/_core/pipes/subprocess.py
+++ b/python_modules/dagster/dagster/_core/pipes/subprocess.py
@@ -9,7 +9,8 @@ from dagster import _check as check
 from dagster._annotations import public
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.errors import DagsterExecutionInterruptedError, DagsterPipesExecutionError
-from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from dagster._core.execution.context.op_execution_context import OpExecutionContext
 from dagster._core.pipes.client import (
     PipesClient,
     PipesClientCompletedInvocation,
@@ -83,7 +84,7 @@ class PipesSubprocessClient(PipesClient, TreatAsResourceParam):
     def run(
         self,
         *,
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
         extras: Optional[PipesExtras] = None,
         command: Union[str, Sequence[str]],
         env: Optional[Mapping[str, str]] = None,
@@ -93,7 +94,7 @@ class PipesSubprocessClient(PipesClient, TreatAsResourceParam):
 
         Args:
             command (Union[str, Sequence[str]]): The command to run. Will be passed to `subprocess.Popen()`.
-            context (OpExecutionContext): The context from the executing op or asset.
+            context (Union[OpExecutionContext, AssetExecutionContext]): The context from the executing op or asset.
             extras (Optional[PipesExtras]): An optional dict of extra parameters to pass to the subprocess.
             env (Optional[Mapping[str, str]]): An optional dict of environment variables to pass to the subprocess.
             cwd (Optional[str]): Working directory in which to launch the subprocess command.

--- a/python_modules/dagster/dagster/_core/pipes/utils.py
+++ b/python_modules/dagster/dagster/_core/pipes/utils.py
@@ -8,7 +8,7 @@ import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from threading import Event, Thread
-from typing import IO, Dict, Iterator, Optional, Sequence, Tuple, TypeVar
+from typing import IO, Dict, Iterator, Optional, Sequence, Tuple, TypeVar, Union
 
 from dagster_pipes import (
     PIPES_PROTOCOL_VERSION_FIELD,
@@ -25,6 +25,7 @@ from dagster import (
     _check as check,
 )
 from dagster._core.errors import DagsterInvariantViolationError, DagsterPipesExecutionError
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.client import PipesContextInjector, PipesLaunchedData, PipesMessageReader
 from dagster._core.pipes.context import (
     PipesMessageHandler,
@@ -696,7 +697,7 @@ _FAIL_TO_YIELD_ERROR_MESSAGE = (
 
 @contextmanager
 def open_pipes_session(
-    context: OpExecutionContext,
+    context: Union[OpExecutionContext, AssetExecutionContext],
     context_injector: PipesContextInjector,
     message_reader: PipesMessageReader,
     extras: Optional[PipesExtras] = None,
@@ -716,7 +717,7 @@ def open_pipes_session(
 
 
     Args:
-        context (OpExecutionContext): The context for the current op/asset execution.
+        context (Union[OpExecutionContext, AssetExecutionContext]): The context for the current op/asset execution.
         context_injector (PipesContextInjector): The context injector to use to inject context into the external process.
         message_reader (PipesMessageReader): The message reader to use to read messages from the external process.
         extras (Optional[PipesExtras]): Optional extras to pass to the external process via the injected context.
@@ -732,7 +733,7 @@ def open_pipes_session(
         extras = {"foo": "bar"}
 
         @asset
-        def ext_asset(context: OpExecutionContext):
+        def ext_asset(context: AssetExecutionContext):
             with open_pipes_session(
                 context=context,
                 extras={"foo": "bar"},

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/in_process_client.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/in_process_client.py
@@ -1,9 +1,10 @@
 from contextlib import contextmanager
-from typing import Callable, Iterator, List, Optional
+from typing import Callable, Iterator, List, Optional, Union
 
 from dagster._annotations import public
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
-from dagster._core.execution.context.compute import OpExecutionContext
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
+from dagster._core.execution.context.op_execution_context import OpExecutionContext
 from dagster._core.pipes.client import (
     PipesClient,
     PipesClientCompletedInvocation,
@@ -101,7 +102,7 @@ class InProcessPipesClient(PipesClient, TreatAsResourceParam):
     def run(
         self,
         *,
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
         fn: Callable[[PipesContext], None],
         extras: Optional[PipesExtras] = None,
     ) -> PipesClientCompletedInvocation:

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/ecs.py
@@ -1,5 +1,5 @@
 from pprint import pformat
-from typing import TYPE_CHECKING, Any, Dict, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
 
 import boto3
 import botocore
@@ -8,6 +8,7 @@ from dagster import DagsterInvariantViolationError, PipesClient
 from dagster._annotations import experimental, public
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.errors import DagsterExecutionInterruptedError
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
     PipesClientCompletedInvocation,
@@ -60,7 +61,7 @@ class PipesECSClient(PipesClient, TreatAsResourceParam):
     def run(
         self,
         *,
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
         run_task_params: "RunTaskRequestRequestTypeDef",
         extras: Optional[Dict[str, Any]] = None,
         pipes_container_name: Optional[str] = None,
@@ -68,7 +69,7 @@ class PipesECSClient(PipesClient, TreatAsResourceParam):
         """Run ECS tasks, enriched with the pipes protocol.
 
         Args:
-            context (OpExecutionContext): The context of the currently executing Dagster op or asset.
+            context (Union[OpExecutionContext, AssetExecutionContext]): The context of the currently executing Dagster op or asset.
             run_task_params (dict): Parameters for the ``run_task`` boto3 ECS client call.
                 Must contain ``taskDefinition`` key.
                 See `Boto3 API Documentation <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs/client/run_task.html#run-task>`_
@@ -273,7 +274,7 @@ class PipesECSClient(PipesClient, TreatAsResourceParam):
 
     def _terminate(
         self,
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
         wait_response: "DescribeTasksResponseTypeDef",
         cluster: Optional[str] = None,
     ):

--- a/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/lambda_.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/pipes/clients/lambda_.py
@@ -1,10 +1,11 @@
 import json
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Union
 
 import boto3
 from dagster import PipesClient
 from dagster._annotations import public
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.execution.context.compute import OpExecutionContext
 from dagster._core.pipes.client import (
     PipesClientCompletedInvocation,
@@ -51,14 +52,14 @@ class PipesLambdaClient(PipesClient, TreatAsResourceParam):
         *,
         function_name: str,
         event: Mapping[str, Any],
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
     ) -> PipesClientCompletedInvocation:
         """Synchronously invoke a lambda function, enriched with the pipes protocol.
 
         Args:
             function_name (str): The name of the function to use.
             event (Mapping[str, Any]): A JSON serializable object to pass as input to the lambda.
-            context (OpExecutionContext): The context of the currently executing Dagster op or asset.
+            context (Union[OpExecutionContext, AssetExecutionContext]): The context of the currently executing Dagster op or asset.
 
         Returns:
             PipesClientCompletedInvocation: Wrapper containing results reported by the external

--- a/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
+++ b/python_modules/libraries/dagster-docker/dagster_docker/pipes.py
@@ -9,6 +9,7 @@ from dagster import (
 )
 from dagster._annotations import experimental
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.client import (
     PipesClient,
     PipesClientCompletedInvocation,
@@ -103,7 +104,7 @@ class PipesDockerClient(PipesClient, TreatAsResourceParam):
     def run(
         self,
         *,
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
         image: str,
         extras: Optional[PipesExtras] = None,
         command: Optional[Union[str, Sequence[str]]] = None,

--- a/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
+++ b/python_modules/libraries/dagster-k8s/dagster_k8s/pipes.py
@@ -19,6 +19,7 @@ from dagster import (
 from dagster._annotations import public
 from dagster._core.definitions.resource_annotation import TreatAsResourceParam
 from dagster._core.errors import DagsterInvariantViolationError
+from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.pipes.client import (
     PipesClient,
     PipesClientCompletedInvocation,
@@ -101,7 +102,7 @@ class PipesK8sPodLogsMessageReader(PipesMessageReader):
     @contextmanager
     def async_consume_pod_logs(
         self,
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
         core_api: kubernetes.client.CoreV1Api,
         pod_name: str,
         namespace: str,
@@ -109,7 +110,7 @@ class PipesK8sPodLogsMessageReader(PipesMessageReader):
         """Consume all logs from all containers within the pod.
 
         Args:
-            context (OpExecutionContext): The execution context.
+            context (Union[OpExecutionContext, AssetExecutionContext]): The execution context.
             core_api: The k8s core API.
             pod_name: The pod to collect logs from.
             namespace: The namespace to collect logs from.
@@ -361,7 +362,7 @@ class PipesK8sClient(PipesClient, TreatAsResourceParam):
     def run(
         self,
         *,
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
         extras: Optional[PipesExtras] = None,
         image: Optional[str] = None,
         command: Optional[Union[str, Sequence[str]]] = None,
@@ -375,7 +376,7 @@ class PipesK8sClient(PipesClient, TreatAsResourceParam):
         """Publish a kubernetes pod and wait for it to complete, enriched with the pipes protocol.
 
         Args:
-            context (OpExecutionContext):
+            context (Union[OpExecutionContext, AssetExecutionContext]):
                 The execution context.
             image (Optional[str]):
                 The image to set the first container in the pod spec to use.
@@ -461,7 +462,7 @@ class PipesK8sClient(PipesClient, TreatAsResourceParam):
     @contextmanager
     def consume_pod_logs(
         self,
-        context: OpExecutionContext,
+        context: Union[OpExecutionContext, AssetExecutionContext],
         client: DagsterKubernetesClient,
         namespace: str,
         pod_name: str,
@@ -472,7 +473,7 @@ class PipesK8sClient(PipesClient, TreatAsResourceParam):
         This will be a no-op if the message_reader is of the wrong type.
 
         Args:
-            context (OpExecutionContext): The execution context.
+            context (Union[OpExecutionContext, AssetExecutionContext]): The execution context.
             client (kubernetes.client): _description_
             namespace (str): The namespace the pod lives in
             pod_name (str): The name of the Pipes Pod


### PR DESCRIPTION
## Summary & Motivation
https://github.com/dagster-io/dagster/pull/25541 makes `AssetExecutionContext` not a subclass of `OpExecutionContext`. This PR is the changes to Pipes libraries required to make that change. 

Includes updating type signatures to allow for `AssetExecutionContext`, since previously, type annotation of `OpExecutionContext` would have allowed `AssetExecutionContext` to be passed

For any `context` calls that needed to be updated, I've added a comment explaining the change 

## How I Tested These Changes
existing test suite
