### PR TITLE
[jobless-automation] Exclude anonymous jobs from ResourceSnap job_ops_using list

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/asset_job.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_job.py
@@ -59,8 +59,10 @@ if TYPE_CHECKING:
     from dagster._core.definitions.run_config import RunConfig
 
 
-def is_base_asset_job_name(name: str) -> bool:
-    return name == IMPLICIT_ASSET_JOB_NAME
+def is_reserved_asset_job_name(name: str) -> bool:
+    from dagster._core.definitions.target import ANONYMOUS_ASSET_JOB_PREFIX
+
+    return name == IMPLICIT_ASSET_JOB_NAME or name.startswith(ANONYMOUS_ASSET_JOB_PREFIX)
 
 
 def get_base_asset_job_lambda(

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -25,7 +25,7 @@ from dagster._core.definitions.asset_graph import AssetGraph
 from dagster._core.definitions.asset_job import (
     IMPLICIT_ASSET_JOB_NAME,
     get_base_asset_job_lambda,
-    is_base_asset_job_name,
+    is_reserved_asset_job_name,
 )
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.automation_condition_sensor_definition import (
@@ -194,7 +194,7 @@ def build_caching_repository_data_from_list(
                 raise DagsterInvalidDefinitionError(
                     f"Duplicate job definition found for {definition.describe_target()}"
                 )
-            if is_base_asset_job_name(definition.name):
+            if is_reserved_asset_job_name(definition.name):
                 raise DagsterInvalidDefinitionError(
                     f"Attempted to provide job called {definition.name} to repository, which "
                     "is a reserved name. Please rename the job."

--- a/python_modules/dagster/dagster/_core/remote_representation/external_data.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external_data.py
@@ -45,7 +45,7 @@ from dagster._core.definitions import (
     ScheduleDefinition,
 )
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
-from dagster._core.definitions.asset_job import is_base_asset_job_name
+from dagster._core.definitions.asset_job import is_reserved_asset_job_name
 from dagster._core.definitions.asset_sensor_definition import AssetSensorDefinition
 from dagster._core.definitions.asset_spec import AssetExecutionType
 from dagster._core.definitions.auto_materialize_policy import AutoMaterializePolicy
@@ -1567,7 +1567,7 @@ def _get_resource_job_usage(job_defs: Sequence[JobDefinition]) -> ResourceJobUsa
 
     for job_def in job_defs:
         job_name = job_def.name
-        if is_base_asset_job_name(job_name):
+        if is_reserved_asset_job_name(job_name):
             continue
 
         resource_usage: List[NodeHandleResourceUse] = []


### PR DESCRIPTION
## Summary & Motivation

`ResourceSnap` has a list of jobs using a resource that gets shown on the Resource Detail page in the UI. Anonymous asset jobs created by passing an `AssetSelection` to the `target` parameter of a schedule/sensor were leaking through here.

This PR filters out these jobs when setting the list of jobs, the same way the base asset job is filtered out.

## How I Tested These Changes

Modified existing unit tests.