### PR TITLE
omit run metrics tags on retry

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -74,7 +74,7 @@ from dagster._core.storage.tags import (
     PARTITION_NAME_TAG,
     RESUME_RETRY_TAG,
     ROOT_RUN_ID_TAG,
-    RUN_FAILURE_REASON_TAG,
+    TAGS_TO_OMIT_ON_RETRY,
 )
 from dagster._serdes import ConfigurableClass
 from dagster._time import get_current_datetime, get_current_timestamp
@@ -1645,7 +1645,7 @@ class DagsterInstance(DynamicPartitionsStore):
 
         # these can differ from remote_job.tags if tags were added at launch time
         parent_run_tags = (
-            {key: val for key, val in parent_run.tags.items() if key != RUN_FAILURE_REASON_TAG}
+            {key: val for key, val in parent_run.tags.items() if key not in TAGS_TO_OMIT_ON_RETRY}
             if use_parent_run_tags
             else {}
         )

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -102,6 +102,9 @@ RUN_METRICS_POLLING_INTERVAL_TAG = f"{HIDDEN_TAG_PREFIX}run_metrics_polling_inte
 RUN_METRICS_PYTHON_RUNTIME_TAG = f"{HIDDEN_TAG_PREFIX}python_runtime_metrics"
 
 
+TAGS_TO_OMIT_ON_RETRY = {*RUN_METRIC_TAGS, RUN_FAILURE_REASON_TAG}
+
+
 class TagType(Enum):
     # Custom tag provided by a user
     USER_PROVIDED = "USER_PROVIDED"

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance_reexecution.py
@@ -5,7 +5,7 @@ from dagster import DagsterInstance, job, op, reconstructable, repository
 from dagster._core.execution.api import execute_job
 from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.storage.dagster_run import DagsterRunStatus
-from dagster._core.storage.tags import RESUME_RETRY_TAG
+from dagster._core.storage.tags import RESUME_RETRY_TAG, SYSTEM_TAG_PREFIX
 from dagster._core.test_utils import (
     environ,
     instance_for_test,
@@ -84,7 +84,7 @@ def failed_run_fixture(instance):
         result = execute_job(
             reconstructable(conditional_fail_job),
             instance=instance,
-            tags={"fizz": "buzz", "foo": "not bar!"},
+            tags={"fizz": "buzz", "foo": "not bar!", f"{SYSTEM_TAG_PREFIX}run_metrics": "true"},
         )
 
     assert not result.success
@@ -155,6 +155,7 @@ def test_create_reexecuted_run_from_failure_tags(
 
     assert run.tags["foo"] == "not bar!"
     assert run.tags["fizz"] == "not buzz!!"
+    assert f"{SYSTEM_TAG_PREFIX}run_metrics" not in run.tags
 
 
 def test_create_reexecuted_run_all_steps(


### PR DESCRIPTION
These are set progamatically by the run coordinator so we don't necessarily want to include them automatically on retry.

Test Plan:
Create a run with dagster/run_metrics: True, retry it - tag is not included

## Changelog
NOCHANGELOG

