### PR TITLE
Fix subprocess resource leak in multiprocess executor

### DIFF
--- a/python_modules/dagster/dagster/_core/executor/multiprocess.py
+++ b/python_modules/dagster/dagster/_core/executor/multiprocess.py
@@ -220,8 +220,10 @@ class MultiprocessExecutor(Executor):
                         stopping = True
                         active_execution.mark_interrupted()
                         for key, term_event in term_events.items():
-                            if processes.get(key) and processes[key].is_alive():
-                                term_event.set()
+                            if key in processes:
+                                if processes[key].is_alive():
+                                    term_event.set()
+                                del processes[key]
 
                     while not stopping:
                         steps = active_execution.get_steps_to_execute(
@@ -290,6 +292,8 @@ class MultiprocessExecutor(Executor):
                     for key in empty_iters:
                         del active_iters[key]
                         del term_events[key]
+                        if key in processes:
+                            del processes[key]
                         active_execution.verify_complete(plan_context, key)
 
                     # process skipped and abandoned steps
@@ -310,8 +314,10 @@ class MultiprocessExecutor(Executor):
                         ),
                     )
                     for key, term_event in term_events.items():
-                        if processes.get(key) and processes[key].is_alive():
-                            term_event.set()
+                        if key in processes:
+                            if processes[key].is_alive():
+                                term_event.set()
+                            del processes[key]
 
                 raise
 


### PR DESCRIPTION
## Summary & Motivation
https://github.com/dagster-io/dagster/pull/22839 started keeping processes around in the multiprocess executor to track whether they were still running at termination time, preventing those subprocess objects from being GCed after the step was completed, causing resource buildup issues.

Resolves https://github.com/dagster-io/dagster/issues/25132.


## How I Tested These Changes
Existing automated testing, plus run the following job locally:

```
import dagster as dg

def op_factory(i: int):
    @dg.op(name=f"op_{i}")
    def the_op() -> int:
        return i
    return the_op

@dg.job
def job_with_many_steps():
    for i in range(400):
        op_factory(i)()
```

Before this change, lsof -p <run pid> grew over time for that job, now it stays steady.

## Changelog

- Fixed an issue where the default multiprocess executor kept holding onto subprocesses after their step completed, potentially causing `Too many open files` errors for jobs with many steps.
