### PR TITLE
replace mock with unittest.mock

### DIFF
--- a/docs/content/concepts/assets/asset-checks/define-execute-asset-checks.mdx
+++ b/docs/content/concepts/assets/asset-checks/define-execute-asset-checks.mdx
@@ -143,8 +143,7 @@ To define multiple, similar asset checks, use a factory pattern. In the followin
 
 ```python file=/concepts/assets/asset_checks/factory.py
 from typing import Any, Mapping, Sequence
-
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from dagster import (
     AssetCheckResult,

--- a/docs/content/concepts/testing.mdx
+++ b/docs/content/concepts/testing.mdx
@@ -245,7 +245,7 @@ Mock resources can be provided directly using `materialize_to_memory`:
 
 ```python file=/concepts/ops_jobs_graphs/unit_tests.py startafter=start_materialize_resources endbefore=end_materialize_resources
 from dagster import asset, materialize_to_memory, ConfigurableResource
-import mock
+from unittest import mock
 
 
 class MyServiceResource(ConfigurableResource): ...
@@ -384,7 +384,7 @@ If your ops rely on more complex resources, such as those that build separate cl
 
 ```python file=/concepts/resources/pythonic_resources.py startafter=start_new_resource_testing_with_state_ops endbefore=end_new_resource_testing_with_state_ops dedent=4
 from dagster import ConfigurableResource, op
-import mock
+from unittest import mock
 
 class MyClient:
     ...

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/quality-testing/unit-testing-assets-and-ops/asset-resource.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/quality-testing/unit-testing-assets-and-ops/asset-resource.py
@@ -1,4 +1,5 @@
-import mock
+from unittest import mock
+
 from dagster_aws.s3 import S3FileHandle, S3FileManager
 
 import dagster as dg

--- a/examples/docs_beta_snippets/docs_beta_snippets/guides/quality-testing/unit-testing-assets-and-ops/op-resource.py
+++ b/examples/docs_beta_snippets/docs_beta_snippets/guides/quality-testing/unit-testing-assets-and-ops/op-resource.py
@@ -1,4 +1,5 @@
-import mock
+from unittest import mock
+
 from dagster_aws.s3 import S3FileHandle, S3FileManager
 
 import dagster as dg

--- a/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/factory.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/asset_checks/factory.py
@@ -1,6 +1,5 @@
 from typing import Any, Mapping, Sequence
-
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from dagster import (
     AssetCheckResult,

--- a/examples/docs_snippets/docs_snippets/concepts/assets/graph_backed_asset.py
+++ b/examples/docs_snippets/docs_snippets/concepts/assets/graph_backed_asset.py
@@ -9,7 +9,7 @@ from dagster import (
     Definitions,
     OpExecutionContext,
 )
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 
 def create_db_connection():

--- a/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
+++ b/examples/docs_snippets/docs_snippets/concepts/ops_jobs_graphs/unit_tests.py
@@ -172,7 +172,7 @@ def context_op(context: OpExecutionContext):
 # start_test_op_with_resource_client
 
 from dagster import ConfigurableResource
-import mock
+from unittest import mock
 
 
 class Client:
@@ -407,7 +407,7 @@ def test_data_assets():
 
 # start_materialize_resources
 from dagster import asset, materialize_to_memory, ConfigurableResource
-import mock
+from unittest import mock
 
 
 class MyServiceResource(ConfigurableResource): ...

--- a/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets/concepts/resources/pythonic_resources.py
@@ -700,7 +700,7 @@ def new_resource_testing_with_state_ops() -> None:
     # start_new_resource_testing_with_state_ops
 
     from dagster import ConfigurableResource, op
-    import mock
+    from unittest import mock
 
     class MyClient:
         ...

--- a/examples/docs_snippets/docs_snippets/integrations/airbyte/airbyte.py
+++ b/examples/docs_snippets/docs_snippets/integrations/airbyte/airbyte.py
@@ -110,7 +110,7 @@ def scope_airbyte_cloud_manual_config():
 
 
 def scope_add_downstream_assets():
-    import mock
+    from unittest import mock
 
     with mock.patch("dagster_snowflake_pandas.SnowflakePandasIOManager"):
         # start_add_downstream_assets
@@ -158,7 +158,7 @@ def scope_add_downstream_assets():
 
 
 def scope_add_downstream_assets_w_deps():
-    import mock
+    from unittest import mock
 
     with mock.patch("dagster_snowflake.SnowflakeResource"):
         # start_with_deps_add_downstream_assets
@@ -209,7 +209,7 @@ def scope_add_downstream_assets_w_deps():
 
 
 def scope_add_downstream_assets_cloud():
-    import mock
+    from unittest import mock
 
     with mock.patch("dagster_snowflake_pandas.SnowflakePandasIOManager"):
         # start_add_downstream_assets_cloud
@@ -263,7 +263,7 @@ def scope_add_downstream_assets_cloud():
 
 
 def scope_add_downstream_assets_cloud_with_deps():
-    import mock
+    from unittest import mock
 
     with mock.patch("dagster_snowflake.SnowflakeResource"):
         # start_with_deps_add_downstream_assets_cloud

--- a/examples/docs_snippets/docs_snippets/integrations/fivetran/fivetran.py
+++ b/examples/docs_snippets/docs_snippets/integrations/fivetran/fivetran.py
@@ -107,7 +107,7 @@ def scope_schedule_assets():
 
 
 def scope_add_downstream_assets():
-    import mock
+    from unittest import mock
 
     with mock.patch("dagster_snowflake_pandas.SnowflakePandasIOManager"):
         # start_add_downstream_assets

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_checks.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_checks.py
@@ -1,10 +1,10 @@
 from datetime import datetime
 from importlib import resources
+from unittest import mock
+from unittest.mock import MagicMock
 
-import mock
 import pytest
 from dagster_tests.cli_tests.command_tests.assets import fail_asset
-from mock import MagicMock
 
 from dagster import Definitions
 from dagster._core.definitions.asset_check_spec import AssetCheckKey

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_config.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_config.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from docs_snippets.concepts.assets.asset_config import (
     MyDownstreamAssetConfig,

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_testing.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/assets_tests/test_asset_testing.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 
 def test_uses_resource() -> None:

--- a/examples/docs_snippets/docs_snippets_tests/concepts_tests/resources_tests/test_pythonic_resources.py
+++ b/examples/docs_snippets/docs_snippets_tests/concepts_tests/resources_tests/test_pythonic_resources.py
@@ -1,6 +1,6 @@
 from typing import Any
+from unittest import mock
 
-import mock
 import pytest
 
 from dagster._core.definitions.run_config import RunConfig

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_load_defs.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import cast
+from unittest import mock
 
-import mock
 from dagster import (
     AssetKey,
     AssetsDefinition,

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_sensor.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/core_tests/test_sensor.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Sequence
+from unittest import mock
 
-import mock
 import pytest
 from dagster import (
     AssetCheckKey,

--- a/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/mwaa_tests/test_mwaa_auth.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift_tests/unit_tests/mwaa_tests/test_mwaa_auth.py
@@ -1,5 +1,6 @@
+from unittest import mock
+
 import boto3
-import mock
 from dagster_airlift.mwaa import MwaaSessionAuthBackend
 
 

--- a/examples/experimental/dagster-blueprints/dagster_blueprints_tests/test_cli/test_blueprint_command.py
+++ b/examples/experimental/dagster-blueprints/dagster_blueprints_tests/test_cli/test_blueprint_command.py
@@ -3,8 +3,8 @@ import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List
+from unittest import mock
 
-import mock
 import pytest
 from click.testing import CliRunner
 

--- a/examples/project_fully_featured/setup.py
+++ b/examples/project_fully_featured/setup.py
@@ -24,7 +24,6 @@ setup(
         "dbt-duckdb",
         "dbt-snowflake",
         "duckdb!=0.3.3, <= 6.0.0",  # missing wheels
-        "mock",
         "pandas",
         "pyarrow>=4.0.0",
         "pyspark",

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_asset_backfill.py
@@ -1,6 +1,6 @@
 from typing import Optional, Tuple
+from unittest import mock
 
-import mock
 from dagster import (
     AssetKey,
     DailyPartitionsDefinition,

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_nux.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_nux.py
@@ -1,4 +1,5 @@
-import mock
+from unittest import mock
+
 from dagster_graphql.test.utils import execute_dagster_graphql
 
 SET_NUX_SEEN_MUTATION = """

--- a/python_modules/dagster-test/dagster_test_tests/test_toys.py
+++ b/python_modules/dagster-test/dagster_test_tests/test_toys.py
@@ -1,4 +1,5 @@
-import mock
+from unittest import mock
+
 import pytest
 from dagster import (
     DagsterEvent,

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps_error_informative.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_deps_error_informative.py
@@ -2,8 +2,8 @@ import re
 import sys
 import time
 from typing import List
+from unittest import mock
 
-import mock
 import pytest
 from dagster import AssetIn, AssetKey, Definitions, asset
 from dagster._core.definitions.resolved_asset_deps import resolve_similar_asset_names

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection_error_informative.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection_error_informative.py
@@ -1,7 +1,7 @@
 import re
 import sys
+from unittest import mock
 
-import mock
 import pytest
 from dagster import AssetSelection, Definitions, asset, define_asset_job
 from dagster._core.errors import DagsterInvalidSubsetError

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_cli_commands.py
@@ -4,8 +4,8 @@ import sys
 import tempfile
 from contextlib import contextmanager
 from typing import ContextManager, NoReturn, Optional, Tuple
+from unittest import mock
 
-import mock
 import pytest
 from click.testing import CliRunner
 from dagster import (

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_schedule_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_schedule_commands.py
@@ -1,7 +1,7 @@
 import re
+from unittest import mock
 
 import click
-import mock
 import pytest
 from click.testing import CliRunner
 from dagster._cli.schedule import (

--- a/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_sensor_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/command_tests/test_sensor_commands.py
@@ -1,7 +1,7 @@
 import re
+from unittest import mock
 
 import click
-import mock
 import pytest
 from click.testing import CliRunner
 from dagster._cli.sensor import (

--- a/python_modules/dagster/dagster_tests/cli_tests/test_api_commands.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_api_commands.py
@@ -1,6 +1,6 @@
 import os
+from unittest import mock
 
-import mock
 import pytest
 from click.testing import CliRunner
 from dagster import DagsterEventType, job, op, reconstructable

--- a/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_instance_concurrency_context.py
+++ b/python_modules/dagster/dagster_tests/core_tests/execution_tests/test_instance_concurrency_context.py
@@ -1,7 +1,7 @@
 import time
 from contextlib import ExitStack
+from unittest import mock
 
-import mock
 import pytest
 from dagster import job, op
 from dagster._core.execution.plan.instance_concurrency_context import (

--- a/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_invocation.py
+++ b/python_modules/dagster/dagster_tests/core_tests/hook_tests/test_hook_invocation.py
@@ -1,6 +1,6 @@
 import re
+from unittest import mock
 
-import mock
 import pytest
 from dagster import (
     DagsterInstance,

--- a/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
+++ b/python_modules/dagster/dagster_tests/core_tests/resource_tests/pythonic_resources/test_general_pythonic_resources.py
@@ -1,8 +1,8 @@
 import enum
 from abc import ABC, abstractmethod
 from typing import List, Mapping, Optional
+from unittest import mock
 
-import mock
 import pytest
 from dagster import (
     AssetExecutionContext,

--- a/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_data_time.py
@@ -2,8 +2,8 @@ import datetime
 import random
 from collections import defaultdict
 from typing import List, NamedTuple, Optional
+from unittest import mock
 
-import mock
 import pytest
 from dagster import (
     AssetKey,

--- a/python_modules/dagster/dagster_tests/core_tests/test_telemetry_upload.py
+++ b/python_modules/dagster/dagster_tests/core_tests/test_telemetry_upload.py
@@ -1,7 +1,7 @@
 import logging
 import os
+from unittest import mock
 
-import mock
 import pytest
 import responses
 from click.testing import CliRunner

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_failure_recovery.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_failure_recovery.py
@@ -1,4 +1,5 @@
 import multiprocessing
+from unittest.mock import patch
 
 import pytest
 from dagster._core.definitions.run_request import InstigatorType
@@ -19,7 +20,6 @@ from dagster._daemon.sensor import execute_sensor_iteration
 from dagster._seven import IS_WINDOWS
 from dagster._time import create_datetime, get_timezone
 from dagster._vendored.dateutil.relativedelta import relativedelta
-from mock import patch
 
 from dagster_tests.daemon_sensor_tests.conftest import create_workspace_load_target
 from dagster_tests.daemon_sensor_tests.test_sensor_run import wait_for_all_runs_to_start

--- a/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
+++ b/python_modules/dagster/dagster_tests/daemon_sensor_tests/test_sensor_run.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack
 from typing import Any
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
 from dagster import (
@@ -94,7 +95,6 @@ from dagster._daemon.sensor import execute_sensor_iteration, execute_sensor_iter
 from dagster._record import copy
 from dagster._time import create_datetime, get_current_datetime
 from dagster._vendored.dateutil.relativedelta import relativedelta
-from mock import patch
 
 from dagster_tests.daemon_sensor_tests.conftest import create_workspace_load_target
 

--- a/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
+++ b/python_modules/dagster/dagster_tests/daemon_tests/test_backfill.py
@@ -4,9 +4,9 @@ import random
 import string
 import sys
 import time
+from unittest import mock
 
 import dagster._check as check
-import mock
 import pytest
 from dagster import (
     AllPartitionMapping,

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/base_scenario.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/base_scenario.py
@@ -18,9 +18,9 @@ from typing import (
     Tuple,
     Union,
 )
+from unittest import mock
 
 import dagster._check as check
-import mock
 import pytest
 from dagster import (
     AssetIn,

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/scenario_state.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/scenario_utils/scenario_state.py
@@ -7,8 +7,8 @@ import sys
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import AbstractSet, Iterable, NamedTuple, Optional, Sequence, Union, cast
+from unittest import mock
 
-import mock
 from dagster import (
     AssetExecutionContext,
     AssetKey,

--- a/python_modules/dagster/dagster_tests/logging_tests/test_python_logging.py
+++ b/python_modules/dagster/dagster_tests/logging_tests/test_python_logging.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Mapping, Optional, Sequence, Union
+from unittest import mock
 
-import mock
 import pytest
 from dagster import get_dagster_logger, reconstructable, resource
 from dagster._core.definitions.decorators import op

--- a/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_io_manager.py
@@ -2,8 +2,8 @@ import os
 import tempfile
 import time
 from typing import Mapping
+from unittest import mock
 
-import mock
 import pytest
 from dagster import (
     AssetKey,

--- a/python_modules/dagster/dagster_tests/storage_tests/test_schedule_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_schedule_storage.py
@@ -1,7 +1,7 @@
 import tempfile
 from contextlib import contextmanager
+from unittest import mock
 
-import mock
 import pytest
 from dagster._core.storage.legacy_storage import LegacyScheduleStorage
 from dagster._core.storage.schedules import SqliteScheduleStorage

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -8,8 +8,8 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack, contextmanager
 from typing import List, Optional, Sequence, Tuple, cast
+from unittest import mock
 
-import mock
 import pytest
 import sqlalchemy as db
 from dagster import (

--- a/python_modules/dagster/dagster_tests/utils_tests/test_container_utils.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_container_utils.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Optional
+from unittest import mock
 
-import mock
 import pytest
 from dagster._utils.container import CGroupVersion, retrieve_containerized_utilization_metrics
 from dagster._utils.env import environ

--- a/python_modules/dagster/setup.py
+++ b/python_modules/dagster/setup.py
@@ -120,7 +120,6 @@ setup(
             "buildkite-test-collector",
             "docker",
             f"grpcio-tools>={GRPC_VERSION_FLOOR}",
-            "mock==3.0.5",
             "mypy-protobuf",
             "objgraph",
             "pytest-cov==5.0.0",

--- a/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/test_managed_elements.py
+++ b/python_modules/libraries/dagster-airbyte/dagster_airbyte_tests/integration/test_managed_elements.py
@@ -5,8 +5,8 @@ import os
 import time
 from datetime import datetime
 from typing import cast
+from unittest import mock
 
-import mock
 import pytest
 import requests
 import requests_mock

--- a/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_postprocessing.py
+++ b/python_modules/libraries/dagster-dbt/dagster_dbt_tests/core/test_postprocessing.py
@@ -2,8 +2,8 @@ import json
 import os
 from decimal import Decimal
 from typing import Any, Dict, cast
+from unittest import mock
 
-import mock
 import pytest
 from dagster import (
     AssetExecutionContext,

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_fetch_metadata.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/dlt_tests/test_fetch_metadata.py
@@ -1,6 +1,6 @@
 import asyncio
+from unittest import mock
 
-import mock
 from dagster import AssetExecutionContext, AssetKey, MonthlyPartitionsDefinition
 from dagster._core.definitions.materialize import materialize
 from dagster_embedded_elt.dlt import DagsterDltResource, dlt_assets

--- a/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_fetch_metadata.py
+++ b/python_modules/libraries/dagster-embedded-elt/dagster_embedded_elt_tests/sling_tests/test_fetch_metadata.py
@@ -1,4 +1,5 @@
-import mock
+from unittest import mock
+
 from dagster import AssetExecutionContext, AssetKey
 from dagster._core.definitions.materialize import materialize
 from dagster._core.definitions.metadata.metadata_value import (

--- a/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_client.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_client.py
@@ -1,6 +1,5 @@
 import json
-
-from mock import patch
+from unittest.mock import patch
 
 
 @patch("dagster_msteams.client.TeamsClient.post_message")

--- a/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_hooks.py
@@ -1,9 +1,10 @@
+from unittest.mock import patch
+
 from dagster import op
 from dagster._core.definitions.decorators.job_decorator import job
 from dagster_msteams import MSTeamsResource
 from dagster_msteams.hooks import teams_on_failure, teams_on_success
 from dagster_msteams.resources import msteams_resource
-from mock import patch
 
 
 class SomeUserException(Exception):

--- a/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_resources.py
+++ b/python_modules/libraries/dagster-msteams/dagster_msteams_tests/test_resources.py
@@ -1,9 +1,9 @@
 import json
+from unittest.mock import patch
 
 from dagster import op
 from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_msteams import MSTeamsResource, msteams_resource
-from mock import patch
 
 
 @patch("dagster_msteams.client.TeamsClient.post_message")

--- a/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
@@ -1,3 +1,5 @@
+from unittest.mock import ANY, MagicMock, patch
+
 import pytest
 from dagster import (
     AssetExecutionContext,
@@ -18,7 +20,6 @@ from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.context.init import build_init_resource_context
 from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_openai import OpenAIResource, with_usage_metadata
-from mock import ANY, MagicMock, patch
 
 
 @patch("dagster_openai.resources.Client")

--- a/python_modules/libraries/dagster-slack/dagster_slack_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack_tests/test_hooks.py
@@ -1,8 +1,9 @@
+from unittest.mock import patch
+
 from dagster import op
 from dagster._core.definitions.decorators.job_decorator import job
 from dagster_slack import slack_resource
 from dagster_slack.hooks import slack_on_failure, slack_on_success
-from mock import patch
 
 
 class SomeUserException(Exception):

--- a/python_modules/libraries/dagster-slack/dagster_slack_tests/test_resources.py
+++ b/python_modules/libraries/dagster-slack/dagster_slack_tests/test_resources.py
@@ -1,9 +1,9 @@
 import json
+from unittest.mock import patch
 
 from dagster import op
 from dagster._utils.test import wrap_op_in_graph_and_execute
 from dagster_slack import SlackResource, slack_resource
-from mock import patch
 
 
 @patch("slack_sdk.WebClient.api_call")


### PR DESCRIPTION
> mock is now part of the Python standard library, available as unittest.mock in Python 3.3 onwards.

## How I Tested These Changes

bk