### PR TITLE
[ui] Fix events missing on Asset > Events when mat + observations both present

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
@@ -151,60 +151,54 @@ export const RecentUpdatesTimeline = ({
           {bucketedMaterializations.map((bucket) => {
             const width = bucket.end - bucket.start;
             return (
-              <>
-                <TickWrapper
-                  key={bucket.start}
-                  style={{
-                    left: (100 * bucket.start) / buckets + '%',
-                    width: (100 * width) / buckets + '%',
-                  }}
-                >
-                  {bucket.materializations.map(({timestamp}) => {
-                    const bucketStartTime = startTimestamp + bucket.start * bucketTimeRange;
-                    const bucketEndTimestamp = startTimestamp + bucket.end * bucketTimeRange;
-                    const bucketRange = bucketEndTimestamp - bucketStartTime;
-                    const percent = (100 * (parseInt(timestamp) - bucketStartTime)) / bucketRange;
+              <TickWrapper
+                key={bucket.start}
+                style={{
+                  left: (100 * bucket.start) / buckets + '%',
+                  width: (100 * width) / buckets + '%',
+                }}
+              >
+                {bucket.materializations.map(({timestamp}) => {
+                  const bucketStartTime = startTimestamp + bucket.start * bucketTimeRange;
+                  const bucketEndTimestamp = startTimestamp + bucket.end * bucketTimeRange;
+                  const bucketRange = bucketEndTimestamp - bucketStartTime;
+                  const percent = (100 * (parseInt(timestamp) - bucketStartTime)) / bucketRange;
 
-                    return (
-                      <InnerTick
-                        key={timestamp}
-                        style={{
-                          // Make sure there's enough room to see the last tick.
-                          left: `min(calc(100% - ${INNER_TICK_WIDTH}px), ${percent}%`,
-                        }}
-                      />
-                    );
-                  })}
-                  <Popover
-                    position="top"
-                    interactionKind="hover"
-                    content={
-                      <Box flex={{direction: 'column', gap: 8}}>
-                        <Box padding={8} border="bottom">
-                          <Subtitle2>Updates</Subtitle2>
-                        </Box>
-                        <div style={{maxHeight: 'min(80vh, 300px)', overflow: 'scroll'}}>
-                          {bucket.materializations
-                            .sort((a, b) => parseInt(b.timestamp) - parseInt(a.timestamp))
-                            .map((materialization, index) => (
-                              <AssetUpdate
-                                assetKey={assetKey}
-                                event={materialization}
-                                key={index}
-                              />
-                            ))}
-                        </div>
+                  return (
+                    <InnerTick
+                      key={timestamp}
+                      style={{
+                        // Make sure there's enough room to see the last tick.
+                        left: `min(calc(100% - ${INNER_TICK_WIDTH}px), ${percent}%`,
+                      }}
+                    />
+                  );
+                })}
+                <Popover
+                  position="top"
+                  interactionKind="hover"
+                  content={
+                    <Box flex={{direction: 'column', gap: 8}}>
+                      <Box padding={8} border="bottom">
+                        <Subtitle2>Updates</Subtitle2>
                       </Box>
-                    }
-                  >
-                    <>
-                      <Tick>
-                        <TickText>{bucket.materializations.length}</TickText>
-                      </Tick>
-                    </>
-                  </Popover>
-                </TickWrapper>
-              </>
+                      <div style={{maxHeight: 'min(80vh, 300px)', overflow: 'scroll'}}>
+                        {bucket.materializations
+                          .sort((a, b) => parseInt(b.timestamp) - parseInt(a.timestamp))
+                          .map((materialization, index) => (
+                            <AssetUpdate assetKey={assetKey} event={materialization} key={index} />
+                          ))}
+                      </div>
+                    </Box>
+                  }
+                >
+                  <>
+                    <Tick>
+                      <TickText>{bucket.materializations.length}</TickText>
+                    </Tick>
+                  </>
+                </Popover>
+              </TickWrapper>
             );
           })}
           <TickLines />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/clipEventsToSharedMinimumTime.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/clipEventsToSharedMinimumTime.test.tsx
@@ -1,0 +1,69 @@
+import {clipEventsToSharedMinimumTime} from '../clipEventsToSharedMinimumTime';
+
+const SHORT_TIMESPAN = [
+  {timestamp: `${new Date('2024-01-01').getTime()}`},
+  {timestamp: `${new Date('2024-01-02').getTime()}`},
+  {timestamp: `${new Date('2024-01-03').getTime()}`},
+  {timestamp: `${new Date('2024-01-04').getTime()}`},
+  {timestamp: `${new Date('2024-01-05').getTime()}`},
+  {timestamp: `${new Date('2024-01-06').getTime()}`},
+  {timestamp: `${new Date('2024-01-07').getTime()}`},
+  {timestamp: `${new Date('2024-01-08').getTime()}`},
+  {timestamp: `${new Date('2024-01-09').getTime()}`},
+  {timestamp: `${new Date('2024-01-10').getTime()}`},
+];
+
+const LONG_TIMESPAN = [
+  {timestamp: `${new Date('2023-11-10').getTime()}`},
+  {timestamp: `${new Date('2023-11-17').getTime()}`},
+  {timestamp: `${new Date('2023-11-23').getTime()}`},
+  {timestamp: `${new Date('2023-11-30').getTime()}`},
+  {timestamp: `${new Date('2023-12-06').getTime()}`},
+  {timestamp: `${new Date('2023-12-13').getTime()}`},
+  {timestamp: `${new Date('2023-12-20').getTime()}`},
+  {timestamp: `${new Date('2023-12-27').getTime()}`},
+  {timestamp: `${new Date('2024-01-03').getTime()}`},
+  {timestamp: `${new Date('2024-01-10').getTime()}`},
+];
+
+describe('clipEventsToSharedMinimumTime', () => {
+  it('should clip to the minimum time in both datasets', () => {
+    const {materializations, observations} = clipEventsToSharedMinimumTime(
+      SHORT_TIMESPAN,
+      LONG_TIMESPAN,
+      10,
+    );
+    expect(materializations.length).toEqual(10);
+    expect(observations.length).toEqual(2);
+  });
+
+  it('should clip to the minimum time in both datasets, even if the longer tiemspan dataset has <limit rows', () => {
+    const {materializations, observations} = clipEventsToSharedMinimumTime(
+      SHORT_TIMESPAN,
+      LONG_TIMESPAN.slice(2),
+      10,
+    );
+    expect(materializations.length).toEqual(10);
+    expect(observations.length).toEqual(2);
+  });
+
+  it('should not clip if the dataset shorter timespan dataset has <limit rows', () => {
+    const {materializations, observations} = clipEventsToSharedMinimumTime(
+      SHORT_TIMESPAN.slice(2),
+      LONG_TIMESPAN,
+      10,
+    );
+    expect(materializations.length).toEqual(8);
+    expect(observations.length).toEqual(10);
+  });
+
+  it('should not clip if both datasets returned <limit rows', () => {
+    const {materializations, observations} = clipEventsToSharedMinimumTime(
+      SHORT_TIMESPAN.slice(2),
+      LONG_TIMESPAN.slice(2),
+      10,
+    );
+    expect(materializations.length).toEqual(8);
+    expect(observations.length).toEqual(8);
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/clipEventsToSharedMinimumTime.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/clipEventsToSharedMinimumTime.tsx
@@ -1,0 +1,30 @@
+import min from 'lodash/min';
+
+export function clipEventsToSharedMinimumTime<
+  Mat extends {timestamp: string},
+  Obs extends {timestamp: string},
+>(materializations: Mat[], observations: Obs[], requestedLimit: number) {
+  // If we load 100 observations and get [June 2024 back to Jan 2024], and load
+  // 100 materializations and get [June 2024 back to March 2024], we want to keep
+  // only the observations back to March so the user can't scroll through
+  // [March -> Jan] with the materializations all missing.
+  //
+  // Note: If we have less than 100 datapoints in a dataset, no further pages are
+  // available and we don't want to clip the other to the minimum timestamp.
+  //
+  const minMatTimestamp =
+    materializations.length === requestedLimit
+      ? min(materializations.map((e) => Number(e.timestamp))) || 0
+      : 0;
+  const minObsTimestamp =
+    observations.length === requestedLimit
+      ? min(observations.map((e) => Number(e.timestamp))) || 0
+      : 0;
+
+  const minToKeep = Math.max(minMatTimestamp, minObsTimestamp);
+
+  return {
+    materializations: materializations.filter((m) => Number(m.timestamp) >= minToKeep),
+    observations: observations.filter((m) => Number(m.timestamp) >= minToKeep),
+  };
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/groupByPartition.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/groupByPartition.tsx
@@ -54,22 +54,9 @@ export function useGroupedEvents(
   loadedPartitionKeys: string[] | undefined,
 ) {
   return useMemo<AssetEventGroup[]>(() => {
-    let events = [...materializations, ...observations].sort(
+    const events = [...materializations, ...observations].sort(
       (b, a) => Number(a.timestamp) - Number(b.timestamp),
     );
-
-    // If we're graphing datapoints for an asset that has both materializations and
-    // observations, they may be emitted at different rates so "last 100 events" may
-    // cover different amounts of time. The graph is only 'valid' for the time range
-    // containing both data streams, so we clip it to that timestamp.
-    if (materializations.length && observations.length) {
-      const minMaterializationTimestamp = Math.min(
-        ...materializations.map((m) => Number(m.timestamp)),
-      );
-      const minObservationTimestamp = Math.min(...observations.map((m) => Number(m.timestamp)));
-      const nearerTimestamp = Math.max(minMaterializationTimestamp, minObservationTimestamp);
-      events = events.filter((e) => Number(e.timestamp) > nearerTimestamp);
-    }
 
     if (xAxis === 'partition' && loadedPartitionKeys) {
       return groupByPartition(events, loadedPartitionKeys);


### PR DESCRIPTION
## Summary & Motivation

The previous fix I wrote for https://linear.app/dagster-labs/issue/FE-387/assets-with-both-materializations-and-observations-can-have-plot in #25416 put the "clipping to a shared time range" logic in `useGroupedEvents`, which had an unintended side-effect I noticed this morning. 

This code wasn't verifying that one of the datasets contained `limit` items before clipping them both to the shared timerange. This meant that if you had an asset with a history of materializations, and then emitted an observation for it, the older materializations would disappear from the asset plots. More concerningly they also disappeared from the Asset > Evetns page, which was using `useGroupedEvents` because it can perform grouping on super old non-SDAs that don't have a defined parititon space.

I moved the logic out into a helper and wrote tests for it, and then made both `useRecentAssetEvents` and `usePaginatedEvents` use the same logic. (`usePaginatedEvents` isn't used for plots, but needs the same logic because it uses a single pagination cursor to move through asset observations and materializations at the same time, so the "next" cursor must be the greater of the two minimum values).

Long term, it would be ideal to have a single `events` resolver that returned both materializations and observations, because fetching them separately is proving to be awkward.

## How I Tested These Changes

New test cases + manual verification with 1) assets that have a long history of mixed obs + materialization events, and 2) an asset that has a history materializations and just one new observation.

## Changelog

[ui] The Asset > Events page no longer truncates event history in cases where both materialization and observation events are present.