### PR TITLE
remove "(Experimental)" from Declarative Automation menu title

### DIFF
--- a/docs/content/_navigation.json
+++ b/docs/content/_navigation.json
@@ -170,7 +170,7 @@
             "path": "/concepts/partitions-schedules-sensors/sensors"
           },
           {
-            "title": "Declarative Automation (Experimental)",
+            "title": "Declarative Automation",
             "children": [
               {
                 "title": "Overview",


### PR DESCRIPTION
## Summary & Motivation
`Declarative Automation` is GA as of 1.9.0

## How I Tested These Changes
👀