### PR TITLE
[ui] Fix the launchpad’s “no partition specified” warning for asset jobs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/launchpad/LaunchpadSession.tsx
@@ -571,12 +571,7 @@ const LaunchpadSession = (props: LaunchpadSessionProps) => {
   }
 
   let launchButtonWarning: string | undefined;
-  if (
-    partitionSets.results.length &&
-    currentSession.base &&
-    'partitionsSetName' in currentSession.base &&
-    !currentSession.base.partitionName
-  ) {
+  if (partitionSets.results.length && isMissingPartition(currentSession.base)) {
     launchButtonWarning =
       'This job is partitioned. Are you sure you want to launch' +
       ' a run without a partition specified?';
@@ -897,3 +892,10 @@ const PIPELINE_EXECUTION_CONFIG_SCHEMA_QUERY = gql`
 
   ${CONFIG_EDITOR_RUN_CONFIG_SCHEMA_FRAGMENT}
 `;
+
+function isMissingPartition(base: SessionBase | null) {
+  if (base?.type === 'op-job-partition-set' || base?.type === 'asset-job-partition') {
+    return !base.partitionName;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary & Motivation

Requested here: https://linear.app/dagster-labs/issue/FE-685/add-a-warning-when-submitting-launchpad-for-partitioned-job-with-no, it turns out this already existed but only for old op jobs.

FE-674

## How I Tested These Changes

- Verified that for a partitioned asset job, the warning appears if you do not choose a partition in the launchpad's top right dropdown

I think this highlights the need for some automated tests of the launchpad but it looks like it'll be a bit of an undertaking to get some written.

## Changelog

- Launching partitioned asset jobs from the launchpad now warns if no partition is selected.