### PR TITLE
[ui] Skip runs feed load for automation ticks with no requested run IDs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithData.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeMiddlePanelWithData.tsx
@@ -5,6 +5,7 @@ import {
   Icon,
   MenuItem,
   MiddleTruncate,
+  NonIdealState,
   Popover,
   Subheading,
   Subtitle2,
@@ -158,8 +159,8 @@ export const AutomaterializeMiddlePanelWithData = ({
     return [];
   }, [partitionKeys]);
 
-  const runsFilter: RunsFilter = useMemo(
-    () => ({runIds: selectedEvaluation ? selectedEvaluation.runIds : []}),
+  const runsFilter: RunsFilter | null = useMemo(
+    () => (selectedEvaluation?.runIds.length ? {runIds: selectedEvaluation.runIds} : null),
     [selectedEvaluation],
   );
 
@@ -209,8 +210,16 @@ export const AutomaterializeMiddlePanelWithData = ({
           </Box>
           {flagLegacyRunsPage ? (
             <AutomaterializeRunsTable runIds={selectedEvaluation.runIds} />
-          ) : (
+          ) : runsFilter ? (
             <RunsFeedTableWithFilters filter={runsFilter} />
+          ) : (
+            <Box padding={{vertical: 12}}>
+              <NonIdealState
+                icon="run"
+                title="No runs launched"
+                description="No runs were launched by this evaluation."
+              />
+            </Box>
           )}
           <Box border="bottom" padding={{vertical: 12}}>
             <Subtitle2>Policy evaluation</Subtitle2>


### PR DESCRIPTION
## Summary & Motivation

This is a small fix for a bug on the Asset > Automations page.

If no runs were requested, we were loading the table anyway with the Runs filter `{runIds: []}`.  The backend (in `SqlRunStorage._add_filters_to_query`), sees that value as falsy and does not add a filter, returning all runs instead of no runs.

I think a backend change would likely also be helpful, but it seems like it'd need to be made carefully. In the meantime we should short-circuit loading of the table entirely, since it's guaranteed to return no runs.

## How I Tested These Changes

I tested this manually on the Asset > Automations page and viewed the new empty state. 

I also looked through the other RunsFeed callsites and I don't believe there are any other places where an empty query is likely.