### PR TITLE
do runs table backfill id migration by run tags table

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -328,9 +328,9 @@ def migrate_run_backfill_id(storage: RunStorage, print_fn: Optional[PrintFn] = N
             res = storage.fetchall(query)
             has_more = len(res) >= CHUNK_SIZE
             for row in res:
-                cursor = row[0]
-                run_id = row[1]
-                backfill_id = row[2]
+                cursor = row["id"]
+                run_id = row["run_id"]
+                backfill_id = row["value"]
 
                 add_backfill_id(conn, run_id=run_id, backfill_id=backfill_id)
 

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -341,6 +341,7 @@ def add_backfill_id(conn, run_id: str, backfill_id: str) -> None:
     conn.execute(
         RunsTable.update()
         .where(RunsTable.c.run_id == run_id)
+        .where(RunsTable.c.backfill_id.is_(None))
         .values(
             backfill_id=backfill_id,
         )

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -302,35 +302,47 @@ def migrate_bulk_actions(run_storage: RunStorage, print_fn: Optional[PrintFn] = 
 
 def migrate_run_backfill_id(storage: RunStorage, print_fn: Optional[PrintFn] = None) -> None:
     """Utility method to add a backfill_id column to the runs table and populate it with the backfill_id of the run."""
+    from dagster._core.storage.runs.sql_run_storage import SqlRunStorage
+
     if print_fn:
         print_fn("Querying run storage.")
 
-    for run in chunked_run_iterator(storage, print_fn):
-        if run.tags.get(BACKFILL_ID_TAG) is None:
-            continue
+    check.inst_param(storage, "run_storage", RunStorage)
 
-        add_backfill_id(
-            run_storage=storage, run_id=run.run_id, backfill_id=run.tags[BACKFILL_ID_TAG]
-        )
-
-
-def add_backfill_id(run_storage: RunStorage, run_id: str, backfill_id) -> None:
-    from dagster._core.storage.runs.sql_run_storage import SqlRunStorage
-
-    check.str_param(run_id, "run_id")
-    check.inst_param(run_storage, "run_storage", RunStorage)
-
-    if not isinstance(run_storage, SqlRunStorage):
+    if not isinstance(storage, SqlRunStorage):
         return
 
-    with run_storage.connect() as conn:
-        conn.execute(
-            RunsTable.update()
-            .where(RunsTable.c.run_id == run_id)
-            .values(
-                backfill_id=backfill_id,
-            )
+    with storage.connect() as conn:
+        cursor = None
+        has_more = True
+        query = (
+            db_select([RunTagsTable.c.id, RunTagsTable.c.run_id, RunTagsTable.c.value])
+            .where(RunTagsTable.c.key == BACKFILL_ID_TAG)
+            .limit(CHUNK_SIZE)
         )
+
+        while has_more:
+            if cursor:
+                query = query.where(RunTagsTable.c.id > cursor)
+            res = storage.fetchall(query)
+            has_more = len(res) >= CHUNK_SIZE
+            for row in res:
+                run_id = row[1]
+                backfill_id = row[2]
+                cursor = row[0]
+
+                add_backfill_id(conn, run_id, backfill_id)
+
+
+def add_backfill_id(conn, run_id: str, backfill_id) -> None:
+    check.str_param(run_id, "run_id")
+    conn.execute(
+        RunsTable.update()
+        .where(RunsTable.c.run_id == run_id)
+        .values(
+            backfill_id=backfill_id,
+        )
+    )
 
 
 def migrate_backfill_job_name_and_tags(

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -319,6 +319,7 @@ def migrate_run_backfill_id(storage: RunStorage, print_fn: Optional[PrintFn] = N
             db_select([RunTagsTable.c.id, RunTagsTable.c.run_id, RunTagsTable.c.value])
             .where(RunTagsTable.c.key == BACKFILL_ID_TAG)
             .limit(CHUNK_SIZE)
+            .order_by(RunTagsTable.c.id)
         )
 
         while has_more:
@@ -327,11 +328,11 @@ def migrate_run_backfill_id(storage: RunStorage, print_fn: Optional[PrintFn] = N
             res = storage.fetchall(query)
             has_more = len(res) >= CHUNK_SIZE
             for row in res:
+                cursor = row[0]
                 run_id = row[1]
                 backfill_id = row[2]
-                cursor = row[0]
 
-                add_backfill_id(conn, run_id, backfill_id)
+                add_backfill_id(conn, run_id=run_id, backfill_id=backfill_id)
 
 
 def add_backfill_id(conn, run_id: str, backfill_id: str) -> None:

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -334,8 +334,9 @@ def migrate_run_backfill_id(storage: RunStorage, print_fn: Optional[PrintFn] = N
                 add_backfill_id(conn, run_id, backfill_id)
 
 
-def add_backfill_id(conn, run_id: str, backfill_id) -> None:
+def add_backfill_id(conn, run_id: str, backfill_id: str) -> None:
     check.str_param(run_id, "run_id")
+    check.str_param(backfill_id, "backfill_id")
     conn.execute(
         RunsTable.update()
         .where(RunsTable.c.run_id == run_id)


### PR DESCRIPTION
## Summary & Motivation
Updates the migration for setting the `backfill_id` column of the `runs` table to use the `run_tags` table rather than iterate through each run

before this change, running the migration on my local db took about a minute and a half, after it took about 5 seconds.

## How I Tested These Changes
