### PR TITLE
[ui] Handle failure in code location permalink

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/ContentRoot.tsx
@@ -1,6 +1,6 @@
 import {ErrorBoundary, MainContent} from '@dagster-io/ui-components';
 import {memo, useEffect, useRef} from 'react';
-import {Switch, useLocation} from 'react-router-dom';
+import {Redirect, Switch, useLocation} from 'react-router-dom';
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 import {AssetsOverviewRoot} from 'shared/assets/AssetsOverviewRoot.oss';
 
@@ -88,7 +88,7 @@ export const ContentRoot = memo(() => {
             <InstanceConfig />
           </Route>
           <Route path="/locations" exact>
-            <CodeLocationsPage />
+            <Redirect to="/deployment/locations" />
           </Route>
           <Route path="/locations">
             <WorkspaceRoot />

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefinitionsRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationDefinitionsRoot.tsx
@@ -31,7 +31,11 @@ export const CodeLocationDefinitionsRoot = (props: Props) => {
     <Box style={{height: '100%', overflow: 'hidden'}} flex={{direction: 'column'}}>
       <CodeLocationPageHeader repoAddress={repoAddress} />
       <Box padding={{horizontal: 24}} border="bottom">
-        <CodeLocationTabs selectedTab="definitions" repoAddress={repoAddress} />
+        <CodeLocationTabs
+          selectedTab="definitions"
+          repoAddress={repoAddress}
+          locationEntry={locationEntry}
+        />
       </Box>
       <Box style={{overflow: 'hidden'}} flex={{direction: 'row', grow: 1}}>
         <Box

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationTabs.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/CodeLocationTabs.oss.tsx
@@ -1,6 +1,9 @@
-import {Tabs} from '@dagster-io/ui-components';
+import {Tab, Tabs} from '@dagster-io/ui-components';
+import {useMemo} from 'react';
 
+import {findRepositoryInLocation} from './findRepositoryInLocation';
 import {TabLink} from '../ui/TabLink';
+import {WorkspaceLocationNodeFragment} from '../workspace/WorkspaceContext/types/WorkspaceQueries.types';
 import {RepoAddress} from '../workspace/types';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
 
@@ -9,18 +12,28 @@ export type CodeLocationTabType = 'overview' | 'definitions';
 interface Props {
   repoAddress: RepoAddress;
   selectedTab: CodeLocationTabType;
+  locationEntry: WorkspaceLocationNodeFragment | null;
 }
 
 export const CodeLocationTabs = (props: Props) => {
-  const {repoAddress, selectedTab} = props;
+  const {repoAddress, selectedTab, locationEntry} = props;
+  const repository = useMemo(
+    () => findRepositoryInLocation(locationEntry, repoAddress),
+    [locationEntry, repoAddress],
+  );
+
   return (
     <Tabs selectedTabId={selectedTab}>
       <TabLink id="overview" title="Overview" to={workspacePathFromAddress(repoAddress, '/')} />
-      <TabLink
-        id="definitions"
-        title="Definitions"
-        to={workspacePathFromAddress(repoAddress, '/definitions')}
-      />
+      {repository ? (
+        <TabLink
+          id="definitions"
+          title="Definitions"
+          to={workspacePathFromAddress(repoAddress, '/definitions')}
+        />
+      ) : (
+        <Tab id="definitions" title="Definitions" disabled />
+      )}
     </Tabs>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/code-location/findRepositoryInLocation.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/code-location/findRepositoryInLocation.tsx
@@ -1,0 +1,22 @@
+import {WorkspaceLocationNodeFragment} from '../workspace/WorkspaceContext/types/WorkspaceQueries.types';
+import {RepoAddress} from '../workspace/types';
+
+// Given a `RepoAddress` and a location entry, try to find the matching repository to determine
+// whether there are actual code object definitions available for this `RepoAddress`.
+// It is possible that we have an errored `locationEntry` at a dunder `RepoAddress`, in which
+// case there are no actual code objects available.
+export const findRepositoryInLocation = (
+  locationEntry: WorkspaceLocationNodeFragment | null,
+  repoAddress: RepoAddress,
+) => {
+  if (
+    locationEntry?.__typename !== 'WorkspaceLocationEntry' ||
+    locationEntry.locationOrLoadError?.__typename !== 'RepositoryLocation'
+  ) {
+    return null;
+  }
+
+  const location = locationEntry.locationOrLoadError;
+  const matchingLocation = location.repositories.find((repo) => repo.name === repoAddress.name);
+  return matchingLocation || null;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/CodeLocationRowSet.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/CodeLocationRowSet.tsx
@@ -94,22 +94,22 @@ export const ModuleOrPackageOrFile = ({
 };
 
 export const LocationStatus = (props: {
-  locationStatus: LocationStatusEntryFragment;
+  locationStatus: LocationStatusEntryFragment | null;
   locationOrError: WorkspaceRepositoryLocationNode | null;
 }) => {
   const {locationStatus, locationOrError} = props;
   const [showDialog, setShowDialog] = useState(false);
 
   const reloadFn = useMemo(
-    () => buildReloadFnForLocation(locationStatus.name),
-    [locationStatus.name],
+    () => buildReloadFnForLocation(locationStatus?.name || ''),
+    [locationStatus?.name],
   );
   const {reloading, tryReload} = useRepositoryLocationReload({
     scope: 'location',
     reloadFn,
   });
 
-  if (locationStatus.loadStatus === 'LOADING') {
+  if (locationStatus?.loadStatus === 'LOADING') {
     return (
       <Tag minimal intent="primary">
         Updating…
@@ -117,7 +117,7 @@ export const LocationStatus = (props: {
     );
   }
 
-  if (locationOrError?.versionKey !== locationStatus.versionKey) {
+  if (locationOrError?.versionKey !== locationStatus?.versionKey) {
     return (
       <Tag minimal intent="primary">
         Loading…
@@ -125,7 +125,7 @@ export const LocationStatus = (props: {
     );
   }
 
-  if (locationOrError?.locationOrLoadError?.__typename === 'PythonError') {
+  if (locationStatus && locationOrError?.locationOrLoadError?.__typename === 'PythonError') {
     return (
       <>
         <Box flex={{alignItems: 'center', gap: 12}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedCodeLocationRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedCodeLocationRow.tsx
@@ -12,7 +12,7 @@ import {
   WorkspaceLocationNodeFragment,
   WorkspaceRepositoryFragment,
 } from './WorkspaceContext/types/WorkspaceQueries.types';
-import {buildRepoAddress} from './buildRepoAddress';
+import {DUNDER_REPO_NAME, buildRepoAddress} from './buildRepoAddress';
 import {repoAddressAsHumanString} from './repoAddressAsString';
 import {workspacePathFromAddress} from './workspacePath';
 import {TimeFromNow} from '../ui/TimeFromNow';
@@ -47,11 +47,19 @@ export const VirtualizedCodeLocationRow = React.forwardRef(
   (props: LocationRowProps, ref: React.ForwardedRef<HTMLDivElement>) => {
     const {locationEntry, locationStatus, index} = props;
     const {name} = locationStatus;
+    const repoAddress = buildRepoAddress(DUNDER_REPO_NAME, name);
+
     return (
       <div ref={ref} data-index={index}>
         <RowGrid border="bottom">
           <RowCell>
-            <MiddleTruncate text={name} />
+            <Box flex={{direction: 'column', gap: 4}}>
+              <div style={{fontWeight: 500}}>
+                <Link to={workspacePathFromAddress(repoAddress)}>
+                  <MiddleTruncate text={name} />
+                </Link>
+              </div>
+            </Box>
           </RowCell>
           <RowCell>
             <div>

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/WorkspaceRoot.tsx
@@ -2,7 +2,6 @@ import {Box, MainContent, NonIdealState, SpinnerWithText} from '@dagster-io/ui-c
 import {useContext} from 'react';
 import {Redirect, Switch, useParams} from 'react-router-dom';
 
-import {CodeLocationNotFound} from './CodeLocationNotFound';
 import {GraphRoot} from './GraphRoot';
 import {WorkspaceContext} from './WorkspaceContext/WorkspaceContext';
 import {repoAddressAsHumanString} from './repoAddressAsString';
@@ -60,19 +59,6 @@ const RepoRouteContainer = () => {
         </Box>
       );
     }
-
-    const entryForLocation = workspaceState.locationEntries.find(
-      (entry) => entry.id === addressForPath.location,
-    );
-
-    return (
-      <Box padding={{vertical: 64}}>
-        <CodeLocationNotFound
-          repoAddress={addressForPath}
-          locationEntry={entryForLocation || null}
-        />
-      </Box>
-    );
   }
 
   return (
@@ -115,23 +101,26 @@ const RepoRouteContainer = () => {
       <Route path="/locations/:repoPath/definitions" exact>
         <Redirect to={workspacePathFromAddress(addressForPath, '/assets')} />
       </Route>
-      <Route
-        path={[
-          '/locations/:repoPath/assets',
-          '/locations/:repoPath/jobs',
-          '/locations/:repoPath/resources',
-          '/locations/:repoPath/schedules',
-          '/locations/:repoPath/sensors',
-          '/locations/:repoPath/graphs',
-          '/locations/:repoPath/ops/:name?',
-        ]}
-        exact
-      >
-        <CodeLocationDefinitionsRoot
-          repoAddress={addressForPath}
-          repository={matchingRepo.repository}
-        />
-      </Route>
+      {/* Avoid trying to render a definitions route if there is no actual repo available. */}
+      {matchingRepo ? (
+        <Route
+          path={[
+            '/locations/:repoPath/assets',
+            '/locations/:repoPath/jobs',
+            '/locations/:repoPath/resources',
+            '/locations/:repoPath/schedules',
+            '/locations/:repoPath/sensors',
+            '/locations/:repoPath/graphs',
+            '/locations/:repoPath/ops/:name?',
+          ]}
+          exact
+        >
+          <CodeLocationDefinitionsRoot
+            repoAddress={addressForPath}
+            repository={matchingRepo.repository}
+          />
+        </Route>
+      ) : null}
       <Route path={['/locations/:repoPath/*', '/locations/:repoPath/']}>
         <Redirect to={workspacePathFromAddress(addressForPath, '/assets')} />
       </Route>


### PR DESCRIPTION
## Summary & Motivation

When a code location is in an error state, link to its permalink so that metadata is available.

The current app behavior is to show an empty state when attempting to load an unloadable code location. This change replaces the empty state with the code location overview page.

If the code location has no repositories available (because it's in an error state), disable the "Definitions" tab.

https://github.com/user-attachments/assets/714141b6-ac88-485e-bad2-7764482f0194


## How I Tested These Changes

Load the app locally, cause a Python error in `toys`, reload the code location. Verify that the code location goes into an errored state but is linked from the Code locations page.

Click the link, verify that I arrive at the code location permalink, with metadata and the code location error available.