### PR TITLE
Fixing install_dev_python_modules Make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ install_dev_python_modules_verbose:
 	python scripts/install_dev_python_modules.py
 
 install_dev_python_modules_verbose_m1:
-	python scripts/install_dev_python_modules.py -qqq --include-prebuilt-grpcio-wheel
+	python scripts/install_dev_python_modules.py -q --include-prebuilt-grpcio-wheel
 
 graphql:
 	cd js_modules/dagster-ui/; make generate-graphql; make generate-perms

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ prettier:
 	':!:README.md'` --write
 
 install_dev_python_modules:
-	python scripts/install_dev_python_modules.py -qqq
+	python scripts/install_dev_python_modules.py -q
 
 install_dev_python_modules_verbose:
 	python scripts/install_dev_python_modules.py


### PR DESCRIPTION
## Summary & Motivation
Addressing #25709

## How I Tested These Changes
Created a new virtual environment, then ran `make install_dev_python_modules`, confirming the modules were installed correctly.
