### PR TITLE
Make applied filters persist when navigating to catalog directories

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.oss.tsx
@@ -225,18 +225,18 @@ export function filterAssetDefinition(
   return true;
 }
 
+const KEYS: Record<keyof AssetFilterType, '1'> = {
+  groups: '1',
+  kinds: '1',
+  changedInBranch: '1',
+  owners: '1',
+  tags: '1',
+  codeLocations: '1',
+  selectAllFilters: '1',
+};
 export function getAssetFilterStateQueryString() {
-  const values: Record<keyof AssetFilterType, '1'> = {
-    groups: '1',
-    kinds: '1',
-    changedInBranch: '1',
-    owners: '1',
-    tags: '1',
-    codeLocations: '1',
-    selectAllFilters: '1',
-  };
   const params = new URLSearchParams(location.search);
-  return Object.keys(values).reduce((soFar, key) => {
+  return Object.keys(KEYS).reduce((soFar, key) => {
     if (params.get(key)) {
       return soFar + `&${key}=${params.get(key)}`;
     }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/useAssetDefinitionFilterState.oss.tsx
@@ -224,3 +224,22 @@ export function filterAssetDefinition(
 
   return true;
 }
+
+export function getAssetFilterStateQueryString() {
+  const values: Record<keyof AssetFilterType, '1'> = {
+    groups: '1',
+    kinds: '1',
+    changedInBranch: '1',
+    owners: '1',
+    tags: '1',
+    codeLocations: '1',
+    selectAllFilters: '1',
+  };
+  const params = new URLSearchParams(location.search);
+  return Object.keys(values).reduce((soFar, key) => {
+    if (params.get(key)) {
+      return soFar + `&${key}=${params.get(key)}`;
+    }
+    return soFar;
+  }, '');
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/workspace/VirtualizedAssetRow.tsx
@@ -1,6 +1,7 @@
 import {Box, Caption, Checkbox, Colors, Icon, Skeleton} from '@dagster-io/ui-components';
 import * as React from 'react';
 import {Link} from 'react-router-dom';
+import {getAssetFilterStateQueryString} from 'shared/assets/useAssetDefinitionFilterState.oss';
 import styled from 'styled-components';
 
 import {RepoAddress} from './types';
@@ -67,12 +68,17 @@ export const VirtualizedAssetRow = (props: AssetRowProps) => {
   } = props;
 
   const liveData = useLiveDataOrLatestMaterializationDebounced(path, type);
-  const linkUrl = assetDetailsPathForKey(
+  let linkUrl = assetDetailsPathForKey(
     {path},
     {
       view: type === 'folder' ? 'folder' : undefined,
     },
   );
+
+  if (type === 'folder') {
+    // Forward filters
+    linkUrl += getAssetFilterStateQueryString();
+  }
 
   const onChange = (e: React.FormEvent<HTMLInputElement>) => {
     if (onToggleChecked && e.target instanceof HTMLInputElement) {


### PR DESCRIPTION
## Summary & Motivation
As titled

## How I Tested These Changes
I clicked on a folder link and saw the filters persist to the new page

## Changelog
[ui] Filters in the asset catalog now persist when navigating subdirectories. 