### PR TITLE
[asset graph] all_asset_keys -> get_all_asset_keys()

### DIFF
--- a/examples/experimental/dagster-blueprints/dagster_blueprints_tests/test_load_defs_from_yaml.py
+++ b/examples/experimental/dagster-blueprints/dagster_blueprints_tests/test_load_defs_from_yaml.py
@@ -41,7 +41,7 @@ def test_single_file_single_blueprint() -> None:
         path=Path(__file__).parent / "yaml_files" / "single_blueprint.yaml",
         per_file_blueprint_type=SimpleAssetBlueprint,
     )
-    assert set(defs.get_asset_graph().all_asset_keys) == {AssetKey("asset1")}
+    assert set(defs.get_asset_graph().get_all_asset_keys()) == {AssetKey("asset1")}
 
     metadata = defs.get_assets_def("asset1").metadata_by_key[AssetKey("asset1")]
     code_references_metadata = CodeReferencesMetadataSet.extract(metadata)
@@ -60,7 +60,10 @@ def test_dir_of_single_blueprints() -> None:
         path=Path(__file__).parent / "yaml_files" / "dir_of_single_blueprints",
         per_file_blueprint_type=SimpleAssetBlueprint,
     )
-    assert set(defs.get_asset_graph().all_asset_keys) == {AssetKey("asset2"), AssetKey("asset3")}
+    assert set(defs.get_asset_graph().get_all_asset_keys()) == {
+        AssetKey("asset2"),
+        AssetKey("asset3"),
+    }
 
     for asset_key, expected_filename in (
         (AssetKey("asset2"), "single_blueprint1.yaml"),
@@ -138,7 +141,7 @@ def test_empty_dir() -> None:
         path=Path(__file__).parent / "yaml_files" / "dir_with_no_yaml_files",
         per_file_blueprint_type=SimpleAssetBlueprint,
     )
-    assert len(set(defs.get_asset_graph().all_asset_keys)) == 0
+    assert len(set(defs.get_asset_graph().get_all_asset_keys())) == 0
 
 
 def test_model_validation_error() -> None:
@@ -157,7 +160,7 @@ def test_single_file_union_of_blueprints() -> None:
         path=Path(__file__).parent / "yaml_files" / "single_blueprint.yaml",
         per_file_blueprint_type=Union[SimpleAssetBlueprint, SimpleJobBlueprint],
     )
-    assert set(defs.get_asset_graph().all_asset_keys) == {AssetKey("asset1")}
+    assert set(defs.get_asset_graph().get_all_asset_keys()) == {AssetKey("asset1")}
 
 
 def test_single_file_union_of_blueprints_discriminated_union() -> None:
@@ -182,7 +185,7 @@ def test_single_file_union_of_blueprints_discriminated_union() -> None:
         path=Path(__file__).parent / "yaml_files" / "single_blueprint_with_type.yaml",
         per_file_blueprint_type=Union[SameFieldsAssetBlueprint1, SameFieldsAssetBlueprint2],
     )
-    assert set(defs.get_asset_graph().all_asset_keys) == {AssetKey("asset1")}
+    assert set(defs.get_asset_graph().get_all_asset_keys()) == {AssetKey("asset1")}
 
 
 class SourceFileNameAssetBlueprint(Blueprint):
@@ -200,7 +203,7 @@ def test_source_file_name() -> None:
         path=Path(__file__).parent / "yaml_files" / "single_blueprint.yaml",
         per_file_blueprint_type=SourceFileNameAssetBlueprint,
     )
-    assert set(defs.get_asset_graph().all_asset_keys) == {AssetKey("asset1")}
+    assert set(defs.get_asset_graph().get_all_asset_keys()) == {AssetKey("asset1")}
 
     metadata = defs.get_assets_def("asset1").metadata_by_key[AssetKey("asset1")]
     assert metadata["source_file_name"] == "single_blueprint.yaml"
@@ -234,7 +237,7 @@ def test_additional_resources() -> None:
         resources={"some_resource": "some_value"},
     )
 
-    assert set(defs.get_asset_graph().all_asset_keys) == {AssetKey("asset1")}
+    assert set(defs.get_asset_graph().get_all_asset_keys()) == {AssetKey("asset1")}
 
 
 def test_yaml_blueprints_loader_additional_resources() -> None:
@@ -254,7 +257,7 @@ def test_yaml_blueprints_loader_additional_resources() -> None:
         per_file_blueprint_type=SimpleAssetBlueprintNeedsResource,
     ).load_defs(resources={"some_resource": "some_value"})
 
-    assert set(defs.get_asset_graph().all_asset_keys) == {AssetKey("asset1")}
+    assert set(defs.get_asset_graph().get_all_asset_keys()) == {AssetKey("asset1")}
 
 
 def test_loader_schema(snapshot) -> None:
@@ -320,7 +323,7 @@ def test_single_file_many_blueprints() -> None:
         path=Path(__file__).parent / "yaml_files" / "list_of_blueprints.yaml",
         per_file_blueprint_type=List[SimpleAssetBlueprint],
     )
-    assert set(defs.get_asset_graph().all_asset_keys) == {
+    assert set(defs.get_asset_graph().get_all_asset_keys()) == {
         AssetKey("asset1"),
         AssetKey("asset2"),
         AssetKey("asset3"),
@@ -330,7 +333,7 @@ def test_single_file_many_blueprints() -> None:
         path=Path(__file__).parent / "yaml_files" / "list_of_blueprints.yaml",
         per_file_blueprint_type=Sequence[SimpleAssetBlueprint],
     )
-    assert set(defs.get_asset_graph().all_asset_keys) == {
+    assert set(defs.get_asset_graph().get_all_asset_keys()) == {
         AssetKey("asset1"),
         AssetKey("asset2"),
         AssetKey("asset3"),
@@ -345,7 +348,7 @@ def test_single_file_many_blueprints_builtin_list() -> None:
         path=Path(__file__).parent / "yaml_files" / "list_of_blueprints.yaml",
         per_file_blueprint_type=list[SimpleAssetBlueprint],  # type: ignore
     )
-    assert set(defs.get_asset_graph().all_asset_keys) == {
+    assert set(defs.get_asset_graph().get_all_asset_keys()) == {
         AssetKey("asset1"),
         AssetKey("asset2"),
         AssetKey("asset3"),
@@ -384,7 +387,7 @@ def test_dir_of_many_blueprints() -> None:
         path=Path(__file__).parent / "yaml_files" / "dir_of_lists_of_blueprints",
         per_file_blueprint_type=List[SimpleAssetBlueprint],
     )
-    assert set(defs.get_asset_graph().all_asset_keys) == {
+    assert set(defs.get_asset_graph().get_all_asset_keys()) == {
         AssetKey("asset1"),
         AssetKey("asset2"),
         AssetKey("asset3"),

--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -228,7 +228,7 @@ def get_asset_nodes_by_asset_key(
 
     asset_checks_loader = AssetChecksLoader(
         context=graphene_info.context,
-        asset_keys=graphene_info.context.asset_graph.all_asset_keys,
+        asset_keys=graphene_info.context.asset_graph.get_all_asset_keys(),
     )
 
     return {

--- a/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_graph_differ.py
@@ -180,10 +180,10 @@ class AssetGraphDiffer:
             # is new and doesn't exist in the base deployment. Thus all assets are new.
             return AssetDefinitionDiffDetails(change_types={AssetDefinitionChangeType.NEW})
 
-        if asset_key not in self.base_asset_graph.all_asset_keys:
+        if not self.base_asset_graph.has(asset_key):
             return AssetDefinitionDiffDetails(change_types={AssetDefinitionChangeType.NEW})
 
-        if asset_key not in self.branch_asset_graph.all_asset_keys:
+        if not self.branch_asset_graph.has(asset_key):
             return AssetDefinitionDiffDetails(change_types={AssetDefinitionChangeType.REMOVED})
 
         branch_asset = self.branch_asset_graph.get(asset_key)

--- a/python_modules/dagster/dagster/_core/definitions/asset_layer.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_layer.py
@@ -133,10 +133,6 @@ class AssetLayer(NamedTuple):
         )
 
     @property
-    def all_asset_keys(self) -> Iterable[AssetKey]:
-        return self.asset_graph.all_asset_keys
-
-    @property
     def executable_asset_keys(self) -> Iterable[AssetKey]:
         return self.asset_graph.executable_asset_keys
 

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -542,7 +542,7 @@ class AllSelection(AssetSelection):
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         return (
-            asset_graph.all_asset_keys
+            asset_graph.get_all_asset_keys()
             if self.include_sources
             else asset_graph.materializable_asset_keys
         )
@@ -847,7 +847,7 @@ class GroupsAssetSelection(AssetSelection):
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         base_set = (
-            asset_graph.all_asset_keys
+            asset_graph.get_all_asset_keys()
             if self.include_sources
             else asset_graph.materializable_asset_keys
         )
@@ -879,7 +879,7 @@ class TagAssetSelection(AssetSelection):
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         base_set = (
-            asset_graph.all_asset_keys
+            asset_graph.get_all_asset_keys()
             if self.include_sources
             else asset_graph.materializable_asset_keys
         )
@@ -900,7 +900,7 @@ class OwnerAssetSelection(AssetSelection):
     ) -> AbstractSet[AssetKey]:
         return {
             key
-            for key in asset_graph.all_asset_keys
+            for key in asset_graph.get_all_asset_keys()
             if self.selected_owner in asset_graph.get(key).owners
         }
 
@@ -936,14 +936,16 @@ class KeysAssetSelection(AssetSelection):
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         specified_keys = set(self.selected_keys)
-        missing_keys = {key for key in specified_keys if key not in asset_graph.all_asset_keys}
+        missing_keys = {key for key in specified_keys if not asset_graph.has(key)}
 
         if not allow_missing:
             # Arbitrary limit to avoid huge error messages
             keys_to_suggest = list(missing_keys)[:4]
             suggestions = ""
             for invalid_key in keys_to_suggest:
-                similar_names = resolve_similar_asset_names(invalid_key, asset_graph.all_asset_keys)
+                similar_names = resolve_similar_asset_names(
+                    invalid_key, asset_graph.get_all_asset_keys()
+                )
                 if similar_names:
                     # Arbitrarily limit to 10 similar names to avoid a huge error message
                     subset_similar_names = similar_names[:10]
@@ -988,7 +990,7 @@ class KeyPrefixesAssetSelection(AssetSelection):
         self, asset_graph: BaseAssetGraph, allow_missing: bool
     ) -> AbstractSet[AssetKey]:
         base_set = (
-            asset_graph.all_asset_keys
+            asset_graph.get_all_asset_keys()
             if self.include_sources
             else asset_graph.materializable_asset_keys
         )

--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -267,8 +267,7 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
             "downstream": {node.key: node.child_entity_keys for node in self.nodes},
         }
 
-    @property
-    def all_asset_keys(self) -> AbstractSet[AssetKey]:
+    def get_all_asset_keys(self) -> AbstractSet[AssetKey]:
         return set(self._asset_nodes_by_key)
 
     @cached_property

--- a/python_modules/dagster/dagster/_core/execution/asset_backfill.py
+++ b/python_modules/dagster/dagster/_core/execution/asset_backfill.py
@@ -817,7 +817,7 @@ def _check_target_partitions_subset_is_valid(
     """Checks for any partitions definition changes since backfill launch that should mark
     the backfill as failed.
     """
-    if asset_key not in asset_graph.all_asset_keys:
+    if not asset_graph.has(asset_key):
         raise DagsterDefinitionChangedDeserializationError(
             f"Asset {asset_key} existed at storage-time, but no longer does"
         )

--- a/python_modules/dagster/dagster/_core/execution/context/data_version_cache.py
+++ b/python_modules/dagster/dagster/_core/execution/context/data_version_cache.py
@@ -80,7 +80,7 @@ class DataVersionCache:
 
         all_dep_keys: List[AssetKey] = []
         for output_key in output_keys:
-            if output_key not in self._context.job_def.asset_layer.asset_graph.all_asset_keys:
+            if not self._context.job_def.asset_layer.has(output_key):
                 continue
             dep_keys = self._context.job_def.asset_layer.get(output_key).parent_keys
             for key in dep_keys:

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -1635,7 +1635,7 @@ def asset_node_snaps_from_repo(repo: RepositoryDefinition) -> Sequence[AssetNode
 
     asset_node_snaps: List[AssetNodeSnap] = []
     asset_graph = repo.asset_graph
-    for key in sorted(asset_graph.all_asset_keys):
+    for key in sorted(asset_graph.get_all_asset_keys()):
         asset_node = asset_graph.get(key)
 
         # Materializable assets (which are always part of at least one job, due to asset base jobs)

--- a/python_modules/dagster/dagster/_daemon/asset_daemon.py
+++ b/python_modules/dagster/dagster/_daemon/asset_daemon.py
@@ -696,7 +696,7 @@ class AssetDaemon(DagsterDaemon):
                     repo_asset_graph
                 )
             else:
-                eligible_keys = asset_graph.all_asset_keys
+                eligible_keys = asset_graph.get_all_asset_keys()
 
             auto_materialize_entity_keys = {
                 target_key

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
@@ -24,7 +24,7 @@ def test_basic_construction_and_identity() -> None:
 
     assert asset_graph_view_t0._instance is instance  # noqa: SLF001
 
-    assert asset_graph_view_t0.asset_graph.all_asset_keys == {an_asset.key}
+    assert asset_graph_view_t0.asset_graph.get_all_asset_keys() == {an_asset.key}
 
 
 def test_subset_traversal_static_partitions() -> None:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -89,7 +89,7 @@ def test_basics(asset_graph_from_assets):
     asset2_node = asset_graph.get(asset2.key)
     asset3_node = asset_graph.get(asset3.key)
 
-    assert asset_graph.all_asset_keys == {asset0.key, asset1.key, asset2.key, asset3.key}
+    assert asset_graph.get_all_asset_keys() == {asset0.key, asset1.key, asset2.key, asset3.key}
     assert not asset0_node.is_partitioned
     assert asset1_node.is_partitioned
     assert asset1_node.partitions_def == asset2_node.partitions_def

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_external_asset_graph.py
@@ -325,7 +325,7 @@ def test_cycle_status(instance) -> None:
     asset_graph = context.asset_graph
 
     resolver = CachingStaleStatusResolver(DagsterInstance.ephemeral(), asset_graph, context)
-    for key in asset_graph.all_asset_keys:
+    for key in asset_graph.get_all_asset_keys():
         resolver.get_status(key)
 
 

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/automation_condition_scenario.py
@@ -88,7 +88,7 @@ class AutomationConditionScenarioState(ScenarioState):
             evaluator = AutomationConditionEvaluator(
                 asset_graph=asset_graph,
                 instance=self.instance,
-                entity_keys=asset_graph.all_asset_keys,
+                entity_keys=asset_graph.get_all_asset_keys(),
                 cursor=AssetDaemonCursor.empty().with_updates(
                     0, 0, [], [self.condition_cursor] if self.condition_cursor else []
                 ),

--- a/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/branching_io_manager_tests/utils.py
@@ -33,7 +33,7 @@ class DefinitionsRunner:
             yield DefinitionsRunner(defs, instance)
 
     def materialize_all_assets(self, partition_key: Optional[str] = None) -> ExecuteInProcessResult:
-        all_keys = list(self.defs.get_repository_def().asset_graph.all_asset_keys)
+        all_keys = list(self.defs.get_repository_def().asset_graph.get_all_asset_keys())
         job_def = self.defs.get_implicit_job_def_for_assets(all_keys)
         assert job_def
         return job_def.execute_in_process(instance=self.instance, partition_key=partition_key)

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_code_references.py
@@ -73,7 +73,7 @@ def test_with_source_code_references_wrapper(test_jaffle_shop_manifest: Dict[str
 
     defs = Definitions(assets=with_source_code_references([my_dbt_assets]))
 
-    assets = defs.get_asset_graph().all_asset_keys
+    assets = defs.get_asset_graph().get_all_asset_keys()
 
     for asset_key in assets:
         asset_metadata = defs.get_assets_def(asset_key).specs_by_key[asset_key].metadata
@@ -108,7 +108,7 @@ def test_link_to_git_wrapper(test_jaffle_shop_manifest: Dict[str, Any]) -> None:
         )
     )
 
-    assets = defs.get_asset_graph().all_asset_keys
+    assets = defs.get_asset_graph().get_all_asset_keys()
 
     for asset_key in assets:
         asset_metadata = defs.get_assets_def(asset_key).specs_by_key[asset_key].metadata

--- a/python_modules/libraries/dagster-sdf/dagster_sdf_tests/test_code_references.py
+++ b/python_modules/libraries/dagster-sdf/dagster_sdf_tests/test_code_references.py
@@ -69,7 +69,7 @@ def test_with_source_code_references_wrapper(moms_flower_shop_target_dir: Path) 
 
     defs = Definitions(assets=with_source_code_references([my_flower_shop_assets]))
 
-    assets = defs.get_asset_graph().all_asset_keys
+    assets = defs.get_asset_graph().get_all_asset_keys()
 
     for asset_key in assets:
         asset_metadata = defs.get_assets_def(asset_key).specs_by_key[asset_key].metadata


### PR DESCRIPTION
Rename this method to better communicate that getting the full set of asset keys may not be a "free" operation, as is the case in asset graph implementations that lazily load. This was motivated by the callsites updated in this PR that used `key in graph.all_asset_keys` instead of `graph.has(key)` which can be supported by more performant implementations. 

## How I Tested These Changes

existing coverage