### PR TITLE
[partitions] Update AssetStatusCacheValue to not rely on serialize_partitions_subsets

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/fetch_assets.py
@@ -46,8 +46,11 @@ from dagster._core.storage.event_log.sql_event_log import get_max_event_records_
 from dagster._core.storage.partition_status_cache import (
     build_failed_and_in_progress_partition_subset,
     get_and_update_asset_status_cache_value,
+    get_failed_partitions_subset,
+    get_in_progress_partitions_subset,
     get_last_planned_storage_id,
     get_materialized_multipartitions,
+    get_materialized_partitions_subset,
     get_validated_partition_keys,
     is_cacheable_partition_type,
 )
@@ -432,21 +435,11 @@ def get_partition_subsets(
             dynamic_partitions_loader,
             loading_context,
         )
-        materialized_subset = (
-            updated_cache_value.deserialize_materialized_partition_subsets(partitions_def)
-            if updated_cache_value
-            else partitions_def.empty_subset()
+        materialized_subset = get_materialized_partitions_subset(
+            updated_cache_value, partitions_def
         )
-        failed_subset = (
-            updated_cache_value.deserialize_failed_partition_subsets(partitions_def)
-            if updated_cache_value
-            else partitions_def.empty_subset()
-        )
-        in_progress_subset = (
-            updated_cache_value.deserialize_in_progress_partition_subsets(partitions_def)
-            if updated_cache_value
-            else partitions_def.empty_subset()
-        )
+        failed_subset = get_failed_partitions_subset(updated_cache_value, partitions_def)
+        in_progress_subset = get_in_progress_partitions_subset(updated_cache_value, partitions_def)
 
         return materialized_subset, failed_subset, in_progress_subset
 

--- a/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
+++ b/python_modules/dagster/dagster/_core/asset_graph_view/asset_graph_view.py
@@ -403,18 +403,18 @@ class AssetGraphView(LoadingContext):
         return await self.compute_subset_with_status(key, None)
 
     async def _compute_run_in_progress_asset_subset(self, key: AssetKey) -> EntitySubset[AssetKey]:
-        from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
+        from dagster._core.storage.partition_status_cache import (
+            AssetStatusCacheValue,
+            get_in_progress_partitions_subset,
+        )
 
         partitions_def = self._get_partitions_def(key)
         if partitions_def:
             cache_value = await AssetStatusCacheValue.gen(self, (key, partitions_def))
-            return (
-                cache_value.get_in_progress_subset(self, key, partitions_def)
-                if cache_value
-                else self.get_empty_subset(key=key)
-            )
-        value = self._queryer.get_in_progress_asset_subset(asset_key=key).value
-        return EntitySubset(self, key=key, value=_ValidatedEntitySubsetValue(value))
+            inner_value = get_in_progress_partitions_subset(cache_value, partitions_def)
+        else:
+            inner_value = self._queryer.get_in_progress_asset_subset(asset_key=key).value
+        return EntitySubset(self, key=key, value=_ValidatedEntitySubsetValue(inner_value))
 
     async def _compute_backfill_in_progress_asset_subset(
         self, key: AssetKey
@@ -427,18 +427,28 @@ class AssetGraphView(LoadingContext):
         return EntitySubset(self, key=key, value=_ValidatedEntitySubsetValue(value))
 
     async def _compute_execution_failed_asset_subset(self, key: AssetKey) -> EntitySubset[AssetKey]:
-        from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
+        from dagster._core.storage.partition_status_cache import (
+            AssetStatusCacheValue,
+            get_failed_partitions_subset,
+        )
 
         partitions_def = self._get_partitions_def(key)
         if partitions_def:
             cache_value = await AssetStatusCacheValue.gen(self, (key, partitions_def))
-            return (
-                cache_value.get_failed_subset(self, key, partitions_def)
-                if cache_value
-                else self.get_empty_subset(key=key)
-            )
-        value = self._queryer.get_failed_asset_subset(asset_key=key).value
-        return EntitySubset(self, key=key, value=_ValidatedEntitySubsetValue(value))
+            inner_value = get_failed_partitions_subset(cache_value, partitions_def)
+        else:
+            inner_value = self._queryer.get_failed_asset_subset(asset_key=key).value
+        return EntitySubset(self, key=key, value=_ValidatedEntitySubsetValue(inner_value))
+
+    def _get_asset_status_cache_subset(
+        self, key: AssetKey, serializable_subset: Optional[SerializableEntitySubset]
+    ) -> EntitySubset[AssetKey]:
+        entity_subset = (
+            self.get_subset_from_serializable_subset(serializable_subset)
+            if serializable_subset
+            else None
+        )
+        return entity_subset or self.get_empty_subset(key=key)
 
     async def _compute_missing_asset_subset(
         self, key: AssetKey, from_subset: EntitySubset
@@ -446,7 +456,10 @@ class AssetGraphView(LoadingContext):
         """Returns a subset which is the subset of the input subset that has never been materialized
         (if it is a materializable asset) or observered (if it is an observable asset).
         """
-        from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
+        from dagster._core.storage.partition_status_cache import (
+            AssetStatusCacheValue,
+            get_materialized_partitions_subset,
+        )
 
         # TODO: this logic should be simplified once we have a unified way of detecting both
         # materializations and observations through the parittion status cache. at that point, the
@@ -457,16 +470,12 @@ class AssetGraphView(LoadingContext):
             partitions_def = self._get_partitions_def(key)
             if partitions_def:
                 cache_value = await AssetStatusCacheValue.gen(self, (key, partitions_def))
-                materialized_subset = (
-                    cache_value.get_materialized_subset(self, key, partitions_def)
-                    if cache_value
-                    else self.get_empty_subset(key=key)
-                )
+                inner_value = get_materialized_partitions_subset(cache_value, partitions_def)
             else:
-                value = self._queryer.get_materialized_asset_subset(asset_key=key).value
-                materialized_subset = EntitySubset(
-                    self, key=key, value=_ValidatedEntitySubsetValue(value)
-                )
+                inner_value = self._queryer.get_materialized_asset_subset(asset_key=key).value
+            materialized_subset = EntitySubset(
+                self, key=key, value=_ValidatedEntitySubsetValue(inner_value)
+            )
             return from_subset.compute_difference(materialized_subset)
         else:
             # more expensive call

--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -2164,27 +2164,26 @@ class DagsterInstance(DynamicPartitionsStore):
             AssetPartitionStatus,
             AssetStatusCacheValue,
             get_and_update_asset_status_cache_value,
+            get_failed_partitions_subset,
+            get_in_progress_partitions_subset,
+            get_materialized_partitions_subset,
         )
 
-        cached_value = get_and_update_asset_status_cache_value(self, asset_key, partitions_def)
+        cache_value = get_and_update_asset_status_cache_value(self, asset_key, partitions_def)
 
-        if isinstance(cached_value, AssetStatusCacheValue):
-            materialized_partitions = cached_value.deserialize_materialized_partition_subsets(
-                partitions_def
-            )
-            failed_partitions = cached_value.deserialize_failed_partition_subsets(partitions_def)
-            in_progress_partitions = cached_value.deserialize_in_progress_partition_subsets(
-                partitions_def
-            )
+        if isinstance(cache_value, AssetStatusCacheValue):
+            materialized_subset = get_materialized_partitions_subset(cache_value, partitions_def)
+            in_progress_subset = get_in_progress_partitions_subset(cache_value, partitions_def)
+            failed_subset = get_failed_partitions_subset(cache_value, partitions_def)
 
             status_by_partition = {}
 
             for partition_key in partition_keys:
-                if partition_key in in_progress_partitions:
+                if partition_key in in_progress_subset:
                     status_by_partition[partition_key] = AssetPartitionStatus.IN_PROGRESS
-                elif partition_key in failed_partitions:
+                elif partition_key in failed_subset:
                     status_by_partition[partition_key] = AssetPartitionStatus.FAILED
-                elif partition_key in materialized_partitions:
+                elif partition_key in materialized_subset:
                     status_by_partition[partition_key] = AssetPartitionStatus.MATERIALIZED
                 else:
                     status_by_partition[partition_key] = None

--- a/python_modules/dagster/dagster_tests/cli_tests/test_asset_wipe_command.py
+++ b/python_modules/dagster/dagster_tests/cli_tests/test_asset_wipe_command.py
@@ -154,14 +154,14 @@ def _get_cached_status_for_asset(instance, asset_key):
     return asset_records[0].asset_entry.cached_status
 
 
-def test_asset_single_wipe_cache(instance_runner):
+def test_asset_single_wipe_cache(instance_runner) -> None:
     instance, runner = instance_runner
     job_one.execute_in_process(instance=instance)
     job_two.execute_in_process(instance=instance)
     asset_1 = AssetKey("asset_1")
     asset_2 = AssetKey("asset_2")
 
-    dummy_cache_value = AssetStatusCacheValue(1, "foo", "bar")
+    dummy_cache_value = AssetStatusCacheValue(latest_storage_id=1)
     for key in [asset_1, asset_2]:
         instance.update_asset_cached_status_data(key, dummy_cache_value)
         assert _get_cached_status_for_asset(instance, key) == dummy_cache_value
@@ -182,7 +182,7 @@ def test_asset_multi_wipe_cache(instance_runner):
     asset_2 = AssetKey("asset_2")
     asset_3 = AssetKey(["path", "to", "asset_3"])
 
-    dummy_cache_value = AssetStatusCacheValue(1, "foo", "bar")
+    dummy_cache_value = AssetStatusCacheValue(latest_storage_id=1)
     for key in [asset_1, asset_2, asset_3]:
         instance.update_asset_cached_status_data(key, dummy_cache_value)
         assert _get_cached_status_for_asset(instance, key) == dummy_cache_value
@@ -206,7 +206,7 @@ def test_asset_wipe_all_cache_status_values(instance_runner):
     asset_2 = AssetKey("asset_2")
     asset_3 = AssetKey(["path", "to", "asset_3"])
 
-    dummy_cache_value = AssetStatusCacheValue(1, "foo", "bar")
+    dummy_cache_value = AssetStatusCacheValue(latest_storage_id=1)
     for key in [asset_2, asset_3]:
         instance.update_asset_cached_status_data(key, dummy_cache_value)
         assert _get_cached_status_for_asset(instance, key) == dummy_cache_value

--- a/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
+++ b/python_modules/dagster/dagster_tests/core_tests/instance_tests/test_instance.py
@@ -2,7 +2,7 @@ import os
 import re
 import tempfile
 from typing import Any, Mapping, Optional
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -21,10 +21,12 @@ from dagster import (
 from dagster._check import CheckError
 from dagster._cli.utils import get_instance_for_cli
 from dagster._config import Field
+from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
 from dagster._core.definitions.asset_check_evaluation import AssetCheckEvaluation
 from dagster._core.definitions.asset_check_spec import AssetCheckKey
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.events import AssetMaterialization, AssetObservation
+from dagster._core.definitions.partition import DefaultPartitionsSubset
 from dagster._core.definitions.unresolved_asset_job_definition import define_asset_job
 from dagster._core.errors import (
     DagsterHomeNotSetError,
@@ -725,15 +727,22 @@ def test_configurable_class_missing_methods():
 
 
 @patch("dagster._core.storage.partition_status_cache.get_and_update_asset_status_cache_value")
-def test_get_status_by_partition(mock_get_and_update):
-    mock_cached_value = MagicMock(spec=AssetStatusCacheValue)
-    mock_cached_value.deserialize_materialized_partition_subsets.return_value = [
-        "2023-06-01",
-        "2023-06-02",
-    ]
-    mock_cached_value.deserialize_failed_partition_subsets.return_value = ["2023-06-15"]
-    mock_cached_value.deserialize_in_progress_partition_subsets.return_value = ["2023-07-01"]
-    mock_get_and_update.return_value = mock_cached_value
+def test_get_status_by_partition(mock_get_and_update) -> None:
+    key = AssetKey("a")
+    materialized_subset = SerializableEntitySubset(
+        key, DefaultPartitionsSubset({"2023-06-01", "2023-06-02"})
+    )
+    failed_subset = SerializableEntitySubset(key, DefaultPartitionsSubset({"2023-06-15"}))
+    in_progress_subset = SerializableEntitySubset(key, DefaultPartitionsSubset({"2023-07-01"}))
+    cached_value = AssetStatusCacheValue(
+        latest_storage_id=0,
+        partitions_def_id="...",
+        materialized_subset=materialized_subset,
+        failed_subset=failed_subset,
+        in_progress_subset=in_progress_subset,
+    )
+    mock_get_and_update.return_value = cached_value
+
     with instance_for_test() as instance:
         partition_status = instance.get_status_by_partition(
             AssetKey("test-asset"),

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -36,6 +36,7 @@ from dagster import (
     resource,
 )
 from dagster._check import CheckError
+from dagster._core.asset_graph_view.serializable_entity_subset import SerializableEntitySubset
 from dagster._core.assets import AssetDetails
 from dagster._core.definitions import ExpectationResult
 from dagster._core.definitions.asset_check_evaluation import (
@@ -103,7 +104,10 @@ from dagster._core.storage.event_log.migration import (
 from dagster._core.storage.event_log.schema import SqlEventLogStorageTable
 from dagster._core.storage.event_log.sqlite.sqlite_event_log import SqliteEventLogStorage
 from dagster._core.storage.io_manager import IOManager
-from dagster._core.storage.partition_status_cache import AssetStatusCacheValue
+from dagster._core.storage.partition_status_cache import (
+    AssetStatusCacheValue,
+    get_materialized_partitions_subset,
+)
 from dagster._core.storage.sqlalchemy_compat import db_select
 from dagster._core.storage.tags import (
     ASSET_PARTITION_RANGE_END_TAG,
@@ -4686,16 +4690,11 @@ class TestEventLogStorage:
             cache_value = AssetStatusCacheValue(
                 latest_storage_id=1,
                 partitions_def_id="foo",
-                serialized_materialized_partition_subset="bar",
-                serialized_failed_partition_subset="baz",
-                serialized_in_progress_partition_subset="qux",
+                materialized_subset=SerializableEntitySubset(asset_key, True),
+                in_progress_subset=SerializableEntitySubset(asset_key, True),
+                failed_subset=SerializableEntitySubset(asset_key, True),
                 earliest_in_progress_materialization_event_id=42,
             )
-
-            # Check that AssetStatusCacheValue has all fields set. This ensures that we test that the
-            # cloud gql representation is complete.
-            for field in cache_value._fields:
-                assert getattr(cache_value, field) is not None
 
             if storage.can_write_asset_status_cache():
                 storage.update_asset_cached_status_data(
@@ -4707,7 +4706,7 @@ class TestEventLogStorage:
                 cache_value = AssetStatusCacheValue(
                     latest_storage_id=1,
                     partitions_def_id=None,
-                    serialized_materialized_partition_subset=None,
+                    materialized_subset=None,
                 )
 
                 storage.update_asset_cached_status_data(
@@ -4718,7 +4717,7 @@ class TestEventLogStorage:
             cache_value = AssetStatusCacheValue(
                 latest_storage_id=1,
                 partitions_def_id=None,
-                serialized_materialized_partition_subset=None,
+                materialized_subset=None,
             )
             storage.update_asset_cached_status_data(asset_key=asset_key, cache_values=cache_value)
             assert _get_cached_status_for_asset(storage, asset_key) == cache_value
@@ -6021,15 +6020,15 @@ class TestEventLogStorage:
 
     def test_get_updated_asset_status_cache_values(
         self, instance: DagsterInstance, storage: EventLogStorage
-    ):
-        partition_defs_by_key = {
-            AssetKey("hourly"): HourlyPartitionsDefinition("2020-01-01-00:00"),
-            AssetKey("daily"): DailyPartitionsDefinition("2020-01-01"),
-            AssetKey("static"): StaticPartitionsDefinition(["a", "b", "c"]),
-        }
+    ) -> None:
+        partition_defs_by_key = [
+            (AssetKey("hourly"), HourlyPartitionsDefinition("2020-01-01-00:00")),
+            (AssetKey("daily"), DailyPartitionsDefinition("2020-01-01")),
+            (AssetKey("static"), StaticPartitionsDefinition(["a", "b", "c"])),
+        ]
 
         assert storage.get_asset_status_cache_values(
-            partition_defs_by_key.items(), LoadingContextForTest(instance)
+            partition_defs_by_key, LoadingContextForTest(instance)
         ) == [
             None,
             None,
@@ -6044,11 +6043,15 @@ class TestEventLogStorage:
         )
         instance.report_runless_asset_event(AssetMaterialization(asset_key="static", partition="a"))
 
-        partition_defs = list(partition_defs_by_key.values())
-        for i, value in enumerate(
+        for value, (_, partitions_def) in zip(
             storage.get_asset_status_cache_values(
-                partition_defs_by_key.items(), LoadingContextForTest(instance)
+                partition_defs_by_key, LoadingContextForTest(instance)
             ),
+            partition_defs_by_key,
         ):
-            assert value is not None
-            assert len(value.deserialize_materialized_partition_subsets(partition_defs[i])) == 1
+            assert value is not None and (
+                value.materialized_subset is not None
+                or value.serialized_materialized_partition_subset is not None
+            )
+            partitions_subset = get_materialized_partitions_subset(value, partitions_def)
+            assert len(partitions_subset) == 1


### PR DESCRIPTION
## Summary & Motivation

This is a step towards deleting all of the remaining "old-fashioned" partition subset serialization codepaths.

Alongside this PR, we'll need a new PR in the internal repo that handles the graphql serialization for backwards compatibility.

At a high level, the plan is:

1. (this pr) Add new SerializableEntitySubset fields to the AssetStatusCacheValue object, allow us to read from either this new field or the old field.

2. After some amount of time, delete the old fields. The consequence is that values serialized with the old logic will need to be rebuilt from scratch (hence sequencing these PRs across separate releases, to make the set of things that need to be fully rebuilt smaller.

3. Once these old fields are deleted, we will still need to retain some limited backcompat logic in internal, but otherwise will be free to completely delete all of the old serialization code.

## How I Tested These Changes

## Changelog

NOCHANGELOG
