### PR TITLE
[OPER-1486] Implement AntlrAssetSelectionVisitor on frontend

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/app/GraphQueryImpl.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/GraphQueryImpl.ts
@@ -20,7 +20,7 @@ export interface GraphQueryItem {
 
 type TraverseStepFunction<T> = (item: T, callback: (nextItem: T) => void) => void;
 
-class GraphTraverser<T extends GraphQueryItem> {
+export class GraphTraverser<T extends GraphQueryItem> {
   itemNameMap: {[name: string]: T} = {};
 
   // TODO: One reason doing DFS on the client side is sub optimal.

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/AntlrAssetSelection.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/AntlrAssetSelection.ts
@@ -1,0 +1,19 @@
+import {CharStreams, CommonTokenStream} from 'antlr4ts';
+
+import {AntlrAssetSelectionVisitor} from './AntlrAssetSelectionVisitor';
+import {AssetGraphQueryItem} from '../asset-graph/useAssetGraphData';
+import {AssetSelectionLexer} from './generated/AssetSelectionLexer';
+import {AssetSelectionParser} from './generated/AssetSelectionParser';
+
+export const parseAssetSelectionQuery = (
+  all_assets: AssetGraphQueryItem[],
+  query: string,
+): AssetGraphQueryItem[] => {
+  const lexer = new AssetSelectionLexer(CharStreams.fromString(query));
+  const tokenStream = new CommonTokenStream(lexer);
+  const parser = new AssetSelectionParser(tokenStream);
+  const tree = parser.start();
+
+  const visitor = new AntlrAssetSelectionVisitor(all_assets);
+  return [...visitor.visit(tree)];
+};

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/AntlrAssetSelectionVisitor.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/AntlrAssetSelectionVisitor.ts
@@ -1,0 +1,232 @@
+import {AbstractParseTreeVisitor} from 'antlr4ts/tree/AbstractParseTreeVisitor';
+
+import {
+  AllExpressionContext,
+  AndExpressionContext,
+  AttributeExpressionContext,
+  CodeLocationAttributeExprContext,
+  DownTraversalExpressionContext,
+  FunctionCallExpressionContext,
+  FunctionNameContext,
+  GroupAttributeExprContext,
+  KeyExprContext,
+  KeySubstringExprContext,
+  KindAttributeExprContext,
+  NotExpressionContext,
+  OrExpressionContext,
+  OwnerAttributeExprContext,
+  ParenthesizedExpressionContext,
+  StartContext,
+  TagAttributeExprContext,
+  TraversalContext,
+  UpAndDownTraversalExpressionContext,
+  UpTraversalExpressionContext,
+  ValueContext,
+} from './generated/AssetSelectionParser';
+import {AssetSelectionVisitor} from './generated/AssetSelectionVisitor';
+import {GraphTraverser} from '../app/GraphQueryImpl';
+import {AssetGraphQueryItem} from '../asset-graph/useAssetGraphData';
+import {buildRepoPathForHuman} from '../workspace/buildRepoAddress';
+
+export class AntlrAssetSelectionVisitor
+  extends AbstractParseTreeVisitor<Set<AssetGraphQueryItem>>
+  implements AssetSelectionVisitor<Set<AssetGraphQueryItem>>
+{
+  all_assets: Set<AssetGraphQueryItem>;
+  traverser: GraphTraverser<AssetGraphQueryItem>;
+
+  protected defaultResult() {
+    return new Set<AssetGraphQueryItem>();
+  }
+
+  constructor(all_assets: AssetGraphQueryItem[]) {
+    super();
+    this.all_assets = new Set(all_assets);
+    this.traverser = new GraphTraverser(all_assets);
+  }
+
+  visitAttributeExpression(ctx: AttributeExpressionContext) {
+    return this.visit(ctx.attributeExpr());
+  }
+
+  visitUpTraversalExpression(ctx: UpTraversalExpressionContext) {
+    const selection = this.visit(ctx.expr());
+    const traversal_depth: number = this.visit(ctx.traversal());
+    for (const item of selection) {
+      this.traverser.fetchUpstream(item, traversal_depth).forEach((i) => selection.add(i));
+    }
+    return selection;
+  }
+
+  visitUpAndDownTraversalExpression(ctx: UpAndDownTraversalExpressionContext) {
+    const selection = this.visit(ctx.expr());
+    const up_depth: number = this.visit(ctx.traversal(0));
+    const down_depth: number = this.visit(ctx.traversal(1));
+    for (const item of selection) {
+      this.traverser.fetchUpstream(item, up_depth).forEach((i) => selection.add(i));
+      this.traverser.fetchDownstream(item, down_depth).forEach((i) => selection.add(i));
+    }
+    return selection;
+  }
+
+  visitDownTraversalExpression(ctx: DownTraversalExpressionContext) {
+    const selection = this.visit(ctx.expr());
+    const traversal_depth: number = this.visit(ctx.traversal());
+    for (const item of selection) {
+      this.traverser.fetchDownstream(item, traversal_depth).forEach((i) => selection.add(i));
+    }
+    return selection;
+  }
+
+  visitNotExpression(ctx: NotExpressionContext) {
+    const selection = this.visit(ctx.expr());
+    return new Set([...this.all_assets].filter((i) => !selection.has(i)));
+  }
+
+  visitAndExpression(ctx: AndExpressionContext) {
+    const left = this.visit(ctx.expr(0));
+    const right = this.visit(ctx.expr(1));
+    return new Set([...left].filter((i) => right.has(i)));
+  }
+
+  visitOrExpression(ctx: OrExpressionContext) {
+    const left = this.visit(ctx.expr(0));
+    const right = this.visit(ctx.expr(1));
+    return new Set([...left, ...right]);
+  }
+
+  visitFunctionCallExpression(ctx: FunctionCallExpressionContext) {
+    const function_name: string = this.visit(ctx.functionName());
+    const selection = this.visit(ctx.expr());
+    if (function_name === 'sinks') {
+      const sinks = new Set<AssetGraphQueryItem>();
+      for (const item of selection) {
+        const downstream = this.traverser
+          .fetchDownstream(item, Number.MAX_VALUE)
+          .filter((i) => !selection.has(i));
+        if (downstream.length === 0 || (downstream.length === 1 && downstream[0] === item)) {
+          sinks.add(item);
+        }
+      }
+      return sinks;
+    }
+    if (function_name === 'roots') {
+      const roots = new Set<AssetGraphQueryItem>();
+      for (const item of selection) {
+        const upstream = this.traverser
+          .fetchUpstream(item, Number.MAX_VALUE)
+          .filter((i) => !selection.has(i));
+        if (upstream.length === 0 || (upstream.length === 1 && upstream[0] === item)) {
+          roots.add(item);
+        }
+      }
+      return roots;
+    }
+    throw new Error(`Unknown function: ${function_name}`);
+  }
+
+  visitParenthesizedExpression(ctx: ParenthesizedExpressionContext) {
+    return this.visit(ctx.expr());
+  }
+
+  visitAllExpression(_ctx: AllExpressionContext) {
+    return this.all_assets;
+  }
+
+  visitKeyExpr(ctx: KeyExprContext) {
+    const value: string = this.visit(ctx.value());
+    return new Set([...this.all_assets].filter((i) => i.name === value));
+  }
+
+  visitKeySubstringExpr(ctx: KeySubstringExprContext) {
+    const value: string = this.visit(ctx.value());
+    return new Set([...this.all_assets].filter((i) => i.name.includes(value)));
+  }
+
+  visitTagAttributeExpr(ctx: TagAttributeExprContext) {
+    const key: string = this.visit(ctx.value(0));
+    if (ctx.EQUAL()) {
+      const value: string = this.visit(ctx.value(1));
+      return new Set(
+        [...this.all_assets].filter((i) =>
+          i.node.tags.some((t) => t.key === key && t.value === value),
+        ),
+      );
+    }
+    return new Set([...this.all_assets].filter((i) => i.node.tags.some((t) => t.key === key)));
+  }
+
+  visitOwnerAttributeExpr(ctx: OwnerAttributeExprContext) {
+    const value: string = this.visit(ctx.value());
+    return new Set(
+      [...this.all_assets].filter((i) =>
+        i.node.owners.some((o) => {
+          if (o.__typename === 'TeamAssetOwner') {
+            return o.team === value;
+          } else {
+            return o.email === value;
+          }
+        }),
+      ),
+    );
+  }
+
+  visitGroupAttributeExpr(ctx: GroupAttributeExprContext) {
+    const value: string = this.visit(ctx.value());
+    return new Set([...this.all_assets].filter((i) => i.node.groupName === value));
+  }
+
+  visitKindAttributeExpr(ctx: KindAttributeExprContext) {
+    const value: string = this.visit(ctx.value());
+    return new Set([...this.all_assets].filter((i) => i.node.kinds.some((k) => k === value)));
+  }
+
+  visitCodeLocationAttributeExpr(ctx: CodeLocationAttributeExprContext) {
+    const value: string = this.visit(ctx.value());
+    const selection = new Set<AssetGraphQueryItem>();
+    for (const asset of this.all_assets) {
+      const location = buildRepoPathForHuman(
+        asset.node.repository.name,
+        asset.node.repository.location.name,
+      );
+      if (location === value) {
+        selection.add(asset);
+      }
+    }
+    return selection;
+  }
+
+  visitStart(ctx: StartContext) {
+    return this.visit(ctx.expr());
+  }
+
+  visitTraversal(ctx: TraversalContext) {
+    if (ctx.STAR()) {
+      return Number.MAX_SAFE_INTEGER;
+    }
+    if (ctx.PLUS()) {
+      return ctx.PLUS().length;
+    }
+    throw new Error('Invalid traversal');
+  }
+
+  visitFunctionName(ctx: FunctionNameContext) {
+    if (ctx.SINKS()) {
+      return 'sinks';
+    }
+    if (ctx.ROOTS()) {
+      return 'roots';
+    }
+    throw new Error('Invalid function name');
+  }
+
+  visitValue(ctx: ValueContext) {
+    if (ctx.QUOTED_STRING()) {
+      return ctx.text.slice(1, -1);
+    }
+    if (ctx.UNQUOTED_STRING()) {
+      return ctx.text;
+    }
+    throw new Error('Invalid value');
+  }
+}

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/AntlrAssetSelectionVisitor.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/AntlrAssetSelectionVisitor.ts
@@ -103,7 +103,7 @@ export class AntlrAssetSelectionVisitor
       for (const item of selection) {
         const downstream = this.traverser
           .fetchDownstream(item, Number.MAX_VALUE)
-          .filter((i) => !selection.has(i));
+          .filter((i) => selection.has(i));
         if (downstream.length === 0 || (downstream.length === 1 && downstream[0] === item)) {
           sinks.add(item);
         }
@@ -115,7 +115,7 @@ export class AntlrAssetSelectionVisitor
       for (const item of selection) {
         const upstream = this.traverser
           .fetchUpstream(item, Number.MAX_VALUE)
-          .filter((i) => !selection.has(i));
+          .filter((i) => selection.has(i));
         if (upstream.length === 0 || (upstream.length === 1 && upstream[0] === item)) {
           roots.add(item);
         }

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/__tests__/AntlrAssetSelection.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/__tests__/AntlrAssetSelection.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/expect-expect */
 import {AssetGraphQueryItem} from '../../asset-graph/useAssetGraphData';
 import {
   buildAssetNode,

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/__tests__/AntlrAssetSelection.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/__tests__/AntlrAssetSelection.test.ts
@@ -1,0 +1,43 @@
+import {AssetGraphQueryItem} from '../../asset-graph/useAssetGraphData';
+import {buildAssetNode} from '../../graphql/types';
+import {parseAssetSelectionQuery} from '../AntlrAssetSelection';
+
+const TEST_GRAPH: AssetGraphQueryItem[] = [
+  // Top Layer
+  {
+    name: 'A',
+    node: buildAssetNode({
+      tags: [{__typename: 'DefinitionTag', key: 'foo', value: 'bar'}],
+      owners: [{__typename: 'UserAssetOwner', email: 'owner@owner.com'}],
+    }),
+    inputs: [{dependsOn: []}],
+    outputs: [{dependedBy: [{solid: {name: 'B'}}]}],
+  },
+  // Second Layer
+  {
+    name: 'B',
+    node: buildAssetNode({
+      kinds: ['python', 'snowflake'],
+    }),
+    inputs: [{dependsOn: [{solid: {name: 'A'}}]}],
+    outputs: [{dependedBy: [{solid: {name: 'C'}}]}],
+  },
+
+  // Third Layer
+  {
+    name: 'C',
+    node: buildAssetNode({
+      groupName: 'my_group',
+    }),
+    inputs: [{dependsOn: [{solid: {name: 'B'}}]}],
+    outputs: [{dependedBy: []}],
+  },
+];
+
+describe('parseAssetSelectionQuery', () => {
+  it('should parse a simple query', () => {
+    const result = parseAssetSelectionQuery(TEST_GRAPH, 'key:A');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('A');
+  });
+});

--- a/js_modules/dagster-ui/packages/ui-core/src/asset-selection/__tests__/AntlrAssetSelection.test.ts
+++ b/js_modules/dagster-ui/packages/ui-core/src/asset-selection/__tests__/AntlrAssetSelection.test.ts
@@ -1,5 +1,11 @@
 import {AssetGraphQueryItem} from '../../asset-graph/useAssetGraphData';
-import {buildAssetNode} from '../../graphql/types';
+import {
+  buildAssetNode,
+  buildDefinitionTag,
+  buildRepository,
+  buildRepositoryLocation,
+  buildUserAssetOwner,
+} from '../../graphql/types';
 import {parseAssetSelectionQuery} from '../AntlrAssetSelection';
 
 const TEST_GRAPH: AssetGraphQueryItem[] = [
@@ -7,8 +13,8 @@ const TEST_GRAPH: AssetGraphQueryItem[] = [
   {
     name: 'A',
     node: buildAssetNode({
-      tags: [{__typename: 'DefinitionTag', key: 'foo', value: 'bar'}],
-      owners: [{__typename: 'UserAssetOwner', email: 'owner@owner.com'}],
+      tags: [buildDefinitionTag({key: 'foo', value: 'bar'})],
+      owners: [buildUserAssetOwner({email: 'owner@owner.com'})],
     }),
     inputs: [{dependsOn: []}],
     outputs: [{dependedBy: [{solid: {name: 'B'}}]}],
@@ -17,6 +23,7 @@ const TEST_GRAPH: AssetGraphQueryItem[] = [
   {
     name: 'B',
     node: buildAssetNode({
+      tags: [buildDefinitionTag({key: 'foo', value: 'baz'})],
       kinds: ['python', 'snowflake'],
     }),
     inputs: [{dependsOn: [{solid: {name: 'A'}}]}],
@@ -28,6 +35,10 @@ const TEST_GRAPH: AssetGraphQueryItem[] = [
     name: 'C',
     node: buildAssetNode({
       groupName: 'my_group',
+      repository: buildRepository({
+        name: 'repo',
+        location: buildRepositoryLocation({name: 'my_location'}),
+      }),
     }),
     inputs: [{dependsOn: [{solid: {name: 'B'}}]}],
     outputs: [{dependedBy: []}],
@@ -35,9 +46,146 @@ const TEST_GRAPH: AssetGraphQueryItem[] = [
 ];
 
 describe('parseAssetSelectionQuery', () => {
-  it('should parse a simple query', () => {
+  it('should parse star query', () => {
+    const result = parseAssetSelectionQuery(TEST_GRAPH, '*');
+    expect(result.length).toBe(3);
+    expect(new Set(result.map((r) => r.name))).toEqual(new Set(['A', 'B', 'C']));
+  });
+
+  it('should parse key query', () => {
     const result = parseAssetSelectionQuery(TEST_GRAPH, 'key:A');
     expect(result.length).toBe(1);
     expect(result[0]!.name).toBe('A');
+  });
+
+  it('should parse key_substring query', () => {
+    const result = parseAssetSelectionQuery(TEST_GRAPH, 'key_substring:A');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('A');
+  });
+
+  it('should parse and query', () => {
+    const result = parseAssetSelectionQuery(TEST_GRAPH, 'key:A and key:B');
+    expect(result.length).toBe(0);
+  });
+
+  it('should parse or query', () => {
+    let result = parseAssetSelectionQuery(TEST_GRAPH, 'key:A or key:B');
+    expect(result.length).toBe(2);
+    expect(new Set(result.map((r) => r.name))).toEqual(new Set(['A', 'B']));
+
+    result = parseAssetSelectionQuery(TEST_GRAPH, '(key:A or key:B) and (key:B or key:C)');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('B');
+  });
+
+  it('should parse upstream plus query', () => {
+    let result = parseAssetSelectionQuery(TEST_GRAPH, '+key:A');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('A');
+
+    result = parseAssetSelectionQuery(TEST_GRAPH, '+key:B');
+    expect(result.length).toBe(2);
+    expect(new Set(result.map((r) => r.name))).toEqual(new Set(['A', 'B']));
+
+    result = parseAssetSelectionQuery(TEST_GRAPH, '++key:C');
+    expect(result.length).toBe(3);
+    expect(new Set(result.map((r) => r.name))).toEqual(new Set(['A', 'B', 'C']));
+  });
+
+  it('should parse downstream plus query', () => {
+    let result = parseAssetSelectionQuery(TEST_GRAPH, 'key:C+');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('C');
+
+    result = parseAssetSelectionQuery(TEST_GRAPH, 'key:B+');
+    expect(result.length).toBe(2);
+    expect(new Set(result.map((r) => r.name))).toEqual(new Set(['B', 'C']));
+
+    result = parseAssetSelectionQuery(TEST_GRAPH, 'key:A++');
+    expect(result.length).toBe(3);
+    expect(new Set(result.map((r) => r.name))).toEqual(new Set(['A', 'B', 'C']));
+  });
+
+  it('should parse upstream star query', () => {
+    let result = parseAssetSelectionQuery(TEST_GRAPH, '*key:A');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('A');
+
+    result = parseAssetSelectionQuery(TEST_GRAPH, '*key:C');
+    expect(result.length).toBe(3);
+    expect(new Set(result.map((r) => r.name))).toEqual(new Set(['A', 'B', 'C']));
+  });
+
+  it('should parse downstream star query', () => {
+    let result = parseAssetSelectionQuery(TEST_GRAPH, 'key:C*');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('C');
+
+    result = parseAssetSelectionQuery(TEST_GRAPH, 'key:A*');
+    expect(result.length).toBe(3);
+    expect(new Set(result.map((r) => r.name))).toEqual(new Set(['A', 'B', 'C']));
+  });
+
+  it('should parse sinks query', () => {
+    let result = parseAssetSelectionQuery(TEST_GRAPH, 'sinks(*)');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('C');
+
+    result = parseAssetSelectionQuery(TEST_GRAPH, 'sinks(key:A)');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('A');
+
+    result = parseAssetSelectionQuery(TEST_GRAPH, 'sinks(key:B or key:B)');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('B');
+  });
+
+  it('should parse roots query', () => {
+    let result = parseAssetSelectionQuery(TEST_GRAPH, 'roots(*)');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('A');
+
+    result = parseAssetSelectionQuery(TEST_GRAPH, 'roots(key:C)');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('C');
+
+    result = parseAssetSelectionQuery(TEST_GRAPH, 'roots(key:B or key:C)');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('B');
+  });
+
+  it('should parse tag query', () => {
+    let result = parseAssetSelectionQuery(TEST_GRAPH, 'tag:foo');
+    expect(result.length).toBe(2);
+    expect(new Set(result.map((r) => r.name))).toEqual(new Set(['A', 'B']));
+
+    result = parseAssetSelectionQuery(TEST_GRAPH, 'tag:foo=bar');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('A');
+  });
+
+  it('should parse owner query', () => {
+    const result = parseAssetSelectionQuery(TEST_GRAPH, 'owner:"owner@owner.com"');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('A');
+  });
+
+  it('should parse group query', () => {
+    const result = parseAssetSelectionQuery(TEST_GRAPH, 'group:my_group');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('C');
+  });
+
+  it('should parse kind query', () => {
+    const result = parseAssetSelectionQuery(TEST_GRAPH, 'kind:python');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('B');
+  });
+
+  it('should parse code location query', () => {
+    const result = parseAssetSelectionQuery(TEST_GRAPH, 'code_location:"repo@my_location"');
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('C');
   });
 });


### PR DESCRIPTION
## Summary & Motivation
Now that we support the new asset selection syntax on the backend, we want to support it on the frontend. This requires implementing the visitor methods of the `AssetSelectionVisitor` class generated by ANTLR to perform the various asset selection operations.

## How I Tested These Changes
Ran `AntlrAssetSelection.test.ts`
