### PR TITLE
[dagster-databricks] attach tags and metadata in PipesDatabricksClient

### DIFF
--- a/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
+++ b/python_modules/libraries/dagster-databricks/dagster_databricks_tests/test_pipes.py
@@ -194,6 +194,10 @@ def test_pipes_client(
         assert re.search(r"hello from databricks stdout\n", captured.out, re.MULTILINE)
         assert re.search(r"hello from databricks stderr\n", captured.err, re.MULTILINE)
 
+    # check Databricks metadata automatically added to materialization
+    assert "Databricks Job Run ID" in mats[0].metadata
+    assert "Databricks Job Run URL" in mats[0].metadata
+
 
 @pytest.mark.skipif(IS_BUILDKITE, reason="Not configured to run on BK yet.")
 def test_nonexistent_entry_point(databricks_client: WorkspaceClient):  # noqa: F811


### PR DESCRIPTION
## Summary & Motivation
Attach tags & metadata in `PipesDatabricksClient`

## Changelog

[dagster-databricks] `PipesDatabricksClient` now attaches Databricks metadata to Dagster results produced during Pipes invocation and adds Dagster tags to the Databricks job