### PR TITLE
Fix typehint that doesn't work on py3.8

### DIFF
--- a/python_modules/dagster/dagster/_core/pipes/merge_streams.py
+++ b/python_modules/dagster/dagster/_core/pipes/merge_streams.py
@@ -21,7 +21,7 @@ class LogItem:
     log: Any = field(compare=False)
 
 
-def _deduplicate(recent_messages: "deque[LogItem]") -> Callable[[LogItem], bool]:
+def _deduplicate(recent_messages: deque) -> Callable[[LogItem], bool]:
     def _should_drop(x: LogItem) -> bool:
         if (
             len(recent_messages) == recent_messages.maxlen

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_routers.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_routers.py
@@ -14,10 +14,10 @@ from typing import (
     get_origin,
 )
 
-if sys.version_info >= (3, 9):
-    from typing import TypeAlias
-else:
+if sys.version_info < (3, 10):
     from typing_extensions import TypeAlias
+else:
+    from typing import TypeAlias
 
 import polars as pl
 from dagster import InputContext, OutputContext

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
@@ -2,10 +2,9 @@ import abc
 import json
 import re
 import time
-from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any, Dict, Mapping, Optional, Type
+from typing import Any, Dict, Mapping, Optional, Sequence, Type
 
 import requests
 from dagster import (

--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -3,10 +3,21 @@ import contextlib
 import urllib.parse
 import warnings
 from collections import defaultdict
-from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
-from typing import AbstractSet, Any, Callable, Dict, Iterator, List, Mapping, Optional, Type, Union
+from typing import (
+    AbstractSet,
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Type,
+    Union,
+)
 
 import aiohttp
 import dagster._check as check


### PR DESCRIPTION
## Summary & Motivation

As title. We're considering removing 3.8 support anyway, but this is a quick fix and the scope of removing this type hint is quite limited so I think it's easiest to just make this less specific.

EDIT: also tossed in another typing / version dependent fix. The issue is that version 3.9.1 is >= 3.9, meaning we were doing the typing import for versions of python that we shouldn't have been. I copied the 3.10 logic over from a different part of the codebase, so quite confident that it's correct

EDIT2: I assume importing `Sequence` from collections instead of typing was accidental @benpankow? That was also breaking on older python versions

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
