### PR TITLE
[ui] Fix poor performance when selecting assets with many partitions

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/SidebarAssetInfo.tsx
@@ -195,7 +195,11 @@ export const SidebarAssetInfo = ({graphNode}: {graphNode: GraphNode}) => {
         <SidebarSection title="Partitions">
           <Box padding={{vertical: 16, horizontal: 24}} flex={{direction: 'column', gap: 16}}>
             <p>{asset.partitionDefinition.description}</p>
-            <PartitionHealthSummary assetKey={asset.assetKey} data={partitionHealthData} />
+            <PartitionHealthSummary
+              assetKey={asset.assetKey}
+              partitionStats={liveData?.partitionStats}
+              data={partitionHealthData}
+            />
           </Box>
         </SidebarSection>
       )}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/PartitionHealthSummary.tsx
@@ -1,73 +1,53 @@
 import {Box, Caption, Spinner} from '@dagster-io/ui-components';
 import {memo} from 'react';
 
-import {AssetPartitionStatus} from './AssetPartitionStatus';
 import {isTimeseriesDimension} from './MultipartitioningSupport';
 import {AssetKey} from './types';
-import {PartitionDimensionSelection, PartitionHealthData} from './usePartitionHealthData';
-import {displayNameForAssetKey} from '../asset-graph/Utils';
+import {PartitionHealthData} from './usePartitionHealthData';
+import {LiveDataForNode, displayNameForAssetKey} from '../asset-graph/Utils';
 import {PartitionStatus} from '../partitions/PartitionStatus';
 
 interface Props {
   assetKey: AssetKey;
   showAssetKey?: boolean;
   data: PartitionHealthData[];
-  selections?: PartitionDimensionSelection[];
+  partitionStats: LiveDataForNode['partitionStats'] | undefined;
 }
 
 export const PartitionHealthSummary = memo((props: Props) => {
-  const {showAssetKey, assetKey, data, selections} = props;
+  const {showAssetKey, assetKey, data, partitionStats} = props;
   const assetData = data.find(
     (d) => JSON.stringify(d.assetKey.path) === JSON.stringify(assetKey.path),
   );
-
-  if (!assetData) {
-    return (
-      <div style={{minHeight: 55, position: 'relative'}}>
-        <Spinner purpose="section" />
-      </div>
-    );
-  }
-
-  const keysForTotals = selections
-    ? selections.map((r) => r.selectedKeys)
-    : assetData.dimensions.map((d) => d.partitionKeys);
-
-  const total = keysForTotals.reduce((total, d) => d.length * total, 1);
-
-  const success = keysForTotals
-    .reduce(
-      (combinations, d) =>
-        combinations.length
-          ? combinations.flatMap((keys) => d.map((key) => [...keys, key]))
-          : d.map((key) => [key]),
-      [] as string[][],
-    )
-    .filter((dkeys) => assetData.stateForKey(dkeys) === AssetPartitionStatus.MATERIALIZED).length;
 
   return (
     <div>
       <Box flex={{justifyContent: 'space-between'}} style={{fontWeight: 600}} margin={{bottom: 4}}>
         <Caption>{showAssetKey ? displayNameForAssetKey(assetKey) : 'Materialized'}</Caption>
-        <Caption>{`${success.toLocaleString()}/${total.toLocaleString()}`}</Caption>
+        {partitionStats ? (
+          <Caption>{`${partitionStats.numMaterialized.toLocaleString()}/${partitionStats.numPartitions.toLocaleString()}`}</Caption>
+        ) : null}
       </Box>
-      {assetData.dimensions.map((dimension, dimensionIdx) => (
-        <Box key={dimensionIdx} margin={{bottom: 4}}>
-          {assetData.dimensions.length > 1 && <Caption>{dimension.name}</Caption>}
-          <PartitionStatus
-            small
-            partitionNames={dimension.partitionKeys}
-            splitPartitions={!isTimeseriesDimension(dimension)}
-            selected={selections ? selections[dimensionIdx]!.selectedKeys : undefined}
-            health={{
-              ranges: assetData.rangesForSingleDimension(
-                dimensionIdx,
-                selections?.length === 2 ? selections[1 - dimensionIdx]!.selectedRanges : undefined,
-              ),
-            }}
-          />
+      {!assetData ? (
+        <Box padding={{vertical: 12}}>
+          <Spinner purpose="section" />
         </Box>
-      ))}
+      ) : (
+        assetData.dimensions.map((dimension, dimensionIdx) => (
+          <Box key={dimensionIdx} margin={{bottom: 4}}>
+            {assetData.dimensions.length > 1 && <Caption>{dimension.name}</Caption>}
+            <PartitionStatus
+              small
+              partitionNames={dimension.partitionKeys}
+              splitPartitions={!isTimeseriesDimension(dimension)}
+              selected={undefined}
+              health={{
+                ranges: assetData.rangesForSingleDimension(dimensionIdx, undefined),
+              }}
+            />
+          </Box>
+        ))
+      )}
     </div>
   );
 });

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/PartitionHealthSummary.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/PartitionHealthSummary.stories.tsx
@@ -10,7 +10,7 @@ import {
   SingleDimensionTimePartitionHealthQuery,
 } from '../__fixtures__/PartitionHealthSummary.fixtures';
 import {AssetKey} from '../types';
-import {PartitionDimensionSelection, usePartitionHealthData} from '../usePartitionHealthData';
+import {usePartitionHealthData} from '../usePartitionHealthData';
 
 // eslint-disable-next-line import/no-default-export
 export default {
@@ -20,36 +20,15 @@ export default {
 
 const PartitionHealthSummaryWithData = ({
   assetKey,
-  ranges,
 }: {
   assetKey: AssetKey;
   ranges?: [string, string][];
 }) => {
   const data = usePartitionHealthData([assetKey]);
 
-  // Convert the convenient test shorthand into a PartitionDimensionSelection
-  const selections =
-    data[0] && ranges
-      ? ranges.map((range, idx) => {
-          const dim = data[0]!.dimensions[idx]!;
-          const idx0 = dim.partitionKeys.indexOf(range[0]);
-          const idx1 = dim.partitionKeys.indexOf(range[1]);
-          return {
-            dimension: dim,
-            selectedKeys: dim.partitionKeys.slice(idx0, idx1 + 1),
-            selectedRanges: [{start: {idx: idx0, key: range[0]}, end: {idx: idx1, key: range[1]}}],
-          } as PartitionDimensionSelection;
-        })
-      : undefined;
-
   return (
     <Box style={{width: '50%'}}>
-      <PartitionHealthSummary
-        assetKey={assetKey}
-        showAssetKey
-        data={data}
-        selections={selections}
-      />
+      <PartitionHealthSummary assetKey={assetKey} showAssetKey data={data} partitionStats={null} />
     </Box>
   );
 };
@@ -67,47 +46,23 @@ export const States = () => (
     <Box flex={{direction: 'column', gap: 60}}>
       <Box flex={{direction: 'row', gap: 30}}>
         <PartitionHealthSummaryWithData assetKey={{path: ['single_dimension_time']}} />
-        <PartitionHealthSummaryWithData
-          assetKey={{path: ['single_dimension_time']}}
-          ranges={[['2023-01-01-00:00', '2023-02-01-00:00']]}
-        />
+        <PartitionHealthSummaryWithData assetKey={{path: ['single_dimension_time']}} />
       </Box>
       <Box flex={{direction: 'row', gap: 30}}>
         <PartitionHealthSummaryWithData assetKey={{path: ['single_dimension_static']}} />
-        <PartitionHealthSummaryWithData
-          assetKey={{path: ['single_dimension_static']}}
-          ranges={[['KY', 'FL']]}
-        />
+        <PartitionHealthSummaryWithData assetKey={{path: ['single_dimension_static']}} />
       </Box>
       <Box flex={{direction: 'row', gap: 30}}>
         <PartitionHealthSummaryWithData assetKey={{path: ['multi_dimension_static']}} />
-        <PartitionHealthSummaryWithData
-          assetKey={{path: ['multi_dimension_static']}}
-          ranges={[
-            ['May', 'May'],
-            ['TN', 'VA'],
-          ]}
-        />
+        <PartitionHealthSummaryWithData assetKey={{path: ['multi_dimension_static']}} />
       </Box>
       <Box flex={{direction: 'row', gap: 30}}>
         <PartitionHealthSummaryWithData assetKey={{path: ['multi_dimension_time_first']}} />
-        <PartitionHealthSummaryWithData
-          assetKey={{path: ['multi_dimension_time_first']}}
-          ranges={[
-            ['2022-09-10', '2022-09-16'],
-            ['TN', 'VA'],
-          ]}
-        />
+        <PartitionHealthSummaryWithData assetKey={{path: ['multi_dimension_time_first']}} />
       </Box>
       <Box flex={{direction: 'row', gap: 30}}>
         <PartitionHealthSummaryWithData assetKey={{path: ['multi_dimension_time_second']}} />
-        <PartitionHealthSummaryWithData
-          assetKey={{path: ['multi_dimension_time_second']}}
-          ranges={[
-            ['TN', 'VA'],
-            ['2022-09-28', '2022-11-16'],
-          ]}
-        />
+        <PartitionHealthSummaryWithData assetKey={{path: ['multi_dimension_time_second']}} />
       </Box>
     </Box>
   </MockedProvider>


### PR DESCRIPTION
## Summary & Motivation

I was testing another bug and noticed that selecting assets in the asset graph with 200k+ partitions was freezing the UI for 30+ seconds.  I dug into this and found this component was still iterating over the partition space to find the number of materialized partitions. This is now available via `liveData.partitionStats`, and the component is only used in one place with no `selections` passed in.

I think this code used to be necessary because the component was also used in other contexts where there were either 1) multiple assets being displayed as a single health bar or 2) a subset of the partition space in `selections`, but with just this one callsite left there's no reason to not just show the counts from the asset health data.

## How I Tested These Changes

Tested manually with large assets that load slowly. Clicking this asset is now fast: 
<img width="1358" alt="image" src="https://github.com/user-attachments/assets/84b736e2-be54-436e-a65b-39b1d064fdce">


## Changelog

[ui] Selecting assets with 100k+ partitions no longer causes the asset graph UI to stutter