### PR TITLE
[10/n][dagster-fivetran] Implement fivetran_assets and build_fivetran_assets_definitions

### DIFF
--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
@@ -1,5 +1,6 @@
 from dagster._core.libraries import DagsterLibraryRegistry
 
+from dagster_fivetran.asset_decorator import fivetran_assets as fivetran_assets
 from dagster_fivetran.asset_defs import (
     build_fivetran_assets as build_fivetran_assets,
     load_assets_from_fivetran_instance as load_assets_from_fivetran_instance,
@@ -14,7 +15,10 @@ from dagster_fivetran.resources import (
     fivetran_resource as fivetran_resource,
     load_fivetran_asset_specs as load_fivetran_asset_specs,
 )
-from dagster_fivetran.translator import DagsterFivetranTranslator as DagsterFivetranTranslator
+from dagster_fivetran.translator import (
+    DagsterFivetranTranslator as DagsterFivetranTranslator,
+    FivetranConnectorTableProps as FivetranConnectorTableProps,
+)
 from dagster_fivetran.types import FivetranOutput as FivetranOutput
 from dagster_fivetran.version import __version__ as __version__
 

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/__init__.py
@@ -3,6 +3,7 @@ from dagster._core.libraries import DagsterLibraryRegistry
 from dagster_fivetran.asset_decorator import fivetran_assets as fivetran_assets
 from dagster_fivetran.asset_defs import (
     build_fivetran_assets as build_fivetran_assets,
+    build_fivetran_assets_definitions as build_fivetran_assets_definitions,
     load_assets_from_fivetran_instance as load_assets_from_fivetran_instance,
 )
 from dagster_fivetran.ops import (

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -1,0 +1,113 @@
+from typing import Any, Callable, Optional, Type
+
+from dagster import AssetsDefinition, multi_asset
+from dagster._annotations import experimental
+
+from dagster_fivetran.resources import FivetranWorkspace, load_fivetran_asset_specs
+from dagster_fivetran.translator import DagsterFivetranTranslator, FivetranMetadataSet
+
+
+@experimental
+def fivetran_assets(
+    *,
+    connector_id: str,
+    workspace: FivetranWorkspace,
+    name: Optional[str] = None,
+    group_name: Optional[str] = None,
+    dagster_fivetran_translator: Type[DagsterFivetranTranslator] = DagsterFivetranTranslator,
+) -> Callable[[Callable[..., Any]], AssetsDefinition]:
+    """Create a definition for how to sync the tables of a given Fivetran connector.
+
+    Args:
+        connector_id (str): The Fivetran Connector ID. You can retrieve this value from the
+            "Setup" tab of a given connector in the Fivetran UI.
+        workspace (FivetranWorkspace): The Fivetran workspace to fetch assets from.
+        name (Optional[str], optional): The name of the op.
+        group_name (Optional[str], optional): The name of the asset group.
+        dagster_fivetran_translator (Type[DagsterFivetranTranslator]): The translator to use
+            to convert Fivetran content into AssetSpecs. Defaults to DagsterFivetranTranslator.
+
+    Examples:
+        Sync the tables of a Fivetran connector:
+
+        .. code-block:: python
+            from dagster_fivetran import FivetranWorkspace, fivetran_assets
+
+            import dagster as dg
+
+            fivetran_workspace = FivetranWorkspace(
+                account_id=dg.EnvVar("FIVETRAN_ACCOUNT_ID"),
+                api_key=dg.EnvVar("FIVETRAN_API_KEY"),
+                api_secret=dg.EnvVar("FIVETRAN_API_SECRET"),
+            )
+
+            @fivetran_assets(
+                connector_id="fivetran_connector_id",
+                name="fivetran_connector_id",
+                group_name="fivetran_connector_id",
+                workspace=fivetran_workspace,
+            )
+            def fivetran_connector_assets(context: dg.AssetExecutionContext, fivetran: FivetranWorkspace):
+                yield from fivetran.sync_and_poll(context=context)
+
+            defs = dg.Definitions(
+                assets=[fivetran_connector_assets],
+                resources={"fivetran": fivetran_workspace},
+            )
+
+        Sync the tables of a Fivetran connector with a custom translator:
+
+        .. code-block:: python
+            from dagster_fivetran import (
+                DagsterFivetranTranslator,
+                FivetranConnectorTableProps,
+                FivetranWorkspace,
+                fivetran_assets
+            )
+
+            import dagster as dg
+            from dagster._core.definitions.asset_spec import replace_attributes
+
+            class CustomDagsterFivetranTranslator(DagsterFivetranTranslator):
+                def get_asset_spec(self, props: FivetranConnectorTableProps) -> dg.AssetSpec:
+                    asset_spec = super().get_asset_spec(props)
+                    return replace_attributes(
+                        asset_spec,
+                        key=asset_spec.key.with_prefix("my_prefix"),
+                    )
+
+
+            fivetran_workspace = FivetranWorkspace(
+                account_id=dg.EnvVar("FIVETRAN_ACCOUNT_ID"),
+                api_key=dg.EnvVar("FIVETRAN_API_KEY"),
+                api_secret=dg.EnvVar("FIVETRAN_API_SECRET"),
+            )
+
+            @fivetran_assets(
+                connector_id="fivetran_connector_id",
+                name="fivetran_connector_id",
+                group_name="fivetran_connector_id",
+                workspace=fivetran_workspace,
+                dagster_fivetran_translator=CustomDagsterFivetranTranslator,
+            )
+            def fivetran_connector_assets(context: dg.AssetExecutionContext, fivetran: FivetranWorkspace):
+                yield from fivetran.sync_and_poll(context=context)
+
+            defs = dg.Definitions(
+                assets=[fivetran_connector_assets],
+                resources={"fivetran": fivetran_workspace},
+            )
+
+    """
+    return multi_asset(
+        name=name,
+        group_name=group_name,
+        can_subset=True,
+        specs=[
+            spec
+            for spec in load_fivetran_asset_specs(
+                workspace=workspace, dagster_fivetran_translator=dagster_fivetran_translator
+            )
+            if FivetranMetadataSet.extract(spec.metadata).connector_id == connector_id
+        ],
+    )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -14,7 +14,7 @@ def fivetran_assets(
     workspace: FivetranWorkspace,
     name: Optional[str] = None,
     group_name: Optional[str] = None,
-    dagster_fivetran_translator: Type[DagsterFivetranTranslator] = DagsterFivetranTranslator,
+    dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
 ) -> Callable[[Callable[..., Any]], AssetsDefinition]:
     """Create a definition for how to sync the tables of a given Fivetran connector.
 
@@ -24,7 +24,7 @@ def fivetran_assets(
         workspace (FivetranWorkspace): The Fivetran workspace to fetch assets from.
         name (Optional[str], optional): The name of the op.
         group_name (Optional[str], optional): The name of the asset group.
-        dagster_fivetran_translator (Type[DagsterFivetranTranslator]): The translator to use
+        dagster_fivetran_translator (Optional[DagsterFivetranTranslator], optional): The translator to use
             to convert Fivetran content into :py:class:`dagster.AssetSpec`.
             Defaults to :py:class:`DagsterFivetranTranslator`.
 
@@ -89,7 +89,7 @@ def fivetran_assets(
                 name="fivetran_connector_id",
                 group_name="fivetran_connector_id",
                 workspace=fivetran_workspace,
-                dagster_fivetran_translator=CustomDagsterFivetranTranslator,
+                dagster_fivetran_translator=CustomDagsterFivetranTranslator(),
             )
             def fivetran_connector_assets(context: dg.AssetExecutionContext, fivetran: FivetranWorkspace):
                 yield from fivetran.sync_and_poll(context=context)
@@ -107,7 +107,7 @@ def fivetran_assets(
         specs=[
             spec
             for spec in workspace.load_asset_specs(
-                dagster_fivetran_translator=dagster_fivetran_translator
+                dagster_fivetran_translator=dagster_fivetran_translator or DagsterFivetranTranslator()
             )
             if FivetranMetadataSet.extract(spec.metadata).connector_id == connector_id
         ],

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -25,7 +25,8 @@ def fivetran_assets(
         name (Optional[str], optional): The name of the op.
         group_name (Optional[str], optional): The name of the asset group.
         dagster_fivetran_translator (Type[DagsterFivetranTranslator]): The translator to use
-            to convert Fivetran content into AssetSpecs. Defaults to DagsterFivetranTranslator.
+            to convert Fivetran content into :py:class:`dagster.AssetSpec`.
+            Defaults to :py:class:`DagsterFivetranTranslator`.
 
     Examples:
         Sync the tables of a Fivetran connector:

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Optional, Type
 from dagster import AssetsDefinition, multi_asset
 from dagster._annotations import experimental
 
-from dagster_fivetran.resources import FivetranWorkspace, load_fivetran_asset_specs
+from dagster_fivetran.resources import FivetranWorkspace
 from dagster_fivetran.translator import DagsterFivetranTranslator, FivetranMetadataSet
 
 
@@ -105,8 +105,8 @@ def fivetran_assets(
         can_subset=True,
         specs=[
             spec
-            for spec in load_fivetran_asset_specs(
-                workspace=workspace, dagster_fivetran_translator=dagster_fivetran_translator
+            for spec in workspace.load_asset_specs(
+                dagster_fivetran_translator=dagster_fivetran_translator
             )
             if FivetranMetadataSet.extract(spec.metadata).connector_id == connector_id
         ],

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_decorator.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional, Type
+from typing import Any, Callable, Optional
 
 from dagster import AssetsDefinition, multi_asset
 from dagster._annotations import experimental
@@ -107,7 +107,8 @@ def fivetran_assets(
         specs=[
             spec
             for spec in workspace.load_asset_specs(
-                dagster_fivetran_translator=dagster_fivetran_translator or DagsterFivetranTranslator()
+                dagster_fivetran_translator=dagster_fivetran_translator
+                or DagsterFivetranTranslator()
             )
             if FivetranMetadataSet.extract(spec.metadata).connector_id == connector_id
         ],

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -19,12 +19,14 @@ from typing import (
 )
 
 from dagster import (
+    AssetExecutionContext,
     AssetKey,
     AssetsDefinition,
     OpExecutionContext,
     _check as check,
     multi_asset,
 )
+from dagster._annotations import experimental
 from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.cacheable_assets import (
     AssetsDefinitionCacheableData,
@@ -41,10 +43,17 @@ from dagster._core.execution.context.init import build_init_resource_context
 from dagster._core.utils import imap
 from dagster._utils.log import get_dagster_logger
 
-from dagster_fivetran.resources import DEFAULT_POLL_INTERVAL, FivetranResource
+from dagster_fivetran.asset_decorator import fivetran_assets
+from dagster_fivetran.resources import (
+    DEFAULT_POLL_INTERVAL,
+    FivetranResource,
+    FivetranWorkspace,
+    load_fivetran_asset_specs,
+)
 from dagster_fivetran.translator import (
     DagsterFivetranTranslator,
     FivetranConnectorTableProps,
+    FivetranMetadataSet,
     FivetranSchemaConfig,
 )
 from dagster_fivetran.utils import (
@@ -725,3 +734,111 @@ def load_assets_from_fivetran_instance(
         fetch_column_metadata=fetch_column_metadata,
         translator=translator,
     )
+
+
+# -----------------------
+# Reworked assets factory
+# -----------------------
+
+
+@experimental
+def build_fivetran_assets_definitions(
+    *,
+    workspace: FivetranWorkspace,
+    dagster_fivetran_translator: Type[DagsterFivetranTranslator] = DagsterFivetranTranslator,
+) -> Sequence[AssetsDefinition]:
+    """The list of AssetsDefinition for all connectors in the Fivetran workspace.
+
+    Args:
+        workspace (FivetranWorkspace): The Fivetran workspace to fetch assets from.
+        dagster_fivetran_translator (Type[DagsterFivetranTranslator]): The translator to use
+            to convert Fivetran content into AssetSpecs. Defaults to DagsterFivetranTranslator.
+
+    Returns:
+        List[AssetsDefinition]: The list of AssetsDefinition for all connectors in the Fivetran workspace.
+
+    Examples:
+        Sync the tables of a Fivetran connector:
+
+        .. code-block:: python
+            from dagster_fivetran import FivetranWorkspace, build_fivetran_assets_definitions
+
+            import dagster as dg
+
+            fivetran_workspace = FivetranWorkspace(
+                account_id=dg.EnvVar("FIVETRAN_ACCOUNT_ID"),
+                api_key=dg.EnvVar("FIVETRAN_API_KEY"),
+                api_secret=dg.EnvVar("FIVETRAN_API_SECRET"),
+            )
+
+            fivetran_assets = build_fivetran_assets_definitions(workspace=workspace)
+
+            defs = dg.Definitions(
+                assets=[*fivetran_assets],
+                resources={"fivetran": fivetran_workspace},
+            )
+
+        Sync the tables of a Fivetran connector with a custom translator:
+
+        .. code-block:: python
+            from dagster_fivetran import (
+                DagsterFivetranTranslator,
+                FivetranConnectorTableProps,
+                FivetranWorkspace,
+                 build_fivetran_assets_definitions
+            )
+
+            import dagster as dg
+            from dagster._core.definitions.asset_spec import replace_attributes
+
+            class CustomDagsterFivetranTranslator(DagsterFivetranTranslator):
+                def get_asset_spec(self, props: FivetranConnectorTableProps) -> dg.AssetSpec:
+                    asset_spec = super().get_asset_spec(props)
+                    return replace_attributes(
+                        asset_spec,
+                        key=asset_spec.key.with_prefix("my_prefix"),
+                    )
+
+
+            fivetran_workspace = FivetranWorkspace(
+                account_id=dg.EnvVar("FIVETRAN_ACCOUNT_ID"),
+                api_key=dg.EnvVar("FIVETRAN_API_KEY"),
+                api_secret=dg.EnvVar("FIVETRAN_API_SECRET"),
+            )
+
+            fivetran_assets = build_fivetran_assets_definitions(
+                workspace=workspace,
+                dagster_fivetran_translator=CustomDagsterFivetranTranslator
+            )
+
+            defs = dg.Definitions(
+                assets=[*fivetran_assets],
+                resources={"fivetran": fivetran_workspace},
+            )
+
+    """
+    all_asset_specs = load_fivetran_asset_specs(
+        workspace=workspace, dagster_fivetran_translator=dagster_fivetran_translator
+    )
+
+    connector_ids = {
+        check.not_none(FivetranMetadataSet.extract(spec.metadata).connector_id)
+        for spec in all_asset_specs
+    }
+
+    _asset_fns = []
+    for connector_id in connector_ids:
+
+        @fivetran_assets(
+            connector_id=connector_id,
+            workspace=workspace,
+            name=connector_id,
+            group_name=connector_id,
+            dagster_fivetran_translator=dagster_fivetran_translator,
+        )
+        def _asset_fn(context: AssetExecutionContext, fivetran: FivetranWorkspace):
+            yield from fivetran.sync_and_poll(context=context)
+
+        _asset_fns.append(_asset_fn)
+
+    return _asset_fns

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -740,14 +740,15 @@ def load_assets_from_fivetran_instance(
 def build_fivetran_assets_definitions(
     *,
     workspace: FivetranWorkspace,
-    dagster_fivetran_translator: Type[DagsterFivetranTranslator] = DagsterFivetranTranslator,
+    dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
 ) -> Sequence[AssetsDefinition]:
     """The list of AssetsDefinition for all connectors in the Fivetran workspace.
 
     Args:
         workspace (FivetranWorkspace): The Fivetran workspace to fetch assets from.
-        dagster_fivetran_translator (Type[DagsterFivetranTranslator]): The translator to use
-            to convert Fivetran content into AssetSpecs. Defaults to DagsterFivetranTranslator.
+        dagster_fivetran_translator (Optional[DagsterFivetranTranslator], optional): The translator to use
+            to convert Fivetran content into :py:class:`dagster.AssetSpec`.
+            Defaults to :py:class:`DagsterFivetranTranslator`.
 
     Returns:
         List[AssetsDefinition]: The list of AssetsDefinition for all connectors in the Fivetran workspace.
@@ -803,7 +804,7 @@ def build_fivetran_assets_definitions(
 
             fivetran_assets = build_fivetran_assets_definitions(
                 workspace=workspace,
-                dagster_fivetran_translator=CustomDagsterFivetranTranslator
+                dagster_fivetran_translator=CustomDagsterFivetranTranslator()
             )
 
             defs = dg.Definitions(
@@ -812,6 +813,8 @@ def build_fivetran_assets_definitions(
             )
 
     """
+    dagster_fivetran_translator = dagster_fivetran_translator or DagsterFivetranTranslator()
+
     all_asset_specs = workspace.load_asset_specs(
         dagster_fivetran_translator=dagster_fivetran_translator
     )

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/asset_defs.py
@@ -44,12 +44,7 @@ from dagster._core.utils import imap
 from dagster._utils.log import get_dagster_logger
 
 from dagster_fivetran.asset_decorator import fivetran_assets
-from dagster_fivetran.resources import (
-    DEFAULT_POLL_INTERVAL,
-    FivetranResource,
-    FivetranWorkspace,
-    load_fivetran_asset_specs,
-)
+from dagster_fivetran.resources import DEFAULT_POLL_INTERVAL, FivetranResource, FivetranWorkspace
 from dagster_fivetran.translator import (
     DagsterFivetranTranslator,
     FivetranConnectorTableProps,
@@ -817,8 +812,8 @@ def build_fivetran_assets_definitions(
             )
 
     """
-    all_asset_specs = load_fivetran_asset_specs(
-        workspace=workspace, dagster_fivetran_translator=dagster_fivetran_translator
+    all_asset_specs = workspace.load_asset_specs(
+        dagster_fivetran_translator=dagster_fivetran_translator
     )
 
     connector_ids = {

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -895,13 +895,14 @@ class FivetranWorkspace(ConfigurableResource):
     @cached_method
     def load_asset_specs(
         self,
-        dagster_fivetran_translator: Type[DagsterFivetranTranslator] = DagsterFivetranTranslator,
+        dagster_fivetran_translator: Optional[DagsterFivetranTranslator] = None,
     ) -> Sequence[AssetSpec]:
         """Returns a list of AssetSpecs representing the Fivetran content in the workspace.
 
         Args:
-            dagster_fivetran_translator (Type[DagsterFivetranTranslator]): The translator to use
-                to convert Fivetran content into AssetSpecs. Defaults to DagsterFivetranTranslator.
+            dagster_fivetran_translator (Optional[DagsterFivetranTranslator], optional): The translator to use
+                to convert Fivetran content into :py:class:`dagster.AssetSpec`.
+                Defaults to :py:class:`DagsterFivetranTranslator`.
 
         Returns:
             List[AssetSpec]: The set of assets representing the Fivetran content in the workspace.
@@ -923,8 +924,10 @@ class FivetranWorkspace(ConfigurableResource):
                 fivetran_specs = fivetran_workspace.load_asset_specs()
                 defs = dg.Definitions(assets=[*fivetran_specs], resources={"fivetran": fivetran_workspace}
         """
+        dagster_fivetran_translator = dagster_fivetran_translator or DagsterFivetranTranslator()
+
         return load_fivetran_asset_specs(
-            workspace=self, dagster_fivetran_translator=dagster_fivetran_translator
+            workspace=self, dagster_fivetran_translator=dagster_fivetran_translator.__class__
         )
 
     def sync_and_poll(

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran/resources.py
@@ -906,7 +906,7 @@ class FivetranWorkspace(ConfigurableResource):
         )
 
     def __hash__(self):
-        return hash(self.account_id + self.api_key + self.api_secret)
+        return hash((self.account_id + self.api_key + self.api_secret))
 
 
 @lru_cache(maxsize=None)

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/conftest.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/conftest.py
@@ -14,6 +14,7 @@ TEST_PREVIOUS_MAX_TIME_STR = "2024-12-01T15:43:29.013729Z"
 TEST_ACCOUNT_ID = "test_account_id"
 TEST_API_KEY = "test_api_key"
 TEST_API_SECRET = "test_api_secret"
+TEST_ANOTHER_ACCOUNT_ID = "test_another_account_id"
 
 # Taken from Fivetran API documentation
 # https://fivetran.com/docs/rest-api/api-reference/groups/list-all-groups

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_asset_specs.py
@@ -2,9 +2,12 @@ import responses
 from dagster._config.field_utils import EnvVar
 from dagster._core.test_utils import environ
 from dagster_fivetran import FivetranWorkspace, load_fivetran_asset_specs
+from dagster_fivetran.asset_defs import build_fivetran_assets_definitions
+from dagster_fivetran.translator import FivetranMetadataSet
 
 from dagster_fivetran_tests.experimental.conftest import (
     TEST_ACCOUNT_ID,
+    TEST_ANOTHER_ACCOUNT_ID,
     TEST_API_KEY,
     TEST_API_SECRET,
 )
@@ -45,3 +48,79 @@ def test_translator_spec(
             "schema_name_in_destination_1",
             "table_name_in_destination_1",
         ]
+
+        first_asset_metadata = next(asset.metadata for asset in all_assets)
+        assert FivetranMetadataSet.extract(first_asset_metadata).connector_id == "connector_id"
+
+        # clear the asset specs cache post test
+        load_fivetran_asset_specs.cache_clear()
+
+
+def test_cached_load_spec_single_resource(
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    with environ({"FIVETRAN_API_KEY": TEST_API_KEY, "FIVETRAN_API_SECRET": TEST_API_SECRET}):
+        resource = FivetranWorkspace(
+            account_id=TEST_ACCOUNT_ID,
+            api_key=EnvVar("FIVETRAN_API_KEY"),
+            api_secret=EnvVar("FIVETRAN_API_SECRET"),
+        )
+
+        # load asset specs a first time
+        load_fivetran_asset_specs(resource)
+        assert len(fetch_workspace_data_api_mocks.calls) == 4
+
+        # load asset specs a first time, no additional calls are made
+        load_fivetran_asset_specs(resource)
+        assert len(fetch_workspace_data_api_mocks.calls) == 4
+
+        # clear the asset specs cache post test
+        load_fivetran_asset_specs.cache_clear()
+
+
+def test_cached_load_spec_multiple_resources(
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    with environ({"FIVETRAN_API_KEY": TEST_API_KEY, "FIVETRAN_API_SECRET": TEST_API_SECRET}):
+        resource = FivetranWorkspace(
+            account_id=TEST_ACCOUNT_ID,
+            api_key=EnvVar("FIVETRAN_API_KEY"),
+            api_secret=EnvVar("FIVETRAN_API_SECRET"),
+        )
+
+        another_resource = FivetranWorkspace(
+            account_id=TEST_ANOTHER_ACCOUNT_ID,
+            api_key=EnvVar("FIVETRAN_API_KEY"),
+            api_secret=EnvVar("FIVETRAN_API_SECRET"),
+        )
+
+        # load asset specs with a resource
+        load_fivetran_asset_specs(resource)
+        assert len(fetch_workspace_data_api_mocks.calls) == 4
+
+        # load asset specs with another resource,
+        # additional calls are made to load its specs
+        load_fivetran_asset_specs(another_resource)
+        assert len(fetch_workspace_data_api_mocks.calls) == 4 + 4
+
+        # clear the asset specs cache post test
+        load_fivetran_asset_specs.cache_clear()
+
+
+def test_cached_load_spec_with_asset_factory(
+    fetch_workspace_data_api_mocks: responses.RequestsMock,
+) -> None:
+    with environ({"FIVETRAN_API_KEY": TEST_API_KEY, "FIVETRAN_API_SECRET": TEST_API_SECRET}):
+        resource = FivetranWorkspace(
+            account_id=TEST_ACCOUNT_ID,
+            api_key=EnvVar("FIVETRAN_API_KEY"),
+            api_secret=EnvVar("FIVETRAN_API_SECRET"),
+        )
+
+        # build_fivetran_assets_definitions calls load_fivetran_asset_specs to get the connector IDs,
+        # then load_fivetran_asset_specs is called once per connector ID in fivetran_assets
+        build_fivetran_assets_definitions(workspace=resource)
+        assert len(fetch_workspace_data_api_mocks.calls) == 4
+
+        # clear the asset specs cache post test
+        load_fivetran_asset_specs.cache_clear()

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_asset_specs.py
@@ -52,9 +52,6 @@ def test_translator_spec(
         first_asset_metadata = next(asset.metadata for asset in all_assets)
         assert FivetranMetadataSet.extract(first_asset_metadata).connector_id == "connector_id"
 
-        # clear the asset specs cache post test
-        # load_fivetran_asset_specs.cache_clear()
-
 
 def test_cached_load_spec_single_resource(
     fetch_workspace_data_api_mocks: responses.RequestsMock,
@@ -73,9 +70,6 @@ def test_cached_load_spec_single_resource(
         # load asset specs a first time, no additional calls are made
         workspace.load_asset_specs()
         assert len(fetch_workspace_data_api_mocks.calls) == 4
-
-        # clear the asset specs cache post test
-        # load_fivetran_asset_specs.cache_clear()
 
 
 def test_cached_load_spec_multiple_resources(
@@ -103,9 +97,6 @@ def test_cached_load_spec_multiple_resources(
         another_workspace.load_asset_specs()
         assert len(fetch_workspace_data_api_mocks.calls) == 4 + 4
 
-        # clear the asset specs cache post test
-        # load_fivetran_asset_specs.cache_clear()
-
 
 def test_cached_load_spec_with_asset_factory(
     fetch_workspace_data_api_mocks: responses.RequestsMock,
@@ -121,6 +112,3 @@ def test_cached_load_spec_with_asset_factory(
         # then load_fivetran_asset_specs is called once per connector ID in fivetran_assets
         build_fivetran_assets_definitions(workspace=resource)
         assert len(fetch_workspace_data_api_mocks.calls) == 4
-
-        # clear the asset specs cache post test
-        # load_fivetran_asset_specs.cache_clear()

--- a/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_asset_specs.py
+++ b/python_modules/libraries/dagster-fivetran/dagster_fivetran_tests/experimental/test_asset_specs.py
@@ -53,58 +53,58 @@ def test_translator_spec(
         assert FivetranMetadataSet.extract(first_asset_metadata).connector_id == "connector_id"
 
         # clear the asset specs cache post test
-        load_fivetran_asset_specs.cache_clear()
+        # load_fivetran_asset_specs.cache_clear()
 
 
 def test_cached_load_spec_single_resource(
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:
     with environ({"FIVETRAN_API_KEY": TEST_API_KEY, "FIVETRAN_API_SECRET": TEST_API_SECRET}):
-        resource = FivetranWorkspace(
+        workspace = FivetranWorkspace(
             account_id=TEST_ACCOUNT_ID,
             api_key=EnvVar("FIVETRAN_API_KEY"),
             api_secret=EnvVar("FIVETRAN_API_SECRET"),
         )
 
         # load asset specs a first time
-        load_fivetran_asset_specs(resource)
+        workspace.load_asset_specs()
         assert len(fetch_workspace_data_api_mocks.calls) == 4
 
         # load asset specs a first time, no additional calls are made
-        load_fivetran_asset_specs(resource)
+        workspace.load_asset_specs()
         assert len(fetch_workspace_data_api_mocks.calls) == 4
 
         # clear the asset specs cache post test
-        load_fivetran_asset_specs.cache_clear()
+        # load_fivetran_asset_specs.cache_clear()
 
 
 def test_cached_load_spec_multiple_resources(
     fetch_workspace_data_api_mocks: responses.RequestsMock,
 ) -> None:
     with environ({"FIVETRAN_API_KEY": TEST_API_KEY, "FIVETRAN_API_SECRET": TEST_API_SECRET}):
-        resource = FivetranWorkspace(
+        workspace = FivetranWorkspace(
             account_id=TEST_ACCOUNT_ID,
             api_key=EnvVar("FIVETRAN_API_KEY"),
             api_secret=EnvVar("FIVETRAN_API_SECRET"),
         )
 
-        another_resource = FivetranWorkspace(
+        another_workspace = FivetranWorkspace(
             account_id=TEST_ANOTHER_ACCOUNT_ID,
             api_key=EnvVar("FIVETRAN_API_KEY"),
             api_secret=EnvVar("FIVETRAN_API_SECRET"),
         )
 
         # load asset specs with a resource
-        load_fivetran_asset_specs(resource)
+        workspace.load_asset_specs()
         assert len(fetch_workspace_data_api_mocks.calls) == 4
 
         # load asset specs with another resource,
         # additional calls are made to load its specs
-        load_fivetran_asset_specs(another_resource)
+        another_workspace.load_asset_specs()
         assert len(fetch_workspace_data_api_mocks.calls) == 4 + 4
 
         # clear the asset specs cache post test
-        load_fivetran_asset_specs.cache_clear()
+        # load_fivetran_asset_specs.cache_clear()
 
 
 def test_cached_load_spec_with_asset_factory(
@@ -123,4 +123,4 @@ def test_cached_load_spec_with_asset_factory(
         assert len(fetch_workspace_data_api_mocks.calls) == 4
 
         # clear the asset specs cache post test
-        load_fivetran_asset_specs.cache_clear()
+        # load_fivetran_asset_specs.cache_clear()


### PR DESCRIPTION
## Summary & Motivation

This PR implements the `fivetran_assets` decorator and the `build_fivetran_assets_definitions` factory.
- `fivetran_assets` can be used to create all assets for a given Fivetran connector, i.e. one asset per table in the connector.
- `build_fivetran_assets_definitions` can be used to create all Fivetran assets defs, one per connector. It uses `fivetran_assets`.

Both the asset decorator and factory use `load_fivetran_asset_specs`. This is motivated by the current implementation of `dagster-dbt`, `dagster-dlt` and `dagster-sling` - each leverages an asset decorator that loads the asset specs by itself.

To avoid calling the Fivetran API each time `load_fivetran_asset_specs` is called, it is cached using `functools.lru_cache`. `load_fivetran_asset_specs` uses the state-backed defs, so reloading the code won't make additional calls to the Fivetran API, but calling `load_fivetran_asset_specs` N times in a script will make N calls to the Fivetran API.

The goals here are:
- make the Fivetran integration as similar as possible to the other ELT integrations by using the same patterns, eg. asset decorator
- make the user experience as simple as possible and avoid having users manage the asset specs and number of calls to the Fivetran API.

## How I Tested These Changes

Additional unit tests with BK.

## Changelog

[dagster-fivetran] The `fivetran_assets` decorator is added. It can be used with the `FivetranWorkspace` resource and `DagsterFivetranTranslator` translator to load Fivetran tables for a given connector as assets in Dagster. The `build_fivetran_assets_definitions` factory can be used to create assets for all the connectors in your Fivetran workspace.
