### PR TITLE
[dagster-sigma] Update get_asset_spec usage in custom translator test

### DIFF
--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_translator.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_translator.py
@@ -77,7 +77,7 @@ def test_dataset_translation_custom_translator() -> None:
         def get_asset_key(self, data: SigmaDataset) -> AssetKey:
             return super().get_asset_key(data).with_prefix("sigma")
 
-        def get_asset_spec(self, asset_key: AssetKey, data: SigmaDataset) -> AssetSpec:
+        def get_asset_spec(self, data: SigmaDataset) -> AssetSpec:
             spec = super().get_asset_spec(data)
             if isinstance(data, SigmaDataset):
                 return spec._replace(description="Custom description")
@@ -91,7 +91,7 @@ def test_dataset_translation_custom_translator() -> None:
 
     translator = MyCustomTranslator(SigmaOrganizationData(workbooks=[], datasets=[sample_dataset]))
 
-    asset_spec = translator.get_asset_spec(translator.get_asset_key(sample_dataset), sample_dataset)
+    asset_spec = translator.get_asset_spec(sample_dataset)
 
     assert asset_spec.key.path == ["sigma", "Orders_Dataset"]
     assert asset_spec.description == "Custom description"


### PR DESCRIPTION
## Summary & Motivation

The signature of `get_asset_spec` was still accepting an asset key. This change was reverted in https://github.com/dagster-io/dagster/pull/25432/commits/79e586bb0df4067532f788fced4a1576acac7bd7, but we missed that one.

## How I Tested These Changes

BK
