### PR TITLE
Fix CacheableAssetsDefinition / default_automation_condition_sensor interaction

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/definitions_class.py
+++ b/python_modules/dagster/dagster/_core/definitions/definitions_class.py
@@ -42,10 +42,7 @@ from dagster._core.definitions.repository_definition import (
 from dagster._core.definitions.schedule_definition import ScheduleDefinition
 from dagster._core.definitions.sensor_definition import SensorDefinition
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
-from dagster._core.definitions.utils import (
-    add_default_automation_condition_sensor,
-    dedupe_object_refs,
-)
+from dagster._core.definitions.utils import dedupe_object_refs
 from dagster._core.errors import DagsterInvariantViolationError
 from dagster._core.execution.build_resources import wrap_resources_for_execution
 from dagster._core.execution.with_resources import with_resources
@@ -273,13 +270,6 @@ def _create_repository_using_definitions_args(
     assets = _canonicalize_specs_to_assets_defs(dedupe_object_refs(assets))
     schedules = dedupe_object_refs(schedules)
     asset_checks = dedupe_object_refs(asset_checks)
-
-    # add in a default automation condition sensor definition if required
-    sensors = add_default_automation_condition_sensor(
-        sensors,
-        [asset for asset in assets if not isinstance(asset, CacheableAssetsDefinition)],
-        asset_checks or [],
-    )
 
     executor_def = (
         executor

--- a/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
+++ b/python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py
@@ -56,6 +56,7 @@ from dagster._core.definitions.sensor_definition import SensorDefinition
 from dagster._core.definitions.source_asset import SourceAsset
 from dagster._core.definitions.time_window_partitions import TimeWindowPartitionsDefinition
 from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
+from dagster._core.definitions.utils import get_default_automation_condition_sensor
 from dagster._core.errors import DagsterInvalidDefinitionError
 
 if TYPE_CHECKING:
@@ -326,6 +327,13 @@ def build_caching_repository_data_from_list(
             *source_assets_by_key.values(),  # only ever one key per source asset so no need to dedupe
         ]
     )
+    # add a default automation condition sensor if necessary
+    default_automation_condition_sensor = get_default_automation_condition_sensor(
+        list(sensors.values()), asset_graph
+    )
+    if default_automation_condition_sensor:
+        sensors[default_automation_condition_sensor.name] = default_automation_condition_sensor
+
     if assets_defs or asset_checks_defs or source_assets:
         jobs[IMPLICIT_ASSET_JOB_NAME] = get_base_asset_job_lambda(
             asset_graph=asset_graph,


### PR DESCRIPTION
## Summary & Motivation

This pushes the addition of the default automation condition sensor further down the stack, to a point at which the CacheableAssetsDefinitions are guaranteed to be resolved.

Resolves: https://github.com/dagster-io/dagster/issues/25924

## How I Tested These Changes

## Changelog

Fixed a bug which could cause code location load errors when using `CacheableAssetsDefinitions` in code locations that contained `AutomationConditions`. 
