### PR TITLE
[pipes] add PipesStdioLogWriter

### DIFF
--- a/python_modules/dagster-pipes/dagster_pipes_tests/test_log_writer.py
+++ b/python_modules/dagster-pipes/dagster_pipes_tests/test_log_writer.py
@@ -1,0 +1,46 @@
+import logging
+import os
+import sys
+import tempfile
+from time import sleep
+
+from dagster_pipes import PipesStdioFileLogWriter
+
+
+def test_pipes_stdio_file_log_writer(capsys):
+    logger = logging.getLogger("dagster-pipes")
+    fh = logging.FileHandler("spam.log")
+    fh.setLevel(logging.INFO)
+    logger.addHandler(fh)
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        with capsys.disabled(), PipesStdioFileLogWriter().open(
+            {
+                "logs_dir": tempdir,
+            }
+        ):
+            print(f"Writing this to stdout 1")  # noqa
+            print(f"Writing this to stderr 1", file=sys.stderr)  # noqa
+
+            sleep(1)
+
+            print(f"Writing this to stdout 2")  # noqa
+            print(f"Writing this to stderr 2", file=sys.stderr)  # noqa
+
+            sleep(1)
+
+            print("Writing this to stdout 3")  # noqa
+            print("Writing this to stderr 3", file=sys.stderr)  # noqa
+
+        print("This stdout is not captured")  # noqa
+        print("This stderr is not captured", file=sys.stderr)  # noqa
+
+        assert set(os.listdir(tempdir)) == {"stderr", "stdout"}
+
+        for stream in ["stdout", "stderr"]:
+            with open(os.path.join(tempdir, stream), "r") as stdout_file:
+                contents = stdout_file.read()
+                for i in range(1, 4):
+                    assert f"Writing this to {stream} {i}" in contents
+
+                assert f"This {stream} is not captured" not in contents


### PR DESCRIPTION
## Summary & Motivation

This PR adds:

- `PipesStdioLogWriter` - an partial implementation for `PipesLogWriter` abstract class which captures stdout/err of the current process. It doesn't handle writing logs, only capturing. Child classes should implement writing.
- `PipesStdioFileLogWriter` - an implementation for `PipesStdioLogWriter` which writes logs to the local filesystem (to a given directory)

---

The solution relies on `tee` command so only works on Linux and MacOS. This is required for real-time logs capturing because `tee` creates a normal file where stdout/stderr is duplicated, and it's possible to read from this file immediately (in oppose to other methods such as just running `os.dup2`).  

## How I Tested These Changes

Added tests

## How I Tested These Changes

Added a test. Tests for the Dagster side are upstream.

## Changelog

No changelog