### PR TITLE
[2/4] Add asset selection filtering to asset catalog table.

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -134,12 +134,12 @@ export const AssetGraphExplorer = (props: Props) => {
       clearAssetSelection: React.useCallback(() => {
         onChangeExplorerPath(
           {
-            ...explorerPath,
+            ...explorerPathRef.current,
             opsQuery: '',
           },
           'push',
         );
-      }, [explorerPath, onChangeExplorerPath]),
+      }, [explorerPathRef, onChangeExplorerPath]),
     });
 
   useLayoutEffect(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -131,15 +131,6 @@ export const AssetGraphExplorer = (props: Props) => {
         },
         [explorerPathRef, onChangeExplorerPath],
       ),
-      clearAssetSelection: React.useCallback(() => {
-        onChangeExplorerPath(
-          {
-            ...explorerPathRef.current,
-            opsQuery: '',
-          },
-          'push',
-        );
-      }, [explorerPathRef, onChangeExplorerPath]),
     });
 
   useLayoutEffect(() => {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -131,7 +131,7 @@ export const AssetGraphExplorer = (props: Props) => {
         },
         [explorerPathRef, onChangeExplorerPath],
       ),
-      clearExplorerPath: React.useCallback(() => {
+      clearAssetSelection: React.useCallback(() => {
         onChangeExplorerPath(
           {
             ...explorerPath,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -718,7 +718,6 @@ const AssetGraphExplorerWithData = ({
             <TopbarWrapper>
               <Box flex={{direction: 'column'}} style={{width: '100%'}}>
                 <Box
-                  border={filterBar ? 'bottom' : undefined}
                   flex={{gap: 12, alignItems: 'center'}}
                   padding={{left: showSidebar ? 12 : 24, vertical: 12, right: 12}}
                 >

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphExplorer.tsx
@@ -58,6 +58,7 @@ import {useAssetLayout} from '../graph/asyncGraphLayout';
 import {closestNodeInDirection, isNodeOffscreen} from '../graph/common';
 import {AssetGroupSelector} from '../graphql/types';
 import {useQueryAndLocalStoragePersistedState} from '../hooks/useQueryAndLocalStoragePersistedState';
+import {useUpdatingRef} from '../hooks/useUpdatingRef';
 import {
   GraphExplorerOptions,
   OptionsOverlay,
@@ -107,6 +108,8 @@ export const AssetGraphExplorer = (props: Props) => {
 
   const {explorerPath, onChangeExplorerPath} = props;
 
+  const explorerPathRef = useUpdatingRef(explorerPath);
+
   const {button, filterBar, groupsFilter, kindFilter, filterFn, filteredAssetsLoading} =
     useAssetGraphExplorerFilters({
       nodes: React.useMemo(
@@ -115,7 +118,19 @@ export const AssetGraphExplorer = (props: Props) => {
       ),
       loading: fetchResult.loading,
       viewType: props.viewType,
-      explorerPath: explorerPath.opsQuery,
+      assetSelection: explorerPath.opsQuery,
+      setAssetSelection: React.useCallback(
+        (assetSelection: string) => {
+          onChangeExplorerPath(
+            {
+              ...explorerPathRef.current,
+              opsQuery: assetSelection,
+            },
+            'push',
+          );
+        },
+        [explorerPathRef, onChangeExplorerPath],
+      ),
       clearExplorerPath: React.useCallback(() => {
         onChangeExplorerPath(
           {

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphFilterBar.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphFilterBar.oss.tsx
@@ -5,15 +5,15 @@ import {FilterTag, FilterTagHighlightedText} from '../ui/BaseFilters/useFilter';
 export const AssetGraphFilterBar = ({
   activeFiltersJsx,
   right,
-  explorerPath,
-  clearExplorerPath,
+  clearAssetSelection,
+  assetSelection,
 }: {
   activeFiltersJsx: JSX.Element[];
   right?: JSX.Element;
-  clearExplorerPath: () => void;
-  explorerPath: string;
+  clearAssetSelection: () => void;
+  assetSelection: string;
 }) => {
-  if (!activeFiltersJsx.length && !explorerPath) {
+  if (!activeFiltersJsx.length && !assetSelection) {
     return null;
   }
   return (
@@ -23,17 +23,17 @@ export const AssetGraphFilterBar = ({
     >
       <Box flex={{gap: 12, alignItems: 'center', direction: 'row', grow: 1}}>
         {activeFiltersJsx}
-        {explorerPath ? (
+        {assetSelection ? (
           <FilterTag
             label={
               <Box flex={{direction: 'row', alignItems: 'center'}}>
                 Asset selection is&nbsp;
-                <FilterTagHighlightedText tooltipText={explorerPath}>
-                  {explorerPath}
+                <FilterTagHighlightedText tooltipText={assetSelection}>
+                  {assetSelection}
                 </FilterTagHighlightedText>
               </Box>
             }
-            onRemove={clearExplorerPath}
+            onRemove={clearAssetSelection}
           />
         ) : null}
       </Box>

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphFilterBar.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphFilterBar.oss.tsx
@@ -1,18 +1,22 @@
 import {Box} from '@dagster-io/ui-components';
+import {useCallback} from 'react';
 
 import {FilterTag, FilterTagHighlightedText} from '../ui/BaseFilters/useFilter';
 
 export const AssetGraphFilterBar = ({
   activeFiltersJsx,
   right,
-  clearAssetSelection,
   assetSelection,
+  setAssetSelection,
 }: {
   activeFiltersJsx: JSX.Element[];
   right?: JSX.Element;
-  clearAssetSelection: () => void;
   assetSelection: string;
+  setAssetSelection: (selection: string) => void;
 }) => {
+  const clearAssetSelection = useCallback(() => {
+    setAssetSelection('');
+  }, [setAssetSelection]);
   if (!activeFiltersJsx.length && !assetSelection) {
     return null;
   }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphFilterBar.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/AssetGraphFilterBar.oss.tsx
@@ -24,6 +24,7 @@ export const AssetGraphFilterBar = ({
     <Box
       flex={{direction: 'row', justifyContent: 'space-between', gap: 12, alignItems: 'center'}}
       padding={{vertical: 8, horizontal: 12}}
+      border="top"
     >
       <Box flex={{gap: 12, alignItems: 'center', direction: 'row', grow: 1}}>
         {activeFiltersJsx}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/sidebar/Sidebar.tsx
@@ -306,7 +306,6 @@ export const AssetGraphExplorerSidebar = React.memo(
             padding: '12px 24px',
             paddingRight: 12,
           }}
-          border="bottom"
         >
           <SearchFilter
             values={React.useMemo(() => {
@@ -321,7 +320,7 @@ export const AssetGraphExplorerSidebar = React.memo(
             <Button icon={<Icon name="panel_show_right" />} onClick={hideSidebar} />
           </Tooltip>
         </Box>
-        <div>
+        <Box border="top">
           {loading ? (
             <Box flex={{direction: 'column', gap: 9}} padding={12}>
               <Skeleton $height={21} $width="50%" />
@@ -407,7 +406,7 @@ export const AssetGraphExplorerSidebar = React.memo(
               </Inner>
             </Container>
           )}
-        </div>
+        </Box>
       </div>
     );
   },

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphExplorerFilters.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphExplorerFilters.oss.tsx
@@ -3,10 +3,11 @@ import {useAssetCatalogFiltering} from 'shared/assets/useAssetCatalogFiltering.o
 
 import {AssetGraphViewType, GraphNode} from './Utils';
 
-type Props = {
+export type Props = {
   nodes: GraphNode[];
-  clearExplorerPath: () => void;
-  explorerPath: string;
+  clearAssetSelection: () => void;
+  setAssetSelection: (selection: string) => void;
+  assetSelection: string;
   viewType: AssetGraphViewType;
   loading: boolean;
 };
@@ -14,9 +15,9 @@ type Props = {
 export function useAssetGraphExplorerFilters({
   nodes,
   viewType,
-  explorerPath,
+  assetSelection,
   loading,
-  clearExplorerPath,
+  clearAssetSelection,
 }: Props) {
   const ret = useAssetCatalogFiltering({
     assets: nodes,
@@ -30,8 +31,8 @@ export function useAssetGraphExplorerFilters({
     filterBar: (
       <AssetGraphFilterBar
         activeFiltersJsx={ret.activeFiltersJsx}
-        explorerPath={explorerPath}
-        clearExplorerPath={clearExplorerPath}
+        assetSelection={assetSelection}
+        clearAssetSelection={clearAssetSelection}
       />
     ),
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphExplorerFilters.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-graph/useAssetGraphExplorerFilters.oss.tsx
@@ -5,7 +5,6 @@ import {AssetGraphViewType, GraphNode} from './Utils';
 
 export type Props = {
   nodes: GraphNode[];
-  clearAssetSelection: () => void;
   setAssetSelection: (selection: string) => void;
   assetSelection: string;
   viewType: AssetGraphViewType;
@@ -17,7 +16,7 @@ export function useAssetGraphExplorerFilters({
   viewType,
   assetSelection,
   loading,
-  clearAssetSelection,
+  setAssetSelection,
 }: Props) {
   const ret = useAssetCatalogFiltering({
     assets: nodes,
@@ -32,7 +31,7 @@ export function useAssetGraphExplorerFilters({
       <AssetGraphFilterBar
         activeFiltersJsx={ret.activeFiltersJsx}
         assetSelection={assetSelection}
-        clearAssetSelection={clearAssetSelection}
+        setAssetSelection={setAssetSelection}
       />
     ),
   };

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionFiltering.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionFiltering.tsx
@@ -1,0 +1,50 @@
+import {useMemo} from 'react';
+import {FilterableAssetDefinition} from 'shared/assets/useAssetDefinitionFilterState.oss';
+
+import {COMMON_COLLATOR} from '../app/Util';
+import {tokenForAssetKey} from '../asset-graph/Utils';
+import {AssetNodeForGraphQueryFragment} from '../asset-graph/types/useAssetGraphData.types';
+import {useAssetGraphData} from '../asset-graph/useAssetGraphData';
+
+export const useAssetSelectionFiltering = <
+  T extends {
+    id: string;
+    key: {path: Array<string>};
+    definition?: FilterableAssetDefinition | null;
+  },
+>({
+  assetSelection,
+  assets,
+}: {
+  assetSelection: string;
+
+  assets: T[];
+}) => {
+  const assetsByKey = useMemo(
+    () => Object.fromEntries(assets.map((asset) => [tokenForAssetKey(asset.key), asset])),
+    [assets],
+  );
+
+  const {fetchResult, graphQueryItems, graphAssetKeys} = useAssetGraphData(
+    assetSelection,
+    useMemo(
+      () => ({
+        hideEdgesToNodesOutsideQuery: true,
+        hideNodesMatching: (node: AssetNodeForGraphQueryFragment) => {
+          return !assetsByKey[tokenForAssetKey(node.assetKey)];
+        },
+      }),
+      [assetsByKey],
+    ),
+  );
+
+  const filtered = useMemo(() => {
+    return (
+      graphAssetKeys
+        .map((key) => assetsByKey[tokenForAssetKey(key)]!)
+        .sort((a, b) => COMMON_COLLATOR.compare(a.key.path.join(''), b.key.path.join(''))) ?? []
+    );
+  }, [graphAssetKeys, assetsByKey]);
+
+  return {filtered, fetchResult, graphQueryItems};
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionFiltering.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionFiltering.tsx
@@ -46,5 +46,10 @@ export const useAssetSelectionFiltering = <
     );
   }, [graphAssetKeys, assetsByKey]);
 
-  return {filtered, fetchResult, graphQueryItems};
+  const filteredByKey = useMemo(
+    () => Object.fromEntries(filtered.map((asset) => [tokenForAssetKey(asset.key), asset])),
+    [filtered],
+  );
+
+  return {filtered, filteredByKey, fetchResult, graphAssetKeys, graphQueryItems};
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionInput.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionInput.tsx
@@ -1,0 +1,34 @@
+import {AssetGraphAssetSelectionInput} from 'shared/asset-graph/AssetGraphAssetSelectionInput.oss';
+import {useAssetSelectionState} from 'shared/asset-selection/useAssetSelectionState.oss';
+import {FilterableAssetDefinition} from 'shared/assets/useAssetDefinitionFilterState.oss';
+
+import {useAssetSelectionFiltering} from './useAssetSelectionFiltering';
+
+export const useAssetSelectionInput = <
+  T extends {
+    id: string;
+    key: {path: Array<string>};
+    definition?: FilterableAssetDefinition | null;
+  },
+>(
+  assets: T[],
+) => {
+  const [assetSelection, setAssetSelection] = useAssetSelectionState();
+
+  const {graphQueryItems, fetchResult, filtered} = useAssetSelectionFiltering({
+    assetSelection,
+    assets,
+  });
+
+  const filterInput = (
+    <AssetGraphAssetSelectionInput
+      items={graphQueryItems}
+      value={assetSelection}
+      placeholder="Type an asset subset…"
+      onChange={setAssetSelection}
+      popoverPosition="bottom-left"
+    />
+  );
+
+  return {filterInput, fetchResult, filtered, assetSelection, setAssetSelection};
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionState.oss.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/useAssetSelectionState.oss.tsx
@@ -1,0 +1,8 @@
+import {useQueryPersistedState} from '../hooks/useQueryPersistedState';
+
+export function useAssetSelectionState() {
+  return useQueryPersistedState<string>({
+    queryKey: 'asset-selection',
+    defaults: {['asset-selection']: ''},
+  });
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetTable.tsx
@@ -39,7 +39,7 @@ interface Props {
   belowActionBarComponents: React.ReactNode;
   prefixPath: string[];
   displayPathForAsset: (asset: Asset) => string[];
-  searchPath: string;
+  assetSelection: string;
   isFiltered: boolean;
   kindFilter?: StaticSetFilter<string>;
   isLoading: boolean;
@@ -52,7 +52,7 @@ export const AssetTable = ({
   refreshState,
   prefixPath,
   displayPathForAsset,
-  searchPath,
+  assetSelection,
   isFiltered,
   view,
   kindFilter,
@@ -81,7 +81,7 @@ export const AssetTable = ({
 
   const content = () => {
     if (!assets.length) {
-      if (searchPath) {
+      if (assetSelection) {
         return (
           <Box padding={{top: 64}}>
             <NonIdealState
@@ -90,12 +90,12 @@ export const AssetTable = ({
               description={
                 isFiltered ? (
                   <div>
-                    No assets matching <strong>{searchPath}</strong> were found in the selected
+                    No assets matching <strong>{assetSelection}</strong> were found in the selected
                     filters
                   </div>
                 ) : (
                   <div>
-                    No assets matching <strong>{searchPath}</strong> were found
+                    No assets matching <strong>{assetSelection}</strong> were found
                   </div>
                 )
               }

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AssetsCatalogTable.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {useCallback, useContext, useEffect, useLayoutEffect, useMemo, useState} from 'react';
 import {useRouteMatch} from 'react-router-dom';
 import {useSetRecoilState} from 'recoil';
-import {AssetCatalogTableBottomActionBar} from 'shared/assets/AssetCatalogTableBottomActionBar.oss';
+import {AssetGraphFilterBar} from 'shared/asset-graph/AssetGraphFilterBar.oss';
 import {useAssetCatalogFiltering} from 'shared/assets/useAssetCatalogFiltering.oss';
 
 import {AssetTable} from './AssetTable';
@@ -19,7 +19,6 @@ import {
   AssetCatalogTableQueryVersion,
 } from './types/AssetsCatalogTable.types';
 import {AssetViewType, useAssetView} from './useAssetView';
-import {useBasicAssetSearchInput} from './useBasicAssetSearchInput';
 import {gql, useApolloClient} from '../apollo-client';
 import {AppContext} from '../app/AppContext';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
@@ -27,6 +26,7 @@ import {PythonErrorInfo} from '../app/PythonErrorInfo';
 import {FIFTEEN_SECONDS, useRefreshAtInterval} from '../app/QueryRefresh';
 import {currentPageAtom} from '../app/analytics';
 import {PythonErrorFragment} from '../app/types/PythonErrorFragment.types';
+import {useAssetSelectionInput} from '../asset-selection/useAssetSelectionInput';
 import {AssetGroupSelector} from '../graphql/types';
 import {useUpdatingRef} from '../hooks/useUpdatingRef';
 import {useBlockTraceUntilTrue} from '../performance/TraceContext';
@@ -210,13 +210,10 @@ export const AssetsCatalogTable = ({
     activeFiltersJsx,
     kindFilter,
   } = useAssetCatalogFiltering({assets});
+  const {filterInput, filtered, fetchResult, assetSelection, setAssetSelection} =
+    useAssetSelectionInput(partiallyFiltered);
 
-  const {searchPath, filterInput, filtered} = useBasicAssetSearchInput(
-    partiallyFiltered,
-    prefixPath,
-  );
-
-  useBlockTraceUntilTrue('useAllAssets', !!assets?.length);
+  useBlockTraceUntilTrue('useAllAssets', !!assets?.length && !fetchResult.loading);
 
   const {displayPathForAsset, displayed} = useMemo(
     () =>
@@ -280,11 +277,15 @@ export const AssetsCatalogTable = ({
         </>
       }
       belowActionBarComponents={
-        <AssetCatalogTableBottomActionBar activeFiltersJsx={activeFiltersJsx} />
+        <AssetGraphFilterBar
+          activeFiltersJsx={activeFiltersJsx}
+          assetSelection={assetSelection}
+          setAssetSelection={setAssetSelection}
+        />
       }
       refreshState={refreshState}
       prefixPath={prefixPath || emptyArray}
-      searchPath={searchPath}
+      assetSelection={assetSelection}
       displayPathForAsset={displayPathForAsset}
       kindFilter={kindFilter}
     />

--- a/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetTables.test.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/__tests__/AssetTables.test.tsx
@@ -32,6 +32,20 @@ const MOCKS = [
 // This file must be mocked because Jest can't handle `import.meta.url`.
 jest.mock('../../graph/asyncGraphLayout', () => ({}));
 
+jest.mock('shared/asset-selection/useAssetSelectionInput', () => {
+  return {
+    useAssetSelectionInput: (assets: any) => {
+      return {
+        filterInput: <div />,
+        fetchResult: {loading: false},
+        filtered: assets,
+        assetSelection: '',
+        setAssetSelection: () => {},
+      };
+    },
+  };
+});
+
 describe('AssetTable', () => {
   beforeAll(() => {
     mockViewportClientRect();

--- a/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/types.ts
@@ -9,7 +9,7 @@ import {
   SearchScheduleFragment,
   SearchSensorFragment,
 } from './types/useGlobalSearch.types';
-import {DefinitionTag} from '../graphql/types';
+import {AssetKey, DefinitionTag} from '../graphql/types';
 
 export enum SearchResultType {
   AssetGroup,
@@ -54,6 +54,7 @@ export function isAssetFilterSearchResultType(
 }
 
 export type SearchResult = {
+  key?: AssetKey;
   label: string;
   description: string;
   href: string;

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -208,6 +208,7 @@ const secondaryDataToSearchResults = (
   const assets: SearchResult[] = nodes
     .filter(({definition}) => definition !== null)
     .map((node) => ({
+      key: node.key,
       label: displayNameForAssetKey(node.key),
       description: `Asset in ${buildRepoPathForHuman(
         node.definition!.repository.name,

--- a/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/search/useGlobalSearch.tsx
@@ -17,8 +17,13 @@ import {useIndexedDBCachedQuery} from './useIndexedDBCachedQuery';
 import {gql} from '../apollo-client';
 import {AppContext} from '../app/AppContext';
 import {PYTHON_ERROR_FRAGMENT} from '../app/PythonErrorFragment';
-import {displayNameForAssetKey, isHiddenAssetGroupJob} from '../asset-graph/Utils';
+import {
+  displayNameForAssetKey,
+  isHiddenAssetGroupJob,
+  tokenForAssetKey,
+} from '../asset-graph/Utils';
 import {assetDetailsPathForKey} from '../assets/assetDetailsPathForKey';
+import {AssetTableFragment} from '../assets/types/AssetTableFragment.types';
 import {AssetOwner, DefinitionTag} from '../graphql/types';
 import {buildTagString} from '../ui/tagAsString';
 import {assetOwnerAsString} from '../workspace/assetOwnerAsString';
@@ -195,31 +200,39 @@ const primaryDataToSearchResults = (input: {data?: SearchPrimaryQuery}) => {
 };
 
 const secondaryDataToSearchResults = (
-  input: {data?: SearchSecondaryQuery},
+  input: {data?: SearchSecondaryQuery; includedAssetsByKey?: {[key: string]: AssetTableFragment}},
   searchContext: 'global' | 'catalog',
 ) => {
-  const {data} = input;
+  const {data, includedAssetsByKey} = input;
   if (!data?.assetsOrError || data.assetsOrError.__typename === 'PythonError') {
     return [];
   }
 
-  const {nodes} = data.assetsOrError;
+  const {nodes: _nodes} = data.assetsOrError;
 
-  const assets: SearchResult[] = nodes
-    .filter(({definition}) => definition !== null)
-    .map((node) => ({
-      key: node.key,
-      label: displayNameForAssetKey(node.key),
-      description: `Asset in ${buildRepoPathForHuman(
-        node.definition!.repository.name,
-        node.definition!.repository.location.name,
-      )}`,
-      node,
-      href: assetDetailsPathForKey(node.key),
-      type: SearchResultType.Asset,
-      tags: node.definition!.tags,
-      kinds: node.definition!.kinds,
-    }));
+  const nodes = _nodes.filter(({definition, key}) => {
+    if (definition === null) {
+      return false;
+    }
+    if (includedAssetsByKey && !includedAssetsByKey[tokenForAssetKey(key)]) {
+      return false;
+    }
+    return true;
+  });
+
+  const assets: SearchResult[] = nodes.map((node) => ({
+    key: node.key,
+    label: displayNameForAssetKey(node.key),
+    description: `Asset in ${buildRepoPathForHuman(
+      node.definition!.repository.name,
+      node.definition!.repository.location.name,
+    )}`,
+    node,
+    href: assetDetailsPathForKey(node.key),
+    type: SearchResultType.Asset,
+    tags: node.definition!.tags,
+    kinds: node.definition!.kinds,
+  }));
 
   if (searchContext === 'global') {
     return [...assets];
@@ -321,7 +334,17 @@ type IndexBuffer = {
  *
  * A `terminate` function is provided, but it's probably not necessary to use it.
  */
-export const useGlobalSearch = ({searchContext}: {searchContext: 'global' | 'catalog'}) => {
+export const useGlobalSearch = ({
+  searchContext,
+
+  // includedAssetsByKey - is a pre-filtered list of assets keys that search can show.
+  // This is to take into account any asset selection filtering on the page.
+  // This is only used in the dagster plus catalog.
+  includedAssetsByKey,
+}: {
+  searchContext: 'global' | 'catalog';
+  includedAssetsByKey?: {[key: string]: AssetTableFragment};
+}) => {
   const primarySearch = useRef<WorkerSearchResult | null>(null);
   const secondarySearch = useRef<WorkerSearchResult | null>(null);
 
@@ -384,14 +407,24 @@ export const useGlobalSearch = ({searchContext}: {searchContext: 'global' | 'cat
     if (!secondaryData) {
       return;
     }
-    const results = secondaryDataToSearchResults({data: secondaryData}, searchContext);
+
+    const results = secondaryDataToSearchResults(
+      {data: secondaryData, includedAssetsByKey},
+      searchContext,
+    );
     const augmentedResults = augmentSearchResults(results, searchContext);
     if (!secondarySearch.current) {
       secondarySearch.current = createSearchWorker('secondary', fuseOptions);
     }
     secondarySearch.current.update(augmentedResults);
     consumeBufferEffect(secondarySearchBuffer, secondarySearch.current);
-  }, [consumeBufferEffect, secondaryData, searchContext, augmentSearchResults]);
+  }, [
+    consumeBufferEffect,
+    secondaryData,
+    searchContext,
+    augmentSearchResults,
+    includedAssetsByKey,
+  ]);
 
   const primarySearchBuffer = useRef<IndexBuffer | null>(null);
   const secondarySearchBuffer = useRef<IndexBuffer | null>(null);

--- a/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useFilter.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/ui/BaseFilters/useFilter.tsx
@@ -4,6 +4,7 @@ import {useMemo} from 'react';
 import styled from 'styled-components';
 
 import {TruncatedTextWithFullTextOnHover} from '../../nav/getLeftNavItemsForOption';
+import {testId} from '../../testing/testId';
 
 export type FilterObject<T = any> = {
   isActive: boolean;
@@ -53,7 +54,12 @@ export const FilterTag = ({
         icon={iconName ? <Icon name={iconName} color={textColor} /> : undefined}
         rightIcon={
           onRemove ? (
-            <div onClick={onRemove} style={{cursor: 'pointer'}} tabIndex={0}>
+            <div
+              onClick={onRemove}
+              style={{cursor: 'pointer'}}
+              tabIndex={0}
+              data-testid={testId('filter-tag-remove')}
+            >
               <Icon name="close" color={textColor} />
             </div>
           ) : null


### PR DESCRIPTION
## Summary & Motivation

Add asset selection filtering to asset catalog table.

## How I Tested These Changes

Manually tested
<img width="1718" alt="Screenshot 2024-11-16 at 7 54 23 PM" src="https://github.com/user-attachments/assets/df535d76-2ce5-431b-a89c-34f59dc79173">

## Changelog

[ui] The asset catalog now supports filtering using the asset selection syntax.
