### PR TITLE
[dependencies] Make dagster-polars compatible with polars>=1.14

### DIFF
--- a/python_modules/libraries/dagster-polars/tox.ini
+++ b/python_modules/libraries/dagster-polars/tox.ini
@@ -34,4 +34,4 @@ allowlist_externals =
   uv
 commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
-  pytest -c ../../../pyproject.toml -vv ./dagster_polars_tests
+  pytest -c ../../../pyproject.toml -vv {posargs}


### PR DESCRIPTION
## Summary & Motivation

Add support for `polars>=1.14` in `dagster-polars`.

## How I Tested These Changes

Existing test suite, plus testing on polars<1.14.