### PR TITLE
Update running-dagster-locally.mdx

### DIFF
--- a/docs/content/guides/running-dagster-locally.mdx
+++ b/docs/content/guides/running-dagster-locally.mdx
@@ -56,6 +56,14 @@ For the full list of options that can be set in the `dagster.yaml` file, refer t
 
 ---
 
+## Detecting when you're running in `dagster dev`
+
+You may want to detect whether you're running locally. For example, you might want schedules or sensors to start in the `RUNNING` state in production but not in your local test deployment.
+
+`dagster dev` sets the environment variable `DAGSTER_IS_DEV_CLI` to `1`. You can detect whether you're in a local dev environment by checking for the presence of that environment variable.
+
+---
+
 ## Moving to production
 
 `dagster dev` is primarily useful for running Dagster for local development and testing. It isn't suitable for the demands of most production deployments. Most importantly, `dagster dev` does not include authentication or web security. Additionally, in a production deployment, you might want to run multiple webserver replicas, have zero downtime continuous deployment of your code, or set up your Dagster daemon to automatically restart if it crashes.


### PR DESCRIPTION
Adds documentation for the `DAGSTER_IS_DEV_CLI` environment variable.

## Summary & Motivation

I was looking for ways to detect whether Dagster was running in local dev, since I've run into staging automations triggering from local dev environments when they shouldn't. I stumbled across `DAGSTER_IS_DEV_CLI`, which appears to be used by both the `sdf` and `dbt` Dagster libraries, but isn't really documented anywhere else.

## How I Tested These Changes

This is a documentation fix.

## Changelog

> Document the `DAGSTER_IS_DEV_CLI` environment variable.
