### PR TITLE
[dagster-aws] attach tags and metadata in PipesGlueClient

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/fake_glue.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/fake_glue.py
@@ -46,6 +46,10 @@ class LocalGlueMockClient:
 
         self._job_runs: Dict[str, SimulatedJobRun] = {}  # mapping of JobRunId to SimulatedJobRun
 
+    @property
+    def meta(self):
+        return self.glue_client.meta
+
     def get_job_run(self, JobName: str, RunId: str):
         # get original response
         response = self.glue_client.get_job_run(JobName=JobName, RunId=RunId)

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_pipes.py
@@ -645,6 +645,7 @@ def test_glue_pipes(
         assert mat and mat.asset_materialization
         assert isinstance(mat.asset_materialization.metadata["bar"], MarkdownMetadataValue)
         assert mat.asset_materialization.metadata["bar"].value == "baz"
+        assert "AWS Glue Job Run ID" in mat.asset_materialization.metadata
         assert mat.asset_materialization.tags
         assert mat.asset_materialization.tags[DATA_VERSION_TAG] == "alpha"
         assert mat.asset_materialization.tags[DATA_VERSION_IS_USER_PROVIDED_TAG]


### PR DESCRIPTION
## Summary & Motivation
Add AWS Glue metadata injection to `PipesGlueClient`

Also, when CloudWatch logging is not enabled for a Glue job, the client now logs a warning message instead of failing.

## Changelog
[dagster-aws] `PipesGlueClient` now attaches AWS Glue metadata to Dagster results produced during Pipes invocation