### PR TITLE
[graphql] change mode id scheme

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/mode.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/mode.py
@@ -23,16 +23,16 @@ class GrapheneMode(graphene.ObjectType):
     def __init__(
         self,
         get_config_type: Callable[[str], ConfigTypeSnap],
-        pipeline_snapshot_id: str,
+        job_graphql_id: str,
         mode_def_snap: ModeDefSnap,
     ):
         super().__init__()
         self._mode_def_snap = check.inst_param(mode_def_snap, "mode_def_snap", ModeDefSnap)
         self._get_config_type = get_config_type
-        self._job_snapshot_id = pipeline_snapshot_id
+        self._job_graphql_id = job_graphql_id
 
     def resolve_id(self, _graphene_info: ResolveInfo):
-        return f"{self._job_snapshot_id}-{self._mode_def_snap.name}"
+        return f"{self._job_graphql_id}-{self._mode_def_snap.name}"
 
     def resolve_name(self, _graphene_info: ResolveInfo):
         return self._mode_def_snap.name

--- a/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/pipelines/pipeline.py
@@ -736,12 +736,12 @@ class GrapheneIPipelineSnapshotMixin:
             represented_pipeline.dep_structure_index,
         )
 
-    def resolve_modes(self, _graphene_info: ResolveInfo):
+    def resolve_modes(self, graphene_info: ResolveInfo):
         represented_pipeline = self.get_represented_job()
         return [
             GrapheneMode(
                 represented_pipeline.config_schema_snapshot.get_config_snap,
-                represented_pipeline.identifying_job_snapshot_id,
+                self.resolve_id(graphene_info),
                 mode_def_snap,
             )
             for mode_def_snap in sorted(


### PR DESCRIPTION
for the job portion of the id, just use `resolve_id` directly instead of always using the identifying snapshot id. This will use the more effecient override in `GrapheneJob` when we have a live job definition. 

## How I Tested These Changes

updated test