### PR TITLE
Bump versions for langchain, langchain-community and langchain-openai

### DIFF
--- a/examples/with_openai/setup.py
+++ b/examples/with_openai/setup.py
@@ -9,15 +9,9 @@ setup(
         "dagster-openai",
         "faiss-cpu==1.8.0",
         "filelock",
-<<<<<<< Updated upstream
-        "langchain==0.2.10",
-        "langchain-community==0.2.9",
-        "langchain-openai==0.1.14",
-=======
         "langchain==0.3.7",
         "langchain-community==0.3.5",
         "langchain-openai==0.2.5",
->>>>>>> Stashed changes
     ],
     extras_require={"dev": ["dagster-webserver", "pytest"]},
 )

--- a/examples/with_openai/setup.py
+++ b/examples/with_openai/setup.py
@@ -9,9 +9,15 @@ setup(
         "dagster-openai",
         "faiss-cpu==1.8.0",
         "filelock",
+<<<<<<< Updated upstream
         "langchain==0.2.10",
         "langchain-community==0.2.9",
         "langchain-openai==0.1.14",
+=======
+        "langchain==0.3.7",
+        "langchain-community==0.3.5",
+        "langchain-openai==0.2.5",
+>>>>>>> Stashed changes
     ],
     extras_require={"dev": ["dagster-webserver", "pytest"]},
 )


### PR DESCRIPTION
## Summary & Motivation

Bump to latest versions available following https://github.com/dagster-io/dagster/pull/25641 and https://github.com/dagster-io/dagster/pull/25620

## How I Tested These Changes

`dagster dev` with with_openai

