### PR TITLE
Fix events fields on GrapheneRunStepStats

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/implementation/events.py
@@ -232,6 +232,7 @@ def from_dagster_event_record(event_record: EventLogEntry, pipeline_name: str) -
         GrapheneExecutionStepStartEvent,
         GrapheneExecutionStepSuccessEvent,
         GrapheneExecutionStepUpForRetryEvent,
+        GrapheneExpectationResult,
         GrapheneHandledOutputEvent,
         GrapheneHookCompletedEvent,
         GrapheneHookErroredEvent,
@@ -306,7 +307,7 @@ def from_dagster_event_record(event_record: EventLogEntry, pipeline_name: str) -
     elif dagster_event.event_type == DagsterEventType.STEP_EXPECTATION_RESULT:
         data = cast(StepExpectationResultData, dagster_event.event_specific_data)
         return GrapheneStepExpectationResultEvent(
-            expectation_result=data.expectation_result, **basic_params
+            expectation_result=GrapheneExpectationResult(data.expectation_result), **basic_params
         )
     elif dagster_event.event_type == DagsterEventType.STEP_FAILURE:
         data = dagster_event.step_failure_data

--- a/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
+++ b/python_modules/dagster-graphql/dagster_graphql/schema/logs/events.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 import dagster._check as check
 import graphene
+from dagster._core.definitions import ExpectationResult
 from dagster._core.events import AssetLineageInfo, DagsterEventType
 from dagster._core.events.log import EventLogEntry
 from dagster._core.execution.plan.objects import ErrorSource
@@ -209,10 +210,18 @@ class GrapheneExpectationResult(graphene.ObjectType):
         interfaces = (GrapheneDisplayableEvent,)
         name = "ExpectationResult"
 
+    def __init__(self, expectation_result: ExpectationResult):
+        self._expectation_result = expectation_result
+        super().__init__(
+            success=expectation_result.success,
+            label=expectation_result.label,
+            description=expectation_result.description,
+        )
+
     def resolve_metadataEntries(self, _graphene_info: ResolveInfo):
         from dagster_graphql.implementation.events import _to_metadata_entries
 
-        return _to_metadata_entries(self.metadata)
+        return _to_metadata_entries(self._expectation_result.metadata)
 
 
 class GrapheneTypeCheck(graphene.ObjectType):
@@ -635,8 +644,12 @@ class GrapheneRunStepStats(graphene.ObjectType):
             status=stats.status.value,
             startTime=stats.start_time,
             endTime=stats.end_time,
-            materializations=stats.materialization_events,
-            expectationResults=stats.expectation_results,
+            materializations=[
+                GrapheneMaterializationEvent(event) for event in stats.materialization_events
+            ],
+            expectationResults=[
+                GrapheneExpectationResult(result) for result in stats.expectation_results
+            ],
             attempts=[
                 GrapheneRunMarker(startTime=attempt.start_time, endTime=attempt.end_time)
                 for attempt in stats.attempts_list


### PR DESCRIPTION
## Summary & Motivation
These were passing in the python object directly instead of constructing graphene objects, likely a longstanding issues.

Test Plan: BK

NOCHANGELOG
