### PR TITLE
[asset selection] Introduce AssetSelection.to_selection_str

### DIFF
--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_scheduler.py
@@ -417,7 +417,10 @@ def test_jobless_asset_selection(graphql_context):
 
     assert result.data
     assert result.data["scheduleOrError"]["__typename"] == "Schedule"
-    assert result.data["scheduleOrError"]["assetSelection"]["assetSelectionString"] == "asset_one"
+    assert (
+        result.data["scheduleOrError"]["assetSelection"]["assetSelectionString"]
+        == 'key:"asset_one"'
+    )
     assert result.data["scheduleOrError"]["assetSelection"]["assetKeys"] == [
         {"path": ["asset_one"]}
     ]

--- a/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
+++ b/python_modules/dagster-graphql/dagster_graphql_tests/graphql/test_sensors.py
@@ -1655,7 +1655,7 @@ def test_asset_selection(graphql_context):
 
     assert (
         result.data["sensorOrError"]["assetSelection"]["assetSelectionString"]
-        == "fresh_diamond_bottom or asset_with_automation_condition or asset_with_custom_automation_condition"
+        == 'key:"fresh_diamond_bottom" or key:"asset_with_automation_condition" or key:"asset_with_custom_automation_condition"'
     )
     assert result.data["sensorOrError"]["assetSelection"]["assetKeys"] == [
         {"path": ["asset_with_automation_condition"]},
@@ -1699,7 +1699,9 @@ def test_jobless_asset_selection(graphql_context):
 
     assert result.data
     assert result.data["sensorOrError"]["__typename"] == "Sensor"
-    assert result.data["sensorOrError"]["assetSelection"]["assetSelectionString"] == "asset_one"
+    assert (
+        result.data["sensorOrError"]["assetSelection"]["assetSelectionString"] == 'key:"asset_one"'
+    )
     assert result.data["sensorOrError"]["assetSelection"]["assetKeys"] == [{"path": ["asset_one"]}]
     assert result.data["sensorOrError"]["assetSelection"]["assets"] == [
         {
@@ -1727,7 +1729,8 @@ def test_invalid_sensor_asset_selection(graphql_context):
     assert result.data
     assert result.data["sensorOrError"]["__typename"] == "Sensor"
     assert (
-        result.data["sensorOrError"]["assetSelection"]["assetSelectionString"] == "does_not_exist"
+        result.data["sensorOrError"]["assetSelection"]["assetSelectionString"]
+        == 'key:"does_not_exist"'
     )
     assert (
         result.data["sensorOrError"]["assetSelection"]["assetsOrError"]["__typename"]

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -570,6 +570,11 @@ class AssetSelection(ABC):
         return False
 
     def operand_to_selection_str(self) -> str:
+        """Returns a string representation of the selection when it is a child of a boolean expression,
+        for example, in an `AndAssetSelection` or `OrAssetSelection`. The main difference from `to_selection_str`
+        is that this method may include additional parentheses around the selection to ensure that the
+        expression is parsed correctly.
+        """
         return (
             f"({self.to_selection_str()})"
             if self.needs_parentheses_when_operand()

--- a/python_modules/dagster/dagster/_core/definitions/asset_selection.py
+++ b/python_modules/dagster/dagster/_core/definitions/asset_selection.py
@@ -898,7 +898,7 @@ class DownstreamAssetSelection(ChainedAssetSelection):
         if self.depth is None:
             base = f"{self.child.operand_to_selection_str()}*"
         elif self.depth == 0:
-            base = self.child.to_selection_str()
+            base = self.child.operand_to_selection_str()
         else:
             base = f"{self.child.operand_to_selection_str()}{'+' * self.depth}"
 
@@ -1138,21 +1138,18 @@ class UpstreamAssetSelection(ChainedAssetSelection):
         all_upstream = _fetch_all_upstream(selection, asset_graph, self.depth, self.include_self)
         return {key for key in all_upstream if key in asset_graph.materializable_asset_keys}
 
-    def _to_selection_str(self, child: str) -> str:
+    def to_selection_str(self) -> str:
         if self.depth is None:
-            base = f"*({child})"
+            base = f"*{self.child.operand_to_selection_str()}"
         elif self.depth == 0:
-            base = str(child)
+            base = self.child.operand_to_selection_str()
         else:
-            base = f"{'+' * self.depth}({child})"
+            base = f"{'+' * self.depth}{self.child.operand_to_selection_str()}"
 
         if self.include_self:
             return base
         else:
-            return f"{base} - ({child})"
-
-    def to_selection_str(self) -> str:
-        return self._to_selection_str(self.child.to_selection_str())
+            return f"{base} and not {self.child.operand_to_selection_str()}"
 
 
 @whitelist_for_serdes

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -700,51 +700,19 @@ def test_to_serializable_asset_selection():
 
 
 def test_to_string_basic():
-    assert str(AssetSelection.assets("foo")) == "foo"
-    assert str(AssetSelection.assets(AssetKey(["foo", "bar"]))) == "foo/bar"
-    assert str(AssetSelection.assets("foo", "bar")) == "foo or bar"
-    assert str(AssetSelection.assets(AssetKey(["foo", "bar"]), AssetKey("baz"))) == "foo/bar or baz"
-
-    assert str(AssetSelection.all()) == "all materializable assets"
+    assert str(AssetSelection.assets("foo")) == 'key:"foo"'
+    assert str(AssetSelection.assets(AssetKey(["foo", "bar"]))) == 'key:"foo/bar"'
+    assert str(AssetSelection.assets("foo", "bar")) == 'key:"foo" or key:"bar"'
     assert (
-        str(AssetSelection.all(include_sources=True))
-        == "all materializable assets and source assets"
-    )
-    assert str(AssetSelection.all_asset_checks()) == "all asset checks"
-
-    assert str(AssetSelection.groups("marketing")) == "group:marketing"
-    assert str(AssetSelection.groups("marketing", "finance")) == "group:(marketing or finance)"
-
-    assert str(AssetSelection.key_prefixes("marketing")) == "key_prefix:marketing"
-    assert str(AssetSelection.key_prefixes(["foo", "bar"])) == "key_prefix:foo/bar"
-    assert (
-        str(AssetSelection.key_prefixes("marketing", ["foo", "bar"]))
-        == "key_prefix:(marketing or foo/bar)"
-    )
-    assert (
-        str(AssetSelection.checks(AssetCheckKey(AssetKey("foo"), "bar"))) == "asset_check:foo:bar"
-    )
-    assert (
-        str(
-            AssetSelection.checks(
-                AssetCheckKey(AssetKey("foo"), "bar"), AssetCheckKey(AssetKey("baz"), "qux")
-            )
-        )
-        == "asset_check:(foo:bar or baz:qux)"
+        str(AssetSelection.assets(AssetKey(["foo", "bar"]), AssetKey("baz")))
+        == 'key:"foo/bar" or key:"baz"'
     )
 
-    assert (
-        str(
-            AssetChecksForAssetKeysSelection(
-                selected_asset_keys=[AssetKey("foo"), AssetKey("bar"), AssetKey("baz")]
-            )
-        )
-        == "asset_check:(foo or bar or baz)"
-    )
+    assert str(AssetSelection.all()) == "*"
 
+    assert str(AssetSelection.groups("marketing")) == 'group:"marketing"'
     assert (
-        str(AssetChecksForAssetKeysSelection(selected_asset_keys=[AssetKey("foo")]))
-        == "asset_check:foo"
+        str(AssetSelection.groups("marketing", "finance")) == 'group:"marketing" or group:"finance"'
     )
 
 
@@ -752,45 +720,45 @@ def test_to_string_binary_operators():
     foo_bar = AssetSelection.assets(AssetKey(["foo", "bar"]))
     baz = AssetSelection.assets("baz")
     bork = AssetSelection.assets("bork")
-    assert str(foo_bar | baz) == "foo/bar or baz"
-    assert str(foo_bar & baz) == "foo/bar and baz"
-    assert str(foo_bar - baz) == "foo/bar - baz"
+    assert str(foo_bar | baz) == 'key:"foo/bar" or key:"baz"'
+    assert str(foo_bar & baz) == 'key:"foo/bar" and key:"baz"'
+    assert str(foo_bar - baz) == 'key:"foo/bar" and not key:"baz"'
 
-    assert str(foo_bar | baz | bork) == "foo/bar or baz or bork"
-    assert str(foo_bar & baz & bork) == "foo/bar and baz and bork"
+    assert str(foo_bar | baz | bork) == 'key:"foo/bar" or key:"baz" or key:"bork"'
+    assert str(foo_bar & baz & bork) == 'key:"foo/bar" and key:"baz" and key:"bork"'
 
-    assert str((foo_bar | baz) | bork) == "foo/bar or baz or bork"
-    assert str(foo_bar | (baz | bork)) == "foo/bar or baz or bork"
-    assert str((foo_bar & baz) & bork) == "foo/bar and baz and bork"
-    assert str(foo_bar & (baz & bork)) == "foo/bar and baz and bork"
+    assert str((foo_bar | baz) | bork) == 'key:"foo/bar" or key:"baz" or key:"bork"'
+    assert str(foo_bar | (baz | bork)) == 'key:"foo/bar" or key:"baz" or key:"bork"'
+    assert str((foo_bar & baz) & bork) == 'key:"foo/bar" and key:"baz" and key:"bork"'
+    assert str(foo_bar & (baz & bork)) == 'key:"foo/bar" and key:"baz" and key:"bork"'
 
-    assert str(foo_bar | (baz & bork)) == "foo/bar or (baz and bork)"
-    assert str(foo_bar & (baz | bork)) == "foo/bar and (baz or bork)"
+    assert str(foo_bar | (baz & bork)) == 'key:"foo/bar" or (key:"baz" and key:"bork")'
+    assert str(foo_bar & (baz | bork)) == 'key:"foo/bar" and (key:"baz" or key:"bork")'
 
-    assert str(foo_bar - baz - bork) == "(foo/bar - baz) - bork"
-    assert str((foo_bar - baz) - bork) == "(foo/bar - baz) - bork"
-    assert str(foo_bar - (baz - bork)) == "foo/bar - (baz - bork)"
+    assert str(foo_bar - baz - bork) == '(key:"foo/bar" and not key:"baz") and not key:"bork"'
+    assert str((foo_bar - baz) - bork) == '(key:"foo/bar" and not key:"baz") and not key:"bork"'
+    assert str(foo_bar - (baz - bork)) == 'key:"foo/bar" and not (key:"baz" and not key:"bork")'
 
     assert (
         str(AssetSelection.assets("foo/bar", "baz") & AssetSelection.assets("bork"))
-        == "(foo/bar or baz) and bork"
+        == '(key:"foo/bar" or key:"baz") and key:"bork"'
     )
     assert (
         str(AssetSelection.assets("bork") & AssetSelection.assets("foo/bar", "baz"))
-        == "bork and (foo/bar or baz)"
+        == 'key:"bork" and (key:"foo/bar" or key:"baz")'
     )
     assert (
         str(AssetSelection.assets("foo/bar", "baz") | AssetSelection.assets("bork"))
-        == "(foo/bar or baz) or bork"
+        == '(key:"foo/bar" or key:"baz") or key:"bork"'
     )
     assert (
         str(AssetSelection.assets("bork") | AssetSelection.assets("foo/bar", "baz"))
-        == "bork or (foo/bar or baz)"
+        == 'key:"bork" or (key:"foo/bar" or key:"baz")'
     )
 
     assert (
         str(AssetSelection.groups("foo", "bar") & AssetSelection.groups("baz", "bork"))
-        == "group:(foo or bar) and group:(baz or bork)"
+        == '(group:"foo" or group:"bar") and (group:"baz" or group:"bork")'
     )
 
 

--- a/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
+++ b/python_modules/dagster/dagster_tests/asset_defs_tests/test_asset_selection.py
@@ -171,13 +171,13 @@ def test_asset_selection_groups(all_assets: _AssetList):
 def test_asset_selection_keys(all_assets: _AssetList):
     sel = AssetSelection.keys(AssetKey("alice"), AssetKey("bob"))
     assert sel.resolve(all_assets) == _asset_keys_of({alice, bob})
-    assert str(sel) == "alice or bob"
+    assert str(sel) == 'key:"alice" or key:"bob"'
 
     sel = AssetSelection.keys("alice", "bob")
     assert sel.resolve(all_assets) == _asset_keys_of({alice, bob})
 
     sel = AssetSelection.keys("alice", "bob", "carol", "dave")
-    assert str(sel) == "4 assets"
+    assert str(sel) == 'key:"alice" or key:"bob" or key:"carol" or key:"dave"'
 
     sel = AssetSelection.keys("animals/zebra")
     assert sel.resolve(all_assets) == _asset_keys_of({zebra})

--- a/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
+++ b/python_modules/dagster/dagster_tests/definitions_tests/asset_policy_sensors_tests/test_default_auto_materialize_sensors.py
@@ -216,7 +216,7 @@ def test_combine_default_sensors_with_non_default_sensors(instance_with_auto_mat
 
     assert (
         str(default_sensor.asset_selection)
-        == "all materializable assets and source assets - (auto_materialize_asset or auto_observe_asset)"
+        == 'not key:"auto_materialize_asset" or key:"auto_observe_asset"'
     )
 
     assert default_sensor.asset_selection.resolve(asset_graph) == {


### PR DESCRIPTION
## Summary

On the backend, `AssetSelection` is a nice serializable representation of an asset selection, which we might generate through a few methods:

- From an Antlr asset selection string
- From a set of frontend filters, saved in a catalog view
- Potentially from snapshotted user code, though we don't do this right now (for example, examining an asset job or sensor/schedule target and being able to copy an Antlr-ready string)

We don't have a good way to convert this selection back into a user-readable Antlr string. There are a few possible solutions here:

- Save the user-specified Antlr string alongside a selection. This seems like a promising approach when the initial source of truth is an Antlr string.
- Generate an Antlr string. This is the approach we'll need if the source of truth is user code or frontend filters where no Antlr string previously existed.

This PR introduces a `to_selection_str()` method on `AssetSelection` subclasses, which output a valid Antlr string representing that selection:

- The string must be parsed into an identical AssetSelection
- The string may not identically match the original Antlr string, if one exists

## Test Plan

New tests which
1. Ensure that Antlr strings can be converted to selections, back into equivalent strings (e.g. produce the same selection, but may not be equal)
2. Ensure that we have all Antlr literals under test, a rough proxy for ensuring we have full coverage of the grammar

Updates the existing `__str__` tests, which were introduced in #19059 for similar purposes but never fully fleshed out. For now, drops check selection stuff since the Antlr syntax doesn't include it.
