### PR TITLE
bring backfill page back and add banner

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
@@ -125,8 +125,8 @@ export const InstanceBackfills = () => {
               <span style={{fontWeight: 'normal'}}>
                 {' '}
                 We&apos;re incorporating backfills into the <Link to="/runs/">Runs</Link> page to
-                unify the UI and provide one page to see everything that is running. The Backfills
-                page will be removed in a future release.{' '}
+                unify the UI and provide one page to see all of your executions. The Backfills page
+                will be removed in a future release.{' '}
                 <a
                   href="https://github.com/dagster-io/dagster/discussions/24898"
                   target="_blank"

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
@@ -125,7 +125,8 @@ export const InstanceBackfills = () => {
               <span style={{fontWeight: 'normal'}}>
                 {' '}
                 We&apos;re incorporating backfills into the <Link to="/runs/">Runs</Link> page to
-                simplify the UI and make it easier to see what is running.{' '}
+                unify the UI and provide one page to see everything that is running. The Backfills
+                page will be removed in a future release.{' '}
                 <a
                   href="https://github.com/dagster-io/dagster/discussions/24898"
                   target="_blank"

--- a/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/instance/InstanceBackfills.tsx
@@ -1,19 +1,22 @@
 import {
+  Alert,
   Box,
   Colors,
   CursorPaginationControls,
   NonIdealState,
   Spinner,
 } from '@dagster-io/ui-components';
+import {Link} from 'react-router-dom';
 
 import {gql} from '../apollo-client';
 import {BACKFILL_TABLE_FRAGMENT, BackfillTable} from './backfill/BackfillTable';
+import {PythonErrorInfo} from '../app/PythonErrorInfo';
+import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {
   InstanceBackfillsQuery,
   InstanceBackfillsQueryVariables,
 } from './types/InstanceBackfills.types';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
-import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {
   FIFTEEN_SECONDS,
   QueryRefreshCountdown,
@@ -103,6 +106,41 @@ export const InstanceBackfills = () => {
   const isDaemonHealthy = useIsBackfillDaemonHealthy();
   const refreshState = useQueryRefreshAtInterval(queryResult, FIFTEEN_SECONDS);
   const {loading, data} = queryResult;
+  const [didDismissBackfillPageAlert, setDidDismissBackfillPageAlert] =
+    useStateWithStorage<boolean>('new_backfill_location_alert', (json) => !!json);
+
+  interface AlertProps {
+    setDidDismissBackfillPageAlert: (didDismissBackfillPageAlert: boolean) => void;
+  }
+
+  const BackfillPageDeprecationAlert = (props: AlertProps) => {
+    const {setDidDismissBackfillPageAlert} = props;
+
+    return (
+      <Box padding={8} border="top-and-bottom">
+        <Alert
+          title={
+            <>
+              <span>Backfills are moving:</span>
+              <span style={{fontWeight: 'normal'}}>
+                {' '}
+                We&apos;re incorporating backfills into the <Link to="/runs/">Runs</Link> page to
+                simplify the UI and make it easier to see what is running.{' '}
+                <a
+                  href="https://github.com/dagster-io/dagster/discussions/24898"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Share feedback
+                </a>{' '}
+              </span>
+            </>
+          }
+          onClose={() => setDidDismissBackfillPageAlert(true)}
+        />
+      </Box>
+    );
+  };
 
   const content = () => {
     if (loading && !data) {
@@ -167,6 +205,11 @@ export const InstanceBackfills = () => {
 
   return (
     <>
+      {!didDismissBackfillPageAlert ? (
+        <BackfillPageDeprecationAlert
+          setDidDismissBackfillPageAlert={setDidDismissBackfillPageAlert}
+        />
+      ) : null}
       <Box
         padding={{vertical: 12, horizontal: 20}}
         flex={{direction: 'row', alignItems: 'center', justifyContent: 'space-between'}}

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewRoot.tsx
@@ -1,9 +1,7 @@
 import {Redirect, Switch} from 'react-router-dom';
-import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
 import {OverviewActivityRoot} from './OverviewActivityRoot';
 import {OverviewResourcesRoot} from './OverviewResourcesRoot';
-import {featureEnabled} from '../app/Flags';
 import {Route} from '../app/Route';
 import {AutomaterializationRoot} from '../assets/auto-materialization/AutomaterializationRoot';
 import {InstanceBackfillsRoot} from '../instance/InstanceBackfillsRoot';
@@ -19,21 +17,8 @@ export const OverviewRoot = () => {
       <Route path="/overview/schedules" render={() => <Redirect to="/automation" />} />
       <Route path="/overview/sensors" render={() => <Redirect to="/automation" />} />
       <Route path="/overview/automation" render={() => <AutomaterializationRoot />} />
-      {featureEnabled(FeatureFlag.flagLegacyRunsPage)
-        ? [
-            <Route
-              path="/overview/backfills/:backfillId"
-              render={() => <BackfillPage />}
-              key="1"
-            />,
-            <Route
-              path="/overview/backfills"
-              exact
-              render={() => <InstanceBackfillsRoot />}
-              key="2"
-            />,
-          ]
-        : null}
+      <Route path="/overview/backfills/:backfillId" render={() => <BackfillPage />} />
+      <Route path="/overview/backfills" exact render={() => <InstanceBackfillsRoot />} />
       <Route path="/overview/resources">
         <OverviewResourcesRoot />
       </Route>

--- a/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/overview/OverviewTabs.tsx
@@ -2,7 +2,6 @@ import {Box, Colors, Spinner, Tabs} from '@dagster-io/ui-components';
 import {useContext} from 'react';
 
 import {QueryResult} from '../apollo-client';
-import {useFeatureFlags} from '../app/Flags';
 import {QueryRefreshCountdown, RefreshState} from '../app/QueryRefresh';
 import {AssetFeatureContext} from '../assets/AssetFeatureContext';
 import {useAutoMaterializeSensorFlag} from '../assets/AutoMaterializeSensorFlag';
@@ -17,8 +16,6 @@ interface Props<TData> {
 
 export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TData>) => {
   const {refreshState, tab} = props;
-
-  const {flagLegacyRunsPage} = useFeatureFlags();
 
   const automaterialize = useAutomaterializeDaemonStatus();
   const automaterializeSensorsFlagState = useAutoMaterializeSensorFlag();
@@ -58,9 +55,7 @@ export const OverviewTabs = <TData extends Record<string, any>>(props: Props<TDa
           />
         ) : null}
         <TabLink id="resources" title="Resources" to="/overview/resources" />
-        {flagLegacyRunsPage ? (
-          <TabLink id="backfills" title="Backfills" to="/overview/backfills" />
-        ) : null}
+        <TabLink id="backfills" title="Backfills" to="/overview/backfills" />
       </Tabs>
       {refreshState ? (
         <Box style={{alignSelf: 'center'}}>


### PR DESCRIPTION
## Summary & Motivation
Keeps the backfill page for everyone regardless of what version of the runs feed they are using. We have a banner explaining that the backfills will be moving and linking to the Runs page 

<img width="1918" alt="Screenshot 2024-10-31 at 9 45 54 AM" src="https://github.com/user-attachments/assets/257322d1-4a99-435e-b36b-ade8df7098b3">


The experience is a bit odd if they have the legacy runs page enabled because the link to the runs page does not include backfills. I'm not quite sure what to do about this, but want to start the review process while we figure it out

An alternative is to still hide the backfill page if the new runs feed is being used, and add a banner to the Overview page that says "backfills have moved to the Runs page, or you can revert to the old behavior"

## How I Tested These Changes
👀 