### PR TITLE
test - bk with selection

### DIFF
--- a/examples/docs_snippets/docs_snippets_tests/guides_tests/enriching_with_software_defined_assets/test_sda_nothing.py
+++ b/examples/docs_snippets/docs_snippets_tests/guides_tests/enriching_with_software_defined_assets/test_sda_nothing.py
@@ -5,3 +5,6 @@ from docs_snippets.guides.dagster.enriching_with_software_defined_assets.sda_not
 
 def test_sda_nothing():
     assert defs.get_job_def("users_recommenders_job").execute_in_process().success
+
+
+# add comment to make sure this test is run in bk

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -495,14 +495,14 @@ class AssetSelection(ABC):
 
     @classmethod
     def from_string(cls, string: str) -> "AssetSelection":
-        from dagster._core.definitions.antlr_asset_selection.antlr_asset_selection import (
-            AntlrAssetSelectionParser,
-        )
+        # from dagster._core.definitions.antlr_asset_selection.antlr_asset_selection import (
+        #     AntlrAssetSelectionParser,
+        # )
 
-        try:
-            return AntlrAssetSelectionParser(string).asset_selection
-        except:
-            pass
+        # try:
+        #     return AntlrAssetSelectionParser(string).asset_selection
+        # except:
+        #     pass
         if string == "*":
             return cls.all()
 


### PR DESCRIPTION
## Summary & Motivation
testing part of code to trigger bk -- docs_snippet test green with the part of code commented.

## How I Tested These Changes
without comment:
```bash
dev-202408 $ pytest guides_tests/enriching_with_software_defined_assets/test_sda_nothing.py
/Users/yuhan/.pyenv/versions/3.10.0/envs/dev-202408/lib/python3.10/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
=================================================================================== test session starts ===================================================================================
platform darwin -- Python 3.10.0, pytest-8.3.2, pluggy-1.5.0
rootdir: /Users/yuhan/dev/dagster
configfile: pyproject.toml
plugins: asyncio-0.24.0, cov-5.0.0, time-machine-2.15.0, cases-3.8.5, respx-0.21.1, structlog-1.1, buildkite-test-collector-0.1.8, rerunfailures-14.0, typeguard-4.3.0, syrupy-4.7.1, anyio-3.7.1, ddtrace-2.9.5, hypothesis-6.111.1, mock-3.14.0, xdist-3.6.1, requests-mock-1.12.1
asyncio: mode=strict, default_loop_scope=None
collected 1 item

guides_tests/enriching_with_software_defined_assets/test_sda_nothing.py F                                                                                                           [100%]

======================================================================================== FAILURES =========================================================================================
____________________________________________________________________________________ test_sda_nothing _____________________________________________________________________________________

self = UnresolvedAssetJobDefinition(name='users_recommenders_job', selection=AllSelection(include_sources=True), config=None,...tion=None, tags={}, run_tags={}, metadata={}, partitions_def=None, executor_def=None, hooks=None, op_retry_policy=None)
asset_graph = <dagster._core.definitions.asset_graph.AssetGraph object at 0x14813a530>, default_executor_def = None, resource_defs = {}

    def resolve(
        self,
        asset_graph: "AssetGraph",
        default_executor_def: Optional[ExecutorDefinition] = None,
        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
    ) -> "JobDefinition":
        """Resolve this UnresolvedAssetJobDefinition into a JobDefinition."""
        try:
>           job_asset_graph = get_asset_graph_for_job(asset_graph, self.selection)

../../../python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py:187:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

parent_asset_graph = <dagster._core.definitions.asset_graph.AssetGraph object at 0x14813a530>, selection = AllSelection(include_sources=True), allow_different_partitions_defs = False

    def get_asset_graph_for_job(
        parent_asset_graph: AssetGraph,
        selection: AssetSelection,
        allow_different_partitions_defs: bool = False,
    ) -> AssetGraph:
        """Subset an AssetGraph to create an AssetGraph representing an asset job.

        The provided selection must satisfy certain constraints to comprise a valid asset job:

        - The selected keys must be a subset of the existing executable asset keys.
        - The selected keys must have at most one non-null partitions definition.

        The returned AssetGraph will contain only the selected keys within executable AssetsDefinitions.
        Any unselected dependencies will be included as unexecutable AssetsDefinitions.
        """
        from dagster._core.definitions.external_asset import (
            create_unexecutable_external_asset_from_assets_def,
        )

        selected_keys = selection.resolve(parent_asset_graph)
        invalid_keys = selected_keys - parent_asset_graph.executable_asset_keys
        if invalid_keys:
>           raise DagsterInvalidDefinitionError(
                "Selected keys must be a subset of existing executable asset keys."
                f" Invalid selected keys: {invalid_keys}",
            )
E           dagster._core.errors.DagsterInvalidDefinitionError: Selected keys must be a subset of existing executable asset keys. Invalid selected keys: {AssetKey(['raw_users'])}

../../../python_modules/dagster/dagster/_core/definitions/asset_job.py:242: DagsterInvalidDefinitionError

The above exception was the direct cause of the following exception:

    def test_sda_nothing():
>       assert defs.get_job_def("users_recommenders_job").execute_in_process().success

guides_tests/enriching_with_software_defined_assets/test_sda_nothing.py:7:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../../python_modules/dagster/dagster/_core/definitions/definitions_class.py:479: in get_job_def
    return self.get_repository_def().get_job(name)
../../../python_modules/dagster/dagster/_core/definitions/repository_definition/repository_definition.py:229: in get_job
    return self._repository_data.get_job(name)
../../../python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data.py:443: in get_job
    return self._jobs.get_definition(job_name)
../../../python_modules/dagster/dagster/_core/definitions/repository_definition/caching_index.py:123: in get_definition
    definition = cast(Callable, definition_source)()
../../../python_modules/dagster/dagster/_core/definitions/repository_definition/repository_data_builder.py:136: in resolve_unresolved_job_def
    job_def = unresolved_job_def.resolve(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = UnresolvedAssetJobDefinition(name='users_recommenders_job', selection=AllSelection(include_sources=True), config=None,...tion=None, tags={}, run_tags={}, metadata={}, partitions_def=None, executor_def=None, hooks=None, op_retry_policy=None)
asset_graph = <dagster._core.definitions.asset_graph.AssetGraph object at 0x14813a530>, default_executor_def = None, resource_defs = {}

    def resolve(
        self,
        asset_graph: "AssetGraph",
        default_executor_def: Optional[ExecutorDefinition] = None,
        resource_defs: Optional[Mapping[str, ResourceDefinition]] = None,
    ) -> "JobDefinition":
        """Resolve this UnresolvedAssetJobDefinition into a JobDefinition."""
        try:
            job_asset_graph = get_asset_graph_for_job(asset_graph, self.selection)
        except DagsterInvalidDefinitionError as e:
>           raise DagsterInvalidDefinitionError(
                f'Error resolving selection for asset job "{self.name}": {e}'
            ) from e
E           dagster._core.errors.DagsterInvalidDefinitionError: Error resolving selection for asset job "users_recommenders_job": Selected keys must be a subset of existing executable asset keys. Invalid selected keys: {AssetKey(['raw_users'])}

../../../python_modules/dagster/dagster/_core/definitions/unresolved_asset_job_definition.py:189: DagsterInvalidDefinitionError
================================================================================= short test summary info =================================================================================
FAILED guides_tests/enriching_with_software_defined_assets/test_sda_nothing.py::test_sda_nothing - dagster._core.errors.DagsterInvalidDefinitionError: Error resolving selection for asset job "users_recommenders_job": Selected keys must be a subset of existing executable asset keys...
==================================================================================== 1 failed in 4.83s ====================================================================================

```
with comment
```bash
~/dev/dagster/examples/docs_snippets/docs_snippets_tests master 7s
dev-202408 $ pytest guides_tests/enriching_with_software_defined_assets/test_sda_nothing.py
/Users/yuhan/.pyenv/versions/3.10.0/envs/dev-202408/lib/python3.10/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
================================================================================================ test session starts ================================================================================================
platform darwin -- Python 3.10.0, pytest-8.3.2, pluggy-1.5.0
rootdir: /Users/yuhan/dev/dagster
configfile: pyproject.toml
plugins: asyncio-0.24.0, cov-5.0.0, time-machine-2.15.0, cases-3.8.5, respx-0.21.1, structlog-1.1, buildkite-test-collector-0.1.8, rerunfailures-14.0, typeguard-4.3.0, syrupy-4.7.1, anyio-3.7.1, ddtrace-2.9.5, hypothesis-6.111.1, mock-3.14.0, xdist-3.6.1, requests-mock-1.12.1
asyncio: mode=strict, default_loop_scope=None
collected 1 item

guides_tests/enriching_with_software_defined_assets/test_sda_nothing.py .                                                                                                                                     [100%]

================================================================================================= 1 passed in 1.39s =================================================================================================
```

## Changelog

> Insert changelog entry or delete this section.
