### PR TITLE
[5/n][dagster-fivetran] Implement `FivetranWorkspaceData` to `FivetranConnectorTableProps` method

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -122,7 +122,15 @@ def _build_fivetran_assets(
         table: AssetKey([*asset_key_prefix, *table.split(".")])
         if not translator_instance or not connection_metadata
         else translator_instance.get_asset_spec(
-            FivetranConnectorTableProps(table=table, **connection_metadata._asdict())
+            FivetranConnectorTableProps(
+                table=table,
+                connector_id=connection_metadata.connector_id,
+                name=connection_metadata.name,
+                connector_url=connection_metadata.connector_url,
+                schema_config=connection_metadata.schemas,
+                database=connection_metadata.database,
+                service=connection_metadata.service,
+            )
         ).key
         for table in destination_tables
     }

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -163,7 +163,15 @@ def _build_fivetran_assets(
             )
             if not translator_instance or not connection_metadata
             else translator_instance.get_asset_spec(
-                FivetranConnectorTableProps(table=table, **connection_metadata._asdict())
+                FivetranConnectorTableProps(
+                    table=table,
+                    connector_id=connection_metadata.connector_id,
+                    name=connection_metadata.name,
+                    connector_url=connection_metadata.connector_url,
+                    schema_config=connection_metadata.schemas,
+                    database=connection_metadata.database,
+                    service=connection_metadata.service,
+                )
             )
             for table in tracked_asset_keys.keys()
         ],

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/translator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/translator.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Sequence, cast
 
+from dagster._utils.cached_method import cached_method
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._record import record
@@ -63,6 +64,7 @@ class FivetranWorkspaceData:
             },
         )
 
+    @cached_method
     def to_fivetran_connector_table_props_data(self) -> Sequence[FivetranConnectorTableProps]:
         """Method that converts a `FivetranWorkspaceData` object
         to a collection of `FivetranConnectorTableProps` objects.

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/translator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/translator.py
@@ -1,13 +1,17 @@
 from enum import Enum
 from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Sequence, cast
 
-from dagster._utils.cached_method import cached_method
 from dagster._core.definitions.asset_key import AssetKey
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._record import record
 from dagster._serdes.serdes import whitelist_for_serdes
+from dagster._utils.cached_method import cached_method
 
-from dagster_fivetran.utils import get_fivetran_connector_url, metadata_for_table
+from dagster_fivetran.utils import (
+    get_fivetran_connector_table_name,
+    get_fivetran_connector_url,
+    metadata_for_table,
+)
 
 
 class FivetranConnectorTableProps(NamedTuple):
@@ -96,7 +100,9 @@ class FivetranWorkspaceData:
                             table_name = table["name_in_destination"]
                             data.append(
                                 FivetranConnectorTableProps(
-                                    table=f"{schema_name}.{table_name}",
+                                    table=get_fivetran_connector_table_name(
+                                        schema_name=schema_name, table_name=table_name
+                                    ),
                                     connector_id=connector_id,
                                     name=connector_name,
                                     connector_url=connector_url,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/utils.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/utils.py
@@ -19,6 +19,10 @@ def get_fivetran_logs_url(connector_details: Mapping[str, Any]) -> str:
     return f"{get_fivetran_connector_url(connector_details)}/logs"
 
 
+def get_fivetran_connector_table_name(schema_name: str, table_name: str) -> str:
+    return f"{schema_name}.{table_name}"
+
+
 def metadata_for_table(
     table_data: Mapping[str, Any],
     connector_url: str,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/conftest.py
@@ -1,5 +1,5 @@
-from typing import Iterator
 import uuid
+from typing import Iterator
 
 import pytest
 import responses

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/conftest.py
@@ -1,4 +1,5 @@
 from typing import Iterator
+import uuid
 
 import pytest
 import responses
@@ -379,6 +380,16 @@ SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR = {
         "schema_change_handling": "ALLOW_ALL",
     },
 }
+
+
+@pytest.fixture(name="api_key")
+def api_key_fixture() -> str:
+    return uuid.uuid4().hex
+
+
+@pytest.fixture(name="api_secret")
+def api_secret_fixture() -> str:
+    return uuid.uuid4().hex
 
 
 @pytest.fixture(name="connector_id")

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/conftest.py
@@ -224,16 +224,16 @@ SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR = {
         "enable_new_by_default": True,
         "schemas": {
             "property1": {
-                "name_in_destination": "schema_name_in_destination",
+                "name_in_destination": "schema_name_in_destination_1",
                 "enabled": True,
                 "tables": {
                     "property1": {
                         "sync_mode": "SOFT_DELETE",
-                        "name_in_destination": "table_name_in_destination",
+                        "name_in_destination": "table_name_in_destination_1",
                         "enabled": True,
                         "columns": {
                             "property1": {
-                                "name_in_destination": "column_name_in_destination",
+                                "name_in_destination": "column_name_in_destination_1",
                                 "enabled": True,
                                 "hashed": False,
                                 "enabled_patch_settings": {
@@ -244,7 +244,7 @@ SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR = {
                                 "is_primary_key": True,
                             },
                             "property2": {
-                                "name_in_destination": "column_name_in_destination",
+                                "name_in_destination": "column_name_in_destination_2",
                                 "enabled": True,
                                 "hashed": False,
                                 "enabled_patch_settings": {
@@ -264,11 +264,11 @@ SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR = {
                     },
                     "property2": {
                         "sync_mode": "SOFT_DELETE",
-                        "name_in_destination": "table_name_in_destination",
+                        "name_in_destination": "table_name_in_destination_2",
                         "enabled": True,
                         "columns": {
                             "property1": {
-                                "name_in_destination": "column_name_in_destination",
+                                "name_in_destination": "column_name_in_destination_1",
                                 "enabled": True,
                                 "hashed": False,
                                 "enabled_patch_settings": {
@@ -279,7 +279,7 @@ SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR = {
                                 "is_primary_key": True,
                             },
                             "property2": {
-                                "name_in_destination": "column_name_in_destination",
+                                "name_in_destination": "column_name_in_destination_2",
                                 "enabled": True,
                                 "hashed": False,
                                 "enabled_patch_settings": {
@@ -300,16 +300,16 @@ SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR = {
                 },
             },
             "property2": {
-                "name_in_destination": "schema_name_in_destination",
+                "name_in_destination": "schema_name_in_destination_2",
                 "enabled": True,
                 "tables": {
                     "property1": {
                         "sync_mode": "SOFT_DELETE",
-                        "name_in_destination": "table_name_in_destination",
+                        "name_in_destination": "table_name_in_destination_1",
                         "enabled": True,
                         "columns": {
                             "property1": {
-                                "name_in_destination": "column_name_in_destination",
+                                "name_in_destination": "column_name_in_destination_1",
                                 "enabled": True,
                                 "hashed": False,
                                 "enabled_patch_settings": {
@@ -320,7 +320,7 @@ SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR = {
                                 "is_primary_key": True,
                             },
                             "property2": {
-                                "name_in_destination": "column_name_in_destination",
+                                "name_in_destination": "column_name_in_destination_1",
                                 "enabled": True,
                                 "hashed": False,
                                 "enabled_patch_settings": {
@@ -340,11 +340,11 @@ SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR = {
                     },
                     "property2": {
                         "sync_mode": "SOFT_DELETE",
-                        "name_in_destination": "table_name_in_destination",
+                        "name_in_destination": "table_name_in_destination_2",
                         "enabled": True,
                         "columns": {
                             "property1": {
-                                "name_in_destination": "column_name_in_destination",
+                                "name_in_destination": "column_name_in_destination_1",
                                 "enabled": True,
                                 "hashed": False,
                                 "enabled_patch_settings": {
@@ -355,7 +355,7 @@ SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR = {
                                 "is_primary_key": True,
                             },
                             "property2": {
-                                "name_in_destination": "column_name_in_destination",
+                                "name_in_destination": "column_name_in_destination_2",
                                 "enabled": True,
                                 "hashed": False,
                                 "enabled_patch_settings": {

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/conftest.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import Iterator
 
 import pytest
@@ -381,15 +380,8 @@ SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR = {
     },
 }
 
-
-@pytest.fixture(name="api_key")
-def api_key_fixture() -> str:
-    return uuid.uuid4().hex
-
-
-@pytest.fixture(name="api_secret")
-def api_secret_fixture() -> str:
-    return uuid.uuid4().hex
+TEST_API_KEY = "test_api_key"
+TEST_API_SECRET = "test_api_secret"
 
 
 @pytest.fixture(name="connector_id")

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_asset_specs.py
@@ -1,15 +1,12 @@
-import uuid
-
 import responses
 from dagster_fivetran import FivetranWorkspace
 
 
 def test_fetch_fivetran_workspace_data(
+    api_key: str,
+    api_secret: str,
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:
-    api_key = uuid.uuid4().hex
-    api_secret = uuid.uuid4().hex
-
     resource = FivetranWorkspace(api_key=api_key, api_secret=api_secret)
 
     actual_workspace_data = resource.fetch_fivetran_workspace_data()

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_asset_specs.py
@@ -1,13 +1,13 @@
 import responses
 from dagster_fivetran import FivetranWorkspace
 
+from dagster_fivetran_tests.experimental.conftest import TEST_API_KEY, TEST_API_SECRET
+
 
 def test_fetch_fivetran_workspace_data(
-    api_key: str,
-    api_secret: str,
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:
-    resource = FivetranWorkspace(api_key=api_key, api_secret=api_secret)
+    resource = FivetranWorkspace(api_key=TEST_API_KEY, api_secret=TEST_API_SECRET)
 
     actual_workspace_data = resource.fetch_fivetran_workspace_data()
     assert len(actual_workspace_data.connectors_by_id) == 1

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
@@ -1,18 +1,15 @@
-import uuid
-
 import responses
 from dagster_fivetran import FivetranWorkspace
 
 
 def test_basic_resource_request(
+        api_key: str,
+        api_secret: str,
     connector_id: str,
     destination_id: str,
     group_id: str,
     all_api_mocks: responses.RequestsMock,
 ) -> None:
-    api_key = uuid.uuid4().hex
-    api_secret = uuid.uuid4().hex
-
     resource = FivetranWorkspace(api_key=api_key, api_secret=api_secret)
 
     client = resource.get_client()

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
@@ -3,8 +3,8 @@ from dagster_fivetran import FivetranWorkspace
 
 
 def test_basic_resource_request(
-        api_key: str,
-        api_secret: str,
+    api_key: str,
+    api_secret: str,
     connector_id: str,
     destination_id: str,
     group_id: str,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
@@ -1,16 +1,16 @@
 import responses
 from dagster_fivetran import FivetranWorkspace
 
+from dagster_fivetran_tests.experimental.conftest import TEST_API_KEY, TEST_API_SECRET
+
 
 def test_basic_resource_request(
-    api_key: str,
-    api_secret: str,
     connector_id: str,
     destination_id: str,
     group_id: str,
     all_api_mocks: responses.RequestsMock,
 ) -> None:
-    resource = FivetranWorkspace(api_key=api_key, api_secret=api_secret)
+    resource = FivetranWorkspace(api_key=TEST_API_KEY, api_secret=TEST_API_SECRET)
 
     client = resource.get_client()
     client.get_connector_details(connector_id=connector_id)

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
@@ -4,8 +4,8 @@ from dagster_fivetran import FivetranWorkspace
 
 
 def test_fivetran_workspace_data_to_fivetran_connector_table_props_data(
-        api_key: str,
-        api_secret: str,
+    api_key: str,
+    api_secret: str,
     fetch_workspace_data_api_mocks: Callable,
 ) -> None:
     resource = FivetranWorkspace(api_key=api_key, api_secret=api_secret)

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
@@ -15,15 +15,7 @@ def test_fivetran_workspace_data_to_fivetran_connector_table_props_data(
     actual_workspace_data = resource.fetch_fivetran_workspace_data()
     table_props_data = actual_workspace_data.to_fivetran_connector_table_props_data()
     assert len(table_props_data) == 4
-    assert (
-        table_props_data[0].table == "schema_name_in_destination_1.table_name_in_destination_1"
-    )
-    assert (
-        table_props_data[1].table == "schema_name_in_destination_1.table_name_in_destination_2"
-    )
-    assert (
-        table_props_data[2].table == "schema_name_in_destination_2.table_name_in_destination_1"
-    )
-    assert (
-        table_props_data[3].table == "schema_name_in_destination_2.table_name_in_destination_2"
-    )
+    assert table_props_data[0].table == "schema_name_in_destination_1.table_name_in_destination_1"
+    assert table_props_data[1].table == "schema_name_in_destination_1.table_name_in_destination_2"
+    assert table_props_data[2].table == "schema_name_in_destination_2.table_name_in_destination_1"
+    assert table_props_data[3].table == "schema_name_in_destination_2.table_name_in_destination_2"

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
@@ -1,15 +1,13 @@
-import uuid
 from typing import Callable
 
 from dagster_fivetran import FivetranWorkspace
 
 
 def test_fivetran_workspace_data_to_fivetran_connector_table_props_data(
+        api_key: str,
+        api_secret: str,
     fetch_workspace_data_api_mocks: Callable,
 ) -> None:
-    api_key = uuid.uuid4().hex
-    api_secret = uuid.uuid4().hex
-
     resource = FivetranWorkspace(api_key=api_key, api_secret=api_secret)
 
     actual_workspace_data = resource.fetch_fivetran_workspace_data()

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
@@ -1,0 +1,30 @@
+import uuid
+from typing import Callable
+
+from dagster_fivetran import FivetranWorkspace
+
+
+def test_fivetran_workspace_data_to_fivetran_connector_table_props_data(
+    workspace_data_api_mocks_fn: Callable,
+) -> None:
+    api_key = uuid.uuid4().hex
+    api_secret = uuid.uuid4().hex
+
+    resource = FivetranWorkspace(api_key=api_key, api_secret=api_secret)
+
+    with workspace_data_api_mocks_fn(include_sync_endpoints=False):
+        actual_workspace_data = resource.fetch_fivetran_workspace_data()
+        table_props_data = actual_workspace_data.to_fivetran_connector_table_props_data()
+        assert len(table_props_data) == 4
+        assert (
+            table_props_data[0].table == "schema_name_in_destination_1.table_name_in_destination_1"
+        )
+        assert (
+            table_props_data[1].table == "schema_name_in_destination_1.table_name_in_destination_2"
+        )
+        assert (
+            table_props_data[2].table == "schema_name_in_destination_2.table_name_in_destination_1"
+        )
+        assert (
+            table_props_data[3].table == "schema_name_in_destination_2.table_name_in_destination_2"
+        )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
@@ -5,26 +5,25 @@ from dagster_fivetran import FivetranWorkspace
 
 
 def test_fivetran_workspace_data_to_fivetran_connector_table_props_data(
-    workspace_data_api_mocks_fn: Callable,
+    fetch_workspace_data_api_mocks: Callable,
 ) -> None:
     api_key = uuid.uuid4().hex
     api_secret = uuid.uuid4().hex
 
     resource = FivetranWorkspace(api_key=api_key, api_secret=api_secret)
 
-    with workspace_data_api_mocks_fn(include_sync_endpoints=False):
-        actual_workspace_data = resource.fetch_fivetran_workspace_data()
-        table_props_data = actual_workspace_data.to_fivetran_connector_table_props_data()
-        assert len(table_props_data) == 4
-        assert (
-            table_props_data[0].table == "schema_name_in_destination_1.table_name_in_destination_1"
-        )
-        assert (
-            table_props_data[1].table == "schema_name_in_destination_1.table_name_in_destination_2"
-        )
-        assert (
-            table_props_data[2].table == "schema_name_in_destination_2.table_name_in_destination_1"
-        )
-        assert (
-            table_props_data[3].table == "schema_name_in_destination_2.table_name_in_destination_2"
-        )
+    actual_workspace_data = resource.fetch_fivetran_workspace_data()
+    table_props_data = actual_workspace_data.to_fivetran_connector_table_props_data()
+    assert len(table_props_data) == 4
+    assert (
+        table_props_data[0].table == "schema_name_in_destination_1.table_name_in_destination_1"
+    )
+    assert (
+        table_props_data[1].table == "schema_name_in_destination_1.table_name_in_destination_2"
+    )
+    assert (
+        table_props_data[2].table == "schema_name_in_destination_2.table_name_in_destination_1"
+    )
+    assert (
+        table_props_data[3].table == "schema_name_in_destination_2.table_name_in_destination_2"
+    )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
@@ -2,13 +2,13 @@ from typing import Callable
 
 from dagster_fivetran import FivetranWorkspace
 
+from dagster_fivetran_tests.experimental.conftest import TEST_API_KEY, TEST_API_SECRET
+
 
 def test_fivetran_workspace_data_to_fivetran_connector_table_props_data(
-    api_key: str,
-    api_secret: str,
     fetch_workspace_data_api_mocks: Callable,
 ) -> None:
-    resource = FivetranWorkspace(api_key=api_key, api_secret=api_secret)
+    resource = FivetranWorkspace(api_key=TEST_API_KEY, api_secret=TEST_API_SECRET)
 
     actual_workspace_data = resource.fetch_fivetran_workspace_data()
     table_props_data = actual_workspace_data.to_fivetran_connector_table_props_data()


### PR DESCRIPTION
## Summary & Motivation

This PR implements `FivetranWorkspaceData.to_fivetran_connector_table_props_data()`, a method that converts a `FivetranWorkspaceData` object to a list of FivetranConnectorTableProps.

To create the asset spec, we need one `FivetranConnectorTableProps` object per connector table. This method parses the API raw data to create the FivetranConnectorTableProps` object, which is compatible with the `DagsterFivetranTranslator`. 

This will be used in the `defs_from_state` method of the stated-backed defs loader in a subsequent PR. 

## How I Tested These Changes

Additional unit test

