### PR TITLE
[dagster-airlift][federation-apis] federation APIs accumulator

### DIFF
--- a/docs/sphinx/sections/api/apidocs/libraries/dagster-airlift.rst
+++ b/docs/sphinx/sections/api/apidocs/libraries/dagster-airlift.rst
@@ -12,6 +12,7 @@ AirflowInstance
 ^^^^^^^^^^^^^^^^^
 
 .. autoclass:: AirflowInstance
+    :members:
 
 .. autoclass:: AirflowAuthBackend
 

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/__init__.py
@@ -8,7 +8,6 @@ from .basic_auth import (
 from .load_defs import (
     AirflowInstance as AirflowInstance,
     DagSelectorFn as DagSelectorFn,
-    build_airflow_mapped_defs as build_airflow_mapped_defs,
     build_defs_from_airflow_instance as build_defs_from_airflow_instance,
 )
 from .multiple_tasks import (

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/__init__.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/__init__.py
@@ -18,9 +18,7 @@ from .sensor.event_translation import (
     AssetEvent as AssetEvent,
     DagsterEventTransformerFn as DagsterEventTransformerFn,
 )
-from .sensor.sensor_builder import (
-    build_airflow_polling_sensor_defs as build_airflow_polling_sensor_defs,
-)
+from .sensor.sensor_builder import build_airflow_polling_sensor as build_airflow_polling_sensor
 from .top_level_dag_def_api import (
     assets_with_dag_mappings as assets_with_dag_mappings,
     assets_with_task_mappings as assets_with_task_mappings,

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Callable, Iterable, Iterator, Optional, Union
+from typing import Any, Callable, Iterable, Iterator, Optional, Sequence, Union
 
 from dagster import (
     AssetsDefinition,
@@ -11,6 +11,7 @@ from dagster._core.definitions.definitions_load_context import StateBackedDefini
 from dagster._core.definitions.external_asset import external_asset_from_spec
 from dagster._utils.warnings import suppress_dagster_warnings
 
+from dagster_airlift.core.airflow_defs_data import MappedAsset
 from dagster_airlift.core.airflow_instance import AirflowInstance
 from dagster_airlift.core.sensor.event_translation import (
     DagsterEventTransformerFn,
@@ -36,7 +37,7 @@ from dagster_airlift.core.utils import get_metadata_key
 @dataclass
 class AirflowInstanceDefsLoader(StateBackedDefinitionsLoader[SerializedAirflowDefinitionsData]):
     airflow_instance: AirflowInstance
-    explicit_defs: Definitions
+    mapped_assets: Sequence[MappedAsset]
     sensor_minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS
     dag_selector_fn: Optional[Callable[[DagInfo], bool]] = None
 
@@ -47,30 +48,19 @@ class AirflowInstanceDefsLoader(StateBackedDefinitionsLoader[SerializedAirflowDe
     def fetch_state(self) -> SerializedAirflowDefinitionsData:
         return compute_serialized_data(
             airflow_instance=self.airflow_instance,
-            defs=self.explicit_defs,
+            mapped_assets=self.mapped_assets,
             dag_selector_fn=self.dag_selector_fn,
         )
 
     def defs_from_state(
         self, serialized_airflow_data: SerializedAirflowDefinitionsData
     ) -> Definitions:
-        return Definitions.merge(
-            enrich_explicit_defs_with_airflow_metadata(self.explicit_defs, serialized_airflow_data),
-            construct_dag_assets_defs(serialized_airflow_data),
+        return Definitions(
+            assets=[
+                *_apply_airflow_data_to_specs(self.mapped_assets, serialized_airflow_data),
+                *construct_dag_assets_defs(serialized_airflow_data),
+            ]
         )
-
-
-def build_airflow_mapped_defs(
-    *,
-    airflow_instance: AirflowInstance,
-    defs: Optional[Definitions] = None,
-    dag_selector_fn: Optional[DagSelectorFn] = None,
-) -> Definitions:
-    return AirflowInstanceDefsLoader(
-        airflow_instance=airflow_instance,
-        explicit_defs=defs or Definitions(),
-        dag_selector_fn=dag_selector_fn,
-    ).build_defs()
 
 
 @suppress_dagster_warnings
@@ -216,13 +206,25 @@ def build_defs_from_airflow_instance(
             )
 
     """
-    mapped_defs = build_airflow_mapped_defs(
-        airflow_instance=airflow_instance, defs=defs, dag_selector_fn=dag_selector_fn
+    defs = defs or Definitions()
+    mapped_assets = _type_narrow_defs_assets(defs)
+    serialized_airflow_data = AirflowInstanceDefsLoader(
+        airflow_instance=airflow_instance,
+        mapped_assets=mapped_assets,
+        dag_selector_fn=dag_selector_fn,
+    ).get_or_fetch_state()
+    mapped_and_constructed_assets = [
+        *_apply_airflow_data_to_specs(mapped_assets, serialized_airflow_data),
+        *construct_dag_assets_defs(serialized_airflow_data),
+    ]
+    defs_with_airflow_assets = replace_assets_in_defs(
+        defs=defs, assets=mapped_and_constructed_assets
     )
+
     return Definitions.merge(
-        mapped_defs,
+        defs_with_airflow_assets,
         build_airflow_polling_sensor_defs(
-            mapped_defs=mapped_defs,
+            mapped_assets=mapped_and_constructed_assets,
             airflow_instance=airflow_instance,
             minimum_interval_seconds=sensor_minimum_interval_seconds,
             event_transformer_fn=event_transformer_fn,
@@ -233,7 +235,7 @@ def build_defs_from_airflow_instance(
 @dataclass
 class FullAutomappedDagsLoader(StateBackedDefinitionsLoader[SerializedAirflowDefinitionsData]):
     airflow_instance: AirflowInstance
-    explicit_defs: Definitions
+    mapped_assets: Sequence[MappedAsset]
     sensor_minimum_interval_seconds: int
 
     @property
@@ -242,15 +244,19 @@ class FullAutomappedDagsLoader(StateBackedDefinitionsLoader[SerializedAirflowDef
 
     def fetch_state(self) -> SerializedAirflowDefinitionsData:
         return compute_serialized_data(
-            airflow_instance=self.airflow_instance, defs=self.explicit_defs, dag_selector_fn=None
+            airflow_instance=self.airflow_instance,
+            mapped_assets=self.mapped_assets,
+            dag_selector_fn=None,
         )
 
     def defs_from_state(
         self, serialized_airflow_data: SerializedAirflowDefinitionsData
     ) -> Definitions:
-        return Definitions.merge(
-            enrich_explicit_defs_with_airflow_metadata(self.explicit_defs, serialized_airflow_data),
-            construct_automapped_dag_assets_defs(serialized_airflow_data),
+        return Definitions(
+            assets=[
+                *_apply_airflow_data_to_specs(self.mapped_assets, serialized_airflow_data),
+                *construct_automapped_dag_assets_defs(serialized_airflow_data),
+            ]
         )
 
 
@@ -260,50 +266,51 @@ def build_full_automapped_dags_from_airflow_instance(
     sensor_minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
     defs: Optional[Definitions] = None,
 ) -> Definitions:
-    resolved_defs = FullAutomappedDagsLoader(
+    defs = defs or Definitions()
+    mapped_assets = _type_narrow_defs_assets(defs or Definitions())
+    serialized_data = FullAutomappedDagsLoader(
         airflow_instance=airflow_instance,
         sensor_minimum_interval_seconds=sensor_minimum_interval_seconds,
-        explicit_defs=defs or Definitions(),
-    ).build_defs()
+        mapped_assets=mapped_assets,
+    ).get_or_fetch_state()
+    airflow_assets = [
+        *_apply_airflow_data_to_specs(mapped_assets, serialized_data),
+        *construct_automapped_dag_assets_defs(serialized_data),
+    ]
+    resolved_defs = replace_assets_in_defs(defs=defs, assets=airflow_assets)
     return Definitions.merge(
         resolved_defs,
         build_airflow_polling_sensor_defs(
             minimum_interval_seconds=sensor_minimum_interval_seconds,
-            mapped_defs=resolved_defs,
+            mapped_assets=airflow_assets,
             airflow_instance=airflow_instance,
         ),
     )
 
 
-def enrich_explicit_defs_with_airflow_metadata(
-    explicit_defs: Definitions, serialized_data: SerializedAirflowDefinitionsData
-) -> Definitions:
-    return Definitions(
-        assets=list(_apply_airflow_data_to_specs(explicit_defs, serialized_data)),
-        asset_checks=explicit_defs.asset_checks,
-        sensors=explicit_defs.sensors,
-        schedules=explicit_defs.schedules,
-        jobs=explicit_defs.jobs,
-        executor=explicit_defs.executor,
-        loggers=explicit_defs.loggers,
-        resources=explicit_defs.resources,
-        metadata=explicit_defs.metadata,
+def _type_check_asset(asset: Any) -> MappedAsset:
+    return check.inst(
+        asset,
+        (AssetSpec, AssetsDefinition),
+        "Expected passed assets to all be AssetsDefinitions or AssetSpecs.",
     )
 
 
+def _type_narrow_defs_assets(defs: Definitions) -> Sequence[MappedAsset]:
+    return [_type_check_asset(asset) for asset in defs.assets or []]
+
+
 def _apply_airflow_data_to_specs(
-    explicit_defs: Definitions,
+    assets: Sequence[MappedAsset],
     serialized_data: SerializedAirflowDefinitionsData,
 ) -> Iterator[AssetsDefinition]:
     """Apply asset spec transformations to the asset definitions."""
-    for asset in explicit_defs.assets or []:
-        asset = check.inst(  # noqa: PLW2901
-            asset,
-            (AssetSpec, AssetsDefinition),
-            "Expected passed assets to all be AssetsDefinitions or AssetSpecs.",
-        )
+    for asset in assets:
+        narrowed_asset = _type_check_asset(asset)
         assets_def = (
-            asset if isinstance(asset, AssetsDefinition) else external_asset_from_spec(asset)
+            narrowed_asset
+            if isinstance(narrowed_asset, AssetsDefinition)
+            else external_asset_from_spec(narrowed_asset)
         )
         yield assets_def.map_asset_specs(get_airflow_data_to_spec_mapper(serialized_data))
 
@@ -323,11 +330,12 @@ def replace_assets_in_defs(
     )
 
 
-def assets_def_of_defs(defs: Definitions) -> Iterator[AssetsDefinition]:
-    for asset in defs.assets or []:
-        asset = check.inst(  # noqa: PLW2901
-            asset,
-            (AssetSpec, AssetsDefinition),
-            "Expected passed assets to all be AssetsDefinitions or AssetSpecs.",
-        )
-        yield asset if isinstance(asset, AssetsDefinition) else external_asset_from_spec(asset)
+def enrich_airflow_mapped_assets(
+    mapped_assets: Sequence[MappedAsset],
+    airflow_instance: AirflowInstance,
+) -> Sequence[AssetsDefinition]:
+    """Enrich Airflow-mapped assets with metadata from the provided :py:class:`AirflowInstance`."""
+    serialized_data = AirflowInstanceDefsLoader(
+        airflow_instance=airflow_instance, mapped_assets=mapped_assets
+    ).get_or_fetch_state()
+    return list(_apply_airflow_data_to_specs(mapped_assets, serialized_data))

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
@@ -31,7 +31,7 @@ from dagster_airlift.core.serialization.serialized_data import (
     DagInfo,
     SerializedAirflowDefinitionsData,
 )
-from dagster_airlift.core.utils import get_metadata_key
+from dagster_airlift.core.utils import get_metadata_key, spec_iterator
 
 
 @dataclass
@@ -339,3 +339,14 @@ def enrich_airflow_mapped_assets(
         airflow_instance=airflow_instance, mapped_assets=mapped_assets
     ).get_or_fetch_state()
     return list(_apply_airflow_data_to_specs(mapped_assets, serialized_data))
+
+
+def load_airflow_dag_asset_specs(
+    airflow_instance: AirflowInstance,
+    mapped_assets: Optional[Sequence[MappedAsset]] = None,
+) -> Sequence[AssetSpec]:
+    """Load asset specs for Airflow DAGs from the provided :py:class:`AirflowInstance`, and link upstreams from mapped assets."""
+    serialized_data = AirflowInstanceDefsLoader(
+        airflow_instance=airflow_instance, mapped_assets=mapped_assets or []
+    ).get_or_fetch_state()
+    return list(spec_iterator(construct_dag_assets_defs(serialized_data)))

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/load_defs.py
@@ -19,7 +19,7 @@ from dagster_airlift.core.sensor.event_translation import (
 )
 from dagster_airlift.core.sensor.sensor_builder import (
     DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
-    build_airflow_polling_sensor_defs,
+    build_airflow_polling_sensor,
 )
 from dagster_airlift.core.serialization.compute import DagSelectorFn, compute_serialized_data
 from dagster_airlift.core.serialization.defs_construction import (
@@ -223,11 +223,15 @@ def build_defs_from_airflow_instance(
 
     return Definitions.merge(
         defs_with_airflow_assets,
-        build_airflow_polling_sensor_defs(
-            mapped_assets=mapped_and_constructed_assets,
-            airflow_instance=airflow_instance,
-            minimum_interval_seconds=sensor_minimum_interval_seconds,
-            event_transformer_fn=event_transformer_fn,
+        Definitions(
+            sensors=[
+                build_airflow_polling_sensor(
+                    mapped_assets=mapped_and_constructed_assets,
+                    airflow_instance=airflow_instance,
+                    minimum_interval_seconds=sensor_minimum_interval_seconds,
+                    event_transformer_fn=event_transformer_fn,
+                )
+            ]
         ),
     )
 
@@ -280,10 +284,14 @@ def build_full_automapped_dags_from_airflow_instance(
     resolved_defs = replace_assets_in_defs(defs=defs, assets=airflow_assets)
     return Definitions.merge(
         resolved_defs,
-        build_airflow_polling_sensor_defs(
-            minimum_interval_seconds=sensor_minimum_interval_seconds,
-            mapped_assets=airflow_assets,
-            airflow_instance=airflow_instance,
+        Definitions(
+            sensors=[
+                build_airflow_polling_sensor(
+                    minimum_interval_seconds=sensor_minimum_interval_seconds,
+                    mapped_assets=airflow_assets,
+                    airflow_instance=airflow_instance,
+                )
+            ]
         ),
     )
 

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/sensor_builder.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/sensor_builder.py
@@ -7,6 +7,7 @@ from dagster import (
     AssetMaterialization,
     DefaultSensorStatus,
     RunRequest,
+    SensorDefinition,
     SensorEvaluationContext,
     SensorResult,
     _check as check,
@@ -14,7 +15,6 @@ from dagster import (
 )
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.asset_selection import AssetSelection
-from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetObservation
 from dagster._core.definitions.repository_definition.repository_definition import (
     RepositoryDefinition,
@@ -78,13 +78,13 @@ def check_keys_for_asset_keys(
                 yield check_spec.key
 
 
-def build_airflow_polling_sensor_defs(
+def build_airflow_polling_sensor(
     *,
     mapped_assets: Iterable[MappedAsset],
     airflow_instance: AirflowInstance,
     event_transformer_fn: DagsterEventTransformerFn = default_event_transformer,
     minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
-) -> Definitions:
+) -> SensorDefinition:
     """The constructed sensor polls the Airflow instance for activity, and inserts asset events into Dagster's event log.
 
     The sensor decides which Airflow dags and tasks to monitor by inspecting the metadata of the passed-in Definitions object `mapped_defs`.
@@ -190,7 +190,7 @@ def build_airflow_polling_sensor_defs(
             else None,
         )
 
-    return Definitions(sensors=[airflow_dag_sensor])
+    return airflow_dag_sensor
 
 
 def sorted_asset_events(

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/sensor_builder.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/sensor/sensor_builder.py
@@ -37,7 +37,7 @@ from dagster_airlift.constants import (
     EFFECTIVE_TIMESTAMP_METADATA_KEY,
     TASK_ID_TAG_KEY,
 )
-from dagster_airlift.core.airflow_defs_data import AirflowDefinitionsData
+from dagster_airlift.core.airflow_defs_data import AirflowDefinitionsData, MappedAsset
 from dagster_airlift.core.airflow_instance import AirflowInstance, DagRun, TaskInstance
 from dagster_airlift.core.sensor.event_translation import (
     AssetEvent,
@@ -80,7 +80,7 @@ def check_keys_for_asset_keys(
 
 def build_airflow_polling_sensor_defs(
     *,
-    mapped_defs: Definitions,
+    mapped_assets: Iterable[MappedAsset],
     airflow_instance: AirflowInstance,
     event_transformer_fn: DagsterEventTransformerFn = default_event_transformer,
     minimum_interval_seconds: int = DEFAULT_AIRFLOW_SENSOR_INTERVAL_SECONDS,
@@ -105,7 +105,7 @@ def build_airflow_polling_sensor_defs(
         Definitions: A `Definitions` object containing the constructed sensor.
     """
     airflow_data = AirflowDefinitionsData(
-        airflow_instance=airflow_instance, mapped_defs=mapped_defs
+        airflow_instance=airflow_instance, airflow_mapped_assets=mapped_assets
     )
 
     @sensor(
@@ -390,7 +390,7 @@ def automapped_tasks_asset_keys(
     asset_keys_to_emit = set()
     asset_keys = airflow_data.asset_keys_in_task(dag_run.dag_id, task_instance.task_id)
     for asset_key in asset_keys:
-        spec = airflow_data.mapped_defs.get_assets_def(asset_key).get_asset_spec(asset_key)
+        spec = airflow_data.all_asset_specs_by_key[asset_key]
         if spec.metadata.get(AUTOMAPPED_TASK_METADATA_KEY):
             asset_keys_to_emit.add(asset_key)
     return asset_keys_to_emit

--- a/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/defs_construction.py
+++ b/examples/experimental/dagster-airlift/dagster_airlift/core/serialization/defs_construction.py
@@ -1,6 +1,6 @@
-from typing import AbstractSet, Any, Callable, Dict, Mapping, Set
+from typing import AbstractSet, Any, Callable, Dict, Mapping, Sequence, Set
 
-from dagster import AssetKey, AssetSpec, Definitions, JsonMetadataValue, UrlMetadataValue
+from dagster import AssetKey, AssetSpec, JsonMetadataValue, UrlMetadataValue
 from dagster._core.definitions.assets import AssetsDefinition
 from dagster._core.definitions.external_asset import external_asset_from_spec
 from dagster._core.storage.tags import KIND_PREFIX
@@ -103,13 +103,13 @@ def get_airflow_data_to_spec_mapper(
     return _fn
 
 
-def construct_dag_assets_defs(serialized_data: SerializedAirflowDefinitionsData) -> Definitions:
-    return Definitions(
-        [
-            make_dag_external_asset(serialized_data.instance_name, dag_data)
-            for dag_data in serialized_data.dag_datas.values()
-        ]
-    )
+def construct_dag_assets_defs(
+    serialized_data: SerializedAirflowDefinitionsData,
+) -> Sequence[AssetsDefinition]:
+    return [
+        make_dag_external_asset(serialized_data.instance_name, dag_data)
+        for dag_data in serialized_data.dag_datas.values()
+    ]
 
 
 def key_for_automapped_task_asset(instance_name, dag_id, task_id) -> AssetKey:
@@ -139,7 +139,7 @@ def metadata_for_automapped_task_asset(task_info: TaskInfo) -> Mapping[str, Any]
 
 def construct_automapped_dag_assets_defs(
     serialized_data: SerializedAirflowDefinitionsData,
-) -> Definitions:
+) -> Sequence[AssetsDefinition]:
     dag_specs = []
     task_specs = []
     for dag_data in serialized_data.dag_datas.values():
@@ -186,7 +186,7 @@ def construct_automapped_dag_assets_defs(
             )
         )
 
-    return Definitions(assets=task_specs + dag_specs)
+    return task_specs + dag_specs
 
 
 def make_default_dag_asset_key(instance_name: str, dag_id: str) -> AssetKey:


### PR DESCRIPTION
This PR is now being used to accumulate federation API commits before landing.
ORIGINAL DESCRIPTION:
## Summary & Motivation
Right now, all airlift internals which operate over mapped airflow assets take in a fully-qualified Definitions object. This PR changes them to instead operate over an iterable of assets, and leaves the definitions munging to the callsites.

After making this change, it becomes easy to add asset-oriented airlift methods - and I demonstrate that with a standalone method to enrich airflow assets. We'll eventually be able to re-implement the full defs loader on top of this.

## How I Tested These Changes
New test for the new method, existing test suite.

## Changelog
NOCHANGELOG
