### PR TITLE
Add dagster tolerations to runs

### DIFF
--- a/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
+++ b/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl
@@ -148,5 +148,9 @@ DAGSTER_K8S_PIPELINE_RUN_ENV_CONFIGMAP: "{{ template "dagster.fullname" . }}-pip
       pod_template_spec_metadata:
         annotations: {{- toYaml .annotations | nindent 10 }}
       {{- end }}
+      {{- if .tolerations }}
+      pod_template_spec_metadata:
+        tolerations: {{- toYaml .tolerations | nindent 10 }}
+      {{- end }}
   {{- end }}
 {{- end -}}

--- a/helm/dagster/schema/schema_tests/test_user_deployments.py
+++ b/helm/dagster/schema/schema_tests/test_user_deployments.py
@@ -933,6 +933,61 @@ def test_annotations(template: HelmTemplate, include_config_in_launched_runs: bo
     else:
         _assert_no_container_context(user_deployments[0])
 
+@pytest.mark.parametrize("include_config_in_launched_runs", [False, True])
+def test_tolerations(template: HelmTemplate, include_config_in_launched_runs: bool):
+    name = "foo"
+
+    tolerations = kubernetes.Tolerations.parse_obj([{"my-toleration-key": "my-toleration-val", 
+                                                        "toleration-operator": "Equal", 
+                                                        "toleration-value": "1", 
+                                                        "toleration-effect": "NoSchedule"}])
+
+    deployment = UserDeployment.construct(
+        name=name,
+        image=kubernetes.Image(repository=f"repo/{name}", tag="tag1", pullPolicy="Always"),
+        dagsterApiGrpcArgs=["-m", name],
+        port=3030,
+        tolerations=tolerations,
+        includeConfigInLaunchedRuns=UserDeploymentIncludeConfigInLaunchedRuns(
+            enabled=include_config_in_launched_runs
+        ),
+    )
+
+    helm_values = DagsterHelmValues.construct(
+        dagsterUserDeployments=UserDeployments.construct(
+            enabled=True,
+            enableSubchart=True,
+            deployments=[deployment],
+        )
+    )
+
+    user_deployments = template.render(helm_values)
+
+    assert len(user_deployments) == 1
+
+    if include_config_in_launched_runs:
+        container_context = user_deployments[0].spec.template.spec.containers[0].env[2]
+        assert container_context.name == "DAGSTER_CLI_API_GRPC_CONTAINER_CONTEXT"
+        assert json.loads(container_context.value) == {
+            "k8s": {
+                "image_pull_policy": "Always",
+                "env_config_maps": [
+                    "release-name-dagster-user-deployments-foo-user-env",
+                ],
+                "namespace": "default",
+                "service_account_name": "release-name-dagster-user-deployments-user-deployments",
+                "run_k8s_config": {
+                    "pod_spec_config": {
+                        "automount_service_account_token": True,
+                    },
+                    "pod_template_spec_metadata": {
+                        "tolerations": tolerations.model_dump(),
+                    },
+                },
+            }
+        }
+    else:
+        _assert_no_container_context(user_deployments[0])
 
 @pytest.mark.parametrize("include_config_in_launched_runs", [False, True])
 def test_user_deployment_resources(template: HelmTemplate, include_config_in_launched_runs: bool):


### PR DESCRIPTION
## Summary & Motivation
Add dagster tolerations to runs -- 
Goal was to mimic the way that dagster hybrid works; the annotations set in the user deployments currently cascade to the steps but not the run pods; id like the tolerations to be set for all steps/runs related to my user deployment 

## How I Tested These Changes
Added a `test_tolerations` test for the user deployments


## Changelog

Tolerations added to dagster k8 runs
