### PR TITLE
[dagster-dbt] Fix generating column metadata when manifest uses Windows-style filepaths

### DIFF
--- a/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt/core/dbt_cli_event.py
@@ -125,7 +125,7 @@ def _build_column_lineage_metadata(
     node_sql_path = target_path.joinpath(
         "compiled",
         package_name,
-        dbt_resource_props["original_file_path"],
+        dbt_resource_props["original_file_path"].replace("\\", "/"),
     )
     optimized_node_ast = cast(
         exp.Query,

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/conftest.py
@@ -196,3 +196,19 @@ def test_dependencies_manifest_fixture() -> Dict[str, Any]:
         test_dependencies_path,
         build_project=True,
     ).get_artifact("manifest.json")
+
+
+@pytest.fixture(name="test_dependencies_manifest_windows", scope="session")
+def test_dependencies_manifest_windows_fixture(
+    test_dependencies_manifest: Dict[str, Any],
+) -> Dict[str, Any]:
+    return {
+        **test_dependencies_manifest,
+        "nodes": {
+            node: {
+                **node_details,
+                "original_file_path": node_details.get("original_file_path").replace("/", "\\"),
+            }
+            for node, node_details in test_dependencies_manifest["nodes"].items()
+        },
+    }

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/dbt_packages/test_columns_metadata.py
@@ -745,11 +745,17 @@ EXPECTED_COLUMN_LINEAGE_FOR_DEPENDENCIES_PROJECT = {
 }
 
 
+@pytest.mark.parametrize(
+    "use_windows_manifest",
+    [False, True],
+)
 def test_column_lineage_dependencies(
     test_dependencies_manifest: Dict[str, Any],
+    test_dependencies_manifest_windows: Dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,
     mocker: MockFixture,
     capsys,
+    use_windows_manifest: bool,
 ) -> None:
     # Patch get_relation_from_adapter so that we can track how often
     # relations are queried from the adapter vs cached
@@ -759,7 +765,11 @@ def test_column_lineage_dependencies(
     dbt = DbtCliResource(project_dir=os.fspath(test_dependencies_path))
     dbt.cli(["--quiet", "build", "--exclude", "resource_type:test"]).wait()
 
-    @dbt_assets(manifest=test_dependencies_manifest)
+    @dbt_assets(
+        manifest=test_dependencies_manifest_windows
+        if use_windows_manifest
+        else test_dependencies_manifest
+    )
     def my_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
         cli_invocation = dbt.cli(["build"], context=context).stream().fetch_column_metadata()
         yield from cli_invocation


### PR DESCRIPTION
## Summary

When using a dbt manifest that was built on a Windows machine but executed on a Unix machine, Dagster does not correctly resolve the sql filepath of the model's backing file.

This PR handles and tests that case.

## How I Tested These Changes

New unit test.

## Changelog

> [dagster-dbt] Fixed an error arising when fetching column lineage for dbt assets using a manifest built on Windows machines.
