### PR TITLE
[dagster-tableau] Update custom translator example in Tableau docs

### DIFF
--- a/docs/content/integrations/tableau.mdx
+++ b/docs/content/integrations/tableau.mdx
@@ -104,7 +104,7 @@ defs = dg.Definitions(assets=[*tableau_specs], resources={"tableau": tableau_wor
 
 ### Customize asset definition metadata for Tableau assets
 
-By default, Dagster will generate asset spec for each Tableau asset based on its type and populate default metadata. You can further customize asset properties by passing a custom <PyObject module="dagster_tableau" object="DagsterTableauTranslator" /> subclass to the <PyObject module="dagster_tableau" method="load_tableau_asset_specs" /> function. This subclass can implement methods to customize the asset specs for each Tableau asset type.
+By default, Dagster will generate asset specs for each Tableau asset based on its type and populate default metadata. You can further customize asset properties by passing a custom <PyObject module="dagster_tableau" object="DagsterTableauTranslator" /> subclass to the <PyObject module="dagster_tableau" method="load_tableau_asset_specs" /> function. This subclass can implement methods to customize the asset specs for each Tableau asset type.
 
 ```python file=/integrations/tableau/customize-tableau-asset-defs.py
 from dagster_tableau import (

--- a/docs/content/integrations/tableau.mdx
+++ b/docs/content/integrations/tableau.mdx
@@ -104,7 +104,7 @@ defs = dg.Definitions(assets=[*tableau_specs], resources={"tableau": tableau_wor
 
 ### Customize asset definition metadata for Tableau assets
 
-By default, Dagster will generate asset keys for each Tableau asset based on its type and name and populate default metadata. You can further customize asset properties by passing a custom <PyObject module="dagster_tableau" object="DagsterTableauTranslator" /> subclass to the <PyObject module="dagster_tableau" method="load_tableau_asset_specs" /> function. This subclass can implement methods to customize the asset keys or specs for each Tableau asset type.
+By default, Dagster will generate asset spec for each Tableau asset based on its type and populate default metadata. You can further customize asset properties by passing a custom <PyObject module="dagster_tableau" object="DagsterTableauTranslator" /> subclass to the <PyObject module="dagster_tableau" method="load_tableau_asset_specs" /> function. This subclass can implement methods to customize the asset specs for each Tableau asset type.
 
 ```python file=/integrations/tableau/customize-tableau-asset-defs.py
 from dagster_tableau import (
@@ -115,6 +115,7 @@ from dagster_tableau import (
 from dagster_tableau.translator import TableauContentData
 
 import dagster as dg
+from dagster._core.definitions.asset_spec import replace_attributes
 
 tableau_workspace = TableauCloudWorkspace(
     connected_app_client_id=dg.EnvVar("TABLEAU_CONNECTED_APP_CLIENT_ID"),
@@ -130,8 +131,20 @@ tableau_workspace = TableauCloudWorkspace(
 # Tableau assets, such as the owners or asset key
 class MyCustomTableauTranslator(DagsterTableauTranslator):
     def get_sheet_spec(self, data: TableauContentData) -> dg.AssetSpec:
-        # We add a custom team owner tag to all sheets
-        return super().get_sheet_spec(data)._replace(owners=["team:my_team"])
+        # We create the default asset spec for a given sheet using super()
+        default_spec = super().get_sheet_spec(data)
+        # We customize the team owner tag only for sheets
+        return replace_attributes(default_spec, owners=["team:my_team"])
+
+    def get_asset_spec(self, data: TableauContentData) -> dg.AssetSpec:
+        # We create the default asset spec using super()
+        default_spec = super().get_asset_spec(data)
+        # We customize the metadata and asset key prefix for all assets, including sheets
+        return replace_attributes(
+            default_spec,
+            key=default_spec.key.with_prefix("prefix"),
+            metadata={**default_spec.metadata, "custom": "metadata"},
+        )
 
 
 tableau_specs = load_tableau_asset_specs(
@@ -139,6 +152,8 @@ tableau_specs = load_tableau_asset_specs(
 )
 defs = dg.Definitions(assets=[*tableau_specs], resources={"tableau": tableau_workspace})
 ```
+
+Note that `super()` is called in each of the overridden methods to generate the default asset spec. It is best practice to generate the default asset spec before customizing it.
 
 ### Load Tableau assets from multiple workspaces
 

--- a/docs/content/integrations/tableau.mdx
+++ b/docs/content/integrations/tableau.mdx
@@ -104,7 +104,7 @@ defs = dg.Definitions(assets=[*tableau_specs], resources={"tableau": tableau_wor
 
 ### Customize asset definition metadata for Tableau assets
 
-By default, Dagster will generate asset specs for each Tableau asset based on its type and populate default metadata. You can further customize asset properties by passing a custom <PyObject module="dagster_tableau" object="DagsterTableauTranslator" /> subclass to the <PyObject module="dagster_tableau" method="load_tableau_asset_specs" /> function. This subclass can implement methods to customize the asset specs for each Tableau asset type.
+By default, Dagster will generate asset specs for each Tableau asset based on its type, and populate default metadata. You can further customize asset properties by passing a custom <PyObject module="dagster_tableau" object="DagsterTableauTranslator" /> subclass to the <PyObject module="dagster_tableau" method="load_tableau_asset_specs" /> function. This subclass can implement methods to customize the asset specs for each Tableau asset type.
 
 ```python file=/integrations/tableau/customize-tableau-asset-defs.py
 from dagster_tableau import (

--- a/docs/content/integrations/tableau.mdx
+++ b/docs/content/integrations/tableau.mdx
@@ -112,7 +112,7 @@ from dagster_tableau import (
     TableauCloudWorkspace,
     load_tableau_asset_specs,
 )
-from dagster_tableau.translator import TableauContentData
+from dagster_tableau.translator import TableauContentData, TableauContentType
 
 import dagster as dg
 from dagster._core.definitions.asset_spec import replace_attributes
@@ -130,20 +130,20 @@ tableau_workspace = TableauCloudWorkspace(
 # A translator class lets us customize properties of the built
 # Tableau assets, such as the owners or asset key
 class MyCustomTableauTranslator(DagsterTableauTranslator):
-    def get_sheet_spec(self, data: TableauContentData) -> dg.AssetSpec:
-        # We create the default asset spec for a given sheet using super()
-        default_spec = super().get_sheet_spec(data)
-        # We customize the team owner tag only for sheets
-        return replace_attributes(default_spec, owners=["team:my_team"])
-
     def get_asset_spec(self, data: TableauContentData) -> dg.AssetSpec:
         # We create the default asset spec using super()
         default_spec = super().get_asset_spec(data)
-        # We customize the metadata and asset key prefix for all assets, including sheets
+        # We customize the metadata and asset key prefix for all assets, including sheets,
+        # and we customize the team owner tag only for sheets.
         return replace_attributes(
             default_spec,
             key=default_spec.key.with_prefix("prefix"),
             metadata={**default_spec.metadata, "custom": "metadata"},
+            owners=(
+                ["team:my_team"]
+                if data.content_type == TableauContentType.SHEET
+                else ...
+            ),
         )
 
 

--- a/docs/content/integrations/tableau.mdx
+++ b/docs/content/integrations/tableau.mdx
@@ -115,7 +115,6 @@ from dagster_tableau import (
 from dagster_tableau.translator import TableauContentData, TableauContentType
 
 import dagster as dg
-from dagster._core.definitions.asset_spec import replace_attributes
 
 tableau_workspace = TableauCloudWorkspace(
     connected_app_client_id=dg.EnvVar("TABLEAU_CONNECTED_APP_CLIENT_ID"),
@@ -135,8 +134,7 @@ class MyCustomTableauTranslator(DagsterTableauTranslator):
         default_spec = super().get_asset_spec(data)
         # We customize the metadata and asset key prefix for all assets, including sheets,
         # and we customize the team owner tag only for sheets.
-        return replace_attributes(
-            default_spec,
+        return default_spec.replace_attributes(
             key=default_spec.key.with_prefix("prefix"),
             metadata={**default_spec.metadata, "custom": "metadata"},
             owners=(

--- a/examples/docs_snippets/docs_snippets/integrations/tableau/customize-tableau-asset-defs.py
+++ b/examples/docs_snippets/docs_snippets/integrations/tableau/customize-tableau-asset-defs.py
@@ -3,7 +3,7 @@ from dagster_tableau import (
     TableauCloudWorkspace,
     load_tableau_asset_specs,
 )
-from dagster_tableau.translator import TableauContentData
+from dagster_tableau.translator import TableauContentData, TableauContentType
 
 import dagster as dg
 from dagster._core.definitions.asset_spec import replace_attributes
@@ -21,20 +21,20 @@ tableau_workspace = TableauCloudWorkspace(
 # A translator class lets us customize properties of the built
 # Tableau assets, such as the owners or asset key
 class MyCustomTableauTranslator(DagsterTableauTranslator):
-    def get_sheet_spec(self, data: TableauContentData) -> dg.AssetSpec:
-        # We create the default asset spec for a given sheet using super()
-        default_spec = super().get_sheet_spec(data)
-        # We customize the team owner tag only for sheets
-        return replace_attributes(default_spec, owners=["team:my_team"])
-
     def get_asset_spec(self, data: TableauContentData) -> dg.AssetSpec:
         # We create the default asset spec using super()
         default_spec = super().get_asset_spec(data)
-        # We customize the metadata and asset key prefix for all assets, including sheets
+        # We customize the metadata and asset key prefix for all assets, including sheets,
+        # and we customize the team owner tag only for sheets.
         return replace_attributes(
             default_spec,
             key=default_spec.key.with_prefix("prefix"),
             metadata={**default_spec.metadata, "custom": "metadata"},
+            owners=(
+                ["team:my_team"]
+                if data.content_type == TableauContentType.SHEET
+                else ...
+            ),
         )
 
 

--- a/examples/docs_snippets/docs_snippets/integrations/tableau/customize-tableau-asset-defs.py
+++ b/examples/docs_snippets/docs_snippets/integrations/tableau/customize-tableau-asset-defs.py
@@ -6,7 +6,6 @@ from dagster_tableau import (
 from dagster_tableau.translator import TableauContentData, TableauContentType
 
 import dagster as dg
-from dagster._core.definitions.asset_spec import replace_attributes
 
 tableau_workspace = TableauCloudWorkspace(
     connected_app_client_id=dg.EnvVar("TABLEAU_CONNECTED_APP_CLIENT_ID"),
@@ -26,8 +25,7 @@ class MyCustomTableauTranslator(DagsterTableauTranslator):
         default_spec = super().get_asset_spec(data)
         # We customize the metadata and asset key prefix for all assets, including sheets,
         # and we customize the team owner tag only for sheets.
-        return replace_attributes(
-            default_spec,
+        return default_spec.replace_attributes(
             key=default_spec.key.with_prefix("prefix"),
             metadata={**default_spec.metadata, "custom": "metadata"},
             owners=(


### PR DESCRIPTION
## Summary & Motivation

Update the custom translator example in the Tableau docs to reflect `get_asset_spec().key`.

This PR stack will be merged after #25941 lands, so that `replace_attributes()` can be called as `AssetSpec().replace_attributes()`
