### PR TITLE
Fix user settings dialog saving default values on open

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/Flags.tsx
@@ -12,7 +12,7 @@ export const DAGSTER_FLAGS_KEY = 'DAGSTER_FLAGS';
 type FeatureFlagMap = Partial<Record<FeatureFlag, boolean>>;
 
 /**
- * In-memory cache for feature flags.
+ * In-memory cache for feature flags, excludes default values.
  */
 let currentFeatureFlags: FeatureFlagMap = {};
 
@@ -56,14 +56,12 @@ const featureFlagsChannel = new BroadcastChannel('feature-flags');
 // Initialize feature flags on module load
 initializeFeatureFlags();
 
-/**
- * Function to retrieve the current feature flags from the in-memory cache.
- */
-export const getFeatureFlags = (): FeatureFlagMap => {
-  return {
-    ...DEFAULT_FEATURE_FLAG_VALUES,
-    ...currentFeatureFlags,
-  };
+export const getFeatureFlagsWithoutDefaultValues = (): FeatureFlagMap => {
+  return currentFeatureFlags;
+};
+
+export const getFeatureFlagDefaults = (): FeatureFlagMap => {
+  return DEFAULT_FEATURE_FLAG_VALUES;
 };
 
 /**

--- a/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/UserSettingsDialog.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/UserSettingsDialog/UserSettingsDialog.tsx
@@ -17,7 +17,11 @@ import {UserPreferences} from 'shared/app/UserSettingsDialog/UserPreferences.oss
 
 import {CodeLinkProtocolSelect} from '../../code-links/CodeLinkProtocol';
 import {showCustomAlert} from '../CustomAlertProvider';
-import {getFeatureFlags, setFeatureFlags} from '../Flags';
+import {
+  getFeatureFlagDefaults,
+  getFeatureFlagsWithoutDefaultValues,
+  setFeatureFlags,
+} from '../Flags';
 import {useTrackEvent} from '../analytics';
 
 type OnCloseFn = (event: React.SyntheticEvent<HTMLElement>) => void;
@@ -53,10 +57,12 @@ interface DialogContentProps {
  */
 const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) => {
   const trackEvent = useTrackEvent();
-  const [flags, setFlags] = React.useState(() => getFeatureFlags());
+  const [flags, setFlags] = React.useState(() => getFeatureFlagsWithoutDefaultValues());
   const [reloading, setReloading] = React.useState(false);
 
-  const initialFlagState = React.useRef(JSON.stringify(getFeatureFlags()));
+  const initialFlagState = React.useRef(JSON.stringify(getFeatureFlagsWithoutDefaultValues()));
+
+  const defaultValues = getFeatureFlagDefaults();
 
   React.useEffect(() => {
     setFeatureFlags(flags);
@@ -73,8 +79,7 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
 
   const [arePreferencesChanged, setAreaPreferencesChanged] = React.useState(false);
 
-  const anyChange =
-    initialFlagState.current !== JSON.stringify(getFeatureFlags()) || arePreferencesChanged;
+  const anyChange = initialFlagState.current !== JSON.stringify(flags) || arePreferencesChanged;
 
   const handleClose = (event: React.SyntheticEvent<HTMLElement>) => {
     if (anyChange) {
@@ -92,7 +97,11 @@ const UserSettingsDialogContent = ({onClose, visibleFlags}: DialogContentProps) 
       key={key}
     >
       <div>{label || key}</div>
-      <Checkbox format="switch" checked={!!flags[flagType]} onChange={() => toggleFlag(flagType)} />
+      <Checkbox
+        format="switch"
+        checked={flags[flagType] === undefined ? !!defaultValues[flagType] : !!flags[flagType]}
+        onChange={() => toggleFlag(flagType)}
+      />
     </Box>
   ));
 


### PR DESCRIPTION
## Summary & Motivation

Fixes an issue where the user settings dialog would immediately save default feature flag values to localStorage

## How I Tested These Changes

jest + manual testing:

With local host cloud I opened the user settings dialog and output my localStorage in the console and confirmed that it hadn't saved the default value:
<img width="1547" alt="Screenshot 2024-11-14 at 2 02 42 PM" src="https://github.com/user-attachments/assets/6382f43b-b2ae-495c-9c37-8fb9b8ca5a22">


Next I switched to a branch deployment where the default value is off and confirmed that it defaulted to off and still the default value was not saved in localStorage.
<img width="1616" alt="Screenshot 2024-11-14 at 2 03 18 PM" src="https://github.com/user-attachments/assets/efc5f245-e512-4a01-a0e2-2e79aab0e52c">