### PR TITLE
[dagster-looker] Remove duplicated closing tag to fix Looker docs

### DIFF
--- a/docs/content/integrations/looker.mdx
+++ b/docs/content/integrations/looker.mdx
@@ -26,8 +26,6 @@ This guide provides instructions for using Dagster with Looker using the `dagste
 
 </details>
 
-</details>
-
 ## Set up your environment
 
 To get started, you'll need to install the `dagster` and `dagster-looker` Python packages:


### PR DESCRIPTION
## Summary & Motivation

A duplicated `</details>` closing tag was added by mistake in #25526, resulting in the Looker docs page returning an HTTP 404 error, see [here](https://dagster-docs-52e9achy6-elementl.vercel.app/integrations/looker).

This PR fixes this by removing the duplicated closing tag.

The main problem here is that the page disappeared silently. My understanding is that the compilation of this page failed because of the duplicated tag, but that was not flagged when deploying the preview.

## How I Tested These Changes

Docs preview, the [page is back](https://maxime-fix-looker-docs-404.dagster.dagster-docs.io/integrations/looker) 
