### PR TITLE
[dagster-aws] attach tags and metadata for PipesECSClient

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/fake_ecs.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/fake_ecs.py
@@ -34,6 +34,10 @@ class LocalECSMockClient:
             str, SimulatedTaskRun
         ] = {}  # mapping of TaskDefinitionArn to TaskDefinition
 
+    @property
+    def meta(self):
+        return self.ecs_client.meta
+
     def get_waiter(self, waiter_name: str):
         return WaiterMock(self, waiter_name)
 

--- a/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws_tests/pipes_tests/test_pipes.py
@@ -868,6 +868,7 @@ def test_ecs_pipes(
         assert mat and mat.asset_materialization
         assert isinstance(mat.asset_materialization.metadata["bar"], MarkdownMetadataValue)
         assert mat.asset_materialization.metadata["bar"].value == "baz"
+        assert "AWS ECS Task URL" in mat.asset_materialization.metadata
         assert mat.asset_materialization.tags
         assert mat.asset_materialization.tags[DATA_VERSION_TAG] == "alpha"
         assert mat.asset_materialization.tags[DATA_VERSION_IS_USER_PROVIDED_TAG]


### PR DESCRIPTION
## Summary & Motivation

Attach tags & metadata in `PipesECSClient`

## Changelog

[dagster-aws] `PipesECSClient` now attaches AWS ECS metadata to Dagster results produced during Pipes invocation and adds Dagster tags to the ECS task