### PR TITLE
[dagster-looker] Fix lkml parsing of unions, try/except optimize

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker/lkml/dagster_looker_lkml_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/lkml/dagster_looker_lkml_translator.py
@@ -10,6 +10,7 @@ from sqlglot import exp, parse_one, to_table
 from sqlglot.optimizer import Scope, build_scope, optimize
 
 from dagster_looker.lkml.liquid_utils import best_effort_render_liquid_sql
+from dagster_looker.lkml.sqlglot_utils import custom_bigquery_dialect_inst
 
 LookMLStructureType = Literal["dashboard", "explore", "table", "view"]
 
@@ -75,14 +76,15 @@ def build_deps_for_looker_view(
     lookml_structure: Tuple[Path, LookMLStructureType, Mapping[str, Any]],
 ) -> Sequence[AssetKey]:
     lookml_view_path, _, lookml_view_props = lookml_structure
-    sql_dialect = "bigquery"
 
     # https://cloud.google.com/looker/docs/derived-tables
     derived_table_sql: Optional[str] = lookml_view_props.get("derived_table", {}).get("sql")
     if not derived_table_sql:
         # https://cloud.google.com/looker/docs/reference/param-view-sql-table-name
         sql_table_name = lookml_view_props.get("sql_table_name") or lookml_view_props["name"]
-        sqlglot_table = to_table(sql_table_name.replace("`", ""), dialect=sql_dialect)
+        sqlglot_table = to_table(
+            sql_table_name.replace("`", ""), dialect=custom_bigquery_dialect_inst
+        )
 
         return [
             dagster_looker_translator.get_asset_key(
@@ -116,12 +118,20 @@ def build_deps_for_looker_view(
         rendered_liquid_sql = best_effort_render_liquid_sql(
             lookml_view_props["name"], lookml_view_path.name, derived_table_sql
         )
-        optimized_derived_table_ast = optimize(
-            parse_one(sql=rendered_liquid_sql, dialect=sql_dialect),
-            dialect=sql_dialect,
-            validate_qualify_columns=False,
+        parsed_derived_table_ast = parse_one(
+            sql=rendered_liquid_sql, dialect=custom_bigquery_dialect_inst
         )
-        root_scope = build_scope(optimized_derived_table_ast)
+        ast_to_evaluate = parsed_derived_table_ast
+        try:
+            optimized_derived_table_ast = optimize(
+                parsed_derived_table_ast,
+                dialect=custom_bigquery_dialect_inst,
+                validate_qualify_columns=False,
+            )
+            ast_to_evaluate = optimized_derived_table_ast
+        except Exception:
+            pass
+        root_scope = build_scope(ast_to_evaluate)
 
         upstream_sqlglot_tables = [
             source
@@ -131,7 +141,7 @@ def build_deps_for_looker_view(
         ]
     except Exception as e:
         logger.warn(
-            f"Failed to optimize derived table SQL for view `{lookml_view_props['name']}`"
+            f"Failed to parse derived table SQL for view `{lookml_view_props['name']}`"
             f" in file `{lookml_view_path.name}`."
             " The upstream dependencies for the view will be omitted.\n\n"
             f"Exception: {e}"

--- a/python_modules/libraries/dagster-looker/dagster_looker/lkml/dagster_looker_lkml_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/lkml/dagster_looker_lkml_translator.py
@@ -6,7 +6,7 @@ from typing import Any, Iterator, Literal, Mapping, Optional, Sequence, Tuple, c
 
 from dagster import AssetKey
 from dagster._annotations import experimental, public
-from sqlglot import exp, parse_one, to_table
+from sqlglot import ParseError, exp, parse_one, to_table
 from sqlglot.optimizer import Scope, build_scope, optimize
 
 from dagster_looker.lkml.liquid_utils import best_effort_render_liquid_sql
@@ -129,7 +129,7 @@ def build_deps_for_looker_view(
                 validate_qualify_columns=False,
             )
             ast_to_evaluate = optimized_derived_table_ast
-        except Exception:
+        except ParseError:
             pass
         root_scope = build_scope(ast_to_evaluate)
 

--- a/python_modules/libraries/dagster-looker/dagster_looker/lkml/liquid_utils.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/lkml/liquid_utils.py
@@ -3,6 +3,7 @@ import sys
 
 from liquid import Environment
 from liquid.ast import Node
+from liquid.builtin.literal import LiteralNode, Token
 from liquid.parse import expect, get_parser
 from liquid.stream import TokenStream
 from liquid.tag import Tag
@@ -39,8 +40,33 @@ class ConditionTag(Tag):
         return block
 
 
+TAG_DATE_START = sys.intern("date_start")
+TAG_DATE_END = sys.intern("date_end")
+
+
+class DateTag(Tag):
+    def __init__(self, env: Environment):
+        super().__init__(env)
+        self.parser = get_parser(self.env)
+
+    def parse(self, stream: TokenStream) -> Node:
+        expect(stream, TOKEN_TAG, value=self.name)
+        stream.next_token()
+        return LiteralNode(tok=Token(1, "date", "'2021-01-01'"))
+
+
+class DateStartTag(DateTag):
+    name = TAG_DATE_START
+
+
+class DateEndTag(DateTag):
+    name = TAG_DATE_END
+
+
 env = Environment()
 env.add_tag(ConditionTag)
+env.add_tag(DateStartTag)
+env.add_tag(DateEndTag)
 
 
 def best_effort_render_liquid_sql(model_name: str, filename: str, sql: str) -> str:

--- a/python_modules/libraries/dagster-looker/dagster_looker/lkml/sqlglot_utils.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/lkml/sqlglot_utils.py
@@ -1,0 +1,20 @@
+from dagster import _check as check
+from sqlglot import (
+    Dialect,
+    Dialects,
+    expressions as exp,
+)
+
+bq = Dialects.BIGQUERY
+
+custom_bigquery_dialect = check.not_none(Dialect.get(key=Dialects.BIGQUERY))
+custom_bigquery_dialect_inst = custom_bigquery_dialect()
+
+# Set the default value for the DISTINCT keyword in set operations to True.
+# Right now, unions which don't specify UNIQUE or DISTINCT keywords lead to an error
+# because sqlglot doesn't assume default behavior for bigquery set operations. Looker
+# is OK with this behavior, so we're setting the default to True.
+custom_bigquery_dialect_inst.SET_OP_DISTINCT_BY_DEFAULT = {
+    **custom_bigquery_dialect_inst.SET_OP_DISTINCT_BY_DEFAULT,
+    exp.Union: True,
+}

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/lkml/test_asset_specs.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/lkml/test_asset_specs.py
@@ -15,6 +15,7 @@ from dagster_looker_tests.looker_projects import (
     test_liquid_path,
     test_refinements,
     test_retail_demo_path,
+    test_union_no_distinct_path,
 )
 
 
@@ -296,6 +297,14 @@ def test_asset_deps_exception_derived_table(caplog: pytest.LogCaptureFixture) ->
         " in file `exception_derived_table.view.lkml`."
         " The upstream dependencies for the view will be omitted."
     ) in caplog.text
+
+
+def test_union_no_distinct_table(caplog: pytest.LogCaptureFixture) -> None:
+    [spec] = build_looker_asset_specs(project_dir=test_union_no_distinct_path)
+
+    assert spec.key == AssetKey(["view", "union_table"])
+    # Ensure we parse out the union correctly
+    assert len(list(spec.deps)) == 2
 
 
 def test_liquid(caplog: pytest.LogCaptureFixture) -> None:

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/lkml/test_asset_specs.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/lkml/test_asset_specs.py
@@ -293,7 +293,7 @@ def test_asset_deps_exception_derived_table(caplog: pytest.LogCaptureFixture) ->
     assert spec.key == AssetKey(["view", "exception_derived_table"])
     assert not spec.deps
     assert (
-        "Failed to optimize derived table SQL for view `exception_derived_table`"
+        "Failed to parse derived table SQL for view `exception_derived_table`"
         " in file `exception_derived_table.view.lkml`."
         " The upstream dependencies for the view will be omitted."
     ) in caplog.text

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/looker_projects/__init__.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/looker_projects/__init__.py
@@ -7,3 +7,4 @@ test_exception_derived_table_path = projects_path.joinpath("test_exception_deriv
 test_refinements = projects_path.joinpath("test_refinements")
 test_extensions = projects_path.joinpath("test_extensions")
 test_liquid_path = projects_path.joinpath("test_liquid")
+test_union_no_distinct_path = projects_path.joinpath("test_union_no_distinct")

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/looker_projects/test_liquid/views/liquid_derived_table.view.lkml
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/looker_projects/test_liquid/views/liquid_derived_table.view.lkml
@@ -6,6 +6,10 @@ view: liquid_derived_table {
       FROM `looker-private-demo.retail.us_stores`
       WHERE 1=1
         {% if _model._name == 'thelook' %} AND 1=1 {% endif %}
-        AND {% condition holiday %} holiday {% endcondition %} ;;
+        AND {% condition holiday %} holiday {% endcondition %}
+        AND CONVERT_TIMEZONE('America/New_York', timestamp)::DATE BETWEEN
+            COALESCE({% date_start us_stores.start_date %},  DATEADD(week, -1, {% date_end us_stores.end_date %}))
+            AND COALESCE({% date_end us_stores.end_date %}, CONVERT_TIMEZONE('UTC', 'America/New_York', GETDATE()))
+        ;;
   }
 }

--- a/python_modules/libraries/dagster-looker/dagster_looker_tests/looker_projects/test_union_no_distinct/views/union_table.view.lkml
+++ b/python_modules/libraries/dagster-looker/dagster_looker_tests/looker_projects/test_union_no_distinct/views/union_table.view.lkml
@@ -1,0 +1,12 @@
+view: union_table {
+  derived_table: {
+    sql:
+      SELECT
+        *
+      FROM (
+        select * from `looker-private-demo.retail.us_stores`
+        UNION
+        select * from `looker-private-demo.retail.eu_stores`
+      ) ;;
+  }
+}


### PR DESCRIPTION
## Summary

try/catch guards the sqlglot optimize of looker derived tables, in case the optimization fails but the parse succeeds, we may still be able to extract lineage.

Also fixes an issue where Looker union syntax supports not specifying unique/distinct criteria, but sqlglot errors - do this by constructing a custom sqlglot dialect.

## How I Tested These Changes

New unit test.

## Changelog

> `[dagster-looker] More gracefully handle errors in optimizing derived table parsing. Properly handle unions without unique/distinct criteria.`
