### PR TITLE
Fix issue where ToposortedPriorityQueue could return children after their parents

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -910,9 +910,7 @@ class ToposortedPriorityQueue:
         else:
             execution_set_keys = {asset_key}
 
-        level = max(
-            self._toposort_level_by_asset_key[asset_key] for asset_key in execution_set_keys
-        )
+        level = self._toposort_level_by_asset_key[asset_key]
 
         return ToposortedPriorityQueue.QueueItem(
             level,


### PR DESCRIPTION
Summary:
Doing this max could cause us to break the invariant that parents are always considered before parents.

If you have a graph like this:

```

@asset
def a():
    pass

@asset
def b(a):
    pass

@asset
def c(b):
    pass

@multi_asset(specs=[AssetSpec("d", deps=["a"]), AssetSpec("e", deps=["c"])])
def my_complex_assets():
    pass

@asset(deps=["d"])
def f():
    pass
```

and pass in both a and f, it would evaluate f before d, because d gets incorrectly bumped up to the same toposort level as e.

Now, instead, D+E will always be visited before F. This arguably still breaks the invariant in a different way, in that E can now be visited (as part of the D+E multi-asset) before C, but I think that is happening in a more principled way now because when that happens D is still the 'main' asset and E is just along for the ride since it's part of D's multi-asset

It looks like this was added way back in https://github.com/dagster-io/dagster/pull/11190/files when this logic was being used for AMP.

> Insert changelog entry or delete this section.

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
