### PR TITLE
removes legacy python classifiers from setup.py

### DIFF
--- a/docs/dagster-ui-screenshot/setup.py
+++ b/docs/dagster-ui-screenshot/setup.py
@@ -15,7 +15,6 @@ setup(
     license="Apache-2.0",
     description="Utility for taking automated screenshots from the Dagster UI",
     classifiers=[
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",

--- a/python_modules/libraries/dagster-deltalake-pandas/setup.py
+++ b/python_modules/libraries/dagster-deltalake-pandas/setup.py
@@ -24,7 +24,6 @@ setup(
     description="Package for storing Pandas DataFrames in Delta tables.",
     url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-deltalake-pandas",
     classifiers=[
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/python_modules/libraries/dagster-deltalake-polars/setup.py
+++ b/python_modules/libraries/dagster-deltalake-polars/setup.py
@@ -24,7 +24,6 @@ setup(
     description="Package for storing Polars DataFrames in Delta tables.",
     url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-deltalake-polars",
     classifiers=[
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/python_modules/libraries/dagster-deltalake/setup.py
+++ b/python_modules/libraries/dagster-deltalake/setup.py
@@ -24,7 +24,6 @@ setup(
     description="Package for Deltalake-specific Dagster framework op and resource components.",
     url="https://github.com/dagster-io/dagster/tree/master/python_modules/libraries/dagster-deltalake",
     classifiers=[
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
## Summary & Motivation

We no longer target these versions of Python; open to discussion on better ways of maintaining accuracy of these classifiers.

## How I Tested These Changes

bk

## Changelog

> Insert changelog entry or delete this section.
