### PR TITLE
Display partition id in run view

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
@@ -16,7 +16,7 @@ import {RunAssetTags} from './RunAssetTags';
 import {RUN_PAGE_FRAGMENT} from './RunFragments';
 import {RunHeaderActions} from './RunHeaderActions';
 import {RunStatusTag} from './RunStatusTag';
-import {DagsterTag} from './RunTag';
+import {DagsterTag, RunTag} from './RunTag';
 import {RunTimingTags} from './RunTimingTags';
 import {getBackfillPath} from './RunsFeedUtils';
 import {TickTagForRun} from './TickTagForRun';
@@ -92,6 +92,8 @@ export const RunRoot = () => {
     return null;
   }, [run, repoAddress]);
 
+  const partitionTag = run?.tags.find((tag) => tag.key === DagsterTag.Partition);
+
   return (
     <div
       style={{
@@ -135,6 +137,7 @@ export const RunRoot = () => {
                     tickId={tickDetails.tickId}
                   />
                 ) : null}
+                {partitionTag && <RunTag tag={partitionTag} />}
                 <RunAssetTags run={run} />
                 <RunAssetCheckTags run={run} />
                 <RunTimingTags run={run} loading={loading} />


### PR DESCRIPTION
## Summary & Motivation

as titled
<img width="962" alt="Screenshot 2024-11-05 at 11 07 30 AM" src="https://github.com/user-attachments/assets/02d8c741-e57a-4695-aeff-7054f5cb3473">

## How I Tested These Changes



## Changelog
[ui] The Run page now displays the partition(s) a run was for.