### PR TITLE
[ui] Fix backfill coordinator logs not transitioning from loading => empty

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/useCursorAccumulatedQuery.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/useCursorAccumulatedQuery.tsx
@@ -51,6 +51,7 @@ class AccumulatingDataFetcher<DataType, CursorType, ErrorType> {
       // continue requesting with updated cursors + accumulating data until
       // stop() is called or hasMore=false.
       while (this.hasMoreData && !this.stopped) {
+        const isFirstPage = !this.currentCursor;
         const {cursor, hasMore, data, error} = await this.fetchData(this.currentCursor);
         if (this.stopped) {
           break;
@@ -61,7 +62,11 @@ class AccumulatingDataFetcher<DataType, CursorType, ErrorType> {
         }
         this.currentCursor = cursor;
         this.hasMoreData = hasMore;
-        if (data.length > 0) {
+
+        // Emit an onData event - note that we always call onData after loading
+        // the first page, even if there is no data to display, so that consumers
+        // can implement a state transition from loading => empty.
+        if (isFirstPage || data.length > 0) {
           this.dataSoFar = this.dataSoFar.concat(data);
           this.onData(this.dataSoFar);
         }


### PR DESCRIPTION
## Summary & Motivation

There was a report during dogfooding that the Coordinator logs tab does not transition from loading to empty for old backfills like this one: https://dogfood-test-1.dogfood.dagster.cloud/prod/runs/b/zjexmmzx?tab=logs

This UI actually implements both loading and empty states, but the empty state wasn't reached because `useCursorAccumulatedQuery` uses an `AccumulatingDataFetcher`, and the fetcher's `.fetch()` method never called `onData` if the first page of results was empty.  I think it should so that consumers have a way to transition from loading > empty.

## How I Tested These Changes

I tested these changes on the coordintor logs page viewing the backfill linked above. At the moment, this is the only place `AccumulatingDataFetcher` or `useCursorAccumulatedQuery` are used. It looks like they still need tests, but I'll add them in a follow-up. Before we write tests for the current implementation, I think it'd make sense to try to use it in at least one more place (seems like are other log views that it would work for??) and see if other changes are necessary.

## Changelog

[ui] The backfill coordinator logs tab no longer sits in a loading state when no logs are available to display.

Newly-visible empty state:
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/85c733a1-0b13-4ef4-9e04-4a4aea049b56">
