### PR TITLE
[dagster-ge] Drop python 3.9 support

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -310,6 +310,9 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     ),
     PackageSpec(
         "examples/with_great_expectations",
+        unsupported_python_versions=[
+            AvailablePythonVersion.V3_9,
+        ],
     ),
     PackageSpec(
         "examples/with_pyspark",
@@ -636,6 +639,9 @@ LIBRARY_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     ),
     PackageSpec(
         "python_modules/libraries/dagster-ge",
+        unsupported_python_versions=[
+            AvailablePythonVersion.V3_9,
+        ],
     ),
     PackageSpec(
         "python_modules/libraries/dagster-k8s",

--- a/python_modules/libraries/dagster-ge/setup.py
+++ b/python_modules/libraries/dagster-ge/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     packages=find_packages(exclude=["dagster_ge_tests*"]),
     include_package_data=True,
-    python_requires=">=3.9,<3.13",
+    python_requires=">=3.10,<3.13",
     install_requires=[
         f"dagster{pin}",
         f"dagster-pandas{pin}",


### PR DESCRIPTION
## Summary & Motivation

Second order dependencies prevent `dagster-ge` from being supported on 3.9.

## How I Tested These Changes

Existing test suite.

## Changelog

[dagster-ge] The minimum Python version for `dagster-ge` is now 3.10.