### PR TITLE
Make UpstreamPartitionsResult subset-aware

### DIFF
--- a/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
+++ b/python_modules/dagster/dagster/_core/definitions/base_asset_graph.py
@@ -535,7 +535,7 @@ class BaseAssetGraph(ABC, Generic[T_AssetNode]):
                 required_but_nonexistent_parent_partitions.update(
                     {
                         AssetKeyPartitionKey(parent_asset_key, invalid_partition)
-                        for invalid_partition in mapped_partitions_result.required_but_nonexistent_partition_keys
+                        for invalid_partition in mapped_partitions_result.required_but_nonexistent_subset.get_partition_keys()
                     }
                 )
             else:

--- a/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
+++ b/python_modules/dagster/dagster/_core/definitions/time_window_partition_mapping.py
@@ -331,7 +331,7 @@ class TimeWindowPartitionMapping(
                 time_windows.append(TimeWindow(offsetted_to_start_dt, offsetted_to_end_dt))
 
         filtered_time_windows = []
-        required_but_nonexistent_partition_keys = set()
+        required_but_nonexistent_subset = to_partitions_def.empty_subset()
 
         for time_window in time_windows:
             if (
@@ -369,21 +369,20 @@ class TimeWindowPartitionMapping(
                     )
 
                 if invalid_time_window:
-                    required_but_nonexistent_partition_keys.update(
-                        set(
-                            to_partitions_def.get_partition_keys_in_time_window(
-                                time_window=invalid_time_window
-                            )
+                    required_but_nonexistent_subset = (
+                        required_but_nonexistent_subset
+                        | to_partitions_def.get_partition_subset_in_time_window(
+                            time_window=invalid_time_window
                         )
                     )
 
         return UpstreamPartitionsResult(
-            TimeWindowPartitionsSubset(
+            partitions_subset=TimeWindowPartitionsSubset(
                 to_partitions_def,
                 num_partitions=None,
                 included_time_windows=self._merge_time_windows(filtered_time_windows),
             ),
-            sorted(list(required_but_nonexistent_partition_keys)),
+            required_but_nonexistent_subset=required_but_nonexistent_subset,
         )
 
     def _do_cheap_partition_mapping_if_possible(
@@ -401,14 +400,20 @@ class TimeWindowPartitionMapping(
         None if the mapping doesn't fit into any of these cases.
         """
         if from_partitions_subset.is_empty:
-            return UpstreamPartitionsResult(to_partitions_def.empty_subset(), [])
+            return UpstreamPartitionsResult(
+                partitions_subset=to_partitions_def.empty_subset(),
+                required_but_nonexistent_subset=to_partitions_def.empty_subset(),
+            )
 
         if start_offset != 0 or end_offset != 0:
             return None
 
         # Same PartitionsDefinitions
         if from_partitions_def == to_partitions_def:
-            return UpstreamPartitionsResult(from_partitions_subset, [])
+            return UpstreamPartitionsResult(
+                partitions_subset=from_partitions_subset,
+                required_but_nonexistent_subset=to_partitions_def.empty_subset(),
+            )
 
         # Same PartitionsDefinitions except for start and end dates
         if (
@@ -427,7 +432,8 @@ class TimeWindowPartitionMapping(
             )
         ):
             return UpstreamPartitionsResult(
-                from_partitions_subset.with_partitions_def(to_partitions_def), []
+                partitions_subset=from_partitions_subset.with_partitions_def(to_partitions_def),
+                required_but_nonexistent_subset=to_partitions_def.empty_subset(),
             )
 
         # Daily to hourly
@@ -449,12 +455,12 @@ class TimeWindowPartitionMapping(
             )
         ):
             return UpstreamPartitionsResult(
-                TimeWindowPartitionsSubset(
+                partitions_subset=TimeWindowPartitionsSubset(
                     partitions_def=to_partitions_def,
                     num_partitions=None,
                     included_time_windows=from_partitions_subset.included_time_windows,
                 ),
-                [],
+                required_but_nonexistent_subset=to_partitions_def.empty_subset(),
             )
 
         # The subset we're mapping from doesn't exist in the PartitionsDefinition we're mapping to
@@ -462,18 +468,20 @@ class TimeWindowPartitionMapping(
             to_partitions_def.start, to_partitions_def.cron_schedule
         ):
             if self.allow_nonexistent_upstream_partitions:
-                required_but_nonexistent_partition_keys = []
+                required_but_nonexistent_subset = to_partitions_def.empty_subset()
             else:
-                required_but_nonexistent_partition_keys = [
-                    pk
-                    for time_window in from_partitions_subset.included_time_windows
-                    for pk in to_partitions_def.get_partition_keys_in_time_window(
-                        time_window=time_window
+                required_but_nonexistent_subset = to_partitions_def.empty_subset()
+                for time_window in from_partitions_subset.included_time_windows:
+                    required_but_nonexistent_subset = (
+                        required_but_nonexistent_subset
+                        | to_partitions_def.get_partition_subset_in_time_window(
+                            time_window.to_public_time_window()
+                        )
                     )
-                ]
 
             return UpstreamPartitionsResult(
-                to_partitions_def.empty_subset(), required_but_nonexistent_partition_keys
+                partitions_subset=to_partitions_def.empty_subset(),
+                required_but_nonexistent_subset=required_but_nonexistent_subset,
             )
 
         return None

--- a/python_modules/dagster/dagster/_core/execution/context/input.py
+++ b/python_modules/dagster/dagster/_core/execution/context/input.py
@@ -719,8 +719,11 @@ class KeyRangeNoPartitionsDefPartitionsSubset(PartitionsSubset):
     ) -> bool:
         raise NotImplementedError()
 
+    def empty_subset(self) -> "PartitionsSubset":
+        raise NotImplementedError()
+
     @classmethod
-    def empty_subset(
+    def create_empty_subset(
         cls, partitions_def: Optional["PartitionsDefinition"] = None
     ) -> "PartitionsSubset":
         raise NotImplementedError()

--- a/python_modules/dagster/dagster/_core/execution/context/system.py
+++ b/python_modules/dagster/dagster/_core/execution/context/system.py
@@ -1106,12 +1106,12 @@ class StepExecutionContext(PlanExecutionContext, IStepContext):
 
                 if (
                     require_valid_partitions
-                    and mapped_partitions_result.required_but_nonexistent_partition_keys
+                    and not mapped_partitions_result.required_but_nonexistent_subset.is_empty
                 ):
                     raise DagsterInvariantViolationError(
                         f"Partition key range {self.partition_key_range} in"
-                        f" {self.node_handle.name} depends on invalid partition keys"
-                        f" {mapped_partitions_result.required_but_nonexistent_partition_keys} in"
+                        f" {self.node_handle.name} depends on invalid partitions"
+                        f" {mapped_partitions_result.required_but_nonexistent_subset} in"
                         f" upstream asset {upstream_asset_key}"
                     )
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/asset_graph_view_tests/test_basic_asset_graph_view.py
@@ -47,24 +47,24 @@ def test_upstream_non_existent_partitions():
         down_subset = asset_graph_view.get_full_subset(key=down_asset.key)
         assert down_subset.expensively_compute_partition_keys() == {"x", "z"}
 
-        parent_subset, required_but_nonexistent_partition_keys = (
-            asset_graph_view.compute_parent_subset_and_required_but_nonexistent_partition_keys(
+        parent_subset, required_but_nonexistent_subset = (
+            asset_graph_view.compute_parent_subset_and_required_but_nonexistent_subset(
                 parent_key=up_asset.key, subset=down_subset
             )
         )
 
         assert parent_subset.expensively_compute_partition_keys() == {"x"}
-        assert required_but_nonexistent_partition_keys == ["z"]
+        assert required_but_nonexistent_subset.expensively_compute_partition_keys() == {"z"}
 
         # Mapping onto an empty subset is empty
         empty_down_subset = asset_graph_view.get_empty_subset(key=down_asset.key)
-        parent_subset, required_but_nonexistent_partition_keys = (
-            asset_graph_view.compute_parent_subset_and_required_but_nonexistent_partition_keys(
+        parent_subset, required_but_nonexistent_subset = (
+            asset_graph_view.compute_parent_subset_and_required_but_nonexistent_subset(
                 parent_key=up_asset.key, subset=empty_down_subset
             )
         )
         assert parent_subset.is_empty
-        assert required_but_nonexistent_partition_keys == []
+        assert required_but_nonexistent_subset.is_empty
 
 
 def test_subset_traversal_static_partitions() -> None:
@@ -201,13 +201,13 @@ def test_downstream_of_unpartitioned_partition_mapping() -> None:
         downstream_empty.compute_parent_subset(parent_key=unpartitioned.key) == unpartitioned_empty
     )
 
-    assert asset_graph_view.compute_parent_subset_and_required_but_nonexistent_partition_keys(
+    assert asset_graph_view.compute_parent_subset_and_required_but_nonexistent_subset(
         parent_key=unpartitioned.key, subset=downstream_full
-    ) == (unpartitioned_full, [])
+    ) == (unpartitioned_full, unpartitioned_empty)
 
-    assert asset_graph_view.compute_parent_subset_and_required_but_nonexistent_partition_keys(
+    assert asset_graph_view.compute_parent_subset_and_required_but_nonexistent_subset(
         parent_key=unpartitioned.key, subset=downstream_empty
-    ) == (unpartitioned_empty, [])
+    ) == (unpartitioned_empty, unpartitioned_empty)
 
 
 def test_upstream_of_unpartitioned_partition_mapping() -> None:

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_asset_partition_mappings.py
@@ -74,11 +74,11 @@ def test_access_partition_keys_from_context_non_identity_partition_mapping():
 
             partition_keys = list(downstream_partitions_subset.get_partition_keys())
             return UpstreamPartitionsResult(
-                upstream_partitions_def.empty_subset().with_partition_key_range(
+                partitions_subset=upstream_partitions_def.empty_subset().with_partition_key_range(
                     upstream_partitions_def,
                     PartitionKeyRange(str(max(1, int(partition_keys[0]) - 1)), partition_keys[-1]),
                 ),
-                [],
+                required_but_nonexistent_subset=upstream_partitions_def.empty_subset(),
             )
 
         def get_downstream_partitions_for_partitions(
@@ -561,7 +561,11 @@ def test_identity_partition_mapping():
         zx.empty_subset().with_partition_keys(["z", "x"]), zx, xy
     )
     assert result.partitions_subset.get_partition_keys() == set(["x"])
+    assert result.required_but_nonexistent_subset.get_partition_keys() == {"z"}
     assert result.required_but_nonexistent_partition_keys == ["z"]
+
+    # Make sure repr() still can output the subset
+    assert str(result.required_but_nonexistent_subset) == "DefaultPartitionsSubset(subset={'z'})"
 
     result = IdentityPartitionMapping().get_downstream_partitions_for_partitions(
         zx.empty_subset().with_partition_keys(["z", "x"]), zx, xy

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/partition_mapping_tests/test_multipartition_partition_mapping.py
@@ -694,6 +694,12 @@ def test_multipartitions_required_but_invalid_upstream_partitions():
     assert result.partitions_subset.get_partition_keys() == set(
         [MultiPartitionKey({"time": "2023-06-01", "123": "1"})]
     )
+    assert result.required_but_nonexistent_subset.get_partition_keys() == {"2023-05-01"}
+    assert (
+        str(result.required_but_nonexistent_subset)
+        == "DefaultPartitionsSubset(subset={'2023-05-01'})"
+    )
+
     assert result.required_but_nonexistent_partition_keys == ["2023-05-01"]
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_graph.py
@@ -237,11 +237,11 @@ def test_custom_unsupported_partition_mapping():
 
             partition_keys = list(downstream_partitions_subset.get_partition_keys())
             return UpstreamPartitionsResult(
-                upstream_partitions_def.empty_subset().with_partition_key_range(
+                partitions_subset=upstream_partitions_def.empty_subset().with_partition_key_range(
                     upstream_partitions_def,
                     PartitionKeyRange(str(max(1, int(partition_keys[0]) - 1)), partition_keys[-1]),
                 ),
-                [],
+                required_but_nonexistent_subset=upstream_partitions_def.empty_subset(),
             )
 
         def get_downstream_partitions_for_partitions(

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitioned_assets.py
@@ -868,7 +868,7 @@ def test_error_on_nonexistent_upstream_partition():
     with freeze_time(create_datetime(2020, 1, 2, 10, 0)):
         with pytest.raises(
             DagsterInvariantViolationError,
-            match="invalid partition keys",
+            match="depends on invalid partitions",
         ):
             materialize(
                 [downstream_asset, upstream_asset.to_source_asset()],

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_partitions_subset.py
@@ -106,9 +106,9 @@ def test_time_window_partitions_subset_serialization_deserialization(
     )
     subset = cast(
         TimeWindowPartitionsSubset,
-        TimeWindowPartitionsSubset.empty_subset(time_window_partitions_def).with_partition_keys(
-            ["2023-01-01"]
-        ),
+        TimeWindowPartitionsSubset.create_empty_subset(
+            time_window_partitions_def
+        ).with_partition_keys(["2023-01-01"]),
     )
 
     deserialized = deserialize_value(
@@ -208,4 +208,4 @@ def test_partitions_set_short_circuiting() -> None:
     assert and_result is default_ps
 
     # Test short-circuiting of -. Returns an empty DefaultPartitionsSubset
-    assert (default_ps - all_ps) == DefaultPartitionsSubset.empty_subset()
+    assert (default_ps - all_ps) == DefaultPartitionsSubset.create_empty_subset()

--- a/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition_tester.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/declarative_automation_tests/automation_condition_tests/fundamentals/test_automation_condition_tester.py
@@ -155,6 +155,25 @@ def test_observable_asset_defs() -> None:
         ),
         (
             HourlyPartitionsDefinition("2020-01-01-00:00"),
+            StaticPartitionsDefinition(
+                ["2019-01-02-00:00", "2019-01-03-00:00", "2019-01-04-00:00"]
+            ),
+            0,
+        ),
+        (
+            HourlyPartitionsDefinition("2020-01-01-00:00"),
+            StaticPartitionsDefinition(
+                ["2020-01-02-00:00", "2020-01-03-00:00", "2020-01-04-00:00"]
+            ),
+            3,
+        ),
+        (
+            HourlyPartitionsDefinition("2020-01-01-00:00"),
+            StaticPartitionsDefinition(["2019-01-02-00:00", "a", "2020-01-02-00:00"]),
+            1,
+        ),
+        (
+            HourlyPartitionsDefinition("2020-01-01-00:00"),
             StaticPartitionsDefinition(["a", "b", "c"]),
             0,
         ),

--- a/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/test_time_window_partitions.py
@@ -822,7 +822,9 @@ def test_partition_subset_get_partition_keys_not_in_subset(case_str: str):
 
     subset = cast(
         TimeWindowPartitionsSubset,
-        TimeWindowPartitionsSubset.empty_subset(partitions_def).with_partition_keys(subset_keys),
+        TimeWindowPartitionsSubset.create_empty_subset(partitions_def).with_partition_keys(
+            subset_keys
+        ),
     )
     for partition_key in subset_keys:
         assert partition_key in subset
@@ -951,7 +953,7 @@ def test_partition_subset_with_partition_keys(initial: str, added: str):
         if initial[i] != "+" and added[i] != "+":
             expected_keys_not_in_updated_subset.append(full_set_keys[i])
 
-    subset = TimeWindowPartitionsSubset.empty_subset(partitions_def).with_partition_keys(
+    subset = TimeWindowPartitionsSubset.create_empty_subset(partitions_def).with_partition_keys(
         initial_subset_keys
     )
     assert all(partition_key in subset for partition_key in initial_subset_keys)
@@ -1029,7 +1031,9 @@ def test_current_time_window_partitions_serialization():
 def test_time_window_partitions_contains() -> None:
     partitions_def = DailyPartitionsDefinition(start_date="2015-01-01")
     keys = ["2015-01-06", "2015-01-07", "2015-01-08", "2015-01-10"]
-    subset = TimeWindowPartitionsSubset.empty_subset(partitions_def).with_partition_keys(keys)
+    subset = TimeWindowPartitionsSubset.create_empty_subset(partitions_def).with_partition_keys(
+        keys
+    )
     for key in keys:
         assert key in subset
 

--- a/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
+++ b/python_modules/dagster/dagster_tests/storage_tests/test_fs_io_manager.py
@@ -270,7 +270,10 @@ def test_fs_io_manager_partitioned_no_partitions():
                 current_time: Optional[datetime] = None,
                 dynamic_partitions_store: Optional[DynamicPartitionsStore] = None,
             ) -> UpstreamPartitionsResult:
-                return UpstreamPartitionsResult(upstream_partitions_def.empty_subset(), [])
+                return UpstreamPartitionsResult(
+                    partitions_subset=upstream_partitions_def.empty_subset(),
+                    required_but_nonexistent_subset=upstream_partitions_def.empty_subset(),
+                )
 
             def get_downstream_partitions_for_partitions(
                 self,


### PR DESCRIPTION
Summary:
This allows us to make the method on AssetGraphView compute_parent_subset_and_required_but_nonexistent_subset instead of still working in terms of a list of partition keys.

I'm a little trepeditious about this because I could imagine cases where the invalid upstream partition is so invalid that it can't even be expressed as part of a PartitionsSubset? I guess in that case we could just raise an exception when you try to do the mapping like we already do in many cases (e.g. the timezones not matching).

The trickiest bit here was making sure that it was still possible to create and pass around an 'invalid' partitions subset (since we are a bit inconsistent in our APIs about whether or not we allow that when doing the various transformations from keys to subset and back).

Test Plan: BK

NOCHANGELOG

## Summary & Motivation

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
