### PR TITLE
Update default python version language in docs

### DIFF
--- a/docs/content/dagster-plus/deployment/serverless.mdx
+++ b/docs/content/dagster-plus/deployment/serverless.mdx
@@ -164,7 +164,7 @@ if __name__ == "__main__":
 
 ### Using a different Python version
 
-The default version of Python for Serverless deployments is Python 3.9. Versions 3.10 through 3.12 are also supported. You can specify the version you want by updating your GitHub workflow or using the `--python-version` command line argument:
+Python versions 3.9 through 3.12 are all supported for Serverless deployments. You can specify the version you want by updating your GitHub workflow or using the `--python-version` command line argument:
 
 - **With GitHub**: Change the `python_version` parameter for the `build_deploy_python_executable` job in your `.github/workflows` files. For example:
 
@@ -175,7 +175,7 @@ The default version of Python for Serverless deployments is Python 3.9. Versions
     with:
       dagster_cloud_file: "$GITHUB_WORKSPACE/project-repo/dagster_cloud.yaml"
       build_output_dir: "$GITHUB_WORKSPACE/build"
-      python_version: "3.9" # Change this value to the desired Python version
+      python_version: "3.10" # Change this value to the desired Python version
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ```
@@ -183,14 +183,14 @@ The default version of Python for Serverless deployments is Python 3.9. Versions
 - **With the CLI**: Add the `--python-version` CLI argument to the deploy command to specify the registry path to the desired base image:
 
   ```shell
-  dagster-cloud serverless deploy-python-executable --location-name=my_location --python-version=3.9
+  dagster-cloud serverless deploy-python-executable --location-name=my_location --python-version=3.10
   ```
 
 ### Using a different base image or using native dependencies
 
 Dagster+ runs your code on a Docker image that we build as follows:
 
-1. The standard Python "slim" [Docker image](https://hub.docker.com/\_/python), such as `python:3.9-slim` is used as the base.
+1. The standard Python "slim" [Docker image](https://hub.docker.com/\_/python), such as `python:3.10-slim` is used as the base.
 2. The `dagster-cloud[serverless]` module installed in the image.
 
 As far as possible, add all dependencies by including the corresponding native Python bindings in your `setup.py`. When that is not possible, you can build and upload a custom base image that will be used to run your Python code.


### PR DESCRIPTION
Summary:
The default here is a little ambiguous because the CLI defaults to 3.9 if nothing is set, but a newly scaffolded Github action specifies 3.10. Make the docs just specify what is allowed and how to change it.

NOCHANGELOG

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
