### PR TITLE
CodeMirror lint: stop patching global lint

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/components/NewConfigEditor.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/components/NewConfigEditor.tsx
@@ -47,7 +47,7 @@ interface ConfigEditorProps {
 
 const AUTO_COMPLETE_AFTER_KEY = /^[a-zA-Z0-9_@(]$/;
 const performLint = debounce((editor: any) => {
-  editor.performLint();
+  editor.performPatchedLint();
 }, 1000);
 
 const performInitialPass = (
@@ -127,7 +127,7 @@ export const NewConfigEditor = forwardRef<ConfigEditorHandle, ConfigEditorProps>
       smartIndent: true,
       showCursorWhenSelecting: true,
       lintOnChange: false,
-      lint: {
+      patchedLint: {
         checkConfig,
         lintOnChange: false,
         onUpdateLinting: false,


### PR DESCRIPTION
## Summary & Motivation

We currently override CodeMirror's global lint addon with a custom implementation that conflicts with the original addon. This incompatibility surfaced while developing the new asset selection syntax input; specifically, loading the launchpad and then accessing the new syntax input triggers JavaScript errors due to the overridden lint behavior.

To fix this issue, this PR stops patching the global lint addon and instead uses a separate patchedLint namespace. By doing so, our custom lint functionality is isolated to specific editor instances, allowing the original lint addon to operate correctly in other editors without interference.


## How I Tested These Changes

Use the launchpad and see that it lints and surfaces errors correctly by starting with a valid config, adding invalid stuff, and then making it valid again and making sure we lint each step along the way.

<img width="1089" alt="Screenshot 2024-11-19 at 3 41 55 PM" src="https://github.com/user-attachments/assets/c58e9637-42cf-4c28-9f75-5b5f50d1dce7">
<img width="908" alt="Screenshot 2024-11-19 at 3 42 28 PM" src="https://github.com/user-attachments/assets/74a66579-2a1f-487a-bfa5-a817793bd102">
<img width="784" alt="Screenshot 2024-11-19 at 3 42 20 PM" src="https://github.com/user-attachments/assets/b895f385-a0ad-42b4-bc8f-47944dc2e284">


