### PR TITLE
[sdf] modify context type signatures and usage for making AssetExecutionContext a standalone class

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -18,6 +18,7 @@ import dateutil.parser
 from dagster import (
     AssetCheckResult,
     AssetCheckSeverity,
+    AssetExecutionContext,
     AssetMaterialization,
     AssetObservation,
     OpExecutionContext,
@@ -277,7 +278,7 @@ class DbtCliEventMessage:
         self,
         manifest: DbtManifestParam,
         dagster_dbt_translator: DagsterDbtTranslator = DagsterDbtTranslator(),
-        context: Optional[OpExecutionContext] = None,
+        context: Optional[Union[OpExecutionContext, AssetExecutionContext]] = None,
         target_path: Optional[Path] = None,
     ) -> Iterator[Union[Output, AssetMaterialization, AssetObservation, AssetCheckResult]]:
         """Convert a dbt CLI event to a set of corresponding Dagster events.
@@ -286,7 +287,7 @@ class DbtCliEventMessage:
             manifest (Union[Mapping[str, Any], str, Path]): The dbt manifest blob.
             dagster_dbt_translator (DagsterDbtTranslator): Optionally, a custom translator for
                 linking dbt nodes to Dagster assets.
-            context (Optional[OpExecutionContext]): The execution context.
+            context (Optional[Union[OpExecutionContext, AssetExecutionContext]]): The execution context.
             target_path (Optional[Path]): An explicit path to a target folder used to retrieve
                 dbt artifacts while generating events.
 

--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_invocation.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_invocation.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Iterator, List, Mapping, NamedTuple, Optional, Seq
 import orjson
 from dagster import (
     AssetCheckResult,
+    AssetExecutionContext,
     AssetMaterialization,
     AssetObservation,
     OpExecutionContext,
@@ -83,7 +84,9 @@ class DbtCliInvocation:
     project_dir: Path
     target_path: Path
     raise_on_error: bool
-    context: Optional[OpExecutionContext] = field(default=None, repr=False)
+    context: Optional[Union[OpExecutionContext, AssetExecutionContext]] = field(
+        default=None, repr=False
+    )
     termination_timeout_seconds: float = field(
         init=False, default=DAGSTER_DBT_TERMINATION_TIMEOUT_SECONDS
     )
@@ -133,7 +136,7 @@ class DbtCliInvocation:
         project_dir: Path,
         target_path: Path,
         raise_on_error: bool,
-        context: Optional[OpExecutionContext],
+        context: Optional[Union[OpExecutionContext, AssetExecutionContext]],
         adapter: Optional[BaseAdapter],
     ) -> "DbtCliInvocation":
         # Attempt to take advantage of partial parsing. If there is a `partial_parse.msgpack` in

--- a/python_modules/libraries/dagster-sdf/dagster_sdf/sdf_cli_event.py
+++ b/python_modules/libraries/dagster-sdf/dagster_sdf/sdf_cli_event.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
-from typing import AbstractSet, Any, Dict, Iterator, Optional
+from typing import AbstractSet, Any, Dict, Iterator, Optional, Union
 
 from dagster import (
     AssetCheckResult,
     AssetCheckSeverity,
+    AssetExecutionContext,
     AssetMaterialization,
     OpExecutionContext,
     Output,
@@ -49,12 +50,12 @@ class SdfCliEventMessage:
     def to_default_asset_events(
         self,
         dagster_sdf_translator: DagsterSdfTranslator = DagsterSdfTranslator(),
-        context: Optional[OpExecutionContext] = None,
+        context: Optional[Union[OpExecutionContext, AssetExecutionContext]] = None,
     ) -> Iterator[SdfDagsterEventType]:
         """Convert an sdf CLI event to a set of corresponding Dagster events.
 
         Args:
-            context (Optional[OpExecutionContext]): The execution context.
+            context (Optional[Union[OpExecutionContext, AssetExecutionContext]]): The execution context.
 
         Returns:
             Iterator[Union[Output, AssetMaterialization]]:
@@ -74,7 +75,7 @@ class SdfCliEventMessage:
             return
 
         selected_output_names: AbstractSet[str] = (
-            context.selected_output_names if context else set()
+            context.op_execution_context.selected_output_names if context else set()
         )
 
         catalog = self.raw_event["ev_tb_catalog"]

--- a/python_modules/libraries/dagster-sdf/dagster_sdf/sdf_cli_invocation.py
+++ b/python_modules/libraries/dagster-sdf/dagster_sdf/sdf_cli_invocation.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Union, cast
 
 import orjson
-from dagster import OpExecutionContext, get_dagster_logger
+from dagster import AssetExecutionContext, OpExecutionContext, get_dagster_logger
 from dagster._annotations import public
 from dagster._core.errors import DagsterExecutionInterruptedError
 from typing_extensions import Literal
@@ -44,7 +44,9 @@ class SdfCliInvocation:
     environment: str
     dagster_sdf_translator: DagsterSdfTranslator
     raise_on_error: bool
-    context: Optional[OpExecutionContext] = field(default=None, repr=False)
+    context: Optional[Union[OpExecutionContext, AssetExecutionContext]] = field(
+        default=None, repr=False
+    )
     termination_timeout_seconds: float = field(
         init=False, default=DAGSTER_SDF_TERMINATION_TIMEOUT_SECONDS
     )
@@ -60,7 +62,7 @@ class SdfCliInvocation:
         environment: str,
         dagster_sdf_translator: DagsterSdfTranslator,
         raise_on_error: bool,
-        context: Optional[OpExecutionContext],
+        context: Optional[Union[OpExecutionContext, AssetExecutionContext]],
     ) -> "SdfCliInvocation":
         # Create a subprocess that runs the sdf CLI command.
         process = subprocess.Popen(

--- a/python_modules/libraries/dagster-sdf/dagster_sdf/sdf_information_schema.py
+++ b/python_modules/libraries/dagster-sdf/dagster_sdf/sdf_information_schema.py
@@ -18,6 +18,7 @@ import dagster._check as check
 import polars as pl
 from dagster import (
     AssetCheckSpec,
+    AssetExecutionContext,
     AssetKey,
     AssetObservation,
     AssetSpec,
@@ -289,10 +290,10 @@ class SdfInformationSchema(IHaveNew):
     def stream_asset_observations(
         self,
         dagster_sdf_translator: DagsterSdfTranslator,
-        context: Optional[OpExecutionContext] = None,
+        context: Optional[Union[OpExecutionContext, AssetExecutionContext]] = None,
     ) -> Iterator[SdfDagsterEventType]:
         selected_output_names: AbstractSet[str] = (
-            context.selected_output_names if context else set()
+            context.op_execution_context.selected_output_names if context else set()
         )
         tables = self.read_table("tables")
         tables = tables.filter(~pl.col("purpose").is_in(["system", "external-system"]))


### PR DESCRIPTION
## Summary & Motivation
https://github.com/dagster-io/dagster/pull/25541 makes `AssetExecutionContext` not a subclass of `OpExecutionContext`. This PR is the changes to the sdf integration required to make that change. 

Includes updating type signatures to allow for `AssetExecutionContext`, since previously, type annotation of `OpExecutionContext` would have allowed `AssetExecutionContext` to be passed

For any `context` calls that needed to be updated, I've added a comment explaining the change 

## How I Tested These Changes
existing tests
