### PR TITLE
[dagster-looker] Attach URL metadata, owners to dashboards, explores

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker/api/assets.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/assets.py
@@ -32,7 +32,7 @@ def build_looker_pdt_assets_definitions(
     Returns:
         AssetsDefinition: The AssetsDefinitions of the executable assets for the given the list of refreshable PDTs.
     """
-    translator = dagster_looker_translator()
+    translator = dagster_looker_translator(None)
     result = []
     for request_start_pdt_build in request_start_pdt_builds:
 

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/api/mock_looker_data.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/api/mock_looker_data.py
@@ -9,6 +9,7 @@ from looker_sdk.sdk.api40.models import (
     LookmlModelExplore,
     LookmlModelNavExplore,
     MaterializePDT,
+    User,
 )
 
 mock_lookml_models = [
@@ -50,6 +51,8 @@ mock_looker_dashboard = Dashboard(
     dashboard_filters=[
         DashboardFilter(model="my_model", explore="my_explore"),
     ],
+    user_id="1",
+    url="/dashboards/1",
 )
 
 mock_other_looker_dashboard = Dashboard(
@@ -58,6 +61,15 @@ mock_other_looker_dashboard = Dashboard(
     dashboard_filters=[
         DashboardFilter(model="my_model", explore="my_other_explore"),
     ],
+    user_id="2",
+    url="/dashboards/2",
+)
+
+mock_user = User(id="1", email="ben@dagsterlabs.com")
+
+mock_other_user = User(
+    id="2",
+    email="rex@dagsterlabs.com",
 )
 
 mock_start_pdt_build = MaterializePDT(


### PR DESCRIPTION
## Summary & Motivation

Attaches new metadata to point to a Looker dashboard/explore's URL, as well as fetching user emails for dashboards and attaching those as owners.

## How I Tested These Changes

New unit test.

## Changelog

> [dagster-looker] Looker assets now by default have owner and URL metadata.
