### PR TITLE
(feat.) Update Feature Flags to support default values.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/DefaultFeatureFlags.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/DefaultFeatureFlags.oss.tsx
@@ -1,0 +1,10 @@
+import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
+
+/**
+ * Default values for feature flags when they are unset.
+ */
+export const DEFAULT_FEATURE_FLAG_VALUES: Partial<Record<FeatureFlag, boolean>> = {
+  // Flags for tests
+  [FeatureFlag.__TestFlagDefaultTrue]: true,
+  [FeatureFlag.__TestFlagDefaultFalse]: false,
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/app/FeatureFlags.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/FeatureFlags.oss.tsx
@@ -4,4 +4,9 @@ export enum FeatureFlag {
   flagSidebarResources = 'flagSidebarResources',
   flagDisableAutoLoadDefaults = 'flagDisableAutoLoadDefaults',
   flagLegacyRunsPage = 'flagLegacyRunsPage',
+
+  // Flags for tests
+  __TestFlagDefaultNone = '__TestFlagDefaultNone',
+  __TestFlagDefaultTrue = '__TestFlagDefaultTrue',
+  __TestFlagDefaultFalse = '__TestFlagDefaultFalse',
 }

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -1,35 +1,130 @@
-import memoize from 'lodash/memoize';
-import {useMemo} from 'react';
+import {useEffect, useState} from 'react';
+import {DEFAULT_FEATURE_FLAG_VALUES} from 'shared/app/DefaultFeatureFlags.oss';
 import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
 
 import {getJSONForKey} from '../hooks/useStateWithStorage';
 
 export const DAGSTER_FLAGS_KEY = 'DAGSTER_FLAGS';
 
-export const getFeatureFlags: () => FeatureFlag[] = memoize(
-  () => getJSONForKey(DAGSTER_FLAGS_KEY) || [],
-);
+/**
+ * Type representing the mapping of feature flags to their boolean states.
+ */
+type FeatureFlagMap = Partial<Record<FeatureFlag, boolean>>;
 
-export const featureEnabled = memoize((flag: FeatureFlag) => getFeatureFlags().includes(flag));
+/**
+ * In-memory cache for feature flags.
+ */
+let currentFeatureFlags: FeatureFlagMap = {};
 
-type FlagMap = {
-  readonly [_ in FeatureFlag]: boolean;
-};
+/**
+ * Initialize the in-memory cache by loading from localStorage and handling migration.
+ */
+const initializeFeatureFlags = () => {
+  let flags = getJSONForKey(DAGSTER_FLAGS_KEY);
 
-export const useFeatureFlags = () => {
-  return useMemo(() => {
-    const flagSet = new Set(getFeatureFlags());
-    const all: Record<string, boolean> = {};
-    for (const flag in FeatureFlag) {
-      all[flag] = flagSet.has(flag as FeatureFlag);
-    }
-    return all as FlagMap;
-  }, []);
-};
-
-export const setFeatureFlags = (flags: FeatureFlag[]) => {
-  if (!(flags instanceof Array)) {
-    throw new Error('flags must be an array');
+  // Handle backward compatibility by migrating array to object
+  if (Array.isArray(flags)) {
+    const migratedFlags: FeatureFlagMap = {};
+    flags.forEach((flag: FeatureFlag) => {
+      migratedFlags[flag] = true;
+    });
+    setFeatureFlagsInternal(migratedFlags, false); // Prevent broadcasting during migration
+    flags = migratedFlags;
   }
+
+  currentFeatureFlags = flags || {};
+};
+
+/**
+ * Internal function to set feature flags without broadcasting.
+ * Used during initialization and migration.
+ */
+const setFeatureFlagsInternal = (flags: FeatureFlagMap, broadcast: boolean = true) => {
+  if (typeof flags !== 'object' || Array.isArray(flags)) {
+    throw new Error('flags must be an object mapping FeatureFlag to boolean values');
+  }
+  currentFeatureFlags = flags;
   localStorage.setItem(DAGSTER_FLAGS_KEY, JSON.stringify(flags));
+  if (broadcast) {
+    featureFlagsChannel.postMessage('updated');
+  }
+};
+
+// Initialize the BroadcastChannel
+const featureFlagsChannel = new BroadcastChannel('feature-flags');
+
+// Initialize feature flags on module load
+initializeFeatureFlags();
+
+/**
+ * Function to retrieve the current feature flags from the in-memory cache.
+ */
+export const getFeatureFlags = (): FeatureFlagMap => {
+  return currentFeatureFlags;
+};
+
+/**
+ * Function to check if a specific feature flag is enabled.
+ * Falls back to default values if the flag is unset.
+ */
+export const featureEnabled = (flag: FeatureFlag): boolean => {
+  if (flag in currentFeatureFlags) {
+    return currentFeatureFlags[flag]!;
+  }
+
+  // Return default value if flag is unset
+  return DEFAULT_FEATURE_FLAG_VALUES[flag] ?? false;
+};
+
+/**
+ * Hook to access feature flags within React components.
+ * Returns a flag map with resolved values (considering defaults).
+ */
+export const useFeatureFlags = (): Readonly<Record<FeatureFlag, boolean>> => {
+  const [flags, setFlags] = useState<Record<FeatureFlag, boolean>>(() => {
+    const allFlags: Partial<Record<FeatureFlag, boolean>> = {};
+
+    for (const flag in FeatureFlag) {
+      const key = flag as FeatureFlag;
+      if (key in currentFeatureFlags) {
+        allFlags[key] = currentFeatureFlags[key];
+      } else {
+        allFlags[key] = DEFAULT_FEATURE_FLAG_VALUES[key] ?? false;
+      }
+    }
+    return allFlags as Record<FeatureFlag, boolean>;
+  });
+
+  useEffect(() => {
+    const handleFlagsChange = () => {
+      const allFlags: Partial<Record<FeatureFlag, boolean>> = {};
+
+      for (const flag in FeatureFlag) {
+        const key = flag as FeatureFlag;
+        if (key in currentFeatureFlags) {
+          allFlags[key] = currentFeatureFlags[key];
+        } else {
+          allFlags[key] = DEFAULT_FEATURE_FLAG_VALUES[key] ?? false;
+        }
+      }
+      setFlags(allFlags as Record<FeatureFlag, boolean>);
+    };
+
+    // Listen for messages from the BroadcastChannel
+    featureFlagsChannel.addEventListener('message', handleFlagsChange);
+
+    return () => {
+      featureFlagsChannel.removeEventListener('message', handleFlagsChange);
+    };
+  }, []);
+
+  return flags;
+};
+
+/**
+ * Function to update feature flags.
+ * Updates the in-memory cache, persists to localStorage, and broadcasts the change.
+ */
+export const setFeatureFlags = (flags: FeatureFlagMap) => {
+  setFeatureFlagsInternal(flags);
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -60,7 +60,10 @@ initializeFeatureFlags();
  * Function to retrieve the current feature flags from the in-memory cache.
  */
 export const getFeatureFlags = (): FeatureFlagMap => {
-  return currentFeatureFlags;
+  return {
+    ...DEFAULT_FEATURE_FLAG_VALUES,
+    ...currentFeatureFlags,
+  };
 };
 
 /**

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsButton.tsx
@@ -9,8 +9,6 @@ export const UserSettingsButton = () => {
   const [isOpen, setIsOpen] = useState(false);
   const visibleFlags = useVisibleFeatureFlagRows();
 
-  console.log({visibleFlags});
-
   return (
     <>
       <TopNavButton onClick={() => setIsOpen(true)} title="User settings">

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsButton.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsButton.tsx
@@ -9,6 +9,8 @@ export const UserSettingsButton = () => {
   const [isOpen, setIsOpen] = useState(false);
   const visibleFlags = useVisibleFeatureFlagRows();
 
+  console.log({visibleFlags});
+
   return (
     <>
       <TopNavButton onClick={() => setIsOpen(true)} title="User settings">

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/UserSettingsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/UserSettingsDialog.tsx
@@ -85,8 +85,6 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
     }
   };
 
-  console.log({visibleFlags});
-
   const experimentalSettings = visibleFlags.map(({key, label, flagType}) => (
     <Box
       padding={{vertical: 8}}

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/UserSettingsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/UserSettingsDialog.tsx
@@ -85,6 +85,8 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
     }
   };
 
+  console.log({visibleFlags});
+
   const experimentalSettings = visibleFlags.map(({key, label, flagType}) => (
     <Box
       padding={{vertical: 8}}

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/Flags.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/Flags.test.tsx
@@ -51,13 +51,17 @@ describe('Feature Flags with In-Memory Cache and BroadcastChannel', () => {
 
   it('should return default value for unset flags', () => {
     jest.isolateModules(() => {
-      const {featureEnabled} = require('../Flags');
+      const {featureEnabled, getFeatureFlags} = require('../Flags');
 
       const isEnabled = featureEnabled(FeatureFlag.__TestFlagDefaultTrue);
       expect(isEnabled).toBe(true);
 
       const isEnabled2 = featureEnabled(FeatureFlag.__TestFlagDefaultFalse);
       expect(isEnabled2).toBe(false);
+
+      expect(getFeatureFlags()[FeatureFlag.__TestFlagDefaultFalse]).toBe(false);
+      expect(getFeatureFlags()[FeatureFlag.__TestFlagDefaultTrue]).toBe(true);
+      expect(getFeatureFlags()[FeatureFlag.__TestFlagDefaultNone]).toBe(undefined);
     });
   });
 

--- a/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/Flags.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/__tests__/Flags.test.tsx
@@ -1,0 +1,130 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import {act, renderHook} from '@testing-library/react';
+import {FeatureFlag} from 'shared/app/FeatureFlags.oss';
+
+// Immediately import to force the mock constructor to file
+import '../../hooks/useStateWithStorage';
+
+// We're using isolateModules but we want to enforce the reference to React stays the same otherwise testing-library will fail
+// https://github.com/jestjs/jest/issues/11471
+jest.mock('react', () => jest.requireActual('react'));
+
+// eslint-disable-next-line no-var
+var mockGetJSONForKey: jest.Mock;
+
+jest.mock('../../hooks/useStateWithStorage', () => {
+  if (!mockGetJSONForKey) {
+    mockGetJSONForKey = jest.fn(() => {});
+  }
+  return {
+    getJSONForKey: mockGetJSONForKey,
+  };
+});
+
+describe('Feature Flags with In-Memory Cache and BroadcastChannel', () => {
+  const mockBroadcastChannel: any = new global.BroadcastChannel('feature-flags');
+
+  let mockBroadcastChannelInstance: any;
+
+  beforeEach(() => {
+    localStorage.clear();
+    mockGetJSONForKey.mockClear();
+
+    mockBroadcastChannelInstance = (global as any).BroadcastChannel.prototype;
+    mockBroadcastChannelInstance.listeners = [];
+  });
+
+  it('should migrate old array format to new object format', () => {
+    jest.isolateModules(() => {
+      const oldFlags = [FeatureFlag.__TestFlagDefaultTrue];
+      mockGetJSONForKey.mockReturnValue(oldFlags);
+
+      const {getFeatureFlags} = require('../Flags');
+
+      expect(getFeatureFlags()[FeatureFlag.__TestFlagDefaultTrue]).toBe(true);
+      expect(localStorage.getItem('DAGSTER_FLAGS')).toBe(
+        JSON.stringify({[FeatureFlag.__TestFlagDefaultTrue]: true}),
+      );
+      expect(Array.isArray(getFeatureFlags())).toBe(false);
+    });
+  });
+
+  it('should return default value for unset flags', () => {
+    jest.isolateModules(() => {
+      const {featureEnabled} = require('../Flags');
+
+      const isEnabled = featureEnabled(FeatureFlag.__TestFlagDefaultTrue);
+      expect(isEnabled).toBe(true);
+
+      const isEnabled2 = featureEnabled(FeatureFlag.__TestFlagDefaultFalse);
+      expect(isEnabled2).toBe(false);
+    });
+  });
+
+  it('should react to changes in feature flags across contexts', () => {
+    jest.isolateModules(() => {
+      const {useFeatureFlags, setFeatureFlags} = require('../Flags');
+      const {result} = renderHook(() => useFeatureFlags());
+
+      expect(result.current[FeatureFlag.__TestFlagDefaultNone]).toBe(false); // Default
+
+      act(() => {
+        setFeatureFlags({[FeatureFlag.__TestFlagDefaultNone]: true});
+      });
+
+      expect(result.current[FeatureFlag.__TestFlagDefaultNone]).toBe(true);
+
+      act(() => {
+        setFeatureFlags({[FeatureFlag.__TestFlagDefaultNone]: false});
+        mockBroadcastChannel.postMessage('updated');
+      });
+
+      expect(result.current[FeatureFlag.__TestFlagDefaultNone]).toBe(false);
+    });
+  });
+
+  it('should handle unset state correctly', () => {
+    jest.isolateModules(() => {
+      const {useFeatureFlags, setFeatureFlags} = require('../Flags');
+      const {result} = renderHook(() => useFeatureFlags());
+
+      expect(result.current[FeatureFlag.__TestFlagDefaultNone]).toBe(false); // Default
+
+      act(() => {
+        setFeatureFlags({[FeatureFlag.__TestFlagDefaultNone]: true});
+        mockBroadcastChannel.postMessage('updated');
+      });
+      expect(result.current[FeatureFlag.__TestFlagDefaultNone]).toBe(true);
+
+      act(() => {
+        setFeatureFlags({[FeatureFlag.__TestFlagDefaultNone]: false});
+        mockBroadcastChannel.postMessage('updated');
+      });
+      expect(result.current[FeatureFlag.__TestFlagDefaultNone]).toBe(false);
+
+      act(() => {
+        setFeatureFlags({});
+        mockBroadcastChannel.postMessage('updated');
+      });
+      expect(result.current[FeatureFlag.__TestFlagDefaultNone]).toBe(false); // Default
+    });
+  });
+
+  it('should update in-memory cache without reading localStorage on each access', () => {
+    jest.isolateModules(() => {
+      const {featureEnabled, setFeatureFlags, getFeatureFlags} = require('../Flags');
+      expect(mockGetJSONForKey).toHaveBeenCalledTimes(1);
+
+      expect(featureEnabled(FeatureFlag.__TestFlagDefaultNone)).toBe(false);
+
+      act(() => {
+        setFeatureFlags({[FeatureFlag.__TestFlagDefaultNone]: true});
+        mockBroadcastChannel.postMessage('updated');
+      });
+
+      expect(getFeatureFlags()[FeatureFlag.__TestFlagDefaultNone]).toBe(true);
+      expect(featureEnabled(FeatureFlag.__TestFlagDefaultNone)).toBe(true);
+      expect(mockGetJSONForKey).toHaveBeenCalledTimes(1); // Still only 1, from initialization
+    });
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/setupTests.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/setupTests.ts
@@ -30,7 +30,6 @@ afterAll(() => {
 
 global.ResizeObserver = ResizeObserver;
 
-// Define a minimal MessageEvent interface for the mock
 interface MockMessageEvent extends Event {
   data: any;
 }
@@ -99,5 +98,4 @@ class MockBroadcastChannel {
   }
 }
 
-// Assign the mock to the global object
 (global as any).BroadcastChannel = MockBroadcastChannel;

--- a/js_modules/dagster-ui/packages/ui-core/src/setupTests.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/setupTests.ts
@@ -29,3 +29,75 @@ afterAll(() => {
 });
 
 global.ResizeObserver = ResizeObserver;
+
+// Define a minimal MessageEvent interface for the mock
+interface MockMessageEvent extends Event {
+  data: any;
+}
+
+class MockBroadcastChannel {
+  name: string = '';
+  listeners: Array<(event: MockMessageEvent) => void> = [];
+
+  onmessage: ((this: MockBroadcastChannel, ev: MockMessageEvent) => any) | null = null;
+  onmessageerror: ((this: MockBroadcastChannel, ev: MockMessageEvent) => any) | null = null;
+
+  private static _instancesByName: Record<string, MockBroadcastChannel> = {};
+
+  constructor(name: string) {
+    if (!MockBroadcastChannel._instancesByName[name]) {
+      MockBroadcastChannel._instancesByName[name] = this;
+      this.name = name;
+      this.listeners = [];
+    }
+    return MockBroadcastChannel._instancesByName[name]!;
+  }
+
+  postMessage(message: any): void {
+    const event: MockMessageEvent = {type: 'message', data: message} as any;
+    this.listeners.forEach((listener) => listener(event));
+    if (this.onmessage) {
+      this.onmessage(event);
+    }
+  }
+
+  addEventListener(
+    type: string,
+    callback: (event: MockMessageEvent) => void,
+    _options?: boolean | AddEventListenerOptions,
+  ): void {
+    if (type === 'message') {
+      this.listeners.push(callback);
+    }
+  }
+
+  removeEventListener(
+    type: string,
+    callback: (event: MockMessageEvent) => void,
+    _options?: boolean | EventListenerOptions,
+  ): void {
+    if (type === 'message') {
+      this.listeners = this.listeners.filter((listener) => listener !== callback);
+    }
+  }
+
+  dispatchEvent(event: MockMessageEvent): boolean {
+    if (event.type === 'message') {
+      this.listeners.forEach((listener) => listener(event));
+      if (this.onmessage) {
+        this.onmessage(event);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  close(): void {
+    this.listeners = [];
+    this.onmessage = null;
+    this.onmessageerror = null;
+  }
+}
+
+// Assign the mock to the global object
+(global as any).BroadcastChannel = MockBroadcastChannel;


### PR DESCRIPTION
## Summary & Motivation

We want to support having a default value if a feature flag was never set before. To do this we need to distinguish between a flag being off because it was explicitly turned off or off because it was never turned on/off before. To do that I updated our localStorage schema to store an object with boolean values (on/off). The absence of a key in the object means the flag is unset and we should use the default value.

I also opted to use a BroadcastChannel for broadcasting feature flag updates across multiple tabs (probably overkill but still useful IMO).

I added logic to migrate from the old array localStorage schema to the new schema.

## How I Tested These Changes

jest.

Toggle flags on/off

Used in cloud for https://github.com/dagster-io/internal/pull/12543