### PR TITLE
Make filtering case insensitive

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/filterAssetDefinition.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/filterAssetDefinition.test.tsx
@@ -167,6 +167,58 @@ describe('filterAssetDefinition', () => {
     expect(filterAssetDefinition(filters, definition)).toBe(true);
   });
 
+  it('does case in-sensitive matching', () => {
+    const tag = buildDefinitionTag({
+      key: 'test',
+      value: 'test',
+    });
+    const group = buildAssetGroupSelector({
+      groupName: 'groupName',
+      repositoryLocationName: 'repositoryLocationName',
+      repositoryName: 'repositoryName',
+    });
+    const repo = {
+      location: group.repositoryLocationName,
+      name: group.repositoryName,
+    };
+    const owner = buildTeamAssetOwner({
+      team: 'team1',
+    });
+    const filters = {
+      codeLocations: [repo],
+      groups: [
+        {
+          ...group,
+          groupName: group.groupName.toUpperCase(),
+        },
+      ],
+      kinds: ['COMPUTEkind1'],
+      changedInBranch: [ChangeReason.DEPENDENCIES, ChangeReason.PARTITIONS_DEFINITION],
+      owners: [
+        {
+          ...owner,
+          team: owner.team.toUpperCase(),
+        },
+      ],
+      tags: [{...tag, key: tag.key.toUpperCase(), value: tag.value.toUpperCase()}],
+    };
+    const definition = {
+      repository: buildRepository({
+        name: group.repositoryName,
+        location: buildRepositoryLocation({
+          name: group.repositoryLocationName,
+        }),
+      }),
+      groupName: group.groupName,
+      kinds: ['computeKind1'],
+      changedReasons: [ChangeReason.DEPENDENCIES, ChangeReason.PARTITIONS_DEFINITION],
+      owners: [owner],
+      tags: [tag],
+    };
+
+    expect(filterAssetDefinition(filters, definition)).toBe(true);
+  });
+
   (
     ['changedInBranch', 'kinds', 'groups', 'owners', 'codeLocations', 'tags'] as Array<
       keyof AssetFilterBaseType

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.oss.tsx
@@ -10,7 +10,7 @@ import {
   DefinitionTag,
 } from '../graphql/types';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
-import {doesFilterArrayMatchValueArray, Tag} from '../ui/Filters/useDefinitionTagFilter';
+import {Tag, doesFilterArrayMatchValueArray} from '../ui/Filters/useDefinitionTagFilter';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
 

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.oss.tsx
@@ -10,7 +10,7 @@ import {
   DefinitionTag,
 } from '../graphql/types';
 import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
-import {doesFilterArrayMatchValueArray} from '../ui/Filters/useDefinitionTagFilter';
+import {doesFilterArrayMatchValueArray, Tag} from '../ui/Filters/useDefinitionTagFilter';
 import {buildRepoAddress} from '../workspace/buildRepoAddress';
 import {RepoAddress} from '../workspace/types';
 
@@ -158,7 +158,7 @@ export function filterAssetDefinition(
     if (
       !filters.groups.some((g) => {
         return (
-          g.groupName === nodeGroup?.groupName &&
+          g.groupName.toLowerCase() === nodeGroup?.groupName.toLowerCase() &&
           g.repositoryLocationName === nodeGroup.repositoryLocationName &&
           g.repositoryName === nodeGroup.repositoryName
         );
@@ -175,7 +175,13 @@ export function filterAssetDefinition(
       return false;
     }
   } else if (filters.kinds?.length) {
-    if (!kinds || !doesFilterArrayMatchValueArray(filters.kinds, kinds)) {
+    if (
+      !kinds ||
+      !doesFilterArrayMatchValueArray(
+        filters.kinds.map((kind) => kind.toLowerCase()),
+        kinds.map((kind) => kind.toLowerCase()),
+      )
+    ) {
       return false;
     }
   }
@@ -202,7 +208,9 @@ export function filterAssetDefinition(
     if (
       !definition?.owners?.length ||
       !filters.owners.some((owner) =>
-        definition.owners!.some((defOwner) => isEqual(defOwner, owner)),
+        definition.owners!.some((defOwner) =>
+          isEqual(lowerCaseOwner(defOwner), lowerCaseOwner(owner)),
+        ),
       )
     ) {
       return false;
@@ -216,11 +224,36 @@ export function filterAssetDefinition(
   } else if (filters.tags?.length) {
     if (
       !definition?.tags?.length ||
-      !doesFilterArrayMatchValueArray(filters.tags, definition.tags)
+      !doesFilterArrayMatchValueArray(
+        filters.tags.map(lowerCaseTag),
+        definition.tags.map(lowerCaseTag),
+      )
     ) {
       return false;
     }
   }
 
   return true;
+}
+
+function lowerCaseOwner(owner: AssetOwner) {
+  if (owner.__typename === 'TeamAssetOwner') {
+    return {
+      ...owner,
+      team: owner.team.toLowerCase(),
+    };
+  } else {
+    return {
+      ...owner,
+      email: owner.email.toLowerCase(),
+    };
+  }
+}
+
+function lowerCaseTag(tag: Tag) {
+  return {
+    ...tag,
+    key: tag.key.toLowerCase(),
+    value: tag.value?.toLowerCase(),
+  };
 }


### PR DESCRIPTION
## Summary & Motivation

As titled https://linear.app/dagster-labs/issue/FE-658/make-client-side-filtering-case-insensitive


## Changelog

[ui] Filtering on owners/groups/tags is now case-insensitive.