### PR TITLE
[ui] Eliminate legacy nav

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/App.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/App.tsx
@@ -1,12 +1,7 @@
-import {Alert, Box, ButtonLink} from '@dagster-io/ui-components';
 import * as React from 'react';
-import {useState} from 'react';
-import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 import styled from 'styled-components';
 
-import {getFeatureFlags, setFeatureFlags, useFeatureFlags} from './Flags';
 import {LayoutContext} from './LayoutProvider';
-import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {LEFT_NAV_WIDTH, LeftNav} from '../nav/LeftNav';
 
 interface Props {
@@ -16,13 +11,6 @@ interface Props {
 
 export const App = ({banner, children}: Props) => {
   const {nav} = React.useContext(LayoutContext);
-
-  // todo dish: Remove flag and alert once this change has shipped.
-  const {flagLegacyNav} = useFeatureFlags();
-  const [didDismissNavAlert, setDidDismissNavAlert] = useStateWithStorage<boolean>(
-    'new_navigation_alert',
-    (json) => !!json,
-  );
 
   const onClickMain = React.useCallback(() => {
     if (nav.isSmallScreen) {
@@ -35,58 +23,9 @@ export const App = ({banner, children}: Props) => {
       <LeftNav />
       <Main $smallScreen={nav.isSmallScreen} $navOpen={nav.isOpen} onClick={onClickMain}>
         <div>{banner}</div>
-        {!flagLegacyNav && !didDismissNavAlert ? (
-          <ExperimentalNavAlert setDidDismissNavAlert={setDidDismissNavAlert} />
-        ) : null}
         <ChildContainer>{children}</ChildContainer>
       </Main>
     </Container>
-  );
-};
-
-interface AlertProps {
-  setDidDismissNavAlert: (didDismissNavAlert: boolean) => void;
-}
-
-const ExperimentalNavAlert = (props: AlertProps) => {
-  const {setDidDismissNavAlert} = props;
-  const [flags] = useState<FeatureFlag[]>(() => getFeatureFlags());
-
-  const revertToLegacyNavigation = () => {
-    const copy = new Set(flags);
-    copy.add(FeatureFlag.flagLegacyNav);
-    setFeatureFlags(Array.from(copy));
-    setDidDismissNavAlert(true);
-    window.location.reload();
-  };
-
-  return (
-    <Box padding={8} border="top-and-bottom">
-      <Alert
-        title={
-          <>
-            <span>Experimental navigation:</span>
-            <span style={{fontWeight: 'normal'}}>
-              {' '}
-              We&apos;re testing some changes to make it easier to explore jobs and automations.{' '}
-              <a
-                href="https://github.com/dagster-io/dagster/discussions/21370"
-                target="_blank"
-                rel="noreferrer"
-              >
-                Share feedback
-              </a>{' '}
-              or{' '}
-              <ButtonLink underline="always" onClick={revertToLegacyNavigation}>
-                revert to legacy navigation
-              </ButtonLink>
-              .
-            </span>
-          </>
-        }
-        onClose={() => setDidDismissNavAlert(true)}
-      />
-    </Box>
   );
 };
 

--- a/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavLinks.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/AppTopNav/AppTopNavLinks.tsx
@@ -1,7 +1,6 @@
 import {Box} from '@dagster-io/ui-components';
 import {ReactElement} from 'react';
 import {useHistory} from 'react-router-dom';
-import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
 import {TopNavLink} from './AppTopNav';
 import {
@@ -9,11 +8,9 @@ import {
   automationPathMatcher,
   deploymentPathMatcher,
   jobsPathMatcher,
-  locationPathMatcher,
 } from './activePathMatchers';
 import {JobStateForNav} from './useJobStateForNav';
 import {DeploymentStatusIcon} from '../../nav/DeploymentStatusIcon';
-import {featureEnabled} from '../Flags';
 import {ShortcutHandler} from '../ShortcutHandler';
 
 export type AppNavLinkType = {
@@ -94,47 +91,28 @@ export const navLinks = (config: Config): AppNavLinkType[] => {
     ),
   };
 
-  if (!featureEnabled(FeatureFlag.flagLegacyNav)) {
-    const jobs =
-      jobState === 'has-jobs'
-        ? {
-            key: 'jobs',
-            path: '/jobs',
-            element: (
-              <TopNavLink to="/jobs" data-cy="AppTopNav_JobsLink" isActive={jobsPathMatcher}>
-                Jobs
-              </TopNavLink>
-            ),
-          }
-        : null;
-
-    const deployment = {
-      key: 'deployment',
-      path: '/deployment',
-      element: (
-        <TopNavLink
-          to="/deployment"
-          data-cy="AppTopNav_DeploymentLink"
-          isActive={deploymentPathMatcher}
-        >
-          <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
-            Deployment
-            <DeploymentStatusIcon />
-          </Box>
-        </TopNavLink>
-      ),
-    };
-
-    return [overview, runs, assets, jobs, automation, deployment].filter(
-      (link): link is AppNavLinkType => !!link,
-    );
-  }
+  const jobs =
+    jobState === 'has-jobs'
+      ? {
+          key: 'jobs',
+          path: '/jobs',
+          element: (
+            <TopNavLink to="/jobs" data-cy="AppTopNav_JobsLink" isActive={jobsPathMatcher}>
+              Jobs
+            </TopNavLink>
+          ),
+        }
+      : null;
 
   const deployment = {
-    key: 'locations',
-    path: '/locations',
+    key: 'deployment',
+    path: '/deployment',
     element: (
-      <TopNavLink to="/locations" data-cy="AppTopNav_StatusLink" isActive={locationPathMatcher}>
+      <TopNavLink
+        to="/deployment"
+        data-cy="AppTopNav_DeploymentLink"
+        isActive={deploymentPathMatcher}
+      >
         <Box flex={{direction: 'row', alignItems: 'center', gap: 6}}>
           Deployment
           <DeploymentStatusIcon />
@@ -143,5 +121,7 @@ export const navLinks = (config: Config): AppNavLinkType[] => {
     ),
   };
 
-  return [overview, runs, assets, deployment];
+  return [overview, runs, assets, jobs, automation, deployment].filter(
+    (link): link is AppNavLinkType => !!link,
+  );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/app/FeatureFlags.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/FeatureFlags.oss.tsx
@@ -3,6 +3,5 @@ export enum FeatureFlag {
   flagDisableWebsockets = 'flagDisableWebsockets',
   flagSidebarResources = 'flagSidebarResources',
   flagDisableAutoLoadDefaults = 'flagDisableAutoLoadDefaults',
-  flagLegacyNav = 'flagLegacyNav',
   flagLegacyRunsPage = 'flagLegacyRunsPage',
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/useVisibleFeatureFlagRows.oss.tsx
@@ -21,23 +21,6 @@ export const useVisibleFeatureFlagRows = () => [
     flagType: FeatureFlag.flagDebugConsoleLogging,
   },
   {
-    key: 'Revert to legacy navigation',
-    label: (
-      <>
-        Revert to legacy navigation (
-        <a
-          href="https://github.com/dagster-io/dagster/discussions/21370"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Learn more
-        </a>
-        )
-      </>
-    ),
-    flagType: FeatureFlag.flagLegacyNav,
-  },
-  {
     key: 'Revert to legacy Runs page',
     flagType: FeatureFlag.flagLegacyRunsPage,
     label: (

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/auto-materialization/AutomaterializationRoot.tsx
@@ -2,7 +2,6 @@ import {Page} from '@dagster-io/ui-components';
 import {Redirect} from 'react-router-dom';
 
 import {GlobalAutomaterializationContent} from './GlobalAutomaterializationContent';
-import {useFeatureFlags} from '../../app/Flags';
 import {assertUnreachable} from '../../app/Util';
 import {useTrackPageView} from '../../app/analytics';
 import {useDocumentTitle} from '../../hooks/useDocumentTitle';
@@ -14,14 +13,13 @@ import {useAutoMaterializeSensorFlag} from '../AutoMaterializeSensorFlag';
 // depending on their nav flag state.
 export const AutomaterializationRoot = () => {
   const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
-  const {flagLegacyNav} = useFeatureFlags();
   switch (automaterializeSensorsFlagState) {
     case 'unknown':
       return <div />; // Waiting for result
     case 'has-global-amp':
       return <GlobalAutomaterializationRoot />;
     case 'has-sensor-amp':
-      return <Redirect to={flagLegacyNav ? '/overview/sensors' : '/automation'} />;
+      return <Redirect to="/automation" />;
     default:
       assertUnreachable(automaterializeSensorsFlagState);
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
@@ -2,35 +2,22 @@ import {Redirect, Switch} from 'react-router-dom';
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
 import {OverviewActivityRoot} from './OverviewActivityRoot';
-import {OverviewJobsRoot} from './OverviewJobsRoot';
 import {OverviewResourcesRoot} from './OverviewResourcesRoot';
-import {OverviewSchedulesRoot} from './OverviewSchedulesRoot';
-import {OverviewSensorsRoot} from './OverviewSensorsRoot';
-import {featureEnabled, useFeatureFlags} from '../app/Flags';
+import {featureEnabled} from '../app/Flags';
 import {Route} from '../app/Route';
 import {AutomaterializationRoot} from '../assets/auto-materialization/AutomaterializationRoot';
 import {InstanceBackfillsRoot} from '../instance/InstanceBackfillsRoot';
 import {BackfillPage} from '../instance/backfill/BackfillPage';
 
 export const OverviewRoot = () => {
-  const {flagLegacyNav} = useFeatureFlags();
   return (
     <Switch>
       <Route path="/overview/activity" isNestingRoute>
         <OverviewActivityRoot />
       </Route>
-      <Route
-        path="/overview/jobs"
-        render={() => (flagLegacyNav ? <OverviewJobsRoot /> : <Redirect to="/jobs" />)}
-      />
-      <Route
-        path="/overview/schedules"
-        render={() => (flagLegacyNav ? <OverviewSchedulesRoot /> : <Redirect to="/automation" />)}
-      />
-      <Route
-        path="/overview/sensors"
-        render={() => (flagLegacyNav ? <OverviewSensorsRoot /> : <Redirect to="/automation" />)}
-      />
+      <Route path="/overview/jobs" render={() => <Redirect to="/jobs" />} />
+      <Route path="/overview/schedules" render={() => <Redirect to="/automation" />} />
+      <Route path="/overview/sensors" render={() => <Redirect to="/automation" />} />
       <Route path="/overview/automation" render={() => <AutomaterializationRoot />} />
       {featureEnabled(FeatureFlag.flagLegacyRunsPage)
         ? [

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
@@ -18,7 +18,7 @@ interface Props<TData> {
 export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TData>) => {
   const {refreshState, tab} = props;
 
-  const {flagLegacyNav, flagLegacyRunsPage} = useFeatureFlags();
+  const {flagLegacyRunsPage} = useFeatureFlags();
 
   const automaterialize = useAutomaterializeDaemonStatus();
   const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
@@ -31,12 +31,6 @@ export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TDa
         {enableAssetHealthOverviewPreview && (
           <TabLink id="asset-health" title="Asset health" to="/overview/asset-health" />
         )}
-        {/* These are flagged individually because the links must be children of `Tabs`: */}
-        {flagLegacyNav ? <TabLink id="jobs" title="Jobs" to="/overview/jobs" /> : null}
-        {flagLegacyNav ? (
-          <TabLink id="schedules" title="Schedules" to="/overview/schedules" />
-        ) : null}
-        {flagLegacyNav ? <TabLink id="sensors" title="Sensors" to="/overview/sensors" /> : null}
         {automaterializeSensorsFlagState === 'has-global-amp' ? (
           <TabLink
             id="amp"

--- a/js_modules/dagster-ui/packages/ui-core/src/settings/SettingsMainPane.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/settings/SettingsMainPane.tsx
@@ -1,7 +1,6 @@
 import {Box} from '@dagster-io/ui-components';
 import {Redirect, Switch} from 'react-router-dom';
 
-import {useFeatureFlags} from '../app/Flags';
 import {Route} from '../app/Route';
 import {CodeLocationsPageContent} from '../instance/CodeLocationsPage';
 import {InstanceConcurrencyPageContent} from '../instance/InstanceConcurrency';
@@ -9,11 +8,6 @@ import {InstanceConfigContent} from '../instance/InstanceConfig';
 import {InstanceHealthPageContent} from '../instance/InstanceHealthPage';
 
 export const SettingsMainPane = () => {
-  const {flagLegacyNav} = useFeatureFlags();
-  if (flagLegacyNav) {
-    return <Redirect to="/locations" />;
-  }
-
   return (
     <Box flex={{direction: 'column', alignItems: 'stretch'}} style={{flex: 1, overflow: 'hidden'}}>
       <Switch>


### PR DESCRIPTION
## Summary & Motivation

Eliminate `isLegacyNav` flag, put all users into new navigation structure.

## How I Tested These Changes

Buildkite. Load app, verify that nav and routes are rendered properly.

## Changelog

[ui] Enable new top navigation and deployment pages for all users.
