### PR TITLE
[perf] Kill `useDelayedRowQuery`

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedWorkspaceTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedWorkspaceTable.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 
 import {RepoAddress} from './types';
 import {QueryResult} from '../apollo-client';
-import {CompletionType, useTraceDependency} from '../performance/TraceContext';
 import {RepoSectionHeader} from '../runs/RepoSectionHeader';
 import {Row} from '../ui/VirtualizedTable';
 
@@ -106,19 +105,3 @@ const CaptionTextContainer = styled.div`
     white-space: nowrap;
   }
 `;
-
-const JOB_QUERY_DELAY = 100;
-
-export const useDelayedRowQuery = (lazyQueryFn: () => void) => {
-  const dependency = useTraceDependency('DelayedRowQuery');
-  React.useEffect(() => {
-    const timer = setTimeout(() => {
-      lazyQueryFn();
-      dependency.completeDependency(CompletionType.SUCCESS);
-    }, JOB_QUERY_DELAY);
-
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [lazyQueryFn, dependency]);
-};


### PR DESCRIPTION
## Summary & Motivation
![image](https://github.com/user-attachments/assets/b8ed9b95-c477-4462-a017-72df790e05b9)

Context: https://dagsterlabs.slack.com/archives/C04J8BRN9ST/p1730307470251059?thread_ts=1730304382.266269&cid=C04J8BRN9ST

`useDelayedRowQuery` doesn't cancel inflight queries when you navigate away which seems to be causing queueing somewhere (unclear where it's coming from, maybe apollo, maybe chrome, maybe the server???).



## How I Tested These Changes
app proxy to canary-test-1

Navigate to automations, then navigate to a specific sensor while queries are still inflight

<img width="1538" alt="Screenshot 2024-10-30 at 1 10 48 PM" src="https://github.com/user-attachments/assets/82c92a51-4ba9-4dea-a042-59e0d0e280bf">
