### PR TITLE
[dagster-fivetran] avoid whitelisting fivetran meta class for serdes

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -427,9 +427,16 @@ class FivetranConnectionMetadata(
                 "connector_id": self.connector_id,
                 "io_manager_key": io_manager_key,
                 "storage_kind": self.service,
-                "connection_metadata": self._asdict(),
+                "connection_metadata": self.to_serializable_repr(),
             },
         )
+
+    def to_serializable_repr(self) -> Any:
+        return self._asdict()
+
+    @staticmethod
+    def from_serializable_repr(rep: Any) -> "FivetranConnectionMetadata":
+        return FivetranConnectionMetadata(**rep)
 
 
 def _build_fivetran_assets_from_metadata(
@@ -445,7 +452,9 @@ def _build_fivetran_assets_from_metadata(
     io_manager_key = cast(Optional[str], metadata["io_manager_key"])
     storage_kind = cast(Optional[str], metadata.get("storage_kind"))
 
-    connection_metadata = FivetranConnectionMetadata(**metadata["connection_metadata"])
+    connection_metadata = FivetranConnectionMetadata.from_serializable_repr(
+        metadata["connection_metadata"]
+    )
 
     return _build_fivetran_assets(
         connector_id=connector_id,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -427,7 +427,7 @@ class FivetranConnectionMetadata(
                 "connector_id": self.connector_id,
                 "io_manager_key": io_manager_key,
                 "storage_kind": self.service,
-                "connection_metadata": tuple(self),
+                "connection_metadata": self._asdict(),
             },
         )
 
@@ -445,7 +445,7 @@ def _build_fivetran_assets_from_metadata(
     io_manager_key = cast(Optional[str], metadata["io_manager_key"])
     storage_kind = cast(Optional[str], metadata.get("storage_kind"))
 
-    connection_metadata = FivetranConnectionMetadata(*metadata["connection_metadata"])
+    connection_metadata = FivetranConnectionMetadata(**metadata["connection_metadata"])
 
     return _build_fivetran_assets(
         connector_id=connector_id,

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -39,7 +39,6 @@ from dagster._core.definitions.tags import build_kind_tag
 from dagster._core.errors import DagsterStepOutputNotFoundError
 from dagster._core.execution.context.init import build_init_resource_context
 from dagster._core.utils import imap
-from dagster._serdes.serdes import whitelist_for_serdes
 from dagster._utils.log import get_dagster_logger
 
 from dagster_fivetran.resources import DEFAULT_POLL_INTERVAL, FivetranResource
@@ -367,7 +366,6 @@ def build_fivetran_assets(
     )
 
 
-@whitelist_for_serdes
 class FivetranConnectionMetadata(
     NamedTuple(
         "_FivetranConnectionMetadata",
@@ -429,7 +427,7 @@ class FivetranConnectionMetadata(
                 "connector_id": self.connector_id,
                 "io_manager_key": io_manager_key,
                 "storage_kind": self.service,
-                "connection_metadata": self,
+                "connection_metadata": tuple(self),
             },
         )
 
@@ -447,7 +445,7 @@ def _build_fivetran_assets_from_metadata(
     io_manager_key = cast(Optional[str], metadata["io_manager_key"])
     storage_kind = cast(Optional[str], metadata.get("storage_kind"))
 
-    connection_metadata = metadata["connection_metadata"]
+    connection_metadata = FivetranConnectionMetadata(*metadata["connection_metadata"])
 
     return _build_fivetran_assets(
         connector_id=connector_id,


### PR DESCRIPTION
## Summary

Since this is a namedtuple, we can convert it to a serializable tuple and back rather than whitelisting this integration class.

## Test Plan

Unit test.

