### PR TITLE
add debug log for scheduler daemon no running schedules

### DIFF
--- a/python_modules/dagster/dagster/_scheduler/scheduler.py
+++ b/python_modules/dagster/dagster/_scheduler/scheduler.py
@@ -355,6 +355,7 @@ def launch_scheduled_runs(
             instance.delete_instigator_state(state.instigator_origin_id, state.selector_id)
 
     if not running_schedules:
+        logger.debug("no running schedules")
         yield
         return
 


### PR DESCRIPTION
## Summary & Motivation

would be nice to have debug logs for when the scheduler doesn't find any running schedules
