### PR TITLE
[ui] Add padding to page headers for scenarios when they wrap

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/PageHeader.tsx
@@ -25,8 +25,9 @@ export const PageHeader = (props: Props) => {
     >
       {title && (
         <Box
+          padding={{vertical: 8}}
           style={{minHeight: 52, alignContent: 'center'}}
-          flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center'}}
+          flex={{direction: 'row', justifyContent: 'space-between', alignItems: 'center', gap: 8}}
         >
           <Box flex={{direction: 'row', alignItems: 'center', gap: 12, wrap: 'wrap'}}>
             {title}


### PR DESCRIPTION
## Summary & Motivation

This was noticed during the runs feed testing but wasn't specific to the runs feed. In general, if you make the page narrow enough that the page header wraps, there is no padding and the top text touches the navbar. We also didn't mandate padding to the left of the right-side actions, and this PR adds a gap there as well.

## How I Tested These Changes

Tested manually on a variety of pages + screen sizes