### PR TITLE
[dagster-sigma][bk] Add aiohttp pin

### DIFF
--- a/python_modules/libraries/dagster-sigma/setup.py
+++ b/python_modules/libraries/dagster-sigma/setup.py
@@ -35,7 +35,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_sigma_tests*"]),
-    install_requires=[f"dagster{pin}", "sqlglot", "aiohttp"],
+    install_requires=[f"dagster{pin}", "sqlglot", "aiohttp<3.11"],
     extras_require={
         "test": [
             "aioresponses",

--- a/python_modules/libraries/dagster-sigma/setup.py
+++ b/python_modules/libraries/dagster-sigma/setup.py
@@ -35,12 +35,8 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(exclude=["dagster_sigma_tests*"]),
-    install_requires=[f"dagster{pin}", "sqlglot", "aiohttp<3.11"],
-    extras_require={
-        "test": [
-            "aioresponses",
-        ]
-    },
+    install_requires=[f"dagster{pin}", "sqlglot", "aiohttp"],
+    extras_require={"test": ["aioresponses", "aiohttp<3.11"]},
     include_package_data=True,
     python_requires=">=3.9,<3.13",
     zip_safe=False,


### PR DESCRIPTION
## Summary

Pin `aiohttp<3.11`, which released this morning, since it is not compatible with `aioresponses`, which we use for testing.

