### PR TITLE
[wip][rfc] Add alert indicator to runs

### DIFF
--- a/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRunsTable.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/assets/AutoMaterializePolicyPage/AutomaterializeRunsTable.tsx
@@ -72,7 +72,7 @@ export const AutomaterializeRunsTable = ({runIds}: {runIds: string[]}) => {
                 <RunTime run={run} />
               </td>
               <td>
-                <RunStatusTagWithStats runId={run.runId} status={run.status} />
+                <RunStatusTagWithStats status={run.status} runId={run.runId} />
               </td>
               <td>
                 <RunStateSummary run={run} />

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRoot.tsx
@@ -15,7 +15,7 @@ import {RunAssetCheckTags} from './RunAssetCheckTags';
 import {RunAssetTags} from './RunAssetTags';
 import {RUN_PAGE_FRAGMENT} from './RunFragments';
 import {RunHeaderActions} from './RunHeaderActions';
-import {RunStatusTag} from './RunStatusTag';
+import {RunAlertStatus, RunStatusTag} from './RunStatusTag';
 import {DagsterTag, RunTag} from './RunTag';
 import {RunTimingTags} from './RunTimingTags';
 import {getBackfillPath} from './RunsFeedUtils';
@@ -118,6 +118,7 @@ export const RunRoot = () => {
             run ? (
               <Box flex={{direction: 'row', alignItems: 'flex-start', gap: 12, wrap: 'wrap'}}>
                 <RunStatusTag status={run.status} />
+                <RunAlertStatus tags={run.tags} />
                 {!isHiddenAssetGroupJob(run.pipelineName) ? (
                   <Tag icon="run">
                     Run of{' '}

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunRow.tsx
@@ -7,7 +7,7 @@ import {CreatedByTagCell} from './CreatedByTag';
 import {QueuedRunCriteriaDialog} from './QueuedRunCriteriaDialog';
 import {RunActionsMenu} from './RunActionsMenu';
 import {RunRowTags} from './RunRowTags';
-import {RunStatusTagWithStats} from './RunStatusTag';
+import {RunAlertStatus, RunStatusTagWithStats} from './RunStatusTag';
 import {DagsterTag} from './RunTag';
 import {RunTargetLink} from './RunTargetLink';
 import {RunStateSummary, RunTime, titleForRun} from './RunUtils';
@@ -117,7 +117,10 @@ export const RunRow = ({
         </td>
       )}
       <td>
-        <RunStatusTagWithStats status={run.status} runId={run.id} />
+        <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+          <RunStatusTagWithStats status={run.status} runId={run.id} />
+          <RunAlertStatus tags={run.tags} />
+        </Box>
       </td>
       <td>
         <RunStateSummary run={run} />

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusTag.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunStatusTag.tsx
@@ -1,4 +1,4 @@
-import {Box, CaptionMono, Colors, Popover, Tag} from '@dagster-io/ui-components';
+import {Box, CaptionMono, Colors, Popover, Tag, Tooltip} from '@dagster-io/ui-components';
 
 import {RunStats} from './RunStats';
 import {RunStatusIndicator} from './RunStatusDots';
@@ -128,5 +128,27 @@ export const RunStatusTagWithStats = (props: Props) => {
     >
       <RunStatusTag status={status} />
     </Popover>
+  );
+};
+
+export const RunAlertStatus = (props: {tags: {key: string; value: string}[]}) => {
+  const {tags} = props;
+
+  const alerted = tags?.some((tag) => tag.key === 'dagster-cloud/triggered_alert');
+  const numAlerts = tags?.filter((tag) =>
+    tag.key.startsWith('dagster-cloud/triggered_alert/'),
+  ).length;
+
+  return (
+    <>
+      {alerted ? (
+        <Tooltip
+          content={`This run has triggered ${numAlerts} alert${numAlerts === 1 ? '' : 's'}`}
+          position="bottom"
+        >
+          <Tag icon="alert" intent="warning"></Tag>
+        </Tooltip>
+      ) : null}
+    </>
   );
 };

--- a/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/runs/RunsFeedRow.tsx
@@ -16,7 +16,7 @@ import {CreatedByTagCell, CreatedByTagCellWrapper} from './CreatedByTag';
 import {QueuedRunCriteriaDialog} from './QueuedRunCriteriaDialog';
 import {RunActionsMenu} from './RunActionsMenu';
 import {RunRowTags} from './RunRowTags';
-import {RunStatusTag, RunStatusTagWithStats} from './RunStatusTag';
+import {RunAlertStatus, RunStatusTag, RunStatusTagWithStats} from './RunStatusTag';
 import {DagsterTag} from './RunTag';
 import {RunTargetLink} from './RunTargetLink';
 import {RunStateSummary, RunTime, titleForRun} from './RunUtils';
@@ -151,7 +151,10 @@ export const RunsFeedRow = ({
           {entry.__typename === 'PartitionBackfill' ? (
             <RunStatusTag status={entry.runStatus} />
           ) : (
-            <RunStatusTagWithStats status={entry.runStatus} runId={entry.id} />
+            <Box flex={{direction: 'row', alignItems: 'center', gap: 4}}>
+              <RunStatusTagWithStats status={entry.runStatus} runId={entry.id} />
+              <RunAlertStatus tags={entry.tags} />
+            </Box>
           )}
         </div>
       </RowCell>


### PR DESCRIPTION
## Summary

Proof-of-concept of a "this run triggered an alert" icon powered by https://github.com/dagster-io/internal/pull/12739.

We probably want to get this into the internal codebase if we want to move forward with this implementation, probably with a  .oss/.internal file for this component?

Right now, just shows up if a run triggered any alert. In the future, could link/break out to an modal or to the alert policy or alert page.

<img width="1384" alt="Screenshot 2024-11-19 at 2 28 29 PM" src="https://github.com/user-attachments/assets/6fcffa4e-c38a-499c-9dbc-1fb2022ab626">
<img width="1098" alt="Screenshot 2024-11-19 at 2 18 27 PM" src="https://github.com/user-attachments/assets/eb4b44d2-07d1-4d10-b5e3-de75e79292fa">


## Test Plan

Tested locally.
