### PR TITLE
[dagster-sigma] Add filter option to hide unused datasets

### DIFF
--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -55,20 +55,22 @@ class SigmaFilter(IHaveNew):
         workbook_folders (Optional[Sequence[Sequence[str]]]): A list of folder paths to fetch workbooks from.
             Each folder path is a list of folder names, starting from the root folder. All workbooks
             contained in the specified folders will be fetched. If not provided, all workbooks will be fetched.
+        include_unused_datasets (bool): Whether to include datasets that are not used in any workbooks.
+            Defaults to True.
     """
 
     workbook_folders: Optional[Sequence[Sequence[str]]] = None
-    hide_unused_datasets: bool = False
+    include_unused_datasets: bool = True
 
     def __new__(
         cls,
         workbook_folders: Optional[Sequence[Sequence[str]]] = None,
-        hide_unused_datasets: bool = False,
+        include_unused_datasets: bool = True,
     ):
         return super().__new__(
             cls,
             workbook_folders=tuple([tuple(folder) for folder in workbook_folders or []]),
-            hide_unused_datasets=hide_unused_datasets,
+            include_unused_datasets=include_unused_datasets,
         )
 
 
@@ -452,7 +454,7 @@ class SigmaOrganization(ConfigurableResource):
         )
 
         used_datasets = None
-        if _sigma_filter and _sigma_filter.hide_unused_datasets:
+        if _sigma_filter and not _sigma_filter.include_unused_datasets:
             used_datasets = set()
             for workbook in workbooks:
                 used_datasets.update(workbook.datasets)

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
@@ -111,17 +111,30 @@ def test_model_organization_data_filter(sigma_auth_token: str, sigma_sample_data
             fetch_column_data=True,
         )
     )
-
     assert len(data.workbooks) == 0
+    assert len(data.datasets) == 1
+    data = asyncio.run(
+        resource.build_organization_data(
+            sigma_filter=SigmaFilter(
+                workbook_folders=[("My Documents", "Test Folder")], hide_unused_datasets=True
+            ),
+            fetch_column_data=True,
+        )
+    )
+    assert len(data.workbooks) == 0
+    assert len(data.datasets) == 0
 
     data = asyncio.run(
         resource.build_organization_data(
-            sigma_filter=SigmaFilter(workbook_folders=[("My Documents", "My Subfolder")]),
+            sigma_filter=SigmaFilter(
+                workbook_folders=[("My Documents", "My Subfolder")], hide_unused_datasets=True
+            ),
             fetch_column_data=True,
         )
     )
 
     assert len(data.workbooks) == 1
+    assert len(data.datasets) == 1
     assert data.workbooks[0].properties["name"] == "Sample Workbook"
 
     data = asyncio.run(

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_resource.py
@@ -116,7 +116,7 @@ def test_model_organization_data_filter(sigma_auth_token: str, sigma_sample_data
     data = asyncio.run(
         resource.build_organization_data(
             sigma_filter=SigmaFilter(
-                workbook_folders=[("My Documents", "Test Folder")], hide_unused_datasets=True
+                workbook_folders=[("My Documents", "Test Folder")], include_unused_datasets=False
             ),
             fetch_column_data=True,
         )
@@ -127,7 +127,7 @@ def test_model_organization_data_filter(sigma_auth_token: str, sigma_sample_data
     data = asyncio.run(
         resource.build_organization_data(
             sigma_filter=SigmaFilter(
-                workbook_folders=[("My Documents", "My Subfolder")], hide_unused_datasets=True
+                workbook_folders=[("My Documents", "My Subfolder")], include_unused_datasets=False
             ),
             fetch_column_data=True,
         )


### PR DESCRIPTION
## Summary

Adds an optional config field to `SigmaFilter` to hide datasets which are unused by any workbook.

## How I Tested These Changes

Update unit test.

## Changelog

> [dagster-sigma] Added include_unused_datasets field to `SigmaFilter` to disable pulling datasets that aren't used by a downstream workbook.
