### PR TITLE
[ui] Change cursor query key used for runs feed

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useCursorPaginatedQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useCursorPaginatedQuery.tsx
@@ -29,9 +29,12 @@ export function useCursorPaginatedQuery<T, TVars extends CursorPaginationQueryVa
   variables: Omit<TVars, 'cursor' | 'limit'>;
   pageSize: number;
   getResultArray: (result: T | undefined) => any[];
+  queryKey?: string;
 }) {
   const [cursorStack, setCursorStack] = useState<string[]>(() => []);
-  const [cursor, setCursor] = useQueryPersistedState<string | undefined>({queryKey: 'cursor'});
+  const [cursor, setCursor] = useQueryPersistedState<string | undefined>({
+    queryKey: options.queryKey || 'cursor',
+  });
 
   const queryVars: any = {
     ...options.variables,

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsFeedEntries.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsFeedEntries.tsx
@@ -13,6 +13,8 @@ import {RunsFilter} from '../graphql/types';
 
 const PAGE_SIZE = 25;
 
+const RUNS_FEED_CURSOR_KEY = `runs_before`;
+
 export function useRunsFeedEntries(
   filter: RunsFilter,
   currentTab: ReturnType<typeof useSelectedRunsFeedTab>,
@@ -24,6 +26,7 @@ export function useRunsFeedEntries(
     RunsFeedRootQueryVariables
   >({
     query: RUNS_FEED_ROOT_QUERY,
+    queryKey: RUNS_FEED_CURSOR_KEY,
     pageSize: PAGE_SIZE,
     variables: {filter, includeRunsFromBackfills},
     skip: isScheduled,


### PR DESCRIPTION
## Summary & Motivation

This fixes an issue flagged here: https://dagsterlabs.slack.com/archives/C03CCE471E0/p1729870052943159, in which two uses of `useCursorPaginatedQuery` exist on the page and need to separately store their pagination state in the URL.

I chose to change the new `RunsFeed`'s cursor because 1) the runs feed is embedded within a variety of pages (eg: asset automation tab, sensor runs / schedule runs, etc), and I think it's likely to be the common element conflicting with other uses of the hook and 2) it's new, and uses a new cursor style, so any saved pre-1.9 links would be broken anyway.

I changed the cursor to `runs_before=abcd123`, which reflects how the cursor operates in the run feed API.

## How I Tested These Changes

I repro'd the case in the slack discussion and verified that the offending scenario works correctly with this change. 

I verified that there are no places where we use `cursor=${` to explicitly navigate to the runs page with a cursor already applied.