### PR TITLE
[dagster-powerbi] Default-on admin scan APIs

### DIFF
--- a/docs/content/integrations/powerbi.mdx
+++ b/docs/content/integrations/powerbi.mdx
@@ -70,6 +70,10 @@ defs = dg.Definitions(
 )
 ```
 
+By default, Dagster will attempt to snapshot ¥our entire workspace using Power BI's [metadata scanner APIs](https://learn.microsoft.com/en-us/fabric/governance/metadata-scanning-overview), which are able to retrieve more detailed information about your Power BI assets, but rely on the workspace being configured to allow this access.
+
+If you encounter issues with the scanner APIs, you may disable them using `load_powerbi_asset_specs(power_bi_workspace, use_metadata_scanner=False)`.
+
 ### Customize asset definition metadata for Power BI assets
 
 By default, Dagster will generate asset keys for each Power BI asset based on its type and name and populate default metadata. You can further customize asset properties by passing a custom <PyObject module="dagster_powerbi" object="DagsterPowerBITranslator" /> subclass to the <PyObject module="dagster_powerbi" object="load_powerbi_asset_specs" /> function. This subclass can implement methods to customize the asset keys or specs for each Power BI asset type.

--- a/docs/content/integrations/powerbi.mdx
+++ b/docs/content/integrations/powerbi.mdx
@@ -72,7 +72,7 @@ defs = dg.Definitions(
 
 By default, Dagster will attempt to snapshot your entire workspace using Power BI's [metadata scanner APIs](https://learn.microsoft.com/en-us/fabric/governance/metadata-scanning-overview), which are able to retrieve more detailed information about your Power BI assets, but rely on the workspace being configured to allow this access.
 
-If you encounter issues with the scanner APIs, you may disable them using `load_powerbi_asset_specs(power_bi_workspace, use_metadata_scanner=False)`.
+If you encounter issues with the scanner APIs, you may disable them using `load_powerbi_asset_specs(power_bi_workspace, use_workspace_scan=False)`.
 
 ### Customize asset definition metadata for Power BI assets
 

--- a/docs/content/integrations/powerbi.mdx
+++ b/docs/content/integrations/powerbi.mdx
@@ -70,7 +70,7 @@ defs = dg.Definitions(
 )
 ```
 
-By default, Dagster will attempt to snapshot ¥our entire workspace using Power BI's [metadata scanner APIs](https://learn.microsoft.com/en-us/fabric/governance/metadata-scanning-overview), which are able to retrieve more detailed information about your Power BI assets, but rely on the workspace being configured to allow this access.
+By default, Dagster will attempt to snapshot your entire workspace using Power BI's [metadata scanner APIs](https://learn.microsoft.com/en-us/fabric/governance/metadata-scanning-overview), which are able to retrieve more detailed information about your Power BI assets, but rely on the workspace being configured to allow this access.
 
 If you encounter issues with the scanner APIs, you may disable them using `load_powerbi_asset_specs(power_bi_workspace, use_metadata_scanner=False)`.
 

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
@@ -393,14 +393,14 @@ class PowerBIWorkspace(ConfigurableResource):
 def load_powerbi_asset_specs(
     workspace: PowerBIWorkspace,
     dagster_powerbi_translator: Type[DagsterPowerBITranslator] = DagsterPowerBITranslator,
-    use_workspace_scan: bool = False,
+    use_workspace_scan: bool = True,
 ) -> Sequence[AssetSpec]:
     """Returns a list of AssetSpecs representing the Power BI content in the workspace.
 
     Args:
         workspace (PowerBIWorkspace): The Power BI workspace to load assets from.
         use_workspace_scan (bool): Whether to scan the entire workspace using admin APIs
-            at once to get all content. Defaults to False.
+            at once to get all content. Defaults to True.
 
     Returns:
         List[AssetSpec]: The set of assets representing the Power BI content in the workspace.

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi/resource.py
@@ -383,7 +383,9 @@ class PowerBIWorkspace(ConfigurableResource):
                 build_semantic_model_refresh_asset_definition(resource_key, spec)
                 if PowerBITagSet.extract(spec.tags).asset_type == "semantic_model"
                 else spec
-                for spec in load_powerbi_asset_specs(self, dagster_powerbi_translator)
+                for spec in load_powerbi_asset_specs(
+                    self, dagster_powerbi_translator, use_workspace_scan=False
+                )
             ],
             resources={resource_key: self},
         )

--- a/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
+++ b/python_modules/libraries/dagster-powerbi/dagster_powerbi_tests/test_asset_specs.py
@@ -64,7 +64,7 @@ def test_translator_dashboard_spec(workspace_data_api_mocks: None, workspace_id:
         credentials=PowerBIToken(api_token=fake_token),
         workspace_id=workspace_id,
     )
-    all_assets = load_powerbi_asset_specs(resource)
+    all_assets = load_powerbi_asset_specs(resource, use_workspace_scan=False)
 
     # 1 dashboard, 1 report, 1 semantic model
     assert len(all_assets) == 3
@@ -94,8 +94,8 @@ def state_derived_defs_two_workspaces() -> Definitions:
     )
     return Definitions(
         assets=[
-            *load_powerbi_asset_specs(resource),
-            *load_powerbi_asset_specs(resource_second_workspace),
+            *load_powerbi_asset_specs(resource, use_workspace_scan=False),
+            *load_powerbi_asset_specs(resource_second_workspace, use_workspace_scan=False),
         ]
     )
 
@@ -125,7 +125,7 @@ def test_refreshable_semantic_model(
         workspace_id=workspace_id,
         refresh_poll_interval=0,
     )
-    all_specs = load_powerbi_asset_specs(resource)
+    all_specs = load_powerbi_asset_specs(resource, use_workspace_scan=False)
 
     assets_with_semantic_models = [
         build_semantic_model_refresh_asset_definition(resource_key="powerbi", spec=spec)
@@ -235,7 +235,7 @@ def state_derived_defs() -> Definitions:
         credentials=PowerBIToken(api_token=fake_token),
         workspace_id="a2122b8f-d7e1-42e8-be2b-a5e636ca3221",
     )
-    powerbi_specs = load_powerbi_asset_specs(resource)
+    powerbi_specs = load_powerbi_asset_specs(resource, use_workspace_scan=False)
 
     @asset
     def my_materializable_asset(): ...


### PR DESCRIPTION
## Summary

Defaults-on the admin scan behavior for `dagster-powerbi`, since this gives us more data to work with including better representation of direct connections to warehouses. Updates docs to instruct users how to disable this behavior and revert to the current, individual API accesses if need be.

## How I Tested These Changes

Existing unit tests.

## Changelog

> [dagster-powerbi] Opts in to using admin scan APIs to pull data from a Power BI instance. This can be disabled by passing `load_powerbi_asset_specs(..., use_workspace_scan=False)`.
