### PR TITLE
Fix asset wipe mutation with missing dynamic partitions store

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/execution/__init__.py
@@ -360,7 +360,9 @@ def wipe_assets(
 
             node = graphene_info.context.asset_graph.asset_node_snaps_by_key[apr.asset_key]
             partitions_def = check.not_none(node.partitions).get_partitions_definition()
-            partition_keys = partitions_def.get_partition_keys_in_range(apr.partition_range)
+            partition_keys = partitions_def.get_partition_keys_in_range(
+                apr.partition_range, dynamic_partitions_store=instance
+            )
             try:
                 instance.wipe_asset_partitions(apr.asset_key, partition_keys)
 


### PR DESCRIPTION
## Summary & Motivation
Fix the asset wipe mutation for dynamically partitioned assets.

## How I Tested These Changes
Will add test in a follow up PR.

## Changelog
Fixes an issue where wiping a dynamically partitioned asset causes an error.
