### PR TITLE
Get rid of risk of order dependence

### DIFF
--- a/python_modules/dagster/dagster/_core/storage/event_log/base.py
+++ b/python_modules/dagster/dagster/_core/storage/event_log/base.py
@@ -657,12 +657,12 @@ class EventLogStorage(ABC, MayHaveInstanceWeakref[T_DagsterInstance]):
 
     def get_asset_status_cache_values(
         self,
-        partitions_defs_by_key: Mapping[AssetKey, Optional[PartitionsDefinition]],
+        partitions_defs_by_key: Iterable[Tuple[AssetKey, Optional[PartitionsDefinition]]],
         context: LoadingContext,
     ) -> Sequence[Optional["AssetStatusCacheValue"]]:
         """Get the cached status information for each asset."""
         values = []
-        for asset_key, partitions_def in partitions_defs_by_key.items():
+        for asset_key, partitions_def in partitions_defs_by_key:
             values.append(
                 get_and_update_asset_status_cache_value(
                     self._instance, asset_key, partitions_def, loading_context=context

--- a/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
+++ b/python_modules/dagster/dagster/_core/storage/partition_status_cache.py
@@ -150,7 +150,7 @@ class AssetStatusCacheValue(
     def _blocking_batch_load(
         cls, keys: Iterable[Tuple[AssetKey, PartitionsDefinition]], context: LoadingContext
     ) -> Iterable[Optional["AssetStatusCacheValue"]]:
-        return context.instance.event_log_storage.get_asset_status_cache_values(dict(keys), context)
+        return context.instance.event_log_storage.get_asset_status_cache_values(keys, context)
 
     def deserialize_materialized_partition_subsets(
         self, partitions_def: PartitionsDefinition

--- a/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/utils/event_log_storage.py
@@ -6029,7 +6029,7 @@ class TestEventLogStorage:
         }
 
         assert storage.get_asset_status_cache_values(
-            partition_defs_by_key, LoadingContextForTest(instance)
+            partition_defs_by_key.items(), LoadingContextForTest(instance)
         ) == [
             None,
             None,
@@ -6047,7 +6047,7 @@ class TestEventLogStorage:
         partition_defs = list(partition_defs_by_key.values())
         for i, value in enumerate(
             storage.get_asset_status_cache_values(
-                partition_defs_by_key, LoadingContextForTest(instance)
+                partition_defs_by_key.items(), LoadingContextForTest(instance)
             ),
         ):
             assert value is not None


### PR DESCRIPTION
## Summary & Motivation

Noticed this while working in this area -- the LoadingContext system expects the output of these methods to be in the same order as the input, which is not currently guaranteed. The AssetStatusCacheValues don't have a reference to what asset key they came from, meaning we can't reconstruct this mapping from an unordered list.

Simplest solution is to just not use dictionaries at all.

Surprised this hasn't caused issues, to be honest!

Internal: https://github.com/dagster-io/internal/pull/12702

## How I Tested These Changes

## Changelog

NOCHANGELOG
