### PR TITLE
[core, pipes] Start PipesLogWriter from Dagster

### DIFF
--- a/python_modules/dagster-pipes/dagster_pipes_tests/test_log_writer.py
+++ b/python_modules/dagster-pipes/dagster_pipes_tests/test_log_writer.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import tempfile
+
+from dagster_pipes import PipesDefaultLogWriter
+
+
+def test_pipes_log_writer(capsys):
+    with tempfile.TemporaryDirectory() as tempdir:
+        with capsys.disabled(), PipesDefaultLogWriter().open(
+            {
+                "logs_dir": tempdir,
+            }
+        ):
+            print("Writing this to stdout")  # noqa
+            print("And this to stderr", file=sys.stderr)  # noqa
+
+        assert set(os.listdir(tempdir)) == {"stderr", "stdout"}
+
+        with open(os.path.join(tempdir, "stdout"), "r") as stdout_file:
+            contents = stdout_file.read()
+            assert "Writing this to stdout" in contents
+
+        with open(os.path.join(tempdir, "stderr"), "r") as stderr_file:
+            contents = stderr_file.read()
+            assert "And this to stderr" in contents

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_log_writer.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_log_writer.py
@@ -1,0 +1,71 @@
+import shutil
+from typing import Iterator
+
+import pytest
+from dagster import AssetExecutionContext, DagsterInstance, asset, materialize
+from dagster._core.pipes.subprocess import PipesSubprocessClient
+from dagster._core.pipes.utils import PipesTempFileMessageReader
+
+from dagster_tests.execution_tests.pipes_tests.utils import temp_script
+
+_PYTHON_EXECUTABLE = shutil.which("python")
+
+
+@pytest.fixture
+def external_script() -> Iterator[str]:
+    # This is called in an external process and so cannot access outer scope
+    def script_fn():
+        import os
+        import sys
+
+        from dagster_pipes import (
+            DAGSTER_PIPES_LOG_WRITER_KEY,
+            PipesDefaultLogWriter,
+            PipesEnvVarParamsLoader,
+            open_dagster_pipes,
+        )
+
+        with open_dagster_pipes(log_writer=PipesDefaultLogWriter()):
+            print("Writing this to stdout")  # noqa: T201
+            print("And this to stderr", file=sys.stderr)  # noqa: T201
+
+            logs_dir = PipesEnvVarParamsLoader().load_messages_params()[
+                DAGSTER_PIPES_LOG_WRITER_KEY
+            ][PipesDefaultLogWriter.LOGS_DIR_KEY]
+
+        assert set(os.listdir(logs_dir)) == {"stderr", "stdout"}
+
+        with open(os.path.join(logs_dir, "stdout"), "r") as stdout_file:
+            contents = stdout_file.read()
+            assert "Writing this to stdout" in contents
+
+        with open(os.path.join(logs_dir, "stderr"), "r") as stderr_file:
+            contents = stderr_file.read()
+            assert "And this to stderr" in contents
+
+    with temp_script(script_fn) as script_path:
+        yield script_path
+
+
+# in this test we do not check log reading logic in Dagster
+# only that the log writer is correctly configured and launched in the remote process
+def test_pipes_log_writer_on_remote_process_side(
+    capsys,
+    tmpdir,
+    external_script,
+):
+    message_reader = PipesTempFileMessageReader(enable_log_writer=True)
+
+    @asset
+    def foo(context: AssetExecutionContext, ext: PipesSubprocessClient):
+        cmd = [_PYTHON_EXECUTABLE, external_script]
+        return ext.run(
+            command=cmd,
+            context=context,
+        ).get_results()
+
+    resource = PipesSubprocessClient(message_reader=message_reader)
+
+    with capsys.disabled(), DagsterInstance.ephemeral() as instance:
+        result = materialize([foo], instance=instance, resources={"ext": resource})
+        assert result.success

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_subprocess.py
@@ -1,13 +1,10 @@
-import inspect
 import re
 import shutil
 import subprocess
-import textwrap
 import time
-from contextlib import contextmanager
 from multiprocessing import Process
 from tempfile import NamedTemporaryFile
-from typing import Any, Callable, Iterator
+from typing import Iterator
 
 import pytest
 from dagster import op
@@ -54,17 +51,9 @@ from dagster._utils.env import environ
 from dagster._utils.warnings import ExperimentalWarning
 from dagster_pipes import DagsterPipesError
 
+from dagster_tests.execution_tests.pipes_tests.utils import temp_script
+
 _PYTHON_EXECUTABLE = shutil.which("python")
-
-
-@contextmanager
-def temp_script(script_fn: Callable[[], Any]) -> Iterator[str]:
-    # drop the signature line
-    source = textwrap.dedent(inspect.getsource(script_fn).split("\n", 1)[1])
-    with NamedTemporaryFile() as file:
-        file.write(source.encode())
-        file.flush()
-        yield file.name
 
 
 @pytest.fixture

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/utils.py
@@ -1,0 +1,15 @@
+import inspect
+import textwrap
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+from typing import Any, Callable, Iterator
+
+
+@contextmanager
+def temp_script(script_fn: Callable[[], Any]) -> Iterator[str]:
+    # drop the signature line
+    source = textwrap.dedent(inspect.getsource(script_fn).split("\n", 1)[1])
+    with NamedTemporaryFile() as file:
+        file.write(source.encode())
+        file.flush()
+        yield file.name


### PR DESCRIPTION
## Summary & Motivation

This PR adds the ability to set `PipesLogWriter` params from a few `PipesMessageReader`s. 

It looks like this flag (call it `enable_pipes_log_writer` or something else) should be enabled from `PipesMessageReader` because both `PipesLogWriter` parameters and the logic for adding `PipesLogReader` (if necessary) depends on it. 

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
