### PR TITLE
[ui] Use skeleton to improve Asset “Recent Updates” loading state

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/RecentUpdatesTimeline.tsx
@@ -4,7 +4,7 @@ import {
   Colors,
   Icon,
   Popover,
-  Spinner,
+  Skeleton,
   Subtitle2,
   Tag,
   useViewport,
@@ -120,30 +120,33 @@ export const RecentUpdatesTimeline = ({
 
   if (loading) {
     return (
-      <Box flex={{direction: 'row', alignItems: 'center', gap: 8}}>
-        <Subtitle2>Recent updates</Subtitle2>
-        <Spinner purpose="body-text" />
+      <Box flex={{direction: 'column', gap: 4}}>
+        <Box flex={{direction: 'row'}}>
+          <Subtitle2>Recent updates</Subtitle2>
+        </Box>
+        <Skeleton $width="100%" $height={32} />
+        <Box padding={{top: 4}} flex={{justifyContent: 'space-between'}}>
+          <Skeleton $width={70} $height="1em" style={{minHeight: '1em'}} />
+          <Skeleton $width={70} $height="1em" style={{minHeight: '1em'}} />
+        </Box>
       </Box>
     );
   }
 
-  if (!materializations?.length) {
-    return (
-      <Box flex={{direction: 'column', gap: 8}}>
-        <Subtitle2>Recent updates</Subtitle2>
-        <Caption color={Colors.textLighter()}>No materialization events found</Caption>
-      </Box>
-    );
-  }
+  const count = materializations?.length ?? 0;
 
   return (
     <Box flex={{direction: 'column', gap: 4}}>
       <Box flex={{direction: 'row', justifyContent: 'space-between'}}>
         <Subtitle2>Recent updates</Subtitle2>
         <Caption color={Colors.textLighter()}>
-          {materializations.length === 100
+          {count === 100
             ? 'Last 100 updates'
-            : `Showing all ${materializations.length} updates`}
+            : count === 0
+              ? 'No materialization events found'
+              : count === 1
+                ? 'Showing one update'
+                : `Showing all ${count} updates`}
         </Caption>
       </Box>
       <Box border="all" padding={6 as any} style={{height: 32, overflow: 'hidden'}}>

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/RecentUpdatesTimeline.stories.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__stories__/RecentUpdatesTimeline.stories.tsx
@@ -8,11 +8,19 @@ export default {
   component: PartitionHealthSummary,
 };
 
+export const Loading = () => (
+  <RecentUpdatesTimeline assetKey={buildAssetKey()} loading={true} materializations={undefined} />
+);
+
+export const Empty = () => (
+  <RecentUpdatesTimeline assetKey={buildAssetKey()} loading={false} materializations={[]} />
+);
+
 export const Single = () => (
   <RecentUpdatesTimeline
     assetKey={buildAssetKey()}
     loading={false}
-    materializations={[buildMaterializationEvent({timestamp: '1'})]}
+    materializations={[buildMaterializationEvent({timestamp: '1731685045904'})]}
   />
 );
 
@@ -22,22 +30,22 @@ export const Multiple = () => (
     loading={false}
     materializations={[
       buildMaterializationEvent({
-        timestamp: '1',
+        timestamp: '1731685015904',
       }),
       buildMaterializationEvent({
-        timestamp: '2',
+        timestamp: '1731685020904',
       }),
       buildMaterializationEvent({
-        timestamp: '4',
+        timestamp: '1731685032904',
       }),
       buildMaterializationEvent({
-        timestamp: '5',
+        timestamp: '1731685043904',
       }),
       buildMaterializationEvent({
-        timestamp: '9',
+        timestamp: '1731685044904',
       }),
       buildMaterializationEvent({
-        timestamp: '12',
+        timestamp: '1731685045904',
       }),
     ]}
   />


### PR DESCRIPTION
## Summary & Motivation

This is a small change to the RecentUpdatesTimeline so that it 1) doesn't change height when it transitions from loading to populated and 2) uses the skeleton component.

It does change the "empty, no events" state -- that one was shorter and just had a text label in it, and we now show the bar and the "none to display" message over on the right where the count is displayed.
 
## How I Tested These Changes

Storybook!

<img width="955" alt="image" src="https://github.com/user-attachments/assets/fe734595-7b33-4e6b-8e23-415019058ca9">
<img width="955" alt="image" src="https://github.com/user-attachments/assets/77328762-0294-41b5-959e-a68a167c6dc0">
<img width="955" alt="image" src="https://github.com/user-attachments/assets/2685000e-9fb9-48cc-b087-796e91fe1581">
