### PR TITLE
Add shared component for `AssetGraphAssetSelectionInput`

### DIFF
--- a/js_modules/dagster-ui/packages/eslint-config/rules/missing-shared-import.js
+++ b/js_modules/dagster-ui/packages/eslint-config/rules/missing-shared-import.js
@@ -69,6 +69,19 @@ module.exports = createRule({
           });
         }
       }
+
+      if (importPath.startsWith('js_modules/dagster-ui/packages/ui-core/src')) {
+        context.report({
+          node,
+          messageId: 'invalidSharedImport',
+          fix: (fixer) => {
+            return fixer.replaceText(
+              node.source,
+              `'${importPath.replace('js_modules/dagster-ui/packages/ui-core/src', 'shared')}'`,
+            );
+          },
+        });
+      }
     }
 
     return {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphAssetSelectionInput.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphAssetSelectionInput.oss.tsx
@@ -1,0 +1,9 @@
+import {ComponentProps} from 'react';
+
+import {GraphQueryInput} from '../ui/GraphQueryInput';
+
+export const AssetGraphAssetSelectionInput = (
+  props: Omit<ComponentProps<typeof GraphQueryInput>, 'type'>,
+) => {
+  return <GraphQueryInput {...props} type="asset_graph" />;
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -16,6 +16,7 @@ import uniq from 'lodash/uniq';
 import without from 'lodash/without';
 import * as React from 'react';
 import {useLayoutEffect, useMemo, useState} from 'react';
+import {AssetGraphAssetSelectionInput} from 'shared/asset-graph/AssetGraphAssetSelectionInput.oss';
 import {useAssetGraphExplorerFilters} from 'shared/asset-graph/useAssetGraphExplorerFilters.oss';
 import styled from 'styled-components';
 
@@ -71,7 +72,6 @@ import {
 } from '../pipelines/GraphNotices';
 import {ExplorerPath} from '../pipelines/PipelinePathUtils';
 import {StaticSetFilter} from '../ui/BaseFilters/useStaticSetFilter';
-import {GraphQueryInput} from '../ui/GraphQueryInput';
 import {Loading} from '../ui/Loading';
 
 type AssetNode = AssetNodeForGraphQueryFragment;
@@ -721,8 +721,7 @@ const AssetGraphExplorerWithData = ({
                   )}
                   <div>{filterButton}</div>
                   <GraphQueryInputFlexWrap>
-                    <GraphQueryInput
-                      type="asset_graph"
+                    <AssetGraphAssetSelectionInput
                       items={graphQueryItems}
                       value={explorerPath.opsQuery}
                       placeholder="Type an asset subset…"


### PR DESCRIPTION
## Summary & Motivation

Cloud is going to override the component to do catalog view integration.

Also updated the lint rule to fix the bad auto import of shared components.

## How I Tested These Changes

yarn lint for the lint rule (after having bad import)
