### PR TITLE
[ui] Consistently hide metadata entries shown in the asset overview sidebar

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetNodeOverview.tsx
@@ -60,7 +60,7 @@ import {AssetNodeForGraphQueryFragment} from '../asset-graph/types/useAssetGraph
 import {CodeLink, getCodeReferenceKey} from '../code-links/CodeLink';
 import {DagsterTypeSummary} from '../dagstertype/DagsterType';
 import {AssetKind, isCanonicalStorageKindTag, isSystemTag} from '../graph/KindTags';
-import {CodeReferencesMetadataEntry, IntMetadataEntry} from '../graphql/types';
+import {IntMetadataEntry} from '../graphql/types';
 import {useStateWithStorage} from '../hooks/useStateWithStorage';
 import {isCanonicalRowCountMetadataEntry} from '../metadata/MetadataEntry';
 import {
@@ -296,10 +296,7 @@ export const AssetNodeOverview = ({
 
   const tableNameMetadata = assetNode?.metadataEntries?.find(isCanonicalTableNameEntry);
   const uriMetadata = assetNode?.metadataEntries?.find(isCanonicalUriEntry);
-
-  const codeSource = assetNode?.metadataEntries?.find((m) => isCanonicalCodeSourceEntry(m)) as
-    | CodeReferencesMetadataEntry
-    | undefined;
+  const codeSource = assetNode?.metadataEntries?.find(isCanonicalCodeSourceEntry);
 
   const renderDefinitionSection = () => (
     <Box flex={{direction: 'column', gap: 12}}>
@@ -624,7 +621,7 @@ export const AssetNodeOverview = ({
               showHeader
               showTimestamps
               showFilter
-              hideTableSchema
+              hideEntriesShownOnOverview
               observations={[]}
               definitionMetadata={assetMetadata}
               definitionLoadTimestamp={assetNodeLoadTimestamp}

--- a/js_modules/dagster-ui/packages/ui-core/src/metadata/MetadataEntry.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/metadata/MetadataEntry.tsx
@@ -33,7 +33,9 @@ import {Markdown} from '../ui/Markdown';
 import {NotebookButton} from '../ui/NotebookButton';
 import {DUNDER_REPO_NAME, buildRepoAddress} from '../workspace/buildRepoAddress';
 import {workspacePathFromAddress} from '../workspace/workspacePath';
+
 const TIME_FORMAT = {showSeconds: true, showTimezone: true};
+
 export const HIDDEN_METADATA_ENTRY_LABELS = new Set([
   'dagster_dbt/select',
   'dagster_dbt/exclude',


### PR DESCRIPTION
This PR makes the behavior of the asset metadata entries table more consistent:

## Summary & Motivation

- Some asset metadata entries are internal / used to implement features and are never displayed

- Some asset metadata entries are hidden on the overview page specifically because they appear in the right sidebar (row count, table name, and URI)

We were previously hiding row_count everywhere, and not hiding table_name or uri on the overview, which was inconsistent.

## How I Tested These Changes

Used the dev proxy to look at a bunch of production assets that have this metadata populated.

## Changelog

[ui] Asset metadata entries like `dagster/row_count` appear on the events page and are properly hidden on the overview page where they appear in the sidebar.