### PR TITLE
[DA] Fix issue with label for dep operators

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
+++ b/python_modules/dagster/dagster/_core/definitions/declarative_automation/operators/dep_operators.py
@@ -75,9 +75,9 @@ class DepsAutomationCondition(BuiltinAutomationCondition[T_EntityKey]):
         name = self.base_name
         props = []
         if self.allow_selection is not None:
-            props.append("allow_selection={self.allow_selection}")
+            props.append(f"allow_selection={self.allow_selection}")
         if self.ignore_selection is not None:
-            props.append("ignore_selection={self.ignore_selection}")
+            props.append(f"ignore_selection={self.ignore_selection}")
 
         if props:
             name += f"({','.join(props)})"


### PR DESCRIPTION
## Summary & Motivation

See changelog

## How I Tested These Changes

## Changelog

Fixed an issue that would cause the label for `AutomationCondition.any_deps_match()` and `AutomationCondition.all_deps_match()` to render incorrectly when `allow_selection` or `ignore_selection` were set.
