### PR TITLE
[pipes] add PipesDefaultLogWriter (send logs via Pipes messages)

### DIFF
--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -1684,9 +1684,7 @@ class PipesContext:
         """
         self._write_message("report_custom_message", {"payload": payload})
 
-    def log_external_stream(
-        self, stream: Literal["stdout", "stderr"], text: str, extras: Optional[PipesExtras] = None
-    ):
+    def log_external_stream(self, stream: str, text: str, extras: Optional[PipesExtras] = None):
         self._write_message(
             "log_external_stream", {"stream": stream, "text": text, "extras": extras or {}}
         )

--- a/python_modules/dagster-pipes/dagster_pipes_tests/test_log_writer.py
+++ b/python_modules/dagster-pipes/dagster_pipes_tests/test_log_writer.py
@@ -6,12 +6,13 @@ from time import sleep
 
 from dagster_pipes import (
     PipesDefaultLogWriter,
+    PipesDefaultMessageWriter,
     PipesFileMessageWriterChannel,
     PipesStdioFileLogWriter,
 )
 
 
-def test_pipes_out_err_file_log_writer(capsys):
+def test_pipes_stdio_file_log_writer(capsys):
     with tempfile.TemporaryDirectory() as tempdir:
         with capsys.disabled(), PipesStdioFileLogWriter().open(
             {
@@ -47,10 +48,10 @@ def test_pipes_default_log_writer(capsys):
     with tempfile.NamedTemporaryFile() as file:
         message_channel = PipesFileMessageWriterChannel(file.name)
 
-        log_writer = PipesDefaultLogWriter(
-            message_channel=message_channel
-        )  # large interval will cause all lines to appear in a single message
-        with capsys.disabled(), log_writer.open({}):
+        log_writer = PipesDefaultLogWriter(message_channel=message_channel)
+        with capsys.disabled(), log_writer.open(
+            {PipesDefaultMessageWriter.INCLUDE_STDIO_IN_MESSAGES_KEY: True}
+        ):
             print("Writing this to stdout")  # noqa
             print("And this to stderr", file=sys.stderr)  # noqa
         with open(file.name, "r") as log_file:

--- a/python_modules/dagster/dagster/_core/pipes/context.py
+++ b/python_modules/dagster/dagster/_core/pipes/context.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -9,6 +10,7 @@ from typing import (
     Any,
     Dict,
     Iterator,
+    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -51,7 +53,7 @@ from dagster._core.definitions.time_window_partitions import (
     TimeWindow,
     has_one_dimension_time_window_partitioning,
 )
-from dagster._core.errors import DagsterPipesExecutionError
+from dagster._core.errors import DagsterInvariantViolationError, DagsterPipesExecutionError
 from dagster._core.events import EngineEventData
 from dagster._core.execution.context.asset_execution_context import AssetExecutionContext
 from dagster._core.execution.context.invocation import BaseDirectExecutionContext
@@ -101,6 +103,7 @@ class PipesMessageHandler:
         self._extra_msg_queue: Queue[Any] = Queue()
         # Only read by the main thread after all messages are handled, so no need for a lock
         self._received_opened_msg = False
+        self._messages_include_stdio_logs = False
         self._received_closed_msg = False
         self._opened_payload: Optional[PipesOpenedData] = None
 
@@ -182,6 +185,8 @@ class PipesMessageHandler:
             self._handle_report_asset_check(**message["params"])  # type: ignore
         elif method == "log":
             self._handle_log(**message["params"])  # type: ignore
+        elif method == "log_external_stream":
+            self._handle_log_external_stream(**message["params"])  # type: ignore
         elif method == "report_custom_message":
             self._handle_extra_message(**message["params"])  # type: ignore
         else:
@@ -250,6 +255,16 @@ class PipesMessageHandler:
     def _handle_log(self, message: str, level: str = "info") -> None:
         check.str_param(message, "message")
         self._context.log.log(level, message)
+
+    def _handle_log_external_stream(
+        self, stream: Literal["stdout", "stderr"], text: str, extras: Optional[PipesExtras] = None
+    ):
+        if stream == "stdout":
+            sys.stdout.write(text)
+        elif stream == "stderr":
+            sys.stderr.write(text)
+        else:
+            raise DagsterInvariantViolationError(f"Unexpected stream: {stream}")
 
     def _handle_extra_message(self, payload: Any):
         self._extra_msg_queue.put(payload)

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_log_writer.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_log_writer.py
@@ -1,0 +1,67 @@
+import shutil
+from typing import Iterator
+
+import pytest
+from dagster import AssetExecutionContext, DagsterInstance, asset, materialize
+from dagster._core.pipes.subprocess import PipesSubprocessClient
+from dagster._core.pipes.utils import PipesTempFileMessageReader
+
+from dagster_tests.execution_tests.pipes_tests.utils import temp_script
+
+_PYTHON_EXECUTABLE = shutil.which("python")
+
+
+@pytest.fixture
+def external_script_default_log_writer() -> Iterator[str]:
+    # This is called in an external process and so cannot access outer scope
+    def script_fn():
+        import sys
+
+        from dagster_pipes import open_dagster_pipes
+
+        with open_dagster_pipes():
+            print("Writing this to stdout")  # noqa
+            print("And this to stderr", file=sys.stderr)  # noqa
+
+        print("this stdout should not be captured")  # noqa
+        print("this stderr should not be captured", file=sys.stderr)  # noqa
+
+    with temp_script(script_fn) as script_path:
+        yield script_path
+
+
+def test_pipes_default_log_writer(
+    tmpdir,
+    capsys,
+    external_script_default_log_writer,
+):
+    message_reader = PipesTempFileMessageReader(
+        include_stdio_in_messages=True,
+    )
+
+    @asset
+    def foo(context: AssetExecutionContext, ext: PipesSubprocessClient):
+        cmd = [_PYTHON_EXECUTABLE, external_script_default_log_writer]
+        return ext.run(
+            command=cmd,
+            context=context,
+        ).get_results()
+
+    resource = PipesSubprocessClient(message_reader=message_reader, forward_stdio=False)
+
+    with DagsterInstance.ephemeral() as instance:
+        result = materialize(
+            [foo], instance=instance, resources={"ext": resource}, raise_on_error=False
+        )
+
+    # return
+    assert result.success
+
+    captured = capsys.readouterr()
+    stdout, stderr = captured.out, captured.err
+
+    assert "Writing this to stdout" in stdout
+    assert "This stdout should not be captured" not in stdout
+
+    assert "And this to stderr" in stderr
+    assert "This stderr should not be captured" not in stderr


### PR DESCRIPTION
## Summary & Motivation

This PR adds a new `PipesDefaultLogWriter` which writes stdout/stderr via the `PipesMessageWriter` messages. 

It emits messages of a new type `log_external_stream`.  

## How I Tested These Changes

Added tests

## Changelog

[dagster-pipes] Experimental: A new Dagster Pipes message type `log_external_stream` has been added. It can be used to forward external logs to Dagster via Pipes messages. 
