### PR TITLE
[dagster-sigma] Add support for direct workbook->table deps

### DIFF
--- a/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma/resource.py
@@ -363,8 +363,7 @@ class SigmaOrganization(ConfigurableResource):
                 split = column["columnId"].split("/")
                 if len(split) == 2:
                     inode, column_name = split
-                    if inode in columns_by_dataset_inode:
-                        columns_by_dataset_inode[inode].add(column_name)
+                    columns_by_dataset_inode[inode].add(column_name)
 
         await asyncio.gather(*[process_workbook(workbook) for workbook in workbooks])
 

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/conftest.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/conftest.py
@@ -76,6 +76,13 @@ SAMPLE_DATASET_DATA = {
     "url": "https://app.sigmacomputing.com/dagster-labs/b/Iq557kfHN8KRu76HdGSWi",
 }
 
+SAMPLE_TABLE_INODE = "inode-C5ZiVq1GkaANMaD334AnA"
+SAMPLE_TABLE_DATA = {
+    "path": "Content Root/My Database/My Schema",
+    "urlId": SAMPLE_TABLE_INODE.split("-")[-1],
+    "name": "Payments",
+}
+
 
 @pytest.fixture(name="lineage_warn")
 def lineage_warn_fixture(responses: aioresponses) -> None:
@@ -113,6 +120,12 @@ def sigma_sample_data_fixture(responses: aioresponses) -> None:
         body=json.dumps(_build_paginated_response([SAMPLE_DATASET_DATA])),
         status=200,
     )
+    responses.add(
+        method=hdrs.METH_GET,
+        url="https://aws-api.sigmacomputing.com/v2/files?limit=1000&typeFilters=table",
+        body=json.dumps(_build_paginated_response([SAMPLE_TABLE_DATA])),
+        status=200,
+    )
 
     responses.add(
         method=hdrs.METH_GET,
@@ -147,6 +160,13 @@ def sigma_sample_data_fixture(responses: aioresponses) -> None:
             ],
             "vizualizationType": "bar",
         },
+        {
+            "elementId": "A49pknzHb1",
+            "type": "table",
+            "name": "Payments",
+            "columns": [],
+            "vizualizationType": "levelTable",
+        },
     ]
     responses.add(
         method=hdrs.METH_GET,
@@ -157,7 +177,7 @@ def sigma_sample_data_fixture(responses: aioresponses) -> None:
     responses.add(
         method=hdrs.METH_GET,
         url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/pages/qwMyyHBCuC/elements?limit=1000&page=1",
-        body=json.dumps(_build_paginated_response(elements, 1, 2)),
+        body=json.dumps(_build_paginated_response(elements, 1, 3)),
         status=200,
     )
     responses.add(
@@ -212,6 +232,29 @@ def sigma_sample_data_fixture(responses: aioresponses) -> None:
     )
     responses.add(
         method=hdrs.METH_GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/lineage/elements/A49pknzHb1",
+        body=json.dumps(
+            {
+                "dependencies": {
+                    SAMPLE_TABLE_INODE: {
+                        "nodeId": SAMPLE_TABLE_INODE,
+                        "type": "table",
+                        "name": "Payments",
+                    },
+                },
+            }
+        ),
+        status=200,
+    )
+    responses.add(
+        method=hdrs.METH_GET,
+        url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/elements/A49pknzHb1/columns",
+        body=json.dumps(_build_paginated_response([])),
+        status=200,
+    )
+
+    responses.add(
+        method=hdrs.METH_GET,
         url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/lineage/elements/V29pknzHb6",
         body=json.dumps(
             {
@@ -239,6 +282,7 @@ def sigma_sample_data_fixture(responses: aioresponses) -> None:
         ),
         status=200,
     )
+
     responses.add(
         method=hdrs.METH_GET,
         url="https://aws-api.sigmacomputing.com/v2/workbooks/4ea60fe9-f487-43b0-aa7a-3ef43ca3a90e/elements/V29pknzHb6/columns",

--- a/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_translator.py
+++ b/python_modules/libraries/dagster-sigma/dagster_sigma_tests/test_translator.py
@@ -6,12 +6,15 @@ from dagster_sigma.translator import (
     DagsterSigmaTranslator,
     SigmaDataset,
     SigmaOrganizationData,
+    SigmaTable,
     SigmaWorkbook,
 )
 
 from dagster_sigma_tests.conftest import (
     SAMPLE_DATASET_DATA,
     SAMPLE_DATASET_INODE,
+    SAMPLE_TABLE_DATA,
+    SAMPLE_TABLE_INODE,
     SAMPLE_WORKBOOK_DATA,
 )
 
@@ -21,12 +24,17 @@ def test_workbook_translation() -> None:
         properties=SAMPLE_WORKBOOK_DATA,
         datasets={SAMPLE_DATASET_INODE},
         owner_email="ben@dagsterlabs.com",
+        direct_table_deps={SAMPLE_TABLE_INODE},
     )
 
     sample_dataset = SigmaDataset(properties=SAMPLE_DATASET_DATA, columns=set(), inputs=set())
 
     translator = DagsterSigmaTranslator(
-        SigmaOrganizationData(workbooks=[sample_workbook], datasets=[sample_dataset])
+        SigmaOrganizationData(
+            workbooks=[sample_workbook],
+            datasets=[sample_dataset],
+            tables=[SigmaTable(properties=SAMPLE_TABLE_DATA)],
+        )
     )
 
     asset_spec = translator.get_asset_spec(sample_workbook)
@@ -36,8 +44,11 @@ def test_workbook_translation() -> None:
     assert asset_spec.metadata["dagster_sigma/version"] == 5
     assert asset_spec.metadata["dagster_sigma/created_at"].value == 1726176169.072
     assert build_kind_tag_key("sigma") in asset_spec.tags
-    assert {dep.asset_key for dep in asset_spec.deps} == {AssetKey(["Orders_Dataset"])}
     assert asset_spec.owners == ["ben@dagsterlabs.com"]
+    assert {dep.asset_key for dep in asset_spec.deps} == {
+        AssetKey(["Orders_Dataset"]),
+        AssetKey(["my_database", "my_schema", "payments"]),
+    }
 
 
 def test_dataset_translation() -> None:
@@ -48,7 +59,7 @@ def test_dataset_translation() -> None:
     )
 
     translator = DagsterSigmaTranslator(
-        SigmaOrganizationData(workbooks=[], datasets=[sample_dataset])
+        SigmaOrganizationData(workbooks=[], datasets=[sample_dataset], tables=[])
     )
 
     asset_spec = translator.get_asset_spec(sample_dataset)
@@ -89,7 +100,9 @@ def test_dataset_translation_custom_translator() -> None:
         inputs={"TESTDB.JAFFLE_SHOP.STG_ORDERS"},
     )
 
-    translator = MyCustomTranslator(SigmaOrganizationData(workbooks=[], datasets=[sample_dataset]))
+    translator = MyCustomTranslator(
+        SigmaOrganizationData(workbooks=[], datasets=[sample_dataset], tables=[])
+    )
 
     asset_spec = translator.get_asset_spec(sample_dataset)
 


### PR DESCRIPTION
## Summary

Sigma workbooks typically depend on datasets, which passthrough data from a database to structured tables that users can refresh or rename. However, you can also point workbooks directly at tables in your warehouse. This PR allows our integration to be aware of the latter, creating upstream external assets for each table.

## Test Plan

Update unit test, test locally against real Sigma instance.

## Changelog

> [dagster-sigma] Added support for direct workbook->warehouse table dependencies.