### PR TITLE
Bugfix/#25898 Adding registry to postgresql configuration

### DIFF
--- a/helm/dagster/templates/helpers/_helpers.tpl
+++ b/helm/dagster/templates/helpers/_helpers.tpl
@@ -27,7 +27,7 @@ If release name contains chart name it will be used as a full name.
 
 # Image utils
 {{- define "dagster.externalImage.name" }}
-{{- .repository -}}:{{- .tag -}}
+{{- .registry}}/{{- .repository -}}:{{- .tag -}}
 {{- end }}
 
 {{- define "dagster.dagsterImage.name" }}

--- a/helm/dagster/values.yaml
+++ b/helm/dagster/values.yaml
@@ -761,6 +761,7 @@ postgresql:
 
   # Used by init container to check that db is running. (Even if enabled:false)
   image:
+    registry: "docker.io"
     repository: "library/postgres"
     tag: "14.6"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary & Motivation
The motivation is following the bug notified here https://github.com/dagster-io/dagster/issues/25898
When trying to deploy the daemon or the webserver, I encountered a failure because the chart deploys a container called `check-db-ready`, which does not point to my explicit registry. 

With this modification, we can now overwrite the registry of the PostgreSQL image making it functional for the deployment of the postgresql and also the init container for webserver and daemon. 

## How I Tested These Changes
Building the templates
` helm template . --output-dir=manifests-dev -f values.yaml `
 and checking that for the generated, both the `check-db-ready` container points to my `registry/repository:tag` structure. 
- dagster/templates/deployment-daemon.yaml
- dagster/templates/deployment-webserver.yaml 

Also review that dagster/charts/postgresql/templates/statefulset.yaml has the correct image path


## Changelog
- Add the registry in the template helpers
- Add the registry declaration in values

