### PR TITLE
[dagster-aws] attach tags and metadata in PipesEMRServerlessClient

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_pipes.py
@@ -969,7 +969,7 @@ def test_emr_serverless_manual(emr_serverless_setup: Tuple["EMRServerlessClient"
                 },
             )
 
-            assert params["tags"]["dagster/run_id"] == context.run_id  # pyright: ignore[reportTypedDictNotRequiredAccess]
+            assert params["tags"]["dagster/run-id"] == context.run_id  # pyright: ignore[reportTypedDictNotRequiredAccess]
             assert (
                 "--conf spark.emr-serverless.driverEnv.DAGSTER_PIPES_CONTEXT="
                 in params["jobDriver"]["sparkSubmit"]["sparkSubmitParameters"]  # pyright: ignore[reportTypedDictNotRequiredAccess]


### PR DESCRIPTION
## Summary & Motivation
Attach tags & metadata with `PipesEMRServerlessClient`

## Changelog
[dagster-aws] `PipesEMRServerlessClient` now attaches AWS EMR Serverless metadata to Dagster results produced during Pipes invocation and adds Dagster tags to the job run