### PR TITLE
[DA] Fix unpartitioned in_progress calculation

### DIFF
--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_in_progress_condition.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/builtins/test_in_progress_condition.py
@@ -1,7 +1,17 @@
 import pytest
-from dagster import AutomationCondition
-from dagster._core.definitions.asset_key import AssetKey
+from dagster import (
+    AssetKey,
+    AutomationCondition,
+    DagsterInstance,
+    Definitions,
+    asset,
+    evaluate_automation_conditions,
+)
 from dagster._core.definitions.events import AssetKeyPartitionKey
+from dagster._core.events import DagsterEventType
+from dagster._core.execution.api import create_execution_plan
+from dagster._core.storage.dagster_run import DagsterRunStatus
+from dagster._core.utils import make_new_run_id
 
 from dagster_tests.definitions_tests.declarative_automation_tests.scenario_utils.automation_condition_scenario import (
     AutomationConditionScenarioState,
@@ -72,3 +82,47 @@ async def test_in_progress_static_partitioned() -> None:
     state = state.with_in_progress_runs_completed()
     _, result = await state.evaluate("A")
     assert result.true_subset.size == 0
+
+
+def test_unpartitioned() -> None:
+    RUN_ID = make_new_run_id()
+
+    @asset(automation_condition=AutomationCondition.in_progress())
+    def A() -> None: ...
+
+    @asset
+    def B() -> None: ...
+
+    defs = Definitions(assets=[A, B])
+    instance = DagsterInstance.ephemeral()
+    job = defs.get_implicit_job_def_for_assets([A.key, B.key])
+    assert job is not None
+
+    result = evaluate_automation_conditions(defs=defs, instance=instance)
+    assert result.total_requested == 0
+
+    # create an execution plan targeted at both A and B
+    execution_plan = create_execution_plan(job, run_config={})
+    instance.create_run_for_job(
+        job_def=job,
+        run_id=RUN_ID,
+        status=DagsterRunStatus.STARTING,
+        asset_selection=frozenset({A.key, B.key}),
+        execution_plan=execution_plan,
+    )
+
+    # now A is in progress, as there's a run targeting it
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 1
+
+    events = job.execute_in_process(run_id=RUN_ID).all_events
+    for event in events:
+        instance.report_dagster_event(event, RUN_ID)
+        # only log events up to the point that A gets materialized
+        if event.event_type == DagsterEventType.ASSET_MATERIALIZATION:
+            assert event.asset_key == A.key
+            break
+
+    # now A is no longer in progress, as it got materialized within that run
+    result = evaluate_automation_conditions(defs=defs, instance=instance, cursor=result.cursor)
+    assert result.total_requested == 0


### PR DESCRIPTION
## Summary & Motivation

See changelog

## How I Tested These Changes

Added test -- it failed before the changes, and passes now

## Changelog

Fixed issue with `AutomationCondition.execution_in_progress` which would cause it to evaluate to True for unpartitioned assets that were part of a run that was in progress, even if the asset itself had already been materialized.
