### PR TITLE
[dagster, pipes] consume messages from PipesDefaultLogWriter

### DIFF
--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -69,6 +69,7 @@ Method = Literal[
     "report_asset_materialization",
     "report_asset_check",
     "report_custom_message",
+    "log_stdio",
 ]
 
 
@@ -1029,17 +1030,18 @@ class PipesDefaultLogWriterChannel(PipesStdioLogWriterChannel):
         # write the chunk to a file
         self.message_channel.write_message(
             _make_message(
-                method="report_custom_message",  # maybe this needs new method types for stderr and stdout?
+                method="log_stdio",
                 params={
                     "stream": self.stream,
                     "text": chunk,
+                    "extras": {}
                 },
             )
         )
 
 
 class PipesDefaultLogWriter(PipesStdioLogWriter):
-    """A log writer that writes stdout and stderr via the message writer channel."""
+    """[Experimental] A log writer that writes stdout and stderr via the message writer channel."""
 
     def __init__(self, interval: float = 1):
         self.interval = interval
@@ -1672,6 +1674,9 @@ class PipesContext:
             payload (Any): JSON serializable data.
         """
         self._write_message("report_custom_message", {"payload": payload})
+
+    def log_stdio(self, stream: Literal["stdout", "stderr"], text: str, extras: Optional[PipesExtras] = None):
+        self._write_message("log_stdio", {"stream": stream, "text": text, "extras": extras or {}})
 
     @property
     def log(self) -> logging.Logger:

--- a/python_modules/dagster-pipes/dagster_pipes_tests/test_log_writer.py
+++ b/python_modules/dagster-pipes/dagster_pipes_tests/test_log_writer.py
@@ -2,10 +2,14 @@ import os
 import sys
 import tempfile
 
-from dagster_pipes import PipesStdioFileLogWriter
+from dagster_pipes import (
+    PipesDefaultLogWriter,
+    PipesFileMessageWriterChannel,
+    PipesStdioFileLogWriter,
+)
 
 
-def test_pipes_log_writer(capsys):
+def test_pipes_out_err_file_log_writer(capsys):
     with tempfile.TemporaryDirectory() as tempdir:
         with capsys.disabled(), PipesStdioFileLogWriter().open(
             {
@@ -24,3 +28,20 @@ def test_pipes_log_writer(capsys):
         with open(os.path.join(tempdir, "stderr"), "r") as stderr_file:
             contents = stderr_file.read()
             assert "And this to stderr" in contents
+
+
+def test_pipes_default_log_writer(capsys):
+    with tempfile.NamedTemporaryFile() as file:
+        message_channel = PipesFileMessageWriterChannel(file.name)
+
+        log_writer = PipesDefaultLogWriter()
+        log_writer.message_channel = message_channel
+        with capsys.disabled(), log_writer.open({}):
+            print("Writing this to stdout")  # noqa
+            print("And this to stderr", file=sys.stderr)  # noqa
+        with open(file.name, "r") as log_file:
+            messages = log_file.read().splitlines()
+            assert (
+                '{"__dagster_pipes_version": "0.1", "method": "report_custom_message", "params": {"stream": "stdout", "text": "Starting PipesDefaultLogWriterChannel(stdout)\\nStarting PipesDefaultLogWriterChannel(stderr)\\nWriting this to stdout\\nAnd this to stderr\\n"}}'
+                in messages
+            )

--- a/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_log_writer.py
+++ b/python_modules/dagster/dagster_tests/execution_tests/pipes_tests/test_log_writer.py
@@ -1,0 +1,66 @@
+import shutil
+from typing import Iterator
+
+import pytest
+from dagster import AssetExecutionContext, DagsterInstance, asset, materialize
+from dagster._core.pipes.subprocess import PipesSubprocessClient
+from dagster._core.pipes.utils import PipesTempFileMessageReader
+
+from dagster_tests.execution_tests.pipes_tests.utils import temp_script
+
+_PYTHON_EXECUTABLE = shutil.which("python")
+
+
+@pytest.fixture
+def external_script_default_log_writer() -> Iterator[str]:
+    # This is called in an external process and so cannot access outer scope
+    def script_fn():
+        import os
+        import sys
+
+        from dagster_pipes import (
+            DAGSTER_PIPES_LOG_WRITER_KEY,
+            PipesEnvVarParamsLoader,
+            PipesDefaultLogWriter,
+            PipesDefaultMessageWriter,
+            open_dagster_pipes,
+        )
+
+        with open_dagster_pipes(message_writer=PipesDefaultMessageWriter(
+            log_writer=PipesDefaultLogWriter()
+        )) as context:
+            print("Writing this to stdout")  # noqa: T201
+            print("And this to stderr", file=sys.stderr)  # noqa: T201
+
+            logs_dir = PipesEnvVarParamsLoader().load_messages_params()[
+                DAGSTER_PIPES_LOG_WRITER_KEY
+            ][PipesOutErrFileLogWriter.LOGS_DIR_KEY]
+
+    with temp_script(script_fn) as script_path:
+        yield script_path
+
+
+# in this test we do not check log reading logic in Dagster
+# only that the log writer is correctly configured and launched in the remote process
+def test_pipes_default_log_writer(
+    capsys,
+    tmpdir,
+    external_script_default_log_writer,
+):
+    message_reader = PipesTempFileMessageReader()
+
+    @asset
+    def foo(context: AssetExecutionContext, ext: PipesSubprocessClient):
+        cmd = [_PYTHON_EXECUTABLE, external_script_default_log_writer]
+        return ext.run(
+            command=cmd,
+            context=context,
+        ).get_results()
+
+    resource = PipesSubprocessClient(message_reader=message_reader)
+
+    with capsys.disabled(), DagsterInstance.ephemeral() as instance:
+        result = materialize([foo], instance=instance, resources={"ext": resource})
+        assert result.success
+
+    breakpoint()


### PR DESCRIPTION
## Summary & Motivation

This PR allows consuming `PipesDefaultLogWriter` messages in Dagster

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
