### PR TITLE
Respect `auto_materialize_use_sensors`

### DIFF
--- a/python_modules/dagster/dagster/_core/remote_representation/external.py
+++ b/python_modules/dagster/dagster/_core/remote_representation/external.py
@@ -202,6 +202,9 @@ class RemoteRepository:
             for sensor_snap in self.repository_snap.sensors
         }
 
+        if not self._instance.auto_materialize_use_sensors:
+            return sensor_datas
+
         # if necessary, create a default automation condition sensor
         # NOTE: if a user's code location is at a version >= 1.9, then this step should
         # never be necessary, as this will be added in Definitions construction process


### PR DESCRIPTION
## Summary & Motivation

If a user has this setting turned off, then we shouldn't construct a sensor for them. 

Note: this only impacts cases where the user code server is on a lower dagster version than the host process, as in dagster>=1.9.0, the user code server will be constructing this sensor anyway.

## How I Tested These Changes

## Changelog

Fixed issue which would cause a `default_automation_condition_sensor` to be constructed for user code servers running on dagster version < 1.9.0 even if the legacy `auto_materialize: use_sensors` configuration setting was set to `False`.
