### PR TITLE
Set canEscapeKeyClose to false on launchpad dialog

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/LaunchAssetChoosePartitionsDialog.tsx
@@ -108,7 +108,7 @@ export const LaunchAssetChoosePartitionsDialog = (
     <Dialog
       style={{width: 700}}
       isOpen={props.open}
-      canEscapeKeyClose
+      canEscapeKeyClose={false}
       canOutsideClickClose
       onClose={() => props.setOpen(false)}
     >

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadRoot.tsx
@@ -31,7 +31,7 @@ export const AssetLaunchpad = ({
     <Dialog
       style={{height: '90vh', width: '80%'}}
       isOpen={open}
-      canEscapeKeyClose={true}
+      canEscapeKeyClose={false}
       canOutsideClickClose={true}
       onClose={() => setOpen(false)}
     >


### PR DESCRIPTION
## Summary & Motivation

https://linear.app/dagster-labs/issue/FE-619/prevent-accidental-escape-and-clearing-on-launchpad-ui-if-a-change-is


