### PR TITLE
[ui] Fix dark mode scrollbars

### DIFF
--- a/js_modules/dagster-ui/packages/ui-components/src/theme/darkThemeColors.tsx
+++ b/js_modules/dagster-ui/packages/ui-components/src/theme/darkThemeColors.tsx
@@ -1,7 +1,7 @@
 import {css} from 'styled-components';
 
 export const darkThemeColors = css`
-  --browser-color-scheme: 'dark';
+  --browser-color-scheme: dark;
   --color-keyline-default: var(--color-translucent-gray15);
   --color-link-default: var(--color-core-blue200);
   --color-link-hover: var(--color-core-blue400);

--- a/js_modules/dagster-ui/packages/ui-core/src/app/GlobalStyleProvider.tsx
+++ b/js_modules/dagster-ui/packages/ui-core/src/app/GlobalStyleProvider.tsx
@@ -26,6 +26,7 @@ const GlobalStyle = createGlobalStyle`
     color-scheme: ${Colors.browserColorScheme()};
     background-color: ${Colors.backgroundDefault()};
     color: ${Colors.textDefault()};
+    scrollbar-color: ${Colors.accentGrayHover()} ${Colors.backgroundDefault()};
     width: 100vw;
     height: 100vh;
     overflow: hidden;


### PR DESCRIPTION
## Summary & Motivation

Fix scrollbars in dark mode.

- Use `dark` instead of `'dark'` as the color scheme value. This fixes the main issue, where we're rendering light-mode browser controls. I'm not sure if this has been broken since we shipped dark mode, or if something recently changed. Either way, sorry for leaving it broken for so long.
- Style the scrollbar to use our themed colors, instead of the (mismatching) defaults.

<img width="1098" alt="Screenshot 2024-11-20 at 08 31 03" src="https://github.com/user-attachments/assets/638d77b9-5add-4cc2-a2ba-0de7c2c68b40">

<img width="1098" alt="Screenshot 2024-11-20 at 08 31 18" src="https://github.com/user-attachments/assets/f062f452-0e97-42db-9311-07ba0017626b">


## How I Tested These Changes

Change MacOS settings to show scrollbars in all cases. Load an asset detail page, shrink the viewport to force scrollbars to appear.

Verify that they look correct (including themed colors) in both dark mode and light mode.

## Changelog

[ui] Fix scrollbars in dark mode.
