### PR TITLE
[dagster-airlift] Fix kitchen sink test on 3.12

### DIFF
--- a/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_instance.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/airflow_instance.py
@@ -53,7 +53,9 @@ class AirflowInstance:
         return f"{self.auth_backend.get_webserver_url()}/api/v1"
 
     def list_dags(self) -> List["DagInfo"]:
-        response = self.auth_backend.get_session().get(f"{self.get_api_url()}/dags")
+        response = self.auth_backend.get_session().get(
+            f"{self.get_api_url()}/dags", params={"limit": 1000}
+        )
         if response.status_code == 200:
             dags = response.json()
             webserver_url = self.auth_backend.get_webserver_url()

--- a/examples/experimental/dagster-airlift/dagster_airlift/test/shared_fixtures.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/test/shared_fixtures.py
@@ -1,6 +1,7 @@
 import os
 import signal
 import subprocess
+import sys
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -129,6 +130,11 @@ def dagster_dev_cmd(dagster_defs_path: str) -> List[str]:
 def setup_dagster(
     airflow_instance: None, dagster_home: str, dagster_dev_cmd: List[str]
 ) -> Generator[Any, None, None]:
+    # The version of airflow we use on 3.12 or greater (2.10.2) takes longer to reconcile the dags, and sometimes does it partially.
+    # We need to wait for all the dags to be loaded before we can start dagster.
+    # A better solution would be to poll the airflow instance for the existence of all expected dags, but this is a stopgap.
+    if sys.version_info >= (3, 12):
+        time.sleep(20)
     with stand_up_dagster(dagster_dev_cmd) as process:
         yield process
 


### PR DESCRIPTION
## Summary & Motivation
For some reason kitchen sink dags take extra long to load on 2.10.2. For now, just going to wait extra long on 3.12 (the tests that use 2.10.2)
## How I Tested These Changes
Existing tests actually pass on 3.12 now
