### PR TITLE
[auto run retry tags] 3/n - when a run is retried, add the`auto_retry_run_id` tag

### DIFF
--- a/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
+++ b/integration_tests/test_suites/daemon-test-suite/auto_run_reexecution_tests/test_auto_run_reexecution.py
@@ -10,7 +10,7 @@ from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.snap import snapshot_from_execution_plan
 from dagster._core.storage.dagster_run import DagsterRunStatus, RunsFilter
 from dagster._core.storage.tags import (
-    AUTO_RETRY_RUN_ID,
+    AUTO_RETRY_RUN_ID_TAG,
     MAX_RETRIES_TAG,
     RETRY_ON_ASSET_OR_OP_FAILURE_TAG,
     RETRY_STRATEGY_TAG,
@@ -349,7 +349,7 @@ def test_consume_new_runs_for_automatic_reexecution(instance, workspace_context)
     assert len(instance.run_coordinator.queue()) == 1
     first_retry = instance.run_coordinator.queue()[0]
     run = instance.get_run_by_id(run.run_id)
-    assert run.tags.get(AUTO_RETRY_RUN_ID) == first_retry.run_id
+    assert run.tags.get(AUTO_RETRY_RUN_ID_TAG) == first_retry.run_id
 
     # doesn't retry again
     list(
@@ -389,7 +389,7 @@ def test_consume_new_runs_for_automatic_reexecution(instance, workspace_context)
     assert len(instance.run_coordinator.queue()) == 2
     second_retry = instance.run_coordinator.queue()[1]
     first_retry = instance.get_run_by_id(first_retry.run_id)
-    assert first_retry.tags.get(AUTO_RETRY_RUN_ID) == second_retry.run_id
+    assert first_retry.tags.get(AUTO_RETRY_RUN_ID_TAG) == second_retry.run_id
 
     # doesn't retry a third time
     dagster_event = DagsterEvent(
@@ -419,7 +419,7 @@ def test_consume_new_runs_for_automatic_reexecution(instance, workspace_context)
     )
     assert len(instance.run_coordinator.queue()) == 2
     second_retry = instance.get_run_by_id(second_retry.run_id)
-    assert second_retry.tags.get(AUTO_RETRY_RUN_ID) is None
+    assert second_retry.tags.get(AUTO_RETRY_RUN_ID_TAG) is None
 
 
 def test_daemon_enabled(instance):

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -61,7 +61,7 @@ RETRY_ON_ASSET_OR_OP_FAILURE_TAG = f"{SYSTEM_TAG_PREFIX}retry_on_asset_or_op_fai
 # This tag is used to indicate that the automatic retry daemon will launch a retry for this run
 # If this tag is not on a run, it means the run did not fail or automatic retries is disabled.
 WILL_RETRY_TAG = f"{SYSTEM_TAG_PREFIX}will_retry"
-DID_RETRY_TAG = f"{SYSTEM_TAG_PREFIX}did_retry"
+AUTO_RETRY_RUN_ID_TAG = f"{SYSTEM_TAG_PREFIX}auto_retry_run_id"
 
 MAX_RUNTIME_SECONDS_TAG = f"{SYSTEM_TAG_PREFIX}max_runtime"
 
@@ -107,7 +107,12 @@ RUN_METRICS_POLLING_INTERVAL_TAG = f"{HIDDEN_TAG_PREFIX}run_metrics_polling_inte
 RUN_METRICS_PYTHON_RUNTIME_TAG = f"{HIDDEN_TAG_PREFIX}python_runtime_metrics"
 
 
-TAGS_TO_OMIT_ON_RETRY = {*RUN_METRIC_TAGS, RUN_FAILURE_REASON_TAG, WILL_RETRY_TAG, DID_RETRY_TAG}
+TAGS_TO_OMIT_ON_RETRY = {
+    *RUN_METRIC_TAGS,
+    RUN_FAILURE_REASON_TAG,
+    WILL_RETRY_TAG,
+    AUTO_RETRY_RUN_ID_TAG,
+}
 
 
 class TagType(Enum):

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -61,6 +61,7 @@ RETRY_ON_ASSET_OR_OP_FAILURE_TAG = f"{SYSTEM_TAG_PREFIX}retry_on_asset_or_op_fai
 # This tag is used to indicate that the automatic retry daemon will launch a retry for this run
 # If this tag is not on a run, it means the run did not fail or automatic retries is disabled.
 WILL_RETRY_TAG = f"{SYSTEM_TAG_PREFIX}will_retry"
+DID_RETRY_TAG = f"{SYSTEM_TAG_PREFIX}did_retry"
 
 MAX_RUNTIME_SECONDS_TAG = f"{SYSTEM_TAG_PREFIX}max_runtime"
 
@@ -106,7 +107,7 @@ RUN_METRICS_POLLING_INTERVAL_TAG = f"{HIDDEN_TAG_PREFIX}run_metrics_polling_inte
 RUN_METRICS_PYTHON_RUNTIME_TAG = f"{HIDDEN_TAG_PREFIX}python_runtime_metrics"
 
 
-TAGS_TO_OMIT_ON_RETRY = {*RUN_METRIC_TAGS, RUN_FAILURE_REASON_TAG, WILL_RETRY_TAG}
+TAGS_TO_OMIT_ON_RETRY = {*RUN_METRIC_TAGS, RUN_FAILURE_REASON_TAG, WILL_RETRY_TAG, DID_RETRY_TAG}
 
 
 class TagType(Enum):

--- a/python_modules/dagster/dagster/_core/storage/tags.py
+++ b/python_modules/dagster/dagster/_core/storage/tags.py
@@ -61,6 +61,8 @@ RETRY_ON_ASSET_OR_OP_FAILURE_TAG = f"{SYSTEM_TAG_PREFIX}retry_on_asset_or_op_fai
 # This tag is used to indicate that the automatic retry daemon will launch a retry for this run
 # If this tag is not on a run, it means the run did not fail or automatic retries is disabled.
 WILL_RETRY_TAG = f"{SYSTEM_TAG_PREFIX}will_retry"
+# This tag will be added by the automatic retry daemon once it launches a retry for the run. The
+# value will be the run_id of the retry.
 AUTO_RETRY_RUN_ID_TAG = f"{SYSTEM_TAG_PREFIX}auto_retry_run_id"
 
 MAX_RUNTIME_SECONDS_TAG = f"{SYSTEM_TAG_PREFIX}max_runtime"

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -8,6 +8,7 @@ from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunRecord
 from dagster._core.storage.tags import (
+    DID_RETRY_TAG,
     MAX_RETRIES_TAG,
     RETRY_NUMBER_TAG,
     RETRY_ON_ASSET_OR_OP_FAILURE_TAG,
@@ -176,6 +177,7 @@ def retry_run(
     )
 
     instance.submit_run(new_run.run_id, workspace)
+    instance.add_run_tags(failed_run.run_id, {DID_RETRY_TAG: "true"})
 
 
 def consume_new_runs_for_automatic_reexecution(

--- a/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
+++ b/python_modules/dagster/dagster/_daemon/auto_run_reexecution/auto_run_reexecution.py
@@ -8,7 +8,7 @@ from dagster._core.execution.plan.resume_retry import ReexecutionStrategy
 from dagster._core.instance import DagsterInstance
 from dagster._core.storage.dagster_run import DagsterRun, DagsterRunStatus, RunRecord
 from dagster._core.storage.tags import (
-    DID_RETRY_TAG,
+    AUTO_RETRY_RUN_ID_TAG,
     MAX_RETRIES_TAG,
     RETRY_NUMBER_TAG,
     RETRY_ON_ASSET_OR_OP_FAILURE_TAG,
@@ -177,7 +177,7 @@ def retry_run(
     )
 
     instance.submit_run(new_run.run_id, workspace)
-    instance.add_run_tags(failed_run.run_id, {DID_RETRY_TAG: "true"})
+    instance.add_run_tags(failed_run.run_id, {AUTO_RETRY_RUN_ID_TAG: new_run.run_id})
 
 
 def consume_new_runs_for_automatic_reexecution(


### PR DESCRIPTION
## Summary & Motivation

Adds a `dagster/auto_rety_run_id=<run_id>` tag to any run that had a retry launched by the auto run reexecution daemon. This allows us to determine if a run is waiting to be retried by looking at the values of `dagster/will_retry` and `dagster/auto_rety_run_id` 

Examples:
`dagster/will_retry=False` - no retry will be launched for this run
`dagster/will_retry=True` - a retry will be launched for this run, but has not been launched yet
`dagster/will_retry=True` and `dagster/auto_rety_run_id=<run_id>` - a retry has been launched for this run

associated internal pr https://github.com/dagster-io/internal/pull/12787

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
