### PR TITLE
[dagster-sling] Backcompat handling for DagsterSlingTranslator

### DIFF
--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt/sling/dagster_sling_translator.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from typing import Any, Iterable, Mapping, Optional, Set
+from typing import Any, Iterable, Mapping, Optional, Set, Union
 
 from dagster import AssetKey, AutoMaterializePolicy, FreshnessPolicy, MetadataValue
 from dagster._annotations import public
@@ -99,7 +99,9 @@ class DagsterSlingTranslator:
         return AssetKey([self.target_prefix] + sanitized_components)
 
     @public
-    def get_deps_asset_key(self, stream_definition: Mapping[str, Any]) -> Iterable[AssetKey]:
+    def get_deps_asset_key(
+        self, stream_definition: Mapping[str, Any]
+    ) -> Union[AssetKey, Iterable[AssetKey]]:
         """A function that takes a stream name from a Sling replication config and returns a
         Dagster AssetKey for the dependencies of the replication stream.
 


### PR DESCRIPTION
## Summary & Motivation

As title -- the docs were out of sync with the type hint, this change makes either option valid

## How I Tested These Changes

## Changelog

[dagster-sling] The `get_deps_asset_key` method of the `DagsterSlingTranslator` was erroneously given a return type of `Iterable[AssetKey]` in code, whereas documentation examples showed `AssetKey` as the proper return type. Due to an unintended interaction, overriding this method and returning a single `AssetKey` would work prior to 1.9.0, but this interaction was intentionally broken, which would result in errors for methods returning an `AssetKey`. The return type of this method has been updated to `Union[AssetKey, Iterable[AssetKey]]`, and now either return type will function without error.
