### PR TITLE
[dagster-tableau] Add helper fn to parse Tableau asset specs

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/__init__.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/__init__.py
@@ -1,5 +1,8 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
+from dagster_tableau.asset_utils import (
+    parse_tableau_external_and_materializable_asset_specs as parse_tableau_external_and_materializable_asset_specs,
+)
 from dagster_tableau.assets import (
     build_tableau_materializable_assets_definition as build_tableau_materializable_assets_definition,
 )

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/asset_utils.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/asset_utils.py
@@ -1,0 +1,21 @@
+from typing import Sequence, Tuple
+
+from dagster import AssetSpec
+
+from dagster_tableau.translator import TableauTagSet
+
+
+def parse_tableau_external_and_materializable_asset_specs(
+    specs: Sequence[AssetSpec],
+) -> Tuple[Sequence[AssetSpec], Sequence[AssetSpec]]:
+    external_asset_specs = [
+        spec for spec in specs if TableauTagSet.extract(spec.tags).asset_type == "data_source"
+    ]
+
+    materializable_asset_specs = [
+        spec
+        for spec in specs
+        if TableauTagSet.extract(spec.tags).asset_type in ["dashboard", "sheet"]
+    ]
+
+    return external_asset_specs, materializable_asset_specs

--- a/python_modules/libraries/dagster-tableau/dagster_tableau/asset_utils.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/asset_utils.py
@@ -1,13 +1,36 @@
-from typing import Sequence, Tuple
+from collections import namedtuple
+from typing import Sequence
 
-from dagster import AssetSpec
+from dagster import (
+    AssetSpec,
+    _check as check,
+)
 
 from dagster_tableau.translator import TableauTagSet
 
 
+class ParsedTableauAssetSpecs(
+    namedtuple("_ParsedTableauAssetSpecs", ["external_asset_specs", "materializable_asset_specs"])
+):
+    """Used to represent the parsed Tableau asset specs
+    as returned by the `parse_tableau_external_and_materializable_asset_specs` function below.
+    """
+
+    def __new__(cls, external_asset_specs, materializable_asset_specs):
+        return super(ParsedTableauAssetSpecs, cls).__new__(
+            cls,
+            external_asset_specs=check.list_param(
+                external_asset_specs, "external_asset_specs", AssetSpec
+            ),
+            materializable_asset_specs=check.list_param(
+                materializable_asset_specs, "materializable_asset_specs", AssetSpec
+            ),
+        )
+
+
 def parse_tableau_external_and_materializable_asset_specs(
     specs: Sequence[AssetSpec],
-) -> Tuple[Sequence[AssetSpec], Sequence[AssetSpec]]:
+) -> ParsedTableauAssetSpecs:
     external_asset_specs = [
         spec for spec in specs if TableauTagSet.extract(spec.tags).asset_type == "data_source"
     ]
@@ -18,4 +41,7 @@ def parse_tableau_external_and_materializable_asset_specs(
         if TableauTagSet.extract(spec.tags).asset_type in ["dashboard", "sheet"]
     ]
 
-    return external_asset_specs, materializable_asset_specs
+    return ParsedTableauAssetSpecs(
+        external_asset_specs=external_asset_specs,
+        materializable_asset_specs=materializable_asset_specs,
+    )

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
@@ -14,6 +14,7 @@ from dagster._core.events import DagsterEventType
 from dagster._core.execution.api import create_execution_plan, execute_plan
 from dagster._core.instance_for_test import instance_for_test
 from dagster._utils.test.definitions import lazy_definitions
+from dagster_tableau.asset_utils import parse_tableau_external_and_materializable_asset_specs
 from dagster_tableau.assets import build_tableau_materializable_assets_definition
 from dagster_tableau.resources import TableauCloudWorkspace, load_tableau_asset_specs
 from dagster_tableau.translator import DagsterTableauTranslator
@@ -43,17 +44,9 @@ def cacheable_asset_defs_refreshable_workbooks():
         workspace=resource,
     )
 
-    external_asset_specs = [
-        spec
-        for spec in tableau_specs
-        if spec.tags.get("dagster-tableau/asset_type") == "data_source"
-    ]
-
-    materializable_asset_specs = [
-        spec
-        for spec in tableau_specs
-        if spec.tags.get("dagster-tableau/asset_type") in ["dashboard", "sheet"]
-    ]
+    external_asset_specs, materializable_asset_specs = (
+        parse_tableau_external_and_materializable_asset_specs(tableau_specs)
+    )
 
     resource_key = "tableau"
 


### PR DESCRIPTION
## Summary & Motivation

Adds `parse_tableau_external_and_materializable_asset_specs` as an helper function, to make it easier for users to parse external and materializable asset specs for Tableau.

Updated boilerplate to build materializable asset definitions:

```python
# Load Tableau asset specs
tableau_specs = load_tableau_asset_specs(
    workspace=tableau_workspace,
)

external_asset_specs, materializable_asset_specs = (
    parse_tableau_external_and_materializable_asset_specs(tableau_specs)
)

# Use the asset definition builder to construct the definition for tableau materializable assets
defs = dg.Definitions(
    assets=[
        build_tableau_materializable_assets_definition(
            resource_key="tableau",
            specs=materializable_asset_specs,
            refreshable_workbook_ids=["b75fc023-a7ca-4115-857b-4342028640d0"],
        ),
        *external_asset_specs,
    ],
    resources={"tableau": tableau_workspace},
)
```

## How I Tested These Changes

Updated tests

## Changelog

[dagster-tableau] the helper function `parse_tableau_external_and_materializable_asset_specs` is now available to parse a list of Tableau asst specs into a list of external asset specs and materializable asset specs.

