### PR TITLE
Improve DaemonErrorCapture coverage and accuracy

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
+++ b/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
@@ -30,6 +30,8 @@ from dagster._daemon.auto_run_reexecution.event_log_consumer import EventLogCons
 
 from auto_run_reexecution_tests.utils import foo, get_foo_job_handle
 
+logger = logging.getLogger("dagster.test_auto_run_reexecution")
+
 
 def create_run(instance, **kwargs):
     with get_foo_job_handle(instance) as handle:
@@ -390,6 +392,7 @@ def test_consume_new_runs_for_automatic_reexecution(instance, workspace_context)
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
 
@@ -428,6 +431,7 @@ def test_consume_new_runs_for_automatic_reexecution(instance, workspace_context)
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
     assert len(instance.run_coordinator.queue()) == 1
@@ -445,6 +449,7 @@ def test_consume_new_runs_for_automatic_reexecution(instance, workspace_context)
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
     assert len(instance.run_coordinator.queue()) == 1
@@ -473,6 +478,7 @@ def test_consume_new_runs_for_automatic_reexecution(instance, workspace_context)
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
     assert len(instance.run_coordinator.queue()) == 2
@@ -505,6 +511,7 @@ def test_consume_new_runs_for_automatic_reexecution(instance, workspace_context)
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
     assert len(instance.run_coordinator.queue()) == 2
@@ -527,6 +534,7 @@ def test_consume_new_runs_for_automatic_reexecution_mimic_daemon_fails_before_ru
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
 
@@ -556,6 +564,7 @@ def test_consume_new_runs_for_automatic_reexecution_mimic_daemon_fails_before_ru
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
     assert len(instance.run_coordinator.queue()) == 1
@@ -572,6 +581,7 @@ def test_consume_new_runs_for_automatic_reexecution_mimic_daemon_fails_before_ru
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
 
@@ -596,6 +606,7 @@ def test_consume_new_runs_for_automatic_reexecution_mimic_daemon_fails_before_re
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
 
@@ -625,6 +636,7 @@ def test_consume_new_runs_for_automatic_reexecution_mimic_daemon_fails_before_re
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
     assert len(instance.run_coordinator.queue()) == 1
@@ -649,6 +661,7 @@ def test_consume_new_runs_for_automatic_reexecution_mimic_daemon_fails_before_re
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
 
@@ -676,6 +689,7 @@ def test_consume_new_runs_for_automatic_reexecution_retry_run_deleted(instance, 
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
 
@@ -705,6 +719,7 @@ def test_consume_new_runs_for_automatic_reexecution_retry_run_deleted(instance, 
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
     assert len(instance.run_coordinator.queue()) == 1
@@ -722,6 +737,7 @@ def test_consume_new_runs_for_automatic_reexecution_retry_run_deleted(instance, 
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
 
@@ -747,6 +763,7 @@ def test_code_location_unavailable(instance, workspace_context):
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
 
@@ -783,6 +800,7 @@ def test_code_location_unavailable(instance, workspace_context):
             consume_new_runs_for_automatic_reexecution(
                 workspace_context,
                 instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+                logger,
             )
         )
 
@@ -803,6 +821,7 @@ def test_consume_new_runs_for_automatic_reexecution_with_manual_retry(instance, 
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
 
@@ -838,6 +857,7 @@ def test_consume_new_runs_for_automatic_reexecution_with_manual_retry(instance, 
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
     # the daemon can distinguish between a manual retry of a run and an auto-retry of a run and still
@@ -925,6 +945,7 @@ def test_subset_run(instance: DagsterInstance, workspace_context):
         consume_new_runs_for_automatic_reexecution(
             workspace_context,
             instance.get_run_records(filters=RunsFilter(statuses=[DagsterRunStatus.FAILURE])),
+            logger,
         )
     )
     assert len(run_coordinator.queue()) == 1

--- a/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_event_log_consumer.py
+++ b/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_event_log_consumer.py
@@ -23,7 +23,7 @@ class TestEventLogConsumerDaemon(EventLogConsumerDaemon):
 
     @property
     def handle_updated_runs_fns(self):
-        def stash_run_records(_ctx, run_records):
+        def stash_run_records(_ctx, run_records, _logger):
             self.run_records = run_records
             yield
 

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from typing import Iterator, Optional, Sequence, cast
 
@@ -208,6 +209,7 @@ def retry_run(
 def consume_new_runs_for_automatic_reexecution(
     workspace_process_context: IWorkspaceProcessContext,
     run_records: Sequence[RunRecord],
+    logger: logging.Logger,
 ) -> Iterator[None]:
     """Check which runs should be retried, and retry them.
 
@@ -223,7 +225,11 @@ def consume_new_runs_for_automatic_reexecution(
         try:
             retry_run(run, workspace_process_context)
         except Exception:
-            error_info = DaemonErrorCapture.on_exception(exc_info=sys.exc_info())
+            error_info = DaemonErrorCapture.process_exception(
+                exc_info=sys.exc_info(),
+                logger=logger,
+                log_message=f"Failed to retry run {run.run_id}",
+            )
             workspace_process_context.instance.report_engine_event(
                 "Failed to retry run",
                 run,

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/event_log_consumer.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/event_log_consumer.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, Mapping, Optional, Sequence
 
 import dagster._check as check
@@ -11,6 +12,7 @@ from dagster._daemon.auto_run_reexecution.auto_run_reexecution import (
     consume_new_runs_for_automatic_reexecution,
 )
 from dagster._daemon.daemon import IntervalDaemon
+from dagster._daemon.utils import DaemonErrorCapture
 
 if TYPE_CHECKING:
     from dagster._core.events.log import EventLogEntry
@@ -37,7 +39,9 @@ class EventLogConsumerDaemon(IntervalDaemon):
     @property
     def handle_updated_runs_fns(
         self,
-    ) -> Sequence[Callable[[IWorkspaceProcessContext, Sequence[RunRecord]], Iterator]]:
+    ) -> Sequence[
+        Callable[[IWorkspaceProcessContext, Sequence[RunRecord], logging.Logger], Iterator]
+    ]:
         """List of functions that will be called with the list of run records that have new events."""
         return [consume_new_runs_for_automatic_reexecution]
 
@@ -84,10 +88,12 @@ class EventLogConsumerDaemon(IntervalDaemon):
             # call each handler with the list of runs that have events
             for fn in self.handle_updated_runs_fns:
                 try:
-                    yield from fn(workspace_process_context, run_records)
+                    yield from fn(workspace_process_context, run_records, self._logger)
                 except Exception:
-                    self._logger.exception(
-                        f"Error calling event event log consumer handler: {fn.__name__}"
+                    DaemonErrorCapture.process_exception(
+                        sys.exc_info(),
+                        logger=self._logger,
+                        log_message=f"Error calling event event log consumer handler: {fn.__name__}",
                     )
 
         # persist cursors now that we've processed all the events through the handlers

--- a/python_modules/dagster/dagster/_daemon/backfill.py
+++ b/python_modules/dagster/dagster/_daemon/backfill.py
@@ -79,7 +79,7 @@ def execute_backfill_iteration_loop(
                 backfill_futures=backfill_futures,
             )
         except Exception:
-            error_info = DaemonErrorCapture.on_exception(
+            error_info = DaemonErrorCapture.process_exception(
                 exc_info=sys.exc_info(),
                 logger=logger,
                 log_message="BackfillDaemon caught an error",
@@ -217,18 +217,18 @@ def execute_backfill_jobs(
                         e, (DagsterUserCodeUnreachableError, DagsterCodeLocationLoadError)
                     ):
                         try:
-                            raise Exception(
+                            raise DagsterUserCodeUnreachableError(
                                 "Unable to reach the code server. Backfill will resume once the code server is available."
                             ) from e
                         except:
-                            error_info = DaemonErrorCapture.on_exception(
+                            error_info = DaemonErrorCapture.process_exception(
                                 sys.exc_info(),
                                 logger=backfill_logger,
                                 log_message=f"Backfill failed for {backfill.backfill_id} due to unreachable code server and will retry",
                             )
                             instance.update_backfill(backfill.with_error(error_info))
                     else:
-                        error_info = DaemonErrorCapture.on_exception(
+                        error_info = DaemonErrorCapture.process_exception(
                             sys.exc_info(),
                             logger=backfill_logger,
                             log_message=f"Backfill failed for {backfill.backfill_id} and will retry.",
@@ -239,7 +239,7 @@ def execute_backfill_jobs(
                             )
                         )
                 else:
-                    error_info = DaemonErrorCapture.on_exception(
+                    error_info = DaemonErrorCapture.process_exception(
                         sys.exc_info(),
                         logger=backfill_logger,
                         log_message=f"Backfill failed for {backfill.backfill_id}",

--- a/python_modules/dagster/dagster/_daemon/daemon.py
+++ b/python_modules/dagster/dagster/_daemon/daemon.py
@@ -126,7 +126,7 @@ class DagsterDaemon(AbstractContextManager, ABC, Generic[TContext]):
                         )
                         break
                     except Exception:
-                        error_info = DaemonErrorCapture.on_exception(
+                        error_info = DaemonErrorCapture.process_exception(
                             exc_info=sys.exc_info(),
                             logger=self._logger,
                             log_message="Caught error, daemon loop will restart",

--- a/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
+++ b/python_modules/dagster/dagster/_daemon/monitoring/run_monitoring.py
@@ -200,7 +200,7 @@ def execute_run_monitoring_iteration(
             else:
                 check.invariant(False, f"Unexpected run status: {run_record.dagster_run.status}")
         except Exception:
-            yield DaemonErrorCapture.on_exception(
+            yield DaemonErrorCapture.process_exception(
                 exc_info=sys.exc_info(),
                 logger=logger,
                 log_message=f"Hit error while monitoring run {run_record.dagster_run.run_id}",

--- a/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/run_coordinator/queued_run_coordinator_daemon.py
@@ -388,7 +388,11 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
         try:
             instance.run_launcher.launch_run(LaunchRunContext(dagster_run=run, workspace=workspace))
         except Exception as e:
-            error = DaemonErrorCapture.on_exception(exc_info=sys.exc_info())
+            error = DaemonErrorCapture.process_exception(
+                exc_info=sys.exc_info(),
+                logger=self._logger,
+                log_message=f"Caught on error dequeing run {run.run_id}",
+            )
 
             run = check.not_none(instance.get_run_by_id(run.run_id))
             # Make sure we don't re-enqueue a run if it has already finished or moved into STARTED:
@@ -421,8 +425,6 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
                         "Run dequeue failed to reach the user code server after"
                         f" {run_queue_config.max_user_code_failure_retries} attempts, failing run"
                     )
-                    message_with_full_error = f"{message}: {error.to_string()}"
-                    self._logger.error(message_with_full_error)
                     instance.report_engine_event(
                         message,
                         run,
@@ -439,9 +441,6 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
                         "Run dequeue failed to reach the user code server, re-submitting the run"
                         f" into the queue ({retries_left} {retries_str} remaining)"
                     )
-                    message_with_full_error = f"{message}: {error.to_string()}"
-                    self._logger.warning(message_with_full_error)
-
                     instance.report_engine_event(
                         message,
                         run,
@@ -459,8 +458,6 @@ class QueuedRunCoordinatorDaemon(IntervalDaemon):
                     "Caught an unrecoverable error while dequeuing the run. Marking the run as"
                     " failed and dropping it from the queue"
                 )
-                message_with_full_error = f"{message}: {error.to_string()}"
-                self._logger.error(message_with_full_error)
 
                 instance.report_engine_event(
                     message,

--- a/python_modules/dagster/dagster/_daemon/utils.py
+++ b/python_modules/dagster/dagster/_daemon/utils.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 
 from dagster._utils.error import (
     ExceptionInfo,
@@ -10,15 +9,14 @@ from dagster._utils.error import (
 
 class DaemonErrorCapture:
     @staticmethod
-    def default_on_exception(
+    def default_process_exception(
         exc_info: ExceptionInfo,
-        logger: Optional[logging.Logger] = None,
-        log_message: Optional[str] = None,
+        logger: logging.Logger,
+        log_message: str,
     ) -> SerializableErrorInfo:
         error_info = serializable_error_info_from_exc_info(exc_info)
-        if logger and log_message:
-            logger.exception(log_message)
+        logger.exception(log_message)
         return error_info
 
     # global behavior for how to handle unexpected exceptions
-    on_exception = default_on_exception
+    process_exception = default_process_exception

--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -41,7 +41,7 @@ from dagster._core.scheduler.instigation import (
     TickData,
     TickStatus,
 )
-from dagster._core.scheduler.scheduler import DEFAULT_MAX_CATCHUP_RUNS, DagsterSchedulerError
+from dagster._core.scheduler.scheduler import DEFAULT_MAX_CATCHUP_RUNS
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import RUN_KEY_TAG, SCHEDULED_EXECUTION_TIME_TAG
 from dagster._core.telemetry import SCHEDULED_RUN_CREATED, hash_name, log_action
@@ -51,7 +51,7 @@ from dagster._daemon.utils import DaemonErrorCapture
 from dagster._scheduler.stale import resolve_stale_or_missing_assets
 from dagster._time import get_current_datetime, get_current_timestamp
 from dagster._utils import DebugCrashFlags, SingleInstigatorDebugCrashFlags, check_for_debug_crash
-from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
+from dagster._utils.error import SerializableErrorInfo
 from dagster._utils.log import default_date_format_string
 from dagster._utils.merger import merge_dicts
 
@@ -239,7 +239,7 @@ def execute_scheduler_iteration_loop(
                     max_tick_retries=max_tick_retries,
                 )
             except Exception:
-                error_info = DaemonErrorCapture.on_exception(
+                error_info = DaemonErrorCapture.process_exception(
                     exc_info=sys.exc_info(),
                     logger=logger,
                     log_message="SchedulerDaemon caught an error",
@@ -393,8 +393,11 @@ def launch_scheduled_runs(
                             iteration_times[schedule.selector_id] = result
                         except Exception:
                             # Log exception and continue on rather than erroring the whole scheduler loop
-                            logger.exception(
-                                f"Error getting tick result for schedule {schedule.name}"
+
+                            DaemonErrorCapture.process_exception(
+                                exc_info=sys.exc_info(),
+                                logger=logger,
+                                log_message=f"Error getting tick result for schedule {schedule.name}",
                             )
                         del scheduler_run_futures[schedule.selector_id]
                     else:
@@ -477,8 +480,12 @@ def launch_scheduled_runs(
                     "launch_scheduled_runs_for_schedule_iterator did not yield a ScheduleIterationTimes",
                 )
         except Exception:
-            error_info = serializable_error_info_from_exc_info(sys.exc_info())
-            logger.exception(f"Scheduler caught an error for schedule {schedule.name}")
+            error_info = DaemonErrorCapture.process_exception(
+                exc_info=sys.exc_info(),
+                logger=logger,
+                log_message=f"Scheduler caught an error for schedule {schedule.name}",
+            )
+
         yield error_info
 
 
@@ -665,18 +672,16 @@ def launch_scheduled_runs_for_schedule_iterator(
             except Exception as e:
                 if isinstance(e, (DagsterUserCodeUnreachableError, DagsterCodeLocationLoadError)):
                     try:
-                        raise DagsterSchedulerError(
+                        raise DagsterUserCodeUnreachableError(
                             f"Unable to reach the user code server for schedule {schedule_name}."
                             " Schedule will resume execution once the server is available."
                         ) from e
                     except:
-                        error_data = serializable_error_info_from_exc_info(sys.exc_info())
-
-                        logger.exception(
-                            "Scheduler daemon caught an error for schedule "
-                            f"{remote_schedule.name}"
+                        error_data = DaemonErrorCapture.process_exception(
+                            sys.exc_info(),
+                            logger=logger,
+                            log_message=f"Scheduler daemon caught an error for schedule {remote_schedule.name}",
                         )
-
                         tick_context.update_state(
                             TickStatus.FAILURE,
                             error=error_data,
@@ -686,7 +691,11 @@ def launch_scheduled_runs_for_schedule_iterator(
                         )
                         yield error_data
                 else:
-                    error_data = serializable_error_info_from_exc_info(sys.exc_info())
+                    error_data = DaemonErrorCapture.process_exception(
+                        sys.exc_info(),
+                        logger=logger,
+                        log_message=f"Scheduler daemon caught an error for schedule {remote_schedule.name}",
+                    )
                     tick_context.update_state(
                         TickStatus.FAILURE,
                         error=error_data,
@@ -792,8 +801,11 @@ def _submit_run_request(
                 f"Completed scheduled launch of run {run.run_id} for {remote_schedule.name}"
             )
         except Exception:
-            error_info = serializable_error_info_from_exc_info(sys.exc_info())
-            logger.exception(f"Run {run.run_id} created successfully but failed to launch")
+            error_info = DaemonErrorCapture.process_exception(
+                exc_info=sys.exc_info(),
+                logger=logger,
+                log_message=f"Run {run.run_id} created successfully but failed to launch",
+            )
 
     return SubmitRunRequestResult(
         run_key=run_request.run_key,

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import random
 import string
@@ -106,6 +107,7 @@ from dagster._utils import touch_file
 from dagster._utils.error import SerializableErrorInfo
 
 default_resource_defs = resource_defs = {"io_manager": fs_io_manager}
+logger = logging.getLogger("dagster.test_auto_run_reexecution")
 
 
 DEFAULT_CHUNK_SIZE = 5
@@ -3339,7 +3341,9 @@ def test_asset_backfill_not_complete_if_automatic_retry_could_happen(
     runs = instance.get_run_records()
     list(
         consume_new_runs_for_automatic_reexecution(
-            workspace_process_context=workspace_context, run_records=runs
+            workspace_process_context=workspace_context,
+            run_records=runs,
+            logger=logger,
         )
     )
     wait_for_all_runs_to_finish(instance, timeout=30)
@@ -3405,7 +3409,9 @@ def test_asset_backfill_fails_if_retries_fail(
     runs = instance.get_run_records()
     list(
         consume_new_runs_for_automatic_reexecution(
-            workspace_process_context=workspace_context, run_records=runs
+            workspace_process_context=workspace_context,
+            run_records=runs,
+            logger=logger,
         )
     )
     wait_for_all_runs_to_finish(instance, timeout=30)
@@ -3420,7 +3426,9 @@ def test_asset_backfill_fails_if_retries_fail(
     runs = instance.get_run_records()
     list(
         consume_new_runs_for_automatic_reexecution(
-            workspace_process_context=workspace_context, run_records=runs
+            workspace_process_context=workspace_context,
+            run_records=runs,
+            logger=logger,
         )
     )
     wait_for_all_runs_to_finish(instance, timeout=30)
@@ -3495,7 +3503,9 @@ def test_asset_backfill_retries_make_downstreams_runnable(
     runs = instance.get_run_records()
     list(
         consume_new_runs_for_automatic_reexecution(
-            workspace_process_context=workspace_context, run_records=runs
+            workspace_process_context=workspace_context,
+            run_records=runs,
+            logger=logger,
         )
     )
     wait_for_all_runs_to_finish(instance, timeout=30)


### PR DESCRIPTION
Summary:
- Run all logger.exception calls in the daemon through DaemonErrorCapture.on_exception
- Always require and include a logger, without one it never logs
- When a daemon re-raises due to a UserCodeUnreachableError, ensure that the exception that is re-raised is also a UserCodeUnreachable error, so that it still gets classified as a user code error


Test Plan:
BK (existing tests include verifying that schedules and sensors retry on unreachable errors - verify), run a failed schedule, sensor, backfill, and AMP tick and inspect resulting daemon logs.