### PR TITLE
Don't fetch the whole asset graph in get_additional_required_keys

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -128,20 +128,11 @@ def get_additional_required_keys(
     graphene_info: "ResolveInfo",
     asset_keys: AbstractSet[AssetKey],
 ) -> List["AssetKey"]:
-    asset_nodes_by_key = get_asset_nodes_by_asset_key(graphene_info)
+    asset_nodes = {graphene_info.context.asset_graph.get(asset_key) for asset_key in asset_keys}
 
-    # the set of atomic execution ids that any of the input asset keys are a part of
-    required_execution_set_identifiers = {
-        asset_nodes_by_key[asset_key].asset_node_snap.execution_set_identifier
-        for asset_key in asset_keys
-    } - {None}
-
-    # the set of all asset keys that are part of the required execution sets
-    required_asset_keys = {
-        asset_node.asset_node_snap.asset_key
-        for asset_node in asset_nodes_by_key.values()
-        if asset_node.asset_node_snap.execution_set_identifier in required_execution_set_identifiers
-    }
+    required_asset_keys = set()
+    for asset_node in asset_nodes:
+        required_asset_keys.update(asset_node.execution_set_asset_keys)
 
     return list(required_asset_keys - asset_keys)
 

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_assets.py
@@ -188,6 +188,14 @@ GET_ASSET_LATEST_RUN_STATS = """
     }
 """
 
+ADDITIONAL_REQUIRED_KEYS_QUERY = """
+  query AdditionalRequiredKeysQuery($assetKeys: [AssetKeyInput!]!) {
+    assetNodeAdditionalRequiredKeys(assetKeys: $assetKeys) {
+      path
+    }
+  }
+"""
+
 GET_ASSET_DATA_VERSIONS = """
     query AssetNodeQuery($pipelineSelector: PipelineSelector!, $assetKeys: [AssetKeyInput!]) {
         assetNodes(pipeline: $pipelineSelector, assetKeys: $assetKeys) {
@@ -1007,6 +1015,18 @@ class TestAssetAwareEventLog(ExecutingGraphQLContextTestMatrix):
         )
         assert result.data
         snapshot.assert_match(result.data)
+
+    def test_additional_required_keys_query(self, graphql_context: WorkspaceRequestContext):
+        result = execute_dagster_graphql(
+            graphql_context,
+            ADDITIONAL_REQUIRED_KEYS_QUERY,
+            variables={
+                "assetKeys": [{"path": ["int_asset"]}],
+            },
+        )
+        required_keys = result.data["assetNodeAdditionalRequiredKeys"]
+        assert len(required_keys) == 1
+        assert required_keys == [{"path": ["str_asset"]}]
 
     def test_get_partitioned_asset_key_materialization(
         self, graphql_context: WorkspaceRequestContext, snapshot


### PR DESCRIPTION
## Summary & Motivation
Another callsite where we pass in a small number of asset keys and don't need to fetch the full graph.

## How I Tested These Changes BK

## Changelog

> Insert changelog entry or delete this section.
