### PR TITLE
add managing concurrency to sidebar

### DIFF
--- a/docs/docs-beta/sidebars.ts
+++ b/docs/docs-beta/sidebars.ts
@@ -40,6 +40,7 @@ const sidebars: SidebarsConfig = {
             'guides/databases',
             'guides/apis',
             'guides/io-managers',
+            'guides/managing-concurrency',
           ],
         },
         {


### PR DESCRIPTION
## Summary & Motivation

I forgot to add managing concurrency to the sidebar. In the old docs this was in an "Advanced" section. I think it might make sense under "Build/Configure", but am open to moving it to a different or even a new section!