### PR TITLE
[PLUS-1409] Introduce translator pattern for Fivetran

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
@@ -1,6 +1,7 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
 from dagster_fivetran.asset_defs import (
+    DagsterFivetranTranslator as DagsterFivetranTranslator,
     build_fivetran_assets as build_fivetran_assets,
     load_assets_from_fivetran_instance as load_assets_from_fivetran_instance,
 )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -59,9 +59,11 @@ class DagsterFivetranTranslatorProps(NamedTuple):
 
 class DagsterFivetranTranslator:
     def get_asset_key(self, props: DagsterFivetranTranslatorProps) -> AssetKey:
+        """Get the AssetKey for a Fivetran table."""
         return AssetKey(*props.table_name.split("."))
 
     def get_asset_spec(self, props: DagsterFivetranTranslatorProps) -> AssetSpec:
+        """Get the AssetSpec for a Fivetran table."""
         return AssetSpec(
             key=self.get_asset_key(props),
             metadata={

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -40,7 +40,6 @@ from dagster._core.errors import DagsterStepOutputNotFoundError
 from dagster._core.execution.context.init import build_init_resource_context
 from dagster._core.utils import imap
 from dagster._serdes.serdes import whitelist_for_serdes
-from dagster._utils import xor
 from dagster._utils.log import get_dagster_logger
 
 from dagster_fivetran.resources import DEFAULT_POLL_INTERVAL, FivetranResource
@@ -157,7 +156,8 @@ def _build_fivetran_assets(
 ) -> Sequence[AssetsDefinition]:
     asset_key_prefix = check.opt_sequence_param(asset_key_prefix, "asset_key_prefix", of_type=str)
     check.invariant(
-        xor(translator, connection_metadata), "Translator and connection_metadata required."
+        (translator and connection_metadata) or not translator,
+        "Translator and connection_metadata required.",
     )
 
     translator_instance = translator() if translator else None

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -40,6 +40,7 @@ from dagster._core.errors import DagsterStepOutputNotFoundError
 from dagster._core.execution.context.init import build_init_resource_context
 from dagster._core.utils import imap
 from dagster._serdes.serdes import whitelist_for_serdes
+from dagster._utils import xor
 from dagster._utils.log import get_dagster_logger
 
 from dagster_fivetran.resources import DEFAULT_POLL_INTERVAL, FivetranResource
@@ -156,7 +157,7 @@ def _build_fivetran_assets(
 ) -> Sequence[AssetsDefinition]:
     asset_key_prefix = check.opt_sequence_param(asset_key_prefix, "asset_key_prefix", of_type=str)
     check.invariant(
-        translator and connection_metadata, "Translator and connection_metadata required."
+        xor(translator, connection_metadata), "Translator and connection_metadata required."
     )
 
     translator_instance = translator() if translator else None


### PR DESCRIPTION
## Summary & Motivation
Our BI integrations (Power BI, Sigma, Tableau, Looker) and DBT integration use a translator pattern to allow users to customize the assets they load from the external tool. We want to do the same for Fivetran.

## How I Tested These Changes

## Changelog
[Fivetran] Introduced `DagsterFivetranTranslator` to customize assets loaded from Fivetran.
