### PR TITLE
[dagster-openai] Fix not called assertion in tests for Python 3.12

### DIFF
--- a/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
@@ -71,7 +71,7 @@ def test_openai_resource_with_op(mock_client, mock_context, mock_wrapper):
             )
 
         assert mock_client.called
-        assert mock_wrapper.call_count == 0
+        assert not mock_wrapper.called
 
     result = wrap_op_in_graph_and_execute(
         openai_op,

--- a/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
+++ b/python_modules/libraries/dagster-openai/dagster_openai_tests/test_resources.py
@@ -71,7 +71,7 @@ def test_openai_resource_with_op(mock_client, mock_context, mock_wrapper):
             )
 
         assert mock_client.called
-        assert mock_wrapper.not_called
+        assert mock_wrapper.call_count == 0
 
     result = wrap_op_in_graph_and_execute(
         openai_op,


### PR DESCRIPTION
## Summary & Motivation

`mock.not_called` is deprecated in Python 3.12, using `not mock.called` instead.

## How I Tested These Changes

BK, local tests with Python 3.12