### PR TITLE
[docs] Fix custom owners examples in BI integrations docs

### DIFF
--- a/docs/content/integrations/looker.mdx
+++ b/docs/content/integrations/looker.mdx
@@ -114,7 +114,7 @@ class CustomDagsterLookerApiTranslator(DagsterLookerApiTranslator):
         asset_spec = super().get_asset_spec(looker_structure)
 
         # Add a team owner for all Looker assets
-        asset_spec = asset_spec._replace(owners=["my_team"])
+        asset_spec = asset_spec._replace(owners=["team:my_team"])
 
         # For only Looker dashboard, prefix the asset key with "looker" for organizational purposes
         if looker_structure.structure_type == LookerStructureType.DASHBOARD:

--- a/docs/content/integrations/looker.mdx
+++ b/docs/content/integrations/looker.mdx
@@ -113,7 +113,7 @@ class CustomDagsterLookerApiTranslator(DagsterLookerApiTranslator):
     def get_asset_spec(self, looker_structure: LookerStructureData) -> dg.AssetSpec:
         asset_spec = super().get_asset_spec(looker_structure)
 
-        # Add a team owner for all Looker assets
+        # Add a team owner tag for all Looker assets
         asset_spec = asset_spec._replace(owners=["team:my_team"])
 
         # For only Looker dashboard, prefix the asset key with "looker" for organizational purposes

--- a/docs/content/integrations/powerbi.mdx
+++ b/docs/content/integrations/powerbi.mdx
@@ -97,13 +97,13 @@ resource = PowerBIWorkspace(
 class MyCustomPowerBITranslator(DagsterPowerBITranslator):
     def get_report_spec(self, data: PowerBIContentData) -> dg.AssetSpec:
         # We add a team owner tag to all reports
-        return super().get_report_spec(data)._replace(owners=["my_team"])
+        return super().get_report_spec(data)._replace(owners=["team:my_team"])
 
     def get_semantic_model_spec(self, data: PowerBIContentData) -> dg.AssetSpec:
-        return super().get_semantic_model_spec(data)._replace(owners=["my_team"])
+        return super().get_semantic_model_spec(data)._replace(owners=["team:my_team"])
 
     def get_dashboard_spec(self, data: PowerBIContentData) -> dg.AssetSpec:
-        return super().get_dashboard_spec(data)._replace(owners=["my_team"])
+        return super().get_dashboard_spec(data)._replace(owners=["team:my_team"])
 
     def get_dashboard_asset_key(self, data: PowerBIContentData) -> dg.AssetKey:
         # We prefix all dashboard asset keys with "powerbi" for organizational

--- a/docs/content/integrations/sigma.mdx
+++ b/docs/content/integrations/sigma.mdx
@@ -114,7 +114,7 @@ sigma_organization = SigmaOrganization(
 # A translator class lets us customize properties of the built Sigma assets, such as the owners or asset key
 class MyCustomSigmaTranslator(DagsterSigmaTranslator):
     def get_asset_spec(self, data: SigmaWorkbook) -> dg.AssetSpec:
-        # Adds a custom team owner for all Sigma assets
+        # Adds a custom team owner tag for all Sigma assets
         return super().get_asset_spec(data)._replace(owners=["team:my_team"])
 
 

--- a/docs/content/integrations/sigma.mdx
+++ b/docs/content/integrations/sigma.mdx
@@ -113,9 +113,9 @@ sigma_organization = SigmaOrganization(
 
 # A translator class lets us customize properties of the built Sigma assets, such as the owners or asset key
 class MyCustomSigmaTranslator(DagsterSigmaTranslator):
-    def get_workbook_spec(self, data: SigmaWorkbook) -> dg.AssetSpec:
-        # Adds a custom team owner tag to all reports
-        return super().get_asset_spec(data)._replace(owners=["my_team"])
+    def get_asset_spec(self, data: SigmaWorkbook) -> dg.AssetSpec:
+        # Adds a custom team owner for all Sigma assets
+        return super().get_asset_spec(data)._replace(owners=["team:my_team"])
 
 
 sigma_specs = load_sigma_asset_specs(

--- a/docs/content/integrations/tableau.mdx
+++ b/docs/content/integrations/tableau.mdx
@@ -131,7 +131,7 @@ tableau_workspace = TableauCloudWorkspace(
 class MyCustomTableauTranslator(DagsterTableauTranslator):
     def get_sheet_spec(self, data: TableauContentData) -> dg.AssetSpec:
         # We add a custom team owner tag to all sheets
-        return super().get_sheet_spec(data)._replace(owners=["my_team"])
+        return super().get_sheet_spec(data)._replace(owners=["team:my_team"])
 
 
 tableau_specs = load_tableau_asset_specs(

--- a/examples/docs_snippets/docs_snippets/integrations/looker/customize-looker-assets.py
+++ b/examples/docs_snippets/docs_snippets/integrations/looker/customize-looker-assets.py
@@ -19,7 +19,7 @@ class CustomDagsterLookerApiTranslator(DagsterLookerApiTranslator):
     def get_asset_spec(self, looker_structure: LookerStructureData) -> dg.AssetSpec:
         asset_spec = super().get_asset_spec(looker_structure)
 
-        # Add a team owner for all Looker assets
+        # Add a team owner tag for all Looker assets
         asset_spec = asset_spec._replace(owners=["team:my_team"])
 
         # For only Looker dashboard, prefix the asset key with "looker" for organizational purposes

--- a/examples/docs_snippets/docs_snippets/integrations/looker/customize-looker-assets.py
+++ b/examples/docs_snippets/docs_snippets/integrations/looker/customize-looker-assets.py
@@ -20,7 +20,7 @@ class CustomDagsterLookerApiTranslator(DagsterLookerApiTranslator):
         asset_spec = super().get_asset_spec(looker_structure)
 
         # Add a team owner for all Looker assets
-        asset_spec = asset_spec._replace(owners=["my_team"])
+        asset_spec = asset_spec._replace(owners=["team:my_team"])
 
         # For only Looker dashboard, prefix the asset key with "looker" for organizational purposes
         if looker_structure.structure_type == LookerStructureType.DASHBOARD:

--- a/examples/docs_snippets/docs_snippets/integrations/power-bi/customize-power-bi-asset-defs.py
+++ b/examples/docs_snippets/docs_snippets/integrations/power-bi/customize-power-bi-asset-defs.py
@@ -22,13 +22,13 @@ resource = PowerBIWorkspace(
 class MyCustomPowerBITranslator(DagsterPowerBITranslator):
     def get_report_spec(self, data: PowerBIContentData) -> dg.AssetSpec:
         # We add a team owner tag to all reports
-        return super().get_report_spec(data)._replace(owners=["my_team"])
+        return super().get_report_spec(data)._replace(owners=["team:my_team"])
 
     def get_semantic_model_spec(self, data: PowerBIContentData) -> dg.AssetSpec:
-        return super().get_semantic_model_spec(data)._replace(owners=["my_team"])
+        return super().get_semantic_model_spec(data)._replace(owners=["team:my_team"])
 
     def get_dashboard_spec(self, data: PowerBIContentData) -> dg.AssetSpec:
-        return super().get_dashboard_spec(data)._replace(owners=["my_team"])
+        return super().get_dashboard_spec(data)._replace(owners=["team:my_team"])
 
     def get_dashboard_asset_key(self, data: PowerBIContentData) -> dg.AssetKey:
         # We prefix all dashboard asset keys with "powerbi" for organizational

--- a/examples/docs_snippets/docs_snippets/integrations/sigma/customize-sigma-asset-defs.py
+++ b/examples/docs_snippets/docs_snippets/integrations/sigma/customize-sigma-asset-defs.py
@@ -17,9 +17,9 @@ sigma_organization = SigmaOrganization(
 
 # A translator class lets us customize properties of the built Sigma assets, such as the owners or asset key
 class MyCustomSigmaTranslator(DagsterSigmaTranslator):
-    def get_workbook_spec(self, data: SigmaWorkbook) -> dg.AssetSpec:
-        # Adds a custom team owner tag to all reports
-        return super().get_asset_spec(data)._replace(owners=["my_team"])
+    def get_asset_spec(self, data: SigmaWorkbook) -> dg.AssetSpec:
+        # Adds a custom team owner for all Sigma assets
+        return super().get_asset_spec(data)._replace(owners=["team:my_team"])
 
 
 sigma_specs = load_sigma_asset_specs(

--- a/examples/docs_snippets/docs_snippets/integrations/sigma/customize-sigma-asset-defs.py
+++ b/examples/docs_snippets/docs_snippets/integrations/sigma/customize-sigma-asset-defs.py
@@ -18,7 +18,7 @@ sigma_organization = SigmaOrganization(
 # A translator class lets us customize properties of the built Sigma assets, such as the owners or asset key
 class MyCustomSigmaTranslator(DagsterSigmaTranslator):
     def get_asset_spec(self, data: SigmaWorkbook) -> dg.AssetSpec:
-        # Adds a custom team owner for all Sigma assets
+        # Adds a custom team owner tag for all Sigma assets
         return super().get_asset_spec(data)._replace(owners=["team:my_team"])
 
 

--- a/examples/docs_snippets/docs_snippets/integrations/tableau/customize-tableau-asset-defs.py
+++ b/examples/docs_snippets/docs_snippets/integrations/tableau/customize-tableau-asset-defs.py
@@ -22,7 +22,7 @@ tableau_workspace = TableauCloudWorkspace(
 class MyCustomTableauTranslator(DagsterTableauTranslator):
     def get_sheet_spec(self, data: TableauContentData) -> dg.AssetSpec:
         # We add a custom team owner tag to all sheets
-        return super().get_sheet_spec(data)._replace(owners=["my_team"])
+        return super().get_sheet_spec(data)._replace(owners=["team:my_team"])
 
 
 tableau_specs = load_tableau_asset_specs(


### PR DESCRIPTION
## Summary & Motivation

Fixes the custom translator examples for all four BI integrations - Looker, Power BI, Sigma and Tableau. Previous examples raised that error:

`dagster._core.errors.DagsterInvalidDefinitionError: Invalid owner 'my_team' for asset 'AssetKey(['My_Workbook'])'. Owner must be an email address or a team name prefixed with 'team:'.`

Also fixes comments and the method that is overloaded for Sigma.

