### PR TITLE
[6/n][dagster-fivetran] Implement FivetranWorkspaceDefsLoader

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -605,6 +605,7 @@ class FivetranWorkspace(ConfigurableResource):
     to interact with Fivetran APIs.
     """
 
+    account_id: str = Field(description="The Fivetran account ID.")
     api_key: str = Field(description="The Fivetran API key to use for this resource.")
     api_secret: str = Field(description="The Fivetran API secret to use for this resource.")
     request_max_retries: int = Field(
@@ -689,7 +690,7 @@ class FivetranWorkspaceDefsLoader(StateBackedDefinitionsLoader[Mapping[str, Any]
 
     @property
     def defs_key(self) -> str:
-        return f"{FIVETRAN_RECONSTRUCTION_METADATA_KEY_PREFIX}/{self.workspace.site_name}"
+        return f"{FIVETRAN_RECONSTRUCTION_METADATA_KEY_PREFIX}/{self.workspace.account_id}"
 
     def fetch_state(self) -> FivetranWorkspaceData:
         return self.workspace.fetch_fivetran_workspace_data()

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/conftest.py
@@ -380,6 +380,7 @@ SAMPLE_SCHEMA_CONFIG_FOR_CONNECTOR = {
     },
 }
 
+TEST_ACCOUNT_ID = "test_account_id"
 TEST_API_KEY = "test_api_key"
 TEST_API_SECRET = "test_api_secret"
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_asset_specs.py
@@ -1,13 +1,19 @@
 import responses
 from dagster_fivetran import FivetranWorkspace
 
-from dagster_fivetran_tests.experimental.conftest import TEST_API_KEY, TEST_API_SECRET
+from dagster_fivetran_tests.experimental.conftest import (
+    TEST_ACCOUNT_ID,
+    TEST_API_KEY,
+    TEST_API_SECRET,
+)
 
 
 def test_fetch_fivetran_workspace_data(
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:
-    resource = FivetranWorkspace(api_key=TEST_API_KEY, api_secret=TEST_API_SECRET)
+    resource = FivetranWorkspace(
+        account_id=TEST_ACCOUNT_ID, api_key=TEST_API_KEY, api_secret=TEST_API_SECRET
+    )
 
     actual_workspace_data = resource.fetch_fivetran_workspace_data()
     assert len(actual_workspace_data.connectors_by_id) == 1

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_resources.py
@@ -1,7 +1,11 @@
 import responses
 from dagster_fivetran import FivetranWorkspace
 
-from dagster_fivetran_tests.experimental.conftest import TEST_API_KEY, TEST_API_SECRET
+from dagster_fivetran_tests.experimental.conftest import (
+    TEST_ACCOUNT_ID,
+    TEST_API_KEY,
+    TEST_API_SECRET,
+)
 
 
 def test_basic_resource_request(
@@ -10,7 +14,9 @@ def test_basic_resource_request(
     group_id: str,
     all_api_mocks: responses.RequestsMock,
 ) -> None:
-    resource = FivetranWorkspace(api_key=TEST_API_KEY, api_secret=TEST_API_SECRET)
+    resource = FivetranWorkspace(
+        account_id=TEST_ACCOUNT_ID, api_key=TEST_API_KEY, api_secret=TEST_API_SECRET
+    )
 
     client = resource.get_client()
     client.get_connector_details(connector_id=connector_id)

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_translator.py
@@ -2,13 +2,19 @@ from typing import Callable
 
 from dagster_fivetran import FivetranWorkspace
 
-from dagster_fivetran_tests.experimental.conftest import TEST_API_KEY, TEST_API_SECRET
+from dagster_fivetran_tests.experimental.conftest import (
+    TEST_ACCOUNT_ID,
+    TEST_API_KEY,
+    TEST_API_SECRET,
+)
 
 
 def test_fivetran_workspace_data_to_fivetran_connector_table_props_data(
     fetch_workspace_data_api_mocks: Callable,
 ) -> None:
-    resource = FivetranWorkspace(api_key=TEST_API_KEY, api_secret=TEST_API_SECRET)
+    resource = FivetranWorkspace(
+        account_id=TEST_ACCOUNT_ID, api_key=TEST_API_KEY, api_secret=TEST_API_SECRET
+    )
 
     actual_workspace_data = resource.fetch_fivetran_workspace_data()
     table_props_data = actual_workspace_data.to_fivetran_connector_table_props_data()


### PR DESCRIPTION
## Summary & Motivation

This PR implements the `FivetranWorkspaceDefsLoader` to be used to load asset specs. `account_id` is added as a parameter to `FivetranWorkspace` - we need a unique ID for the Fivetran workspace to implement `defs_key`.

## How I Tested These Changes

Updated unit tests

