### PR TITLE
[ui] Fix issue with candidate count

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PolicyEvaluationTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/PolicyEvaluationTable.tsx
@@ -131,7 +131,7 @@ const NewPolicyEvaluationTable = ({
       <tbody>
         {flattenedRecords.map(({evaluation, id, parentId, depth, type}) => {
           const {userLabel, uniqueId, numTrue, numCandidates, expandedLabel} = evaluation;
-          const anyCandidatePartitions = typeof numCandidates === 'number' && numCandidates > 0;
+          const anyCandidatePartitions = numCandidates === null || numCandidates > 0;
           const status =
             numTrue === 0 && !anyCandidatePartitions
               ? AssetConditionEvaluationStatus.SKIPPED
@@ -205,7 +205,7 @@ const NewPolicyEvaluationTable = ({
                   <PolicyEvaluationStatusTag status={status} />
                 </td>
               )}
-              {isPartitioned ? <td>{numCandidates || '0'}</td> : null}
+              {isPartitioned ? <td>{numCandidates === null ? 'All' : numCandidates}</td> : null}
               <td>
                 {startTimestamp && endTimestamp ? (
                   <TimeElapsed startUnix={startTimestamp} endUnix={endTimestamp} showMsec />


### PR DESCRIPTION
## Summary & Motivation

See changelog -- core thing is that numCandidates is Null when all partitions are evaluated

## How I Tested These Changes

## Changelog

[ui] Fixed issue which would cause the "Partitions evaluated" label to incorrectly display "0" in cases where all partitions were evaluated.
