### PR TITLE
[helm] feat: allow configmap to be optional in helm

### DIFF
--- a/helm/dagster/templates/helpers/_deployment-webserver.tpl
+++ b/helm/dagster/templates/helpers/_deployment-webserver.tpl
@@ -151,6 +151,7 @@ spec:
         - name: dagster-workspace-yaml
           configMap:
             name: {{ include "dagster.workspace.configmapName" . }}
+            optional: {{ include "dagster.workspace.configmapOptional" . }}
         {{- end }}
         {{- if $_.Values.dagsterWebserver.volumes }}
         {{- range $volume := $_.Values.dagsterWebserver.volumes }}

--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -221,3 +221,13 @@ DAGSTER_K8S_PIPELINE_RUN_IMAGE_PULL_POLICY: "{{ .Values.pipelineRun.image.pullPo
 {{ template "dagster.fullname" . }}-workspace-yaml
 {{- end -}}
 {{- end -}}
+
+{{- define "dagster.workspace.configmapOptional" -}}
+{{- $_ := include "dagster.backcompat" . | mustFromJson -}}
+{{- $webserverWorkspace := $_.Values.dagsterWebserver.workspace }}
+{{- if and $webserverWorkspace.enabled $webserverWorkspace.externalConfigmapOptional }}
+{{- $webserverWorkspace.externalConfigmapOptional -}}
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -69,6 +69,11 @@ dagsterWebserver:
     # must be empty.
     externalConfigmap: ~
 
+    # Defines if the external configmap is optional. If set to false,
+    # the configmap will have to exist before deploying the helm chart
+    # default: false
+    externalConfigmapOptional: false
+
   # Deploy a separate instance of the webserver in --read-only mode (can't launch runs, disable schedules, etc.)
   enableReadOnly: false
 


### PR DESCRIPTION
## Summary & Motivation

Gives the ability to set the configmap is optional, this is so that there is not a hard dependency on the configmap to deploy the helm chart

fixes: https://github.com/dagster-io/dagster/issues/25491

## How I Tested These Changes

```bash
helm template dagster helm/dagster/ \
  --set dagsterWebserver.workspace.externalConfigmapOptional=true,dagsterWebserver.workspace.enabled=true
```
outputs the the webserver with:
```yaml
...
      volumes:
        - name: dagster-instance
          configMap:
            name: dagster-instance
        - name: dagster-workspace-yaml
          configMap:
            name: dagster-workspace-yaml
            optional: true
...
```
```bash
helm template dagster helm/dagster/ \ 
  --set dagsterWebserver.workspace.enabled=true
```
outputs the the webserver with:
```yaml
...
      volumes:
        - name: dagster-instance
          configMap:
            name: dagster-instance
        - name: dagster-workspace-yaml
          configMap:
            name: dagster-workspace-yaml
            optional: false
...
```
