### PR TITLE
[dagster-looker] Mark asset key methods as deprecated in DagsterLookerApiTranslator

### DIFF
--- a/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
@@ -6,7 +6,7 @@ from dagster import (
     AssetSpec,
     _check as check,
 )
-from dagster._annotations import public
+from dagster._annotations import public, deprecated
 from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._record import record
 from dagster._utils.log import get_dagster_logger
@@ -115,6 +115,7 @@ class DagsterLookerApiTranslator:
     def instance_data(self) -> Optional[LookerInstanceData]:
         return self._looker_instance_data
 
+    @deprecated(breaking_version="1.10")
     def get_view_asset_key(self, looker_structure: LookerStructureData) -> AssetKey:
         return self.get_view_asset_spec(looker_structure).key
 
@@ -124,6 +125,7 @@ class DagsterLookerApiTranslator:
             key=AssetKey(["view", lookml_view.view_name]),
         )
 
+    @deprecated(breaking_version="1.10")
     def get_explore_asset_key(self, looker_structure: LookerStructureData) -> AssetKey:
         return self.get_explore_asset_spec(looker_structure).key
 
@@ -173,6 +175,7 @@ class DagsterLookerApiTranslator:
         else:
             check.assert_never(lookml_explore)
 
+    @deprecated(breaking_version="1.10")
     def get_dashboard_asset_key(self, looker_structure: LookerStructureData) -> AssetKey:
         return self.get_dashboard_asset_spec(looker_structure).key
 
@@ -218,6 +221,10 @@ class DagsterLookerApiTranslator:
         else:
             check.assert_never(looker_structure.structure_type)
 
+    @deprecated(
+        breaking_version="1.10",
+        additional_warn_text="Use `DagsterLookerApiTranslator.get_asset_spec().key` instead",
+    )
     @public
     def get_asset_key(self, looker_structure: LookerStructureData) -> AssetKey:
         return self.get_asset_spec(looker_structure).key

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
@@ -6,7 +6,7 @@ from dagster import (
     AssetSpec,
     _check as check,
 )
-from dagster._annotations import public, deprecated
+from dagster._annotations import deprecated, public
 from dagster._core.definitions.metadata.metadata_value import MetadataValue
 from dagster._record import record
 from dagster._utils.log import get_dagster_logger

--- a/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
+++ b/python_modules/libraries/dagster-looker/dagster_looker/api/dagster_looker_api_translator.py
@@ -115,7 +115,10 @@ class DagsterLookerApiTranslator:
     def instance_data(self) -> Optional[LookerInstanceData]:
         return self._looker_instance_data
 
-    @deprecated(breaking_version="1.10")
+    @deprecated(
+        breaking_version="1.10",
+        additional_warn_text="Use `DagsterLookerApiTranslator.get_asset_spec().key` instead",
+    )
     def get_view_asset_key(self, looker_structure: LookerStructureData) -> AssetKey:
         return self.get_view_asset_spec(looker_structure).key
 
@@ -125,7 +128,10 @@ class DagsterLookerApiTranslator:
             key=AssetKey(["view", lookml_view.view_name]),
         )
 
-    @deprecated(breaking_version="1.10")
+    @deprecated(
+        breaking_version="1.10",
+        additional_warn_text="Use `DagsterLookerApiTranslator.get_asset_spec().key` instead",
+    )
     def get_explore_asset_key(self, looker_structure: LookerStructureData) -> AssetKey:
         return self.get_explore_asset_spec(looker_structure).key
 
@@ -175,7 +181,10 @@ class DagsterLookerApiTranslator:
         else:
             check.assert_never(lookml_explore)
 
-    @deprecated(breaking_version="1.10")
+    @deprecated(
+        breaking_version="1.10",
+        additional_warn_text="Use `DagsterLookerApiTranslator.get_asset_spec().key` instead",
+    )
     def get_dashboard_asset_key(self, looker_structure: LookerStructureData) -> AssetKey:
         return self.get_dashboard_asset_spec(looker_structure).key
 


### PR DESCRIPTION
## Summary & Motivation

Like #26028 but for Looker API

## Changelog

[dagster-looker] `DagsterLookerApiTranslator.get_asset_key` is deprecated in favor of `DagsterLookerApiTranslator.get_asset_spec().key`
