### PR TITLE
Move types-sqlalchemy to requirements.txt

### DIFF
--- a/pyright/master/requirements.txt
+++ b/pyright/master/requirements.txt
@@ -104,6 +104,8 @@ wordcloud  # (quickstart-*)
 # that trigger type errors
 apache-airflow>2.7
 pendulum<3
+types-sqlalchemy==1.4.53.34
+
 
 ### EXAMPLES
 

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -155,7 +155,6 @@ setup(
             "types-requests",  # version will be resolved against requests
             "types-simplejson",  # version will be resolved against simplejson
             "types-six",  # needed but not specified by grpcio
-            "types-sqlalchemy==1.4.53.34",  # later versions introduce odd errors
             "types-tabulate",  # version will be resolved against tabulate
             "types-tzlocal",  # version will be resolved against tzlocal
             "types-toml",  # version will be resolved against toml


### PR DESCRIPTION
Move types-sqlalchemy into managed pyright environment

## Summary & Motivation

If you're using sqlalchemy 2, then this type package is no longer correctly representing the sqlalchemy types. This change moves the pinned package into the managed pyright environment instead of being in the pyright extra.

## How I Tested These Changes

make pyright

## Changelog

The `types-sqlalchemy` package is no longer included in the `dagster[pyright]` extra package. 
