### PR TITLE
Check if asset graph has asset before getting it

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/roots/query.py
@@ -1157,14 +1157,15 @@ class GrapheneQuery(graphene.ObjectType):
         asset_keys = set(AssetKey.from_graphql_input(asset_key) for asset_key in assetKeys)
 
         remote_nodes = {
-            graphene_info.context.asset_graph.get(asset_key) for asset_key in asset_keys
+            graphene_info.context.asset_graph.get(asset_key)
+            for asset_key in asset_keys
+            if graphene_info.context.asset_graph.has(asset_key)
         }
 
         # Build mapping of asset key to the step keys required to generate the asset
         step_keys_by_asset: Dict[AssetKey, Sequence[str]] = {
             remote_node.key: remote_node.resolve_to_singular_repo_scoped_node().asset_node_snap.op_names
             for remote_node in remote_nodes
-            if remote_node
         }
 
         AssetRecord.prepare(graphene_info.context, asset_keys)

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -1905,6 +1905,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
             return {stat["assetKey"]["path"][0]: stat for stat in response}
 
         # Confirm that when no runs are present, run returned is None
+        FAKE_KEY = "<key does not exist>"
         result = execute_dagster_graphql(
             graphql_context,
             GET_ASSET_LATEST_RUN_STATS,
@@ -1913,6 +1914,8 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
                     {"path": "asset_1"},
                     {"path": "asset_2"},
                     {"path": "asset_3"},
+                    # fake key should not cause error
+                    {"path": FAKE_KEY},
                 ]
             },
         )
@@ -1923,6 +1926,7 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
 
         assert result["asset_1"]["latestRun"] is None
         assert result["asset_1"]["latestMaterialization"] is None
+        assert FAKE_KEY not in result
 
         # Test with 1 run on all assets
         first_run_id = _create_run(graphql_context, "failure_assets_job")


### PR DESCRIPTION
## Summary & Motivation

See changelog

## How I Tested These Changes

## Changelog

Fixed bug that could cause a GraphQL error on certain views when running `dagster dev` on a code location after removing an asset.
