### PR TITLE
Instruct users how to configure gRPC timeout

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
@@ -90,7 +90,9 @@ class GrpcServerRegistry(AbstractContextManager):
 
         self._heartbeat_ttl = check.int_param(heartbeat_ttl, "heartbeat_ttl")
         self._startup_timeout = check.int_param(startup_timeout, "startup_timeout")
-        self._additional_timeout_msg = check.opt_str_param(additional_timeout_msg, "additional_timeout_msg")
+        self._additional_timeout_msg = check.opt_str_param(
+            additional_timeout_msg, "additional_timeout_msg"
+        )
 
         self._lock = threading.Lock()
 
@@ -195,7 +197,7 @@ class GrpcServerRegistry(AbstractContextManager):
                     inject_env_vars_from_instance=self._inject_env_vars_from_instance,
                     container_image=self._container_image,
                     container_context=self._container_context,
-                    additional_timeout_msg=self._additional_timeout_msg
+                    additional_timeout_msg=self._additional_timeout_msg,
                 )
                 self._all_processes.append(server_process)
                 self._active_entries[origin_id] = ServerRegistryEntry(

--- a/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/grpc_server_registry.py
@@ -79,6 +79,7 @@ class GrpcServerRegistry(AbstractContextManager):
         inject_env_vars_from_instance: bool = True,
         container_image: Optional[str] = None,
         container_context: Optional[Dict[str, Any]] = None,
+        additional_timeout_msg: Optional[str] = None,
     ):
         self.instance_ref = instance_ref
 
@@ -89,6 +90,7 @@ class GrpcServerRegistry(AbstractContextManager):
 
         self._heartbeat_ttl = check.int_param(heartbeat_ttl, "heartbeat_ttl")
         self._startup_timeout = check.int_param(startup_timeout, "startup_timeout")
+        self._additional_timeout_msg = check.opt_str_param(additional_timeout_msg, "additional_timeout_msg")
 
         self._lock = threading.Lock()
 
@@ -193,6 +195,7 @@ class GrpcServerRegistry(AbstractContextManager):
                     inject_env_vars_from_instance=self._inject_env_vars_from_instance,
                     container_image=self._container_image,
                     container_context=self._container_context,
+                    additional_timeout_msg=self._additional_timeout_msg
                 )
                 self._all_processes.append(server_process)
                 self._active_entries[origin_id] = ServerRegistryEntry(

--- a/python_modules/dagster/dagster/_core/remote_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/origin.py
@@ -283,7 +283,9 @@ class ManagedGrpcPythonEnvCodeLocationOrigin(
                 if instance
                 else DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
             ),
-                                additional_timeout_msg="To increase the timeout, set the `code_servers.local_startup_timeout` instance configuration option. " if instance else "Using default timeout. ",
+            additional_timeout_msg="To increase the timeout, set the `code_servers.local_startup_timeout` instance configuration option. "
+            if instance
+            else "Using default timeout. ",
             wait_for_processes_on_shutdown=instance.wait_for_local_code_server_processes_on_shutdown,
         ) as grpc_server_registry:
             endpoint = grpc_server_registry.get_grpc_endpoint(self)

--- a/python_modules/dagster/dagster/_core/remote_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/origin.py
@@ -283,6 +283,7 @@ class ManagedGrpcPythonEnvCodeLocationOrigin(
                 if instance
                 else DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
             ),
+                                additional_timeout_msg="To increase the timeout, set the `code_servers.local_startup_timeout` instance configuration option. " if instance else "Using default timeout. ",
             wait_for_processes_on_shutdown=instance.wait_for_local_code_server_processes_on_shutdown,
         ) as grpc_server_registry:
             endpoint = grpc_server_registry.get_grpc_endpoint(self)

--- a/python_modules/dagster/dagster/_core/remote_representation/origin.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/origin.py
@@ -283,9 +283,6 @@ class ManagedGrpcPythonEnvCodeLocationOrigin(
                 if instance
                 else DEFAULT_LOCAL_CODE_SERVER_STARTUP_TIMEOUT
             ),
-            additional_timeout_msg="To increase the timeout, set the `code_servers.local_startup_timeout` instance configuration option. "
-            if instance
-            else "Using default timeout. ",
             wait_for_processes_on_shutdown=instance.wait_for_local_code_server_processes_on_shutdown,
         ) as grpc_server_registry:
             endpoint = grpc_server_registry.get_grpc_endpoint(self)

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -75,6 +75,7 @@ from dagster._core.workspace.workspace import (
     WorkspaceSnapshot,
     location_status_from_location_entry,
 )
+from dagster._grpc.server import INCREASE_TIMEOUT_DAGSTER_YAML_MSG
 from dagster._time import get_current_timestamp
 from dagster._utils.aiodataloader import DataLoader
 from dagster._utils.error import SerializableErrorInfo, serializable_error_info_from_exc_info
@@ -650,7 +651,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
                     startup_timeout=instance.code_server_process_startup_timeout,
                     log_level=code_server_log_level,
                     wait_for_processes_on_shutdown=instance.wait_for_local_code_server_processes_on_shutdown,
-                    additional_timeout_msg="To increase the timeout, set the `code_servers.local_startup_timeout` instance configuration option. ",
+                    additional_timeout_msg=INCREASE_TIMEOUT_DAGSTER_YAML_MSG,
                 )
             )
 

--- a/python_modules/dagster/dagster/_core/workspace/context.py
+++ b/python_modules/dagster/dagster/_core/workspace/context.py
@@ -650,6 +650,7 @@ class WorkspaceProcessContext(IWorkspaceProcessContext):
                     startup_timeout=instance.code_server_process_startup_timeout,
                     log_level=code_server_log_level,
                     wait_for_processes_on_shutdown=instance.wait_for_local_code_server_processes_on_shutdown,
+                    additional_timeout_msg="To increase the timeout, set the `code_servers.local_startup_timeout` instance configuration option. ",
                 )
             )
 

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -75,8 +75,7 @@ def create_daemon_grpc_server_registry(
         instance_ref=instance.get_ref(),
         heartbeat_ttl=DAEMON_GRPC_SERVER_HEARTBEAT_TTL,
         startup_timeout=instance.code_server_process_startup_timeout,
-                                        additional_timeout_msg="To increase the timeout, set the `code_servers.local_startup_timeout` instance configuration option. ",
-
+        additional_timeout_msg="To increase the timeout, set the `code_servers.local_startup_timeout` instance configuration option. ",
         log_level=code_server_log_level,
         wait_for_processes_on_shutdown=instance.wait_for_local_code_server_processes_on_shutdown,
     )

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -75,6 +75,8 @@ def create_daemon_grpc_server_registry(
         instance_ref=instance.get_ref(),
         heartbeat_ttl=DAEMON_GRPC_SERVER_HEARTBEAT_TTL,
         startup_timeout=instance.code_server_process_startup_timeout,
+                                        additional_timeout_msg="To increase the timeout, set the `code_servers.local_startup_timeout` instance configuration option. ",
+
         log_level=code_server_log_level,
         wait_for_processes_on_shutdown=instance.wait_for_local_code_server_processes_on_shutdown,
     )

--- a/python_modules/dagster/dagster/_daemon/controller.py
+++ b/python_modules/dagster/dagster/_daemon/controller.py
@@ -26,6 +26,7 @@ from dagster._daemon.daemon import (
 )
 from dagster._daemon.run_coordinator.queued_run_coordinator_daemon import QueuedRunCoordinatorDaemon
 from dagster._daemon.types import DaemonHeartbeat, DaemonStatus
+from dagster._grpc.server import INCREASE_TIMEOUT_DAGSTER_YAML_MSG
 from dagster._time import get_current_datetime, get_current_timestamp
 from dagster._utils.interrupts import raise_interrupts_as
 from dagster._utils.log import configure_loggers
@@ -75,7 +76,7 @@ def create_daemon_grpc_server_registry(
         instance_ref=instance.get_ref(),
         heartbeat_ttl=DAEMON_GRPC_SERVER_HEARTBEAT_TTL,
         startup_timeout=instance.code_server_process_startup_timeout,
-        additional_timeout_msg="To increase the timeout, set the `code_servers.local_startup_timeout` instance configuration option. ",
+        additional_timeout_msg=INCREASE_TIMEOUT_DAGSTER_YAML_MSG,
         log_level=code_server_log_level,
         wait_for_processes_on_shutdown=instance.wait_for_local_code_server_processes_on_shutdown,
     )

--- a/python_modules/dagster/dagster/_grpc/proxy_server.py
+++ b/python_modules/dagster/dagster/_grpc/proxy_server.py
@@ -80,6 +80,7 @@ class DagsterProxyApiServicer(DagsterApiServicer):
                 container_image=self._container_image,
                 container_context=self._container_context,
                 wait_for_processes_on_shutdown=True,
+                additional_timeout_msg="Set from --startup-timeout command line argument. ",
             )
         )
         self._origin = ManagedGrpcPythonEnvCodeLocationOrigin(

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -1296,7 +1296,7 @@ class CouldNotStartServerProcess(Exception):
         )
 
 
-def wait_for_grpc_server(server_process, client, subprocess_args, timeout=60):
+def wait_for_grpc_server(server_process, client, subprocess_args, timeout=60, additional_timeout_msg: Optional[str] = None):
     start_time = time.time()
 
     last_error = None
@@ -1310,7 +1310,7 @@ def wait_for_grpc_server(server_process, client, subprocess_args, timeout=60):
 
         if timeout > 0 and (time.time() - start_time > timeout):
             raise Exception(
-                f"Timed out waiting for gRPC server to start after {timeout}s with arguments:"
+                f"Timed out waiting for gRPC server to start after {timeout}s. {additional_timeout_msg}Launched with arguments:"
                 f" \"{' '.join(subprocess_args)}\". Most recent connection error: {last_error}"
             )
 
@@ -1341,6 +1341,7 @@ def open_server_process(
     container_image: Optional[str] = None,
     container_context: Optional[Dict[str, Any]] = None,
     enable_metrics: bool = False,
+    additional_timeout_msg: Optional[str] = None,
 ):
     check.invariant((port or socket) and not (port and socket), "Set only port or socket")
     check.opt_inst_param(loadable_target_origin, "loadable_target_origin", LoadableTargetOrigin)
@@ -1395,7 +1396,7 @@ def open_server_process(
     )
 
     try:
-        wait_for_grpc_server(server_process, client, subprocess_args, timeout=startup_timeout)
+        wait_for_grpc_server(server_process, client, subprocess_args, timeout=startup_timeout, additional_timeout_msg=additional_timeout_msg)
     except:
         if server_process.poll() is None:
             server_process.terminate()
@@ -1443,6 +1444,7 @@ class GrpcServerProcess:
         inject_env_vars_from_instance: bool = True,
         container_image: Optional[str] = None,
         container_context: Optional[Dict[str, Any]] = None,
+                additional_timeout_msg: Optional[str] = None,
     ):
         self.port = None
         self.socket = None
@@ -1484,6 +1486,7 @@ class GrpcServerProcess:
                 inject_env_vars_from_instance=inject_env_vars_from_instance,
                 container_image=container_image,
                 container_context=container_context,
+                additional_timeout_msg=additional_timeout_msg,
             )
         else:
             self.socket = safe_tempfile_path_unmanaged()
@@ -1505,6 +1508,7 @@ class GrpcServerProcess:
                 inject_env_vars_from_instance=inject_env_vars_from_instance,
                 container_image=container_image,
                 container_context=container_context,
+                additional_timeout_msg=additional_timeout_msg,
             )
 
         if server_process is None:

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -1296,7 +1296,13 @@ class CouldNotStartServerProcess(Exception):
         )
 
 
-def wait_for_grpc_server(server_process, client, subprocess_args, timeout=60, additional_timeout_msg: Optional[str] = None):
+def wait_for_grpc_server(
+    server_process,
+    client,
+    subprocess_args,
+    timeout=60,
+    additional_timeout_msg: Optional[str] = None,
+):
     start_time = time.time()
 
     last_error = None
@@ -1396,7 +1402,13 @@ def open_server_process(
     )
 
     try:
-        wait_for_grpc_server(server_process, client, subprocess_args, timeout=startup_timeout, additional_timeout_msg=additional_timeout_msg)
+        wait_for_grpc_server(
+            server_process,
+            client,
+            subprocess_args,
+            timeout=startup_timeout,
+            additional_timeout_msg=additional_timeout_msg,
+        )
     except:
         if server_process.poll() is None:
             server_process.terminate()
@@ -1444,7 +1456,7 @@ class GrpcServerProcess:
         inject_env_vars_from_instance: bool = True,
         container_image: Optional[str] = None,
         container_context: Optional[Dict[str, Any]] = None,
-                additional_timeout_msg: Optional[str] = None,
+        additional_timeout_msg: Optional[str] = None,
     ):
         self.port = None
         self.socket = None

--- a/python_modules/dagster/dagster/_grpc/server.py
+++ b/python_modules/dagster/dagster/_grpc/server.py
@@ -1296,6 +1296,14 @@ class CouldNotStartServerProcess(Exception):
         )
 
 
+INCREASE_TIMEOUT_DAGSTER_YAML_MSG = """To increase the timeout, add the following to a dagster.yaml file, located in your $DAGSTER_HOME folder or the folder where you are running `dagster dev`:
+
+code_servers:
+  local_startup_timeout: <timeout value>
+
+"""
+
+
 def wait_for_grpc_server(
     server_process,
     client,


### PR DESCRIPTION
## Summary

Adds a segment to the gRPC timeout error explaining where the value is sourced from. Since this value propagates differently in different scenarios, the actual explanatory message is passed down the callstack.

