### PR TITLE
Rename InstanceLoadableBy

### DIFF
--- a/python_modules/dagster/dagster/_core/loader.py
+++ b/python_modules/dagster/dagster/_core/loader.py
@@ -58,11 +58,9 @@ class LoadingContext(ABC):
     def loaders(self) -> Dict[Type, Tuple[DataLoader, BlockingDataLoader]]:
         raise NotImplementedError()
 
-    def get_loaders_for(
-        self, ttype: Type["InstanceLoadableBy"]
-    ) -> Tuple[DataLoader, BlockingDataLoader]:
+    def get_loaders_for(self, ttype: Type["LoadableBy"]) -> Tuple[DataLoader, BlockingDataLoader]:
         if ttype not in self.loaders:
-            if not issubclass(ttype, InstanceLoadableBy):
+            if not issubclass(ttype, LoadableBy):
                 check.failed(f"{ttype} is not Loadable")
 
             batch_load_fn = partial(ttype._batch_load, context=self)  # noqa
@@ -83,7 +81,7 @@ class LoadingContext(ABC):
 # Expected there may be other "Loadable" base classes based on what is needed to load.
 
 
-class InstanceLoadableBy(ABC, Generic[TKey]):
+class LoadableBy(ABC, Generic[TKey]):
     """Make An object Loadable by ID of type TKey using a DagsterInstance."""
 
     @classmethod

--- a/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
+++ b/python_modules/dagster/dagster/_core/storage/asset_check_execution_record.py
@@ -5,7 +5,7 @@ import dagster._check as check
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.asset_key import AssetCheckKey
 from dagster._core.events.log import DagsterEventType, EventLogEntry
-from dagster._core.loader import InstanceLoadableBy, LoadingContext
+from dagster._core.loader import LoadableBy, LoadingContext
 from dagster._core.storage.dagster_run import DagsterRunStatus, RunRecord
 from dagster._serdes.serdes import deserialize_value
 from dagster._time import utc_datetime_from_naive
@@ -52,7 +52,7 @@ class AssetCheckExecutionRecord(
             ("create_timestamp", float),
         ],
     ),
-    InstanceLoadableBy[AssetCheckKey],
+    LoadableBy[AssetCheckKey],
 ):
     def __new__(
         cls,

--- a/python_modules/dagster/dagster/_core/storage/dagster_run.py
+++ b/python_modules/dagster/dagster/_core/storage/dagster_run.py
@@ -20,7 +20,7 @@ import dagster._check as check
 from dagster._annotations import PublicAttr, experimental_param, public
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.events import AssetKey
-from dagster._core.loader import InstanceLoadableBy, LoadingContext
+from dagster._core.loader import LoadableBy, LoadingContext
 from dagster._core.origin import JobPythonOrigin
 from dagster._core.storage.tags import (
     ASSET_EVALUATION_ID_TAG,
@@ -612,7 +612,7 @@ class RunRecord(
             ("end_time", Optional[float]),
         ],
     ),
-    InstanceLoadableBy[str],
+    LoadableBy[str],
 ):
     """Internal representation of a run record, as stored in a
     :py:class:`~dagster._core.storage.runs.RunStorage`.

--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -33,7 +33,7 @@ from dagster._core.execution.stats import (
     build_run_step_stats_from_events,
 )
 from dagster._core.instance import MayHaveInstanceWeakref, T_DagsterInstance
-from dagster._core.loader import InstanceLoadableBy, LoadingContext
+from dagster._core.loader import LoadableBy, LoadingContext
 from dagster._core.storage.asset_check_execution_record import AssetCheckExecutionRecord
 from dagster._core.storage.dagster_run import DagsterRunStatsSnapshot
 from dagster._core.storage.partition_status_cache import get_and_update_asset_status_cache_value
@@ -129,7 +129,7 @@ class AssetEntry(
 
 class AssetRecord(
     NamedTuple("_NamedTuple", [("storage_id", int), ("asset_entry", AssetEntry)]),
-    InstanceLoadableBy[AssetKey],
+    LoadableBy[AssetKey],
 ):
     """Internal representation of an asset record, as stored in a :py:class:`~dagster._core.storage.event_log.EventLogStorage`.
 
@@ -156,7 +156,7 @@ class AssetCheckSummaryRecord(
             ("last_run_id", Optional[str]),
         ],
     ),
-    InstanceLoadableBy[AssetCheckKey],
+    LoadableBy[AssetCheckKey],
 ):
     @classmethod
     def _blocking_batch_load(

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -21,7 +21,7 @@ from dagster._core.definitions.partition import (
 )
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
 from dagster._core.instance import DynamicPartitionsStore
-from dagster._core.loader import InstanceLoadableBy, LoadingContext
+from dagster._core.loader import LoadableBy, LoadingContext
 from dagster._core.storage.dagster_run import FINISHED_STATUSES, RunsFilter
 from dagster._core.storage.tags import (
     MULTIDIMENSIONAL_PARTITION_PREFIX,
@@ -82,7 +82,7 @@ class AssetStatusCacheValue(
             ("earliest_in_progress_materialization_event_id", Optional[int]),
         ],
     ),
-    InstanceLoadableBy[Tuple[AssetKey, PartitionsDefinition]],
+    LoadableBy[Tuple[AssetKey, PartitionsDefinition]],
 ):
     """Set of asset fields that reflect partition materialization status. This is used to display
     global partition status in the asset view.

--- a/python_modules/dagster/dagster_tests/utils_tests/test_dataloader.py
+++ b/python_modules/dagster/dagster_tests/utils_tests/test_dataloader.py
@@ -5,7 +5,7 @@ from typing import Iterable, List, NamedTuple
 from unittest import mock
 
 import pytest
-from dagster._core.loader import InstanceLoadableBy, LoadingContext
+from dagster._core.loader import LoadableBy, LoadingContext
 from dagster._model import DagsterModel
 from dagster._utils.aiodataloader import DataLoader
 
@@ -139,9 +139,7 @@ def test_bad_load_fn():
     asyncio.run(_test())
 
 
-class LoadableThing(
-    NamedTuple("_LoadableThing", [("key", str), ("val", int)]), InstanceLoadableBy[str]
-):
+class LoadableThing(NamedTuple("_LoadableThing", [("key", str), ("val", int)]), LoadableBy[str]):
     @classmethod
     def _blocking_batch_load(
         cls, keys: Iterable[str], context: mock.MagicMock


### PR DESCRIPTION
## Summary & Motivation

We now pass in the whole context object into the loading methods, so "InstanceLoadableBy" isn't the most accurate name

## How I Tested These Changes

## Changelog

NOCHANGELOG
