### PR TITLE
[dagster-tableau] Use get_asset_spec().key in DagsterTableauTranslator

### DIFF
--- a/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau/translator.py
@@ -111,14 +111,7 @@ class DagsterTableauTranslator:
         return self._context
 
     def get_asset_key(self, data: TableauContentData) -> AssetKey:
-        if data.content_type == TableauContentType.SHEET:
-            return self.get_sheet_asset_key(data)
-        elif data.content_type == TableauContentType.DASHBOARD:
-            return self.get_dashboard_asset_key(data)
-        elif data.content_type == TableauContentType.DATA_SOURCE:
-            return self.get_data_source_asset_key(data)
-        else:
-            check.assert_never(data.content_type)
+        return self.get_asset_spec(data).key
 
     def get_asset_spec(self, data: TableauContentData) -> AssetSpec:
         if data.content_type == TableauContentType.SHEET:
@@ -131,15 +124,7 @@ class DagsterTableauTranslator:
             check.assert_never(data.content_type)
 
     def get_sheet_asset_key(self, data: TableauContentData) -> AssetKey:
-        workbook_id = data.properties["workbook"]["luid"]
-        workbook_data = self.workspace_data.workbooks_by_id[workbook_id]
-        return AssetKey(
-            [
-                _coerce_input_to_valid_name(workbook_data.properties["name"]),
-                "sheet",
-                _coerce_input_to_valid_name(data.properties["name"]),
-            ]
-        )
+        return self.get_sheet_spec(data).key
 
     def get_sheet_spec(self, data: TableauContentData) -> AssetSpec:
         sheet_embedded_data_sources = data.properties.get("parentEmbeddedDatasources", [])
@@ -176,15 +161,7 @@ class DagsterTableauTranslator:
         )
 
     def get_dashboard_asset_key(self, data: TableauContentData) -> AssetKey:
-        workbook_id = data.properties["workbook"]["luid"]
-        workbook_data = self.workspace_data.workbooks_by_id[workbook_id]
-        return AssetKey(
-            [
-                _coerce_input_to_valid_name(workbook_data.properties["name"]),
-                "dashboard",
-                _coerce_input_to_valid_name(data.properties["name"]),
-            ]
-        )
+        return self.get_dashboard_spec(data).key
 
     def get_dashboard_spec(self, data: TableauContentData) -> AssetSpec:
         dashboard_upstream_sheets = data.properties.get("sheets", [])
@@ -217,7 +194,7 @@ class DagsterTableauTranslator:
         )
 
     def get_data_source_asset_key(self, data: TableauContentData) -> AssetKey:
-        return AssetKey([_coerce_input_to_valid_name(data.properties["name"])])
+        return self.get_data_source_spec(data).key
 
     def get_data_source_spec(self, data: TableauContentData) -> AssetSpec:
         return AssetSpec(

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 from dagster._core.code_pointer import CodePointer
-from dagster._core.definitions.asset_key import AssetKey
+from dagster._core.definitions.asset_spec import AssetSpec, replace_attributes
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.reconstruct import (
     ReconstructableJob,
@@ -67,8 +67,9 @@ def cacheable_asset_defs_refreshable_workbooks():
 @lazy_definitions
 def cacheable_asset_defs_custom_translator():
     class MyCoolTranslator(DagsterTableauTranslator):
-        def get_asset_key(self, data) -> AssetKey:
-            return super().get_asset_key(data).with_prefix("my_prefix")
+        def get_asset_spec(self, data) -> AssetSpec:
+            default_spec = super().get_asset_spec(data)
+            return replace_attributes(default_spec, key=default_spec.key.with_prefix("my_prefix"))
 
     tableau_specs = load_tableau_asset_specs(
         workspace=resource, dagster_tableau_translator=MyCoolTranslator

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_reconstruction.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 from dagster._core.code_pointer import CodePointer
-from dagster._core.definitions.asset_spec import AssetSpec, replace_attributes
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster._core.definitions.definitions_class import Definitions
 from dagster._core.definitions.reconstruct import (
     ReconstructableJob,
@@ -69,7 +69,7 @@ def cacheable_asset_defs_custom_translator():
     class MyCoolTranslator(DagsterTableauTranslator):
         def get_asset_spec(self, data) -> AssetSpec:
             default_spec = super().get_asset_spec(data)
-            return replace_attributes(default_spec, key=default_spec.key.with_prefix("my_prefix"))
+            return default_spec.replace_attributes(key=default_spec.key.with_prefix("my_prefix"))
 
     tableau_specs = load_tableau_asset_specs(
         workspace=resource, dagster_tableau_translator=MyCoolTranslator

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_translator.py
@@ -1,5 +1,5 @@
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.asset_spec import AssetSpec
+from dagster._core.definitions.asset_spec import AssetSpec, replace_attributes
 from dagster_tableau import DagsterTableauTranslator
 from dagster_tableau.translator import TableauContentData, TableauWorkspaceData
 
@@ -67,8 +67,13 @@ def test_translator_data_source_spec(
 
 
 class MyCustomTranslator(DagsterTableauTranslator):
-    def get_sheet_spec(self, sheet: TableauContentData) -> AssetSpec:
-        return super().get_sheet_spec(sheet)._replace(metadata={"custom": "metadata"})
+    def get_asset_spec(self, data: TableauContentData) -> AssetSpec:
+        default_spec = super().get_asset_spec(data)
+        return replace_attributes(
+            default_spec,
+            key=default_spec.key.with_prefix("prefix"),
+            metadata={**default_spec.metadata, "custom": "metadata"},
+        )
 
 
 def test_translator_custom_metadata(workspace_data: TableauWorkspaceData) -> None:
@@ -77,8 +82,9 @@ def test_translator_custom_metadata(workspace_data: TableauWorkspaceData) -> Non
     translator = MyCustomTranslator(workspace_data)
     asset_spec = translator.get_asset_spec(sheet)
 
-    assert asset_spec.metadata == {"custom": "metadata"}
-    assert asset_spec.key.path == ["test_workbook", "sheet", "sales"]
+    assert "custom" in asset_spec.metadata
+    assert asset_spec.metadata["custom"] == "metadata"
+    assert asset_spec.key.path == ["prefix", "test_workbook", "sheet", "sales"]
     assert asset_spec.tags == {
         "dagster/storage_kind": "tableau",
         "dagster-tableau/asset_type": "sheet",

--- a/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_translator.py
+++ b/python_modules/libraries/dagster-tableau/dagster_tableau_tests/test_translator.py
@@ -1,5 +1,5 @@
 from dagster._core.definitions.asset_key import AssetKey
-from dagster._core.definitions.asset_spec import AssetSpec, replace_attributes
+from dagster._core.definitions.asset_spec import AssetSpec
 from dagster_tableau import DagsterTableauTranslator
 from dagster_tableau.translator import TableauContentData, TableauWorkspaceData
 
@@ -69,8 +69,7 @@ def test_translator_data_source_spec(
 class MyCustomTranslator(DagsterTableauTranslator):
     def get_asset_spec(self, data: TableauContentData) -> AssetSpec:
         default_spec = super().get_asset_spec(data)
-        return replace_attributes(
-            default_spec,
+        return default_spec.replace_attributes(
             key=default_spec.key.with_prefix("prefix"),
             metadata={**default_spec.metadata, "custom": "metadata"},
         )


### PR DESCRIPTION
## Summary & Motivation

Following an internal discussion [here](https://github.com/dagster-io/internal/discussions/12670) and product review [here](https://www.notion.so/dagster/Product-Reviews-1805443bfd5d4d40b3f6be8c79897295?p=13f18b92e4628020bd6fd3ac45f28af0&pm=s), get_asset_spec().key is the new recommended way to access the asset key in the Translator.

Asset keys can now be customized in a custom translator using `replace_attributes`, like:

```python
class MyCustomTableauTranslator(DagsterTableauTranslator):
    def get_asset_spec(self, data: TableauContentData) -> dg.AssetSpec:
        default_spec = super().get_asset_spec(data)
        return replace_attributes(
            default_spec,
            key=default_spec.key.with_prefix("prefix"),
        )
```

This PR stack will be merged after #25941 lands, so that `replace_attributes()` can be called as `AssetSpec().replace_attributes()`

These changes will also be done to the following integrations: 
- Power BI
- Sigma
- Looker
- dlt
- Sling
- sdf

We will need to rework dbt to use this pattern.

## How I Tested These Changes

Updated unit test with BK

