### PR TITLE
[auto run retry tags] 1/n - make run_retries retry_on_asset_or_op_failure setting available on instance

### DIFF
--- a/python_modules/dagster/dagster/_core/instance/__init__.py
+++ b/python_modules/dagster/dagster/_core/instance/__init__.py
@@ -933,6 +933,10 @@ class DagsterInstance(DynamicPartitionsStore):
         return self.get_settings("run_retries").get("max_retries", 0)
 
     @property
+    def run_retries_retry_on_asset_or_op_failure(self) -> bool:
+        return self.get_settings("run_retries").get("retry_on_asset_or_op_failure", True)
+
+    @property
     def auto_materialize_enabled(self) -> bool:
         return self.get_settings("auto_materialize").get("enabled", True)
 

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -63,9 +63,7 @@ def filter_runs_to_should_retry(
         else:
             return 1
 
-    default_retry_on_asset_or_op_failure: bool = instance.get_settings("run_retries").get(
-        "retry_on_asset_or_op_failure", True
-    )
+    default_retry_on_asset_or_op_failure: bool = instance.run_retries_retry_on_asset_or_op_failure
 
     for run in runs:
         retry_number = get_retry_number(run)


### PR DESCRIPTION
## Summary & Motivation
Small PR, just makes run_retries_retry_on_asset_or_op_failure available via `instance.run_retries_retry_on_asset_or_op_failure`

Associated internal PR: https://github.com/dagster-io/internal/pull/12763

## How I Tested These Changes
