### PR TITLE
Fix "Large launchpad configs returned by Test Sensor feature causes URL to be too long and page to be unloadable"

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
@@ -162,7 +162,7 @@ const buildValidator =
     return data;
   };
 
-export const makeKey = (basePath: string, repoAddress: RepoAddress, pipelineOrJobName: string) =>
+const makeKey = (basePath: string, repoAddress: RepoAddress, pipelineOrJobName: string) =>
   `dagster.v2.${basePath}-${repoAddress.location}-${repoAddress.name}-${pipelineOrJobName}`;
 
 export function useExecutionSessionStorage(

--- a/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ExecutionSessionStorage.tsx
@@ -55,7 +55,7 @@ export interface IExecutionSession {
   base: SessionBase | null;
   mode: string | null;
   needsRefresh: boolean;
-  assetSelection: {assetKey: AssetKeyInput; opNames: string[]}[] | null;
+  assetSelection: {assetKey: AssetKeyInput; opNames?: string[]}[] | null;
   // Nullable for backwards compatibility
   assetChecksAvailable?: Pick<AssetCheck, 'name' | 'canExecuteIndividually' | 'assetKey'>[];
   includeSeparatelyExecutableChecks: boolean;
@@ -162,7 +162,7 @@ const buildValidator =
     return data;
   };
 
-const makeKey = (basePath: string, repoAddress: RepoAddress, pipelineOrJobName: string) =>
+export const makeKey = (basePath: string, repoAddress: RepoAddress, pipelineOrJobName: string) =>
   `dagster.v2.${basePath}-${repoAddress.location}-${repoAddress.name}-${pipelineOrJobName}`;
 
 export function useExecutionSessionStorage(

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadAllowedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadAllowedRoot.tsx
@@ -29,11 +29,11 @@ interface Props {
   sessionPresets?: Partial<IExecutionSession>;
 }
 
-const filterDefaultYamlForSubselection = (defaultYaml: string, opNames: Set<string>): string => {
+const filterDefaultYamlForSubselection = (defaultYaml: string, opNames?: Set<string>): string => {
   const parsedYaml = yaml.parse(defaultYaml);
 
   const opsConfig = parsedYaml['ops'];
-  if (opsConfig) {
+  if (opsConfig && opNames) {
     const filteredOpKeys = Object.keys(opsConfig).filter((entry: any) => {
       return opNames.has(entry);
     });
@@ -79,7 +79,7 @@ export const LaunchpadAllowedRoot = (props: Props) => {
 
     const rootDefaultYaml = runConfigSchemaOrError.rootDefaultYaml;
     const opNameList = sessionPresets?.assetSelection
-      ? sessionPresets.assetSelection.map((entry) => entry.opNames).flat()
+      ? sessionPresets.assetSelection.map((entry) => entry.opNames ?? []).flat()
       : [];
     const opNames = new Set(opNameList);
     return filterDefaultYamlForSubselection(rootDefaultYaml, opNames);

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadAllowedRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadAllowedRoot.tsx
@@ -29,11 +29,11 @@ interface Props {
   sessionPresets?: Partial<IExecutionSession>;
 }
 
-const filterDefaultYamlForSubselection = (defaultYaml: string, opNames?: Set<string>): string => {
+const filterDefaultYamlForSubselection = (defaultYaml: string, opNames: Set<string>): string => {
   const parsedYaml = yaml.parse(defaultYaml);
 
   const opsConfig = parsedYaml['ops'];
-  if (opsConfig && opNames) {
+  if (opsConfig) {
     const filteredOpKeys = Object.keys(opsConfig).filter((entry: any) => {
       return opNames.has(entry);
     });


### PR DESCRIPTION
## Summary & Motivation
As titled, fixes the above issue.

So the original implementation redirects to the `/setup` path which all it does is save the configuration to localStorage and then immediately redirects to the `/playground` route. This solution cuts out the middleman and just directly saves the config to localStorage and then opens `/playground` directly. This avoids the need to pass a large config via the URL.

## How I Tested These Changes

Used the test sensor feature and opened one of the config's it returned.
