### PR TITLE
Fixed S3 sensor returning all objects instead of latest objects

### DIFF
--- a/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
+++ b/python_modules/libraries/dagster-aws/dagster_aws/s3/sensor.py
@@ -65,6 +65,7 @@ def get_objects(
         for idx, obj in enumerate(sorted_objects):
             if obj.get("LastModified") > since_last_modified:
                 return sorted_objects[idx:]
+        return []
 
     return sorted_objects
 


### PR DESCRIPTION
## Summary & Motivation
Fixes cases when there are no new objects since the previously provided last_modified timestamp.
Related to this issue: [https://github.com/dagster-io/dagster/issues/25890](https://github.com/dagster-io/dagster/issues/25890)


