### PR TITLE
[dagster-azure] add support for US Government Cloud tenant

### DIFF
--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
@@ -88,7 +88,7 @@ class FakeADLS2ServiceClient:
     @property
     def account_name(self):
         return self._account_name
-    
+
     @property
     def cloud_type(self):
         return self._cloud_type

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
@@ -87,6 +87,10 @@ class FakeADLS2ServiceClient:
     @property
     def account_name(self):
         return self._account_name
+    
+    @property
+    def cloud_type(self):
+        return self._cloud_type
 
     @property
     def credential(self):

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
@@ -25,6 +25,7 @@ class FakeADLS2Resource(ConfigurableResource):
     """
 
     account_name: str
+    cloud_type: Optional[str] = "public"
     storage_account: Optional[str] = None
 
     @classmethod
@@ -76,8 +77,9 @@ class FakeADLS2ServiceClient:
     Wraps a ``mock.MagicMock``. Containers are implemented using an in-memory dict.
     """
 
-    def __init__(self, account_name, credential="fake-creds"):
+    def __init__(self, account_name, credential="fake-creds", cloud_type="public"):
         self._account_name = account_name
+        self._cloud_type = cloud_type
         self._credential = mock.MagicMock()
         self._credential.account_key = credential
         self._file_systems = {}

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/fake_adls2_resource.py
@@ -83,6 +83,7 @@ class FakeADLS2ServiceClient:
         self._credential = mock.MagicMock()
         self._credential.account_key = credential
         self._file_systems = {}
+        self.primary_endpoint = f"https://{account_name}.dfs.core.windows.net"
 
     @property
     def account_name(self):

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/file_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/file_manager.py
@@ -1,7 +1,7 @@
 import io
+import re
 import uuid
 from contextlib import contextmanager
-import re
 
 import dagster._check as check
 from dagster._core.storage.file_manager import (
@@ -40,7 +40,7 @@ class ADLS2FileHandle(FileHandle):
     def path_desc(self):
         """str: The file's ADLS2 URL."""
         return self.adls2_path
-    
+
     @property
     def subdomain(self):
         """str: The subdomain of the ADLS2 URL."""
@@ -113,7 +113,9 @@ class ADLS2FileManager(FileManager):
             file_system=self._file_system, file_path=adls2_key
         )
         adls2_file.upload_data(file_obj, overwrite=True)
-        return ADLS2FileHandle(self._client.account_name, self._file_system, adls2_key, self._client.primary_endpoint)
+        return ADLS2FileHandle(
+            self._client.account_name, self._file_system, adls2_key, self._client.primary_endpoint
+        )
 
     def get_full_key(self, file_key):
         return f"{self._prefix}/{file_key}"

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/file_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/file_manager.py
@@ -122,3 +122,6 @@ class ADLS2FileManager(FileManager):
 
     def delete_local_temp(self):
         self._temp_file_manager.close()
+
+    def get_client(self):
+        return self._client

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -75,7 +75,7 @@ class PickledObjectADLS2IOManager(UPathIOManager):
         except ResourceNotFoundError:
             return False
         return True
-    
+
     def get_subdomain(self) -> str:
         return re.search(r"(dfs.+$)", self.adls2_client.primary_endpoint).group(0)
 

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -1,4 +1,5 @@
 import pickle
+import re
 from contextlib import contextmanager
 from typing import Any, Iterator, Union
 
@@ -74,9 +75,12 @@ class PickledObjectADLS2IOManager(UPathIOManager):
         except ResourceNotFoundError:
             return False
         return True
+    
+    def get_subdomain(self) -> str:
+        return re.search(r"(dfs.+$)", self.adls2_client.primary_endpoint).group(0)
 
     def _uri_for_path(self, path: UPath, protocol: str = "abfss://") -> str:
-        return f"{protocol}{self.file_system_client.file_system_name}@{self.file_system_client.account_name}.dfs.core.windows.net/{path.as_posix()}"
+        return f"{protocol}{self.file_system_client.file_system_name}@{self.file_system_client.account_name}.{self.get_subdomain()}/{path.as_posix()}"
 
     @contextmanager
     def _acquire_lease(self, client: Any, is_rm: bool = False) -> Iterator[str]:

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/io_manager.py
@@ -77,7 +77,10 @@ class PickledObjectADLS2IOManager(UPathIOManager):
         return True
 
     def get_subdomain(self) -> str:
-        return re.search(r"(dfs.+$)", self.adls2_client.primary_endpoint).group(0)
+        match = re.search(r"(dfs.+$)", self.adls2_client.primary_endpoint)
+        if not match:
+            raise ValueError("Could not extract subdomain from the primary endpoint.")
+        return match.group(0)
 
     def _uri_for_path(self, path: UPath, protocol: str = "abfss://") -> str:
         return f"{protocol}{self.file_system_client.file_system_name}@{self.file_system_client.account_name}.{self.get_subdomain()}/{path.as_posix()}"

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
@@ -5,6 +5,8 @@ from azure.storage.filedatalake import DataLakeLeaseClient
 from dagster import (
     Config,
     ConfigurableResource,
+    Enum,
+    EnumValue,
     Field as DagsterField,
     Permissive,
     Selector,
@@ -52,7 +54,12 @@ DEFAULT_AZURE_CREDENTIAL_CONFIG = DagsterField(
 
 ADLS2_CLIENT_CONFIG = {
     "storage_account": DagsterField(StringSource, description="The storage account name."),
-    "cloud_type": DagsterField(StringSource, description="The Azure Cloud type. Either 'public' or 'government.'")
+    "cloud_type": DagsterField(
+        Enum("cloud_type", [EnumValue("public"), EnumValue("government")]),
+        description="The Azure Cloud type. Either 'public' or 'government.'",
+        is_required=False,
+        default_value="public"
+    ),
     "credential": DagsterField(
         Selector(
             {
@@ -167,7 +174,7 @@ def adls2_resource(context):
             "adls2_file_system": DagsterField(
                 StringSource, description="ADLS Gen2 file system name"
             ),
-            "adls2_prefix": DagsterField(StringSource, is_required=False, default_value="dagster"),
+            "adls2_prefix": DagsterField(StringSource, is_required=False, default_value="dagster")
         },
     )
 )

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
@@ -52,6 +52,7 @@ DEFAULT_AZURE_CREDENTIAL_CONFIG = DagsterField(
 
 ADLS2_CLIENT_CONFIG = {
     "storage_account": DagsterField(StringSource, description="The storage account name."),
+    "cloud_type": DagsterField(StringSource, description="The Azure Cloud type. Either 'public' or 'government.'")
     "credential": DagsterField(
         Selector(
             {

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
@@ -199,6 +199,7 @@ def _adls2_resource_from_config(config) -> ADLS2Resource:
     Returns: An adls2 client.
     """
     storage_account = config["storage_account"]
+    cloud_type = config["cloud_type"]
     if "DefaultAzureCredential" in config["credential"]:
         credential = ADLS2DefaultAzureCredential(
             kwargs=config["credential"]["DefaultAzureCredential"]
@@ -208,4 +209,4 @@ def _adls2_resource_from_config(config) -> ADLS2Resource:
     else:
         credential = ADLS2Key(key=config["credential"]["key"])
     
-    return ADLS2Resource(storage_account=storage_account, cloud_type=config["cloud_type"], credential=credential)
+    return ADLS2Resource(storage_account=storage_account, cloud_type=cloud_type, credential=credential)

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
@@ -97,7 +97,7 @@ class ADLS2Resource(ADLS2BaseResource):
     @property
     @cached_method
     def adls2_client(self) -> DataLakeServiceClient:
-        return create_adls2_client(self.storage_account, self._raw_credential)
+        return create_adls2_client(self.storage_account, self.cloud_type, self._raw_credential)
 
     @property
     @cached_method
@@ -207,5 +207,5 @@ def _adls2_resource_from_config(config) -> ADLS2Resource:
         credential = ADLS2SASToken(token=config["credential"]["sas"])
     else:
         credential = ADLS2Key(key=config["credential"]["key"])
-
-    return ADLS2Resource(storage_account=storage_account, credential=credential)
+    
+    return ADLS2Resource(storage_account=storage_account, cloud_type=config["cloud_type"], credential=credential)

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
@@ -61,7 +61,7 @@ ADLS2_CLIENT_CONFIG = {
         Enum("cloud_type", [EnumValue("public"), EnumValue("government")]),
         description="The Azure Cloud type. Either 'public' or 'government.'",
         is_required=False,
-        default_value="public"
+        default_value="public",
     ),
     "credential": DagsterField(
         Selector(
@@ -179,7 +179,7 @@ def adls2_resource(context):
             "adls2_file_system": DagsterField(
                 StringSource, description="ADLS Gen2 file system name"
             ),
-            "adls2_prefix": DagsterField(StringSource, is_required=False, default_value="dagster")
+            "adls2_prefix": DagsterField(StringSource, is_required=False, default_value="dagster"),
         },
     )
 )
@@ -213,5 +213,7 @@ def _adls2_resource_from_config(config) -> ADLS2Resource:
         credential = ADLS2SASToken(token=config["credential"]["sas"])
     else:
         credential = ADLS2Key(key=config["credential"]["key"])
-    
-    return ADLS2Resource(storage_account=storage_account, cloud_type=cloud_type, credential=credential)
+
+    return ADLS2Resource(
+        storage_account=storage_account, cloud_type=cloud_type, credential=credential
+    )

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
@@ -164,6 +164,8 @@ def adls2_resource(context):
                 # or leave the object empty for no arguments
                 DefaultAzureCredential:
                     exclude_environment_credential: true
+                cloud_type: public
+                # str: The Azure Cloud type. Either 'public' or 'government.' Default is 'public'.
 
     """
     return _adls2_resource_from_config(context.resource_config)

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/resources.py
@@ -44,6 +44,9 @@ class ADLS2BaseResource(ConfigurableResource):
     credential: Union[ADLS2SASToken, ADLS2Key, ADLS2DefaultAzureCredential] = Field(
         discriminator="credential_type", description="The credentials with which to authenticate."
     )
+    cloud_type: Literal["public", "government"] = Field(
+        default="public", description="The Azure Cloud type. Either 'public' or 'government'."
+    )
 
 
 DEFAULT_AZURE_CREDENTIAL_CONFIG = DagsterField(

--- a/python_modules/libraries/dagster-azure/dagster_azure/adls2/utils.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/adls2/utils.py
@@ -17,12 +17,16 @@ except ImportError:
 
 
 def _create_url(storage_account, subdomain):
-    return f"https://{storage_account}.{subdomain}.core.windows.net/"
+    return f"https://{storage_account}.{subdomain}.net/"
 
 
-def create_adls2_client(storage_account: str, credential) -> DataLakeServiceClient:
+def create_adls2_client(storage_account: str, cloud_type: str, credential) -> DataLakeServiceClient:
     """Create an ADLS2 client."""
-    account_url = _create_url(storage_account, "dfs")
+    if cloud_type == "public":
+        subdomain = "dfs.core.windows"
+    elif cloud_type == "government":
+        subdomain = "dfs.core.usgovcloudapi"
+    account_url = _create_url(storage_account, subdomain)
     return DataLakeServiceClient(account_url, credential)
 
 

--- a/python_modules/libraries/dagster-azure/dagster_azure/blob/fake_blob_client.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/blob/fake_blob_client.py
@@ -13,10 +13,11 @@ class FakeBlobServiceClient:
     Wraps a ``mock.MagicMock``. Containers are implemented using an in-memory dict.
     """
 
-    def __init__(self, account_name, credential="fake-creds"):
+    def __init__(self, account_name, credential="fake-creds", cloud_type="public"):
         self._account_name = account_name
         self._credential = mock.MagicMock()
         self._credential.account_key = credential
+        self._cloud_type = cloud_type
         self._containers = {}
 
     @property
@@ -61,6 +62,10 @@ class FakeBlobContainerClient:
     @property
     def container_name(self):
         return self._container_name
+    
+    @property
+    def cloud_type(self):
+        return self._cloud_type
 
     def keys(self):
         return self._container.keys()

--- a/python_modules/libraries/dagster-azure/dagster_azure/blob/fake_blob_client.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/blob/fake_blob_client.py
@@ -62,7 +62,7 @@ class FakeBlobContainerClient:
     @property
     def container_name(self):
         return self._container_name
-    
+
     @property
     def cloud_type(self):
         return self._cloud_type

--- a/python_modules/libraries/dagster-azure/dagster_azure/blob/utils.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/blob/utils.py
@@ -23,7 +23,9 @@ def _create_url(storage_account, subdomain, cloud_type: str = "public"):
         return f"https://{storage_account}.{subdomain}.core.usgovcloudapi.net/"
 
 
-def create_blob_client(storage_account, credential, cloud_type: str = "public") -> BlobServiceClient:
+def create_blob_client(
+    storage_account, credential, cloud_type: str = "public"
+) -> BlobServiceClient:
     """Create a Blob Storage client."""
     account_url = _create_url(storage_account, "blob", cloud_type)
     if hasattr(credential, "account_key"):

--- a/python_modules/libraries/dagster-azure/dagster_azure/blob/utils.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/blob/utils.py
@@ -21,6 +21,8 @@ def _create_url(storage_account, subdomain, cloud_type: str = "public"):
         return f"https://{storage_account}.{subdomain}.core.windows.net/"
     elif cloud_type == "government":
         return f"https://{storage_account}.{subdomain}.core.usgovcloudapi.net/"
+    else:
+        raise ValueError(f"Unsupported cloud_type: {cloud_type}")
 
 
 def create_blob_client(

--- a/python_modules/libraries/dagster-azure/dagster_azure/blob/utils.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure/blob/utils.py
@@ -16,13 +16,16 @@ except ImportError:
     raise
 
 
-def _create_url(storage_account, subdomain):
-    return f"https://{storage_account}.{subdomain}.core.windows.net/"
+def _create_url(storage_account, subdomain, cloud_type: str = "public"):
+    if cloud_type == "public":
+        return f"https://{storage_account}.{subdomain}.core.windows.net/"
+    elif cloud_type == "government":
+        return f"https://{storage_account}.{subdomain}.core.usgovcloudapi.net/"
 
 
-def create_blob_client(storage_account, credential) -> BlobServiceClient:
+def create_blob_client(storage_account, credential, cloud_type: str = "public") -> BlobServiceClient:
     """Create a Blob Storage client."""
-    account_url = _create_url(storage_account, "blob")
+    account_url = _create_url(storage_account, "blob", cloud_type)
     if hasattr(credential, "account_key"):
         credential = credential.account_key
     return BlobServiceClient(account_url, credential)

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/conftest.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/conftest.py
@@ -12,6 +12,9 @@ def storage_account():
 def file_system():
     yield "dagster-azure-tests"
 
+@pytest.fixture(scope="session")
+def primary_endpoint():
+    yield "some-endpoint.dfs.core.windows.net"
 
 @pytest.fixture(scope="session")
 def credential():

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/conftest.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/conftest.py
@@ -12,9 +12,11 @@ def storage_account():
 def file_system():
     yield "dagster-azure-tests"
 
+
 @pytest.fixture(scope="session")
 def primary_endpoint():
     yield "some-endpoint.dfs.core.windows.net"
+
 
 @pytest.fixture(scope="session")
 def credential():

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
@@ -179,6 +179,46 @@ def test_adls_file_manager_resource(MockADLS2FileManager, MockADLS2Resource):
     test_op(context)
     assert did_it_run["it_ran"]
 
+@mock.patch("dagster_azure.adls2.resources.ADLS2Resource")
+@mock.patch("dagster_azure.adls2.resources.ADLS2FileManager")
+def test_adls_file_manager_resource_cloud_type(MockADLS2FileManager, MockADLS2Resource):
+    did_it_run = dict(it_ran=False)
+
+    resource_config = {
+        "storage_account": "some-storage-account",
+        "credential": {
+            "key": "some-key",
+        },
+        "adls2_file_system": "some-file-system",
+        "adls2_prefix": "some-prefix",
+        "cloud_type": "government",
+    }
+
+    @op(required_resource_keys={"file_manager"})
+    def test_op(context):
+        # test that we got back a ADLS2FileManager
+        assert context.resources.file_manager == MockADLS2FileManager.return_value
+
+        # make sure the file manager was initalized with the config we are supplying
+        MockADLS2FileManager.assert_called_once_with(
+            adls2_client=MockADLS2Resource.return_value.adls2_client,
+            file_system=resource_config["adls2_file_system"],
+            prefix=resource_config["adls2_prefix"],
+        )
+        MockADLS2Resource.assert_called_once_with(
+            storage_account=resource_config["storage_account"],
+            credential=ADLS2Key(key=resource_config["credential"]["key"]),
+        )
+
+        did_it_run["it_ran"] = True
+
+    context = build_op_context(
+        resources={"file_manager": configured(adls2_file_manager)(resource_config)},
+    )
+    test_op(context)
+    assert did_it_run["it_ran"]
+
+
 
 @mock.patch("dagster_azure.adls2.resources.ADLS2DefaultAzureCredential")
 @mock.patch("dagster_azure.adls2.resources.ADLS2Resource")

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
@@ -22,7 +22,6 @@ def test_adls2_file_manager_write(storage_account, file_system):
     adls2_mock = mock.MagicMock()
     adls2_mock.get_file_client.return_value = file_mock
     adls2_mock.account_name = storage_account
-    adls2_mock._cloud_type = "public"
     adls2_mock.primary_endpoint = "some-endpoint.dfs.core.windows.net"
     file_manager = ADLS2FileManager(adls2_mock, file_system, "some-key")
 

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
@@ -169,7 +169,7 @@ def test_adls_file_manager_resource(MockADLS2FileManager, MockADLS2Resource):
         MockADLS2Resource.assert_called_once_with(
             storage_account=resource_config["storage_account"],
             credential=ADLS2Key(key=resource_config["credential"]["key"]),
-            cloud_type=None
+            cloud_type=resource_config.get("cloud_type", "public"),
         )
 
         did_it_run["it_ran"] = True
@@ -254,6 +254,7 @@ def test_adls_file_manager_resource_defaultazurecredential(
         MockADLS2Resource.assert_called_once_with(
             storage_account=resource_config["storage_account"],
             credential=MockADLS2DefaultAzureCredential.return_value,
+            cloud_type=resource_config.get("cloud_type", "public"),
         )
 
         did_it_run["it_ran"] = True

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
@@ -241,7 +241,7 @@ def test_adls_file_handle_adls2_path(cloud_type):
         resources={"file_manager": configured(adls2_file_manager)(resource_config)},
     )
     adls_file_manager = context.resources.file_manager
-    
+
     with mock.patch.object(adls_file_manager, 'write_data', return_value=ADLS2FileHandle(adls_file_manager._client.account_name, 
     adls_file_manager._file_system, 'some-key', adls_file_manager._client.primary_endpoint)) as mock_write:
         file_handle = adls_file_manager.write_data(b"mock data")

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
@@ -169,6 +169,7 @@ def test_adls_file_manager_resource(MockADLS2FileManager, MockADLS2Resource):
         MockADLS2Resource.assert_called_once_with(
             storage_account=resource_config["storage_account"],
             credential=ADLS2Key(key=resource_config["credential"]["key"]),
+            cloud_type=None
         )
 
         did_it_run["it_ran"] = True
@@ -208,6 +209,7 @@ def test_adls_file_manager_resource_cloud_type(MockADLS2FileManager, MockADLS2Re
         MockADLS2Resource.assert_called_once_with(
             storage_account=resource_config["storage_account"],
             credential=ADLS2Key(key=resource_config["credential"]["key"]),
+            cloud_type=resource_config["cloud_type"],
         )
 
         did_it_run["it_ran"] = True

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
@@ -1,17 +1,16 @@
 import uuid
 from unittest import mock
 
+import pytest
 from dagster import ResourceDefinition, build_op_context, configured, op
 from dagster._core.definitions.decorators.job_decorator import job
 from dagster._core.definitions.input import In
 from dagster._core.definitions.output import Out
-import pytest
 from dagster_azure.adls2 import (
     ADLS2FileHandle,
     ADLS2FileManager,
     ADLS2Key,
     FakeADLS2Resource,
-    ADLS2Resource,
     adls2_file_manager,
 )
 
@@ -74,7 +73,9 @@ def test_adls2_file_manager_read(storage_account, file_system, primary_endpoint)
 
     adls2_mock = ADLS2Mock()
     file_manager = ADLS2FileManager(adls2_mock, file_system, "some-key")
-    file_handle = ADLS2FileHandle(storage_account, file_system, "some-key/kdjfkjdkfjkd", primary_endpoint)
+    file_handle = ADLS2FileHandle(
+        storage_account, file_system, "some-key/kdjfkjdkfjkd", primary_endpoint
+    )
     with file_manager.read(file_handle) as file_obj:
         assert file_obj.read() == bar_bytes
 
@@ -184,6 +185,7 @@ def test_adls_file_manager_resource(MockADLS2FileManager, MockADLS2Resource):
     test_op(context)
     assert did_it_run["it_ran"]
 
+
 @mock.patch("dagster_azure.adls2.resources.ADLS2Resource")
 @mock.patch("dagster_azure.adls2.resources.ADLS2FileManager")
 def test_adls_file_manager_resource_cloud_type(MockADLS2FileManager, MockADLS2Resource):
@@ -224,6 +226,7 @@ def test_adls_file_manager_resource_cloud_type(MockADLS2FileManager, MockADLS2Re
     test_op(context)
     assert did_it_run["it_ran"]
 
+
 @pytest.mark.parametrize("cloud_type", ["government", "public", None])
 def test_adls_file_handle_adls2_path(cloud_type):
     resource_config = {
@@ -242,14 +245,23 @@ def test_adls_file_handle_adls2_path(cloud_type):
     )
     adls_file_manager = context.resources.file_manager
 
-    with mock.patch.object(adls_file_manager, 'write_data', return_value=ADLS2FileHandle(adls_file_manager._client.account_name, 
-    adls_file_manager._file_system, 'some-key', adls_file_manager._client.primary_endpoint)) as mock_write:
+    with mock.patch.object(
+        adls_file_manager,
+        "write_data",
+        return_value=ADLS2FileHandle(
+            adls_file_manager._client.account_name,
+            adls_file_manager._file_system,
+            "some-key",
+            adls_file_manager._client.primary_endpoint,
+        ),
+    ) as mock_write:
         file_handle = adls_file_manager.write_data(b"mock data")
         mock_write.assert_called_once_with(b"mock data")
         if cloud_type == "government":
             assert "usgovcloudapi" in file_handle.adls2_path
         else:
             assert "windows" in file_handle.adls2_path
+
 
 @mock.patch("dagster_azure.adls2.resources.ADLS2DefaultAzureCredential")
 @mock.patch("dagster_azure.adls2.resources.ADLS2Resource")

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
@@ -249,10 +249,10 @@ def test_adls_file_handle_adls2_path(cloud_type):
         adls_file_manager,
         "write_data",
         return_value=ADLS2FileHandle(
-            adls_file_manager._client.account_name,
-            adls_file_manager._file_system,
+            resource_config["storage_account"],
+            resource_config["adls2_file_system"],
             "some-key",
-            adls_file_manager._client.primary_endpoint,
+            adls_file_manager.get_client().primary_endpoint,
         ),
     ) as mock_write:
         file_handle = adls_file_manager.write_data(b"mock data")

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_adls2_file_manager.py
@@ -21,6 +21,7 @@ def test_adls2_file_manager_write(storage_account, file_system):
     adls2_mock = mock.MagicMock()
     adls2_mock.get_file_client.return_value = file_mock
     adls2_mock.account_name = storage_account
+    adls2_mock._cloud_type = "public"
     file_manager = ADLS2FileManager(adls2_mock, file_system, "some-key")
 
     foo_bytes = b"foo"

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
@@ -350,5 +350,5 @@ def test_adls2_pickle_io_manager_uri(primary_endpoint, expected_uri_part):
     )
 
     path = UPath("my/path/to/object")
-    uri = io_manager._uri_for_path(path)
-    assert expected_uri_part in uri
+    message = io_manager.get_loading_input_log_message(path)
+    assert expected_uri_part in message

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/adls2_tests/test_io_manager.py
@@ -1,6 +1,5 @@
-from uuid import uuid4
 from unittest import mock
-
+from uuid import uuid4
 
 import pytest
 from azure.storage.filedatalake import DataLakeLeaseClient
@@ -18,8 +17,6 @@ from dagster import (
     asset,
     build_input_context,
     build_output_context,
-    build_op_context,
-    configured,
     graph,
     op,
     resource,
@@ -41,7 +38,6 @@ from dagster_azure.adls2.io_manager import PickledObjectADLS2IOManager, adls2_pi
 from dagster_azure.adls2.resources import adls2_resource
 from dagster_azure.blob import create_blob_client
 from upath import UPath
-import pytest
 
 
 def fake_io_manager_factory(io_manager):
@@ -320,7 +316,6 @@ def test_asset_io_manager(storage_account, file_system, credential):
     assert result.success
 
 
-
 def test_with_fake_adls2_resource():
     job = define_inty_job(adls_io_resource=fake_adls2_resource)
 
@@ -333,6 +328,7 @@ def test_with_fake_adls2_resource():
 
     result = job.execute_in_process(run_config=run_config)
     assert result.success
+
 
 @pytest.mark.parametrize(
     "primary_endpoint, expected_uri_part",

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
@@ -29,6 +29,10 @@ EXPECTED_LOGS = [
 ]
 
 
+def test_create_blob_client():
+    pass
+
+
 @mock.patch("dagster_azure.blob.compute_log_manager.generate_blob_sas")
 @mock.patch("dagster_azure.blob.compute_log_manager.create_blob_client")
 def test_compute_log_manager(

--- a/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
+++ b/python_modules/libraries/dagster-azure/dagster_azure_tests/blob_tests/test_compute_log_manager.py
@@ -29,10 +29,6 @@ EXPECTED_LOGS = [
 ]
 
 
-def test_create_blob_client():
-    pass
-
-
 @mock.patch("dagster_azure.blob.compute_log_manager.generate_blob_sas")
 @mock.patch("dagster_azure.blob.compute_log_manager.create_blob_client")
 def test_compute_log_manager(


### PR DESCRIPTION
## Summary & Motivation

This PR addresses issue #7790 by removing the hard-coding to the Azure commercial cloud tenant and adding a `cloud_type` parameter that can accept either `public` or `government`, which can be specified in the ADLS2 configurations. This value defaults to `public`, so existing code calling these functions can run without breaking. The PR adds a `primary_endpoint` parameter to `ADLS2FileHandle` so the appropriate subdomain gets propagated from the `ADLS2Resource`. 

## How I Tested These Changes

- added `test_adls2_pickle_io_manager_uri` to ensure the correct URI is generated
- added `test_adls_file_handle_adls2_path` to ensure the file path changes based on the `cloud_type` parameter (and that the path reflects the public cloud tenant when no cloud_type is supplied)
- added `test_adls_file_manager_resource_cloud_type` to ensure assets are materialized without error when specifying the government cloud type
- ran `pytest dagster_azure_tests/` to ensure all tests (old and new) run successfully

## Changelog

> You can now specify either `public` or `government` as `cloud_type` as a parameter to `ADLS2Resource()` and `create_adls2_client()`, and in the ADLS resource .yaml configuration. This parameter is optional and defaults to `public`.
