### PR TITLE
[buildkite] use longer commit hash in linked builds

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/trigger.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/trigger.py
@@ -28,7 +28,7 @@ def build_trigger_step(
     dagster_commit_hash = safe_getenv("BUILDKITE_COMMIT")
     step: TriggerStep = {
         "trigger": pipeline,
-        "label": f":link: {pipeline} from dagster@{dagster_commit_hash[:6]}",
+        "label": f":link: {pipeline} from dagster@{dagster_commit_hash[:10]}",
         "async": async_step,
         "build": {
             "env": env or {},


### PR DESCRIPTION
6 is to short to do lookup in github

## How I Tested These Changes

10 seems to be what is used elsewhere