### PR TITLE
[check] handle TypedDict

### DIFF
--- a/python_modules/dagster/dagster/_check/builder.py
+++ b/python_modules/dagster/dagster/_check/builder.py
@@ -165,7 +165,7 @@ def _coerce_type(
     # coerce input type in to the type we want to pass to the check call
 
     # Any type translates to passing None for the of_type argument
-    if ttype is Any:
+    if ttype is Any or ttype is None:
         return None
 
     # assume naked strings should be ForwardRefs
@@ -184,6 +184,11 @@ def _coerce_type(
     if _is_annotated(origin, args):
         _process_annotated(ttype, args, eval_ctx)
         return _coerce_type(args[0], eval_ctx)
+
+    # cant do isinstance against TypeDict (and we cant subclass check for it)
+    # so just coerce any dict subclasses in to dict
+    if isinstance(ttype, type) and issubclass(ttype, dict):
+        return dict
 
     # Unions should become a tuple of types to pass to the of_type argument
     # ultimately used as second arg in isinstance(target, tuple_of_types)

--- a/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
+++ b/python_modules/dagster/dagster_tests/general_tests/check_tests/test_check.py
@@ -18,6 +18,7 @@ from typing import (
     Sequence,
     Set,
     Type,
+    TypedDict,
     TypeVar,
     Union,
 )
@@ -1650,6 +1651,11 @@ class Gen(Generic[T]): ...
 class SubGen(Gen[str]): ...
 
 
+class MyTypedDict(TypedDict):
+    foo: str
+    bar: str
+
+
 BUILD_CASES = [
     (int, [4], ["4"]),
     (float, [4.2], ["4.1"]),
@@ -1714,6 +1720,15 @@ BUILD_CASES = [
     (SubGen, [SubGen()], [Bar()]),
     (Sequence[SubGen], [[SubGen()]], [[Bar()]]),
     (Sequence[Gen[str]], [[Gen()]], [[Bar()]]),
+    (
+        MyTypedDict,
+        [
+            {"foo": "f", "bar": "b"},
+            {},  # cant actually validate TypeDict structure, just that its a dict
+        ],
+        [None, Foo()],
+    ),
+    (Optional[MyTypedDict], [{"foo": "f", "bar": "b"}, None], [Foo()]),
 ]
 
 


### PR DESCRIPTION
`TypedDict` doesn't allow `isinstance` or `issubclass` calls against it so in order to let them flow through check builder we coerce any `dict` subclass to `dict` inst checks. 

## How I Tested These Changes

added test cases