### PR TITLE
fix backfill_id migration query issue where query was repeated appended with cursor

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -315,7 +315,7 @@ def migrate_run_backfill_id(storage: RunStorage, print_fn: Optional[PrintFn] = N
     with storage.connect() as conn:
         cursor = None
         has_more = True
-        query = (
+        base_query = (
             db_select([RunTagsTable.c.id, RunTagsTable.c.run_id, RunTagsTable.c.value])
             .where(RunTagsTable.c.key == BACKFILL_ID_TAG)
             .limit(CHUNK_SIZE)
@@ -324,7 +324,7 @@ def migrate_run_backfill_id(storage: RunStorage, print_fn: Optional[PrintFn] = N
 
         while has_more:
             if cursor:
-                query = query.where(RunTagsTable.c.id > cursor)
+                query = base_query.where(RunTagsTable.c.id > cursor)
             res = storage.fetchall(query)
             has_more = len(res) >= CHUNK_SIZE
             for row in res:

--- a/python_modules/dagster/dagster/_core/storage/runs/migration.py
+++ b/python_modules/dagster/dagster/_core/storage/runs/migration.py
@@ -325,6 +325,8 @@ def migrate_run_backfill_id(storage: RunStorage, print_fn: Optional[PrintFn] = N
         while has_more:
             if cursor:
                 query = base_query.where(RunTagsTable.c.id > cursor)
+            else:
+                query = base_query
             res = storage.fetchall(query)
             has_more = len(res) >= CHUNK_SIZE
             for row in res:


### PR DESCRIPTION
## Summary & Motivation
instead of adding the cursor WHERE clause to a static base query, we were repeatedly appending the WHERE clauses onto the query 

## How I Tested These Changes

## Changelog

Fixed an issue where running `dagster instance migrate` on Dagster version 1.9.0 constructed a SQL query that exceeded the maximum allowed depth. 
