### PR TITLE
[docs] update Serverless IP address date

### DIFF
--- a/docs/content/dagster-plus/deployment/serverless.mdx
+++ b/docs/content/dagster-plus/deployment/serverless.mdx
@@ -370,7 +370,7 @@ Serverless code will make requests from one of the following IP addresses. You m
 54.71.18.84
 ```
 
-**Note**: Additional IP addresses may be added over time. This list was last updated on **January 31, 2024.**
+**Note**: Additional IP addresses may be added over time. This list was last updated on **October 24, 2024.**
 
 ---
 


### PR DESCRIPTION
## Summary & Motivation
I confirmed the freshness of these IPs during the writing of the docs beta replacement page: https://docs-preview.dagster.io/dagster-plus/deployment/serverless/dagster-ips

Just want to update in the original docs too since they're still staying up.

## How I Tested These Changes
👀