### PR TITLE
[dagster-looker][wip] Cleaned up path for simultaneously loading LKML views & API data

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker/__init__.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/__init__.py
@@ -2,6 +2,8 @@ from dagster._core.libraries import DagsterLibraryRegistry
 
 from dagster_looker.api.assets import (
     build_looker_pdt_assets_definitions as build_looker_pdt_assets_definitions,
+    load_looker_asset_specs_from_instance as load_looker_asset_specs_from_instance,
+    load_looker_view_specs_from_project as load_looker_view_specs_from_project,
 )
 from dagster_looker.api.dagster_looker_api_translator import (
     DagsterLookerApiTranslator as DagsterLookerApiTranslator,
@@ -12,7 +14,6 @@ from dagster_looker.api.dagster_looker_api_translator import (
 from dagster_looker.api.resource import (
     LookerFilter as LookerFilter,
     LookerResource as LookerResource,
-    load_looker_asset_specs as load_looker_asset_specs,
 )
 from dagster_looker.lkml.asset_specs import build_looker_asset_specs as build_looker_asset_specs
 from dagster_looker.lkml.dagster_looker_lkml_translator import (


### PR DESCRIPTION
## Summary

While the Looker API provides us with access to [Dashboards, Models, and Explores](https://cloud.google.com/looker/docs/lookml-terms-and-concepts#major_lookml_structures) defined in LKML or in the UI, it does not provide us with details on Views. To get the upstream lineage of Views, we must parse the LKML files directly.

This means that users who want a full picture of their instance will need to load data from both the API and LKML files.
This currently requires interfacing with the newer Looker API integration (e.g. `DagsterLookerApiTranslator`), and the older Looker LKML integration (`DagsterLookerLkmlTranslator`).

This PR is a first pass at trying to "translate/graft" over the older LKML patterns into the new API integration, and adds a new `load_looker_view_specs_from_project` user-facing method which takes a `DagsterLookerApiTranslator`