### PR TITLE
[dagster-ssh]: Removes unnecessary type ignores

### DIFF
--- a/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
+++ b/python_modules/libraries/dagster-ssh/dagster_ssh/resources.py
@@ -144,7 +144,7 @@ class SSHResource(ConfigurableResource):
                 timeout=self.timeout,
                 compress=self.compress,
                 port=self.remote_port,  # type: ignore
-                sock=self._host_proxy,  # type: ignore
+                sock=self._host_proxy,
                 look_for_keys=False,
             )
         else:
@@ -156,7 +156,7 @@ class SSHResource(ConfigurableResource):
                 timeout=self.timeout,
                 compress=self.compress,
                 port=self.remote_port,  # type: ignore
-                sock=self._host_proxy,  # type: ignore
+                sock=self._host_proxy,
             )
 
         if self.keepalive_interval:


### PR DESCRIPTION
## Summary & Motivation

Running pyright locally was giving the warning that some `# type: ignore` comments were unnecessary. This removes them.

## How I Tested These Changes

```
make pyright
```