### PR TITLE
removes logic for 3.7 back-compatibility

### DIFF
--- a/python_modules/dagster/dagster/_config/pythonic_config/config.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/config.py
@@ -1,5 +1,6 @@
 import re
 from enum import Enum
+from functools import cached_property
 from typing import Any, Dict, List, Mapping, Optional, Set, Type, cast
 
 from pydantic import BaseModel, ConfigDict
@@ -34,14 +35,6 @@ from dagster._model.pydantic_compat_layer import (
     model_fields,
 )
 from dagster._utils.cached_method import CACHED_METHOD_CACHE_FIELD
-
-try:
-    from functools import cached_property  # type: ignore  # (py37 compat)
-except ImportError:
-
-    class cached_property:
-        pass
-
 
 INTERNAL_MARKER = "__internal__"
 

--- a/python_modules/dagster/dagster/_config/pythonic_config/conversion_utils.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/conversion_utils.py
@@ -4,15 +4,20 @@ from typing import Any, Dict, List, Literal, Mapping, Optional, Type, TypeVar, U
 
 from typing_extensions import Annotated, get_args, get_origin
 
+import dagster._check as check
 from dagster import (
     Enum as DagsterEnum,
     EnumValue as DagsterEnumValue,
+    Field,
+    Selector,
 )
 from dagster._config.config_type import Array, ConfigType, Noneable
+from dagster._config.field_utils import FIELD_NO_DEFAULT_PROVIDED, Map, convert_potential_field
 from dagster._config.post_process import resolve_defaults
 from dagster._config.pythonic_config.attach_other_object_to_context import (
     IAttachDifferentObjectToOpContext as IAttachDifferentObjectToOpContext,
 )
+from dagster._config.pythonic_config.type_check_utils import safe_is_subclass
 from dagster._config.source import BoolSource, IntSource, StringSource
 from dagster._config.validate import validate_config
 from dagster._core.definitions.definition_config_schema import DefinitionConfigSchema
@@ -22,19 +27,6 @@ from dagster._core.errors import (
     DagsterInvalidDefinitionError,
     DagsterInvalidPythonicConfigDefinitionError,
 )
-
-try:
-    from functools import cached_property  # type: ignore  # (py37 compat)
-except ImportError:
-
-    class cached_property:
-        pass
-
-
-import dagster._check as check
-from dagster import Field, Selector
-from dagster._config.field_utils import FIELD_NO_DEFAULT_PROVIDED, Map, convert_potential_field
-from dagster._config.pythonic_config.type_check_utils import safe_is_subclass
 from dagster._model.pydantic_compat_layer import ModelFieldCompat, PydanticUndefined, model_fields
 from dagster._utils.typing_api import is_closed_python_optional_type
 

--- a/python_modules/dagster/dagster/_config/pythonic_config/io_manager.py
+++ b/python_modules/dagster/dagster/_config/pythonic_config/io_manager.py
@@ -22,14 +22,6 @@ from dagster._core.execution.context.init import InitResourceContext
 from dagster._core.storage.io_manager import IOManager, IOManagerDefinition
 from dagster._utils.cached_method import cached_method
 
-try:
-    from functools import cached_property  # type: ignore  # (py37 compat)
-except ImportError:
-
-    class cached_property:
-        pass
-
-
 TIOManagerValue = TypeVar("TIOManagerValue", bound=IOManager)
 
 

--- a/python_modules/dagster/dagster/_utils/typing_api.py
+++ b/python_modules/dagster/dagster/_utils/typing_api.py
@@ -52,12 +52,7 @@ def is_closed_python_list_type(ttype):
     origin = get_origin(ttype)
     args = get_args(ttype)
 
-    return (
-        origin is list
-        and args != ()
-        # py3.7 compat
-        and type(args[0]) != typing.TypeVar
-    )
+    return origin is list and args != ()
 
 
 def is_closed_python_dict_type(ttype):
@@ -73,13 +68,7 @@ def is_closed_python_dict_type(ttype):
     origin = get_origin(ttype)
     args = get_args(ttype)
 
-    return (
-        origin is dict
-        and args != ()
-        # py3.7 compat
-        and type(args[0]) != typing.TypeVar
-        and type(args[1]) != typing.TypeVar
-    )
+    return origin is dict and args != ()
 
 
 def is_closed_python_tuple_type(ttype):
@@ -107,12 +96,7 @@ def is_closed_python_set_type(ttype):
     origin = get_origin(ttype)
     args = get_args(ttype)
 
-    return (
-        origin is set
-        and args != ()
-        # py3.7 compat
-        and type(args[0]) != typing.TypeVar
-    )
+    return origin is set and args != ()
 
 
 def get_optional_inner_type(ttype):


### PR DESCRIPTION
## Summary & Motivation

Now that we're targeting Python 3.9+, I suspect we can remove this 3.7 back-compatibility logic.

## How I Tested These Changes

bk

## Changelog

> Insert changelog entry or delete this section.
