### PR TITLE
fix(dagster-snowflake): fix test_fetch_last_updated_timestamps_missing_table

### DIFF
--- a/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
+++ b/python_modules/libraries/dagster-snowflake/dagster_snowflake_tests/test_resources.py
@@ -317,19 +317,20 @@ def test_fetch_last_updated_timestamps_missing_table():
             conn.cursor().execute(f"create table {table_name} (foo string)")
             conn.cursor().execute(f"insert into {table_name} values ('bar')")
 
+            reversed_table_name = table_name[::-1]
             with pytest.raises(ValueError):
                 freshness = fetch_last_updated_timestamps(
                     snowflake_connection=conn,
                     database="TESTDB",
                     # Second table does not exist, expects ValueError
-                    tables=[table_name, reversed(table_name)],
+                    tables=[table_name, reversed_table_name],
                     schema="TESTSCHEMA",
                 )
 
             freshness = fetch_last_updated_timestamps(
                 snowflake_connection=conn,
                 database="TESTDB",
-                tables=[table_name, reversed(table_name)],
+                tables=[table_name, reversed_table_name],
                 schema="TESTSCHEMA",
                 ignore_missing_tables=True,
             )

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_asset_specs.py
@@ -86,7 +86,7 @@ def test_translator_spec(
             host_key: host_value,
         }
 
-        resource = clazz(**resource_args)  # type: ignore
+        resource = clazz(**resource_args)
         resource.build_client()
 
         all_assets = load_tableau_asset_specs(resource)


### PR DESCRIPTION
## Summary & Motivation

This change fix the `test_fetch_last_updated_timestamps_missing_table` function in the Snowflake resource tests. 


## How I Tested These Changes

- [ ] validate that the failing BK test is now passing