### PR TITLE
[graphql] handle config mapped resources

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/logger.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/logger.py
@@ -29,6 +29,12 @@ class GrapheneLogger(graphene.ObjectType):
 
     def resolve_configField(self, _: ResolveInfo):
         if self._logger_def_snap.config_field_snap:
+            try:
+                # config type may not be present if mode config mapped, null out gracefully
+                self._get_config_type(self._logger_def_snap.config_field_snap.type_key)
+            except KeyError:
+                return None
+
             return GrapheneConfigTypeField(
                 self._get_config_type,
                 field_snap=self._logger_def_snap.config_field_snap,

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/resource.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/resource.py
@@ -32,6 +32,12 @@ class GrapheneResource(graphene.ObjectType):
 
     def resolve_configField(self, _graphene_info: ResolveInfo):
         if self._resource_def_snap.config_field_snap:
+            try:
+                # config type may not be present if mode config mapped, null out gracefully
+                self._get_config_type(self._resource_def_snap.config_field_snap.type_key)
+            except KeyError:
+                return None
+
             return GrapheneConfigTypeField(
                 get_config_type=self._get_config_type,
                 field_snap=self._resource_def_snap.config_field_snap,


### PR DESCRIPTION
I dropped some handling here https://github.com/dagster-io/dagster/pull/25552/files#r1833202428 thinking it was for `mode` which is now defunct, but this can still happen so handle it. Since the config type is nullable the behavior is the same so this just gracefully handles the condition without error.

## How I Tested These Changes

loaded a job in the UI that was previously failing, now loads without error