### PR TITLE
adjust the timeline runs status filter to match all in progress runs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useRunsForTimeline.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/__tests__/useRunsForTimeline.test.tsx
@@ -85,7 +85,7 @@ const mockOngoingRuns = ({
     query: ONGOING_RUN_TIMELINE_QUERY,
     variables: {
       inProgressFilter: {
-        statuses: ['CANCELING', 'STARTED'],
+        statuses: ['STARTED', 'STARTING', 'CANCELING'],
         ...runsFilter,
       },
       cursor,

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useRunsForTimeline.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useContext, useLayoutEffect, useMemo, useRef, useState} from 'react';
 
 import {HourlyDataCache, getHourlyBuckets} from './HourlyDataCache/HourlyDataCache';
-import {doneStatuses} from './RunStatuses';
+import {doneStatuses, inProgressStatuses} from './RunStatuses';
 import {TimelineRow, TimelineRun} from './RunTimelineTypes';
 import {RUN_TIME_FRAGMENT} from './RunUtils';
 import {overlap} from './batchRunsForTimeline';
@@ -21,7 +21,7 @@ import {
 import {AppContext} from '../app/AppContext';
 import {FIFTEEN_SECONDS, useRefreshAtInterval} from '../app/QueryRefresh';
 import {isHiddenAssetGroupJob} from '../asset-graph/Utils';
-import {InstigationStatus, RunStatus, RunsFilter} from '../graphql/types';
+import {InstigationStatus, RunsFilter} from '../graphql/types';
 import {SCHEDULE_FUTURE_TICKS_FRAGMENT} from '../instance/NextTick';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
@@ -255,7 +255,7 @@ export const useRunsForTimeline = ({
             variables: {
               inProgressFilter: {
                 ...runsFilter,
-                statuses: [RunStatus.CANCELING, RunStatus.STARTED],
+                statuses: Array.from(inProgressStatuses),
               },
               cursor,
               limit: batchLimit,


### PR DESCRIPTION
## Summary & Motivation
Minor, but for consistency we should grab all in progress runs.  Currently, we ignore `STARTING` state, but that should be included.

## How I Tested These Changes
Inspection
