### PR TITLE
[pipes] use PipesDefaultLogWriter for AWS EMR

### DIFF
--- a/python_modules/dagster-pipes/dagster_pipes/__init__.py
+++ b/python_modules/dagster-pipes/dagster_pipes/__init__.py
@@ -645,7 +645,17 @@ class PipesBlobStoreMessageWriter(PipesMessageWriter[T_BlobStoreMessageWriterCha
         """
         channel = self.make_channel(params)
         with channel.buffered_upload_loop():
-            yield channel
+            if params.get(self.INCLUDE_STDIO_IN_MESSAGES_KEY):
+                log_writer = PipesDefaultLogWriter(message_channel=channel)
+
+                maybe_open_log_writer = log_writer.open(
+                    params.get(PipesLogWriter.LOG_WRITER_KEY, {})
+                )
+            else:
+                maybe_open_log_writer = nullcontext()
+
+            with maybe_open_log_writer:
+                yield channel
 
     @abstractmethod
     def make_channel(self, params: PipesParams) -> T_BlobStoreMessageWriterChannel: ...

--- a/python_modules/dagster-pipes/dagster_pipes_tests/test_log_writer.py
+++ b/python_modules/dagster-pipes/dagster_pipes_tests/test_log_writer.py
@@ -14,10 +14,13 @@ from dagster_pipes import (
 
 def test_pipes_stdio_file_log_writer(capsys):
     with tempfile.TemporaryDirectory() as tempdir:
-        with capsys.disabled(), PipesStdioFileLogWriter().open(
-            {
-                "logs_dir": tempdir,
-            }
+        with (
+            capsys.disabled(),
+            PipesStdioFileLogWriter().open(
+                {
+                    "logs_dir": tempdir,
+                }
+            ),
         ):
             print(f"Writing this to stdout 1")  # noqa
             print(f"Writing this to stderr 1", file=sys.stderr)  # noqa
@@ -49,8 +52,9 @@ def test_pipes_default_log_writer(capsys):
         message_channel = PipesFileMessageWriterChannel(file.name)
 
         log_writer = PipesDefaultLogWriter(message_channel=message_channel)
-        with capsys.disabled(), log_writer.open(
-            {PipesDefaultMessageWriter.INCLUDE_STDIO_IN_MESSAGES_KEY: True}
+        with (
+            capsys.disabled(),
+            log_writer.open({PipesDefaultMessageWriter.INCLUDE_STDIO_IN_MESSAGES_KEY: True}),
         ):
             print("Writing this to stdout")  # noqa
             print("And this to stderr", file=sys.stderr)  # noqa


### PR DESCRIPTION
## Summary & Motivation

Add a new `include_stdio_in_messages` parameter to `PipesS3MessageReader`. It enables log forwarding to Dagster via Pipes messages. 

## How I Tested These Changes

Executed a real AWS EMR job and confirmed we are getting the logs

## Changelog

[dagster-pipes, dagster-aws] `PipesS3MessageReader` now has a new parameter `include_stdio_in_messages` which enables log forwarding to Dagster via Pipes messages. 