### PR TITLE
[bk] Remove spaces from dlift package spec names

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -360,7 +360,7 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     ),
     PackageSpec(
         "examples/quickstart_snowflake",
-        pytest_tox_factors=["pypi"],
+        pytest_tox_factors=["pypi"],d
     ),
     PackageSpec(
         "examples/experimental/dagster-blueprints",
@@ -386,7 +386,7 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     ),
     PackageSpec(
         "examples/experimental/dagster-dlift",
-        name=":dlift",
+        name="dlift",
     ),
     # Runs against live dbt cloud instance, we only want to run on commits and on the
     # nightly build

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -360,7 +360,7 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     ),
     PackageSpec(
         "examples/quickstart_snowflake",
-        pytest_tox_factors=["pypi"],d
+        pytest_tox_factors=["pypi"],
     ),
     PackageSpec(
         "examples/experimental/dagster-blueprints",

--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/packages.py
@@ -386,14 +386,14 @@ EXAMPLE_PACKAGES_WITH_CUSTOM_CONFIG: List[PackageSpec] = [
     ),
     PackageSpec(
         "examples/experimental/dagster-dlift",
-        name=":dbt: dlift",
+        name=":dlift",
     ),
     # Runs against live dbt cloud instance, we only want to run on commits and on the
     # nightly build
     PackageSpec(
         "examples/experimental/dagster-dlift/kitchen-sink",
         skip_if=skip_if_not_dlift_commit,
-        name=":dbt: dlift live",
+        name="dlift-live",
         env_vars=[
             "KS_DBT_CLOUD_ACCOUNT_ID",
             "KS_DBT_CLOUD_PROJECT_ID",


### PR DESCRIPTION
## Summary & Motivation

BK was unhappy with non-alphanumeric chars in the release branch step names

