### PR TITLE
[5/n] [RFC] add launch all frontend functionality for sensors

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/client.json
+++ b/js_modules/dagster-ui/packages/ui-core/client.json
@@ -126,6 +126,7 @@
   "RunRootQuery": "1aa4561b33c2cfb079d7a3ff284096fc3208a46dee748a24c7af827a2cb22919",
   "RunStatsQuery": "75e80f740a79607de9e1152f9b7074d319197fbc219784c767c1abd5553e9a49",
   "LaunchPipelineExecution": "292088c4a697aca6be1d3bbc0cfc45d8a13cdb2e75cfedc64b68c6245ea34f89",
+  "LaunchMultipleRuns": "a56d9efdb35e71e0fd1744dd768129248943bc5b23e717458b82c46829661763",
   "Delete": "3c61c79b99122910e754a8863e80dc5ed479a0c23cc1a9d9878d91e603fc0dfe",
   "Terminate": "67acf403eb320a93c9a9aa07f675a1557e0887d499cd5598f1d5ff360afc15c0",
   "LaunchPipelineReexecution": "d21e4ecaf3d1d163c4772f1d847dbdcbdaa9a40e6de0808a064ae767adf0c311",

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Telemetry.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Telemetry.tsx
@@ -9,6 +9,7 @@ import {gql} from '../apollo-client';
 
 export enum TelemetryAction {
   LAUNCH_RUN = 'LAUNCH_RUN',
+  LAUNCH_MULTIPLE_RUNS = 'LAUNCH_MULTIPLE_RUNS',
   GRAPHQL_QUERY_COMPLETED = 'GRAPHQL_QUERY_COMPLETED',
 }
 
@@ -38,7 +39,7 @@ const LOG_TELEMETRY_MUTATION = gql`
 export async function logTelemetry(
   pathPrefix: string,
   action: TelemetryAction,
-  metadata: {[key: string]: string | null | undefined} = {},
+  metadata: {[key: string]: string | string[] | null | undefined} = {},
 ) {
   const graphqlPath = `${pathPrefix || ''}/graphql`;
 
@@ -63,7 +64,10 @@ export async function logTelemetry(
 export const useTelemetryAction = () => {
   const {basePath, telemetryEnabled} = useContext(AppContext);
   return useCallback(
-    (action: TelemetryAction, metadata: {[key: string]: string | null | undefined} = {}) => {
+    (
+      action: TelemetryAction,
+      metadata: {[key: string]: string | string[] | null | undefined} = {},
+    ) => {
       if (telemetryEnabled) {
         logTelemetry(basePath, action, metadata);
       }

--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/useLaunchMultipleRunsWithTelemetry.ts
@@ -1,0 +1,62 @@
+import {useCallback} from 'react';
+import {useHistory} from 'react-router-dom';
+
+import {showLaunchError} from './showLaunchError';
+import {useMutation} from '../apollo-client';
+import {TelemetryAction, useTelemetryAction} from '../app/Telemetry';
+import {
+  LAUNCH_MULTIPLE_RUNS_MUTATION,
+  LaunchBehavior,
+  handleLaunchMultipleResult,
+} from '../runs/RunUtils';
+import {
+  LaunchMultipleRunsMutation,
+  LaunchMultipleRunsMutationVariables,
+} from '../runs/types/RunUtils.types';
+
+export function useLaunchMultipleRunsWithTelemetry() {
+  const [launchMultipleRuns] = useMutation<
+    LaunchMultipleRunsMutation,
+    LaunchMultipleRunsMutationVariables
+  >(LAUNCH_MULTIPLE_RUNS_MUTATION);
+
+  const logTelemetry = useTelemetryAction();
+  const history = useHistory();
+
+  return useCallback(
+    async (variables: LaunchMultipleRunsMutationVariables, behavior: LaunchBehavior) => {
+      const executionParamsList = Array.isArray(variables.executionParamsList)
+        ? variables.executionParamsList
+        : [variables.executionParamsList];
+      const jobNames = executionParamsList.map((params) => params.selector?.jobName);
+
+      if (jobNames.length !== executionParamsList.length || jobNames.includes(undefined)) {
+        return;
+      }
+
+      const metadata: {[key: string]: string | string[] | null | undefined} = {
+        jobNames: jobNames.filter((name): name is string => name !== undefined),
+        opSelection: undefined,
+      };
+
+      let result;
+      try {
+        result = (await launchMultipleRuns({variables})).data?.launchMultipleRuns;
+        if (result) {
+          handleLaunchMultipleResult(result, history, {behavior});
+          logTelemetry(
+            TelemetryAction.LAUNCH_MULTIPLE_RUNS,
+            metadata as {[key: string]: string | string[] | null | undefined},
+          );
+        }
+
+        return result;
+      } catch (error) {
+        console.error('error', error);
+        showLaunchError(error as Error);
+      }
+      return undefined;
+    },
+    [history, launchMultipleRuns, logTelemetry],
+  );
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunUtils.types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/types/RunUtils.types.ts
@@ -42,6 +42,106 @@ export type LaunchPipelineExecutionMutation = {
     | {__typename: 'UnauthorizedError'};
 };
 
+export type LaunchMultipleRunsMutationVariables = Types.Exact<{
+  executionParamsList: Array<Types.ExecutionParams> | Types.ExecutionParams;
+}>;
+
+export type LaunchMultipleRunsMutation = {
+  __typename: 'Mutation';
+  launchMultipleRuns:
+    | {
+        __typename: 'LaunchMultipleRunsResult';
+        launchMultipleRunsResult: Array<
+          | {__typename: 'ConflictingExecutionParamsError'; message: string}
+          | {__typename: 'InvalidOutputError'; stepKey: string; invalidOutputName: string}
+          | {__typename: 'InvalidStepError'; invalidStepKey: string}
+          | {__typename: 'InvalidSubsetError'}
+          | {
+              __typename: 'LaunchRunSuccess';
+              run: {
+                __typename: 'Run';
+                id: string;
+                status: Types.RunStatus;
+                runConfigYaml: string;
+                mode: string;
+                resolvedOpSelection: Array<string> | null;
+                pipeline:
+                  | {__typename: 'PipelineSnapshot'; name: string}
+                  | {__typename: 'UnknownPipeline'; name: string};
+                tags: Array<{__typename: 'PipelineTag'; key: string; value: string}>;
+              };
+            }
+          | {__typename: 'NoModeProvidedError'}
+          | {__typename: 'PipelineNotFoundError'; message: string; pipelineName: string}
+          | {__typename: 'PresetNotFoundError'; preset: string; message: string}
+          | {
+              __typename: 'PythonError';
+              message: string;
+              stack: Array<string>;
+              errorChain: Array<{
+                __typename: 'ErrorChainLink';
+                isExplicitLink: boolean;
+                error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+              }>;
+            }
+          | {
+              __typename: 'RunConfigValidationInvalid';
+              pipelineName: string;
+              errors: Array<
+                | {
+                    __typename: 'FieldNotDefinedConfigError';
+                    message: string;
+                    path: Array<string>;
+                    reason: Types.EvaluationErrorReason;
+                  }
+                | {
+                    __typename: 'FieldsNotDefinedConfigError';
+                    message: string;
+                    path: Array<string>;
+                    reason: Types.EvaluationErrorReason;
+                  }
+                | {
+                    __typename: 'MissingFieldConfigError';
+                    message: string;
+                    path: Array<string>;
+                    reason: Types.EvaluationErrorReason;
+                  }
+                | {
+                    __typename: 'MissingFieldsConfigError';
+                    message: string;
+                    path: Array<string>;
+                    reason: Types.EvaluationErrorReason;
+                  }
+                | {
+                    __typename: 'RuntimeMismatchConfigError';
+                    message: string;
+                    path: Array<string>;
+                    reason: Types.EvaluationErrorReason;
+                  }
+                | {
+                    __typename: 'SelectorTypeConfigError';
+                    message: string;
+                    path: Array<string>;
+                    reason: Types.EvaluationErrorReason;
+                  }
+              >;
+            }
+          | {__typename: 'RunConflict'}
+          | {__typename: 'UnauthorizedError'}
+        >;
+      }
+    | {
+        __typename: 'PythonError';
+        message: string;
+        stack: Array<string>;
+        errorChain: Array<{
+          __typename: 'ErrorChainLink';
+          isExplicitLink: boolean;
+          error: {__typename: 'PythonError'; message: string; stack: Array<string>};
+        }>;
+      };
+};
+
 export type DeleteMutationVariables = Types.Exact<{
   runId: Types.Scalars['String']['input'];
 }>;
@@ -167,6 +267,8 @@ export type RunTimeFragment = {
 };
 
 export const LaunchPipelineExecutionVersion = '292088c4a697aca6be1d3bbc0cfc45d8a13cdb2e75cfedc64b68c6245ea34f89';
+
+export const LaunchMultipleRunsVersion = 'a56d9efdb35e71e0fd1744dd768129248943bc5b23e717458b82c46829661763';
 
 export const DeleteVersion = '3c61c79b99122910e754a8863e80dc5ed479a0c23cc1a9d9878d91e603fc0dfe';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/util/buildExecutionParamsList.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/util/buildExecutionParamsList.ts
@@ -1,0 +1,53 @@
+import * as yaml from 'yaml';
+
+import {showCustomAlert} from '../app/CustomAlertProvider';
+import {ExecutionParams, SensorSelector} from '../graphql/types';
+import {sanitizeConfigYamlString} from '../launchpad/yamlUtils';
+import {SensorDryRunInstigationTick} from '../ticks/SensorDryRunDialog';
+
+const YAML_SYNTAX_INVALID = `The YAML you provided couldn't be parsed. Please fix the syntax errors and try again.`;
+
+// This helper removes __typename, which prevents tags from being passed back to GraphQL
+const onlyKeyAndValue = ({key, value}: {key: string; value: string}) => ({key, value});
+
+// adapted from buildExecutionVariables() in LaunchpadSession.tsx
+export const buildExecutionParamsListSensor = (
+  sensorExecutionData: SensorDryRunInstigationTick,
+  sensorSelector: SensorSelector,
+) => {
+  if (!sensorExecutionData) {
+    return [];
+  }
+
+  const executionParamsList: ExecutionParams[] = [];
+
+  sensorExecutionData?.evaluationResult?.runRequests?.forEach((request) => {
+    const configYamlOrEmpty = sanitizeConfigYamlString(request.runConfigYaml);
+
+    try {
+      yaml.parse(configYamlOrEmpty);
+    } catch {
+      showCustomAlert({title: 'Invalid YAML', body: YAML_SYNTAX_INVALID});
+      return;
+    }
+    const {repositoryLocationName, repositoryName} = sensorSelector;
+
+    const executionParams: ExecutionParams = {
+      runConfigData: configYamlOrEmpty,
+      selector: {
+        jobName: request.jobName, // get jobName from runRequest
+        repositoryLocationName,
+        repositoryName,
+        assetSelection: [],
+        assetCheckSelection: [],
+        solidSelection: undefined,
+      },
+      mode: 'default',
+      executionMetadata: {
+        tags: [...request.tags.map(onlyKeyAndValue)],
+      },
+    };
+    executionParamsList.push(executionParams);
+  });
+  return executionParamsList;
+};


### PR DESCRIPTION
## Summary & Motivation
Linear: https://linear.app/dagster-labs/issue/FE-624/[fe]-implement-launch-all-frontend-sensor

Adds the frontend for 'launch all' for manual tick sensors

Video:

https://github.com/user-attachments/assets/222b35c2-19c7-4bb9-a975-85f9ae56c328


## How I Tested These Changes
yarn ts, lint, make graphql

## Changelog

> Insert changelog entry or delete this section.
