### PR TITLE
[pipes] add PipesLogWriter

### DIFF
--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -512,6 +512,34 @@ class PipesContextLoader(ABC):
 T_MessageChannel = TypeVar("T_MessageChannel", bound="PipesMessageWriterChannel")
 
 
+class PipesLogWriterChannel(ABC):
+    @contextmanager
+    @abstractmethod
+    def capture(self, capturing_started: Event) -> Iterator[None]: ...
+
+
+T_LogChannel = TypeVar("T_LogChannel", bound=PipesLogWriterChannel)
+
+
+class PipesLogWriterOpenedData(TypedDict):
+    extras: PipesExtras
+
+
+class PipesLogWriter(ABC, Generic[T_LogChannel]):
+    LOG_WRITER_KEY = "log_writer"
+
+    @abstractmethod
+    @contextmanager
+    def open(self, params: PipesParams) -> Iterator[T_LogChannel]: ...
+
+    @final
+    def get_opened_payload(self) -> PipesLogWriterOpenedData:
+        return {"extras": self.get_opened_extras()}
+
+    def get_opened_extras(self) -> PipesExtras:
+        return {}
+
+
 class PipesMessageWriter(ABC, Generic[T_MessageChannel]):
     @abstractmethod
     @contextmanager


### PR DESCRIPTION
## Summary & Motivation

Adding new abstract classes for `PipesLogWriter` Pipes component. 

This is meant to be an escape hatch for execution environments which don't have a clean way of accessing logs, such as Databricks or AWS EMR. 

## How I tested these changes
 
More tests involving Dagster are in upstack.

## Changelog

Added a new Dagster Pipes component - `PipesLogWriter`. 