### PR TITLE
[dagster-sigma] Add option to skip fetching column-level data for workbooks to speed loading

### DIFF
--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
@@ -75,9 +75,7 @@ def test_model_organization_data(sigma_auth_token: str, sigma_sample_data: None)
         client_secret=fake_client_secret,
     )
 
-    data = asyncio.run(
-        resource.build_organization_data(sigma_filter=None, skip_fetch_column_data=False)
-    )
+    data = asyncio.run(resource.build_organization_data(sigma_filter=None, fetch_column_data=True))
 
     assert len(data.workbooks) == 1
     assert data.workbooks[0].properties["name"] == "Sample Workbook"
@@ -110,7 +108,7 @@ def test_model_organization_data_filter(sigma_auth_token: str, sigma_sample_data
     data = asyncio.run(
         resource.build_organization_data(
             sigma_filter=SigmaFilter(workbook_folders=[("My Documents", "Test Folder")]),
-            skip_fetch_column_data=False,
+            fetch_column_data=True,
         )
     )
 
@@ -119,7 +117,7 @@ def test_model_organization_data_filter(sigma_auth_token: str, sigma_sample_data
     data = asyncio.run(
         resource.build_organization_data(
             sigma_filter=SigmaFilter(workbook_folders=[("My Documents", "My Subfolder")]),
-            skip_fetch_column_data=False,
+            fetch_column_data=True,
         )
     )
 
@@ -129,7 +127,7 @@ def test_model_organization_data_filter(sigma_auth_token: str, sigma_sample_data
     data = asyncio.run(
         resource.build_organization_data(
             sigma_filter=SigmaFilter(workbook_folders=[("My Documents",)]),
-            skip_fetch_column_data=False,
+            fetch_column_data=True,
         )
     )
 
@@ -151,7 +149,7 @@ def test_model_organization_data_skip_fetch(sigma_auth_token: str, sigma_sample_
     data = asyncio.run(
         resource.build_organization_data(
             sigma_filter=None,
-            skip_fetch_column_data=True,
+            fetch_column_data=False,
         )
     )
 
@@ -177,9 +175,7 @@ def test_model_organization_data_warn_err(
     )
 
     with pytest.raises(ClientResponseError):
-        asyncio.run(
-            resource.build_organization_data(sigma_filter=None, skip_fetch_column_data=False)
-        )
+        asyncio.run(resource.build_organization_data(sigma_filter=None, fetch_column_data=True))
 
 
 @responses.activate
@@ -197,7 +193,7 @@ def test_model_organization_data_warn_no_err(
     )
 
     data = asyncio.run(
-        resource_warn.build_organization_data(sigma_filter=None, skip_fetch_column_data=False)
+        resource_warn.build_organization_data(sigma_filter=None, fetch_column_data=True)
     )
 
     assert len(data.workbooks) == 1

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
@@ -75,7 +75,9 @@ def test_model_organization_data(sigma_auth_token: str, sigma_sample_data: None)
         client_secret=fake_client_secret,
     )
 
-    data = asyncio.run(resource.build_organization_data(sigma_filter=None))
+    data = asyncio.run(
+        resource.build_organization_data(sigma_filter=None, skip_fetch_column_data=False)
+    )
 
     assert len(data.workbooks) == 1
     assert data.workbooks[0].properties["name"] == "Sample Workbook"
@@ -107,7 +109,8 @@ def test_model_organization_data_filter(sigma_auth_token: str, sigma_sample_data
 
     data = asyncio.run(
         resource.build_organization_data(
-            sigma_filter=SigmaFilter(workbook_folders=[("My Documents", "Test Folder")])
+            sigma_filter=SigmaFilter(workbook_folders=[("My Documents", "Test Folder")]),
+            skip_fetch_column_data=False,
         )
     )
 
@@ -115,7 +118,8 @@ def test_model_organization_data_filter(sigma_auth_token: str, sigma_sample_data
 
     data = asyncio.run(
         resource.build_organization_data(
-            sigma_filter=SigmaFilter(workbook_folders=[("My Documents", "My Subfolder")])
+            sigma_filter=SigmaFilter(workbook_folders=[("My Documents", "My Subfolder")]),
+            skip_fetch_column_data=False,
         )
     )
 
@@ -124,12 +128,38 @@ def test_model_organization_data_filter(sigma_auth_token: str, sigma_sample_data
 
     data = asyncio.run(
         resource.build_organization_data(
-            sigma_filter=SigmaFilter(workbook_folders=[("My Documents",)])
+            sigma_filter=SigmaFilter(workbook_folders=[("My Documents",)]),
+            skip_fetch_column_data=False,
         )
     )
 
     assert len(data.workbooks) == 1
     assert data.workbooks[0].properties["name"] == "Sample Workbook"
+
+
+@responses.activate
+def test_model_organization_data_skip_fetch(sigma_auth_token: str, sigma_sample_data: None) -> None:
+    fake_client_id = uuid.uuid4().hex
+    fake_client_secret = uuid.uuid4().hex
+
+    resource = SigmaOrganization(
+        base_url=SigmaBaseUrl.AWS_US,
+        client_id=fake_client_id,
+        client_secret=fake_client_secret,
+    )
+
+    data = asyncio.run(
+        resource.build_organization_data(
+            sigma_filter=None,
+            skip_fetch_column_data=True,
+        )
+    )
+
+    assert len(data.datasets) == 1
+    assert data.workbooks[0].datasets == {_inode_from_url(data.datasets[0].properties["url"])}
+
+    assert data.datasets[0].properties["name"] == "Orders Dataset"
+    assert data.datasets[0].columns == set()
 
 
 @responses.activate
@@ -147,7 +177,9 @@ def test_model_organization_data_warn_err(
     )
 
     with pytest.raises(ClientResponseError):
-        asyncio.run(resource.build_organization_data(sigma_filter=None))
+        asyncio.run(
+            resource.build_organization_data(sigma_filter=None, skip_fetch_column_data=False)
+        )
 
 
 @responses.activate
@@ -164,7 +196,9 @@ def test_model_organization_data_warn_no_err(
         warn_on_lineage_fetch_error=True,
     )
 
-    data = asyncio.run(resource_warn.build_organization_data(sigma_filter=None))
+    data = asyncio.run(
+        resource_warn.build_organization_data(sigma_filter=None, skip_fetch_column_data=False)
+    )
 
     assert len(data.workbooks) == 1
     assert data.workbooks[0].properties["name"] == "Sample Workbook"


### PR DESCRIPTION
## Summary

Adds an optional config option to loading Sigma data which allows users to skip loading column lineage.

## How I Tested These Changes

New unit test.

## Changelog

> `[dagster-sigma]` Add `skip_fetch_column_data` option to skip loading Sigma column lineage, which can speed up loading large instances.
