### PR TITLE
[graphql] handle asset key that does not exist in assetNodes

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -1018,6 +1018,7 @@ class GrapheneQuery(graphene.ObjectType):
                 remote_nodes = [
                     graphene_info.context.asset_graph.get(asset_key)
                     for asset_key in resolved_asset_keys
+                    if graphene_info.context.asset_graph.has(asset_key)
                 ]
             else:
                 remote_nodes = [

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -254,7 +254,7 @@ GET_ASSET_DATA_VERSIONS_BY_PARTITION = """
 
 
 GET_ASSET_NODES_FROM_KEYS = """
-    query AssetNodeQuery($pipelineSelector: PipelineSelector!, $assetKeys: [AssetKeyInput!]) {
+    query AssetNodeQuery($pipelineSelector: PipelineSelector, $assetKeys: [AssetKeyInput!]) {
         assetNodes(pipeline: $pipelineSelector, assetKeys: $assetKeys) {
             id
             hasMaterializePermission
@@ -1189,6 +1189,17 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
             variables={
                 "pipelineSelector": selector,
                 "assetKeys": [{"path": ["asset_one"]}],
+            },
+        )
+        assert result.data
+        assert len(result.data["assetNodes"]) == 0
+
+    def test_asset_node_does_not_exist(self, graphql_context: WorkspaceRequestContext):
+        result = execute_dagster_graphql(
+            graphql_context,
+            GET_ASSET_NODES_FROM_KEYS,
+            variables={
+                "assetKeys": [{"path": ["does_not_exist"]}],
             },
         )
         assert result.data


### PR DESCRIPTION
broken in https://github.com/dagster-io/dagster/pull/25580 because not tested, discovered in manual QA 

## How I Tested These Changes

added test
