### PR TITLE
[docs-beta] fix broken build due to typo in anchor

### DIFF
--- a/docs/docs-beta/docs/dagster-plus/deployment/serverless.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/serverless.md
@@ -10,7 +10,7 @@ Dagster+ Serverless is a fully managed version of Dagster+ and is the easiest wa
 
 ---
 
-## When to choose Serverless {#when-to-choose-serverless}
+## When to choose Serverless \{#when-to-choose-serverless}
 
 Serverless works best with workloads that primarily orchestrate other services or perform light computation. Most workloads fit into this category, especially those that orchestrate third-party SaaS products like cloud data warehouses and ETL tools.
 
@@ -23,7 +23,7 @@ If any of the following are applicable, you should select [Hybrid deployment](/d
 
 ---
 
-## Limitations {#limitations}
+## Limitations \{#limitations}
 
 Serverless is subject to the following limitations:
 

--- a/docs/docs-beta/docs/dagster-plus/deployment/serverless/runtime-environment.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/serverless/runtime-environment.md
@@ -43,6 +43,7 @@ setup(
 To add a package from a private GitHub repository, see: [Use private Python packages](#private-packages)
 
 ## Use a different Python version \{#python-version}
+
 The default Python version for Dagster+ Serverless is Python 3.9. Python versions 3.10 through 3.12 are also supported. You can specify the Python version you want to use in your GitHub or GitLab workflow, or by using the `dagster-cloud` CLI.
 
 <Tabs groupId="method">
@@ -200,7 +201,7 @@ Setting a custom base image isn't supported for GitLab CI/CD workflows out of th
 </TabItem>
 </Tabs>
 
-## Use private Python packages \{#private-packages]}
+## Use private Python packages \{#private-packages}
 
 If you use PEX deploys in your workflow (`ENABLE_FAST_DEPLOYS: 'true'`), the following steps can install a package from a private GitHub repository, eg. `my-org/private-repo`, as a dependency:
 

--- a/docs/docs-beta/docs/dagster-plus/deployment/serverless/security.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/serverless/security.md
@@ -28,7 +28,7 @@ In Serverless, code that uses the default [I/O manager](/guides/io-managers) is 
 
 However, this automatic change also means potentially sensitive data could be **stored** and not just processed or orchestrated by Dagster+.
 
-To prevent this, you can use [another I/O manager](/guides/io-managers#built-in) that stores data in your infrastructure or [adapt your code to avoid using an I/O manager](io-managers#before-you-begin).
+To prevent this, you can use [another I/O manager](/guides/io-managers#built-in) that stores data in your infrastructure or [adapt your code to avoid using an I/O manager](/guides/io-managers#before-you-begin).
 
 :::note
 You must have [boto3](https://pypi.org/project/boto3/) or `dagster-cloud[serverless]` installed as a project dependency otherwise the Dagster+ managed storage can fail and silently fall back to using the default I/O manager.

--- a/docs/docs-beta/docs/dagster-plus/deployment/serverless/security.md
+++ b/docs/docs-beta/docs/dagster-plus/deployment/serverless/security.md
@@ -34,7 +34,7 @@ To prevent this, you can use [another I/O manager](/guides/io-managers#built-in)
 You must have [boto3](https://pypi.org/project/boto3/) or `dagster-cloud[serverless]` installed as a project dependency otherwise the Dagster+ managed storage can fail and silently fall back to using the default I/O manager.
 :::
 
-## Adding environment variables and secrets {#adding-secrets}
+## Adding environment variables and secrets \{#adding-secrets}
 
 Often you'll need to securely access secrets from your jobs. Dagster+ supports several methods for adding secrets—refer to the [Dagster+ environment variables documentation](/dagster-plus/deployment/environment-variables) for more information.
 


### PR DESCRIPTION
## Summary & Motivation

- This fixes the broken Docusaurus build due to malformed anchor tags

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
